### PR TITLE
fix(svelte-ds-app-launchpad): Increase specificity of button styles

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
@@ -1,4 +1,4 @@
-.ds.button {
+.ds.button.button-primitive {
   --color-background-button-active: var(
     --lp-color-background-active-context,
     var(--lp-color-background-neutral-active)


### PR DESCRIPTION
## Done
Increase the specificity of Button styles to ensure proper override of `.ds.button-primitive` styles.

## QA

- `bun run check && bun run test`
- Verify `Components/Button` in Storybook

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify.