### PR TITLE
chore(CI): fix CI step to publish packages; fix publish status script

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -110,8 +110,8 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Publish packages
         run: lerna publish --yes --no-private from-package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/scripts/publish-status.ts
+++ b/scripts/publish-status.ts
@@ -84,7 +84,7 @@ const publicPackages = packages.filter((p) => !p.private);
 const registryVersions = await Promise.all(
   publicPackages.map(async (pkg) => {
     try {
-      const proc = Bun.spawn(["npm", "view", pkg.name, "version", "--json"], {
+      const proc = Bun.spawn(["npm", "view", pkg.name, "version", "--json", "--prefer-online"], {
         stdout: "pipe",
         stderr: "ignore",
       });


### PR DESCRIPTION
## Done

- Set correct node auth env var
- Add `--prefer-online` to force a fresh registry lookup on npm. I was having issues where after publishing a package by hand, the script still showed it as unpublished.

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [ ] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify.
