### PR TITLE
feat(ds-app): SideNavigation baseline alignment

### DIFF
--- a/packages/react/ds-app/.storybook/styles.css
+++ b/packages/react/ds-app/.storybook/styles.css
@@ -22,3 +22,18 @@ body,
   /* Temporary, waiting for a better understanding */
   --baseline-shift: 1px;
 }
+
+/*
+ * Shared row-grid vars for SideNavigation subcomponents shown in isolation.
+ *
+ * These are authored on `.ds.side-navigation` in the component's own styles.css,
+ * but that file is only imported by the root SideNavigation component. The
+ * subcomponent stories (Header, Item, NavTree, …) render inside a bare
+ * `.ds.side-navigation` shell (withSideNavShell) without mounting the root, so
+ * the vars would be undefined and the shared row grid would collapse. Re-declare
+ * them here so the row template resolves on every isolated story.
+ */
+.ds.side-navigation {
+  --sidenav-start: 1.5rem;
+  --sidenav-row-columns: var(--sidenav-start) 1fr auto;
+}

--- a/packages/react/ds-app/.storybook/styles.css
+++ b/packages/react/ds-app/.storybook/styles.css
@@ -34,6 +34,6 @@ body,
  * them here so the row template resolves on every isolated story.
  */
 .ds.side-navigation {
-  --sidenav-start: 1.5rem;
+  --sidenav-start: calc(var(--space-baseline) * 3); /* 1.5rem — 3bU */
   --sidenav-row-columns: var(--sidenav-start) 1fr auto;
 }

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
@@ -27,6 +27,7 @@ const meta: Meta<typeof SideNavigation> = {
   decorators: [...navDecorators, withNavigationRouterProps, withNavLayout],
   args: {
     brand: <Brand />,
+    applicationName: "Canonical",
   },
 };
 
@@ -36,6 +37,7 @@ type Story = StoryObj<typeof SideNavigation>;
 /** MAAS navigation: grouped hardware/KVM/organisation/config/networking. */
 export const MAAS: Story = {
   args: {
+    applicationName: "MAAS",
     root: maasContentRoot,
     footerRoot: maasFooterRoot,
   },
@@ -44,6 +46,7 @@ export const MAAS: Story = {
 /** LXD navigation: project-scoped instances/profiles/networking/storage/images. */
 export const LXD: Story = {
   args: {
+    applicationName: "LXD",
     root: lxdContentRoot,
     footerRoot: lxdFooterRoot,
   },
@@ -53,6 +56,7 @@ export const LXD: Story = {
 export const Collapsed: Story = {
   args: {
     defaultExpanded: false,
+    applicationName: "MAAS",
     root: maasContentRoot,
     footerRoot: maasFooterRoot,
   },

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
@@ -6,7 +6,7 @@ import {
   maasFooterRoot,
 } from "#storybook/navigation/fixtures.js";
 import {
-  Brand,
+  CanonicalLogo,
   navDecorators,
   withNavigationRouterProps,
   withNavLayout,
@@ -26,7 +26,7 @@ const meta: Meta<typeof SideNavigation> = {
   // surface and withNavLayout the page grid.
   decorators: [...navDecorators, withNavigationRouterProps, withNavLayout],
   args: {
-    brand: <Brand />,
+    brand: <CanonicalLogo />,
     applicationName: "Canonical",
   },
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tsx
@@ -62,13 +62,12 @@ const SideNavigation = ({
       {...props}
     >
       <Header
+        brand={brand}
         applicationName={applicationName}
         expanded={expanded}
         onToggle={handleToggle}
         collapseControls={contentId}
-      >
-        {brand}
-      </Header>
+      />
       <Content
         id={contentId}
         root={root}

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Content/Content.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Content/Content.stories.tsx
@@ -11,6 +11,9 @@ const meta: Meta<typeof Content> = {
   title: "Components/SideNavigation/Content",
   component: Content,
   tags: ["autodocs"],
+  // Render flush to the canvas origin (no Storybook padding) so the baseline
+  // overlay grid aligns to the component's own box.
+  parameters: { layout: "fullscreen" },
   // withNavigationRouterProps is self-contained (owns its RouterProvider), so
   // decorator order isn't load-bearing here. withSideNavShell provides the
   // .ds.side-navigation context so the shared row-grid var + surface tokens

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.ssr.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.ssr.tests.tsx
@@ -6,7 +6,7 @@ import Header from "./Header.js";
 
 describe("Header SSR", () => {
   it("renders without hydration errors", () => {
-    const html = renderToString(<Header>Test content</Header>);
+    const html = renderToString(<Header brand="Test content" />);
     expect(html).toContain("Test content");
     expect(html).toContain("ds side-navigation-header");
   });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Header> = {
   // row-grid var resolves (logo aligns with item icons) + surface tokens.
   decorators: [withSideNavShell],
   args: {
-    children: <Brand />,
+    brand: <Brand />,
     onToggle: fn(),
   },
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.stories.tsx
@@ -7,6 +7,9 @@ const meta: Meta<typeof Header> = {
   title: "Components/SideNavigation/Header",
   component: Header,
   tags: ["autodocs"],
+  // Render flush to the canvas origin (no Storybook padding) so the baseline
+  // overlay grid aligns to the component's own box.
+  parameters: { layout: "fullscreen" },
   // withSideNavShell provides the .ds.side-navigation context so the shared
   // row-grid var resolves (logo aligns with item icons) + surface tokens.
   decorators: [withSideNavShell],

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.tests.tsx
@@ -4,13 +4,13 @@ import Header from "./Header.js";
 
 describe("Header", () => {
   it("renders brand content", () => {
-    render(<Header>Test content</Header>);
+    render(<Header brand="Test content" />);
     expect(screen.getByText("Test content")).toBeInTheDocument();
   });
 
   it("applies the base and custom class to the root", () => {
     const { container } = render(
-      <Header className="custom-class">Content</Header>,
+      <Header className="custom-class" brand="Content" />,
     );
     const root = container.firstElementChild;
     expect(root?.className).toContain("ds side-navigation-header");
@@ -18,21 +18,24 @@ describe("Header", () => {
   });
 
   it("passes through additional props", () => {
-    render(<Header data-testid="test-component">Content</Header>);
+    render(<Header data-testid="test-component" brand="Content" />);
     expect(screen.getByTestId("test-component")).toBeInTheDocument();
   });
 
   it("does not render the collapse toggle without an onToggle handler", () => {
-    render(<Header>Content</Header>);
+    render(<Header brand="Content" />);
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("renders the collapse toggle when onToggle is provided", () => {
     const onToggle = vi.fn();
     render(
-      <Header expanded onToggle={onToggle} collapseControls="nav-content">
-        Content
-      </Header>,
+      <Header
+        expanded
+        onToggle={onToggle}
+        collapseControls="nav-content"
+        brand="Content"
+      />,
     );
     const toggle = screen.getByRole("button");
     expect(toggle).toHaveAttribute("aria-controls", "nav-content");

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.tsx
@@ -32,7 +32,7 @@ const Header = ({
       {/* Optional, consumer-supplied; the grid's middle column is simply empty
           when no application name is given. */}
       {applicationName != null && (
-        <span className="title">{applicationName}</span>
+        <span className="title p">{applicationName}</span>
       )}
       {onToggle && (
         <CollapseToggle

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.tsx
@@ -8,15 +8,15 @@ import "./styles.css";
 const componentCssClassName = "ds side-navigation-header";
 
 /**
- * SideNavigation.Header — top region holding the brand (children, at the start)
- * and the collapse toggle (at the end). The toggle is omitted when no
+ * SideNavigation.Header — top region holding the brand (the `brand` node, at the
+ * start) and the collapse toggle (at the end). The toggle is omitted when no
  * `onToggle` handler is provided.
  *
  * @implements ds:apps.subcomponent.side-navigation-header
  */
 const Header = ({
   className,
-  children,
+  brand,
   applicationName,
   expanded,
   onToggle,
@@ -28,7 +28,7 @@ const Header = ({
       className={[componentCssClassName, className].filter(Boolean).join(" ")}
       {...props}
     >
-      <div className="brand">{children}</div>
+      <div className="brand">{brand}</div>
       {/* Optional, consumer-supplied; the grid's middle column is simply empty
           when no application name is given. */}
       {applicationName != null && (

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
@@ -5,19 +5,22 @@
   display: grid;
   grid-template-columns: var(--sidenav-row-columns);
   /* Baseline grid: a fixed box height of whole baseline units (5bU/40px, the
-     same row height as the items below) keeps the header on the rail's rhythm;
-     align-items: baseline seats the title text baseline on the grid (the brand
-     image aligns to its own box baseline). */
+     same row height as the items below) keeps the header on the rail's rhythm.
+     align-items: start tops every cell so the brand rectangle fills from the
+     top and the title/toggle sit at the top of the row. */
   block-size: calc(var(--space-baseline) * 5); /* 40px — 5bU */
   box-sizing: border-box;
-  align-items: baseline;
+  align-items: start;
   gap: var(--dimension-100); /* 0.5rem */
 
   /* Pin each part to its column explicitly so the toggle stays in the end
      column even when the optional title is absent. */
   .brand {
-    /* Start column, aligned with the item icons below. */
+    /* Start column, aligned with the item icons below. Stretch to the full row
+       height (overriding the header's align-items: start) so the brand logo
+       fills the header top → bottom. */
     grid-column: 1;
+    align-self: stretch;
     display: flex;
     align-items: center;
   }

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
@@ -16,11 +16,10 @@
   /* Pin each part to its column explicitly so the toggle stays in the end
      column even when the optional title is absent. */
   .brand {
-    /* Start column, aligned with the item icons below. Stretch to the full row
-       height (overriding the header's align-items: start) so the brand logo
-       fills the header top → bottom. */
+    /* Start column, aligned with the item icons below. Tops-align with the rest
+       of the row (align-items: start); the brand's own margin/padding handles
+       its vertical placement, not a stretched cell. */
     grid-column: 1;
-    align-self: stretch;
     display: flex;
     align-items: center;
   }

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
@@ -4,7 +4,13 @@
   /* Shared row template with Item so the brand/logo aligns with item icons. */
   display: grid;
   grid-template-columns: var(--sidenav-row-columns);
-  align-items: center;
+  /* Baseline grid: a fixed box height of whole baseline units (5bU/40px, the
+     same row height as the items below) keeps the header on the rail's rhythm;
+     align-items: baseline seats the title text baseline on the grid (the brand
+     image aligns to its own box baseline). */
+  block-size: calc(var(--space-baseline) * 5); /* 40px — 5bU */
+  box-sizing: border-box;
+  align-items: baseline;
   gap: var(--dimension-100); /* 0.5rem */
 
   /* Pin each part to its column explicitly so the toggle stays in the end

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/types.ts
@@ -1,8 +1,8 @@
 import type { HTMLAttributes, ReactNode } from "react";
 
 export interface HeaderProps extends HTMLAttributes<HTMLDivElement> {
-  /** Brand content (logo/wordmark) rendered at the start of the header. */
-  children?: ReactNode;
+  /** Brand content (logo mark) rendered at the start of the header. */
+  brand?: ReactNode;
   /** Optional application name/wordmark shown beside the brand. Omitted when absent. */
   applicationName?: ReactNode;
   /** Whether the navigation is currently expanded. Passed to the collapse toggle. */

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.stories.tsx
@@ -10,6 +10,9 @@ const meta: Meta<typeof Item> = {
   title: "Components/SideNavigation/Item",
   component: Item,
   tags: ["autodocs"],
+  // Render flush to the canvas origin (no Storybook padding) so the baseline
+  // overlay grid aligns to the component's own box.
+  parameters: { layout: "fullscreen" },
   // Item is presentational and renders inside a <ul>; withSideNavShell provides
   // the .ds.side-navigation context (shared row grid + surface), and the inner
   // <ul.list> gives valid list markup.

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.stories.tsx
@@ -40,6 +40,15 @@ export const Link: Story = {
   },
 };
 
+/** A link item with a leading icon (icon ↔ label baseline alignment). */
+export const WithIcon: Story = {
+  args: {
+    url: "/machines",
+    label: "Machines",
+    icon: "machines",
+  },
+};
+
 /** The active (current) item. */
 export const Active: Story = {
   args: {

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
@@ -43,7 +43,7 @@ const Item = ({
     <>
       {/* Start cell is always rendered (empty when no icon) so the label stays
           in the middle column — labels align whether or not a row has an icon. */}
-      <span className="start">{icon ? <Icon icon={icon} /> : null}</span>
+      <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
       <span className="label p">{label}</span>
       {/* End slot: caret for groups (static in PR1), else the leaf slot. */}
       {hasSubitems ? (

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
@@ -44,7 +44,7 @@ const Item = ({
       {/* Start cell is always rendered (empty when no icon) so the label stays
           in the middle column — labels align whether or not a row has an icon. */}
       <span className="start">{icon ? <Icon icon={icon} /> : null}</span>
-      <span className="label">{label}</span>
+      <span className="label p">{label}</span>
       {/* End slot: caret for groups (static in PR1), else the leaf slot. */}
       {hasSubitems ? (
         <Icon icon="chevron-down" className="end caret" />

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
@@ -11,13 +11,14 @@
   /* The row: link or label. Shares the SideNavigation row template so the
      leading icon aligns with the header logo. [icon] [label] [end].
      Baseline grid: a fixed 5bU/40px row height (matching the header) carries the
-     vertical rhythm, and align-items: baseline seats the label text baseline on
-     the grid (the .p label is baseline-snapped, the icon aligns to it). No
+     vertical rhythm. Cells STRETCH to the full row height (align-items: stretch)
+     so each container owns its block, and its child positions itself — the icon
+     centred in its cell, the label's baseline-snapped (.p) line on the grid. No
      block padding — the fixed height owns the row's height. */
   & > .row {
     display: grid;
     grid-template-columns: var(--sidenav-row-columns);
-    align-items: baseline;
+    align-items: stretch;
     gap: var(--dimension-100); /* 0.5rem */
     width: 100%;
     block-size: calc(var(--space-baseline) * 5); /* 40px — 5bU */
@@ -26,22 +27,30 @@
     text-decoration: none;
   }
 
-  /* Leading icon → start column. */
+  /* Leading icon → start column. Full-height cell; the icon is centred within
+     it (see ADR open question: centred vs baseline-aligned with the text). */
   & .start {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: center;
+    block-size: 100%;
   }
 
-  /* Label → middle (1fr) column. */
+  /* Label → middle (1fr) column. Full-height cell; the baseline-snapped (.p)
+     line sits centred so its baseline lands on the grid. */
   & .label {
+    display: flex;
+    align-items: center;
     min-width: 0;
+    block-size: 100%;
   }
 
-  /* Trailing caret / slot → end (auto) column. */
+  /* Trailing caret / slot → end (auto) column. Full-height cell, content
+     centred. */
   & .end {
-    display: inline-flex;
+    display: flex;
     align-items: center;
+    block-size: 100%;
   }
 
   /* Keyboard focus visibility (structural a11y; styling refined in PR2). */

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
@@ -32,7 +32,7 @@
     text-align: center;
 
     & > .ds.icon {
-      vertical-align: baseline;
+      vertical-align: sub;
     }
   }
 

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
@@ -9,14 +9,20 @@
   list-style: none;
 
   /* The row: link or label. Shares the SideNavigation row template so the
-     leading icon aligns with the header logo. [icon] [label] [end]. */
+     leading icon aligns with the header logo. [icon] [label] [end].
+     Baseline grid: a fixed 5bU/40px row height (matching the header) carries the
+     vertical rhythm, and align-items: baseline seats the label text baseline on
+     the grid (the .p label is baseline-snapped, the icon aligns to it). No
+     block padding — the fixed height owns the row's height. */
   & > .row {
     display: grid;
     grid-template-columns: var(--sidenav-row-columns);
-    align-items: center;
+    align-items: baseline;
     gap: var(--dimension-100); /* 0.5rem */
     width: 100%;
-    padding-block: var(--dimension-150); /* 0.75rem */
+    block-size: calc(var(--space-baseline) * 5); /* 40px — 5bU */
+    box-sizing: border-box;
+    padding-block: 0;
     text-decoration: none;
   }
 

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
@@ -11,14 +11,13 @@
   /* The row: link or label. Shares the SideNavigation row template so the
      leading icon aligns with the header logo. [icon] [label] [end].
      Baseline grid: a fixed 5bU/40px row height (matching the header) carries the
-     vertical rhythm. Cells STRETCH to the full row height (align-items: stretch)
-     so each container owns its block, and its child positions itself — the icon
-     centred in its cell, the label's baseline-snapped (.p) line on the grid. No
-     block padding — the fixed height owns the row's height. */
+     vertical rhythm. Every cell top-anchors (align-items: start) so the .p line
+     boxes (icon + label) start at the same row top with equal line-height — their
+     baselines line up on the grid. No block padding — the fixed height owns it. */
   & > .row {
     display: grid;
     grid-template-columns: var(--sidenav-row-columns);
-    align-items: stretch;
+    align-items: start;
     gap: var(--dimension-100); /* 0.5rem */
     width: 100%;
     block-size: calc(var(--space-baseline) * 5); /* 40px — 5bU */
@@ -27,30 +26,24 @@
     text-decoration: none;
   }
 
-  /* Leading icon → start column. Full-height cell; the icon is centred within
-     it (see ADR open question: centred vs baseline-aligned with the text). */
+  /* Leading icon → start column. A .p line box: the icon is inline and rides the
+     baseline-snapped line like a text glyph, so it shares the label baseline. */
   & .start {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    block-size: 100%;
+    text-align: center;
+
+    & > .ds.icon {
+      vertical-align: baseline;
+    }
   }
 
-  /* Label → middle (1fr) column. Full-height cell; the baseline-snapped (.p)
-     line sits centred so its baseline lands on the grid. */
+  /* Label → middle (1fr) column. .p line box, top-anchored like .start. */
   & .label {
-    display: flex;
-    align-items: center;
     min-width: 0;
-    block-size: 100%;
   }
 
-  /* Trailing caret / slot → end (auto) column. Full-height cell, content
-     centred. */
+  /* Trailing caret / slot → end (auto) column, top-anchored. */
   & .end {
-    display: flex;
-    align-items: center;
-    block-size: 100%;
+    text-align: center;
   }
 
   /* Keyboard focus visibility (structural a11y; styling refined in PR2). */

--- a/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.stories.tsx
@@ -1,31 +1,39 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { maasFooterRoot } from "#storybook/navigation/fixtures.js";
+import { flatRoot, maasContentRoot } from "#storybook/navigation/fixtures.js";
 import {
   navDecorators,
   withNavigationRouterProps,
   withSideNavShell,
 } from "#storybook/navigation/story-utils.js";
-import Footer from "./Footer.js";
+import { NavTree } from "./index.js";
 
-const meta: Meta<typeof Footer> = {
-  title: "Components/SideNavigation/Footer",
-  component: Footer,
+const meta: Meta<typeof NavTree> = {
+  title: "Components/SideNavigation/NavTree",
+  component: NavTree,
   tags: ["autodocs"],
   // Render flush to the canvas origin (no Storybook padding) so the baseline
   // overlay grid aligns to the component's own box.
   parameters: { layout: "fullscreen" },
   // withNavigationRouterProps is self-contained (owns its RouterProvider), so
   // decorator order isn't load-bearing here. withSideNavShell provides the
-  // .ds.side-navigation context so shared tokens resolve in isolation.
+  // .ds.side-navigation context so the shared row-grid var + surface tokens
+  // resolve when the tree renders in isolation.
   decorators: [...navDecorators, withNavigationRouterProps, withSideNavShell],
 };
 
 export default meta;
-type Story = StoryObj<typeof Footer>;
+type Story = StoryObj<typeof NavTree>;
 
-/** Renders the footer navigation from a WD405 root. */
-export const Default: Story = {
+/** Grouped tree: level-1 groups, each wrapping its level-2 items. */
+export const Grouped: Story = {
   args: {
-    root: maasFooterRoot,
+    root: maasContentRoot,
+  },
+};
+
+/** A single unlabelled group — a flat list of items. */
+export const Flat: Story = {
+  args: {
+    root: flatRoot,
   },
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.tsx
@@ -45,7 +45,9 @@ const NavTree = ({
         const items = group.items ?? [];
         return (
           <section className="group" key={groupId} data-depth={group.depth}>
-            {group.label ? <span className="header">{group.label}</span> : null}
+            {group.label ? (
+              <span className="header p">{group.label}</span>
+            ) : null}
             <ul className="list">
               {/* Loop 2 — level-2 items */}
               {items.map((item) => (

--- a/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/styles.css
@@ -9,7 +9,15 @@
 
   & > .group {
     > .header {
-      display: block;
+      /* Group header sits on the baseline grid like a row: a fixed bU-multiple
+         height (4bU) with the .p label baseline-snapped, and inline padding that
+         aligns the header text with the item labels below (past the start column
+         + its gap). */
+      display: flex;
+      align-items: baseline;
+      block-size: calc(var(--space-baseline) * 4); /* 32px — 4bU */
+      box-sizing: border-box;
+      padding-inline-start: calc(var(--sidenav-start) + var(--dimension-100));
     }
 
     > .list {

--- a/packages/react/ds-app/src/lib/SideNavigation/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/styles.css
@@ -5,15 +5,21 @@
   background: var(--color-foreground-navigation-primary);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  /* Gap between Header / Content / Footer, in baseline units (2bU). */
+  gap: calc(var(--space-baseline) * 2);
   /* Cap to the parent's height so the nav never overflows the screen; Header
      and Footer pin (flex auto) and Content (flex:1, min-height:0) takes the
-     leftover space and scrolls internally. */
+     leftover space and scrolls internally.
+     KNOWN (parked, see K.02): Content is flex:1, so it absorbs *leftover*
+     height. If the nav's outer height isn't itself a whole baseline multiple,
+     that leftover is fractional and the Footer can seat a sub-pixel off the
+     grid. Not solved in this pass. */
   max-height: 100%;
 
   /* Shared row template: [start] [label/title] [end]. The Header and each Item
      row use this so the logo aligns with the item icons down the rail. The
-     start column is a fixed width matching the icon box; the logo sits in it. */
-  --sidenav-start: 1.5rem;
+     start column is a fixed width (3bU) matching the icon box; the logo sits in
+     it. */
+  --sidenav-start: calc(var(--space-baseline) * 3); /* 1.5rem — 3bU */
   --sidenav-row-columns: var(--sidenav-start) 1fr auto;
 }

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.ssr.tests.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.ssr.tests.tsx
@@ -1,0 +1,11 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import CanonicalLogo from "./CanonicalLogo.js";
+
+describe("CanonicalLogo SSR", () => {
+  it("renders without hydration errors", () => {
+    const html = renderToString(<CanonicalLogo />);
+    expect(html).toContain("ds canonical-logo");
+    expect(html).toContain("Canonical");
+  });
+});

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.stories.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withSideNavShell } from "#storybook/navigation/story-utils.js";
+import CanonicalLogo from "./CanonicalLogo.js";
+
+const meta: Meta<typeof CanonicalLogo> = {
+  title: "Components/SideNavigation/CanonicalLogo",
+  component: CanonicalLogo,
+  tags: ["autodocs"],
+  // Render flush to the canvas origin (no Storybook padding) so the baseline
+  // overlay grid aligns to the component's own box.
+  parameters: { layout: "fullscreen" },
+  // withSideNavShell provides the .ds.side-navigation context so --sidenav-start
+  // and the brand-background token resolve. The fixed-height frame mimics the
+  // header so the rectangle's full-height (top→bottom) behaviour is visible.
+  decorators: [
+    withSideNavShell,
+    (Story) => (
+      <div style={{ blockSize: "calc(var(--space-baseline) * 5)" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CanonicalLogo>;
+
+/** The brand-orange rectangle with the circle-of-friends on the baseline. */
+export const Default: Story = {};

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.tests.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.tests.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CanonicalLogo from "./CanonicalLogo.js";
+
+describe("CanonicalLogo", () => {
+  it("renders a home link with the mark", () => {
+    const { container } = render(<CanonicalLogo />);
+    const root = container.firstElementChild as HTMLAnchorElement;
+    expect(root.tagName).toBe("A");
+    expect(root.getAttribute("href")).toBe("/");
+    expect(root.querySelector("img.mark")).not.toBeNull();
+  });
+
+  it("applies the base and custom class to the root", () => {
+    const { container } = render(<CanonicalLogo className="custom-class" />);
+    const root = container.firstElementChild;
+    expect(root?.className).toContain("ds canonical-logo");
+    expect(root?.className).toContain("custom-class");
+  });
+
+  it("honours a custom href", () => {
+    const { container } = render(<CanonicalLogo href="/home" />);
+    expect(container.firstElementChild?.getAttribute("href")).toBe("/home");
+  });
+
+  it("passes through additional props", () => {
+    const { container } = render(<CanonicalLogo data-testid="logo" />);
+    expect(container.querySelector('[data-testid="logo"]')).not.toBeNull();
+  });
+});

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.tsx
@@ -1,0 +1,32 @@
+import type React from "react";
+import { CANONICAL_LOGO } from "./constants.js";
+import type { CanonicalLogoProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds canonical-logo";
+
+/**
+ * Canonical logo placeholder for story brand slots: a portrait brand-orange
+ * rectangle (`--color-background-logo`) that fills the start column and the full
+ * header height (flush to the top, extending to the bottom), with the
+ * circle-of-friends mark seated on the baseline grid inside it. A stand-in for
+ * the real Canonical logo while app-shell rhythm is aligned.
+ */
+const CanonicalLogo = ({
+  href = "/",
+  className,
+  ...props
+}: CanonicalLogoProps): React.ReactElement => {
+  return (
+    <a
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      href={href}
+      aria-label="Home"
+      {...props}
+    >
+      <img src={CANONICAL_LOGO} alt="Canonical" className="mark" />
+    </a>
+  );
+};
+
+export default CanonicalLogo;

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/constants.ts
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Canonical circle-of-friends mark (white, transparent), from Canonical's asset
+ * CDN. External by design: this is a story-only placeholder for the brand slot.
+ */
+export const CANONICAL_LOGO =
+  "https://assets.ubuntu.com/v1/82818827-CoF_white.svg";

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/index.ts
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/index.ts
@@ -1,0 +1,2 @@
+export { default as CanonicalLogo } from "./CanonicalLogo.js";
+export type { CanonicalLogoProps } from "./types.js";

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/styles.css
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/styles.css
@@ -2,21 +2,29 @@
  * CanonicalLogo — story placeholder brand mark.
  *
  * The rectangle is brand-orange (`--color-background-logo`), fills the start
- * column, and spans the full header height: flush to the top (no top padding)
- * and extending to the bottom. The circle-of-friends mark is a baseline-unit
- * square, offset from the top by a baseline-unit margin, so it snaps to the grid.
+ * column, and tops-align with the header row. Its height is built from baseline
+ * units plus a small extra so it overflows just past a grid line (an
+ * intentional overshoot). The circle-of-friends mark is a baseline-unit square,
+ * offset from the top by a baseline-unit margin.
  */
 .ds.canonical-logo {
   /* Mark geometry in baseline units (bU = --space-baseline). */
   --mark-size: 2; /* mark side, in bU */
   --mark-margin-top: 1; /* gap above the mark, in bU */
 
+  /* Rectangle height = bU multiples + a small overflow past the baseline. */
+  --logo-height: 4; /* base height, in bU */
+  --logo-overflow: 0.25rem; /* extra so it overshoots the grid line */
+
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  /* Fill the shared start column and the full header height. */
   inline-size: var(--sidenav-start, 1.5rem);
-  block-size: 100%;
+  block-size: calc(
+    var(--space-baseline) *
+    var(--logo-height) +
+    var(--logo-overflow)
+  );
   padding: 0;
   background: var(--color-background-logo);
 

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/styles.css
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/styles.css
@@ -3,28 +3,29 @@
  *
  * The rectangle is brand-orange (`--color-background-logo`), fills the start
  * column, and spans the full header height: flush to the top (no top padding)
- * and extending to the bottom. The circle-of-friends mark is pushed to the foot
- * and seated on the baseline grid — its bottom edge is lifted by one baseline
- * unit so it lands on a grid line rather than the box edge.
+ * and extending to the bottom. The circle-of-friends mark is a baseline-unit
+ * square, offset from the top by a baseline-unit margin, so it snaps to the grid.
  */
 .ds.canonical-logo {
+  /* Mark geometry in baseline units (bU = --space-baseline). */
+  --mark-size: 2; /* mark side, in bU */
+  --mark-margin-top: 1; /* gap above the mark, in bU */
+
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   /* Fill the shared start column and the full header height. */
   inline-size: var(--sidenav-start, 1.5rem);
   block-size: 100%;
-  /* Flush to the top; the mark is seated near the bottom via its own offset. */
   padding: 0;
   background: var(--color-background-logo);
 
   & > .mark {
     display: block;
-    /* Mark box on a baseline multiple (2bU) so it snaps to the grid. */
-    inline-size: calc(var(--space-baseline) * 2);
-    block-size: calc(var(--space-baseline) * 2);
-    /* Push to the foot of the rectangle, then lift by one baseline unit so the
-       mark sits on the baseline grid inside the box. */
-    margin-block: auto var(--space-baseline);
+    /* Square sized in bU multiples so it lands on the grid. */
+    inline-size: calc(var(--space-baseline) * var(--mark-size));
+    block-size: calc(var(--space-baseline) * var(--mark-size));
+    /* Top offset in bU multiples. */
+    margin-block-start: calc(var(--space-baseline) * var(--mark-margin-top));
   }
 }

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/styles.css
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/styles.css
@@ -1,0 +1,30 @@
+/*
+ * CanonicalLogo — story placeholder brand mark.
+ *
+ * The rectangle is brand-orange (`--color-background-logo`), fills the start
+ * column, and spans the full header height: flush to the top (no top padding)
+ * and extending to the bottom. The circle-of-friends mark is pushed to the foot
+ * and seated on the baseline grid — its bottom edge is lifted by one baseline
+ * unit so it lands on a grid line rather than the box edge.
+ */
+.ds.canonical-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Fill the shared start column and the full header height. */
+  inline-size: var(--sidenav-start, 1.5rem);
+  block-size: 100%;
+  /* Flush to the top; the mark is seated near the bottom via its own offset. */
+  padding: 0;
+  background: var(--color-background-logo);
+
+  & > .mark {
+    display: block;
+    /* Mark box on a baseline multiple (2bU) so it snaps to the grid. */
+    inline-size: calc(var(--space-baseline) * 2);
+    block-size: calc(var(--space-baseline) * 2);
+    /* Push to the foot of the rectangle, then lift by one baseline unit so the
+       mark sits on the baseline grid inside the box. */
+    margin-block: auto var(--space-baseline);
+  }
+}

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/styles.css
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/styles.css
@@ -3,9 +3,12 @@
  *
  * The rectangle is brand-orange (`--color-background-logo`), fills the start
  * column, and tops-align with the header row. Its height is built from baseline
- * units plus a small extra so it overflows just past a grid line (an
- * intentional overshoot). The circle-of-friends mark is a baseline-unit square,
- * offset from the top by a baseline-unit margin.
+ * units plus a small extra so the orange overshoots a grid line (an intentional
+ * overshoot). To keep the HEADER height a whole multiple of the baseline, the
+ * overshoot is cancelled by an external bottom margin: rectangle + margin (the
+ * margin-box) sums back to a bU multiple, so the overflow is purely visual and
+ * doesn't push the header off-grid. The circle-of-friends mark is a baseline-
+ * unit square, offset from the top by a baseline-unit margin.
  */
 .ds.canonical-logo {
   /* Mark geometry in baseline units (bU = --space-baseline). */
@@ -14,7 +17,7 @@
 
   /* Rectangle height = bU multiples + a small overflow past the baseline. */
   --logo-height: 4; /* base height, in bU */
-  --logo-overflow: 0.25rem; /* extra so it overshoots the grid line */
+  --logo-overflow: 0.25rem; /* extra so the orange overshoots the grid line */
 
   display: flex;
   align-items: flex-start;
@@ -25,6 +28,9 @@
     var(--logo-height) +
     var(--logo-overflow)
   );
+  /* Cancel the overshoot so the margin-box lands back on the grid: the rectangle
+     (logo-height bU + overflow) plus this margin sums to (logo-height + 1) bU. */
+  margin-block-end: calc(var(--space-baseline) - var(--logo-overflow));
   padding: 0;
   background: var(--color-background-logo);
 

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/types.ts
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/types.ts
@@ -1,0 +1,9 @@
+import type { HTMLAttributes } from "react";
+
+/**
+ * Props for the CanonicalLogo component.
+ */
+export interface CanonicalLogoProps extends HTMLAttributes<HTMLAnchorElement> {
+  /** Destination for the home link. Defaults to "/". */
+  href?: string;
+}

--- a/packages/react/ds-app/src/storybook/navigation/story-utils.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/story-utils.tsx
@@ -140,7 +140,9 @@ export const withNavLayout: Decorator = (Story) => (
     <Story />
     {/* The main canvas is its own scroll container so its content scrolls
         independently of the navigation, demonstrating the app-shell layout. */}
-    <main style={{ minHeight: 0, overflow: "auto", padding: "1rem" }}>
+    {/* Inline padding only (side gutters); no block padding so the canvas
+        content starts flush with the top and stays on the baseline grid. */}
+    <main style={{ minHeight: 0, overflow: "auto", paddingInline: "1rem" }}>
       <Lorem paragraphs={8} />
     </main>
   </div>

--- a/packages/react/ds-app/src/storybook/navigation/story-utils.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/story-utils.tsx
@@ -23,30 +23,9 @@ export const Brand = (): ReactNode => (
   </a>
 );
 
-/**
- * Canonical logo placeholder for the brand slot: a portrait brand-orange
- * rectangle (`--color-background-logo`) with the circle-of-friends mark anchored
- * at the bottom — a stand-in for the real Canonical logo while we align the
- * header rhythm. The rectangle fills the start column and the header's height,
- * so the CoF marks the header baseline at its foot.
- */
-export const CanonicalLogo = (): ReactNode => (
-  <a
-    href="/"
-    aria-label="Home"
-    style={{
-      display: "flex",
-      alignItems: "flex-end",
-      justifyContent: "center",
-      inlineSize: "var(--sidenav-start, 1.5rem)",
-      blockSize: "100%",
-      background: "var(--color-background-logo)",
-      paddingBlockEnd: "var(--dimension-050, 0.25rem)",
-    }}
-  >
-    <img src={CANONICAL_LOGO} alt="Canonical" width={16} height={16} />
-  </a>
-);
+// CanonicalLogo is generated (component/react) and re-exported here so stories
+// keep importing brand helpers from one place.
+export { CanonicalLogo } from "./CanonicalLogo/index.js";
 
 /**
  * Link adapter for the stories. SideNavigation is router-agnostic (it only sees

--- a/packages/react/ds-app/src/storybook/navigation/story-utils.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/story-utils.tsx
@@ -24,6 +24,31 @@ export const Brand = (): ReactNode => (
 );
 
 /**
+ * Canonical logo placeholder for the brand slot: a portrait brand-orange
+ * rectangle (`--color-background-logo`) with the circle-of-friends mark anchored
+ * at the bottom — a stand-in for the real Canonical logo while we align the
+ * header rhythm. The rectangle fills the start column and the header's height,
+ * so the CoF marks the header baseline at its foot.
+ */
+export const CanonicalLogo = (): ReactNode => (
+  <a
+    href="/"
+    aria-label="Home"
+    style={{
+      display: "flex",
+      alignItems: "flex-end",
+      justifyContent: "center",
+      inlineSize: "var(--sidenav-start, 1.5rem)",
+      blockSize: "100%",
+      background: "var(--color-background-logo)",
+      paddingBlockEnd: "var(--dimension-050, 0.25rem)",
+    }}
+  >
+    <img src={CANONICAL_LOGO} alt="Canonical" width={16} height={16} />
+  </a>
+);
+
+/**
  * Link adapter for the stories. SideNavigation is router-agnostic (it only sees
  * `LinkComponentProps`); this bridges its raw-URL nav items to the hash router
  * that `withNavigationRouterProps` provides — `createHashRouter` reads

--- a/packages/styles/debug/src/baseline-grid.css
+++ b/packages/styles/debug/src/baseline-grid.css
@@ -1,18 +1,20 @@
 .with-baseline-grid {
+  /* Lines are partly transparent so content reads through the grid. */
   --addon-baseline-grid-color: var(
     --baseline-grid-color,
     color-mix(
       in oklch,
-      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 50%,
+      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 35%,
       transparent
     )
   );
-  /* Every 4th line — a distinct, stronger tint so groups of 4 are countable. */
+  /* Every 4th line — a distinct, stronger (but still translucent) tint so groups
+     of 4 are countable. */
   --addon-baseline-grid-major-color: var(
     --baseline-grid-major-color,
     color-mix(
       in oklch,
-      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 85%,
+      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 60%,
       transparent
     )
   );
@@ -23,34 +25,43 @@
   position: relative;
 
   /*
-   * Paint the grid as a repeating BACKGROUND on the element itself rather than
-   * an absolutely-positioned ::after. A pseudo pinned to inset:0 is clipped to
-   * the element's rendered box, so any content TALLER than 100% (a scroll
-   * container, an overflowing child) loses the grid past the fold. A tiled
-   * background covers the full content/scroll height automatically.
+   * The grid is an ::after overlay (kept so it paints ON TOP and can cover the
+   * full page, not just behind content). To survive content TALLER than 100%
+   * (overflowing children), the pseudo grows with the host: min-block-size:100%
+   * fills the box, and because the host is position:relative and content-sized,
+   * the pseudo stretches over the whole content height rather than clipping at
+   * the fold.
    *
    * Two layers: a minor line every baseline unit, and a major (different colour)
-   * line every 4 units. The major layer is listed first so it paints on top
-   * where they coincide.
+   * line every 4 units, listed first so it paints on top where they coincide.
    */
-  background-image:
-    linear-gradient(
-      to top,
-      var(--addon-baseline-grid-major-color),
-      var(--addon-baseline-grid-major-color) 1px,
-      transparent 1px,
-      transparent
-    ),
-    linear-gradient(
-      to top,
-      var(--addon-baseline-grid-color),
-      var(--addon-baseline-grid-color) 1px,
-      transparent 1px,
-      transparent
-    );
-  background-size:
-    100% var(--addon-baseline-major),
-    100% var(--addon-baseline-height);
-  background-position: 0 var(--addon-baseline-shift);
-  background-repeat: repeat;
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    block-size: 100%;
+    min-block-size: 100%;
+    pointer-events: none;
+    z-index: 200;
+    background-image:
+      linear-gradient(
+        to top,
+        var(--addon-baseline-grid-major-color),
+        var(--addon-baseline-grid-major-color) 1px,
+        transparent 1px,
+        transparent
+      ),
+      linear-gradient(
+        to top,
+        var(--addon-baseline-grid-color),
+        var(--addon-baseline-grid-color) 1px,
+        transparent 1px,
+        transparent
+      );
+    background-size:
+      100% var(--addon-baseline-major),
+      100% var(--addon-baseline-height);
+    background-position: 0 var(--addon-baseline-shift);
+    background-repeat: repeat;
+  }
 }

--- a/packages/styles/debug/src/baseline-grid.css
+++ b/packages/styles/debug/src/baseline-grid.css
@@ -8,8 +8,8 @@
       transparent
     )
   );
-  /* Every 4th line — a distinct, stronger (but still translucent) tint so groups
-     of 4 are countable. */
+  /* Every Nth line (see --baseline-grid-major-every) — a distinct, stronger
+     (but still translucent) tint so groups are countable. */
   --addon-baseline-grid-major-color: var(
     --baseline-grid-major-color,
     color-mix(
@@ -19,7 +19,12 @@
     )
   );
   --addon-baseline-height: var(--baseline-height, 0.5rem);
-  --addon-baseline-major: calc(var(--addon-baseline-height) * 4);
+  /* Major line every Nth baseline (configurable; default every 4). */
+  --addon-baseline-major-every: var(--baseline-grid-major-every, 4);
+  --addon-baseline-major: calc(
+    var(--addon-baseline-height) *
+    var(--addon-baseline-major-every)
+  );
   --addon-baseline-shift: var(--baseline-shift, 0);
 
   position: relative;
@@ -33,7 +38,8 @@
    * the fold.
    *
    * Two layers: a minor line every baseline unit, and a major (different colour)
-   * line every 4 units, listed first so it paints on top where they coincide.
+   * line every Nth unit (--baseline-grid-major-every), listed first so it paints
+   * on top where they coincide.
    */
   &::after {
     content: "";

--- a/packages/styles/debug/src/baseline-grid.css
+++ b/packages/styles/debug/src/baseline-grid.css
@@ -7,29 +7,50 @@
       transparent
     )
   );
+  /* Every 4th line — a distinct, stronger tint so groups of 4 are countable. */
+  --addon-baseline-grid-major-color: var(
+    --baseline-grid-major-color,
+    color-mix(
+      in oklch,
+      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 85%,
+      transparent
+    )
+  );
   --addon-baseline-height: var(--baseline-height, 0.5rem);
+  --addon-baseline-major: calc(var(--addon-baseline-height) * 4);
   --addon-baseline-shift: var(--baseline-shift, 0);
 
   position: relative;
 
-  &::after {
-    background: linear-gradient(
+  /*
+   * Paint the grid as a repeating BACKGROUND on the element itself rather than
+   * an absolutely-positioned ::after. A pseudo pinned to inset:0 is clipped to
+   * the element's rendered box, so any content TALLER than 100% (a scroll
+   * container, an overflowing child) loses the grid past the fold. A tiled
+   * background covers the full content/scroll height automatically.
+   *
+   * Two layers: a minor line every baseline unit, and a major (different colour)
+   * line every 4 units. The major layer is listed first so it paints on top
+   * where they coincide.
+   */
+  background-image:
+    linear-gradient(
+      to top,
+      var(--addon-baseline-grid-major-color),
+      var(--addon-baseline-grid-major-color) 1px,
+      transparent 1px,
+      transparent
+    ),
+    linear-gradient(
       to top,
       var(--addon-baseline-grid-color),
       var(--addon-baseline-grid-color) 1px,
       transparent 1px,
       transparent
     );
-    background-size: 100% var(--addon-baseline-height);
-    background-position: 0 var(--addon-baseline-shift);
-    bottom: 0;
-    content: "";
-    display: block;
-    left: 0;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: 200;
-  }
+  background-size:
+    100% var(--addon-baseline-major),
+    100% var(--addon-baseline-height);
+  background-position: 0 var(--addon-baseline-shift);
+  background-repeat: repeat;
 }


### PR DESCRIPTION
## Done

Baseline-grid alignment for SideNavigation (PR2 of the styles work; PR1 #655 shipped structure-only). Each subcomponent was aligned in isolation on its own story under the baseline overlay, then verified assembled.

- **Item row** — fixed 5bU/40px height, cells top-anchored (`align-items: start`) so the `.p` baseline-cap nudges snap the label (and icon) onto the grid rather than being fought by centring. Label + icon cell both carry `.p`; icon `vertical-align: sub`.
- **Header** — 5bU box, brand cell start-aligned; the title gets `.p`. Brand is now an explicit `brand` prop (was `children`).
- **Group headers** (NavTree) — 4bU box with `.p`, inline-padded to align with the item labels.
- **Shell** — flex gap and `--sidenav-start` expressed in baseline units (2bU / 3bU).
- **CanonicalLogo** — new generated story-brand component (brand-orange rail mark, CoF on baseline); its margin-box compensates the visual overflow so the header stays a whole bU multiple.
- **Stories** — subcomponent stories set `layout: fullscreen` (padding-free for the overlay); added a NavTree story; root stories set `applicationName` + use CanonicalLogo.
- **Baseline-grid debug helper** (`@canonical/styles-debug`) drive-bys: translucent lines, a configurable major line every Nth baseline (`--baseline-grid-major-every`, default 4), and it grows with content past 100%.

Accessibility + styling decisions tracked in pragma-adrs `session/K/K.02`. Known parked item (documented): Content `flex:1` can seat the Footer a sub-pixel off-grid in the assembled shell — each part is baseline-correct in isolation.

Deferred (per K.01/K.02): colour/state token pairings, focus tokenisation, `--overflow-gradient-height` semantic token, per-state anatomy tokens, keyboard nav.

## QA

1. Storybook → `Components/SideNavigation/*`. Toggle the baseline overlay (ruler icon / `B`).
2. **Item**: rows are 40px; the label and leading icon sit on the same grid baseline (check `WithIcon` and the no-icon `Link`).
3. **Header**: 5bU box; brand rail mark fills top→bottom with the CoF on the baseline; title aligns.
4. **NavTree / Content / Footer**: group headers on-grid and inline-aligned with item labels.
5. **Assembled MAAS / LXD**: the full rail (logo → header → group headers → items → footer) reads as one rhythm.

### PR readiness check

- [ ] Label: `Feature 🎁`
- [x] Conventional Commits title
- [x] Code standards
- [x] Packages define `check` / `check:fix` / `test`
- [ ] No new package (CanonicalLogo lives inside ds-app's storybook helpers)

## Screenshots

_To add: baseline overlay on the assembled MAAS nav._