### PR TITLE
fix(tty): acknowledge case when Ink can't read from STDIN [AC-4269]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The server starts at http://localhost:6006. Each component package has its own S
 
 - **React 19** or later for component packages (Svelte 5 for Svelte packages)
 - **Bun 1.3.9** or later for package management and script execution
+  - Installing Bun via the snap package is not recommended as it may cause permission issues. This is a known [issue](https://github.com/shakeelansari63/snap-packages/issues/79). Use the official installation script instead.
 - **Node.js 22.12 or 24** because Storybook and Lerna depend on Node internals that Bun does not yet fully support. Node 22.12 specifically is required as earlier 22.x versions have module resolution issues.
 
 Node 23 has a [known compatibility issue](https://github.com/canonical/pragma/issues/226) and should be avoided.


### PR DESCRIPTION
## Done
**CURRENT STATE OF PR:**
- Acknowledge the problem in the docs

**PREVIOUS ACTIONS DONE IN PR:**

- Improved the way we handle the ```isTTY``` check
- On top of checking if it is a tty, I also tried setting the stdin mode to raw, in order to not get cooked input, but raw one
- If it throws an error, we can't read from tty

Fixes [AC-4269](https://warthogs.atlassian.net/browse/AC-4269)

## QA

- Run ```summon component react ./path
- If you are in an env where you can't read from stdin but still in tty (actually do not kn ow how this happens, will have to keep investigating), you should see a handled error
- If you pass in the ```--yes``` flag, it should work as expected

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
## Screenshots

<img width="2621" height="111" alt="image" src="https://github.com/user-attachments/assets/1fbaeb7d-ed9d-4f8d-9e1c-3cf883c37936" />



[AC-4269]: https://warthogs.atlassian.net/browse/AC-4269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ