### PR TITLE
feat(monorepo): Added `.mcp.json` with two mcp servers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "nx-mcp@latest",
-        "/home/adrian/code/cn/pragma"
+        "."
       ],
       "env": {}
     },


### PR DESCRIPTION
## Done
- Adds a .mcp.json file 
- Adds [Context7](https://context7.com/) to `.mcp.json`
- Adds the [NX mcp](https://nx.dev/blog/building-mcp-server-with-nx) to `.mcp.json`

Caveat : while the format is the same between editors, the resolution mechanism is different. Please look at [this primer from grok](https://grok.com/share/bGVnYWN5_ee4fd773-cb9d-4d82-90de-d36f192d2d61). It makes me wonder what's the best approach to store this information - hence the draft status.

## QA

- Run a `.mcp.json` compatible tool in the monorepo. It should be able to access both mcps successfully.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
