### PR TITLE
docs(summon): Summon installation docs improvements

### DIFF
--- a/packages/summon/core/README.md
+++ b/packages/summon/core/README.md
@@ -13,12 +13,14 @@ generate: (answers) => writeFile(`src/${answers.name}.ts`, code)
 ## Installation
 
 ```bash
-bun add @canonical/summon
+bun install -g @canonical/summon
 ```
 
 ## Using Generators
 
 Summon discovers generators from installed packages automatically.
+See [installing generator packages](#installing-generator-packages) to install an existing generator package,
+or [creating generators](#creating-generators) to create a new one.
 
 ```bash
 # See what's available
@@ -139,7 +141,7 @@ Generator packages follow the naming convention `summon-*` or `@scope/summon-*`:
 
 ```bash
 # Install a generator package
-bun add @canonical/summon-component
+bun install -g @canonical/summon-component
 
 # Now available (completions work immediately!)
 summon component react

--- a/packages/summon/core/README.md
+++ b/packages/summon/core/README.md
@@ -13,7 +13,7 @@ generate: (answers) => writeFile(`src/${answers.name}.ts`, code)
 ## Installation
 
 ```bash
-bun install -g @canonical/summon
+bun add -g @canonical/summon
 ```
 
 ## Using Generators
@@ -141,7 +141,7 @@ Generator packages follow the naming convention `summon-*` or `@scope/summon-*`:
 
 ```bash
 # Install a generator package
-bun install -g @canonical/summon-component
+bun add -g @canonical/summon-component
 
 # Now available (completions work immediately!)
 summon component react


### PR DESCRIPTION
## Done

Tweaks the installation instructions of Summon to hopefully prevent future users from having the installation issues I had just now (Summon wasn't installed globally, and it wasn't clear at the top level of the README how to install a generator).

## QA

- Completely uninstall Summon and its generators.
- Reinstall it following the proposed README
- Verify summon functions as expected

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.
