### PR TITLE
chore: fix react core missing dep on utils package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
         "@chromatic-com/storybook": "^4.0.0",
         "@storybook/addon-a11y": "^9.0.8",
         "@storybook/addon-docs": "^9.0.8",
-        "@storybook/addon-themes": "^9.0.9",
+        "@storybook/addon-themes": "^9.0.8",
         "@storybook/addon-vitest": "^9.0.8",
         "@storybook/react-vite": "^9.0.8",
       },
@@ -337,6 +337,7 @@
       "dependencies": {
         "@canonical/storybook-config": "^0.9.0-experimental.19",
         "@canonical/styles": "^0.9.0-experimental.20",
+        "@canonical/utils": "^0.9.0-experimental.12",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
       },

--- a/packages/react/ds-core/package.json
+++ b/packages/react/ds-core/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@canonical/storybook-config": "^0.9.0-experimental.19",
     "@canonical/styles": "^0.9.0-experimental.20",
+    "@canonical/utils": "^0.9.0-experimental.12",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
## Done

Adds dependency on the utils package to the React core. If this dependency is missing, react core may build before the utils package, causing a race condition that may cause build failures.

Fixes https://github.com/canonical/pragma/actions/runs/15683544643/job/44180812277

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

