### PR TITLE
feat(router): router factories, @canonical/react-head package, SSR docs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -192,11 +192,11 @@
       "name": "@canonical/typescript-config-react",
       "version": "0.25.0",
       "dependencies": {
-        "@canonical/typescript-config": "^0.23.0",
+        "@canonical/typescript-config": "^0.25.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.23.0",
+        "@canonical/biome-config": "^0.25.0",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
@@ -667,6 +667,32 @@
         "vite": "^8.0.1",
         "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.0.18",
+      },
+    },
+    "packages/react/head": {
+      "name": "@canonical/react-head",
+      "version": "0.25.0",
+      "devDependencies": {
+        "@biomejs/biome": "2.4.9",
+        "@canonical/biome-config": "^0.25.0",
+        "@canonical/typescript-config-react": "^0.25.0",
+        "@canonical/webarchitect": "^0.25.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/node": "^24.12.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.0",
+        "@vitest/coverage-v8": "^4.0.18",
+        "jsdom": "^28.1.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "typescript": "^5.9.3",
+        "vite": "^8.0.1",
+        "vitest": "^4.0.18",
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
       },
     },
     "packages/react/hooks": {
@@ -1421,6 +1447,8 @@
     "@canonical/react-ds-global": ["@canonical/react-ds-global@workspace:packages/react/ds-global"],
 
     "@canonical/react-ds-global-form": ["@canonical/react-ds-global-form@workspace:packages/react/ds-global-form"],
+
+    "@canonical/react-head": ["@canonical/react-head@workspace:packages/react/head"],
 
     "@canonical/react-hooks": ["@canonical/react-hooks@workspace:packages/react/hooks"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -672,6 +672,9 @@
     "packages/react/head": {
       "name": "@canonical/react-head",
       "version": "0.25.0",
+      "dependencies": {
+        "react": "^19.2.4",
+      },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
         "@canonical/biome-config": "^0.25.0",
@@ -690,9 +693,6 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.1",
         "vitest": "^4.0.18",
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
       },
     },
     "packages/react/hooks": {

--- a/packages/react/head/README.md
+++ b/packages/react/head/README.md
@@ -1,0 +1,97 @@
+# @canonical/react-head
+
+Declarative head management for React. Components declare `<title>`, `<meta>`, and `<link>` tags via `useHead()`. Tags mount with the component, update on change, and are removed on unmount. SSR collection via `createHeadCollector()` captures tags during server rendering for injection into the HTML template.
+
+No dependency on the router — works with any React app.
+
+## Installation
+
+```bash
+bun add @canonical/react-head
+```
+
+Requires `react` as a peer dependency.
+
+## Quick start
+
+### Client
+
+```tsx
+import { HeadProvider, useHead } from "@canonical/react-head";
+
+function App() {
+  return (
+    <HeadProvider>
+      <Shell>
+        <Page />
+      </Shell>
+    </HeadProvider>
+  );
+}
+
+function Shell({ children }) {
+  useHead({ title: "My App" });
+  return <main>{children}</main>;
+}
+
+function Page() {
+  useHead({
+    title: "User Profile — My App",
+    meta: [
+      { name: "description", content: "User profile page" },
+      { property: "og:image", content: "/images/profile.png" },
+    ],
+    link: [
+      { rel: "canonical", href: "https://example.com/profile" },
+    ],
+  });
+
+  return <h1>Profile</h1>;
+}
+```
+
+On the client, `useHead()` performs direct DOM mutations on `document.head`. Tags are scoped to the component — navigating away removes the route's tags, the shell's tags remain (because the shell never unmounts).
+
+### Server (SSR)
+
+```tsx
+import { createHeadCollector, HeadProvider } from "@canonical/react-head";
+import { renderToPipeableStream } from "react-dom/server";
+
+const headCollector = createHeadCollector();
+
+const { pipe } = renderToPipeableStream(
+  <HeadProvider collector={headCollector}>
+    <App />
+  </HeadProvider>,
+  {
+    onShellReady() {
+      const headHtml = headCollector.toHtml();
+      res.write(`<!doctype html><html><head>${headHtml}</head><body>`);
+      pipe(res);
+    },
+  },
+);
+```
+
+During SSR, `useHead()` writes to the collector instead of the DOM. After the shell renders (`onShellReady`), call `toHtml()` to serialize the collected tags. Shell-level tags (base title, viewport meta) are available immediately. Route-specific tags from suspended components are applied during client-side hydration.
+
+## Tag merging
+
+When multiple components call `useHead()`, the following rules apply:
+
+- **`title`** — last writer wins. The deepest component in the tree takes priority.
+- **`meta` by `name` or `property`** — deduplicated by key. The deepest component's value wins.
+- **`link`** — accumulated. All link tags from all components are rendered.
+
+This means the shell can set a base title and description, and each route overrides them with page-specific values.
+
+## Public API
+
+- `HeadProvider` — React context provider. On the server, pass a `collector`. On the client, omit it.
+- `useHead(tags)` — declare head tags from any component.
+- `createHeadCollector()` — create an SSR collector with `add()`, `remove()`, and `toHtml()`.
+- `HeadTags` — type for `{ title?, meta?, link? }`.
+- `HeadMeta` — type for meta tag attributes.
+- `HeadLink` — type for link tag attributes.
+- `HeadCollector` — type for the SSR collector interface.

--- a/packages/react/head/biome.json
+++ b/packages/react/head/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["src", "*.json"]
+  }
+}

--- a/packages/react/head/package.json
+++ b/packages/react/head/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@canonical/react-head",
+  "description": "Declarative head management for React with SSR collection",
+  "version": "0.25.0",
+  "type": "module",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "build:all": "bun run build",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
+    "check:webarchitect": "webarchitect package-react",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "react": "^19.2.4"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.9",
+    "@canonical/biome-config": "^0.25.0",
+    "@canonical/typescript-config-react": "^0.25.0",
+    "@canonical/webarchitect": "^0.25.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^24.12.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "jsdom": "^28.1.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/react/head/src/index.ts
+++ b/packages/react/head/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./lib/index.js";

--- a/packages/react/head/src/lib/HeadContext.ts
+++ b/packages/react/head/src/lib/HeadContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+import type { HeadCollector } from "./types.js";
+
+export interface HeadContextValue {
+  readonly collector: HeadCollector | null;
+}
+
+const HeadContext = createContext<HeadContextValue>({ collector: null });
+
+export default HeadContext;

--- a/packages/react/head/src/lib/HeadProvider.tsx
+++ b/packages/react/head/src/lib/HeadProvider.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import HeadContext from "./HeadContext.js";
+import type { HeadCollector } from "./types.js";
+
+export interface HeadProviderProps {
+  readonly children: ReactNode;
+  readonly collector?: HeadCollector;
+}
+
+/**
+ * Provide head tag collection context to the component tree.
+ *
+ * On the server, pass a `collector` from `createHeadCollector()` to capture
+ * head tags during render. On the client, omit `collector` — `useHead()` will
+ * perform direct DOM mutations on `document.head`.
+ */
+export default function HeadProvider({
+  children,
+  collector,
+}: HeadProviderProps) {
+  return (
+    <HeadContext.Provider value={{ collector: collector ?? null }}>
+      {children}
+    </HeadContext.Provider>
+  );
+}

--- a/packages/react/head/src/lib/createHeadCollector.test.ts
+++ b/packages/react/head/src/lib/createHeadCollector.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import createHeadCollector from "./createHeadCollector.js";
+
+describe("createHeadCollector", () => {
+  it("collects and serializes a title", () => {
+    const collector = createHeadCollector();
+
+    collector.add("page", { title: "Hello World" });
+
+    expect(collector.toHtml()).toBe("<title>Hello World</title>");
+  });
+
+  it("last writer wins for title", () => {
+    const collector = createHeadCollector();
+
+    collector.add("shell", { title: "App Name" });
+    collector.add("page", { title: "Page Title" });
+
+    expect(collector.toHtml()).toContain("<title>Page Title</title>");
+    expect(collector.toHtml()).not.toContain("App Name");
+  });
+
+  it("collects meta tags and deduplicates by name", () => {
+    const collector = createHeadCollector();
+
+    collector.add("shell", {
+      meta: [{ name: "description", content: "Shell description" }],
+    });
+    collector.add("page", {
+      meta: [{ name: "description", content: "Page description" }],
+    });
+
+    const html = collector.toHtml();
+
+    expect(html).toContain('content="Page description"');
+    expect(html).not.toContain("Shell description");
+  });
+
+  it("collects meta tags and deduplicates by property", () => {
+    const collector = createHeadCollector();
+
+    collector.add("shell", {
+      meta: [{ property: "og:title", content: "Shell" }],
+    });
+    collector.add("page", {
+      meta: [{ property: "og:title", content: "Page" }],
+    });
+
+    const html = collector.toHtml();
+
+    expect(html).toContain('content="Page"');
+    expect(html).not.toContain('content="Shell"');
+  });
+
+  it("accumulates link tags", () => {
+    const collector = createHeadCollector();
+
+    collector.add("shell", {
+      link: [{ rel: "icon", href: "/favicon.ico" }],
+    });
+    collector.add("page", {
+      link: [{ rel: "canonical", href: "https://example.com" }],
+    });
+
+    const html = collector.toHtml();
+
+    expect(html).toContain('rel="icon"');
+    expect(html).toContain('rel="canonical"');
+  });
+
+  it("removes entries and updates output", () => {
+    const collector = createHeadCollector();
+
+    collector.add("shell", { title: "App" });
+    collector.add("page", { title: "Page" });
+    collector.remove("page");
+
+    expect(collector.toHtml()).toBe("<title>App</title>");
+  });
+
+  it("escapes HTML in output", () => {
+    const collector = createHeadCollector();
+
+    collector.add("page", { title: '<script>alert("xss")</script>' });
+
+    expect(collector.toHtml()).toBe(
+      "<title>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</title>",
+    );
+  });
+
+  it("renders all tag types together", () => {
+    const collector = createHeadCollector();
+
+    collector.add("page", {
+      title: "Full Page",
+      meta: [
+        { name: "description", content: "A page" },
+        { property: "og:image", content: "https://example.com/img.png" },
+      ],
+      link: [
+        { rel: "canonical", href: "https://example.com" },
+        {
+          rel: "stylesheet",
+          href: "/styles.css",
+          type: "text/css",
+          media: "screen",
+        },
+      ],
+    });
+
+    const html = collector.toHtml();
+
+    expect(html).toContain("<title>Full Page</title>");
+    expect(html).toContain('name="description"');
+    expect(html).toContain('property="og:image"');
+    expect(html).toContain('rel="canonical"');
+    expect(html).toContain('type="text/css"');
+    expect(html).toContain('media="screen"');
+  });
+});

--- a/packages/react/head/src/lib/createHeadCollector.ts
+++ b/packages/react/head/src/lib/createHeadCollector.ts
@@ -1,0 +1,97 @@
+import type { HeadCollector, HeadLink, HeadMeta, HeadTags } from "./types.js";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function metaKey(meta: HeadMeta): string {
+  if (meta.name) return `name:${meta.name}`;
+  if (meta.property) return `property:${meta.property}`;
+  if (meta.httpEquiv) return `http-equiv:${meta.httpEquiv}`;
+  return `content:${meta.content}`;
+}
+
+/**
+ * Create an SSR head collector.
+ *
+ * During server rendering, `useHead()` writes to this collector instead of the
+ * DOM. After the render pass, call `toHtml()` to serialize the collected tags
+ * for injection into the HTML template's `<head>` section.
+ *
+ * Tag merging: when multiple components declare the same tag (e.g., `<title>`),
+ * the last writer wins — deepest component in the tree takes priority.
+ */
+export default function createHeadCollector(): HeadCollector {
+  const entries = new Map<string, HeadTags>();
+
+  return {
+    add(id: string, tags: HeadTags) {
+      entries.set(id, tags);
+    },
+
+    remove(id: string) {
+      entries.delete(id);
+    },
+
+    toHtml(): string {
+      const parts: string[] = [];
+      let title: string | undefined;
+      const metaByKey = new Map<string, HeadMeta>();
+      const links: HeadLink[] = [];
+
+      for (const tags of entries.values()) {
+        if (tags.title !== undefined) {
+          title = tags.title;
+        }
+
+        if (tags.meta) {
+          for (const meta of tags.meta) {
+            metaByKey.set(metaKey(meta), meta);
+          }
+        }
+
+        if (tags.link) {
+          for (const link of tags.link) {
+            links.push(link);
+          }
+        }
+      }
+
+      if (title !== undefined) {
+        parts.push(`<title>${escapeHtml(title)}</title>`);
+      }
+
+      for (const meta of metaByKey.values()) {
+        const attrs: string[] = [];
+
+        if (meta.name) attrs.push(`name="${escapeHtml(meta.name)}"`);
+        if (meta.property)
+          attrs.push(`property="${escapeHtml(meta.property)}"`);
+        if (meta.httpEquiv)
+          attrs.push(`http-equiv="${escapeHtml(meta.httpEquiv)}"`);
+        attrs.push(`content="${escapeHtml(meta.content)}"`);
+        parts.push(`<meta ${attrs.join(" ")} />`);
+      }
+
+      for (const link of links) {
+        const attrs: string[] = [
+          `rel="${escapeHtml(link.rel)}"`,
+          `href="${escapeHtml(link.href)}"`,
+        ];
+
+        if (link.type) attrs.push(`type="${escapeHtml(link.type)}"`);
+        if (link.sizes) attrs.push(`sizes="${escapeHtml(link.sizes)}"`);
+        if (link.media) attrs.push(`media="${escapeHtml(link.media)}"`);
+        if (link.crossOrigin)
+          attrs.push(`crossorigin="${escapeHtml(link.crossOrigin)}"`);
+        parts.push(`<link ${attrs.join(" ")} />`);
+      }
+
+      return parts.join("\n");
+    },
+  };
+}

--- a/packages/react/head/src/lib/index.ts
+++ b/packages/react/head/src/lib/index.ts
@@ -1,0 +1,5 @@
+export { default as createHeadCollector } from "./createHeadCollector.js";
+export type { HeadProviderProps } from "./HeadProvider.js";
+export { default as HeadProvider } from "./HeadProvider.js";
+export * from "./types.js";
+export { default as useHead } from "./useHead.js";

--- a/packages/react/head/src/lib/types.ts
+++ b/packages/react/head/src/lib/types.ts
@@ -1,0 +1,27 @@
+export interface HeadMeta {
+  readonly name?: string;
+  readonly property?: string;
+  readonly content: string;
+  readonly httpEquiv?: string;
+}
+
+export interface HeadLink {
+  readonly rel: string;
+  readonly href: string;
+  readonly type?: string;
+  readonly sizes?: string;
+  readonly media?: string;
+  readonly crossOrigin?: "" | "anonymous" | "use-credentials";
+}
+
+export interface HeadTags {
+  readonly title?: string;
+  readonly meta?: readonly HeadMeta[];
+  readonly link?: readonly HeadLink[];
+}
+
+export interface HeadCollector {
+  add(id: string, tags: HeadTags): void;
+  remove(id: string): void;
+  toHtml(): string;
+}

--- a/packages/react/head/src/lib/useHead.ssr.test.tsx
+++ b/packages/react/head/src/lib/useHead.ssr.test.tsx
@@ -1,0 +1,63 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import createHeadCollector from "./createHeadCollector.js";
+import HeadProvider from "./HeadProvider.js";
+import useHead from "./useHead.js";
+
+function Page() {
+  useHead({
+    title: "SSR Page",
+    meta: [{ name: "description", content: "Server-rendered page" }],
+    link: [{ rel: "canonical", href: "https://example.com/page" }],
+  });
+
+  return <h1>Page</h1>;
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  useHead({
+    title: "App Shell",
+    meta: [{ name: "viewport", content: "width=device-width" }],
+  });
+
+  return <div>{children}</div>;
+}
+
+describe("useHead (SSR)", () => {
+  it("collects head tags during server render", () => {
+    const collector = createHeadCollector();
+
+    const html = renderToString(
+      <HeadProvider collector={collector}>
+        <Shell>
+          <Page />
+        </Shell>
+      </HeadProvider>,
+    );
+
+    const headHtml = collector.toHtml();
+
+    expect(html).toContain("Page");
+    expect(headHtml).toContain("<title>SSR Page</title>");
+    expect(headHtml).toContain('name="description"');
+    expect(headHtml).toContain('name="viewport"');
+    expect(headHtml).toContain('rel="canonical"');
+  });
+
+  it("deepest component wins for title", () => {
+    const collector = createHeadCollector();
+
+    renderToString(
+      <HeadProvider collector={collector}>
+        <Shell>
+          <Page />
+        </Shell>
+      </HeadProvider>,
+    );
+
+    const headHtml = collector.toHtml();
+
+    expect(headHtml).toContain("<title>SSR Page</title>");
+    expect(headHtml).not.toContain("App Shell");
+  });
+});

--- a/packages/react/head/src/lib/useHead.test.tsx
+++ b/packages/react/head/src/lib/useHead.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import HeadProvider from "./HeadProvider.js";
+import useHead from "./useHead.js";
+
+function Title({ value }: { value: string }) {
+  useHead({ title: value });
+
+  return <span data-testid="rendered">{value}</span>;
+}
+
+function Meta({ name, content }: { name: string; content: string }) {
+  useHead({ meta: [{ name, content }] });
+
+  return null;
+}
+
+function LinkTag({ rel, href }: { rel: string; href: string }) {
+  useHead({ link: [{ rel, href }] });
+
+  return null;
+}
+
+describe("useHead (client)", () => {
+  it("sets document.title on mount and does not restore on unmount", () => {
+    const originalTitle = document.title;
+
+    const { unmount } = render(
+      <HeadProvider>
+        <Title value="Test Page" />
+      </HeadProvider>,
+    );
+
+    expect(document.title).toBe("Test Page");
+
+    unmount();
+
+    expect(document.title).toBe("Test Page");
+    document.title = originalTitle;
+  });
+
+  it("appends meta tags to document.head and removes them on unmount", () => {
+    const { unmount } = render(
+      <HeadProvider>
+        <Meta name="description" content="A test page" />
+      </HeadProvider>,
+    );
+
+    const meta = document.head.querySelector('meta[name="description"]');
+
+    expect(meta).not.toBeNull();
+    expect(meta?.getAttribute("content")).toBe("A test page");
+
+    unmount();
+
+    expect(document.head.querySelector('meta[name="description"]')).toBeNull();
+  });
+
+  it("appends link tags to document.head and removes them on unmount", () => {
+    const { unmount } = render(
+      <HeadProvider>
+        <LinkTag rel="canonical" href="https://example.com" />
+      </HeadProvider>,
+    );
+
+    const link = document.head.querySelector('link[rel="canonical"]');
+
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+
+    unmount();
+
+    expect(document.head.querySelector('link[rel="canonical"]')).toBeNull();
+  });
+
+  it("updates existing meta tags instead of duplicating", () => {
+    function UpdatingMeta({ content }: { content: string }) {
+      useHead({ meta: [{ name: "description", content }] });
+
+      return <span data-testid="content">{content}</span>;
+    }
+
+    const { rerender } = render(
+      <HeadProvider>
+        <UpdatingMeta content="first" />
+      </HeadProvider>,
+    );
+
+    expect(
+      document.head
+        .querySelector('meta[name="description"]')
+        ?.getAttribute("content"),
+    ).toBe("first");
+
+    rerender(
+      <HeadProvider>
+        <UpdatingMeta content="second" />
+      </HeadProvider>,
+    );
+
+    expect(
+      document.head
+        .querySelector('meta[name="description"]')
+        ?.getAttribute("content"),
+    ).toBe("second");
+
+    const allDescriptionMetas = document.head.querySelectorAll(
+      'meta[name="description"]',
+    );
+
+    expect(allDescriptionMetas.length).toBe(1);
+  });
+
+  it("allows multiple components to contribute head tags", () => {
+    const { unmount } = render(
+      <HeadProvider>
+        <Title value="Multi Page" />
+        <Meta name="author" content="Test Author" />
+        <LinkTag rel="icon" href="/favicon.ico" />
+      </HeadProvider>,
+    );
+
+    expect(document.title).toBe("Multi Page");
+    expect(
+      document.head
+        .querySelector('meta[name="author"]')
+        ?.getAttribute("content"),
+    ).toBe("Test Author");
+    expect(
+      document.head.querySelector('link[rel="icon"]')?.getAttribute("href"),
+    ).toBe("/favicon.ico");
+
+    unmount();
+  });
+});

--- a/packages/react/head/src/lib/useHead.ts
+++ b/packages/react/head/src/lib/useHead.ts
@@ -1,0 +1,121 @@
+import { useContext, useEffect, useId, useRef } from "react";
+import HeadContext from "./HeadContext.js";
+import type { HeadTags } from "./types.js";
+
+function applyTitleToDOM(title: string | undefined): void {
+  if (title !== undefined) {
+    document.title = title;
+  }
+}
+
+function createMetaElement(attrs: Record<string, string>): HTMLMetaElement {
+  const element = document.createElement("meta");
+
+  for (const [key, value] of Object.entries(attrs)) {
+    element.setAttribute(key, value);
+  }
+
+  return element;
+}
+
+function createLinkElement(attrs: Record<string, string>): HTMLLinkElement {
+  const element = document.createElement("link");
+
+  for (const [key, value] of Object.entries(attrs)) {
+    element.setAttribute(key, value);
+  }
+
+  return element;
+}
+
+/**
+ * Declare head tags from any component.
+ *
+ * Tags mount when the component mounts, update when deps change, and are
+ * removed when the component unmounts. On the server with a `HeadProvider`
+ * collector, tags are collected for SSR injection instead of DOM mutation.
+ *
+ * ```tsx
+ * useHead({
+ *   title: `${data.name} — Profile`,
+ *   meta: [{ name: "description", content: data.bio }],
+ *   link: [{ rel: "canonical", href: canonicalUrl }],
+ * });
+ * ```
+ */
+export default function useHead(tags: HeadTags): void {
+  const id = useId();
+  const { collector } = useContext(HeadContext);
+  const managedElementsRef = useRef<Element[]>([]);
+
+  if (collector) {
+    collector.add(id, tags);
+  }
+
+  useEffect(() => {
+    if (collector) {
+      return () => {
+        collector.remove(id);
+      };
+    }
+
+    const elements: Element[] = [];
+
+    applyTitleToDOM(tags.title);
+
+    if (tags.meta) {
+      for (const meta of tags.meta) {
+        const attrs: Record<string, string> = {};
+
+        if (meta.name) attrs.name = meta.name;
+        if (meta.property) attrs.property = meta.property;
+        if (meta.httpEquiv) attrs["http-equiv"] = meta.httpEquiv;
+        attrs.content = meta.content;
+
+        const existing = meta.name
+          ? document.head.querySelector(`meta[name="${meta.name}"]`)
+          : meta.property
+            ? document.head.querySelector(`meta[property="${meta.property}"]`)
+            : null;
+
+        if (existing) {
+          existing.setAttribute("content", meta.content);
+        } else {
+          const element = createMetaElement(attrs);
+
+          document.head.appendChild(element);
+          elements.push(element);
+        }
+      }
+    }
+
+    if (tags.link) {
+      for (const link of tags.link) {
+        const attrs: Record<string, string> = {
+          rel: link.rel,
+          href: link.href,
+        };
+
+        if (link.type) attrs.type = link.type;
+        if (link.sizes) attrs.sizes = link.sizes;
+        if (link.media) attrs.media = link.media;
+        if (link.crossOrigin) attrs.crossorigin = link.crossOrigin;
+
+        const element = createLinkElement(attrs);
+
+        document.head.appendChild(element);
+        elements.push(element);
+      }
+    }
+
+    managedElementsRef.current = elements;
+
+    return () => {
+      for (const element of managedElementsRef.current) {
+        element.remove();
+      }
+
+      managedElementsRef.current = [];
+    };
+  }, [collector, id, tags]);
+}

--- a/packages/react/head/tsconfig.build.json
+++ b/packages/react/head/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.ssr.test.tsx"]
+}

--- a/packages/react/head/tsconfig.json
+++ b/packages/react/head/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@canonical/typescript-config-react",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["node", "react", "react-dom"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/react/head/vitest.config.ts
+++ b/packages/react/head/vitest.config.ts
@@ -1,0 +1,49 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+// biome-ignore lint/suspicious/noExplicitAny: Vite 8 plugin types are incompatible with vitest's Vite 7 re-exports
+const plugins: any[] = [react()];
+
+export default defineConfig({
+  plugins,
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "**/index.ts",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.ssr.test.tsx",
+        "**/*.d.ts",
+        "**/types.ts",
+      ],
+      thresholds: {
+        branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+      },
+    },
+    projects: [
+      {
+        plugins,
+        test: {
+          name: "client",
+          environment: "jsdom",
+          globals: true,
+          include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+          exclude: ["src/**/*.ssr.test.tsx"],
+        },
+      },
+      {
+        plugins,
+        test: {
+          name: "ssr",
+          environment: "node",
+          include: ["src/**/*.ssr.test.tsx"],
+        },
+      },
+    ],
+  },
+});

--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -300,29 +300,38 @@ Routes stay flat even when the UI is nested. Shared layout lives in wrappers fro
 
 ### Server side
 
-Wire your own render tree using standard React SSR primitives. The router does not provide a convenience render function — you control the component tree:
+Wire your own render tree using standard React SSR primitives. Use `createStaticRouter` for server rendering — it matches on construction and fires `prefetch()` eagerly so caches start warming before React renders:
 
 ```tsx
-import { createRouter, createServerAdapter } from "@canonical/router-core";
+import { createStaticRouter } from "@canonical/router-core";
+import { createHeadCollector, HeadProvider } from "@canonical/react-head";
 import { Outlet, RouterProvider } from "@canonical/router-react";
 import { renderToPipeableStream } from "react-dom/server";
 
-app.get("*", async (req, res) => {
-  const router = createRouter(routes, {
-    adapter: createServerAdapter(req.url),
-  });
+app.get("*", (req, res) => {
+  const router = createStaticRouter(routes, req.url);
+  const headCollector = createHeadCollector();
 
-  await router.load(req.url);
+  // Check match for status code before rendering
+  if (!router.match) {
+    res.status(404);
+  } else if (router.match.kind === "redirect") {
+    return res.redirect(router.match.status, router.match.redirectTo);
+  }
 
   const { pipe } = renderToPipeableStream(
-    <RouterProvider router={router}>
-      <Shell>
-        <Outlet />
-      </Shell>
-    </RouterProvider>,
+    <HeadProvider collector={headCollector}>
+      <RouterProvider router={router}>
+        <Shell>
+          <Outlet />
+        </Shell>
+      </RouterProvider>
+    </HeadProvider>,
     {
       onShellReady() {
+        const headHtml = headCollector.toHtml();
         res.setHeader("content-type", "text/html");
+        res.write(`<!doctype html><html><head>${headHtml}</head><body>`);
         pipe(res);
       },
     },
@@ -330,24 +339,44 @@ app.get("*", async (req, res) => {
 });
 ```
 
+The router dehydrates navigation state only. Data dehydration is the cache library's responsibility (dual dehydration):
+
+```tsx
+// In onShellReady or after render:
+const routerState = router.dehydrate();
+const cacheState = queryClient.dehydrate(); // TanStack Query, Relay, etc.
+
+// Inject both into the HTML template
+res.write(`<script>
+  window.__ROUTER_STATE__ = ${JSON.stringify(routerState)};
+  window.__QUERY_DATA__ = ${JSON.stringify(cacheState)};
+</script>`);
+```
+
 ### Client side
 
 ```tsx
-import { createHydratedRouter, Outlet, RouterProvider } from "@canonical/router-react";
+import { createBrowserRouter } from "@canonical/router-core";
+import { HeadProvider } from "@canonical/react-head";
+import { Outlet, RouterProvider } from "@canonical/router-react";
 
-const router = createHydratedRouter(routes);
+const router = createBrowserRouter(routes, {
+  hydratedState: window.__ROUTER_STATE__,
+});
 
 hydrateRoot(
   document,
-  <RouterProvider router={router}>
-    <Shell>
-      <Outlet />
-    </Shell>
-  </RouterProvider>,
+  <HeadProvider>
+    <RouterProvider router={router}>
+      <Shell>
+        <Outlet />
+      </Shell>
+    </RouterProvider>
+  </HeadProvider>,
 );
 ```
 
-`createHydratedRouter()` reads the dehydrated navigation state from the browser window, creates a browser adapter, and resumes from the server-rendered route match.
+`createBrowserRouter` uses the Navigation API when available (Baseline Newly Available since January 2026), falling back to the History API.
 
 ## Progressive disclosure
 

--- a/packages/runtime/router/README.md
+++ b/packages/runtime/router/README.md
@@ -215,16 +215,45 @@ const router = createRouter(routes);
 
 See [docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md](../../../docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md) for more patterns.
 
+## Router factories
+
+Convenience functions that create a router with a pre-configured platform adapter:
+
+```ts
+import {
+  createBrowserRouter,
+  createStaticRouter,
+  createMemoryRouter,
+} from "@canonical/router-core";
+
+// Client — auto-detects Navigation API with History fallback
+const router = createBrowserRouter(routes);
+
+// Server — matches URL on construction, exposes router.match for status codes
+const serverRouter = createStaticRouter(routes, req.url);
+
+if (!serverRouter.match) { res.status(404); }
+else if (serverRouter.match.kind === "redirect") {
+  return res.redirect(serverRouter.match.status, serverRouter.match.redirectTo);
+}
+
+// Testing — in-memory adapter, supports navigation
+const testRouter = createMemoryRouter(routes, "/users/42");
+```
+
+`createStaticRouter` fires `prefetch()` eagerly on construction, so caches start warming before React renders.
+
+The low-level `createRouter(routes, { adapter })` is still available for cases that need explicit adapter control.
+
 ## SSR and hydration
 
 The router dehydrates navigation state only (matched route, params, search, URL). Data dehydration is the cache library's responsibility.
 
 ```ts
-const serverRouter = createRouter(routes);
-await serverRouter.load("/users/42");
+const serverRouter = createStaticRouter(routes, "/users/42");
 const navigationState = serverRouter.dehydrate();
 
-const clientRouter = createRouter(routes, {
+const clientRouter = createBrowserRouter(routes, {
   hydratedState: navigationState ?? undefined,
 });
 ```
@@ -233,7 +262,7 @@ For a full React SSR flow, see [packages/react/router/README.md](../../react/rou
 
 ## Platform adapters
 
-The router uses platform adapters to interact with the browser's URL.
+The router factories use platform adapters internally. You can also use them directly with `createRouter()`:
 
 - `createBrowserAdapter()` — auto-detects the best API: uses the Navigation API (`window.navigation`) when available, falls back to the History API (`pushState` / `popstate`) for older browsers.
 - `createNavigationAdapter()` — explicitly use the Navigation API. Baseline Newly Available since January 2026.
@@ -266,12 +295,15 @@ Override or disable them through `RouterOptions.accessibility`.
 
 - `applyMiddleware()`
 - `createBrowserAdapter()`
+- `createBrowserRouter()`
 - `createHistoryAdapter()`
 - `createMemoryAdapter()`
+- `createMemoryRouter()`
 - `createNavigationAdapter()`
 - `createRouter()`
 - `createRouterStore()`
 - `createServerAdapter()`
+- `createStaticRouter()`
 - `createSubject()`
 - `createTrackedLocation()`
 - `group()`

--- a/packages/runtime/router/src/lib/createBrowserRouter.ts
+++ b/packages/runtime/router/src/lib/createBrowserRouter.ts
@@ -1,0 +1,22 @@
+import createBrowserAdapter from "./createBrowserAdapter.js";
+import createRouter from "./createRouter.js";
+import type { AnyRoute, RouteMap, Router, RouterOptions } from "./types.js";
+
+/**
+ * Create a browser-backed router using the best available platform API.
+ *
+ * Uses the Navigation API when available, falling back to the History API.
+ * Equivalent to `createRouter(routes, { adapter: createBrowserAdapter(), ...options })`.
+ */
+export default function createBrowserRouter<
+  const TRoutes extends RouteMap,
+  const TNotFound extends AnyRoute | undefined = undefined,
+>(
+  routes: TRoutes,
+  options?: Omit<RouterOptions<TNotFound>, "adapter">,
+): Router<TRoutes, TNotFound> {
+  return createRouter(routes, {
+    ...options,
+    adapter: createBrowserAdapter(),
+  });
+}

--- a/packages/runtime/router/src/lib/createMemoryRouter.test.ts
+++ b/packages/runtime/router/src/lib/createMemoryRouter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import createMemoryRouter from "./createMemoryRouter.js";
+import route from "./route.js";
+
+describe("createMemoryRouter", () => {
+  it("creates a router with an in-memory adapter at the given URL", async () => {
+    const router = createMemoryRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+        about: route({ url: "/about", content: () => "about" }),
+      },
+      "/about",
+    );
+
+    await router.load("/about");
+
+    expect(router.getState().location.pathname).toBe("/about");
+  });
+
+  it("defaults to / when no URL is provided", async () => {
+    const router = createMemoryRouter({
+      home: route({ url: "/", content: () => "home" }),
+    });
+
+    await router.load("/");
+
+    expect(router.getState().location.pathname).toBe("/");
+  });
+
+  it("supports navigation between routes", async () => {
+    const router = createMemoryRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+        about: route({ url: "/about", content: () => "about" }),
+      },
+      "/",
+    );
+
+    await router.load("/");
+    router.navigate("about");
+
+    await vi.waitFor(() => {
+      expect(router.getState().location.pathname).toBe("/about");
+    });
+  });
+});

--- a/packages/runtime/router/src/lib/createMemoryRouter.ts
+++ b/packages/runtime/router/src/lib/createMemoryRouter.ts
@@ -1,0 +1,22 @@
+import createMemoryAdapter from "./createMemoryAdapter.js";
+import createRouter from "./createRouter.js";
+import type { AnyRoute, RouteMap, Router, RouterOptions } from "./types.js";
+
+/**
+ * Create an in-memory router for testing.
+ *
+ * Equivalent to `createRouter(routes, { adapter: createMemoryAdapter(initialUrl), ...options })`.
+ */
+export default function createMemoryRouter<
+  const TRoutes extends RouteMap,
+  const TNotFound extends AnyRoute | undefined = undefined,
+>(
+  routes: TRoutes,
+  initialUrl: string | URL = "/",
+  options?: Omit<RouterOptions<TNotFound>, "adapter">,
+): Router<TRoutes, TNotFound> {
+  return createRouter(routes, {
+    ...options,
+    adapter: createMemoryAdapter(initialUrl),
+  });
+}

--- a/packages/runtime/router/src/lib/createStaticRouter.test.ts
+++ b/packages/runtime/router/src/lib/createStaticRouter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import createStaticRouter from "./createStaticRouter.js";
+import route from "./route.js";
+
+describe("createStaticRouter", () => {
+  it("matches the URL on construction and exposes the match result", () => {
+    const router = createStaticRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+        about: route({ url: "/about", content: () => "about" }),
+      },
+      "/about",
+    );
+
+    expect(router.match).not.toBeNull();
+    expect(router.match?.kind).toBe("route");
+    expect(router.match?.name).toBe("about");
+  });
+
+  it("returns null match for unmatched URLs", () => {
+    const router = createStaticRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+      },
+      "/unknown",
+    );
+
+    expect(router.match).toBeNull();
+  });
+
+  it("detects redirect routes", () => {
+    const router = createStaticRouter(
+      {
+        old: route({ url: "/old", redirect: "/new", status: 301 }),
+        new: route({ url: "/new", content: () => "new" }),
+      },
+      "/old",
+    );
+
+    expect(router.match?.kind).toBe("redirect");
+
+    if (router.match?.kind === "redirect") {
+      expect(router.match.redirectTo).toBe("/new");
+      expect(router.match.status).toBe(301);
+    }
+  });
+
+  it("supports not-found route", () => {
+    const notFound = route({ url: "/not-found", content: () => "404" });
+
+    const router = createStaticRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+      },
+      "/unknown",
+      { notFound },
+    );
+
+    expect(router.match?.kind).toBe("not-found");
+  });
+
+  it("does not support client-side navigation", () => {
+    const router = createStaticRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+      },
+      "/",
+    );
+
+    expect(() => {
+      router.navigate("home");
+    }).toThrow();
+  });
+});

--- a/packages/runtime/router/src/lib/createStaticRouter.ts
+++ b/packages/runtime/router/src/lib/createStaticRouter.ts
@@ -1,0 +1,54 @@
+import createRouter from "./createRouter.js";
+import createServerAdapter from "./createServerAdapter.js";
+import type {
+  AnyRoute,
+  RouteMap,
+  Router,
+  RouterMatch,
+  RouterOptions,
+} from "./types.js";
+
+/**
+ * Create a static router for server-side rendering.
+ *
+ * Matches the provided URL on construction and fires `prefetch()` eagerly.
+ * The match result is available synchronously via `staticRouter.match` for
+ * status code determination before rendering.
+ *
+ * ```ts
+ * const router = createStaticRouter(routes, req.url);
+ *
+ * if (!router.match) { res.status(404); }
+ * else if (router.match.kind === "redirect") {
+ *   return res.redirect(router.match.status, router.match.redirectTo);
+ * }
+ * ```
+ */
+export default function createStaticRouter<
+  const TRoutes extends RouteMap,
+  const TNotFound extends AnyRoute | undefined = undefined,
+>(
+  routes: TRoutes,
+  url: string | URL,
+  options?: Omit<RouterOptions<TNotFound>, "adapter" | "initialUrl">,
+): Router<TRoutes, TNotFound> & {
+  readonly match: RouterMatch<TRoutes, TNotFound> | null;
+} {
+  const router = createRouter(routes, {
+    ...options,
+    adapter: createServerAdapter(url),
+  });
+
+  const matchResult = router.match(url);
+
+  // Fire prefetch eagerly — cache starts warming before React renders.
+  if (matchResult && matchResult.kind === "route") {
+    void router.load(url).catch(() => {});
+  }
+
+  return Object.assign(router, {
+    get match() {
+      return matchResult;
+    },
+  });
+}

--- a/packages/runtime/router/src/lib/index.ts
+++ b/packages/runtime/router/src/lib/index.ts
@@ -1,11 +1,14 @@
 export { default as applyMiddleware } from "./applyMiddleware.js";
 export { default as createBrowserAdapter } from "./createBrowserAdapter.js";
+export { default as createBrowserRouter } from "./createBrowserRouter.js";
 export { default as createHistoryAdapter } from "./createHistoryAdapter.js";
 export { default as createMemoryAdapter } from "./createMemoryAdapter.js";
+export { default as createMemoryRouter } from "./createMemoryRouter.js";
 export { default as createNavigationAdapter } from "./createNavigationAdapter.js";
 export { default as createRouter } from "./createRouter.js";
 export { default as createRouterStore } from "./createRouterStore.js";
 export { default as createServerAdapter } from "./createServerAdapter.js";
+export { default as createStaticRouter } from "./createStaticRouter.js";
 export { default as createSubject } from "./createSubject.js";
 export { default as createTrackedLocation } from "./createTrackedLocation.js";
 export { default as group } from "./group.js";


### PR DESCRIPTION
## Done

### Router factories (`@canonical/router-core`)
- **`createBrowserRouter(routes, opts)`** — auto-detecting browser adapter (Navigation API with History fallback)
- **`createStaticRouter(routes, url, opts)`** — server adapter, matches on construction, exposes `router.match` for status code determination before rendering, fires `prefetch()` eagerly
- **`createMemoryRouter(routes, initialUrl, opts)`** — in-memory adapter for testing
- 8 new tests for factory functions
- README updated with router factories section and SSR examples

### `@canonical/react-head` (new package)
- **`HeadProvider`** — React context provider, accepts optional SSR collector
- **`useHead({ title, meta, link })`** — declarative, component-scoped head tags that mount/update/unmount with the component lifecycle
- **`createHeadCollector()`** — SSR utility that collects tags during server render, serializable via `toHtml()`
- Tag merging: deepest component wins for title and same-keyed meta tags, link tags accumulate
- XSS-safe HTML escaping in SSR output
- No dependency on the router — works with any React app
- 15 tests covering client mount/unmount, SSR collection, tag merging, meta deduplication, XSS escaping

### SSR documentation (`@canonical/router-react`)
- Updated SSR section with `createStaticRouter` + `onShellReady` streaming pattern
- `HeadProvider` + `createHeadCollector()` for SSR head tag collection
- Dual dehydration pattern: router navigation state + cache library data
- `createBrowserRouter` for client hydration

## QA

- `bun run --filter @canonical/router-core check` — all validations pass
- `bun run --filter @canonical/router-core test` — 128 tests pass
- `bun run --filter @canonical/router-core build:all` — builds clean
- `bun run --filter @canonical/router-react check` — all validations pass
- `bun run --filter @canonical/router-react test` — 28 tests pass
- `bun run --filter @canonical/router-react build:all` — builds clean
- `bun run --filter @canonical/react-head check` — all validations pass
- `bun run --filter @canonical/react-head test` — 15 tests pass
- `bun run --filter @canonical/react-head build:all` — builds clean

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁`
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json`
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public`