### PR TITLE
fix(cli-core): show contextual help at each command level

### DIFF
--- a/packages/cli/core/src/lib/registerAll.ts
+++ b/packages/cli/core/src/lib/registerAll.ts
@@ -7,6 +7,7 @@
 
 import { Command, type OptionValues } from "commander";
 import { convertCamelToKebab } from "./convertCase.js";
+import { formatNounHelp, formatVerbHelp } from "./help.js";
 import type {
   CommandContext,
   CommandDefinition,
@@ -103,9 +104,19 @@ export default function registerAll(
         parent.description(`${noun} commands`);
       }
 
+      // Attach noun-level help (e.g. `pragma component --help`)
+      const programName = program.name();
+      const allCommands = commands;
+      const nounParent = parent;
+      parent.addHelpText("beforeAll", (_ctx) => {
+        if (_ctx.command !== nounParent) return "";
+        return formatNounHelp(programName, noun, allCommands);
+      });
+      parent.configureHelp({ formatHelp: () => "" });
+
       for (const cmd of multiSegment) {
         const verb = cmd.path.slice(1).join(" ");
-        attachCommand(parent, { ...cmd, path: [verb] }, ctx);
+        attachCommand(parent, { ...cmd, path: [verb] }, ctx, cmd);
       }
     }
   }
@@ -115,6 +126,7 @@ function attachCommand(
   parent: Command,
   cmd: CommandDefinition,
   ctx: CommandContext,
+  originalCmd?: CommandDefinition,
 ): void {
   const name = cmd.path[cmd.path.length - 1];
   if (!name) return;
@@ -126,6 +138,16 @@ function attachCommand(
 
   const fullName = positionalSuffix ? `${name} ${positionalSuffix}` : name;
   const sub = parent.command(fullName).description(cmd.description);
+
+  // Attach verb-level help (e.g. `pragma component list --help`)
+  const helpCmd = originalCmd ?? cmd;
+  const rootProgram = findRootProgram(parent);
+  const verbCommand = sub;
+  sub.addHelpText("beforeAll", (_ctx) => {
+    if (_ctx.command !== verbCommand) return "";
+    return formatVerbHelp(rootProgram.name(), helpCmd);
+  });
+  sub.configureHelp({ formatHelp: () => "" });
 
   for (const param of cmd.parameters) {
     if (param.positional) continue;
@@ -186,4 +208,12 @@ function handleResult(result: CommandResult): void {
 
 function findSubcommand(parent: Command, name: string): Command | undefined {
   return parent.commands.find((c) => c.name() === name);
+}
+
+function findRootProgram(cmd: Command): Command {
+  let current = cmd;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current;
 }

--- a/packages/cli/pragma/src/lib/runCli.ts
+++ b/packages/cli/pragma/src/lib/runCli.ts
@@ -77,7 +77,10 @@ function createProgram(
   program.option("--format <type>", "Output format (text or json)", "text");
   program.option("--verbose", "Diagnostic output to stderr", false);
 
-  program.addHelpText("beforeAll", () => {
+  program.addHelpText("beforeAll", (_ctx) => {
+    // Only show root-level help when the help is for the root program itself.
+    // Subcommand help is handled by registerAll via formatNounHelp/formatVerbHelp.
+    if (_ctx.command !== program) return "";
     if (ctx.globalFlags.llm) {
       return formatLlmHelp(PROGRAM_NAME, commands);
     }


### PR DESCRIPTION
## Done

- `registerAll` now attaches `formatNounHelp` on noun-level parents and `formatVerbHelp` on verb-level subcommands, each scoped to only fire for the exact command being helped
- Root-level help in `runCli.ts` scoped to only fire when the help target is the root program itself
- Drive-by: `formatNounHelp` and `formatVerbHelp` (already exported from cli-core) were unused until now

Before:
```
pragma --help              → root help
pragma component --help    → root help (wrong)
pragma component list --help → root help (wrong)
```

After:
```
pragma --help              → root help (commands, global flags)
pragma component --help    → noun help (lists verbs: list, get)
pragma component list --help → verb help (flags, examples)
```

## QA

- `pragma --help` — shows command list and global flags
- `pragma component --help` — shows available verbs (list, get)
- `pragma component list --help` — shows flags and examples for list
- `pragma component get --help` — shows positional args, flags, examples for get
- All existing tests pass (158 cli-core + 704 pragma)

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.

## Screenshots

N/A — CLI text output only.