### PR TITLE
fix(Biome): pin biome

### DIFF
--- a/apps/react/boilerplate-vite/biome.json
+++ b/apps/react/boilerplate-vite/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json", "vite.config.ts"]

--- a/apps/react/boilerplate-vite/package.json
+++ b/apps/react/boilerplate-vite/package.json
@@ -32,7 +32,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/react-ds-core": "^0.9.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",

--- a/apps/react/demo/biome.json
+++ b/apps/react/demo/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json", "vite.config.ts"]

--- a/apps/react/demo/package.json
+++ b/apps/react/demo/package.json
@@ -36,7 +36,7 @@
     "react-shadow": "^20.6.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^4.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/react-ds-core": "^0.9.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
@@ -51,7 +51,7 @@
         "react-shadow": "^20.6.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^4.0.0",
@@ -72,10 +72,10 @@
       "name": "@canonical/biome-config",
       "version": "0.10.0-experimental.0",
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
       },
       "peerDependencies": {
-        "@biomejs/biome": "^1.9.4 || ^2.0.0",
+        "@biomejs/biome": "2.1.1",
       },
     },
     "configs/storybook": {
@@ -91,7 +91,7 @@
         "@storybook/react-vite": "^9.0.8",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "typescript": "^5.8.3",
@@ -104,7 +104,7 @@
       "name": "@canonical/typescript-config-base",
       "version": "0.10.0-experimental.0",
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "typescript": "^5.8.3",
       },
@@ -119,7 +119,7 @@
         "@canonical/typescript-config-base": "^0.10.0-experimental.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "typescript": "^5.8.3",
       },
@@ -135,7 +135,7 @@
         "yeoman-generator": "^7.5.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-base": "^0.10.0-experimental.0",
         "@types/debug": "^4.1.12",
@@ -156,7 +156,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^3.2.2",
@@ -186,7 +186,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^4.0.0",
@@ -223,7 +223,7 @@
         "remark-gfm": "^4.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^4.0.0",
@@ -253,7 +253,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^3.2.2",
@@ -283,7 +283,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^4.0.0",
@@ -313,7 +313,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^4.0.0",
@@ -343,7 +343,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^3.2.2",
@@ -374,7 +374,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^4.0.0",
@@ -408,7 +408,7 @@
         "react-hook-form": "^7.57.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@chromatic-com/storybook": "^4.0.0",
@@ -443,7 +443,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-base": "^0.10.0-experimental.0",
         "@types/express": "^5.0.3",
@@ -460,7 +460,7 @@
         "@storybook/icons": "^1.2.10",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@types/node": "^24.0.0",
@@ -485,7 +485,7 @@
         "@storybook/icons": "^1.2.10",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-react": "^0.10.0-experimental.0",
         "@types/node": "^24.0.0",
@@ -507,7 +507,7 @@
       "name": "@canonical/styles-debug",
       "version": "0.10.0-experimental.0",
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
       },
     },
@@ -518,7 +518,7 @@
         "normalize.css": "^8.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
       },
     },
@@ -535,7 +535,7 @@
         "normalize.css": "^8.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
       },
     },
@@ -543,7 +543,7 @@
       "name": "@canonical/styles-modes-canonical",
       "version": "0.10.0-experimental.0",
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
       },
     },
@@ -551,7 +551,7 @@
       "name": "@canonical/styles-modes-density",
       "version": "0.10.0-experimental.0",
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
       },
     },
@@ -562,7 +562,7 @@
         "@canonical/tokens": "^0.10.0-experimental.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
       },
     },
@@ -573,7 +573,7 @@
         "normalize.css": "^8.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
       },
     },
@@ -586,7 +586,7 @@
         "normalize.css": "^8.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/tokens": "^0.9.0",
       },
@@ -598,7 +598,7 @@
         "style-dictionary": "^4.3.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
       },
     },
@@ -612,7 +612,7 @@
         "opentype.js": "^1.3.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@types/bun": "latest",
       },
@@ -624,7 +624,7 @@
       "name": "@canonical/utils",
       "version": "0.10.0-experimental.0",
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-base": "^0.10.0-experimental.0",
         "typescript": "^5.8.3",
@@ -642,7 +642,7 @@
         "commander": "^14.0.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.1.1",
         "@canonical/biome-config": "^0.10.0-experimental.0",
         "@canonical/typescript-config-base": "^0.10.0-experimental.0",
         "@types/json-schema": "^7.0.15",
@@ -2918,8 +2918,6 @@
     "@canonical/react-ds-app-wpe/@chromatic-com/storybook": ["@chromatic-com/storybook@3.2.6", "", { "dependencies": { "chromatic": "^11.15.0", "filesize": "^10.0.12", "jsonfile": "^6.1.0", "react-confetti": "^6.1.0", "strip-ansi": "^7.1.0" }, "peerDependencies": { "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0" } }, "sha512-FDmn5Ry2DzQdik+eq2sp/kJMMT36Ewe7ONXUXM2Izd97c7r6R/QyGli8eyh/F0iyqVvbLveNYFyF0dBOJNwLqw=="],
 
     "@canonical/styles-primitives-canonical/@canonical/tokens": ["@canonical/tokens@0.9.0", "", { "dependencies": { "style-dictionary": "^4.3.3" } }, "sha512-S4YC2G80NxbmFU/JgYBJn4zXaQdVkJeIBFcXQurELQXlzHLVOizgacmfVRnw9UKfAGoOK6JezwLwhLyVWI6ozA=="],
-
-    "@canonical/webarchitect/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "@inquirer/core/cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 

--- a/configs/biome/biome.json
+++ b/configs/biome/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/configs/biome/package.json
+++ b/configs/biome/package.json
@@ -22,9 +22,9 @@
     "check:biome:fix": "biome check --write *.json"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0"
+    "@biomejs/biome": "2.1.1"
   },
   "peerDependencies": {
-    "@biomejs/biome": "^1.9.4 || ^2.0.0"
+    "@biomejs/biome": "2.1.1"
   }
 }

--- a/configs/storybook/biome.json
+++ b/configs/storybook/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/configs/storybook/package.json
+++ b/configs/storybook/package.json
@@ -36,7 +36,7 @@
     "@storybook/react-vite": "^9.0.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "typescript": "^5.8.3"

--- a/configs/typescript-base/biome.json
+++ b/configs/typescript-base/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["*.json"]

--- a/configs/typescript-base/package.json
+++ b/configs/typescript-base/package.json
@@ -23,7 +23,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "typescript": "^5.8.3"
   },

--- a/configs/typescript-react/biome.json
+++ b/configs/typescript-react/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["*.json"]

--- a/configs/typescript-react/package.json
+++ b/configs/typescript-react/package.json
@@ -23,7 +23,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "typescript": "^5.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "check": "lerna run check",
     "check:fix": "lerna run check:fix",
     "test": "lerna run test",
-    "special:clean": "rm -rf node_modules .nx"
+    "special:clean": "lerna clean --yes && nx reset && rm -rf node_modules"
   },
   "devDependencies": {
     "lerna": "^8.1.8"

--- a/packages/generator-ds/biome.json
+++ b/packages/generator-ds/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json", "!generators"]

--- a/packages/generator-ds/package.json
+++ b/packages/generator-ds/package.json
@@ -35,7 +35,7 @@
     "yeoman-generator": "^7.5.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-base": "^0.10.0-experimental.0",
     "@types/debug": "^4.1.12",

--- a/packages/react/ds-app-anbox/biome.json
+++ b/packages/react/ds-app-anbox/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-app-anbox/package.json
+++ b/packages/react/ds-app-anbox/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^4.0.0",

--- a/packages/react/ds-app-launchpad/biome.json
+++ b/packages/react/ds-app-launchpad/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-app-launchpad/package.json
+++ b/packages/react/ds-app-launchpad/package.json
@@ -52,7 +52,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^4.0.0",

--- a/packages/react/ds-app-lxd/biome.json
+++ b/packages/react/ds-app-lxd/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-app-lxd/package.json
+++ b/packages/react/ds-app-lxd/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^3.2.2",

--- a/packages/react/ds-app-maas/biome.json
+++ b/packages/react/ds-app-maas/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-app-maas/package.json
+++ b/packages/react/ds-app-maas/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^4.0.0",

--- a/packages/react/ds-app-stores/biome.json
+++ b/packages/react/ds-app-stores/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-app-stores/package.json
+++ b/packages/react/ds-app-stores/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^4.0.0",

--- a/packages/react/ds-app-wpe/biome.json
+++ b/packages/react/ds-app-wpe/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-app-wpe/package.json
+++ b/packages/react/ds-app-wpe/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^3.2.2",

--- a/packages/react/ds-app/biome.json
+++ b/packages/react/ds-app/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-app/package.json
+++ b/packages/react/ds-app/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^3.2.2",

--- a/packages/react/ds-core-form/biome.json
+++ b/packages/react/ds-core-form/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-core-form/package.json
+++ b/packages/react/ds-core-form/package.json
@@ -50,7 +50,7 @@
     "react-hook-form": "^7.57.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^4.0.0",

--- a/packages/react/ds-core/biome.json
+++ b/packages/react/ds-core/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": [

--- a/packages/react/ds-core/package.json
+++ b/packages/react/ds-core/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@chromatic-com/storybook": "^4.0.0",

--- a/packages/react/ssr/biome.json
+++ b/packages/react/ssr/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/react/ssr/package.json
+++ b/packages/react/ssr/package.json
@@ -48,7 +48,7 @@
     }
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-base": "^0.10.0-experimental.0",
     "@types/express": "^5.0.3",

--- a/packages/storybook/addon-baseline-grid/biome.json
+++ b/packages/storybook/addon-baseline-grid/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json", "!src/styles/normalize.css"]

--- a/packages/storybook/addon-baseline-grid/package.json
+++ b/packages/storybook/addon-baseline-grid/package.json
@@ -44,7 +44,7 @@
     "@storybook/icons": "^1.2.10"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@types/node": "^24.0.0",

--- a/packages/storybook/addon-msw/biome.json
+++ b/packages/storybook/addon-msw/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json", "!src/styles/normalize.css"]

--- a/packages/storybook/addon-msw/package.json
+++ b/packages/storybook/addon-msw/package.json
@@ -47,7 +47,7 @@
     "@storybook/icons": "^1.2.10"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-react": "^0.10.0-experimental.0",
     "@types/node": "^24.0.0",

--- a/packages/styles/debug/biome.json
+++ b/packages/styles/debug/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/styles/debug/package.json
+++ b/packages/styles/debug/package.json
@@ -34,7 +34,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0"
   }
 }

--- a/packages/styles/elements/biome.json
+++ b/packages/styles/elements/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/styles/elements/package.json
+++ b/packages/styles/elements/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0"
   },
   "dependencies": {

--- a/packages/styles/main/canonical/biome.json
+++ b/packages/styles/main/canonical/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/styles/main/canonical/package.json
+++ b/packages/styles/main/canonical/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0"
   },
   "dependencies": {

--- a/packages/styles/modes/canonical/biome.json
+++ b/packages/styles/modes/canonical/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/styles/modes/canonical/package.json
+++ b/packages/styles/modes/canonical/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0"
   }
 }

--- a/packages/styles/modes/density/biome.json
+++ b/packages/styles/modes/density/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/styles/modes/density/package.json
+++ b/packages/styles/modes/density/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0"
   }
 }

--- a/packages/styles/modes/intents/biome.json
+++ b/packages/styles/modes/intents/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/styles/modes/intents/package.json
+++ b/packages/styles/modes/intents/package.json
@@ -29,7 +29,7 @@
     "@canonical/tokens": "^0.10.0-experimental.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0"
   }
 }

--- a/packages/styles/modes/motion/biome.json
+++ b/packages/styles/modes/motion/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/styles/modes/motion/package.json
+++ b/packages/styles/modes/motion/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0"
   },
   "dependencies": {

--- a/packages/styles/primitives/canonical/biome.json
+++ b/packages/styles/primitives/canonical/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/styles/primitives/canonical/package.json
+++ b/packages/styles/primitives/canonical/package.json
@@ -31,7 +31,7 @@
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/tokens": "^0.9.0"
   }

--- a/packages/tokens/biome.json
+++ b/packages/tokens/biome.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"]
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -30,7 +30,7 @@
     "check:biome:fix": "biome check --write src *.json *.js"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0"
   },
   "dependencies": {

--- a/packages/typography/biome.json
+++ b/packages/typography/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json"]

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -16,7 +16,7 @@
     "check:ts": "tsc --noEmit"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@types/bun": "latest"
   },

--- a/packages/utils/biome.json
+++ b/packages/utils/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["**/src/**", "**/*.json"]

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -39,7 +39,7 @@
     "test": "echo 'No tests defined yet'"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-base": "^0.10.0-experimental.0",
     "typescript": "^5.8.3"

--- a/packages/webarchitect/biome.json
+++ b/packages/webarchitect/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["src", "*.json", "rulesets"]

--- a/packages/webarchitect/package.json
+++ b/packages/webarchitect/package.json
@@ -35,7 +35,7 @@
     "test": "echo 'No tests defined yet'"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.1.1",
     "@canonical/biome-config": "^0.10.0-experimental.0",
     "@canonical/typescript-config-base": "^0.10.0-experimental.0",
     "@types/json-schema": "^7.0.15",


### PR DESCRIPTION
## Done

Fixes possibility of installed Biome versions and remote versions of the Biome schema mismatching. 

Fixes inconsistent linting failures like the one effecting #305 (see [workflow logs](https://github.com/canonical/pragma/actions/runs/17103388036/job/48505780779))

Ideally, we could include an instruction in the biome config to use the locally served Biome schema which is in the user's `node_modules` directory - however the [biome documentation](https://biomejs.dev/reference/configuration/#schema) suggests that this is not yet possible for monorepos. 

### `special_clean` updates
If you have ever run `bun i`, `npm i`, or similar at the package level, rather than the monorepo level, you may have a `node_modules` folder in package directories. If Biome is found there, it will be used instead of the root Biome version - leading to the possibility of schema version mismatches. This PR updates the `special:clean` script to delete nested `node_modules` directories (at the package level) with [`lerna clean`](https://github.com/lerna/lerna/tree/main/libs/commands/clean#readme). Also, `rm -rf .nx` has been replaced with [`nx reset`](https://nx.dev/reference/core-api/nx/documents/reset) which also clears some internal nx daemon state and can help resolve intermittent package problems.

## QA

- See that CI passes
- Clone PR
- `bun run i && bun run special:clean && bun run check` -> verify this succeeds locally.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
