### PR TITLE
fix(typography): @types/bun dependency version set to "latest" causes…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -687,7 +687,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.2.4",
         "@canonical/biome-config": "^0.10.0-experimental.4",
-        "@types/bun": "latest",
+        "@types/bun": "^1.2.19",
       },
       "peerDependencies": {
         "typescript": "^5.8.2",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
     "@canonical/biome-config": "^0.10.0-experimental.4",
-    "@types/bun": "latest"
+    "@types/bun": "^1.2.19"
   },
   "peerDependencies": {
     "typescript": "^5.8.2"


### PR DESCRIPTION
… conflict with frozen lock on CI

## Done

This PR resolves a CI build failure that occurred during the `bun install` with frozen lockfile observed on #355.

The root cause was the `@types/bun` dependency in `packages/typography/package.json` being set to "latest". Using a mutable tag like "latest" meant that the lockfile-specified version was becoming incompatible with the version resolved from the `package.json` each time a new `@types/bun` release happened, which was rightfully causing the `--frozen-lockfile` flag to fail the installation.

## QA

- Run `bun install --frozen-lockfile`.
- Make sure that it exits without errors.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
