### PR TITLE
feat(summon): add react application, route, and wrapper generators

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -821,9 +821,9 @@
       "version": "0.22.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.21.0",
-        "@canonical/typescript-config": "^0.21.0",
-        "@canonical/webarchitect": "^0.21.0",
+        "@canonical/biome-config": "^0.22.0",
+        "@canonical/typescript-config": "^0.22.0",
+        "@canonical/webarchitect": "^0.22.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1091,6 +1091,24 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/summon/application": {
+      "name": "@canonical/summon-application",
+      "version": "0.22.0",
+      "devDependencies": {
+        "@biomejs/biome": "2.4.9",
+        "@canonical/biome-config": "^0.22.0",
+        "@canonical/typescript-config": "^0.22.0",
+        "@canonical/typescript-config-react": "^0.22.0",
+        "@types/bun": "^1.3.10",
+        "@types/node": "^24.12.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
+      },
+      "peerDependencies": {
+        "@canonical/summon-core": "^0.22.0",
+        "@canonical/task": "^0.22.0",
+      },
+    },
     "packages/summon/component": {
       "name": "@canonical/summon-component",
       "version": "0.22.0",
@@ -1116,16 +1134,16 @@
       "name": "@canonical/summon-core",
       "version": "0.22.0",
       "dependencies": {
-        "@canonical/task": "^0.21.0",
-        "@canonical/utils": "^0.21.0",
+        "@canonical/task": "^0.22.0",
+        "@canonical/utils": "^0.22.0",
         "chalk": "^5.6.2",
         "ejs": "^5.0.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.21.0",
-        "@canonical/typescript-config": "^0.21.0",
-        "@canonical/webarchitect": "^0.21.0",
+        "@canonical/biome-config": "^0.22.0",
+        "@canonical/typescript-config": "^0.22.0",
+        "@canonical/webarchitect": "^0.22.0",
         "@types/bun": "^1.3.10",
         "@types/ejs": "^3.1.5",
         "@types/node": "^24.12.0",
@@ -1440,6 +1458,8 @@
     "@canonical/styles-typography": ["@canonical/styles-typography@workspace:packages/styles/typography"],
 
     "@canonical/summon": ["@canonical/summon@workspace:packages/cli/summon"],
+
+    "@canonical/summon-application": ["@canonical/summon-application@workspace:packages/summon/application"],
 
     "@canonical/summon-component": ["@canonical/summon-component@workspace:packages/summon/component"],
 

--- a/packages/cli/summon/generators/application/react/index.ts
+++ b/packages/cli/summon/generators/application/react/index.ts
@@ -1,0 +1,1 @@
+export { generator as default, generator } from "../../../../../summon/application/src/application/react/index.js";

--- a/packages/cli/summon/generators/route/index.ts
+++ b/packages/cli/summon/generators/route/index.ts
@@ -1,0 +1,1 @@
+export { generator as default, generator } from "../../../../summon/application/src/route/index.js";

--- a/packages/cli/summon/generators/wrapper/index.ts
+++ b/packages/cli/summon/generators/wrapper/index.ts
@@ -1,0 +1,1 @@
+export { generator as default, generator } from "../../../../summon/application/src/wrapper/index.js";

--- a/packages/summon/application/README.md
+++ b/packages/summon/application/README.md
@@ -1,0 +1,21 @@
+# @canonical/summon-application
+
+Application scaffolding for Summon. This package adds generators for a router-enabled React SSR app plus standalone route and wrapper scaffolds.
+
+## Commands
+
+```bash
+summon application react --app-path=my-router-app --ssr --router
+summon route settings/billing
+summon wrapper settings
+```
+
+## What it generates
+
+- `summon application react --ssr --router` creates a React + Vite SSR app wired to `@canonical/router-core` and `@canonical/router-react`
+- `summon route` creates a route module under `src/routes/`
+- `summon wrapper` creates a wrapper module under `src/wrappers/`
+
+## Notes
+
+This package is the replacement direction for deprecated `generator-ds` app scaffolding. The generated app follows the Track E router boilerplate pattern and is designed to be discovered by the Summon CLI.

--- a/packages/summon/application/biome.json
+++ b/packages/summon/application/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["src", "*.json"]
+  }
+}

--- a/packages/summon/application/package.json
+++ b/packages/summon/application/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@canonical/summon-application",
+  "description": "Application, route, and wrapper generators for Summon",
+  "version": "0.22.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "scripts": {
+    "build": "echo 'No build needed - runs directly from TypeScript'",
+    "build:all": "bun run build",
+    "check": "bun run check:biome && bun run check:ts",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.9",
+    "@canonical/biome-config": "^0.22.0",
+    "@canonical/typescript-config": "^0.22.0",
+    "@canonical/typescript-config-react": "^0.22.0",
+    "@types/bun": "^1.3.10",
+    "@types/node": "^24.12.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  },
+  "peerDependencies": {
+    "@canonical/summon-core": "^0.22.0",
+    "@canonical/task": "^0.22.0"
+  }
+}

--- a/packages/summon/application/src/application/react/index.ts
+++ b/packages/summon/application/src/application/react/index.ts
@@ -1,0 +1,696 @@
+import * as path from "node:path";
+import type { GeneratorDefinition, PromptDefinition } from "@canonical/summon-core";
+import {
+  debug,
+  exec,
+  info,
+  map,
+  mkdir,
+  sequence_,
+  when,
+  writeFile,
+} from "@canonical/task";
+import pkg from "../../../package.json" with { type: "json" };
+
+interface ApplicationAnswers {
+  readonly appPath: string;
+  readonly router: boolean;
+  readonly runInstall: boolean;
+  readonly ssr: boolean;
+}
+
+const prompts: PromptDefinition[] = [
+  {
+    name: "appPath",
+    type: "text",
+    message: "Application path:",
+    default: "my-react-app",
+    group: "Application",
+  },
+  {
+    name: "ssr",
+    type: "confirm",
+    message: "Enable SSR?",
+    default: false,
+    group: "Features",
+  },
+  {
+    name: "router",
+    type: "confirm",
+    message: "Enable @canonical/router-core and @canonical/router-react?",
+    default: false,
+    group: "Features",
+  },
+  {
+    name: "runInstall",
+    type: "confirm",
+    message: "Run bun install after generation?",
+    default: false,
+    group: "Post-setup",
+  },
+];
+
+function appPackageJson(appName: string): string {
+  return `${JSON.stringify(
+    {
+      name: appName,
+      private: true,
+      version: "0.22.0",
+      type: "module",
+      license: "GPL-3.0-only",
+      scripts: {
+        dev: "vite",
+        build: "bun run build:client && bun run build:server",
+        "build:client": "vite build --ssrManifest --outDir dist/client",
+        "build:server": "vite build --ssr src/ssr/server.ts --outDir dist/server",
+        serve: "bun run build && node dist/server/server.js",
+        check: "bun run check:biome && bun run check:ts",
+        "check:biome": "biome check",
+        "check:biome:fix": "biome check --write",
+        "check:ts": "tsc --noEmit",
+      },
+      dependencies: {
+        "@canonical/react-ssr": "^0.22.0",
+        "@canonical/router-core": "^0.22.0",
+        "@canonical/router-react": "^0.22.0",
+        express: "^5.2.1",
+        react: "^19.2.4",
+        "react-dom": "^19.2.4",
+      },
+      devDependencies: {
+        "@biomejs/biome": "2.4.9",
+        "@canonical/biome-config": "^0.22.0",
+        "@canonical/typescript-config-react": "^0.22.0",
+        "@types/express": "^5.0.6",
+        "@types/node": "^24.12.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.0",
+        typescript: "^5.9.3",
+        vite: "^8.0.1",
+        "vite-tsconfig-paths": "^6.1.1",
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+const tsconfigJson = `{
+  "extends": "@canonical/typescript-config-react",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "skipLibCheck": true,
+    "types": ["node", "react", "react-dom"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]
+}\n`;
+
+const viteConfigTs = `import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths(), react()],
+});
+`;
+
+const biomeJson = `{
+  "extends": ["@canonical/biome-config"]
+}\n`;
+
+const gitignore = `node_modules
+.DS_Store
+dist
+coverage
+`;
+
+const indexHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Canonical router app</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/ssr/entry-client.tsx"></script>
+  </body>
+</html>
+`;
+
+const indexCss = `:root {
+  background:
+    radial-gradient(circle at top, rgba(15, 98, 254, 0.12), transparent 28%),
+    linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+  color: #111827;
+  font-family: Inter, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+}
+`;
+
+const applicationCss = `#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  box-sizing: border-box;
+  display: grid;
+  gap: 2rem;
+  margin: 0 auto;
+  max-width: 1120px;
+  min-height: 100vh;
+  padding: 3rem 1.5rem;
+}
+
+.shell-header {
+  align-items: start;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.shell-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 0;
+}
+
+.shell-copy,
+.lede {
+  color: #4b5563;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  margin: 0;
+}
+
+.shell-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.shell-nav a {
+  background: #ffffff;
+  border: 1px solid #d7dbe6;
+  border-radius: 999px;
+  color: #111827;
+  padding: 0.7rem 1rem;
+  text-decoration: none;
+}
+
+.shell-main {
+  display: grid;
+}
+
+.route-panel {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.08);
+  padding: 2rem;
+}
+
+.eyebrow {
+  color: #0f62fe;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.feature-list {
+  display: grid;
+  gap: 0.9rem;
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.route-fallback {
+  color: #4b5563;
+  margin: 0;
+}
+
+.stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.stack-tight {
+  display: grid;
+  gap: 0.5rem;
+}
+`;
+
+const shellTsx = `import type { ReactElement, ReactNode } from "react";
+import Navigation from "./Navigation.js";
+
+interface ShellProps {
+  readonly children: ReactNode;
+}
+
+export default function Shell({ children }: ShellProps): ReactElement {
+  return (
+    <div className="app-shell">
+      <header className="shell-header">
+        <div className="brand stack-tight">
+          <p className="eyebrow">Summon application</p>
+          <h1 className="shell-title">React SSR router app</h1>
+          <p className="shell-copy">
+            Generated by <strong>summon application react --ssr --router</strong>.
+          </p>
+        </div>
+        <Navigation />
+      </header>
+      <main className="shell-main">{children}</main>
+    </div>
+  );
+}
+`;
+
+const navigationTsx = `import { Link } from "@canonical/router-react";
+import type { ReactElement } from "react";
+
+export default function Navigation(): ReactElement {
+  return (
+    <nav aria-label="Primary" className="shell-nav">
+      <Link to="home">
+        Home
+      </Link>
+      <Link to="about">
+        About
+      </Link>
+    </nav>
+  );
+}
+`;
+
+const wrapperTsx = `import { wrapper } from "@canonical/router-core";
+import type { ReactElement } from "react";
+import Shell from "../Shell.js";
+
+export const appShell = wrapper<void, ReactElement>({
+  id: "app-shell",
+  component: ({ children }): ReactElement => {
+    return <Shell>{children}</Shell>;
+  },
+});
+
+export default appShell;
+`;
+
+const wrappersIndexTs = `export { appShell } from "./app-shell.js";
+`;
+
+const homeRouteTsx = `import { route } from "@canonical/router-core";
+import type { ReactElement } from "react";
+
+interface HomeData {
+  readonly highlights: readonly string[];
+}
+
+const homeRoute = route({
+  url: "/",
+  fetch: async (): Promise<HomeData> => ({
+    highlights: [
+      "Flat route definitions stay easy to extend.",
+      "SSR and hydration share the same route map.",
+      "Summon can scaffold new routes and wrappers as your app grows.",
+    ],
+  }),
+  content: ({ data }: { data: HomeData }): ReactElement => {
+    return (
+      <section className="route-panel stack" aria-labelledby="home-title">
+        <p className="eyebrow">Home route</p>
+        <h1 id="home-title">Canonical router starter</h1>
+        <p className="lede">
+          This route comes from the generated React application preset.
+        </p>
+        <ul className="feature-list">
+          {data.highlights.map((highlight) => (
+            <li key={highlight}>{highlight}</li>
+          ))}
+        </ul>
+      </section>
+    );
+  },
+});
+
+export default homeRoute;
+`;
+
+const aboutRouteTsx = `import { route } from "@canonical/router-core";
+import type { ReactElement } from "react";
+
+interface AboutData {
+  readonly bullets: readonly string[];
+}
+
+const aboutRoute = route({
+  url: "/about",
+  fetch: async (): Promise<AboutData> => ({
+    bullets: [
+      "Use summon route settings/billing to add a new route module.",
+      "Use summon wrapper settings to add a reusable layout boundary.",
+      "Keep app-specific assembly in src/router.tsx.",
+    ],
+  }),
+  content: ({ data }: { data: AboutData }): ReactElement => {
+    return (
+      <section className="route-panel stack" aria-labelledby="about-title">
+        <p className="eyebrow">About route</p>
+        <h1 id="about-title">Why this preset exists</h1>
+        <p className="lede">
+          It replaces deprecated generator-ds app scaffolding with a Summon-native application flow.
+        </p>
+        <ul className="feature-list">
+          {data.bullets.map((bullet) => (
+            <li key={bullet}>{bullet}</li>
+          ))}
+        </ul>
+      </section>
+    );
+  },
+});
+
+export default aboutRoute;
+`;
+
+const routesIndexTsx = `import { group } from "@canonical/router-core";
+import aboutRoute from "./about.js";
+import homeRoute from "./home.js";
+import { appShell } from "../wrappers/index.js";
+
+const [home, about] = group(appShell, [homeRoute, aboutRoute] as const);
+
+export const appRoutes = {
+  home,
+  about,
+} as const;
+
+export default appRoutes;
+`;
+
+const routerTsx = `import {
+  type AnyRoute,
+  createRouter,
+  type NavigationContext,
+  type RouteMap,
+  type RouteMiddleware,
+  type RouterDehydratedState,
+  route,
+} from "@canonical/router-core";
+import { createHydratedRouter } from "@canonical/router-react";
+import type { ReactElement } from "react";
+import appRoutes from "./routes/index.js";
+
+export type AppRoutes = typeof appRoutes;
+export type AppInitialData = RouterDehydratedState<AppRoutes>;
+
+declare module "@canonical/router-react" {
+  interface RouterRegister {
+    routes: AppRoutes;
+  }
+}
+
+export function withI18n(defaultLocale: string): RouteMiddleware {
+  return ((currentRoute: AnyRoute) => {
+    const currentFetch = currentRoute.fetch;
+
+    if (!currentFetch) {
+      return currentRoute;
+    }
+
+    return {
+      ...currentRoute,
+      fetch: async (params: unknown, search: unknown, context: NavigationContext) => {
+        return currentFetch(params, {
+          locale: defaultLocale,
+          ...(search as Record<string, unknown>),
+        }, context);
+      },
+    };
+  }) as RouteMiddleware;
+}
+
+const notFoundRoute = route({
+  url: "/404",
+  content: (): ReactElement => {
+    return (
+      <section className="route-panel stack" aria-labelledby="not-found-title">
+        <p className="eyebrow">Fallback route</p>
+        <h1 id="not-found-title">Page not found</h1>
+        <p className="lede">
+          Add more route modules under src/routes and export them from src/routes/index.tsx.
+        </p>
+      </section>
+    );
+  },
+});
+
+export function createServerAppRouter(
+  initialData?: RouterDehydratedState<RouteMap>,
+) {
+  return createRouter(appRoutes, {
+    hydratedState: initialData,
+    middleware: [withI18n("en")],
+    notFound: notFoundRoute,
+  });
+}
+
+export function createHydratedAppRouter() {
+  return createHydratedRouter(appRoutes, {
+    middleware: [withI18n("en")],
+    notFound: notFoundRoute,
+  });
+}
+`;
+
+const ssrDocumentTsx = `import type { ServerEntrypointProps } from "@canonical/react-ssr/renderer";
+import type { ReactElement, ReactNode } from "react";
+
+interface DocumentProps extends ServerEntrypointProps<Record<string, unknown>> {
+  readonly children: ReactNode;
+}
+
+export default function Document(props: DocumentProps): ReactElement {
+  return (
+    <html lang={props.lang}>
+      <head>
+        <title>Canonical router starter</title>
+        <meta
+          name="description"
+          content="React SSR starter generated by Summon with @canonical/router-core."
+        />
+        {props.otherHeadElements}
+        {props.scriptElements}
+        {props.linkElements}
+      </head>
+      <body>
+        <div id="root">{props.children}</div>
+      </body>
+    </html>
+  );
+}
+`;
+
+const entryClientTsx = `import { Outlet, RouterProvider } from "@canonical/router-react";
+import { hydrateRoot } from "react-dom/client";
+import Shell from "../Shell.js";
+import { createHydratedAppRouter } from "../router.js";
+import "../Application.css";
+import "../index.css";
+
+const router = createHydratedAppRouter();
+
+hydrateRoot(
+  document,
+  <RouterProvider router={router}>
+    <Shell>
+      <Outlet fallback={<p className="route-fallback">Loading route…</p>} />
+    </Shell>
+  </RouterProvider>,
+);
+`;
+
+const entryServerTsx = `import type { ServerEntrypoint } from "@canonical/react-ssr/renderer";
+import type { RouterDehydratedState, RouteMap } from "@canonical/router-core";
+import { Outlet, RouterProvider } from "@canonical/router-react";
+import Shell from "../Shell.js";
+import { createServerAppRouter } from "../router.js";
+import Document from "./Document.js";
+
+const EntryServer: ServerEntrypoint<Record<string, unknown>> = (props) => {
+  const initialData = props.initialData as
+    | RouterDehydratedState<RouteMap>
+    | undefined;
+  const router = createServerAppRouter(initialData);
+
+  return (
+    <Document {...props}>
+      <RouterProvider router={router}>
+        <Shell>
+          <Outlet
+            fallback={<p className="route-fallback">Loading route…</p>}
+          />
+        </Shell>
+      </RouterProvider>
+    </Document>
+  );
+};
+
+export default EntryServer;
+`;
+
+const rendererTsx = `import fs from "node:fs/promises";
+import path from "node:path";
+import { JSXRenderer } from "@canonical/react-ssr/renderer";
+import { createServerAppRouter } from "../router.js";
+import EntryServer from "./entry-server.js";
+
+const htmlString = await fs.readFile(
+  path.join(process.cwd(), "dist", "client", "index.html"),
+  "utf-8",
+);
+
+export default async function prepareRender(requestUrl: string) {
+  const router = createServerAppRouter();
+  const loadResult = await router.load(requestUrl);
+  const initialData = loadResult.dehydrate() as Record<string, unknown>;
+
+  return {
+    initialData,
+    renderer: new JSXRenderer(EntryServer, initialData, {
+      htmlString,
+    }),
+  };
+}
+`;
+
+const serverTs = `import * as process from "node:process";
+import express from "express";
+import prepareRender from "./renderer.js";
+
+const PORT = process.env.PORT || 5173;
+const app = express();
+
+app.use("/assets", express.static("dist/client/assets"));
+
+app.use(async (req, res, next) => {
+  try {
+    const requestUrl = req.originalUrl || req.url || "/";
+    const { renderer } = await prepareRender(requestUrl);
+
+    renderer.renderToStream(req, res);
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.listen(PORT, () => {
+  console.log("Server started on http://localhost:" + PORT + "/");
+});
+
+export default app;
+`;
+
+const readmeMd = `# React SSR router app
+
+Generated by \`summon application react --ssr --router\`.
+
+## Commands
+
+- \`bun run dev\`
+- \`bun run build\`
+- \`bun run serve\`
+- \`bun run check\`
+
+## Structure
+
+- [src/router.tsx](src/router.tsx) wires router creation and middleware
+- [src/routes](src/routes) holds route modules
+- [src/wrappers](src/wrappers) holds reusable wrappers
+- [src/ssr](src/ssr) contains SSR entry points and the Express server
+`;
+
+export const generator: GeneratorDefinition<ApplicationAnswers> = {
+  meta: {
+    name: "application/react",
+    displayName: `${pkg.name}:react`,
+    description: "Generate a React application preset that can enable SSR and the Canonical router",
+    version: "0.1.0",
+    help: `Generate a React application preset for Summon.
+
+CURRENT PRESET:
+  This generator currently targets the routed SSR application flow.
+  Invoke it as: summon application react --ssr --router
+
+GENERATED STRUCTURE:
+  - src/router.tsx
+  - src/routes/*
+  - src/wrappers/*
+  - src/Shell.tsx
+  - SSR entry points under src/ssr/
+`,
+    examples: [
+      "summon application react --app-path=my-router-app --ssr --router",
+      "summon application react --app-path=apps/customer-portal --ssr --router --run-install",
+    ],
+  },
+  prompts,
+  generate: (answers: ApplicationAnswers) => {
+    if (!answers.ssr || !answers.router) {
+      throw new Error(
+        "The current React application preset is the routed SSR preset. Run: summon application react --ssr --router",
+      );
+    }
+
+    const appName = path.basename(answers.appPath);
+
+    return sequence_([
+      info(`Generating React application: ${answers.appPath}`),
+      mkdir(answers.appPath),
+      mkdir(path.join(answers.appPath, "src")),
+      mkdir(path.join(answers.appPath, "src", "routes")),
+      mkdir(path.join(answers.appPath, "src", "ssr")),
+      mkdir(path.join(answers.appPath, "src", "wrappers")),
+      debug("Writing application files"),
+      writeFile(path.join(answers.appPath, "package.json"), appPackageJson(appName)),
+      writeFile(path.join(answers.appPath, "tsconfig.json"), tsconfigJson),
+      writeFile(path.join(answers.appPath, "vite.config.ts"), viteConfigTs),
+      writeFile(path.join(answers.appPath, "biome.json"), biomeJson),
+      writeFile(path.join(answers.appPath, ".gitignore"), gitignore),
+      writeFile(path.join(answers.appPath, "index.html"), indexHtml),
+      writeFile(path.join(answers.appPath, "README.md"), readmeMd),
+      writeFile(path.join(answers.appPath, "src", "index.css"), indexCss),
+      writeFile(path.join(answers.appPath, "src", "Application.css"), applicationCss),
+      writeFile(path.join(answers.appPath, "src", "Shell.tsx"), shellTsx),
+      writeFile(path.join(answers.appPath, "src", "Navigation.tsx"), navigationTsx),
+      writeFile(path.join(answers.appPath, "src", "router.tsx"), routerTsx),
+      writeFile(path.join(answers.appPath, "src", "routes", "home.tsx"), homeRouteTsx),
+      writeFile(path.join(answers.appPath, "src", "routes", "about.tsx"), aboutRouteTsx),
+      writeFile(path.join(answers.appPath, "src", "routes", "index.tsx"), routesIndexTsx),
+      writeFile(path.join(answers.appPath, "src", "wrappers", "app-shell.tsx"), wrapperTsx),
+      writeFile(path.join(answers.appPath, "src", "wrappers", "index.tsx"), wrappersIndexTs),
+      writeFile(path.join(answers.appPath, "src", "ssr", "Document.tsx"), ssrDocumentTsx),
+      writeFile(path.join(answers.appPath, "src", "ssr", "entry-client.tsx"), entryClientTsx),
+      writeFile(path.join(answers.appPath, "src", "ssr", "entry-server.tsx"), entryServerTsx),
+      writeFile(path.join(answers.appPath, "src", "ssr", "renderer.tsx"), rendererTsx),
+      writeFile(path.join(answers.appPath, "src", "ssr", "server.ts"), serverTs),
+      when(
+        answers.runInstall,
+        map(exec("bun", ["install"], answers.appPath), () => undefined),
+      ),
+      info(`Created React application at ${answers.appPath}`),
+    ]);
+  },
+};
+
+export default generator;

--- a/packages/summon/application/src/index.test.ts
+++ b/packages/summon/application/src/index.test.ts
@@ -1,0 +1,106 @@
+import { dryRun, type Effect } from "@canonical/task";
+import { describe, expect, it } from "vitest";
+import { generators } from "./index.js";
+
+type WriteFileEffect = Extract<Effect, { _tag: "WriteFile" }>;
+type AppendFileEffect = Extract<Effect, { _tag: "AppendFile" }>;
+
+const getWritePaths = (effects: readonly Effect[]): string[] =>
+  effects
+    .filter((effect): effect is WriteFileEffect => effect._tag === "WriteFile")
+    .map((effect) => effect.path);
+
+describe("generators barrel", () => {
+  it("exports application/react generator", () => {
+    expect(generators["application/react"]).toBeDefined();
+    expect(generators["application/react"].meta.name).toBe("application/react");
+  });
+
+  it("exports route generator", () => {
+    expect(generators.route.meta.name).toBe("route");
+  });
+
+  it("exports wrapper generator", () => {
+    expect(generators.wrapper.meta.name).toBe("wrapper");
+  });
+});
+
+describe("application/react generator", () => {
+  const generator = generators["application/react"];
+
+  it("requires the routed SSR preset flags", () => {
+    expect(() =>
+      generator.generate({
+        appPath: "my-react-app",
+        router: false,
+        runInstall: false,
+        ssr: true,
+      }),
+    ).toThrow(/summon application react --ssr --router/);
+  });
+
+  it("creates the expected routed SSR app structure", () => {
+    const result = dryRun(
+      generator.generate({
+        appPath: "my-react-app",
+        router: true,
+        runInstall: false,
+        ssr: true,
+      }),
+    );
+
+    const paths = getWritePaths(result.effects);
+
+    expect(paths).toContain("my-react-app/package.json");
+    expect(paths).toContain("my-react-app/src/router.tsx");
+    expect(paths).toContain("my-react-app/src/routes/index.tsx");
+    expect(paths).toContain("my-react-app/src/routes/home.tsx");
+    expect(paths).toContain("my-react-app/src/routes/about.tsx");
+    expect(paths).toContain("my-react-app/src/wrappers/app-shell.tsx");
+    expect(paths).toContain("my-react-app/src/ssr/entry-client.tsx");
+    expect(paths).toContain("my-react-app/src/ssr/entry-server.tsx");
+    expect(paths).toContain("my-react-app/src/ssr/server.ts");
+  });
+});
+
+describe("route generator", () => {
+  const generator = generators.route;
+
+  it("creates a route module and appends an index export", () => {
+    const result = dryRun(
+      generator.generate({
+        routePath: "settings/billing",
+      }),
+    );
+
+    const paths = getWritePaths(result.effects);
+    const append = result.effects.find(
+      (effect): effect is AppendFileEffect => effect._tag === "AppendFile",
+    );
+
+    expect(paths).toContain("src/routes/settings/billing.tsx");
+    expect(append?.path).toBe("src/routes/index.tsx");
+    expect(append?.content).toContain("settings/billing");
+  });
+});
+
+describe("wrapper generator", () => {
+  const generator = generators.wrapper;
+
+  it("creates a wrapper module and appends an index export", () => {
+    const result = dryRun(
+      generator.generate({
+        wrapperPath: "settings",
+      }),
+    );
+
+    const paths = getWritePaths(result.effects);
+    const append = result.effects.find(
+      (effect): effect is AppendFileEffect => effect._tag === "AppendFile",
+    );
+
+    expect(paths).toContain("src/wrappers/settings.tsx");
+    expect(append?.path).toBe("src/wrappers/index.tsx");
+    expect(append?.content).toContain("settings");
+  });
+});

--- a/packages/summon/application/src/index.ts
+++ b/packages/summon/application/src/index.ts
@@ -1,0 +1,12 @@
+import type { AnyGenerator } from "@canonical/summon-core";
+import { generator as applicationReactGenerator } from "./application/react/index.js";
+import { generator as routeGenerator } from "./route/index.js";
+import { generator as wrapperGenerator } from "./wrapper/index.js";
+
+export const generators = {
+  "application/react": applicationReactGenerator,
+  route: routeGenerator,
+  wrapper: wrapperGenerator,
+} as const satisfies Record<string, AnyGenerator>;
+
+export default generators;

--- a/packages/summon/application/src/route/index.ts
+++ b/packages/summon/application/src/route/index.ts
@@ -1,0 +1,92 @@
+import * as path from "node:path";
+import type { GeneratorDefinition, PromptDefinition } from "@canonical/summon-core";
+import {
+  appendFile,
+  info,
+  mkdir,
+  sequence_,
+  writeFile,
+} from "@canonical/task";
+import pkg from "../../package.json" with { type: "json" };
+import { normalizeCommandPath, toCamelCase, toTitleCase } from "../shared/casing.js";
+
+interface RouteAnswers {
+  readonly routePath: string;
+}
+
+const prompts: PromptDefinition[] = [
+  {
+    name: "routePath",
+    type: "text",
+    message: "Route path (for example settings/billing):",
+    default: "settings/billing",
+    positional: true,
+    group: "Route",
+  },
+];
+
+function buildRouteFile(routePath: string): string {
+  const normalized = normalizeCommandPath(routePath);
+  const segments = normalized.split("/");
+  const routeUrl = `/${normalized}`;
+  const variableName = `${toCamelCase(segments.join("-"))}Route`;
+  const title = toTitleCase(segments.join(" "));
+
+  return `import { route } from "@canonical/router-core";
+import type { ReactElement } from "react";
+
+const ${variableName} = route({
+  url: "${routeUrl}",
+  content: (): ReactElement => {
+    return (
+      <section className="route-panel stack" aria-labelledby="${variableName}-title">
+        <p className="eyebrow">Generated route</p>
+        <h1 id="${variableName}-title">${title}</h1>
+        <p className="lede">
+          Replace this placeholder content with your real route implementation.
+        </p>
+      </section>
+    );
+  },
+});
+
+export default ${variableName};
+`;
+}
+
+export const generator: GeneratorDefinition<RouteAnswers> = {
+  meta: {
+    name: "route",
+    displayName: `${pkg.name}:route`,
+    description: "Generate a route module under src/routes/",
+    version: "0.1.0",
+    help: `Generate a route module.
+
+EXAMPLE:
+  summon route settings/billing
+
+OUTPUT:
+  src/routes/settings/billing.tsx
+`,
+    examples: [
+      "summon route settings/billing",
+      "summon route account/preferences",
+    ],
+  },
+  prompts,
+  generate: (answers: RouteAnswers) => {
+    const normalized = normalizeCommandPath(answers.routePath);
+    const dirname = path.join("src", "routes", path.dirname(normalized));
+    const filename = path.join("src", "routes", `${normalized}.tsx`);
+    const exportLine = `export { default as ${toCamelCase(normalized)}Route } from "./${normalized}.js";\n`;
+
+    return sequence_([
+      info(`Generating route: ${normalized}`),
+      mkdir(dirname),
+      writeFile(filename, buildRouteFile(normalized)),
+      appendFile(path.join("src", "routes", "index.tsx"), exportLine),
+    ]);
+  },
+};
+
+export default generator;

--- a/packages/summon/application/src/shared/casing.ts
+++ b/packages/summon/application/src/shared/casing.ts
@@ -1,0 +1,39 @@
+export function toSegments(value: string): string[] {
+  return value
+    .split(/[\/_-]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+export function toPascalCase(value: string): string {
+  return toSegments(value)
+    .map((segment) => {
+      return segment.charAt(0).toUpperCase() + segment.slice(1);
+    })
+    .join("");
+}
+
+export function toCamelCase(value: string): string {
+  const pascal = toPascalCase(value);
+
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+export function toKebabCase(value: string): string {
+  return toSegments(value)
+    .map((segment) => segment.toLowerCase())
+    .join("-");
+}
+
+export function toTitleCase(value: string): string {
+  return toSegments(value)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export function normalizeCommandPath(value: string): string {
+  return value
+    .trim()
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/\\/g, "/");
+}

--- a/packages/summon/application/src/wrapper/index.ts
+++ b/packages/summon/application/src/wrapper/index.ts
@@ -1,0 +1,88 @@
+import * as path from "node:path";
+import type { GeneratorDefinition, PromptDefinition } from "@canonical/summon-core";
+import {
+  appendFile,
+  info,
+  mkdir,
+  sequence_,
+  writeFile,
+} from "@canonical/task";
+import pkg from "../../package.json" with { type: "json" };
+import { normalizeCommandPath, toCamelCase, toTitleCase } from "../shared/casing.js";
+
+interface WrapperAnswers {
+  readonly wrapperPath: string;
+}
+
+const prompts: PromptDefinition[] = [
+  {
+    name: "wrapperPath",
+    type: "text",
+    message: "Wrapper path (for example settings):",
+    default: "settings",
+    positional: true,
+    group: "Wrapper",
+  },
+];
+
+function buildWrapperFile(wrapperPath: string): string {
+  const normalized = normalizeCommandPath(wrapperPath);
+  const variableName = `${toCamelCase(normalized)}Wrapper`;
+  const title = toTitleCase(normalized);
+
+  return `import { wrapper } from "@canonical/router-core";
+import type { ReactElement, ReactNode } from "react";
+
+export const ${variableName} = wrapper<void, ReactElement>({
+  id: "${normalized}",
+  component: ({ children }): ReactElement => {
+    return (
+      <section className="route-panel stack" aria-labelledby="${variableName}-title">
+        <p className="eyebrow">Generated wrapper</p>
+        <h1 id="${variableName}-title">${title}</h1>
+        <div>{children as ReactNode}</div>
+      </section>
+    );
+  },
+});
+
+export default ${variableName};
+`;
+}
+
+export const generator: GeneratorDefinition<WrapperAnswers> = {
+  meta: {
+    name: "wrapper",
+    displayName: `${pkg.name}:wrapper`,
+    description: "Generate a wrapper module under src/wrappers/",
+    version: "0.1.0",
+    help: `Generate a wrapper module.
+
+EXAMPLE:
+  summon wrapper settings
+
+OUTPUT:
+  src/wrappers/settings.tsx
+`,
+    examples: [
+      "summon wrapper settings",
+      "summon wrapper account-shell",
+    ],
+  },
+  prompts,
+  generate: (answers: WrapperAnswers) => {
+    const normalized = normalizeCommandPath(answers.wrapperPath);
+    const dirname = path.join("src", "wrappers", path.dirname(normalized));
+    const filename = path.join("src", "wrappers", `${normalized}.tsx`);
+    const exportLine = `export { default as ${toCamelCase(normalized)}Wrapper } from "./${normalized}.js";\n`;
+
+    return sequence_([
+      info(`Generating wrapper: ${normalized}`),
+      mkdir(dirname),
+      writeFile(filename, buildWrapperFile(normalized)),
+      appendFile(path.join("src", "wrappers", "index.tsx"), exportLine),
+    ]);
+  },
+};
+
+export default generator;

--- a/packages/summon/application/tsconfig.json
+++ b/packages/summon/application/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../configs/typescript/tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "jsx": "react-jsx",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
## Done

- Add `@canonical/summon-application` with three generators:
  - `summon application react --ssr --router`: scaffolds a full React SSR app with router integration, grouped routes via `wrapper()` + `group()`, withI18n middleware, and working SSR entry points
  - `summon route <path>`: generates a route module and appends its export
  - `summon wrapper <name>`: generates a wrapper module and appends its export
- Generator templates emit `declare module` augmentation, `RouteMiddleware`-typed middleware, proper `RouterDehydratedState` usage, single `RouterProvider`
- Replace relative cross-package imports with `@canonical/summon-core`, `@canonical/task`
- Fix peer dep ranges to `^0.22.0`
- Register generators in `packages/cli/summon/generators/`

Depends on canonical/pragma#601 and canonical/pragma#602

## QA

- `bun run --filter @canonical/summon-application test` — 7 tests pass
- Verify `summon application react --ssr --router --app-path=test-app` generates a valid project

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public`.