### PR TITLE
chore(pr-template): Added a reference to the code standards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Fixes [list issues/bugs if needed]
 - [ ] PR should have one of the following labels:
   - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
 - [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
-- [ ] The code follows the appripriate [code standards](github.com/canonical/code-standards) 
+- [ ] The code follows the appripriate [code standards](https://github.com/canonical/code-standards) 
 - [ ] All packages define the required scripts in `package.json`:
   - [ ] All packages: `check`, `check:fix`, and `test`.
   - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 


### PR DESCRIPTION
## Done

- Adds a reference to the code standards in the PR template.

## QA

- N/A
### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
