### PR TITLE
feat(svelte-ds-app-launchpad): Add UserAvatar component

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.ssr.test.ts
@@ -1,4 +1,4 @@
-import { render } from "@canonical/svelte-ssr-test";
+import { type RenderResult, render } from "@canonical/svelte-ssr-test";
 import type { ComponentProps } from "svelte";
 import { describe, expect, it } from "vitest";
 import Component from "./UserAvatar.svelte";
@@ -10,21 +10,6 @@ describe("UserAvatar SSR", () => {
     "data-testid": "user-avatar",
   } satisfies ComponentProps<typeof Component>;
 
-  describe("basics", () => {
-    it("doesn't throw", () => {
-      expect(() => {
-        render(Component, { props: { ...baseProps } });
-      }).not.toThrow();
-    });
-
-    it("renders", () => {
-      const page = render(Component, { props: { ...baseProps } });
-      expect(page.getByTestId("user-avatar")).toBeInstanceOf(
-        page.window.HTMLDivElement,
-      );
-    });
-  });
-
   describe("renders as <img>", () => {
     it("when userAvatarUrl and userName are provided", () => {
       const page = render(Component, {
@@ -32,16 +17,17 @@ describe("UserAvatar SSR", () => {
           ...baseProps,
           userAvatarUrl: avatarUrl,
           userName: "John Doe",
+          alt: "John Doe's avatar",
         },
       });
+
+      expectIs("img", page);
+
       const element = page.getByRole("img", { name: "John Doe's avatar" });
-      expect(element).toBeInstanceOf(page.window.HTMLImageElement);
       expect(element.getAttribute("src")).toBe(avatarUrl);
       expect(element.getAttribute("alt")).toBe("John Doe's avatar");
       expect(element.getAttribute("title")).toBe("John Doe");
       expect(element.getAttribute("data-initials")).toBeTruthy();
-      expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();
-      expect(page.queryByLabelText("User avatar icon")).toBeNull();
     });
 
     it("when userAvatarUrl is provided without userName", () => {
@@ -49,16 +35,18 @@ describe("UserAvatar SSR", () => {
         props: {
           ...baseProps,
           userAvatarUrl: avatarUrl,
+          alt: "User avatar",
         },
       });
+
+      expectIs("img", page);
+
       const element = page.getByRole("img", { name: "User avatar" });
       expect(element).toBeInstanceOf(page.window.HTMLImageElement);
       expect(element.getAttribute("src")).toBe(avatarUrl);
       expect(element.getAttribute("alt")).toBe("User avatar");
       expect(element.getAttribute("title")).toBeNull();
       expect(element.getAttribute("data-initials")).toBeNull();
-      expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();
-      expect(page.queryByLabelText("User avatar icon")).toBeNull();
     });
   });
 
@@ -70,15 +58,13 @@ describe("UserAvatar SSR", () => {
           userName: "John Doe",
         },
       });
-      const element = page.getByTestId("user-avatar");
 
-      expect(element).toBeInstanceOf(page.window.HTMLDivElement);
-      expect(element.classList).toContain("no-image");
-      expect(element.querySelector("abbr")?.getAttribute("title")).toBe(
-        "John Doe",
-      );
-      expect(element.querySelector("img")).toBeNull();
-      expect(page.queryByLabelText("User avatar icon")).toBeNull();
+      expectIs("abbr", page);
+
+      const element = page.getByTestId("user-avatar");
+      expect(element.tagName).toBe("ABBR");
+      expect(element.getAttribute("title")).toBe("John Doe");
+      expect(element.textContent).toBe("JD");
     });
 
     it("when userAvatarUrl is an empty string and userName is provided", () => {
@@ -89,32 +75,21 @@ describe("UserAvatar SSR", () => {
           userName: "John Doe",
         },
       });
-      const element = page.getByTestId("user-avatar");
 
-      expect(element).toBeInstanceOf(page.window.HTMLDivElement);
-      expect(element.classList).toContain("no-image");
-      expect(element.querySelector("abbr")?.getAttribute("title")).toBe(
-        "John Doe",
-      );
-      expect(element.querySelector("img")).toBeNull();
-      expect(page.queryByLabelText("User avatar icon")).toBeNull();
+      expectIs("abbr", page);
+
+      const element = page.getByTestId("user-avatar");
+      expect(element.tagName).toBe("ABBR");
+      expect(element.getAttribute("title")).toBe("John Doe");
+      expect(element.textContent).toBe("JD");
     });
   });
 
   describe("renders as icon", () => {
     it("when no user data is provided", () => {
       const page = render(Component, { props: { ...baseProps } });
-      const element = page.getByTestId("user-avatar");
 
-      expect(element).toBeInstanceOf(page.window.HTMLDivElement);
-      expect(element.classList).toContain("ds");
-      expect(element.classList).toContain("user-avatar");
-      expect(element.classList).toContain("no-image");
-      expect(page.getByLabelText("User avatar icon")).toBeInstanceOf(
-        page.window.SVGElement,
-      );
-      expect(element.querySelector("img")).toBeNull();
-      expect(element.querySelector("abbr")).toBeNull();
+      expectIs("svg", page);
     });
 
     it("when userName is an empty string", () => {
@@ -124,15 +99,8 @@ describe("UserAvatar SSR", () => {
           userName: "",
         },
       });
-      const element = page.getByTestId("user-avatar");
 
-      expect(element).toBeInstanceOf(page.window.HTMLDivElement);
-      expect(element.classList).toContain("no-image");
-      expect(page.getByLabelText("User avatar icon")).toBeInstanceOf(
-        page.window.SVGElement,
-      );
-      expect(element.querySelector("img")).toBeNull();
-      expect(element.querySelector("abbr")).toBeNull();
+      expectIs("svg", page);
     });
   });
 
@@ -143,15 +111,13 @@ describe("UserAvatar SSR", () => {
           ...baseProps,
           userAvatarUrl: avatarUrl,
           userName: "John Doe",
+          alt: "John Doe's avatar",
         },
       });
       const element = page.getByRole("img", { name: "John Doe's avatar" });
 
-      expect(element).toBeInstanceOf(page.window.HTMLImageElement);
       expect(element.getAttribute("data-initials")).toBeTruthy();
       expect(element.getAttribute("title")).toBe("John Doe");
-      expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();
-      expect(page.queryByLabelText("User avatar icon")).toBeNull();
     });
 
     it("does not have icon fallback hooks for no-JS image failure without userName", () => {
@@ -159,14 +125,25 @@ describe("UserAvatar SSR", () => {
         props: {
           ...baseProps,
           userAvatarUrl: avatarUrl,
+          alt: "User avatar",
         },
       });
       const element = page.getByRole("img", { name: "User avatar" });
 
-      expect(element).toBeInstanceOf(page.window.HTMLImageElement);
       expect(element.getAttribute("data-initials")).toBeNull();
       expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();
-      expect(page.queryByLabelText("User avatar icon")).toBeNull();
     });
   });
 });
+
+const elements = ["img", "abbr", "svg"] as const;
+
+function expectIs(element: (typeof elements)[number], page: RenderResult) {
+  for (const el of elements) {
+    if (el === element) {
+      expect(page.container.querySelector(el)).toBeTruthy();
+    } else {
+      expect(page.container.querySelector(el)).toBeNull();
+    }
+  }
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.ssr.test.ts
@@ -1,0 +1,172 @@
+import { render } from "@canonical/svelte-ssr-test";
+import type { ComponentProps } from "svelte";
+import { describe, expect, it } from "vitest";
+import Component from "./UserAvatar.svelte";
+
+describe("UserAvatar SSR", () => {
+  const avatarUrl = "https://assets.ubuntu.com/v1/fca94c45-snap+icon.png";
+
+  const baseProps = {
+    "data-testid": "user-avatar",
+  } satisfies ComponentProps<typeof Component>;
+
+  describe("basics", () => {
+    it("doesn't throw", () => {
+      expect(() => {
+        render(Component, { props: { ...baseProps } });
+      }).not.toThrow();
+    });
+
+    it("renders", () => {
+      const page = render(Component, { props: { ...baseProps } });
+      expect(page.getByTestId("user-avatar")).toBeInstanceOf(
+        page.window.HTMLDivElement,
+      );
+    });
+  });
+
+  describe("renders as <img>", () => {
+    it("when userAvatarUrl and userName are provided", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userAvatarUrl: avatarUrl,
+          userName: "John Doe",
+        },
+      });
+      const element = page.getByRole("img", { name: "John Doe's avatar" });
+      expect(element).toBeInstanceOf(page.window.HTMLImageElement);
+      expect(element.getAttribute("src")).toBe(avatarUrl);
+      expect(element.getAttribute("alt")).toBe("John Doe's avatar");
+      expect(element.getAttribute("title")).toBe("John Doe");
+      expect(element.getAttribute("data-initials")).toBeTruthy();
+      expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();
+      expect(page.queryByLabelText("User avatar icon")).toBeNull();
+    });
+
+    it("when userAvatarUrl is provided without userName", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userAvatarUrl: avatarUrl,
+        },
+      });
+      const element = page.getByRole("img", { name: "User avatar" });
+      expect(element).toBeInstanceOf(page.window.HTMLImageElement);
+      expect(element.getAttribute("src")).toBe(avatarUrl);
+      expect(element.getAttribute("alt")).toBe("User avatar");
+      expect(element.getAttribute("title")).toBeNull();
+      expect(element.getAttribute("data-initials")).toBeNull();
+      expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();
+      expect(page.queryByLabelText("User avatar icon")).toBeNull();
+    });
+  });
+
+  describe("renders as <abbr>", () => {
+    it("when userName is provided without userAvatarUrl", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userName: "John Doe",
+        },
+      });
+      const element = page.getByTestId("user-avatar");
+
+      expect(element).toBeInstanceOf(page.window.HTMLDivElement);
+      expect(element.classList).toContain("no-image");
+      expect(element.querySelector("abbr")?.getAttribute("title")).toBe(
+        "John Doe",
+      );
+      expect(element.querySelector("img")).toBeNull();
+      expect(page.queryByLabelText("User avatar icon")).toBeNull();
+    });
+
+    it("when userAvatarUrl is an empty string and userName is provided", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userAvatarUrl: "",
+          userName: "John Doe",
+        },
+      });
+      const element = page.getByTestId("user-avatar");
+
+      expect(element).toBeInstanceOf(page.window.HTMLDivElement);
+      expect(element.classList).toContain("no-image");
+      expect(element.querySelector("abbr")?.getAttribute("title")).toBe(
+        "John Doe",
+      );
+      expect(element.querySelector("img")).toBeNull();
+      expect(page.queryByLabelText("User avatar icon")).toBeNull();
+    });
+  });
+
+  describe("renders as icon", () => {
+    it("when no user data is provided", () => {
+      const page = render(Component, { props: { ...baseProps } });
+      const element = page.getByTestId("user-avatar");
+
+      expect(element).toBeInstanceOf(page.window.HTMLDivElement);
+      expect(element.classList).toContain("ds");
+      expect(element.classList).toContain("user-avatar");
+      expect(element.classList).toContain("no-image");
+      expect(page.getByLabelText("User avatar icon")).toBeInstanceOf(
+        page.window.SVGElement,
+      );
+      expect(element.querySelector("img")).toBeNull();
+      expect(element.querySelector("abbr")).toBeNull();
+    });
+
+    it("when userName is an empty string", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userName: "",
+        },
+      });
+      const element = page.getByTestId("user-avatar");
+
+      expect(element).toBeInstanceOf(page.window.HTMLDivElement);
+      expect(element.classList).toContain("no-image");
+      expect(page.getByLabelText("User avatar icon")).toBeInstanceOf(
+        page.window.SVGElement,
+      );
+      expect(element.querySelector("img")).toBeNull();
+      expect(element.querySelector("abbr")).toBeNull();
+    });
+  });
+
+  describe("fallback behaviors", () => {
+    it("includes CSS fallback hooks for no-JS image failure when userName is provided", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userAvatarUrl: avatarUrl,
+          userName: "John Doe",
+        },
+      });
+      const element = page.getByRole("img", { name: "John Doe's avatar" });
+
+      expect(element).toBeInstanceOf(page.window.HTMLImageElement);
+      expect(element.getAttribute("data-initials")).toBeTruthy();
+      expect(element.getAttribute("title")).toBe("John Doe");
+      expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();
+      expect(page.queryByLabelText("User avatar icon")).toBeNull();
+    });
+
+    it("does not have icon fallback hooks for no-JS image failure without userName", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userAvatarUrl: avatarUrl,
+        },
+      });
+      const element = page.getByRole("img", { name: "User avatar" });
+
+      expect(element).toBeInstanceOf(page.window.HTMLImageElement);
+      expect(element.getAttribute("data-initials")).toBeNull();
+      expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();
+      expect(page.queryByLabelText("User avatar icon")).toBeNull();
+    });
+  });
+});

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.stories.svelte
@@ -1,0 +1,87 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import UserAvatar from "./UserAvatar.svelte";
+
+  const userAvatarUrl = "https://assets.ubuntu.com/v1/fca94c45-snap+icon.png";
+
+  const { Story } = defineMeta({
+    title: "Components/UserAvatar",
+    tags: ["autodocs"],
+    component: UserAvatar,
+  });
+</script>
+
+<Story name="Default" args={{ userName: "John Doe", userAvatarUrl }} />
+
+<Story
+  name="Sizes"
+  args={{ userName: "John Doe" }}
+  argTypes={{ size: { table: { disable: true } } }}
+>
+  {#snippet template(args)}
+    <div class="row">
+      {#each ["small", "medium", "large"] as const as size (size)}
+        <UserAvatar {...args} {size} />
+      {/each}
+    </div>
+    <br />
+    <div class="row">
+      {#each ["small", "medium", "large"] as const as size (size)}
+        <UserAvatar {...args} {size} userName={undefined} />
+      {/each}
+    </div>
+  {/snippet}
+</Story>
+
+<Story name="Without user data" />
+
+<Story
+  name="Without avatar URL"
+  args={{
+    userName: "Jane Doe",
+  }}
+/>
+
+<Story
+  name="When avatar fails to load"
+  args={{
+    userName: "That's Not An Image",
+    userAvatarUrl: "invalid-url",
+  }}
+/>
+
+<Story
+  name="When avatar fails to load and no name is provided"
+  args={{
+    userAvatarUrl: "invalid-url",
+  }}
+/>
+
+<Story
+  name="With a very long name"
+  tags={["!autodocs"]}
+  args={{
+    userName: "Lorem Ipsum Dolor Sit Amet Consectetur Adipiscing Elit",
+  }}
+/>
+
+<!-- Simulate no JavaScript environment by overriding the onerror handler -->
+
+<Story
+  name="When avatar fails to load (no JavaScript)"
+  tags={["!autodocs"]}
+  args={{
+    userAvatarUrl: "invalid-url",
+    userName: "John Doe",
+    onerror: () => {},
+  }}
+/>
+
+<Story
+  name="When avatar fails to load and no name is provided (no JavaScript)"
+  tags={["!autodocs"]}
+  args={{
+    userAvatarUrl: "invalid-url",
+    onerror: () => {},
+  }}
+/>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte
@@ -12,6 +12,7 @@
     userName: userNameProp,
     userAvatarUrl,
     size = "medium",
+    alt,
     ...rest
   }: UserAvatarProps = $props();
 
@@ -31,7 +32,7 @@
   <img
     class={[componentCssClassName, size, className]}
     src={userAvatarUrl}
-    alt={userName ? `${userName}'s avatar` : "User avatar"}
+    {alt}
     title={userName || undefined}
     data-initials={userInitials}
     onerror={() => (imageError = true)}
@@ -42,7 +43,7 @@
     {#if userName}
       <abbr title={userName}>{userInitials}</abbr>
     {:else}
-      <UserIcon aria-label="User avatar icon" />
+      <UserIcon />
     {/if}
   </div>
 {/if}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  /* @canonical/generator-ds 0.9.0-experimental.22 */
+  import { UserIcon } from "@canonical/svelte-icons";
+  import type { UserAvatarProps } from "./types.js";
+  import "./styles.css";
+  import { getInitials } from "./utils/index.js";
+
+  const componentCssClassName = "ds user-avatar";
+
+  const {
+    class: className,
+    userName: userNameProp,
+    userAvatarUrl,
+    size = "medium",
+    ...rest
+  }: UserAvatarProps = $props();
+
+  const userName = $derived(userNameProp?.trim() || null);
+  const userInitials = $derived(userName ? getInitials(userName) : null);
+
+  let imageError = $state(false);
+
+  // Reset image error state when the avatar URL changes
+  $effect.pre(() => {
+    userAvatarUrl;
+    imageError = false;
+  });
+</script>
+
+{#if userAvatarUrl && !imageError}
+  <img
+    class={[componentCssClassName, size, className]}
+    src={userAvatarUrl}
+    alt={userName ? `${userName}'s avatar` : "User avatar"}
+    title={userName || undefined}
+    data-initials={userInitials}
+    onerror={() => (imageError = true)}
+    {...rest}
+  />
+{:else}
+  <div class={[componentCssClassName, "no-image", size, className]} {...rest}>
+    {#if userName}
+      <abbr title={userName}>{userInitials}</abbr>
+    {:else}
+      <UserIcon aria-label="User avatar icon" />
+    {/if}
+  </div>
+{/if}
+
+<!-- @component
+`UserAvatar` A component that displays a user's avatar.
+
+The avatar will display the user's image if available and able to be loaded, otherwise it will display the first two initials. If neither is available, it will display a default icon placeholder.
+
+In case JavaScript is disabled, and the image at `userAvatarUrl` fails to load, the component will provide a fallback: displaying the user's initials when `userName` is provided, or `?` when it is not.
+
+## Example Usage
+```svelte
+<UserAvatar userName="John Doe" userAvatarUrl="https://example.com/avatar.png" />
+```
+-->

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte
@@ -8,7 +8,7 @@
   const componentCssClassName = "ds user-avatar";
 
   const {
-    class: className,
+    class: classProp,
     userName: userNameProp,
     userAvatarUrl,
     size = "medium",
@@ -16,6 +16,7 @@
     ...rest
   }: UserAvatarProps = $props();
 
+  const className = $derived([componentCssClassName, size, classProp]);
   const userName = $derived(userNameProp?.trim() || null);
   const userInitials = $derived(userName ? getInitials(userName) : null);
 
@@ -30,7 +31,7 @@
 
 {#if userAvatarUrl && !imageError}
   <img
-    class={[componentCssClassName, size, className]}
+    class={className}
     src={userAvatarUrl}
     {alt}
     title={userName || undefined}
@@ -38,13 +39,13 @@
     onerror={() => (imageError = true)}
     {...rest}
   />
+{:else if userName}
+  <abbr class={className} title={userName} {...rest}>
+    {userInitials}
+  </abbr>
 {:else}
-  <div class={[componentCssClassName, "no-image", size, className]} {...rest}>
-    {#if userName}
-      <abbr title={userName}>{userInitials}</abbr>
-    {:else}
-      <UserIcon />
-    {/if}
+  <div class={className} {...rest}>
+    <UserIcon />
   </div>
 {/if}
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte.test.ts
@@ -1,0 +1,216 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import type { ComponentProps } from "svelte";
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-svelte";
+import Component from "./UserAvatar.svelte";
+
+describe("UserAvatar component", () => {
+  const avatarUrl = "https://assets.ubuntu.com/v1/fca94c45-snap+icon.png";
+
+  const baseProps = {
+    "data-testid": "user-avatar",
+  } satisfies ComponentProps<typeof Component>;
+
+  describe("basics", () => {
+    it("renders", async () => {
+      const page = render(Component, { ...baseProps });
+      await expect.element(page.getByTestId("user-avatar")).toBeInTheDocument();
+    });
+  });
+
+  describe("attributes", () => {
+    it.each([
+      ["id", "test-id"],
+      ["aria-label", "test-aria-label"],
+    ])("applies %s", async (attribute, expected) => {
+      const page = render(Component, { ...baseProps, [attribute]: expected });
+      await expect
+        .element(page.getByTestId("user-avatar"))
+        .toHaveAttribute(attribute, expected);
+    });
+
+    it("applies classes", async () => {
+      const page = render(Component, { ...baseProps, class: "test-class" });
+      const element = page.getByTestId("user-avatar");
+      await expect.element(element).toHaveClass("test-class");
+      await expect.element(element).toHaveClass("ds");
+      await expect.element(element).toHaveClass("user-avatar");
+    });
+
+    it("applies style", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        style: "color: orange;",
+      });
+      await expect
+        .element(page.getByTestId("user-avatar"))
+        .toHaveStyle({ color: "orange" });
+    });
+  });
+
+  describe("renders as <img>", () => {
+    it("when userAvatarUrl and userName are provided", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        userAvatarUrl: avatarUrl,
+        userName: "John Doe",
+      });
+
+      const element = page.getByRole("img", { name: "John Doe's avatar" });
+      await expect.element(element).toBeInTheDocument();
+      await expect.element(element).toHaveAttribute("src", avatarUrl);
+      await expect.element(element).toHaveAttribute("alt", "John Doe's avatar");
+      await expect.element(element).toHaveAttribute("title", "John Doe");
+      await expect.element(element).toHaveAttribute("data-initials");
+      await expect
+        .element(page.getByLabelText("User avatar icon"))
+        .not.toBeInTheDocument();
+      expect(page.container.querySelector("abbr")).toBeNull();
+    });
+
+    it("when userAvatarUrl is provided without userName", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        userAvatarUrl: avatarUrl,
+      });
+
+      const element = page.getByRole("img", { name: "User avatar" });
+      await expect.element(element).toBeInTheDocument();
+      await expect.element(element).toHaveAttribute("src", avatarUrl);
+      await expect.element(element).toHaveAttribute("alt", "User avatar");
+      await expect.element(element).not.toHaveAttribute("title");
+      await expect.element(element).not.toHaveAttribute("data-initials");
+      await expect
+        .element(page.getByLabelText("User avatar icon"))
+        .not.toBeInTheDocument();
+      expect(page.container.querySelector("abbr")).toBeNull();
+    });
+  });
+
+  describe("renders as <abbr>", () => {
+    it("when userName is provided without userAvatarUrl", async () => {
+      const page = render(Component, { ...baseProps, userName: "John Doe" });
+
+      await expect.element(page.getByTitle("John Doe")).toBeInTheDocument();
+      await expect
+        .element(page.getByLabelText("User avatar icon"))
+        .not.toBeInTheDocument();
+      await expect.element(page.getByRole("img")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders as icon", () => {
+    it("when no user data is provided", async () => {
+      const page = render(Component, { ...baseProps });
+
+      await expect
+        .element(page.getByLabelText("User avatar icon"))
+        .toBeInTheDocument();
+      expect(page.getByTestId("user-avatar").element().tagName).toBe("DIV");
+      expect(page.container.querySelector("img")).toBeNull();
+      expect(page.container.querySelector("abbr")).toBeNull();
+    });
+  });
+
+  describe("fallback behaviors", () => {
+    it("falls back to <abbr> when JS handles image error and userName is provided", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        userAvatarUrl: "invalid-url",
+        userName: "John Doe",
+      });
+
+      const imageElement = page.getByRole("img", { name: "John Doe's avatar" });
+      imageElement.element().dispatchEvent(new Event("error"));
+
+      await expect.element(page.getByTitle("John Doe")).toBeInTheDocument();
+      await expect
+        .element(page.getByRole("img", { name: "John Doe's avatar" }))
+        .not.toBeInTheDocument();
+      await expect
+        .element(page.getByLabelText("User avatar icon"))
+        .not.toBeInTheDocument();
+    });
+
+    it("falls back to icon when JS handles image error and userName is missing", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        userAvatarUrl: "invalid-url",
+      });
+
+      const imageElement = page.getByRole("img", { name: "User avatar" });
+      imageElement.element().dispatchEvent(new Event("error"));
+
+      await expect
+        .element(page.getByLabelText("User avatar icon"))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByRole("img", { name: "User avatar", exact: true }))
+        .not.toBeInTheDocument();
+      expect(page.container.querySelector("abbr")).toBeNull();
+    });
+
+    describe("when no JS is available", () => {
+      it("keeps rendering as <img> in no-JS when userName is provided", async () => {
+        const page = render(Component, {
+          ...baseProps,
+          userAvatarUrl: `invalid-url`,
+          userName: "John Doe",
+          onerror: () => {},
+        });
+
+        const imageElement = page.getByRole("img", {
+          name: "John Doe's avatar",
+        });
+        imageElement.element().dispatchEvent(new Event("error"));
+
+        await expect.element(imageElement).toBeInTheDocument();
+        await expect.element(imageElement).toHaveAttribute("data-initials");
+        await expect
+          .element(page.getByLabelText("User avatar icon"))
+          .not.toBeInTheDocument();
+      });
+
+      it("keeps rendering as <img> in no-JS without userName", async () => {
+        const page = render(Component, {
+          ...baseProps,
+          userAvatarUrl: "invalid-url",
+          onerror: () => {},
+        });
+
+        const imageElement = page.getByRole("img", {
+          name: "User avatar",
+          exact: true,
+        });
+        imageElement.element().dispatchEvent(new Event("error"));
+
+        await expect.element(imageElement).toBeInTheDocument();
+        await expect.element(imageElement).not.toHaveAttribute("data-initials");
+        await expect
+          .element(page.getByLabelText("User avatar icon"))
+          .not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("modifiers", () => {
+    const sizeModifiers = ["small", "large"] as const;
+
+    it.each(sizeModifiers)("applies %s modifier", async (size) => {
+      const page = render(Component, {
+        ...baseProps,
+        size,
+      });
+      const element = page.getByTestId("user-avatar");
+      const classList = element.element().classList;
+
+      expect(classList.contains(size)).toBe(true);
+      sizeModifiers.forEach((s) => {
+        if (s !== size) {
+          expect(classList.contains(s)).toBe(false);
+        }
+      });
+    });
+  });
+});

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte.test.ts
@@ -15,7 +15,7 @@ describe("UserAvatar component", () => {
   describe("basics", () => {
     it("renders", async () => {
       const page = render(Component, { ...baseProps });
-      await expect.element(page.getByTestId("user-avatar")).toBeInTheDocument();
+      await expect.element(page.getByTestId("user-avatar")).toBeVisible();
     });
   });
 
@@ -55,36 +55,34 @@ describe("UserAvatar component", () => {
         ...baseProps,
         userAvatarUrl: avatarUrl,
         userName: "John Doe",
+        alt: "John Doe's avatar",
       });
 
+      await expectIs("img", page);
+
       const element = page.getByRole("img", { name: "John Doe's avatar" });
-      await expect.element(element).toBeInTheDocument();
+      await expect.element(element).toBeVisible();
       await expect.element(element).toHaveAttribute("src", avatarUrl);
       await expect.element(element).toHaveAttribute("alt", "John Doe's avatar");
       await expect.element(element).toHaveAttribute("title", "John Doe");
       await expect.element(element).toHaveAttribute("data-initials");
-      await expect
-        .element(page.getByLabelText("User avatar icon"))
-        .not.toBeInTheDocument();
-      expect(page.container.querySelector("abbr")).toBeNull();
     });
 
     it("when userAvatarUrl is provided without userName", async () => {
       const page = render(Component, {
         ...baseProps,
         userAvatarUrl: avatarUrl,
+        alt: "User avatar",
       });
 
+      await expectIs("img", page);
+
       const element = page.getByRole("img", { name: "User avatar" });
-      await expect.element(element).toBeInTheDocument();
+      await expect.element(element).toBeVisible();
       await expect.element(element).toHaveAttribute("src", avatarUrl);
       await expect.element(element).toHaveAttribute("alt", "User avatar");
       await expect.element(element).not.toHaveAttribute("title");
       await expect.element(element).not.toHaveAttribute("data-initials");
-      await expect
-        .element(page.getByLabelText("User avatar icon"))
-        .not.toBeInTheDocument();
-      expect(page.container.querySelector("abbr")).toBeNull();
     });
   });
 
@@ -92,11 +90,8 @@ describe("UserAvatar component", () => {
     it("when userName is provided without userAvatarUrl", async () => {
       const page = render(Component, { ...baseProps, userName: "John Doe" });
 
-      await expect.element(page.getByTitle("John Doe")).toBeInTheDocument();
-      await expect
-        .element(page.getByLabelText("User avatar icon"))
-        .not.toBeInTheDocument();
-      await expect.element(page.getByRole("img")).not.toBeInTheDocument();
+      await expectIs("abbr", page);
+      await expect.element(page.getByTitle("John Doe")).toBeVisible();
     });
   });
 
@@ -104,12 +99,7 @@ describe("UserAvatar component", () => {
     it("when no user data is provided", async () => {
       const page = render(Component, { ...baseProps });
 
-      await expect
-        .element(page.getByLabelText("User avatar icon"))
-        .toBeInTheDocument();
-      expect(page.getByTestId("user-avatar").element().tagName).toBe("DIV");
-      expect(page.container.querySelector("img")).toBeNull();
-      expect(page.container.querySelector("abbr")).toBeNull();
+      await expectIs("svg", page);
     });
   });
 
@@ -119,36 +109,27 @@ describe("UserAvatar component", () => {
         ...baseProps,
         userAvatarUrl: "invalid-url",
         userName: "John Doe",
+        alt: "John Doe's avatar",
       });
 
       const imageElement = page.getByRole("img", { name: "John Doe's avatar" });
       imageElement.element().dispatchEvent(new Event("error"));
 
-      await expect.element(page.getByTitle("John Doe")).toBeInTheDocument();
-      await expect
-        .element(page.getByRole("img", { name: "John Doe's avatar" }))
-        .not.toBeInTheDocument();
-      await expect
-        .element(page.getByLabelText("User avatar icon"))
-        .not.toBeInTheDocument();
+      await expectIs("abbr", page);
+      await expect.element(page.getByTitle("John Doe")).toBeVisible();
     });
 
     it("falls back to icon when JS handles image error and userName is missing", async () => {
       const page = render(Component, {
         ...baseProps,
         userAvatarUrl: "invalid-url",
+        alt: "User avatar",
       });
 
       const imageElement = page.getByRole("img", { name: "User avatar" });
       imageElement.element().dispatchEvent(new Event("error"));
 
-      await expect
-        .element(page.getByLabelText("User avatar icon"))
-        .toBeInTheDocument();
-      await expect
-        .element(page.getByRole("img", { name: "User avatar", exact: true }))
-        .not.toBeInTheDocument();
-      expect(page.container.querySelector("abbr")).toBeNull();
+      await expectIs("svg", page);
     });
 
     describe("when no JS is available", () => {
@@ -157,6 +138,7 @@ describe("UserAvatar component", () => {
           ...baseProps,
           userAvatarUrl: `invalid-url`,
           userName: "John Doe",
+          alt: "John Doe's avatar",
           onerror: () => {},
         });
 
@@ -165,31 +147,25 @@ describe("UserAvatar component", () => {
         });
         imageElement.element().dispatchEvent(new Event("error"));
 
-        await expect.element(imageElement).toBeInTheDocument();
         await expect.element(imageElement).toHaveAttribute("data-initials");
-        await expect
-          .element(page.getByLabelText("User avatar icon"))
-          .not.toBeInTheDocument();
+        await expect.element(imageElement).toBeVisible();
       });
 
       it("keeps rendering as <img> in no-JS without userName", async () => {
         const page = render(Component, {
           ...baseProps,
           userAvatarUrl: "invalid-url",
+          alt: "User avatar",
           onerror: () => {},
         });
 
         const imageElement = page.getByRole("img", {
           name: "User avatar",
-          exact: true,
         });
         imageElement.element().dispatchEvent(new Event("error"));
 
-        await expect.element(imageElement).toBeInTheDocument();
         await expect.element(imageElement).not.toHaveAttribute("data-initials");
-        await expect
-          .element(page.getByLabelText("User avatar icon"))
-          .not.toBeInTheDocument();
+        await expect.element(imageElement).toBeVisible();
       });
     });
   });
@@ -214,3 +190,31 @@ describe("UserAvatar component", () => {
     });
   });
 });
+
+const elements = ["img", "abbr", "svg"] as const;
+
+async function expectIs(
+  element: (typeof elements)[number],
+  page: ReturnType<typeof render>,
+) {
+  const rootLocator = page.getByTestId("user-avatar");
+
+  // Check the presence of the expected element
+  if (element === "svg") {
+    // Actual root is a div
+    await expect.element(rootLocator).toHaveProperty("tagName", "DIV");
+    expect(rootLocator.element().querySelector("svg")).toBeTruthy();
+  } else {
+    await expect
+      .element(rootLocator)
+      .toHaveProperty("tagName", element.toUpperCase());
+  }
+
+  // Ensure the other element types are not present
+  elements
+    .filter((e) => e !== element)
+    .forEach((e) => {
+      // Using `querySelector` is acceptable here as we guard DOM being settled on the locators above.
+      expect(page.container.querySelector(e)).toBeNull();
+    });
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/index.ts
@@ -1,0 +1,4 @@
+/* @canonical/generator-ds 0.9.0-experimental.22 */
+
+export * from "./types.js";
+export { default as UserAvatar } from "./UserAvatar.svelte";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/styles.css
@@ -1,0 +1,65 @@
+.ds.user-avatar {
+  display: inline-grid;
+  flex: none;
+
+  border: var(--lp-dimension-stroke-thickness-default) solid
+    var(--lp-color-border-default);
+  background-color: var(--lp-color-background-alt);
+  color: var(--lp-color-text-default);
+
+  width: var(--lp-dimension-size-m);
+  height: var(--lp-dimension-size-m);
+  font: var(--lp-typography-paragraph-default-strong);
+
+  &.small {
+    width: var(--lp-dimension-size-s);
+    height: var(--lp-dimension-size-s);
+    font: var(--lp-typography-paragraph-s-strong);
+  }
+
+  &.large {
+    width: var(--lp-dimension-size-l);
+    height: var(--lp-dimension-size-l);
+    font: var(--lp-typography-h5);
+  }
+
+  &:is(img) {
+    object-fit: cover;
+    position: relative;
+    overflow: hidden;
+
+    /*
+    A fallback for when there is no JS and the image cannot be loaded.
+     
+    When userName is provided, the initials are displayed. When userName is not provided, a "?" is displayed.
+    Ideally this would be a user icon instead of "?", but that would require either
+    - a base64 encoded SVG, that would bloat CSS (rather unnecessarily, for the rare case of no userName and image load failure),
+    - or a url to a static asset (difficult to achieve for a component library without making assumptions on the hosting app's bundler and asset management).
+    */
+    &::after {
+      position: absolute;
+      inset: 0;
+      background-color: inherit;
+      display: grid;
+      place-content: center;
+      text-transform: uppercase;
+      user-select: none;
+
+      content: "?";
+    }
+
+    &[data-initials]::after {
+      content: attr(data-initials);
+    }
+  }
+
+  &.no-image {
+    user-select: none;
+    place-content: center;
+
+    > abbr {
+      text-transform: uppercase;
+      text-decoration: none;
+    }
+  }
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/styles.css
@@ -53,13 +53,14 @@
     }
   }
 
-  &.no-image {
+  &:is(abbr) {
     user-select: none;
     place-content: center;
+    text-transform: uppercase;
+    text-decoration: none;
+  }
 
-    > abbr {
-      text-transform: uppercase;
-      text-decoration: none;
-    }
+  &:is(div) {
+    place-content: center;
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/types.ts
@@ -13,4 +13,6 @@ export interface UserAvatarProps
   extends Omit<HTMLAttributes<HTMLElement>, "children">,
     UserOptions {
   size?: "small" | "medium" | "large";
+  /** The alt text for the avatar image, if available */
+  alt?: string;
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/types.ts
@@ -1,0 +1,16 @@
+/* @canonical/generator-ds 0.9.0-experimental.22 */
+
+import type { HTMLAttributes } from "svelte/elements";
+
+export type UserOptions = {
+  /** The user's name */
+  userName?: string;
+  /** The URL of the user's avatar image */
+  userAvatarUrl?: string;
+};
+
+export interface UserAvatarProps
+  extends Omit<HTMLAttributes<HTMLElement>, "children">,
+    UserOptions {
+  size?: "small" | "medium" | "large";
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/utils/getInitials.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/utils/getInitials.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getInitials } from "./getInitials";
+
+describe("getInitials", () => {
+  it.each([
+    ["Ada", "A"],
+    ["Ada Lovelace", "AL"],
+    ["Ada Lovelace Byron", "AL"],
+    ["  Ada   Lovelace  ", "AL"],
+    ["", ""],
+    ["     ", ""],
+    ["A B", "AB"],
+    ["Jean-Luc Picard", "JP"],
+  ])("maps %j -> %j", (userName, expected) => {
+    expect(getInitials(userName)).toBe(expected);
+  });
+
+  it("keeps the first character of each selected word as-is", () => {
+    expect(getInitials("alice bob")).toBe("ab");
+  });
+
+  it("treats only spaces as separators", () => {
+    expect(getInitials("Ada\tLovelace")).toBe("A");
+    expect(getInitials("Ada\nLovelace")).toBe("A");
+  });
+});

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/utils/getInitials.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/utils/getInitials.ts
@@ -1,0 +1,8 @@
+export function getInitials(userName: string): string {
+  return userName
+    .split(" ")
+    .filter((word) => word.length > 0)
+    .slice(0, 2)
+    .map((word) => word[0])
+    .join("");
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/utils/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./getInitials.js";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/index.ts
@@ -14,3 +14,4 @@ export * from "./Spinner/index.js";
 export * from "./Switch/index.js";
 export * from "./Textarea/index.js";
 export * from "./TextInput/index.js";
+export * from "./UserAvatar/index.js";


### PR DESCRIPTION
## Done
- Add `UserAvatar` component that displays an avatar image when available, falls back to user initials if `userName` is provided, and a generic icon placeholder otherwise.
- No-JS fallback: when the image fails to load without JS, initials are shown via CSS `::after` on the `<img>` if `userName` is provided and a `?` otherwise.

## QA
- `bun run check && bun run test`
- verify `Components/UserAvatar` in Storybook
  - check image renders when `userAvatarUrl` is provided
  - check initials fallback when no image URL is given or image fails to load
  - check icon placeholder renders when neither image nor name is provided

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify.

## Screenshots

<img width="87" height="89" alt="image" src="https://github.com/user-attachments/assets/b9c8e1b1-38b8-4de8-a892-0641edbf9853" />

<img width="137" height="124" alt="image" src="https://github.com/user-attachments/assets/fe45b2c6-cfe7-44a5-80b3-a58458c53e98" />
