### PR TITLE
feat(generator): Include Svelte SSR Test package

### DIFF
--- a/packages/generator-ds/DEVELOPING.md
+++ b/packages/generator-ds/DEVELOPING.md
@@ -1,0 +1,29 @@
+### Developing and trying the generator locally
+
+Follow these steps from the `packages/generator-ds` directory to build and try the generator during development.
+
+Build the generator:
+
+```bash
+bun install
+bun run build
+```
+
+List available generators:
+
+```bash
+ls src
+```
+
+Try it in a fresh test project:
+
+```bash
+mkdir test-project
+cd test-project
+bunx yo @canonical/ds:component Button --withStyles
+```
+
+Notes:
+
+- The command above will run the `component` sub-generator to scaffold a `Button` component with styles.
+- Re-run `bun run build` after making changes to the generator source to pick up updates.

--- a/packages/generator-ds/src/sv-component/templates/Component.ssr.test.ts.ejs
+++ b/packages/generator-ds/src/sv-component/templates/Component.ssr.test.ts.ejs
@@ -1,24 +1,55 @@
 /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
 
-import { render } from "svelte/server";
+import { render } from "@canonical/svelte-ssr-test";
+import { createRawSnippet } from "svelte";
 import { describe, expect, it } from "vitest";
 import Component from "./<%= componentName %>.svelte";
+import type { <%= componentName %>Props } from "./types.js";
 
 describe("<%= componentName %> SSR", () => {
-  it("doesn't throw", () => {
-    expect(() => {
-      render(Component);
-    }).not.toThrow();
+  const baseProps = {
+    children: createRawSnippet(() => ({
+      render: () => `<span><%= componentName %></span>`,
+    })),
+  } satisfies <%= componentName %>Props;
+
+  describe("basics", () => {
+    it("doesn't throw", () => {
+      expect(() => {
+        render(Component, { props: { ...baseProps} });
+      }).not.toThrow();
+    });
+
+    it("renders", () => {
+      const { window, container } = render(Component, { props: { ...baseProps } });
+      expect(container.firstElementChild).toBeInstanceOf(window.HTMLDivElement);
+    });
   });
 
-  it("renders", () => {
-    const { body } = render(Component);
-    expect(body).toContain("<div");
-    expect(body).toContain("</div>");
-  });
+  describe("attributes", () => {
+    it.each([
+      ["id", "test-id"],
+      ["style", "color: orange;"],
+      ["aria-label", "test-aria-label"],
+    ])("applies %s", (attribute, expected) => {
+      const { container } = render(Component, {
+        props: { [attribute]: expected, ...baseProps},
+      });
+      expect(container.firstElementChild?.getAttribute(attribute)).toBe(
+        expected,
+      );
+    });
 
-  it("applies class", () => {
-    const { body } = render(Component, { props: { class: "test-class" } });
-    expect(body).toContain('class="<% if (withStyles) { %><%= cssNamespace %> <%= componentCssClassName %> <% } %>test-class"');
+    it("applies classes", () => {
+      const { container } = render(Component, {
+        props: { class: "test-class", ...baseProps },
+      });
+      const classes = ["test-class"];
+      <% if (withStyles) { %>classes.push("<%= cssNamespace %>", "<%= componentCssClassName %>");<% } %>
+
+      for (const className of classes) {
+        expect(container.firstElementChild?.classList).toContain(className);
+      }
+    });
   });
 });

--- a/packages/svelte/ssr-test/package.json
+++ b/packages/svelte/ssr-test/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@canonical/svelte-ssr-test",
   "description": "Test package for Svelte SSR testing",
+  "keywords": [
+    "svelte",
+    "ssr",
+    "server-side rendering",
+    "testing",
+    "canonical"
+  ],
   "version": "0.10.0-experimental.0",
   "type": "module",
   "module": "dist/esm/index.js",
@@ -21,13 +28,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:all": "tsc -p tsconfig.build.json",

--- a/packages/svelte/ssr-test/src/fixtures/Greeting.svelte
+++ b/packages/svelte/ssr-test/src/fixtures/Greeting.svelte
@@ -3,6 +3,6 @@
 const { name }: { name: string } = $props();
 </script>
 
-<div>
+<div class="test-class">
   <span data-testid="greeting">Hello {name}</span>
 </div>

--- a/packages/svelte/ssr-test/src/render.tests.ts
+++ b/packages/svelte/ssr-test/src/render.tests.ts
@@ -9,7 +9,7 @@ describe("render", () => {
         fixtures.Greeting,
         { props: { name: "World" } },
       );
-      expect(container).toBeInstanceOf(window.HTMLElement);
+      expect(container.firstElementChild).toBeInstanceOf(window.HTMLDivElement);
       expect(() => getByText("Hello World")).not.toThrow();
       const prettyOutput = pretty();
       expect(typeof prettyOutput).toBe("string");
@@ -21,6 +21,13 @@ describe("render", () => {
       const short = pretty(10);
       expect(short.length).toBeLessThanOrEqual(10 + 100);
     });
+  });
+
+  it("maintains class names", () => {
+    const { container } = render(fixtures.Greeting, {
+      props: { name: "World" },
+    });
+    expect(container.firstElementChild?.classList).toContain("test-class");
   });
 
   describe("selectors", () => {


### PR DESCRIPTION
## Done

- Include Svelte SSR Test package and improve SSR testing template

Fixes [LP-2917](https://warthogs.atlassian.net/browse/LP-2917)


### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 

## Screenshots

Test output from a generated SSR test:
<img width="510" height="152" alt="image" src="https://github.com/user-attachments/assets/49fe3025-f608-47bc-88b6-4b4fb948b49b" />


[LP-2917]: https://warthogs.atlassian.net/browse/LP-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ