### PR TITLE
feat(generator): Make generator metadata comment location consistent

### DIFF
--- a/packages/generator-ds/src/component/templates/Component.ssr.tests.tsx.ejs
+++ b/packages/generator-ds/src/component/templates/Component.ssr.tests.tsx.ejs
@@ -1,3 +1,5 @@
+/* <%= generatorPackageName %> <%= generatorPackageVersion %> */
+
 import { renderToString } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import Component from "./<%= componentName %>.js";

--- a/packages/generator-ds/src/component/templates/Component.tsx.ejs
+++ b/packages/generator-ds/src/component/templates/Component.tsx.ejs
@@ -1,4 +1,5 @@
 /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
+
 import type React from 'react';
 import type { <%= componentName %>Props } from './types.js';
 <% if (withStyles) { _%>

--- a/packages/generator-ds/src/component/templates/index.ts.ejs
+++ b/packages/generator-ds/src/component/templates/index.ts.ejs
@@ -1,3 +1,4 @@
 /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
+
 export { default as <%= componentName %> } from './<%= componentName %>.js'
 export * from './types.js'

--- a/packages/generator-ds/src/component/templates/types.ts.ejs
+++ b/packages/generator-ds/src/component/templates/types.ts.ejs
@@ -1,4 +1,5 @@
 /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
+
 import type React from 'react'
 
 export interface <%= componentName %>Props {

--- a/packages/generator-ds/src/sv-component/templates/Component.ssr.test.ts.ejs
+++ b/packages/generator-ds/src/sv-component/templates/Component.ssr.test.ts.ejs
@@ -1,3 +1,5 @@
+/* <%= generatorPackageName %> <%= generatorPackageVersion %> */
+
 import { render } from "svelte/server";
 import { describe, expect, it } from "vitest";
 import Component from "./<%= componentName %>.svelte";

--- a/packages/generator-ds/src/sv-component/templates/Component.svelte.ejs
+++ b/packages/generator-ds/src/sv-component/templates/Component.svelte.ejs
@@ -1,5 +1,6 @@
+<!-- <%= generatorPackageName %> <%= generatorPackageVersion %> -->
+
 <script lang="ts">
-  /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
   import type { <%= componentName %>Props } from "./types.js";
 <% if (withStyles) { _%>
   import "./styles.css";

--- a/packages/generator-ds/src/sv-component/templates/index.ts.ejs
+++ b/packages/generator-ds/src/sv-component/templates/index.ts.ejs
@@ -1,3 +1,4 @@
 /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
+
 export { default as <%= componentName %> } from "./<%= componentName %>.svelte";
 export * from "./types.js";

--- a/packages/generator-ds/src/sv-component/templates/types.ts.ejs
+++ b/packages/generator-ds/src/sv-component/templates/types.ts.ejs
@@ -1,4 +1,5 @@
 /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
+
 import type { Snippet } from "svelte";
 
 export type <%= componentName %>Props = {


### PR DESCRIPTION
## Done

- The generator's template files were modified so that all of them (except the `parent-index`) consistently begin with the generator metadata comment on the first line, followed by an empty line and then the actual generated source code.

## QA

- Run `yo @canonical/ds:component` and `yo @canonical/ds:sv-component`.
- Check that all the generated files (except the `parent-index`) have the correct metadata comment placement.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 