### PR TITLE
feat(svelte-generator): Add semantics-oriented test element selectors

### DIFF
--- a/packages/generator-ds/src/sv-component/templates/Component.ssr.test.ts.ejs
+++ b/packages/generator-ds/src/sv-component/templates/Component.ssr.test.ts.ejs
@@ -3,16 +3,16 @@
 import { render } from "@canonical/svelte-ssr-test";
 import type { RenderResult } from "@canonical/svelte-ssr-test";
 import { createRawSnippet } from "svelte";
+import type { ComponentProps } from "svelte";
 import { describe, expect, it } from "vitest";
 import Component from "./<%= componentName %>.svelte";
-import type { <%= componentName %>Props } from "./types.js";
 
 describe("<%= componentName %> SSR", () => {
   const baseProps = {
     children: createRawSnippet(() => ({
       render: () => `<span><%= componentName %></span>`,
     })),
-  } satisfies <%= componentName %>Props;
+  } satisfies ComponentProps<typeof Component>;
 
   describe("basics", () => {
     it("doesn't throw", () => {

--- a/packages/generator-ds/src/sv-component/templates/Component.svelte.test.ts.ejs
+++ b/packages/generator-ds/src/sv-component/templates/Component.svelte.test.ts.ejs
@@ -2,18 +2,18 @@
 
 import type { Locator } from "@vitest/browser/context";
 import { createRawSnippet } from "svelte";
+import type { ComponentProps } from "svelte";
 import { describe, expect, it } from "vitest";
 import { render } from "vitest-browser-svelte";
 import type { RenderResult } from "vitest-browser-svelte";
 import Component from "./<%= componentName %>.svelte";
-import type { <%= componentName %>Props } from "./types.js";
 
 describe("<%= componentName %> component", () => {
   const baseProps = {
     children: createRawSnippet(() => ({
       render: () => `<span><%= componentName %></span>`,
     })),
-  } satisfies <%= componentName %>Props;
+  } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
     const page = render(Component, { ...baseProps });


### PR DESCRIPTION
## Done

This PR refactors Svelte component test templates to prioritize selecting elements by user-facing attributes (like role, label, etc.). It introduces a `componentLocator` helper to encourage and guide developers toward writing more accessible and maintainable tests.

The prioritized order of selectors is based on the guides detailed in:
- https://testing-library.com/docs/queries/about/#priority
- https://scottspence.com/posts/testing-with-vitest-browser-svelte-guide#locator-priority-order

## QA

- Run `yo @canonical/ds:sv-component`.
- Check if the generated tests contain the new `componentLocator` helper function.
- Check if the `componentLocator` contains different ways of selecting the root component's element (all commented out).

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
