### PR TITLE
test(pragma): parity hardening and edge cases

### DIFF
--- a/packages/cli/pragma/src/domains/config/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/config/mcp/specs.ts
@@ -1,10 +1,19 @@
 /**
  * MCP tool specs for the config domain.
+ *
+ * config_show uses the shared resolveConfigShow() operation so that
+ * MCP data matches what the CLI produces (tierChain, includedReleases, etc.).
  */
 
 import { readConfig, writeConfig } from "#config";
+import { detectInstallSource } from "#package-manager";
 import type { ToolSpec } from "../../shared/ToolSpec.js";
-import { validateChannel, validateTier } from "../operations/index.js";
+import { showFormatters } from "../formatters/index.js";
+import {
+  resolveConfigShow,
+  validateChannel,
+  validateTier,
+} from "../operations/index.js";
 
 const specs: readonly ToolSpec[] = [
   {
@@ -20,13 +29,16 @@ const specs: readonly ToolSpec[] = [
     },
     readOnly: true,
     async execute(rt, { condensed }) {
-      const data = {
-        tier: rt.config.tier ?? null,
-        channel: rt.config.channel,
-      };
+      const install = detectInstallSource();
+      const data = resolveConfigShow(rt.config, {
+        packageManager: install.packageManager,
+        installSource: install.label,
+        configFilePath: "pragma.config.json",
+        configFileExists: true,
+      });
 
       if (condensed) {
-        const text = `Config: tier=${data.tier ?? "(none)"} channel=${data.channel}`;
+        const text = showFormatters.llm(data);
         return {
           condensed: true,
           text,

--- a/packages/cli/pragma/src/domains/doctor/mcp/index.ts
+++ b/packages/cli/pragma/src/domains/doctor/mcp/index.ts
@@ -1,2 +1,2 @@
-/** @module Doctor domain MCP barrel — doctor, info. */
+/** @module Doctor domain MCP barrel — doctor. */
 export { default as specs } from "./specs.js";

--- a/packages/cli/pragma/src/domains/doctor/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/doctor/mcp/specs.ts
@@ -1,15 +1,9 @@
 /**
- * MCP tool specs for doctor domain — doctor, info.
+ * MCP tool specs for the doctor domain.
  *
- * The info tool is cross-domain: it uses operations and formatters from
- * the info domain, plus VERSION from #constants.
+ * The info tool has moved to its own domain: `info/mcp/specs.ts`.
  */
 
-import { VERSION } from "#constants";
-import { detectInstallSource } from "#package-manager";
-import { renderInfoLlm } from "../../info/formatters/index.js";
-import { collectStoreSummary } from "../../info/operations/index.js";
-import type { InfoData } from "../../info/types.js";
 import type { ToolSpec } from "../../shared/ToolSpec.js";
 import { doctorFormatters } from "../formatters/index.js";
 import { runChecks } from "../operations/index.js";
@@ -40,47 +34,6 @@ const specs: readonly ToolSpec[] = [
       }
 
       return { data: result };
-    },
-  },
-  {
-    name: "info",
-    description: "Show pragma version, configuration, and store summary.",
-    params: {
-      condensed: {
-        type: "boolean",
-        description: "Token-optimized output",
-        optional: true,
-      },
-    },
-    readOnly: true,
-    async execute(rt, params) {
-      const storeSummary = await collectStoreSummary(rt.store);
-      const install = detectInstallSource();
-
-      const data: InfoData = {
-        version: VERSION,
-        pm: install.packageManager,
-        installSource: install.label,
-        configPath: "pragma.config.json",
-        tier: rt.config.tier,
-        tierChain: [],
-        channel: rt.config.channel,
-        channelReleases: [],
-        update: undefined,
-        updateSkipped: true,
-        store: storeSummary,
-      };
-
-      if (params.condensed) {
-        const text = renderInfoLlm(data);
-        return {
-          condensed: true,
-          text,
-          tokens: `~${Math.ceil(text.length / 4)}`,
-        };
-      }
-
-      return { data };
     },
   },
 ];

--- a/packages/cli/pragma/src/domains/info/index.ts
+++ b/packages/cli/pragma/src/domains/info/index.ts
@@ -1,7 +1,9 @@
 /**
  * @module Info domain barrel.
  *
- * Provides the `pragma info` and `pragma upgrade` commands.
+ * Provides the `pragma info` and `pragma upgrade` commands,
+ * and the `info` MCP tool spec.
  */
 
 export { infoCommand, upgradeCommand } from "./commands/index.js";
+export { specs as infoSpecs } from "./mcp/index.js";

--- a/packages/cli/pragma/src/domains/info/mcp/index.ts
+++ b/packages/cli/pragma/src/domains/info/mcp/index.ts
@@ -1,0 +1,2 @@
+/** @module Info domain MCP barrel — info. */
+export { default as specs } from "./specs.js";

--- a/packages/cli/pragma/src/domains/info/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/info/mcp/specs.ts
@@ -1,0 +1,65 @@
+/**
+ * MCP tool spec for the info domain.
+ *
+ * Uses shared operations (collectStoreSummary, resolveTierChain) instead of
+ * inlining data assembly. Skips the npm registry check to avoid network
+ * latency in MCP tool calls — sets `updateSkipped: true`.
+ */
+
+import { VERSION } from "#constants";
+import { detectInstallSource } from "#package-manager";
+import { CHANNEL_RELEASES } from "../../shared/filters/buildChannelFilter.js";
+import { resolveTierChain } from "../../shared/filters/buildTierFilter.js";
+import type { ToolSpec } from "../../shared/ToolSpec.js";
+import { renderInfoLlm } from "../formatters/index.js";
+import { collectStoreSummary } from "../operations/index.js";
+import type { InfoData } from "../types.js";
+
+const specs: readonly ToolSpec[] = [
+  {
+    name: "info",
+    description: "Show pragma version, configuration, and store summary.",
+    params: {
+      condensed: {
+        type: "boolean",
+        description: "Token-optimized output",
+        optional: true,
+      },
+    },
+    readOnly: true,
+    async execute(rt, params) {
+      const install = detectInstallSource();
+      const tierChain =
+        rt.config.tier !== undefined ? resolveTierChain(rt.config.tier) : [];
+      const channelReleases = CHANNEL_RELEASES[rt.config.channel];
+      const storeSummary = await collectStoreSummary(rt.store);
+
+      const data: InfoData = {
+        version: VERSION,
+        pm: install.packageManager,
+        installSource: install.label,
+        configPath: "pragma.config.json",
+        tier: rt.config.tier,
+        tierChain,
+        channel: rt.config.channel,
+        channelReleases: [...channelReleases],
+        update: undefined,
+        updateSkipped: true,
+        store: storeSummary,
+      };
+
+      if (params.condensed) {
+        const text = renderInfoLlm(data);
+        return {
+          condensed: true,
+          text,
+          tokens: `~${Math.ceil(text.length / 4)}`,
+        };
+      }
+
+      return { data };
+    },
+  },
+];
+
+export default specs;

--- a/packages/cli/pragma/src/domains/llm/data/decisionTrees.ts
+++ b/packages/cli/pragma/src/domains/llm/data/decisionTrees.ts
@@ -10,30 +10,32 @@ export const DECISION_TREES: readonly DecisionTree[] = [
   {
     intent: "Build a block",
     tree: `? Know IRI or name?
-  yes → block lookup <name-or-iri> --detailed  [~500]
+  yes → block lookup <name-or-iri...> --detailed  [~500]
+        e.g. block lookup ds:global.component.button
   no  → block list [~200] → pick compact IRI → lookup`,
   },
   {
     intent: "Audit standards",
     tree: `? Know standard IRI or name?
-  yes → standard lookup <name-or-iri> --detailed [~400]
+  yes → standard lookup <name-or-iri...> --detailed [~400]
+        e.g. standard lookup react/component/props
   no  → ? Know block IRI or name?
-      yes → block lookup <name-or-iri> --detailed [~500]
+      yes → block lookup <name-or-iri...> --detailed [~500]
         → inspect related guidance manually Σ500
         no  → standard list --category <cat> [~100]
-              → standard lookup <std-iri> --detailed [~400] Σ500`,
+              → standard lookup <std-iri...> --detailed [~400] Σ500`,
   },
   {
     intent: "Find a token",
     tree: `? Know token IRI or name?
-  yes → token lookup <name-or-iri> --detailed [~150]
+  yes → token lookup <name-or-iri...> --detailed [~150]
   no  → token list --category <cat> [~100]
-        → token lookup <name-or-iri> --detailed [~150] Σ250`,
+        → token lookup <name-or-iri...> --detailed [~150] Σ250`,
   },
   {
     intent: "Explore the design system",
     tree: `high-level → ontology list [~80] → ontology show <ns> [~300]
-modifiers  → modifier list [~100] → modifier lookup <name-or-iri> [~80]
+modifiers  → modifier list [~100] → modifier lookup <name-or-iri...> [~80]
 tiers      → tier list [~50]
 raw        → graph query "SELECT ..." → graph inspect <uri> [~200]`,
   },

--- a/packages/cli/pragma/src/mcp/tools/index.ts
+++ b/packages/cli/pragma/src/mcp/tools/index.ts
@@ -13,6 +13,7 @@ import { specs as configSpecs } from "../../domains/config/mcp/index.js";
 import { specs as createSpecs } from "../../domains/create/mcp/index.js";
 import { specs as diagnosticSpecs } from "../../domains/doctor/mcp/index.js";
 import { specs as graphSpecs } from "../../domains/graph/mcp/index.js";
+import { specs as infoSpecs } from "../../domains/info/mcp/index.js";
 import { specs as orientationSpecs } from "../../domains/llm/mcp/index.js";
 import { specs as modifierSpecs } from "../../domains/modifier/mcp/index.js";
 import { specs as ontologySpecs } from "../../domains/ontology/mcp/index.js";
@@ -35,6 +36,7 @@ const allSpecs: readonly ToolSpec[] = [
   ...graphSpecs,
   ...skillSpecs,
   ...diagnosticSpecs,
+  ...infoSpecs,
   ...orientationSpecs,
   ...createSpecs,
 ];

--- a/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
+++ b/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
@@ -476,11 +476,15 @@ describe("config_show", () => {
       arguments: {},
     });
     const data = parseData(result) as {
-      tier: string | null;
+      tier: string | undefined;
       channel: string;
+      tierChain: string[];
+      includedReleases: string[];
     };
     expect(data.channel).toBe("normal");
-    expect(data.tier).toBeNull();
+    expect(data.tier).toBeUndefined();
+    expect(data.tierChain).toEqual([]);
+    expect(data.includedReleases).toContain("stable");
   });
 
   it("returns condensed config text", async () => {
@@ -491,7 +495,8 @@ describe("config_show", () => {
     const envelope = parseEnvelope(result);
     expect(envelope.ok).toBe(true);
     expect(envelope.condensed).toBe(true);
-    expect(envelope.text).toBe("Config: tier=(none) channel=normal");
+    expect(typeof envelope.text).toBe("string");
+    expect(envelope.text as string).toContain("Configuration");
   });
 });
 

--- a/packages/cli/pragma/src/pipeline/createProgram.ts
+++ b/packages/cli/pragma/src/pipeline/createProgram.ts
@@ -35,6 +35,9 @@ export default function createProgram(
     writeErr: (str) => process.stderr.write(str),
   });
 
+  // Global flags (--llm, --format, --verbose) are pre-parsed by
+  // parseGlobalFlags() and stripped from argv before Commander sees it.
+  // Declaring them here keeps them visible in --help output.
   program.option(
     "--llm",
     "Condensed Markdown output for LLM consumption",
@@ -42,6 +45,8 @@ export default function createProgram(
   );
   program.option("--format <type>", "Output format (text or json)", "text");
   program.option("--verbose", "Diagnostic output to stderr", false);
+  // Commander will never see these flags in argv (they're stripped),
+  // so enablePositionalOptions() scoping can't reject them.
 
   program.addHelpText("beforeAll", (_ctx) => {
     // Only show root-level help when the help is for the root program itself.

--- a/packages/cli/pragma/src/pipeline/index.ts
+++ b/packages/cli/pragma/src/pipeline/index.ts
@@ -8,7 +8,10 @@ export {
   formatSection,
 } from "./formatTerminal.js";
 export { default as mapExitCode } from "./mapExitCode.js";
-export { default as parseGlobalFlags } from "./parseGlobalFlags.js";
+export {
+  default as parseGlobalFlags,
+  stripGlobalFlags,
+} from "./parseGlobalFlags.js";
 export {
   renderErrorJson,
   renderErrorLlm,

--- a/packages/cli/pragma/src/pipeline/parseGlobalFlags.test.ts
+++ b/packages/cli/pragma/src/pipeline/parseGlobalFlags.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import parseGlobalFlags, { stripGlobalFlags } from "./parseGlobalFlags.js";
+
+describe("parseGlobalFlags", () => {
+  it("extracts --llm", () => {
+    const flags = parseGlobalFlags([
+      "node",
+      "pragma",
+      "block",
+      "list",
+      "--llm",
+    ]);
+    expect(flags.llm).toBe(true);
+  });
+
+  it("extracts --format json", () => {
+    const flags = parseGlobalFlags([
+      "node",
+      "pragma",
+      "--format",
+      "json",
+      "info",
+    ]);
+    expect(flags.format).toBe("json");
+  });
+
+  it("defaults to text when --format is absent", () => {
+    const flags = parseGlobalFlags(["node", "pragma", "info"]);
+    expect(flags.format).toBe("text");
+  });
+
+  it("extracts --verbose", () => {
+    const flags = parseGlobalFlags([
+      "node",
+      "pragma",
+      "--verbose",
+      "block",
+      "list",
+    ]);
+    expect(flags.verbose).toBe(true);
+  });
+});
+
+describe("stripGlobalFlags", () => {
+  it("removes --llm from any position", () => {
+    expect(
+      stripGlobalFlags(["node", "pragma", "--llm", "tier", "list"]),
+    ).toEqual(["node", "pragma", "tier", "list"]);
+    expect(
+      stripGlobalFlags(["node", "pragma", "tier", "list", "--llm"]),
+    ).toEqual(["node", "pragma", "tier", "list"]);
+  });
+
+  it("removes --format and its value", () => {
+    expect(
+      stripGlobalFlags(["node", "pragma", "--format", "json", "info"]),
+    ).toEqual(["node", "pragma", "info"]);
+    expect(
+      stripGlobalFlags(["node", "pragma", "info", "--format", "json"]),
+    ).toEqual(["node", "pragma", "info"]);
+  });
+
+  it("removes --verbose from any position", () => {
+    expect(
+      stripGlobalFlags(["node", "pragma", "block", "list", "--verbose"]),
+    ).toEqual(["node", "pragma", "block", "list"]);
+  });
+
+  it("removes all global flags at once", () => {
+    expect(
+      stripGlobalFlags([
+        "node",
+        "pragma",
+        "--llm",
+        "--verbose",
+        "--format",
+        "json",
+        "block",
+        "list",
+      ]),
+    ).toEqual(["node", "pragma", "block", "list"]);
+  });
+
+  it("preserves argv when no global flags present", () => {
+    expect(stripGlobalFlags(["node", "pragma", "block", "list"])).toEqual([
+      "node",
+      "pragma",
+      "block",
+      "list",
+    ]);
+  });
+});

--- a/packages/cli/pragma/src/pipeline/parseGlobalFlags.ts
+++ b/packages/cli/pragma/src/pipeline/parseGlobalFlags.ts
@@ -19,3 +19,28 @@ export default function parseGlobalFlags(argv: readonly string[]): GlobalFlags {
     verbose: argv.includes("--verbose"),
   };
 }
+
+/**
+ * Return a copy of argv with global flags stripped out.
+ *
+ * Since {@link parseGlobalFlags} pre-parses these flags before Commander
+ * runs, we remove them so they don't collide with Commander's
+ * `enablePositionalOptions()` scoping. This lets users place `--llm`,
+ * `--format`, and `--verbose` anywhere in the command line.
+ *
+ * @param argv - Raw process.argv array.
+ * @returns New array with global flags removed.
+ */
+export function stripGlobalFlags(argv: readonly string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--llm" || arg === "--verbose") continue;
+    if (arg === "--format") {
+      i += 1; // skip the value too
+      continue;
+    }
+    result.push(arg as string);
+  }
+  return result;
+}

--- a/packages/cli/pragma/src/pipeline/runCli.orchestration.test.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.orchestration.test.ts
@@ -32,6 +32,7 @@ vi.mock("./mapExitCode.js", () => ({
 
 vi.mock("./parseGlobalFlags.js", () => ({
   default: parseGlobalFlagsMock,
+  stripGlobalFlags: (argv: readonly string[]) => [...argv],
 }));
 
 vi.mock("./resolveCommandKind.js", () => ({

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -8,7 +8,7 @@ import { PragmaError } from "../error/index.js";
 import collectCommands from "./collectCommands.js";
 import createProgram from "./createProgram.js";
 import mapExitCode from "./mapExitCode.js";
-import parseGlobalFlags from "./parseGlobalFlags.js";
+import parseGlobalFlags, { stripGlobalFlags } from "./parseGlobalFlags.js";
 import {
   renderErrorJson,
   renderErrorLlm,
@@ -114,7 +114,7 @@ async function bootAndRun(
     const ctx: PragmaContext = { ...runtime, globalFlags };
     const commands = collectCommands(ctx);
     const program = createProgram(commands, ctx);
-    await program.parseAsync(argv);
+    await program.parseAsync(stripGlobalFlags(argv));
   } catch (err) {
     handleProgramError(err, globalFlags);
   } finally {
@@ -137,7 +137,7 @@ async function runStoreSkip(
   const program = createProgram(commands, stubCtx);
 
   try {
-    await program.parseAsync(argv);
+    await program.parseAsync(stripGlobalFlags(argv));
   } catch (err) {
     handleProgramError(err, globalFlags);
   }

--- a/packages/cli/pragma/src/testing/integration/edge-cases.test.ts
+++ b/packages/cli/pragma/src/testing/integration/edge-cases.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Layer 3b: Edge-case and error-path tests.
+ *
+ * Covers error conditions that are not exercised by the happy-path
+ * parity tests or the basic MCP surface tests: unknown prefixes,
+ * all-fail batches, empty result sets, and condensed-mode error
+ * rendering.
+ */
+
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PragmaRuntime } from "../../domains/shared/runtime.js";
+import createTestMcpClient from "../helpers/createTestMcpClient.js";
+import createTestRuntime from "../helpers/createTestRuntime.js";
+
+let rt: PragmaRuntime;
+let client: Client;
+let cleanup: () => Promise<void>;
+
+beforeAll(async () => {
+  rt = await createTestRuntime();
+  const mcp = await createTestMcpClient(rt);
+  client = mcp.client;
+  cleanup = mcp.cleanup;
+});
+
+afterAll(async () => {
+  await cleanup();
+  rt.dispose();
+});
+
+/** Parse MCP response envelope. */
+function parseEnvelope(
+  mcpResponse: Record<string, unknown>,
+): Record<string, unknown> {
+  const content = mcpResponse.content as unknown[];
+  const first = content[0] as { text: string };
+  return JSON.parse(first.text) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Unknown prefix IRI resolution
+// ---------------------------------------------------------------------------
+
+describe("IRI resolution edge cases", () => {
+  it("block_lookup with unknown prefix returns error", async () => {
+    const res = await client.callTool({
+      name: "block_lookup",
+      arguments: { names: ["zz:nonexistent.block"] },
+    });
+    const body = parseEnvelope(res);
+    expect(body.ok).toBe(true);
+    const data = body.data as { results: unknown[]; errors: unknown[] };
+    expect(data.results).toHaveLength(0);
+    expect(data.errors).toHaveLength(1);
+  });
+
+  it("standard_lookup with unknown prefix returns error", async () => {
+    const res = await client.callTool({
+      name: "standard_lookup",
+      arguments: { names: ["zz:nonexistent.standard"] },
+    });
+    const body = parseEnvelope(res);
+    expect(body.ok).toBe(true);
+    const data = body.data as { results: unknown[]; errors: unknown[] };
+    expect(data.results).toHaveLength(0);
+    expect(data.errors).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// All-fail batch lookups
+// ---------------------------------------------------------------------------
+
+describe("all-fail batch lookups", () => {
+  it("block_lookup: all names unknown → empty results, all errors", async () => {
+    const res = await client.callTool({
+      name: "block_lookup",
+      arguments: { names: ["Unknown1", "Unknown2", "Unknown3"] },
+    });
+    const body = parseEnvelope(res);
+    expect(body.ok).toBe(true);
+    const data = body.data as {
+      results: unknown[];
+      errors: { query: string; code: string }[];
+    };
+    expect(data.results).toHaveLength(0);
+    expect(data.errors).toHaveLength(3);
+    for (const err of data.errors) {
+      expect(err.code).toBe("ENTITY_NOT_FOUND");
+    }
+  });
+
+  it("standard_lookup: all names unknown → empty results, all errors", async () => {
+    const res = await client.callTool({
+      name: "standard_lookup",
+      arguments: { names: ["no/such/standard", "also/missing"] },
+    });
+    const body = parseEnvelope(res);
+    expect(body.ok).toBe(true);
+    const data = body.data as {
+      results: unknown[];
+      errors: { query: string }[];
+    };
+    expect(data.results).toHaveLength(0);
+    expect(data.errors).toHaveLength(2);
+  });
+
+  it("modifier_lookup: unknown family → error", async () => {
+    const res = await client.callTool({
+      name: "modifier_lookup",
+      arguments: { names: ["nonexistent_family"] },
+    });
+    const body = parseEnvelope(res);
+    expect(body.ok).toBe(true);
+    const data = body.data as {
+      results: unknown[];
+      errors: { query: string; code: string }[];
+    };
+    expect(data.results).toHaveLength(0);
+    expect(data.errors).toHaveLength(1);
+    expect(data.errors[0]?.code).toBe("ENTITY_NOT_FOUND");
+  });
+
+  it("token_lookup: unknown token → error", async () => {
+    const res = await client.callTool({
+      name: "token_lookup",
+      arguments: { names: ["color.nonexistent"] },
+    });
+    const body = parseEnvelope(res);
+    expect(body.ok).toBe(true);
+    const data = body.data as {
+      results: unknown[];
+      errors: { query: string; code: string }[];
+    };
+    expect(data.results).toHaveLength(0);
+    expect(data.errors).toHaveLength(1);
+    expect(data.errors[0]?.code).toBe("ENTITY_NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty result sets (filtered lists)
+// ---------------------------------------------------------------------------
+
+describe("empty result sets", () => {
+  it("standard_list with nonexistent category → error envelope", async () => {
+    const res = await client.callTool({
+      name: "standard_list",
+      arguments: { category: "nonexistent_category" },
+    });
+    const body = parseEnvelope(res);
+    // resolveStandardList throws when no results found
+    expect(body.ok).toBe(false);
+    const error = body.error as { code: string };
+    expect(error.code).toBeDefined();
+  });
+
+  it("token_list with nonexistent category → empty or error", async () => {
+    const res = await client.callTool({
+      name: "token_list",
+      arguments: { category: "NonexistentType" },
+    });
+    const body = parseEnvelope(res);
+    if (body.ok) {
+      const data = body.data as unknown[];
+      expect(data).toHaveLength(0);
+    } else {
+      // Token list may throw on empty results
+      const error = body.error as { code: string };
+      expect(error.code).toBeDefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ontology_show with unknown prefix
+// ---------------------------------------------------------------------------
+
+describe("ontology_show edge cases", () => {
+  it("unknown prefix → error envelope", async () => {
+    const res = await client.callTool({
+      name: "ontology_show",
+      arguments: { prefix: "zzz" },
+    });
+    const body = parseEnvelope(res);
+    expect(body.ok).toBe(false);
+    const error = body.error as { code: string };
+    expect(error.code).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Condensed mode with errors
+// ---------------------------------------------------------------------------
+
+describe("condensed mode error rendering", () => {
+  it("block_lookup condensed: includes error section for unknown blocks", async () => {
+    const res = await client.callTool({
+      name: "block_lookup",
+      arguments: {
+        names: ["Button", "Nonexistent"],
+        condensed: true,
+      },
+    });
+    const body = parseEnvelope(res);
+    expect(body.condensed).toBe(true);
+    const text = body.text as string;
+    // Should contain the successful block
+    expect(text).toContain("Button");
+    // Should contain the errors section
+    expect(text).toContain("Errors");
+    expect(text).toContain("Nonexistent");
+  });
+
+  it("standard_lookup condensed: includes error section for unknown standards", async () => {
+    const res = await client.callTool({
+      name: "standard_lookup",
+      arguments: {
+        names: ["react/component/folder-structure", "no/such/standard"],
+        condensed: true,
+      },
+    });
+    const body = parseEnvelope(res);
+    expect(body.condensed).toBe(true);
+    const text = body.text as string;
+    expect(text).toContain("folder-structure");
+    expect(text).toContain("Errors");
+    expect(text).toContain("no/such/standard");
+  });
+
+  it("modifier_lookup condensed: includes error for unknown family", async () => {
+    const res = await client.callTool({
+      name: "modifier_lookup",
+      arguments: {
+        names: ["importance", "nonexistent"],
+        condensed: true,
+      },
+    });
+    const body = parseEnvelope(res);
+    expect(body.condensed).toBe(true);
+    const text = body.text as string;
+    expect(text).toContain("importance");
+    expect(text).toContain("Errors");
+    expect(text).toContain("nonexistent");
+  });
+
+  it("token_lookup condensed: includes error for unknown token", async () => {
+    const res = await client.callTool({
+      name: "token_lookup",
+      arguments: {
+        names: ["color.primary", "color.nonexistent"],
+        condensed: true,
+      },
+    });
+    const body = parseEnvelope(res);
+    expect(body.condensed).toBe(true);
+    const text = body.text as string;
+    expect(text).toContain("color.primary");
+    expect(text).toContain("Errors");
+    expect(text).toContain("color.nonexistent");
+  });
+});

--- a/packages/cli/pragma/src/testing/integration/parity.test.ts
+++ b/packages/cli/pragma/src/testing/integration/parity.test.ts
@@ -3,28 +3,68 @@
  *
  * Each test calls the same query through both the operation layer
  * (what CLI uses) and the MCP tool (what agents use), then asserts
- * data equality.
+ * data equality. Condensed-mode tests verify that the MCP condensed
+ * text matches what the LLM formatter produces for the same data.
  */
 
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { listFormatters as blockListFmt } from "../../domains/block/formatters/index.js";
+// ---- Shared utilities ----
+import { VERSION } from "#constants";
+import { detectInstallSource } from "#package-manager";
+// ---- Formatters ----
+import {
+  listFormatters as blockListFmt,
+  lookupFormatters as blockLookupFmt,
+} from "../../domains/block/formatters/index.js";
+// ---- Operations ----
 import {
   listBlocks,
   lookupBlock,
 } from "../../domains/block/operations/index.js";
+import { showFormatters as configShowFmt } from "../../domains/config/formatters/index.js";
+import { resolveConfigShow } from "../../domains/config/operations/index.js";
+import { renderInfoLlm } from "../../domains/info/formatters/index.js";
+import { collectStoreSummary } from "../../domains/info/operations/index.js";
+import type { InfoData } from "../../domains/info/types.js";
+import {
+  listFormatters as modifierListFmt,
+  lookupFormatters as modifierLookupFmt,
+} from "../../domains/modifier/formatters/index.js";
 import {
   listModifiers,
   lookupModifier,
 } from "../../domains/modifier/operations/index.js";
-import { listOntologies } from "../../domains/ontology/operations/index.js";
+import {
+  listOntologies,
+  showOntology,
+} from "../../domains/ontology/operations/index.js";
+import { CHANNEL_RELEASES } from "../../domains/shared/filters/buildChannelFilter.js";
+import { resolveTierChain } from "../../domains/shared/filters/buildTierFilter.js";
 import type { PragmaRuntime } from "../../domains/shared/runtime.js";
-import { listStandards } from "../../domains/standard/operations/index.js";
+import {
+  type StandardListOutput,
+  categoriesFormatters as standardCatFmt,
+  listFormatters as standardListFmt,
+  lookupFormatters as standardLookupFmt,
+} from "../../domains/standard/formatters/index.js";
+import {
+  listCategories,
+  listStandards,
+  lookupStandard,
+} from "../../domains/standard/operations/index.js";
+import { listFormatters as tierListFmt } from "../../domains/tier/formatters/index.js";
 import { listTiers } from "../../domains/tier/operations/index.js";
+import {
+  createLookupFormatters as createTokenLookupFmt,
+  listFormatters as tokenListFmt,
+} from "../../domains/token/formatters/index.js";
 import {
   listTokens,
   lookupToken,
 } from "../../domains/token/operations/index.js";
+
+// ---- Test helpers ----
 import assertParity from "../helpers/assertParity.js";
 import createTestMcpClient from "../helpers/createTestMcpClient.js";
 import createTestRuntime from "../helpers/createTestRuntime.js";
@@ -44,6 +84,30 @@ afterAll(async () => {
   await cleanup();
   rt.dispose();
 });
+
+/** Parse condensed MCP response envelope. */
+function parseCondensed(mcpResponse: Record<string, unknown>): {
+  text: string;
+  condensed: boolean;
+  tokens: string;
+} {
+  const content = mcpResponse.content as unknown[];
+  const first = content[0] as { text: string };
+  return JSON.parse(first.text) as {
+    text: string;
+    condensed: boolean;
+    tokens: string;
+  };
+}
+
+/** Parse MCP response envelope. */
+function parseEnvelope(
+  mcpResponse: Record<string, unknown>,
+): Record<string, unknown> {
+  const content = mcpResponse.content as unknown[];
+  const first = content[0] as { text: string };
+  return JSON.parse(first.text) as Record<string, unknown>;
+}
 
 // ---------------------------------------------------------------------------
 // Block parity
@@ -67,24 +131,39 @@ describe("block parity", () => {
       name: "block_list",
       arguments: { condensed: true },
     });
-    const content = mcpRes.content as unknown[];
-    const first = content[0] as { text: string };
-    const body = JSON.parse(first.text) as { text: string };
+    const body = parseCondensed(mcpRes);
     expect(body.text).toBe(expectedText);
   });
 
-  it("block_lookup: detailed fields match", async () => {
+  it("block_lookup: detailed result matches", async () => {
     const opResult = await lookupBlock(rt.store, "Button", rt.config);
     const mcpRes = await client.callTool({
       name: "block_lookup",
       arguments: { names: ["Button"] },
     });
-    const content = mcpRes.content as unknown[];
-    const first = content[0] as { text: string };
-    const body = JSON.parse(first.text) as {
-      data: { results: unknown[] };
-    };
-    expect(body.data.results[0]).toEqual(opResult);
+    const body = parseEnvelope(mcpRes);
+    expect(body.data).toEqual({ results: [opResult], errors: [] });
+  });
+
+  it("block_lookup condensed: matches llm formatter", async () => {
+    const opResult = await lookupBlock(rt.store, "Button", rt.config);
+    const expectedText = blockLookupFmt.llm({
+      block: opResult,
+      detailed: true,
+      aspects: {
+        anatomy: true,
+        modifiers: true,
+        tokens: true,
+        implementations: true,
+      },
+    });
+
+    const mcpRes = await client.callTool({
+      name: "block_lookup",
+      arguments: { names: ["Button"], condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
   });
 });
 
@@ -101,6 +180,80 @@ describe("standard parity", () => {
     });
     assertParity(opResult, mcpRes);
   });
+
+  it("standard_list condensed: matches llm formatter", async () => {
+    const opResult = await listStandards(rt.store);
+    const output: StandardListOutput = {
+      items: opResult,
+      details: undefined,
+      disclosure: { level: "summary" },
+    };
+    const expectedText = standardListFmt.llm(output);
+
+    const mcpRes = await client.callTool({
+      name: "standard_list",
+      arguments: { condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
+  });
+
+  it("standard_lookup: detailed fields match", async () => {
+    const opResult = await lookupStandard(
+      rt.store,
+      "react/component/folder-structure",
+    );
+    const mcpRes = await client.callTool({
+      name: "standard_lookup",
+      arguments: { names: ["react/component/folder-structure"] },
+    });
+    const body = parseEnvelope(mcpRes);
+    const data = body.data as { results: unknown[]; errors: unknown[] };
+    expect(data.results[0]).toEqual(opResult);
+    expect(data.errors).toEqual([]);
+  });
+
+  it("standard_lookup condensed: matches llm formatter", async () => {
+    const opResult = await lookupStandard(
+      rt.store,
+      "react/component/folder-structure",
+    );
+    const expectedText = standardLookupFmt.llm({
+      standard: opResult,
+      detailed: true,
+    });
+
+    const mcpRes = await client.callTool({
+      name: "standard_lookup",
+      arguments: {
+        names: ["react/component/folder-structure"],
+        condensed: true,
+      },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
+  });
+
+  it("standard_categories: data matches", async () => {
+    const opResult = await listCategories(rt.store);
+    const mcpRes = await client.callTool({
+      name: "standard_categories",
+      arguments: {},
+    });
+    assertParity(opResult, mcpRes);
+  });
+
+  it("standard_categories condensed: matches llm formatter", async () => {
+    const opResult = await listCategories(rt.store);
+    const expectedText = standardCatFmt.llm(opResult);
+
+    const mcpRes = await client.callTool({
+      name: "standard_categories",
+      arguments: { condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -115,6 +268,18 @@ describe("tier parity", () => {
       arguments: {},
     });
     assertParity(opResult, mcpRes);
+  });
+
+  it("tier_list condensed: matches llm formatter", async () => {
+    const opResult = await listTiers(rt.store);
+    const expectedText = tierListFmt.llm(opResult);
+
+    const mcpRes = await client.callTool({
+      name: "tier_list",
+      arguments: { condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
   });
 });
 
@@ -132,18 +297,39 @@ describe("modifier parity", () => {
     assertParity(opResult, mcpRes);
   });
 
+  it("modifier_list condensed: matches llm formatter", async () => {
+    const opResult = await listModifiers(rt.store);
+    const expectedText = modifierListFmt.llm([...opResult]);
+
+    const mcpRes = await client.callTool({
+      name: "modifier_list",
+      arguments: { condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
+  });
+
   it("modifier_lookup: values match", async () => {
     const opResult = await lookupModifier(rt.store, "importance");
     const mcpRes = await client.callTool({
       name: "modifier_lookup",
       arguments: { names: ["importance"] },
     });
-    const content = mcpRes.content as unknown[];
-    const first = content[0] as { text: string };
-    const body = JSON.parse(first.text) as {
-      data: { results: unknown[] };
-    };
-    expect(body.data.results[0]).toEqual(opResult);
+    const body = parseEnvelope(mcpRes);
+    const data = body.data as { results: unknown[]; errors: unknown[] };
+    expect(data.results[0]).toEqual(opResult);
+  });
+
+  it("modifier_lookup condensed: matches llm formatter", async () => {
+    const opResult = await lookupModifier(rt.store, "importance");
+    const expectedText = modifierLookupFmt.llm(opResult);
+
+    const mcpRes = await client.callTool({
+      name: "modifier_lookup",
+      arguments: { names: ["importance"], condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
   });
 });
 
@@ -161,18 +347,40 @@ describe("token parity", () => {
     assertParity(opResult, mcpRes);
   });
 
+  it("token_list condensed: matches llm formatter", async () => {
+    const opResult = await listTokens(rt.store);
+    const expectedText = tokenListFmt.llm([...opResult]);
+
+    const mcpRes = await client.callTool({
+      name: "token_list",
+      arguments: { condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
+  });
+
   it("token_lookup: values match", async () => {
     const opResult = await lookupToken(rt.store, "color.primary");
     const mcpRes = await client.callTool({
       name: "token_lookup",
       arguments: { names: ["color.primary"] },
     });
-    const content = mcpRes.content as unknown[];
-    const first = content[0] as { text: string };
-    const body = JSON.parse(first.text) as {
-      data: { results: unknown[] };
-    };
-    expect(body.data.results[0]).toEqual(opResult);
+    const body = parseEnvelope(mcpRes);
+    const data = body.data as { results: unknown[]; errors: unknown[] };
+    expect(data.results[0]).toEqual(opResult);
+  });
+
+  it("token_lookup condensed: matches llm formatter", async () => {
+    const opResult = await lookupToken(rt.store, "color.primary");
+    const fmt = createTokenLookupFmt({ detailed: true });
+    const expectedText = fmt.llm(opResult);
+
+    const mcpRes = await client.callTool({
+      name: "token_lookup",
+      arguments: { names: ["color.primary"], condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
   });
 });
 
@@ -188,5 +396,143 @@ describe("ontology parity", () => {
       arguments: {},
     });
     assertParity(opResult, mcpRes);
+  });
+
+  it("ontology_list condensed: text contains ontology data", async () => {
+    const mcpRes = await client.callTool({
+      name: "ontology_list",
+      arguments: { condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.condensed).toBe(true);
+    expect(body.text).toContain("Ontologies");
+    expect(body.text).toContain("ds:");
+  });
+
+  it("ontology_show: data matches operation", async () => {
+    const opResult = await showOntology(rt.store, "ds");
+    const mcpRes = await client.callTool({
+      name: "ontology_show",
+      arguments: { prefix: "ds" },
+    });
+    const body = parseEnvelope(mcpRes);
+    expect(body.data).toEqual(opResult);
+  });
+
+  it("ontology_show condensed: text contains schema data", async () => {
+    const mcpRes = await client.callTool({
+      name: "ontology_show",
+      arguments: { prefix: "ds", condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.condensed).toBe(true);
+    expect(body.text).toContain("ds:");
+    expect(body.text).toContain("Classes");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config parity
+// ---------------------------------------------------------------------------
+
+describe("config parity", () => {
+  it("config_show: data matches resolveConfigShow", async () => {
+    const install = detectInstallSource();
+    const opResult = resolveConfigShow(rt.config, {
+      packageManager: install.packageManager,
+      installSource: install.label,
+      configFilePath: "pragma.config.json",
+      configFileExists: true,
+    });
+
+    const mcpRes = await client.callTool({
+      name: "config_show",
+      arguments: {},
+    });
+    const body = parseEnvelope(mcpRes);
+    expect(body.data).toEqual(opResult);
+  });
+
+  it("config_show condensed: matches llm formatter", async () => {
+    const install = detectInstallSource();
+    const opResult = resolveConfigShow(rt.config, {
+      packageManager: install.packageManager,
+      installSource: install.label,
+      configFilePath: "pragma.config.json",
+      configFileExists: true,
+    });
+    const expectedText = configShowFmt.llm(opResult);
+
+    const mcpRes = await client.callTool({
+      name: "config_show",
+      arguments: { condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Info parity
+// ---------------------------------------------------------------------------
+
+describe("info parity", () => {
+  it("info: data matches shared operations", async () => {
+    const install = detectInstallSource();
+    const tierChain =
+      rt.config.tier !== undefined ? resolveTierChain(rt.config.tier) : [];
+    const channelReleases = CHANNEL_RELEASES[rt.config.channel];
+    const storeSummary = await collectStoreSummary(rt.store);
+
+    const expected: InfoData = {
+      version: VERSION,
+      pm: install.packageManager,
+      installSource: install.label,
+      configPath: "pragma.config.json",
+      tier: rt.config.tier,
+      tierChain,
+      channel: rt.config.channel,
+      channelReleases: [...channelReleases],
+      update: undefined,
+      updateSkipped: true,
+      store: storeSummary,
+    };
+
+    const mcpRes = await client.callTool({
+      name: "info",
+      arguments: {},
+    });
+    const body = parseEnvelope(mcpRes);
+    expect(body.data).toEqual(expected);
+  });
+
+  it("info condensed: matches llm formatter", async () => {
+    const install = detectInstallSource();
+    const tierChain =
+      rt.config.tier !== undefined ? resolveTierChain(rt.config.tier) : [];
+    const channelReleases = CHANNEL_RELEASES[rt.config.channel];
+    const storeSummary = await collectStoreSummary(rt.store);
+
+    const data: InfoData = {
+      version: VERSION,
+      pm: install.packageManager,
+      installSource: install.label,
+      configPath: "pragma.config.json",
+      tier: rt.config.tier,
+      tierChain,
+      channel: rt.config.channel,
+      channelReleases: [...channelReleases],
+      update: undefined,
+      updateSkipped: true,
+      store: storeSummary,
+    };
+    const expectedText = renderInfoLlm(data);
+
+    const mcpRes = await client.callTool({
+      name: "info",
+      arguments: { condensed: true },
+    });
+    const body = parseCondensed(mcpRes);
+    expect(body.text).toBe(expectedText);
   });
 });


### PR DESCRIPTION
## Done

- **Parity tests expanded** (11 → 28): data + condensed-mode parity for all entity domains — block, standard (list/lookup/categories), modifier, token, tier, ontology (list/show), config show, and info
- **Config show MCP shared operation**: `config_show` now uses `resolveConfigShow()` + `showFormatters.llm()` instead of inline logic, returning full `ConfigShowData` (tierChain, includedReleases, packageManager, installSource)
- **Info MCP moved to info domain**: created `info/mcp/specs.ts` using shared operations (`collectStoreSummary`, `resolveTierChain`, `CHANNEL_RELEASES`); removed cross-domain imports from doctor; fixes empty `tierChain: []` and `channelReleases: []`
- **MCP orientation IRI-based refs**: aligned `<name-or-iri...>` notation in decision trees with IRI examples
- **Edge case tests** (13 new): unknown prefix IRI, all-fail batch lookups, empty result sets, ontology_show unknown prefix, condensed-mode error rendering across all lookup domains
- **Global flags work at any position**: `--llm`, `--format`, `--verbose` now work before or after the subcommand (`pragma tier list --llm`) via `stripGlobalFlags()` pre-parse
- **registerTools.test.ts** updated for new config_show data shape

## QA

```bash
cd packages/cli/pragma

# Run all tests (869 pass, 0 fail)
bunx vitest run

# Run just the new/changed test files
bunx vitest run src/testing/integration/parity.test.ts
bunx vitest run src/testing/integration/edge-cases.test.ts
bunx vitest run src/pipeline/parseGlobalFlags.test.ts

# Verify global flags work at any position
bun src/bin.ts tier list --llm
bun src/bin.ts config show --format json
bun src/bin.ts --llm block list
bun src/bin.ts info --llm

# Verify error paths
bun src/bin.ts block lookup Nonexistent
bun src/bin.ts ontology show zzz

# Type check
bunx tsc --noEmit
```

### PR readiness check

- [x] PR should have one of the following labels:
  - `Maintenance 🔨`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`
- [x] No new packages introduced