### PR TITLE
chore(Storybook): enable the storybook code panel on all storybook projects

### DIFF
--- a/apps/react/boilerplate-vite/.storybook/preview.ts
+++ b/apps/react/boilerplate-vite/.storybook/preview.ts
@@ -15,6 +15,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/apps/react/demo/.storybook/preview.ts
+++ b/apps/react/demo/.storybook/preview.ts
@@ -14,6 +14,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-app-anbox/.storybook/preview.ts
+++ b/packages/react/ds-app-anbox/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-app-launchpad/.storybook/preview.ts
+++ b/packages/react/ds-app-launchpad/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-app-lxd/.storybook/preview.ts
+++ b/packages/react/ds-app-lxd/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-app-maas/.storybook/preview.ts
+++ b/packages/react/ds-app-maas/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-app-stores/.storybook/preview.ts
+++ b/packages/react/ds-app-stores/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-app-wpe/.storybook/preview.ts
+++ b/packages/react/ds-app-wpe/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-app/.storybook/preview.ts
+++ b/packages/react/ds-app/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-core-form/.storybook/preview.ts
+++ b/packages/react/ds-core-form/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-core/.storybook/preview.ts
+++ b/packages/react/ds-core/.storybook/preview.ts
@@ -16,6 +16,11 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
 };
 
 export default preview;

--- a/packages/storybook/addon-baseline-grid/.storybook/preview.ts
+++ b/packages/storybook/addon-baseline-grid/.storybook/preview.ts
@@ -5,6 +5,9 @@ import "@canonical/styles-debug/baseline-grid";
 
 const preview: Preview = {
   parameters: {
+    docs: {
+      codePanel: true,
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/packages/storybook/addon-msw/.storybook/preview.ts
+++ b/packages/storybook/addon-msw/.storybook/preview.ts
@@ -5,6 +5,9 @@ import "@canonical/styles-debug/baseline-grid";
 
 const preview: Preview = {
   parameters: {
+    docs: {
+      codePanel: true,
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,


### PR DESCRIPTION
## Done

Enables the [storybook code panel](https://storybook.js.org/docs/writing-docs/code-panel) by default in all storybook projects

Fixes https://github.com/canonical/pragma/pull/302/files#r2291650843

## QA

- Open any storybook published by this PR
- See that all stories have a "Code" panel on the bottom of the screen, which shows you the code necessary to produce the output on screen.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 

## Screenshots

<img width="557" height="220" alt="image" src="https://github.com/user-attachments/assets/25d07544-9dfb-473d-b9b1-cc8c338447a4" />