### PR TITLE
docs: publish with `--access public` for first time publishes

### DIFF
--- a/docs/how-to-guides/PUBLISH_A_PACKAGE.md
+++ b/docs/how-to-guides/PUBLISH_A_PACKAGE.md
@@ -14,7 +14,7 @@ This guide shows you how to publish a package from this repository to NPM.
   4. Set the token as the `NODE_AUTH_TOKEN` GitHub secret for this repository. 
 
 ## Publishing a new package
-Use these steps if your package has never been published to NPM before (for example, it was just merged to `main`).
+Follow these steps if your package has never been published to NPM before (for example, it was just merged to `main`).
 
 1. **Log in to NPM**
    - Run `npm login` and enter your credentials for the [@canonical](https://www.npmjs.com/org/canonical) organization.
@@ -30,7 +30,7 @@ Use these steps if your package has never been published to NPM before (for exam
    - Change directory to your new package, e.g. `cd packages/react/ds-app-<your-package>`.
 
 5. **Publish the package**
-   - Run `npm publish --access public`.
+   - Run `npm publish --access public`. Note that the `--access public` flag is only required on first publish, subsequent invocations can omit it.
    - Confirm the package is now available on [NPM](https://npmjs.org).
 
 After the first manual publish, you can use the automated workflow for future releases.


### PR DESCRIPTION
## Done

Small tweak to package publishing documentation to fix a (seemingly intermittent?) issue with publishing packages for the first time without explicit package publicity settings. 

- Fixes https://github.com/canonical/pragma/actions/runs/15899256592
  - https://www.npmjs.com/package/@canonical/storybook-addon-msw has been published manually with `npm publish --access public`

<details>
<code>
jmuzina@jmuzina-ubuntu-desktop:~/source/work/canonical/repos/ds25/packages/storybook/addon-msw$ npm publish
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm notice 📦  @canonical/storybook-addon-msw@0.9.0-experimental.21
npm notice total files: 38
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
npm error 402 Payment Required - PUT https://registry.npmjs.org/@canonical%2fstorybook-addon-msw - You must sign up for private packages
</code>
<summary>
Fixes this error that sometimes occurred on first-publish
</summary>
</details>

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

