### PR TITLE
feat(svelte-ds-app-launchpad): Allow passing img-specific attributes …

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.ssr.test.ts
@@ -17,15 +17,13 @@ describe("UserAvatar SSR", () => {
           ...baseProps,
           userAvatarUrl: avatarUrl,
           userName: "John Doe",
-          alt: "John Doe's avatar",
         },
       });
 
       expectIs("img", page);
 
-      const element = page.getByRole("img", { name: "John Doe's avatar" });
+      const element = page.getByRole("img");
       expect(element.getAttribute("src")).toBe(avatarUrl);
-      expect(element.getAttribute("alt")).toBe("John Doe's avatar");
       expect(element.getAttribute("title")).toBe("John Doe");
       expect(element.getAttribute("data-initials")).toBeTruthy();
     });
@@ -35,16 +33,14 @@ describe("UserAvatar SSR", () => {
         props: {
           ...baseProps,
           userAvatarUrl: avatarUrl,
-          alt: "User avatar",
         },
       });
 
       expectIs("img", page);
 
-      const element = page.getByRole("img", { name: "User avatar" });
+      const element = page.getByRole("img");
       expect(element).toBeInstanceOf(page.window.HTMLImageElement);
       expect(element.getAttribute("src")).toBe(avatarUrl);
-      expect(element.getAttribute("alt")).toBe("User avatar");
       expect(element.getAttribute("title")).toBeNull();
       expect(element.getAttribute("data-initials")).toBeNull();
     });
@@ -104,6 +100,51 @@ describe("UserAvatar SSR", () => {
     });
   });
 
+  describe("imageAttributes", () => {
+    it("applies img-specific attributes to the avatar image", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userAvatarUrl: avatarUrl,
+          imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
+        },
+      });
+
+      const element = page.getByRole("img");
+      expect(element.getAttribute("alt")).toBe("John Doe's avatar");
+      expect(element.getAttribute("loading")).toBe("lazy");
+    });
+
+    it("are not applied when rendering as <abbr>", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          userName: "John Doe",
+          imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
+        },
+      });
+
+      const element = page.getByTestId("user-avatar");
+      expect(element.tagName).toBe("ABBR");
+      expect(element.getAttribute("alt")).toBeNull();
+      expect(element.getAttribute("loading")).toBeNull();
+    });
+
+    it("are not applied when rendering as icon", () => {
+      const page = render(Component, {
+        props: {
+          ...baseProps,
+          imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
+        },
+      });
+
+      const element = page.getByTestId("user-avatar");
+      expect(element.tagName).toBe("DIV");
+      expect(element.getAttribute("alt")).toBeNull();
+      expect(element.getAttribute("loading")).toBeNull();
+    });
+  });
+
   describe("fallback behaviors", () => {
     it("includes CSS fallback hooks for no-JS image failure when userName is provided", () => {
       const page = render(Component, {
@@ -111,10 +152,9 @@ describe("UserAvatar SSR", () => {
           ...baseProps,
           userAvatarUrl: avatarUrl,
           userName: "John Doe",
-          alt: "John Doe's avatar",
         },
       });
-      const element = page.getByRole("img", { name: "John Doe's avatar" });
+      const element = page.getByRole("img");
 
       expect(element.getAttribute("data-initials")).toBeTruthy();
       expect(element.getAttribute("title")).toBe("John Doe");
@@ -125,10 +165,9 @@ describe("UserAvatar SSR", () => {
         props: {
           ...baseProps,
           userAvatarUrl: avatarUrl,
-          alt: "User avatar",
         },
       });
-      const element = page.getByRole("img", { name: "User avatar" });
+      const element = page.getByRole("img");
 
       expect(element.getAttribute("data-initials")).toBeNull();
       expect(page.getByTestId("user-avatar").querySelector("abbr")).toBeNull();

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.stories.svelte
@@ -43,6 +43,15 @@
 />
 
 <Story
+  name="With image attributes"
+  args={{
+    userName: "John Doe",
+    userAvatarUrl,
+    imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
+  }}
+/>
+
+<Story
   name="When avatar fails to load"
   args={{
     userName: "That's Not An Image",

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte
@@ -12,7 +12,7 @@
     userName: userNameProp,
     userAvatarUrl,
     size = "medium",
-    alt,
+    imageAttributes,
     ...rest
   }: UserAvatarProps = $props();
 
@@ -33,11 +33,11 @@
   <img
     class={className}
     src={userAvatarUrl}
-    {alt}
     title={userName || undefined}
     data-initials={userInitials}
     onerror={() => (imageError = true)}
     {...rest}
+    {...imageAttributes}
   />
 {:else if userName}
   <abbr class={className} title={userName} {...rest}>
@@ -59,5 +59,16 @@ In case JavaScript is disabled, and the image at `userAvatarUrl` fails to load, 
 ## Example Usage
 ```svelte
 <UserAvatar userName="John Doe" userAvatarUrl="https://example.com/avatar.png" />
+```
+
+`<img>`-specific attributes (such as `alt` or `loading`) can be passed via `imageAttributes`.
+They only take effect when the avatar renders as an image.
+
+```svelte
+<UserAvatar
+  userName="John Doe"
+  userAvatarUrl="https://example.com/avatar.png"
+  imageAttributes={{ alt: "John Doe's avatar", loading: "lazy" }}
+/>
 ```
 -->

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte.test.ts
@@ -55,15 +55,13 @@ describe("UserAvatar component", () => {
         ...baseProps,
         userAvatarUrl: avatarUrl,
         userName: "John Doe",
-        alt: "John Doe's avatar",
       });
 
       await expectIs("img", page);
 
-      const element = page.getByRole("img", { name: "John Doe's avatar" });
+      const element = page.getByRole("img");
       await expect.element(element).toBeVisible();
       await expect.element(element).toHaveAttribute("src", avatarUrl);
-      await expect.element(element).toHaveAttribute("alt", "John Doe's avatar");
       await expect.element(element).toHaveAttribute("title", "John Doe");
       await expect.element(element).toHaveAttribute("data-initials");
     });
@@ -72,15 +70,13 @@ describe("UserAvatar component", () => {
       const page = render(Component, {
         ...baseProps,
         userAvatarUrl: avatarUrl,
-        alt: "User avatar",
       });
 
       await expectIs("img", page);
 
-      const element = page.getByRole("img", { name: "User avatar" });
+      const element = page.getByRole("img");
       await expect.element(element).toBeVisible();
       await expect.element(element).toHaveAttribute("src", avatarUrl);
-      await expect.element(element).toHaveAttribute("alt", "User avatar");
       await expect.element(element).not.toHaveAttribute("title");
       await expect.element(element).not.toHaveAttribute("data-initials");
     });
@@ -103,16 +99,54 @@ describe("UserAvatar component", () => {
     });
   });
 
+  describe("imageAttributes", () => {
+    it("applies img-specific attributes to the avatar image", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        userAvatarUrl: avatarUrl,
+        imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
+      });
+
+      const element = page.getByRole("img");
+      await expect.element(element).toHaveAttribute("alt", "John Doe's avatar");
+      await expect.element(element).toHaveAttribute("loading", "lazy");
+    });
+
+    it("are not applied when rendering as <abbr>", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        userName: "John Doe",
+        imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
+      });
+
+      await expectIs("abbr", page);
+      const element = page.getByTestId("user-avatar");
+      await expect.element(element).not.toHaveAttribute("alt");
+      await expect.element(element).not.toHaveAttribute("loading");
+    });
+
+    it("are not applied when rendering as icon", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
+      });
+
+      await expectIs("svg", page);
+      const element = page.getByTestId("user-avatar");
+      await expect.element(element).not.toHaveAttribute("alt");
+      await expect.element(element).not.toHaveAttribute("loading");
+    });
+  });
+
   describe("fallback behaviors", () => {
     it("falls back to <abbr> when JS handles image error and userName is provided", async () => {
       const page = render(Component, {
         ...baseProps,
         userAvatarUrl: "invalid-url",
         userName: "John Doe",
-        alt: "John Doe's avatar",
       });
 
-      const imageElement = page.getByRole("img", { name: "John Doe's avatar" });
+      const imageElement = page.getByRole("img");
       imageElement.element().dispatchEvent(new Event("error"));
 
       await expectIs("abbr", page);
@@ -123,10 +157,9 @@ describe("UserAvatar component", () => {
       const page = render(Component, {
         ...baseProps,
         userAvatarUrl: "invalid-url",
-        alt: "User avatar",
       });
 
-      const imageElement = page.getByRole("img", { name: "User avatar" });
+      const imageElement = page.getByRole("img");
       imageElement.element().dispatchEvent(new Event("error"));
 
       await expectIs("svg", page);
@@ -138,13 +171,10 @@ describe("UserAvatar component", () => {
           ...baseProps,
           userAvatarUrl: `invalid-url`,
           userName: "John Doe",
-          alt: "John Doe's avatar",
           onerror: () => {},
         });
 
-        const imageElement = page.getByRole("img", {
-          name: "John Doe's avatar",
-        });
+        const imageElement = page.getByRole("img");
         imageElement.element().dispatchEvent(new Event("error"));
 
         await expect.element(imageElement).toHaveAttribute("data-initials");
@@ -155,13 +185,10 @@ describe("UserAvatar component", () => {
         const page = render(Component, {
           ...baseProps,
           userAvatarUrl: "invalid-url",
-          alt: "User avatar",
           onerror: () => {},
         });
 
-        const imageElement = page.getByRole("img", {
-          name: "User avatar",
-        });
+        const imageElement = page.getByRole("img");
         imageElement.element().dispatchEvent(new Event("error"));
 
         await expect.element(imageElement).not.toHaveAttribute("data-initials");

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/types.ts
@@ -1,6 +1,15 @@
 /* @canonical/generator-ds 0.9.0-experimental.22 */
 
-import type { HTMLAttributes } from "svelte/elements";
+import type { HTMLAttributes, HTMLImgAttributes } from "svelte/elements";
+
+type ImageOnlyAttributes = Omit<
+  HTMLImgAttributes,
+  | keyof HTMLAttributes<HTMLElement>
+  | "bind:naturalWidth"
+  | "bind:naturalHeight"
+  | "children"
+  | "src" // userAvatarUrl maps to src
+>;
 
 export type UserOptions = {
   /** The user's name */
@@ -13,6 +22,9 @@ export interface UserAvatarProps
   extends Omit<HTMLAttributes<HTMLElement>, "children">,
     UserOptions {
   size?: "small" | "medium" | "large";
-  /** The alt text for the avatar image, if available */
-  alt?: string;
+  /**
+   * `<img>`-specific attributes (e.g. `alt`, `loading`, `fetchpriority`) for the avatar image.
+   * Only applied when the avatar renders as an image — i.e. `userAvatarUrl` is set and the image has not failed to load.
+   */
+  imageAttributes?: ImageOnlyAttributes;
 }


### PR DESCRIPTION
…to UserAvatar

## Done

Replaces the single `alt` prop on `UserAvatar` with a more general `imageAttributes` prop, letting consumers forward any `<img>`-specific attribute (`alt`, `loading`, `decoding`, …) to the avatar image.

- **`types.ts`**: new `ImageOnlyAttributes` type (`HTMLImgAttributes` minus generic element attrs, binds, `children`, and `src`).
- **`UserAvatar.svelte`**: spreads `imageAttributes` onto the `<img>` (only the image branch).
- **Story**: added "With image attributes".
- **Tests**: baseline tests no longer depend on the `alt` prop. New `imageAttributes` suite asserts the attrs apply to the `<img>` and are *not* applied in the `<abbr>` / icon fallbacks.

Fixes #627 

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.