### PR TITLE
docs(cicd): update npm token docs per recent npm security changes

### DIFF
--- a/docs/how-to-guides/PUBLISH_A_PACKAGE.md
+++ b/docs/how-to-guides/PUBLISH_A_PACKAGE.md
@@ -14,6 +14,11 @@ This guide shows you how to publish a package from this repository to NPM.
   4. Set the token as the `NODE_AUTH_TOKEN` GitHub secret for this repository. 
   5. Select "Bypass two-factor authentication (2FA)".
 
+Note: GitHub has [recently tightened NPM token security](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/). 
+Among the measures introduced is a reduction in maximum token lifetime from infinite to 90 days, 
+so the above process will need to be repeated every 90 days until [these steps](https://github.com/canonical/pragma/issues/374) 
+are completed to migrate to [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom).
+
 ## Publishing a new package
 Follow these steps if your package has never been published to NPM before (for example, it was just merged to `main`).
 


### PR DESCRIPTION
## Done

Updates the package publishing docs to reflect [recent changes to NPM security token policy](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/). 

Follow-up of token refresh carried out this morning (requested by @steciuk ), during which I noticed that I needed to specifically bypass 2FA in the token generation process.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
