### PR TITLE
fix(svelte-ds-app-launchpad): ButtonPrimitive doesn't have styles

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
@@ -1,85 +1,73 @@
 .ds.button {
-	cursor: pointer;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
+  --color-background-button-active: var(
+    --lp-color-background-active-context,
+    var(--lp-color-background-neutral-active)
+  );
+  --color-background-button-hover: var(
+    --lp-color-background-hover-context,
+    var(--lp-color-background-neutral-hover)
+  );
+  --color-background-button: var(
+    --lp-color-background-context,
+    var(--lp-color-background-default)
+  );
+  --color-border-button: var(
+    --lp-color-border-context,
+    var(--lp-color-border-high-contrast)
+  );
+  --color-border-button-hover: var(
+    --lp-color-border-hover-context,
+    var(--color-border-button)
+  );
+  --color-border-button-active: var(
+    --lp-color-border-active-context,
+    var(--color-border-button)
+  );
+  --color-text-button: var(
+    --lp-color-text-context,
+    var(--lp-color-text-default)
+  );
+  --typography-button: var(
+    --lp-typography-context,
+    var(--lp-typography-paragraph-default)
+  );
 
-	background-color: var(
-		--lp-color-background-context,
-		var(--lp-color-background-default)
-	);
-	border: var(--lp-dimension-stroke-thickness-default) solid
-		var(--lp-color-border-context, var(--lp-color-border-high-contrast));
-	border-radius: var(--lp-dimension-radius-medium);
-	font: var(--lp-typography-context, var(--lp-typography-paragraph-default));
-	color: var(--lp-color-text-context, var(--lp-color-text-default));
-	text-decoration: none;
-	padding-inline: 0;
-	padding-block: 0;
+  padding-inline: 0;
+  padding-block: 0;
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
 
-	transition-duration: var(--lp-transition-duration-snap);
-	transition-property: background-color, border-color;
-	transition-timing-function: var(--lp-transition-timing-ease-in);
+  &:not(.explicit-disabled) {
+    --opacity-button-disabled: 1;
+  }
 
-	&:not(:disabled):not([aria-disabled="true"]) {
-		&:hover {
-			background-color: var(
-				--lp-color-background-hover-context,
-				var(--lp-color-background-neutral-hover)
-			);
-			border-color: var(
-				--lp-color-border-hover-context,
-				var(--lp-color-border-context, var(--lp-color-border-high-contrast))
-			);
-		}
+  &.loading {
+    position: relative;
 
-		&:active {
-			background-color: var(
-				--lp-color-background-active-context,
-				var(--lp-color-background-neutral-active)
-			);
-			border-color: var(
-				--lp-color-border-active-context,
-				var(--lp-color-border-context, var(--lp-color-border-high-contrast))
-			);
-		}
-	}
+    > .button-content {
+      visibility: hidden;
+    }
 
-	&:disabled,
-	&[aria-disabled="true"] {
-		cursor: not-allowed;
-	}
+    > .loader {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
 
-	&.explicit-disabled {
-		opacity: var(--lp-opacity-muted);
-	}
+  /* Button-specific modifiers */
+  &.brand {
+    --lp-color-text-context: var(--lp-color-text-white);
+    --lp-color-border-context: var(--lp-color-brand-default);
+    --lp-color-background-context: var(--lp-color-brand-default);
+    --lp-color-background-hover-context: var(--lp-color-brand-hover);
+    --lp-color-background-active-context: var(--lp-color-brand-active);
+  }
 
-	&.loading {
-		position: relative;
-
-		> .button-content {
-			visibility: hidden;
-		}
-
-		> .loader {
-			position: absolute;
-			inset: 0;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-		}
-	}
-
-	/* Button-specific modifiers */
-	&.brand {
-		--lp-color-text-context: var(--lp-color-text-white);
-		--lp-color-border-context: var(--lp-color-brand-default);
-		--lp-color-background-context: var(--lp-color-brand-default);
-		--lp-color-background-hover-context: var(--lp-color-brand-hover);
-		--lp-color-background-active-context: var(--lp-color-brand-active);
-	}
-
-	&.base {
-		--lp-color-border-context: transparent;
-	}
+  &.base {
+    --lp-color-border-context: transparent;
+  }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/ButtonPrimitive/ButtonPrimitive.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/ButtonPrimitive/ButtonPrimitive.svelte
@@ -1,33 +1,43 @@
 <script lang="ts">
-	import type {
-		HTMLAnchorAttributes,
-		HTMLButtonAttributes,
-	} from "svelte/elements";
-	import type { ButtonPrimitiveProps } from "./types";
+  import type {
+    HTMLAnchorAttributes,
+    HTMLButtonAttributes,
+  } from "svelte/elements";
+  import type { ButtonPrimitiveProps } from "./types";
+  import "./styles.css";
 
-	let {
-		ref = $bindable(),
-		href,
-		children,
-		disabled,
-		...rest
-	}: ButtonPrimitiveProps = $props();
+  const componentCssClassName = "ds button-primitive";
+
+  let {
+    ref = $bindable(),
+    href,
+    children,
+    disabled,
+    class: className,
+    ...rest
+  }: ButtonPrimitiveProps = $props();
 </script>
 
 {#if href}
-	<!--
+  <!--
 		Disabled anchor state implementation is inspired by: https://github.com/huntabyte/bits-ui/blob/main/packages/bits-ui/src/lib/bits/button/components/button.svelte
 	-->
-	<a
-		bind:this={ref}
-		role={disabled && href ? "link" : undefined}
-		href={disabled ? undefined : href}
-		aria-disabled={disabled}
-		tabindex={disabled ? -1 : 0}
-		{...rest as HTMLAnchorAttributes}>{@render children?.()}</a
-	>
+  <a
+    bind:this={ref}
+    role={disabled && href ? "link" : undefined}
+    href={disabled ? undefined : href}
+    aria-disabled={disabled}
+    tabindex={disabled ? -1 : 0}
+    class={[componentCssClassName, className]}
+    {...rest as HTMLAnchorAttributes}>{@render children?.()}</a
+  >
 {:else}
-	<button bind:this={ref} {disabled} {...rest as HTMLButtonAttributes}>
-		{@render children?.()}
-	</button>
+  <button
+    bind:this={ref}
+    {disabled}
+    class={[componentCssClassName, className]}
+    {...rest as HTMLButtonAttributes}
+  >
+    {@render children?.()}
+  </button>
 {/if}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/ButtonPrimitive/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/ButtonPrimitive/styles.css
@@ -1,0 +1,47 @@
+.ds.button-primitive {
+  --border-style-button: solid;
+  --color-background-button-active: var(--lp-color-background-neutral-active);
+  --color-background-button-hover: var(--lp-color-background-neutral-hover);
+  --color-background-button: transparent;
+  --color-border-button-active: var(--color-border-button);
+  --color-border-button-hover: var(--color-border-button);
+  --color-border-button: transparent;
+  --color-text-button: var(--lp-color-text-default);
+  --dimension-border-width-button: var(--lp-dimension-stroke-thickness-default);
+  --opacity-button-disabled: var(--lp-opacity-muted);
+  --typography-button: var(--lp-typography-paragraph-default);
+
+  cursor: pointer;
+  display: inline-block;
+  text-decoration: none;
+
+  background-color: var(--color-background-button);
+  border: var(--dimension-border-width-button) var(--border-style-button)
+    var(--color-border-button);
+  font: var(--typography-button);
+  color: var(--color-text-button);
+  padding-inline: var(--lp-dimension-spacing-inline-s);
+  padding-block: var(--lp-dimension-spacing-block-xxs);
+
+  transition-duration: var(--lp-transition-duration-snap);
+  transition-property: background-color, border-color;
+  transition-timing-function: var(--lp-transition-timing-ease-in);
+
+  &:not(:disabled):not([aria-disabled="true"]) {
+    &:hover {
+      background-color: var(--color-background-button-hover);
+      border-color: var(--color-border-button-hover);
+    }
+
+    &:active {
+      background-color: var(--color-background-button-active);
+      border-color: var(--color-border-button-active);
+    }
+  }
+
+  &:disabled,
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: var(--opacity-button-disabled);
+  }
+}


### PR DESCRIPTION
## Done
In #433 part of the `Button` styles should be shipped as `ButtonPrimitive` styles. This PR aims to fix this.

- Base styles were moved to `ButtonPrimitive`.
- Button now implements modifiers and loading state by overriding the base styles.

## QA
Open the Storybook and verify that the Button component is still styled properly.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
