### PR TITLE
chore(tokens): add terrazzo LSP config to all storybook packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -391,6 +391,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/storybook-helpers": "^0.18.0",
         "@canonical/typescript-config-react": "^0.18.0",
         "@canonical/webarchitect": "^0.18.0",
@@ -426,6 +427,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/storybook-helpers": "^0.18.0",
         "@canonical/typescript-config-react": "^0.18.0",
         "@canonical/webarchitect": "^0.18.0",
@@ -461,6 +463,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/storybook-helpers": "^0.18.0",
         "@canonical/typescript-config-react": "^0.18.0",
         "@canonical/webarchitect": "^0.18.0",
@@ -502,6 +505,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/storybook-helpers": "^0.18.0",
         "@canonical/typescript-config-react": "^0.18.0",
         "@canonical/webarchitect": "^0.18.0",
@@ -538,6 +542,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/storybook-helpers": "^0.18.0",
         "@canonical/typescript-config-react": "^0.18.0",
         "@canonical/webarchitect": "^0.18.0",
@@ -573,6 +578,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/storybook-helpers": "^0.18.0",
         "@canonical/typescript-config-react": "^0.18.0",
         "@canonical/webarchitect": "^0.18.0",
@@ -610,6 +616,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/ds-types": "^0.18.0",
         "@canonical/storybook-helpers": "^0.18.0",
         "@canonical/typescript-config-react": "^0.18.0",
@@ -649,6 +656,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/storybook-addon-form-state": "^0.18.0",
         "@canonical/storybook-addon-msw": "^0.18.0",
         "@canonical/storybook-helpers": "^0.18.0",
@@ -714,6 +722,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/ds-types": "^0.18.0",
         "@canonical/typescript-config-react": "^0.18.0",
         "@canonical/webarchitect": "^0.18.0",
@@ -1109,6 +1118,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@canonical/biome-config": "^0.18.0",
+        "@canonical/design-tokens": "^0.5.2",
         "@canonical/storybook-helpers": "^0.18.0",
         "@canonical/svelte-ssr-test": "^0.18.0",
         "@canonical/typescript-config-svelte": "^0.18.0",

--- a/packages/react/ds-app-anbox/package.json
+++ b/packages/react/ds-app-anbox/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/storybook-helpers": "^0.20.0",
     "@canonical/typescript-config-react": "^0.20.0",
     "@canonical/webarchitect": "^0.20.0",

--- a/packages/react/ds-app-anbox/terrazzo-lsp.config.json
+++ b/packages/react/ds-app-anbox/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}

--- a/packages/react/ds-app-landscape/package.json
+++ b/packages/react/ds-app-landscape/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/storybook-helpers": "^0.20.0",
     "@canonical/typescript-config-react": "^0.20.0",
     "@canonical/webarchitect": "^0.20.0",

--- a/packages/react/ds-app-landscape/terrazzo-lsp.config.json
+++ b/packages/react/ds-app-landscape/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}

--- a/packages/react/ds-app-launchpad/package.json
+++ b/packages/react/ds-app-launchpad/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/storybook-helpers": "^0.20.0",
     "@canonical/typescript-config-react": "^0.20.0",
     "@canonical/webarchitect": "^0.20.0",

--- a/packages/react/ds-app-launchpad/terrazzo-lsp.config.json
+++ b/packages/react/ds-app-launchpad/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}

--- a/packages/react/ds-app-lxd/package.json
+++ b/packages/react/ds-app-lxd/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/storybook-helpers": "^0.20.0",
     "@canonical/typescript-config-react": "^0.20.0",
     "@canonical/webarchitect": "^0.20.0",

--- a/packages/react/ds-app-lxd/terrazzo-lsp.config.json
+++ b/packages/react/ds-app-lxd/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}

--- a/packages/react/ds-app-portal/package.json
+++ b/packages/react/ds-app-portal/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/storybook-helpers": "^0.20.0",
     "@canonical/typescript-config-react": "^0.20.0",
     "@canonical/webarchitect": "^0.20.0",

--- a/packages/react/ds-app-portal/terrazzo-lsp.config.json
+++ b/packages/react/ds-app-portal/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}

--- a/packages/react/ds-app/package.json
+++ b/packages/react/ds-app/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/storybook-helpers": "^0.20.0",
     "@canonical/typescript-config-react": "^0.20.0",
     "@canonical/webarchitect": "^0.20.0",

--- a/packages/react/ds-app/terrazzo-lsp.config.json
+++ b/packages/react/ds-app/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}

--- a/packages/react/ds-global-form/package.json
+++ b/packages/react/ds-global-form/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/storybook-addon-form-state": "^0.20.0",
     "@canonical/storybook-addon-msw": "^0.20.0",
     "@canonical/storybook-helpers": "^0.20.0",

--- a/packages/react/ds-global-form/terrazzo-lsp.config.json
+++ b/packages/react/ds-global-form/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}

--- a/packages/react/ds-global/package.json
+++ b/packages/react/ds-global/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/ds-types": "^0.20.0",
     "@canonical/storybook-helpers": "^0.20.0",
     "@canonical/typescript-config-react": "^0.20.0",

--- a/packages/react/tokens/package.json
+++ b/packages/react/tokens/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/ds-types": "^0.20.0",
     "@canonical/typescript-config-react": "^0.20.0",
     "@canonical/webarchitect": "^0.20.0",

--- a/packages/react/tokens/terrazzo-lsp.config.json
+++ b/packages/react/tokens/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}

--- a/packages/svelte/ds-app-launchpad/package.json
+++ b/packages/svelte/ds-app-launchpad/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^0.20.0",
+    "@canonical/design-tokens": "^0.5.2",
     "@canonical/storybook-helpers": "^0.20.0",
     "@canonical/svelte-ssr-test": "^0.20.0",
     "@canonical/typescript-config-svelte": "^0.20.0",

--- a/packages/svelte/ds-app-launchpad/terrazzo-lsp.config.json
+++ b/packages/svelte/ds-app-launchpad/terrazzo-lsp.config.json
@@ -1,0 +1,4 @@
+{
+  "artifacts": ["@canonical/design-tokens/dist/tokens.json"],
+  "globalStylesheets": ["@canonical/styles/src/index.css"]
+}


### PR DESCRIPTION
## Done

- Added `terrazzo-lsp.config.json` to all 9 React and Svelte storybook packages that were missing it (mirroring `ds-global`)
- Added `@canonical/design-tokens` as a devDependency to all 10 storybook packages (including `ds-global` which had the config but not the dep)

## QA

- Verify the terrazzo LSP picks up token autocomplete in any of the target packages
- `bun install` succeeds cleanly

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify.

## Screenshots

N/A — config-only change, no visual impact.