### PR TITLE
chore(publishing): fix unpublished packages

### DIFF
--- a/configs/biome/package.json
+++ b/configs/biome/package.json
@@ -8,13 +8,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/configs/renovate/package.json
+++ b/configs/renovate/package.json
@@ -9,12 +9,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nicholasgasior/pragma"
+    "url": "https://github.com/canonical/pragma"
   },
   "bugs": {
-    "url": "https://github.com/nicholasgasior/pragma/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/nicholasgasior/pragma#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "files": ["default.json"],
   "renovate-config": {
     "default": {

--- a/configs/storybook/package.json
+++ b/configs/storybook/package.json
@@ -21,13 +21,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:all": "tsc -p tsconfig.build.json",

--- a/configs/typescript-react/package.json
+++ b/configs/typescript-react/package.json
@@ -9,13 +9,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/configs/typescript-svelte/package.json
+++ b/configs/typescript-svelte/package.json
@@ -9,11 +9,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
   "homepage": "https://github.com/canonical/pragma/tree/main/configs/typescript-svelte#readme",
   "scripts": {

--- a/configs/typescript/package.json
+++ b/configs/typescript/package.json
@@ -9,13 +9,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "workspaces": [
     "configs/*",
     "packages/*",

--- a/packages/ds-assets/package.json
+++ b/packages/ds-assets/package.json
@@ -15,13 +15,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package",

--- a/packages/ds-types/package.json
+++ b/packages/ds-types/package.json
@@ -21,13 +21,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package",

--- a/packages/react/ds-app-anbox/package.json
+++ b/packages/react/ds-app-anbox/package.json
@@ -14,13 +14,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/react/ds-app-landscape/package.json
+++ b/packages/react/ds-app-landscape/package.json
@@ -14,13 +14,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/react/ds-app-launchpad/package.json
+++ b/packages/react/ds-app-launchpad/package.json
@@ -13,13 +13,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/react/ds-app-lxd/package.json
+++ b/packages/react/ds-app-lxd/package.json
@@ -14,13 +14,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/react/ds-app-portal/package.json
+++ b/packages/react/ds-app-portal/package.json
@@ -14,13 +14,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/react/ds-app/package.json
+++ b/packages/react/ds-app/package.json
@@ -14,13 +14,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/react/ds-global-form/package.json
+++ b/packages/react/ds-global-form/package.json
@@ -13,13 +13,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/react/ds-global/package.json
+++ b/packages/react/ds-global/package.json
@@ -13,13 +13,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/react/ssr/package.json
+++ b/packages/react/ssr/package.json
@@ -17,13 +17,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:all": "tsc -p tsconfig.build.json",

--- a/packages/react/tokens/package.json
+++ b/packages/react/tokens/package.json
@@ -13,13 +13,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/storybook/addon-baseline-grid/package.json
+++ b/packages/storybook/addon-baseline-grid/package.json
@@ -14,10 +14,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
   "license": "LGPL-3.0",
   "exports": {

--- a/packages/storybook/addon-msw/package.json
+++ b/packages/storybook/addon-msw/package.json
@@ -18,10 +18,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
   "license": "LGPL-3.0",
   "exports": {

--- a/packages/styles-old/elements/package.json
+++ b/packages/styles-old/elements/package.json
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/packages/styles-old/main/canonical/package.json
+++ b/packages/styles-old/main/canonical/package.json
@@ -13,13 +13,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/packages/styles-old/modes/canonical/package.json
+++ b/packages/styles-old/modes/canonical/package.json
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/packages/styles-old/modes/density/package.json
+++ b/packages/styles-old/modes/density/package.json
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/packages/styles-old/modes/intents/package.json
+++ b/packages/styles-old/modes/intents/package.json
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/packages/styles-old/modes/motion/package.json
+++ b/packages/styles-old/modes/motion/package.json
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/packages/styles-old/primitives/canonical/package.json
+++ b/packages/styles-old/primitives/canonical/package.json
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/packages/styles/debug/package.json
+++ b/packages/styles/debug/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "exports": {
     ".": {
@@ -24,9 +24,9 @@
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "check": "bun run check:biome",
     "check:fix": "bun run check:biome:fix",

--- a/packages/styles/main/package.json
+++ b/packages/styles/main/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "scripts": {

--- a/packages/styles/typography/package.json
+++ b/packages/styles/typography/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,13 +21,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:all": "tsc -p tsconfig.build.json",

--- a/packages/webarchitect/package.json
+++ b/packages/webarchitect/package.json
@@ -18,13 +18,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical/ds25"
+    "url": "https://github.com/canonical/pragma"
   },
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/canonical/ds25/issues"
+    "url": "https://github.com/canonical/pragma/issues"
   },
-  "homepage": "https://github.com/canonical/ds25#readme",
+  "homepage": "https://github.com/canonical/pragma#readme",
   "scripts": {
     "build": "echo 'No build needed - runs directly from TypeScript'",
     "build:all": "bun run build",


### PR DESCRIPTION
## Done

- Mark `@canonical/styles-old` as `private: true` — this package should not be published to npm
- Fix repository URLs across all 33 `package.json` files:
  - Replace legacy `canonical/ds25` and other wrong names to→ `canonical/pragma`
- Initial npm publish (`--access public`) for 6 previously-unpublished packages:
  - `@canonical/react-tokens`
  - `@canonical/renovate-config`
  - `@canonical/styles-typography`
  - `@canonical/summon-monorepo`
  - `@canonical/typescript-config-lit`
  - `@canonical/webcomponents-ds-global`

## QA

- Verify `bun install` completes without errors
- Confirm all 6 newly-published packages are accessible on npm: `npm view @canonical/<name> version`
- Confirm `@canonical/styles-old` is excluded from any publish workflow

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appripriate [code standards](https://github.com/canonical/code-standards) 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
## Screenshots

[if relevant, include a screenshot or screen capture]
