### PR TITLE
feat(storybook-config): establish full-height chain via previewHead

### DIFF
--- a/configs/storybook/src/createConfig.ts
+++ b/configs/storybook/src/createConfig.ts
@@ -63,6 +63,11 @@ function createConfig<T extends keyof typeof frameworks>(
       name: frameworks[framework].framework,
       options: {},
     },
+    // Establish the full-height chain in the preview iframe so components with
+    // `height: 100%` (e.g. application layouts, SideNavigation) resolve against
+    // a real height. Storybook does not set this by default.
+    previewHead: (head) =>
+      `${head}\n<style>html, body, #storybook-root, #root-inner, #root { height: 100%; }</style>`,
     core: {
       disableTelemetry: true,
     },

--- a/packages/lit/ds-prototype/.storybook/styles.css
+++ b/packages/lit/ds-prototype/.storybook/styles.css
@@ -1,14 +1,6 @@
 @import url("@canonical/styles");
 
-html {
-  height: 100%;
-}
-
-body {
-  height: 100%;
-}
-
-#storybook-root,
-#root-inner {
-  height: 100%;
-}
+/*
+ * The full-height chain (html, body, #storybook-root, …) is now established
+ * centrally via previewHead in @canonical/storybook-config (createConfig).
+ */


### PR DESCRIPTION
## Done

- Inject the full-height chain (`html, body, #storybook-root, #root-inner, #root { height: 100% }`) into the preview iframe from `createConfig` (`configs/storybook`), via `previewHead`.
- Every package's Storybook now inherits it automatically (React/Svelte/Lit all call `createConfig`), so components with `height: 100%` — application layouts, SideNavigation — resolve against a real height. Storybook does not set this by default.
- Remove the now-redundant manual copy from `packages/lit/ds-prototype/.storybook/styles.css` (the only place it was hand-coded).

## Why

Components specced with `size.height: fill` only fill the viewport if every ancestor from `html` down to the Storybook mount node has a resolved height. This was previously only done (by hand) in the Lit prototype; React storybooks lacked it. Centralising it in the shared config removes per-package duplication and fixes it everywhere at once.

## QA

- `configs/storybook`: `tsc --noEmit` and `biome check` pass.
- Open any Storybook (e.g. `ds-app`, `ds-prototype`); a `height: 100%` story now fills the canvas.

### PR readiness check

- [x] Label: `Maintenance 🔨` / `Feature 🎁`
- [x] Conventional Commit title
- [x] Required package scripts present (`check`, `check:fix`, `test`)