### PR TITLE
feat(tokens): add primitive and semantic color tokens

### DIFF
--- a/packages/styles/primitives/canonical/src/tokens.css
+++ b/packages/styles/primitives/canonical/src/tokens.css
@@ -4,51 +4,242 @@
 :root {
   /* color tokens */
   /* based on: https://docs.google.com/spreadsheets/d/1AY6BLFU-Cnj48ggHUnNVlWRxwWZ6Z-66s7jxJC1HLSU/edit?gid=1738212977#gid=1738212977 */
-  --color-palette-white: #fff;
-  --color-palette-black: #000;
-  --color-palette-blue: #24598f;
-  --color-palette-yellow: #cc7900;
 
-  --color-background-default: var(--color-palette-white);
+  --color-palette-black: rgba(0, 0, 0, 1);
+
+  --color-palette-blue-1: rgba(229, 239, 249, 1);
+  --color-palette-blue-2: rgba(217, 232, 247, 1);
+  --color-palette-blue-3: rgba(219, 229, 239, 1);
+  --color-palette-blue-4: rgba(209, 227, 245, 1);
+  --color-palette-blue-5: rgba(207, 221, 236, 1);
+  --color-palette-blue-6: rgba(199, 217, 235, 1);
+  --color-palette-blue-7: rgba(153, 204, 255, 1);
+  --color-palette-blue-8: rgba(94, 166, 237, 1);
+  --color-palette-blue-9: rgba(46, 150, 255, 1);
+  --color-palette-blue-10: rgba(102, 153, 204, 1);
+  --color-palette-blue-11: rgba(0, 102, 204, 1);
+  --color-palette-blue-12: rgba(36, 89, 143, 1);
+  --color-palette-blue-13: rgba(24, 74, 116, 1);
+  --color-palette-blue-14: rgba(27, 68, 103, 1);
+  --color-palette-blue-15: rgba(30, 58, 81, 1);
+
+  --color-palette-gray-1: rgba(247, 247, 247, 1);
+  --color-palette-gray-2: rgba(245, 245, 245, 1);
+  --color-palette-gray-3: rgba(243, 243, 243, 1);
+  --color-palette-gray-4: rgba(242, 242, 242, 1);
+  --color-palette-gray-5: rgba(236, 236, 236, 1);
+  --color-palette-gray-6: rgba(235, 235, 235, 1);
+  --color-palette-gray-7: rgba(233, 233, 233, 1);
+  --color-palette-gray-8: rgba(231, 231, 231, 1);
+  --color-palette-gray-9: rgba(229, 229, 229, 1);
+  --color-palette-gray-10: rgba(224, 224, 224, 1);
+  --color-palette-gray-11: rgba(222, 222, 222, 1);
+  --color-palette-gray-12: rgba(219, 219, 219, 1);
+  --color-palette-gray-13: rgba(218, 218, 218, 1);
+  --color-palette-gray-14: rgba(217, 217, 217, 1);
+  --color-palette-gray-15: rgba(204, 204, 204, 1);
+  --color-palette-gray-16: rgba(201, 201, 201, 1);
+  --color-palette-gray-17: rgba(194, 194, 194, 1);
+  --color-palette-gray-18: rgba(168, 168, 168, 1);
+  --color-palette-gray-19: rgba(166, 166, 166, 1);
+  --color-palette-gray-20: rgba(146, 146, 146, 1);
+  --color-palette-gray-21: rgba(112, 112, 112, 1);
+  --color-palette-gray-22: rgba(107, 107, 107, 1);
+  --color-palette-gray-23: rgba(102, 102, 102, 1);
+  --color-palette-gray-24: rgba(97, 97, 97, 1);
+  --color-palette-gray-25: rgba(92, 92, 92, 1);
+  --color-palette-gray-26: rgba(81, 81, 81, 1);
+  --color-palette-gray-27: rgba(71, 71, 71, 1);
+  --color-palette-gray-28: rgba(64, 64, 64, 1);
+  --color-palette-gray-29: rgba(61, 61, 61, 1);
+  --color-palette-gray-30: rgba(60, 60, 60, 1);
+  --color-palette-gray-31: rgba(55, 55, 55, 1);
+  --color-palette-gray-32: rgba(49, 49, 49, 1);
+  --color-palette-gray-33: rgba(47, 47, 47, 1);
+  --color-palette-gray-34: rgba(45, 45, 45, 1);
+  --color-palette-gray-35: rgba(38, 38, 38, 1);
+  --color-palette-gray-36: rgba(32, 32, 32, 1);
+  --color-palette-gray-37: rgba(17, 17, 17, 1);
+  --color-palette-gray-38: rgba(17, 17, 17, 0.85);
+
+  --color-palette-green-1: rgba(230, 248, 233, 1);
+  --color-palette-green-2: rgba(217, 247, 221, 1);
+  --color-palette-green-3: rgba(209, 245, 214, 1);
+  --color-palette-green-4: rgba(220, 238, 222, 1);
+  --color-palette-green-5: rgba(207, 236, 211, 1);
+  --color-palette-green-6: rgba(199, 235, 205, 1);
+  --color-palette-green-7: rgba(98, 163, 108, 1);
+  --color-palette-green-8: rgba(14, 132, 32, 1);
+  --color-palette-green-9: rgba(0, 128, 19, 1);
+  --color-palette-green-10: rgba(12, 109, 26, 1);
+  --color-palette-green-11: rgba(0, 103, 15, 1);
+  --color-palette-green-12: rgba(24, 96, 35, 1);
+  --color-palette-green-13: rgba(10, 95, 23, 1);
+  --color-palette-green-14: rgba(27, 86, 36, 1);
+  --color-palette-green-15: rgba(0, 87, 13, 1);
+  --color-palette-green-16: rgba(32, 68, 38, 1);
+
+  --color-palette-orange-1: rgba(233, 84, 32, 1);
+  --color-palette-orange-2: rgba(218, 72, 22, 1);
+  --color-palette-orange-3: rgba(204, 68, 20, 1);
+
+  --color-palette-purple-1: rgba(166, 121, 210, 1);
+  --color-palette-purple-2: rgba(125, 66, 184, 1);
+
+  --color-palette-red-1: rgba(249, 229, 231, 1);
+  --color-palette-red-2: rgba(247, 217, 220, 1);
+  --color-palette-red-3: rgba(239, 219, 221, 1);
+  --color-palette-red-4: rgba(245, 209, 212, 1);
+  --color-palette-red-5: rgba(236, 207, 210, 1);
+  --color-palette-red-6: rgba(235, 199, 203, 1);
+  --color-palette-red-7: rgba(209, 123, 133, 1);
+  --color-palette-red-8: rgba(199, 22, 43, 1);
+  --color-palette-red-9: rgba(176, 19, 38, 1);
+  --color-palette-red-10: rgba(162, 18, 35, 1);
+  --color-palette-red-11: rgba(161, 18, 35, 1);
+  --color-palette-red-12: rgba(116, 61, 68, 1);
+  --color-palette-red-13: rgba(138, 15, 30, 1);
+  --color-palette-red-14: rgba(103, 57, 63, 1);
+  --color-palette-red-15: rgba(124, 14, 27, 1);
+  --color-palette-red-16: rgba(81, 51, 54, 1);
+
+  --color-palette-teal-1: rgba(15, 149, 161, 1);
+
+  --color-palette-transparent: rgba(0, 0, 0, 0);
+
+  --color-palette-white: rgba(255, 255, 255, 1);
+
+  --color-palette-yellow-1: rgba(249, 238, 229, 1);
+  --color-palette-yellow-2: rgba(247, 230, 217, 1);
+  --color-palette-yellow-3: rgba(239, 228, 219, 1);
+  --color-palette-yellow-4: rgba(245, 225, 209, 1);
+  --color-palette-yellow-5: rgba(236, 220, 207, 1);
+  --color-palette-yellow-6: rgba(235, 215, 199, 1);
+  --color-palette-yellow-7: rgba(196, 136, 49, 1);
+  --color-palette-yellow-8: rgba(204, 121, 0, 1);
+  --color-palette-yellow-9: rgba(116, 66, 24, 1);
+  --color-palette-yellow-10: rgba(103, 69, 42, 1);
+  --color-palette-yellow-11: rgba(81, 53, 30, 1);
+
+  /*
+     Semantic Token Bindings
+    */
+
+  /* Base Semantic Colors */
+  --color-positive: var(--color-palette-green-8);
+  --color-negative: var(--color-palette-red-8);
+  --color-information: var(--color-palette-blue-12);
+  --color-caution: var(--color-palette-yellow-8);
+
+  /* Text Colors */
   --color-text-default: var(--color-palette-black);
-  --color-background-hover: rgba(242, 242, 242, 1);
-  --color-background-active: rgba(235, 235, 235, 1);
+  --color-text-muted: rgba(0, 0, 0, 0.6);
+  --color-text-inactive: rgba(0, 0, 0, 0.75);
+  --color-text-link-default: var(--color-palette-blue-11);
+  --color-text-link-visited: var(--color-palette-purple-2);
+  --color-text-button-positive: var(--color-palette-white);
+  --color-text-button-negative: var(--color-palette-white);
+  --color-text-button-brand: var(--color-palette-white);
+  --color-text-button-default: var(--color-text-default);
+  --color-text-button-base: var(--color-text-default);
+  --color-text-positive: var(--color-positive);
+  --color-text-negative: var(--color-negative);
+  --color-text-caution: var(--color-caution);
+  --color-text-tooltip: var(--color-palette-white);
+  --color-text-status-label: var(--color-palette-white);
+  --color-text-badge: var(--color-palette-white);
+  --color-text-search-and-filter-overflow: var(--color-information);
 
-  --color-background-neutral-default: rgb(242, 242, 242);
-  --color-background-neutral-hover: rgb(229, 229, 229);
-  --color-background-neutral-active: rgb(222, 222, 222);
+  /* Background Colors */
+  --color-background-default: var(--color-palette-white);
+  --color-background-hover: var(--color-palette-gray-4);
+  --color-background-active: var(--color-palette-gray-6);
+  --color-background-alt: var(--color-palette-gray-1);
+  --color-background-code: rgba(0, 0, 0, 0.03);
+  --color-background-input-default: var(--color-palette-gray-2);
+  --color-background-overlay: var(--color-palette-gray-38);
+  --color-background-neutral-default: var(--color-palette-gray-4);
+  --color-background-neutral-hover: var(--color-palette-gray-9);
+  --color-background-neutral-active: var(--color-palette-gray-11);
+  --color-background-positive-default: rgba(10, 189, 37, 0.1);
+  --color-background-positive-hover: rgba(0, 199, 30, 0.15);
+  --color-background-positive-active: rgba(0, 199, 30, 0.18);
+  --color-background-caution-default: rgba(199, 90, 0, 0.1);
+  --color-background-caution-hover: rgba(199, 90, 0, 0.15);
+  --color-background-caution-active: rgba(199, 90, 0, 0.18);
+  --color-background-negative-default: rgba(199, 0, 20, 0.1);
+  --color-background-negative-hover: rgba(199, 0, 20, 0.15);
+  --color-background-negative-active: rgba(199, 0, 20, 0.18);
+  --color-background-information-default: rgba(0, 99, 199, 0.1);
+  --color-background-information-hover: rgba(0, 99, 199, 0.15);
+  --color-background-information-active: rgba(0, 99, 199, 0.18);
+  --color-background-button-positive-default: var(--color-palette-green-8);
+  --color-background-button-positive-hover: var(--color-palette-green-10);
+  --color-background-button-positive-active: var(--color-palette-green-13);
+  --color-background-button-negative-default: var(--color-palette-red-8);
+  --color-background-button-negative-hover: var(--color-palette-red-9);
+  --color-background-button-negative-active: var(--color-palette-red-10);
+  --color-background-button-brand-default: var(--color-palette-orange-1);
+  --color-background-button-brand-hover: var(--color-palette-orange-2);
+  --color-background-button-brand-active: var(--color-palette-orange-3);
+  --color-background-button-default-default: var(--color-background-default);
+  --color-background-button-default-hover: var(--color-background-hover);
+  --color-background-button-default-active: var(--color-background-active);
+  --color-background-button-base-default: var(--color-palette-transparent);
+  --color-background-button-base-hover: var(--color-background-hover);
+  --color-background-button-base-active: var(--color-background-active);
+  --color-background-checkbox-checked: var(--color-text-link-default);
+  --color-background-tooltip: var(--color-palette-gray-37);
+  --color-background-canonical-logo: var(--color-palette-orange-1);
+  --color-background-radio-checked: var(--color-text-link-default);
+  --color-background-status-label-default: var(--color-palette-gray-23);
+  --color-background-status-label-positive: var(--color-palette-green-8);
+  --color-background-status-label-caution: var(--color-palette-yellow-8);
+  --color-background-status-label-negative: var(--color-palette-red-8);
+  --color-background-status-label-information: var(--color-palette-blue-12);
+  --color-background-badge-default: var(--color-palette-black);
+  --color-background-badge-negative: var(--color-palette-red-8);
+  --color-background-switch-track: var(--color-background-neutral-default);
+  --color-background-switch-checked: var(--color-text-link-default);
+  --color-background-switch-knob: var(--color-background-default);
+  --color-background-slider-progress: var(--color-background-default);
+  --color-background-slider-track: var(--color-border-default);
 
+  /* Border Colors */
+  --color-border-default: rgba(0, 0, 0, 0.2);
   --color-border-high-contrast: rgba(0, 0, 0, 0.56);
+  --color-border-low-contrast: rgba(0, 0, 0, 0.1);
+  --color-border-neutral: rgba(0, 0, 0, 0.56);
+  --color-border-positive: var(--color-positive);
+  --color-border-negative: var(--color-negative);
+  --color-border-information: var(--color-information);
+  --color-border-caution: var(--color-caution);
+  --color-border-highlight: var(--color-palette-black);
+  --color-border-accent: var(--color-palette-teal-1);
+  --color-border-focus: var(--color-palette-blue-9);
+  --color-border-switch-knob: var(--color-background-neutral-default);
+  --color-border-tab-active: var(--color-border-highlight);
 
-  --color-background-positive-default: rgba(14, 132, 32, 1);
-  --color-background-positive-hover: rgba(12, 109, 26, 1);
-  --color-background-positive-active: rgba(10, 95, 23, 1);
-  --color-background-positive-text: var(--color-palette-white); /* text on positive background */
+  /* Icon Colors */
+  --color-icon-default: var(--color-text-default);
+  --color-icon-muted: var(--color-text-muted);
+  --color-icon-positive: var(--color-positive);
+  --color-icon-negative: var(--color-negative);
+  --color-icon-information: var(--color-information);
+  --color-icon-caution: var(--color-caution);
+  --color-icon-link: var(--color-text-link-default);
+  --color-icon-status-shade-1: var(--color-palette-gray-1);
+  --color-icon-status-shade-2: var(--color-palette-gray-14);
+  --color-icon-status-queued: var(--color-palette-gray-13);
+  --color-icon-pull-quote-quotation-mark: var(--color-text-muted);
+  --color-icon-canonical-logo: var(--color-palette-white);
+  --color-icon-button-brand: var(--color-palette-white);
+  --color-icon-button-default: var(--color-icon-default);
+  --color-icon-button-base: var(--color-icon-default);
+  --color-icon-button-positive: var(--color-palette-white);
+  --color-icon-button-negative: var(--color-palette-white);
 
-  --color-background-positive-tinted-default: rgba(10, 189, 37, 0.1);
-  --color-background-positive-tinted-hover: rgba(0, 199, 30, 0.15);
-  --color-background-positive-tinted-active: rgba(0, 199, 30, 0.18);
-
-  --color-background-negative-tinted-default: rgba(199, 0, 20, 0.1);
-  --color-background-negative-tinted-hover: rgba(199, 0, 20, 0.15);
-  --color-background-negative-tinted-active: rgba(199, 0, 20, 0.18);
-
-  --color-background-negative-default: rgba(199, 22, 43, 1);
-  --color-background-negative-hover: rgba(176, 19, 38, 1);
-  --color-background-negative-active: rgba(162, 18, 35, 1);
-  --color-background-negative-text: var(--color-palette-white); /* text on positive background */
-
-  --color-background-information-default: var(--color-palette-blue);
-  --color-background-information-tinted-default: rgba(0, 99, 199, 0.1);
-  --color-background-information-tinted-hover: rgba(0, 99, 199, 0.15);
-  --color-background-information-tinted-active: rgba(0, 99, 199, 0.18);
-
-  --color-background-caution-default: var(--color-palette-yellow);
-  --color-background-caution-tinted-default: rgba(199, 90, 0, 0.1);
-  --color-background-caution-tinted-hover: rgba(199, 90, 0, 0.15);
-  --color-background-caution-tinted-active: rgba(199, 90, 0, 0.18);
-
-  /* spacing tokens */
+  /* Spacing Tokens */
   --spacing-horizontal-xsmall: 0.25rem;
   --spacing-horizontal-small: 0.5rem;
   --spacing-horizontal-medium: 1.25rem;
@@ -63,7 +254,7 @@
 
   --spacing-border-width: 1.5px; /* TODO: 1.5px was causing some baseline issues in Vanilla */
 
-  /* font tokens */
+  /* Font Tokens */
   --font-size-default: 1rem;
   --font-size-small: 0.875rem;
   --font-weight-default: 400;
@@ -71,7 +262,6 @@
   --line-height-small: 1.25rem;
 }
 
-/* component semantic tokens */
 :root {
   --button-color-background: var(--color-background-default);
   --button-color-background-hover: var(--color-background-hover);
@@ -107,10 +297,10 @@
   --chip-margin-left: var(--spacing-horizontal-medium);
 
   /*
-      TODO the tooltip's color tokens should be inverted from the active color theme.
-          This is to provide greater color contrast against its context.
-          This will be implemented once theming DS-wide is added.
-    */
+    TODO the tooltip's color tokens should be inverted from the active color theme.
+        This is to provide greater color contrast against its context.
+        This will be implemented once theming DS-wide is added.
+  */
 
   --tooltip-color-background: var(--color-background-default);
   --tooltip-color-background-hover: var(--color-background-hover);


### PR DESCRIPTION
## Done

Adds the rest of the [primitive and semantic color tokens](https://docs.google.com/spreadsheets/d/1AY6BLFU-Cnj48ggHUnNVlWRxwWZ6Z-66s7jxJC1HLSU/edit?gid=1738212977#gid=1738212977) to the tokens package.

A style dictionary integration is forthcoming pending some finalization of the token work - these tokens being defined in CSS directly is temporary and will allow me to build new components in the meantime. 

## QA

- See that there are no Chromatic diffs

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
