### PR TITLE
chore(codeowners): add @advl as code owner for configs/biome

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 
 /packages/svelte/ssr-test/    @canonical/launchpad-ui  @canonical/workplace-engineering-ui
 /configs/typescript-svelte/   @canonical/launchpad-ui  @canonical/workplace-engineering-ui
-/configs/biome/               @canonical/launchpad-ui  @canonical/workplace-engineering-ui
+/configs/biome/               @canonical/launchpad-ui  @canonical/workplace-engineering-ui  @advl


### PR DESCRIPTION
## Done

- Add `@advl` to the `/configs/biome/` CODEOWNERS entry.

Enables reviewing biome config changes (e.g. the `$schema` version bump that #626 needs) without pulling in the launchpad-ui / workplace-engineering-ui teams who own this path alongside their Svelte packages.

## QA

- Touches only `.github/CODEOWNERS` (an unowned path), so no code-owner review is triggered.

### PR readiness check

- [x] `Maintenance 🔨` label.
- [x] Conventional-commit title.

## Screenshots

N/A