### PR TITLE
feat(pragma): parallel doctor checks + S-grade empty-result recovery hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# AGENTS.md — Working on a Pragma PR
+
+Guidance for AI agents (and humans) contributing to `canonical/pragma`. For deeper
+setup and monorepo mechanics see [`old/CONTRIBUTING.md`](old/CONTRIBUTING.md); this
+file is the PR workflow contract.
+
+## Toolchain
+
+- **Bun is required** and is the canonical package manager/runner (`bun install`,
+  `bun run <script>`). Node.js 22.12+ or 24 must also be present (Lerna/Storybook
+  need it); avoid Node 23.
+- **npm appears only for first-time package publishing** (`npm publish --access public`
+  from inside a new package dir) — never for day-to-day dev. Don't use `npm install`.
+
+## Commits
+
+- **Conventional / semantic commits**, enforced. CI (`.github/workflows/pr-lint.yml`)
+  rejects a PR whose **title** is not Conventional-Commits compliant, so the title
+  needs a `type(scope): subject` form, e.g. `feat(pragma): …`, `fix(summon): …`,
+  `docs(tokens): …`, `chore(deps): …`, `refactor(cli): …`.
+- **Keep commits atomic.** One logical change per commit; the diff should be reviewable
+  on its own and tell a single story. Bundling unrelated items into one commit/PR is
+  allowed but should be **rare** and called out in the PR body (a "drive-by" line).
+- The PR also needs one of these **labels**: `Feature 🎁`, `Breaking Change 💣`,
+  `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
+- The release CHANGELOG is Lerna-generated from commit history — write commit subjects
+  for the changelog reader, not just yourself.
+
+## Branches & worktrees (local development)
+
+- **Branch names follow `type/semantic-description`** — the `type` matches the
+  conventional-commit types (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, …) and
+  the description is kebab-case and meaningful, e.g. `feat/minor-cli-improvements`,
+  `fix/storybook-subpath-imports`. Every branch carries a `/`.
+- **Work in a git worktree, not by switching the main checkout.** Create one per branch
+  under `.claude/worktrees/`. Name the worktree directory after the branch, with the
+  `/` replaced by `-` (a `/` can't be a single path segment). So:
+
+  ```bash
+  # branch feat/minor-cli-improvements  →  worktree dir feat-minor-cli-improvements
+  git worktree add -b feat/minor-cli-improvements \
+    .claude/worktrees/feat-minor-cli-improvements origin/main
+  ```
+
+  This keeps each line of work isolated, lets several proceed in parallel, and leaves the
+  main checkout untouched. Branch from an up-to-date `origin/main`. Note a fresh worktree
+  has no `node_modules` — run `bun install` inside it before the first `check`/`test`.
+
+## Where to run commands
+
+- **Before pushing, always run the full gate from the repo ROOT.** Root scripts fan out
+  across every affected package via Lerna (with Nx caching), so the root is the only
+  place that covers the whole change. Per-package runs can miss cross-package breakage.
+- **During focused development**, it's fine to run a single package's scripts from inside
+  that package dir (`cd packages/<area> && bun run check`/`test`) for a faster loop —
+  but the root run is the gate of record before pushing.
+
+## Pre-push checklist (run from the repo root, in order)
+
+```bash
+# 0. clean install if deps changed (the prepare hook builds linked packages)
+bun install
+
+# 1. lint + format + type-check + architecture rules, every package
+bun run check          # → lerna run check  (biome + tsc --noEmit + webarchitect)
+
+# 2. if check reports fixable issues, apply and re-run check
+bun run check:fix      # → lerna run check:fix
+
+# 3. tests, every package
+bun run test           # → lerna run test  (vitest run)
+
+# 4. only if the change affects build artifacts / a publishable package
+bun run build          # → lerna run build   (dev/link build)
+# full artifact build (Storybook, docs, etc.) is a CI concern via each
+# package's build:all; run locally only when validating release artifacts
+```
+
+A change is push-ready when `bun run check` and `bun run test` both pass from the root.
+That mirrors what CI runs, so green locally → green CI (modulo Chromatic visual review
+and environment-only tests). If a single test fails for environment reasons unrelated to
+the diff, confirm it fails the same way on a clean `origin/main` before discounting it.
+
+> Per-package `check` = `check:biome` (lint+format) → `check:ts` (`tsc --noEmit`) →
+> `check:webarchitect` (architecture ruleset). `check:fix` auto-fixes biome then
+> re-runs tsc. Every package must define `check`, `check:fix`, and `test`; packages
+> with build steps also define `build` and `build:all`.
+
+## Conventions
+
+This is a **convention-heavy monorepo**. Most conventions are documented — in
+`old/CONTRIBUTING.md`, `docs/`, the package-folder-structure doc, and the
+`pragma-adrs` repo (the `session/I.*` "Pragma Maturity" decisions). **When unsure how
+something should be structured, look for the existing convention first** — read a
+sibling package/domain and match its layout, naming, error handling, and test
+placement — rather than inventing a new pattern. Match the surrounding code's idioms;
+a new file should be indistinguishable in style from its neighbours.
+
+## PR mechanics
+
+- Branch from up-to-date `origin/main`; never push to `main` directly — **all changes
+  land via PR** on a feature branch.
+- Fill in `.github/PULL_REQUEST_TEMPLATE.md` (Done / QA / readiness checklist).
+- Add `no visual change` to skip Chromatic when there's no visual diff.
+- New package? First-time publish is manual (`npm publish --access public` from the
+  package dir); verify with `bun run publish:status` from the root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ file is the PR workflow contract.
 ## Toolchain
 
 - **Bun is required** and is the canonical package manager/runner (`bun install`,
-  `bun run <script>`). Node.js 22.12+ or 24 must also be present (Lerna/Storybook
-  need it); avoid Node 23.
+  `bun run <script>`). Node.js 20+ must also be present (the floor `pragma doctor`
+  enforces and `old/CONTRIBUTING.md` documents); avoid Node 23.
 - **npm appears only for first-time package publishing** (`npm publish --access public`
   from inside a new package dir) — never for day-to-day dev. Don't use `npm install`.
 

--- a/packages/cli/pragma/src/domains/block/orchestration/blockEmptyError.test.ts
+++ b/packages/cli/pragma/src/domains/block/orchestration/blockEmptyError.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { FilterConfig } from "../../shared/types/index.js";
+import blockEmptyError from "./blockEmptyError.js";
+
+const filters: FilterConfig = { tier: "Apps/WPE", channel: "normal" };
+
+describe("blockEmptyError", () => {
+  it("filter-narrowing: a tier was active → widen to all tiers", () => {
+    const err = blockEmptyError(filters, false);
+
+    expect(err.filters).toEqual({ tier: "Apps/WPE", channel: "normal" });
+    expect(err.recovery).toEqual({
+      message: "Widen the search to show all tiers.",
+      cli: "pragma block list --all-tiers",
+      mcp: { tool: "block_list", params: { allTiers: true } },
+    });
+  });
+
+  it("honest terminal: already at all-tiers → no recovery (no self-loop)", () => {
+    const err = blockEmptyError({ tier: undefined, channel: "normal" }, true);
+
+    // The widest tier query already returned empty; suggesting --all-tiers
+    // again would loop. recovery: undefined is the correct terminal state.
+    expect(err.recovery).toBeUndefined();
+  });
+});

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
@@ -142,7 +142,9 @@ describe("runChecks", () => {
     expect(data.failed).toBe(1);
     const failed = data.checks[2];
     expect(failed.status).toBe("fail");
-    expect(failed.name).toBe("config file");
+    // Fallback name matches checkConfigFile's own `name` so a thrown check
+    // reports the same label as a normal pass/fail.
+    expect(failed.name).toBe("pragma.config.json");
     expect(failed.detail).toContain("disk on fire");
     expect(failed.remedy).toBeDefined();
   });

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
@@ -22,6 +22,7 @@ import {
   checkSkillsSymlinked,
 } from "./checks/index.js";
 import runChecks from "./runChecks.js";
+import type { CheckResult } from "./types.js";
 
 const pass = (name: string) => ({
   name,
@@ -91,5 +92,74 @@ describe("runChecks", () => {
     expect(data.checks[3].name).toBe("refs");
     expect(data.checks[4].name).toBe("store");
     expect(data.checks[7].name).toBe("skills");
+  });
+
+  it("preserves order even when checks resolve out of order", async () => {
+    const delayed = (result: CheckResult, ms: number) =>
+      new Promise<CheckResult>((resolve) =>
+        setTimeout(() => resolve(result), ms),
+      );
+
+    // Resolve the first check slowest and the last fastest to prove the report
+    // order follows declaration order, not completion order.
+    vi.mocked(checkNodeVersion).mockReturnValue(delayed(pass("Node"), 30));
+    vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
+    vi.mocked(checkConfigFile).mockResolvedValue(pass("config"));
+    vi.mocked(checkPackageRefs).mockResolvedValue(pass("refs"));
+    vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
+    vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
+    vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkSkillsSymlinked).mockReturnValue(delayed(pass("skills"), 0));
+
+    const data = await runChecks({ cwd: "/test" });
+    expect(data.checks.map((c) => c.name)).toEqual([
+      "Node",
+      "pragma",
+      "config",
+      "refs",
+      "store",
+      "completions",
+      "mcp",
+      "skills",
+    ]);
+  });
+
+  it("surfaces a thrown check as an attributable fail instead of aborting", async () => {
+    vi.mocked(checkNodeVersion).mockResolvedValue(pass("Node"));
+    vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
+    vi.mocked(checkConfigFile).mockRejectedValue(new Error("disk on fire"));
+    vi.mocked(checkPackageRefs).mockResolvedValue(pass("refs"));
+    vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
+    vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
+    vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
+
+    const data = await runChecks({ cwd: "/test" });
+
+    // The whole run still completes; the thrown check becomes a fail in place.
+    expect(data.checks).toHaveLength(8);
+    expect(data.passed).toBe(7);
+    expect(data.failed).toBe(1);
+    const failed = data.checks[2];
+    expect(failed.status).toBe("fail");
+    expect(failed.name).toBe("config file");
+    expect(failed.detail).toContain("disk on fire");
+    expect(failed.remedy).toBeDefined();
+  });
+
+  it("handles a non-Error rejection without crashing", async () => {
+    vi.mocked(checkNodeVersion).mockResolvedValue(pass("Node"));
+    vi.mocked(checkPragmaVersion).mockResolvedValue(pass("pragma"));
+    vi.mocked(checkConfigFile).mockResolvedValue(pass("config"));
+    vi.mocked(checkPackageRefs).mockResolvedValue(pass("refs"));
+    vi.mocked(checkKeStore).mockRejectedValue("string failure");
+    vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
+    vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
+
+    const data = await runChecks({ cwd: "/test" });
+    expect(data.failed).toBe(1);
+    expect(data.checks[4].name).toBe("ke store");
+    expect(data.checks[4].detail).toContain("string failure");
   });
 });

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
@@ -11,8 +11,33 @@ import {
 import type { CheckContext, CheckResult, DoctorData } from "./types.js";
 
 /**
- * Orchestrate all environment health checks sequentially and return
- * a DoctorData summary with pass/fail/skip counts.
+ * Each check paired with the display name used if it rejects. The checks are
+ * mutually independent, so they run concurrently; this list also fixes the
+ * stable display order of the results.
+ */
+function buildChecks(
+  ctx: CheckContext,
+): readonly [string, Promise<CheckResult>][] {
+  return [
+    ["Node version", checkNodeVersion()],
+    ["pragma version", checkPragmaVersion()],
+    ["config file", checkConfigFile(ctx)],
+    ["package refs", checkPackageRefs(ctx)],
+    ["ke store", checkKeStore(ctx)],
+    ["shell completions", checkShellCompletions()],
+    ["MCP configured", checkMcpConfigured(ctx)],
+    ["skills symlinked", checkSkillsSymlinked(ctx)],
+  ];
+}
+
+/**
+ * Orchestrate all environment health checks concurrently and return a
+ * DoctorData summary with pass/fail/skip counts.
+ *
+ * Checks run concurrently; results are collected in declaration order so the
+ * report is deterministic. A check that throws is surfaced as a fail (rather
+ * than aborting `pragma doctor`), tagged with the check's name so the failure
+ * remains attributable.
  *
  * @param ctx - Check context containing the working directory.
  * @returns Aggregated check results.
@@ -21,16 +46,25 @@ import type { CheckContext, CheckResult, DoctorData } from "./types.js";
 export default async function runChecks(
   ctx: CheckContext,
 ): Promise<DoctorData> {
-  const checks: CheckResult[] = [];
-
-  checks.push(await checkNodeVersion());
-  checks.push(await checkPragmaVersion());
-  checks.push(await checkConfigFile(ctx));
-  checks.push(await checkPackageRefs(ctx));
-  checks.push(await checkKeStore(ctx));
-  checks.push(await checkShellCompletions());
-  checks.push(await checkMcpConfigured(ctx));
-  checks.push(await checkSkillsSymlinked(ctx));
+  // buildChecks starts every check eagerly, so they run concurrently; each is
+  // guarded so a thrown check becomes an attributable fail rather than
+  // rejecting the whole run. Mapping preserves declaration order.
+  const checks: CheckResult[] = await Promise.all(
+    buildChecks(ctx).map(async ([name, promise]): Promise<CheckResult> => {
+      try {
+        return await promise;
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        return {
+          name,
+          status: "fail",
+          detail: `Check threw an unexpected error: ${reason}`,
+          remedy:
+            "Re-run `pragma doctor`; if it persists, report this as a bug.",
+        };
+      }
+    }),
+  );
 
   const passed = checks.filter((c) => c.status === "pass").length;
   const failed = checks.filter((c) => c.status === "fail").length;

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
@@ -13,7 +13,9 @@ import type { CheckContext, CheckResult, DoctorData } from "./types.js";
 /**
  * Each check paired with the display name used if it rejects. The checks are
  * mutually independent, so they run concurrently; this list also fixes the
- * stable display order of the results.
+ * stable display order of the results. The fallback name must match the
+ * `name` each check returns on success, so a thrown check reports the same
+ * label as a normal pass/fail and stays correlatable.
  */
 function buildChecks(
   ctx: CheckContext,
@@ -21,12 +23,12 @@ function buildChecks(
   return [
     ["Node version", checkNodeVersion()],
     ["pragma version", checkPragmaVersion()],
-    ["config file", checkConfigFile(ctx)],
+    ["pragma.config.json", checkConfigFile(ctx)],
     ["package refs", checkPackageRefs(ctx)],
     ["ke store", checkKeStore(ctx)],
-    ["shell completions", checkShellCompletions()],
+    ["Shell completions", checkShellCompletions()],
     ["MCP configured", checkMcpConfigured(ctx)],
-    ["skills symlinked", checkSkillsSymlinked(ctx)],
+    ["Skills symlinked", checkSkillsSymlinked(ctx)],
   ];
 }
 

--- a/packages/cli/pragma/src/domains/modifier/orchestration/modifierEmptyError.test.ts
+++ b/packages/cli/pragma/src/domains/modifier/orchestration/modifierEmptyError.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import modifierEmptyError from "./modifierEmptyError.js";
+
+describe("modifierEmptyError", () => {
+  it("recovers via a runnable install command (store-empty is its only scenario)", () => {
+    const err = modifierEmptyError();
+
+    // `modifier list` takes no filters, so an empty result is always
+    // store-empty: the recovery is the install, not a widen.
+    expect(err.recovery).toEqual({
+      message: "Install the design system packages that provide modifiers.",
+      cli: "bun add -D @canonical/design-system",
+    });
+  });
+
+  it("cites a real default package, not @canonical/ds-global", () => {
+    const err = modifierEmptyError();
+    expect(err.recovery?.cli).toContain("@canonical/design-system");
+    expect(err.recovery?.cli).not.toContain("ds-global");
+  });
+
+  it("has no mcp retry for store-empty (re-listing would return empty again)", () => {
+    const err = modifierEmptyError();
+    expect(err.recovery?.mcp).toBeUndefined();
+  });
+});

--- a/packages/cli/pragma/src/domains/modifier/orchestration/modifierEmptyError.ts
+++ b/packages/cli/pragma/src/domains/modifier/orchestration/modifierEmptyError.ts
@@ -1,10 +1,15 @@
 import { PragmaError } from "#error";
 
 export default function modifierEmptyError(): PragmaError {
+  // `modifier list` takes no filters, so an empty result always means the
+  // design system packages that supply modifier triples are absent. The
+  // recovery is the runnable install command, not a (non-existent) widen.
   return PragmaError.emptyResults("modifier", {
     recovery: {
-      message:
-        "Ensure design system packages are installed: bun add -D @canonical/ds-global",
+      // The base error already states "No modifiers found"; the recovery adds
+      // only the cause + the runnable fix (the cli line is what renders on CLI).
+      message: "Install the design system packages that provide modifiers.",
+      cli: "bun add -D @canonical/design-system",
     },
   });
 }

--- a/packages/cli/pragma/src/domains/shared/emptyErrorRecovery.test.ts
+++ b/packages/cli/pragma/src/domains/shared/emptyErrorRecovery.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { PragmaError } from "#error";
+import blockSpecs from "../block/mcp/specs.js";
+import blockEmptyError from "../block/orchestration/blockEmptyError.js";
+import modifierSpecs from "../modifier/mcp/specs.js";
+import modifierEmptyError from "../modifier/orchestration/modifierEmptyError.js";
+import standardSpecs from "../standard/mcp/specs.js";
+import standardEmptyError from "../standard/orchestration/standardEmptyError.js";
+import tokenSpecs from "../token/mcp/specs.js";
+import tokenEmptyError from "../token/orchestration/tokenEmptyError.js";
+import type { FilterConfig } from "./types/index.js";
+
+const filters: FilterConfig = { tier: "Apps/WPE", channel: "normal" };
+const allTiers: FilterConfig = { tier: undefined, channel: "normal" };
+
+/**
+ * Every distinct empty-result scenario each domain can produce, paired with the
+ * set of MCP tool names that domain actually registers. The invariant below
+ * holds the four hints to the S-grade contract so authored consistency cannot
+ * silently re-drift.
+ */
+const cases: ReadonlyArray<{
+  domain: string;
+  error: PragmaError;
+  toolNames: ReadonlySet<string>;
+  // store-empty (packages absent) → the install rung, which must NOT carry an
+  // mcp retry (re-listing an absent store loops). filter-narrowing → may carry
+  // a list-retry mcp pointer.
+  storeEmpty: boolean;
+}> = [
+  {
+    domain: "block (filter active)",
+    error: blockEmptyError(filters, false),
+    toolNames: new Set(blockSpecs.map((s) => s.name)),
+    storeEmpty: false,
+  },
+  {
+    domain: "block (all tiers — terminal)",
+    error: blockEmptyError(allTiers, true),
+    toolNames: new Set(blockSpecs.map((s) => s.name)),
+    storeEmpty: false,
+  },
+  {
+    domain: "token (category active)",
+    error: tokenEmptyError("color"),
+    toolNames: new Set(tokenSpecs.map((s) => s.name)),
+    storeEmpty: false,
+  },
+  {
+    domain: "token (store-empty)",
+    error: tokenEmptyError(),
+    toolNames: new Set(tokenSpecs.map((s) => s.name)),
+    storeEmpty: true,
+  },
+  {
+    domain: "modifier (store-empty)",
+    error: modifierEmptyError(),
+    toolNames: new Set(modifierSpecs.map((s) => s.name)),
+    storeEmpty: true,
+  },
+  {
+    domain: "standard (filter active)",
+    error: standardEmptyError({ category: "react" }),
+    toolNames: new Set(standardSpecs.map((s) => s.name)),
+    storeEmpty: false,
+  },
+  {
+    domain: "standard (store-empty)",
+    error: standardEmptyError({}),
+    toolNames: new Set(standardSpecs.map((s) => s.name)),
+    storeEmpty: true,
+  },
+];
+
+describe("empty-error recovery contract (cross-domain)", () => {
+  it.each(cases)("$domain honours the S-grade recovery shape", ({
+    error,
+    toolNames,
+    storeEmpty,
+  }) => {
+    const recovery = error.recovery;
+
+    // Terminal state (e.g. block already at all-tiers) is allowed.
+    if (recovery === undefined) return;
+
+    // Every hint carries a human-readable message.
+    expect(recovery.message).toBeTruthy();
+
+    // No hint is message-only: a runnable cli is always present (either a
+    // pragma re-list for filter-narrowing, or a bun add for store-empty).
+    expect(recovery.cli).toBeTruthy();
+
+    if (storeEmpty) {
+      // Store-empty must NOT carry an mcp retry: re-listing an absent store
+      // just loops. This is the anti-drift guard for the install rung.
+      expect(recovery.mcp).toBeUndefined();
+    } else if (recovery.mcp !== undefined) {
+      // A filter-narrowing mcp pointer must name a tool the domain actually
+      // registers — catches renamed/dangling tool references.
+      expect(toolNames.has(recovery.mcp.tool)).toBe(true);
+    }
+  });
+
+  it("never points an install hint at @canonical/ds-global (not a real default)", () => {
+    for (const { error } of cases) {
+      expect(error.recovery?.cli ?? "").not.toContain("ds-global");
+    }
+  });
+});

--- a/packages/cli/pragma/src/domains/standard/orchestration/standardEmptyError.test.ts
+++ b/packages/cli/pragma/src/domains/standard/orchestration/standardEmptyError.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import standardEmptyError from "./standardEmptyError.js";
+
+describe("standardEmptyError", () => {
+  it("filter-narrowing: a category/search was active → clear filters and re-list", () => {
+    const err = standardEmptyError({ category: "react", search: "fold" });
+
+    expect(err.filters).toEqual({ category: "react", search: "fold" });
+    expect(err.recovery).toEqual({
+      message: "List all standards without filters.",
+      cli: "pragma standard list",
+      mcp: { tool: "standard_list" },
+    });
+  });
+
+  it("store-empty: no filter active → install, not a self-looping list", () => {
+    const err = standardEmptyError({});
+
+    expect(err.filters).toBeUndefined();
+    // Must NOT suggest `pragma standard list` again — that just re-returns empty.
+    expect(err.recovery).toEqual({
+      message: "Install the code standards packages that provide standards.",
+      cli: "bun add -D @canonical/code-standards",
+    });
+    expect(err.recovery?.mcp).toBeUndefined();
+  });
+
+  it("install branch cites the code-standards package", () => {
+    const err = standardEmptyError({});
+    expect(err.recovery?.cli).toContain("@canonical/code-standards");
+    expect(err.recovery?.cli).not.toContain("ds-global");
+  });
+});

--- a/packages/cli/pragma/src/domains/standard/orchestration/standardEmptyError.ts
+++ b/packages/cli/pragma/src/domains/standard/orchestration/standardEmptyError.ts
@@ -7,13 +7,23 @@ export default function standardEmptyError(
   const active: Record<string, string> = {};
   if (filters.category) active.category = filters.category;
   if (filters.search) active.search = filters.search;
+  const hasFilter = Object.keys(active).length > 0;
 
   return PragmaError.emptyResults("standard", {
-    filters: Object.keys(active).length > 0 ? active : undefined,
-    recovery: {
-      message: "List all standards without filters.",
-      cli: "pragma standard list",
-      mcp: { tool: "standard_list" },
-    },
+    filters: hasFilter ? active : undefined,
+    recovery: hasFilter
+      ? {
+          // Filter-narrowing: clear the active category/search and re-list.
+          message: "List all standards without filters.",
+          cli: "pragma standard list",
+          mcp: { tool: "standard_list" },
+        }
+      : {
+          // Store-empty with no filter active: suggesting `standard list`
+          // again would just re-return empty, so route to the install.
+          message:
+            "Install the code standards packages that provide standards.",
+          cli: "bun add -D @canonical/code-standards",
+        },
   });
 }

--- a/packages/cli/pragma/src/domains/token/orchestration/tokenEmptyError.test.ts
+++ b/packages/cli/pragma/src/domains/token/orchestration/tokenEmptyError.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import tokenEmptyError from "./tokenEmptyError.js";
+
+describe("tokenEmptyError", () => {
+  it("filter-narrowing: a category was active → clear it and re-list", () => {
+    const err = tokenEmptyError("color");
+
+    expect(err.filters).toEqual({ category: "color" });
+    expect(err.recovery).toEqual({
+      message: "List all tokens without category filter.",
+      cli: "pragma token list",
+      mcp: { tool: "token_list" },
+    });
+  });
+
+  it("store-empty: no category active → runnable install, no mcp retry", () => {
+    const err = tokenEmptyError();
+
+    expect(err.filters).toBeUndefined();
+    expect(err.recovery).toEqual({
+      message: "Install the design system packages that provide tokens.",
+      cli: "bun add -D @canonical/design-system",
+    });
+    // No mcp: re-calling token_list on an absent store returns empty again.
+    expect(err.recovery?.mcp).toBeUndefined();
+  });
+
+  it("install branch cites a real default package, not @canonical/ds-global", () => {
+    const err = tokenEmptyError();
+    expect(err.recovery?.cli).toContain("@canonical/design-system");
+    expect(err.recovery?.cli).not.toContain("ds-global");
+  });
+});

--- a/packages/cli/pragma/src/domains/token/orchestration/tokenEmptyError.ts
+++ b/packages/cli/pragma/src/domains/token/orchestration/tokenEmptyError.ts
@@ -5,13 +5,16 @@ export default function tokenEmptyError(category?: string): PragmaError {
     filters: category ? { category } : undefined,
     recovery: category
       ? {
+          // Filter-narrowing: a category was active — clear it and re-list.
           message: "List all tokens without category filter.",
           cli: "pragma token list",
           mcp: { tool: "token_list" },
         }
       : {
-          message:
-            "Ensure design system packages are installed: bun add -D @canonical/ds-global",
+          // Store-empty: no category was active, so the token-supplying
+          // packages are absent. No mcp retry — re-listing returns empty.
+          message: "Install the design system packages that provide tokens.",
+          cli: "bun add -D @canonical/design-system",
         },
   });
 }


### PR DESCRIPTION
## Done

Two small CLI improvements (salvaged from the closed #543), plus an agent-facing workflow doc as a declared drive-by.

**Parallel `pragma doctor` checks** — `runChecks` now starts all 8 environment checks concurrently instead of awaiting them sequentially. A check that throws becomes an attributable `fail` (tagged with the check name) rather than aborting the whole run; declaration order is preserved for a deterministic report.

**S-grade empty-result recovery hints** (`block` / `token` / `modifier` / `standard`) — make every `<domain>EmptyError` hint dual-surface symmetric and cause-matched:
- `modifier` (previously message-only) and `token`'s install branch now carry a runnable `cli`.
- `standard` no longer self-loops (`standard list` again) on a no-filter empty — it routes to the install.
- **Corrects the install package**: hints referenced `@canonical/ds-global`, which is not a real default package. The token/modifier triples come from `@canonical/design-system`, standards from `@canonical/code-standards` (per `DEFAULT_PACKAGES`).
- Store-empty hints carry no `mcp` retry (re-listing an absent store loops; `doctor` false-passes on missing packages).
- `block` is unchanged — it is the reference shape, including its honest all-tiers terminal (`recovery: undefined`).

**Tests** — per-domain empty-error tests + a cross-domain invariant (every hint is `message`+`cli`, or a permitted `undefined` terminal; any `mcp.tool` names a registered spec; store-empty hints carry no `mcp`), plus `runChecks` order/throw/non-Error coverage.

**Drive-by:** `docs: add AGENTS.md` — an agent-facing PR-workflow contract (bun toolchain, conventional/semantic atomic commits, the exact root-level pre-push command sequence, branches & worktrees convention, convention-first guidance). Separate atomic commit; happy to split into its own PR if preferred.

## QA

- `bun run check` and `bun run test` pass from the repo root.
- `pragma doctor` — all checks still report correctly (run concurrently now).
- `pragma modifier list` / `token list` / `standard list` with packages absent → each surfaces a runnable `bun add -D <correct-package>` recovery.
- `pragma block list` then `--all-tiers` when already widened → no self-loop (`recovery: undefined`).

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] All packages define the required scripts in `package.json` (no new packages; no package manifests changed).
- [ ] N/A — no new package introduced.
- [x] No visual change — `no visual change` label added to skip Chromatic.
