### PR TITLE
feat(pragma): add graph-driven MCP resources (v0.2-D12)

### DIFF
--- a/packages/cli/pragma/src/constants.ts
+++ b/packages/cli/pragma/src/constants.ts
@@ -7,5 +7,23 @@ const VERSION = pkg.version;
 const VALID_CHANNELS = ["normal", "experimental", "prerelease"] as const;
 type Channel = (typeof VALID_CHANNELS)[number];
 
-export { PROGRAM_DESCRIPTION, PROGRAM_NAME, VALID_CHANNELS, VERSION };
+/**
+ * Maps namespace prefix → property URI used to fetch a human-readable label
+ * for instances in that namespace. Used by MCP resource handlers to resolve
+ * level-1 object relations to summaries.
+ */
+const LABEL_PROPERTY: Record<string, string> = {
+  ds: "https://ds.canonical.com/name",
+  cso: "http://pragma.canonical.com/codestandards#name",
+  rdfs: "http://www.w3.org/2000/01/rdf-schema#label",
+  owl: "http://www.w3.org/2000/01/rdf-schema#label",
+};
+
+export {
+  LABEL_PROPERTY,
+  PROGRAM_DESCRIPTION,
+  PROGRAM_NAME,
+  VALID_CHANNELS,
+  VERSION,
+};
 export type { Channel };

--- a/packages/cli/pragma/src/mcp/createMcpServer.test.ts
+++ b/packages/cli/pragma/src/mcp/createMcpServer.test.ts
@@ -28,4 +28,14 @@ describe("createMcpServer", () => {
       expect(tool.inputSchema.type).toBe("object");
     }
   });
+
+  it("creates a server with registered resources", async () => {
+    const { resources } = await client.listResources();
+    expect(resources.length).toBeGreaterThan(0);
+  });
+
+  it("creates a server with registered resource templates", async () => {
+    const { resourceTemplates } = await client.listResourceTemplates();
+    expect(resourceTemplates.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/cli/pragma/src/mcp/createMcpServer.ts
+++ b/packages/cli/pragma/src/mcp/createMcpServer.ts
@@ -2,13 +2,14 @@
  * MCP server factory.
  *
  * Boots the ke store, reads config, creates the McpServer,
- * and registers all tools. Returns the server ready for transport.
+ * and registers all tools and resources. Returns the server ready for transport.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { readConfig } from "../config.js";
 import { VERSION } from "../constants.js";
 import { bootStore } from "../domains/shared/bootStore.js";
+import registerResources from "./registerResources.js";
 import registerTools from "./registerTools.js";
 
 /**
@@ -26,5 +27,6 @@ export default async function createMcpServer(options?: {
     version: VERSION,
   });
   registerTools(server, store, config);
+  registerResources(server, store, config);
   return server;
 }

--- a/packages/cli/pragma/src/mcp/registerResources.test.ts
+++ b/packages/cli/pragma/src/mcp/registerResources.test.ts
@@ -1,0 +1,230 @@
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import createTestMcpClient from "../../testing/createTestMcpClient.js";
+
+let client: Client;
+let cleanup: () => Promise<void>;
+
+beforeAll(async () => {
+  const result = await createTestMcpClient();
+  client = result.client;
+  cleanup = result.cleanup;
+});
+
+afterAll(async () => {
+  await cleanup();
+});
+
+interface ResourceContent {
+  uri: string;
+  mimeType: string;
+  text: string;
+}
+
+function parseContents(result: { contents: unknown[] }): unknown {
+  const first = result.contents[0] as ResourceContent;
+  return JSON.parse(first.text);
+}
+
+// =============================================================================
+// Resource listing
+// =============================================================================
+
+describe("resource listing", () => {
+  it("registers 1 resource template", async () => {
+    const { resourceTemplates } = await client.listResourceTemplates();
+    expect(resourceTemplates).toHaveLength(1);
+    expect(resourceTemplates[0]?.uriTemplate).toBe("pragma:{+uri}");
+  });
+
+  it("lists resources including known entities", async () => {
+    const { resources } = await client.listResources();
+    const uris = resources.map((r) => r.uri);
+    expect(uris).toContain("pragma:ds:button");
+    expect(uris).toContain("pragma:ds:card");
+    expect(uris).toContain("pragma:ds:global");
+  });
+
+  it("lists OWL classes as resources", async () => {
+    const { resources } = await client.listResources();
+    const uris = resources.map((r) => r.uri);
+    expect(uris).toContain("pragma:ds:UIBlock");
+    expect(uris).toContain("pragma:ds:Component");
+  });
+
+  it("lists code standards as resources", async () => {
+    const { resources } = await client.listResources();
+    const uris = resources.map((r) => r.uri);
+    expect(uris).toContain("pragma:cso:react_folder");
+    expect(uris).toContain("pragma:cso:code_purity");
+  });
+
+  it("uses label as resource name when available", async () => {
+    const { resources } = await client.listResources();
+    const button = resources.find((r) => r.uri === "pragma:ds:button");
+    expect(button?.name).toBe("Button");
+  });
+});
+
+// =============================================================================
+// Read instances
+// =============================================================================
+
+describe("read component instance", () => {
+  it("returns entity with types and label", async () => {
+    const result = await client.readResource({
+      uri: "pragma:ds:button",
+    });
+    const entity = parseContents(result) as {
+      uri: string;
+      prefixed: string;
+      types: string[];
+      label: string | null;
+      properties: { predicate: string; values: unknown[] }[];
+    };
+    expect(entity.prefixed).toBe("ds:button");
+    expect(entity.types).toContain("ds:Component");
+    expect(entity.label).toBe("Button");
+  });
+
+  it("resolves level-1 URI objects to summaries", async () => {
+    const result = await client.readResource({
+      uri: "pragma:ds:button",
+    });
+    const entity = parseContents(result) as {
+      properties: {
+        predicate: string;
+        values: {
+          type: string;
+          uri?: string;
+          prefixed?: string;
+          label?: string | null;
+        }[];
+      }[];
+    };
+
+    const tierProp = entity.properties.find((p) => p.predicate === "ds:tier");
+    expect(tierProp).toBeDefined();
+    const tierValue = tierProp?.values[0];
+    expect(tierValue?.type).toBe("uri");
+    expect(tierValue?.prefixed).toBe("ds:global");
+  });
+
+  it("includes literal values", async () => {
+    const result = await client.readResource({
+      uri: "pragma:ds:button",
+    });
+    const entity = parseContents(result) as {
+      properties: {
+        predicate: string;
+        values: { type: string; value?: string }[];
+      }[];
+    };
+
+    const nameProp = entity.properties.find((p) => p.predicate === "ds:name");
+    expect(nameProp).toBeDefined();
+    expect(nameProp?.values[0]?.type).toBe("literal");
+    expect(nameProp?.values[0]?.value).toBe("Button");
+  });
+});
+
+// =============================================================================
+// Read OWL classes
+// =============================================================================
+
+describe("read OWL class", () => {
+  it("returns class with rdfs:label", async () => {
+    const result = await client.readResource({
+      uri: "pragma:ds:UIBlock",
+    });
+    const entity = parseContents(result) as {
+      types: string[];
+      label: string | null;
+      properties: {
+        predicate: string;
+        values: { type: string; value?: string }[];
+      }[];
+    };
+    expect(entity.types).toContain("owl:Class");
+    const labelProp = entity.properties.find(
+      (p) => p.predicate === "rdfs:label",
+    );
+    expect(labelProp?.values[0]?.value).toBe("UI Block");
+  });
+});
+
+// =============================================================================
+// Read code standards
+// =============================================================================
+
+describe("read code standard", () => {
+  it("returns standard with properties", async () => {
+    const result = await client.readResource({
+      uri: "pragma:cso:code_purity",
+    });
+    const entity = parseContents(result) as {
+      types: string[];
+      label: string | null;
+      properties: {
+        predicate: string;
+        values: { type: string; value?: string }[];
+      }[];
+    };
+    expect(entity.types).toContain("cso:CodeStandard");
+
+    const nameProp = entity.properties.find((p) => p.predicate === "cso:name");
+    expect(nameProp?.values[0]?.value).toBe("code/function/purity");
+
+    const doProp = entity.properties.find((p) => p.predicate === "cso:do");
+    expect(doProp).toBeDefined();
+    expect(doProp?.values.length).toBeGreaterThan(0);
+
+    const dontProp = entity.properties.find((p) => p.predicate === "cso:dont");
+    expect(dontProp).toBeDefined();
+  });
+});
+
+// =============================================================================
+// Read tiers
+// =============================================================================
+
+describe("read tier", () => {
+  it("returns tier with path and hierarchy", async () => {
+    const result = await client.readResource({
+      uri: "pragma:ds:apps_lxd",
+    });
+    const entity = parseContents(result) as {
+      types: string[];
+      properties: {
+        predicate: string;
+        values: { type: string; value?: string; prefixed?: string }[];
+      }[];
+    };
+    expect(entity.types).toContain("ds:Tier");
+
+    const pathProp = entity.properties.find(
+      (p) => p.predicate === "ds:tierPath",
+    );
+    expect(pathProp?.values[0]?.value).toBe("apps/lxd");
+
+    const parentProp = entity.properties.find(
+      (p) => p.predicate === "ds:parentTier",
+    );
+    expect(parentProp?.values[0]?.prefixed).toBe("ds:apps");
+  });
+});
+
+// =============================================================================
+// Error handling
+// =============================================================================
+
+describe("error handling", () => {
+  it("returns text/plain error for unknown entity", async () => {
+    const result = await client.readResource({
+      uri: "pragma:ds:nonexistent",
+    });
+    const first = result.contents[0] as ResourceContent;
+    expect(first.mimeType).toBe("text/plain");
+    expect(first.text).toContain("ENTITY_NOT_FOUND");
+  });
+});

--- a/packages/cli/pragma/src/mcp/registerResources.ts
+++ b/packages/cli/pragma/src/mcp/registerResources.ts
@@ -1,0 +1,287 @@
+/**
+ * MCP resource registration.
+ *
+ * Every subject URI in the ke graph becomes a discoverable MCP resource.
+ * Reading a resource returns the entity's properties with level-1 object
+ * relations resolved to summaries (label from LABEL_PROPERTY map).
+ *
+ * MR.01–MR.04 — graph-driven resources
+ */
+
+import type { Store } from "@canonical/ke";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { PragmaConfig } from "../config.js";
+import { LABEL_PROPERTY } from "../constants.js";
+import resolveUri from "../domains/graph/resolveUri.js";
+import { buildQuery } from "../domains/shared/buildQuery.js";
+import { PragmaError } from "../error/PragmaError.js";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface PropertyValueLiteral {
+  readonly type: "literal";
+  readonly value: string;
+  readonly datatype?: string;
+}
+
+interface PropertyValueUri {
+  readonly type: "uri";
+  readonly uri: string;
+  readonly prefixed: string;
+  readonly label: string | null;
+}
+
+type PropertyValue = PropertyValueLiteral | PropertyValueUri;
+
+interface PropertyGroup {
+  readonly predicate: string;
+  readonly values: PropertyValue[];
+}
+
+interface ResourceEntity {
+  readonly uri: string;
+  readonly prefixed: string;
+  readonly types: string[];
+  readonly label: string | null;
+  readonly properties: PropertyGroup[];
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/**
+ * Convert a full URI to its compact prefixed form (e.g. `ds:button`).
+ * Falls back to the full URI if no prefix matches.
+ */
+function compactUri(
+  fullUri: string,
+  prefixes: Readonly<Record<string, string>>,
+): string {
+  for (const [prefix, namespace] of Object.entries(prefixes)) {
+    if (fullUri.startsWith(namespace)) {
+      return `${prefix}:${fullUri.slice(namespace.length)}`;
+    }
+  }
+  return fullUri;
+}
+
+/**
+ * Determine the namespace prefix for a full URI.
+ */
+function findPrefix(
+  fullUri: string,
+  prefixes: Readonly<Record<string, string>>,
+): string | null {
+  for (const [prefix, namespace] of Object.entries(prefixes)) {
+    if (fullUri.startsWith(namespace)) return prefix;
+  }
+  return null;
+}
+
+/**
+ * Fetch the human-readable label for a URI using the LABEL_PROPERTY map.
+ */
+async function fetchLabel(
+  store: Store,
+  fullUri: string,
+  prefixes: Readonly<Record<string, string>>,
+): Promise<string | null> {
+  const prefix = findPrefix(fullUri, prefixes);
+  if (!prefix) return null;
+
+  const labelProp = LABEL_PROPERTY[prefix];
+  if (!labelProp) return null;
+
+  const result = await store.query(
+    buildQuery(`
+      SELECT ?label
+      WHERE { <${fullUri}> <${labelProp}> ?label }
+      LIMIT 1
+    `),
+  );
+
+  if (result.type === "select" && result.bindings.length > 0) {
+    return result.bindings[0]?.label ?? null;
+  }
+  return null;
+}
+
+/**
+ * Detect whether a SPARQL binding value is a URI or a literal.
+ * URIs start with http:// or https:// or are prefixed; literals are everything else.
+ */
+function isUri(value: string): boolean {
+  return (
+    value.startsWith("http://") ||
+    value.startsWith("https://") ||
+    value.startsWith("urn:")
+  );
+}
+
+/**
+ * Enumerate all distinct subject URIs in the graph.
+ */
+async function listAllSubjects(store: Store): Promise<string[]> {
+  const result = await store.query(
+    buildQuery("SELECT DISTINCT ?s WHERE { ?s ?p ?o } ORDER BY ?s"),
+  );
+
+  if (result.type !== "select") return [];
+  return result.bindings.map((b) => b.s ?? "").filter((s) => isUri(s));
+}
+
+/**
+ * Read a single entity: all its triples with level-1 object summaries.
+ */
+async function readEntity(
+  store: Store,
+  fullUri: string,
+  prefixes: Readonly<Record<string, string>>,
+): Promise<ResourceEntity> {
+  const result = await store.query(
+    buildQuery(`
+      SELECT ?p ?o
+      WHERE { <${fullUri}> ?p ?o }
+      ORDER BY ?p ?o
+    `),
+  );
+
+  if (result.type !== "select" || result.bindings.length === 0) {
+    throw PragmaError.notFound("entity", compactUri(fullUri, prefixes), {
+      recovery:
+        "Check the URI is correct. Run `pragma graph query` with a SELECT to find valid URIs.",
+    });
+  }
+
+  const types: string[] = [];
+  const groupMap = new Map<string, PropertyValue[]>();
+
+  for (const b of result.bindings) {
+    const predicate = b.p ?? "";
+    const object = b.o ?? "";
+
+    if (predicate === RDF_TYPE) {
+      types.push(compactUri(object, prefixes));
+      continue;
+    }
+
+    const compactPred = compactUri(predicate, prefixes);
+    const existing = groupMap.get(compactPred) ?? [];
+
+    if (isUri(object)) {
+      const label = await fetchLabel(store, object, prefixes);
+      existing.push({
+        type: "uri",
+        uri: object,
+        prefixed: compactUri(object, prefixes),
+        label,
+      });
+    } else {
+      existing.push({ type: "literal", value: object });
+    }
+
+    groupMap.set(compactPred, existing);
+  }
+
+  const label = await fetchLabel(store, fullUri, prefixes);
+
+  const properties: PropertyGroup[] = [...groupMap.entries()].map(
+    ([predicate, values]) => ({ predicate, values }),
+  );
+
+  return {
+    uri: fullUri,
+    prefixed: compactUri(fullUri, prefixes),
+    types,
+    label,
+    properties,
+  };
+}
+
+// =============================================================================
+// Registration
+// =============================================================================
+
+/**
+ * Register graph-driven MCP resources on the server.
+ */
+export default function registerResources(
+  server: McpServer,
+  store: Store,
+  _config: PragmaConfig,
+): void {
+  const prefixes = store.prefixes;
+
+  const template = new ResourceTemplate("pragma:{+uri}", {
+    list: async () => {
+      const subjects = await listAllSubjects(store);
+      const resources = await Promise.all(
+        subjects.map(async (fullUri) => {
+          const prefixed = compactUri(fullUri, prefixes);
+          const label = await fetchLabel(store, fullUri, prefixes);
+          return {
+            uri: `pragma:${prefixed}`,
+            name: label ?? prefixed,
+            mimeType: "application/json" as const,
+          };
+        }),
+      );
+      return { resources };
+    },
+    complete: {
+      uri: async (value) => {
+        const subjects = await listAllSubjects(store);
+        const compacted = subjects.map((s) => compactUri(s, prefixes));
+        return compacted.filter((p) =>
+          p.toLowerCase().startsWith(value.toLowerCase()),
+        );
+      },
+    },
+  });
+
+  server.registerResource(
+    "graph-entity",
+    template,
+    {
+      description:
+        "An entity in the pragma knowledge graph. Returns all properties with level-1 relation summaries.",
+      mimeType: "application/json",
+    },
+    async (url, variables) => {
+      try {
+        const prefixedUri = variables.uri as string;
+        const fullUri = resolveUri(prefixedUri, prefixes);
+        const entity = await readEntity(store, fullUri, prefixes);
+        return {
+          contents: [
+            {
+              uri: url.href,
+              mimeType: "application/json",
+              text: JSON.stringify(entity, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message =
+          error instanceof PragmaError
+            ? JSON.stringify({ code: error.code, message: error.message })
+            : String(error);
+        return {
+          contents: [
+            {
+              uri: url.href,
+              mimeType: "text/plain",
+              text: message,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/packages/cli/pragma/testing/createTestMcpClient.ts
+++ b/packages/cli/pragma/testing/createTestMcpClient.ts
@@ -7,6 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { PragmaConfig } from "../src/config.js";
+import registerResources from "../src/mcp/registerResources.js";
 import registerTools from "../src/mcp/registerTools.js";
 import { DS_ALL_TTL } from "./dsFixtures.js";
 import { createTestStore } from "./store.js";
@@ -14,7 +15,7 @@ import type { TestMcpClientResult } from "./types.js";
 
 /**
  * Create an in-process MCP client connected to a server with
- * all tools registered against a test store.
+ * all tools and resources registered against a test store.
  */
 export default async function createTestMcpClient(options?: {
   ttl?: string;
@@ -30,6 +31,7 @@ export default async function createTestMcpClient(options?: {
 
   const server = new McpServer({ name: "pragma-test", version: "0.0.0" });
   registerTools(server, store, config);
+  registerResources(server, store, config);
 
   const [serverTransport, clientTransport] =
     InMemoryTransport.createLinkedPair();


### PR DESCRIPTION
## Done

- **Graph-driven MCP resources** — every subject URI in the ke graph becomes a discoverable, readable MCP resource at `pragma:{prefix}:{localName}` (e.g. `pragma:ds:button`, `pragma:ds:UIBlock`, `pragma:cso:react_folder`)
- **`LABEL_PROPERTY` map** in `constants.ts` — maps each namespace prefix to its label property URI (`ds:name`, `cso:name`, `rdfs:label`) for resolving level-1 object relations to human-readable summaries
- **`registerResources.ts`** — single `ResourceTemplate` (`pragma:{+uri}`) with `list` callback (enumerates all graph subjects), `complete` callback (prefix-based autocompletion), and read handler (returns entity properties with URI objects resolved to `{ uri, prefixed, label }` summaries)
- **Wired into `createMcpServer.ts`** and **`createTestMcpClient.ts`**
- **12 integration tests** covering resource listing, instance reads, OWL class reads, code standard reads, tier reads, and error handling

Implements MR.01–MR.04 from `session/B.13.MCP_RESOURCES.md`, adapted to a graph-driven approach (every class and instance is a resource, no hand-curated statics/catalogs).

## QA

- `cd packages/cli/pragma && bun test src/mcp/registerResources.test.ts` — 12 tests pass
- `bun test src/mcp/` — all 64 MCP tests pass (0 regressions)
- `bunx tsc --noEmit` — clean
- `bunx biome check src/mcp/registerResources.ts` — clean

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.

## Screenshots

N/A — server-side MCP resource registration, no UI.