### PR TITLE
fix(svelte-ds-app-launchpad): Fix hover/active Select styles

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Select/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Select/styles.css
@@ -69,7 +69,7 @@
     transition-property: background-color, border-color, outline-color;
     transition-timing-function: var(--lp-transition-timing-ease-in);
 
-    :not(:disabled) {
+    &:not(:disabled) {
       &:hover {
         background-color: var(--color-background-select-input-hover);
       }
@@ -140,17 +140,18 @@
   }
 
   &.base {
-    --lp-color-background-secondary-hover-context: initial;
-    --lp-color-background-secondary-active-context: initial;
-    --lp-color-background-secondary-context: transparent;
-    --lp-color-border-secondary-context: initial;
+    --color-background-select-input-hover: var(
+      --lp-color-background-neutral-hover
+    );
+    --color-background-select-input-active: var(
+      --lp-color-background-neutral-active
+    );
+    --color-background-select-input: transparent;
 
     > select {
       border: none;
-    }
 
-    &:not([multiple]) {
-      > select {
+      &:not([multiple]) {
         option {
           /* FIXME(steciuk): Pt. 2 of the transparency workaround */
           background-color: var(--lp-color-background-default);


### PR DESCRIPTION
## Done
- Fixes hover/active styles not being applied to Select element.
- Aligns `base` severity select hover/active colors with the ones used for Button.

## QA

- `bun run check && bun run test`
- verify `Components/Select` in Storybook
  - Confirm default, base, and disabled Select variants show the expected hover/active behavior and that disabled controls do not change state on hover.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.
