### PR TITLE
feat(pragma): add CLI adapter with federation, output formatting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,9 @@
       },
       "dependencies": {
         "@canonical/ke": "workspace:*",
+        "chalk": "^5.6.2",
+        "cli-framework": "workspace:*",
+        "commander": "^14.0.3",
         "smol-toml": "^1.3.1",
       },
       "devDependencies": {

--- a/packages/cli/pragma/README.md
+++ b/packages/cli/pragma/README.md
@@ -8,9 +8,61 @@ CLI and MCP server for Canonical's design system. Query components, standards, m
 bun add -g @canonical/pragma
 ```
 
-## Status
+## Usage
 
-v0.1 kernel — package scaffold, config, PM detection, error infrastructure. Commands land in v0.2.
+```sh
+pragma --help
+pragma --version
+pragma component list
+pragma component get Button --detailed
+```
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--llm` | Condensed Markdown output for LLM consumption |
+| `--format json` | JSON output |
+| `--verbose` | Diagnostic output to stderr |
+
+## Configuration
+
+Create a `pragma.config.toml` in your project root:
+
+```toml
+tier = "apps/lxd"
+channel = "normal"    # normal | experimental | prerelease
+```
+
+When no config file is present, pragma defaults to no tier and `normal` channel.
+
+## Error Handling
+
+Errors follow a three-part structure (message, context, recovery):
+
+```
+Error: component "Buton" not found.
+
+Did you mean?
+  - Button
+  - ButtonGroup
+
+Run `pragma component list`
+```
+
+With `--format json`, errors are returned as structured JSON. With `--llm`, errors are Markdown.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Entity not found |
+| 2 | Empty results |
+| 3 | Invalid or ambiguous input |
+| 4 | Configuration error |
+| 5 | Store error |
+| 127 | Internal error |
 
 ## Scripts
 
@@ -31,7 +83,16 @@ bun build --compile --minify src/bin.ts --outfile dist/pragma
 
 Binary size: ~98 MB (linux-x64), ~58 MB (darwin-arm64). The Bun runtime (~90 MB) dominates; Oxigraph WASM adds ~4 MB.
 
+## Architecture
+
+pragma uses the federation pattern from `cli-framework`: each domain exports `CommandDefinition[]`, and the root CLI registers them into a single Commander.js program. Output adapters handle plain text, LLM markdown, and JSON rendering.
+
 ## Dependencies
 
 - [`@canonical/ke`](../runtime/ke/) — triple store runtime (Oxigraph WASM)
+- [`cli-framework`](../core/) — shared CLI machinery (Commander.js registration, help formatting, completions)
 - [`smol-toml`](https://github.com/nicolo-ribaudo/smol-toml) — TOML parser for `pragma.config.toml`
+
+## License
+
+GPL-3.0

--- a/packages/cli/pragma/package.json
+++ b/packages/cli/pragma/package.json
@@ -50,6 +50,9 @@
   },
   "dependencies": {
     "@canonical/ke": "workspace:*",
+    "chalk": "^5.6.2",
+    "cli-framework": "workspace:*",
+    "commander": "^14.0.3",
     "smol-toml": "^1.3.1"
   }
 }

--- a/packages/cli/pragma/src/bin.ts
+++ b/packages/cli/pragma/src/bin.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import { runCli } from "./lib/runCli.js";
 import { detectLocalInstall } from "./pm.js";
 
 const localWarning = detectLocalInstall();
@@ -7,4 +8,4 @@ if (localWarning) {
   console.warn(localWarning);
 }
 
-console.log("pragma — not yet implemented");
+await runCli(process.argv);

--- a/packages/cli/pragma/src/constants.ts
+++ b/packages/cli/pragma/src/constants.ts
@@ -1,5 +1,11 @@
+import pkg from "../package.json" with { type: "json" };
+
+const PROGRAM_NAME = "pragma";
+const PROGRAM_DESCRIPTION = "CLI and MCP server for Canonical's design system.";
+const VERSION = pkg.version;
+
 const VALID_CHANNELS = ["normal", "experimental", "prerelease"] as const;
 type Channel = (typeof VALID_CHANNELS)[number];
 
-export { VALID_CHANNELS };
+export { PROGRAM_DESCRIPTION, PROGRAM_NAME, VALID_CHANNELS, VERSION };
 export type { Channel };

--- a/packages/cli/pragma/src/index.ts
+++ b/packages/cli/pragma/src/index.ts
@@ -1,8 +1,29 @@
 export type { PragmaConfig } from "./config.js";
 export { readConfig } from "./config.js";
 export type { Channel } from "./constants.js";
-export { VALID_CHANNELS } from "./constants.js";
+export {
+  PROGRAM_DESCRIPTION,
+  PROGRAM_NAME,
+  VALID_CHANNELS,
+  VERSION,
+} from "./constants.js";
 export type { ErrorCode, PragmaErrorData } from "./error/index.js";
 export { ERROR_CODES, PragmaError } from "./error/index.js";
+export {
+  formatField,
+  formatHeading,
+  formatList,
+  formatSection,
+} from "./lib/formatTerminal.js";
+export { EXIT_CODES, mapExitCode } from "./lib/mapExitCode.js";
+export {
+  renderErrorJson,
+  renderErrorLlm,
+  renderErrorPlain,
+} from "./lib/renderError.js";
 export type { PackageManager } from "./pm.js";
-export { detectLocalInstall, detectPackageManager, PM_COMMANDS } from "./pm.js";
+export {
+  detectLocalInstall,
+  detectPackageManager,
+  PM_COMMANDS,
+} from "./pm.js";

--- a/packages/cli/pragma/src/lib/formatTerminal.test.ts
+++ b/packages/cli/pragma/src/lib/formatTerminal.test.ts
@@ -1,0 +1,43 @@
+import chalk from "chalk";
+import { describe, expect, it } from "vitest";
+import {
+  formatField,
+  formatHeading,
+  formatList,
+  formatSection,
+} from "./formatTerminal.js";
+
+describe("formatHeading", () => {
+  it("applies bold and underline", () => {
+    expect(formatHeading("Title")).toBe(chalk.bold.underline("Title"));
+  });
+});
+
+describe("formatField", () => {
+  it("renders dim label with value", () => {
+    expect(formatField("Name:", "Button")).toBe(`${chalk.dim("Name:")} Button`);
+  });
+});
+
+describe("formatList", () => {
+  it("renders items with default bullet", () => {
+    const result = formatList(["one", "two", "three"]);
+    expect(result).toBe("  - one\n  - two\n  - three");
+  });
+
+  it("uses custom bullet", () => {
+    const result = formatList(["a", "b"], "*");
+    expect(result).toBe("  * a\n  * b");
+  });
+
+  it("returns empty string for empty array", () => {
+    expect(formatList([])).toBe("");
+  });
+});
+
+describe("formatSection", () => {
+  it("combines heading and body", () => {
+    const result = formatSection("Details", "some content");
+    expect(result).toBe(`${chalk.bold.underline("Details")}\nsome content`);
+  });
+});

--- a/packages/cli/pragma/src/lib/formatTerminal.ts
+++ b/packages/cli/pragma/src/lib/formatTerminal.ts
@@ -1,0 +1,19 @@
+import chalk from "chalk";
+
+function formatHeading(text: string): string {
+  return chalk.bold.underline(text);
+}
+
+function formatField(label: string, value: string): string {
+  return `${chalk.dim(label)} ${value}`;
+}
+
+function formatList(items: string[], bullet = "-"): string {
+  return items.map((item) => `  ${bullet} ${item}`).join("\n");
+}
+
+function formatSection(heading: string, body: string): string {
+  return `${formatHeading(heading)}\n${body}`;
+}
+
+export { formatField, formatHeading, formatList, formatSection };

--- a/packages/cli/pragma/src/lib/mapExitCode.test.ts
+++ b/packages/cli/pragma/src/lib/mapExitCode.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { ERROR_CODES } from "../error/index.js";
+import { EXIT_CODES, mapExitCode } from "./mapExitCode.js";
+
+describe("mapExitCode", () => {
+  it("maps ENTITY_NOT_FOUND to 1", () => {
+    expect(mapExitCode("ENTITY_NOT_FOUND")).toBe(1);
+  });
+
+  it("maps EMPTY_RESULTS to 2", () => {
+    expect(mapExitCode("EMPTY_RESULTS")).toBe(2);
+  });
+
+  it("maps INVALID_INPUT to 3", () => {
+    expect(mapExitCode("INVALID_INPUT")).toBe(3);
+  });
+
+  it("maps AMBIGUOUS_INPUT to 3", () => {
+    expect(mapExitCode("AMBIGUOUS_INPUT")).toBe(3);
+  });
+
+  it("maps CONFIG_ERROR to 4", () => {
+    expect(mapExitCode("CONFIG_ERROR")).toBe(4);
+  });
+
+  it("maps STORE_ERROR to 5", () => {
+    expect(mapExitCode("STORE_ERROR")).toBe(5);
+  });
+
+  it("maps INTERNAL_ERROR to 127", () => {
+    expect(mapExitCode("INTERNAL_ERROR")).toBe(127);
+  });
+
+  it("covers every ErrorCode", () => {
+    for (const code of ERROR_CODES) {
+      expect(typeof mapExitCode(code)).toBe("number");
+    }
+    expect(Object.keys(EXIT_CODES)).toHaveLength(ERROR_CODES.length);
+  });
+});

--- a/packages/cli/pragma/src/lib/mapExitCode.ts
+++ b/packages/cli/pragma/src/lib/mapExitCode.ts
@@ -1,0 +1,17 @@
+import type { ErrorCode } from "../error/index.js";
+
+const EXIT_CODES: Record<ErrorCode, number> = {
+  ENTITY_NOT_FOUND: 1,
+  EMPTY_RESULTS: 2,
+  INVALID_INPUT: 3,
+  AMBIGUOUS_INPUT: 3,
+  CONFIG_ERROR: 4,
+  STORE_ERROR: 5,
+  INTERNAL_ERROR: 127,
+};
+
+function mapExitCode(code: ErrorCode): number {
+  return EXIT_CODES[code];
+}
+
+export { EXIT_CODES, mapExitCode };

--- a/packages/cli/pragma/src/lib/renderError.test.ts
+++ b/packages/cli/pragma/src/lib/renderError.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { PragmaError } from "../error/index.js";
+import {
+  renderErrorJson,
+  renderErrorLlm,
+  renderErrorPlain,
+} from "./renderError.js";
+
+describe("renderErrorPlain", () => {
+  it("renders a basic error", () => {
+    const err = PragmaError.internalError("something broke");
+    const out = renderErrorPlain(err);
+    expect(out).toContain("Error: Internal error: something broke");
+    expect(out).toContain("Run `Please report this issue.`");
+  });
+
+  it("renders suggestions", () => {
+    const err = PragmaError.notFound("component", "Buton", {
+      suggestions: ["Button", "ButtonGroup"],
+    });
+    const out = renderErrorPlain(err);
+    expect(out).toContain("Did you mean?");
+    expect(out).toContain("  - Button");
+    expect(out).toContain("  - ButtonGroup");
+  });
+
+  it("renders filters (ER.05)", () => {
+    const err = PragmaError.emptyResults("component", {
+      filters: { tier: "apps/lxd", channel: "normal" },
+    });
+    const out = renderErrorPlain(err);
+    expect(out).toContain("Active filters:");
+    expect(out).toContain("  tier: apps/lxd");
+    expect(out).toContain("  channel: normal");
+  });
+
+  it("renders validOptions", () => {
+    const err = PragmaError.invalidInput("channel", "aggressive", {
+      validOptions: ["normal", "experimental", "prerelease"],
+    });
+    const out = renderErrorPlain(err);
+    expect(out).toContain("Valid options: normal, experimental, prerelease");
+  });
+
+  it("renders recovery as string", () => {
+    const err = PragmaError.notFound("component", "Foo", {
+      recovery: "pragma component list",
+    });
+    const out = renderErrorPlain(err);
+    expect(out).toContain("Run `pragma component list`");
+  });
+
+  it("renders recovery as array", () => {
+    const err = PragmaError.emptyResults("component", {
+      recovery: ["pragma component list --all-tiers", "pragma config show"],
+    });
+    const out = renderErrorPlain(err);
+    expect(out).toContain("  - pragma component list --all-tiers");
+    expect(out).toContain("  - pragma config show");
+  });
+});
+
+describe("renderErrorLlm", () => {
+  it("renders structured markdown", () => {
+    const err = PragmaError.notFound("component", "Buton", {
+      suggestions: ["Button", "ButtonGroup"],
+      recovery: "pragma component list",
+    });
+    const out = renderErrorLlm(err);
+    expect(out).toContain("## Error: ENTITY_NOT_FOUND");
+    expect(out).toContain('component "Buton" not found.');
+    expect(out).toContain("Suggestions: Button, ButtonGroup");
+    expect(out).toContain("Recovery: `pragma component list`");
+  });
+
+  it("renders filters", () => {
+    const err = PragmaError.emptyResults("component", {
+      filters: { tier: "apps/lxd" },
+    });
+    const out = renderErrorLlm(err);
+    expect(out).toContain("Filters: tier=apps/lxd");
+  });
+
+  it("renders validOptions", () => {
+    const err = PragmaError.invalidInput("channel", "bad", {
+      validOptions: ["normal", "experimental"],
+    });
+    const out = renderErrorLlm(err);
+    expect(out).toContain("Valid options: normal, experimental");
+  });
+
+  it("renders recovery as array", () => {
+    const err = PragmaError.emptyResults("component", {
+      recovery: ["pragma component list", "pragma config show"],
+    });
+    const out = renderErrorLlm(err);
+    expect(out).toContain(
+      "Recovery: `pragma component list`, `pragma config show`",
+    );
+  });
+});
+
+describe("renderErrorJson", () => {
+  it("produces valid JSON with all fields", () => {
+    const err = PragmaError.notFound("component", "Buton", {
+      suggestions: ["Button"],
+      recovery: "pragma component list",
+    });
+    const parsed = JSON.parse(renderErrorJson(err));
+    expect(parsed.code).toBe("ENTITY_NOT_FOUND");
+    expect(parsed.message).toBe('component "Buton" not found.');
+    expect(parsed.entity).toEqual({ type: "component", name: "Buton" });
+    expect(parsed.suggestions).toEqual(["Button"]);
+    expect(parsed.recovery).toBe("pragma component list");
+  });
+
+  it("includes filters and validOptions", () => {
+    const err = PragmaError.emptyResults("component", {
+      filters: { tier: "global" },
+    });
+    const parsed = JSON.parse(renderErrorJson(err));
+    expect(parsed.code).toBe("EMPTY_RESULTS");
+    expect(parsed.filters).toEqual({ tier: "global" });
+  });
+
+  it("includes undefined fields as undefined/null", () => {
+    const err = PragmaError.storeError("disk full");
+    const parsed = JSON.parse(renderErrorJson(err));
+    expect(parsed.code).toBe("STORE_ERROR");
+    expect(parsed.entity).toBeUndefined();
+    expect(parsed.filters).toBeUndefined();
+    expect(parsed.validOptions).toBeUndefined();
+  });
+});

--- a/packages/cli/pragma/src/lib/renderError.ts
+++ b/packages/cli/pragma/src/lib/renderError.ts
@@ -1,0 +1,89 @@
+import type { PragmaError } from "../error/index.js";
+
+function renderErrorPlain(error: PragmaError): string {
+  const lines: string[] = [];
+
+  lines.push(`Error: ${error.message}`);
+
+  if (error.suggestions.length > 0) {
+    lines.push("");
+    lines.push("Did you mean?");
+    for (const s of error.suggestions) {
+      lines.push(`  - ${s}`);
+    }
+  }
+
+  if (error.filters) {
+    lines.push("");
+    lines.push("Active filters:");
+    for (const [key, value] of Object.entries(error.filters)) {
+      lines.push(`  ${key}: ${value}`);
+    }
+  }
+
+  if (error.validOptions && error.validOptions.length > 0) {
+    lines.push("");
+    lines.push(`Valid options: ${error.validOptions.join(", ")}`);
+  }
+
+  if (error.recovery) {
+    lines.push("");
+    if (Array.isArray(error.recovery)) {
+      for (const r of error.recovery) {
+        lines.push(`  - ${r}`);
+      }
+    } else {
+      lines.push(`Run \`${error.recovery}\``);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderErrorLlm(error: PragmaError): string {
+  const lines: string[] = [];
+
+  lines.push(`## Error: ${error.code}`);
+  lines.push(error.message);
+
+  if (error.suggestions.length > 0) {
+    lines.push(`Suggestions: ${error.suggestions.join(", ")}`);
+  }
+
+  if (error.filters) {
+    const filterParts = Object.entries(error.filters)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(", ");
+    lines.push(`Filters: ${filterParts}`);
+  }
+
+  if (error.validOptions && error.validOptions.length > 0) {
+    lines.push(`Valid options: ${error.validOptions.join(", ")}`);
+  }
+
+  if (error.recovery) {
+    if (Array.isArray(error.recovery)) {
+      lines.push(
+        `Recovery: ${error.recovery.map((r) => `\`${r}\``).join(", ")}`,
+      );
+    } else {
+      lines.push(`Recovery: \`${error.recovery}\``);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderErrorJson(error: PragmaError): string {
+  return JSON.stringify({
+    code: error.code,
+    message: error.message,
+    entity: error.entity,
+    suggestions: error.suggestions,
+    recovery: error.recovery,
+    filters: error.filters,
+    validOptions: error.validOptions,
+  });
+}
+
+export { renderErrorJson, renderErrorLlm, renderErrorPlain };

--- a/packages/cli/pragma/src/lib/runCli.test.ts
+++ b/packages/cli/pragma/src/lib/runCli.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { VERSION } from "../constants.js";
+import { collectCommands, createProgram, parseGlobalFlags } from "./runCli.js";
+
+describe("collectCommands", () => {
+  it("returns an empty array", () => {
+    expect(collectCommands()).toEqual([]);
+  });
+});
+
+describe("parseGlobalFlags", () => {
+  it("parses defaults", () => {
+    const flags = parseGlobalFlags(["node", "pragma"]);
+    expect(flags).toEqual({ llm: false, format: "text", verbose: false });
+  });
+
+  it("parses --llm", () => {
+    const flags = parseGlobalFlags(["node", "pragma", "--llm"]);
+    expect(flags.llm).toBe(true);
+  });
+
+  it("parses --format json", () => {
+    const flags = parseGlobalFlags(["node", "pragma", "--format", "json"]);
+    expect(flags.format).toBe("json");
+  });
+
+  it("parses --verbose", () => {
+    const flags = parseGlobalFlags(["node", "pragma", "--verbose"]);
+    expect(flags.verbose).toBe(true);
+  });
+
+  it("parses all flags together", () => {
+    const flags = parseGlobalFlags([
+      "node",
+      "pragma",
+      "--llm",
+      "--format",
+      "json",
+      "--verbose",
+    ]);
+    expect(flags).toEqual({ llm: true, format: "json", verbose: true });
+  });
+});
+
+describe("createProgram", () => {
+  it("creates a Commander program named pragma", () => {
+    const ctx = {
+      cwd: "/tmp",
+      globalFlags: { llm: false, format: "text" as const, verbose: false },
+    };
+    const program = createProgram([], ctx);
+    expect(program.name()).toBe("pragma");
+  });
+
+  it("has version set", () => {
+    const ctx = {
+      cwd: "/tmp",
+      globalFlags: { llm: false, format: "text" as const, verbose: false },
+    };
+    const program = createProgram([], ctx);
+    expect(program.version()).toBe(VERSION);
+  });
+
+  it("has global flags registered", () => {
+    const ctx = {
+      cwd: "/tmp",
+      globalFlags: { llm: false, format: "text" as const, verbose: false },
+    };
+    const program = createProgram([], ctx);
+    const optionNames = program.options.map((o) => o.long);
+    expect(optionNames).toContain("--llm");
+    expect(optionNames).toContain("--format");
+    expect(optionNames).toContain("--verbose");
+  });
+});

--- a/packages/cli/pragma/src/lib/runCli.ts
+++ b/packages/cli/pragma/src/lib/runCli.ts
@@ -1,0 +1,140 @@
+import {
+  type CommandContext,
+  type CommandDefinition,
+  formatHelp,
+  formatLlmHelp,
+  type GlobalFlags,
+  registerAll,
+} from "cli-framework";
+import { Command, CommanderError } from "commander";
+import { readConfig } from "../config.js";
+import { PROGRAM_DESCRIPTION, PROGRAM_NAME, VERSION } from "../constants.js";
+import { PragmaError } from "../error/index.js";
+import { mapExitCode } from "./mapExitCode.js";
+import {
+  renderErrorJson,
+  renderErrorLlm,
+  renderErrorPlain,
+} from "./renderError.js";
+
+function collectCommands(): CommandDefinition[] {
+  return [];
+}
+
+function createProgram(
+  commands: readonly CommandDefinition[],
+  ctx: CommandContext,
+): Command {
+  const program = new Command();
+  program.name(PROGRAM_NAME);
+  program.version(VERSION, "-V, --version");
+  program.description(PROGRAM_DESCRIPTION);
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (str) => process.stdout.write(str),
+    writeErr: (str) => process.stderr.write(str),
+  });
+
+  program.option(
+    "--llm",
+    "Condensed Markdown output for LLM consumption",
+    false,
+  );
+  program.option("--format <type>", "Output format (text or json)", "text");
+  program.option("--verbose", "Diagnostic output to stderr", false);
+
+  program.addHelpText("beforeAll", () => {
+    if (ctx.globalFlags.llm) {
+      return formatLlmHelp(PROGRAM_NAME, commands);
+    }
+    return formatHelp(PROGRAM_NAME, PROGRAM_DESCRIPTION, commands);
+  });
+
+  program.helpOption("-h, --help", "Show help");
+  program.configureHelp({ formatHelp: () => "" });
+
+  registerAll(program, commands, ctx);
+
+  return program;
+}
+
+function parseGlobalFlags(argv: readonly string[]): GlobalFlags {
+  return {
+    llm: argv.includes("--llm"),
+    format:
+      argv.includes("--format") && argv[argv.indexOf("--format") + 1] === "json"
+        ? "json"
+        : "text",
+    verbose: argv.includes("--verbose"),
+  };
+}
+
+function renderError(error: PragmaError, flags: GlobalFlags): string {
+  if (flags.format === "json") {
+    return renderErrorJson(error);
+  }
+  if (flags.llm) {
+    return renderErrorLlm(error);
+  }
+  return renderErrorPlain(error);
+}
+
+async function runCli(argv: readonly string[]): Promise<void> {
+  const globalFlags = parseGlobalFlags(argv);
+
+  let cwd: string;
+  try {
+    const config = readConfig();
+    cwd = process.cwd();
+    if (globalFlags.verbose) {
+      const tier = config.tier ?? "(none)";
+      process.stderr.write(`Config: tier=${tier} channel=${config.channel}\n`);
+    }
+  } catch (err) {
+    const pragmaErr =
+      err instanceof PragmaError
+        ? err
+        : PragmaError.configError(
+            err instanceof Error ? err.message : String(err),
+          );
+    process.stderr.write(`${renderError(pragmaErr, globalFlags)}\n`);
+    process.exitCode = mapExitCode(pragmaErr.code);
+    return;
+  }
+
+  const ctx: CommandContext = { cwd, globalFlags };
+  const commands = collectCommands();
+  const program = createProgram(commands, ctx);
+
+  try {
+    await program.parseAsync(argv);
+  } catch (err) {
+    if (err instanceof CommanderError) {
+      if (
+        err.code === "commander.helpDisplayed" ||
+        err.code === "commander.version"
+      ) {
+        process.exitCode = 0;
+        return;
+      }
+      // Commander already wrote the error via configureOutput.writeErr,
+      // so just set the exit code without re-printing.
+      process.exitCode = err.exitCode;
+      return;
+    }
+
+    if (err instanceof PragmaError) {
+      process.stderr.write(`${renderError(err, globalFlags)}\n`);
+      process.exitCode = mapExitCode(err.code);
+      return;
+    }
+
+    const wrapped = PragmaError.internalError(
+      err instanceof Error ? err.message : String(err),
+    );
+    process.stderr.write(`${renderError(wrapped, globalFlags)}\n`);
+    process.exitCode = 127;
+  }
+}
+
+export { collectCommands, createProgram, parseGlobalFlags, runCli };


### PR DESCRIPTION
## Done

- Wire `pragma` binary to Commander.js using `cli-framework`'s federation pattern (PA.11)
- Add `runCli()` lifecycle: config → context → Commander program → `registerAll` → error boundary
- Add three-mode error rendering: `renderErrorPlain` (ER.01 three-part), `renderErrorLlm` (structured markdown, ER.07), `renderErrorJson`
- Add `mapExitCode()` mapping all 7 `ErrorCode` values to numeric exit codes (CL.11)
- Add terminal formatting helpers: `formatHeading`, `formatField`, `formatList`, `formatSection`
- Register global flags: `--llm`, `--format <type>`, `--verbose`
- Override Commander help with cli-framework's `formatHelp`/`formatLlmHelp`
- `collectCommands()` returns `[]` — domain commands plug in during v0.2
- `--detailed` and aspect flags are per-command `ParameterDefinition[]`, not global (PA.09)
- Add README with usage, flags, exit codes, configuration, and architecture

## QA

```sh
cd packages/cli/pragma
bun run check          # biome + tsc + webarchitect pass
bun run test           # 65 tests pass (7 files)
bun run src/bin.ts --version   # → 0.18.0, exit 0
bun run src/bin.ts --help      # → formatted help with global flags
bun run src/bin.ts --llm --help  # → condensed markdown
bun run src/bin.ts --verbose --version  # → config diagnostics on stderr
bun run src/bin.ts badcommand  # → error message, exit 1
```

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appripriate [code standards](https://github.com/canonical/code-standards) 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 
