### PR TITLE
fix(generator-svelte): styles.css fails formatting check

### DIFF
--- a/packages/generator-ds/src/sv-component/templates/styles.css.ejs
+++ b/packages/generator-ds/src/sv-component/templates/styles.css.ejs
@@ -1,5 +1,7 @@
 /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
 
+/*
 .<%= cssNamespace %>.<%= componentCssClassName %> {
 
 }
+*/


### PR DESCRIPTION
## Done

- Empty CSS ruleset generated in `styles.css` for Svelte is commented out by default (same as it is for React) so that the lint/formatting check is not failed by the output of the generator.

## QA

- Run `yo @canonical/ds:sv-component --withStyles`.
- Make sure that the ruleset in `styles.css` is commented out.
- Make sure that `styles.css` pass the lint/formatting check without any modifications.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 