### PR TITLE
feat(task): add Symlink effect, switchMap, gen(), suppressed errors, …

### DIFF
--- a/packages/runtime/task/src/index.ts
+++ b/packages/runtime/task/src/index.ts
@@ -10,6 +10,7 @@
 // =============================================================================
 
 export type {
+  BaseErrorCode,
   ConfirmPrompt,
   DryRunResult,
   Effect,
@@ -31,12 +32,15 @@ export type {
 // Task Monad
 // =============================================================================
 
+export type { TaskGen } from "./lib/task.js";
 export {
+  $,
   ap,
   effect,
   fail,
   failWith,
   flatMap,
+  gen,
   hasEffects,
   isFailed,
   isPure,
@@ -72,6 +76,7 @@ export {
   raceEffect,
   readContextEffect,
   readFileEffect,
+  symlinkEffect,
   writeContextEffect,
   writeFileEffect,
 } from "./lib/effect.js";
@@ -107,6 +112,7 @@ export {
   setContext,
   sortFileLines,
   succeed,
+  symlink,
   warn,
   withContext,
   writeFile,
@@ -133,6 +139,7 @@ export {
   retryWithBackoff,
   sequence,
   sequence_,
+  switchMap,
   tap,
   tapError,
   timeout,

--- a/packages/runtime/task/src/lib/combinators.test.ts
+++ b/packages/runtime/task/src/lib/combinators.test.ts
@@ -16,6 +16,7 @@ import {
   retryWithBackoff,
   sequence,
   sequence_,
+  switchMap,
   tap,
   tapError,
   timeout,
@@ -890,6 +891,62 @@ describe("Combinators - Edge Cases", () => {
 
       const { value } = dryRun(t);
       expect(value).toEqual({ type: "success", value: 42 });
+    });
+  });
+
+  // ===========================================================================
+  // switchMap
+  // ===========================================================================
+
+  describe("switchMap", () => {
+    it("dispatches to the matched handler", () => {
+      const t = switchMap<"a" | "b", string>(
+        pure("a"),
+        {
+          a: pure("handled-a"),
+          b: pure("handled-b"),
+        },
+        pure("fallback"),
+      );
+
+      const { value } = dryRun(t);
+      expect(value).toBe("handled-a");
+    });
+
+    it("dispatches to fallback when key is null", () => {
+      const t = switchMap<"a" | "b", string>(
+        pure(null),
+        {
+          a: pure("handled-a"),
+          b: pure("handled-b"),
+        },
+        pure("fallback"),
+      );
+
+      const { value } = dryRun(t);
+      expect(value).toBe("fallback");
+    });
+
+    it("dispatches to fallback when key is not in handlers", () => {
+      const t = switchMap<"a" | "b" | "c", string>(
+        pure("c"),
+        {
+          a: pure("handled-a"),
+          b: pure("handled-b"),
+        },
+        pure("fallback"),
+      );
+
+      const { value } = dryRun(t);
+      expect(value).toBe("fallback");
+    });
+
+    it("works with effectful detect task", () => {
+      const detect: Task<"x" | null> = pure("x");
+      const t = switchMap<"x", number>(detect, { x: pure(42) }, pure(0));
+
+      const { value } = dryRun(t);
+      expect(value).toBe(42);
     });
   });
 });

--- a/packages/runtime/task/src/lib/combinators.ts
+++ b/packages/runtime/task/src/lib/combinators.ts
@@ -145,6 +145,30 @@ export const ifElseM = <A>(
   flatMap(conditionTask, (condition) => ifElse(condition, onTrue, onFalse));
 
 // =============================================================================
+// Dispatch Combinators
+// =============================================================================
+
+/**
+ * Detect-then-dispatch: run a detection task, then dispatch to a handler
+ * based on the detected key. Falls back to the fallback task if the key
+ * is null or not found in handlers.
+ */
+export const switchMap = <K extends string, A>(
+  detect: Task<K | null>,
+  handlers: Partial<Record<K, Task<A>>>,
+  fallback: Task<A>,
+): Task<A> =>
+  flatMap(detect, (key) => {
+    if (key !== null && key in handlers) {
+      const handler = handlers[key];
+      if (handler) {
+        return handler;
+      }
+    }
+    return fallback;
+  });
+
+// =============================================================================
 // Error Handling Combinators
 // =============================================================================
 

--- a/packages/runtime/task/src/lib/dry-run.ts
+++ b/packages/runtime/task/src/lib/dry-run.ts
@@ -28,6 +28,7 @@ export const mockEffect = (effect: Effect): unknown => {
     case "DeleteFile":
     case "DeleteDirectory":
     case "MakeDir":
+    case "Symlink":
     case "Log":
     case "WriteContext":
       return undefined;
@@ -94,6 +95,9 @@ export const dryRun = <A>(task: Task<A>): DryRunResult<A> => {
         virtualFs.add(effect.path);
         return undefined;
       case "MakeDir":
+        virtualFs.add(effect.path);
+        return undefined;
+      case "Symlink":
         virtualFs.add(effect.path);
         return undefined;
       case "Exists":
@@ -322,6 +326,9 @@ export const getAffectedFiles = (effects: Effect[]): string[] => {
         break;
       case "CopyFile":
         files.add(effect.dest);
+        break;
+      case "Symlink":
+        files.add(effect.path);
         break;
       case "MakeDir":
         files.add(effect.path);

--- a/packages/runtime/task/src/lib/effect.test.ts
+++ b/packages/runtime/task/src/lib/effect.test.ts
@@ -17,6 +17,7 @@ import {
   raceEffect,
   readContextEffect,
   readFileEffect,
+  symlinkEffect,
   writeContextEffect,
   writeFileEffect,
 } from "./effect.js";
@@ -183,6 +184,16 @@ describe("Effect Constructors - File System", () => {
 
       expect(effect._tag).toBe("Exists");
       expect((effect as { path: string }).path).toBe("/path/to/check");
+    });
+  });
+
+  describe("symlinkEffect", () => {
+    it("creates a Symlink effect with target and path", () => {
+      const effect = symlinkEffect("/target/dir", "/link/path");
+
+      expect(effect._tag).toBe("Symlink");
+      expect((effect as { target: string }).target).toBe("/target/dir");
+      expect((effect as { path: string }).path).toBe("/link/path");
     });
   });
 
@@ -596,6 +607,11 @@ describe("Effect Utilities - describeEffect", () => {
     const effect = raceEffect([pure(1), pure(2)]);
     expect(describeEffect(effect)).toBe("Race: 2 tasks");
   });
+
+  it("describes Symlink effect", () => {
+    const effect = symlinkEffect("/target", "/link");
+    expect(describeEffect(effect)).toBe("Symlink: /link → /target");
+  });
 });
 
 describe("Effect Utilities - isWriteEffect", () => {
@@ -621,6 +637,10 @@ describe("Effect Utilities - isWriteEffect", () => {
 
   it("returns true for MakeDir", () => {
     expect(isWriteEffect(makeDirEffect("/path"))).toBe(true);
+  });
+
+  it("returns true for Symlink", () => {
+    expect(isWriteEffect(symlinkEffect("/target", "/link"))).toBe(true);
   });
 
   it("returns false for ReadFile", () => {
@@ -692,6 +712,13 @@ describe("Effect Utilities - getAffectedPaths", () => {
   it("returns path for Exists", () => {
     expect(getAffectedPaths(existsEffect("/path/to/check"))).toEqual([
       "/path/to/check",
+    ]);
+  });
+
+  it("returns target and path for Symlink", () => {
+    expect(getAffectedPaths(symlinkEffect("/target", "/link"))).toEqual([
+      "/target",
+      "/link",
     ]);
   });
 

--- a/packages/runtime/task/src/lib/effect.ts
+++ b/packages/runtime/task/src/lib/effect.ts
@@ -66,6 +66,12 @@ export const existsEffect = (path: string): Effect => ({
   path,
 });
 
+export const symlinkEffect = (target: string, path: string): Effect => ({
+  _tag: "Symlink",
+  target,
+  path,
+});
+
 export const globEffect = (pattern: string, cwd: string): Effect => ({
   _tag: "Glob",
   pattern,
@@ -162,6 +168,8 @@ export const describeEffect = (effect: Effect): string => {
       return `Created ${effect.path}/`;
     case "Exists":
       return `Check exists: ${effect.path}`;
+    case "Symlink":
+      return `Symlink: ${effect.path} → ${effect.target}`;
     case "Glob":
       return `Glob: ${effect.pattern} in ${effect.cwd}`;
     case "Exec":
@@ -193,6 +201,7 @@ export const isWriteEffect = (effect: Effect): boolean => {
     case "DeleteFile":
     case "DeleteDirectory":
     case "MakeDir":
+    case "Symlink":
       return true;
     default:
       return false;
@@ -211,6 +220,8 @@ export const getAffectedPaths = (effect: Effect): string[] => {
     case "MakeDir":
     case "Exists":
       return [effect.path];
+    case "Symlink":
+      return [effect.target, effect.path];
     case "CopyFile":
     case "CopyDirectory":
       return [effect.source, effect.dest];

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { sequence_ } from "./combinators.js";
+import { parallel, sequence_ } from "./combinators.js";
 import {
   executeEffect,
   run,
@@ -669,5 +669,95 @@ describe("Interpreter - Integration", () => {
 
     expect(result).toBe(84);
     expect(logs).toEqual(["Starting", "Value: 42"]);
+  });
+
+  // ===========================================================================
+  // AbortSignal
+  // ===========================================================================
+
+  describe("signal (AbortSignal)", () => {
+    it("interrupts before first effect when already aborted", async () => {
+      const controller = new AbortController();
+      controller.abort("cancelled");
+
+      const task = info("should not run");
+
+      await expect(
+        runTask(task, {
+          signal: controller.signal,
+          onLog: () => {},
+        }),
+      ).rejects.toThrow("Task interrupted");
+    });
+
+    it("includes reason in error message", async () => {
+      const controller = new AbortController();
+      controller.abort("user cancelled");
+
+      try {
+        await runTask(pure(42), { signal: controller.signal });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(TaskExecutionError);
+        expect((err as TaskExecutionError).code).toBe("TASK_INTERRUPTED");
+      }
+    });
+
+    it("does not interrupt when signal is not aborted", async () => {
+      const controller = new AbortController();
+      const logs: string[] = [];
+
+      const result = await runTask(
+        flatMap(info("ok"), () => pure(42)),
+        {
+          signal: controller.signal,
+          onLog: (_, msg) => logs.push(msg),
+        },
+      );
+
+      expect(result).toBe(42);
+      expect(logs).toEqual(["ok"]);
+    });
+  });
+
+  // ===========================================================================
+  // Parallel Suppressed Errors
+  // ===========================================================================
+
+  describe("parallel suppressed errors", () => {
+    it("captures all errors from parallel failures", async () => {
+      const task = parallel([
+        fail({ code: "ERR_A", message: "error a" }),
+        fail({ code: "ERR_B", message: "error b" }),
+        pure(42),
+      ]);
+
+      try {
+        await runTask(task, {});
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(TaskExecutionError);
+        const taskErr = (err as TaskExecutionError).taskError;
+        expect(taskErr.code).toBe("ERR_A");
+        expect(taskErr.suppressed).toHaveLength(1);
+        expect(taskErr.suppressed?.[0].code).toBe("ERR_B");
+      }
+    });
+
+    it("does not set suppressed when only one error", async () => {
+      const task = parallel([
+        fail({ code: "ERR_A", message: "error a" }),
+        pure(42),
+      ]);
+
+      try {
+        await runTask(task, {});
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        const taskErr = (err as TaskExecutionError).taskError;
+        expect(taskErr.code).toBe("ERR_A");
+        expect(taskErr.suppressed).toBeUndefined();
+      }
+    });
   });
 });

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -98,6 +98,13 @@ export const executeEffect = async (
       return undefined;
     }
 
+    case "Symlink": {
+      const dir = path.dirname(effect.path);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.symlink(effect.target, effect.path);
+      return undefined;
+    }
+
     case "Exists": {
       try {
         await fs.access(effect.path);
@@ -254,6 +261,8 @@ export interface RunTaskOptions {
   onEffectComplete?: (effect: Effect, duration: number) => void;
   /** Handler for log effects. If provided, log output goes here instead of console */
   onLog?: (level: "debug" | "info" | "warn" | "error", message: string) => void;
+  /** AbortSignal for interrupting task execution */
+  signal?: AbortSignal;
 }
 
 // =============================================================================
@@ -273,9 +282,23 @@ export const runTask = async <A>(
     onEffectStart,
     onEffectComplete,
     onLog,
+    signal,
   } = options;
 
+  const checkInterrupted = (): void => {
+    if (signal?.aborted) {
+      throw new TaskExecutionError({
+        code: "TASK_INTERRUPTED",
+        message: signal.reason
+          ? `Task interrupted: ${signal.reason}`
+          : "Task interrupted",
+      });
+    }
+  };
+
   const runInternal = async <B>(t: Task<B>): Promise<B> => {
+    checkInterrupted();
+
     switch (t._tag) {
       case "Pure":
         return t.value;
@@ -291,9 +314,33 @@ export const runTask = async <A>(
           onEffectStart?.(effect);
           const startTime = performance.now();
 
-          const results = await Promise.all(
+          const settled = await Promise.allSettled(
             effect.tasks.map((task) => runInternal(task)),
           );
+
+          const errors: TaskError[] = [];
+          const results: unknown[] = [];
+
+          for (const result of settled) {
+            if (result.status === "fulfilled") {
+              results.push(result.value);
+            } else {
+              const err = result.reason;
+              errors.push(
+                err instanceof TaskExecutionError
+                  ? err.taskError
+                  : { code: "INTERNAL", message: String(err) },
+              );
+            }
+          }
+
+          if (errors.length > 0) {
+            const primary = errors[0];
+            throw new TaskExecutionError({
+              ...primary,
+              suppressed: errors.length > 1 ? errors.slice(1) : undefined,
+            });
+          }
 
           const duration = performance.now() - startTime;
           onEffectComplete?.(effect, duration);

--- a/packages/runtime/task/src/lib/primitives.test.ts
+++ b/packages/runtime/task/src/lib/primitives.test.ts
@@ -25,6 +25,7 @@ import {
   setContext,
   sortFileLines,
   succeed,
+  symlink,
   warn,
   withContext,
   writeFile,
@@ -205,6 +206,24 @@ describe("Primitives - File System", () => {
       const task = flatMap(writeFile("/any/path", "content"), () =>
         exists("/any/path"),
       );
+      const { value } = dryRun(task);
+      expect(value).toBe(true);
+    });
+  });
+
+  describe("symlink", () => {
+    it("creates a Symlink effect", () => {
+      const task = symlink("/target/dir", "/link/path");
+      const { effects } = dryRun(task);
+
+      expect(effects.length).toBe(1);
+      expect(effects[0]._tag).toBe("Symlink");
+      expect((effects[0] as { target: string }).target).toBe("/target/dir");
+      expect((effects[0] as { path: string }).path).toBe("/link/path");
+    });
+
+    it("symlink makes path exist in dry run", () => {
+      const task = flatMap(symlink("/target", "/link"), () => exists("/link"));
       const { value } = dryRun(task);
       expect(value).toBe(true);
     });

--- a/packages/runtime/task/src/lib/primitives.ts
+++ b/packages/runtime/task/src/lib/primitives.ts
@@ -19,6 +19,7 @@ import {
   promptEffect,
   readContextEffect,
   readFileEffect,
+  symlinkEffect,
   writeContextEffect,
   writeFileEffect,
 } from "./effect.js";
@@ -88,6 +89,14 @@ export const mkdir = (path: string, recursive = true): Task<void> =>
  */
 export const exists = (path: string): Task<boolean> =>
   effect(existsEffect(path));
+
+/**
+ * Create a symbolic link.
+ * @param target - The target path the symlink points to
+ * @param linkPath - The path where the symlink is created
+ */
+export const symlink = (target: string, linkPath: string): Task<void> =>
+  effect(symlinkEffect(target, linkPath));
 
 /**
  * Find files matching a glob pattern.

--- a/packages/runtime/task/src/lib/task.test.ts
+++ b/packages/runtime/task/src/lib/task.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
+import { dryRun } from "./dry-run.js";
+import { readFileEffect, writeFileEffect } from "./effect.js";
 import {
+  $,
   ap,
   effect,
   fail,
   failWith,
   flatMap,
+  gen,
   hasEffects,
   isFailed,
   isPure,
@@ -924,6 +928,74 @@ describe("Task Monad - Edge Cases", () => {
       expect(
         (t as { value: { nested: { value: number } } }).value.nested.value,
       ).toBe(42);
+    });
+  });
+
+  // ===========================================================================
+  // Generator Syntax
+  // ===========================================================================
+
+  describe("gen", () => {
+    it("returns pure value from generator", () => {
+      const t = gen(function* () {
+        yield* $(pure(undefined));
+        return 42;
+      });
+
+      const { value } = dryRun(t);
+      expect(value).toBe(42);
+    });
+
+    it("yields effects and gets results", () => {
+      const readTask: Task<string> = effect(readFileEffect("test.json"));
+
+      const t = gen(function* () {
+        const content = yield* $(readTask);
+        return `got: ${content}`;
+      });
+
+      const { value, effects } = dryRun(t);
+      expect(effects.length).toBe(1);
+      expect(effects[0]._tag).toBe("ReadFile");
+      expect(value).toBe("got: [mock content of test.json]");
+    });
+
+    it("sequences multiple effects", () => {
+      const readTask: Task<string> = effect(readFileEffect("input.txt"));
+      const writeTask: Task<void> = effect(
+        writeFileEffect("output.txt", "data"),
+      );
+
+      const t = gen(function* () {
+        const content = yield* $(readTask);
+        yield* $(writeTask);
+        return content;
+      });
+
+      const { effects } = dryRun(t);
+      expect(effects.length).toBe(2);
+      expect(effects[0]._tag).toBe("ReadFile");
+      expect(effects[1]._tag).toBe("WriteFile");
+    });
+
+    it("propagates failures", () => {
+      const t = gen(function* () {
+        yield* $(fail({ code: "TEST", message: "boom" }));
+        return "unreachable";
+      });
+
+      expect(() => dryRun(t)).toThrow("boom");
+    });
+
+    it("composes with flatMap outside gen", () => {
+      const inner = gen(function* () {
+        const v = yield* $(pure(10));
+        return v * 2;
+      });
+
+      const outer = flatMap(inner, (n) => pure(n + 1));
+      const { value } = dryRun(outer);
+      expect(value).toBe(21);
     });
   });
 });

--- a/packages/runtime/task/src/lib/task.ts
+++ b/packages/runtime/task/src/lib/task.ts
@@ -217,6 +217,66 @@ export const task = <A>(t: Task<A>): TaskBuilder<A> => new TaskBuilder(t);
 export const of = <A>(value: A): TaskBuilder<A> => task(pure(value));
 
 // =============================================================================
+// Generator Syntax
+// =============================================================================
+
+/**
+ * A wrapper that makes a Task iterable, enabling `yield*` syntax
+ * in generator-based task composition with proper type inference.
+ */
+export interface TaskGen<A> {
+  [Symbol.iterator](): Generator<Task<unknown>, A, unknown>;
+}
+
+/**
+ * Wrap a Task for use with `yield*` inside `gen()`.
+ *
+ * @example
+ * ```typescript
+ * const content = yield* $(readFile("package.json"))
+ * ```
+ */
+export const $ = <A>(task: Task<A>): TaskGen<A> => ({
+  *[Symbol.iterator]() {
+    return (yield task) as A;
+  },
+});
+
+/**
+ * Write sequential effectful code using generator syntax.
+ * Avoids nested flatMap chains for complex sequential tasks.
+ *
+ * Use `yield*` with `$(task)` to unwrap a task, getting back its value.
+ * Under the hood this composes flatMap calls.
+ *
+ * @example
+ * ```typescript
+ * const myTask = gen(function* () {
+ *   const content = yield* $(readFile("package.json"))
+ *   const parsed = JSON.parse(content)
+ *   yield* $(writeFile("output.json", JSON.stringify(parsed)))
+ *   yield* $(info("Wrote output.json"))
+ *   return parsed
+ * })
+ * ```
+ */
+export const gen = <A>(
+  f: () => Generator<Task<unknown>, A, unknown>,
+): Task<A> => {
+  const iterator = f();
+
+  const step = (nextValue: unknown): Task<A> => {
+    const result = iterator.next(nextValue);
+    if (result.done) {
+      return pure(result.value);
+    }
+    return flatMap(result.value, (value) => step(value));
+  };
+
+  return step(undefined);
+};
+
+// =============================================================================
 // Utility Functions
 // =============================================================================
 

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -137,6 +137,8 @@ export type Effect =
   | { _tag: "WriteContext"; key: string; value: unknown }
   /** Run tasks in parallel */
   | { _tag: "Parallel"; tasks: Task<unknown>[] }
+  /** Create a symbolic link */
+  | { _tag: "Symlink"; target: string; path: string }
   /** Race tasks, return first to complete */
   | { _tag: "Race"; tasks: Task<unknown>[] };
 
@@ -158,7 +160,24 @@ export interface TaskError {
   context?: Record<string, unknown>;
   /** Stack trace if available */
   stack?: string;
+  /** For parallel failures: all errors, not just the first */
+  suppressed?: TaskError[];
 }
+
+// =============================================================================
+// Base Error Codes
+// =============================================================================
+
+/**
+ * Base error codes used by the task framework.
+ * Domains can extend this with their own codes.
+ */
+export type BaseErrorCode =
+  | "FILE_NOT_FOUND"
+  | "EXEC_FAILED"
+  | "PROMPT_CANCELLED"
+  | "TASK_INTERRUPTED"
+  | "INTERNAL";
 
 // =============================================================================
 // Task Monad - The core abstraction for composable operations


### PR DESCRIPTION
## Done

- Add `Symlink` effect to the `Effect` union + `symlinkEffect` constructor + `symlink` primitive
- Add `switchMap` combinator for detect-then-dispatch patterns
- Add `gen()` generator syntax with `$()` wrapper for `yield*` type inference
- Add `TaskError.suppressed` field for parallel failure aggregation (interpreter uses `Promise.allSettled`)
- Add `signal?: AbortSignal` on `RunTaskOptions` with `TASK_INTERRUPTED` error code
- Add `BaseErrorCode` string literal union type
- Update `describeEffect`, `isWriteEffect`, `getAffectedPaths` for `Symlink`
- Update dry-run interpreter to track symlinks in virtual filesystem
- 20 new tests covering all additions (544 total, up from 524)

## QA

- `bun run --filter @canonical/task test` → 544 tests pass
- `bun run --filter @canonical/task check` → biome lint + TypeScript clean
- All changes are additive — no breaking changes to existing API

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.

