### PR TITLE
fix(storybook): use package.json subpath imports for storybook decorators

### DIFF
--- a/packages/react/ds-global-form/package.json
+++ b/packages/react/ds-global-form/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/canonical/pragma"
   },
+  "imports": {
+    "#storybook/*": "./src/storybook/*"
+  },
   "license": "LGPL-3.0",
   "bugs": {
     "url": "https://github.com/canonical/pragma/issues"

--- a/packages/react/ds-global-form/src/lib/Field/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/Field.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 // Needed for function-based story, safe to remove otherwise
 // import type { FieldProps } from './types.js'
 import { useMemo } from "react";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import type { FieldProps } from "../Field/types.js";
 import Component from "./Field.js";
 

--- a/packages/react/ds-global-form/src/lib/Field/common/Wrapper/Wrapper.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/common/Wrapper/Wrapper.stories.tsx
@@ -3,7 +3,7 @@
 // Needed for function-based story, safe to remove otherwise
 // import type { WrapperProps } from './types.js'
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import {
   Textarea as TextareaInput,
   Text as TextInput,

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Checkbox/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useEffect } from "react";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Checkbox.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Choices/Choices.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Choices/Choices.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type React from "react";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Choices.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Color/Color.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Color/Color.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Color.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Combobox/Combobox.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Combobox/Combobox.stories.tsx
@@ -3,10 +3,10 @@
 // Needed for function-based story, safe to remove otherwise
 // import type { ComboboxProps } from './types.js'
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
 // Needed for template-based story, safe to remove otherwise
 // import type { StoryFn } from '@storybook/react-vite'
 import * as fixtures from "storybook/fixtures.options.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Combobox.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Date/DateInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Date/DateInput.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./DateInput.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Date/DateTimeInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Date/DateTimeInput.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./DateTimeInput.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Date/TimeInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Date/TimeInput.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./TimeInput.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/FileUpload/FileUpload.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/FileUpload/FileUpload.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./FileUpload.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Hidden/Hidden.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Hidden/Hidden.stories.tsx
@@ -1,6 +1,6 @@
 /* @canonical/generator-ds 0.9.0-experimental.9 */
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Hidden.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Phone/Phone.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Phone/Phone.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Phone.js";
 
 const meta = {

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Range/Range.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Range/Range.stories.tsx
@@ -3,7 +3,7 @@
 // Needed for function-based story, safe to remove otherwise
 // import type { RangeProps } from './types.js'
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Range.js";
 
 // Needed for template-based story, safe to remove otherwise

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Select/Select.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Select/Select.stories.tsx
@@ -3,8 +3,8 @@
 // Needed for function-based story, safe to remove otherwise
 // import type { SelectProps } from './types.js'
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
 import * as fixtures from "storybook/fixtures.options.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Select.js";
 
 // Needed for template-based story, safe to remove otherwise

--- a/packages/react/ds-global-form/src/lib/Field/inputs/SimpleChoices/SimpleChoices.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/SimpleChoices/SimpleChoices.stories.tsx
@@ -3,8 +3,8 @@
 // Needed for function-based story, safe to remove otherwise
 // import type { SimpleChoicesProps } from './types.js'
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
 import * as fixtures from "storybook/fixtures.options.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./SimpleChoices.js";
 
 // Needed for template-based story, safe to remove otherwise

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Text/Text.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Text/Text.stories.tsx
@@ -3,7 +3,7 @@
 // Needed for function-based story, safe to remove otherwise
 // import type { TextProps } from './types.js'
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Text.js";
 
 // Needed for template-based story, safe to remove otherwise

--- a/packages/react/ds-global-form/src/lib/Field/inputs/Textarea/Textarea.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Field/inputs/Textarea/Textarea.stories.tsx
@@ -3,7 +3,7 @@
 // Needed for function-based story, safe to remove otherwise
 // import type { TextareaProps } from './types.js'
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./Textarea.js";
 
 // Needed for template-based story, safe to remove otherwise

--- a/packages/react/ds-global-form/src/lib/Form/Form.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Form/Form.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
 import * as fieldMaps from "storybook/fixtures.fields.js";
+import * as decorators from "#storybook/decorators.js";
 import { Field } from "../Field/index.js";
 import type { FieldProps } from "../Field/types.js";
 

--- a/packages/react/ds-global-form/src/lib/middleware/middleware.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/middleware/middleware.stories.tsx
@@ -3,8 +3,8 @@
 // Needed for template-based story, safe to remove otherwise
 import type { Meta, StoryFn, StoryObj } from "@storybook/react-vite";
 import { http } from "msw";
-import * as decorators from "storybook/decorators.js";
 import * as fixtures from "storybook/fixtures.options.js";
+import * as decorators from "#storybook/decorators.js";
 import { Field } from "../Field/index.js";
 import * as middleware from "./index.js";
 

--- a/packages/react/ds-global/package.json
+++ b/packages/react/ds-global/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "https://github.com/canonical/pragma"
   },
+  "imports": {
+    "#storybook/*": "./src/storybook/*"
+  },
   "license": "LGPL-3.0",
   "bugs": {
     "url": "https://github.com/canonical/pragma/issues"

--- a/packages/react/ds-global/src/lib/SkipLink/SkipLink.stories.tsx
+++ b/packages/react/ds-global/src/lib/SkipLink/SkipLink.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as decorators from "storybook/decorators.js";
 import { expect } from "storybook/test";
+import * as decorators from "#storybook/decorators.js";
 import Component from "./SkipLink.js";
 
 const MainContents = () => (


### PR DESCRIPTION
## Done

- Add `"imports": { "#storybook/*": "./src/storybook/*" }` to `ds-global` and `ds-global-form` package.json
- Replace `from "storybook/decorators.js"` → `from "#storybook/decorators.js"` across 20 story files
- Fixes SkipLink:Focused and SkipLink:Focused (RTL) Chromatic test failures in the hub storybook

**Root cause:** The bare `storybook/decorators.js` import relied on tsconfig `baseUrl: "src"` for resolution. This works in each package's standalone storybook but fails in the hub storybook — the hub's Vite does not use each federated package's tsconfig for module resolution. The `beforeMain` decorator failed to import, so the SkipLink story rendered without a `<main>` element, and the play function's `getByText("Skip to main content")` found nothing.

**Fix:** Node.js/Bun [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) via the `imports` field in `package.json` are resolved by the runtime and bundler natively — no tsconfig or plugin dependency. The `#storybook/*` pattern works in both standalone and federated contexts.

## QA

- [ ] Hub storybook: SkipLink:Focused story renders and play function passes
- [ ] Hub storybook: SkipLink:Focused (RTL) story renders and play function passes
- [ ] ds-global standalone storybook: all stories render
- [ ] ds-global-form standalone storybook: all stories render (decorators still work)
- [ ] `bun run check` passes

### PR readiness check

- [x] PR should have one of the following labels: `Bug 🐛`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`
- [ ] N/A — no new packages introduced