### PR TITLE
fix: Moved Button types to a new file

### DIFF
--- a/packages/ds-react-core/src/ui/Button/Button.tsx
+++ b/packages/ds-react-core/src/ui/Button/Button.tsx
@@ -1,33 +1,5 @@
-import type React from "react";
-
+import type Props from "./types.js";
 import "./styles.css";
-
-// TODO: this is how appearance could work as enum
-//
-// export enum ButtonAppearance {
-//   DEFAULT = "default",
-//   BASE = "base",
-//   POSITIVE = "positive",
-//   NEGATIVE = "negative",
-//   LINK = "link",
-// }
-
-export interface ButtonProps {
-  /* A unique identifier for the button */
-  id?: string;
-  /** Additional CSS classes */
-  className?: string;
-  /** The visual style of the button */
-  appearance?: "neutral" | "base" | "positive" | "negative" | "link";
-  /** Button contents */
-  label: string;
-  /** Optional click handler */
-  onClick?: () => void;
-}
-
-// combine custom props with all native button element attributes
-export type ButtonPropsType = ButtonProps &
-  React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 /** Buttons are clickable elements used to perform an action. */
 const Button = ({
@@ -36,7 +8,7 @@ const Button = ({
   appearance,
   label,
   ...props
-}: ButtonPropsType): React.ReactElement => {
+}: Props): React.ReactElement => {
   return (
     <button
       id={id}

--- a/packages/ds-react-core/src/ui/Button/index.ts
+++ b/packages/ds-react-core/src/ui/Button/index.ts
@@ -1,1 +1,5 @@
-export { default as Button, type ButtonProps } from "./Button.js";
+export { default as Button } from "./Button.js";
+export type {
+  default as ButtonProps,
+  BaseProps as ButtonBaseProps,
+} from "./types.js";

--- a/packages/ds-react-core/src/ui/Button/types.ts
+++ b/packages/ds-react-core/src/ui/Button/types.ts
@@ -1,0 +1,29 @@
+import type React from "react";
+
+// TODO: this is how appearance could work as enum
+//
+// export enum ButtonAppearance {
+//   DEFAULT = "default",
+//   BASE = "base",
+//   POSITIVE = "positive",
+//   NEGATIVE = "negative",
+//   LINK = "link",
+// }
+//
+
+export interface BaseProps {
+  /* A unique identifier for the button */
+  id?: string;
+  /** Additional CSS classes */
+  className?: string;
+  /** The visual style of the button */
+  appearance?: "neutral" | "base" | "positive" | "negative" | "link";
+  /** Button contents */
+  label: string;
+  /** Optional click handler */
+  onClick?: () => void;
+}
+
+type Props = BaseProps & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export default Props;


### PR DESCRIPTION
## Done

A quick one to move the Button Types into their own files, to be more compliant with the generator format.
I removed the domain prefix of the types, assuming that all types in the Button folder are related to it.

## QA

- Verify that all code has been successfully moved.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
