### PR TITLE
docs(tokens): add Diátaxis documentation for grid, spacing, typography, and cascade layers

### DIFF
--- a/apps/react/storybook-hub/src/Introduction.mdx
+++ b/apps/react/storybook-hub/src/Introduction.mdx
@@ -11,7 +11,63 @@ libraries in the Canonical design system.
 
 This hub composes all individual Storybook instances across the monorepo into a single
 navigable interface. Each section in the sidebar corresponds to a separate component
-library:
+library or documentation area.
+
+## Documentation
+
+Documentation in the **Tokens** section follows the [Diátaxis](https://diataxis.fr/)
+framework — four distinct types of content, each serving a different need.
+
+### 🎓 Learn (Tutorials)
+
+Step-by-step guided builds. Start here if you are new to the system.
+
+- **Tutorial: First Component** — build a themed card from scratch
+- **Tutorial: Surface Depth** — layer surfaces with automatic depth compounding
+- **Tutorial: First Grid** — assemble a responsive dashboard layout
+
+### 🔧 How to (Guides)
+
+Task-oriented recipes. Each guide solves one specific problem and assumes you
+already understand the basics.
+
+- **How to Find a Token** — search strategies for the token catalogue
+- **How to Support Modifiers** — wire modifier channels into a component
+- **How to Handle Changes** — manage breaking changes during pre-1.0
+- **How to Use Responsive Grid** — breakpoint-driven column layouts
+- **How to Use Intrinsic Grid** — fluid content-driven layouts
+- **How to Force Theme** — override dark / light in a subtree
+- **How to Debug Tokens** — trace any visual anomaly back to its token
+- **How to Align to Baseline** — snap type and spacing to the 8px grid
+
+### 💡 Understanding (Explanations)
+
+Conceptual deep-dives. Read these to understand *why* the system works the way
+it does.
+
+- **Token Architecture** — tiers, stability guarantees, naming conventions
+- **Modifier Contract** — how channel custom properties compose
+- **Surface Depth Model** — background compounding and depth semantics
+- **Theme Mechanics** — dark / light resolution via media and class cascade
+- **Grid System** — why responsive, intrinsic, and subgrid each exist
+- **Spacing Scale** — the 8px base unit, rem rationale, and token scale
+
+### 📖 Reference
+
+Lookup tables and exhaustive listings. Use these while coding.
+
+- **Overview** — token KPIs, tier distribution, system summary
+- **Explorer** — searchable, filterable token table
+- **Modifiers** — all modifier families and their channels
+- **Surfaces** — surface depth stack and compounding preview
+- **Interaction States** — hover, active, disabled state tokens
+- **Spacing Scale** — visual bar chart of all 17 dimension tokens
+- **Typography Scale** — live heading and text style previews
+- **Grid Reference** — all grid classes, custom properties, breakpoints
+- **Cascade Layers Reference** — the 5-layer architecture with all channels
+- **Consumer Guidance** — quick consumption rules and stability policy
+
+## Component libraries
 
 | Library | Framework | Description |
 |---------|-----------|-------------|
@@ -23,21 +79,22 @@ library:
 | **App LXD** | React | LXD-specific components |
 | **App Portal** | React | Portal-specific components |
 | **App Anbox** | React | Anbox-specific components |
-| **Tokens** | React | Design token showcase |
+| **Tokens** | React | Design token showcase and documentation |
 | **Lit PoC** | Lit | Web Components proof of concept |
 | **Svelte App Launchpad** | Svelte | Svelte Launchpad components |
 | **Demo Site** | React | Full demo application |
 
 ## Design principles
 
-The design system is built on a **modifier-based ontology** with three axes:
+The design system is built on a **modifier-based ontology** with four semantic axes:
 
-- **Importance**: primary, secondary, tertiary
-- **Anticipation**: constructive, caution, destructive
-- **Variant**: link, ghost, etc.
+- **Importance**: primary, secondary, tertiary — controls visual emphasis
+- **Anticipation**: constructive, caution, destructive — signals the outcome of an action
+- **Criticality**: success, error, warning, information — system-level feedback
+- **Emphasis**: muted, branded — surface-level adjustments
 
-Components express these modifiers consistently, enabling predictable composition
-across the entire system.
+Components express these modifiers through CSS custom-property channels, enabling
+predictable composition across the entire system.
 
 ## Getting started
 

--- a/packages/react/tokens/src/lib/Tokens.stories.tsx
+++ b/packages/react/tokens/src/lib/Tokens.stories.tsx
@@ -600,6 +600,316 @@ export const InteractionStates = {
   ),
 };
 
+export const SpacingScale = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The complete dimension token scale with visual bars showing relative size. Use this page for quick spacing lookup and comparison.",
+      },
+    },
+  },
+  render: () => {
+    const spacingTokens = [
+      { name: "--dimension-025", rem: 0.125, px: 2 },
+      { name: "--dimension-050", rem: 0.25, px: 4 },
+      { name: "--dimension-100", rem: 0.5, px: 8 },
+      { name: "--dimension-150", rem: 0.75, px: 12 },
+      { name: "--dimension-175", rem: 0.875, px: 14 },
+      { name: "--dimension-200", rem: 1, px: 16 },
+      { name: "--dimension-225", rem: 1.125, px: 18 },
+      { name: "--dimension-250", rem: 1.25, px: 20 },
+      { name: "--dimension-300", rem: 1.5, px: 24 },
+      { name: "--dimension-400", rem: 2, px: 32 },
+      { name: "--dimension-500", rem: 2.5, px: 40 },
+      { name: "--dimension-600", rem: 3, px: 48 },
+      { name: "--dimension-700", rem: 3.5, px: 56 },
+      { name: "--dimension-800", rem: 4, px: 64 },
+      { name: "--dimension-900", rem: 4.5, px: 72 },
+      { name: "--dimension-1000", rem: 5, px: 80 },
+      { name: "--dimension-1100", rem: 5.5, px: 88 },
+    ];
+
+    const baselineMultiples = new Set([8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88]);
+
+    return (
+      <div className="ds token-page">
+        <section className="panel">
+          <div className="header">
+            <h3>Spacing scale</h3>
+            <p>
+              All 17 dimension tokens with visual bars. Values marked with ◆ are
+              on the 8px baseline grid. Pixel equivalents assume a 16px root font
+              size.
+            </p>
+          </div>
+          <div className="stack">
+            {spacingTokens.map(({ name, rem, px }) => (
+              <div
+                key={name}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "11rem 4.5rem 4rem 1.5rem 1fr",
+                  alignItems: "center",
+                  gap: "0.5rem",
+                  fontSize: "0.8125rem",
+                  padding: "0.25rem 0",
+                  borderBottom: "1px solid var(--token-story-border, color-mix(in srgb, #171717 6%, transparent))",
+                }}
+              >
+                <code style={{ fontFamily: "ui-monospace, monospace", fontSize: "0.75rem" }}>
+                  {name}
+                </code>
+                <span style={{ fontFamily: "ui-monospace, monospace", fontSize: "0.75rem" }}>
+                  {rem}rem
+                </span>
+                <span style={{ color: "color-mix(in srgb, currentColor 60%, transparent)", fontSize: "0.75rem" }}>
+                  {px}px
+                </span>
+                <span style={{ fontSize: "0.625rem", opacity: baselineMultiples.has(px) ? 1 : 0.2 }}>
+                  {baselineMultiples.has(px) ? "◆" : "·"}
+                </span>
+                <div
+                  style={{
+                    height: "8px",
+                    width: `${rem}rem`,
+                    background: "var(--color-foreground-primary, #e95420)",
+                    borderRadius: "2px",
+                    minWidth: "2px",
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="header">
+            <h3>Common spacing patterns</h3>
+            <p>Quick reference for the most frequently used spacing values.</p>
+          </div>
+          <div className="rule-grid">
+            <article className="rule">
+              <strong>Tight internal padding</strong>
+              <p>
+                <code>var(--dimension-050)</code> — 4px.
+                Badges, tags, inline chips.
+              </p>
+            </article>
+            <article className="rule">
+              <strong>Compact padding</strong>
+              <p>
+                <code>var(--dimension-100)</code> — 8px.
+                Table cells, small buttons, tight list items.
+              </p>
+            </article>
+            <article className="rule">
+              <strong>Standard padding</strong>
+              <p>
+                <code>var(--dimension-200)</code> — 16px.
+                Cards, panels, form groups, dialog bodies.
+              </p>
+            </article>
+            <article className="rule">
+              <strong>Section spacing</strong>
+              <p>
+                <code>var(--dimension-400)</code> — 32px.
+                Between major page sections.
+              </p>
+            </article>
+            <article className="rule">
+              <strong>Grid gap</strong>
+              <p>
+                <code>var(--grid-gap, 1rem)</code> — 16px default.
+                Override with dimension tokens.
+              </p>
+            </article>
+            <article className="rule">
+              <strong>Page inset</strong>
+              <p>
+                <code>var(--dimension-300)</code> — 24px.
+                Page-level horizontal and vertical padding.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <TokenTable
+          tokens={dimensions}
+          title="Dimension tokens in the explorer"
+          caption="All dimension tokens shown with the standard explorer columns."
+          columns={["token", "swatch", "value", "stability"]}
+          searchable
+        />
+      </div>
+    );
+  },
+};
+
+export const TypographyScale = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Typography tokens for headings (1–6), text styles (primary, secondary, tertiary), and their variants (bold, code, prose, smallcaps). Each style is shown as a live preview.",
+      },
+    },
+  },
+  render: () => {
+    const headingStyles = [
+      { name: "Heading 1", prefix: "--typography-heading-1", sample: "The quick brown fox" },
+      { name: "Heading 2", prefix: "--typography-heading-2", sample: "The quick brown fox" },
+      { name: "Heading 3", prefix: "--typography-heading-3", sample: "The quick brown fox jumps" },
+      { name: "Heading 4", prefix: "--typography-heading-4", sample: "The quick brown fox jumps over" },
+      { name: "Heading 5", prefix: "--typography-heading-5", sample: "The quick brown fox jumps over the lazy dog" },
+      { name: "Heading 6", prefix: "--typography-heading-6", sample: "The quick brown fox jumps over the lazy dog" },
+    ];
+
+    const textStyles = [
+      { name: "Text Primary", prefix: "--typography-text-primary", sample: "Body text at the primary reading size. This is the default for most content." },
+      { name: "Text Secondary", prefix: "--typography-text-secondary", sample: "Smaller body text for captions, metadata, and supplementary information." },
+      { name: "Text Tertiary", prefix: "--typography-text-tertiary", sample: "The smallest body text for fine print and legal copy." },
+    ];
+
+    return (
+      <div className="ds token-page">
+        <section className="panel">
+          <div className="header">
+            <h3>Heading scale</h3>
+            <p>
+              Each heading level uses coordinated font-family, font-size, font-weight,
+              line-height, and letter-spacing tokens. Headings are available in
+              regular and bold variants.
+            </p>
+          </div>
+          <div className="stack">
+            {headingStyles.map(({ name, prefix, sample }) => (
+              <div key={prefix} style={{
+                display: "grid",
+                gap: "0.25rem",
+                padding: "0.75rem 0",
+                borderBottom: "1px solid var(--token-story-border, color-mix(in srgb, #171717 6%, transparent))",
+              }}>
+                <div style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "baseline",
+                }}>
+                  <span className="eyebrow">{name}</span>
+                  <code style={{
+                    fontFamily: "ui-monospace, monospace",
+                    fontSize: "0.6875rem",
+                    color: "color-mix(in srgb, currentColor 55%, transparent)",
+                  }}>
+                    {prefix}-*
+                  </code>
+                </div>
+                <p style={{
+                  margin: 0,
+                  fontFamily: `var(${prefix}-font-family, inherit)`,
+                  fontSize: `var(${prefix}-font-size, inherit)`,
+                  fontWeight: `var(${prefix}-font-weight, inherit)`,
+                  lineHeight: `var(${prefix}-line-height, inherit)`,
+                  letterSpacing: `var(${prefix}-letter-spacing, inherit)`,
+                }}>
+                  {sample}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="header">
+            <h3>Text styles</h3>
+            <p>
+              Body text styles with regular, bold, code, and prose variants.
+              Text styles follow the same token structure as headings.
+            </p>
+          </div>
+          <div className="stack">
+            {textStyles.map(({ name, prefix, sample }) => (
+              <div key={prefix} style={{
+                display: "grid",
+                gap: "0.375rem",
+                padding: "0.75rem 0",
+                borderBottom: "1px solid var(--token-story-border, color-mix(in srgb, #171717 6%, transparent))",
+              }}>
+                <div style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "baseline",
+                }}>
+                  <span className="eyebrow">{name}</span>
+                  <code style={{
+                    fontFamily: "ui-monospace, monospace",
+                    fontSize: "0.6875rem",
+                    color: "color-mix(in srgb, currentColor 55%, transparent)",
+                  }}>
+                    {prefix}-*
+                  </code>
+                </div>
+                <p style={{
+                  margin: 0,
+                  fontFamily: `var(${prefix}-font-family, inherit)`,
+                  fontSize: `var(${prefix}-font-size, inherit)`,
+                  fontWeight: `var(${prefix}-font-weight, inherit)`,
+                  lineHeight: `var(${prefix}-line-height, inherit)`,
+                  letterSpacing: `var(${prefix}-letter-spacing, inherit)`,
+                }}>
+                  {sample}
+                </p>
+                <p style={{
+                  margin: 0,
+                  fontFamily: `var(${prefix}-bold-font-family, inherit)`,
+                  fontSize: `var(${prefix}-bold-font-size, inherit)`,
+                  fontWeight: `var(${prefix}-bold-font-weight, inherit)`,
+                  lineHeight: `var(${prefix}-bold-line-height, inherit)`,
+                  letterSpacing: `var(${prefix}-bold-letter-spacing, inherit)`,
+                }}>
+                  <strong>Bold:</strong> {sample}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="header">
+            <h3>Token structure</h3>
+            <p>
+              Every typography style is composed of 5 tokens. The naming pattern is
+              consistent across all styles.
+            </p>
+          </div>
+          <div className="rule-grid">
+            <article className="rule">
+              <strong><code>*-font-family</code></strong>
+              <p>The font stack. Resolves to <code>var(--typography-font-family-default)</code> or <code>var(--typography-font-family-code)</code>.</p>
+            </article>
+            <article className="rule">
+              <strong><code>*-font-size</code></strong>
+              <p>The size. Resolves to a <code>--dimension-size-font-size-*</code> token from the spacing scale.</p>
+            </article>
+            <article className="rule">
+              <strong><code>*-font-weight</code></strong>
+              <p>The weight. Resolves to a <code>--typography-weight-*</code> value (light, regular, medium, semi-bold, bold, extra-bold).</p>
+            </article>
+            <article className="rule">
+              <strong><code>*-line-height</code></strong>
+              <p>The line height. Resolves to a <code>--number-line-height-*</code> value tuned for the 8px baseline grid.</p>
+            </article>
+            <article className="rule">
+              <strong><code>*-letter-spacing</code></strong>
+              <p>The tracking. Resolves to <code>--dimension-letter-spacing-default</code> or <code>--dimension-letter-spacing-wide</code>.</p>
+            </article>
+          </div>
+        </section>
+      </div>
+    );
+  },
+};
+
 export const ConsumerGuidance = {
   parameters: {
     docs: {

--- a/packages/react/tokens/src/lib/docs/CascadeLayersReference.mdx
+++ b/packages/react/tokens/src/lib/docs/CascadeLayersReference.mdx
@@ -1,0 +1,219 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/Reference/Cascade Layers" />
+
+# Cascade layers reference
+
+The token system uses CSS `@layer` to establish a strict resolution order. This page documents every layer, what it contains, and how they interact.
+
+## Layer ordering
+
+```css
+@layer ds.tokens;       /* 1 — Lowest precedence */
+@layer ds.modifiers;    /* 2 */
+@layer ds.surfaces;     /* 3 */
+@layer ds.states;       /* 4 */
+@layer ds.components;   /* 5 — Highest precedence */
+```
+
+A later layer _always_ overrides an earlier layer, regardless of selector specificity. This is the core guarantee that makes the system predictable.
+
+## Layer details
+
+<div className="ds token-page">
+  <section className="panel">
+    <div className="stack">
+      <article className="rule">
+        <strong><code>@layer ds.tokens</code></strong>
+        <p>
+          <strong>Contains:</strong> Primitive palette values, semantic token defaults, and theme-paired values.
+          <br />
+          <strong>Generated files:</strong> <code>sets.primitive.css</code>, <code>modifiers.theme.css</code>
+          <br />
+          <strong>Sets:</strong> Base <code>--color-*</code> tokens, <code>--dimension-*</code> tokens, <code>--typography-*</code> tokens, delta variables.
+          <br />
+          <strong>Role:</strong> Provides the default values that every other layer can override. This is where semantic tokens get their "no context" values.
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>@layer ds.modifiers</code></strong>
+        <p>
+          <strong>Contains:</strong> Modifier channel variable overrides.
+          <br />
+          <strong>Generated files:</strong> <code>modifiers.criticality.css</code>, <code>modifiers.emphasis.css</code>, <code>modifiers.anticipation.css</code>, <code>modifiers.importance.css</code>, <code>modifiers.typography.css</code>
+          <br />
+          <strong>Sets:</strong> <code>--modifier-color-*</code> variables when a modifier class (<code>.error</code>, <code>.success</code>, <code>.branded</code>, etc.) is applied to an ancestor.
+          <br />
+          <strong>Role:</strong> Rebinds color channels so descendant components shift their output without code changes. Overrides <code>ds.tokens</code>.
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>@layer ds.surfaces</code></strong>
+        <p>
+          <strong>Contains:</strong> Surface depth compounding rules.
+          <br />
+          <strong>Generated file:</strong> <code>modifiers.surfaces.css</code>
+          <br />
+          <strong>Sets:</strong> <code>--surface-color-*</code> variables using compound descendant selectors (<code>.surface</code>, <code>.surface .surface</code>, <code>.surface .surface .surface</code>).
+          <br />
+          <strong>Role:</strong> Provides depth-aware backgrounds and foreground colors. Can override modifier values when surface-specific colors are needed. Overrides <code>ds.modifiers</code>.
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>@layer ds.states</code></strong>
+        <p>
+          <strong>Contains:</strong> Interaction state derivations.
+          <br />
+          <strong>Generated file:</strong> <code>states.css</code>
+          <br />
+          <strong>Sets:</strong> <code>--hover--*</code>, <code>--active--*</code>, <code>--disabled--*</code> variables using <code>oklch()</code> relative color syntax and <code>color-mix()</code>.
+          <br />
+          <strong>Role:</strong> Derives hover, active, and disabled colors from the current token context. Overrides everything else. Highest color-related precedence.
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>@layer ds.components</code></strong>
+        <p>
+          <strong>Contains:</strong> Structural patterns — grid system, layout utilities.
+          <br />
+          <strong>Source file:</strong> <code>grid.css</code>
+          <br />
+          <strong>Sets:</strong> <code>display: grid</code>, <code>grid-template-columns</code>, <code>subgrid</code> behavior.
+          <br />
+          <strong>Role:</strong> Provides layout structure. Does not set color tokens. Highest overall precedence so component structure can't be overridden by token or modifier layers.
+        </p>
+      </article>
+    </div>
+  </section>
+</div>
+
+## Resolution example
+
+Consider a button inside `.error` on `.surface .surface`:
+
+```css
+.ds.button {
+  background: var(
+    --hover--color-foreground-primary,     /* ds.states */
+    var(--modifier-color-foreground-primary,  /* ds.modifiers */
+      var(--surface-color-foreground-primary, /* ds.surfaces */
+        var(--color-foreground-primary)))     /* ds.tokens */
+  );
+}
+```
+
+At rest (no hover):
+
+1. `--hover--color-foreground-primary` is **unset** → skip
+2. `--modifier-color-foreground-primary` is **set** by `.error` → resolves to `var(--color-foreground-primary-error)` → **used**
+3. `--surface-color-foreground-primary` and `--color-foreground-primary` are never reached
+
+On hover:
+
+1. `--hover--color-foreground-primary` is **set** by the state layer → computed from the modifier value via oklch shift → **used**
+2. All other variables are never reached
+
+The fallback chain and the cascade layer ordering work together: the chain defines _which variables to try_, and the layers ensure that _if multiple are set, the correct one has priority_.
+
+## Modifier families and their channels
+
+<div className="ds token-page">
+  <section className="panel">
+    <div className="header">
+      <h3>Modifier families</h3>
+      <p>Each family sets the same channel variables to different intent-specific semantic tokens.</p>
+    </div>
+    <div className="stack">
+      <article className="rule">
+        <strong>Criticality</strong>
+        <p>
+          <strong>Classes:</strong> <code>.success</code>, <code>.error</code>, <code>.warning</code>, <code>.information</code>
+          <br />
+          <strong>Channels set:</strong> <code>--modifier-color-border</code>, <code>--modifier-color-focusRing</code>, <code>--modifier-color-foreground-input</code>, <code>--modifier-color-foreground-secondary</code>, <code>--modifier-color-icon</code>, <code>--modifier-color-text</code>
+          <br />
+          <strong>Purpose:</strong> Feedback states for forms and validation.
+        </p>
+      </article>
+      <article className="rule">
+        <strong>Emphasis</strong>
+        <p>
+          <strong>Classes:</strong> <code>.muted</code>, <code>.branded</code>
+          <br />
+          <strong>Channels set:</strong> <code>--modifier-color-border</code>, <code>--modifier-color-icon</code>, <code>--modifier-color-text</code>; <code>.branded</code> also sets <code>--modifier-color-foreground-ghost</code>, <code>--modifier-color-foreground-primary</code>, <code>--modifier-color-foreground-secondary</code>
+          <br />
+          <strong>Purpose:</strong> Visual prominence adjustment — de-emphasize or brand-highlight content.
+        </p>
+      </article>
+      <article className="rule">
+        <strong>Anticipation</strong>
+        <p>
+          <strong>Classes:</strong> <code>.constructive</code>, <code>.destructive</code>, <code>.caution</code>
+          <br />
+          <strong>Channels set:</strong> <code>--modifier-color-border</code>, <code>--modifier-color-foreground-ghost</code>, <code>--modifier-color-foreground-primary</code>, <code>--modifier-color-icon</code>, <code>--modifier-color-text</code>
+          <br />
+          <strong>Purpose:</strong> Communicates the expected outcome of an action — confirmation, danger, or careful attention.
+        </p>
+      </article>
+      <article className="rule">
+        <strong>Importance</strong>
+        <p>
+          <strong>Classes:</strong> (currently empty — reserved for future use)
+          <br />
+          <strong>Purpose:</strong> Will control visual weight and hierarchy emphasis.
+        </p>
+      </article>
+    </div>
+  </section>
+</div>
+
+## Surface channels
+
+The surface system sets 15 channel variables at each of 3 depth levels:
+
+<div className="ds token-page">
+  <section className="panel">
+    <div className="header">
+      <h3>Surface channel variables</h3>
+      <p>Set by <code>.surface</code>, <code>.surface .surface</code>, and <code>.surface .surface .surface</code>.</p>
+    </div>
+    <div className="stack">
+      {[
+        "background",
+        "foreground-checkbox-checkmark",
+        "foreground-checkbox-unselected",
+        "foreground-ghost",
+        "foreground-ghost-branded",
+        "foreground-ghost-constructive",
+        "foreground-ghost-destructive",
+        "foreground-input",
+        "foreground-input-error",
+        "foreground-input-success",
+        "foreground-input-warning",
+        "foreground-navigation-primary",
+        "foreground-radio-checkmark",
+        "foreground-radio-unselected",
+        "foreground-switch-knob",
+      ].map((channel) => (
+        <div key={channel} style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: "0.5rem",
+          fontSize: "0.8125rem",
+          fontFamily: "ui-monospace, monospace",
+          padding: "0.125rem 0",
+        }}>
+          <code>--surface-color-{channel}</code>
+        </div>
+      ))}
+    </div>
+  </section>
+</div>
+
+At depth 1, these resolve to root values. At depth 2, they resolve to `-layer2` variants. At depth 3, they resolve to `-layer3` variants. Beyond depth 3, the pattern oscillates back to depth 1 values.
+
+## Related
+
+- [Token Architecture](?path=/docs/foundation-design-tokens-understanding-token-architecture--docs): why layers and channels exist
+- [The Modifier Contract](?path=/docs/foundation-design-tokens-understanding-modifier-contract--docs): the channel variable pattern
+- [Surface Depth Model](?path=/docs/foundation-design-tokens-understanding-surface-depth-model--docs): compound selectors for depth
+- [Grid classes reference](?path=/docs/foundation-design-tokens-reference-grid-classes--docs): the component layer

--- a/packages/react/tokens/src/lib/docs/GridReference.mdx
+++ b/packages/react/tokens/src/lib/docs/GridReference.mdx
@@ -1,0 +1,192 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+import { Unstyled } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/Reference/Grid Classes" />
+
+# Grid classes reference
+
+This page documents every CSS class, custom property, and breakpoint in the grid system.
+
+## Classes
+
+<div className="ds token-page">
+  <section className="panel">
+    <div className="header">
+      <h3>Grid classes</h3>
+      <p>The four classes that compose to create any layout.</p>
+    </div>
+    <div className="stack">
+      <article className="rule">
+        <strong><code>.grid</code></strong>
+        <p>
+          Establishes a grid context. Sets <code>display: grid</code>,
+          reads <code>--modifier-grid-template</code> for columns, and
+          applies <code>var(--grid-gap, 1rem)</code> as the gap. Without a
+          modifier class, no columns are defined — the grid is a bare
+          block-level context for custom column definitions.
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>.grid.responsive</code></strong>
+        <p>
+          Breakpoint-driven columns.
+          Sets <code>--modifier-grid-template</code> to
+          4 columns (&lt; 768px),
+          8 columns (768px–1279px), or
+          12 columns (≥ 1280px).
+          Use for page-level layout.
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>.grid.intrinsic</code></strong>
+        <p>
+          Fluid auto-fill columns.
+          Sets <code>--modifier-grid-template</code> to
+          <code>repeat(auto-fill, minmax(var(--grid-col-min), 1fr) × 4)</code>.
+          Items wrap in groups of 4 based on available space.
+          Use for card grids, galleries, and dashboard widgets.
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>.subgrid</code></strong>
+        <p>
+          Inherits parent grid column tracks via CSS <code>subgrid</code>.
+          Spans <code>var(--subgrid-span, 1 / -1)</code> of the parent's columns.
+          Use for cross-row alignment (forms, tables).
+          Requires a CSS Grid parent.
+        </p>
+      </article>
+    </div>
+  </section>
+</div>
+
+## Custom properties
+
+<div className="ds token-page">
+  <section className="panel">
+    <div className="header">
+      <h3>Custom properties</h3>
+      <p>Properties that control grid behavior. Set these on the grid container or a parent element.</p>
+    </div>
+    <div className="stack">
+      <article className="rule">
+        <strong><code>--modifier-grid-template</code></strong>
+        <p>
+          Controls <code>grid-template-columns</code> on <code>.grid</code> elements.
+          Set by <code>.responsive</code> and <code>.intrinsic</code>, or override manually.
+          <br />
+          <strong>Default:</strong> unset (no columns defined)
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>--grid-gap</code></strong>
+        <p>
+          Controls the <code>gap</code> on <code>.grid</code> elements.
+          Use dimension tokens for values.
+          <br />
+          <strong>Default:</strong> <code>1rem</code>
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>--grid-col-min</code></strong>
+        <p>
+          Minimum column width for the intrinsic grid's <code>minmax()</code> function.
+          Affects when columns wrap.
+          <br />
+          <strong>Default:</strong> <code>100px</code>
+          <br />
+          <strong>Scope:</strong> <code>:root</code> (global), overridable per container.
+        </p>
+      </article>
+      <article className="rule">
+        <strong><code>--subgrid-span</code></strong>
+        <p>
+          Controls <code>grid-column</code> on <code>.subgrid</code> elements.
+          Determines how many parent columns the subgrid spans.
+          <br />
+          <strong>Default:</strong> <code>1 / -1</code> (all columns)
+        </p>
+      </article>
+    </div>
+  </section>
+</div>
+
+## Breakpoints
+
+<div className="ds token-page">
+  <section className="panel">
+    <div className="header">
+      <h3>Responsive breakpoints</h3>
+      <p>Used by <code>.responsive</code> to set column count.</p>
+    </div>
+    <div className="stack">
+      <article className="rule">
+        <strong>Mobile</strong>
+        <p>
+          <code>&lt; 768px</code> — 4 columns.
+          <code>--modifier-grid-template: repeat(4, 1fr)</code>
+        </p>
+      </article>
+      <article className="rule">
+        <strong>Tablet</strong>
+        <p>
+          <code>768px – 1279px</code> — 8 columns.
+          <code>--modifier-grid-template: repeat(8, 1fr)</code>
+        </p>
+      </article>
+      <article className="rule">
+        <strong>Desktop</strong>
+        <p>
+          <code>≥ 1280px</code> — 12 columns.
+          <code>--modifier-grid-template: repeat(12, 1fr)</code>
+        </p>
+      </article>
+    </div>
+  </section>
+</div>
+
+## Cascade layer
+
+The grid system is declared in `@layer ds.components`.
+
+```
+@layer ds.tokens;       /* Token values */
+@layer ds.modifiers;    /* Color modifier channels */
+@layer ds.surfaces;     /* Surface depth compounding */
+@layer ds.states;       /* Interaction state derivations */
+@layer ds.components;   /* Structural patterns (grid, typography blocks) */
+```
+
+Component-layer styles can be overridden by more specific component CSS without layer conflicts.
+
+## Source
+
+The grid implementation is in `@canonical/styles` at `packages/styles/main/src/grid.css`.
+
+## Browser support
+
+<div className="ds token-page">
+  <section className="panel">
+    <div className="stack">
+      <article className="rule">
+        <strong><code>.grid</code> and <code>.responsive</code></strong>
+        <p>CSS Grid Level 1. Supported in all modern browsers.</p>
+      </article>
+      <article className="rule">
+        <strong><code>.intrinsic</code></strong>
+        <p>CSS Grid Level 1 with <code>auto-fill</code>. Supported in all modern browsers.</p>
+      </article>
+      <article className="rule">
+        <strong><code>.subgrid</code></strong>
+        <p>CSS Grid Level 2 (Subgrid). Chrome 117+, Firefox 71+, Safari 16+. No IE or legacy Edge support.</p>
+      </article>
+    </div>
+  </section>
+</div>
+
+## Related
+
+- [Understanding the grid system](?path=/docs/foundation-design-tokens-understanding-the-grid-system--docs): design rationale
+- [How to use the responsive grid](?path=/docs/foundation-design-tokens-how-to-use-the-responsive-grid--docs): step-by-step guide
+- [How to use the intrinsic grid](?path=/docs/foundation-design-tokens-how-to-use-the-intrinsic-grid--docs): step-by-step guide
+- [Cascade layers reference](?path=/docs/foundation-design-tokens-reference-cascade-layers--docs): the full layer ordering

--- a/packages/react/tokens/src/lib/docs/GridSystem.mdx
+++ b/packages/react/tokens/src/lib/docs/GridSystem.mdx
@@ -1,0 +1,172 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+import { Unstyled } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/Understanding/The Grid System" />
+
+# Understanding the grid system
+
+The grid system provides layout structure for every page and component in the design system. It is intentionally minimal — four CSS classes and two custom properties — because layout is a solved problem that benefits from constraint, not from abstraction.
+
+This page explains _why_ the grid is designed the way it is. For practical steps, see [How to use the responsive grid](?path=/docs/foundation-design-tokens-how-to-use-the-responsive-grid--docs) or [How to use the intrinsic grid](?path=/docs/foundation-design-tokens-how-to-use-the-intrinsic-grid--docs).
+
+## What the grid solves
+
+Every interface needs columns. A dashboard needs a 12-column grid for its main content area. A card grid needs to wrap items fluidly based on available space. A form inside a card needs to inherit its parent's column structure.
+
+Without a shared system, each of these cases spawns its own ad-hoc grid — inline styles, component-scoped `grid-template-columns`, and utility classes that conflict with each other. The result is a layout surface that cannot be reasoned about globally.
+
+The grid system provides three answers to three different layout questions:
+
+| Question | Answer | Class |
+|---|---|---|
+| "I need a fixed-column responsive layout" | Breakpoint-driven 4 → 8 → 12 columns | `.grid.responsive` |
+| "I need fluid wrapping for a set of cards" | Auto-fill groups of 4, minimum width per column | `.grid.intrinsic` |
+| "I need to align to my parent's columns" | CSS subgrid inheritance | `.subgrid` |
+
+## Two grid strategies, one contract
+
+The distinction between `.responsive` and `.intrinsic` reflects a fundamental tension in layout design: should columns be controlled by the viewport or by the content?
+
+### Responsive: the viewport decides
+
+The responsive grid follows the classic breakpoint model:
+
+- **Mobile** (< 768px): 4 columns
+- **Tablet** (768px – 1279px): 8 columns
+- **Desktop** (≥ 1280px): 12 columns
+
+This is the right choice for page-level layout — navigation rails, main content areas, sidebars — where the _structure_ of the page changes at breakpoints. A 12-column desktop layout that collapses to a 4-column mobile layout is a structural decision, not a content decision.
+
+The breakpoints are set through `@media` queries on a single custom property:
+
+```css
+.responsive {
+  --modifier-grid-template: repeat(4, 1fr);
+
+  @media (min-width: 768px) {
+    --modifier-grid-template: repeat(8, 1fr);
+  }
+
+  @media (min-width: 1280px) {
+    --modifier-grid-template: repeat(12, 1fr);
+  }
+}
+```
+
+Notice that the responsive class does not set `grid-template-columns` directly. It sets `--modifier-grid-template`, which the base `.grid` class reads. This indirection is the same modifier pattern used throughout the token system — it means a parent container can override the grid template without fighting CSS specificity.
+
+### Intrinsic: the content decides
+
+The intrinsic grid uses `auto-fill` to let the browser decide how many columns fit:
+
+```css
+.intrinsic {
+  --modifier-grid-template: repeat(
+    auto-fill,
+    minmax(var(--grid-col-min), 1fr)
+    minmax(var(--grid-col-min), 1fr)
+    minmax(var(--grid-col-min), 1fr)
+    minmax(var(--grid-col-min), 1fr)
+  );
+}
+```
+
+The items are grouped in sets of 4 — each group of 4 `minmax()` tracks fills or wraps as a unit. `--grid-col-min` (default: `100px`) controls the minimum column width before wrapping occurs.
+
+This is the right choice for content-driven layouts — card grids, gallery views, dashboard widgets — where the number of items varies and the layout should adapt to the container, not the viewport.
+
+### Why not just one?
+
+The two strategies serve different masters. A page layout with a sidebar and a main content area _must_ change structure at breakpoints — it cannot simply wrap. A card grid _must not_ be locked to breakpoint-driven column counts — it should use all available space regardless of viewport width.
+
+Trying to serve both needs with a single mechanism leads to either over-constrained cards (locked to viewport breakpoints when they should flow) or under-constrained page layouts (wrapping when they should restructure).
+
+## The modifier pattern in grid
+
+The grid uses the same `--modifier-*` custom property pattern as the color token system. The base `.grid` class reads `--modifier-grid-template`:
+
+```css
+.grid {
+  display: grid;
+  grid-template-columns: var(--modifier-grid-template);
+  gap: var(--grid-gap, 1rem);
+}
+```
+
+This means `.responsive` and `.intrinsic` are _modifier classes_ — they set the custom property that `.grid` reads. The same pattern enables custom grid configurations:
+
+```css
+/* A custom 3-column grid for a specific layout */
+.my-layout {
+  --modifier-grid-template: 240px 1fr 320px;
+}
+```
+
+This custom layout class composes with `.grid` exactly as `.responsive` does, because it uses the same contract: set `--modifier-grid-template`, and `.grid` will apply it.
+
+## Why subgrid
+
+CSS Subgrid lets a child element inherit its parent's column tracks. Without subgrid, nested grids create their _own_ column definitions, which means inner content cannot align with outer content.
+
+```css
+.subgrid {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: var(--subgrid-span, 1 / -1);
+}
+```
+
+The `--subgrid-span` property controls how many parent columns the subgrid spans. The default (`1 / -1`) spans all columns, which is the most common case: a row inside a grid that needs its children to align with the grid's columns.
+
+Subgrid is essential for forms, tables, and any layout where label-to-input alignment across rows matters. Without it, each row would need to independently define its column widths, and alignment would be a manual coordination problem.
+
+## Why `@layer ds.components`
+
+The grid is declared in `@layer ds.components`, not `@layer ds.tokens` or `@layer ds.modifiers`. This is deliberate:
+
+- **Tokens** define values (colors, dimensions, typography).
+- **Modifiers** rebind token channels contextually (error, success, emphasis).
+- **Components** provide structural patterns (grid, surfaces, typography blocks).
+
+The grid provides _structure_, not _values_. It is a pattern that uses the modifier custom property convention but is not itself a modifier. Placing it in the component layer means it can be overridden by component-specific styles without layer conflicts.
+
+## Gap and the spacing scale
+
+The grid gap defaults to `1rem` via `var(--grid-gap, 1rem)`. This can be overridden per grid context:
+
+```css
+.tight-grid {
+  --grid-gap: var(--dimension-1);  /* 0.5rem / 8px */
+}
+
+.spacious-grid {
+  --grid-gap: var(--dimension-4);  /* 2rem / 32px */
+}
+```
+
+Gap uses the spacing scale tokens (`--dimension-*`) when overridden, keeping grid spacing consistent with the rest of the spacing system. See [Understanding the spacing scale](?path=/docs/foundation-design-tokens-understanding-the-spacing-scale--docs) for why these values exist.
+
+## Design decisions and alternatives
+
+### Why not a utility-class system?
+
+Grid utility classes (`.col-span-4`, `.col-start-2`, etc.) were considered and rejected. They move layout decisions into HTML, making them harder to manage at scale and impossible to change responsively without duplicating classes for each breakpoint. The custom property approach keeps layout in CSS where it belongs, while HTML expresses only the structural intent (`.grid.responsive`).
+
+### Why not CSS Container Queries for responsive?
+
+Container queries let elements respond to their _container's_ size rather than the viewport. This is powerful for components, but page-level layout genuinely needs viewport awareness — a sidebar should collapse based on the browser width, not its own container. The responsive grid uses `@media` queries because page structure is a viewport concern.
+
+For component-level responsive behavior, container queries are the right tool — but they operate at a different level than the grid system.
+
+### Why groups of 4 in intrinsic?
+
+The intrinsic grid groups 4 `minmax()` tracks together. This means items wrap in multiples of 4 — the grid shows 4, 8, 12, or more columns depending on space. The grouping prevents odd single-column stragglers and maintains visual rhythm. The number 4 aligns with the responsive grid's smallest breakpoint (4 columns on mobile), creating consistency between the two strategies.
+
+## Further reading
+
+- [How to use the responsive grid](?path=/docs/foundation-design-tokens-how-to-use-the-responsive-grid--docs): step-by-step guide for page layouts
+- [How to use the intrinsic grid](?path=/docs/foundation-design-tokens-how-to-use-the-intrinsic-grid--docs): step-by-step guide for content grids
+- [Your first grid layout](?path=/docs/foundation-design-tokens-learn-your-first-grid-layout--docs): hands-on tutorial building a complete layout
+- [Grid classes reference](?path=/docs/foundation-design-tokens-reference-grid-classes--docs): all classes, properties, and breakpoints
+- [Understanding the spacing scale](?path=/docs/foundation-design-tokens-understanding-the-spacing-scale--docs): the dimension tokens used for gap
+- [Token Architecture](?path=/docs/foundation-design-tokens-understanding-token-architecture--docs): how the modifier pattern works system-wide

--- a/packages/react/tokens/src/lib/docs/HowToAlignBaseline.mdx
+++ b/packages/react/tokens/src/lib/docs/HowToAlignBaseline.mdx
@@ -1,0 +1,124 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/How to/Align to the Baseline Grid" />
+
+# How to align to the baseline grid
+
+This guide shows you how to use the 8px baseline grid to create consistent vertical rhythm across headings, body text, and spacing. The baseline grid ensures that text lines up across columns and that spacing between elements feels intentional.
+
+## Prerequisites
+
+- `@canonical/styles` imported in your project
+- Familiarity with CSS `padding`, `margin`, and `line-height`
+- Understanding of the [spacing scale](?path=/docs/foundation-design-tokens-understanding-the-spacing-scale--docs)
+
+## Steps
+
+### 1. Understand the baseline unit
+
+The baseline grid uses an 8px (0.5rem) unit. Every vertical measurement — line-height, padding, margin, gap — should resolve to a multiple of 8px. When this is true, text across adjacent columns aligns on the same horizontal lines, and the spacing between sections maintains a visual cadence.
+
+```css
+/* These values sit on the 8px grid */
+padding: var(--dimension-100);      /* 8px — 1 baseline unit */
+padding: var(--dimension-200);      /* 16px — 2 baseline units */
+gap: var(--dimension-300);          /* 24px — 3 baseline units */
+margin-bottom: var(--dimension-400); /* 32px — 4 baseline units */
+```
+
+### 2. Use the typography tokens
+
+The typography system pre-computes line-heights that align with the baseline grid. Use typography tokens instead of setting `font-size` and `line-height` manually:
+
+```css
+.ds.my-heading {
+  font-family: var(--typography-heading-3-font-family);
+  font-size: var(--typography-heading-3-font-size);
+  font-weight: var(--typography-heading-3-font-weight);
+  line-height: var(--typography-heading-3-line-height);
+}
+```
+
+The typography tokens are coordinated sets — the line-height for each heading level is chosen so that the total block height (line-height × number of lines) lands on an 8px boundary.
+
+### 3. Apply baseline nudge tokens (advanced)
+
+Some typography sizes don't produce line-heights that land exactly on the 8px grid. The system provides **baseline nudge** tokens that add sub-pixel padding to realign:
+
+```css
+.ds.my-heading {
+  font-family: var(--typography-heading-3-font-family);
+  font-size: var(--typography-heading-3-font-size);
+  font-weight: var(--typography-heading-3-font-weight);
+  line-height: var(--typography-heading-3-line-height);
+  padding-bottom: var(--dimension-baseline-nudge-bottom-500);
+}
+```
+
+Baseline nudge tokens are small values (0–7px) that compensate for the difference between the actual line-height and the nearest 8px multiple. They are indexed by font-size step — the `500` in `baseline-nudge-bottom-500` corresponds to the `--dimension-size-font-size-500` that heading 3 uses.
+
+> **Note:** Baseline nudge tokens are infrastructure. The design system's typography components apply them automatically. You only need them when building custom typography components from scratch.
+
+### 4. Keep spacing on-grid
+
+When adding vertical spacing between elements, use dimension tokens that are multiples of 8px:
+
+```css
+/* On the baseline grid — all multiples of 8px */
+.section + .section {
+  margin-top: var(--dimension-400);  /* 32px */
+}
+
+.paragraph + .paragraph {
+  margin-top: var(--dimension-200);  /* 16px */
+}
+
+/* Off the baseline grid — avoid for vertical spacing */
+.paragraph + .paragraph {
+  margin-top: var(--dimension-175);  /* 14px — breaks alignment */
+}
+```
+
+Half-step tokens (`--dimension-050`, `--dimension-150`, `--dimension-175`, `--dimension-225`, `--dimension-250`) are designed for _horizontal_ spacing (padding inside buttons, icon-to-text gaps) where baseline alignment is not a concern. For _vertical_ spacing, prefer full-step tokens.
+
+### 5. Verify alignment visually
+
+In Storybook, enable the baseline grid addon to overlay an 8px grid on your stories. Check that:
+
+- Text baselines across adjacent columns align
+- Spacing between sections is consistent
+- Headings and body text sit on grid lines
+
+In browser DevTools, you can also add a temporary background to verify:
+
+```css
+/* Temporary debug overlay */
+body {
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 0, 0, 0.1) 1px,
+    transparent 1px
+  );
+  background-size: 100% 8px;
+}
+```
+
+## Troubleshooting
+
+### Text doesn't align across columns
+
+Check that both columns use typography tokens with matching line-heights. If one column uses a custom `line-height`, it may drift off the baseline grid.
+
+### Spacing between sections is inconsistent
+
+Verify that all vertical margins and paddings use full-step dimension tokens. A single `14px` gap between two `16px` gaps will be visible as a rhythm break.
+
+### Baseline nudge makes text look shifted
+
+Baseline nudge tokens add `padding-bottom`, which shifts the text block upward within its container. This is intentional — it moves the _baseline_ of the last line onto the grid. If the shift looks wrong, check that the nudge token index matches the font-size step being used.
+
+## Related
+
+- [Understanding the spacing scale](?path=/docs/foundation-design-tokens-understanding-the-spacing-scale--docs): the dimension token system
+- [How to find the right token](?path=/docs/foundation-design-tokens-how-to-find-the-right-token--docs): choosing dimension tokens
+- [Token Explorer](?path=/docs/foundation-design-tokens-explorer--docs): browse typography and dimension tokens

--- a/packages/react/tokens/src/lib/docs/HowToDebugTokens.mdx
+++ b/packages/react/tokens/src/lib/docs/HowToDebugTokens.mdx
@@ -1,0 +1,133 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/How to/Debug Token Resolution" />
+
+# How to debug token resolution
+
+This guide shows you how to trace the resolution of a token value from the component's CSS through channel variables, modifiers, surfaces, and themes to the final computed color. Use this when a token isn't resolving as expected.
+
+## Prerequisites
+
+- Browser DevTools (Chrome, Firefox, or Safari)
+- A running Storybook or application using `@canonical/styles`
+- Familiarity with the [token architecture](?path=/docs/foundation-design-tokens-understanding-token-architecture--docs) (tiers and channels)
+
+## Steps
+
+### 1. Inspect the element
+
+Right-click the element whose color or spacing looks wrong and open DevTools → Elements (Chrome) or Inspector (Firefox).
+
+In the **Styles** panel, find the CSS rule that sets the property in question. For a button background, you might see:
+
+```css
+.ds.button {
+  background: var(
+    --modifier-color-foreground-primary,
+    var(--surface-color-foreground-primary,
+      var(--color-foreground-primary))
+  );
+}
+```
+
+This is the fallback chain. Read it right to left: the base semantic token is `--color-foreground-primary`, the surface channel is `--surface-color-foreground-primary`, and the modifier channel is `--modifier-color-foreground-primary`.
+
+### 2. Check which variable is active
+
+In the **Computed** panel (Chrome) or computed styles section (Firefox), search for the custom property names in the fallback chain:
+
+- **`--modifier-color-foreground-primary`**: If this has a value, a modifier class (`.error`, `.constructive`, etc.) is active on an ancestor. The value will point to an intent-specific semantic token like `var(--color-foreground-primary-destructive)`.
+- **`--surface-color-foreground-primary`**: If this has a value, the element is inside a `.surface` container. The value will point to a depth-specific token like `var(--color-foreground-primary-layer2)`.
+- **`--color-foreground-primary`**: This is the base semantic token. It always has a value (unless `@canonical/styles` is not loaded).
+
+The first non-empty variable in the chain determines the final computed value.
+
+### 3. Trace the resolution path
+
+For each variable that has a value, follow the chain deeper:
+
+```
+--modifier-color-foreground-primary
+  → var(--color-foreground-primary-destructive)
+    → oklch(56.29% 0.229 27.33)   [light mode]
+    → oklch(69.02% 0.187 28.45)   [dark mode]
+```
+
+In Chrome DevTools, you can click on a `var()` reference in the Styles panel to jump to the definition. In Firefox, hovering over a custom property shows its resolved value.
+
+### 4. Check the cascade layer
+
+If a variable is set but seems to be overridden, check the cascade layer. Open DevTools → Styles, and look for the `@layer` badge next to each rule:
+
+```
+@layer ds.tokens     → base semantic values
+@layer ds.modifiers  → modifier channel overrides
+@layer ds.surfaces   → surface depth compounding
+@layer ds.states     → interaction state derivations
+```
+
+A later layer always wins over an earlier layer, regardless of selector specificity. If a modifier value is being overridden by a surface value, that is the cascade layer system working as designed.
+
+### 5. Identify the theme context
+
+Check whether `.dark` or `.light` is applied to any ancestor of the element. In the Elements panel, walk up the DOM tree and look for theme classes.
+
+If no theme class is present, the element follows `prefers-color-scheme`. Toggle your system preference (or use the Storybook theme switcher) to verify that paired tokens switch values.
+
+### 6. Test by removing variables
+
+To isolate a problem, temporarily remove a channel variable in DevTools:
+
+1. In the Styles panel, find the rule that sets `--modifier-color-*` (typically on a `.error` or `.success` ancestor)
+2. Uncheck the checkbox next to the property to disable it
+3. Observe whether the element falls through to the next variable in the chain
+
+This technique quickly reveals whether the issue is in the modifier, the surface, or the base token.
+
+## Common diagnostic patterns
+
+### The element shows the wrong color
+
+**Check:** Is the element inside an unexpected modifier context? Walk up the DOM tree and look for `.error`, `.success`, `.warning`, `.constructive`, `.destructive`, `.caution`, `.branded`, `.muted`, or `.information` classes on any ancestor.
+
+### The element doesn't respond to a modifier
+
+**Check:** Is the component using the modifier channel in its CSS? Search the component's CSS for `--modifier-color-*`. If the component references `--color-text` directly without the `var(--modifier-color-text, ...)` wrapper, modifiers cannot intercept it.
+
+### The surface depth is wrong
+
+**Check:** Count the `.surface` ancestors. Each `.surface` class in the DOM ancestry increments the depth. A non-surface wrapper between two surfaces does not affect depth (it's a passthrough). If the depth is unexpected, a `.surface` class is either missing or present on an element that shouldn't have it.
+
+### Colors are identical in light and dark mode
+
+**Check:** The component may be using a primitive token instead of a semantic token. Primitive tokens (e.g., `--color-palette-gray-500`) are not paired — they have the same value in both themes. Replace with the semantic equivalent.
+
+### Hover state doesn't match the modifier context
+
+**Check:** The hover token should derive from the modifier channel, not the base token directly. The correct pattern is:
+
+```css
+background: var(
+  --hover--color-foreground-primary,
+  var(--modifier-color-foreground-primary,
+    var(--color-foreground-primary))
+);
+```
+
+If the hover token derives from `--color-foreground-primary` without the modifier intermediate, it will show the default hover color even inside a modifier context.
+
+## Firefox-specific: custom property viewer
+
+Firefox DevTools has a dedicated "Custom Properties" section in the inspector that lists all custom properties inherited by an element, grouped by source. This is often faster than manually searching the Computed panel.
+
+## Chrome-specific: CSS overview
+
+Chrome DevTools → More tools → CSS Overview provides a summary of all colors used on the page. This can help identify rogue hardcoded colors that should be tokens.
+
+## Related
+
+- [Token Architecture](?path=/docs/foundation-design-tokens-understanding-token-architecture--docs): the fallback chain model
+- [The Modifier Contract](?path=/docs/foundation-design-tokens-understanding-modifier-contract--docs): how channel variables work
+- [Surface Depth Model](?path=/docs/foundation-design-tokens-understanding-surface-depth-model--docs): compound selectors and depth tracking
+- [Theme Mechanics](?path=/docs/foundation-design-tokens-understanding-theme-mechanics--docs): paired values and delta variables
+- [How to find the right token](?path=/docs/foundation-design-tokens-how-to-find-the-right-token--docs): choosing the correct token from the start

--- a/packages/react/tokens/src/lib/docs/HowToForceTheme.mdx
+++ b/packages/react/tokens/src/lib/docs/HowToForceTheme.mdx
@@ -1,0 +1,161 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/How to/Force a Theme on a Subtree" />
+
+# How to force a theme on a subtree
+
+This guide shows you how to force light or dark mode on a section of your interface, overriding the user's system preference. This is useful for sidebars, hero sections, footers, or any region that should maintain a specific appearance regardless of the global theme.
+
+## Prerequisites
+
+- `@canonical/styles` imported in your project
+- Familiarity with CSS custom properties
+- Understanding of how [theme mechanics](?path=/docs/foundation-design-tokens-understanding-theme-mechanics--docs) work
+
+## Steps
+
+### 1. Apply the theme class
+
+Add `.dark` or `.light` to the container element:
+
+```html
+<body>
+  <!-- This section follows the system preference -->
+  <main>
+    <p>Adapts to light/dark automatically</p>
+  </main>
+
+  <!-- This sidebar is always dark -->
+  <aside class="dark">
+    <nav>Always rendered in dark mode</nav>
+  </aside>
+</body>
+```
+
+Every token inside the `.dark` container resolves to its dark-mode value. Every token inside `.light` resolves to its light-mode value. The class can be applied to any element — `<div>`, `<section>`, `<aside>`, `<footer>`, or even a `<span>`.
+
+### 2. Ensure surface tokens resolve correctly
+
+If the forced-theme region also uses surfaces, apply `.surface` as you normally would:
+
+```html
+<aside class="dark">
+  <div class="surface">
+    <!-- Dark surface layer 1 -->
+    <div class="surface">
+      <!-- Dark surface layer 2 — shifted background in dark mode -->
+    </div>
+  </div>
+</aside>
+```
+
+Surface tokens inside a forced-theme region use the forced theme's values. The cascade order (tokens → modifiers → surfaces → states) applies identically — the theme class only changes _which values_ the token layer provides.
+
+### 3. Handle transitions at the theme boundary
+
+The boundary between theme regions may need visual separation. Use a border or shadow to mark the transition:
+
+```css
+.dark-sidebar {
+  border-inline-start: 1px solid var(--color-border-subtle);
+}
+```
+
+The `--color-border-subtle` token inside the `.dark` region resolves to the dark-mode border color, which works against the dark background.
+
+### 4. Test native form controls
+
+When forcing a theme, set `color-scheme` to ensure native form controls (scrollbars, checkboxes, selects) match:
+
+```css
+.dark {
+  color-scheme: dark;
+}
+
+.light {
+  color-scheme: light;
+}
+```
+
+The generated CSS from `@canonical/styles` already includes this, but if you are building a custom theme override, ensure `color-scheme` is set alongside the theme class.
+
+### 5. Test modifier composition
+
+Modifiers work identically inside forced-theme regions:
+
+```html
+<aside class="dark">
+  <div class="error">
+    <p>Error text in dark mode</p>
+  </div>
+</aside>
+```
+
+The `.error` modifier sets `--modifier-color-text` to `var(--color-text-error)`. Inside `.dark`, `--color-text-error` resolves to its dark-mode value. No special handling is needed.
+
+## Variations
+
+### Hero section in dark mode on a light page
+
+```html
+<body class="light">
+  <section class="dark hero">
+    <h1>Welcome</h1>
+    <p>This hero is always dark, even on a light page</p>
+  </section>
+  <main>
+    <p>Normal light-mode content</p>
+  </main>
+</body>
+```
+
+### Inline dark region (code block, terminal preview)
+
+```html
+<article>
+  <p>Regular article text</p>
+  <div class="dark surface" style="padding: var(--dimension-2); border-radius: 0.5rem;">
+    <pre><code>Terminal-style code preview on a dark background</code></pre>
+  </div>
+  <p>More article text</p>
+</article>
+```
+
+### Nested theme forcing (rare)
+
+Theme classes can nest. The innermost class wins:
+
+```html
+<div class="dark">
+  <!-- Dark region -->
+  <div class="light">
+    <!-- Light island inside the dark region -->
+    <div class="dark">
+      <!-- Dark island inside the light island -->
+    </div>
+  </div>
+</div>
+```
+
+This works because CSS custom properties inherit to the closest ancestor that sets them. Each theme class re-sets all semantic tokens to its theme values. Use sparingly — deeply nested theme flips are confusing for users.
+
+## Troubleshooting
+
+### Colors inside the forced region don't change
+
+Verify that `@canonical/styles` is imported. The `.dark` and `.light` classes are defined in the generated CSS — without it, the classes have no effect.
+
+### Native controls (scrollbars, selects) are in the wrong theme
+
+Add `color-scheme: dark` or `color-scheme: light` to the forced region. This tells the browser to render native UI elements in the matching theme.
+
+### Interaction states look wrong
+
+Interaction states (hover, active, disabled) use delta variables that are theme-aware. Inside a `.dark` region, hover deltas shift in the opposite direction from light mode. This is automatic — if deltas aren't working, check that the state tokens are being consumed from the generated CSS, not hardcoded.
+
+## Related
+
+- [Theme Mechanics](?path=/docs/foundation-design-tokens-understanding-theme-mechanics--docs): how paired values, deltas, and `color-scheme` work
+- [Surface Depth Model](?path=/docs/foundation-design-tokens-understanding-surface-depth-model--docs): surfaces inside forced-theme regions
+- [The Modifier Contract](?path=/docs/foundation-design-tokens-understanding-modifier-contract--docs): modifiers are theme-independent
+- [How to debug token resolution](?path=/docs/foundation-design-tokens-how-to-debug-token-resolution--docs): tracing values through forced themes

--- a/packages/react/tokens/src/lib/docs/HowToUseIntrinsicGrid.mdx
+++ b/packages/react/tokens/src/lib/docs/HowToUseIntrinsicGrid.mdx
@@ -1,0 +1,152 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/How to/Use the Intrinsic Grid" />
+
+# How to use the intrinsic grid
+
+This guide shows you how to build fluid content layouts using the intrinsic grid. The intrinsic grid wraps items automatically based on available space, without breakpoints.
+
+## Prerequisites
+
+- `@canonical/styles` imported in your project
+- Basic CSS Grid knowledge
+
+## Steps
+
+### 1. Apply the grid classes
+
+Add `.grid.intrinsic` to the container:
+
+```html
+<div class="grid intrinsic">
+  <div class="card">Card 1</div>
+  <div class="card">Card 2</div>
+  <div class="card">Card 3</div>
+  <div class="card">Card 4</div>
+  <div class="card">Card 5</div>
+</div>
+```
+
+The grid will show as many groups of 4 columns as the container width allows, wrapping to fewer columns in narrower spaces.
+
+### 2. Control the minimum column width
+
+The default minimum column width is `100px`. Override it with `--grid-col-min`:
+
+```css
+.wide-cards {
+  --grid-col-min: 200px;
+}
+```
+
+```html
+<div class="grid intrinsic wide-cards">
+  <!-- Cards won't shrink below 200px each -->
+</div>
+```
+
+Larger `--grid-col-min` values cause wrapping to happen sooner. Smaller values allow more columns in tight spaces.
+
+### 3. Adjust the gap
+
+As with the responsive grid, use `--grid-gap`:
+
+```css
+.tight-cards {
+  --grid-gap: var(--dimension-050);  /* 0.25rem / 4px */
+}
+```
+
+```html
+<div class="grid intrinsic tight-cards">
+  <!-- Minimal spacing between cards -->
+</div>
+```
+
+### 4. Let items span multiple columns
+
+Individual items can span multiple columns using `grid-column`:
+
+```css
+.featured-card {
+  grid-column: span 2;
+}
+```
+
+```html
+<div class="grid intrinsic">
+  <div class="card featured-card">Featured — spans 2 columns</div>
+  <div class="card">Card 2</div>
+  <div class="card">Card 3</div>
+</div>
+```
+
+When the grid wraps to fewer columns, the featured card will still span 2, adapting naturally to the available space.
+
+## Variations
+
+### Dashboard widget grid
+
+For a dashboard with mixed-size widgets:
+
+```css
+.dashboard {
+  --grid-col-min: 180px;
+  --grid-gap: var(--dimension-2);  /* 1rem / 16px */
+}
+
+.widget--wide {
+  grid-column: span 2;
+}
+
+.widget--tall {
+  grid-row: span 2;
+}
+```
+
+### Thumbnail gallery
+
+For a tight image grid:
+
+```css
+.gallery {
+  --grid-col-min: 120px;
+  --grid-gap: var(--dimension-050);  /* 0.25rem / 4px */
+}
+```
+
+### Combining with responsive at different levels
+
+The intrinsic grid can nest inside a responsive grid:
+
+```html
+<div class="grid responsive">
+  <main style="grid-column: 1 / -1">
+    <div class="grid intrinsic">
+      <!-- Cards flow within the main content area -->
+    </div>
+  </main>
+</div>
+```
+
+The responsive grid controls page structure; the intrinsic grid controls content flow within a section. They compose without conflict because each is an independent grid context.
+
+## Troubleshooting
+
+### All items are in a single column
+
+Check that the container is wide enough for the minimum column width. If `--grid-col-min` is `200px` and the container is `300px`, only one group of columns can fit. Reduce `--grid-col-min` or widen the container.
+
+### Items don't wrap evenly
+
+The intrinsic grid groups columns in sets of 4. If you have 5 items, the 5th will start a new row with 1 item. This is by design — the grouping maintains visual rhythm. If you need different grouping, override `--modifier-grid-template` with a custom `repeat(auto-fill, ...)`.
+
+### Items have unequal heights
+
+CSS Grid rows are sized by the tallest item in each row. If cards have varying content lengths, consider setting a `min-height` or using `align-items: start` on the grid container to prevent shorter cards from stretching.
+
+## Related
+
+- [How to use the responsive grid](?path=/docs/foundation-design-tokens-how-to-use-the-responsive-grid--docs): breakpoint-driven layouts
+- [Understanding the grid system](?path=/docs/foundation-design-tokens-understanding-the-grid-system--docs): why two grid strategies exist
+- [Grid classes reference](?path=/docs/foundation-design-tokens-reference-grid-classes--docs): all classes and properties

--- a/packages/react/tokens/src/lib/docs/HowToUseResponsiveGrid.mdx
+++ b/packages/react/tokens/src/lib/docs/HowToUseResponsiveGrid.mdx
@@ -1,0 +1,170 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/How to/Use the Responsive Grid" />
+
+# How to use the responsive grid
+
+This guide shows you how to build page-level layouts using the breakpoint-driven responsive grid. The responsive grid provides 4 columns on mobile, 8 on tablet, and 12 on desktop.
+
+## Prerequisites
+
+- `@canonical/styles` imported in your project
+- Basic CSS Grid knowledge (what `grid-column` does)
+
+## Steps
+
+### 1. Apply the grid classes
+
+Add `.grid.responsive` to the layout container:
+
+```html
+<div class="grid responsive">
+  <main>Page content</main>
+  <aside>Sidebar</aside>
+</div>
+```
+
+This establishes a responsive grid context. The container now has `display: grid` with breakpoint-driven columns.
+
+### 2. Place children on the grid
+
+Use `grid-column` to control how children span columns:
+
+```css
+.page-layout > main {
+  grid-column: 1 / -1;          /* Full width on mobile (4 cols) */
+}
+
+.page-layout > aside {
+  grid-column: 1 / -1;          /* Full width on mobile */
+}
+
+@media (min-width: 768px) {
+  .page-layout > main {
+    grid-column: 1 / 7;         /* 6 of 8 columns on tablet */
+  }
+
+  .page-layout > aside {
+    grid-column: 7 / -1;        /* Remaining 2 columns */
+  }
+}
+
+@media (min-width: 1280px) {
+  .page-layout > main {
+    grid-column: 1 / 10;        /* 9 of 12 columns on desktop */
+  }
+
+  .page-layout > aside {
+    grid-column: 10 / -1;       /* Remaining 3 columns */
+  }
+}
+```
+
+### 3. Adjust the gap (if needed)
+
+The default gap is `1rem`. Override it with `--grid-gap`:
+
+```css
+.compact-layout {
+  --grid-gap: var(--dimension-1);  /* 0.5rem / 8px */
+}
+```
+
+```html
+<div class="grid responsive compact-layout">
+  <!-- Tighter spacing between columns -->
+</div>
+```
+
+Use spacing tokens (`--dimension-*`) for gap values to stay on the spacing scale.
+
+### 4. Use subgrid for aligned children
+
+When a grid child needs its own children to align with the parent grid, use `.subgrid`:
+
+```html
+<div class="grid responsive">
+  <div class="subgrid" style="grid-column: 1 / -1">
+    <div style="grid-column: 1 / 5">Aligned to parent column 1–4</div>
+    <div style="grid-column: 5 / 9">Aligned to parent column 5–8</div>
+  </div>
+</div>
+```
+
+The subgrid inherits its parent's column tracks, so children align precisely. This is essential for forms where labels and inputs must align across rows.
+
+### 5. Control subgrid span
+
+By default, `.subgrid` spans all parent columns (`1 / -1`). To span a subset, set `--subgrid-span`:
+
+```css
+.partial-subgrid {
+  --subgrid-span: 1 / 7;  /* Span columns 1–6 of the parent */
+}
+```
+
+```html
+<div class="grid responsive">
+  <div class="subgrid partial-subgrid">
+    <!-- Only inherits columns 1–6 from parent -->
+  </div>
+</div>
+```
+
+## Variations
+
+### Full-bleed children
+
+To make a child break out of the grid and span the full viewport:
+
+```css
+.full-bleed {
+  grid-column: 1 / -1;
+  margin-inline: calc(-1 * var(--grid-gap, 1rem));
+}
+```
+
+### Centering content within columns
+
+To center a content block that doesn't span the full grid:
+
+```css
+@media (min-width: 1280px) {
+  .centered-content {
+    grid-column: 3 / 11;  /* 8 of 12 columns, centered */
+  }
+}
+```
+
+### Custom column count at a breakpoint
+
+If a specific layout needs a different column count, override `--modifier-grid-template`:
+
+```css
+.three-column-layout {
+  --modifier-grid-template: repeat(3, 1fr);
+}
+```
+
+This replaces the responsive breakpoints entirely. Use this sparingly — most layouts should use the standard 4/8/12 progression.
+
+## Troubleshooting
+
+### Children aren't placed on the grid
+
+Ensure the container has both `.grid` and `.responsive`. The `.grid` class sets `display: grid`; the `.responsive` class sets the column template. Without `.grid`, there is no grid context.
+
+### Gap looks wrong
+
+Check that you are setting `--grid-gap`, not `gap` directly. The `.grid` class reads `var(--grid-gap, 1rem)`, so setting the custom property ensures consistent behavior.
+
+### Subgrid children don't align
+
+Verify that the parent is using `.grid` (not just a plain `display: grid` element). The subgrid needs to inherit column tracks from a CSS Grid parent. Also verify browser support — `subgrid` is supported in Chrome 117+, Firefox 71+, Safari 16+.
+
+## Related
+
+- [How to use the intrinsic grid](?path=/docs/foundation-design-tokens-how-to-use-the-intrinsic-grid--docs): fluid content grids
+- [Understanding the grid system](?path=/docs/foundation-design-tokens-understanding-the-grid-system--docs): why responsive vs. intrinsic
+- [Grid classes reference](?path=/docs/foundation-design-tokens-reference-grid-classes--docs): all classes and properties
+- [Your first grid layout](?path=/docs/foundation-design-tokens-learn-your-first-grid-layout--docs): end-to-end tutorial

--- a/packages/react/tokens/src/lib/docs/SpacingScale.mdx
+++ b/packages/react/tokens/src/lib/docs/SpacingScale.mdx
@@ -1,0 +1,146 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/Understanding/The Spacing Scale" />
+
+# Understanding the spacing scale
+
+Spacing in the design system is a closed set of dimension tokens. Every `padding`, `margin`, `gap`, and size value in the system draws from the same scale. This page explains _why_ the scale exists, how it relates to the 8px baseline grid, and why the values are what they are.
+
+For practical usage, see [How to find the right token](?path=/docs/foundation-design-tokens-how-to-find-the-right-token--docs).
+
+## What the spacing scale solves
+
+Without a shared scale, spacing drifts. One component uses `12px` padding, another uses `14px`, a third uses `0.8rem`. The differences are imperceptible individually but collectively they produce an interface that feels unresolved — elements don't align, cards have inconsistent insets, and vertical rhythm breaks down.
+
+The spacing scale eliminates drift by providing exactly 18 values. If a value isn't in the scale, it isn't used. This constraint is the point — it forces every spacing decision through a shared vocabulary.
+
+## The scale
+
+The dimension token scale follows a progression from `0.125rem` (2px) to `5.5rem` (88px):
+
+<div className="ds token-page">
+  <section className="panel">
+    <div className="header">
+      <h3>Dimension token scale</h3>
+      <p>Each step is a primitive dimension token. Pixel equivalents assume a 16px root font size.</p>
+    </div>
+    <div className="stack">
+      {[
+        { token: "--dimension-025", rem: "0.125", px: "2" },
+        { token: "--dimension-050", rem: "0.25", px: "4" },
+        { token: "--dimension-100", rem: "0.5", px: "8" },
+        { token: "--dimension-150", rem: "0.75", px: "12" },
+        { token: "--dimension-175", rem: "0.875", px: "14" },
+        { token: "--dimension-200", rem: "1", px: "16" },
+        { token: "--dimension-225", rem: "1.125", px: "18" },
+        { token: "--dimension-250", rem: "1.25", px: "20" },
+        { token: "--dimension-300", rem: "1.5", px: "24" },
+        { token: "--dimension-400", rem: "2", px: "32" },
+        { token: "--dimension-500", rem: "2.5", px: "40" },
+        { token: "--dimension-600", rem: "3", px: "48" },
+        { token: "--dimension-700", rem: "3.5", px: "56" },
+        { token: "--dimension-800", rem: "4", px: "64" },
+        { token: "--dimension-900", rem: "4.5", px: "72" },
+        { token: "--dimension-1000", rem: "5", px: "80" },
+        { token: "--dimension-1100", rem: "5.5", px: "88" },
+      ].map(({ token, rem, px }) => (
+        <div key={token} style={{
+          display: "grid",
+          gridTemplateColumns: "12rem 5rem 4rem 1fr",
+          alignItems: "center",
+          gap: "0.5rem",
+          fontSize: "0.8125rem",
+          fontFamily: "ui-monospace, monospace",
+          padding: "0.25rem 0",
+        }}>
+          <code>{token}</code>
+          <span>{rem}rem</span>
+          <span style={{ color: "color-mix(in srgb, currentColor 60%, transparent)" }}>{px}px</span>
+          <div style={{
+            height: "8px",
+            width: `${rem}rem`,
+            background: "var(--color-foreground-primary, #e95420)",
+            borderRadius: "2px",
+            minWidth: "2px",
+          }} />
+        </div>
+      ))}
+    </div>
+  </section>
+</div>
+
+## Why these specific values
+
+The scale is not arbitrary. It follows three overlapping principles:
+
+### 1. 8px base unit
+
+The core of the scale is multiples of 8px (0.5rem): `--dimension-100` (8px), `--dimension-200` (16px), `--dimension-300` (24px), `--dimension-400` (32px), and so on. Eight pixels is the baseline grid unit — it divides cleanly into screen pixels, works well with common font sizes (16px body text sits on exactly 2 baseline units), and creates visually balanced spacing at every viewport size.
+
+The 8px grid is widely adopted because it produces spacing that _looks_ intentional. Human visual perception is sensitive to alignment on a regular grid — 8px provides enough granularity for fine work without the chaos of pixel-level freedom.
+
+### 2. Half-step refinements
+
+Between the 8px multiples, the scale includes half-steps for fine control: `--dimension-025` (2px), `--dimension-050` (4px), `--dimension-150` (12px), `--dimension-175` (14px), `--dimension-225` (18px), `--dimension-250` (20px). These exist because strict 8px adherence is too coarse for certain elements:
+
+- **2px** (`--dimension-025`): hairline gaps, border compensation, icon-to-text nudges
+- **4px** (`--dimension-050`): tight internal padding in compact elements (badges, tags)
+- **12px** (`--dimension-150`): button padding that is tighter than 16px but not as cramped as 8px
+- **14px** (`--dimension-175`): supplementary font size, aligned with common typographic tradition
+
+The half-steps are deliberately sparse. Having _some_ intermediate values provides escape hatches without undermining the grid.
+
+### 3. Naming encodes scale position
+
+Token names use a numeric suffix that encodes the scale position, not the pixel value. `--dimension-200` is 1rem (16px), not 200px. The hundreds-based naming leaves room for future intermediate values without renaming existing tokens — `--dimension-125` could be inserted between `100` and `150` without disruption.
+
+## Rem, not pixels
+
+Every dimension token is defined in `rem`, not `px`. This is a deliberate accessibility choice:
+
+- Users who set a larger default font size in their browser get proportionally larger spacing, maintaining the visual relationship between text and whitespace.
+- Users who zoom the page scale everything uniformly — `rem` values scale with the root font size, while `px` values scale independently of text.
+- The system can adapt to different root font sizes per breakpoint. The `small` breakpoint uses a 16px root; the `xLarge` breakpoint uses 18px. All dimension tokens scale proportionally.
+
+This is why the dimension token descriptions include pixel equivalents as documentation aids ("Primitive dimension 200 (16px)") — the pixel value assumes a 16px root and is provided for mental model purposes only. The actual value is always `rem`.
+
+## Spacing tokens are not modifier-aware
+
+Unlike color tokens, dimension tokens do not participate in the modifier channel system. There is no `--modifier-dimension-*` or `--surface-dimension-*`. This is a deliberate design constraint:
+
+- **Color changes with context.** An error state needs red text. A surface layer needs a shifted background. Color is inherently contextual.
+- **Spacing does not change with context.** A card has the same padding in an error state as in a success state. A surface layer has the same gap as the root. Spacing is structural, not contextual.
+
+If a component needs different spacing in different states, that is a component-specific concern — it should be handled with component-level CSS, not with a system-wide modifier channel.
+
+## The baseline grid and typography
+
+The spacing scale connects to typography through the baseline grid. The system defines a baseline of 8px (matching `--dimension-100`), and typography line-heights are tuned to sit on this grid:
+
+- **Heading 1**: `--dimension-size-font-size-700` with a line-height that produces a total block height divisible by 8px
+- **Body text**: `--dimension-size-font-size-350` with a line-height of approximately 24px (3 × 8px)
+
+When line-heights don't land exactly on the 8px grid (because font metrics vary), the system provides **baseline nudge tokens** — small sub-pixel adjustments that push an element's top or bottom padding to re-align subsequent content with the baseline grid.
+
+Baseline nudge tokens (e.g., `--dimension-baseline-nudge-bottom-350`) are infrastructure — they are consumed by typography components, not by application code. Most developers will never need to use them directly.
+
+See [How to align to the baseline grid](?path=/docs/foundation-design-tokens-how-to-align-to-the-baseline-grid--docs) for practical steps.
+
+## Semantic vs. primitive dimensions
+
+The dimension tokens described above are **primitive** — raw values in the scale. The system also defines **semantic** dimension tokens that carry meaning:
+
+- `--dimension-size-font-size-350`: "the font size for primary body text" — resolves to a dimension primitive, but its name carries typographic intent
+- `--dimension-size-font-size-700`: "the font size for heading 1" — a different semantic assignment from the same primitive scale
+
+Semantic dimension tokens follow the same principle as semantic color tokens: they express _intent_ rather than _value_. The intent is stable even when the underlying value changes (for example, if `heading-1` shifts from 2rem to 2.25rem in a future design iteration).
+
+For spacing, most usage is direct primitive references (`--dimension-2` for standard padding) because spacing intent is usually self-evident from context. For typography, semantic references are preferred because the relationship between font size, line-height, and baseline nudge is a coordinated set.
+
+## Further reading
+
+- [How to find the right token](?path=/docs/foundation-design-tokens-how-to-find-the-right-token--docs): decision tree including dimension tokens
+- [How to align to the baseline grid](?path=/docs/foundation-design-tokens-how-to-align-to-the-baseline-grid--docs): using nudge tokens in practice
+- [Understanding the grid system](?path=/docs/foundation-design-tokens-understanding-the-grid-system--docs): how spacing and grid gap interact
+- [Token Architecture](?path=/docs/foundation-design-tokens-understanding-token-architecture--docs): the three-tier model for all tokens
+- [Token Explorer](?path=/docs/foundation-design-tokens-explorer--docs): browse dimension tokens with visual previews

--- a/packages/react/tokens/src/lib/docs/TutorialFirstGrid.mdx
+++ b/packages/react/tokens/src/lib/docs/TutorialFirstGrid.mdx
@@ -1,0 +1,258 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Foundation/Design Tokens/Learn/Your First Grid Layout" />
+
+# Your first grid layout
+
+> In this tutorial, you will build a complete page layout with a responsive grid, place content into columns, nest an intrinsic card grid inside it, and use subgrid for form alignment. By the end, you will understand how the grid classes compose.
+
+## Prerequisites
+
+- A Pragma monorepo checkout with `bun install` completed
+- A package that imports `@canonical/styles`
+- Completion of the [first token-aware component](?path=/docs/foundation-design-tokens-learn-your-first-token-aware-component--docs) tutorial is recommended but not required
+
+## What you'll build
+
+A dashboard page with:
+
+- A responsive 12-column grid for the page structure
+- A sidebar and main content area that reflow at breakpoints
+- An intrinsic card grid for a set of status cards
+- A subgrid form where labels and inputs align across rows
+
+## Steps
+
+### 1. Create the page shell
+
+Start with the responsive grid:
+
+```tsx
+function DashboardPage() {
+  return (
+    <div className="grid responsive" style={{ padding: "var(--dimension-3)" }}>
+      <aside style={{ gridColumn: "1 / -1" }}>
+        <h2>Sidebar</h2>
+        <nav>Navigation links here</nav>
+      </aside>
+      <main style={{ gridColumn: "1 / -1" }}>
+        <h1>Dashboard</h1>
+        <p>Main content area</p>
+      </main>
+    </div>
+  );
+}
+```
+
+You should see: a stacked layout. Both the sidebar and main content span all available columns. On mobile (4 columns), this is the desired layout.
+
+### 2. Add breakpoint-specific placement
+
+Create a CSS file for the responsive placement:
+
+```css
+.ds.dashboard {
+  & > aside {
+    grid-column: 1 / -1;
+  }
+
+  & > main {
+    grid-column: 1 / -1;
+  }
+
+  @media (min-width: 768px) {
+    & > aside {
+      grid-column: 1 / 3;    /* 2 of 8 columns */
+    }
+
+    & > main {
+      grid-column: 3 / -1;   /* Remaining 6 columns */
+    }
+  }
+
+  @media (min-width: 1280px) {
+    & > aside {
+      grid-column: 1 / 3;    /* 2 of 12 columns */
+    }
+
+    & > main {
+      grid-column: 3 / -1;   /* Remaining 10 columns */
+    }
+  }
+}
+```
+
+Update the component:
+
+```tsx
+import "./Dashboard.css";
+
+function DashboardPage() {
+  return (
+    <div className="ds dashboard grid responsive">
+      <aside>
+        <h2>Sidebar</h2>
+        <nav>Navigation links here</nav>
+      </aside>
+      <main>
+        <h1>Dashboard</h1>
+        <p>Main content area</p>
+      </main>
+    </div>
+  );
+}
+```
+
+You should see: on desktop (≥ 1280px), a narrow sidebar on the left and a wide main area on the right. On tablet (768px–1279px), the sidebar is 2 of 8 columns. On mobile, both stack vertically.
+
+Resize your browser window to verify the breakpoints.
+
+### 3. Add an intrinsic card grid inside main
+
+Inside the main content area, add a set of status cards using the intrinsic grid:
+
+```tsx
+<main>
+  <h1>Dashboard</h1>
+
+  <div className="grid intrinsic" style={{ marginTop: "var(--dimension-2)" }}>
+    <div className="surface" style={{
+      padding: "var(--dimension-2)",
+      borderRadius: "0.75rem",
+    }}>
+      <h3>Users</h3>
+      <p>1,247 active</p>
+    </div>
+    <div className="surface" style={{
+      padding: "var(--dimension-2)",
+      borderRadius: "0.75rem",
+    }}>
+      <h3>Revenue</h3>
+      <p>$42,300</p>
+    </div>
+    <div className="surface" style={{
+      padding: "var(--dimension-2)",
+      borderRadius: "0.75rem",
+    }}>
+      <h3>Uptime</h3>
+      <p>99.97%</p>
+    </div>
+    <div className="surface" style={{
+      padding: "var(--dimension-2)",
+      borderRadius: "0.75rem",
+    }}>
+      <h3>Deploys</h3>
+      <p>14 today</p>
+    </div>
+  </div>
+</main>
+```
+
+You should see: four cards in a fluid row. As you narrow the window, they wrap to fewer columns automatically. Each card has a surface background (slightly shifted from the page background because it's inside a `.surface` container).
+
+Notice that the intrinsic grid is _inside_ the main area, which is _inside_ the responsive grid. The two grid types nest naturally — they are independent grid contexts.
+
+### 4. Add a subgrid form
+
+Below the cards, add a form that uses subgrid to align labels and inputs:
+
+```tsx
+<main>
+  {/* ... cards from step 3 ... */}
+
+  <section style={{ marginTop: "var(--dimension-3)" }}>
+    <h2>Settings</h2>
+    <div
+      className="grid responsive"
+      style={{ marginTop: "var(--dimension-2)" }}
+    >
+      <div className="subgrid" style={{ gridColumn: "1 / -1" }}>
+        <label style={{ gridColumn: "1 / 3" }}>Display name</label>
+        <input
+          type="text"
+          style={{ gridColumn: "3 / 7" }}
+          defaultValue="Adrian"
+        />
+      </div>
+      <div className="subgrid" style={{ gridColumn: "1 / -1" }}>
+        <label style={{ gridColumn: "1 / 3" }}>Email</label>
+        <input
+          type="email"
+          style={{ gridColumn: "3 / 7" }}
+          defaultValue="adrian@example.com"
+        />
+      </div>
+      <div className="subgrid" style={{ gridColumn: "1 / -1" }}>
+        <label style={{ gridColumn: "1 / 3" }}>Role</label>
+        <select style={{ gridColumn: "3 / 7" }}>
+          <option>Administrator</option>
+          <option>Editor</option>
+        </select>
+      </div>
+    </div>
+  </section>
+</main>
+```
+
+You should see: a form where all labels align in columns 1–2 and all inputs align in columns 3–6. This alignment is inherited from the parent responsive grid — the subgrid doesn't define its own columns, it uses the parent's. If you change the parent grid's column widths, the form adapts automatically.
+
+### 5. Combine with surface depth
+
+Wrap the entire page in a `.surface` to activate depth tracking:
+
+```tsx
+function DashboardPage() {
+  return (
+    <div className="surface" style={{ padding: "var(--dimension-3)" }}>
+      <div className="ds dashboard grid responsive">
+        <aside className="surface" style={{
+          padding: "var(--dimension-2)",
+          borderRadius: "0.75rem",
+        }}>
+          <h2>Sidebar</h2>
+          <nav>Navigation links here</nav>
+        </aside>
+        <main>
+          {/* Cards and form from previous steps */}
+        </main>
+      </div>
+    </div>
+  );
+}
+```
+
+You should see: the sidebar has a depth-2 surface background (it's `.surface` inside `.surface`). The status cards are also at depth 2 (they already have `.surface` from step 3). The page-level wrapper at depth 1 provides the base context.
+
+### 6. Test across viewports
+
+Resize the browser through all three breakpoints:
+
+- **≤ 767px**: 4 columns. Sidebar and main stack. Cards wrap to 1–2 per row.
+- **768px – 1279px**: 8 columns. Sidebar takes 2 columns, main takes 6. Cards may show 2–4 per row.
+- **≥ 1280px**: 12 columns. Full desktop layout. Cards show 4 per row.
+
+You should see: the responsive grid restructures the page at each breakpoint. The intrinsic card grid adapts fluidly within whatever space the main area provides. The subgrid form maintains label-input alignment at every width.
+
+### 7. Switch themes and verify
+
+Toggle between light and dark mode.
+
+You should see: the grid structure is unchanged — layout does not depend on theme. Surface backgrounds shift according to the theme. Text and border colors adapt. The grid system and the token system are independent.
+
+## What you learned
+
+You've built a complete page layout using all three grid classes. You now know:
+
+- `.grid.responsive` provides breakpoint-driven columns for page structure
+- `.grid.intrinsic` provides fluid wrapping for content grids
+- `.subgrid` inherits parent columns for cross-row alignment
+- Grids nest naturally — intrinsic inside responsive, subgrid inside either
+- Grids compose with surfaces and modifiers without conflict
+- Layout is viewport-driven; tokens are context-driven — they are independent systems
+
+## Next steps
+
+- [Understanding the grid system](?path=/docs/foundation-design-tokens-understanding-the-grid-system--docs): why responsive and intrinsic coexist
+- [How to use the responsive grid](?path=/docs/foundation-design-tokens-how-to-use-the-responsive-grid--docs): deeper responsive patterns
+- [How to use the intrinsic grid](?path=/docs/foundation-design-tokens-how-to-use-the-intrinsic-grid--docs): advanced fluid layouts
+- [Adding surface depth](?path=/docs/foundation-design-tokens-learn-adding-surface-depth--docs): more on surface nesting


### PR DESCRIPTION
## Done

- Add 10 new MDX documentation files following the [Diátaxis](https://diataxis.fr/) framework (explanations, how-to guides, tutorials, reference)
- Add `SpacingScale` and `TypographyScale` story exports to `Tokens.stories.tsx`
- Restructure hub `Introduction.mdx` to surface the Diátaxis navigation map

### New documentation files

**Explanations**
- `GridSystem.mdx` — why responsive vs intrinsic, modifier pattern in the grid, why subgrid
- `SpacingScale.mdx` — 8px base unit, half-step refinements, rem rationale, baseline grid relationship

**How-to guides**
- `HowToUseResponsiveGrid.mdx` — 5-step breakpoint-driven column layout recipe
- `HowToUseIntrinsicGrid.mdx` — 4-step fluid content-driven layout recipe
- `HowToForceTheme.mdx` — 5-step dark/light subtree override
- `HowToDebugTokens.mdx` — 6-step DevTools token tracing
- `HowToAlignBaseline.mdx` — 5-step baseline grid alignment

**Tutorial**
- `TutorialFirstGrid.mdx` — 7-step guided dashboard layout build

**Reference**
- `GridReference.mdx` — all grid classes, custom properties, breakpoints, browser support
- `CascadeLayersReference.mdx` — the 5-layer cascade architecture with all modifier channels

### New story exports

- `SpacingScale` — visual bar chart of all 17 dimension tokens with rem/px values and baseline-grid markers, common spacing patterns, and a `TokenTable` explorer
- `TypographyScale` — live-rendered heading 1–6 previews, text primary/secondary/tertiary with bold variants, and a 5-token structure reference

### Hub update

- `Introduction.mdx` — added Diátaxis navigation map (🎓 Learn / 🔧 How to / 💡 Understanding / 📖 Reference), corrected modifier ontology to four axes (Importance, Anticipation, Criticality, Emphasis)

## QA

- [ ] Run `nx storybook ds-tokens` and verify all new stories render without errors
- [ ] Verify SpacingScale story shows 17 dimension tokens with visual bars and ◆ baseline markers
- [ ] Verify TypographyScale story shows heading 1–6 and text styles with live previews
- [ ] Navigate to each new MDX doc page and confirm Storybook doc blocks render correctly
- [ ] Run `nx storybook storybook-hub` and verify the updated Introduction page renders the Diátaxis navigation map
- [ ] Confirm cross-links between docs resolve to correct Storybook paths

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.

## Screenshots

N/A — documentation-only change, no visual component changes.