### PR TITLE
feat(svelte-ds-app-launchpad): Add Table

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.ssr.test.ts
@@ -1,0 +1,94 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import type { RenderResult } from "@canonical/svelte-ssr-test";
+import { render } from "@canonical/svelte-ssr-test";
+import type { ComponentProps } from "svelte";
+import { beforeEach, describe, expect, it } from "vitest";
+import Component from "./Table.svelte";
+import {
+  caption,
+  children,
+  setSortDirection,
+  tdText,
+  thText,
+} from "./test.fixtures.svelte";
+
+describe("Table SSR", () => {
+  beforeEach(() => {
+    setSortDirection(undefined);
+  });
+
+  const baseProps = {
+    children,
+  } satisfies ComponentProps<typeof Component>;
+
+  describe("basics", () => {
+    it("doesn't throw", () => {
+      expect(() => {
+        render(Component, { props: { ...baseProps } });
+      }).not.toThrow();
+    });
+
+    it("renders", () => {
+      const page = render(Component, { props: { ...baseProps } });
+      expect(componentLocator(page)).toBeInstanceOf(
+        page.window.HTMLTableElement,
+      );
+      expect(thLocator(page)).toBeInstanceOf(page.window.HTMLTableCellElement);
+      expect(tdLocator(page)).toBeInstanceOf(page.window.HTMLTableCellElement);
+    });
+  });
+
+  describe("attributes", () => {
+    it.each([["id", "test-id"]])("applies %s", (attribute, expected) => {
+      const page = render(Component, {
+        props: { ...baseProps, [attribute]: expected },
+      });
+      expect(componentLocator(page).getAttribute(attribute)).toBe(expected);
+    });
+
+    it("applies classes", () => {
+      const page = render(Component, {
+        props: { class: "test-class", ...baseProps },
+      });
+      expect(componentLocator(page).classList).toContain("test-class");
+      expect(componentLocator(page).classList).toContain("ds");
+      expect(componentLocator(page).classList).toContain("table");
+    });
+
+    it("applies style", () => {
+      const page = render(Component, {
+        props: { style: "color: orange;", ...baseProps },
+      });
+      expect(componentLocator(page).style.color).toBe("orange");
+    });
+  });
+
+  describe("sort direction", () => {
+    it("renders ascending", () => {
+      setSortDirection("ascending");
+      const page = render(Component, { props: { ...baseProps } });
+      const th = thLocator(page);
+      expect(th.getAttribute("aria-sort")).toBe("ascending");
+    });
+
+    it("renders descending", () => {
+      setSortDirection("descending");
+      const page = render(Component, { props: { ...baseProps } });
+      const th = thLocator(page);
+      expect(th.getAttribute("aria-sort")).toBe("descending");
+    });
+  });
+});
+
+function componentLocator(page: RenderResult): HTMLElement {
+  return page.getByRole("table", { name: caption });
+}
+
+function thLocator(page: RenderResult): HTMLElement {
+  return page.getByRole("columnheader", { name: thText });
+}
+
+function tdLocator(page: RenderResult): HTMLElement {
+  return page.getByRole("cell", { name: tdText });
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.stories.svelte
@@ -1,0 +1,224 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import type { HTMLThAttributes } from "svelte/elements";
+  import { SeededRandom } from "../../../../testing/SeededRandom.js";
+  import { DateTime } from "../DateTime/index.js";
+  import { Link } from "../Link/index.js";
+  import { RelativeDateTime } from "../RelativeDateTime/index.js";
+  import { Table } from "./index.js";
+
+  const { Story } = defineMeta({
+    title: "Components/Table",
+    tags: ["autodocs"],
+    component: Table,
+  });
+
+  type FakeRow = {
+    id: number;
+    name: string;
+    surname: string;
+    city: string;
+    street: string;
+    birthday: Date;
+    registered: Date;
+    profile: string;
+    balance: number;
+  };
+
+  function generateFakeTableData(count: number): FakeRow[] {
+    const seededRandom = new SeededRandom();
+
+    return Array.from({ length: count }, (_, i) => ({
+      id: i + 1,
+      name: seededRandom.pick([
+        "Alice",
+        "Bob",
+        "Charlie",
+        "Dana",
+        "Evan",
+        "Fatima",
+        "Grace",
+        "Hugo",
+        "Ivy",
+        "Jules",
+        "Kai",
+        "Lena",
+      ]),
+      surname: seededRandom.pick([
+        "Smith",
+        "Johnson",
+        "Williams",
+        "Brown",
+        "Jones",
+        "Garcia",
+        "Miller",
+        "Davis",
+      ]),
+      city: seededRandom.pick([
+        "New York",
+        "San Francisco",
+        "Chicago",
+        "Austin",
+        "Seattle",
+        "Denver",
+        "Boston",
+        "Atlanta",
+      ]),
+      street: seededRandom.pick([
+        "5th Avenue",
+        "Market Street",
+        "Michigan Avenue",
+        "Broadway",
+        "Sunset Blvd",
+        "Pine Street",
+        "Lake Shore Dr",
+      ]),
+      birthday: seededRandom.date("1975-01-01", "2005-12-31"),
+      registered: seededRandom.date("2016-01-01", "2024-12-31"),
+      profile: `https://example.com/${i + 1}`,
+      balance: seededRandom.int(-500, 5000),
+    }));
+  }
+
+  const fakeData = generateFakeTableData(30);
+  const totalBalance = fakeData.reduce((sum, row) => sum + row.balance, 0);
+
+  let sortKey = $state<keyof FakeRow>();
+  let sortDirection = $state<HTMLThAttributes["aria-sort"]>();
+</script>
+
+<Story name="Default" asChild>
+  <Table style="width: 100%;">
+    <caption>Static table</caption>
+    <thead>
+      <tr>
+        <th scope="col">User</th>
+        <th scope="col">Address</th>
+        <th scope="col">Birthday</th>
+        <th scope="col">Registered</th>
+        <th scope="col">Balance</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each fakeData as row (row.id)}
+        <tr>
+          <th scope="row">
+            <Link href={row.profile}>
+              {row.name}
+              {row.surname}
+            </Link>
+          </th>
+          <td>{row.street}, {row.city}</td>
+          <td><DateTime date={row.birthday} /></td>
+          <td><RelativeDateTime date={row.registered} /></td>
+          <td>
+            {row.balance.toLocaleString("en-US", {
+              style: "currency",
+              currency: "USD",
+            })}
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+    <tfoot>
+      <tr>
+        <th colspan="4" scope="row" style="text-align: end;">Total Balance</th>
+        <td>
+          {totalBalance.toLocaleString("en-US", {
+            style: "currency",
+            currency: "USD",
+          })}
+        </td>
+      </tr>
+    </tfoot>
+  </Table>
+</Story>
+
+<Story name="With sorting headers" asChild>
+  <!-- 
+    <script>
+      let sortKey = $state();
+      let sortDirection = $state();
+    </script>
+  -->
+  <Table style="width: 100%;">
+    <caption>Sortable table</caption>
+    <thead>
+      <tr>
+        {#each [["name", "User"], ["street", "Address"], ["birthday", "Birthday"], ["registered", "Registered"], ["balance", "Balance"]] as const as [key, label]}
+          <Table.TH
+            scope="col"
+            aria-sort={sortKey === key ? sortDirection : "none"}
+          >
+            {label}
+            {#snippet action()}
+              <Table.TH.SortButton
+                onclick={() => {
+                  if (sortKey !== key) {
+                    sortKey = key;
+                    sortDirection = "ascending";
+                  } else if (sortDirection === "ascending") {
+                    sortDirection = "descending";
+                  } else {
+                    sortKey = undefined;
+                    sortDirection = undefined;
+                  }
+                }}
+                aria-label={sortKey !== key
+                  ? `Sort by ${label} ascending`
+                  : sortDirection === "ascending"
+                    ? `Sort by ${label} descending`
+                    : `Remove sorting by ${label}`}
+              />
+            {/snippet}
+          </Table.TH>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      {#each fakeData.toSorted((a, b) => {
+        if (sortKey && sortDirection) {
+          const aValue = a[sortKey];
+          const bValue = b[sortKey];
+
+          if (typeof aValue === "string" && typeof bValue === "string") {
+            return sortDirection === "ascending" ? aValue.localeCompare(bValue) : bValue.localeCompare(aValue);
+          }
+
+          if (aValue < bValue) return sortDirection === "ascending" ? -1 : 1;
+          if (aValue > bValue) return sortDirection === "ascending" ? 1 : -1;
+        }
+        return 0;
+      }) as row (row.id)}
+        <tr>
+          <th scope="row">
+            <Link href={row.profile}>
+              {row.name}
+              {row.surname}
+            </Link>
+          </th>
+          <td>{row.street}, {row.city}</td>
+          <td><DateTime date={row.birthday} /></td>
+          <td><RelativeDateTime date={row.registered} /></td>
+          <td>
+            {row.balance.toLocaleString("en-US", {
+              style: "currency",
+              currency: "USD",
+            })}
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+    <tfoot>
+      <tr>
+        <th colspan="4" scope="row" style="text-align: end;">Total Balance</th>
+        <td>
+          {totalBalance.toLocaleString("en-US", {
+            style: "currency",
+            currency: "USD",
+          })}
+        </td>
+      </tr>
+    </tfoot>
+  </Table>
+</Story>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.svelte
@@ -1,0 +1,52 @@
+<!-- @canonical/generator-ds 0.10.0-experimental.5 -->
+
+<script lang="ts">
+  import type { TableProps } from "./types.js";
+  import "./styles.css";
+
+  const componentCssClassName = "ds table";
+
+  let { class: className, children, ...rest }: TableProps = $props();
+</script>
+
+<table class={[componentCssClassName, className]} {...rest}>
+  {@render children?.()}
+</table>
+
+<!-- @component
+`Table` is a styled table element.
+
+## Example Usage
+```svelte
+<Table>
+  <caption>Sample Data</caption>
+  <thead>
+    <tr>
+      <Table.TH aria-sort="ascending" scope="col">
+        Sortable Column
+        {#snippet action()}
+          <Table.TH.SortButton onclick={handleSortClick} aria-label="Sort descending by Sortable Column" />
+        {/snippet}
+      </Table.TH>
+      <th scope="col">Non-Sortable Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Data 1</td>
+      <td>Data 2</td>
+    </tr>
+    <tr>
+      <td>Data 3</td>
+      <td>Data 4</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td>Footer 1</td>
+      <td>Footer 2</td>
+    </tr>
+  </tfoot>
+</Table>
+```
+-->

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.svelte.test.ts
@@ -1,0 +1,103 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import type { ComponentProps } from "svelte";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Locator } from "vitest/browser";
+import { userEvent } from "vitest/browser";
+import type { RenderResult } from "vitest-browser-svelte";
+import { render } from "vitest-browser-svelte";
+import Component from "./Table.svelte";
+import {
+  caption,
+  children,
+  setSortDirection,
+  sortButtonText,
+  tdText,
+  thText,
+} from "./test.fixtures.svelte";
+
+describe("Table component", () => {
+  beforeEach(() => {
+    setSortDirection(undefined);
+  });
+
+  const baseProps = {
+    children,
+  } satisfies ComponentProps<typeof Component>;
+
+  it("renders", async () => {
+    const page = render(Component, { ...baseProps });
+    await expect.element(componentLocator(page)).toBeVisible();
+    await expect.element(thLocator(page)).toBeVisible();
+    await expect.element(tdLocator(page)).toBeVisible();
+  });
+
+  describe("attributes", () => {
+    it.each([["id", "test-id"]])("applies %s", async (attribute, expected) => {
+      const page = render(Component, { ...baseProps, [attribute]: expected });
+      await expect
+        .element(componentLocator(page))
+        .toHaveAttribute(attribute, expected);
+    });
+
+    it("applies classes", async () => {
+      const page = render(Component, { ...baseProps, class: "test-class" });
+      await expect.element(componentLocator(page)).toHaveClass("test-class");
+      await expect.element(componentLocator(page)).toHaveClass("ds");
+      await expect.element(componentLocator(page)).toHaveClass("table");
+    });
+
+    it("applies style", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        style: "color: orange;",
+      });
+      await expect
+        .element(componentLocator(page))
+        .toHaveStyle({ color: "orange" });
+    });
+  });
+
+  describe("sort direction", () => {
+    it.each([
+      "ascending",
+      "descending",
+    ] as const)("shows sort button when sort direction is %s", async (direction) => {
+      setSortDirection(direction);
+      const page = render(Component, { ...baseProps });
+      await expect.element(sortButtonLocator(page)).toBeVisible();
+    });
+
+    it("sort button shown when header cell is hovered", async () => {
+      const page = render(Component, { ...baseProps });
+      await thLocator(page).hover();
+      await expect.element(sortButtonLocator(page)).toBeVisible();
+    });
+
+    it("sort button is tabbable into even when not visible", async () => {
+      const page = render(Component, { ...baseProps });
+      await userEvent.click(page.baseElement);
+      await userEvent.tab();
+      await expect.element(sortButtonLocator(page)).toHaveFocus();
+      await expect.element(sortButtonLocator(page)).toBeVisible();
+    });
+  });
+});
+
+function componentLocator(page: RenderResult<typeof Component>): Locator {
+  return page.getByRole("table", { name: caption });
+}
+
+function thLocator(page: RenderResult<typeof Component>): Locator {
+  return page.getByRole("columnheader", { name: thText });
+}
+
+function tdLocator(page: RenderResult<typeof Component>): Locator {
+  return page.getByRole("cell", { name: tdText });
+}
+
+function sortButtonLocator(page: RenderResult<typeof Component>): Locator {
+  return page.getByRole("button", {
+    name: sortButtonText,
+  });
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/TH.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/TH.stories.svelte
@@ -1,0 +1,48 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import { Table } from "../../index.js";
+  import TH from "./TH.svelte";
+
+  const { Story } = defineMeta({
+    title: "Components/Table/TH",
+    tags: ["autodocs"],
+    component: TH,
+    argTypes: {
+      action: { control: false },
+    },
+  });
+</script>
+
+<Story name="With Sort Button">
+  {#snippet template({ action: _, ...args })}
+    <Table>
+      <thead>
+        <tr>
+          <Table.TH {...args}>
+            Header
+            {#snippet action()}
+              <Table.TH.SortButton aria-label="Sort" />
+            {/snippet}
+          </Table.TH>
+        </tr>
+      </thead>
+    </Table>
+  {/snippet}
+</Story>
+
+<Story name="With Sort Link">
+  {#snippet template({ action: _, ...args })}
+    <Table>
+      <thead>
+        <tr>
+          <Table.TH {...args}>
+            Header
+            {#snippet action()}
+              <Table.TH.SortButton aria-label="Sort" href="?sort=asc" />
+            {/snippet}
+          </Table.TH>
+        </tr>
+      </thead>
+    </Table>
+  {/snippet}
+</Story>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/TH.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/TH.svelte
@@ -1,0 +1,40 @@
+<!-- @canonical/generator-ds 0.10.0-experimental.5 -->
+
+<script lang="ts">
+  import { setTHContext } from "./context.js";
+  import type { THProps } from "./types.js";
+  import "./styles.css";
+
+  const componentCssClassName = "ds table-th";
+
+  let {
+    class: className,
+    children,
+    "aria-sort": sortDirection,
+    action,
+    ...rest
+  }: THProps = $props();
+
+  const cellContentId = $props.id();
+
+  setTHContext({
+    get sortDirection() {
+      return sortDirection;
+    },
+  });
+</script>
+
+<th
+  class={[componentCssClassName, className]}
+  aria-sort={sortDirection}
+  // Omit actions from the cell's accessible name. Otherwise, when user navigates the table, the sort button's label (e.g. "Sort by Name ascending") would be included every time when a screen reader announces associated header cell.
+  aria-labelledby={cellContentId}
+  {...rest}
+>
+  <div>
+    <span id={cellContentId}>
+      {@render children?.()}
+    </span>
+    {@render action?.()}
+  </div>
+</th>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/SortButton.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/SortButton.ssr.test.ts
@@ -1,0 +1,64 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import type { RenderResult } from "@canonical/svelte-ssr-test";
+import { render } from "@canonical/svelte-ssr-test";
+import type { ComponentProps } from "svelte";
+import { describe, expect, it, vi } from "vitest";
+import type { THContext } from "../../types.js";
+import Component from "./SortButton.svelte";
+
+vi.mock("../../context.js", () => {
+  return {
+    getTHContext: (): THContext => ({
+      sortDirection: undefined,
+    }),
+  };
+});
+
+describe("SortButton SSR", () => {
+  const baseProps = {
+    "aria-label": "Sort",
+  } satisfies ComponentProps<typeof Component>;
+
+  describe("basics", () => {
+    it("doesn't throw", () => {
+      expect(() => {
+        render(Component, { props: { ...baseProps } });
+      }).not.toThrow();
+    });
+
+    it("renders", () => {
+      const page = render(Component, { props: { ...baseProps } });
+      expect(componentLocator(page)).toBeInstanceOf(
+        page.window.HTMLButtonElement,
+      );
+    });
+  });
+
+  describe("attributes", () => {
+    it.each([["id", "test-id"]])("applies %s", (attribute, expected) => {
+      const page = render(Component, {
+        props: { ...baseProps, [attribute]: expected },
+      });
+      expect(componentLocator(page).getAttribute(attribute)).toBe(expected);
+    });
+
+    it("applies classes", () => {
+      const page = render(Component, {
+        props: { class: "test-class", ...baseProps },
+      });
+      expect(componentLocator(page).classList).toContain("test-class");
+    });
+
+    it("applies style", () => {
+      const page = render(Component, {
+        props: { style: "color: orange;", ...baseProps },
+      });
+      expect(componentLocator(page).style.color).toBe("orange");
+    });
+  });
+});
+
+function componentLocator(page: RenderResult): HTMLElement {
+  return page.getByRole("button", { name: "Sort" });
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/SortButton.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/SortButton.svelte
@@ -1,0 +1,36 @@
+<!-- @canonical/generator-ds 0.10.0-experimental.5 -->
+
+<script lang="ts">
+  import { getTHContext } from "../../context.js";
+  import type { SortButtonProps } from "./types.js";
+  import "./styles.css";
+  import { ArrowDownIcon, ArrowUpIcon } from "@canonical/svelte-icons";
+  import { ButtonPrimitive } from "../../../../../common/index.js";
+  import { SortIcon } from "../../../../../icons/index.js";
+
+  const componentCssClassName = "ds table-th-sort";
+
+  let { class: className, ...rest }: SortButtonProps = $props();
+
+  const thContext = getTHContext();
+  const sortDirection = $derived(thContext.sortDirection);
+</script>
+
+<ButtonPrimitive
+  class={[
+    componentCssClassName,
+    className,
+    {
+      sorted: sortDirection && sortDirection !== "none",
+    },
+  ]}
+  {...rest}
+>
+  {#if sortDirection === "ascending"}
+    <ArrowUpIcon aria-hidden="true" />
+  {:else if sortDirection === "descending"}
+    <ArrowDownIcon aria-hidden="true" />
+  {:else}
+    <SortIcon aria-hidden="true" />
+  {/if}
+</ButtonPrimitive>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/SortButton.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/SortButton.svelte.test.ts
@@ -1,0 +1,66 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import type { ComponentProps } from "svelte";
+import { describe, expect, it, vi } from "vitest";
+import type { Locator } from "vitest/browser";
+import type { RenderResult } from "vitest-browser-svelte";
+import { render } from "vitest-browser-svelte";
+import type { THContext } from "../../types.js";
+import Component from "./SortButton.svelte";
+
+vi.mock("../../context.js", () => {
+  return {
+    getTHContext: (): THContext => ({
+      sortDirection: undefined,
+    }),
+  };
+});
+
+describe("SortButton component", () => {
+  const baseProps = {
+    "aria-label": "Sort",
+  } satisfies ComponentProps<typeof Component>;
+
+  it("renders", async () => {
+    const page = render(Component, { ...baseProps });
+    await expect.element(componentLocator(page)).toBeInTheDocument();
+  });
+
+  describe("attributes", () => {
+    it.each([["id", "test-id"]])("applies %s", async (attribute, expected) => {
+      const page = render(Component, { ...baseProps, [attribute]: expected });
+      await expect
+        .element(componentLocator(page))
+        .toHaveAttribute(attribute, expected);
+    });
+
+    it("applies classes", async () => {
+      const page = render(Component, { ...baseProps, class: "test-class" });
+      await expect.element(componentLocator(page)).toHaveClass("test-class");
+    });
+
+    it("applies style", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        style: "color: orange;",
+      });
+      await expect
+        .element(componentLocator(page))
+        .toHaveStyle({ color: "orange" });
+    });
+  });
+
+  it("renders as link when href is provided", async () => {
+    const page = render(Component, {
+      ...baseProps,
+      href: "https://example.com",
+    });
+    await expect
+      .element(page.getByRole("link", { name: "Sort" }))
+      .toHaveAttribute("href", "https://example.com");
+  });
+});
+
+function componentLocator(page: RenderResult<typeof Component>): Locator {
+  return page.getByRole("button", { name: "Sort" });
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/index.ts
@@ -1,0 +1,4 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+export { default as SortButton } from "./SortButton.svelte";
+export * from "./types.js";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/styles.css
@@ -1,0 +1,19 @@
+.ds.table-th-sort.button-primitive {
+  padding: var(--lp-dimension-spacing-block-xxxs)
+    var(--lp-dimension-spacing-inline-xxxs);
+  background: none;
+  border: none;
+  min-width: fit-content;
+
+  font-size: var(--lp-typography-font-size-m);
+  color: var(--lp-color-icon-status-queued);
+
+  --color-background-button-hover: transparent;
+  --color-background-button-active: transparent;
+
+  &:hover,
+  &:focus-visible,
+  &.sorted {
+    color: var(--lp-color-text-default);
+  }
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/types.ts
@@ -1,0 +1,16 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import type { DistributiveOmit } from "../../../../../../type-utils/index.js";
+import type { ButtonPrimitiveProps } from "../../../../../common/index.js";
+
+export type SortButtonProps = DistributiveOmit<
+  ButtonPrimitiveProps,
+  "children"
+> & {
+  /**
+   * Label describing the sort action of the button.
+   *
+   * @example "Sort by Name ascending", "Sort by Name descending", "Remove sorting by Name"
+   */
+  "aria-label": string;
+};

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./SortButton/index.js";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/context.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from "svelte";
+import type { THContext } from "./types.js";
+
+export const [getTHContext, setTHContext] = createContext<THContext>();

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/index.ts
@@ -1,0 +1,16 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import { SortButton } from "./common/index.js";
+import { default as THRoot } from "./TH.svelte";
+
+const TH = THRoot as typeof THRoot & {
+  /**
+   * A button that toggles the sort direction of the column.
+   */
+  SortButton: typeof SortButton;
+};
+
+TH.SortButton = SortButton;
+
+export * from "./types.js";
+export { TH };

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/styles.css
@@ -1,0 +1,22 @@
+.ds.table-th {
+  div {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--lp-dimension-spacing-inline-xxs);
+  }
+
+  &:not([aria-sort]),
+  &[aria-sort="none"] {
+    .ds.table-th-sort:not(:focus-visible) {
+      opacity: 0;
+    }
+
+    &:hover {
+      .ds.table-th-sort {
+        opacity: 1;
+      }
+    }
+  }
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/types.ts
@@ -1,0 +1,25 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import type { Snippet } from "svelte";
+import type { HTMLThAttributes } from "svelte/elements";
+
+type BaseProps = HTMLThAttributes;
+
+export interface THProps extends BaseProps {
+  /**
+   * The sort direction of the column.
+   *
+   * Provided value will be applied to the `aria-sort` attribute of the header and used to determine the visual state of the `TH.SortButton` if included as an action.
+   */
+  "aria-sort"?: HTMLThAttributes["aria-sort"];
+  /**
+   * A button or link to be included in the header cell.
+   *
+   * Usually <Table.TH.SortButton>.
+   */
+  action?: Snippet<[]>;
+}
+
+export type THContext = {
+  sortDirection: HTMLThAttributes["aria-sort"];
+};

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./TH/index.js";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/index.ts
@@ -1,0 +1,26 @@
+import { TH } from "./common/index.js";
+import { default as TableRoot } from "./Table.svelte";
+
+const Table = TableRoot as typeof TableRoot & {
+  /**
+   * A table header cell component meant to be used for sortable columns.
+   *
+   * @example
+   * ```svelte
+   * <Table.TH aria-sort="ascending" scope="col">
+   *   Sortable Column
+   *   {#snippet action()}
+   *     <Table.TH.SortButton onclick={handleSortClick} />
+   *   {/snippet}
+   * </Table.TH>
+   * ```
+   */
+  TH: typeof TH;
+};
+
+Table.TH = TH;
+
+export type { THProps as TableTHProps } from "./common/index.js";
+
+export * from "./types.js";
+export { Table };

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/styles.css
@@ -1,0 +1,46 @@
+.ds.table {
+  border-collapse: collapse;
+
+  --border-table-row: var(--lp-dimension-stroke-thickness-default) solid
+    var(--lp-color-border-low-contrast);
+  --dimension-padding-block-table-cell: var(--lp-dimension-spacing-block-xs);
+  --dimension-padding-inline-table-cell: var(--lp-dimension-spacing-inline-xs);
+
+  th,
+  td {
+    padding-inline: var(--dimension-padding-inline-table-cell);
+    padding-block: var(--dimension-padding-block-table-cell);
+  }
+
+  th {
+    text-align: start;
+    font: var(--lp-typography-paragraph-s-strong);
+  }
+
+  td {
+    font: var(--lp-typography-paragraph-s);
+  }
+
+  thead,
+  tr:not(:last-child) {
+    border-bottom: var(--border-table-row);
+  }
+
+  tfoot {
+    border-top: var(--border-table-row);
+  }
+
+  thead th {
+    position: relative;
+
+    &:not(:last-child)::after {
+      content: "";
+      position: absolute;
+      height: calc(100% - var(--dimension-padding-block-table-cell) * 2);
+      width: var(--lp-dimension-stroke-thickness-default);
+      inset-inline-end: calc(var(--lp-dimension-stroke-thickness-default) / -2);
+      inset-block-start: var(--dimension-padding-block-table-cell);
+      background-color: var(--lp-color-border-default);
+    }
+  }
+}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/test.fixtures.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/test.fixtures.svelte
@@ -1,0 +1,43 @@
+<script lang="ts" module>
+  import type { HTMLThAttributes } from "svelte/elements";
+  import { TH } from "./common/index.js";
+
+  let sortDirection = $state<HTMLThAttributes["aria-sort"]>();
+  const setSortDirection = (direction: HTMLThAttributes["aria-sort"]) => {
+    sortDirection = direction;
+  };
+
+  const caption = "Table Caption";
+  const thText = "Sortable Header Cell";
+  const tdText = "Cell 1";
+  const sortButtonText = `Sort by ${thText}`;
+
+  // biome-ignore lint/style/useExportType: False positive, presumably due to "cross-language" export
+  export {
+    caption,
+    children,
+    setSortDirection,
+    sortButtonText,
+    tdText,
+    thText,
+  };
+</script>
+
+{#snippet children()}
+  <caption>{caption}</caption>
+  <thead>
+    <tr>
+      <TH aria-sort={sortDirection} scope="col">
+        {thText}
+        {#snippet action()}
+          <TH.SortButton aria-label={sortButtonText} />
+        {/snippet}
+      </TH>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{tdText}</td>
+    </tr>
+  </tbody>
+{/snippet}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/types.ts
@@ -1,0 +1,5 @@
+/* @canonical/generator-ds 0.10.0-experimental.5 */
+
+import type { SvelteHTMLElements } from "svelte/elements";
+
+export type TableProps = SvelteHTMLElements["table"];

--- a/packages/svelte/ds-app-launchpad/src/lib/components/icons/SortIcon.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/icons/SortIcon.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { IconProps } from "@canonical/svelte-icons";
+  import { IconBase } from "@canonical/svelte-icons";
+
+  const props: IconProps = $props();
+</script>
+
+<IconBase iconName="sort" {...props}>
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10.5303 1.46973L9.25 2.00006V14.5001H10.75V3.81072L13.4697 6.53039L14.5303 5.46973L10.5303 1.46973Z"
+      fill="currentColor"
+    ></path>
+    <path
+      d="M5.46967 14.5303L6.75 13.9999V1.49994H5.25V12.1893L2.53033 9.46961L1.46967 10.5303L5.46967 14.5303Z"
+      fill="currentColor"
+    ></path>
+  </svg>
+</IconBase>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/icons/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/icons/index.ts
@@ -1,0 +1,2 @@
+// TODO: Remove icons when they are approved, upstreamed to `@canonical/ds-assets` included in `@canonical/svelte-icons`.
+export { default as SortIcon } from "./SortIcon.svelte";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/icons/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/icons/index.ts
@@ -1,2 +1,2 @@
-// TODO: Remove icons when they are approved, upstreamed to `@canonical/ds-assets` included in `@canonical/svelte-icons`.
+// TODO(steciuk): Remove icons when they are approved, upstreamed to `@canonical/ds-assets` included in `@canonical/svelte-icons`.
 export { default as SortIcon } from "./SortIcon.svelte";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/index.ts
@@ -13,5 +13,6 @@ export * from "./Radio/index.js";
 export * from "./RelativeDateTime/index.js";
 export * from "./Spinner/index.js";
 export * from "./Switch/index.js";
+export * from "./Table/index.js";
 export * from "./Textarea/index.js";
 export * from "./TextInput/index.js";

--- a/packages/svelte/ds-app-launchpad/src/lib/type-utils/DistributiveOmit.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/type-utils/DistributiveOmit.ts
@@ -1,0 +1,6 @@
+/**
+ * A utility type that applies `Omit` to each member of a union type without collapsing the union.
+ */
+export type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;

--- a/packages/svelte/ds-app-launchpad/src/lib/type-utils/index.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/type-utils/index.ts
@@ -1,0 +1,1 @@
+export type * from "./DistributiveOmit.js";

--- a/packages/svelte/ds-app-launchpad/testing/SeededRandom.ts
+++ b/packages/svelte/ds-app-launchpad/testing/SeededRandom.ts
@@ -1,0 +1,48 @@
+/**
+ * A simple seeded pseudo-random number generator for use in tests/stories.
+ */
+export class SeededRandom {
+  constructor(private seed: number = 42) {}
+
+  /**
+   * @returns A pseudo-random number between 0 and 1.
+   */
+  public random(): number {
+    // Mulberry32 PRNG (https://github.com/cprosche/mulberry32)
+    this.seed += 0x6d2b79f5;
+    let t = this.seed;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  /**
+   * @returns A pseudo-random integer between `min` and `max` (inclusive).
+   */
+  public int(min: number, max: number): number {
+    return Math.floor(this.random() * (max - min + 1)) + min;
+  }
+
+  /**
+   * @returns A random element from the given array.
+   */
+  public pick<T>(arr: T[]): T {
+    if (arr.length === 0) {
+      throw new Error("SeededRandom.pick() requires a non-empty array.");
+    }
+
+    return arr[Math.floor(this.random() * arr.length)];
+  }
+
+  /**
+   * @returns A pseudo-random Date between `start` and `end`.
+   */
+  public date(
+    start: Date | string | number,
+    end: Date | string | number,
+  ): Date {
+    return new Date(
+      this.int(new Date(start).getTime(), new Date(end).getTime()),
+    );
+  }
+}


### PR DESCRIPTION
## Done

- Add `Table` component supporting sortable columns via a `TH` sub-component with `SortButton`
- Temporarily add `SortIcon` icon used by the sort indicator (to be removed when the icon is approved for general use and upstreamed to `@canonical/ds-assets`).
- Add `DistributiveOmit` type utility.
- Add `SeededRandom` helper for deterministic test fixtures/stories data generation.

## QA
- `bun run check && bun run test`
- verify `Components/Table` in Storybook
  - Check default rendering with multiple columns and rows
  - Make sure the table is styled properly when the native table-related elements are used
  - Interact with sortable column headers and confirm that sort direction is correctly indicated both visually and to assistive technologies 

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify.

## Screenshots

<img width="969" height="645" alt="image" src="https://github.com/user-attachments/assets/71ff6257-8ddf-46af-bdd6-5cc1d75814f1" />

