### PR TITLE
chore(ci): fix package publishing workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -94,6 +94,6 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Publish packages
-        run: lerna publish --yes --no-private from-package
+        run: lerna publish --yes --no-private from-package --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Done
- Fix first-time publish of scoped packages

When a scoped package (e.g. `@canonical/storybook-helpers`) is published to npm for the first time, npm has no record of its intended access level and defaults to private. This causes the CI publish step to fail with:

```
lerna WARN notice Package failed to publish: @canonical/storybook-helpers
lerna ERR! E402 You must sign up for private packages
```

Packages that have been published before are unaffected since their access level is already set on the registry.

## Why this is safe

- Packages with `"private": true` in their `package.json` are already excluded entirely by the existing `--no-private` flag, so `--access public` never touches them
- For packages that have already been published, their access level is already set on the registry and is not overridden by this flag
- The flag only has a meaningful effect on the first publish of a new package, which is the case we need to fix


### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appripriate [code standards](https://github.com/canonical/code-standards) 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 