### PR TITLE
fix(Chromatic): fix chromatic baseline path filter typos

### DIFF
--- a/.github/workflows/chromatic.ds-react-app-launchpad.yml
+++ b/.github/workflows/chromatic.ds-react-app-launchpad.yml
@@ -17,7 +17,7 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
-      - packages/react/ds-app-anbox/**
+      - packages/react/ds-app-launchpad/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-lxd.yml
+++ b/.github/workflows/chromatic.ds-react-app-lxd.yml
@@ -17,7 +17,7 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
-      - packages/react/ds-app-anbox/**
+      - packages/react/ds-app-lxd/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-maas.yml
+++ b/.github/workflows/chromatic.ds-react-app-maas.yml
@@ -17,7 +17,7 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
-      - packages/react/ds-app-anbox/**
+      - packages/react/ds-app-maas/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-stores.yml
+++ b/.github/workflows/chromatic.ds-react-app-stores.yml
@@ -17,7 +17,7 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
-      - packages/react/ds-app-anbox/**
+      - packages/react/ds-app-stores/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-wpe.yml
+++ b/.github/workflows/chromatic.ds-react-app-wpe.yml
@@ -17,7 +17,7 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
-      - packages/react/ds-app-anbox/**
+      - packages/react/ds-app-wpe/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-core-form.yml
+++ b/.github/workflows/chromatic.ds-react-core-form.yml
@@ -17,7 +17,7 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
-      - packages/react/ds-app-anbox/**
+      - packages/react/ds-core-form/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-core.yml
+++ b/.github/workflows/chromatic.ds-react-core.yml
@@ -16,7 +16,6 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
-      - packages/react/ds-app-anbox/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.react-boilerplate-vite.yml
+++ b/.github/workflows/chromatic.react-boilerplate-vite.yml
@@ -17,7 +17,7 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-core/**
-      - packages/react/ds-app-anbox/**
+      - apps/react/boilerplate-vite/**
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml


### PR DESCRIPTION
## Done

An unfortunate case of copy-pasting in #280 caused all package baseline configurations to listen to the Anbox package to determine whether to run a baseline update - rather than themselves. This resolves that by making the path filters for the push event identical to those for the PR event.

Fixes [this Launchpad merge](https://github.com/canonical/pragma/commit/af8ed0d642fb3fbfaba85bcf8e89a02f8a539986) did not cause a baseline update because it did not modify files in the Anbox package

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
