### PR TITLE
feat(workshop): integrate workshop dev tool in pragma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ sem_modules/
 .claude/
 .kg/
 node_modules
+.workshop.lock

--- a/.workshop/pragma-dev-tools/hooks/setup-base
+++ b/.workshop/pragma-dev-tools/hooks/setup-base
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+# Copyright 2026 Canonical Ltd.  All rights reserved.
+
+curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+apt-get install -y nodejs
+npm install -g bun@1.3.11 lerna

--- a/.workshop/pragma-dev-tools/hooks/setup-project
+++ b/.workshop/pragma-dev-tools/hooks/setup-project
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+# Copyright 2026 Canonical Ltd.  All rights reserved.
+
+bun install
+cd packages/summon && bun link
+cd ../summon-component && bun link
+cd ../summon-package && bun link

--- a/.workshop/pragma-dev-tools/sdk.yaml
+++ b/.workshop/pragma-dev-tools/sdk.yaml
@@ -1,0 +1,4 @@
+# Copyright 2026 Canonical Ltd.  All rights reserved.
+
+name: pragma-dev-tools
+base: ubuntu@24.04

--- a/.workshop/pragma.yaml
+++ b/.workshop/pragma.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Canonical Ltd.  All rights reserved.
+
+name: pragma
+base: ubuntu@24.04
+
+sdks:
+- name: project-pragma-dev-tools
+
+actions:
+  install: bun install
+  build: bun run build
+  clean: bun run special:clean
+  lint: bun run check
+  fix: bun run check:fix
+  test: bun run test
+  coverage: bun run test:coverage
+  publish: bun run publish:status

--- a/README.md
+++ b/README.md
@@ -4,6 +4,49 @@ Pragma is Canonical's implementation of the [Design System](https://github.com/c
 
 ## Quick Start
 
+**Required:**
+- **workshop latest** [installation guide](https://github.com/canonical/workshop)
+
+```bash
+sudo snap login
+sudo snap install --classic workshop
+
+# or download and install the latest Workshop snap from the Releases page
+sudo snap install --dangerous --classic ./workshop_0.1.29_amd64.snap
+```
+
+Clone the repository and setup Pragma environment
+
+```bash
+git clone https://github.com/canonical/pragma
+cd pragma
+workshop launch pragma
+```
+**Usage**
+
+```bash
+workshop run pragma <action>
+```
+
+Available actions in `.workshop/pragma.yaml` map to `package.json` scripts and could be further extended.
+
+```yaml
+actions:
+  install: bun install
+  build: bun run build
+  clean: bun run special:clean
+  check: bun run check
+  fix: bun run check:fix
+  test: bun run test
+  coverage: bun run test:coverage
+  publish: bun run publish:status
+
+```
+
+To list available actions, you can run `workshop actions`.
+
+## Manual Setup
+
 Clone the repository and install dependencies. The installation step also builds all packages, which takes roughly 30 seconds on first run.
 
 ```bash


### PR DESCRIPTION
## Done

- Integrated workshop in pragma project to create and setup a consistent development environment, shipped with node, bun and lerna out of the box .
- Mapped `package.json` scripts into workshop actions to: `build | check | fix | test ` etc ..
- Usage:
```
 workshop launch pragma
 workshop run pragma build
 workshop run pragma <action>
``` 
- Added workshop installation and usage guide in the **Quick Start** section in README.md

## QA

- README Quick setup and Prerequisites should be easier to follow. 

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 

## Screenshots

[if relevant, include a screenshot or screen capture]
