### PR TITLE
docs(router): add middleware cookbook and API reference

### DIFF
--- a/docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md
+++ b/docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md
@@ -1,0 +1,354 @@
+# Router middleware cookbook
+
+Middleware in `@canonical/router-core` transforms routes once, before the router is created. Use middleware when a concern should apply consistently across a route map without editing every route declaration by hand.
+
+This is a recipe collection. Each recipe is a self-contained middleware factory you can copy, adapt, and compose. Every example is valid against the current API: the route data hook is `prefetch(params, search, context)` — there is no `fetch` field.
+
+## When to use middleware
+
+Use middleware for cross-cutting policy:
+
+- auth redirects
+- locale prefixes or locale-aware navigation setup
+- timing or tracing of navigation-time work
+- shared wrapper or error-boundary policy
+
+Avoid middleware when the concern is relevant to a single route. In that case, keep it in the route's `prefetch` or `content`. Prefer wrappers (`wrapper()` + `group()`) for layout and shared UI; reserve middleware for behaviour that rewrites the route itself.
+
+## The middleware contract
+
+A `RouteMiddleware` is a route endomorphism: a function from a route to a route of the same type.
+
+```ts
+import type { AnyRoute, RouteMiddleware } from "@canonical/router-core";
+
+const passthrough: RouteMiddleware = <TRoute extends AnyRoute>(
+  currentRoute: TRoute,
+): TRoute => {
+  return currentRoute;
+};
+```
+
+The `<TRoute extends AnyRoute>` generic is what keeps middleware type-preserving: the route you return is the same shape (and same named-route type) as the one you received. Returning the route unchanged is always valid — that is the correct response when a rule does not apply.
+
+A middleware **factory** is a function that captures configuration and returns a `RouteMiddleware`:
+
+```ts
+function withSomething(config: string): RouteMiddleware {
+  return ((currentRoute: AnyRoute) => {
+    // inspect currentRoute.url, currentRoute.meta, etc.
+    return currentRoute;
+  }) as RouteMiddleware;
+}
+```
+
+The cast on the inner arrow (`as RouteMiddleware`) is the practical idiom: the body works with `AnyRoute`, but the exported value advertises the type-preserving generic signature. This mirrors the real `withAuth` factory in the boilerplate.
+
+## How middleware is applied
+
+`applyMiddleware(routes, middleware)` runs the middleware over an array of routes and rebuilds each route's `parse`/`render` codec from the (possibly changed) `url`. You rarely call it directly — `createBrowserRouter`, `createStaticRouter`, and `createMemoryRouter` all accept a `middleware` option and apply it for you.
+
+```ts
+import { createBrowserRouter } from "@canonical/router-core";
+
+const router = createBrowserRouter(appRoutes, {
+  middleware: [withAuth("/login")],
+  notFound: notFoundRoute,
+});
+```
+
+Two facts about `applyMiddleware` worth internalising:
+
+1. **It rebuilds the codec from `url`.** After the middleware chain runs, `parse(url)` and `render(params)` are regenerated from `transformed.url`. So a middleware that rewrites `url` (for example, a locale prefix) gets coherent matching and link-building for free — you do not rebuild the codec yourself.
+2. **Outermost-first array semantics.** The middleware array is reversed and folded, so the **first** entry in the array is the **outermost** transform: it sees the route last on the way in and its effect wraps everything after it. Order your array from broadest policy to narrowest. See [Composition order](#composition-order).
+
+## Recipe: `withAuth(loginPath)`
+
+Redirect anonymous visitors away from protected routes before their data is warmed. This is the canonical recipe, and the one place the runtime-redirect mechanics matter most.
+
+```ts
+import {
+  type AnyRoute,
+  type NavigationContext,
+  redirect,
+  type RouteMiddleware,
+  type RouteParamValues,
+} from "@canonical/router-core";
+
+const protectedPaths = new Set(["/account"]);
+
+function hasDemoAuth(search: unknown): boolean {
+  return (search as Record<string, unknown>)?.auth === "1";
+}
+
+export function withAuth(loginPath: string): RouteMiddleware {
+  return ((currentRoute: AnyRoute) => {
+    if (!protectedPaths.has(currentRoute.url)) {
+      return currentRoute;
+    }
+
+    const currentPrefetch = currentRoute.prefetch;
+
+    return {
+      ...currentRoute,
+      prefetch: (
+        params: unknown,
+        search: unknown,
+        context: NavigationContext,
+      ) => {
+        if (!hasDemoAuth(search)) {
+          const from = currentRoute.render(
+            (params ?? {}) as RouteParamValues | Record<string, never>,
+          );
+
+          redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);
+        }
+
+        if (currentPrefetch) {
+          return currentPrefetch(params, search, context);
+        }
+      },
+    };
+  }) as RouteMiddleware;
+}
+```
+
+What makes this correct against the current API:
+
+- **The data hook is `prefetch`, not `fetch`.** The route's only data hook is `prefetch(params, search, context)`. The middleware captures the original (`const currentPrefetch = currentRoute.prefetch;`) and delegates to it once the auth check passes.
+- **`redirect()` does not return — it throws.** `redirect(to, status)` constructs a `RouteRedirect` (exported as `Redirect`) and throws it; its return type is `never`. You do not `return redirect(...)`. The throw unwinds out of the void-returning `prefetch`, and the router catches it and performs the navigation. Because the redirect throws, the `currentPrefetch(...)` call below it is unreachable for unauthenticated visitors — exactly the intent.
+- **`prefetch` returns `void | Promise<void>`.** The redirect is a side effect on the control flow, not a value the hook hands back. Never try to model the redirect as a return value or a resolved promise.
+- **Status `302` is the runtime default.** The runtime `redirect()` helper accepts `301 | 302 | 307 | 308` and defaults to `302`. The boilerplate passes `302` explicitly. Do not confuse this with static redirect routes (`route({ url, redirect, status })`), whose `status` is narrower: `301 | 308` only.
+
+### The pure-decision companion: `getAuthRedirectHref`
+
+The middleware decides at navigation time, inside `prefetch`. But a server (sitemap generation, an SSR pre-flight, an edge function) often needs the **same** decision *without* a router and without throwing. Factor the decision into a pure helper and call it from both places:
+
+```ts
+export function getAuthRedirectHref(input: string | URL): string | null {
+  const url =
+    input instanceof URL
+      ? input
+      : new URL(input, "https://router.local");
+
+  if (
+    !protectedPaths.has(url.pathname) ||
+    hasDemoAuth({ auth: url.searchParams.get("auth") })
+  ) {
+    return null;
+  }
+
+  return `/login?from=${encodeURIComponent(url.pathname)}`;
+}
+```
+
+`getAuthRedirectHref` returns the redirect target as a string, or `null` when no redirect is needed. It never throws and never touches the router, so a server can branch on it before rendering:
+
+```ts
+const redirectHref = getAuthRedirectHref(requestUrl);
+if (redirectHref) {
+  return Response.redirect(redirectHref, 302);
+}
+// otherwise fall through to createStaticRouter(...) + render
+```
+
+This is the corrected shape of the auth recipe: the **throwing** path lives inside `prefetch` (client navigation), the **pure** path is a reusable function (server pre-flight), and both share `protectedPaths` and `hasDemoAuth` so the policy cannot drift between them.
+
+### Rationale
+
+- centralises auth policy in one factory plus one pure helper
+- preserves the route's typed helpers (`render`, `parse`) — `applyMiddleware` rebuilds the codec
+- keeps the throwing redirect strictly out of any value position
+
+## Recipe: `withI18n(defaultLocale)`
+
+Prefix every route with a `:locale` segment and inject the resolved locale into downstream `prefetch` work. Because `applyMiddleware` rebuilds the codec from the rewritten `url`, both matching and link-building pick up the new segment automatically.
+
+```ts
+import {
+  type AnyRoute,
+  type NavigationContext,
+  type RouteMiddleware,
+} from "@canonical/router-core";
+
+export function withI18n(defaultLocale: string): RouteMiddleware {
+  return ((currentRoute: AnyRoute) => {
+    const currentPrefetch = currentRoute.prefetch;
+
+    return {
+      ...currentRoute,
+      url: `/:locale${currentRoute.url === "/" ? "" : currentRoute.url}`,
+      prefetch: currentPrefetch
+        ? (
+            params: Record<string, string>,
+            search: unknown,
+            context: NavigationContext,
+          ) => {
+            const locale = params.locale ?? defaultLocale;
+
+            return currentPrefetch(params, { ...(search as object), locale }, context);
+          }
+        : undefined,
+    };
+  }) as RouteMiddleware;
+}
+```
+
+Notes:
+
+- The rewritten `url` becomes `/:locale/account`, `/:locale/guides/:slug`, and so on. You do not call `matchPath`/`renderPattern` yourself — `applyMiddleware` does it from `transformed.url`.
+- `prefetch` stays `undefined` when the source route has no data hook. Wrapping a non-existent hook would force a hook onto a route that never had one.
+- The locale is folded into `search` for the delegated `prefetch` call; the original three-argument shape `(params, search, context)` is preserved.
+
+### Rationale
+
+- one place to enforce locale-aware URLs
+- pairs naturally with boilerplate/route generators
+- the codec rebuild means typed `Link`/`navigate` keep working after the URL changes
+
+## Recipe: `withTiming(report)`
+
+Measure how long a route's navigation-time `prefetch` runs. Pure instrumentation: it never changes routing behaviour.
+
+```ts
+import {
+  type AnyRoute,
+  type NavigationContext,
+  type RouteMiddleware,
+} from "@canonical/router-core";
+
+export function withTiming(
+  report: (event: { route: string; durationMs: number }) => void,
+): RouteMiddleware {
+  return ((currentRoute: AnyRoute) => {
+    const currentPrefetch = currentRoute.prefetch;
+
+    if (!currentPrefetch) {
+      return currentRoute;
+    }
+
+    return {
+      ...currentRoute,
+      prefetch: async (
+        params: unknown,
+        search: unknown,
+        context: NavigationContext,
+      ) => {
+        const startedAt = performance.now();
+
+        try {
+          return await currentPrefetch(params, search, context);
+        } finally {
+          report({
+            durationMs: performance.now() - startedAt,
+            route: currentRoute.url,
+          });
+        }
+      },
+    };
+  }) as RouteMiddleware;
+}
+```
+
+Notes:
+
+- Return the route untouched when there is no `prefetch` to time.
+- `prefetch` may return `void` or `Promise<void>`; `await` handles both, and the `finally` reports even if the hook throws (including a `redirect()` thrown by an inner auth middleware) — instrumentation should not swallow that throw.
+
+### Rationale
+
+- keeps instrumentation orthogonal to route logic
+- trivial to disable in tests (pass a no-op `report`)
+- works for analytics, tracing, and SLO dashboards
+
+## Recipe: `withErrorBoundary(boundary)`
+
+Share one wrapper across a set of routes by prepending it to each route's `wrappers` array. This is the middleware route to applying a wrapper uniformly when `group()` at the call site is inconvenient.
+
+```ts
+import {
+  type AnyRoute,
+  type RouteMiddleware,
+  type WrapperDefinition,
+} from "@canonical/router-core";
+import type { ReactElement } from "react";
+import { wrapper } from "@canonical/router-core";
+
+const shellBoundary = wrapper<ReactElement>({
+  id: "shell:error-boundary",
+  component: ({ children }) => children,
+});
+
+export function withErrorBoundary(
+  boundary: WrapperDefinition<ReactElement> = shellBoundary,
+): RouteMiddleware {
+  return ((currentRoute: AnyRoute) => {
+    return {
+      ...currentRoute,
+      wrappers: [boundary, ...currentRoute.wrappers],
+    };
+  }) as RouteMiddleware;
+}
+```
+
+Notes:
+
+- `wrappers` is always present on a `RouteDefinition` (it defaults to `[]`), so `[boundary, ...currentRoute.wrappers]` is safe without a guard.
+- `wrapper()` takes a single type parameter, `wrapper<TRendered>` (here `ReactElement`). A wrapper's own optional `prefetch` is `(params, context)` — two arguments, no `search` — distinct from a route's three-argument `prefetch`.
+- The error experience itself is a React `<ErrorBoundary>` inside the wrapper component. The router has no error-UI field; render errors propagate past `<Outlet>`, so the boundary belongs in the wrapper's JSX. Use `StatusResponse` from a `prefetch` to signal an HTTP-like status to that boundary.
+
+### Rationale
+
+- consistent fallback behaviour across many routes
+- keeps route declarations focused on `content` and data
+- composes with layout wrappers (it prepends, so it nests outside them)
+
+## Composition order
+
+Middleware runs with outermost-first array semantics: the first array entry is the outermost transform. Order from broadest URL policy to narrowest concern.
+
+```ts
+import { createBrowserRouter } from "@canonical/router-core";
+
+const router = createBrowserRouter(appRoutes, {
+  middleware: [withI18n("en"), withAuth("/login"), withTiming(report)],
+  notFound: notFoundRoute,
+});
+```
+
+Reading the array left to right:
+
+1. `withI18n("en")` rewrites the URL first, so `withAuth` and `withTiming` see the locale-prefixed route and the locale-aware `prefetch`.
+2. `withAuth("/login")` wraps the (now locale-aware) `prefetch` with its redirect guard.
+3. `withTiming(report)` wraps last, so its timer is the innermost wrapper around whatever the chain produced — it measures the full composed `prefetch`, redirect throw included.
+
+If you reverse the order, `withAuth` would inspect the unprefixed URL and the timer would sit outside the redirect logic. Order is meaningful; choose it deliberately.
+
+The boilerplate exports its chain as a `const` tuple and spreads it into both entries so client and server apply identical policy:
+
+```ts
+export const middleware = [withAuth("/login")] as const;
+
+// client: createBrowserRouter(appRoutes, { middleware: [...middleware], notFound: notFoundRoute })
+// server: createStaticRouter(appRoutes, url, { middleware: [...middleware], notFound: notFoundRoute })
+```
+
+## Rules of thumb
+
+- return the original route unchanged when the rule does not apply
+- capture and delegate to `currentRoute.prefetch` — never assume it exists, and never replace it with a hook the route never had
+- there is no `fetch` field; `prefetch(params, search, context)` is the only route data hook
+- `redirect()` throws (`never`) — call it for its side effect inside `prefetch`, never `return` it
+- factor any decision a server also needs into a pure helper (the `getAuthRedirectHref` pattern) so client and server share one policy
+- prefer middleware for cross-cutting policy, wrappers (`wrapper()` + `group()`) for layout and shared UI
+- document any redirect or URL-shape change clearly for consumers — middleware rewrites routes out from under the call site
+
+## See a working example
+
+The live auth middleware — `withAuth` and the pure `getAuthRedirectHref` companion — is in [apps/react/boilerplate-vite/src/routes.tsx](../../apps/react/boilerplate-vite/src/routes.tsx). The routes it transforms, including the `~standard` search schemas, are in [apps/react/boilerplate-vite/src/domains/account/routes.ts](../../apps/react/boilerplate-vite/src/domains/account/routes.ts) and [apps/react/boilerplate-vite/src/domains/marketing/routes.ts](../../apps/react/boilerplate-vite/src/domains/marketing/routes.ts). The client and server entries that apply the middleware are [src/client/entry.tsx](../../apps/react/boilerplate-vite/src/client/entry.tsx) and [src/server/entry.tsx](../../apps/react/boilerplate-vite/src/server/entry.tsx).
+
+## Reference
+
+- [Router core README](../../packages/runtime/router/README.md)
+- [`applyMiddleware` source](../../packages/runtime/router/src/lib/applyMiddleware.ts)
+- [Migrating to the pragma router](./MIGRATE_TO_PRAGMA_ROUTER.md)

--- a/docs/references/ROUTER_API.md
+++ b/docs/references/ROUTER_API.md
@@ -1,0 +1,879 @@
+# Router API reference
+
+Complete public API for the pragma router. Two packages:
+
+- **`@canonical/router-core`** (`packages/runtime/router`) — framework-agnostic routing engine: factories, route/wrapper/group/middleware primitives, adapters, types.
+- **`@canonical/router-react`** (`packages/react/router`) — React binding: provider, `Link`, `Outlet`, hooks, SSR and hydration helpers.
+
+Every signature below is transcribed from source. Type parameters are elided to their load-bearing form where the full constraint adds no information; defaults are preserved.
+
+Conventions used throughout:
+
+- `TRoutes extends RouteMap` — the application route map (`Record<string, AnyRoute>`).
+- `TNotFound extends AnyRoute | undefined = undefined` — the optional not-found route.
+- `TRendered` — the value a `content`/`wrapper.component` returns. The React layer fixes it to `ReactElement`; core leaves it `unknown`.
+
+---
+
+## @canonical/router-core
+
+### Router factories
+
+All four return a [`Router`](#router). `createBrowserRouter`, `createMemoryRouter`, and `createStaticRouter` wrap `createRouter` with a preset adapter. Pick by environment.
+
+| Factory | Adapter | Use when |
+|---|---|---|
+| `createBrowserRouter` | `createBrowserAdapter()` (Navigation API → History API fallback) | Client, non-SSR app entry |
+| `createStaticRouter` | `createServerAdapter(url)` | Server-side render of one request |
+| `createMemoryRouter` | `createMemoryAdapter(initialUrl)` | Tests and non-DOM environments |
+| `createRouter` | none unless you pass `adapter` | Custom adapter / low-level control |
+
+#### `createRouter`
+
+```ts
+function createRouter<
+  const TRoutes extends RouteMap,
+  const TNotFound extends AnyRoute | undefined = undefined,
+>(
+  routes: TRoutes,
+  options?: RouterOptions<TNotFound>,
+): Router<TRoutes, TNotFound>;
+```
+
+Base factory. Applies `options.middleware` to the route map, asserts unique wrapper ids, wires accessibility managers, and constructs the store. Every other factory delegates here.
+
+```ts
+const router = createRouter(appRoutes, { adapter: myAdapter, notFound: notFoundRoute });
+```
+
+#### `createBrowserRouter`
+
+```ts
+function createBrowserRouter<
+  const TRoutes extends RouteMap,
+  const TNotFound extends AnyRoute | undefined = undefined,
+>(
+  routes: TRoutes,
+  options?: Omit<RouterOptions<TNotFound>, "adapter">,
+): Router<TRoutes, TNotFound>;
+```
+
+Client router. Injects `createBrowserAdapter()` (Navigation API where available, History API otherwise). `options` omits `adapter`.
+
+```ts
+const router = createBrowserRouter(appRoutes, {
+  middleware: [...middleware],
+  notFound: notFoundRoute,
+});
+```
+
+#### `createStaticRouter`
+
+```ts
+function createStaticRouter<
+  const TRoutes extends RouteMap,
+  const TNotFound extends AnyRoute | undefined = undefined,
+>(
+  routes: TRoutes,
+  url: string | URL,
+  options?: Omit<RouterOptions<TNotFound>, "adapter" | "initialUrl">,
+): Router<TRoutes, TNotFound> & {
+  readonly match: RouterMatch<TRoutes, TNotFound> | null;
+};
+```
+
+SSR router. Matches `url` synchronously and hydrates the store so `render()`/`<Outlet>` work without awaiting `load()`; prefetch fires in the background. The returned object adds a `match` field for status-code and redirect decisions before rendering. `options` omits `adapter` and `initialUrl`.
+
+```ts
+const router = createStaticRouter(appRoutes, req.url, {
+  middleware: [...middleware],
+  notFound: notFoundRoute,
+});
+
+if (!router.match) {
+  res.status(404);
+} else if (router.match.kind === "redirect") {
+  return res.redirect(router.match.status, router.match.redirectTo);
+}
+```
+
+#### `createMemoryRouter`
+
+```ts
+function createMemoryRouter<
+  const TRoutes extends RouteMap,
+  const TNotFound extends AnyRoute | undefined = undefined,
+>(
+  routes: TRoutes,
+  initialUrl: string | URL = "/",
+  options?: Omit<RouterOptions<TNotFound>, "adapter">,
+): Router<TRoutes, TNotFound>;
+```
+
+In-memory router for tests. Injects `createMemoryAdapter(initialUrl)`, whose adapter additionally exposes `back()` / `forward()`. `initialUrl` defaults to `"/"`.
+
+```ts
+const router = createMemoryRouter(appRoutes, "/account?auth=1");
+await router.load(router.getState().location.url);
+```
+
+### `RouterOptions`
+
+```ts
+interface RouterOptions<TNotFound extends AnyRoute | undefined = undefined> {
+  readonly adapter?: PlatformAdapter;
+  readonly accessibility?: RouterAccessibilityOptions;
+  readonly hydratedState?: RouterDehydratedState<RouteMap>;
+  readonly initialUrl?: string | URL;
+  readonly middleware?: readonly RouteMiddleware[];
+  readonly notFound?: TNotFound;
+}
+```
+
+`accessibility` configures focus, route announcement, scroll restoration, and view transitions (each `false` to disable); see `RouterAccessibilityOptions` in `types.ts`. `hydratedState` resumes from a dehydrated SSR snapshot.
+
+### `Router`
+
+The router instance. Selected members (full surface in `types.ts`, lines 586–636):
+
+```ts
+interface Router<TRoutes extends RouteMap, TNotFound extends AnyRoute | undefined = undefined> {
+  readonly routes: TRoutes;
+  readonly notFound: TNotFound;
+  readonly adapter: PlatformAdapter | null;
+  readonly store: RouterStore<TRoutes, TNotFound>;
+  getRoute<TName extends RouteName<TRoutes>>(name: TName): RouteOf<TRoutes, TName>;
+  getState(): RouterState<TRoutes, TNotFound>;
+  getTrackedLocation(onAccess: (key: RouterLocationKey) => void): TrackedLocation<RouterLocationState>;
+  buildPath: BuildPathFn<TRoutes>;                       // (name, options?) => string
+  dehydrate(): RouterDehydratedState<TRoutes> | null;
+  dispose(): void;
+  hydrate(state: RouterDehydratedState<TRoutes>): RouterLoadResult<TRoutes, TNotFound>;
+  load(url: string | URL): Promise<RouterLoadResult<TRoutes, TNotFound>>;
+  match(url: string | URL): RouterMatch<TRoutes, TNotFound> | null;
+  navigate: NavigateFn<TRoutes>;                         // (name, options?) => NavigationIntent
+  prefetch: PrefetchFn<TRoutes>;                         // (name, options?) => Promise<void>
+  registerBlocker(blocker: RouterBlocker): void;
+  unregisterBlocker(id: string): void;
+  readonly blockerState: "idle" | "blocked";
+  proceedNavigation(): void;
+  cancelNavigation(): void;
+  render(result?: RouterLoadResult<TRoutes, TNotFound> | null): unknown;
+  setSearchParams(
+    params:
+      | Record<string, string | null>
+      | ((current: Record<string, string>) => Record<string, string | null>),
+    options?: { readonly replace?: boolean },
+  ): void;
+  subscribe(listener: (snapshot: RouterSnapshot<TRoutes, TNotFound>) => void): () => void;
+  subscribeToNavigation(listener: (state: RouterNavigationState, previousState: RouterNavigationState) => void): () => void;
+  subscribeToSearchParam(key: string, listener: (value: string | null, previousValue: string | null) => void): () => void;
+}
+```
+
+- **`navigate(name, options?)`** and **`buildPath(name, options?)`** take a route name and `PathBuildOptions`. `params` is required at the type level iff the route's `url` contains `:params`; `search`, `hash`, and `replace` are optional. `navigate` returns a `NavigationIntent` (`{ name, href, params, search, hash? }`); `buildPath` returns the built path string.
+- **`prefetch(name, options?)`** returns `Promise<void>` — warms the route's `prefetch` hook ahead of navigation.
+- **`render(result?)`** returns `unknown` (framework-agnostic); the React layer consumes it via `<Outlet>`.
+- **`render()` returns `unknown`**, not a React element — typing is supplied by `TRendered` on `content`/`wrapper.component`.
+
+```ts
+router.navigate("account", { search: { auth: "1" } });
+const href = router.buildPath("guide", { params: { slug: "intro" } });
+await router.prefetch("home");
+```
+
+### Route definition — `route`
+
+```ts
+// Redirect overload (matched first; presence of `redirect` selects it):
+function route<const TPath extends string, TTarget extends string, TWrappers extends readonly AnyWrapper[] = readonly []>(
+  definition: RedirectRouteInput<TPath, TTarget, TWrappers>,
+): RedirectRouteDefinition<TPath, TTarget, TWrappers>;
+
+// Data overload:
+function route<
+  const TPath extends string,
+  TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
+  TRendered = unknown,
+  TWrappers extends readonly AnyWrapper[] = readonly [],
+>(
+  definition: DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers>,
+): DataRouteDefinition<TPath, TSearchSchema, TRendered, TWrappers>;
+```
+
+Constructs one flat route and derives its path codec. The returned definition adds `parse(url) → params | null` and `render(params) → string` over the input, and defaults `wrappers` to `[]`. Routes are **flat** — there is no nesting or `children`. Shared layout comes from [`wrapper`](#wrapper) + [`group`](#group); cross-cutting logic from [middleware](#middleware-applymiddleware).
+
+#### `DataRouteInput`
+
+```ts
+interface DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers> {
+  readonly url: TPath;
+  readonly content: RouteContent<TPath, TSearchSchema, TRendered>;
+  readonly prefetch?: BivariantCallback<
+    [params: RouteParams<TPath>, search: InferSearch<TSearchSchema>, context: NavigationContext],
+    void | Promise<void>
+  >;
+  readonly search?: TSearchSchema;
+  readonly wrappers?: TWrappers;
+  readonly meta?: Readonly<Record<string, unknown>>;
+}
+```
+
+- **`url`** — path pattern. `:param` segments become typed params; modifiers (`?`, `*`, `+`, `(regex)`) are stripped for naming. `RouteParams<TPath>` infers `{ readonly [name]: string }`, or `Record<string, never>` when the path has none.
+- **`content`** — the component, called with `RouteContentProps`. Carries an optional `preload?: () => Promise<RouteModule>` for code-splitting.
+- **`prefetch`** — see [the prefetch hook](#the-prefetch-hook).
+- **`search`** — a [Standard-Schema-like](#search-validation) validator; its `output` type flows to `content`'s `search` prop and the route's `SearchOf`.
+- **`wrappers`** — layout wrappers (usually applied via `group`, not set by hand).
+- **`meta`** — arbitrary readonly metadata.
+
+```ts
+const account = route({
+  url: "/account",
+  search: accountSearchSchema,
+  content: AccountPage,
+});
+```
+
+#### `RouteContentProps`
+
+Props passed to a route's `content`:
+
+```ts
+interface RouteContentProps<
+  TParams extends RouteParamValues | Record<string, never> = Record<string, never>,
+  TSearch = Record<string, never>,
+> {
+  readonly params: TParams;
+  readonly search: TSearch;
+}
+```
+
+```ts
+function AccountPage({ params, search }: RouteContentProps<{ readonly id: string }, { auth?: string }>) {
+  return <p>{params.id} {search.auth}</p>;
+}
+```
+
+#### The `prefetch` hook
+
+`prefetch` is the **only** data hook — there is no `fetch` field anywhere. It is fire-and-forget: the router does **not** block render on it or feed its result to the component. Use it to warm an external cache (Relay, TanStack Query, SWR) or preload assets at navigation time; components own their own data.
+
+```ts
+readonly prefetch?: (
+  params: RouteParams<TPath>,
+  search: InferSearch<TSearchSchema>,
+  context: NavigationContext,
+) => void | Promise<void>;
+```
+
+The third argument is the navigation context:
+
+```ts
+interface NavigationContext {
+  readonly signal: AbortSignal;   // aborts when the navigation is superseded
+}
+```
+
+Throwing inside `prefetch` is meaningful: throw a [`StatusResponse`](#statusresponse) for an HTTP-like error, or call [`redirect()`](#redirect-redirect-routeredirect) to short-circuit navigation. Both propagate to standard React error boundaries on the client and to the server handler under SSR.
+
+```ts
+prefetch: (params, search, context) => {
+  void queryClient.prefetchQuery({
+    queryKey: ["user", params.id],
+    queryFn: ({ signal }) => fetchUser(params.id, signal),
+    signal: context.signal,
+  });
+},
+```
+
+#### `RedirectRouteInput` — static redirect routes
+
+```ts
+type StaticRedirectStatus = 301 | 308;
+
+interface RedirectRouteInput<TPath, TTarget, TWrappers> {
+  readonly url: TPath;
+  readonly redirect: TTarget;       // destination path
+  readonly status: StaticRedirectStatus;
+  readonly wrappers?: TWrappers;
+  readonly meta?: Readonly<Record<string, unknown>>;
+}
+```
+
+A route with no `content`. The `status` is restricted to permanent redirects (`301 | 308`) — distinct from the runtime [`redirect()`](#redirect-redirect-routeredirect) helper's wider union. Matched ahead of data routes by the presence of `redirect`.
+
+```ts
+const legacy = route({ url: "/old", redirect: "/new", status: 308 });
+```
+
+#### Definition shapes and codec
+
+`RouteInput = DataRouteInput | RedirectRouteInput` (what `route()` accepts); `RouteDefinition = DataRouteDefinition | RedirectRouteDefinition` (what it returns). Both definitions extend `RouteCodec<TPath>`:
+
+```ts
+interface RouteCodec<TPath extends string = string> {
+  parse(url: string | URL): RouteParams<TPath> | null;
+  render(params: RouteParams<TPath>): string;
+}
+```
+
+The definition is the input shape with `wrappers` made required (defaulted to `[]`) plus `parse`/`render`. `DataRouteDefinition` keeps the same three-arg `prefetch` signature as the input.
+
+### Composition — `wrapper`, `group`
+
+A **wrapper** is a reusable layout shell; **`group`** applies one wrapper to a list of routes. This replaces nested layout routes.
+
+#### `wrapper`
+
+```ts
+function wrapper<TRendered = unknown>(
+  definition: WrapperDefinition<TRendered>,
+): WrapperDefinition<TRendered>;
+```
+
+Identity passthrough that fixes the single type parameter `TRendered`. The definition:
+
+```ts
+interface WrapperDefinition<TRendered = unknown> {
+  readonly id: string;                                          // must be unique across the route map
+  readonly component: (props: WrapperComponentProps<TRendered>) => TRendered;
+  readonly prefetch?: (params: RouteParamValues, context: NavigationContext) => void | Promise<void>;
+}
+
+interface WrapperComponentProps<TRendered = unknown> {
+  readonly children: TRendered;
+}
+```
+
+Note the wrapper `prefetch` takes **two** args `(params, context)` — no `search`, unlike route `prefetch`. Wrapper prefetches are fire-and-forget and not cached.
+
+```ts
+const publicLayout = wrapper<ReactElement>({
+  id: "public-layout",
+  component: ({ children }) => (
+    <div className="app-shell">
+      <header><Navigation /></header>
+      <main>{children}</main>
+    </div>
+  ),
+});
+```
+
+#### `group`
+
+```ts
+function group<TWrapper extends AnyWrapper, TRoutes extends readonly AnyRoute[]>(
+  nextWrapper: TWrapper,
+  routes: TRoutes,
+): GroupedRoutes<TWrapper, TRoutes>;
+```
+
+Prepends `nextWrapper` to every route's `wrappers` array and returns the rewrapped list (positionally typed, so destructuring preserves each route's type). Nest `group(...)` calls to stack wrappers (outermost wrapper outermost).
+
+```ts
+const [account, login] = group(publicLayout, [
+  accountRoutes.account,
+  accountRoutes.login,
+] as const);
+```
+
+#### The publicLayout pattern
+
+Assemble routes flat, attach shared layout with `group`, then collect into a route map:
+
+```ts
+const [guide, home] = group(publicLayout, [marketingRoutes.guide, marketingRoutes.home] as const);
+const [account, login] = group(publicLayout, [accountRoutes.account, accountRoutes.login] as const);
+
+const appRoutes = { guide, home, account, login } as const;
+export type AppRoutes = typeof appRoutes;
+```
+
+### Middleware — `applyMiddleware`
+
+A **`RouteMiddleware`** is a route endomorphism applied before the router is built. Use it for auth, i18n, analytics — anything cross-cutting that rewrites routes.
+
+```ts
+type RouteMiddleware = <TRoute extends AnyRoute>(route: TRoute) => TRoute;
+```
+
+#### `applyMiddleware`
+
+```ts
+function applyMiddleware<TRoutes extends readonly AnyRoute[]>(
+  routes: TRoutes,
+  middleware: readonly RouteMiddleware[],
+): TRoutes;
+```
+
+Applies each middleware to each route with **outermost-first** array semantics (the first entry runs last, wrapping the rest), then rebuilds `parse`/`render` from the possibly-changed `url`. `createRouter` runs this internally over `options.middleware`, so passing `middleware` to a factory is equivalent; call `applyMiddleware` directly only when manipulating a route array outside a router.
+
+#### Middleware contract (the `withAuth` pattern)
+
+A middleware that guards protected paths wraps the route's existing `prefetch`, preserving it for the authorised case:
+
+```ts
+export function withAuth(loginPath: string): RouteMiddleware {
+  return ((currentRoute: AnyRoute) => {
+    if (!protectedPaths.has(currentRoute.url)) {
+      return currentRoute;                          // leave unprotected routes untouched
+    }
+
+    const currentPrefetch = currentRoute.prefetch;  // preserve the original
+
+    return {
+      ...currentRoute,
+      prefetch: (params: unknown, search: unknown, context: NavigationContext) => {
+        if (!hasDemoAuth(search)) {
+          const from = currentRoute.render((params ?? {}) as RouteParamValues | Record<string, never>);
+          redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);  // throws RouteRedirect
+        }
+        if (currentPrefetch) {
+          return currentPrefetch(params, search, context);
+        }
+      },
+    };
+  }) as RouteMiddleware;
+}
+
+export const middleware = [withAuth("/login")] as const;
+```
+
+Wire it into both entries:
+
+```ts
+createBrowserRouter(appRoutes, { middleware: [...middleware], notFound: notFoundRoute });   // client
+createStaticRouter(appRoutes, url, { middleware: [...middleware], notFound: notFoundRoute }); // server
+```
+
+For a server-side pre-render decision that must not throw, mirror the same logic in a pure helper that returns the redirect href or `null`:
+
+```ts
+function getAuthRedirectHref(input: string | URL): string | null {
+  const url = input instanceof URL ? input : new URL(input, "https://router.local");
+  if (!protectedPaths.has(url.pathname) || hasDemoAuth({ auth: url.searchParams.get("auth") })) {
+    return null;
+  }
+  return `/login?from=${encodeURIComponent(url.pathname)}`;
+}
+```
+
+### Runtime redirects — `redirect`, `Redirect`, `RouteRedirect`
+
+> **`Redirect` is not a React component.** It is the `RouteRedirect` class, re-exported from `@canonical/router-core` under the name `Redirect`. There is no `<Redirect>` element. Use these as the throwable redirect primitives inside a `prefetch`/`fetch`-time hook.
+
+#### `redirect`
+
+```ts
+function redirect(to: string, status: 301 | 302 | 307 | 308 = 302): never;
+```
+
+Throws a `RouteRedirect` to short-circuit navigation from inside a route or wrapper `prefetch` (or middleware). Status union is **wider** than static redirect routes (which only allow `301 | 308`); default is `302`.
+
+```ts
+redirect(`/login?from=${encodeURIComponent(from)}`, 302);
+```
+
+#### `RouteRedirect` (exported as `Redirect`)
+
+```ts
+class RouteRedirect {        // export { default as Redirect } from "./RouteRedirect.js"
+  readonly to: string;
+  readonly status: 301 | 302 | 307 | 308;
+  constructor(to: string, status: 301 | 302 | 307 | 308 = 302);
+}
+```
+
+The throwable value `redirect()` constructs. Catch it (or read `router.match` / `RedirectRouteMatch`) on the server to emit a real HTTP redirect.
+
+### `StatusResponse`
+
+```ts
+class StatusResponse<TData = unknown> {
+  readonly status: number;
+  readonly data: TData;
+  constructor(status: number, data: TData);
+}
+```
+
+A typed non-success status thrown from a `prefetch`. Surfaces to React error boundaries (client) or the SSR handler (server) for HTTP-like error UI.
+
+```ts
+prefetch: async (params) => {
+  const user = await fetchUser(params.id);
+  if (!user) throw new StatusResponse(404, { id: params.id });
+},
+```
+
+### Search validation
+
+`search` accepts any [Standard Schema](https://github.com/standard-schema/standard-schema)-compatible validator (`StandardSchemaLike`) — Zod, Valibot, ArkType, or a hand-rolled `~standard` object. Its `output` type flows to `content`'s `search` prop and to `SearchOf<TRoute>`.
+
+```ts
+interface StandardSchemaLike<TOutput = unknown> {
+  readonly "~standard": {
+    readonly output?: TOutput;
+    readonly validate?: (value: unknown) => unknown;
+  };
+}
+```
+
+```ts
+const accountSearchSchema = {
+  "~standard": {
+    output: {} as { readonly auth?: string },
+    validate(value: unknown): { readonly auth?: string } {
+      const record = value as Record<string, unknown>;
+      return { auth: typeof record.auth === "string" ? record.auth : undefined };
+    },
+  },
+};
+```
+
+### Adapters and low-level helpers
+
+Also exported from `@canonical/router-core`:
+
+```ts
+function createBrowserAdapter(): PlatformAdapter;                          // Navigation API → History API
+function createHistoryAdapter(browserWindow?): PlatformAdapter;           // History API
+function createNavigationAdapter(navigationWindow?): PlatformAdapter;     // Navigation API
+function createServerAdapter(initialUrl: string | URL): PlatformAdapter;
+function createMemoryAdapter(initialUrl: string | URL = "/"): MemoryAdapter;
+function createRouterStore<TRoutes, TNotFound>(
+  resolveMatch: (input: string | URL) => RouterMatch<TRoutes, TNotFound> | null,
+  initialUrl: string | URL = "/",
+): RouterStore<TRoutes, TNotFound>;
+function createSubject<TValue>(): Subject<TValue>;
+function createTrackedLocation<TLocation extends object>(
+  location: TLocation,
+  onAccess: (key: Extract<keyof TLocation, RouterLocationKey>) => void,
+): TrackedLocation<TLocation>;
+```
+
+```ts
+interface PlatformAdapter {
+  getLocation(): string | URL;
+  navigate(url: string, options?: PlatformNavigateOptions): void;
+  subscribe(callback: (location: string | URL) => void): () => void;
+}
+interface MemoryAdapter extends PlatformAdapter {
+  back(): void;
+  forward(): void;
+}
+```
+
+### Supporting types
+
+| Type | Shape / meaning |
+|---|---|
+| `RouteMap` | `Record<string, AnyRoute>` |
+| `RouterState` | `{ location: RouterLocationState; match: RouterMatch \| null; navigation: { state } }` |
+| `RouterLocationState` | `{ hash; href; pathname; searchParams: URLSearchParams; status; url: URL }` |
+| `RouterNavigationState` | `"idle" \| "loading"` |
+| `RouterMatch` | union of `DataRouteMatch` (`kind: "route"`, `status: 200`), `RedirectRouteMatch` (`kind: "redirect"`, `redirectTo`, `status`), `NotFoundRouteMatch` (`kind: "not-found"`, `status: 404`) |
+| `RouterDehydratedState` | `{ href; kind: "route" \| "not-found" \| "unmatched"; routeId; status }` |
+| `RouterLoadResult` | `{ dehydrate(); error; location; match; status }` (returned by `load`/`hydrate`) |
+| `PathBuildOptions<TRoute>` | `{ params?; search?; hash?; replace? }` — `params` required iff the path has params |
+| `NavigationIntent` | `{ name; href; params; search; hash? }` (returned by `navigate`) |
+| `TrackedLocation<T>` | proxy over a location; reading a field subscribes to just that field |
+| `Subject<T>` | `{ next(value); subscribe(subscriber) → unsubscribe }` |
+
+---
+
+## @canonical/router-react
+
+### `RouterProvider`
+
+```ts
+interface RouterProviderProps<TRoutes extends RouteMap, TNotFound extends AnyRoute | undefined = undefined> {
+  readonly children?: ReactNode;
+  readonly router: Router<TRoutes, TNotFound>;
+}
+
+function RouterProvider<TRoutes, TNotFound>(
+  props: RouterProviderProps<TRoutes, TNotFound>,
+): ReactElement;
+```
+
+Supplies a router instance through React context. Required ancestor for `Link`, `Outlet`, and all hooks.
+
+```tsx
+<RouterProvider router={router}>
+  <Outlet fallback={<p>Loading…</p>} />
+</RouterProvider>
+```
+
+### `Link`
+
+```ts
+function Link<
+  TRoutes extends RouteMap = RegisteredRouteMap,
+  TName extends RouteName<TRoutes> = RouteName<TRoutes>,
+>(props: LinkProps<TRoutes, TName>): ReactElement;
+```
+
+A `forwardRef` anchor that builds `href` from a **typed route name**. Intercepts primary-button clicks → `router.navigate()`, hover (`onMouseEnter`) → `router.prefetch()`, and sets `aria-current="page"` when its target matches the current pathname. Modified clicks, `download`, and `target` fall through to native anchor behaviour.
+
+```ts
+type LinkProps<TRoutes, TName> =
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> &
+  LinkBuildOptions<RouteOf<TRoutes, TName>> & {
+    readonly children?: ReactNode;
+    readonly download?: AnchorHTMLAttributes<HTMLAnchorElement>["download"];
+    readonly onClick?: MouseEventHandler<HTMLAnchorElement>;
+    readonly onMouseEnter?: MouseEventHandler<HTMLAnchorElement>;
+    readonly ref?: Ref<HTMLAnchorElement>;
+    readonly to: TName;          // the named route
+  };
+
+type LinkBuildOptions<TRoute> = {
+  readonly hash?: string;
+  readonly replace?: boolean;
+  readonly search?: SearchOf<TRoute>;
+} & (HasParams<TRoute> extends true
+  ? { readonly params: ParamsOf<TRoute> }      // required iff the route has params
+  : { readonly params?: ParamsOf<TRoute> });
+```
+
+```tsx
+<Link to="account" search={{ auth: "1" }}>Account</Link>
+<Link to="guide" params={{ slug: "intro" }} replace>Guide</Link>
+```
+
+### `Outlet`
+
+```ts
+interface OutletProps {
+  readonly fallback?: ReactNode;
+}
+
+function Outlet({ fallback = null }: OutletProps): ReactElement;
+```
+
+Renders the matched route subtree (route content wrapped by its wrappers). Rerenders only when the location `href` or `match` changes — not on `idle → loading` transitions. Output is wrapped in `<Suspense key={routeName} fallback={fallback}>`. Render errors from route content propagate **past** `Outlet`; wrap it in an error boundary to catch them.
+
+```tsx
+<Outlet fallback={<p>Loading…</p>} />
+```
+
+### Hooks
+
+All default their generics to `RegisteredRouteMap` / `RegisteredNotFound` (see [`register`](#register)), so once you register your routes no generics are needed. Each subscribes to the narrowest channel it needs.
+
+#### `useRouter`
+
+```ts
+function useRouter<TRoutes = RegisteredRouteMap, TNotFound = RegisteredNotFound>(): Router<TRoutes, TNotFound>;
+```
+
+The raw router from the nearest provider. Throws if no provider is present. Use for imperative `navigate`/`buildPath`/`prefetch`.
+
+```ts
+const router = useRouter();
+router.navigate("home");
+```
+
+#### `useRoute`
+
+```ts
+function useRoute<TRoutes = RegisteredRouteMap, TNotFound = RegisteredNotFound>(): TrackedLocation<RouterLocationState>;
+```
+
+The current location as a tracked proxy. Reading a field (e.g. `pathname`) subscribes the component to **only** that field.
+
+```ts
+const { pathname, searchParams } = useRoute();
+```
+
+#### `useRouterState`
+
+```ts
+function useRouterState<TRoutes, TNotFound>(): RouterState<TRoutes, TNotFound>;
+function useRouterState<TRoutes, TNotFound, TSelected>(
+  selector: (state: RouterState<TRoutes, TNotFound>) => TSelected,
+  options?: UseRouterStateOptions<TSelected>,   // { isEqual?: (previous, next) => boolean }
+): TSelected;
+```
+
+Power-user state subscription. Without a selector, returns the whole `RouterState`. With one, returns the narrowed slice and rerenders only when it changes (compared with `isEqual`, default `Object.is`).
+
+```ts
+const status = useRouterState((state) => state.match?.status ?? 200);
+```
+
+#### `useNavigationState`
+
+```ts
+function useNavigationState<TRoutes, TNotFound>(): RouterNavigationState;   // "idle" | "loading"
+```
+
+Subscribes only to the navigation channel. Use for pending/loading UI.
+
+```ts
+const navState = useNavigationState();
+return navState === "loading" ? <Spinner /> : <Content />;
+```
+
+#### `useSearchParam`
+
+```ts
+function useSearchParam<TRoutes, TNotFound>(key: string): string | null;
+```
+
+A single search-param value; subscribes to that key only.
+
+```ts
+const auth = useSearchParam("auth");
+```
+
+#### `useSearchParams`
+
+```ts
+function useSearchParams(): URLSearchParams;
+function useSearchParams<_TRoutes, _TNotFound, const TKeys extends readonly string[]>(
+  keys: TKeys,
+): SearchParamValues<TKeys>;
+
+type SearchParamValues<TKeys> = Readonly<{ [K in TKeys[number]]: string | null }>;
+```
+
+With no args, returns the full `URLSearchParams`. With a `keys` tuple, returns a record of just those keys and subscribes only to them.
+
+```ts
+const params = useSearchParams();                 // URLSearchParams
+const { auth, from } = useSearchParams(["auth", "from"] as const);
+```
+
+#### `useBlocker`
+
+```ts
+interface BlockerState {
+  readonly state: "idle" | "blocked";
+  proceed(): void;
+  cancel(): void;
+}
+
+function useBlocker(isActive: boolean): BlockerState;
+```
+
+Registers a navigation blocker while `isActive` is true. When a navigation is attempted, `state` becomes `"blocked"`; call `proceed()` to continue or `cancel()` to stay.
+
+```tsx
+const blocker = useBlocker(form.isDirty);
+return blocker.state === "blocked" ? (
+  <div role="dialog">
+    <button onClick={blocker.proceed}>Leave</button>
+    <button onClick={blocker.cancel}>Stay</button>
+  </div>
+) : null;
+```
+
+### `createHydratedRouter`
+
+```ts
+interface CreateHydratedRouterOptions<TNotFound extends AnyRoute | undefined>
+  extends Omit<RouterOptions<TNotFound>, "adapter"> {
+  readonly browserWindow?: HydrationWindow;
+}
+
+function createHydratedRouter<
+  const TRoutes extends RouteMap,
+  const TNotFound extends AnyRoute | undefined = undefined,
+>(
+  routes: TRoutes,
+  options?: CreateHydratedRouterOptions<TNotFound>,
+): Router<TRoutes, TNotFound>;
+```
+
+Browser router that resumes from dehydrated SSR state read off `window` (key `INITIAL_DATA_KEY`). Injects `createHistoryAdapter` and passes the read state as `hydratedState`. Use as the client entry of an SSR app instead of `createBrowserRouter`. `browserWindow` overrides the source of the hydration payload (defaults to `window`).
+
+```ts
+const router = createHydratedRouter(appRoutes, { middleware: [...middleware], notFound: notFoundRoute });
+```
+
+### `renderToStream`
+
+```ts
+interface RenderToStreamOptions {
+  readonly fallback?: ReactNode;
+}
+interface RenderToStreamResult<TRoutes, TNotFound> {
+  readonly bootstrapScriptContent: string | null;   // inline script that assigns window[INITIAL_DATA_KEY]
+  readonly initialData: RouterDehydratedState<TRoutes> | null;
+  readonly loadResult: RouterLoadResult<TRoutes, TNotFound>;
+  readonly stream: ReadableStream;
+}
+
+function renderToStream<TRoutes extends RouteMap, TNotFound extends AnyRoute | undefined = undefined>(
+  router: Router<TRoutes, TNotFound>,
+  url: string | URL,
+  options?: RenderToStreamOptions,
+): Promise<RenderToStreamResult<TRoutes, TNotFound>>;
+```
+
+SSR helper. Calls `router.load(url)`, then `renderToReadableStream` of `<RouterProvider><Outlet/></RouterProvider>`. Returns the stream plus dehydrated state and a bootstrap script for client hydration (pairs with `createHydratedRouter`).
+
+```ts
+const { stream, bootstrapScriptContent, loadResult } = await renderToStream(router, req.url);
+if (loadResult.status >= 400) res.status(loadResult.status);
+```
+
+### `register` — typed routing without generics
+
+```ts
+interface RouterRegister {}   // augment this
+
+type RegisteredRouteMap = RouterRegister extends { routes: infer T extends RouteMap } ? T : RouteMap;
+type RegisteredNotFound = RouterRegister extends { notFound: infer T extends AnyRoute | undefined } ? T : undefined;
+```
+
+Module-augmentation interface for ambient typing. Declare `RouterRegister.routes` (and optionally `notFound`) once, and every hook plus `Link` infers your route map — no per-call generics. Without registration the fallback is `RouteMap` (any string key: compiles, but no autocomplete or typo detection).
+
+```ts
+declare module "@canonical/router-react" {
+  interface RouterRegister {
+    routes: typeof appRoutes;
+  }
+}
+
+// now fully typed, no generics:
+<Link to="account" />;          // "account" autocompleted, typos caught
+useRouter().navigate("home");
+```
+
+---
+
+## Entry wiring (reference)
+
+**Client** (`createBrowserRouter` or `createHydratedRouter`):
+
+```tsx
+const router = createBrowserRouter(appRoutes, { middleware: [...middleware], notFound: notFoundRoute });
+
+hydrateRoot(
+  document.getElementById("root")!,
+  <RouterProvider router={router}>
+    <Outlet fallback={<p>Loading…</p>} />
+  </RouterProvider>,
+);
+```
+
+**Server** (`createStaticRouter`, render inside the full HTML document):
+
+```tsx
+const router = createStaticRouter(appRoutes, url, { middleware: [...middleware], notFound: notFoundRoute });
+// inspect router.match for status / redirect, then:
+<RouterProvider router={router}>
+  <Outlet fallback={<p>Loading…</p>} />
+</RouterProvider>;
+```
+
+---
+
+## See also
+
+- [Migrating to the pragma router](../how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md)
+- Router core package: `packages/runtime/router`
+- Router React package: `packages/react/router`
+- Reference app: `apps/react/boilerplate-vite`


### PR DESCRIPTION
## Done

Two router docs, written against the **current** `@canonical/router-core` / `@canonical/router-react` API on `main`. Salvaged from the superseded #604 (closed) — but verified afresh, not ported wholesale.

- **`docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md`** — the route-middleware contract (`<TRoute extends AnyRoute>(route) => route`), `applyMiddleware`, composition order, and recipes (`withAuth`, `withI18n`). Ported from #604's version but **rewritten to the current API**: the route data hook is `prefetch` (there is no `fetch`), and the auth recipe mirrors the real boilerplate pattern — a throwing `redirect()` inside `prefetch` for client navigation, plus a pure `getAuthRedirectHref` companion for server pre-flight.
- **`docs/references/ROUTER_API.md`** — a **freshly generated** reference (not #604's stale 1040-line version): the factories (`createBrowserRouter` / `createStaticRouter` / `createMemoryRouter`), `route` / `wrapper<TRendered>` / `group` / `applyMiddleware` / `redirect`, the router-react layer (`RouterProvider`, `Link`, `Outlet`, hooks, `renderToStream`), and typed routing via the `declare module` register augmentation.

Every documented signature was checked against the source on `main` (83 signatures across the two docs; the `redirect(): never`, `prefetch`, and `wrapper<TRendered>` claims all confirmed).

Supersedes #604's `ROUTER_API.md` (stale `fetch`/`wrapper`/SSR) and its TanStack migration guide (already covered by `docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md`).

## QA

- Docs-only change — `nx affected` is empty (no package build/test impacted).
- Each code block in both docs is valid against the current router exports (`prefetch`, the factory signatures, `wrapper<TRendered>`, `redirect` throwing `never`).

### PR readiness check

- [x] PR should have one of the following labels: `Documentation 📝`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate code standards.
- [x] No new packages; docs-only.
- [x] No visual change — `no visual change` label added to skip Chromatic.

## Screenshots

N/A — documentation only.
