### PR TITLE
fix: syntax highlighting part 2

### DIFF
--- a/packages/react/ds-app-launchpad/src/ui/GitDiffViewer/common/CodeDiffViewer/HighlighTheme.css
+++ b/packages/react/ds-app-launchpad/src/ui/GitDiffViewer/common/CodeDiffViewer/HighlighTheme.css
@@ -157,12 +157,12 @@
 
 .hljs-deletion {
   color: #dc3023;
-  background-color: #490202;
+  background-color: transparent;
 }
 
 .hljs-addition {
   color: #0e811f;
-  background-color: #04260f;
+  background-color: transparent;
 }
 
 .hljs-link {


### PR DESCRIPTION
## Done

- Split `<span>` element into multiple elements with the same attributes if it is a multi line element
- Fix Diff output syntax highlighted background color

Fixes [LP-2679](https://warthogs.atlassian.net/browse/LP-2679)


### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 

## Screenshots


### Before
![image](https://github.com/user-attachments/assets/02485f58-db21-4826-8f95-943ebdeed0cb)


### After
![image](https://github.com/user-attachments/assets/1650bb8a-03d9-4d62-8871-d95c41406122)



[LP-2679]: https://warthogs.atlassian.net/browse/LP-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ