### PR TITLE
chore(Chromatic): Chromatic runs on main branch to update baseline

### DIFF
--- a/.github/workflows/chromatic._template.yml
+++ b/.github/workflows/chromatic._template.yml
@@ -16,7 +16,7 @@ on:
         required: true
         description: Chromatic project token for publishing
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.working-directory }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.working-directory }}
   cancel-in-progress: true
 jobs:
   build:
@@ -57,3 +57,4 @@ jobs:
           buildScriptName: "build:storybook"
           onlyChanged: true
           externals: ${{ inputs.externals }}
+          autoAcceptChanges: ${{ github.event_name == 'push' }}

--- a/.github/workflows/chromatic.demo.yml
+++ b/.github/workflows/chromatic.demo.yml
@@ -7,6 +7,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - apps/react/demo/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-anbox.yml
+++ b/.github/workflows/chromatic.ds-react-app-anbox.yml
@@ -8,6 +8,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - packages/react/ds-app-anbox/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-launchpad.yml
+++ b/.github/workflows/chromatic.ds-react-app-launchpad.yml
@@ -8,6 +8,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - packages/react/ds-app-launchpad/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-lxd.yml
+++ b/.github/workflows/chromatic.ds-react-app-lxd.yml
@@ -8,6 +8,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - packages/react/ds-app-lxd/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-maas.yml
+++ b/.github/workflows/chromatic.ds-react-app-maas.yml
@@ -8,6 +8,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - packages/react/ds-app-maas/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-stores.yml
+++ b/.github/workflows/chromatic.ds-react-app-stores.yml
@@ -8,6 +8,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - packages/react/ds-app-stores/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-wpe.yml
+++ b/.github/workflows/chromatic.ds-react-app-wpe.yml
@@ -8,6 +8,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - packages/react/ds-app-wpe/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-core-form.yml
+++ b/.github/workflows/chromatic.ds-react-core-form.yml
@@ -8,6 +8,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - packages/react/ds-core-form/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-core.yml
+++ b/.github/workflows/chromatic.ds-react-core.yml
@@ -7,6 +7,16 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.react-boilerplate-vite.yml
+++ b/.github/workflows/chromatic.react-boilerplate-vite.yml
@@ -8,6 +8,16 @@ on:
       - packages/utils/**
       - packages/react/ds-core/**
       - apps/react/boilerplate-vite/**
+  push:
+    branches:
+      - main
+    paths:
+      - configs/storybook/**
+      - packages/tokens/**
+      - packages/styles/**
+      - packages/utils/**
+      - packages/react/ds-core/**
+      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.react-boilerplate-vite.yml
+++ b/.github/workflows/chromatic.react-boilerplate-vite.yml
@@ -1,4 +1,4 @@
-name: "react-ds-core/chromatic"
+name: "react-boilerplate-vite/chromatic"
 on:
   pull_request:
     paths:


### PR DESCRIPTION
## Done

Runs Chromatic tests on pushes to `main` to keep an up-to-date baseline. 

Fixes #275 
Fixes [WD-23293](https://warthogs.atlassian.net/browse/WD-23293)

## QA

- Verify that [main branch update](https://github.com/jmuzina/pragma/actions/runs/15977386303) workflow runs successfully, creates an [auto-accepted baseline build](https://www.chromatic.com/build?appId=67be30a0b85c4e44b6744158&number=115). Note the build number of the baseline build: 115
- Verify that an intentional regression in a 1-commit [PR](https://github.com/jmuzina/pragma/pull/44) causes a [workflow run](https://github.com/jmuzina/pragma/actions/runs/15977646958/job/45064311129) that creates a [Chromatic build](https://www.chromatic.com/build?appId=67be30a0b85c4e44b6744158&number=116) number 116 with the correct ancestor/baseline of 115. 
- Verify that a follow-up commit to the same PR causes a [workflow](https://github.com/jmuzina/pragma/actions/runs/15977876405/job/45065111479) with TurboSnap enabled, which only captures new tests for changed stories.  The [build](https://www.chromatic.com/build?appId=67be30a0b85c4e44b6744158&number=117) 117's ancestor is the previous commit's build, number 116. 
- Verify that a squash-merge of the regression causes a [workflow](https://github.com/jmuzina/pragma/actions/runs/15978013475/job/45065553276), and creates a new [Baseline build](https://www.chromatic.com/build?appId=67be30a0b85c4e44b6744158&number=118) number 118 with all changes auto-accepted
- Verify that a [PR](https://github.com/jmuzina/pragma/pull/45) to fix the regressions, opened after the squash-merge, creates a [build](https://www.chromatic.com/build?appId=67be30a0b85c4e44b6744158&number=119) that uses the new baseline build 118 from main as an ancestor and has the correct visual diffs. Visual diffs recorded by the previous PR are not lost in the squash-merge. 

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 


[WD-23293]: https://warthogs.atlassian.net/browse/WD-23293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ