### PR TITLE
chore: Enable TICS

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -1,0 +1,26 @@
+name: Upload TICS report
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tics-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Test
+        run: bun run test
+
+      - name: Produce TICS report
+        shell: bash
+        run: |
+          set -x
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
+          curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
+          . ./install_tics.sh
+          TICSQServer -project ds25 -tmpdir /tmp/tics -branchdir .


### PR DESCRIPTION
Improve compliance with SDLC by enabling TICS for DS25

**Still needed**: I'm not sure if there is any other setup required to enable TICS, such as configuring it on the TICS backend ourselves or requesting someone else to do it. This is just an adapation of the [react components TICS workflow](https://github.com/canonical/react-components/blob/811db9f701194ebd145969a50bf0e5ebe315ff98/.github/workflows/tics-coverage.yml) for DS25.