### PR TITLE
chore(ci): add caching, skip prepare hook, remove redundant chromatic checks

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,5 +1,5 @@
 name: Setup environment
-description: Installs build tools and dependencies
+description: Installs build tools, restores caches, and installs dependencies
 inputs:
   bun-version:
     default: '1.3.9'
@@ -21,7 +21,26 @@ runs:
       with:
         bun-version: ${{ inputs.bun-version }}
 
-      # "prepare" hook on `bun install` runs `bun run build`
+    - name: Cache node_modules
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles('bun.lock') }}
+
+    - name: Cache Bun global cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+    - name: Cache Nx
+      uses: actions/cache@v4
+      with:
+        path: .nx/cache
+        key: nx-cache-${{ runner.os }}-${{ inputs.node-version }}-${{ github.sha }}
+        restore-keys: |
+          nx-cache-${{ runner.os }}-${{ inputs.node-version }}-
+
     - name: Install dependencies
       shell: bash
       # NOTE: --frozen-lockfile disabled for now due to a known Bun bug where bun install
@@ -30,10 +49,14 @@ runs:
       # https://github.com/oven-sh/bun/issues/16692
       # https://github.com/oven-sh/bun/issues/19088
       # run: bun install --frozen-lockfile
-      run: bun install && git diff --exit-code bun.lock
+      #
+      # --ignore-scripts prevents the "prepare" lifecycle hook from triggering a full
+      # monorepo build during install. Workflows that need a build invoke it explicitly
+      # or rely on Nx transitive dependsOn.
+      run: bun install --ignore-scripts && git diff --exit-code bun.lock
 
       # Workaround for https://github.com/oven-sh/bun/issues/19782
       # Workspace bin symlinks aren't created on first install. Remove after fix is merged.
     - name: Re-link workspace binaries
       shell: bash
-      run: bun install
+      run: bun install --ignore-scripts

--- a/.github/workflows/chromatic._template.yml
+++ b/.github/workflows/chromatic._template.yml
@@ -19,31 +19,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.working-directory }}
   cancel-in-progress: true
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-
-        # "prepare" hook on `bun install` runs `bun run build`
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
-
-      - name: Code quality checks
-        run: bun run check
-
-      - name: Test
-        run: bun run test
   publish-to-chromatic:
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-        # "prepare" hook on `bun install` runs `bun run build`
       - name: Setup environment
         uses: ./.github/actions/setup-env
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           fetch-depth: 1
 
-        # "prepare" hook on `bun install` runs `bun run build`
       - name: Setup environment
         uses: ./.github/actions/setup-env
 
@@ -60,7 +59,6 @@ jobs:
           # Lerna needs *all* the git history to determine which packages have changed
           fetch-depth: 0
 
-        # "prepare" hook on `bun install` runs `bun run build`
       - name: Setup environment
         uses: ./.github/actions/setup-env
 
@@ -83,9 +81,11 @@ jobs:
           # Lerna needs *all* the git history to determine which packages have changed
           fetch-depth: 0
 
-        # "prepare" hook on `bun install` runs `bun run build`
       - name: Setup Environment
         uses: ./.github/actions/setup-env
+
+      - name: Build
+        run: bun run build
 
       - name: Setup Node, authenticate with NPM registry
         uses: actions/setup-node@v6

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -48,13 +48,25 @@ The pipeline uses several tools, each chosen for specific reasons.
 
 **Lerna** manages versioning and publishing. It understands the monorepo structure, tracks which packages have changed since the last release, generates changelogs from conventional commits, and publishes packages to npm in the correct dependency order. Lerna's fixed versioning mode keeps all packages at the same version number, eliminating compatibility matrices.
 
-**Nx** provides task orchestration and caching. When you run `bun run build`, Nx determines the dependency graph between packages and builds them in the correct order. When you run the same command again, Nx skips packages that haven't changed. This caching dramatically speeds up CI builds after the first run.
+**Nx** provides task orchestration and caching. When you run `bun run build`, Nx determines the dependency graph between packages and builds them in the correct order. When you run the same command again, Nx skips packages that haven't changed. The `setup-env` action persists the Nx cache across CI runs using `actions/cache`, so this caching benefits CI as well as local development — subsequent jobs within the same PR and across PRs on the same branch reuse prior build outputs.
 
 **Bun** handles package management. It resolves workspace dependencies, installs packages, and runs scripts. Bun is significantly faster than npm or yarn for these operations. However, Bun does not yet fully support all Node.js APIs that Storybook and Lerna require.
 
 **Node.js** runs Storybook and Lerna. The pipeline installs both Bun and Node, using Bun for package management and Node for tools that require fuller Node.js compatibility. The build matrix tests against Node 22 (LTS) and Node 24 (current) to catch compatibility issues.
 
-**Chromatic** provides visual regression testing. It captures screenshots of Storybook stories, stores baselines, and highlights visual differences between builds. Chromatic runs as a separate workflow with path filtering, so changes to `react-ds-global` only trigger visual tests for that package. This conserves snapshot credits while ensuring visual changes are reviewed.
+**Chromatic** provides visual regression testing. It captures screenshots of Storybook stories, stores baselines, and highlights visual differences between builds. Chromatic runs as a separate workflow with path filtering, so changes to `react-ds-global` only trigger visual tests for that package. This conserves snapshot credits while ensuring visual changes are reviewed. Chromatic workflows are focused solely on visual baselines — they do not run code quality checks or tests. Correctness is owned by `pr.yml` (on PRs) and `push.yml` (on main).
+
+## Caching
+
+CI uses `actions/cache` in the `setup-env` composite action to persist three things across jobs and runs:
+
+- **`node_modules/`** — keyed on `bun.lock` hash and Node version. Eliminates redundant dependency downloads.
+- **`~/.bun/install/cache/`** — Bun's global download cache. Speeds up `bun install` even when `node_modules` misses.
+- **`.nx/cache/`** — Nx's local computation cache. Allows Nx to skip rebuilding or re-checking packages whose inputs haven't changed, even on fresh CI runners.
+
+The `setup-env` action is responsible only for toolchain setup (Node, Bun), cache restoration, and dependency installation. It does not build, check, or test. In CI, `bun install` runs with `--ignore-scripts` to prevent the `prepare` lifecycle hook from triggering a full monorepo build. Workflows that need a build invoke it explicitly (e.g. `lerna run build:all` in `pr.yml`) or rely on Nx's transitive `dependsOn` configuration (e.g. `test` depends on `^build`).
+
+Locally, `bun install` still triggers the `prepare` hook and builds the workspace automatically. This divergence is intentional: local development prioritises convenience, while CI prioritises explicit, cacheable steps.
 
 ## Workflows
 
@@ -87,7 +99,7 @@ The workflow has three jobs:
 
 1. **build** runs checks and tests to verify the release candidate
 2. **version** bumps version numbers, generates changelogs, commits, and creates a git tag
-3. **publish** checks out the tagged commit and publishes packages to npm
+3. **publish** checks out the tagged commit, builds all packages, and publishes them to npm
 
 The version job uses Lerna's conventional commit analysis to determine version bumps. A `feat:` commit triggers a minor bump, a `fix:` commit triggers a patch bump, and a `BREAKING CHANGE:` footer triggers a major bump.
 
@@ -106,7 +118,7 @@ on:
 
 The path list includes both the package itself and its dependencies. Changes to `styles` packages trigger Chromatic for all component packages because style changes affect visual output.
 
-Chromatic workflows use a shared template (`.github/workflows/chromatic._template.yml`) that defines the common build and publish steps. Each package workflow passes its working directory and external dependencies to the template.
+Chromatic workflows use a shared template (`.github/workflows/chromatic._template.yml`) that defines the publish step. Each package workflow passes its working directory and external dependencies to the template. The template does not run `check` or `test` — correctness is enforced by `pr.yml`'s `build-gate` status check, which is required by branch protection.
 
 On pull requests, Chromatic requires manual approval for visual changes. On pushes to main, changes are automatically accepted as new baselines. This allows reviewing visual changes during PR review while keeping baselines current after merge.
 
@@ -155,7 +167,7 @@ bun run check
 bun run test
 ```
 
-If the failure involves Nx caching, the CI cache may contain stale artifacts. Nx caches are keyed by file content hashes; if a file changed in a way that doesn't affect its hash (unlikely but possible), the cache may serve outdated results. Re-running the workflow usually resolves this.
+If the failure involves Nx caching, the CI cache may contain stale artifacts. Nx caches are keyed by file content hashes; if a file changed in a way that doesn't affect its hash (unlikely but possible), the cache may serve outdated results. Re-running the workflow usually resolves this. If the problem persists, the Nx cache can be busted by pushing a trivial change (the cache key includes `github.sha`).
 
 ### Chromatic shows unexpected visual changes
 

--- a/packages/summon/monorepo/src/templates/setup-env.yml.ejs
+++ b/packages/summon/monorepo/src/templates/setup-env.yml.ejs
@@ -1,5 +1,5 @@
 name: Setup environment
-description: Installs Bun and dependencies
+description: Installs Bun, restores caches, and installs dependencies
 
 inputs:
   bun-version:
@@ -13,6 +13,26 @@ runs:
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: ${{ inputs.bun-version }}
+
+    - name: Cache node_modules
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+    - name: Cache Bun global cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+    - name: Cache Nx
+      uses: actions/cache@v4
+      with:
+        path: .nx/cache
+        key: nx-cache-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          nx-cache-${{ runner.os }}-
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Done

- Add `actions/cache` for `node_modules/`, `~/.bun/install/cache/`, and `.nx/cache/` to `setup-env` composite action
- Use `--ignore-scripts` in CI `bun install` to skip the `prepare` hook (eliminates redundant full monorepo build on every job)
- Remove `build` gate job from `chromatic._template.yml` — check+test already enforced by `pr.yml` / `push.yml`
- Add explicit `bun run build` to `tag.yml` publish job (previously relied on `prepare` hook)
- Update `summon-monorepo` generator template (`setup-env.yml.ejs`) with caching
- Update `docs/ci.md` with caching section and reflect chromatic template changes
- Add ADR-001 (`docs/decisions/001-ci-install-build-reduction.md`)

## QA

- [ ] Push a PR touching a shared package (`packages/styles/` or `packages/utils/`). Verify `pr.yml` passes on both Node 22 and 24.
- [ ] Verify chromatic workflows publish successfully (single `publish-to-chromatic` job, no `build` gate job).
- [ ] Push a second commit to the same PR. Verify cache hits in Actions logs for `node_modules`, Bun cache, and Nx cache.
- [ ] Verify install time is under 30s on cache hit.
- [ ] Run `tag.yml` with `experimental` release type — all 3 jobs (build → version → publish) must pass.
- [ ] Verify `setup-git` and `lerna-version` actions are untouched.
- [ ] Run `summon monorepo --name=test-ci` and verify generated `setup-env` includes caching steps.

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [ ] The code follows the appropriate [code standards](https://github.com/canonical/code-standards) 
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. 

## Screenshots

N/A — CI-only changes, no visual impact.