### PR TITLE
fix(pragma): resolve TTL sources via require.resolve, thread cwd through ke

### DIFF
--- a/packages/cli/pragma/src/domains/shared/bootStore.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.ts
@@ -8,25 +8,59 @@
  * @see CF.01, CF.02 in B.08.CONFIG
  */
 
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import type { SourceSpec, Store } from "@canonical/ke";
 import { createStore } from "@canonical/ke";
 import type { PragmaConfig } from "../../config.js";
 import { PragmaError } from "../../error/index.js";
 import { PREFIX_MAP } from "./prefixes.js";
 
+const require = createRequire(import.meta.url);
+
 /**
- * Default TTL source patterns when pragma.config.json has no `sources` field.
- * Point at published packages in node_modules.
+ * Source package definitions — each entry maps a package name to the glob
+ * patterns (relative to its package root) that contain TTL data.
  *
  * @see CF.02
  */
-export const DEFAULT_SOURCES: readonly string[] = [
-  "node_modules/@canonical/design-system/definitions/ontology.ttl",
-  "node_modules/@canonical/design-system/data/**/*.ttl",
-  "node_modules/@canonical/anatomy-dsl/definitions/**/*.ttl",
-  "node_modules/@canonical/code-standards/definitions/**/*.ttl",
-  "node_modules/@canonical/code-standards/data/**/*.ttl",
-];
+const SOURCE_PACKAGES = [
+  {
+    pkg: "@canonical/design-system",
+    globs: ["definitions/ontology.ttl", "data/**/*.ttl"],
+  },
+  {
+    pkg: "@canonical/anatomy-dsl",
+    globs: ["definitions/**/*.ttl"],
+  },
+  {
+    pkg: "@canonical/code-standards",
+    globs: ["definitions/**/*.ttl", "data/**/*.ttl"],
+  },
+] as const;
+
+/**
+ * Resolve default TTL sources by locating each package via require.resolve.
+ * This is package-manager agnostic — works with bun, npm, pnpm, and yarn
+ * regardless of hoisting strategy.
+ */
+export function defaultSources(): SourceSpec[] {
+  const sources: SourceSpec[] = [];
+
+  for (const { pkg, globs } of SOURCE_PACKAGES) {
+    let pkgDir: string;
+    try {
+      pkgDir = dirname(require.resolve(`${pkg}/package.json`));
+    } catch {
+      continue; // package not installed — skip
+    }
+    for (const glob of globs) {
+      sources.push(join(pkgDir, glob));
+    }
+  }
+
+  return sources;
+}
 
 export interface BootStoreOptions {
   /** Override config (skip reading from disk). */
@@ -47,13 +81,14 @@ export interface BootStoreOptions {
 export async function bootStore(
   options: BootStoreOptions = {},
 ): Promise<Store> {
-  const sources = options.sources ?? [...DEFAULT_SOURCES];
+  const sources = options.sources ?? defaultSources();
 
   try {
     const store = await createStore({
       sources,
       prefixes: PREFIX_MAP,
       cache: options.cache,
+      cwd: options.cwd,
     });
     return store;
   } catch (error) {

--- a/packages/runtime/ke/src/lib/createStore.ts
+++ b/packages/runtime/ke/src/lib/createStore.ts
@@ -116,7 +116,7 @@ function normalizeSource(spec: SourceSpec): SourceConfig {
  *
  * @note Impure — reads filesystem to resolve glob patterns and check existence.
  */
-function resolveGlobsSync(patterns: string[]): string[] {
+function resolveGlobsSync(patterns: string[], cwd: string): string[] {
   const files: string[] = [];
   for (const pattern of patterns) {
     // Detect glob patterns by the presence of wildcard characters
@@ -125,12 +125,12 @@ function resolveGlobsSync(patterns: string[]): string[] {
       pattern.includes("?") ||
       pattern.includes("[")
     ) {
-      for (const file of globSync(pattern)) {
-        files.push(resolve(file));
+      for (const file of globSync(pattern, { cwd })) {
+        files.push(resolve(cwd, file));
       }
     } else {
       // Literal file path — resolve to absolute and verify it exists
-      const absPath = resolve(pattern);
+      const absPath = resolve(cwd, pattern);
       if (existsSync(absPath)) {
         files.push(absPath);
       }
@@ -145,12 +145,12 @@ function resolveGlobsSync(patterns: string[]): string[] {
  *
  * @note Impure — reads file contents from disk.
  */
-function resolveSources(specs: SourceSpec[]): ResolvedSource[] {
+function resolveSources(specs: SourceSpec[], cwd: string): ResolvedSource[] {
   const resolved: ResolvedSource[] = [];
 
   for (const spec of specs) {
     const config = normalizeSource(spec);
-    const files = resolveGlobsSync(config.patterns);
+    const files = resolveGlobsSync(config.patterns, cwd);
 
     for (const filePath of files) {
       const format = config.format ?? inferFormat(filePath);
@@ -480,7 +480,10 @@ class KeStore implements Store {
     );
 
     // Re-resolve sources from disk (files may have changed)
-    const sources = resolveSources(this.config.sources);
+    const sources = resolveSources(
+      this.config.sources,
+      this.config.cwd ?? process.cwd(),
+    );
 
     for (const source of sources) {
       // Run onLoad plugins for each source
@@ -674,6 +677,7 @@ export default async function createStore(config: StoreConfig): Promise<Store> {
   const oxigraph = await loadOxigraph();
   const oxStore = new oxigraph.Store();
 
+  const cwd = config.cwd ?? process.cwd();
   const prefixes = config.prefixes ?? {};
   const plugins = config.plugins ?? [];
 
@@ -688,7 +692,7 @@ export default async function createStore(config: StoreConfig): Promise<Store> {
 
   // No cache hit — resolve sources, run plugins, load into Oxigraph
   if (!loadedFromCache) {
-    const sources = resolveSources(config.sources);
+    const sources = resolveSources(config.sources, cwd);
 
     for (const source of sources) {
       // Run onLoad plugin hooks before Oxigraph parses the content

--- a/packages/runtime/ke/src/lib/types.ts
+++ b/packages/runtime/ke/src/lib/types.ts
@@ -143,6 +143,12 @@ export interface StoreConfig {
    * Use `store.reload({ force: true })` to bypass the cache.
    */
   cache?: string;
+
+  /**
+   * Base directory for resolving relative source paths and glob patterns.
+   * Defaults to `process.cwd()` if omitted.
+   */
+  cwd?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Done

- Replace hardcoded `node_modules/` source paths with `require.resolve`-based package discovery — works with bun, npm, pnpm, yarn regardless of hoisting strategy
- Add `cwd` field to ke `StoreConfig` and thread it through `resolveGlobsSync` → `resolveSources` → `createStore` → `reload`
- Forward `cwd` from `bootStore` to `createStore` (was accepted but silently dropped)

Fixes store booting with zero triples when running `pragma` from outside the monorepo root.

## QA

- `cd /tmp && pragma component list` — should list design system components (previously returned empty)
- `cd /home/user/any-project && pragma component list` — same
- `cd <monorepo-root> && pragma component list` — still works
- All existing ke and pragma tests pass (801 total)

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.

## Screenshots

N/A — CLI-only fix, no visual changes.