### PR TITLE
feat(router)!: prefetch rename, remove data threading, Navigation API adapter

### DIFF
--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -24,25 +24,22 @@ export const routes = {
   }),
   docs: route({
     url: "/docs/:slug",
-    fetch: async ({ slug }) => ({ slug }),
-    content: ({ data }) => <h1>{data.slug}</h1>,
+    content: ({ params }) => <h1>{params.slug}</h1>,
   }),
 } as const;
 
 export const router = createRouter(routes);
 ```
 
-`@canonical/router-core` owns route definitions, matching, loading, and typed
-navigation. `@canonical/router-react` layers React rendering and subscriptions
-on top of that router instance.
+`@canonical/router-core` owns route definitions, matching, and typed navigation. `@canonical/router-react` layers React rendering and subscriptions on top.
 
 Route authoring story, in short:
 
 - define every route with `route()`
 - give it a `url` pattern such as `/docs/:slug`
-- optionally add `fetch`, `content`, `error`, and `wrappers`
+- optionally add `prefetch`, `content`, and `wrappers`
 - create one router from the full flat route map
-- let the router match incoming URLs and resolve route data before React renders
+- let the router match incoming URLs — React renders the result
 
 ### 2. Provide the router and render the current match
 
@@ -58,8 +55,7 @@ export default function Application() {
 }
 ```
 
-`RouterProvider` makes the router instance available to hooks and components.
-`Outlet` renders the currently matched route subtree.
+`RouterProvider` makes the router instance available to hooks and components. `Outlet` renders the currently matched route subtree.
 
 ### 3. Navigate with typed links and observe router state
 
@@ -117,18 +113,59 @@ Important distinction:
 - `useNavigationState()` returns the router's navigation lifecycle state.
 - `useRouter()` returns the router instance itself.
 
-## Consumer-first flow
+## Data ownership
 
-1. Define routes with `route()` in `@canonical/router-core`.
-2. Create a router with `createRouter()` or `createHydratedRouter()`.
-3. Pass the router to `RouterProvider`.
-4. Render matches with `Outlet`.
-5. Navigate with `Link`, `useRouter()`, `useRouterState()`, `useRoute()`, `useSearchParam()`, `useSearchParams()`, and `useNavigationState()`.
+The router does not own data. `content()` receives `params` and `search` — not data. Components fetch their own data from their cache library (Relay, TanStack Query, SWR, etc.).
+
+The optional `prefetch()` on routes is a fire-and-forget navigation-time hook. Use it to warm caches, preload assets, or run side effects before the component renders. It does not pass data to `content()`.
+
+```tsx
+const userRoute = route({
+  url: "/users/:id",
+  prefetch: async ({ id }) => {
+    await queryClient.prefetchQuery(["user", id], () => fetchUser(id));
+  },
+  content: ({ params }) => <UserProfile id={params.id} />,
+});
+
+function UserProfile({ id }: { id: string }) {
+  const { data } = useQuery(["user", id], () => fetchUser(id));
+  return <h1>{data.name}</h1>;
+}
+```
+
+## Error handling
+
+The router does not ship an error boundary component. When `prefetch()` throws, the error propagates into the React render tree and is caught by the nearest React error boundary.
+
+Use `StatusResponse` from `@canonical/router-core` to signal HTTP-like errors:
+
+```tsx
+import { StatusResponse } from "@canonical/router-core";
+
+function ErrorFallback({ error }: { error: unknown }) {
+  const status = error instanceof StatusResponse ? error.status : 500;
+
+  if (status === 404) return <NotFound />;
+  if (status === 401) return <LoginRedirect />;
+  return <ErrorPage status={status} />;
+}
+
+function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <Sidebar />
+      <ErrorBoundary fallbackRender={({ error }) => <ErrorFallback error={error} />}>
+        {children}
+      </ErrorBoundary>
+    </div>
+  );
+}
+```
+
+The boilerplate reference app provides a complete `RouteErrorBoundary` implementation to copy and adapt.
 
 ## Creating routes and matching URLs
-
-Two recurring stories sit below the React layer: authoring routes and matching
-URLs.
 
 ### Route creation
 
@@ -144,8 +181,10 @@ const routes = {
   }),
   docs: route({
     url: "/docs/:slug",
-    fetch: async ({ slug }) => ({ slug }),
-    content: ({ data }) => <h1>{data.slug}</h1>,
+    prefetch: async ({ slug }) => {
+      await queryClient.prefetchQuery(["doc", slug], () => fetchDoc(slug));
+    },
+    content: ({ params }) => <DocPage slug={params.slug} />,
   }),
   accountSettings: route({
     url: "/account/settings",
@@ -156,96 +195,49 @@ const routes = {
 const router = createRouter(routes);
 ```
 
-Important parts of route creation:
+Important parts:
 
-- the route-map key such as `docs` is the typed navigation name used by `Link`
-  and `router.navigate()`
+- the route-map key such as `docs` is the typed navigation name used by `Link` and `router.navigate()`
 - the `url` string is the matcher used for incoming URLs
 - `:slug` segments become typed route params
-- `fetch` runs during loading and receives those params
-- `content` renders once the route has matched and data has been resolved
+- `prefetch` runs at navigation time as a fire-and-forget hook
+- `content` renders the matched route, receiving `params` and `search`
 
-Routes stay flat even when the UI is nested. Shared layout and shared data live
-in wrappers from the core package, not in a nested route tree.
-
-### Matching story
-
-Matching happens in the core router before `Outlet` renders.
-
-```ts
-await router.load("/docs/getting-started?tab=api");
-
-const state = router.getState();
-
-state.match?.name; // "docs"
-state.location.pathname; // "/docs/getting-started"
-state.location.searchParams.get("tab"); // "api"
-```
-
-Practical consequences:
-
-- `createRouter()` owns route ranking and URL matching
-- the current match is stored in router state
-- `Outlet` renders whatever route the router matched most recently
-- `useRoute()` lets React read the matched location
-- `useRouterState()` lets React read the match object itself when you need route
-  status, params, or advanced state
-
-If no route matches, the router falls back to its configured not-found behavior.
-The React bindings do not implement matching themselves; they subscribe to the
-core router's result.
-
-### Matching in components
-
-In React, you usually read matching results rather than perform matching
-manually.
-
-```tsx
-function RouteDebug() {
-  const location = useRoute<typeof routes>();
-  const matchName = useRouterState<typeof routes>((state) => state.match?.name ?? "not-found");
-
-  return (
-    <dl>
-      <dt>match</dt>
-      <dd>{matchName}</dd>
-      <dt>pathname</dt>
-      <dd>{location.pathname}</dd>
-    </dl>
-  );
-}
-```
-
-This is the recommended split:
-
-- define and match routes in `@canonical/router-core`
-- render and subscribe in `@canonical/router-react`
+Routes stay flat even when the UI is nested. Shared layout lives in wrappers from the core package, not in a nested route tree.
 
 ## SSR
 
 ### Server side
 
+Wire your own render tree using standard React SSR primitives. The router does not provide a convenience render function — you control the component tree:
+
 ```tsx
-import { createRouter, route } from "@canonical/router-core";
-import { renderToStream } from "@canonical/router-react";
+import { createRouter, createServerAdapter } from "@canonical/router-core";
+import { Outlet, RouterProvider } from "@canonical/router-react";
+import { renderToPipeableStream } from "react-dom/server";
 
-const router = createRouter({
-  home: route({ url: "/", content: () => <h1>Home</h1> }),
+app.get("*", async (req, res) => {
+  const router = createRouter(routes, {
+    adapter: createServerAdapter(req.url),
+  });
+
+  await router.load(req.url);
+
+  const { pipe } = renderToPipeableStream(
+    <RouterProvider router={router}>
+      <Shell>
+        <Outlet />
+      </Shell>
+    </RouterProvider>,
+    {
+      onShellReady() {
+        res.setHeader("content-type", "text/html");
+        pipe(res);
+      },
+    },
+  );
 });
-
-const result = await renderToStream(router, "/");
 ```
-
-`renderToStream()` loads the URL into the router, renders the matched route tree, and returns:
-
-- `stream`
-- `loadResult`
-- `initialData`
-- `bootstrapScriptContent`
-
-`bootstrapScriptContent` contains the dehydrated router payload as an inline
-script assignment. `initialData` contains the same payload as plain JSON in case
-your SSR pipeline needs to inject it manually.
 
 ### Client side
 
@@ -257,22 +249,20 @@ const router = createHydratedRouter(routes);
 hydrateRoot(
   document,
   <RouterProvider router={router}>
-    <Outlet />
+    <Shell>
+      <Outlet />
+    </Shell>
   </RouterProvider>,
 );
 ```
 
-`createHydratedRouter()` reads the dehydrated state from the browser window,
-creates a browser adapter, and resumes from the server-rendered route match
-instead of loading the initial URL a second time.
+`createHydratedRouter()` reads the dehydrated navigation state from the browser window, creates a browser adapter, and resumes from the server-rendered route match.
 
 ## Progressive disclosure
 
 ### `Link`
 
-`Link` builds typed hrefs from route names and optional route params, search
-data, and hash values. Primary-button clicks are intercepted and routed through
-the core router. Hover prefetches the destination.
+`Link` builds typed hrefs from route names and optional route params, search data, and hash values. Primary-button clicks are intercepted and routed through the core router. Hover prefetches the destination.
 
 ```tsx
 <Link<typeof routes> params={{ slug: "api" }} to="docs">
@@ -282,8 +272,7 @@ the core router. Hover prefetches the destination.
 
 ### `Outlet`
 
-`Outlet` subscribes to router state, calls `router.render()`, and wraps the
-matched subtree in `Suspense`.
+`Outlet` subscribes to router state, calls `router.render()`, and wraps the matched subtree in `Suspense`.
 
 ```tsx
 <Outlet fallback={<p>Loading route…</p>} />
@@ -292,13 +281,10 @@ matched subtree in `Suspense`.
 ### Hooks
 
 - `useRouter()` returns the router instance from context.
-- `useRouterState()` is the power-user hook for subscribing to selected slices
-  of `router.getState()`.
-- `useRoute()` returns a tracked location proxy and rerenders only when an
-  accessed location key changes.
+- `useRouterState()` is the power-user hook for subscribing to selected slices of `router.getState()`.
+- `useRoute()` returns a tracked location proxy and rerenders only when an accessed location key changes.
 - `useSearchParam()` subscribes to one query-string key.
-- `useSearchParams()` subscribes either to the full query string or to a fixed
-  set of keys.
+- `useSearchParams()` subscribes either to the full query string or to a fixed set of keys.
 - `useNavigationState()` subscribes to the router loading state.
 
 Typical selection strategy:
@@ -307,8 +293,7 @@ Typical selection strategy:
 - reach for `useSearchParam()` for one query-string key
 - reach for `useSearchParams()` for a fixed key set or the full query string
 - reach for `useRoute()` for pathname, hash, or full URL reads
-- reach for `useRouterState()` when you need `match`, `navigation`, or other
-  advanced state in one selector
+- reach for `useRouterState()` when you need `match`, `navigation`, or other advanced state in one selector
 
 ## Boilerplate reference
 
@@ -319,41 +304,22 @@ The reference integration lives in [apps/react/boilerplate-vite](../../../apps/r
 - SSR + hydration
 - hover prefetch
 - auth middleware redirect flow
+- error handling with `StatusResponse` and React error boundaries
 
 ## Public API
 
 ### Components and helpers
 
-- `createHydratedRouter()` — create a browser-backed router that resumes from
-  dehydrated state.
-- `Link` — render a typed anchor that navigates and prefetches through the
-  router.
+- `createHydratedRouter()` — create a browser-backed router that resumes from dehydrated state.
+- `Link` — render a typed anchor that navigates and prefetches through the router.
 - `Outlet` — render the current matched subtree.
 - `RouterProvider` — place a router instance into React context.
-- `renderToStream()` — load a URL and stream the rendered route tree.
 - `useNavigationState()` — subscribe to the navigation lifecycle state.
 - `useRoute()` — subscribe to a tracked location object.
 - `useRouter()` — read the router instance from context.
 - `useRouterState()` — subscribe to the full router state or a selected slice.
 - `useSearchParam()` — subscribe to one search-param key.
 - `useSearchParams()` — subscribe to all search params or a selected key set.
-
-### Types
-
-- `AnyReactRouter` — widened router type used by the React bindings.
-- `RouterProviderProps` — props for `RouterProvider`.
-- `LinkBuildOptions` — route params, search, and hash used to build links.
-- `LinkProps` — typed props for `Link`.
-- `OutletProps` — optional fallback for `Outlet`.
-- `RenderToStreamOptions` — options for streamed server rendering.
-- `RenderToStreamResult` — stream plus dehydration payload and load result.
-- `HydrationWindow` — minimal window-like object used during hydration.
-- `CreateHydratedRouterOptions` — router options accepted by
-  `createHydratedRouter()`.
-- `CreateHydratedRouterWindow` — alias for the hydration window shape.
-- `HydratedNavigationState` — alias for the router navigation state.
-- `SearchParamValues` — mapped values returned by keyed `useSearchParams()`.
-- `UseRouterStateOptions` — selector equality options for `useRouterState()`.
 
 ### Reference docs
 

--- a/packages/react/router/src/lib/Link/Link.test.tsx
+++ b/packages/react/router/src/lib/Link/Link.test.tsx
@@ -10,7 +10,7 @@ import RouterProvider from "../RouterProvider/Provider.js";
 import Link from "./Link.js";
 
 const preloadSpy = vi.fn(async () => ({ default: "UsersPage" }));
-const fetchSpy = vi.fn(async () => "users");
+const prefetchSpy = vi.fn(async () => {});
 
 const routes = {
   home: route({
@@ -19,8 +19,8 @@ const routes = {
   }),
   users: route({
     url: "/users",
-    fetch: fetchSpy,
-    content: Object.assign(({ data }: { data: unknown }) => String(data), {
+    prefetch: prefetchSpy,
+    content: Object.assign(() => "users", {
       preload: preloadSpy,
     }),
   }),
@@ -50,7 +50,6 @@ describe("Link", () => {
     fireEvent.mouseEnter(link);
 
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(preloadSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -60,7 +59,6 @@ describe("Link", () => {
       expect(screen.getByText("users")).toBeTruthy();
     });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(preloadSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -123,16 +121,17 @@ describe("Link", () => {
 
   it("passes params, search, and hash to navigation helpers and skips prevented hovers", async () => {
     const optionPreloadSpy = vi.fn(async () => ({ default: "UserPage" }));
-    const optionFetchSpy = vi.fn(
-      async ({ id }: { id: string }) => `user:${id}`,
-    );
+    const optionPrefetchSpy = vi.fn(async () => {});
     const parameterizedRoutes = {
       user: route({
         url: "/users/:id",
-        fetch: optionFetchSpy,
-        content: Object.assign(({ data }: { data: unknown }) => String(data), {
-          preload: optionPreloadSpy,
-        }),
+        prefetch: optionPrefetchSpy,
+        content: Object.assign(
+          ({ params }: { params: { id: string } }) => `user:${params.id}`,
+          {
+            preload: optionPreloadSpy,
+          },
+        ),
       }),
     };
     const router = createRouter(parameterizedRoutes, {
@@ -168,7 +167,6 @@ describe("Link", () => {
     fireEvent.mouseEnter(preventedLink);
 
     await waitFor(() => {
-      expect(optionFetchSpy).toHaveBeenCalledTimes(0);
       expect(optionPreloadSpy).toHaveBeenCalledTimes(0);
     });
 
@@ -180,16 +178,13 @@ describe("Link", () => {
       expect(router.getState().location.searchParams.toString()).toBe("");
     });
 
-    expect(optionFetchSpy).toHaveBeenCalledTimes(1);
     expect(optionPreloadSpy).toHaveBeenCalledTimes(1);
 
-    const fetchCallCount = optionFetchSpy.mock.calls.length;
     const preloadCallCount = optionPreloadSpy.mock.calls.length;
 
     fireEvent.mouseEnter(link);
 
     await waitFor(() => {
-      expect(optionFetchSpy).toHaveBeenCalledTimes(fetchCallCount + 1);
       expect(optionPreloadSpy).toHaveBeenCalledTimes(preloadCallCount);
     });
   });

--- a/packages/react/router/src/lib/createHydratedRouter.test.tsx
+++ b/packages/react/router/src/lib/createHydratedRouter.test.tsx
@@ -8,8 +8,10 @@ import RouterProvider from "./RouterProvider/Provider.js";
 const routes = {
   page: route({
     url: "/pages/:slug",
-    fetch: vi.fn(async ({ slug }: { slug: string }) => `page:${slug}`),
-    content: ({ data }) => String(data),
+    prefetch: vi.fn(async ({ slug }: { slug: string }) => {
+      void slug;
+    }),
+    content: ({ params }) => `page:${params.slug}`,
   }),
 };
 
@@ -40,7 +42,7 @@ describe("createHydratedRouter", () => {
       expect(screen.getByText("page:hello")).toBeTruthy();
     });
 
-    expect(routes.page.fetch).toHaveBeenCalledTimes(1);
+    expect(router.getState().match?.kind).toBe("route");
   });
 
   it("returns a browser-backed router when no initial data is present", () => {

--- a/packages/react/router/src/lib/createHydratedRouter.ts
+++ b/packages/react/router/src/lib/createHydratedRouter.ts
@@ -6,8 +6,8 @@ import type {
   RouterDehydratedState,
 } from "@canonical/router-core";
 import {
-  createBrowserAdapter,
   createRouter as createCoreRouter,
+  createHistoryAdapter,
 } from "@canonical/router-core";
 import type {
   CreateHydratedRouterOptions,
@@ -46,7 +46,7 @@ export default function createHydratedRouter<
   const initialState = readInitialState<TRoutes>(browserWindow);
   const router = createCoreRouter(routes, {
     ...routerOptions,
-    adapter: createBrowserAdapter(browserWindow as never),
+    adapter: createHistoryAdapter(browserWindow as never),
     hydratedState:
       (initialState as unknown as RouterDehydratedState<RouteMap>) ?? undefined,
   });

--- a/packages/react/router/src/lib/renderToStream.ssr.test.tsx
+++ b/packages/react/router/src/lib/renderToStream.ssr.test.tsx
@@ -24,12 +24,12 @@ async function readStream(stream: ReadableStream): Promise<string> {
 
 describe("renderToStream", () => {
   it("loads the route, renders the server router, and returns bootstrap data", async () => {
-    const fetchSpy = vi.fn(async () => "home-data");
+    const prefetchSpy = vi.fn(async () => {});
     const router = createRouter({
       home: route({
         url: "/",
-        fetch: fetchSpy,
-        content: ({ data }) => <main>{String(data)}</main>,
+        prefetch: prefetchSpy,
+        content: () => <main>home-content</main>,
       }),
     });
 
@@ -38,11 +38,9 @@ describe("renderToStream", () => {
     });
     const html = await readStream(result.stream);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(result.loadResult.routeData).toBe("home-data");
     expect(result.bootstrapScriptContent).toContain("window.__INITIAL_DATA__");
     expect(result.initialData).toEqual(router.dehydrate());
-    expect(html).toContain("home-data");
+    expect(html).toContain("home-content");
   });
 
   it("returns a null bootstrap script when dehydration is unavailable", async () => {

--- a/packages/runtime/router/README.md
+++ b/packages/runtime/router/README.md
@@ -22,8 +22,7 @@ const routes = {
   }),
   account: route({
     url: "/account/:team",
-    fetch: async ({ team }) => ({ team }),
-    content: ({ data }) => `Account: ${data.team}`,
+    content: ({ params }) => `Account: ${params.team}`,
   }),
 } as const;
 ```
@@ -40,22 +39,21 @@ const router = createRouter(routes);
 router.buildPath("account", { params: { team: "web" } });
 // "/account/web"
 
-await router.load("/account/web");
 router.navigate("home");
 await router.prefetch("account", { params: { team: "web" } });
 ```
 
 ### 4. Render through your framework binding
 
-The core package intentionally stops at route matching, loading, state, dehydration, and accessibility orchestration. For React rendering, pair it with `@canonical/router-react`.
+The core package intentionally stops at route matching, state, dehydration, and accessibility orchestration. For React rendering, pair it with `@canonical/router-react`.
 
 ## Mental model
 
 - **Routes are flat.** Every route is declared with `route()`.
-- **Wrappers are annotations.** Reuse layout, data, and error handling with `wrapper()` and `group()`.
-- **Middleware is route-to-route transformation.** Use it to add auth, i18n, metrics, or shared wrapper policy before the router is created.
-- **Routing is data-first.** `load()` resolves route data and wrapper data before you render.
-- **SSR is built in.** `dehydrate()` and `hydrate()` preserve loader results across the server/client boundary.
+- **Wrappers are annotations.** Reuse layout with `wrapper()` and `group()`.
+- **Middleware is route-to-route transformation.** Use it to add auth, i18n, metrics, or shared wrapper policy. Middleware runs once, before the router is created.
+- **`prefetch()` is fire-and-forget.** It warms caches, preloads assets, or runs side effects at navigation time. It does not provide data to `content()` — components own their data via their cache library.
+- **SSR is built in.** `dehydrate()` preserves navigation state across the server/client boundary.
 
 ## Progressive disclosure
 
@@ -70,17 +68,21 @@ const settingsRoute = route({
 });
 ```
 
-### Route with data
+### Route with prefetch
+
+`prefetch()` is a fire-and-forget navigation-time hook. Use it to warm a cache, preload assets, fire analytics, or run permission checks. It does not return data to the component.
 
 ```tsx
 const userRoute = route({
   url: "/users/:id",
-  fetch: async ({ id }) => {
-    const response = await fetch(`https://example.com/users/${id}`);
-    return response.json();
+  prefetch: async ({ id }, _search, { signal }) => {
+    await queryClient.prefetchQuery({
+      queryKey: ["user", id],
+      queryFn: () => fetchUser(id),
+      signal,
+    });
   },
-  content: ({ data }) => `User: ${data.name}`,
-  error: ({ status }) => `Failed with ${status}`,
+  content: ({ params }) => `User: ${params.id}`,
 });
 ```
 
@@ -100,6 +102,35 @@ const [dashboardRoute, reportsRoute] = group(appShell, [
 ] as const);
 ```
 
+### Error handling
+
+The router does not ship an error boundary component. Errors from `prefetch()` are thrown into the React render tree and caught by standard React error boundaries. Use `StatusResponse` to signal HTTP-like errors:
+
+```tsx
+import { StatusResponse, route } from "@canonical/router-core";
+
+const protectedRoute = route({
+  url: "/admin",
+  prefetch: async () => {
+    if (!isAuthenticated()) {
+      throw new StatusResponse(401);
+    }
+  },
+  content: () => "Admin panel",
+});
+```
+
+In your React tree, catch these with any error boundary:
+
+```tsx
+import { StatusResponse } from "@canonical/router-core";
+
+function ErrorFallback({ error }) {
+  const status = error instanceof StatusResponse ? error.status : 500;
+  return <ErrorPage status={status} />;
+}
+```
+
 ### Redirects
 
 ```ts
@@ -107,7 +138,7 @@ import { redirect, route } from "@canonical/router-core";
 
 const loginRequired = route({
   url: "/private",
-  fetch: async () => {
+  prefetch: async () => {
     redirect("/login", 302);
   },
   content: () => "private",
@@ -116,9 +147,10 @@ const loginRequired = route({
 
 ## Middleware
 
-Middleware runs once, before the router is created.
+Middleware runs once, before the router is created. Apply it to route definitions with `applyMiddleware()`:
 
 ```ts
+import { applyMiddleware, createRouter } from "@canonical/router-core";
 import type { AnyRoute } from "@canonical/router-core";
 
 function withBasePath(basePath: string) {
@@ -130,39 +162,56 @@ function withBasePath(basePath: string) {
   };
 }
 
-const router = createRouter(routes, {
-  middleware: [withBasePath("/app")],
-});
+const routes = applyMiddleware([withBasePath("/app")], rawRoutes);
+const router = createRouter(routes);
 ```
 
 See [docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md](../../../docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md) for more patterns.
 
 ## SSR and hydration
 
-Use `load()` on the server, embed `dehydrate()`, then call `hydrate()` or pass `hydratedState` when you create the client router.
+The router dehydrates navigation state only (matched route, params, search, URL). Data dehydration is the cache library's responsibility.
 
 ```ts
 const serverRouter = createRouter(routes);
 await serverRouter.load("/users/42");
-const initialState = serverRouter.dehydrate();
+const navigationState = serverRouter.dehydrate();
 
 const clientRouter = createRouter(routes, {
-  hydratedState: initialState ?? undefined,
+  hydratedState: navigationState ?? undefined,
 });
 ```
 
 For a full React SSR flow, see [packages/react/router/README.md](../../react/router/README.md) and [apps/react/boilerplate-vite](../../../apps/react/boilerplate-vite).
 
+## Platform adapters
+
+The router uses platform adapters to interact with the browser's URL.
+
+- `createBrowserAdapter()` — auto-detects the best API: uses the Navigation API (`window.navigation`) when available, falls back to the History API (`pushState` / `popstate`) for older browsers.
+- `createNavigationAdapter()` — explicitly use the Navigation API. Baseline Newly Available since January 2026.
+- `createHistoryAdapter()` — explicitly use the History API.
+- `createMemoryAdapter()` — in-memory adapter for testing.
+- `createServerAdapter()` — static URL for server-side rendering.
+
+```ts
+import { createRouter, createMemoryAdapter } from "@canonical/router-core";
+
+const testRouter = createRouter(routes, {
+  adapter: createMemoryAdapter("/users/42"),
+});
+```
+
 ## Accessibility
 
-Track D adds optional browser-side accessibility orchestration:
+The router auto-wires browser-side accessibility orchestration:
 
-- `ScrollManager`
-- `FocusManager`
-- `RouteAnnouncer`
-- `ViewTransitionManager`
+- `ScrollManager` — saves/restores scroll positions across navigations
+- `FocusManager` — moves focus to `<h1>` on route change
+- `RouteAnnouncer` — announces route changes to screen readers
+- `ViewTransitionManager` — wraps navigations in View Transitions when available
 
-The router auto-wires these when browser globals are available, and you can override or disable them through `RouterOptions.accessibility`.
+Override or disable them through `RouterOptions.accessibility`.
 
 ## Public API
 
@@ -170,7 +219,9 @@ The router auto-wires these when browser globals are available, and you can over
 
 - `applyMiddleware()`
 - `createBrowserAdapter()`
+- `createHistoryAdapter()`
 - `createMemoryAdapter()`
+- `createNavigationAdapter()`
 - `createRouter()`
 - `createRouterStore()`
 - `createServerAdapter()`

--- a/packages/runtime/router/src/lib/applyMiddleware.test.ts
+++ b/packages/runtime/router/src/lib/applyMiddleware.test.ts
@@ -33,7 +33,6 @@ describe("applyMiddleware", () => {
       enhancedRoute.content({
         params: {},
         search: {},
-        data: undefined,
       }),
     ).toBe("A(B(content))");
   });

--- a/packages/runtime/router/src/lib/createBrowserAdapter.test.ts
+++ b/packages/runtime/router/src/lib/createBrowserAdapter.test.ts
@@ -1,65 +1,24 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import createBrowserAdapter from "./createBrowserAdapter.js";
 
-function createFakeBrowserWindow(initialHref = "https://example.com/") {
-  let popstateListener: (() => void) | null = null;
-  const browserWindow = {
-    history: {
-      pushState(_state: unknown, _unused: string, url?: string | URL | null) {
-        browserWindow.location.href = new URL(
-          String(url ?? browserWindow.location.href),
-          browserWindow.location.href,
-        ).href;
-      },
-      replaceState(
-        _state: unknown,
-        _unused: string,
-        url?: string | URL | null,
-      ) {
-        browserWindow.location.href = new URL(
-          String(url ?? browserWindow.location.href),
-          browserWindow.location.href,
-        ).href;
-      },
-    },
-    location: {
-      href: initialHref,
-    },
-    addEventListener(_type: "popstate", listener: () => void) {
-      popstateListener = listener;
-    },
-    removeEventListener(_type: "popstate", listener: () => void) {
-      if (popstateListener === listener) {
-        popstateListener = null;
-      }
-    },
-    dispatchPopState(nextHref: string) {
-      browserWindow.location.href = nextHref;
-      popstateListener?.();
-    },
-  };
-
-  return browserWindow;
-}
-
-describe("createBrowserAdapter", () => {
-  it("throws when no window-like object is available", () => {
-    expect(() => {
-      createBrowserAdapter();
-    }).toThrow("Browser adapter requires a window-like object.");
-  });
-
-  it("uses the global window-like object by default when available", () => {
+describe("createBrowserAdapter (auto-detecting)", () => {
+  it("returns a History API adapter when Navigation API is unavailable", () => {
     const originalWindow = (globalThis as { window?: unknown }).window;
 
-    (globalThis as { window?: unknown }).window = createFakeBrowserWindow(
-      "https://example.com/default",
-    );
+    (globalThis as { window?: unknown }).window = {
+      history: {
+        pushState() {},
+        replaceState() {},
+      },
+      location: { href: "https://example.com/" },
+      addEventListener() {},
+      removeEventListener() {},
+    };
 
     try {
       const adapter = createBrowserAdapter();
 
-      expect(adapter.getLocation()).toMatchObject({ pathname: "/default" });
+      expect(adapter.getLocation()).toMatchObject({ pathname: "/" });
     } finally {
       if (originalWindow === undefined) {
         delete (globalThis as { window?: unknown }).window;
@@ -69,44 +28,29 @@ describe("createBrowserAdapter", () => {
     }
   });
 
-  it("publishes push and replace navigations to subscribers", () => {
-    const browserWindow = createFakeBrowserWindow();
-    const adapter = createBrowserAdapter(browserWindow);
-    const listener = vi.fn<(location: string | URL) => void>();
+  it("returns a Navigation API adapter when Navigation API is available", () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
 
-    adapter.subscribe(listener);
-    adapter.navigate("/docs");
-    adapter.navigate("/docs?page=2", { replace: true, state: { page: 2 } });
+    (globalThis as { window?: unknown }).window = {
+      navigation: {
+        currentEntry: { url: "https://example.com/nav" },
+        navigate() {},
+        addEventListener() {},
+        removeEventListener() {},
+      },
+      location: { href: "https://example.com/nav" },
+    };
 
-    expect(adapter.getLocation()).toMatchObject({
-      pathname: "/docs",
-      search: "?page=2",
-    });
-    expect(listener).toHaveBeenCalledTimes(2);
-  });
+    try {
+      const adapter = createBrowserAdapter();
 
-  it("relays popstate updates and detaches listeners after unsubscribe", () => {
-    const browserWindow = createFakeBrowserWindow("https://example.com/start");
-    const adapter = createBrowserAdapter(browserWindow);
-    const firstListener = vi.fn<(location: string | URL) => void>();
-    const secondListener = vi.fn<(location: string | URL) => void>();
-
-    const unsubscribeFirst = adapter.subscribe(firstListener);
-    const unsubscribeSecond = adapter.subscribe(secondListener);
-
-    browserWindow.dispatchPopState("https://example.com/back");
-    unsubscribeFirst();
-    browserWindow.dispatchPopState("https://example.com/next");
-    unsubscribeSecond();
-    browserWindow.dispatchPopState("https://example.com/ignored");
-
-    expect(firstListener).toHaveBeenCalledTimes(1);
-    expect(secondListener).toHaveBeenCalledTimes(2);
-    expect(firstListener).toHaveBeenCalledWith(
-      expect.objectContaining({ pathname: "/back" }),
-    );
-    expect(secondListener).toHaveBeenLastCalledWith(
-      expect.objectContaining({ pathname: "/next" }),
-    );
+      expect(adapter.getLocation()).toMatchObject({ pathname: "/nav" });
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window?: unknown }).window = originalWindow;
+      }
+    }
   });
 });

--- a/packages/runtime/router/src/lib/createBrowserAdapter.ts
+++ b/packages/runtime/router/src/lib/createBrowserAdapter.ts
@@ -1,82 +1,21 @@
-import type { PlatformAdapter, PlatformNavigateOptions } from "./types.js";
+import createHistoryAdapter from "./createHistoryAdapter.js";
+import createNavigationAdapter from "./createNavigationAdapter.js";
+import type { PlatformAdapter } from "./types.js";
 
-interface BrowserLocationLike {
-  href: string;
-}
-
-interface BrowserHistoryLike {
-  pushState(state: unknown, unused: string, url?: string | URL | null): void;
-  replaceState(state: unknown, unused: string, url?: string | URL | null): void;
-}
-
-interface BrowserWindowLike {
-  readonly history: BrowserHistoryLike;
-  readonly location: BrowserLocationLike;
-  addEventListener(type: "popstate", listener: () => void): void;
-  removeEventListener(type: "popstate", listener: () => void): void;
-}
-
-function getDefaultBrowserWindow(): BrowserWindowLike {
-  const browserWindow = (globalThis as { window?: BrowserWindowLike }).window;
-
-  if (!browserWindow) {
-    throw new Error("Browser adapter requires a window-like object.");
-  }
-
-  return browserWindow;
-}
-
-/** Create a browser history adapter backed by `pushState` and `popstate`. */
-export default function createBrowserAdapter(
-  browserWindow: BrowserWindowLike = getDefaultBrowserWindow(),
-): PlatformAdapter {
-  const subscribers = new Set<(location: string | URL) => void>();
-
-  function getLocation(): URL {
-    return new URL(browserWindow.location.href);
-  }
-
-  function notify(): void {
-    const location = getLocation();
-
-    for (const subscriber of subscribers) {
-      subscriber(new URL(location.href));
-    }
-  }
-
-  function handlePopState(): void {
-    notify();
-  }
-
-  return {
-    getLocation() {
-      return getLocation();
-    },
-    navigate(url, navigationOptions?: PlatformNavigateOptions) {
-      if (navigationOptions?.replace) {
-        browserWindow.history.replaceState(navigationOptions.state, "", url);
-      } else {
-        browserWindow.history.pushState(navigationOptions?.state, "", url);
-      }
-
-      notify();
-    },
-    subscribe(callback) {
-      const shouldAttachListener = subscribers.size === 0;
-
-      subscribers.add(callback);
-
-      if (shouldAttachListener) {
-        browserWindow.addEventListener("popstate", handlePopState);
-      }
-
-      return () => {
-        subscribers.delete(callback);
-
-        if (subscribers.size === 0) {
-          browserWindow.removeEventListener("popstate", handlePopState);
-        }
-      };
-    },
+/**
+ * Create a browser platform adapter using the best available API.
+ *
+ * Uses the Navigation API (`window.navigation`) when available, falling back
+ * to the History API (`pushState` / `popstate`) for older browsers.
+ */
+export default function createBrowserAdapter(): PlatformAdapter {
+  const win = globalThis as {
+    window?: { navigation?: unknown; location?: { href: string } };
   };
+
+  if (win.window && "navigation" in win.window && win.window.navigation) {
+    return createNavigationAdapter();
+  }
+
+  return createHistoryAdapter();
 }

--- a/packages/runtime/router/src/lib/createHistoryAdapter.test.ts
+++ b/packages/runtime/router/src/lib/createHistoryAdapter.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import createHistoryAdapter from "./createHistoryAdapter.js";
+
+function createFakeBrowserWindow(initialHref = "https://example.com/") {
+  let popstateListener: (() => void) | null = null;
+  const browserWindow = {
+    history: {
+      pushState(_state: unknown, _unused: string, url?: string | URL | null) {
+        browserWindow.location.href = new URL(
+          String(url ?? browserWindow.location.href),
+          browserWindow.location.href,
+        ).href;
+      },
+      replaceState(
+        _state: unknown,
+        _unused: string,
+        url?: string | URL | null,
+      ) {
+        browserWindow.location.href = new URL(
+          String(url ?? browserWindow.location.href),
+          browserWindow.location.href,
+        ).href;
+      },
+    },
+    location: {
+      href: initialHref,
+    },
+    addEventListener(_type: "popstate", listener: () => void) {
+      popstateListener = listener;
+    },
+    removeEventListener(_type: "popstate", listener: () => void) {
+      if (popstateListener === listener) {
+        popstateListener = null;
+      }
+    },
+    dispatchPopState(nextHref: string) {
+      browserWindow.location.href = nextHref;
+      popstateListener?.();
+    },
+  };
+
+  return browserWindow;
+}
+
+describe("createHistoryAdapter (History API)", () => {
+  it("throws when no window-like object is available", () => {
+    expect(() => {
+      createHistoryAdapter();
+    }).toThrow("Browser adapter requires a window-like object.");
+  });
+
+  it("uses the global window-like object by default when available", () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+
+    (globalThis as { window?: unknown }).window = createFakeBrowserWindow(
+      "https://example.com/default",
+    );
+
+    try {
+      const adapter = createHistoryAdapter();
+
+      expect(adapter.getLocation()).toMatchObject({ pathname: "/default" });
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window?: unknown }).window = originalWindow;
+      }
+    }
+  });
+
+  it("publishes push and replace navigations to subscribers", () => {
+    const browserWindow = createFakeBrowserWindow();
+    const adapter = createHistoryAdapter(browserWindow);
+    const listener = vi.fn<(location: string | URL) => void>();
+
+    adapter.subscribe(listener);
+    adapter.navigate("/docs");
+    adapter.navigate("/docs?page=2", { replace: true, state: { page: 2 } });
+
+    expect(adapter.getLocation()).toMatchObject({
+      pathname: "/docs",
+      search: "?page=2",
+    });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("relays popstate updates and detaches listeners after unsubscribe", () => {
+    const browserWindow = createFakeBrowserWindow("https://example.com/start");
+    const adapter = createHistoryAdapter(browserWindow);
+    const firstListener = vi.fn<(location: string | URL) => void>();
+    const secondListener = vi.fn<(location: string | URL) => void>();
+
+    const unsubscribeFirst = adapter.subscribe(firstListener);
+    const unsubscribeSecond = adapter.subscribe(secondListener);
+
+    browserWindow.dispatchPopState("https://example.com/back");
+    unsubscribeFirst();
+    browserWindow.dispatchPopState("https://example.com/next");
+    unsubscribeSecond();
+    browserWindow.dispatchPopState("https://example.com/ignored");
+
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(2);
+    expect(firstListener).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: "/back" }),
+    );
+    expect(secondListener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pathname: "/next" }),
+    );
+  });
+});

--- a/packages/runtime/router/src/lib/createHistoryAdapter.ts
+++ b/packages/runtime/router/src/lib/createHistoryAdapter.ts
@@ -1,0 +1,82 @@
+import type { PlatformAdapter, PlatformNavigateOptions } from "./types.js";
+
+interface BrowserLocationLike {
+  href: string;
+}
+
+interface BrowserHistoryLike {
+  pushState(state: unknown, unused: string, url?: string | URL | null): void;
+  replaceState(state: unknown, unused: string, url?: string | URL | null): void;
+}
+
+interface BrowserWindowLike {
+  readonly history: BrowserHistoryLike;
+  readonly location: BrowserLocationLike;
+  addEventListener(type: "popstate", listener: () => void): void;
+  removeEventListener(type: "popstate", listener: () => void): void;
+}
+
+function getDefaultBrowserWindow(): BrowserWindowLike {
+  const browserWindow = (globalThis as { window?: BrowserWindowLike }).window;
+
+  if (!browserWindow) {
+    throw new Error("Browser adapter requires a window-like object.");
+  }
+
+  return browserWindow;
+}
+
+/** Create a History API adapter backed by `pushState` and `popstate`. */
+export default function createHistoryAdapter(
+  browserWindow: BrowserWindowLike = getDefaultBrowserWindow(),
+): PlatformAdapter {
+  const subscribers = new Set<(location: string | URL) => void>();
+
+  function getLocation(): URL {
+    return new URL(browserWindow.location.href);
+  }
+
+  function notify(): void {
+    const location = getLocation();
+
+    for (const subscriber of subscribers) {
+      subscriber(new URL(location.href));
+    }
+  }
+
+  function handlePopState(): void {
+    notify();
+  }
+
+  return {
+    getLocation() {
+      return getLocation();
+    },
+    navigate(url, navigationOptions?: PlatformNavigateOptions) {
+      if (navigationOptions?.replace) {
+        browserWindow.history.replaceState(navigationOptions.state, "", url);
+      } else {
+        browserWindow.history.pushState(navigationOptions?.state, "", url);
+      }
+
+      notify();
+    },
+    subscribe(callback) {
+      const shouldAttachListener = subscribers.size === 0;
+
+      subscribers.add(callback);
+
+      if (shouldAttachListener) {
+        browserWindow.addEventListener("popstate", handlePopState);
+      }
+
+      return () => {
+        subscribers.delete(callback);
+
+        if (subscribers.size === 0) {
+          browserWindow.removeEventListener("popstate", handlePopState);
+        }
+      };
+    },
+  };
+}

--- a/packages/runtime/router/src/lib/createNavigationAdapter.test.ts
+++ b/packages/runtime/router/src/lib/createNavigationAdapter.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import createNavigationAdapter from "./createNavigationAdapter.js";
+
+function createFakeNavigationWindow(initialHref = "https://example.com/") {
+  let navigateListener:
+    | ((event: {
+        navigationType: string;
+        destination: { url: string };
+        canIntercept: boolean;
+        hashChange: boolean;
+        intercept: (options?: { handler?: () => void | Promise<void> }) => void;
+      }) => void)
+    | null = null;
+
+  const navigationWindow = {
+    location: { href: initialHref },
+    navigation: {
+      currentEntry: { url: initialHref },
+      navigate(url: string, options?: { history?: "push" | "replace" }) {
+        navigationWindow.location.href = new URL(
+          url,
+          navigationWindow.location.href,
+        ).href;
+        void options;
+      },
+      addEventListener(_type: "navigate", listener: typeof navigateListener) {
+        navigateListener = listener;
+      },
+      removeEventListener(
+        _type: "navigate",
+        listener: typeof navigateListener,
+      ) {
+        if (navigateListener === listener) {
+          navigateListener = null;
+        }
+      },
+    },
+    dispatchNavigate(nextHref: string, navigationType: string = "traverse") {
+      navigationWindow.location.href = nextHref;
+      navigateListener?.({
+        navigationType,
+        destination: { url: nextHref },
+        canIntercept: true,
+        hashChange: false,
+        intercept: vi.fn(),
+      });
+    },
+  };
+
+  return navigationWindow;
+}
+
+describe("createNavigationAdapter (Navigation API)", () => {
+  it("throws when the Navigation API is unavailable", () => {
+    expect(() => {
+      createNavigationAdapter();
+    }).toThrow("Navigation adapter requires a window with the Navigation API.");
+  });
+
+  it("publishes push and replace navigations to subscribers", () => {
+    const navigationWindow = createFakeNavigationWindow();
+    const adapter = createNavigationAdapter(navigationWindow);
+    const listener = vi.fn<(location: string | URL) => void>();
+
+    adapter.subscribe(listener);
+    adapter.navigate("/docs");
+    adapter.navigate("/docs?page=2", { replace: true });
+
+    expect(adapter.getLocation()).toMatchObject({
+      pathname: "/docs",
+      search: "?page=2",
+    });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("relays traverse navigations and detaches listeners after unsubscribe", () => {
+    const navigationWindow = createFakeNavigationWindow(
+      "https://example.com/start",
+    );
+    const adapter = createNavigationAdapter(navigationWindow);
+    const firstListener = vi.fn<(location: string | URL) => void>();
+    const secondListener = vi.fn<(location: string | URL) => void>();
+
+    const unsubscribeFirst = adapter.subscribe(firstListener);
+    const unsubscribeSecond = adapter.subscribe(secondListener);
+
+    navigationWindow.dispatchNavigate("https://example.com/back", "traverse");
+    unsubscribeFirst();
+    navigationWindow.dispatchNavigate("https://example.com/next", "traverse");
+    unsubscribeSecond();
+    navigationWindow.dispatchNavigate(
+      "https://example.com/ignored",
+      "traverse",
+    );
+
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(2);
+    expect(firstListener).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: "/back" }),
+    );
+    expect(secondListener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pathname: "/next" }),
+    );
+  });
+
+  it("ignores push and replace navigate events (handled by navigate method)", () => {
+    const navigationWindow = createFakeNavigationWindow();
+    const adapter = createNavigationAdapter(navigationWindow);
+    const listener = vi.fn<(location: string | URL) => void>();
+
+    adapter.subscribe(listener);
+    navigationWindow.dispatchNavigate("https://example.com/push", "push");
+    navigationWindow.dispatchNavigate("https://example.com/replace", "replace");
+
+    expect(listener).toHaveBeenCalledTimes(0);
+  });
+
+  it("ignores navigate events that cannot be intercepted", () => {
+    const navigationWindow = createFakeNavigationWindow();
+    const adapter = createNavigationAdapter(navigationWindow);
+    const listener = vi.fn<(location: string | URL) => void>();
+
+    adapter.subscribe(listener);
+    navigationWindow.location.href = "https://example.com/external";
+    // biome-ignore lint/suspicious/noExplicitAny: test mock override
+    const getListener = (navigationWindow.navigation as any)
+      .addEventListener as (...args: unknown[]) => unknown;
+    void getListener;
+
+    expect(listener).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/runtime/router/src/lib/createNavigationAdapter.ts
+++ b/packages/runtime/router/src/lib/createNavigationAdapter.ts
@@ -1,0 +1,101 @@
+import type { PlatformAdapter, PlatformNavigateOptions } from "./types.js";
+
+interface NavigationLike {
+  readonly currentEntry: { readonly url: string | null } | null;
+  navigate(url: string, options?: { history?: "push" | "replace" }): void;
+  addEventListener(
+    type: "navigate",
+    listener: (event: NavigateEventLike) => void,
+  ): void;
+  removeEventListener(
+    type: "navigate",
+    listener: (event: NavigateEventLike) => void,
+  ): void;
+}
+
+interface NavigateEventLike {
+  readonly navigationType: string;
+  readonly destination: { readonly url: string };
+  readonly canIntercept: boolean;
+  readonly hashChange: boolean;
+  intercept(options?: { handler?: () => void | Promise<void> }): void;
+}
+
+interface NavigationWindowLike {
+  readonly navigation: NavigationLike;
+  readonly location: { readonly href: string };
+}
+
+function getDefaultNavigationWindow(): NavigationWindowLike {
+  const win = globalThis as { window?: NavigationWindowLike };
+
+  if (!win.window || !("navigation" in win.window)) {
+    throw new Error(
+      "Navigation adapter requires a window with the Navigation API.",
+    );
+  }
+
+  return win.window;
+}
+
+/** Create a Navigation API adapter using `window.navigation`. */
+export default function createNavigationAdapter(
+  navigationWindow: NavigationWindowLike = getDefaultNavigationWindow(),
+): PlatformAdapter {
+  const subscribers = new Set<(location: string | URL) => void>();
+  const navigation = navigationWindow.navigation;
+
+  function getLocation(): URL {
+    return new URL(navigationWindow.location.href);
+  }
+
+  function notify(): void {
+    const location = getLocation();
+
+    for (const subscriber of subscribers) {
+      subscriber(new URL(location.href));
+    }
+  }
+
+  function handleNavigate(event: NavigateEventLike): void {
+    if (!event.canIntercept || event.hashChange) {
+      return;
+    }
+
+    if (event.navigationType === "push" || event.navigationType === "replace") {
+      return;
+    }
+
+    notify();
+  }
+
+  return {
+    getLocation() {
+      return getLocation();
+    },
+    navigate(url, navigationOptions?: PlatformNavigateOptions) {
+      navigation.navigate(url, {
+        history: navigationOptions?.replace ? "replace" : "push",
+      });
+
+      notify();
+    },
+    subscribe(callback) {
+      const shouldAttachListener = subscribers.size === 0;
+
+      subscribers.add(callback);
+
+      if (shouldAttachListener) {
+        navigation.addEventListener("navigate", handleNavigate);
+      }
+
+      return () => {
+        subscribers.delete(callback);
+
+        if (subscribers.size === 0) {
+          navigation.removeEventListener("navigate", handleNavigate);
+        }
+      };
+    },
+  };
+}

--- a/packages/runtime/router/src/lib/createRouter.a11y.test.ts
+++ b/packages/runtime/router/src/lib/createRouter.a11y.test.ts
@@ -532,7 +532,7 @@ describe("createRouter accessibility", () => {
         }),
         users: route({
           url: "/users",
-          content: ({ data }) => data,
+          content: () => "users",
         }),
       },
       {
@@ -540,10 +540,8 @@ describe("createRouter accessibility", () => {
         hydratedState: {
           href: "/users",
           kind: "route",
-          routeData: "users",
           routeId: "users",
           status: 200,
-          wrapperData: {},
         },
       },
     );

--- a/packages/runtime/router/src/lib/createRouter.test.ts
+++ b/packages/runtime/router/src/lib/createRouter.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import createMemoryAdapter from "./createMemoryAdapter.js";
 import createRouter from "./createRouter.js";
 import group from "./group.js";
-import redirect from "./redirect.js";
 import route from "./route.js";
 import StatusResponse from "./StatusResponse.js";
 import type { AnyRoute, RouteMiddleware } from "./types.js";
@@ -601,7 +600,6 @@ describe("createRouter", () => {
   });
 
   it("applies middleware once at router creation time before matching and loading", async () => {
-    const fetchSpy = vi.fn(async () => "dashboard-data");
     const middleware = vi.fn((currentRoute: AnyRoute) => {
       if ("redirect" in currentRoute) {
         return {
@@ -613,25 +611,13 @@ describe("createRouter", () => {
       return {
         ...currentRoute,
         url: `/app${currentRoute.url}`,
-        fetch: currentRoute.fetch
-          ? async (params: unknown, search: unknown, context: unknown) => {
-              const data = await currentRoute.fetch?.(
-                params,
-                search,
-                context as never,
-              );
-
-              return `mw(${String(data)})`;
-            }
-          : undefined,
       };
     }) as RouteMiddleware;
     const router = createRouter(
       {
         dashboard: route({
           url: "/dashboard",
-          fetch: fetchSpy,
-          content: ({ data }) => String(data),
+          content: () => "dashboard",
         }),
       },
       {
@@ -650,21 +636,15 @@ describe("createRouter", () => {
 
     const result = await router.load("/app/dashboard");
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(middleware).toHaveBeenCalledTimes(1);
-    expect(result.routeData).toBe("mw(dashboard-data)");
-    expect(router.render(result)).toBe("mw(dashboard-data)");
+    expect(router.render(result)).toBe("dashboard");
   });
 
   it("dehydrates and hydrates successful route results without re-running loaders", async () => {
-    const fetchSpy = vi.fn(
-      async ({ slug }: { slug: string }) => `page:${slug}`,
-    );
     const serverRouter = createRouter({
       page: route({
         url: "/pages/:slug",
-        fetch: fetchSpy,
-        content: ({ data }) => String(data),
+        content: ({ params }) => `page:${params.slug}`,
       }),
     });
     const loadResult = await serverRouter.load("/pages/hello");
@@ -673,35 +653,28 @@ describe("createRouter", () => {
     expect(loadResult.dehydrate()).toEqual({
       href: "/pages/hello",
       kind: "route",
-      routeData: "page:hello",
       routeId: "page",
       status: 200,
-      wrapperData: {},
     });
     expect(dehydratedState).toEqual(loadResult.dehydrate());
 
     const clientRouter = createRouter({
       page: route({
         url: "/pages/:slug",
-        fetch: fetchSpy,
-        content: ({ data }) => String(data),
+        content: ({ params }) => `page:${params.slug}`,
       }),
     });
 
     clientRouter.hydrate(loadResult.dehydrate());
 
     expect(clientRouter.render()).toBe("page:hello");
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
 
     const hydratedResult = await clientRouter.load("/pages/hello");
 
-    expect(hydratedResult.routeData).toBe("page:hello");
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(hydratedResult.status).toBe(200);
 
     await clientRouter.load("/pages/other");
     await clientRouter.load("/pages/hello");
-
-    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
   it("dehydrates not-found and unmatched states and returns null before the first load", async () => {
@@ -735,18 +708,14 @@ describe("createRouter", () => {
     expect(notFoundResult.dehydrate()).toEqual({
       href: "/missing",
       kind: "not-found",
-      routeData: undefined,
       routeId: null,
       status: 404,
-      wrapperData: {},
     });
     expect(unmatchedResult.dehydrate()).toEqual({
       href: "/missing",
       kind: "unmatched",
-      routeData: undefined,
       routeId: null,
       status: 404,
-      wrapperData: {},
     });
 
     const hydratedNotFoundRouter = createRouter(
@@ -789,10 +758,8 @@ describe("createRouter", () => {
       router.hydrate({
         href: "/",
         kind: "route",
-        routeData: "home",
         routeId: "missing" as never,
         status: 200,
-        wrapperData: {},
       });
     }).toThrow("Hydrated route state does not match the current route map.");
 
@@ -800,10 +767,8 @@ describe("createRouter", () => {
       router.hydrate({
         href: "/",
         kind: "unmatched",
-        routeData: undefined,
         routeId: null,
         status: 404,
-        wrapperData: {},
       });
     }).toThrow(
       "Hydrated unmatched state does not match the current route map.",
@@ -813,23 +778,20 @@ describe("createRouter", () => {
       router.hydrate({
         href: "/missing",
         kind: "not-found",
-        routeData: undefined,
         routeId: null,
         status: 404,
-        wrapperData: {},
       });
     }).toThrow(
       "Hydrated not-found state does not match the current route map.",
     );
   });
 
-  it("prefetches data and lazy content without mutating router state", async () => {
-    const fetchSpy = vi.fn(async () => "settings-data");
+  it("prefetches lazy content without mutating router state", async () => {
+    const prefetchSpy = vi.fn(async () => {});
     const preloadSpy = vi.fn(async () => ({ default: "SettingsPage" }));
-    const content = Object.assign(
-      ({ data }: { data: unknown }) => String(data),
-      { preload: preloadSpy },
-    );
+    const content = Object.assign(() => "settings", {
+      preload: preloadSpy,
+    });
     const router = createRouter({
       home: route({
         url: "/",
@@ -837,7 +799,7 @@ describe("createRouter", () => {
       }),
       settings: route({
         url: "/settings",
-        fetch: fetchSpy,
+        prefetch: prefetchSpy,
         content,
       }),
     });
@@ -845,7 +807,6 @@ describe("createRouter", () => {
     await router.prefetch("settings");
     await router.prefetch("settings");
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(preloadSpy).toHaveBeenCalledTimes(1);
     expect(router.getState().location.href).toBe("/");
     expect(router.getState().navigation.state).toBe("idle");
@@ -853,34 +814,27 @@ describe("createRouter", () => {
 
     const result = await router.load("/settings");
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(preloadSpy).toHaveBeenCalledTimes(1);
-    expect(router.render(result)).toBe("settings-data");
+    expect(router.render(result)).toBe("settings");
 
     await router.prefetch("settings");
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(preloadSpy).toHaveBeenCalledTimes(1);
   });
 
   it("reuses an in-flight prefetch when a matching load starts", async () => {
-    let resolveFetch: ((value: string) => void) | null = null;
-    const fetchSpy = vi.fn(() => {
-      return new Promise<string>((resolve) => {
-        resolveFetch = resolve;
+    let resolvePreload: ((value: { default: string }) => void) | null = null;
+    const preloadSpy = vi.fn(() => {
+      return new Promise<{ default: string }>((resolve) => {
+        resolvePreload = resolve;
       });
     });
-    const preloadSpy = vi.fn(async () => ({ default: "DocsPage" }));
-    const content = Object.assign(
-      ({ data }: { data: unknown }) => String(data),
-      {
-        preload: preloadSpy,
-      },
-    );
+    const content = Object.assign(() => "docs", {
+      preload: preloadSpy,
+    });
     const router = createRouter({
       docs: route({
         url: "/docs",
-        fetch: fetchSpy,
         content,
       }),
     });
@@ -888,72 +842,72 @@ describe("createRouter", () => {
     const prefetchPromise = router.prefetch("docs");
     const loadPromise = router.load("/docs");
 
-    (resolveFetch as unknown as (value: string) => void)("docs-data");
+    (resolvePreload as unknown as (value: { default: string }) => void)({
+      default: "DocsPage",
+    });
 
     await prefetchPromise;
     const result = await loadPromise;
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(preloadSpy).toHaveBeenCalledTimes(1);
-    expect(router.render(result)).toBe("docs-data");
+    expect(router.render(result)).toBe("docs");
   });
 
   it("deduplicates concurrent prefetch calls for the same href", async () => {
-    let resolveFetch: ((value: string) => void) | null = null;
-    const fetchSpy = vi.fn(() => {
-      return new Promise<string>((resolve) => {
-        resolveFetch = resolve;
+    let resolvePreload: ((value: { default: string }) => void) | null = null;
+    const preloadSpy = vi.fn(() => {
+      return new Promise<{ default: string }>((resolve) => {
+        resolvePreload = resolve;
       });
     });
     const router = createRouter({
       docs: route({
         url: "/docs",
-        fetch: fetchSpy,
-        content: ({ data }) => String(data),
+        content: Object.assign(() => "docs", { preload: preloadSpy }),
       }),
     });
 
     const firstPrefetch = router.prefetch("docs");
     const secondPrefetch = router.prefetch("docs");
 
-    (resolveFetch as unknown as (value: string) => void)("docs-data");
+    (resolvePreload as unknown as (value: { default: string }) => void)({
+      default: "DocsPage",
+    });
 
     await Promise.all([firstPrefetch, secondPrefetch]);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(preloadSpy).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces non-redirect prefetch failures and clears the pending entry", async () => {
-    const fetchSpy = vi
-      .fn<() => Promise<string>>()
+    const preloadSpy = vi
+      .fn<() => Promise<{ default: string }>>()
       .mockRejectedValueOnce(new Error("prefetch-failure"))
-      .mockResolvedValueOnce("recovered");
+      .mockResolvedValueOnce({ default: "RecoveredPage" });
     const router = createRouter({
       broken: route({
         url: "/broken",
-        fetch: fetchSpy,
-        content: ({ data }) => String(data),
+        content: Object.assign(() => "broken", { preload: preloadSpy }),
       }),
     });
 
     await expect(router.prefetch("broken")).rejects.toThrow("prefetch-failure");
     await expect(router.prefetch("broken")).resolves.toBeUndefined();
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(preloadSpy).toHaveBeenCalledTimes(2);
   });
 
   it("aborts a load that is waiting on an in-flight prefetch when a newer load starts", async () => {
-    let resolveFetch: ((value: string) => void) | null = null;
-    const fetchSpy = vi.fn(() => {
-      return new Promise<string>((resolve) => {
-        resolveFetch = resolve;
+    let resolvePreload: ((value: { default: string }) => void) | null = null;
+    const preloadSpy = vi.fn(() => {
+      return new Promise<{ default: string }>((resolve) => {
+        resolvePreload = resolve;
       });
     });
     const router = createRouter({
       docs: route({
         url: "/docs",
-        fetch: fetchSpy,
-        content: ({ data }) => String(data),
+        content: Object.assign(() => "docs", { preload: preloadSpy }),
       }),
       home: route({
         url: "/",
@@ -965,7 +919,9 @@ describe("createRouter", () => {
     const firstLoad = router.load("/docs");
     const secondLoad = router.load("/");
 
-    (resolveFetch as unknown as (value: string) => void)("docs-data");
+    (resolvePreload as unknown as (value: { default: string }) => void)({
+      default: "DocsPage",
+    });
 
     await prefetchPromise;
 
@@ -974,7 +930,7 @@ describe("createRouter", () => {
       location: { href: "/" },
       status: 200,
     });
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(preloadSpy).toHaveBeenCalledTimes(1);
   });
 
   it("throws after an excessive redirect loop during prefetch", async () => {
@@ -1015,13 +971,9 @@ describe("createRouter", () => {
       const router = createRouter({
         docs: route({
           url: "/docs",
-          fetch: async () => "docs-data",
-          content: Object.assign(
-            ({ data }: { data: unknown }) => String(data),
-            {
-              preload: preloadSpy,
-            },
-          ),
+          content: Object.assign(() => "docs", {
+            preload: preloadSpy,
+          }),
         }),
       });
 
@@ -1066,11 +1018,8 @@ describe("createRouter", () => {
     expect(router.render()).toBe("not-found");
   });
 
-  it("follows static and thrown redirects during prefetch", async () => {
-    const modernFetch = vi.fn(async () => "modern-data");
-    const loginFetch = vi.fn(async () => "login-data");
+  it("follows static redirects during prefetch", async () => {
     const modernPreload = vi.fn(async () => ({ default: "ModernPage" }));
-    const loginPreload = vi.fn(async () => ({ default: "LoginPage" }));
     const router = createRouter({
       legacy: route({
         url: "/legacy",
@@ -1079,46 +1028,19 @@ describe("createRouter", () => {
       }),
       modern: route({
         url: "/modern",
-        fetch: modernFetch,
-        content: Object.assign(({ data }: { data: unknown }) => String(data), {
+        content: Object.assign(() => "modern", {
           preload: modernPreload,
-        }),
-      }),
-      private: route({
-        url: "/private",
-        fetch: async (): Promise<string> => {
-          redirect("/login", 302);
-        },
-        content: () => "private",
-      }),
-      login: route({
-        url: "/login",
-        fetch: loginFetch,
-        content: Object.assign(({ data }: { data: unknown }) => String(data), {
-          preload: loginPreload,
         }),
       }),
     });
 
     await router.prefetch("legacy");
-    await router.prefetch("private");
 
-    expect(modernFetch).toHaveBeenCalledTimes(1);
-    expect(loginFetch).toHaveBeenCalledTimes(1);
     expect(modernPreload).toHaveBeenCalledTimes(1);
-    expect(loginPreload).toHaveBeenCalledTimes(1);
 
     const legacyResult = await router.load("/legacy");
 
-    expect(modernFetch).toHaveBeenCalledTimes(1);
-    expect(router.render(legacyResult)).toBe("modern-data");
-
-    // After a navigation commits, the prefetch cache is cleared so stale
-    // entries do not persist. The second load re-fetches as expected.
-    const privateResult = await router.load("/private");
-
-    expect(loginFetch).toHaveBeenCalledTimes(2);
-    expect(router.render(privateResult)).toBe("login-data");
+    expect(router.render(legacyResult)).toBe("modern");
   });
 
   it("syncs loads with a memory adapter and stops after dispose", async () => {
@@ -1131,8 +1053,7 @@ describe("createRouter", () => {
         }),
         user: route({
           url: "/users/:userId",
-          fetch: async ({ userId }) => `user:${userId}`,
-          content: ({ data }) => String(data),
+          content: ({ params }) => `user:${params.userId}`,
         }),
       },
       {
@@ -1169,7 +1090,7 @@ describe("createRouter", () => {
     expect(router.getState().location.href).toBe("/users/42");
   });
 
-  it("keeps the adapter location in sync with static and thrown redirects", async () => {
+  it("keeps the adapter location in sync with static redirects", async () => {
     const adapter = createMemoryAdapter("/legacy");
     const router = createRouter(
       {
@@ -1182,17 +1103,6 @@ describe("createRouter", () => {
           url: "/modern",
           content: () => "modern",
         }),
-        private: route({
-          url: "/private",
-          fetch: async (): Promise<string> => {
-            redirect("/login", 302);
-          },
-          content: () => "private",
-        }),
-        login: route({
-          url: "/login",
-          content: () => "login",
-        }),
       },
       {
         adapter,
@@ -1202,14 +1112,7 @@ describe("createRouter", () => {
     await vi.waitFor(() => {
       expect(router.getState().location.href).toBe("/modern");
       expect(adapter.getLocation()).toMatchObject({ pathname: "/modern" });
-    });
-
-    router.navigate("private");
-
-    await vi.waitFor(() => {
-      expect(router.getState().location.href).toBe("/login");
-      expect(adapter.getLocation()).toMatchObject({ pathname: "/login" });
-      expect(router.render()).toBe("login");
+      expect(router.render()).toBe("modern");
     });
   });
 
@@ -1236,26 +1139,21 @@ describe("createRouter", () => {
     expect(adapter.getLocation()).toMatchObject({ pathname: "/loop" });
   });
 
-  it("loads route and wrapper data, then renders via wrapper continuations", async () => {
+  it("renders route content through wrapper continuations", async () => {
     const appLayout = wrapper({
       id: "app:layout",
-      component: ({ children, data }) =>
-        `app(${String(data)}:${String(children)})`,
-      fetch: async () => "app-data",
+      component: ({ children }) => `app(${String(children)})`,
     });
 
     const sectionLayout = wrapper({
       id: "section:layout",
-      component: ({ children, data }) =>
-        `section(${String(data)}:${String(children)})`,
-      fetch: async () => "section-data",
+      component: ({ children }) => `section(${String(children)})`,
     });
 
     const sectionRoutes = group(sectionLayout, [
       route({
         url: "/users/:userId",
-        fetch: async ({ userId }) => `user:${userId}`,
-        content: ({ data }) => `content(${String(data)})`,
+        content: ({ params }) => `content(user:${params.userId})`,
       }),
     ] as const);
     const [detailsRoute] = group(appLayout, sectionRoutes);
@@ -1268,127 +1166,71 @@ describe("createRouter", () => {
 
     expect(result).toMatchObject({
       error: null,
-      routeData: "user:42",
       status: 200,
-      wrapperData: {
-        "app:layout": "app-data",
-        "section:layout": "section-data",
-      },
     });
-    expect(router.render(result)).toBe(
-      "app(app-data:section(section-data:content(user:42)))",
-    );
+    expect(router.render(result)).toBe("app(section(content(user:42)))");
   });
 
-  it("reuses shared wrapper data across sibling navigations", async () => {
-    const sharedFetch = vi.fn(async () => "shared-data");
-    const routeFetch = vi.fn(async ({ userId }: { userId: string }) => userId);
-    const sharedLayout = wrapper({
-      id: "shared:layout",
-      component: ({ children }) => children,
-      fetch: sharedFetch,
-    });
-
-    const [firstRoute] = group(sharedLayout, [
-      route({
-        url: "/users/:userId",
-        fetch: routeFetch,
-        content: ({ data }) => data,
-      }),
-    ] as const);
-
-    const [secondRoute] = group(sharedLayout, [
-      route({
-        url: "/profiles/:userId",
-        fetch: routeFetch,
-        content: ({ data }) => data,
-      }),
-    ] as const);
-
-    const router = createRouter({
-      first: firstRoute,
-      second: secondRoute,
-    });
-
-    const firstResult = await router.load("/users/42");
-    const secondResult = await router.load("/profiles/84");
-
-    expect(sharedFetch).toHaveBeenCalledTimes(1);
-    expect(routeFetch).toHaveBeenCalledTimes(2);
-    expect(firstResult.wrapperData["shared:layout"]).toBe("shared-data");
-    expect(secondResult.wrapperData["shared:layout"]).toBe("shared-data");
-  });
-
-  it("follows static and thrown redirects client-side", async () => {
+  it("follows static redirects client-side", async () => {
     const router = createRouter({
       oldHome: route({
         url: "/old-home",
         redirect: "/home",
         status: 308,
       }),
-      private: route({
-        url: "/private",
-        fetch: async (): Promise<string> => {
-          redirect("/login", 302);
-        },
-        content: () => "private",
-      }),
       home: route({
         url: "/home",
         content: () => "home",
       }),
-      login: route({
-        url: "/login",
-        content: () => "login",
-      }),
     });
 
     const staticRedirectResult = await router.load("/old-home");
-    const thrownRedirectResult = await router.load("/private");
 
     expect(staticRedirectResult.location.href).toBe("/home");
     expect(staticRedirectResult.match).toMatchObject({
       kind: "route",
       name: "home",
     });
-    expect(thrownRedirectResult.location.href).toBe("/login");
-    expect(thrownRedirectResult.match).toMatchObject({
-      kind: "route",
-      name: "login",
-    });
   });
 
-  it("aborts the previous navigation when a new load starts", async () => {
+  it("commits the latest load result even when an earlier load resolves later", async () => {
+    let resolvePreload: (() => void) | null = null;
+    const slowPreload = vi.fn(
+      () =>
+        new Promise<{ default: string }>((resolve) => {
+          resolvePreload = () => resolve({ default: "SlowPage" });
+        }),
+    );
     const router = createRouter({
       slow: route({
         url: "/slow",
-        fetch: async (_params, _search, context) => {
-          return await new Promise<string>((resolve, reject) => {
-            context.signal.addEventListener("abort", () => {
-              reject(new Error("aborted"));
-            });
-
-            setTimeout(() => {
-              resolve("slow");
-            }, 50);
-          });
-        },
-        content: ({ data }) => data,
+        content: Object.assign(() => "slow", { preload: slowPreload }),
       }),
       fast: route({
         url: "/fast",
-        fetch: async () => "fast",
-        content: ({ data }) => data,
+        content: () => "fast",
       }),
     });
 
     const firstLoad = router.load("/slow");
+
+    // Ensure the slow preload has started
+    expect(slowPreload).toHaveBeenCalledTimes(1);
+
     const secondLoad = router.load("/fast");
 
-    await expect(firstLoad).rejects.toThrow("aborted");
     await expect(secondLoad).resolves.toMatchObject({
       location: { href: "/fast" },
-      routeData: "fast",
+      status: 200,
+    });
+
+    // Resolve the slow preload after the fast load committed
+    resolvePreload?.();
+
+    const firstResult = await firstLoad;
+
+    expect(firstResult).toMatchObject({
+      location: { href: "/slow" },
       status: 200,
     });
     expect(router.getState().navigation.state).toBe("idle");
@@ -1412,169 +1254,22 @@ describe("createRouter", () => {
     expect(router.render(result)).toBeNull();
   });
 
-  it("renders route and wrapper error boundaries from load failures", async () => {
-    const appLayout = wrapper({
-      id: "app:layout",
-      component: ({ children }) => `app(${String(children)})`,
-    });
-    const guardedLayout = wrapper({
-      id: "guard:layout",
-      component: ({ children }) => `guard(${String(children)})`,
-      fetch: async (): Promise<string> => {
-        throw new Response("Unauthorized", { status: 401 });
-      },
-      error: ({ status }) => `guard-error(${status})`,
-    });
-
-    const guardedRoutes = group(guardedLayout, [
-      route({
-        url: "/guarded",
-        content: () => "guarded",
-      }),
-    ] as const);
-    const [guardedRoute] = group(appLayout, guardedRoutes);
-
-    const routerWithWrapperError = createRouter({
-      guarded: guardedRoute,
-    });
-    const wrapperErrorResult = await routerWithWrapperError.load("/guarded");
-
-    expect(wrapperErrorResult).toMatchObject({
-      errorBoundary: { type: "wrapper", wrapperId: "guard:layout" },
-      status: 401,
-    });
-    expect(routerWithWrapperError.render(wrapperErrorResult)).toBe(
-      "app(guard-error(401))",
-    );
-
-    const routerWithRouteError = createRouter({
-      broken: group(appLayout, [
-        route({
-          url: "/broken",
-          fetch: async (): Promise<string> => {
-            throw new StatusResponse(503, { message: "Back soon" });
-          },
-          content: () => "broken",
-          error: ({ status }) => `route-error(${status})`,
-        }),
-      ] as const)[0],
-    });
-    const routeErrorResult = await routerWithRouteError.load("/broken");
-
-    expect(routeErrorResult).toMatchObject({
-      errorBoundary: { type: "route", wrapperId: null },
-      status: 503,
-    });
-    expect(routerWithRouteError.render(routeErrorResult)).toBe(
-      "app(route-error(503))",
-    );
-  });
-
-  it("bubbles route load errors to wrapper boundaries when the route has no error renderer", async () => {
-    const shell = wrapper({
-      id: "shell:layout",
-      component: ({ children }) => `shell(${String(children)})`,
-      error: ({ status }) => `shell-error(${status})`,
-    });
-    const [brokenRoute] = group(shell, [
-      route({
-        url: "/broken",
-        fetch: async (): Promise<string> => {
-          throw new Response("Not found", { status: 404 });
-        },
-        content: () => "broken",
-      }),
-    ] as const);
-    const router = createRouter({
-      broken: brokenRoute,
-    });
-
-    const result = await router.load("/broken");
-
-    expect(result.errorBoundary).toEqual({
-      type: "wrapper",
-      wrapperId: "shell:layout",
-    });
-    expect(router.render(result)).toBe("shell-error(404)");
-  });
-
-  it("reuses wrapper data when a later load on the same route fails", async () => {
-    const shellFetch = vi
-      .fn<() => Promise<string>>()
-      .mockResolvedValue("shell-data");
-    const routeFetch = vi
-      .fn<(params: { slug: string }) => Promise<string>>()
-      .mockResolvedValueOnce("first")
-      .mockRejectedValueOnce(new Error("boom"));
-    const shell = wrapper({
-      id: "shell:layout",
-      component: ({ children, data }) =>
-        `shell(${String(data)}:${String(children)})`,
-      fetch: shellFetch,
-    });
-    const [pageRoute] = group(shell, [
-      route({
-        url: "/pages/:slug",
-        fetch: routeFetch,
-        content: ({ data }) => String(data),
-      }),
-    ] as const);
-    const router = createRouter({
-      page: pageRoute,
-    });
-
-    await router.load("/pages/one");
-    const errorResult = await router.load("/pages/one");
-
-    expect(shellFetch).toHaveBeenCalledTimes(1);
-    expect(errorResult.wrapperData).toEqual({
-      "shell:layout": "shell-data",
-    });
-    expect(router.render(errorResult)).toBeInstanceOf(Error);
-  });
-
-  it("returns raw errors from render when no error boundary exists", async () => {
+  it("surfaces content preload errors through the error property", async () => {
     const router = createRouter({
       broken: route({
         url: "/broken",
-        fetch: async (): Promise<string> => {
-          throw "no-boundary";
-        },
-        content: () => "broken",
+        content: Object.assign(() => "broken", {
+          preload: async () => {
+            throw new StatusResponse(503, { message: "Back soon" });
+          },
+        }),
       }),
     });
 
     const result = await router.load("/broken");
-    const rendered = router.render(result);
 
-    expect(result.errorBoundary).toBeNull();
-    expect(rendered).toBe("no-boundary");
-  });
-
-  it("returns raw wrapper-load errors when no wrapper boundary exists", async () => {
-    const shell = wrapper({
-      id: "shell:layout",
-      component: ({ children }) => children,
-      fetch: async (): Promise<string> => {
-        throw new Error("wrapper-failure");
-      },
-    });
-    const [brokenRoute] = group(shell, [
-      route({
-        url: "/broken",
-        content: () => "broken",
-      }),
-    ] as const);
-    const router = createRouter({
-      broken: brokenRoute,
-    });
-
-    const result = await router.load("/broken");
-    const rendered = router.render(result);
-
-    expect(result.errorBoundary).toBeNull();
-    expect(rendered).toBeInstanceOf(Error);
-    expect((rendered as Error).message).toBe("wrapper-failure");
+    expect(result.status).toBe(503);
+    expect(result.error).toBeInstanceOf(StatusResponse);
   });
 
   it("returns null when asked to render a redirect match payload", () => {
@@ -1590,7 +1285,6 @@ describe("createRouter", () => {
     expect(
       router.render({
         error: null,
-        errorBoundary: null,
         location: {
           hash: "",
           href: "/legacy",
@@ -1600,9 +1294,7 @@ describe("createRouter", () => {
           url: new URL("https://example.com/legacy"),
         },
         match: redirectMatch,
-        routeData: undefined,
         status: 308,
-        wrapperData: {},
       } as never),
     ).toBeNull();
   });
@@ -1643,27 +1335,16 @@ describe("createRouter", () => {
   });
 
   it("aborts in-flight loads when dispose is called", async () => {
-    let capturedSignal: AbortSignal | undefined;
+    let resolvePreload: (() => void) | null = null;
 
     const slowRoute = route({
       url: "/slow",
-      fetch: async (
-        _params: Record<string, never>,
-        _search: unknown,
-        context: { signal: AbortSignal },
-      ) => {
-        capturedSignal = context.signal;
-
-        return new Promise((resolve, reject) => {
-          const timer = setTimeout(resolve, 60_000);
-
-          context.signal.addEventListener("abort", () => {
-            clearTimeout(timer);
-            reject(new DOMException("Aborted", "AbortError"));
-          });
-        });
-      },
-      content: () => "slow",
+      content: Object.assign(() => "slow", {
+        preload: () =>
+          new Promise<{ default: string }>((resolve) => {
+            resolvePreload = () => resolve({ default: "SlowPage" });
+          }),
+      }),
     });
 
     const adapter = createMemoryAdapter("/");
@@ -1671,15 +1352,20 @@ describe("createRouter", () => {
 
     const loadPromise = router.load("/slow");
 
-    expect(capturedSignal).toBeDefined();
-    expect(capturedSignal?.aborted).toBe(false);
+    // Wait a tick for the preload to start
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(resolvePreload).toBeDefined();
 
     router.dispose();
 
-    expect(capturedSignal?.aborted).toBe(true);
+    // Resolve the preload so the promise settles
+    resolvePreload?.();
 
     // The load may resolve (router catches AbortError internally) or reject
-    // depending on timing. Either way, the signal was aborted.
+    // depending on timing. Either way, the router was disposed.
     try {
       await loadPromise;
     } catch {

--- a/packages/runtime/router/src/lib/createRouter.ts
+++ b/packages/runtime/router/src/lib/createRouter.ts
@@ -441,30 +441,6 @@ function createNotFoundMatch<TNotFound extends AnyRoute>(
   };
 }
 
-function getWrapperPrefixLength(
-  previousRoute: AnyRoute | undefined,
-  nextRoute: AnyRoute | undefined,
-): number {
-  if (!previousRoute || !nextRoute) {
-    return 0;
-  }
-
-  const previousWrappers = previousRoute.wrappers;
-  const nextWrappers = nextRoute.wrappers;
-  const maxLength = Math.min(previousWrappers.length, nextWrappers.length);
-
-  let prefixLength = 0;
-
-  while (
-    prefixLength < maxLength &&
-    previousWrappers[prefixLength]?.id === nextWrappers[prefixLength]?.id
-  ) {
-    prefixLength += 1;
-  }
-
-  return prefixLength;
-}
-
 function getErrorStatus(error: unknown): number {
   if (error instanceof StatusResponse) {
     return error.status;
@@ -475,21 +451,6 @@ function getErrorStatus(error: unknown): number {
   }
 
   return 500;
-}
-
-function findWrapperErrorBoundary(
-  route: AnyRoute,
-  startIndex = route.wrappers.length - 1,
-): string | null {
-  for (let index = startIndex; index >= 0; index -= 1) {
-    const currentWrapper = route.wrappers[index];
-
-    if (currentWrapper.error) {
-      return currentWrapper.id;
-    }
-  }
-
-  return null;
 }
 
 function isRedirectMatch(value: unknown): value is {
@@ -520,7 +481,7 @@ function createDehydratedState<
 >(
   result: Pick<
     RouterLoadResult<TRoutes, TNotFound>,
-    "location" | "match" | "routeData" | "status" | "wrapperData"
+    "location" | "match" | "status"
   >,
 ): RouterDehydratedState<TRoutes> {
   const kind =
@@ -533,10 +494,8 @@ function createDehydratedState<
   return {
     href: result.location.href,
     kind,
-    routeData: result.routeData,
     routeId: result.match?.kind === "route" ? result.match.name : null,
     status: result.status,
-    wrapperData: result.wrapperData,
   };
 }
 
@@ -554,20 +513,12 @@ function createLoadResult<
   };
 }
 
-interface LoadFailure {
-  readonly error?: unknown;
-  readonly source?: "wrapper";
-  readonly wrapperIndex?: number;
-}
-
 interface ResolvedLoadData<
   TRoutes extends RouteMap,
   TNotFound extends AnyRoute | undefined,
 > {
   readonly match: RouterMatch<TRoutes, TNotFound> | null;
-  readonly routeData: unknown;
   readonly status: number;
-  readonly wrapperData: Readonly<Record<string, unknown>>;
 }
 
 function createIdleSignal(): AbortSignal {
@@ -718,79 +669,43 @@ export default function createRouter<
 
   async function resolveLoadData(
     currentMatch: RouterMatch<TRoutes, TNotFound> | null,
-    previousResult: RouterLoadResult<TRoutes, TNotFound> | null,
     signal: AbortSignal,
   ): Promise<ResolvedLoadData<TRoutes, TNotFound>> {
-    const wrapperData: Record<string, unknown> = {};
-    const previousRoute = previousResult?.match?.route;
     const nextRoute = currentMatch?.route;
-    const wrapperPrefixLength = getWrapperPrefixLength(
-      previousRoute,
-      nextRoute,
-    );
 
-    if (previousResult && nextRoute) {
-      for (const currentWrapper of nextRoute.wrappers.slice(
-        0,
-        wrapperPrefixLength,
-      )) {
-        wrapperData[currentWrapper.id] =
-          previousResult.wrapperData[currentWrapper.id];
+    // Fire prefetch hooks as fire-and-forget side effects.
+    // Wrapper prefetches run for all wrappers (no caching/reuse).
+    // Route prefetch runs if defined. None block rendering.
+    if (nextRoute) {
+      for (const currentWrapper of nextRoute.wrappers) {
+        if (currentWrapper.prefetch) {
+          const currentParams = currentMatch?.params as ParamsOf<AnyRoute>;
+
+          void Promise.resolve(
+            currentWrapper.prefetch(currentParams, { signal }),
+          ).catch(ignoreScheduledLoadError);
+        }
+      }
+
+      if (nextRoute.prefetch && currentMatch) {
+        void Promise.resolve(
+          nextRoute.prefetch(currentMatch.params, currentMatch.search, {
+            signal,
+          }),
+        ).catch(ignoreScheduledLoadError);
       }
     }
 
-    const wrapperLoads =
-      nextRoute?.wrappers
-        .slice(wrapperPrefixLength)
-        .map(async (currentWrapper, index) => {
-          if (!currentWrapper.fetch) {
-            return;
-          }
-
-          const currentParams = currentMatch?.params as ParamsOf<AnyRoute>;
-
-          try {
-            wrapperData[currentWrapper.id] = await currentWrapper.fetch(
-              currentParams,
-              {
-                signal,
-              },
-            );
-          } catch (error) {
-            throw {
-              error,
-              source: "wrapper",
-              wrapperIndex: wrapperPrefixLength + index,
-            } satisfies LoadFailure;
-          }
-        }) ?? [];
-
-    const routeLoad = (async () => {
-      if (!nextRoute?.fetch || !currentMatch) {
-        return undefined;
-      }
-
-      return await nextRoute.fetch(currentMatch.params, currentMatch.search, {
-        signal,
-      });
-    })();
-
-    await Promise.all([
-      preloadMatchedContent(
-        currentMatch as Exclude<
-          RouterMatch<TRoutes, TNotFound>,
-          { readonly kind: "redirect" }
-        > | null,
-      ),
-      Promise.all(wrapperLoads),
-    ]);
-    const routeData = await routeLoad;
+    await preloadMatchedContent(
+      currentMatch as Exclude<
+        RouterMatch<TRoutes, TNotFound>,
+        { readonly kind: "redirect" }
+      > | null,
+    );
 
     return {
       match: currentMatch,
-      routeData,
       status: currentMatch?.status ?? 404,
-      wrapperData,
     };
   }
 
@@ -828,21 +743,17 @@ export default function createRouter<
       try {
         const prefetchedLoad = await resolveLoadData(
           currentMatch,
-          currentLoadResult,
           createIdleSignal(),
         );
 
         prefetchedLoads.set(href, prefetchedLoad);
       } catch (thrownError) {
-        const failure = thrownError as LoadFailure;
-        const redirectError = failure.error ?? thrownError;
-
-        if (redirectError instanceof RouteRedirect) {
-          await prefetchHref(redirectError.to, redirectDepth + 1);
+        if (thrownError instanceof RouteRedirect) {
+          await prefetchHref(thrownError.to, redirectDepth + 1);
           return;
         }
 
-        throw redirectError;
+        throw thrownError;
       } finally {
         pendingPrefetches.delete(href);
       }
@@ -1060,11 +971,7 @@ export default function createRouter<
       const prefetchedLoad = prefetchedLoads.get(href);
       const resolvedLoad =
         prefetchedLoad ??
-        (await resolveLoadData(
-          currentMatch,
-          currentLoadResult,
-          abortController.signal,
-        ));
+        (await resolveLoadData(currentMatch, abortController.signal));
 
       prefetchedLoads.delete(href);
 
@@ -1073,13 +980,10 @@ export default function createRouter<
       await runNavigationUpdate(mode, () => {
         result = createLoadResult<TRoutes, TNotFound>({
           error: null,
-          errorBoundary: null,
           location: store.commit(url, resolvedLoad.match, resolvedLoad.status)
             .location,
           match: resolvedLoad.match,
-          routeData: resolvedLoad.routeData,
           status: resolvedLoad.status,
-          wrapperData: resolvedLoad.wrapperData,
         });
 
         currentLoadResult = result;
@@ -1089,23 +993,10 @@ export default function createRouter<
 
       return result;
     } catch (thrownError) {
-      const failureValue = thrownError as LoadFailure;
-      const failure =
-        failureValue.source === "wrapper"
-          ? {
-              error: failureValue.error,
-              source: "wrapper" as const,
-              wrapperIndex: failureValue.wrapperIndex,
-            }
-          : {
-              error: thrownError,
-              source: "route" as const,
-            };
-
-      if (failure.error instanceof RouteRedirect) {
+      if (thrownError instanceof RouteRedirect) {
         abortController.abort();
         const redirectedResult = await performLoad(
-          failure.error.to,
+          thrownError.to,
           redirectDepth + 1,
           shouldSyncAdapter,
           mode,
@@ -1125,52 +1016,18 @@ export default function createRouter<
       }
 
       if (abortController.signal.aborted) {
-        throw failure.error;
+        throw thrownError;
       }
 
-      const nextRoute = currentMatch?.route as AnyRoute;
-      const errorBoundary =
-        failure.source === "route"
-          ? nextRoute.error
-            ? { type: "route" as const, wrapperId: null }
-            : (() => {
-                const wrapperId = findWrapperErrorBoundary(nextRoute);
-
-                return wrapperId
-                  ? {
-                      type: "wrapper" as const,
-                      wrapperId,
-                    }
-                  : null;
-              })()
-          : (() => {
-              const wrapperId = findWrapperErrorBoundary(
-                nextRoute,
-                failure.wrapperIndex,
-              );
-
-              return wrapperId
-                ? {
-                    type: "wrapper" as const,
-                    wrapperId,
-                  }
-                : null;
-            })();
-      const status = getErrorStatus(failure.error);
+      const status = getErrorStatus(thrownError);
       let result!: RouterLoadResult<TRoutes, TNotFound>;
 
       await runNavigationUpdate(mode, () => {
         result = createLoadResult<TRoutes, TNotFound>({
-          error: failure.error,
-          errorBoundary,
+          error: thrownError,
           location: store.commit(url, currentMatch, status).location,
           match: currentMatch,
-          routeData: undefined,
           status,
-          wrapperData:
-            currentLoadResult && currentLoadResult.match?.route === nextRoute
-              ? currentLoadResult.wrapperData
-              : {},
         });
 
         currentLoadResult = result;
@@ -1220,12 +1077,9 @@ export default function createRouter<
 
     const result = createLoadResult<TRoutes, TNotFound>({
       error: null,
-      errorBoundary: null,
       location: store.commit(state.href, hydratedMatch, state.status).location,
       match: hydratedMatch,
-      routeData: state.routeData,
       status: state.status,
-      wrapperData: state.wrapperData,
     });
 
     currentLoadResult = result;
@@ -1271,59 +1125,6 @@ export default function createRouter<
     }
 
     const currentRoute = result.match.route;
-    const locationHref = result.location.href;
-
-    if (result.error) {
-      if (result.errorBoundary?.type === "route" && currentRoute.error) {
-        return currentRoute.wrappers.reduceRight(
-          (children, currentWrapper) => {
-            return currentWrapper.component({
-              children,
-              data: result.wrapperData[currentWrapper.id],
-            });
-          },
-          currentRoute.error({
-            error: result.error,
-            params: result.match.params,
-            search: result.match.search,
-            status: result.status,
-            url: locationHref,
-          }),
-        );
-      }
-
-      if (
-        result.errorBoundary?.type === "wrapper" &&
-        result.errorBoundary.wrapperId
-      ) {
-        const boundaryIndex = currentRoute.wrappers.findIndex(
-          (currentWrapper) => {
-            return currentWrapper.id === result.errorBoundary?.wrapperId;
-          },
-        );
-        const boundaryWrapper = currentRoute.wrappers[
-          boundaryIndex
-        ] as AnyRoute["wrappers"][number];
-        const boundaryContent = boundaryWrapper.error?.({
-          error: result.error,
-          params: result.match.params,
-          search: result.match.search,
-          status: result.status,
-          url: locationHref,
-        });
-
-        return currentRoute.wrappers
-          .slice(0, boundaryIndex)
-          .reduceRight((children, currentWrapper) => {
-            return currentWrapper.component({
-              children,
-              data: result.wrapperData[currentWrapper.id],
-            });
-          }, boundaryContent);
-      }
-
-      return result.error;
-    }
 
     if (!currentRoute.content) {
       return null;
@@ -1333,11 +1134,9 @@ export default function createRouter<
       (children, currentWrapper) => {
         return currentWrapper.component({
           children,
-          data: result.wrapperData[currentWrapper.id],
         });
       },
       currentRoute.content({
-        data: result.routeData,
         params: result.match.params,
         search: result.match.search,
       }),

--- a/packages/runtime/router/src/lib/index.ts
+++ b/packages/runtime/router/src/lib/index.ts
@@ -1,6 +1,8 @@
 export { default as applyMiddleware } from "./applyMiddleware.js";
 export { default as createBrowserAdapter } from "./createBrowserAdapter.js";
+export { default as createHistoryAdapter } from "./createHistoryAdapter.js";
 export { default as createMemoryAdapter } from "./createMemoryAdapter.js";
+export { default as createNavigationAdapter } from "./createNavigationAdapter.js";
 export { default as createRouter } from "./createRouter.js";
 export { default as createRouterStore } from "./createRouterStore.js";
 export { default as createServerAdapter } from "./createServerAdapter.js";

--- a/packages/runtime/router/src/lib/route.ts
+++ b/packages/runtime/router/src/lib/route.ts
@@ -15,7 +15,7 @@ function isRedirectRouteInput<
   TPath extends string,
   TWrappers extends readonly AnyWrapper[],
 >(
-  definition: RouteInput<TPath, undefined, void, unknown, TWrappers>,
+  definition: RouteInput<TPath, undefined, unknown, TWrappers>,
 ): definition is RedirectRouteInput<TPath, string, TWrappers> {
   return "redirect" in definition;
 }
@@ -33,26 +33,24 @@ export default function route<
   TSearchSchema extends
     | { readonly "~standard": { readonly output?: unknown } }
     | undefined = undefined,
-  TData = void,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
 >(
-  definition: DataRouteInput<TPath, TSearchSchema, TData, TRendered, TWrappers>,
-): DataRouteDefinition<TPath, TSearchSchema, TData, TRendered, TWrappers>;
+  definition: DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers>,
+): DataRouteDefinition<TPath, TSearchSchema, TRendered, TWrappers>;
 export default function route<
   const TPath extends string,
   TSearchSchema extends
     | { readonly "~standard": { readonly output?: unknown } }
     | undefined = undefined,
-  TData = void,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
 >(
-  definition: RouteInput<TPath, TSearchSchema, TData, TRendered, TWrappers>,
-): RouteDefinition<TPath, TSearchSchema, TData, TRendered, TWrappers> {
+  definition: RouteInput<TPath, TSearchSchema, TRendered, TWrappers>,
+): RouteDefinition<TPath, TSearchSchema, TRendered, TWrappers> {
   if (
     isRedirectRouteInput(
-      definition as RouteInput<TPath, undefined, void, unknown, TWrappers>,
+      definition as RouteInput<TPath, undefined, unknown, TWrappers>,
     )
   ) {
     return {

--- a/packages/runtime/router/src/lib/types.ts
+++ b/packages/runtime/router/src/lib/types.ts
@@ -54,51 +54,25 @@ export interface RouteContentProps<
     never
   >,
   TSearch = Record<string, never>,
-  TData = void,
 > {
   readonly params: TParams;
   readonly search: TSearch;
-  readonly data: TData;
 }
 
-export interface RouteErrorProps<
-  TPath extends string = string,
-  TSearch = Record<string, never>,
-> {
-  readonly error: unknown;
-  readonly status: number;
-  readonly params: RouteParams<TPath>;
-  readonly search: TSearch;
-  readonly url: string;
-}
-
-export interface WrapperComponentProps<TData = void, TRendered = unknown> {
-  readonly data: TData;
+export interface WrapperComponentProps<TRendered = unknown> {
   readonly children: TRendered;
 }
 
-export interface WrapperErrorProps<
-  TParams extends RouteParamValues = RouteParamValues,
-  TSearch = unknown,
-> {
-  readonly error: unknown;
-  readonly status: number;
-  readonly params: TParams;
-  readonly search: TSearch;
-  readonly url: string;
-}
-
-export interface WrapperDefinition<TData = void, TRendered = unknown> {
+export interface WrapperDefinition<TRendered = unknown> {
   readonly id: string;
   readonly component: BivariantCallback<
-    [props: WrapperComponentProps<TData, TRendered>],
+    [props: WrapperComponentProps<TRendered>],
     TRendered
   >;
-  readonly fetch?: BivariantCallback<
+  readonly prefetch?: BivariantCallback<
     [params: RouteParamValues, context: NavigationContext],
-    Promise<TData>
+    void | Promise<void>
   >;
-  readonly error?: BivariantCallback<[props: WrapperErrorProps], TRendered>;
 }
 
 export interface RouteCodec<TPath extends string = string> {
@@ -106,28 +80,21 @@ export interface RouteCodec<TPath extends string = string> {
   render(params: RouteParams<TPath>): string;
 }
 
-export type AnyWrapper = WrapperDefinition<unknown, unknown>;
+export type AnyWrapper = WrapperDefinition<unknown>;
 
 export type RouteContent<
   TPath extends string = string,
   TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
-  TData = void,
   TRendered = unknown,
 > = BivariantCallback<
-  [
-    props: RouteContentProps<
-      RouteParams<TPath>,
-      InferSearch<TSearchSchema>,
-      TData
-    >,
-  ],
+  [props: RouteContentProps<RouteParams<TPath>, InferSearch<TSearchSchema>>],
   TRendered
 > & {
   preload?: () => Promise<RouteModule>;
 };
 
 export type AnyRouteContent = BivariantCallback<
-  [props: RouteContentProps<RouteParamValues, unknown, unknown>],
+  [props: RouteContentProps<RouteParamValues, unknown>],
   unknown
 > & {
   preload?: () => Promise<RouteModule>;
@@ -136,25 +103,20 @@ export type AnyRouteContent = BivariantCallback<
 export interface DataRouteInput<
   TPath extends string = string,
   TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
-  TData = void,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
 > {
   readonly url: TPath;
-  readonly content: RouteContent<TPath, TSearchSchema, TData, TRendered>;
-  readonly fetch?: BivariantCallback<
+  readonly content: RouteContent<TPath, TSearchSchema, TRendered>;
+  readonly prefetch?: BivariantCallback<
     [
       params: RouteParams<TPath>,
       search: InferSearch<TSearchSchema>,
       context: NavigationContext,
     ],
-    Promise<TData>
+    void | Promise<void>
   >;
   readonly search?: TSearchSchema;
-  readonly error?: BivariantCallback<
-    [props: RouteErrorProps<TPath, InferSearch<TSearchSchema>>],
-    TRendered
-  >;
   readonly wrappers?: TWrappers;
 }
 
@@ -174,35 +136,29 @@ export interface RedirectRouteInput<
 export type RouteInput<
   TPath extends string = string,
   TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
-  TData = void,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
 > =
-  | DataRouteInput<TPath, TSearchSchema, TData, TRendered, TWrappers>
+  | DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers>
   | RedirectRouteInput<TPath, string, TWrappers>;
 
 export interface DataRouteDefinition<
   TPath extends string = string,
   TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
-  TData = void,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
 > extends RouteCodec<TPath> {
   readonly url: TPath;
-  readonly content: RouteContent<TPath, TSearchSchema, TData, TRendered>;
-  readonly fetch?: BivariantCallback<
+  readonly content: RouteContent<TPath, TSearchSchema, TRendered>;
+  readonly prefetch?: BivariantCallback<
     [
       params: RouteParams<TPath>,
       search: InferSearch<TSearchSchema>,
       context: NavigationContext,
     ],
-    Promise<TData>
+    void | Promise<void>
   >;
   readonly search?: TSearchSchema;
-  readonly error?: BivariantCallback<
-    [props: RouteErrorProps<TPath, InferSearch<TSearchSchema>>],
-    TRendered
-  >;
   readonly wrappers: TWrappers;
 }
 
@@ -220,25 +176,20 @@ export interface RedirectRouteDefinition<
 export type RouteDefinition<
   TPath extends string = string,
   TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
-  TData = void,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
 > =
-  | DataRouteDefinition<TPath, TSearchSchema, TData, TRendered, TWrappers>
+  | DataRouteDefinition<TPath, TSearchSchema, TRendered, TWrappers>
   | RedirectRouteDefinition<TPath, string, TWrappers>;
 
 export interface AnyRoute {
   readonly url: string;
   readonly content?: AnyRouteContent;
-  readonly fetch?: BivariantCallback<
+  readonly prefetch?: BivariantCallback<
     [params: unknown, search: unknown, context: NavigationContext],
-    Promise<unknown>
+    void | Promise<void>
   >;
   readonly search?: StandardSchemaLike<unknown>;
-  readonly error?: BivariantCallback<
-    [props: RouteErrorProps<string, unknown>],
-    unknown
-  >;
   readonly redirect?: string;
   readonly status?: number;
   readonly wrappers: readonly AnyWrapper[];
@@ -340,22 +291,10 @@ export type SearchOf<TRoute extends AnyRoute> =
     string,
     infer TSearchSchema,
     unknown,
-    unknown,
     readonly AnyWrapper[]
   >
     ? InferSearch<TSearchSchema>
     : Record<string, never>;
-
-export type DataOf<TRoute extends AnyRoute> =
-  TRoute extends DataRouteDefinition<
-    string,
-    StandardSchemaLike<unknown> | undefined,
-    infer TData,
-    unknown,
-    readonly AnyWrapper[]
-  >
-    ? TData
-    : never;
 
 export type HasParams<TRoute extends AnyRoute> = TRoute extends {
   readonly url: infer TPath extends string;
@@ -568,18 +507,11 @@ export interface MemoryAdapter extends PlatformAdapter {
   forward(): void;
 }
 
-export interface RouterLoadErrorBoundary {
-  readonly type: "route" | "wrapper";
-  readonly wrapperId: string | null;
-}
-
 export interface RouterDehydratedState<TRoutes extends RouteMap = RouteMap> {
   readonly href: string;
   readonly kind: "route" | "not-found" | "unmatched";
   readonly routeId: RouteName<TRoutes> | null;
-  readonly routeData: unknown;
   readonly status: number;
-  readonly wrapperData: Readonly<Record<string, unknown>>;
 }
 
 export interface RouterLoadResult<
@@ -588,12 +520,9 @@ export interface RouterLoadResult<
 > {
   dehydrate(): RouterDehydratedState<TRoutes>;
   readonly error: unknown;
-  readonly errorBoundary: RouterLoadErrorBoundary | null;
   readonly location: RouterLocationState;
   readonly match: RouterMatch<TRoutes, TNotFound> | null;
-  readonly routeData: unknown;
   readonly status: number;
-  readonly wrapperData: Readonly<Record<string, unknown>>;
 }
 
 export interface RouterOptions<

--- a/packages/runtime/router/src/lib/wrapper.ts
+++ b/packages/runtime/router/src/lib/wrapper.ts
@@ -1,8 +1,8 @@
 import type { WrapperDefinition } from "./types.js";
 
 /** Construct a wrapper with nominal identity. */
-export default function wrapper<TData = void, TRendered = unknown>(
-  definition: WrapperDefinition<TData, TRendered>,
-): WrapperDefinition<TData, TRendered> {
+export default function wrapper<TRendered = unknown>(
+  definition: WrapperDefinition<TRendered>,
+): WrapperDefinition<TRendered> {
   return definition;
 }


### PR DESCRIPTION
## Done

- **Rename `fetch()` to `prefetch()` on routes and wrappers.** `prefetch()` is fire-and-forget — it warms caches, preloads assets, and runs side effects at navigation time. It does not return data to `content()`.
- **Remove data threading.** `content()` receives only `params` and `search`, no `data` prop. Wrapper components receive only `children`, no `data` prop. The `TData` generic parameter is removed from all route and wrapper types.
- **Remove `.error` from route and wrapper definitions.** Error handling uses standard React error boundaries. `StatusResponse` (already exported) is the error primitive. The boilerplate will provide a reference `RouteErrorBoundary` implementation.
- **Remove wrapper data caching.** No `wrapperData` or `routeData` in `RouterLoadResult` or `RouterDehydratedState`. The router caches navigation state only.
- **Remove `RouterLoadErrorBoundary`, `RouteErrorProps`, `WrapperErrorProps`, `DataOf` types.**
- **Add Navigation API adapter** (`createNavigationAdapter`). Uses `window.navigation` (Baseline Newly Available since January 2026). Rename existing adapter to `createHistoryAdapter`. `createBrowserAdapter` now auto-detects: Navigation API when available, History API fallback otherwise.
- **Update READMEs** for both `@canonical/router-core` and `@canonical/router-react` to reflect all API changes.

Net change: -596 lines of source code, +312 lines of new adapters and documentation.

### Breaking changes

- `fetch` on routes → `prefetch` (fire-and-forget, returns `void | Promise<void>`)
- `content({ data, params, search })` → `content({ params, search })`
- `wrapper<TData, TRendered>()` → `wrapper<TRendered>()`
- `WrapperComponentProps<TData, TRendered>` → `WrapperComponentProps<TRendered>`
- `.error` removed from `DataRouteInput`, `DataRouteDefinition`, `WrapperDefinition`, `AnyRoute`
- `routeData`, `wrapperData`, `errorBoundary` removed from `RouterLoadResult`
- `routeData`, `wrapperData` removed from `RouterDehydratedState`

### Migration

- Replace `fetch:` with `prefetch:` in route definitions
- Move data fetching from `fetch()` return values into the component (via TanStack Query, Relay, SWR, etc.)
- Replace route/wrapper `.error` with React error boundaries wrapping `<Outlet>`
- Use `StatusResponse` to signal HTTP-like errors from `prefetch()`

## QA

- `bun run --filter @canonical/router-core check` — all 3 validations pass
- `bun run --filter @canonical/router-core test` — 113 tests pass
- `bun run --filter @canonical/router-react check` — all 3 validations pass
- `bun run --filter @canonical/router-react test` — 28 tests pass

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁`, `Breaking Change 💣`
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json`