### PR TITLE
fix: migrate story backgrounds to sb 9

### DIFF
--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
@@ -14,8 +14,10 @@ const meta = {
   // Add padding to all tooltips to allow their entire contents to be visible
   parameters: {
     layout: "centered",
+  },
+  globals: {
     backgrounds: {
-      default: "dark",
+      value: "dark",
     },
   },
   tags: ["autodocs"],

--- a/packages/react/ds-core/src/ui/Tooltip/withTooltip.stories.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/withTooltip.stories.tsx
@@ -9,8 +9,10 @@ const meta = {
   title: "Tooltip/withTooltip",
   parameters: {
     layout: "centered",
+  },
+  globals: {
     backgrounds: {
-      default: "dark",
+      value: "dark",
     },
   },
   tags: ["autodocs"],


### PR DESCRIPTION
## Done

Updates stories the define specific backgrounds to use the new `globals` API for defining story backgrounds, which has changed in SB 9.

Fixes https://github.com/canonical/pragma/pull/245#issuecomment-2976976961

## QA

- Open `TooltipArea` stories and verify they have a dark background
- Open `withTooltip` stories and verify they have a dark background

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.
