### PR TITLE
fix(react-ssr): serve dev SSR assets and resolve module-only deps (viteFetchMiddleware)

### DIFF
--- a/apps/react/boilerplate-vite/src/server/server.bun.ts
+++ b/apps/react/boilerplate-vite/src/server/server.bun.ts
@@ -1,15 +1,19 @@
 /**
  * Bun development server with SSR and streaming.
  *
- * Uses Bun.serve() for the HTTP layer and Vite in middleware mode for
- * module transforms and client HMR. Server modules are loaded via
- * vite.ssrLoadModule() — changes are picked up without restart.
+ * Uses Bun.serve() for the HTTP layer and Vite in middleware mode for module
+ * transforms and client HMR. Asset, module, and HMR requests (/@vite/client,
+ * /src/**, /@id/**, /@fs/**, /@react-refresh, /node_modules/.vite/**) are
+ * delegated to Vite via `viteFetchMiddleware`; everything else is
+ * server-rendered. Server modules are loaded via vite.ssrLoadModule() —
+ * changes are picked up without restart.
  *
  * Production deployments use platform adapters (Vercel, Cloudflare, etc.),
  * not this server.
  */
 import fs from "node:fs";
 import * as process from "node:process";
+import { viteFetchMiddleware } from "@canonical/react-ssr/server";
 import { createServer as createViteServer } from "vite";
 
 const PORT = Number(process.env.PORT) || 5174;
@@ -19,6 +23,9 @@ const vite = await createViteServer({
   appType: "custom",
 });
 
+// Serve Vite's client assets/HMR; returns null for page routes (→ SSR below).
+const handleAsset = viteFetchMiddleware(vite);
+
 Bun.serve({
   port: PORT,
   async fetch(req: Request) {
@@ -26,6 +33,9 @@ Bun.serve({
     const requestUrl = url.pathname + url.search;
 
     try {
+      const asset = await handleAsset(req);
+      if (asset) return asset;
+
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(requestUrl, template);
 

--- a/apps/react/boilerplate-vite/vite.config.ts
+++ b/apps/react/boilerplate-vite/vite.config.ts
@@ -6,12 +6,14 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [react()],
   ssr: {
-    // @canonical/* packages ship a "module" field (no "main"/"exports") that
-    // Vite's SSR resolver — which does Node-style resolution — does not honour.
-    // Bundling them for SSR uses the resolver that reads "module", so
-    // ssrLoadModule resolves them instead of failing with
-    // ERR_RESOLVE_PACKAGE_ENTRY_FAIL. Only relevant when deps are installed
-    // from the registry (real directories); workspace symlinks resolve anyway.
+    // Bundle @canonical/* for SSR rather than externalising them, for two
+    // reasons: (1) some packages declare only a "module" entry (no
+    // "main"/"exports"), which Vite's SSR (Node-style) resolver ignores —
+    // externalising them fails with ERR_RESOLVE_PACKAGE_ENTRY_FAIL; (2) their
+    // built output imports CSS as a side effect (e.g. `import "./x.css"`),
+    // which Node cannot load (ERR_UNKNOWN_FILE_EXTENSION) but Vite's SSR
+    // transform no-ops. The regex covers the whole scope so any current or
+    // future @canonical dependency is handled.
     noExternal: [/^@canonical\//],
   },
 });

--- a/apps/react/boilerplate-vite/vite.config.ts
+++ b/apps/react/boilerplate-vite/vite.config.ts
@@ -5,4 +5,13 @@ import { defineConfig } from "vite";
 // in package.json "imports" and resolved natively by Vite — no resolver plugin.
 export default defineConfig({
   plugins: [react()],
+  ssr: {
+    // @canonical/* packages ship a "module" field (no "main"/"exports") that
+    // Vite's SSR resolver — which does Node-style resolution — does not honour.
+    // Bundling them for SSR uses the resolver that reads "module", so
+    // ssrLoadModule resolves them instead of failing with
+    // ERR_RESOLVE_PACKAGE_ENTRY_FAIL. Only relevant when deps are installed
+    // from the registry (real directories); workspace symlinks resolve anyway.
+    noExternal: [/^@canonical\//],
+  },
 });

--- a/bun.lock
+++ b/bun.lock
@@ -791,9 +791,11 @@
       },
       "peerDependencies": {
         "express": "^5.2.1",
+        "vite": "^8.0.0",
       },
       "optionalPeers": [
         "express",
+        "vite",
       ],
     },
     "packages/react/ssr-adapter-cloudflare": {

--- a/packages/react/ssr/README.md
+++ b/packages/react/ssr/README.md
@@ -33,6 +33,35 @@ The rest of the page is then streamed to the client as it is rendered on the ser
 
 This is accomplished by using `JSXRenderer.renderToStream()`.
 
+## Dev vs production SSR
+
+The renderer is the invariant of every SSR setup: it takes an `htmlString`
+shell, extracts the `<head>` `<script>`/`<link>` tags, and injects them into
+the streamed output. **It never reads from disk and never cares which mode you
+run in.** What changes between development and production is only two things —
+*where the HTML shell comes from* and *how client JS/CSS reach the browser*:
+
+| | **Development** (transform) | **Production** (compiled) |
+| --- | --- | --- |
+| HTML shell | root `index.html` → `vite.transformIndexHtml()` | built `dist/client/index.html` (hashed tags baked in) |
+| Server entry | `vite.ssrLoadModule()` (TypeScript, on the fly) | compiled `dist/server` bundle |
+| Client JS/CSS | served by Vite's middleware (source modules, HMR) | static files from `dist/client` |
+| Renderer | **same `JSXRenderer`** | **same `JSXRenderer`** |
+
+This means a dev SSR server and a production SSR server are *deliberately
+different* — the dev server transforms source on the fly (with HMR); the
+production server serves a pre-built client and a compiled renderer. Both feed
+the same renderer; only the shell and asset-serving differ.
+
+In development you mount Vite's middleware so that asset, module, and HMR
+requests (`/@vite/client`, `/src/**`, `/@id/**`, `/@fs/**`, `/@react-refresh`,
+`/node_modules/.vite/**`) are handled by Vite, and only page routes reach the
+renderer. With Express this is `app.use(vite.middlewares)`. For `fetch`-style
+servers (Bun, Deno, Workers) use [`viteFetchMiddleware`](#bun-server) — it
+bridges Vite's connect middleware into a `Request → Response` handler. Without
+it, those asset requests get server-rendered as the HTML page with the wrong
+`Content-Type`, the browser blocks the modules, and the page never hydrates.
+
 ## Express Server
 
 Create a renderer that wraps your server entry component:
@@ -72,46 +101,64 @@ node dist/server/server.js
 
 ## Bun Server
 
-The renderer works the same way. For Bun's native server, convert the pipeable stream:
+`Bun.serve` works with a Web `Request`/`Response` `fetch` handler, so it cannot
+mount Vite's connect middleware directly. `viteFetchMiddleware` bridges the two:
+it runs a `Request` through `vite.middlewares` and returns a `Response` if Vite
+handled it (assets, modules, HMR) or `null` for page routes you should render.
 
 ```ts
-// src/ssr/server-bun.ts
-import render from "./renderer.js";
-import { Readable } from "node:stream";
+// src/server/server.bun.ts — development
+import { JSXRenderer } from "@canonical/react-ssr/renderer";
+import { viteFetchMiddleware } from "@canonical/react-ssr/server";
+import { createServer as createViteServer } from "vite";
+import fs from "node:fs";
+
+const vite = await createViteServer({
+  server: { middlewareMode: true },
+  appType: "custom",
+});
+const handleAsset = viteFetchMiddleware(vite);
 
 Bun.serve({
-  port: 5173,
+  port: 5174,
   async fetch(req) {
+    // Vite handles /@vite/client, /src/**, CSS, HMR; null → page route → SSR.
+    const asset = await handleAsset(req);
+    if (asset) return asset;
+
     const url = new URL(req.url);
-
-    // Serve static assets
-    if (url.pathname.startsWith("/assets")) {
-      return new Response(Bun.file(`dist/client${url.pathname}`));
-    }
-
-    // SSR render
-    const { pipe } = render(req, null);
-    const readable = Readable.toWeb(Readable.from(pipeToIterable(pipe)));
-    return new Response(readable, {
+    const html = await vite.transformIndexHtml(
+      url.pathname + url.search,
+      fs.readFileSync("index.html", "utf-8"),
+    );
+    const { default: EntryServer } = await vite.ssrLoadModule(
+      "/src/server/entry.tsx",
+    );
+    const renderer = new JSXRenderer(
+      EntryServer,
+      { url: url.pathname + url.search },
+      { htmlString: html },
+    );
+    return new Response(await renderer.renderToReadableStream(req.signal), {
+      status: renderer.statusCode,
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   },
 });
-
-function pipeToIterable(pipe: (dest: NodeJS.WritableStream) => void) {
-  const { Readable } = require("node:stream");
-  const passthrough = new (require("node:stream").PassThrough)();
-  pipe(passthrough);
-  return passthrough;
-}
 ```
 
-Or use Express compatibility mode with Bun:
+`viteFetchMiddleware` depends only on `node:http` and Web globals — no Bun APIs
+— so it works under any `fetch`-style runtime (Bun, Deno, Workers, Node's own
+`fetch` servers). The single Bun-specific call (`Bun.serve`) stays in your app.
 
-```ts
-// Bun can run Express directly
-import app from "./server.js";  // Your Express server
-export default app;
+For **production**, you do not run Vite at all. Build the client and a compiled
+renderer, then serve the built output with the `serve-bun` bin (static assets +
+your renderer factory):
+
+```bash
+vite build --ssrManifest --outDir dist/client
+vite build --ssr src/server/renderer.tsx --outDir dist/server
+serve-bun dist/server/renderer.js --static assets:dist/client/assets
 ```
 
 ## Entry Points

--- a/packages/react/ssr/package.json
+++ b/packages/react/ssr/package.json
@@ -88,10 +88,14 @@
     "react-dom": "^19.2.4"
   },
   "peerDependencies": {
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "express": {
+      "optional": true
+    },
+    "vite": {
       "optional": true
     }
   }

--- a/packages/react/ssr/src/lib/renderer/JSXRenderer.tests.ts
+++ b/packages/react/ssr/src/lib/renderer/JSXRenderer.tests.ts
@@ -328,6 +328,27 @@ describe("JSXRenderer", () => {
       expect(onShellError).toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
+
+    it("throws when renderToPipeableStream is unavailable in the runtime (e.g. Bun)", async () => {
+      // Bun's react-dom/server omits renderToPipeableStream. The module
+      // captures it at import time, so mock the export and re-import fresh.
+      vi.resetModules();
+      vi.doMock("react-dom/server", async (importOriginal) => {
+        const actual =
+          await importOriginal<typeof import("react-dom/server")>();
+        return { ...actual, renderToPipeableStream: undefined };
+      });
+
+      const { default: FreshJSXRenderer } = await import("./JSXRenderer.js");
+      const renderer = new FreshJSXRenderer(TestComponent);
+
+      expect(() => renderer.renderToPipeableStream()).toThrow(
+        /renderToPipeableStream is not available|Bun does not support/,
+      );
+
+      vi.doUnmock("react-dom/server");
+      vi.resetModules();
+    });
   });
 
   describe("renderToString", () => {

--- a/packages/react/ssr/src/lib/server/index.ts
+++ b/packages/react/ssr/src/lib/server/index.ts
@@ -1,2 +1,6 @@
 export { serveStream } from "./serveStream.js";
 export { serveString } from "./serveString.js";
+export {
+  type ViteMiddlewareServer,
+  viteFetchMiddleware,
+} from "./viteFetchMiddleware.js";

--- a/packages/react/ssr/src/lib/server/viteFetchMiddleware.tests.ts
+++ b/packages/react/ssr/src/lib/server/viteFetchMiddleware.tests.ts
@@ -1,0 +1,151 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  type ViteMiddlewareServer,
+  viteFetchMiddleware,
+} from "./viteFetchMiddleware.js";
+
+/**
+ * Build a fake Vite middleware that mimics how `vite.middlewares` behaves:
+ * either it writes a response (handled) or calls `next()` (passes through).
+ */
+function fakeVite(
+  handler: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (err?: unknown) => void,
+  ) => void,
+): ViteMiddlewareServer {
+  return { middlewares: handler };
+}
+
+describe("viteFetchMiddleware", () => {
+  it("returns a Response when the middleware handles the request", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.statusCode = 200;
+        res.setHeader("content-type", "text/javascript");
+        res.end('import "x";');
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/@vite/client"));
+
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toBe("text/javascript");
+    expect(await response?.text()).toBe('import "x";');
+  });
+
+  it("returns null when the middleware calls next() (a page route)", async () => {
+    const handle = viteFetchMiddleware(fakeVite((_req, _res, next) => next()));
+
+    const response = await handle(new Request("http://localhost/some/page"));
+
+    expect(response).toBeNull();
+  });
+
+  it("concatenates multiple write() chunks into the body", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.write("hello ");
+        res.write("world");
+        res.end();
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/asset.js"));
+
+    expect(await response?.text()).toBe("hello world");
+  });
+
+  it("propagates a non-200 status code", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.statusCode = 404;
+        res.end("not found");
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/missing.js"));
+
+    expect(response?.status).toBe(404);
+    expect(await response?.text()).toBe("not found");
+  });
+
+  it("transfers request headers (lower-cased) to the Node request", async () => {
+    const seen: Record<string, string | string[] | undefined> = {};
+    const handle = viteFetchMiddleware(
+      fakeVite((req, res) => {
+        Object.assign(seen, req.headers);
+        res.end("ok");
+      }),
+    );
+
+    await handle(
+      new Request("http://localhost/asset.js", {
+        headers: { "Sec-Fetch-Mode": "cors", Accept: "*/*" },
+      }),
+    );
+
+    expect(seen["sec-fetch-mode"]).toBe("cors");
+    expect(seen.accept).toBe("*/*");
+  });
+
+  it("defaults the host header from the request URL when absent", async () => {
+    let host: string | undefined;
+    const handle = viteFetchMiddleware(
+      fakeVite((req, res) => {
+        host = req.headers.host;
+        res.end("ok");
+      }),
+    );
+
+    await handle(new Request("http://example.test/asset.js"));
+
+    expect(host).toBe("example.test");
+  });
+
+  it("passes the request method and url path+query through", async () => {
+    let method: string | undefined;
+    let url: string | undefined;
+    const handle = viteFetchMiddleware(
+      fakeVite((req, res) => {
+        method = req.method;
+        url = req.url;
+        res.end("ok");
+      }),
+    );
+
+    await handle(new Request("http://localhost/a/b?x=1", { method: "POST" }));
+
+    expect(method).toBe("POST");
+    expect(url).toBe("/a/b?x=1");
+  });
+
+  it("rejects when the middleware emits a response error", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.emit("error", new Error("boom"));
+      }),
+    );
+
+    await expect(handle(new Request("http://localhost/x.js"))).rejects.toThrow(
+      "boom",
+    );
+  });
+
+  it("returns a Response with an empty body when nothing is written", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.statusCode = 204;
+        res.end();
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/empty"));
+
+    expect(response?.status).toBe(204);
+    expect(await response?.text()).toBe("");
+  });
+});

--- a/packages/react/ssr/src/lib/server/viteFetchMiddleware.tests.ts
+++ b/packages/react/ssr/src/lib/server/viteFetchMiddleware.tests.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   type ViteMiddlewareServer,
   viteFetchMiddleware,
@@ -117,10 +117,132 @@ describe("viteFetchMiddleware", () => {
       }),
     );
 
-    await handle(new Request("http://localhost/a/b?x=1", { method: "POST" }));
+    await handle(new Request("http://localhost/a/b?x=1"));
 
-    expect(method).toBe("POST");
+    expect(method).toBe("GET");
     expect(url).toBe("/a/b?x=1");
+  });
+
+  it("bridges HEAD requests", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      }),
+    );
+
+    const response = await handle(
+      new Request("http://localhost/asset.js", { method: "HEAD" }),
+    );
+
+    expect(response?.status).toBe(200);
+  });
+
+  it("returns null (passes through) for non-GET/HEAD requests without invoking Vite", async () => {
+    const middlewares = vi.fn();
+    const handle = viteFetchMiddleware({ middlewares });
+
+    const post = await handle(
+      new Request("http://localhost/api", { method: "POST", body: "x" }),
+    );
+    const del = await handle(
+      new Request("http://localhost/api", { method: "DELETE" }),
+    );
+
+    expect(post).toBeNull();
+    expect(del).toBeNull();
+    expect(middlewares).not.toHaveBeenCalled();
+  });
+
+  it("keeps the request's own Host header instead of deriving it from the URL", async () => {
+    let host: string | undefined;
+    const handle = viteFetchMiddleware(
+      fakeVite((req, res) => {
+        host = req.headers.host;
+        res.end("ok");
+      }),
+    );
+
+    await handle(
+      new Request("http://localhost/asset.js", {
+        headers: { Host: "explicit.example:1234" },
+      }),
+    );
+
+    expect(host).toBe("explicit.example:1234");
+  });
+
+  it("emits separate Set-Cookie headers for an array value", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.setHeader("set-cookie", ["a=1", "b=2"]);
+        res.end("ok");
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/asset.js"));
+
+    expect(response?.headers.getSetCookie()).toEqual(["a=1", "b=2"]);
+  });
+
+  it("preserves headers set via writeHead", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.writeHead(200, {
+          "Content-Type": "image/svg+xml",
+          "Cache-Control": "no-cache",
+        });
+        res.end("<svg/>");
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/logo.svg"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toBe("image/svg+xml");
+    expect(response?.headers.get("cache-control")).toBe("no-cache");
+  });
+
+  it("merges writeHead headers with setHeader headers", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.setHeader("x-pre", "1");
+        res.writeHead(200, { "Content-Type": "text/javascript" });
+        res.end("x");
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/asset.js"));
+
+    expect(response?.headers.get("x-pre")).toBe("1");
+    expect(response?.headers.get("content-type")).toBe("text/javascript");
+  });
+
+  it("supports the writeHead(status, statusMessage, headers) overload", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.writeHead(200, "OK", { "Content-Type": "text/css" });
+        res.end(".x{}");
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/style.css"));
+
+    expect(response?.headers.get("content-type")).toBe("text/css");
+  });
+
+  it("skips response headers whose value is null/undefined", async () => {
+    const handle = viteFetchMiddleware(
+      fakeVite((_req, res) => {
+        res.getHeaders = () => ({ "x-real": "yes", "x-empty": undefined });
+        res.end("ok");
+      }),
+    );
+
+    const response = await handle(new Request("http://localhost/asset.js"));
+
+    expect(response?.headers.get("x-real")).toBe("yes");
+    expect(response?.headers.has("x-empty")).toBe(false);
   });
 
   it("rejects when the middleware emits a response error", async () => {

--- a/packages/react/ssr/src/lib/server/viteFetchMiddleware.ts
+++ b/packages/react/ssr/src/lib/server/viteFetchMiddleware.ts
@@ -1,0 +1,139 @@
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+
+/**
+ * Minimal structural type for the parts of Vite's dev server this helper uses.
+ *
+ * `vite` is an optional peer dependency of this package (it is only needed by
+ * consumers running a Vite-backed dev server). Typing structurally avoids a
+ * hard dependency on Vite's types while still describing the contract: a
+ * connect-style middleware stack `(req, res, next) => void`.
+ */
+export interface ViteMiddlewareServer {
+  middlewares: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (err?: unknown) => void,
+  ) => void;
+}
+
+/**
+ * Bridge Vite's connect-style middleware into a `fetch`-style handler.
+ *
+ * Runtime SSR dev servers built on `Bun.serve` (or any Web `fetch` server)
+ * cannot mount Vite's `(req, res, next)` middleware directly: that stack
+ * expects Node's `http.IncomingMessage` / `ServerResponse`, while `fetch`
+ * deals in Web `Request` / `Response`. Without delegating to Vite, every
+ * request — including `/@vite/client`, `/src/**`, `/@id/**`, `/@fs/**`,
+ * `/@react-refresh`, and `/node_modules/.vite/**` — would have to be
+ * server-rendered, so client modules and HMR assets would be returned as the
+ * SSR HTML page with the wrong `Content-Type` (browsers then block them as
+ * modules and the page never hydrates).
+ *
+ * This helper adapts a Web `Request` into a Node `req`/`res` pair, runs Vite's
+ * middleware against it, and returns a Web `Response` if the middleware handled
+ * the request — or `null` if the stack called `next()` (a page route the
+ * caller should server-render).
+ *
+ * The bridge is **runtime-agnostic**: it depends only on `node:http` /
+ * `node:net` and Web globals (`Request`, `Response`), so it works under Bun,
+ * Node's own `fetch` servers, Deno, and Workers — not just Bun. The `vite`
+ * instance is injected, not imported, keeping this module free of a runtime
+ * Vite dependency.
+ *
+ * The response body is **buffered**: chunks written by the middleware are
+ * collected and the `Response` resolves on `end`, with `status` and `headers`
+ * read from the (by-then-final) `ServerResponse`. This is correct and robust
+ * for dev assets — transformed JS/CSS modules and source maps, which are small
+ * and already in memory when Vite writes them. Streaming would buy near-zero
+ * latency here (SSR render streaming goes through the renderer's
+ * `renderToReadableStream`, never this bridge) while introducing header-timing
+ * and backpressure hazards, so it is deliberately avoided.
+ *
+ * @param vite - A Vite dev server created with `middlewareMode: true`.
+ * @returns A function mapping a Web `Request` to a `Response` (Vite handled it)
+ *   or `null` (pass through to SSR).
+ *
+ * @example
+ * ```ts
+ * import { createServer as createViteServer } from "vite";
+ * import { viteFetchMiddleware } from "@canonical/react-ssr/server";
+ *
+ * const vite = await createViteServer({
+ *   server: { middlewareMode: true },
+ *   appType: "custom",
+ * });
+ * const handleAsset = viteFetchMiddleware(vite);
+ *
+ * Bun.serve({
+ *   async fetch(req) {
+ *     const asset = await handleAsset(req);
+ *     if (asset) return asset; // /@vite/client, /src/**, CSS, HMR …
+ *     return ssrRender(req); // page route
+ *   },
+ * });
+ * ```
+ */
+export function viteFetchMiddleware(
+  vite: ViteMiddlewareServer,
+): (request: Request) => Promise<Response | null> {
+  return (request) =>
+    new Promise<Response | null>((resolve, reject) => {
+      const url = new URL(request.url);
+
+      // A bare IncomingMessage needs a socket and a populated, lower-cased
+      // headers object before Vite's middleware runs — Vite reads navigation
+      // hints (e.g. `sec-fetch-mode`) and will throw on an empty header bag.
+      const socket = new Socket();
+      const req = new IncomingMessage(socket);
+      req.url = url.pathname + url.search;
+      req.method = request.method || "GET";
+
+      const headers: Record<string, string> = {};
+      request.headers.forEach((value, key) => {
+        headers[key.toLowerCase()] = value;
+      });
+      if (!headers.host) headers.host = url.host;
+      req.headers = headers;
+
+      const res = new ServerResponse(req);
+
+      const chunks: Buffer[] = [];
+      const originalWrite = res.write.bind(res);
+      const originalEnd = res.end.bind(res);
+
+      res.write = ((chunk: unknown, ...rest: unknown[]) => {
+        if (chunk != null) chunks.push(Buffer.from(chunk as Uint8Array));
+        return (originalWrite as (...args: unknown[]) => boolean)(
+          chunk,
+          ...rest,
+        );
+      }) as ServerResponse["write"];
+
+      res.end = ((chunk: unknown, ...rest: unknown[]) => {
+        if (chunk != null && typeof chunk !== "function") {
+          chunks.push(Buffer.from(chunk as Uint8Array));
+        }
+        const result = (originalEnd as (...args: unknown[]) => ServerResponse)(
+          chunk,
+          ...rest,
+        );
+        const responseHeaders: Record<string, string> = {};
+        for (const [key, value] of Object.entries(res.getHeaders())) {
+          if (value != null) responseHeaders[key] = String(value);
+        }
+        resolve(
+          new Response(chunks.length ? Buffer.concat(chunks) : null, {
+            status: res.statusCode,
+            headers: responseHeaders,
+          }),
+        );
+        return result;
+      }) as ServerResponse["end"];
+
+      res.on("error", reject);
+
+      // `next()` → Vite did not handle it (a page route); the caller renders it.
+      vite.middlewares(req, res, () => resolve(null));
+    });
+}

--- a/packages/react/ssr/src/lib/server/viteFetchMiddleware.ts
+++ b/packages/react/ssr/src/lib/server/viteFetchMiddleware.ts
@@ -50,9 +50,19 @@ export interface ViteMiddlewareServer {
  * `renderToReadableStream`, never this bridge) while introducing header-timing
  * and backpressure hazards, so it is deliberately avoided.
  *
+ * Headers set via `res.writeHead(status, headers)` are captured in addition to
+ * `res.getHeaders()` (Vite's static-file middleware sets `Content-Type` etc.
+ * that way for non-JS assets), and multi-value headers such as `set-cookie` are
+ * preserved as separate entries rather than comma-folded.
+ *
+ * Only `GET`/`HEAD` requests are bridged. A bare `IncomingMessage` carries no
+ * request body, so any middleware that reads one would hang; requests with a
+ * body (and other methods) return `null` so the caller handles them. This
+ * matches Vite's asset/module/HMR surface, which is entirely `GET`/`HEAD`.
+ *
  * @param vite - A Vite dev server created with `middlewareMode: true`.
  * @returns A function mapping a Web `Request` to a `Response` (Vite handled it)
- *   or `null` (pass through to SSR).
+ *   or `null` (a page route, a non-`GET`/`HEAD` request — pass through to SSR).
  *
  * @example
  * ```ts
@@ -77,8 +87,16 @@ export interface ViteMiddlewareServer {
 export function viteFetchMiddleware(
   vite: ViteMiddlewareServer,
 ): (request: Request) => Promise<Response | null> {
-  return (request) =>
-    new Promise<Response | null>((resolve, reject) => {
+  return (request) => {
+    // Asset-only contract: a bare IncomingMessage carries no request body, so a
+    // middleware that reads one (e.g. Vite's proxy when `server.proxy` is set)
+    // would hang. Asset/module/HMR requests are all GET/HEAD; pass anything else
+    // through to the caller (page POSTs are server-rendered, not bridged).
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return Promise.resolve(null);
+    }
+
+    return new Promise<Response | null>((resolve, reject) => {
       const url = new URL(request.url);
 
       // A bare IncomingMessage needs a socket and a populated, lower-cased
@@ -87,7 +105,7 @@ export function viteFetchMiddleware(
       const socket = new Socket();
       const req = new IncomingMessage(socket);
       req.url = url.pathname + url.search;
-      req.method = request.method || "GET";
+      req.method = request.method;
 
       const headers: Record<string, string> = {};
       request.headers.forEach((value, key) => {
@@ -101,9 +119,28 @@ export function viteFetchMiddleware(
       const chunks: Buffer[] = [];
       const originalWrite = res.write.bind(res);
       const originalEnd = res.end.bind(res);
+      const originalWriteHead = res.writeHead.bind(res);
+
+      // Headers passed to writeHead(status, [statusMessage,] headers) are NOT
+      // returned by res.getHeaders() unless also set via setHeader, so capture
+      // them here. Vite's static (sirv) middleware sets Content-Type, ETag,
+      // Cache-Control this way for non-JS assets (svg, fonts, images, maps).
+      let writeHeadHeaders:
+        | ReturnType<ServerResponse["getHeaders"]>
+        | undefined;
+
+      res.writeHead = ((statusCode: number, ...rest: unknown[]) => {
+        const last = rest[rest.length - 1];
+        if (last && typeof last === "object" && !Array.isArray(last)) {
+          writeHeadHeaders = last as ReturnType<ServerResponse["getHeaders"]>;
+        }
+        return (
+          originalWriteHead as unknown as (...args: unknown[]) => ServerResponse
+        )(statusCode, ...rest);
+      }) as ServerResponse["writeHead"];
 
       res.write = ((chunk: unknown, ...rest: unknown[]) => {
-        if (chunk != null) chunks.push(Buffer.from(chunk as Uint8Array));
+        chunks.push(Buffer.from(chunk as Uint8Array));
         return (originalWrite as (...args: unknown[]) => boolean)(
           chunk,
           ...rest,
@@ -118,10 +155,24 @@ export function viteFetchMiddleware(
           chunk,
           ...rest,
         );
-        const responseHeaders: Record<string, string> = {};
-        for (const [key, value] of Object.entries(res.getHeaders())) {
-          if (value != null) responseHeaders[key] = String(value);
+
+        // Merge setHeader() headers with writeHead() headers (the latter win),
+        // and preserve multi-value headers (e.g. set-cookie) as separate
+        // entries rather than comma-folding them via String().
+        const responseHeaders = new Headers();
+        const merged: Record<string, number | string | string[] | undefined> = {
+          ...res.getHeaders(),
+          ...writeHeadHeaders,
+        };
+        for (const [key, value] of Object.entries(merged)) {
+          if (value == null) continue;
+          if (Array.isArray(value)) {
+            for (const item of value) responseHeaders.append(key, String(item));
+          } else {
+            responseHeaders.set(key, String(value));
+          }
         }
+
         resolve(
           new Response(chunks.length ? Buffer.concat(chunks) : null, {
             status: res.statusCode,
@@ -136,4 +187,5 @@ export function viteFetchMiddleware(
       // `next()` → Vite did not handle it (a page route); the caller renders it.
       vite.middlewares(req, res, () => resolve(null));
     });
+  };
 }

--- a/packages/summon/application/src/application/react/templates/src/server/server.bun.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/server.bun.ts
@@ -1,15 +1,19 @@
 /**
  * Bun development server with SSR and streaming.
  *
- * Uses Bun.serve() for the HTTP layer and Vite in middleware mode for
- * module transforms and client HMR. Server modules are loaded via
- * vite.ssrLoadModule() — changes are picked up without restart.
+ * Uses Bun.serve() for the HTTP layer and Vite in middleware mode for module
+ * transforms and client HMR. Asset, module, and HMR requests (/@vite/client,
+ * /src/**, /@id/**, /@fs/**, /@react-refresh, /node_modules/.vite/**) are
+ * delegated to Vite via `viteFetchMiddleware`; everything else is
+ * server-rendered. Server modules are loaded via vite.ssrLoadModule() —
+ * changes are picked up without restart.
  *
  * Production deployments use platform adapters (Vercel, Cloudflare, etc.),
  * not this server.
  */
 import fs from "node:fs";
 import * as process from "node:process";
+import { viteFetchMiddleware } from "@canonical/react-ssr/server";
 import { createServer as createViteServer } from "vite";
 
 const PORT = Number(process.env.PORT) || 5174;
@@ -19,6 +23,9 @@ const vite = await createViteServer({
   appType: "custom",
 });
 
+// Serve Vite's client assets/HMR; returns null for page routes (→ SSR below).
+const handleAsset = viteFetchMiddleware(vite);
+
 Bun.serve({
   port: PORT,
   async fetch(req: Request) {
@@ -26,6 +33,9 @@ Bun.serve({
     const requestUrl = url.pathname + url.search;
 
     try {
+      const asset = await handleAsset(req);
+      if (asset) return asset;
+
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(requestUrl, template);
 

--- a/packages/summon/application/src/application/react/templates/vite.config.ts
+++ b/packages/summon/application/src/application/react/templates/vite.config.ts
@@ -6,12 +6,14 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [react()],
   ssr: {
-    // @canonical/* packages ship a "module" field (no "main"/"exports") that
-    // Vite's SSR resolver — which does Node-style resolution — does not honour.
-    // Bundling them for SSR uses the resolver that reads "module", so
-    // ssrLoadModule resolves them instead of failing with
-    // ERR_RESOLVE_PACKAGE_ENTRY_FAIL. Only relevant when deps are installed
-    // from the registry (real directories); workspace symlinks resolve anyway.
+    // Bundle @canonical/* for SSR rather than externalising them, for two
+    // reasons: (1) some packages declare only a "module" entry (no
+    // "main"/"exports"), which Vite's SSR (Node-style) resolver ignores —
+    // externalising them fails with ERR_RESOLVE_PACKAGE_ENTRY_FAIL; (2) their
+    // built output imports CSS as a side effect (e.g. `import "./x.css"`),
+    // which Node cannot load (ERR_UNKNOWN_FILE_EXTENSION) but Vite's SSR
+    // transform no-ops. The regex covers the whole scope so any current or
+    // future @canonical dependency is handled.
     noExternal: [/^@canonical\//],
   },
 });

--- a/packages/summon/application/src/application/react/templates/vite.config.ts
+++ b/packages/summon/application/src/application/react/templates/vite.config.ts
@@ -5,4 +5,13 @@ import { defineConfig } from "vite";
 // in package.json "imports" and resolved natively by Vite — no resolver plugin.
 export default defineConfig({
   plugins: [react()],
+  ssr: {
+    // @canonical/* packages ship a "module" field (no "main"/"exports") that
+    // Vite's SSR resolver — which does Node-style resolution — does not honour.
+    // Bundling them for SSR uses the resolver that reads "module", so
+    // ssrLoadModule resolves them instead of failing with
+    // ERR_RESOLVE_PACKAGE_ENTRY_FAIL. Only relevant when deps are installed
+    // from the registry (real directories); workspace symlinks resolve anyway.
+    noExternal: [/^@canonical\//],
+  },
 });


### PR DESCRIPTION
## Done

Fixes the React SSR **dev** servers so they actually serve client JS/CSS and so
a generated (registry-installed) app boots — two latent defects that the
monorepo's workspace symlinks had been masking.

- **New `viteFetchMiddleware` in `@canonical/react-ssr/server`.** Bridges Vite's
  connect-style middleware into a `fetch`-style handler:
  `viteFetchMiddleware(vite): (req: Request) => Promise<Response | null>` —
  returns a `Response` when Vite handled the request (assets, modules, HMR), or
  `null` for page routes the caller should server-render. Runtime-agnostic
  (`node:http` + Web globals, no Bun APIs), so it works under Bun, Deno, Workers,
  and Node `fetch` servers. `vite` is added as an **optional peer dependency**.
- **Bun dev server (`server.bun.ts`) now delegates assets to Vite** before SSR,
  in both `apps/react/boilerplate-vite` and the summon application template (kept
  byte-identical). Previously every request was server-rendered, so
  `/@vite/client`, `/src/**`, CSS, and non-JS assets came back as the SSR HTML
  page with the wrong `Content-Type`; the browser blocked them as modules and the
  page never hydrated.
- **`ssr.noExternal: [/^@canonical\//]`** in both `vite.config.ts` files. Vite's
  SSR resolver externalises deps and (a) ignores the `module`-only entry some
  `@canonical/*` packages ship → `ERR_RESOLVE_PACKAGE_ENTRY_FAIL`, and (b) hands
  their CSS side-effect imports to Node → `ERR_UNKNOWN_FILE_EXTENSION`. Bundling
  them for SSR fixes both.
- **`@canonical/react-ssr` README:** new "Dev vs production SSR" strategy section;
  rewrote the Bun section to use `viteFetchMiddleware` (dev) + `serve-bun` (prod),
  replacing an old, broken `pipeToIterable` snippet.

Hardening from an adversarial review pass (caught two real bugs my first cut
shipped):

- **`writeHead(status, headers)` headers were dropped.** `res.getHeaders()` does
  not return them, and Vite's static (sirv) middleware sets `Content-Type`/`ETag`/
  `Cache-Control` that way for non-JS assets (svg, fonts, images, source maps).
  Now intercepted and merged — `/src/assets/*.svg` serves `image/svg+xml` again.
- **Multi-value headers (e.g. `set-cookie`) were comma-folded** by `String(value)`.
  Now built via a `Headers` object that appends array values as separate entries.
- **Only `GET`/`HEAD` are bridged.** A bare `IncomingMessage` has no request body,
  so a body-reading middleware (Vite's proxy when `server.proxy` is set) would
  hang; other methods now pass through to the caller. Vite's asset/module/HMR
  surface is entirely `GET`/`HEAD`.

`@canonical/react-ssr` is at **100% coverage** (statements / branches / functions
/ lines) — the package's enforced threshold — including a new test for the Bun
`renderToPipeableStream`-unavailable path.

This is **PR 1 of 2**. PR 2 will add the compiled `preview:*` path and the 2×3
dev/preview e2e server-test matrix; design is recorded in `pragma-adrs`
(`session/J.SSR_DEV_SERVER_AUDIT.md`).

## QA

Prereq: `bun install` in the worktree, then `cd packages/react/ssr && bun run build`
(so the boilerplate resolves the new export).

1. **Bun dev server serves assets (DS.01):**
   ```bash
   cd apps/react/boilerplate-vite && PORT=5174 bun src/server/server.bun.ts
   curl -s -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:5174/@vite/client
   # → 200 text/javascript   (was 200 text/html before)
   curl -s -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:5174/src/assets/canonical.svg
   # → 200 image/svg+xml     (writeHead header fix)
   curl -s -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:5174/
   # → 200 text/html         (SSR page)
   ```
2. **SSR module resolution in an installed app (DS.02):** scaffold/copy a generated
   app with registry-installed `@canonical/*` deps, ensure its `vite.config.ts` has
   `ssr.noExternal: [/^@canonical\//]`, run `bun src/server/server.bun.ts`, and load
   `/` — it renders (was a 500 `ERR_RESOLVE_PACKAGE_ENTRY_FAIL`).
3. **Coverage gate:** `cd packages/react/ssr && bun run test:coverage` → 155 tests,
   100% across all four metrics, exit 0.
4. **Root gate:** `bun run check` (53 projects, exit 0). `bun run test` passes for
   the affected packages (`react-ssr`, `react-boilerplate-vite`, `summon`) and
   their dependents.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, **`Bug 🐛`**, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: N/A — no new package (new export + helper in the existing `@canonical/react-ssr`).
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — no visual change (dev-server / build-config / docs only). Add the
`no visual change` label.
