### PR TITLE
test(task): colocate tests next to source files

### DIFF
--- a/packages/runtime/task/src/lib/combinators.test.ts
+++ b/packages/runtime/task/src/lib/combinators.test.ts
@@ -26,11 +26,11 @@ import {
   whenM,
   zip,
   zip3,
-} from "../lib/combinators.js";
-import { dryRun } from "../lib/dry-run.js";
-import { info, mkdir, writeFile } from "../lib/primitives.js";
-import { effect, fail, flatMap, map, pure } from "../lib/task.js";
-import type { Effect, Task, TaskError } from "../lib/types.js";
+} from "./combinators.js";
+import { dryRun } from "./dry-run.js";
+import { info, mkdir, writeFile } from "./primitives.js";
+import { effect, fail, flatMap, map, pure } from "./task.js";
+import type { Effect, Task, TaskError } from "./types.js";
 
 // =============================================================================
 // Sequencing Combinators

--- a/packages/runtime/task/src/lib/dry-run.test.ts
+++ b/packages/runtime/task/src/lib/dry-run.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sequence, sequence_, traverse } from "../lib/combinators.js";
+import { sequence, sequence_, traverse } from "./combinators.js";
 import {
   assertEffects,
   assertFileWrites,
@@ -12,7 +12,7 @@ import {
   getAffectedFiles,
   getFileWrites,
   mockEffect,
-} from "../lib/dry-run.js";
+} from "./dry-run.js";
 import {
   copyFile,
   exec,
@@ -27,9 +27,9 @@ import {
   readFile,
   setContext,
   writeFile,
-} from "../lib/primitives.js";
-import { fail, flatMap, map, pure } from "../lib/task.js";
-import type { Effect, TaskError } from "../lib/types.js";
+} from "./primitives.js";
+import { fail, flatMap, map, pure } from "./task.js";
+import type { Effect, TaskError } from "./types.js";
 
 // =============================================================================
 // Core dryRun Function

--- a/packages/runtime/task/src/lib/effect.test.ts
+++ b/packages/runtime/task/src/lib/effect.test.ts
@@ -19,8 +19,8 @@ import {
   readFileEffect,
   writeContextEffect,
   writeFileEffect,
-} from "../lib/effect.js";
-import { pure } from "../lib/task.js";
+} from "./effect.js";
+import { pure } from "./task.js";
 
 // =============================================================================
 // File System Effect Constructors

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { sequence_ } from "../lib/combinators.js";
+import { sequence_ } from "./combinators.js";
 import {
   executeEffect,
   run,
   runTask,
   TaskExecutionError,
-} from "../lib/interpreter.js";
-import { info, succeed, warn } from "../lib/primitives.js";
-import { effect, fail, flatMap, map, pure } from "../lib/task.js";
-import type { Effect, TaskError } from "../lib/types.js";
+} from "./interpreter.js";
+import { info, succeed, warn } from "./primitives.js";
+import { effect, fail, flatMap, map, pure } from "./task.js";
+import type { Effect, TaskError } from "./types.js";
 
 // Note: These tests focus on the interpreter's logic without actually
 // performing I/O. For real I/O testing, integration tests should be used.

--- a/packages/runtime/task/src/lib/primitives.test.ts
+++ b/packages/runtime/task/src/lib/primitives.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { dryRun, dryRunWith } from "../lib/dry-run.js";
+import { dryRun, dryRunWith } from "./dry-run.js";
 import {
   copyDirectory,
   copyFile,
@@ -28,8 +28,8 @@ import {
   warn,
   withContext,
   writeFile,
-} from "../lib/primitives.js";
-import { flatMap } from "../lib/task.js";
+} from "./primitives.js";
+import { flatMap } from "./task.js";
 
 // =============================================================================
 // File System Primitives

--- a/packages/runtime/task/src/lib/task.test.ts
+++ b/packages/runtime/task/src/lib/task.test.ts
@@ -14,8 +14,8 @@ import {
   pure,
   recover,
   task,
-} from "../lib/task.js";
-import type { Effect, Task, TaskError } from "../lib/types.js";
+} from "./task.js";
+import type { Effect, Task, TaskError } from "./types.js";
 
 // =============================================================================
 // Core Constructors


### PR DESCRIPTION
## Done

- Move `@canonical/task` tests from `src/__tests__/` to `src/lib/` (colocated with source per TS.01)
- Fix imports from `../lib/` to `./` after relocation
- 6 test files, 524 tests, no changes to test logic

## QA

- `cd packages/runtime/task && bun run check` — biome + tsc pass
- `cd packages/runtime/task && bun run test` — 6 test files, 524 tests pass

### PR readiness check

- [x] PR should have one of the following labels:
  - `Maintenance 🔨`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.