### PR TITLE
feat(router): migration guide and TanStack removal from demo

### DIFF
--- a/apps/react/demo/package.json
+++ b/apps/react/demo/package.json
@@ -31,7 +31,6 @@
     "@canonical/styles": "^0.25.0",
     "@canonical/styles-debug": "^0.25.0",
     "@canonical/styles-primitives-canonical": "^0.25.0",
-    "@tanstack/react-router": "^1.166.7",
     "express": "^5.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/bun.lock
+++ b/bun.lock
@@ -53,14 +53,13 @@
       "name": "@canonical/ds-demo-site",
       "version": "0.25.0",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.23.0",
-        "@canonical/react-ds-global-form": "^0.23.0",
-        "@canonical/react-ssr": "^0.23.0",
-        "@canonical/storybook-config": "^0.23.0",
-        "@canonical/styles": "^0.23.0",
-        "@canonical/styles-debug": "^0.23.0",
-        "@canonical/styles-primitives-canonical": "^0.23.0",
-        "@tanstack/react-router": "^1.166.7",
+        "@canonical/react-ds-global": "^0.25.0",
+        "@canonical/react-ds-global-form": "^0.25.0",
+        "@canonical/react-ssr": "^0.25.0",
+        "@canonical/storybook-config": "^0.25.0",
+        "@canonical/styles": "^0.25.0",
+        "@canonical/styles-debug": "^0.25.0",
+        "@canonical/styles-primitives-canonical": "^0.25.0",
         "express": "^5.2.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -69,8 +68,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.23.0",
-        "@canonical/typescript-config-react": "^0.23.0",
+        "@canonical/biome-config": "^0.25.0",
+        "@canonical/typescript-config-react": "^0.25.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/react-vite": "^10.3.1",
         "@types/express": "^5.0.6",
@@ -636,10 +635,10 @@
       "name": "@canonical/react-ds-global-form",
       "version": "0.25.0",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.23.0",
-        "@canonical/storybook-config": "^0.23.0",
-        "@canonical/styles": "^0.23.0",
-        "@canonical/utils": "^0.23.0",
+        "@canonical/react-ds-global": "^0.25.0",
+        "@canonical/storybook-config": "^0.25.0",
+        "@canonical/styles": "^0.25.0",
+        "@canonical/utils": "^0.25.0",
         "downshift": "^9.3.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -647,13 +646,13 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.23.0",
+        "@canonical/biome-config": "^0.25.0",
         "@canonical/design-tokens": "^0.6.0",
-        "@canonical/storybook-addon-form-state": "^0.23.0",
-        "@canonical/storybook-addon-msw": "^0.23.0",
-        "@canonical/storybook-helpers": "^0.23.0",
-        "@canonical/typescript-config-react": "^0.23.0",
-        "@canonical/webarchitect": "^0.23.0",
+        "@canonical/storybook-addon-form-state": "^0.25.0",
+        "@canonical/storybook-addon-msw": "^0.25.0",
+        "@canonical/storybook-helpers": "^0.25.0",
+        "@canonical/typescript-config-react": "^0.25.0",
+        "@canonical/webarchitect": "^0.25.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -912,8 +911,8 @@
       "version": "0.25.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.23.0",
-        "@canonical/typescript-config-react": "^0.23.0",
+        "@canonical/biome-config": "^0.25.0",
+        "@canonical/typescript-config-react": "^0.25.0",
         "@storybook/react-vite": "^10.3.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -934,13 +933,13 @@
       "name": "@canonical/storybook-addon-msw",
       "version": "0.25.0",
       "dependencies": {
-        "@canonical/styles-debug": "^0.23.0",
+        "@canonical/styles-debug": "^0.25.0",
         "@storybook/icons": "^2.0.1",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.23.0",
-        "@canonical/typescript-config-react": "^0.23.0",
+        "@canonical/biome-config": "^0.25.0",
+        "@canonical/typescript-config-react": "^0.25.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
         "@types/node": "^24.12.0",
@@ -1916,16 +1915,6 @@
 
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.0.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g=="],
 
-    "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
-
-    "@tanstack/react-router": ["@tanstack/react-router@1.168.10", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.9", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-/RmDlOwDkCug609KdPB3U+U1zmrtadJpvsmRg2zEn8TRCKRNri7dYZIjQZbNg8PgUiRL4T6njrZBV1ChzblNaA=="],
-
-    "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
-
-    "@tanstack/router-core": ["@tanstack/router-core@1.168.9", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g=="],
-
-    "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
-
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
@@ -2281,8 +2270,6 @@
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "cookie-es": ["cookie-es@2.0.1", "", {}, "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -2721,8 +2708,6 @@
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "isarray": ["isarray@0.0.1", "", {}, "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="],
-
-    "isbot": ["isbot@5.1.37", "", {}, "sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ=="],
 
     "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
@@ -3295,10 +3280,6 @@
     "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
-    "seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
-
-    "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 

--- a/docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md
+++ b/docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md
@@ -1,0 +1,235 @@
+# Migrating to the pragma router
+
+Migration guide for apps currently using React Router (v5, v6, v7) or TanStack Router. Covers concept translation, incremental adoption, and coexistence patterns.
+
+## Shared concepts
+
+Before diving into version-specific translations, understand the pragma router's model:
+
+**Flat routes, not nested trees.** Every route is a top-level entry in a route map object. There is no route tree or hierarchy. Shared layout and data live in wrappers, not parent routes.
+
+**Wrappers for layout.** Where other routers use nested routes for shared layout, pragma uses `wrapper()` + `group()`. A wrapper provides a layout shell; `group()` applies it to a set of routes.
+
+**Middleware for cross-cutting concerns.** Auth checks, i18n, analytics, and similar concerns are expressed as middleware — functions that transform routes before the router is created.
+
+**Type-safe navigation by name.** Routes are navigated by their key in the route map (`"home"`, `"userProfile"`), not by path. TypeScript enforces that only valid route names are used.
+
+**Data is not a routing concern.** The router does not own data fetching. `prefetch()` is a fire-and-forget navigation-time hook for warming caches or preloading assets. Components fetch their own data from their cache library (Relay, TanStack Query, SWR, etc.).
+
+**React error boundaries for errors.** No router-specific error UI. Errors from `prefetch()` throw into the React tree and are caught by standard React error boundaries. Use `StatusResponse` to signal HTTP-like errors.
+
+---
+
+## From React Router v5
+
+React Router v5 uses class-based patterns, `<Switch>`, render props, and the `withRouter()` HOC. The gap to pragma is the largest of any migration.
+
+| React Router v5 | Pragma |
+|---|---|
+| `<BrowserRouter>` | `createBrowserRouter(routes)` + `<RouterProvider>` |
+| `<Switch>` / `<Route path="/foo">` | `route({ url: "/foo", content: FooPage })` in a flat route map |
+| `<Route component={Foo}>` | `content: FooPage` on the route definition |
+| `<Route render={() => <Foo />}>` | `content: FooPage` (pass component directly) |
+| `withRouter(Component)` | `useRouter()` hook |
+| `this.props.match.params` | `useRoute().params` or `({ params }) => ...` in content |
+| `this.props.history.push("/bar")` | `router.navigate("bar")` (by route name, not path) |
+| `this.props.location` | `useRoute()` returns pathname, search, hash |
+| `<Redirect to="/login">` | `redirect("/login", 302)` in `prefetch()`, or a static redirect route |
+| `<Link to="/foo">` | `<Link to="foo">` (route name, typed) |
+| `<NavLink activeClassName="on">` | `<Link to="foo">` sets `aria-current="page"` when active |
+| Nested `<Route>` for layout | `wrapper()` + `group()` |
+
+### Key differences
+
+- **No render props or HOCs.** Everything is hooks-based. If your v5 app uses class components with `withRouter()`, you'll need to convert them to function components.
+- **No path-based navigation.** `router.navigate("userProfile", { params: { id: "42" } })` instead of `history.push("/users/42")`. The router builds the URL from the route definition.
+- **No `exact` prop.** Pragma routes match exactly by default. URL patterns use `:param` syntax.
+
+---
+
+## From React Router v6
+
+React Router v6 is hooks-based and closer to pragma's model. The main differences are nested routes (pragma is flat) and relative navigation (pragma uses named routes).
+
+| React Router v6 | Pragma |
+|---|---|
+| `<BrowserRouter>` | `createBrowserRouter(routes)` + `<RouterProvider>` |
+| `<Routes>` / `<Route path="/foo" element={<Foo />}>` | `route({ url: "/foo", content: FooPage })` |
+| Nested `<Route>` for layout | `wrapper()` + `group()` |
+| `<Outlet />` | `<Outlet />` (same concept, different implementation) |
+| `useNavigate()` | `useRouter().navigate("routeName")` |
+| `useParams()` | `useRoute().params` |
+| `useSearchParams()` | `useSearchParams()` (similar API) |
+| `useLocation()` | `useRoute()` returns pathname, hash, searchParams |
+| `<Link to="/foo">` | `<Link to="foo">` (route name, not path) |
+| `<Link to="../sibling">` | Not supported — use absolute route names |
+| `Navigate` component | `redirect()` in `prefetch()` |
+| `loader` (v6.4+) | `prefetch()` (fire-and-forget, not data provider) |
+| `useLoaderData()` | Use your cache library: `useQuery()`, `useLazyLoadQuery()` |
+| Error boundaries via `errorElement` | React `<ErrorBoundary>` with `StatusResponse` |
+
+### Key differences
+
+- **No relative paths.** Pragma routes are flat — there's no hierarchy to navigate relative to. All navigation uses route names.
+- **No `loader` data return.** `prefetch()` warms caches but doesn't return data to the component. Components own their data.
+- **Wrappers instead of layout routes.** Instead of nesting `<Route>` inside a layout route with `<Outlet>`, use `wrapper()` to define the layout and `group()` to apply it.
+
+### Example: nested layout migration
+
+React Router v6:
+```tsx
+<Route element={<DashboardLayout />}>
+  <Route path="/dashboard" element={<Dashboard />} />
+  <Route path="/settings" element={<Settings />} />
+</Route>
+```
+
+Pragma:
+```tsx
+const dashboardLayout = wrapper({
+  id: "dashboard",
+  component: ({ children }) => <DashboardLayout>{children}</DashboardLayout>,
+});
+
+const [dashboard, settings] = group(dashboardLayout, [
+  route({ url: "/dashboard", content: DashboardPage }),
+  route({ url: "/settings", content: SettingsPage }),
+] as const);
+```
+
+---
+
+## From React Router v7
+
+React Router v7 merges Remix's data model (loaders, actions, forms) into the router. Pragma explicitly does not own data mutations — this is the biggest conceptual gap.
+
+| React Router v7 | Pragma |
+|---|---|
+| `loader()` | `prefetch()` — fire-and-forget cache warming, not data provider |
+| `action()` | No equivalent — use your cache library's mutation API |
+| `useLoaderData()` | `useQuery()` / `useLazyLoadQuery()` from cache library |
+| `useActionData()` | Cache library's mutation result state |
+| `<Form>` | Standard `<form>` with cache library mutation |
+| `useFetcher()` | Cache library's `useMutation()` or `useQuery()` |
+| `useNavigation()` | `useNavigationState()` for loading state |
+| `redirect()` in loader | `redirect()` in `prefetch()` |
+| `ErrorBoundary` in route | React `<ErrorBoundary>` wrapping `<Outlet>` |
+| File-based routing (optional) | Code-based only — no file conventions |
+| Framework mode | Library only — no server functions |
+
+### Key differences
+
+- **No mutation system.** This is the fundamental difference. React Router v7 (via Remix) provides `action()`, `<Form>`, `useFetcher()`, and automatic revalidation. Pragma delegates all mutation and data lifecycle to external cache libraries.
+- **No server functions.** Pragma is a client-side routing library. Server logic lives in your server framework (Express, Bun, etc.), not in route definitions.
+- **No automatic revalidation.** After a mutation, your cache library handles invalidation and refetching.
+
+### Migration strategy for data-heavy v7 apps
+
+1. Replace `loader()` with `prefetch()` that warms your cache library
+2. Replace `action()` with standard form handlers using your cache library's mutation API
+3. Replace `useLoaderData()` with your cache library's data hooks
+4. Replace `<Form>` with `<form>` + `onSubmit` handler
+5. Replace `useFetcher()` with `useMutation()` from your cache library
+
+---
+
+## From TanStack Router
+
+TanStack Router's type-safe tree model is the closest competitor to pragma's type safety. The migration preserves type safety but changes the route structure.
+
+| TanStack Router | Pragma |
+|---|---|
+| `createRootRoute()` + `createRoute()` | `route()` in a flat map |
+| Nested route tree | Flat routes + `wrapper()` + `group()` |
+| `createRouter()` | `createBrowserRouter(routes)` |
+| `RouterProvider` | `RouterProvider` (same concept) |
+| `<Outlet />` | `<Outlet />` |
+| `<Link to="/foo" params={...}>` | `<Link to="foo" params={...}>` |
+| `useSearch()` | `useSearchParams()` |
+| `useParams()` | `useRoute().params` |
+| `useNavigate()` | `useRouter().navigate("routeName")` |
+| `beforeLoad` | Middleware via `applyMiddleware()` |
+| `loader` | `prefetch()` (fire-and-forget) |
+| `useLoaderData()` | Cache library hooks |
+| `zodSearchValidator()` | Standard Schema on route: `search: schema` |
+| Route-level `errorComponent` | React `<ErrorBoundary>` |
+| `Pending` component | `<Outlet fallback={...}>` |
+| File-based routing (optional) | Code-based only |
+
+### Key differences
+
+- **Flat routes.** TanStack uses a tree with `createRootRoute()` → `createRoute()` nesting. Pragma uses a flat object where layout is handled by wrappers.
+- **Type registration.** TanStack infers types from the tree. Pragma uses `declare module` augmentation for global type registration.
+- **Search validation.** TanStack uses `zodSearchValidator()` or similar. Pragma uses the Standard Schema protocol (`~standard` interface) — works with Zod, Valibot, ArkType, or custom validators.
+
+---
+
+## Incremental adoption
+
+Most migrations are incremental. Pragma supports two coexistence patterns for running alongside an existing router during transition.
+
+### DOM-subtree partitioning (recommended)
+
+The existing router manages the outer app. Pragma is mounted inside it for new sections:
+
+```tsx
+// Existing React Router v6 app
+<BrowserRouter>
+  <Routes>
+    {/* Legacy routes */}
+    <Route path="/legacy/*" element={<LegacyApp />} />
+
+    {/* New routes handled by pragma */}
+    <Route path="/new/*" element={
+      <RouterProvider router={pragmaRouter}>
+        <Outlet />
+      </RouterProvider>
+    } />
+  </Routes>
+</BrowserRouter>
+```
+
+Navigation within `/new/*` stays inside pragma. Navigation to `/legacy/*` goes through React Router. Migrate sections one at a time.
+
+### URL-prefix partitioning
+
+Each router handles a distinct URL prefix. No nesting required:
+
+```tsx
+const pragmaRouter = createBrowserRouter(newRoutes, {
+  // Only handle routes under /new
+});
+```
+
+The existing router handles everything outside pragma's route definitions. Clear URL-level boundary.
+
+### Limitations
+
+- Navigation between the two routers may cause a full page load (the target router doesn't intercept the other's navigations).
+- Scroll restoration may not work across router boundaries.
+- Browser back/forward may behave unexpectedly if both routers listen to the same history events. The Navigation API adapter (default in modern browsers) mitigates this via `event.intercept()`.
+
+---
+
+## Type registration
+
+After defining routes, register them for global type inference:
+
+```tsx
+declare module "@canonical/router-react" {
+  interface RouterRegister {
+    routes: typeof appRoutes;
+  }
+}
+```
+
+This gives you typed `<Link to="routeName">`, `router.navigate("routeName")`, and `router.buildPath("routeName")` without explicit generics on every call.
+
+---
+
+## Reference
+
+- [Router core README](../../packages/runtime/router/README.md)
+- [Router React README](../../packages/react/router/README.md)
+- [Boilerplate reference app](../../apps/react/boilerplate-vite/)
+- [Middleware cookbook](./ROUTER_MIDDLEWARE_COOKBOOK.md)


### PR DESCRIPTION
## Done

Phase D: migration and adoption.

- **Remove unused `@tanstack/react-router` from demo app** — the dependency was declared in `apps/react/demo/package.json` but never imported anywhere in the codebase. Zero functional impact.
- **Migration guide** (`docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md`) covering:
  - Shared concepts (flat routes, wrappers, middleware, type-safe navigation, data ownership)
  - React Router v5 translation table (class-based, HOCs, render props → hooks)
  - React Router v6 translation table (nested routes → wrappers, relative paths → named routes)
  - React Router v7 translation table (loaders/actions/forms → cache library, no server functions)
  - TanStack Router translation table (tree → flat map, zodSearchValidator → Standard Schema)
  - Incremental adoption: DOM-subtree partitioning (recommended) and URL-prefix partitioning
  - Coexistence limitations and mitigation strategies
  - Type registration pattern

## QA

- `bun run --filter @canonical/ds-demo-site check` — all checks pass
- `bun run --filter @canonical/router-core test` — 128 tests pass
- `bun run --filter @canonical/router-react test` — 28 tests pass

### PR readiness check

- [x] PR should have one of the following labels: `Documentation 📝`
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json`