### PR TITLE
docs: form styles imports + OIDC manual-publish warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,3 +104,11 @@ a new file should be indistinguishable in style from its neighbours.
 - Add `no visual change` to skip Chromatic when there's no visual diff.
 - New package? First-time publish is manual (`npm publish --access public` from the
   package dir); verify with `bun run publish:status` from the root.
+- **New packages need OIDC trusted-publisher setup — a manual human step, agents cannot
+  do it.** Automated releases (`tag.yml`) publish via npm OIDC trusted publishing, but a
+  trusted publisher *cannot be configured until a package's first publish* (the npm
+  settings page doesn't exist yet). So a new package's first publish is manual, and a
+  human must then configure its trusted publisher on npmjs.com — until they do, the
+  automated workflow cannot publish future versions. Beware: merging a new package does
+  not make it releasable on its own. See
+  [`docs/how-to-guides/PUBLISH_A_PACKAGE.md`](docs/how-to-guides/PUBLISH_A_PACKAGE.md).

--- a/docs/adding-a-package.md
+++ b/docs/adding-a-package.md
@@ -307,7 +307,7 @@ New packages integrate into CI automatically through Lerna. The PR workflow runs
 
 The tag workflow publishes all public packages to npm. Packages with `"private": true` in package.json are excluded from publishing but still participate in builds and tests.
 
-If your PR introduces a brand-new npm package, the first publish must be done manually before regular release automation can pick it up. From inside the package directory, run `npm publish --access public` when the package is ready. After publishing, run `bun run publish:status` from the repository root to confirm the package appears in the registry.
+If your PR introduces a brand-new npm package, the first publish must be done manually before regular release automation can pick it up. **This is a manual human step — it requires interactive npm authentication (2FA) and access to npmjs.com, so it cannot be automated or performed by an AI agent.** From inside the package directory, run `npm publish --access public` when the package is ready. After publishing, run `bun run publish:status` from the repository root to confirm the package appears in the registry.
 
 The automated release workflow publishes via [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers), so after the first manual publish you must configure a trusted publisher for the new package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set its publishing access to disallow tokens. Until the trusted publisher is configured, the tag workflow cannot publish new versions of the package. See [How to publish a package](./how-to-guides/PUBLISH_A_PACKAGE.md#authentication-oidc-trusted-publishing) for the full procedure.
 

--- a/docs/how-to-guides/PUBLISH_A_PACKAGE.md
+++ b/docs/how-to-guides/PUBLISH_A_PACKAGE.md
@@ -36,6 +36,8 @@ This ensures the package can only be published via OIDC trusted publishing or an
 Follow these steps if your package has never been published to NPM before (for example, it was just merged to `main`).
 
 > **Note:** OIDC trusted publishing cannot be configured before a package's first publish, because the package settings page does not exist until the package is on npm. The first publish is therefore manual; configure the trusted publisher afterward so future releases are automated.
+>
+> **This is a manual human step — it cannot be automated or done by an AI agent.** It requires interactive npm authentication (2FA login) and access to the package's settings on npmjs.com. Beware when adding a new package: merging it to `main` does **not** make it releasable. Until a human runs the first publish and configures the trusted publisher, the automated `tag.yml` workflow will skip or fail to publish that package, and its version will silently lag the rest of the monorepo.
 
 1. **Log in to NPM**
    - Run `npm login` and enter your credentials for the [@canonical](https://www.npmjs.com/org/canonical) organization.

--- a/packages/react/ds-global-form/README.md
+++ b/packages/react/ds-global-form/README.md
@@ -9,8 +9,17 @@ Form components for the Pragma design system. This package provides a field syst
 ## Installation
 
 ```bash
-bun add @canonical/react-ds-global-form
+bun add @canonical/react-ds-global-form @canonical/styles
 ```
+
+Import the global styles and the form component styles in your application's root stylesheet:
+
+```css
+@import url("@canonical/styles");
+@import url("@canonical/react-ds-global-form/dist/esm/index.css");
+```
+
+The global styles provide the CSS reset, typography baseline, and design tokens (colour, spacing, surfaces, states) that all form components depend on. The form stylesheet provides input chrome, field layout, and component-specific styles.
 
 The package builds on top of `@canonical/react-ds-global`.
 


### PR DESCRIPTION
## Done

Two documentation changes (both docs-only, bundled):

1. **`docs(form)`** — `@canonical/react-ds-global-form` README: add `@canonical/styles` to the install command and document the two required CSS imports via deep `dist/` paths (no `package.json` exports map — deep paths kept reachable). Advances FD.DOC.STYLES (session/I.02 Forms).
2. **`docs(release)` (drive-by)** — flag OIDC trusted-publisher setup as a **manual human step** across AGENTS.md, `docs/adding-a-package.md`, and `docs/how-to-guides/PUBLISH_A_PACKAGE.md`: a new package needs its trusted publisher configured on npmjs.com after the first manual publish, this cannot be automated or done by an AI agent, and merging a new package does not make it releasable.

## QA
Docs/markdown only. No code, no `package.json` changes, no build artifacts affected.

`no visual change`