### PR TITLE
feat(svelte-ssr-test): Remove legacy component types

### DIFF
--- a/packages/svelte/ssr-test/src/render.ts
+++ b/packages/svelte/ssr-test/src/render.ts
@@ -1,9 +1,9 @@
 import { getQueriesForElement, prettyDOM } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { render as renderSvelte } from "svelte/server";
-import type { RenderResult, RenderSvelteFn } from "./types.js";
+import type { RenderFn } from "./types.js";
 
-const render = ((...args): ReturnType<RenderSvelteFn> & RenderResult => {
+const render: RenderFn = (...args) => {
   // biome-ignore lint/suspicious/noExplicitAny: silence Svelte type inference
   const svelteRenderResult = renderSvelte(...(args as [any]));
   const { window } = new JSDOM(
@@ -21,6 +21,6 @@ const render = ((...args): ReturnType<RenderSvelteFn> & RenderResult => {
     container,
     pretty: (maxLength = 10000) => prettyDOM(container, maxLength) || "",
   };
-}) satisfies RenderSvelteFn;
+};
 
 export default render;

--- a/packages/svelte/ssr-test/src/types.ts
+++ b/packages/svelte/ssr-test/src/types.ts
@@ -1,8 +1,7 @@
 import type { BoundFunctions, queries } from "@testing-library/dom";
 import type { DOMWindow } from "jsdom";
+import type { Component, ComponentProps } from "svelte";
 import type { render as renderSvelte } from "svelte/server";
-
-export type RenderSvelteFn = typeof renderSvelte;
 
 type Queries = BoundFunctions<typeof queries>;
 
@@ -12,3 +11,33 @@ export type RenderResult = Queries & {
   container: HTMLElement;
   pretty: (maxLength?: number) => string;
 };
+
+// Types based on Svelte's render function, with the problematic typing for Svelte 4 legacy components removed. This can be removed once the legacy component typing is removed from Svelte itself.
+export type RenderFn = <
+  // biome-ignore lint/suspicious/noExplicitAny: copied from Svelte types
+  Comp extends Component<any>,
+  Props extends ComponentProps<Comp> = ComponentProps<Comp>,
+>(
+  // biome-ignore lint/complexity/noBannedTypes: copied from Svelte types
+  ...args: {} extends Props
+    ? [
+        component: Comp,
+        options?: {
+          props?: Props;
+          // biome-ignore lint/suspicious/noExplicitAny: copied from Svelte types
+          context?: Map<any, any>;
+          idPrefix?: string;
+          csp?: { nonce?: string; hash?: boolean };
+        },
+      ]
+    : [
+        component: Comp,
+        options: {
+          props: Props;
+          // biome-ignore lint/suspicious/noExplicitAny: copied from Svelte types
+          context?: Map<any, any>;
+          idPrefix?: string;
+          csp?: { nonce?: string; hash?: boolean };
+        },
+      ]
+) => ReturnType<typeof renderSvelte> & RenderResult;


### PR DESCRIPTION
## Done

This MP removes the legacy Svelte 4 component types from the `render` function. This aims to mitigate the problem of TS reporting an `Expression produces a union type that is too complex to represent` error for components whose props are of union type.

## QA

- Pass a component whose props are of union type to the `render()` function. Make sure that TS doesn't report `Expression produces a union type that is too complex to represent` error.
- Make sure that `options` (second argument) has a property `props` with a type of component's props.
- Make sure that if a component passed to `render` doesn't have required props, the `options` are optional.
- Make sure that if a component passed to `render` has required props, the `options` are required and have a required property `props`.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 