### PR TITLE
feat: add readonly mode to the editable block component

### DIFF
--- a/packages/react/ds-app-launchpad/src/ui/EditableBlock/EditableBlock.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/EditableBlock/EditableBlock.stories.tsx
@@ -52,7 +52,7 @@ export const Default: Story = {
 export const ReadOnlyBlock: Story = {
   args: {
     title: "Sample Title",
-    readonly: true,
+    isReadOnly: true,
     EditComponent: ({ isEditing, toggleEditing }: SampleChildProps) => (
       <SampleChild isEditing={isEditing} toggleEditing={toggleEditing} />
     ),

--- a/packages/react/ds-app-launchpad/src/ui/EditableBlock/EditableBlock.tests.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/EditableBlock/EditableBlock.tests.tsx
@@ -70,7 +70,7 @@ describe("EditableBlock component", () => {
     expect(document.body.contains(editingElement)).toBe(true);
   });
 
-  it("shouldn't  switch to edit mode when readonly is true", () => {
+  it("shouldn't  switch to edit mode when isReadOnly is true", () => {
     const ChildComponent = () => {
       const { isEditing } = useEditableBlock();
       return <div>{isEditing ? "Editing" : "Not Editing"}</div>;
@@ -80,7 +80,7 @@ describe("EditableBlock component", () => {
       <EditableBlock
         title={"Hello world!"}
         EditComponent={ChildComponent}
-        readonly
+        isReadOnly
       />,
     );
 

--- a/packages/react/ds-app-launchpad/src/ui/EditableBlock/EditableBlock.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/EditableBlock/EditableBlock.tsx
@@ -19,15 +19,15 @@ const EditableBlock = <T extends EditElementProps>({
   style,
   title,
   tag: TitleTag = "h3",
-  readonly = false,
+  isReadOnly = false,
 }: EditableBlockProps<T>): React.ReactElement => {
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const isFocusedRef = useRef<boolean>(false);
 
   const toggleEditing = useCallback(() => {
-    if (readonly) return;
+    if (isReadOnly) return;
     setIsEditing((editing) => !editing);
-  }, [readonly]);
+  }, [isReadOnly]);
 
   const handleBlur = useCallback(() => {
     isFocusedRef.current = false;
@@ -62,7 +62,7 @@ const EditableBlock = <T extends EditElementProps>({
       >
         <header>
           <TitleTag className="title">{title}</TitleTag>
-          {!readonly && (
+          {!isReadOnly && (
             <div
               className={`icon ${isEditing ? "icon-close" : "icon-edit"}`}
               onClick={toggleEditing}

--- a/packages/react/ds-app-launchpad/src/ui/EditableBlock/types.ts
+++ b/packages/react/ds-app-launchpad/src/ui/EditableBlock/types.ts
@@ -28,7 +28,7 @@ export interface EditableBlockProps<T extends EditElementProps> {
   tag?: keyof JSX.IntrinsicElements;
 
   /** Whether the block is read-only */
-  readonly?: boolean;
+  isReadOnly?: boolean;
 }
 
 export default EditableBlockProps;


### PR DESCRIPTION
## Done

#### Add a readonly mode to the editable block component

This is needed as in some cases due to lack of edit permissions we want to disable the editableblock and have it in a readonly mode.


### PR readiness check


- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

