### PR TITLE
feat(router): add setSearchParams() and useBlocker() navigation blocking

### DIFF
--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -165,6 +165,97 @@ function DashboardLayout({ children }: { children: React.ReactNode }) {
 
 The boilerplate reference app provides a complete `RouteErrorBoundary` implementation to copy and adapt.
 
+## Search param mutation
+
+Update search params from any component via the router instance:
+
+```tsx
+function FilterBar() {
+  const router = useRouter();
+  const sort = useSearchParam("sort");
+
+  return (
+    <select
+      value={sort ?? "name"}
+      onChange={(event) => {
+        router.setSearchParams({ sort: event.target.value }, { replace: true });
+      }}
+    >
+      <option value="name">Name</option>
+      <option value="date">Date</option>
+    </select>
+  );
+}
+```
+
+`setSearchParams` merges into the current URL. Set a key to `null` to remove it. Pass `{ replace: true }` to replace the history entry instead of pushing.
+
+## Navigation blocking
+
+`useBlocker()` prevents navigation when the component has unsaved state. The hook returns a state object — the consumer controls the confirmation UI:
+
+```tsx
+import { useBlocker } from "@canonical/router-react";
+import { useState } from "react";
+
+function EditForm() {
+  const [isDirty, setIsDirty] = useState(false);
+  const blocker = useBlocker(isDirty);
+
+  return (
+    <>
+      <form onChange={() => setIsDirty(true)}>
+        <textarea placeholder="Start typing to mark as dirty..." />
+        <button
+          type="submit"
+          onClick={(event) => {
+            event.preventDefault();
+            setIsDirty(false);
+          }}
+        >
+          Save
+        </button>
+      </form>
+
+      {blocker.state === "blocked" && (
+        <div role="alertdialog" aria-modal="true">
+          <h2>Unsaved changes</h2>
+          <p>You have unsaved changes. Do you want to leave this page?</p>
+          <button onClick={blocker.cancel}>Stay on page</button>
+          <button onClick={blocker.proceed}>Leave page</button>
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+For a quick `window.confirm` approach instead of a custom dialog:
+
+```tsx
+import { useBlocker } from "@canonical/router-react";
+import { useEffect, useState } from "react";
+
+function QuickEditForm() {
+  const [isDirty, setIsDirty] = useState(false);
+  const blocker = useBlocker(isDirty);
+
+  useEffect(() => {
+    if (blocker.state === "blocked") {
+      if (window.confirm("You have unsaved changes. Leave anyway?")) {
+        blocker.proceed();
+      } else {
+        blocker.cancel();
+      }
+    }
+  }, [blocker]);
+
+  return <form onChange={() => setIsDirty(true)}>...</form>;
+}
+```
+
+The blocker registers on mount and unregisters on unmount — when the form is submitted or the component is removed, blocking stops automatically.
+
 ## Creating routes and matching URLs
 
 ### Route creation
@@ -280,19 +371,22 @@ hydrateRoot(
 
 ### Hooks
 
-- `useRouter()` returns the router instance from context.
-- `useRouterState()` is the power-user hook for subscribing to selected slices of `router.getState()`.
+- `useBlocker(isActive)` blocks navigation when `isActive` is `true`. Returns `{ state, proceed, cancel }`.
+- `useNavigationState()` subscribes to the router loading state.
 - `useRoute()` returns a tracked location proxy and rerenders only when an accessed location key changes.
+- `useRouter()` returns the router instance from context. Use `useRouter().setSearchParams()` for search param mutation.
+- `useRouterState()` is the power-user hook for subscribing to selected slices of `router.getState()`.
 - `useSearchParam()` subscribes to one query-string key.
 - `useSearchParams()` subscribes either to the full query string or to a fixed set of keys.
-- `useNavigationState()` subscribes to the router loading state.
 
 Typical selection strategy:
 
+- reach for `useBlocker()` when a form has unsaved state
 - reach for `useNavigationState()` when you only need loading lifecycle
 - reach for `useSearchParam()` for one query-string key
 - reach for `useSearchParams()` for a fixed key set or the full query string
 - reach for `useRoute()` for pathname, hash, or full URL reads
+- reach for `useRouter()` for search param mutation or direct router access
 - reach for `useRouterState()` when you need `match`, `navigation`, or other advanced state in one selector
 
 ## Boilerplate reference
@@ -314,6 +408,7 @@ The reference integration lives in [apps/react/boilerplate-vite](../../../apps/r
 - `Link` — render a typed anchor that navigates and prefetches through the router.
 - `Outlet` — render the current matched subtree.
 - `RouterProvider` — place a router instance into React context.
+- `useBlocker()` — block navigation when the component has unsaved state.
 - `useNavigationState()` — subscribe to the navigation lifecycle state.
 - `useRoute()` — subscribe to a tracked location object.
 - `useRouter()` — read the router instance from context.

--- a/packages/react/router/src/lib/hooks/index.ts
+++ b/packages/react/router/src/lib/hooks/index.ts
@@ -1,4 +1,6 @@
 export * from "./types.js";
+export type { BlockerState } from "./useBlocker.js";
+export { default as useBlocker } from "./useBlocker.js";
 export { default as useNavigationState } from "./useNavigationState.js";
 export { default as useRoute } from "./useRoute.js";
 export { default as useRouter } from "./useRouter.js";

--- a/packages/react/router/src/lib/hooks/useBlocker.ts
+++ b/packages/react/router/src/lib/hooks/useBlocker.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useId, useSyncExternalStore } from "react";
+import useRouter from "./useRouter.js";
+
+export interface BlockerState {
+  readonly state: "idle" | "blocked";
+  proceed(): void;
+  cancel(): void;
+}
+
+/**
+ * Block navigation when the component has unsaved state.
+ *
+ * Returns a state object: `state` is `"idle"` or `"blocked"`, `proceed()`
+ * continues the blocked navigation, and `cancel()` stays on the page.
+ * The consumer controls the confirmation UI.
+ *
+ * ```tsx
+ * const blocker = useBlocker(isDirty);
+ *
+ * {blocker.state === "blocked" && (
+ *   <Dialog>
+ *     <button onClick={blocker.proceed}>Leave</button>
+ *     <button onClick={blocker.cancel}>Stay</button>
+ *   </Dialog>
+ * )}
+ * ```
+ */
+export default function useBlocker(isActive: boolean): BlockerState {
+  const router = useRouter();
+  const id = useId();
+
+  useEffect(() => {
+    router.registerBlocker({ id, isActive: () => isActive });
+
+    return () => {
+      router.unregisterBlocker(id);
+    };
+  }, [router, id, isActive]);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => router.subscribe(onStoreChange),
+    [router],
+  );
+
+  const getSnapshot = useCallback(() => router.blockerState, [router]);
+
+  const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  return {
+    state,
+    proceed() {
+      router.proceedNavigation();
+    },
+    cancel() {
+      router.cancelNavigation();
+    },
+  };
+}

--- a/packages/runtime/router/README.md
+++ b/packages/runtime/router/README.md
@@ -145,6 +145,53 @@ const loginRequired = route({
 });
 ```
 
+## Search param mutation
+
+`setSearchParams()` patches the current URL's search params without requiring the route name:
+
+```ts
+// Merge into current search params
+router.setSearchParams({ page: "2" });
+
+// Functional update
+router.setSearchParams((current) => ({
+  ...current,
+  page: String(Number(current.page ?? "0") + 1),
+}));
+
+// Remove a param (set to null)
+router.setSearchParams({ filter: null });
+
+// Replace history entry instead of pushing
+router.setSearchParams({ page: "2" }, { replace: true });
+```
+
+## Navigation blocking
+
+Register blockers to prevent navigation when there is unsaved state. Blockers are checked before any navigation proceeds:
+
+```ts
+const blockerId = "edit-form";
+
+// Register a blocker that checks whether to block
+router.registerBlocker({
+  id: blockerId,
+  isActive: () => formHasUnsavedChanges,
+});
+
+// When navigation is attempted while a blocker is active:
+router.blockerState; // "blocked"
+
+// The consumer decides whether to proceed or cancel
+router.proceedNavigation(); // continue the blocked navigation
+router.cancelNavigation();  // stay on the current page
+
+// Remove the blocker when the form is submitted or discarded
+router.unregisterBlocker(blockerId);
+```
+
+For React, use the `useBlocker()` hook from `@canonical/router-react` instead of these core primitives.
+
 ## Middleware
 
 Middleware runs once, before the router is created. Apply it to route definitions with `applyMiddleware()`:

--- a/packages/runtime/router/src/lib/createRouter.test.ts
+++ b/packages/runtime/router/src/lib/createRouter.test.ts
@@ -1372,4 +1372,156 @@ describe("createRouter", () => {
       // AbortError propagation is acceptable
     }
   });
+
+  it("merges search params into the current URL via setSearchParams", async () => {
+    const router = createRouter(
+      {
+        list: route({
+          url: "/list",
+          content: () => "list",
+        }),
+      },
+      { adapter: createMemoryAdapter("/list?sort=name") },
+    );
+
+    await router.load("/list?sort=name");
+    router.setSearchParams({ page: "2" });
+
+    await vi.waitFor(() => {
+      expect(router.getState().location.searchParams.get("sort")).toBe("name");
+      expect(router.getState().location.searchParams.get("page")).toBe("2");
+    });
+  });
+
+  it("removes search params when set to null via setSearchParams", async () => {
+    const router = createRouter(
+      {
+        list: route({
+          url: "/list",
+          content: () => "list",
+        }),
+      },
+      { adapter: createMemoryAdapter("/list?sort=name&page=2") },
+    );
+
+    await router.load("/list?sort=name&page=2");
+    router.setSearchParams({ page: null });
+
+    await vi.waitFor(() => {
+      expect(router.getState().location.searchParams.get("sort")).toBe("name");
+      expect(router.getState().location.searchParams.has("page")).toBe(false);
+    });
+  });
+
+  it("blocks navigation when an active blocker is registered", async () => {
+    const router = createRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+        about: route({ url: "/about", content: () => "about" }),
+      },
+      { adapter: createMemoryAdapter("/") },
+    );
+
+    await router.load("/");
+
+    router.registerBlocker({ id: "form", isActive: () => true });
+    router.navigate("about");
+
+    expect(router.blockerState).toBe("blocked");
+    expect(router.getState().location.pathname).toBe("/");
+
+    router.proceedNavigation();
+
+    await vi.waitFor(() => {
+      expect(router.getState().location.pathname).toBe("/about");
+    });
+
+    expect(router.blockerState).toBe("idle");
+  });
+
+  it("cancels blocked navigation and stays on the current page", async () => {
+    const router = createRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+        about: route({ url: "/about", content: () => "about" }),
+      },
+      { adapter: createMemoryAdapter("/") },
+    );
+
+    await router.load("/");
+
+    router.registerBlocker({ id: "form", isActive: () => true });
+    router.navigate("about");
+
+    expect(router.blockerState).toBe("blocked");
+    router.cancelNavigation();
+
+    expect(router.blockerState).toBe("idle");
+    expect(router.getState().location.pathname).toBe("/");
+  });
+
+  it("allows navigation when no active blocker is registered", async () => {
+    const router = createRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+        about: route({ url: "/about", content: () => "about" }),
+      },
+      { adapter: createMemoryAdapter("/") },
+    );
+
+    await router.load("/");
+
+    router.registerBlocker({ id: "form", isActive: () => false });
+    router.navigate("about");
+
+    expect(router.blockerState).toBe("idle");
+
+    await vi.waitFor(() => {
+      expect(router.getState().location.pathname).toBe("/about");
+    });
+  });
+
+  it("removes blockers on unregister", async () => {
+    const router = createRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+        about: route({ url: "/about", content: () => "about" }),
+      },
+      { adapter: createMemoryAdapter("/") },
+    );
+
+    await router.load("/");
+
+    router.registerBlocker({ id: "form", isActive: () => true });
+    router.unregisterBlocker("form");
+    router.navigate("about");
+
+    expect(router.blockerState).toBe("idle");
+
+    await vi.waitFor(() => {
+      expect(router.getState().location.pathname).toBe("/about");
+    });
+  });
+
+  it("supports functional updates via setSearchParams", async () => {
+    const router = createRouter(
+      {
+        list: route({
+          url: "/list",
+          content: () => "list",
+        }),
+      },
+      { adapter: createMemoryAdapter("/list?page=1") },
+    );
+
+    await router.load("/list?page=1");
+    router.setSearchParams((current) => ({
+      ...current,
+      page: String(Number(current.page ?? "0") + 1),
+    }));
+
+    await vi.waitFor(() => {
+      expect(router.getState().location.searchParams.get("page")).toBe("2");
+    });
+  });
 });

--- a/packages/runtime/router/src/lib/createRouter.ts
+++ b/packages/runtime/router/src/lib/createRouter.ts
@@ -26,6 +26,7 @@ import type {
   Router,
   RouterAccessibilityContext,
   RouterAccessibilityDocumentLike,
+  RouterBlocker,
   RouterDehydratedState,
   RouterLoadResult,
   RouterMatch,
@@ -835,6 +836,12 @@ export default function createRouter<
     ).href;
   }) as BuildPathFn<TRoutes>;
 
+  let pendingNavigation: {
+    href: string;
+    replace: boolean;
+    resolve: () => void;
+  } | null = null;
+
   const navigate: NavigateFn<TRoutes> = ((
     name: RouteName<TRoutes>,
     ...args: unknown[]
@@ -847,6 +854,29 @@ export default function createRouter<
       ?.replace;
 
     if (adapter) {
+      if (isBlocked()) {
+        pendingNavigation = {
+          href: intent.href,
+          replace: replace ?? false,
+          resolve: () => {
+            pendingNavigation = null;
+            saveScrollPosition();
+            syncAdapterLocation(
+              intent.href,
+              replace ? { replace: true } : undefined,
+            );
+            void performLoad(
+              intent.href,
+              0,
+              true,
+              replace ? "pop" : "push",
+            ).catch(ignoreScheduledLoadError);
+          },
+        };
+
+        return intent;
+      }
+
       saveScrollPosition();
       syncAdapterLocation(intent.href, replace ? { replace: true } : undefined);
       void performLoad(intent.href, 0, true, replace ? "pop" : "push").catch(
@@ -856,6 +886,59 @@ export default function createRouter<
 
     return intent;
   }) as NavigateFn<TRoutes>;
+
+  const blockers = new Map<string, RouterBlocker>();
+
+  function isBlocked(): boolean {
+    for (const blocker of blockers.values()) {
+      if (blocker.isActive()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function setSearchParams(
+    params:
+      | Record<string, string | null>
+      | ((current: Record<string, string>) => Record<string, string | null>),
+    options?: { readonly replace?: boolean },
+  ): void {
+    const currentState = store.getState();
+    const currentUrl = buildUrl(currentState.location.href);
+    const currentSearch: Record<string, string> = {};
+
+    for (const key of new Set(currentUrl.searchParams.keys())) {
+      currentSearch[key] = currentUrl.searchParams.get(key) ?? "";
+    }
+
+    const nextParams =
+      typeof params === "function" ? params(currentSearch) : params;
+
+    const nextUrl = buildUrl(currentUrl.href);
+
+    nextUrl.search = "";
+
+    for (const [key, value] of Object.entries({
+      ...currentSearch,
+      ...nextParams,
+    })) {
+      if (value !== null) {
+        nextUrl.searchParams.set(key, value);
+      }
+    }
+
+    const href = toHref(nextUrl);
+    const replace = options?.replace ?? false;
+
+    if (adapter) {
+      syncAdapterLocation(href, replace ? { replace: true } : undefined);
+      void performLoad(href, 0, true, replace ? "pop" : "push").catch(
+        ignoreScheduledLoadError,
+      );
+    }
+  }
 
   const prefetch: PrefetchFn<TRoutes> = ((
     name: RouteName<TRoutes>,
@@ -1170,7 +1253,27 @@ export default function createRouter<
     match,
     navigate,
     prefetch,
+    get blockerState() {
+      return pendingNavigation ? ("blocked" as const) : ("idle" as const);
+    },
+    proceedNavigation() {
+      pendingNavigation?.resolve();
+    },
+    cancelNavigation() {
+      pendingNavigation = null;
+    },
+    registerBlocker(blocker: RouterBlocker) {
+      blockers.set(blocker.id, blocker);
+    },
+    unregisterBlocker(id: string) {
+      blockers.delete(id);
+
+      if (pendingNavigation) {
+        pendingNavigation = null;
+      }
+    },
     render,
+    setSearchParams,
     subscribe(listener) {
       return store.subscribe(listener);
     },

--- a/packages/runtime/router/src/lib/types.ts
+++ b/packages/runtime/router/src/lib/types.ts
@@ -491,6 +491,11 @@ export interface RouterStore<
   ): () => void;
 }
 
+export interface RouterBlocker {
+  readonly id: string;
+  readonly isActive: () => boolean;
+}
+
 export interface PlatformNavigateOptions {
   readonly replace?: boolean;
   readonly state?: unknown;
@@ -598,7 +603,18 @@ export interface Router<
   match(url: string | URL): RouterMatch<TRoutes, TNotFound> | null;
   navigate: NavigateFn<TRoutes>;
   prefetch: PrefetchFn<TRoutes>;
+  registerBlocker(blocker: RouterBlocker): void;
+  unregisterBlocker(id: string): void;
+  readonly blockerState: "idle" | "blocked";
+  proceedNavigation(): void;
+  cancelNavigation(): void;
   render(result?: RouterLoadResult<TRoutes, TNotFound> | null): unknown;
+  setSearchParams(
+    params:
+      | Record<string, string | null>
+      | ((current: Record<string, string>) => Record<string, string | null>),
+    options?: { readonly replace?: boolean },
+  ): void;
   subscribe(
     listener: (snapshot: RouterSnapshot<TRoutes, TNotFound>) => void,
   ): () => void;


### PR DESCRIPTION
## Done

- **`setSearchParams(params, options?)`** on the core router. Patches the current URL's search params without knowing the route name. Supports:
  - Object merge: `router.setSearchParams({ page: "2" })` 
  - Functional update: `router.setSearchParams(current => ({ ...current, page: "2" }))`
  - Remove params: `router.setSearchParams({ page: null })`
  - Replace history: `router.setSearchParams({ page: "2" }, { replace: true })`
  - React consumers access via `useRouter().setSearchParams()`

- **`useBlocker(isActive)`** hook in `@canonical/router-react`. State-based navigation blocking for unsaved changes:
  - `blocker.state`: `"idle"` or `"blocked"`
  - `blocker.proceed()`: continue the blocked navigation
  - `blocker.cancel()`: stay on the page
  - Consumer controls the confirmation UI (custom dialog, `window.confirm()`, etc.)

- Core router primitives: `registerBlocker()`, `unregisterBlocker()`, `blockerState`, `proceedNavigation()`, `cancelNavigation()`

## QA

- `bun run --filter @canonical/router-core check` — all validations pass
- `bun run --filter @canonical/router-core test` — 120 tests pass (7 new)
- `bun run --filter @canonical/router-core build:all` — builds clean
- `bun run --filter @canonical/router-react check` — all validations pass
- `bun run --filter @canonical/router-react test` — 28 tests pass
- `bun run --filter @canonical/router-react build:all` — builds clean

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁`
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json`