### PR TITLE
feat(generator-svelte): Move styles to .svelte

### DIFF
--- a/packages/generator-ds/src/sv-component/README.md
+++ b/packages/generator-ds/src/sv-component/README.md
@@ -8,7 +8,7 @@ This generator creates a new Svelte component with a basic structure.
 3. The required arguments and possible flags are listed by invoking the generator with the `--help` flag, for instance `yo @canonical/ds:sv-component --help`
 
 ### Options
-- `--withStyles` or `-c`: Creates a `styles.css` file associated with the component
+- `--withStyles` or `-c`: Creates a `<style>` block in the component file
 - `--withStories` or `-s`: Creates a Storybook file for the component
 - `--useTsStories` or `-t`: Uses the `.ts` based story formats instead of the CSF3 & `.svelte` format. Useful when there is a specific need for a template-based stories or function-based stories, otherwise not recommended. Has no effect if `withStories` is not set
 - `--withoutSsrTests` or `-w`: Skips the creation of SSR tests for the component

--- a/packages/generator-ds/src/sv-component/index.ts
+++ b/packages/generator-ds/src/sv-component/index.ts
@@ -47,7 +47,7 @@ export default class ComponentGenerator extends Generator<ComponentGeneratorOpti
 
     this.option("withStyles", {
       type: Boolean,
-      description: "Creates a `styles.css` file associated with the component.",
+      description: "Creates a `<style>` block in the component file.",
       default: false,
       alias: "c",
     });
@@ -144,14 +144,6 @@ export default class ComponentGenerator extends Generator<ComponentGeneratorOpti
         this.destinationPath(
           `${this.answers.componentPath}/${templateData.componentName}.ssr.test.ts`,
         ),
-        templateData,
-      );
-    }
-
-    if (this.answers.withStyles) {
-      this.fs.copyTpl(
-        this.templatePath("styles.css.ejs"),
-        this.destinationPath(`${this.answers.componentPath}/styles.css`),
         templateData,
       );
     }

--- a/packages/generator-ds/src/sv-component/templates/Component.svelte.ejs
+++ b/packages/generator-ds/src/sv-component/templates/Component.svelte.ejs
@@ -3,7 +3,6 @@
 <script lang="ts">
   import type { <%= componentName %>Props } from "./types.js";
 <% if (withStyles) { _%>
-  import "./styles.css";
 
   const componentCssClassName = "<%= cssNamespace %> <%= componentCssClassName %>";
 <%_ } _%>
@@ -25,3 +24,11 @@
 </<%= componentName %>>
 ```
 -->
+<% if (withStyles) { _%>
+
+<style>
+  /* .<%= cssNamespace %>.<%= componentCssClassName %> {
+
+  } */
+</style>
+<%_ } _%>

--- a/packages/generator-ds/src/sv-component/templates/styles.css.ejs
+++ b/packages/generator-ds/src/sv-component/templates/styles.css.ejs
@@ -1,7 +1,0 @@
-/* <%= generatorPackageName %> <%= generatorPackageVersion %> */
-
-/*
-.<%= cssNamespace %>.<%= componentCssClassName %> {
-
-}
-*/


### PR DESCRIPTION
This PR aims to implement in the generator a more idiomatic approach to [styling Svelte components](https://svelte.dev/docs/svelte/scoped-styles). By adopting this method, among others, we benefit from automatic style scoping, style pruning for components that are not rendered, and an improved developer experience through warnings for unused CSS selectors.

## Done

- Move the generated styles boilerplate for Svelte from `styles.css` file to `<style>` block in `.svelte`.
- Update the generator's help and documentation to reflect the change.

## QA

1. Run `yo @canonical/ds:sv-component --withStyles`
2. Verify that no `.css` file is generated and that the `.svelte` file contains `<style>` block prefilled with the component's class.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 