### PR TITLE
fix(summon-component): Fix Svelte component output failing type-checking

### DIFF
--- a/packages/summon/component/src/templates/svelte/component.svelte.ejs
+++ b/packages/summon/component/src/templates/svelte/component.svelte.ejs
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { <%= name %>Props } from "./types";
+	import type { <%= name %>Props } from "./types.js";
 <% if (withStyles) { -%>
 	import "./styles.css";
 <% } -%>

--- a/packages/summon/component/src/templates/svelte/index.ts.ejs
+++ b/packages/summon/component/src/templates/svelte/index.ts.ejs
@@ -1,2 +1,2 @@
 export { default as <%= name %> } from "./<%= name %>.svelte";
-export type { <%= name %>Props } from "./types";
+export type { <%= name %>Props } from "./types.js";

--- a/packages/summon/component/src/templates/svelte/types.ts.ejs
+++ b/packages/summon/component/src/templates/svelte/types.ts.ejs
@@ -1,3 +1,4 @@
+import type { Snippet } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
 /*


### PR DESCRIPTION
## Done

Fixes the summon Svelte component generator output failing type-checking for several reasons:

- types.ts template was missing an import of the `Snippet` type that it relied on
- `<componentName>.svelte ` and `index.ts` did not explicitly specify `.js` file extensions in imports, which fails strict node module resolution.

## QA

- Clone the PR
- Follow the local development instructions in README to use the local version of the generator in the following step.
- Using the locally installed Svelte component generator, generate an example component.
- Select a component locator strategy in the test files (uncomment one of the lines in `componentLocator` in the SSR and non-SSR tests).
- `bun run check:fix` - verify no un-fixable formatting/type-checking errors are thrown.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.
