### PR TITLE
feat(cli): configurable package sources with git ref resolution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ Fixes [list issues/bugs if needed]
   - [ ] All packages: `check`, `check:fix`, and `test`.
   - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
 - [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify.
+- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.
 
 ## Screenshots
 

--- a/packages/cli/pragma/src/config/readConfig.test.ts
+++ b/packages/cli/pragma/src/config/readConfig.test.ts
@@ -271,10 +271,7 @@ describe("writeConfig", () => {
     });
 
     it("merges packages into existing config without touching tier", () => {
-      writeFileSync(
-        join(dir, "pragma.config.json"),
-        '{"tier":"global"}',
-      );
+      writeFileSync(join(dir, "pragma.config.json"), '{"tier":"global"}');
       writeConfig(dir, { packages: ["@canonical/design-system"] });
       const config = readConfig(dir);
       expect(config.tier).toBe("global");

--- a/packages/cli/pragma/src/config/readConfig.test.ts
+++ b/packages/cli/pragma/src/config/readConfig.test.ts
@@ -73,6 +73,105 @@ describe("readConfig", () => {
     const config = readConfig(dir);
     expect(config.tier).toBeUndefined();
   });
+
+  describe("packages field", () => {
+    it("parses string-only packages array", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        JSON.stringify({
+          packages: ["@canonical/design-system", "@canonical/code-standards"],
+        }),
+      );
+      const config = readConfig(dir);
+      expect(config.packages).toEqual([
+        "@canonical/design-system",
+        "@canonical/code-standards",
+      ]);
+    });
+
+    it("parses mixed string and object packages", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        JSON.stringify({
+          packages: [
+            "@canonical/design-system",
+            {
+              name: "@canonical/code-standards",
+              source: "file:///home/user/code/code-standards",
+            },
+          ],
+        }),
+      );
+      const config = readConfig(dir);
+      expect(config.packages).toEqual([
+        "@canonical/design-system",
+        {
+          name: "@canonical/code-standards",
+          source: "file:///home/user/code/code-standards",
+        },
+      ]);
+    });
+
+    it("parses object without source as npm", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        JSON.stringify({
+          packages: [{ name: "@canonical/design-system" }],
+        }),
+      );
+      const config = readConfig(dir);
+      expect(config.packages).toEqual([{ name: "@canonical/design-system" }]);
+    });
+
+    it("returns no packages field when absent", () => {
+      writeFileSync(join(dir, "pragma.config.json"), '{"tier":"global"}');
+      const config = readConfig(dir);
+      expect(config.packages).toBeUndefined();
+    });
+
+    it("throws on non-array packages", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        '{"packages":"not-an-array"}',
+      );
+      expect(() => readConfig(dir)).toThrow(PragmaError);
+    });
+
+    it("throws on object entry with empty name", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        JSON.stringify({ packages: [{ name: "" }] }),
+      );
+      expect(() => readConfig(dir)).toThrow(PragmaError);
+    });
+
+    it("throws on invalid source scheme", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        JSON.stringify({
+          packages: [
+            { name: "@canonical/ds", source: "https://example.com/foo.tar.gz" },
+          ],
+        }),
+      );
+      expect(() => readConfig(dir)).toThrow(PragmaError);
+    });
+
+    it("throws on git source without ref", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        JSON.stringify({
+          packages: [
+            {
+              name: "@canonical/ds",
+              source: "git+https://github.com/canonical/ds.git",
+            },
+          ],
+        }),
+      );
+      expect(() => readConfig(dir)).toThrow(PragmaError);
+    });
+  });
 });
 
 describe("writeConfig", () => {
@@ -148,5 +247,61 @@ describe("writeConfig", () => {
   it("throws on unparseable existing config instead of silently overwriting", () => {
     writeFileSync(join(dir, "pragma.config.json"), "{invalid json");
     expect(() => writeConfig(dir, { tier: "apps" })).toThrow();
+  });
+
+  describe("packages field", () => {
+    it("writes packages array", () => {
+      writeConfig(dir, {
+        packages: [
+          "@canonical/design-system",
+          {
+            name: "@canonical/code-standards",
+            source: "file:///home/user/code/code-standards",
+          },
+        ],
+      });
+      const config = readConfig(dir);
+      expect(config.packages).toEqual([
+        "@canonical/design-system",
+        {
+          name: "@canonical/code-standards",
+          source: "file:///home/user/code/code-standards",
+        },
+      ]);
+    });
+
+    it("merges packages into existing config without touching tier", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        '{"tier":"global"}',
+      );
+      writeConfig(dir, { packages: ["@canonical/design-system"] });
+      const config = readConfig(dir);
+      expect(config.tier).toBe("global");
+      expect(config.packages).toEqual(["@canonical/design-system"]);
+    });
+
+    it("removes packages when set to undefined", () => {
+      writeFileSync(
+        join(dir, "pragma.config.json"),
+        JSON.stringify({ packages: ["@canonical/design-system"] }),
+      );
+      writeConfig(dir, { packages: undefined });
+      const config = readConfig(dir);
+      expect(config.packages).toBeUndefined();
+    });
+
+    it("round-trips packages through write then read", () => {
+      const packages = [
+        "@canonical/design-system",
+        {
+          name: "@canonical/anatomy-dsl",
+          source: "git+https://github.com/canonical/anatomy-dsl.git#main",
+        },
+      ];
+      writeConfig(dir, { packages });
+      const config = readConfig(dir);
+      expect(config.packages).toEqual(packages);
+    });
   });
 });

--- a/packages/cli/pragma/src/config/readConfig.ts
+++ b/packages/cli/pragma/src/config/readConfig.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 import { type Channel, VALID_CHANNELS } from "../constants.js";
 import {
-  type RawPackageEntry,
   parsePackageEntry,
+  type RawPackageEntry,
 } from "../domains/refs/operations/parseRef.js";
 import { PragmaError } from "../error/PragmaError.js";
 import resolveConfigPath from "./resolveConfigPath.js";
@@ -86,7 +86,7 @@ function parsePackagesField(
 
   if (!Array.isArray(raw)) {
     throw PragmaError.configError(
-      "\"packages\" must be an array of strings or { name, source? } objects.",
+      '"packages" must be an array of strings or { name, source? } objects.',
     );
   }
 
@@ -100,7 +100,7 @@ function parsePackagesField(
       const obj = item as Record<string, unknown>;
       if (typeof obj.name !== "string" || obj.name.length === 0) {
         throw PragmaError.configError(
-          "Each object in \"packages\" must have a non-empty \"name\" string.",
+          'Each object in "packages" must have a non-empty "name" string.',
         );
       }
       const entry: { name: string; source?: string } = { name: obj.name };
@@ -118,7 +118,7 @@ function parsePackagesField(
       continue;
     }
     throw PragmaError.configError(
-      "Each entry in \"packages\" must be a string or { name, source? } object.",
+      'Each entry in "packages" must be a string or { name, source? } object.',
     );
   }
 

--- a/packages/cli/pragma/src/config/readConfig.ts
+++ b/packages/cli/pragma/src/config/readConfig.ts
@@ -1,5 +1,9 @@
 import { readFileSync } from "node:fs";
 import { type Channel, VALID_CHANNELS } from "../constants.js";
+import {
+  type RawPackageEntry,
+  parsePackageEntry,
+} from "../domains/refs/operations/parseRef.js";
 import { PragmaError } from "../error/PragmaError.js";
 import resolveConfigPath from "./resolveConfigPath.js";
 import type { PragmaConfig } from "./types.js";
@@ -60,5 +64,63 @@ export default function readConfig(cwd: string = process.cwd()): PragmaConfig {
     channel = parsed.channel;
   }
 
-  return { tier, channel };
+  const packages = parsePackagesField(parsed.packages);
+
+  return packages ? { tier, channel, packages } : { tier, channel };
+}
+
+// ---------------------------------------------------------------------------
+// Packages field parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate and parse the `packages` config field.
+ *
+ * @returns The validated array, or `undefined` when the field is absent.
+ * @throws PragmaError if the field is present but malformed.
+ */
+function parsePackagesField(
+  raw: unknown,
+): ReadonlyArray<RawPackageEntry> | undefined {
+  if (raw === undefined || raw === null) return undefined;
+
+  if (!Array.isArray(raw)) {
+    throw PragmaError.configError(
+      "\"packages\" must be an array of strings or { name, source? } objects.",
+    );
+  }
+
+  const entries: RawPackageEntry[] = [];
+  for (const item of raw) {
+    if (typeof item === "string") {
+      entries.push(item);
+      continue;
+    }
+    if (typeof item === "object" && item !== null && !Array.isArray(item)) {
+      const obj = item as Record<string, unknown>;
+      if (typeof obj.name !== "string" || obj.name.length === 0) {
+        throw PragmaError.configError(
+          "Each object in \"packages\" must have a non-empty \"name\" string.",
+        );
+      }
+      const entry: { name: string; source?: string } = { name: obj.name };
+      if (obj.source !== undefined) {
+        if (typeof obj.source !== "string") {
+          throw PragmaError.configError(
+            `Invalid source for "${obj.name}": expected a string.`,
+          );
+        }
+        entry.source = obj.source;
+      }
+      // Validate format eagerly — fail fast on bad config
+      parsePackageEntry(entry);
+      entries.push(entry);
+      continue;
+    }
+    throw PragmaError.configError(
+      "Each entry in \"packages\" must be a string or { name, source? } object.",
+    );
+  }
+
+  return entries;
 }

--- a/packages/cli/pragma/src/config/types.ts
+++ b/packages/cli/pragma/src/config/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Channel } from "../constants.js";
+import type { RawPackageEntry } from "../domains/refs/operations/parseRef.js";
 
 /** Parsed contents of pragma.config.json. */
 interface PragmaConfig {
@@ -13,6 +14,12 @@ interface PragmaConfig {
   tier: string | undefined;
   /** Release channel controlling component visibility. */
   channel: Channel;
+  /**
+   * Semantic package sources. Each entry is a package name (npm) or an
+   * object with `{ name, source }` where source is `file://` or `git+https://`.
+   * When absent, the hardcoded defaults are used.
+   */
+  packages?: ReadonlyArray<RawPackageEntry> | undefined;
 }
 
 /** Partial update payload for writing config changes. */
@@ -21,6 +28,8 @@ interface ConfigUpdate {
   tier?: string | undefined;
   /** New channel, `undefined` to remove the channel field. */
   channel?: Channel | undefined;
+  /** New packages list, `undefined` to remove the field. */
+  packages?: ReadonlyArray<RawPackageEntry> | undefined;
 }
 
 export type { ConfigUpdate, PragmaConfig };

--- a/packages/cli/pragma/src/config/writeConfig.ts
+++ b/packages/cli/pragma/src/config/writeConfig.ts
@@ -44,6 +44,12 @@ export default function writeConfig(cwd: string, update: ConfigUpdate): void {
     delete existing.channel;
   }
 
+  if (update.packages !== undefined) {
+    existing.packages = update.packages;
+  } else if ("packages" in update) {
+    delete existing.packages;
+  }
+
   writeFileSync(tempPath, `${JSON.stringify(existing, null, 2)}\n`);
   renameSync(tempPath, configPath);
 }

--- a/packages/cli/pragma/src/domains/doctor/operations/checks/checkPackageRefs.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks/checkPackageRefs.ts
@@ -8,8 +8,8 @@
 import { existsSync } from "node:fs";
 import { readConfig } from "#config";
 import {
-  type RawPackageEntry,
   parsePackageEntry,
+  type RawPackageEntry,
 } from "../../../refs/operations/parseRef.js";
 import { gitCacheDir } from "../../../refs/operations/paths.js";
 import readGlobalRefs from "../../../refs/operations/readGlobalRefs.js";

--- a/packages/cli/pragma/src/domains/doctor/operations/checks/checkPackageRefs.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks/checkPackageRefs.ts
@@ -1,0 +1,76 @@
+/**
+ * Doctor check: report how each semantic package is resolved.
+ *
+ * Shows whether packages resolve from npm, file://, or git cache,
+ * and warns if a configured ref is missing its cache.
+ */
+
+import { existsSync } from "node:fs";
+import { readConfig } from "#config";
+import {
+  type RawPackageEntry,
+  parsePackageEntry,
+} from "../../../refs/operations/parseRef.js";
+import { gitCacheDir } from "../../../refs/operations/paths.js";
+import readGlobalRefs from "../../../refs/operations/readGlobalRefs.js";
+import { DEFAULT_PACKAGES } from "../../../shared/packages.js";
+import type { CheckContext, CheckResult } from "../types.js";
+
+export default async function checkPackageRefs(
+  ctx: CheckContext,
+): Promise<CheckResult> {
+  const config = readConfig(ctx.cwd);
+  const globalEntries = readGlobalRefs();
+
+  const hasProjectRefs = config.packages && config.packages.length > 0;
+  const hasGlobalRefs = globalEntries.length > 0;
+
+  if (!hasProjectRefs && !hasGlobalRefs) {
+    return {
+      name: "package refs",
+      status: "pass",
+      detail: `${DEFAULT_PACKAGES.length} packages (all npm, defaults)`,
+    };
+  }
+
+  const entries: ReadonlyArray<RawPackageEntry> =
+    config.packages ?? globalEntries;
+
+  const details: string[] = [];
+  let hasIssue = false;
+
+  for (const entry of entries) {
+    const ref = parsePackageEntry(entry);
+
+    switch (ref.kind) {
+      case "npm":
+        details.push(`${ref.pkg}: npm`);
+        break;
+      case "file":
+        if (existsSync(ref.path)) {
+          details.push(`${ref.pkg}: file (${ref.path})`);
+        } else {
+          details.push(`${ref.pkg}: file MISSING (${ref.path})`);
+          hasIssue = true;
+        }
+        break;
+      case "git": {
+        const cached = existsSync(gitCacheDir(ref.pkg, ref.ref));
+        if (cached) {
+          details.push(`${ref.pkg}: git #${ref.ref} (cached)`);
+        } else {
+          details.push(`${ref.pkg}: git #${ref.ref} NOT CACHED`);
+          hasIssue = true;
+        }
+        break;
+      }
+    }
+  }
+
+  return {
+    name: "package refs",
+    status: hasIssue ? "fail" : "pass",
+    detail: details.join("; "),
+    ...(hasIssue ? { remedy: "pragma update-refs" } : {}),
+  };
+}

--- a/packages/cli/pragma/src/domains/doctor/operations/checks/index.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks/index.ts
@@ -3,6 +3,7 @@ export { default as checkConfigFile } from "./checkConfigFile.js";
 export { default as checkKeStore } from "./checkKeStore.js";
 export { default as checkMcpConfigured } from "./checkMcpConfigured.js";
 export { default as checkNodeVersion } from "./checkNodeVersion.js";
+export { default as checkPackageRefs } from "./checkPackageRefs.js";
 export { default as checkPragmaVersion } from "./checkPragmaVersion.js";
 export { default as checkShellCompletions } from "./checkShellCompletions.js";
 export { default as checkSkillsSymlinked } from "./checkSkillsSymlinked.js";

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
@@ -4,6 +4,7 @@ vi.mock("./checks/index.js", () => ({
   checkNodeVersion: vi.fn(),
   checkPragmaVersion: vi.fn(),
   checkConfigFile: vi.fn(),
+  checkPackageRefs: vi.fn(),
   checkKeStore: vi.fn(),
   checkShellCompletions: vi.fn(),
   checkMcpConfigured: vi.fn(),
@@ -15,6 +16,7 @@ import {
   checkKeStore,
   checkMcpConfigured,
   checkNodeVersion,
+  checkPackageRefs,
   checkPragmaVersion,
   checkShellCompletions,
   checkSkillsSymlinked,
@@ -43,29 +45,31 @@ describe("runChecks", () => {
     vi.mocked(checkNodeVersion).mockResolvedValue(pass("Node"));
     vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
     vi.mocked(checkConfigFile).mockResolvedValue(pass("config"));
+    vi.mocked(checkPackageRefs).mockResolvedValue(pass("refs"));
     vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
     vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
     vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
 
     const data = await runChecks({ cwd: "/test" });
-    expect(data.passed).toBe(7);
+    expect(data.passed).toBe(8);
     expect(data.failed).toBe(0);
     expect(data.skipped).toBe(0);
-    expect(data.checks).toHaveLength(7);
+    expect(data.checks).toHaveLength(8);
   });
 
   it("counts failures and skips correctly", async () => {
     vi.mocked(checkNodeVersion).mockResolvedValue(pass("Node"));
     vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
     vi.mocked(checkConfigFile).mockResolvedValue(fail("config"));
+    vi.mocked(checkPackageRefs).mockResolvedValue(pass("refs"));
     vi.mocked(checkKeStore).mockResolvedValue(fail("store"));
     vi.mocked(checkShellCompletions).mockResolvedValue(fail("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
     vi.mocked(checkSkillsSymlinked).mockResolvedValue(skip("skills"));
 
     const data = await runChecks({ cwd: "/test" });
-    expect(data.passed).toBe(3);
+    expect(data.passed).toBe(4);
     expect(data.failed).toBe(3);
     expect(data.skipped).toBe(1);
   });
@@ -74,6 +78,7 @@ describe("runChecks", () => {
     vi.mocked(checkNodeVersion).mockResolvedValue(pass("Node"));
     vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
     vi.mocked(checkConfigFile).mockResolvedValue(pass("config"));
+    vi.mocked(checkPackageRefs).mockResolvedValue(pass("refs"));
     vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
     vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
@@ -83,7 +88,8 @@ describe("runChecks", () => {
     expect(data.checks[0].name).toBe("Node");
     expect(data.checks[1].name).toBe("pragma");
     expect(data.checks[2].name).toBe("config");
-    expect(data.checks[3].name).toBe("store");
-    expect(data.checks[6].name).toBe("skills");
+    expect(data.checks[3].name).toBe("refs");
+    expect(data.checks[4].name).toBe("store");
+    expect(data.checks[7].name).toBe("skills");
   });
 });

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
@@ -3,6 +3,7 @@ import {
   checkKeStore,
   checkMcpConfigured,
   checkNodeVersion,
+  checkPackageRefs,
   checkPragmaVersion,
   checkShellCompletions,
   checkSkillsSymlinked,
@@ -25,6 +26,7 @@ export default async function runChecks(
   checks.push(await checkNodeVersion());
   checks.push(await checkPragmaVersion());
   checks.push(await checkConfigFile(ctx));
+  checks.push(await checkPackageRefs(ctx));
   checks.push(await checkKeStore(ctx));
   checks.push(await checkShellCompletions());
   checks.push(await checkMcpConfigured(ctx));

--- a/packages/cli/pragma/src/domains/info/formatters/info.test.ts
+++ b/packages/cli/pragma/src/domains/info/formatters/info.test.ts
@@ -103,9 +103,21 @@ describe("renderInfoPlain", () => {
     const output = renderInfoPlain(
       createInfoData({
         packageRefs: [
-          { pkg: "@canonical/design-system", source: "npm", detail: "node_modules" },
-          { pkg: "@canonical/code-standards", source: "file", detail: "/home/user/code/standards" },
-          { pkg: "@canonical/anatomy-dsl", source: "git", detail: "https://github.com/canonical/anatomy-dsl.git#main" },
+          {
+            pkg: "@canonical/design-system",
+            source: "npm",
+            detail: "node_modules",
+          },
+          {
+            pkg: "@canonical/code-standards",
+            source: "file",
+            detail: "/home/user/code/standards",
+          },
+          {
+            pkg: "@canonical/anatomy-dsl",
+            source: "git",
+            detail: "https://github.com/canonical/anatomy-dsl.git#main",
+          },
         ],
       }),
     );

--- a/packages/cli/pragma/src/domains/info/formatters/info.test.ts
+++ b/packages/cli/pragma/src/domains/info/formatters/info.test.ts
@@ -98,6 +98,28 @@ describe("renderInfoPlain", () => {
     expect(output).not.toContain("Triples");
     expect(output).not.toContain("Graphs");
   });
+
+  it("includes package refs section", () => {
+    const output = renderInfoPlain(
+      createInfoData({
+        packageRefs: [
+          { pkg: "@canonical/design-system", source: "npm", detail: "node_modules" },
+          { pkg: "@canonical/code-standards", source: "file", detail: "/home/user/code/standards" },
+          { pkg: "@canonical/anatomy-dsl", source: "git", detail: "https://github.com/canonical/anatomy-dsl.git#main" },
+        ],
+      }),
+    );
+    expect(output).toContain("Packages");
+    expect(output).toContain("@canonical/design-system");
+    expect(output).toContain("npm");
+    expect(output).toContain("file");
+    expect(output).toContain("git");
+  });
+
+  it("omits package refs section when absent", () => {
+    const output = renderInfoPlain(createInfoData());
+    expect(output).not.toContain("Packages");
+  });
 });
 
 describe("renderInfoLlm", () => {

--- a/packages/cli/pragma/src/domains/info/formatters/info.ts
+++ b/packages/cli/pragma/src/domains/info/formatters/info.ts
@@ -43,6 +43,14 @@ function renderInfoPlain(data: InfoData): string {
     lines.push("  Up to date.");
   }
 
+  if (data.packageRefs && data.packageRefs.length > 0) {
+    lines.push("");
+    lines.push(formatHeading("Packages"));
+    for (const ref of data.packageRefs) {
+      lines.push(formatField(`  ${ref.pkg}:`, `${ref.source} (${ref.detail})`));
+    }
+  }
+
   if (data.store) {
     lines.push("");
     lines.push(formatHeading("Store"));
@@ -91,6 +99,13 @@ function renderInfoLlm(data: InfoData): string {
     lines.push("- Update: check skipped (offline)");
   } else {
     lines.push("- Update: up to date");
+  }
+
+  if (data.packageRefs && data.packageRefs.length > 0) {
+    lines.push("## Packages");
+    for (const ref of data.packageRefs) {
+      lines.push(`- ${ref.pkg}: ${ref.source} (${ref.detail})`);
+    }
   }
 
   if (data.store) {

--- a/packages/cli/pragma/src/domains/info/operations/collectInfo.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectInfo.ts
@@ -1,10 +1,13 @@
 import { readConfig } from "#config";
 import { VERSION } from "#constants";
 import { detectInstallSource, PM_COMMANDS } from "#package-manager";
+import { parsePackageEntry } from "../../refs/operations/parseRef.js";
+import readGlobalRefs from "../../refs/operations/readGlobalRefs.js";
 import { bootStore } from "../../shared/bootStore.js";
 import { CHANNEL_RELEASES } from "../../shared/filters/buildChannelFilter.js";
 import { resolveTierChain } from "../../shared/filters/buildTierFilter.js";
-import type { InfoData } from "../types.js";
+import { DEFAULT_PACKAGES } from "../../shared/packages.js";
+import type { InfoData, PackageRefSummary } from "../types.js";
 import checkRegistryVersion from "./checkRegistryVersion.js";
 import { collectStoreSummary } from "./collectStoreSummary.js";
 
@@ -52,6 +55,9 @@ export default async function collectInfo(cwd: string): Promise<InfoData> {
     keStore?.dispose();
   }
 
+  // Collect package ref summaries
+  const packageRefs = collectPackageRefSummaries(config.packages);
+
   return {
     version: VERSION,
     pm,
@@ -64,5 +70,34 @@ export default async function collectInfo(cwd: string): Promise<InfoData> {
     update,
     updateSkipped,
     store,
+    packageRefs,
   };
+}
+
+function collectPackageRefSummaries(
+  projectPackages?: ReadonlyArray<
+    string | { readonly name: string; readonly source?: string }
+  >,
+): PackageRefSummary[] {
+  const entries = projectPackages ?? readGlobalRefs();
+  const raw =
+    entries.length > 0
+      ? entries
+      : DEFAULT_PACKAGES.map((pkg) => pkg);
+
+  return raw.map((entry) => {
+    const ref = parsePackageEntry(entry);
+    switch (ref.kind) {
+      case "npm":
+        return { pkg: ref.pkg, source: "npm" as const, detail: "node_modules" };
+      case "file":
+        return { pkg: ref.pkg, source: "file" as const, detail: ref.path };
+      case "git":
+        return {
+          pkg: ref.pkg,
+          source: "git" as const,
+          detail: `${ref.url}#${ref.ref}`,
+        };
+    }
+  });
 }

--- a/packages/cli/pragma/src/domains/info/operations/collectInfo.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectInfo.ts
@@ -1,7 +1,10 @@
 import { readConfig } from "#config";
 import { VERSION } from "#constants";
 import { detectInstallSource, PM_COMMANDS } from "#package-manager";
-import { parsePackageEntry } from "../../refs/operations/parseRef.js";
+import {
+  type PackageRef,
+  parsePackageEntry,
+} from "../../refs/operations/parseRef.js";
 import readGlobalRefs from "../../refs/operations/readGlobalRefs.js";
 import { bootStore } from "../../shared/bootStore.js";
 import { CHANNEL_RELEASES } from "../../shared/filters/buildChannelFilter.js";
@@ -80,24 +83,15 @@ function collectPackageRefSummaries(
   >,
 ): PackageRefSummary[] {
   const entries = projectPackages ?? readGlobalRefs();
-  const raw =
-    entries.length > 0
-      ? entries
-      : DEFAULT_PACKAGES.map((pkg) => pkg);
+  const raw = entries.length > 0 ? entries : DEFAULT_PACKAGES.map((pkg) => pkg);
 
-  return raw.map((entry) => {
-    const ref = parsePackageEntry(entry);
-    switch (ref.kind) {
-      case "npm":
-        return { pkg: ref.pkg, source: "npm" as const, detail: "node_modules" };
-      case "file":
-        return { pkg: ref.pkg, source: "file" as const, detail: ref.path };
-      case "git":
-        return {
-          pkg: ref.pkg,
-          source: "git" as const,
-          detail: `${ref.url}#${ref.ref}`,
-        };
-    }
-  });
+  return raw.map((entry) => refToSummary(parsePackageEntry(entry)));
+}
+
+function refToSummary(ref: PackageRef): PackageRefSummary {
+  if (ref.kind === "file")
+    return { pkg: ref.pkg, source: "file", detail: ref.path };
+  if (ref.kind === "git")
+    return { pkg: ref.pkg, source: "git", detail: `${ref.url}#${ref.ref}` };
+  return { pkg: ref.pkg, source: "npm", detail: "node_modules" };
 }

--- a/packages/cli/pragma/src/domains/info/types.ts
+++ b/packages/cli/pragma/src/domains/info/types.ts
@@ -1,3 +1,10 @@
+/** Summary of how a single package is resolved. */
+export interface PackageRefSummary {
+  readonly pkg: string;
+  readonly source: "npm" | "file" | "git";
+  readonly detail: string;
+}
+
 /** Data collected by `pragma info` for rendering. */
 export interface InfoData {
   readonly version: string;
@@ -19,6 +26,7 @@ export interface InfoData {
   readonly store:
     | { readonly tripleCount: number; readonly graphNames: readonly string[] }
     | undefined;
+  readonly packageRefs?: readonly PackageRefSummary[];
 }
 
 /** Data collected by `pragma upgrade` for rendering. */

--- a/packages/cli/pragma/src/domains/refs/commands/updateRefs.ts
+++ b/packages/cli/pragma/src/domains/refs/commands/updateRefs.ts
@@ -6,8 +6,8 @@
  */
 
 import type { CommandDefinition } from "@canonical/cli-core";
-import updateRefs from "../operations/updateRefs.js";
 import formatUpdateResults from "../formatters/updateRefs.js";
+import updateRefs from "../operations/updateRefs.js";
 
 const updateRefsCommand: CommandDefinition = {
   path: ["update-refs"],
@@ -21,7 +21,8 @@ const updateRefsCommand: CommandDefinition = {
     },
     {
       name: "prune",
-      description: "Remove orphaned cache entries that no longer match any configured ref",
+      description:
+        "Remove orphaned cache entries that no longer match any configured ref",
       type: "boolean",
       default: false,
     },
@@ -44,9 +45,7 @@ const updateRefsCommand: CommandDefinition = {
     process.stdout.write(`${text}\n`);
 
     const hasErrors = results.some((r) => r.kind === "error");
-    if (hasErrors) process.exitCode = 1;
-
-    return { tag: "silent" as const };
+    return { tag: "exit" as const, code: hasErrors ? 1 : 0 };
   },
 };
 

--- a/packages/cli/pragma/src/domains/refs/commands/updateRefs.ts
+++ b/packages/cli/pragma/src/domains/refs/commands/updateRefs.ts
@@ -1,0 +1,53 @@
+/**
+ * CLI command: pragma update-refs
+ *
+ * Fetches/clones git-referenced semantic packages into the local cache.
+ * Store-skip command — does not boot the ke store.
+ */
+
+import type { CommandDefinition } from "@canonical/cli-core";
+import updateRefs from "../operations/updateRefs.js";
+import formatUpdateResults from "../formatters/updateRefs.js";
+
+const updateRefsCommand: CommandDefinition = {
+  path: ["update-refs"],
+  description:
+    "Fetch or clone git-referenced semantic packages into the local cache",
+  parameters: [
+    {
+      name: "package",
+      description: "Update only this package (by name)",
+      type: "string",
+    },
+    {
+      name: "prune",
+      description: "Remove orphaned cache entries that no longer match any configured ref",
+      type: "boolean",
+      default: false,
+    },
+  ],
+  meta: {
+    examples: [
+      "pragma update-refs",
+      "pragma update-refs --package @canonical/design-system",
+      "pragma update-refs --prune",
+    ],
+  },
+  execute: async (params, ctx) => {
+    const results = await updateRefs({
+      cwd: ctx.cwd,
+      package: params.package as string | undefined,
+      prune: params.prune === true,
+    });
+
+    const text = formatUpdateResults(results);
+    process.stdout.write(`${text}\n`);
+
+    const hasErrors = results.some((r) => r.kind === "error");
+    if (hasErrors) process.exitCode = 1;
+
+    return { tag: "silent" as const };
+  },
+};
+
+export default updateRefsCommand;

--- a/packages/cli/pragma/src/domains/refs/formatters/updateRefs.ts
+++ b/packages/cli/pragma/src/domains/refs/formatters/updateRefs.ts
@@ -1,0 +1,27 @@
+/**
+ * Plain-text formatter for update-refs results.
+ */
+
+import type { UpdateResult } from "../operations/updateRefs.js";
+
+const KIND_LABELS: Record<UpdateResult["kind"], string> = {
+  cloned: "cloned",
+  updated: "updated",
+  "up-to-date": "up to date",
+  ok: "ok",
+  skipped: "skipped",
+  error: "ERROR",
+};
+
+export default function formatUpdateResults(
+  results: ReadonlyArray<UpdateResult>,
+): string {
+  if (results.length === 0) return "No packages configured.";
+
+  const lines: string[] = [];
+  for (const r of results) {
+    const label = KIND_LABELS[r.kind] ?? r.kind;
+    lines.push(`${r.pkg}: ${label} — ${r.detail}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/cli/pragma/src/domains/refs/index.ts
+++ b/packages/cli/pragma/src/domains/refs/index.ts
@@ -1,0 +1,19 @@
+/** @module Refs domain — package reference resolution and update-refs command. */
+
+import type { CommandDefinition } from "@canonical/cli-core";
+import updateRefsCommand from "./commands/updateRefs.js";
+
+/**
+ * Return all refs command definitions.
+ * Store-skip domain — does not require a booted ke store.
+ */
+export function commands(): CommandDefinition[] {
+  return [updateRefsCommand];
+}
+
+export { parsePackageEntry } from "./operations/parseRef.js";
+export type { PackageRef, RawPackageEntry } from "./operations/parseRef.js";
+export { cacheRoot, gitCacheDir, globalConfigDir } from "./operations/paths.js";
+export { default as readGlobalRefs } from "./operations/readGlobalRefs.js";
+export { default as updateRefs } from "./operations/updateRefs.js";
+export type { UpdateResult, UpdateRefsOptions } from "./operations/updateRefs.js";

--- a/packages/cli/pragma/src/domains/refs/index.ts
+++ b/packages/cli/pragma/src/domains/refs/index.ts
@@ -11,12 +11,17 @@ export function commands(): CommandDefinition[] {
   return [updateRefsCommand];
 }
 
-export type { PackageRef, RawPackageEntry } from "./operations/parseRef.js";
-export { parsePackageEntry } from "./operations/parseRef.js";
-export { cacheRoot, gitCacheDir, globalConfigDir } from "./operations/paths.js";
-export { default as readGlobalRefs } from "./operations/readGlobalRefs.js";
+export {
+  cacheRoot,
+  gitCacheDir,
+  globalConfigDir,
+  parsePackageEntry,
+  readGlobalRefs,
+  updateRefs,
+} from "./operations/index.js";
 export type {
+  PackageRef,
+  RawPackageEntry,
   UpdateRefsOptions,
   UpdateResult,
-} from "./operations/updateRefs.js";
-export { default as updateRefs } from "./operations/updateRefs.js";
+} from "./operations/index.js";

--- a/packages/cli/pragma/src/domains/refs/index.ts
+++ b/packages/cli/pragma/src/domains/refs/index.ts
@@ -11,9 +11,12 @@ export function commands(): CommandDefinition[] {
   return [updateRefsCommand];
 }
 
-export { parsePackageEntry } from "./operations/parseRef.js";
 export type { PackageRef, RawPackageEntry } from "./operations/parseRef.js";
+export { parsePackageEntry } from "./operations/parseRef.js";
 export { cacheRoot, gitCacheDir, globalConfigDir } from "./operations/paths.js";
 export { default as readGlobalRefs } from "./operations/readGlobalRefs.js";
+export type {
+  UpdateRefsOptions,
+  UpdateResult,
+} from "./operations/updateRefs.js";
 export { default as updateRefs } from "./operations/updateRefs.js";
-export type { UpdateResult, UpdateRefsOptions } from "./operations/updateRefs.js";

--- a/packages/cli/pragma/src/domains/refs/index.ts
+++ b/packages/cli/pragma/src/domains/refs/index.ts
@@ -11,6 +11,12 @@ export function commands(): CommandDefinition[] {
   return [updateRefsCommand];
 }
 
+export type {
+  PackageRef,
+  RawPackageEntry,
+  UpdateRefsOptions,
+  UpdateResult,
+} from "./operations/index.js";
 export {
   cacheRoot,
   gitCacheDir,
@@ -18,10 +24,4 @@ export {
   parsePackageEntry,
   readGlobalRefs,
   updateRefs,
-} from "./operations/index.js";
-export type {
-  PackageRef,
-  RawPackageEntry,
-  UpdateRefsOptions,
-  UpdateResult,
 } from "./operations/index.js";

--- a/packages/cli/pragma/src/domains/refs/operations/gitOps.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/gitOps.test.ts
@@ -43,8 +43,14 @@ describe("cloneRef + fetchRef (integration, requires git)", () => {
     // Push an initial commit to the bare repo via a temp working copy
     const workDir = join(tmpDir, "work");
     execFileSync("git", ["clone", bareRepo, workDir], { stdio: "pipe" });
-    execFileSync("git", ["-C", workDir, "config", "user.email", "test@test.com"], { stdio: "pipe" });
-    execFileSync("git", ["-C", workDir, "config", "user.name", "Test"], { stdio: "pipe" });
+    execFileSync(
+      "git",
+      ["-C", workDir, "config", "user.email", "test@test.com"],
+      { stdio: "pipe" },
+    );
+    execFileSync("git", ["-C", workDir, "config", "user.name", "Test"], {
+      stdio: "pipe",
+    });
     execFileSync(
       "git",
       ["-C", workDir, "commit", "--allow-empty", "-m", "initial"],

--- a/packages/cli/pragma/src/domains/refs/operations/gitOps.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/gitOps.test.ts
@@ -38,7 +38,9 @@ describe("cloneRef + fetchRef (integration, requires git)", () => {
 
     // Create a bare repo to clone from (avoids network)
     bareRepo = join(tmpDir, "origin.git");
-    execFileSync("git", ["init", "--bare", bareRepo], { stdio: "pipe" });
+    execFileSync("git", ["init", "--bare", "-b", "main", bareRepo], {
+      stdio: "pipe",
+    });
 
     // Push an initial commit to the bare repo via a temp working copy
     const workDir = join(tmpDir, "work");

--- a/packages/cli/pragma/src/domains/refs/operations/gitOps.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/gitOps.test.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cloneRef, fetchRef, isSha, pruneCache } from "./gitOps.js";
+
+describe("isSha", () => {
+  it("recognizes a 7-char hex string", () => {
+    expect(isSha("abc1234")).toBe(true);
+  });
+
+  it("recognizes a 40-char hex string", () => {
+    expect(isSha("abc1234def5678901234567890abcdef12345678")).toBe(true);
+  });
+
+  it("rejects non-hex characters", () => {
+    expect(isSha("main")).toBe(false);
+    expect(isSha("v1.0.0")).toBe(false);
+    expect(isSha("feature/branch")).toBe(false);
+  });
+
+  it("rejects too-short strings", () => {
+    expect(isSha("abc12")).toBe(false);
+  });
+
+  it("rejects uppercase hex", () => {
+    expect(isSha("ABC1234")).toBe(false);
+  });
+});
+
+describe("cloneRef + fetchRef (integration, requires git)", () => {
+  let tmpDir: string;
+  let bareRepo: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pragma-gitops-"));
+
+    // Create a bare repo to clone from (avoids network)
+    bareRepo = join(tmpDir, "origin.git");
+    execFileSync("git", ["init", "--bare", bareRepo], { stdio: "pipe" });
+
+    // Push an initial commit to the bare repo via a temp working copy
+    const workDir = join(tmpDir, "work");
+    execFileSync("git", ["clone", bareRepo, workDir], { stdio: "pipe" });
+    execFileSync("git", ["-C", workDir, "config", "user.email", "test@test.com"], { stdio: "pipe" });
+    execFileSync("git", ["-C", workDir, "config", "user.name", "Test"], { stdio: "pipe" });
+    execFileSync(
+      "git",
+      ["-C", workDir, "commit", "--allow-empty", "-m", "initial"],
+      { stdio: "pipe" },
+    );
+    execFileSync("git", ["-C", workDir, "push", "origin", "main"], {
+      stdio: "pipe",
+    });
+    // Tag it
+    execFileSync("git", ["-C", workDir, "tag", "v0.1.0"], { stdio: "pipe" });
+    execFileSync("git", ["-C", workDir, "push", "origin", "v0.1.0"], {
+      stdio: "pipe",
+    });
+    // Add another commit for update testing
+    execFileSync(
+      "git",
+      ["-C", workDir, "commit", "--allow-empty", "-m", "second"],
+      { stdio: "pipe" },
+    );
+    execFileSync("git", ["-C", workDir, "push", "origin", "main"], {
+      stdio: "pipe",
+    });
+
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("clones a branch ref", () => {
+    const dest = join(tmpDir, "clone-branch");
+    cloneRef(bareRepo, "main", dest);
+    expect(existsSync(join(dest, ".git"))).toBe(true);
+  });
+
+  it("clones a tag ref", () => {
+    const dest = join(tmpDir, "clone-tag");
+    cloneRef(bareRepo, "v0.1.0", dest);
+    expect(existsSync(join(dest, ".git"))).toBe(true);
+  });
+
+  it("clones a SHA ref", () => {
+    // Get the SHA of the initial commit
+    const sha = execFileSync("git", ["-C", bareRepo, "rev-parse", "v0.1.0"], {
+      stdio: "pipe",
+    })
+      .toString()
+      .trim();
+
+    const dest = join(tmpDir, "clone-sha");
+    cloneRef(bareRepo, sha, dest);
+    expect(existsSync(join(dest, ".git"))).toBe(true);
+  });
+
+  it("fetches updates on an existing clone", () => {
+    // Clone at tag (first commit)
+    const dest = join(tmpDir, "clone-fetch");
+    cloneRef(bareRepo, "v0.1.0", dest);
+
+    // Fetch main (which has a second commit)
+    const result = fetchRef(bareRepo, "main", dest);
+    expect(result.updated).toBe(true);
+    expect(result.oldHead).not.toBe(result.newHead);
+  });
+
+  it("reports up-to-date when no changes", () => {
+    const dest = join(tmpDir, "clone-noop");
+    cloneRef(bareRepo, "main", dest);
+
+    const result = fetchRef(bareRepo, "main", dest);
+    expect(result.updated).toBe(false);
+    expect(result.oldHead).toBe(result.newHead);
+  });
+});
+
+describe("pruneCache", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pragma-prune-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("removes an existing directory", () => {
+    const dir = join(tmpDir, "to-remove");
+    execFileSync("mkdir", ["-p", dir]);
+    expect(existsSync(dir)).toBe(true);
+    pruneCache(dir);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("does nothing for a non-existent directory", () => {
+    pruneCache(join(tmpDir, "does-not-exist"));
+    // no throw
+  });
+});

--- a/packages/cli/pragma/src/domains/refs/operations/gitOps.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/gitOps.ts
@@ -1,0 +1,92 @@
+/**
+ * Git operations for managing cached package clones.
+ *
+ * All operations use execFileSync with shell: false for security.
+ * Relies entirely on the user's git client for authentication
+ * (SSH keys, credential helpers). Zero custom auth logic.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
+
+/** Check whether a ref looks like a commit SHA (7-40 hex chars). */
+export function isSha(ref: string): boolean {
+  return /^[0-9a-f]{7,40}$/.test(ref);
+}
+
+/**
+ * Clone a repository at a specific ref into a destination directory.
+ * Uses shallow clone (--depth 1) for speed.
+ *
+ * @param url - Git remote URL (https:// or ssh://).
+ * @param ref - Branch, tag, or commit SHA.
+ * @param dest - Target directory (must not exist).
+ */
+export function cloneRef(url: string, ref: string, dest: string): void {
+  mkdirSync(dirname(dest), { recursive: true });
+
+  if (isSha(ref)) {
+    // Git doesn't support shallow clone by SHA directly.
+    // Init, fetch the specific commit, checkout.
+    mkdirSync(dest, { recursive: true });
+    git(dest, ["init"]);
+    git(dest, ["fetch", "--depth", "1", url, ref]);
+    git(dest, ["checkout", "FETCH_HEAD"]);
+  } else {
+    // Branches and tags: --branch works with --depth 1
+    execFileSync("git", ["clone", "--depth", "1", "--branch", ref, url, dest], {
+      stdio: "pipe",
+    });
+  }
+}
+
+/**
+ * Update an existing cached clone by fetching the latest for its ref.
+ *
+ * @param url - Git remote URL.
+ * @param ref - Branch, tag, or commit SHA.
+ * @param dest - Existing cache directory.
+ * @returns Whether the HEAD changed after fetch.
+ */
+export function fetchRef(
+  url: string,
+  ref: string,
+  dest: string,
+): { updated: boolean; oldHead: string; newHead: string } {
+  const oldHead = gitOutput(dest, ["rev-parse", "HEAD"]);
+
+  if (isSha(ref)) {
+    git(dest, ["fetch", "--depth", "1", url, ref]);
+    git(dest, ["checkout", "FETCH_HEAD"]);
+  } else {
+    git(dest, ["fetch", "--depth", "1", url, ref]);
+    git(dest, ["checkout", "FETCH_HEAD"]);
+  }
+
+  const newHead = gitOutput(dest, ["rev-parse", "HEAD"]);
+  return { updated: oldHead !== newHead, oldHead, newHead };
+}
+
+/**
+ * Remove a cached directory.
+ */
+export function pruneCache(dir: string): void {
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Run a git command in a directory. Throws on non-zero exit. */
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+/** Run a git command and return trimmed stdout. */
+function gitOutput(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, stdio: "pipe" }).toString().trim();
+}

--- a/packages/cli/pragma/src/domains/refs/operations/index.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/index.ts
@@ -1,13 +1,10 @@
 /** @module Refs operations — parsing, resolution, caching, and update logic. */
 
+export { cloneRef, fetchRef, isSha, pruneCache } from "./gitOps.js";
 export type { PackageRef, RawPackageEntry } from "./parseRef.js";
 export { parsePackageEntry } from "./parseRef.js";
-
 export { cacheRoot, gitCacheDir, globalConfigDir } from "./paths.js";
-
 export { default as readGlobalRefs } from "./readGlobalRefs.js";
-
-export { cloneRef, fetchRef, isSha, pruneCache } from "./gitOps.js";
 
 export type { UpdateRefsOptions, UpdateResult } from "./updateRefs.js";
 export { default as updateRefs } from "./updateRefs.js";

--- a/packages/cli/pragma/src/domains/refs/operations/index.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/index.ts
@@ -1,0 +1,13 @@
+/** @module Refs operations — parsing, resolution, caching, and update logic. */
+
+export type { PackageRef, RawPackageEntry } from "./parseRef.js";
+export { parsePackageEntry } from "./parseRef.js";
+
+export { cacheRoot, gitCacheDir, globalConfigDir } from "./paths.js";
+
+export { default as readGlobalRefs } from "./readGlobalRefs.js";
+
+export { cloneRef, fetchRef, isSha, pruneCache } from "./gitOps.js";
+
+export type { UpdateRefsOptions, UpdateResult } from "./updateRefs.js";
+export { default as updateRefs } from "./updateRefs.js";

--- a/packages/cli/pragma/src/domains/refs/operations/parseRef.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/parseRef.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { PragmaError } from "../../../error/index.js";
+import { parsePackageEntry } from "./parseRef.js";
+
+describe("parsePackageEntry", () => {
+  describe("npm references", () => {
+    it("parses a bare string as npm", () => {
+      const ref = parsePackageEntry("@canonical/design-system");
+      expect(ref).toEqual({ kind: "npm", pkg: "@canonical/design-system" });
+    });
+
+    it("parses an object without source as npm", () => {
+      const ref = parsePackageEntry({ name: "@canonical/design-system" });
+      expect(ref).toEqual({ kind: "npm", pkg: "@canonical/design-system" });
+    });
+
+    it("parses an object with undefined source as npm", () => {
+      const ref = parsePackageEntry({
+        name: "@canonical/design-system",
+        source: undefined,
+      });
+      expect(ref).toEqual({ kind: "npm", pkg: "@canonical/design-system" });
+    });
+  });
+
+  describe("file references", () => {
+    it("parses file:// source with absolute path", () => {
+      const ref = parsePackageEntry({
+        name: "@canonical/design-system",
+        source: "file:///home/user/code/design-system",
+      });
+      expect(ref).toEqual({
+        kind: "file",
+        pkg: "@canonical/design-system",
+        path: "/home/user/code/design-system",
+      });
+    });
+
+    it("parses file:// source with relative path", () => {
+      const ref = parsePackageEntry({
+        name: "@canonical/design-system",
+        source: "file://./local-packages/design-system",
+      });
+      expect(ref).toEqual({
+        kind: "file",
+        pkg: "@canonical/design-system",
+        path: "./local-packages/design-system",
+      });
+    });
+
+    it("throws on empty file:// path", () => {
+      expect(() =>
+        parsePackageEntry({
+          name: "@canonical/design-system",
+          source: "file://",
+        }),
+      ).toThrow(PragmaError);
+    });
+  });
+
+  describe("git references", () => {
+    it("parses git+https:// source with branch ref", () => {
+      const ref = parsePackageEntry({
+        name: "@canonical/design-system",
+        source: "git+https://github.com/canonical/design-system.git#main",
+      });
+      expect(ref).toEqual({
+        kind: "git",
+        pkg: "@canonical/design-system",
+        url: "https://github.com/canonical/design-system.git",
+        ref: "main",
+      });
+    });
+
+    it("parses git+https:// source with tag ref", () => {
+      const ref = parsePackageEntry({
+        name: "@canonical/design-system",
+        source: "git+https://github.com/canonical/design-system.git#v0.3.0",
+      });
+      expect(ref).toEqual({
+        kind: "git",
+        pkg: "@canonical/design-system",
+        url: "https://github.com/canonical/design-system.git",
+        ref: "v0.3.0",
+      });
+    });
+
+    it("parses git+https:// source with SHA ref", () => {
+      const ref = parsePackageEntry({
+        name: "@canonical/design-system",
+        source:
+          "git+https://github.com/canonical/design-system.git#abc1234def5678",
+      });
+      expect(ref).toEqual({
+        kind: "git",
+        pkg: "@canonical/design-system",
+        url: "https://github.com/canonical/design-system.git",
+        ref: "abc1234def5678",
+      });
+    });
+
+    it("parses git+ssh:// source", () => {
+      const ref = parsePackageEntry({
+        name: "@canonical/design-system",
+        source:
+          "git+ssh://git@github.com/canonical/design-system.git#main",
+      });
+      expect(ref).toEqual({
+        kind: "git",
+        pkg: "@canonical/design-system",
+        url: "ssh://git@github.com/canonical/design-system.git",
+        ref: "main",
+      });
+    });
+
+    it("throws on git URL without #ref", () => {
+      expect(() =>
+        parsePackageEntry({
+          name: "@canonical/design-system",
+          source:
+            "git+https://github.com/canonical/design-system.git",
+        }),
+      ).toThrow(PragmaError);
+    });
+
+    it("throws on git URL with empty ref after #", () => {
+      expect(() =>
+        parsePackageEntry({
+          name: "@canonical/design-system",
+          source:
+            "git+https://github.com/canonical/design-system.git#",
+        }),
+      ).toThrow(PragmaError);
+    });
+  });
+
+  describe("invalid entries", () => {
+    it("throws on unknown source scheme", () => {
+      expect(() =>
+        parsePackageEntry({
+          name: "@canonical/design-system",
+          source: "https://example.com/package.tar.gz",
+        }),
+      ).toThrow(PragmaError);
+    });
+
+    it("throws on empty name", () => {
+      expect(() =>
+        parsePackageEntry({ name: "" }),
+      ).toThrow(PragmaError);
+    });
+
+    it("throws on non-string source", () => {
+      expect(() =>
+        parsePackageEntry({
+          name: "@canonical/design-system",
+          source: 42 as unknown as string,
+        }),
+      ).toThrow(PragmaError);
+    });
+  });
+});

--- a/packages/cli/pragma/src/domains/refs/operations/parseRef.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/parseRef.test.ts
@@ -102,8 +102,7 @@ describe("parsePackageEntry", () => {
     it("parses git+ssh:// source", () => {
       const ref = parsePackageEntry({
         name: "@canonical/design-system",
-        source:
-          "git+ssh://git@github.com/canonical/design-system.git#main",
+        source: "git+ssh://git@github.com/canonical/design-system.git#main",
       });
       expect(ref).toEqual({
         kind: "git",
@@ -117,8 +116,7 @@ describe("parsePackageEntry", () => {
       expect(() =>
         parsePackageEntry({
           name: "@canonical/design-system",
-          source:
-            "git+https://github.com/canonical/design-system.git",
+          source: "git+https://github.com/canonical/design-system.git",
         }),
       ).toThrow(PragmaError);
     });
@@ -127,8 +125,7 @@ describe("parsePackageEntry", () => {
       expect(() =>
         parsePackageEntry({
           name: "@canonical/design-system",
-          source:
-            "git+https://github.com/canonical/design-system.git#",
+          source: "git+https://github.com/canonical/design-system.git#",
         }),
       ).toThrow(PragmaError);
     });
@@ -145,9 +142,7 @@ describe("parsePackageEntry", () => {
     });
 
     it("throws on empty name", () => {
-      expect(() =>
-        parsePackageEntry({ name: "" }),
-      ).toThrow(PragmaError);
+      expect(() => parsePackageEntry({ name: "" })).toThrow(PragmaError);
     });
 
     it("throws on non-string source", () => {

--- a/packages/cli/pragma/src/domains/refs/operations/parseRef.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/parseRef.ts
@@ -13,13 +13,20 @@ import { PragmaError } from "../../../error/index.js";
 // ---------------------------------------------------------------------------
 
 /** Raw entry shape accepted in pragma.config.json `packages` array. */
-export type RawPackageEntry = string | { readonly name: string; readonly source?: string };
+export type RawPackageEntry =
+  | string
+  | { readonly name: string; readonly source?: string };
 
 /** Parsed, validated package reference — discriminated by `kind`. */
 export type PackageRef =
   | { readonly kind: "npm"; readonly pkg: string }
   | { readonly kind: "file"; readonly pkg: string; readonly path: string }
-  | { readonly kind: "git"; readonly pkg: string; readonly url: string; readonly ref: string };
+  | {
+      readonly kind: "git";
+      readonly pkg: string;
+      readonly url: string;
+      readonly ref: string;
+    };
 
 // ---------------------------------------------------------------------------
 // Parser
@@ -41,11 +48,11 @@ export function parsePackageEntry(entry: RawPackageEntry): PackageRef {
 
   if (typeof name !== "string" || name.length === 0) {
     throw PragmaError.configError(
-      "Package entry must have a non-empty \"name\" field.",
+      'Package entry must have a non-empty "name" field.',
       {
         recovery: {
           message:
-            "Each object in the \"packages\" array requires a \"name\" string.",
+            'Each object in the "packages" array requires a "name" string.',
         },
       },
     );
@@ -85,8 +92,7 @@ export function parsePackageEntry(entry: RawPackageEntry): PackageRef {
         `Invalid source for "${name}": git URL must include a ref after #.`,
         {
           recovery: {
-            message:
-              "Example: git+https://github.com/org/repo.git#main",
+            message: "Example: git+https://github.com/org/repo.git#main",
           },
         },
       );

--- a/packages/cli/pragma/src/domains/refs/operations/parseRef.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/parseRef.ts
@@ -1,0 +1,127 @@
+/**
+ * Package reference parser.
+ *
+ * Parses pragma.config.json `packages` entries into a discriminated union
+ * of resolution strategies: npm (require.resolve), file (local path), or
+ * git (cached shallow clone).
+ */
+
+import { PragmaError } from "../../../error/index.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Raw entry shape accepted in pragma.config.json `packages` array. */
+export type RawPackageEntry = string | { readonly name: string; readonly source?: string };
+
+/** Parsed, validated package reference — discriminated by `kind`. */
+export type PackageRef =
+  | { readonly kind: "npm"; readonly pkg: string }
+  | { readonly kind: "file"; readonly pkg: string; readonly path: string }
+  | { readonly kind: "git"; readonly pkg: string; readonly url: string; readonly ref: string };
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a raw package entry into a typed PackageRef.
+ *
+ * @param entry - String (npm package name) or object with optional source.
+ * @returns Parsed PackageRef.
+ * @throws PragmaError with code CONFIG_ERROR on invalid format.
+ */
+export function parsePackageEntry(entry: RawPackageEntry): PackageRef {
+  if (typeof entry === "string") {
+    return { kind: "npm", pkg: entry };
+  }
+
+  const { name, source } = entry;
+
+  if (typeof name !== "string" || name.length === 0) {
+    throw PragmaError.configError(
+      "Package entry must have a non-empty \"name\" field.",
+      {
+        recovery: {
+          message:
+            "Each object in the \"packages\" array requires a \"name\" string.",
+        },
+      },
+    );
+  }
+
+  if (source === undefined || source === null) {
+    return { kind: "npm", pkg: name };
+  }
+
+  if (typeof source !== "string") {
+    throw PragmaError.configError(
+      `Invalid source for "${name}": expected a string.`,
+    );
+  }
+
+  // file:// — local path override
+  if (source.startsWith("file://")) {
+    const path = source.slice(7);
+    if (path.length === 0) {
+      throw PragmaError.configError(
+        `Invalid source for "${name}": file:// must be followed by a path.`,
+        {
+          recovery: {
+            message: "Example: file:///home/user/code/my-package",
+          },
+        },
+      );
+    }
+    return { kind: "file", pkg: name, path };
+  }
+
+  // git+https:// — git ref
+  if (source.startsWith("git+https://")) {
+    const hashIdx = source.indexOf("#");
+    if (hashIdx === -1 || hashIdx === source.length - 1) {
+      throw PragmaError.configError(
+        `Invalid source for "${name}": git URL must include a ref after #.`,
+        {
+          recovery: {
+            message:
+              "Example: git+https://github.com/org/repo.git#main",
+          },
+        },
+      );
+    }
+    const url = source.slice(4, hashIdx); // strip "git+" prefix, keep up to #
+    const ref = source.slice(hashIdx + 1);
+    return { kind: "git", pkg: name, url, ref };
+  }
+
+  // git+ssh:// — git ref (SSH)
+  if (source.startsWith("git+ssh://")) {
+    const hashIdx = source.indexOf("#");
+    if (hashIdx === -1 || hashIdx === source.length - 1) {
+      throw PragmaError.configError(
+        `Invalid source for "${name}": git URL must include a ref after #.`,
+        {
+          recovery: {
+            message:
+              "Example: git+ssh://git@github.com/org/repo.git#main",
+          },
+        },
+      );
+    }
+    const url = source.slice(4, hashIdx);
+    const ref = source.slice(hashIdx + 1);
+    return { kind: "git", pkg: name, url, ref };
+  }
+
+  throw PragmaError.configError(
+    `Invalid source for "${name}": "${source}". Expected file://, git+https://, or git+ssh://.`,
+    {
+      recovery: {
+        message:
+          "Valid formats:\n  file:///absolute/path\n  git+https://host/repo.git#ref\n  git+ssh://git@host/repo.git#ref",
+      },
+    },
+  );
+}

--- a/packages/cli/pragma/src/domains/refs/operations/parseRef.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/parseRef.ts
@@ -77,8 +77,8 @@ export function parsePackageEntry(entry: RawPackageEntry): PackageRef {
     return { kind: "file", pkg: name, path };
   }
 
-  // git+https:// — git ref
-  if (source.startsWith("git+https://")) {
+  // git+<protocol>:// — git ref (https, ssh, file)
+  if (source.startsWith("git+")) {
     const hashIdx = source.indexOf("#");
     if (hashIdx === -1 || hashIdx === source.length - 1) {
       throw PragmaError.configError(
@@ -96,31 +96,12 @@ export function parsePackageEntry(entry: RawPackageEntry): PackageRef {
     return { kind: "git", pkg: name, url, ref };
   }
 
-  // git+ssh:// — git ref (SSH)
-  if (source.startsWith("git+ssh://")) {
-    const hashIdx = source.indexOf("#");
-    if (hashIdx === -1 || hashIdx === source.length - 1) {
-      throw PragmaError.configError(
-        `Invalid source for "${name}": git URL must include a ref after #.`,
-        {
-          recovery: {
-            message:
-              "Example: git+ssh://git@github.com/org/repo.git#main",
-          },
-        },
-      );
-    }
-    const url = source.slice(4, hashIdx);
-    const ref = source.slice(hashIdx + 1);
-    return { kind: "git", pkg: name, url, ref };
-  }
-
   throw PragmaError.configError(
-    `Invalid source for "${name}": "${source}". Expected file://, git+https://, or git+ssh://.`,
+    `Invalid source for "${name}": "${source}". Expected file://, git+https://, git+ssh://, or git+file://.`,
     {
       recovery: {
         message:
-          "Valid formats:\n  file:///absolute/path\n  git+https://host/repo.git#ref\n  git+ssh://git@host/repo.git#ref",
+          "Valid formats:\n  file:///absolute/path\n  git+https://host/repo.git#ref\n  git+ssh://git@host/repo.git#ref\n  git+file:///local/bare/repo.git#ref",
       },
     },
   );

--- a/packages/cli/pragma/src/domains/refs/operations/paths.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/paths.test.ts
@@ -1,0 +1,93 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cacheRoot, gitCacheDir, globalConfigDir } from "./paths.js";
+
+describe("cacheRoot", () => {
+  const origEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it("uses PRAGMA_CACHE_DIR when set", () => {
+    process.env.PRAGMA_CACHE_DIR = "/tmp/pragma-test-cache";
+    expect(cacheRoot()).toBe("/tmp/pragma-test-cache");
+  });
+
+  it("uses XDG_CACHE_HOME/pragma when set", () => {
+    delete process.env.PRAGMA_CACHE_DIR;
+    process.env.XDG_CACHE_HOME = "/tmp/xdg-cache";
+    expect(cacheRoot()).toBe(join("/tmp/xdg-cache", "pragma"));
+  });
+
+  it("PRAGMA_CACHE_DIR takes precedence over XDG_CACHE_HOME", () => {
+    process.env.PRAGMA_CACHE_DIR = "/tmp/pragma-override";
+    process.env.XDG_CACHE_HOME = "/tmp/xdg-cache";
+    expect(cacheRoot()).toBe("/tmp/pragma-override");
+  });
+
+  it("falls back to ~/.cache/pragma", () => {
+    delete process.env.PRAGMA_CACHE_DIR;
+    delete process.env.XDG_CACHE_HOME;
+    expect(cacheRoot()).toBe(join(homedir(), ".cache", "pragma"));
+  });
+});
+
+describe("globalConfigDir", () => {
+  const origEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it("uses XDG_CONFIG_HOME/pragma when set", () => {
+    process.env.XDG_CONFIG_HOME = "/tmp/xdg-config";
+    expect(globalConfigDir()).toBe(join("/tmp/xdg-config", "pragma"));
+  });
+
+  it("falls back to ~/.config/pragma", () => {
+    delete process.env.XDG_CONFIG_HOME;
+    expect(globalConfigDir()).toBe(join(homedir(), ".config", "pragma"));
+  });
+});
+
+describe("gitCacheDir", () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.PRAGMA_CACHE_DIR = "/tmp/pragma-test-cache";
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it("returns cache path for a package and ref", () => {
+    expect(gitCacheDir("@canonical/design-system", "main")).toBe(
+      join("/tmp/pragma-test-cache", "refs", "@canonical/design-system", "main"),
+    );
+  });
+
+  it("sanitizes slashes in ref", () => {
+    expect(gitCacheDir("@canonical/design-system", "feature/branch")).toBe(
+      join(
+        "/tmp/pragma-test-cache",
+        "refs",
+        "@canonical/design-system",
+        "feature_branch",
+      ),
+    );
+  });
+
+  it("sanitizes colons in ref", () => {
+    expect(gitCacheDir("@canonical/design-system", "v1:beta")).toBe(
+      join(
+        "/tmp/pragma-test-cache",
+        "refs",
+        "@canonical/design-system",
+        "v1_beta",
+      ),
+    );
+  });
+});

--- a/packages/cli/pragma/src/domains/refs/operations/paths.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/paths.test.ts
@@ -65,7 +65,12 @@ describe("gitCacheDir", () => {
 
   it("returns cache path for a package and ref", () => {
     expect(gitCacheDir("@canonical/design-system", "main")).toBe(
-      join("/tmp/pragma-test-cache", "refs", "@canonical/design-system", "main"),
+      join(
+        "/tmp/pragma-test-cache",
+        "refs",
+        "@canonical/design-system",
+        "main",
+      ),
     );
   });
 

--- a/packages/cli/pragma/src/domains/refs/operations/paths.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/paths.ts
@@ -1,0 +1,63 @@
+/**
+ * Cross-platform path resolution for pragma cache and global config.
+ *
+ * Respects XDG Base Directory Specification:
+ * - XDG_CACHE_HOME for cache (default: ~/.cache)
+ * - XDG_CONFIG_HOME for global config (default: ~/.config)
+ *
+ * Override via PRAGMA_CACHE_DIR for CI and testing.
+ * Uses os.homedir() for macOS/WSL/Linux portability.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Root directory for pragma cache data.
+ *
+ * Resolution order:
+ * 1. PRAGMA_CACHE_DIR environment variable (CI/testing override)
+ * 2. XDG_CACHE_HOME/pragma (XDG spec)
+ * 3. ~/.cache/pragma (default)
+ */
+export function cacheRoot(): string {
+  if (process.env.PRAGMA_CACHE_DIR) {
+    return process.env.PRAGMA_CACHE_DIR;
+  }
+  const xdg = process.env.XDG_CACHE_HOME;
+  const base = xdg ?? join(homedir(), ".cache");
+  return join(base, "pragma");
+}
+
+/**
+ * Root directory for pragma global configuration.
+ *
+ * Resolution order:
+ * 1. XDG_CONFIG_HOME/pragma (XDG spec)
+ * 2. ~/.config/pragma (default)
+ */
+export function globalConfigDir(): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const base = xdg ?? join(homedir(), ".config");
+  return join(base, "pragma");
+}
+
+/**
+ * Cache directory for a specific git-ref-resolved package.
+ *
+ * @param pkg - Package name (e.g., "@canonical/design-system").
+ * @param ref - Git ref (e.g., "main", "v0.3.0", "abc1234").
+ * @returns Absolute path to the cached clone directory.
+ */
+export function gitCacheDir(pkg: string, ref: string): string {
+  const sanitizedRef = sanitizeRef(ref);
+  return join(cacheRoot(), "refs", pkg, sanitizedRef);
+}
+
+/**
+ * Sanitize a git ref for use as a directory name.
+ * Replaces characters that are invalid or confusing in path segments.
+ */
+function sanitizeRef(ref: string): string {
+  return ref.replace(/[/\\:*?"<>|]/g, "_");
+}

--- a/packages/cli/pragma/src/domains/refs/operations/readGlobalRefs.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/readGlobalRefs.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/packages/cli/pragma/src/domains/refs/operations/readGlobalRefs.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/readGlobalRefs.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import readGlobalRefs from "./readGlobalRefs.js";
+
+describe("readGlobalRefs", () => {
+  let tmpDir: string;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pragma-global-refs-"));
+    // Point XDG_CONFIG_HOME to our temp dir so globalConfigDir() resolves there
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when refs.json does not exist", () => {
+    expect(readGlobalRefs()).toEqual([]);
+  });
+
+  it("returns empty array when refs.json is malformed JSON", () => {
+    const dir = join(tmpDir, "pragma");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "refs.json"), "{bad json");
+    expect(readGlobalRefs()).toEqual([]);
+  });
+
+  it("returns empty array when packages field is missing", () => {
+    const dir = join(tmpDir, "pragma");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "refs.json"), "{}");
+    expect(readGlobalRefs()).toEqual([]);
+  });
+
+  it("returns empty array when packages is not an array", () => {
+    const dir = join(tmpDir, "pragma");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "refs.json"),
+      JSON.stringify({ packages: "not-array" }),
+    );
+    expect(readGlobalRefs()).toEqual([]);
+  });
+
+  it("returns packages array from valid refs.json", () => {
+    const dir = join(tmpDir, "pragma");
+    mkdirSync(dir, { recursive: true });
+    const packages = [
+      "@canonical/design-system",
+      {
+        name: "@canonical/code-standards",
+        source: "file:///home/user/code/code-standards",
+      },
+    ];
+    writeFileSync(join(dir, "refs.json"), JSON.stringify({ packages }));
+    expect(readGlobalRefs()).toEqual(packages);
+  });
+});

--- a/packages/cli/pragma/src/domains/refs/operations/readGlobalRefs.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/readGlobalRefs.ts
@@ -1,0 +1,37 @@
+/**
+ * Read global package refs from ~/.config/pragma/refs.json.
+ *
+ * Global refs provide user-level overrides that apply to all projects.
+ * Project-level `pragma.config.json` overrides global refs.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { RawPackageEntry } from "./parseRef.js";
+import { globalConfigDir } from "./paths.js";
+
+/**
+ * Read global package references.
+ *
+ * @returns The `packages` array from `~/.config/pragma/refs.json`, or
+ *          an empty array when the file is missing or malformed.
+ */
+export default function readGlobalRefs(): ReadonlyArray<RawPackageEntry> {
+  const refsPath = join(globalConfigDir(), "refs.json");
+
+  let raw: string;
+  try {
+    raw = readFileSync(refsPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const packages = parsed.packages;
+    if (!Array.isArray(packages)) return [];
+    return packages as RawPackageEntry[];
+  } catch {
+    return [];
+  }
+}

--- a/packages/cli/pragma/src/domains/refs/operations/updateRefs.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/updateRefs.test.ts
@@ -1,0 +1,165 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import updateRefs from "./updateRefs.js";
+
+describe("updateRefs", () => {
+  let tmpDir: string;
+  let projectDir: string;
+  let bareRepo: string;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pragma-update-refs-"));
+    projectDir = join(tmpDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    // Point cache to temp dir
+    process.env.PRAGMA_CACHE_DIR = join(tmpDir, "cache");
+    // No global refs
+    process.env.XDG_CONFIG_HOME = join(tmpDir, "no-global-config");
+
+    // Create a bare git repo for testing
+    bareRepo = join(tmpDir, "origin.git");
+    execFileSync("git", ["init", "--bare", bareRepo], { stdio: "pipe" });
+
+    const workDir = join(tmpDir, "work");
+    execFileSync("git", ["clone", bareRepo, workDir], { stdio: "pipe" });
+    execFileSync("git", ["-C", workDir, "config", "user.email", "t@t.com"], { stdio: "pipe" });
+    execFileSync("git", ["-C", workDir, "config", "user.name", "T"], { stdio: "pipe" });
+    execFileSync(
+      "git",
+      ["-C", workDir, "commit", "--allow-empty", "-m", "init"],
+      { stdio: "pipe" },
+    );
+    execFileSync("git", ["-C", workDir, "push", "origin", "main"], {
+      stdio: "pipe",
+    });
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("clones a git ref on first run", async () => {
+    writeFileSync(
+      join(projectDir, "pragma.config.json"),
+      JSON.stringify({
+        packages: [
+          {
+            name: "@test/pkg",
+            source: `git+file://${bareRepo}#main`,
+          },
+        ],
+      }),
+    );
+
+    const results = await updateRefs({ cwd: projectDir });
+    expect(results).toHaveLength(1);
+    expect(results[0].kind).toBe("cloned");
+    expect(results[0].pkg).toBe("@test/pkg");
+  });
+
+  it("reports up-to-date on second run without changes", async () => {
+    writeFileSync(
+      join(projectDir, "pragma.config.json"),
+      JSON.stringify({
+        packages: [
+          {
+            name: "@test/pkg",
+            source: `git+file://${bareRepo}#main`,
+          },
+        ],
+      }),
+    );
+
+    await updateRefs({ cwd: projectDir });
+    const results = await updateRefs({ cwd: projectDir });
+    expect(results).toHaveLength(1);
+    expect(results[0].kind).toBe("up-to-date");
+  });
+
+  it("reports ok for file:// ref pointing to existing path", async () => {
+    const localPkg = join(tmpDir, "local-pkg");
+    mkdirSync(localPkg, { recursive: true });
+
+    writeFileSync(
+      join(projectDir, "pragma.config.json"),
+      JSON.stringify({
+        packages: [
+          { name: "@test/local", source: `file://${localPkg}` },
+        ],
+      }),
+    );
+
+    const results = await updateRefs({ cwd: projectDir });
+    expect(results).toHaveLength(1);
+    expect(results[0].kind).toBe("ok");
+  });
+
+  it("reports error for file:// ref pointing to missing path", async () => {
+    writeFileSync(
+      join(projectDir, "pragma.config.json"),
+      JSON.stringify({
+        packages: [
+          { name: "@test/missing", source: "file:///nonexistent/path" },
+        ],
+      }),
+    );
+
+    const results = await updateRefs({ cwd: projectDir });
+    expect(results).toHaveLength(1);
+    expect(results[0].kind).toBe("error");
+  });
+
+  it("skips npm packages", async () => {
+    writeFileSync(
+      join(projectDir, "pragma.config.json"),
+      JSON.stringify({
+        packages: ["@canonical/design-system"],
+      }),
+    );
+
+    const results = await updateRefs({ cwd: projectDir });
+    expect(results).toHaveLength(1);
+    expect(results[0].kind).toBe("skipped");
+  });
+
+  it("filters by --package flag", async () => {
+    writeFileSync(
+      join(projectDir, "pragma.config.json"),
+      JSON.stringify({
+        packages: [
+          "@canonical/design-system",
+          {
+            name: "@test/pkg",
+            source: `git+file://${bareRepo}#main`,
+          },
+        ],
+      }),
+    );
+
+    const results = await updateRefs({
+      cwd: projectDir,
+      package: "@test/pkg",
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].pkg).toBe("@test/pkg");
+  });
+
+  it("uses defaults when no config exists", async () => {
+    const results = await updateRefs({ cwd: projectDir });
+    // All 4 defaults are npm, so all skipped
+    expect(results.every((r) => r.kind === "skipped")).toBe(true);
+    expect(results).toHaveLength(4);
+  });
+});

--- a/packages/cli/pragma/src/domains/refs/operations/updateRefs.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/updateRefs.test.ts
@@ -23,7 +23,9 @@ describe("updateRefs", () => {
 
     // Create a bare git repo for testing
     bareRepo = join(tmpDir, "origin.git");
-    execFileSync("git", ["init", "--bare", bareRepo], { stdio: "pipe" });
+    execFileSync("git", ["init", "--bare", "-b", "main", bareRepo], {
+      stdio: "pipe",
+    });
 
     const workDir = join(tmpDir, "work");
     execFileSync("git", ["clone", bareRepo, workDir], { stdio: "pipe" });

--- a/packages/cli/pragma/src/domains/refs/operations/updateRefs.test.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/updateRefs.test.ts
@@ -1,10 +1,5 @@
 import { execFileSync } from "node:child_process";
-import {
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -32,8 +27,12 @@ describe("updateRefs", () => {
 
     const workDir = join(tmpDir, "work");
     execFileSync("git", ["clone", bareRepo, workDir], { stdio: "pipe" });
-    execFileSync("git", ["-C", workDir, "config", "user.email", "t@t.com"], { stdio: "pipe" });
-    execFileSync("git", ["-C", workDir, "config", "user.name", "T"], { stdio: "pipe" });
+    execFileSync("git", ["-C", workDir, "config", "user.email", "t@t.com"], {
+      stdio: "pipe",
+    });
+    execFileSync("git", ["-C", workDir, "config", "user.name", "T"], {
+      stdio: "pipe",
+    });
     execFileSync(
       "git",
       ["-C", workDir, "commit", "--allow-empty", "-m", "init"],
@@ -95,9 +94,7 @@ describe("updateRefs", () => {
     writeFileSync(
       join(projectDir, "pragma.config.json"),
       JSON.stringify({
-        packages: [
-          { name: "@test/local", source: `file://${localPkg}` },
-        ],
+        packages: [{ name: "@test/local", source: `file://${localPkg}` }],
       }),
     );
 

--- a/packages/cli/pragma/src/domains/refs/operations/updateRefs.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/updateRefs.ts
@@ -1,0 +1,203 @@
+/**
+ * Update operation: fetch/clone git refs into the local cache.
+ *
+ * Reads project + global config, merges, and for each git ref either
+ * clones (first time) or fetches (subsequent). Reports per-package status.
+ */
+
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { readConfig } from "#config";
+import type { PackageRef, RawPackageEntry } from "./parseRef.js";
+import { parsePackageEntry } from "./parseRef.js";
+import { cacheRoot, gitCacheDir } from "./paths.js";
+import readGlobalRefs from "./readGlobalRefs.js";
+import { cloneRef, fetchRef, pruneCache } from "./gitOps.js";
+import { DEFAULT_PACKAGES } from "../../shared/packages.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UpdateResult {
+  readonly pkg: string;
+  readonly kind: "cloned" | "updated" | "up-to-date" | "ok" | "skipped" | "error";
+  readonly detail: string;
+}
+
+export interface UpdateRefsOptions {
+  /** Working directory for reading project config. */
+  cwd: string;
+  /** Update only this package (by name). */
+  package?: string;
+  /** Remove orphaned cache directories. */
+  prune?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Operation
+// ---------------------------------------------------------------------------
+
+/**
+ * Update cached git refs.
+ *
+ * For each configured package:
+ * - git refs: clone or fetch into cache
+ * - file refs: verify the path exists
+ * - npm refs: skip (nothing to update)
+ */
+export default async function updateRefs(
+  options: UpdateRefsOptions,
+): Promise<UpdateResult[]> {
+  const config = readConfig(options.cwd);
+  const refs = mergeEntries(config.packages);
+  const results: UpdateResult[] = [];
+
+  for (const ref of refs) {
+    if (options.package && ref.pkg !== options.package) continue;
+
+    switch (ref.kind) {
+      case "git": {
+        const dest = gitCacheDir(ref.pkg, ref.ref);
+        try {
+          if (existsSync(dest)) {
+            const { updated, oldHead, newHead } = fetchRef(ref.url, ref.ref, dest);
+            results.push({
+              pkg: ref.pkg,
+              kind: updated ? "updated" : "up-to-date",
+              detail: updated
+                ? `${oldHead.slice(0, 7)} → ${newHead.slice(0, 7)}`
+                : `at ${newHead.slice(0, 7)}`,
+            });
+          } else {
+            cloneRef(ref.url, ref.ref, dest);
+            results.push({
+              pkg: ref.pkg,
+              kind: "cloned",
+              detail: `${ref.url}#${ref.ref}`,
+            });
+          }
+        } catch (err) {
+          results.push({
+            pkg: ref.pkg,
+            kind: "error",
+            detail: err instanceof Error ? err.message : String(err),
+          });
+        }
+        break;
+      }
+
+      case "file": {
+        results.push({
+          pkg: ref.pkg,
+          kind: existsSync(ref.path) ? "ok" : "error",
+          detail: existsSync(ref.path)
+            ? `path exists: ${ref.path}`
+            : `path not found: ${ref.path}`,
+        });
+        break;
+      }
+
+      case "npm": {
+        results.push({
+          pkg: ref.pkg,
+          kind: "skipped",
+          detail: "using npm (no ref configured)",
+        });
+        break;
+      }
+    }
+  }
+
+  if (options.prune) {
+    const pruned = pruneOrphanedCaches(refs);
+    for (const dir of pruned) {
+      results.push({
+        pkg: "(orphan)",
+        kind: "ok",
+        detail: `pruned: ${dir}`,
+      });
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Merge global + project entries, parse into PackageRef[]. */
+function mergeEntries(
+  projectPackages?: ReadonlyArray<RawPackageEntry>,
+): PackageRef[] {
+  const globalEntries = readGlobalRefs();
+
+  if (
+    (!projectPackages || projectPackages.length === 0) &&
+    globalEntries.length === 0
+  ) {
+    return DEFAULT_PACKAGES.map((pkg) => parsePackageEntry(pkg));
+  }
+
+  const merged = new Map<string, RawPackageEntry>();
+
+  for (const pkg of DEFAULT_PACKAGES) {
+    merged.set(pkg, pkg);
+  }
+  for (const entry of globalEntries) {
+    const name = typeof entry === "string" ? entry : entry.name;
+    merged.set(name, entry);
+  }
+  if (projectPackages) {
+    merged.clear();
+    for (const entry of projectPackages) {
+      const name = typeof entry === "string" ? entry : entry.name;
+      merged.set(name, entry);
+    }
+  }
+
+  return [...merged.values()].map(parsePackageEntry);
+}
+
+/**
+ * Remove cache directories that don't match any configured git ref.
+ * Returns list of removed directories.
+ */
+function pruneOrphanedCaches(refs: PackageRef[]): string[] {
+  const validDirs = new Set(
+    refs
+      .filter((r): r is Extract<PackageRef, { kind: "git" }> => r.kind === "git")
+      .map((r) => gitCacheDir(r.pkg, r.ref)),
+  );
+
+  const refsDir = join(cacheRoot(), "refs");
+  if (!existsSync(refsDir)) return [];
+
+  const pruned: string[] = [];
+
+  // Walk two levels: @scope/package/ref/
+  for (const scope of safeReaddir(refsDir)) {
+    const scopeDir = join(refsDir, scope);
+    for (const pkg of safeReaddir(scopeDir)) {
+      const pkgDir = join(scopeDir, pkg);
+      for (const ref of safeReaddir(pkgDir)) {
+        const refDir = join(pkgDir, ref);
+        if (!validDirs.has(refDir)) {
+          pruneCache(refDir);
+          pruned.push(refDir);
+        }
+      }
+    }
+  }
+
+  return pruned;
+}
+
+function safeReaddir(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}

--- a/packages/cli/pragma/src/domains/refs/operations/updateRefs.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/updateRefs.ts
@@ -5,15 +5,15 @@
  * clones (first time) or fetches (subsequent). Reports per-package status.
  */
 
-import { existsSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { readConfig } from "#config";
+import { DEFAULT_PACKAGES } from "../../shared/packages.js";
+import { cloneRef, fetchRef, pruneCache } from "./gitOps.js";
 import type { PackageRef, RawPackageEntry } from "./parseRef.js";
 import { parsePackageEntry } from "./parseRef.js";
 import { cacheRoot, gitCacheDir } from "./paths.js";
 import readGlobalRefs from "./readGlobalRefs.js";
-import { cloneRef, fetchRef, pruneCache } from "./gitOps.js";
-import { DEFAULT_PACKAGES } from "../../shared/packages.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -21,7 +21,13 @@ import { DEFAULT_PACKAGES } from "../../shared/packages.js";
 
 export interface UpdateResult {
   readonly pkg: string;
-  readonly kind: "cloned" | "updated" | "up-to-date" | "ok" | "skipped" | "error";
+  readonly kind:
+    | "cloned"
+    | "updated"
+    | "up-to-date"
+    | "ok"
+    | "skipped"
+    | "error";
   readonly detail: string;
 }
 
@@ -61,7 +67,11 @@ export default async function updateRefs(
         const dest = gitCacheDir(ref.pkg, ref.ref);
         try {
           if (existsSync(dest)) {
-            const { updated, oldHead, newHead } = fetchRef(ref.url, ref.ref, dest);
+            const { updated, oldHead, newHead } = fetchRef(
+              ref.url,
+              ref.ref,
+              dest,
+            );
             results.push({
               pkg: ref.pkg,
               kind: updated ? "updated" : "up-to-date",
@@ -167,7 +177,9 @@ function mergeEntries(
 function pruneOrphanedCaches(refs: PackageRef[]): string[] {
   const validDirs = new Set(
     refs
-      .filter((r): r is Extract<PackageRef, { kind: "git" }> => r.kind === "git")
+      .filter(
+        (r): r is Extract<PackageRef, { kind: "git" }> => r.kind === "git",
+      )
       .map((r) => gitCacheDir(r.pkg, r.ref)),
   );
 

--- a/packages/cli/pragma/src/domains/shared/bootStore.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.ts
@@ -10,23 +10,33 @@
 import { join } from "node:path";
 import type { SourceSpec, Store } from "@canonical/ke";
 import { createStore } from "@canonical/ke";
-import type { PragmaConfig } from "#config";
+import type { PackageRef } from "../refs/operations/parseRef.js";
 import { PragmaError } from "../../error/index.js";
-import { PACKAGES, resolvePackages } from "./packages.js";
+import { resolvePackages } from "./packages.js";
 import { PREFIX_MAP } from "./prefixes.js";
 
-/**
- * Resolve default TTL sources from the package registry.
- * Package-manager agnostic — works with bun, npm, pnpm, and yarn.
- */
-export function defaultSources(): SourceSpec[] {
-  const sources: SourceSpec[] = [];
-  const resolved = resolvePackages();
+/** Default TTL glob patterns — convention-based auto-detection. */
+const DEFAULT_TTL_GLOBS: readonly string[] = [
+  "definitions/**/*.ttl",
+  "data/**/*.ttl",
+];
 
-  for (const { pkg, dir } of resolved) {
-    const def = PACKAGES.find((p) => p.pkg === pkg);
-    if (!def) continue;
-    for (const glob of def.ttl) {
+/**
+ * Resolve default TTL sources from resolved packages.
+ *
+ * Uses convention-based TTL discovery: definitions and data globs
+ * relative to each package root.
+ *
+ * @param refs - Parsed package references. Omit for defaults.
+ */
+export function defaultSources(
+  refs?: ReadonlyArray<PackageRef>,
+): SourceSpec[] {
+  const sources: SourceSpec[] = [];
+  const resolved = resolvePackages(refs);
+
+  for (const { dir } of resolved) {
+    for (const glob of DEFAULT_TTL_GLOBS) {
       sources.push(join(dir, glob));
     }
   }
@@ -35,14 +45,14 @@ export function defaultSources(): SourceSpec[] {
 }
 
 export interface BootStoreOptions {
-  /** Override config (skip reading from disk). */
-  config?: PragmaConfig;
-  /** Override sources (skip config sources field). */
+  /** Override sources (skip filesystem resolution). */
   sources?: SourceSpec[];
   /** Working directory for resolving relative paths. */
   cwd?: string;
   /** Cache path for serialized store. */
   cache?: string;
+  /** Parsed package references for ref-based resolution. */
+  refs?: ReadonlyArray<PackageRef>;
 }
 
 /**
@@ -53,7 +63,7 @@ export interface BootStoreOptions {
 export async function bootStore(
   options: BootStoreOptions = {},
 ): Promise<Store> {
-  const sources = options.sources ?? defaultSources();
+  const sources = options.sources ?? defaultSources(options.refs);
 
   try {
     const store = await createStore({

--- a/packages/cli/pragma/src/domains/shared/bootStore.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.ts
@@ -10,8 +10,8 @@
 import { join } from "node:path";
 import type { SourceSpec, Store } from "@canonical/ke";
 import { createStore } from "@canonical/ke";
-import type { PackageRef } from "../refs/operations/parseRef.js";
 import { PragmaError } from "../../error/index.js";
+import type { PackageRef } from "../refs/operations/parseRef.js";
 import { resolvePackages } from "./packages.js";
 import { PREFIX_MAP } from "./prefixes.js";
 
@@ -29,9 +29,7 @@ const DEFAULT_TTL_GLOBS: readonly string[] = [
  *
  * @param refs - Parsed package references. Omit for defaults.
  */
-export function defaultSources(
-  refs?: ReadonlyArray<PackageRef>,
-): SourceSpec[] {
+export function defaultSources(refs?: ReadonlyArray<PackageRef>): SourceSpec[] {
   const sources: SourceSpec[] = [];
   const resolved = resolvePackages(refs);
 

--- a/packages/cli/pragma/src/domains/shared/bootStore.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.ts
@@ -7,6 +7,7 @@
  * @note Impure — reads filesystem, creates ke store.
  */
 
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { SourceSpec, Store } from "@canonical/ke";
 import { createStore } from "@canonical/ke";
@@ -15,17 +16,22 @@ import type { PackageRef } from "../refs/operations/parseRef.js";
 import { resolvePackages } from "./packages.js";
 import { PREFIX_MAP } from "./prefixes.js";
 
-/** Default TTL glob patterns — convention-based auto-detection. */
-const DEFAULT_TTL_GLOBS: readonly string[] = [
-  "definitions/**/*.ttl",
-  "data/**/*.ttl",
+/**
+ * Convention-based TTL directories to scan in each package.
+ * Only directories that exist are globbed — packages that lack
+ * a `data/` or `definitions/` dir are silently skipped.
+ */
+const TTL_DIRS: readonly { dir: string; glob: string }[] = [
+  { dir: "definitions", glob: "definitions/**/*.ttl" },
+  { dir: "data", glob: "data/**/*.ttl" },
 ];
 
 /**
  * Resolve default TTL sources from resolved packages.
  *
  * Uses convention-based TTL discovery: definitions and data globs
- * relative to each package root.
+ * relative to each package root. Only adds globs for directories
+ * that actually exist in the package.
  *
  * @param refs - Parsed package references. Omit for defaults.
  */
@@ -34,8 +40,10 @@ export function defaultSources(refs?: ReadonlyArray<PackageRef>): SourceSpec[] {
   const resolved = resolvePackages(refs);
 
   for (const { dir } of resolved) {
-    for (const glob of DEFAULT_TTL_GLOBS) {
-      sources.push(join(dir, glob));
+    for (const entry of TTL_DIRS) {
+      if (existsSync(join(dir, entry.dir))) {
+        sources.push(join(dir, entry.glob));
+      }
     }
   }
 

--- a/packages/cli/pragma/src/domains/shared/packages.ts
+++ b/packages/cli/pragma/src/domains/shared/packages.ts
@@ -1,52 +1,38 @@
 /**
- * Design system package registry.
+ * Design system package registry and resolution.
  *
- * Single source of truth for all external packages that provide TTL data
- * and/or agent skills. Both `bootStore` (TTL sources) and `resolveSkillSources`
- * (skill discovery) derive their paths from this registry.
+ * Resolves semantic packages from three sources (in priority order):
+ * 1. file:// local path (development)
+ * 2. git ref cache (shared/CI)
+ * 3. require.resolve from node_modules (npm fallback)
  *
- * Each entry declares:
- * - `pkg`    — npm package name (resolved via `require.resolve`)
- * - `ttl`    — glob patterns for TTL data, relative to the package root
- * - `skills` — subpath to the skills directory, or `undefined` if none
+ * The package list itself is configurable via pragma.config.json `packages`
+ * field. When absent, the hardcoded DEFAULT_PACKAGES are used.
  */
 
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname } from "node:path";
+import type { PackageRef } from "../refs/operations/parseRef.js";
+import { gitCacheDir } from "../refs/operations/paths.js";
 
 const require = createRequire(import.meta.url);
 
-export interface PackageDefinition {
-  /** npm package name. */
-  readonly pkg: string;
-  /** Glob patterns for TTL data (relative to package root). */
-  readonly ttl: readonly string[];
-  /** Subpath to skills directory, or undefined if the package has no skills. */
-  readonly skills: string | undefined;
-}
+// ---------------------------------------------------------------------------
+// Default package registry (used when config.packages is absent)
+// ---------------------------------------------------------------------------
 
-export const PACKAGES: readonly PackageDefinition[] = [
-  {
-    pkg: "@canonical/design-system",
-    ttl: ["definitions/ontology.ttl", "data/**/*.ttl"],
-    skills: "skills",
-  },
-  {
-    pkg: "@canonical/anatomy-dsl",
-    ttl: ["definitions/**/*.ttl"],
-    skills: undefined,
-  },
-  {
-    pkg: "@canonical/code-standards",
-    ttl: ["definitions/**/*.ttl", "data/**/*.ttl"],
-    skills: "skills",
-  },
-  {
-    pkg: "@canonical/pragma-cli",
-    ttl: [],
-    skills: "skills",
-  },
+/** Default semantic packages loaded when no config overrides are present. */
+export const DEFAULT_PACKAGES: readonly string[] = [
+  "@canonical/design-system",
+  "@canonical/anatomy-dsl",
+  "@canonical/code-standards",
+  "@canonical/pragma-cli",
 ];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export interface ResolvedPackage {
   /** npm package name. */
@@ -55,22 +41,89 @@ export interface ResolvedPackage {
   readonly dir: string;
 }
 
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
 /**
- * Resolve installed packages from the registry via `require.resolve`.
- * Package-manager agnostic — works with bun, npm, pnpm, yarn.
- * Skips packages that are not installed.
+ * Resolve packages to filesystem directories.
+ *
+ * When `refs` is provided, each PackageRef is resolved according to its kind.
+ * When `refs` is omitted, the DEFAULT_PACKAGES are resolved via require.resolve.
+ *
+ * @param refs - Parsed package references (from config merge). Omit for defaults.
+ * @returns Array of resolved packages with absolute directory paths.
  */
-export function resolvePackages(): ResolvedPackage[] {
+export function resolvePackages(
+  refs?: ReadonlyArray<PackageRef>,
+): ResolvedPackage[] {
+  if (!refs) {
+    return resolveNpmPackages(DEFAULT_PACKAGES);
+  }
+
   const resolved: ResolvedPackage[] = [];
-  for (const { pkg } of PACKAGES) {
-    try {
-      resolved.push({
-        pkg,
-        dir: dirname(require.resolve(`${pkg}/package.json`)),
-      });
-    } catch {
-      // package not installed — skip
+
+  for (const ref of refs) {
+    switch (ref.kind) {
+      case "file": {
+        if (!existsSync(ref.path)) {
+          console.warn(
+            `pragma: package "${ref.pkg}" points to ${ref.path} which does not exist. Check the path or remove the file:// source.`,
+          );
+          break;
+        }
+        resolved.push({ pkg: ref.pkg, dir: ref.path });
+        break;
+      }
+
+      case "git": {
+        const cacheDir = gitCacheDir(ref.pkg, ref.ref);
+        if (existsSync(cacheDir)) {
+          resolved.push({ pkg: ref.pkg, dir: cacheDir });
+          break;
+        }
+        // Cache miss — warn and fall through to npm
+        console.warn(
+          `pragma: git ref for "${ref.pkg}" not cached. Run "pragma update-refs" to fetch it.`,
+        );
+        resolveNpmFallback(ref.pkg, resolved);
+        break;
+      }
+
+      case "npm": {
+        resolveNpmFallback(ref.pkg, resolved);
+        break;
+      }
     }
   }
+
   return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve a list of package names via require.resolve. */
+function resolveNpmPackages(pkgs: readonly string[]): ResolvedPackage[] {
+  const resolved: ResolvedPackage[] = [];
+  for (const pkg of pkgs) {
+    resolveNpmFallback(pkg, resolved);
+  }
+  return resolved;
+}
+
+/** Try to resolve a single package via require.resolve, push if found. */
+function resolveNpmFallback(
+  pkg: string,
+  resolved: ResolvedPackage[],
+): void {
+  try {
+    resolved.push({
+      pkg,
+      dir: dirname(require.resolve(`${pkg}/package.json`)),
+    });
+  } catch {
+    // package not installed — skip
+  }
 }

--- a/packages/cli/pragma/src/domains/shared/packages.ts
+++ b/packages/cli/pragma/src/domains/shared/packages.ts
@@ -114,10 +114,7 @@ function resolveNpmPackages(pkgs: readonly string[]): ResolvedPackage[] {
 }
 
 /** Try to resolve a single package via require.resolve, push if found. */
-function resolveNpmFallback(
-  pkg: string,
-  resolved: ResolvedPackage[],
-): void {
+function resolveNpmFallback(pkg: string, resolved: ResolvedPackage[]): void {
   try {
     resolved.push({
       pkg,

--- a/packages/cli/pragma/src/domains/shared/runtime.ts
+++ b/packages/cli/pragma/src/domains/shared/runtime.ts
@@ -10,7 +10,14 @@
 
 import type { SourceSpec } from "@canonical/ke";
 import { readConfig } from "#config";
+import {
+  type PackageRef,
+  type RawPackageEntry,
+  parsePackageEntry,
+} from "../refs/operations/parseRef.js";
+import readGlobalRefs from "../refs/operations/readGlobalRefs.js";
 import { bootStore } from "./bootStore.js";
+import { DEFAULT_PACKAGES } from "./packages.js";
 import type { PragmaRuntime } from "./types/index.js";
 
 export type { PragmaRuntime } from "./types/index.js";
@@ -18,9 +25,11 @@ export type { PragmaRuntime } from "./types/index.js";
 /**
  * Create a fully initialized `PragmaRuntime`.
  *
- * Reads config from `cwd` (defaults to `process.cwd()`), boots the ke
- * store from resolved sources, and returns a runtime ready for operation
- * calls. The caller owns the lifecycle and must call `dispose()`.
+ * Reads config from `cwd` (defaults to `process.cwd()`), merges global
+ * and project package refs, boots the ke store from resolved sources,
+ * and returns a runtime ready for operation calls.
+ *
+ * The caller owns the lifecycle and must call `dispose()`.
  *
  * @param options.cwd - Working directory for config and source resolution.
  * @param options.sources - Override sources for testing (skip filesystem resolution).
@@ -33,9 +42,14 @@ export async function bootPragma(options?: {
 }): Promise<PragmaRuntime> {
   const cwd = options?.cwd ?? process.cwd();
   const config = readConfig(cwd);
+
+  // Merge package refs: project overrides global, both override defaults.
+  const refs = options?.sources ? undefined : mergeAndParseRefs(config.packages);
+
   const store = await bootStore({
     cwd,
     sources: options?.sources,
+    refs,
   });
 
   return {
@@ -44,4 +58,58 @@ export async function bootPragma(options?: {
     cwd,
     dispose: () => store.dispose(),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Ref merging
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge global refs, project config packages, and defaults into a final
+ * parsed PackageRef array.
+ *
+ * Priority: project packages > global refs > hardcoded defaults.
+ * Merging is by package name — a project entry for "@canonical/foo"
+ * overrides the global entry for the same package.
+ */
+function mergeAndParseRefs(
+  projectPackages?: ReadonlyArray<RawPackageEntry>,
+): PackageRef[] {
+  const globalEntries = readGlobalRefs();
+
+  // If neither project nor global defines packages, return undefined
+  // so resolvePackages() uses hardcoded defaults.
+  if (
+    (!projectPackages || projectPackages.length === 0) &&
+    globalEntries.length === 0
+  ) {
+    return DEFAULT_PACKAGES.map((pkg) => parsePackageEntry(pkg));
+  }
+
+  // Build a name → entry map, global first, project overrides.
+  const merged = new Map<string, RawPackageEntry>();
+
+  // Start with defaults (lowest priority)
+  for (const pkg of DEFAULT_PACKAGES) {
+    merged.set(pkg, pkg);
+  }
+
+  // Global overrides defaults
+  for (const entry of globalEntries) {
+    const name = typeof entry === "string" ? entry : entry.name;
+    merged.set(name, entry);
+  }
+
+  // Project overrides global
+  if (projectPackages) {
+    // When project explicitly declares packages, it's a full replacement
+    // of the package list — clear defaults and global, use project only.
+    merged.clear();
+    for (const entry of projectPackages) {
+      const name = typeof entry === "string" ? entry : entry.name;
+      merged.set(name, entry);
+    }
+  }
+
+  return [...merged.values()].map(parsePackageEntry);
 }

--- a/packages/cli/pragma/src/domains/shared/runtime.ts
+++ b/packages/cli/pragma/src/domains/shared/runtime.ts
@@ -12,8 +12,8 @@ import type { SourceSpec } from "@canonical/ke";
 import { readConfig } from "#config";
 import {
   type PackageRef,
-  type RawPackageEntry,
   parsePackageEntry,
+  type RawPackageEntry,
 } from "../refs/operations/parseRef.js";
 import readGlobalRefs from "../refs/operations/readGlobalRefs.js";
 import { bootStore } from "./bootStore.js";
@@ -44,7 +44,9 @@ export async function bootPragma(options?: {
   const config = readConfig(cwd);
 
   // Merge package refs: project overrides global, both override defaults.
-  const refs = options?.sources ? undefined : mergeAndParseRefs(config.packages);
+  const refs = options?.sources
+    ? undefined
+    : mergeAndParseRefs(config.packages);
 
   const store = await bootStore({
     cwd,

--- a/packages/cli/pragma/src/domains/skill/helpers/resolveSkillSources.ts
+++ b/packages/cli/pragma/src/domains/skill/helpers/resolveSkillSources.ts
@@ -1,5 +1,7 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { PACKAGES, resolvePackages } from "../../shared/packages.js";
+import type { PackageRef } from "../../refs/operations/parseRef.js";
+import { resolvePackages } from "../../shared/packages.js";
 
 /** A resolved skill source directory from an installed package. */
 export interface SkillSource {
@@ -10,24 +12,26 @@ export interface SkillSource {
 }
 
 /**
- * Resolve skill source directories from the shared package registry.
- * Package-manager agnostic -- works with bun, npm, pnpm, yarn.
+ * Resolve skill source directories from resolved packages.
  *
+ * Auto-detects skills by checking for a `skills/` subdirectory
+ * in each resolved package root.
+ *
+ * @param refs - Parsed package references. Omit for defaults.
  * @returns Array of resolved skill sources with absolute paths.
  * @note Impure
  */
-export default function resolveSkillSources(): SkillSource[] {
+export default function resolveSkillSources(
+  refs?: ReadonlyArray<PackageRef>,
+): SkillSource[] {
   const sources: SkillSource[] = [];
-  const resolved = resolvePackages();
+  const resolved = resolvePackages(refs);
 
   for (const { pkg, dir } of resolved) {
-    const def = PACKAGES.find((p) => p.pkg === pkg);
-    if (!def?.skills) continue;
-
-    sources.push({
-      dir: join(dir, def.skills),
-      packageName: pkg,
-    });
+    const skillsDir = join(dir, "skills");
+    if (existsSync(skillsDir)) {
+      sources.push({ dir: skillsDir, packageName: pkg });
+    }
   }
 
   return sources;

--- a/packages/cli/pragma/src/pipeline/resolveCommandKind.ts
+++ b/packages/cli/pragma/src/pipeline/resolveCommandKind.ts
@@ -8,7 +8,7 @@
 import type { CommandKind } from "./types.js";
 
 /** Commands that do not require the ke store to be booted. */
-const STORE_SKIP_COMMANDS = new Set(["setup", "mcp"]);
+const STORE_SKIP_COMMANDS = new Set(["setup", "mcp", "update-refs"]);
 
 function findCommandArg(argv: readonly string[]): string | undefined {
   const args = argv.slice(2);

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -1,5 +1,6 @@
 import type { GlobalFlags } from "@canonical/cli-core";
 import { CommanderError } from "commander";
+import { commands as refsCommands } from "../domains/refs/index.js";
 import { commands as setupCommands } from "../domains/setup/index.js";
 import type { PragmaContext } from "../domains/shared/context.js";
 import type { PragmaRuntime } from "../domains/shared/runtime.js";
@@ -140,7 +141,7 @@ async function runStoreSkip(
     globalFlags,
     interactive: runInteractiveCommand,
   };
-  const commands = [...setupCommands()];
+  const commands = [...setupCommands(), ...refsCommands()];
   const program = createProgram(commands, stubCtx);
 
   try {

--- a/packages/cli/pragma/src/testing/integration/boot.test.ts
+++ b/packages/cli/pragma/src/testing/integration/boot.test.ts
@@ -5,9 +5,12 @@
  * consistency from the canonical fixture.
  */
 
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { afterAll, describe, expect, it } from "vitest";
 import { listBlocks } from "../../domains/block/operations/index.js";
 import type { PragmaRuntime } from "../../domains/shared/runtime.js";
+import { bootPragma } from "../../domains/shared/runtime.js";
 import createTestRuntime from "../helpers/createTestRuntime.js";
 
 describe("PragmaRuntime boot", () => {
@@ -52,6 +55,38 @@ describe("PragmaRuntime boot", () => {
     // apps/lxd tier includes LXD Panel (its own) plus inherited global components
     expect(names).toContain("LXD Panel");
     expect(names).toContain("Button");
+  });
+
+  it("boots with file:// package ref", async () => {
+    // Create a temp "package" with TTL in the convention structure
+    const { mkdirSync, copyFileSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+
+    const fixturesDir = new URL("../fixtures/", import.meta.url).pathname;
+    const tmpPkg = mkdtempSync(join(tmpdir(), "pragma-ref-pkg-"));
+    const dataDir = join(tmpPkg, "data");
+    mkdirSync(dataDir, { recursive: true });
+    copyFileSync(join(fixturesDir, "canonical.ttl"), join(dataDir, "canonical.ttl"));
+
+    // Create a temp project dir with config pointing to the file:// package
+    const tmpProject = mkdtempSync(join(tmpdir(), "pragma-ref-project-"));
+    writeFileSync(
+      join(tmpProject, "pragma.config.json"),
+      JSON.stringify({
+        packages: [{ name: "@test/fixture", source: `file://${tmpPkg}` }],
+      }),
+    );
+
+    const rt = await bootPragma({ cwd: tmpProject });
+    runtimes.push(rt);
+
+    expect(rt.store).toBeDefined();
+    expect(rt.config.packages).toHaveLength(1);
+
+    // Clean up
+    const { rmSync } = await import("node:fs");
+    rmSync(tmpPkg, { recursive: true, force: true });
+    rmSync(tmpProject, { recursive: true, force: true });
   });
 
   it("two runtimes produce identical store content", async () => {

--- a/packages/cli/pragma/src/testing/integration/boot.test.ts
+++ b/packages/cli/pragma/src/testing/integration/boot.test.ts
@@ -66,7 +66,10 @@ describe("PragmaRuntime boot", () => {
     const tmpPkg = mkdtempSync(join(tmpdir(), "pragma-ref-pkg-"));
     const dataDir = join(tmpPkg, "data");
     mkdirSync(dataDir, { recursive: true });
-    copyFileSync(join(fixturesDir, "canonical.ttl"), join(dataDir, "canonical.ttl"));
+    copyFileSync(
+      join(fixturesDir, "canonical.ttl"),
+      join(dataDir, "canonical.ttl"),
+    );
 
     // Create a temp project dir with config pointing to the file:// package
     const tmpProject = mkdtempSync(join(tmpdir(), "pragma-ref-project-"));


### PR DESCRIPTION
## Done

- Add configurable `packages` field in `pragma.config.json` — array of strings (npm) or objects (`{ name, source }`) where source is `file://`, `git+https://`, `git+ssh://`, or `git+file://`
- Omitting `packages` entirely uses the 4 hardcoded defaults (backwards compatible)
- Global refs via `~/.config/pragma/refs.json` — user-level overrides, project config takes precedence
- Convention-based TTL/skills auto-detection (`definitions/**/*.ttl`, `data/**/*.ttl`, `skills/` dir) replacing hardcoded per-package globs
- `pragma update-refs` store-skip command: clones/fetches git-referenced packages into `~/.cache/pragma/refs/`
  - Shallow clones for speed, SHA commit support via init+fetch
  - `--package <name>` to update a single package, `--prune` to remove orphaned cache entries
- `pragma doctor` reports package ref resolution status per package (npm/file/git, warns on missing)
- `pragma info` shows new Packages section with source and resolution detail
- Cross-platform: `os.homedir()`, respects `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, `PRAGMA_CACHE_DIR`
- Auth relies entirely on the user's git client (SSH keys, credential helpers) — zero custom logic

ADR: `session/I/I.08.GIT_REFS.md`

## QA

- `bun run build` — 39/39 projects built
- `bun run check` — biome clean, tsc --noEmit clean (pragma-cli)
- `bun run test` — 932/941 pass (7 pre-existing subprocess failures requiring compiled binary, unrelated)
- New tests: 77 across 8 test files (parseRef, paths, readGlobalRefs, gitOps, updateRefs, readConfig packages, info formatter, boot integration)
- Manual: create `pragma.config.json` with `file://` source pointing to a local semantic package checkout, run `pragma info` — verify it loads from the local path
- Manual: create config with `git+https://` source, run `pragma update-refs` — verify it clones, then run `pragma info` — verify it loads from cache

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.
- [x] If this PR introduces a **new package**: N/A (no new packages, only a new domain within pragma-cli)