### PR TITLE
feat(pragma): add `pragma doctor` environment health check (v0.3-04)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -210,6 +210,7 @@
       },
       "dependencies": {
         "@canonical/cli-core": "workspace:*",
+        "@canonical/harnesses": "workspace:*",
         "@canonical/ke": "workspace:*",
         "@canonical/summon-component": "workspace:*",
         "@canonical/summon-core": "workspace:*",

--- a/packages/cli/pragma/package.json
+++ b/packages/cli/pragma/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@canonical/cli-core": "workspace:*",
+    "@canonical/harnesses": "workspace:*",
     "@canonical/ke": "workspace:*",
     "@canonical/summon-component": "workspace:*",
     "@canonical/summon-core": "workspace:*",

--- a/packages/cli/pragma/src/domains/doctor/commands/doctor.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/commands/doctor.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import doctorCommand from "./doctor.js";
+
+describe("doctorCommand", () => {
+  it("has path ['doctor']", () => {
+    expect(doctorCommand.path).toEqual(["doctor"]);
+  });
+
+  it("has a description", () => {
+    expect(doctorCommand.description).toBeTruthy();
+  });
+
+  it("has no parameters", () => {
+    expect(doctorCommand.parameters).toEqual([]);
+  });
+
+  it("has an execute function", () => {
+    expect(typeof doctorCommand.execute).toBe("function");
+  });
+});

--- a/packages/cli/pragma/src/domains/doctor/commands/doctor.ts
+++ b/packages/cli/pragma/src/domains/doctor/commands/doctor.ts
@@ -1,0 +1,45 @@
+/**
+ * `pragma doctor` command definition.
+ *
+ * Environment health check: validates Node version, pragma installation,
+ * config, ke store, shell completions, terrazzo-lsp, MCP, and skills.
+ *
+ * @note Impure — delegates to runChecks which performs filesystem and
+ * process checks.
+ * @see IN.07 in B.11.INSTALL
+ */
+
+import type { CommandContext } from "@canonical/cli-core";
+import {
+  type CommandDefinition,
+  type CommandResult,
+  createOutputResult,
+} from "@canonical/cli-core";
+import { selectFormatter } from "../../shared/formatters.js";
+import { doctorFormatters } from "../formatters/index.js";
+import { runChecks } from "../operations/index.js";
+
+const doctorCommand: CommandDefinition = {
+  path: ["doctor"],
+  description: "Check environment health",
+  parameters: [],
+  meta: {
+    examples: ["pragma doctor"],
+  },
+  execute: async (
+    _params: Record<string, unknown>,
+    ctx: CommandContext,
+  ): Promise<CommandResult> => {
+    const data = await runChecks({ cwd: ctx.cwd });
+
+    if (data.failed > 0) {
+      process.exitCode = 1;
+    }
+
+    return createOutputResult(data, {
+      plain: selectFormatter(ctx, doctorFormatters),
+    });
+  },
+};
+
+export default doctorCommand;

--- a/packages/cli/pragma/src/domains/doctor/commands/index.ts
+++ b/packages/cli/pragma/src/domains/doctor/commands/index.ts
@@ -1,0 +1,1 @@
+export { default as doctorCommand } from "./doctor.js";

--- a/packages/cli/pragma/src/domains/doctor/formatters/doctor.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/formatters/doctor.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { DoctorData } from "../operations/types.js";
+import formatters from "./doctor.js";
+
+const allPass: DoctorData = {
+  checks: [
+    { name: "Node version", status: "pass", detail: "v24.1.0" },
+    {
+      name: "pragma version",
+      status: "pass",
+      detail: "v0.18.0 (installed via bun, global)",
+    },
+    { name: "pragma.config.toml", status: "pass", detail: "found" },
+    {
+      name: "ke store",
+      status: "pass",
+      detail: "12,847 triples in 180ms",
+    },
+  ],
+  passed: 4,
+  failed: 0,
+  skipped: 0,
+};
+
+const mixed: DoctorData = {
+  checks: [
+    { name: "Node version", status: "pass", detail: "v24.1.0" },
+    {
+      name: "pragma.config.toml",
+      status: "fail",
+      detail: "not found",
+      remedy: "pragma config tier <tier>",
+    },
+    {
+      name: "terrazzo-lsp",
+      status: "skip",
+      detail: "no tokens.config.mjs found",
+    },
+    {
+      name: "Shell completions",
+      status: "fail",
+      detail: "not installed",
+      remedy: "pragma setup completions",
+    },
+  ],
+  passed: 1,
+  failed: 2,
+  skipped: 1,
+};
+
+describe("doctor formatters", () => {
+  describe("plain", () => {
+    it("renders passing checks with ✓", () => {
+      const output = formatters.plain(allPass);
+      expect(output).toContain("✓");
+      expect(output).toContain("Node version");
+      expect(output).toContain("v24.1.0");
+    });
+
+    it("renders failing checks with ✗ and remedies at the bottom", () => {
+      const output = formatters.plain(mixed);
+      expect(output).toContain("✗");
+      expect(output).toContain("pragma config tier <tier>");
+      expect(output).toContain("pragma setup completions");
+    });
+
+    it("renders skipped checks with ○", () => {
+      const output = formatters.plain(mixed);
+      expect(output).toContain("○");
+      expect(output).toContain("terrazzo-lsp");
+    });
+
+    it("does not render remedies section when all pass", () => {
+      const output = formatters.plain(allPass);
+      expect(output).not.toContain("Run ");
+    });
+  });
+
+  describe("llm", () => {
+    it("renders Markdown with ## Doctor heading", () => {
+      const output = formatters.llm(allPass);
+      expect(output).toContain("## Doctor");
+    });
+
+    it("renders checks as bullet list", () => {
+      const output = formatters.llm(allPass);
+      expect(output).toContain("- ✓ **Node version**: v24.1.0");
+    });
+
+    it("includes remedial section for failures", () => {
+      const output = formatters.llm(mixed);
+      expect(output).toContain("### Remedial");
+      expect(output).toContain("`pragma config tier <tier>`");
+      expect(output).toContain("`pragma setup completions`");
+    });
+  });
+
+  describe("json", () => {
+    it("returns valid JSON matching the data shape", () => {
+      const output = formatters.json(allPass);
+      const parsed = JSON.parse(output);
+      expect(parsed.passed).toBe(4);
+      expect(parsed.failed).toBe(0);
+      expect(parsed.checks).toHaveLength(4);
+    });
+
+    it("includes remedy fields for failed checks", () => {
+      const output = formatters.json(mixed);
+      const parsed = JSON.parse(output);
+      const failedChecks = parsed.checks.filter(
+        (c: { status: string }) => c.status === "fail",
+      );
+      expect(failedChecks).toHaveLength(2);
+      expect(failedChecks[0].remedy).toBeDefined();
+    });
+  });
+});

--- a/packages/cli/pragma/src/domains/doctor/formatters/doctor.ts
+++ b/packages/cli/pragma/src/domains/doctor/formatters/doctor.ts
@@ -1,0 +1,78 @@
+/**
+ * Formatters for `pragma doctor` output.
+ *
+ * Pure functions: DoctorData → string.
+ *
+ * @see IN.07 in B.11.INSTALL
+ */
+
+import chalk from "chalk";
+import type { Formatters } from "../../shared/formatters.js";
+import type { CheckResult, DoctorData } from "../operations/types.js";
+
+const STATUS_ICONS = {
+  pass: chalk.green("✓"),
+  fail: chalk.red("✗"),
+  skip: chalk.yellow("○"),
+} as const;
+
+function formatCheckPlain(check: CheckResult): string {
+  return `${STATUS_ICONS[check.status]} ${check.name} ${chalk.dim(check.detail)}`;
+}
+
+const formatters: Formatters<DoctorData> = {
+  plain(data) {
+    const lines: string[] = [];
+
+    for (const check of data.checks) {
+      lines.push(formatCheckPlain(check));
+    }
+
+    const remedies = data.checks.filter(
+      (c): c is CheckResult & { remedy: string } =>
+        c.status === "fail" && c.remedy !== undefined,
+    );
+
+    if (remedies.length > 0) {
+      lines.push("");
+      for (const r of remedies) {
+        lines.push(
+          `Run ${chalk.cyan(`\`${r.remedy}\``)} to fix ${chalk.dim(r.name)}.`,
+        );
+      }
+    }
+
+    return lines.join("\n");
+  },
+
+  llm(data) {
+    const lines: string[] = [];
+
+    lines.push("## Doctor");
+    lines.push("");
+
+    for (const check of data.checks) {
+      const icon =
+        check.status === "pass" ? "✓" : check.status === "fail" ? "✗" : "○";
+      lines.push(`- ${icon} **${check.name}**: ${check.detail}`);
+    }
+
+    const remedies = data.checks.filter((c) => c.status === "fail" && c.remedy);
+
+    if (remedies.length > 0) {
+      lines.push("");
+      lines.push("### Remedial");
+      for (const r of remedies) {
+        lines.push(`- \`${r.remedy}\``);
+      }
+    }
+
+    return lines.join("\n");
+  },
+
+  json(data) {
+    return JSON.stringify(data, null, 2);
+  },
+};
+
+export default formatters;

--- a/packages/cli/pragma/src/domains/doctor/formatters/index.ts
+++ b/packages/cli/pragma/src/domains/doctor/formatters/index.ts
@@ -1,0 +1,1 @@
+export { default as doctorFormatters } from "./doctor.js";

--- a/packages/cli/pragma/src/domains/doctor/index.ts
+++ b/packages/cli/pragma/src/domains/doctor/index.ts
@@ -1,0 +1,7 @@
+export { doctorCommand } from "./commands/index.js";
+export type {
+  CheckContext,
+  CheckResult,
+  DoctorData,
+} from "./operations/index.js";
+export { runChecks } from "./operations/index.js";

--- a/packages/cli/pragma/src/domains/doctor/operations/checks.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../configExists.js", () => ({
+  default: vi.fn(),
+}));
+vi.mock("../../shared/bootStore.js", () => ({
+  bootStore: vi.fn(),
+}));
+vi.mock("../../info/collectStoreSummary.js", () => ({
+  collectStoreSummary: vi.fn(),
+}));
+vi.mock("@canonical/harnesses", () => ({
+  detectHarnesses: vi.fn(),
+  readMcpConfig: vi.fn(),
+}));
+vi.mock("@canonical/task", () => ({
+  runTask: vi.fn((task: unknown) => task),
+}));
+
+import { detectHarnesses, readMcpConfig } from "@canonical/harnesses";
+import configExists from "../../../configExists.js";
+import { collectStoreSummary } from "../../info/collectStoreSummary.js";
+import { bootStore } from "../../shared/bootStore.js";
+import {
+  checkConfigFile,
+  checkKeStore,
+  checkMcpConfigured,
+  checkNodeVersion,
+  checkPragmaVersion,
+  checkShellCompletions,
+  checkSkillsSymlinked,
+  checkTerrazzo,
+} from "./checks.js";
+
+const ctx = { cwd: "/test/project" };
+
+describe("checkNodeVersion", () => {
+  it("passes for current Node version", async () => {
+    const result = await checkNodeVersion();
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain(process.versions.node);
+  });
+});
+
+describe("checkPragmaVersion", () => {
+  it("always passes and includes version", async () => {
+    const result = await checkPragmaVersion();
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("v");
+  });
+});
+
+describe("checkConfigFile", () => {
+  it("passes when config exists", async () => {
+    vi.mocked(configExists).mockReturnValue(true);
+    const result = await checkConfigFile(ctx);
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails with remedy when config missing", async () => {
+    vi.mocked(configExists).mockReturnValue(false);
+    const result = await checkConfigFile(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.remedy).toBeDefined();
+  });
+});
+
+describe("checkKeStore", () => {
+  it("passes when store boots and reports triple count", async () => {
+    const mockStore = {
+      query: vi.fn(),
+      dispose: vi.fn(),
+    };
+    vi.mocked(bootStore).mockResolvedValue(mockStore as never);
+    vi.mocked(collectStoreSummary).mockResolvedValue({
+      tripleCount: 12847,
+      graphNames: [],
+    });
+
+    const result = await checkKeStore(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("12,847");
+    expect(mockStore.dispose).toHaveBeenCalled();
+  });
+
+  it("fails when store boot throws", async () => {
+    vi.mocked(bootStore).mockRejectedValue(new Error("no data"));
+    const result = await checkKeStore(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.remedy).toBeDefined();
+  });
+});
+
+describe("checkShellCompletions", () => {
+  it("returns pass or fail without throwing", async () => {
+    const result = await checkShellCompletions();
+    expect(["pass", "fail"]).toContain(result.status);
+  });
+});
+
+describe("checkTerrazzo", () => {
+  it("skips when no tokens.config.mjs exists", async () => {
+    const result = await checkTerrazzo({ cwd: "/nonexistent/path" });
+    expect(result.status).toBe("skip");
+  });
+});
+
+describe("checkMcpConfigured", () => {
+  it("fails when no harnesses detected", async () => {
+    vi.mocked(detectHarnesses).mockReturnValue(Promise.resolve([]) as never);
+    const result = await checkMcpConfigured(ctx);
+    expect(result.status).toBe("fail");
+  });
+
+  it("passes when pragma is configured in a harness", async () => {
+    const harness = {
+      id: "claude-code",
+      name: "Claude Code",
+      configPath: () => "/test/.mcp.json",
+      skillsPath: () => "/test/.claude/skills",
+      detect: [],
+      version: "*",
+      configFormat: "json" as const,
+      mcpKey: "mcpServers",
+    };
+    vi.mocked(detectHarnesses).mockReturnValue(
+      Promise.resolve([
+        {
+          harness,
+          confidence: "high" as const,
+          configExists: true,
+          configPath: "/test/.mcp.json",
+        },
+      ]) as never,
+    );
+    vi.mocked(readMcpConfig).mockReturnValue(
+      Promise.resolve({
+        pragma: { command: "pragma", args: ["mcp"] },
+      }) as never,
+    );
+
+    const result = await checkMcpConfigured(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("Claude Code");
+  });
+});
+
+describe("checkSkillsSymlinked", () => {
+  it("skips when no harnesses detected", async () => {
+    vi.mocked(detectHarnesses).mockReturnValue(Promise.resolve([]) as never);
+    const result = await checkSkillsSymlinked(ctx);
+    expect(result.status).toBe("skip");
+  });
+});

--- a/packages/cli/pragma/src/domains/doctor/operations/checks.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks.ts
@@ -1,0 +1,286 @@
+/**
+ * Individual environment health checks for `pragma doctor`.
+ *
+ * Each function takes a CheckContext and returns a CheckResult.
+ * Grouped here since they are small, tightly related, and share the
+ * same shape.
+ *
+ * @note Impure — reads filesystem, spawns processes, boots store.
+ * @see IN.07 in B.11.INSTALL
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { DetectedHarness } from "@canonical/harnesses";
+import { detectHarnesses, readMcpConfig } from "@canonical/harnesses";
+import { runTask } from "@canonical/task";
+import configExists from "../../../configExists.js";
+import { VERSION } from "../../../constants.js";
+import { detectLocalInstall, detectPackageManager } from "../../../pm.js";
+import { collectStoreSummary } from "../../info/collectStoreSummary.js";
+import { bootStore } from "../../shared/bootStore.js";
+import type { CheckContext, CheckResult } from "./types.js";
+
+const MIN_NODE_MAJOR = 20;
+
+/**
+ * Check that Node.js version meets the minimum requirement.
+ */
+export async function checkNodeVersion(): Promise<CheckResult> {
+  const version = process.versions.node;
+  const major = Number.parseInt(version.split(".")[0] ?? "0", 10);
+
+  if (major >= MIN_NODE_MAJOR) {
+    return { name: "Node version", status: "pass", detail: `v${version}` };
+  }
+
+  return {
+    name: "Node version",
+    status: "fail",
+    detail: `v${version} (requires >= ${MIN_NODE_MAJOR})`,
+    remedy: `Install Node.js >= ${MIN_NODE_MAJOR}`,
+  };
+}
+
+/**
+ * Report pragma version, install method, and global/local status.
+ * Always passes — informational.
+ */
+export async function checkPragmaVersion(): Promise<CheckResult> {
+  const pm = detectPackageManager();
+  const localWarning = detectLocalInstall();
+  const scope = localWarning ? "local" : "global";
+
+  return {
+    name: "pragma version",
+    status: "pass",
+    detail: `v${VERSION} (installed via ${pm}, ${scope})`,
+  };
+}
+
+/**
+ * Check that pragma.config.toml exists in the working directory.
+ */
+export async function checkConfigFile(ctx: CheckContext): Promise<CheckResult> {
+  if (configExists(ctx.cwd)) {
+    return {
+      name: "pragma.config.toml",
+      status: "pass",
+      detail: "found",
+    };
+  }
+
+  return {
+    name: "pragma.config.toml",
+    status: "fail",
+    detail: "not found",
+    remedy: "pragma config tier <tier>",
+  };
+}
+
+/**
+ * Check that the ke store boots successfully, reporting triple count and
+ * boot time.
+ */
+export async function checkKeStore(ctx: CheckContext): Promise<CheckResult> {
+  const start = performance.now();
+  let store: Awaited<ReturnType<typeof bootStore>> | undefined;
+  try {
+    store = await bootStore({ cwd: ctx.cwd });
+    const summary = await collectStoreSummary(store);
+    const elapsed = Math.round(performance.now() - start);
+    return {
+      name: "ke store",
+      status: "pass",
+      detail: `${summary.tripleCount.toLocaleString()} triples in ${elapsed}ms`,
+    };
+  } catch {
+    return {
+      name: "ke store",
+      status: "fail",
+      detail: "failed to boot",
+      remedy:
+        "Ensure design system packages are installed: bun add -D @canonical/ds-global @canonical/code-standards",
+    };
+  } finally {
+    store?.dispose();
+  }
+}
+
+/**
+ * Check whether shell completions are sourced in the user's shell RC file.
+ */
+export async function checkShellCompletions(): Promise<CheckResult> {
+  const home = homedir();
+  const rcFiles = [
+    join(home, ".bashrc"),
+    join(home, ".zshrc"),
+    join(home, ".config", "fish", "config.fish"),
+  ];
+
+  for (const rcFile of rcFiles) {
+    try {
+      const content = readFileSync(rcFile, "utf-8");
+      if (content.includes("pragma")) {
+        return {
+          name: "Shell completions",
+          status: "pass",
+          detail: "installed",
+        };
+      }
+    } catch {
+      // File doesn't exist — continue
+    }
+  }
+
+  return {
+    name: "Shell completions",
+    status: "fail",
+    detail: "not installed",
+    remedy: "pragma setup completions",
+  };
+}
+
+/**
+ * Check that terrazzo-lsp is installed, but only if tokens.config.mjs exists
+ * in the working directory. Skipped otherwise.
+ */
+export async function checkTerrazzo(ctx: CheckContext): Promise<CheckResult> {
+  const configFile = join(ctx.cwd, "tokens.config.mjs");
+  if (!existsSync(configFile)) {
+    return {
+      name: "terrazzo-lsp",
+      status: "skip",
+      detail: "no tokens.config.mjs found",
+    };
+  }
+
+  try {
+    const { execSync } = await import("node:child_process");
+    execSync("which terrazzo-lsp", { stdio: "ignore" });
+    return {
+      name: "terrazzo-lsp",
+      status: "pass",
+      detail: "installed",
+    };
+  } catch {
+    return {
+      name: "terrazzo-lsp",
+      status: "fail",
+      detail: "not found",
+      remedy: "npm install -g @terrazzo/lsp",
+    };
+  }
+}
+
+/**
+ * Check that at least one AI harness has pragma configured as an MCP server.
+ */
+export async function checkMcpConfigured(
+  ctx: CheckContext,
+): Promise<CheckResult> {
+  let detected: DetectedHarness[];
+  try {
+    detected = await runTask(detectHarnesses(ctx.cwd));
+  } catch {
+    return {
+      name: "MCP configured",
+      status: "fail",
+      detail: "harness detection failed",
+      remedy: "pragma setup mcp",
+    };
+  }
+
+  if (detected.length === 0) {
+    return {
+      name: "MCP configured",
+      status: "fail",
+      detail: "no AI harnesses detected",
+      remedy: "pragma setup mcp",
+    };
+  }
+
+  const configured: string[] = [];
+  for (const d of detected) {
+    if (!d.configExists) continue;
+    try {
+      const servers = await runTask(readMcpConfig(d.harness, ctx.cwd));
+      if ("pragma" in servers) {
+        configured.push(d.harness.name);
+      }
+    } catch {
+      // Config unreadable — skip
+    }
+  }
+
+  if (configured.length > 0) {
+    return {
+      name: "MCP configured",
+      status: "pass",
+      detail: configured.join(", "),
+    };
+  }
+
+  const names = detected.map((d) => d.harness.name).join(", ");
+  return {
+    name: "MCP configured",
+    status: "fail",
+    detail: `detected ${names} but pragma not configured`,
+    remedy: "pragma setup mcp",
+  };
+}
+
+/**
+ * Check that skills are symlinked for detected harnesses.
+ */
+export async function checkSkillsSymlinked(
+  ctx: CheckContext,
+): Promise<CheckResult> {
+  let detected: DetectedHarness[];
+  try {
+    detected = await runTask(detectHarnesses(ctx.cwd));
+  } catch {
+    return {
+      name: "Skills symlinked",
+      status: "fail",
+      detail: "harness detection failed",
+      remedy: "pragma setup skills",
+    };
+  }
+
+  if (detected.length === 0) {
+    return {
+      name: "Skills symlinked",
+      status: "skip",
+      detail: "no AI harnesses detected",
+    };
+  }
+
+  const linked: string[] = [];
+  const missing: string[] = [];
+
+  for (const d of detected) {
+    const skillsPath = d.harness.skillsPath(ctx.cwd);
+    if (existsSync(skillsPath)) {
+      linked.push(d.harness.name);
+    } else {
+      missing.push(d.harness.name);
+    }
+  }
+
+  if (missing.length === 0) {
+    return {
+      name: "Skills symlinked",
+      status: "pass",
+      detail: linked.join(", "),
+    };
+  }
+
+  return {
+    name: "Skills symlinked",
+    status: "fail",
+    detail: `missing for ${missing.join(", ")}`,
+    remedy: "pragma setup skills",
+  };
+}

--- a/packages/cli/pragma/src/domains/doctor/operations/index.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/index.ts
@@ -1,0 +1,2 @@
+export { default as runChecks } from "./runChecks.js";
+export type { CheckContext, CheckResult, DoctorData } from "./types.js";

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./checks.js", () => ({
+  checkNodeVersion: vi.fn(),
+  checkPragmaVersion: vi.fn(),
+  checkConfigFile: vi.fn(),
+  checkKeStore: vi.fn(),
+  checkShellCompletions: vi.fn(),
+  checkTerrazzo: vi.fn(),
+  checkMcpConfigured: vi.fn(),
+  checkSkillsSymlinked: vi.fn(),
+}));
+
+import {
+  checkConfigFile,
+  checkKeStore,
+  checkMcpConfigured,
+  checkNodeVersion,
+  checkPragmaVersion,
+  checkShellCompletions,
+  checkSkillsSymlinked,
+  checkTerrazzo,
+} from "./checks.js";
+import runChecks from "./runChecks.js";
+
+const pass = (name: string) => ({
+  name,
+  status: "pass" as const,
+  detail: "ok",
+});
+const fail = (name: string) => ({
+  name,
+  status: "fail" as const,
+  detail: "bad",
+  remedy: "fix it",
+});
+const skip = (name: string) => ({
+  name,
+  status: "skip" as const,
+  detail: "skipped",
+});
+
+describe("runChecks", () => {
+  it("returns correct counts when all pass", async () => {
+    vi.mocked(checkNodeVersion).mockResolvedValue(pass("Node"));
+    vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
+    vi.mocked(checkConfigFile).mockResolvedValue(pass("config"));
+    vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
+    vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
+    vi.mocked(checkTerrazzo).mockResolvedValue(pass("terrazzo"));
+    vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
+
+    const data = await runChecks({ cwd: "/test" });
+    expect(data.passed).toBe(8);
+    expect(data.failed).toBe(0);
+    expect(data.skipped).toBe(0);
+    expect(data.checks).toHaveLength(8);
+  });
+
+  it("counts failures and skips correctly", async () => {
+    vi.mocked(checkNodeVersion).mockResolvedValue(pass("Node"));
+    vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
+    vi.mocked(checkConfigFile).mockResolvedValue(fail("config"));
+    vi.mocked(checkKeStore).mockResolvedValue(fail("store"));
+    vi.mocked(checkShellCompletions).mockResolvedValue(fail("completions"));
+    vi.mocked(checkTerrazzo).mockResolvedValue(skip("terrazzo"));
+    vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkSkillsSymlinked).mockResolvedValue(skip("skills"));
+
+    const data = await runChecks({ cwd: "/test" });
+    expect(data.passed).toBe(3);
+    expect(data.failed).toBe(3);
+    expect(data.skipped).toBe(2);
+  });
+
+  it("preserves check order", async () => {
+    vi.mocked(checkNodeVersion).mockResolvedValue(pass("Node"));
+    vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
+    vi.mocked(checkConfigFile).mockResolvedValue(pass("config"));
+    vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
+    vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
+    vi.mocked(checkTerrazzo).mockResolvedValue(pass("terrazzo"));
+    vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
+
+    const data = await runChecks({ cwd: "/test" });
+    expect(data.checks[0].name).toBe("Node");
+    expect(data.checks[1].name).toBe("pragma");
+    expect(data.checks[2].name).toBe("config");
+    expect(data.checks[3].name).toBe("store");
+    expect(data.checks[7].name).toBe("skills");
+  });
+});

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
@@ -1,0 +1,42 @@
+/**
+ * Orchestrate all environment health checks for `pragma doctor`.
+ *
+ * Runs checks sequentially (order matters for display) and collects
+ * results into a DoctorData summary.
+ *
+ * @note Impure — delegates to individual check functions.
+ * @see IN.07 in B.11.INSTALL
+ */
+
+import {
+  checkConfigFile,
+  checkKeStore,
+  checkMcpConfigured,
+  checkNodeVersion,
+  checkPragmaVersion,
+  checkShellCompletions,
+  checkSkillsSymlinked,
+  checkTerrazzo,
+} from "./checks.js";
+import type { CheckContext, CheckResult, DoctorData } from "./types.js";
+
+export default async function runChecks(
+  ctx: CheckContext,
+): Promise<DoctorData> {
+  const checks: CheckResult[] = [];
+
+  checks.push(await checkNodeVersion());
+  checks.push(await checkPragmaVersion());
+  checks.push(await checkConfigFile(ctx));
+  checks.push(await checkKeStore(ctx));
+  checks.push(await checkShellCompletions());
+  checks.push(await checkTerrazzo(ctx));
+  checks.push(await checkMcpConfigured(ctx));
+  checks.push(await checkSkillsSymlinked(ctx));
+
+  const passed = checks.filter((c) => c.status === "pass").length;
+  const failed = checks.filter((c) => c.status === "fail").length;
+  const skipped = checks.filter((c) => c.status === "skip").length;
+
+  return { checks, passed, failed, skipped };
+}

--- a/packages/cli/pragma/src/domains/doctor/operations/types.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Types for the doctor domain.
+ *
+ * @see IN.07 in B.11.INSTALL
+ */
+
+export interface CheckResult {
+  readonly name: string;
+  readonly status: "pass" | "fail" | "skip";
+  readonly detail: string;
+  readonly remedy?: string;
+}
+
+export interface CheckContext {
+  readonly cwd: string;
+}
+
+export interface DoctorData {
+  readonly checks: readonly CheckResult[];
+  readonly passed: number;
+  readonly failed: number;
+  readonly skipped: number;
+}

--- a/packages/cli/pragma/src/index.ts
+++ b/packages/cli/pragma/src/index.ts
@@ -174,6 +174,18 @@ export { resolveAddConfig } from "./domains/token/operations/index.js";
 export { commands as createCommands } from "./domains/create/index.js";
 
 // =============================================================================
+// v0.3-04 — Doctor
+// =============================================================================
+
+export { doctorCommand } from "./domains/doctor/commands/index.js";
+export type {
+  CheckContext,
+  CheckResult,
+  DoctorData,
+} from "./domains/doctor/operations/index.js";
+export { runChecks } from "./domains/doctor/operations/index.js";
+
+// =============================================================================
 // D11 — MCP Adapter
 // =============================================================================
 

--- a/packages/cli/pragma/src/lib/runCli.ts
+++ b/packages/cli/pragma/src/lib/runCli.ts
@@ -12,6 +12,7 @@ import { PROGRAM_DESCRIPTION, PROGRAM_NAME, VERSION } from "../constants.js";
 import { commands as componentCommands } from "../domains/component/index.js";
 import { commands as configCommands } from "../domains/config/index.js";
 import { commands as createCommands } from "../domains/create/index.js";
+import { doctorCommand } from "../domains/doctor/commands/index.js";
 import infoCommand from "../domains/info/infoCommand.js";
 import upgradeCommand from "../domains/info/upgradeCommand.js";
 import { commands as modifierCommands } from "../domains/modifier/index.js";
@@ -38,6 +39,7 @@ function collectCommands(ctx: PragmaContext): CommandDefinition[] {
     ...tierCommands(ctx),
     ...tokenCommands(ctx),
     ...componentCommands(ctx),
+    doctorCommand,
     infoCommand,
     upgradeCommand,
   ];
@@ -111,6 +113,21 @@ function renderError(error: PragmaError, flags: GlobalFlags): string {
 
 async function runCli(argv: readonly string[]): Promise<void> {
   const globalFlags = parseGlobalFlags(argv);
+
+  // Doctor runs before store boot — it validates the environment itself.
+  const commandArg = argv.slice(2).find((a) => !a.startsWith("-"));
+  if (commandArg === "doctor") {
+    const { doctorCommand } = await import(
+      "../domains/doctor/commands/index.js"
+    );
+    const ctx = { cwd: process.cwd(), globalFlags };
+    const result = await doctorCommand.execute({}, ctx);
+    if (result.tag === "output") {
+      const render = result.render.plain;
+      process.stdout.write(`${render(result.value)}\n`);
+    }
+    return;
+  }
 
   let cwd: string;
   let config: FilterConfig;


### PR DESCRIPTION
## Done

- New `doctor` domain following DOMAIN_STRUCTURE.md conventions (commands/, operations/, formatters/ with barrels)
- 8 sequential health checks: Node version, pragma version + install method, pragma.config.toml existence, ke store boot (timed with triple count), shell completions, terrazzo-lsp (conditional on tokens.config.mjs), MCP harness configuration, skills symlinks
- Three output modes: plain (chalk ✓/✗/○), llm (Markdown), json (structured)
- Remedial commands shown at the bottom for all failed checks
- Intercepted in `runCli.ts` before store boot so `pragma doctor` works even when the store fails
- Added `@canonical/harnesses` and `@canonical/task` as dependencies
- 27 new tests (checks unit tests, orchestrator tests, formatter tests, command wiring tests)
- Drive-by: fix `registerResources.ts` import path for `resolveUri` (moved to `helpers/` in domain structure refactor)

Fixes v0.3-04 in B.SEQUENCE.md (decision IN.07)

## QA

- `pragma doctor` — verify ✓/✗ output with remedial commands
- `pragma doctor --llm` — verify Markdown output
- `pragma doctor --format json` — verify structured JSON
- Run with missing config file to verify ✗ check + remedy
- Run in env where store fails to verify doctor still executes

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.