### PR TITLE
feat(pragma): add completions server (v0.2-D10)

### DIFF
--- a/packages/cli/pragma/src/completions/computeSocketPath.test.ts
+++ b/packages/cli/pragma/src/completions/computeSocketPath.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import computeSocketPath from "./computeSocketPath.js";
+
+describe("computeSocketPath", () => {
+  it("returns a path starting with the socket prefix", () => {
+    const path = computeSocketPath("/home/user/project");
+    expect(path).toMatch(/^\/tmp\/pragma-completions-/);
+  });
+
+  it("returns a path ending with .sock", () => {
+    const path = computeSocketPath("/home/user/project");
+    expect(path).toMatch(/\.sock$/);
+  });
+
+  it("is deterministic — same cwd produces same path", () => {
+    const a = computeSocketPath("/home/user/project");
+    const b = computeSocketPath("/home/user/project");
+    expect(a).toBe(b);
+  });
+
+  it("produces different paths for different cwds", () => {
+    const a = computeSocketPath("/home/user/project-a");
+    const b = computeSocketPath("/home/user/project-b");
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/cli/pragma/src/completions/computeSocketPath.ts
+++ b/packages/cli/pragma/src/completions/computeSocketPath.ts
@@ -1,0 +1,8 @@
+import { createHash } from "node:crypto";
+import { SOCKET_PREFIX } from "./constants.js";
+
+/** Compute the Unix domain socket path for a project's completions server. */
+export default function computeSocketPath(cwd: string): string {
+  const hash = createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+  return `${SOCKET_PREFIX}${hash}.sock`;
+}

--- a/packages/cli/pragma/src/completions/constants.ts
+++ b/packages/cli/pragma/src/completions/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Completions server constants.
+ *
+ * Shared by both the server (idle timeout, socket naming) and
+ * client (poll timing, spawn timeout) sides of the completions system.
+ */
+
+export const IDLE_TIMEOUT_MS = 10_000;
+export const SOCKET_PREFIX = "/tmp/pragma-completions-";
+export const POLL_INTERVAL_MS = 50;
+export const SPAWN_TIMEOUT_MS = 5_000;

--- a/packages/cli/pragma/src/completions/handleQuery.test.ts
+++ b/packages/cli/pragma/src/completions/handleQuery.test.ts
@@ -1,0 +1,97 @@
+import type {
+  CommandContext,
+  CommandDefinition,
+  CompletionTree,
+} from "@canonical/cli-core";
+import { buildCompleters, createExitResult } from "@canonical/cli-core";
+import { describe, expect, it } from "vitest";
+import handleQuery from "./handleQuery.js";
+
+const ctx: CommandContext = {
+  cwd: "/test",
+  globalFlags: { llm: false, format: "text", verbose: false },
+};
+
+function makeTree(): CompletionTree {
+  const commands: CommandDefinition[] = [
+    {
+      path: ["component", "list"],
+      description: "List components",
+      parameters: [],
+      execute: async () => createExitResult(0),
+    },
+    {
+      path: ["component", "get"],
+      description: "Get component details",
+      parameters: [
+        {
+          name: "name",
+          description: "Component name",
+          type: "string",
+          positional: true,
+          required: true,
+          complete: async (partial) => {
+            const names = ["Button", "Card", "Modal"];
+            return names.filter((n) =>
+              n.toLowerCase().startsWith(partial.toLowerCase()),
+            );
+          },
+        },
+      ],
+      execute: async () => createExitResult(0),
+    },
+    {
+      path: ["standard", "list"],
+      description: "List standards",
+      parameters: [],
+      execute: async () => createExitResult(0),
+    },
+  ];
+  return buildCompleters(commands);
+}
+
+describe("handleQuery", () => {
+  it("returns all nouns for empty input", async () => {
+    const result = await handleQuery("", makeTree(), ctx);
+    expect(result).toBe("component\nstandard");
+  });
+
+  it("returns filtered nouns for partial input", async () => {
+    const result = await handleQuery("com", makeTree(), ctx);
+    expect(result).toBe("component");
+  });
+
+  it("returns all verbs when noun is complete with trailing space", async () => {
+    const result = await handleQuery("component ", makeTree(), ctx);
+    expect(result).toBe("get\nlist");
+  });
+
+  it("returns filtered verbs for partial verb", async () => {
+    const result = await handleQuery("component g", makeTree(), ctx);
+    expect(result).toBe("get");
+  });
+
+  it("invokes level 3 completer for argument completion", async () => {
+    const result = await handleQuery("component get Bu", makeTree(), ctx);
+    expect(result).toBe("Button");
+  });
+
+  it("returns all level 3 candidates for empty argument partial", async () => {
+    const result = await handleQuery("component get ", makeTree(), ctx);
+    expect(result).toBe("Button\nCard\nModal");
+  });
+
+  it("returns empty string for unknown noun", async () => {
+    const result = await handleQuery("unknown verb", makeTree(), ctx);
+    expect(result).toBe("");
+  });
+
+  it("returns empty string for verb with no completers", async () => {
+    const result = await handleQuery(
+      "component list something",
+      makeTree(),
+      ctx,
+    );
+    expect(result).toBe("");
+  });
+});

--- a/packages/cli/pragma/src/completions/handleQuery.ts
+++ b/packages/cli/pragma/src/completions/handleQuery.ts
@@ -1,0 +1,23 @@
+import type { CommandContext, CompletionTree } from "@canonical/cli-core";
+import { resolveCompletion } from "@canonical/cli-core";
+
+/**
+ * Resolve a partial CLI input against a completion tree and return
+ * newline-separated candidates.
+ *
+ * Splits the partial into words, delegates to resolveCompletion for
+ * level detection (noun/verb/argument), invokes the matched completer,
+ * and joins the results with newlines. Returns an empty string when
+ * no completer matches.
+ */
+export default async function handleQuery(
+  partial: string,
+  tree: CompletionTree,
+  ctx: CommandContext,
+): Promise<string> {
+  const words = partial.length === 0 ? [""] : partial.split(" ");
+  const result = resolveCompletion(tree, words);
+  if (!result.completer) return "";
+  const candidates = await result.completer(result.partial, ctx);
+  return candidates.join("\n");
+}

--- a/packages/cli/pragma/src/completions/index.ts
+++ b/packages/cli/pragma/src/completions/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Completions server public API.
+ *
+ * Exports the server entry point, client entry point, socket path
+ * computation, and query handler for use by runCli and the pragma
+ * package barrel.
+ */
+
+export { default as computeSocketPath } from "./computeSocketPath.js";
+export { default as handleQuery } from "./handleQuery.js";
+export { default as queryCompletions } from "./queryCompletions.js";
+export { default as startCompletionsServer } from "./startCompletionsServer.js";

--- a/packages/cli/pragma/src/completions/queryCompletions.ts
+++ b/packages/cli/pragma/src/completions/queryCompletions.ts
@@ -1,0 +1,60 @@
+/**
+ * Client entry point for shell tab completion.
+ *
+ * Checks for a running completions server, spawns one if absent,
+ * connects via Unix socket, and prints candidates to stdout.
+ * Designed to be called by `pragma --completions <partial>`.
+ * Fails silently on error — shell completion must never block the terminal.
+ *
+ * @note Impure — spawns processes, connects to sockets, writes to stdout.
+ */
+
+import { existsSync, unlinkSync } from "node:fs";
+import { resolve } from "node:path";
+import computeSocketPath from "./computeSocketPath.js";
+import { SPAWN_TIMEOUT_MS } from "./constants.js";
+import querySocket from "./querySocket.js";
+import waitForSocket from "./waitForSocket.js";
+
+export default async function queryCompletions(partial: string): Promise<void> {
+  const socketPath = computeSocketPath(process.cwd());
+
+  // Try an existing server first.
+  if (existsSync(socketPath)) {
+    try {
+      const response = await querySocket(socketPath, partial);
+      if (response.length > 0) {
+        process.stdout.write(`${response}\n`);
+      }
+      return;
+    } catch {
+      // Stale socket from a crashed server — clean up and spawn fresh.
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Socket may have been removed concurrently.
+      }
+    }
+  }
+
+  // No running server — spawn one.
+  const binPath = resolve(import.meta.dirname, "../bin.ts");
+  Bun.spawn(["bun", "run", binPath, "_completions-server"], {
+    stdio: ["ignore", "ignore", "ignore"],
+    cwd: process.cwd(),
+  });
+
+  const ready = await waitForSocket(socketPath, SPAWN_TIMEOUT_MS);
+  if (!ready) {
+    return;
+  }
+
+  try {
+    const response = await querySocket(socketPath, partial);
+    if (response.length > 0) {
+      process.stdout.write(`${response}\n`);
+    }
+  } catch {
+    // Silent — shell completion must never signal failure.
+  }
+}

--- a/packages/cli/pragma/src/completions/querySocket.ts
+++ b/packages/cli/pragma/src/completions/querySocket.ts
@@ -1,0 +1,41 @@
+/**
+ * Connect to a Unix domain socket, send a partial string, and
+ * collect the response.
+ *
+ * Opens a Bun TCP connection to the socket, writes the partial
+ * terminated by a newline, and accumulates response chunks until
+ * the server closes the connection. The newline ensures the
+ * server's data handler fires even for an empty partial.
+ *
+ * @note Impure — opens a Unix socket connection, performs I/O.
+ */
+export default function querySocket(
+  socketPath: string,
+  partial: string,
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    Bun.connect({
+      unix: socketPath,
+      socket: {
+        open(socket) {
+          socket.write(`${partial}\n`);
+          socket.flush();
+        },
+        data(_socket, data) {
+          chunks.push(Buffer.from(data));
+        },
+        close() {
+          resolve(
+            Buffer.concat(chunks)
+              .toString("utf-8")
+              .replace(/\r?\n$/, ""),
+          );
+        },
+        error(_socket, err) {
+          reject(err);
+        },
+      },
+    }).catch(reject);
+  });
+}

--- a/packages/cli/pragma/src/completions/startCompletionsServer.test.ts
+++ b/packages/cli/pragma/src/completions/startCompletionsServer.test.ts
@@ -1,0 +1,74 @@
+import { spawn } from "node:child_process";
+import { unlinkSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import computeSocketPath from "./computeSocketPath.js";
+import waitForSocket from "./waitForSocket.js";
+
+const hasBun = typeof globalThis.Bun !== "undefined";
+
+const BIN_PATH = resolve(import.meta.dirname, "../bin.ts");
+const cwd = process.cwd();
+const socketPath = computeSocketPath(cwd);
+
+function cleanSocket(): void {
+  try {
+    unlinkSync(socketPath);
+  } catch {
+    // May not exist.
+  }
+}
+
+afterEach(() => {
+  cleanSocket();
+});
+
+describe.skipIf(!hasBun)("startCompletionsServer", () => {
+  it("starts, accepts a query, and returns noun completions", async () => {
+    cleanSocket();
+
+    const { default: querySocket } = await import("./querySocket.js");
+
+    const server = spawn("bun", ["run", BIN_PATH, "_completions-server"], {
+      stdio: "ignore",
+      cwd,
+      detached: true,
+    });
+
+    try {
+      const ready = await waitForSocket(socketPath, 10_000);
+      expect(ready).toBe(true);
+
+      const result = await querySocket(socketPath, "");
+      expect(result).toContain("component");
+      expect(result).toContain("standard");
+    } finally {
+      server.kill();
+      cleanSocket();
+    }
+  }, 15_000);
+
+  it("returns verb completions for a noun with trailing space", async () => {
+    cleanSocket();
+
+    const { default: querySocket } = await import("./querySocket.js");
+
+    const server = spawn("bun", ["run", BIN_PATH, "_completions-server"], {
+      stdio: "ignore",
+      cwd,
+      detached: true,
+    });
+
+    try {
+      const ready = await waitForSocket(socketPath, 10_000);
+      expect(ready).toBe(true);
+
+      const result = await querySocket(socketPath, "component ");
+      expect(result).toContain("list");
+      expect(result).toContain("get");
+    } finally {
+      server.kill();
+      cleanSocket();
+    }
+  }, 15_000);
+});

--- a/packages/cli/pragma/src/completions/startCompletionsServer.ts
+++ b/packages/cli/pragma/src/completions/startCompletionsServer.ts
@@ -1,0 +1,84 @@
+/**
+ * Boot a ke-backed completions server on a Unix domain socket.
+ *
+ * Reads config, boots the ke store (with cache), builds the completion
+ * tree from all registered commands, and listens on a project-scoped
+ * Unix domain socket. Auto-exits after 10 seconds of idle. Each
+ * incoming query resets the idle timer.
+ *
+ * @note Impure — boots ke store, binds Unix socket, manages process lifecycle.
+ */
+
+import { existsSync, unlinkSync } from "node:fs";
+import type { GlobalFlags } from "@canonical/cli-core";
+import { buildCompleters } from "@canonical/cli-core";
+import { readConfig } from "../config.js";
+import { bootStore } from "../domains/shared/bootStore.js";
+import type { PragmaContext } from "../domains/shared/context.js";
+import type { FilterConfig } from "../domains/shared/types.js";
+import { collectCommands } from "../lib/runCli.js";
+import computeSocketPath from "./computeSocketPath.js";
+import { IDLE_TIMEOUT_MS } from "./constants.js";
+import handleQuery from "./handleQuery.js";
+
+export default async function startCompletionsServer(): Promise<void> {
+  const cwd = process.cwd();
+  const rawConfig = readConfig();
+  const config: FilterConfig = {
+    tier: rawConfig.tier,
+    channel: rawConfig.channel,
+  };
+  const globalFlags: GlobalFlags = {
+    llm: false,
+    format: "text",
+    verbose: false,
+  };
+
+  const store = await bootStore({ cwd });
+
+  const ctx: PragmaContext = { cwd, globalFlags, store, config };
+  const commands = collectCommands(ctx);
+  const tree = buildCompleters(commands);
+
+  const socketPath = computeSocketPath(cwd);
+
+  if (existsSync(socketPath)) {
+    unlinkSync(socketPath);
+  }
+
+  let idleTimer: Timer;
+
+  function resetIdle(): void {
+    clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      store.dispose();
+      server.stop();
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Socket may already be removed.
+      }
+      process.exit(0);
+    }, IDLE_TIMEOUT_MS);
+  }
+
+  const server = Bun.listen({
+    unix: socketPath,
+    socket: {
+      async data(socket, rawData) {
+        resetIdle();
+        const partial = Buffer.from(rawData)
+          .toString("utf-8")
+          .replace(/\n$/, "");
+        const result = await handleQuery(partial, tree, ctx);
+        socket.write(result);
+        socket.end();
+      },
+      open() {},
+      close() {},
+      error() {},
+    },
+  });
+
+  resetIdle();
+}

--- a/packages/cli/pragma/src/completions/waitForSocket.test.ts
+++ b/packages/cli/pragma/src/completions/waitForSocket.test.ts
@@ -1,0 +1,27 @@
+import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import waitForSocket from "./waitForSocket.js";
+
+describe("waitForSocket", () => {
+  it("returns true immediately when file exists", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pragma-ws-"));
+    const path = join(dir, "test.sock");
+    writeFileSync(path, "");
+
+    try {
+      const result = await waitForSocket(path, 1_000);
+      expect(result).toBe(true);
+    } finally {
+      unlinkSync(path);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false after timeout when file does not exist", async () => {
+    const path = "/tmp/pragma-test-nonexistent-socket.sock";
+    const result = await waitForSocket(path, 200);
+    expect(result).toBe(false);
+  });
+});

--- a/packages/cli/pragma/src/completions/waitForSocket.ts
+++ b/packages/cli/pragma/src/completions/waitForSocket.ts
@@ -1,0 +1,23 @@
+import { existsSync } from "node:fs";
+import { setTimeout } from "node:timers/promises";
+import { POLL_INTERVAL_MS } from "./constants.js";
+
+/**
+ * Poll for a Unix socket file to appear on disk.
+ *
+ * Checks at POLL_INTERVAL_MS intervals until the file exists or
+ * timeoutMs elapses. Returns true if the socket appeared, false on timeout.
+ *
+ * @note Impure — reads filesystem, sleeps between polls.
+ */
+export default async function waitForSocket(
+  path: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (existsSync(path)) return true;
+    await setTimeout(POLL_INTERVAL_MS);
+  }
+  return false;
+}

--- a/packages/cli/pragma/src/index.ts
+++ b/packages/cli/pragma/src/index.ts
@@ -224,3 +224,12 @@ export { default as createMcpServer } from "./mcp/createMcpServer.js";
 export { default as registerTools } from "./mcp/registerTools.js";
 export { default as serializeError } from "./mcp/serializeError.js";
 export type { McpErrorPayload, McpRecovery } from "./mcp/types.js";
+
+// =============================================================================
+// D10 — Completions Server
+// =============================================================================
+
+export { default as computeSocketPath } from "./completions/computeSocketPath.js";
+export { default as handleQuery } from "./completions/handleQuery.js";
+export { default as queryCompletions } from "./completions/queryCompletions.js";
+export { default as startCompletionsServer } from "./completions/startCompletionsServer.js";

--- a/packages/cli/pragma/src/lib/runCli.ts
+++ b/packages/cli/pragma/src/lib/runCli.ts
@@ -120,8 +120,30 @@ function renderError(error: PragmaError, flags: GlobalFlags): string {
 async function runCli(argv: readonly string[]): Promise<void> {
   const globalFlags = parseGlobalFlags(argv);
 
-  // Doctor runs before store boot — it validates the environment itself.
+  // Completions client — intercept before store boot.
+  // The client manages server lifecycle independently.
+  const completionsIdx = argv.indexOf("--completions");
+  if (completionsIdx !== -1) {
+    const partial = argv.slice(completionsIdx + 1).join(" ");
+    const { default: queryCompletions } = await import(
+      "../completions/queryCompletions.js"
+    );
+    await queryCompletions(partial);
+    return;
+  }
+
   const commandArg = argv.slice(2).find((a) => !a.startsWith("-"));
+
+  // Completions server — boots its own store with cache.
+  if (commandArg === "_completions-server") {
+    const { default: startCompletionsServer } = await import(
+      "../completions/startCompletionsServer.js"
+    );
+    await startCompletionsServer();
+    return;
+  }
+
+  // Doctor runs before store boot — it validates the environment itself.
   if (commandArg === "doctor") {
     const { doctorCommand } = await import(
       "../domains/doctor/commands/index.js"


### PR DESCRIPTION
## Done

- `pragma _completions-server` — ke-backed Bun process listening on a Unix domain socket at `/tmp/pragma-completions-<project-hash>.sock`, 10s idle timeout with auto-exit and cleanup
- `pragma --completions <partial>` — shell completion client that checks for running server, spawns if missing, connects, sends partial, reads candidates, prints to stdout
- Completions derived from `CommandDefinition[]` via `buildCompleters` from `@canonical/cli-core` (PA.12): static noun/verb completion from path keys (levels 1–2), dynamic argument completion from `ParameterDefinition.complete` fields backed by ke SPARQL (level 3)
- Colocated tests (16 tests: unit + integration)

## QA

- `bun run check` passes (biome, TypeScript, webarchitect)
- `bun test src/completions/` — 16 tests pass
- Manual verification:
  ```
  pragma --completions ""           → all nouns (component, config, standard, ...)
  pragma --completions "comp"       → component
  pragma --completions "component " → get, list
  pragma --completions "config "    → channel, show, tier
  ```
- Server auto-exits after 10s idle; socket file cleaned up on exit

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.

## Screenshots

N/A — CLI tool, no visual output.