### PR TITLE
fix(React Core): fix badge with empty units showing undefined units

### DIFF
--- a/packages/utils/src/humanizeNumber/humanizeNumber.ts
+++ b/packages/utils/src/humanizeNumber/humanizeNumber.ts
@@ -59,14 +59,10 @@ const humanizeNumber = (
   value: number,
   options?: HumanizeNumberOptions,
 ): HumanizeResult => {
-  const {
-    magnitudeBase = DEFAULT_MAGNITUDE_BASE,
-    overflowIndicator = "+",
-  } = options ?? {};
+  const { magnitudeBase = DEFAULT_MAGNITUDE_BASE, overflowIndicator = "+" } =
+    options ?? {};
 
-  let {
-      units = DEFAULT_UNITS
-  } = options ?? {};
+  let { units = DEFAULT_UNITS } = options ?? {};
 
   // If user passes an undefined or empty units array, fallback to [""] to show no unit suffix instead of `undefined`
   if (!units?.length) units = [""];


### PR DESCRIPTION
## Done

Updates the badge so that passing an empty units array falls back to displaying no units.

## QA

- Review chromatic
- Review [units docs/story](https://badge-empty-units--67be30a0b85c4e44b6744158.chromatic.com/?path=/docs/badge--docs#units) and verify it displays "999+" instead of "999undefined"

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 

## Screenshots

Before
<img width="610" height="323" alt="image" src="https://github.com/user-attachments/assets/163ef681-f336-43c1-96d6-d7360d02d0f3" />

After
<img width="610" height="323" alt="image" src="https://github.com/user-attachments/assets/bcaf330e-7da0-4900-84fc-1bbf849c6cc5" />

