### PR TITLE
feat(webarchitect): add ruleset template variables with --var/--prefix flags

### DIFF
--- a/packages/webarchitect/README.md
+++ b/packages/webarchitect/README.md
@@ -184,7 +184,8 @@ Resolution rules:
 - An override value always wins over the declared `default`.
 - If a variable declares a `schema`, the override value is validated against it (via JSON Schema) before substitution.
 - Overriding a variable that the ruleset does not declare is an error, as is referencing an undeclared `${name}` token inside a rule — both surface typos early. This means `--prefix`/`--var prefix=…` only apply to the prefix-family rulesets above; passing them to a ruleset without a `prefix` variable (e.g. `base`, `assets`) is rejected.
-- Variables declared in a parent ruleset are inherited by rulesets that `extends` it.
+- Variables declared in a parent ruleset are inherited by rulesets that `extends` it; a child may add or refine variables without dropping inherited ones.
+- Values substituted into a rule's `pattern` are treated as regular-expression fragments, not literals — so `--prefix "@my.org/"` matches `@my.org/` *and* `@myXorg/` (the `.` is a wildcard). Escape regex metacharacters if you need a literal match.
 
 ### Ruleset Resolution Mechanism
 

--- a/packages/webarchitect/README.md
+++ b/packages/webarchitect/README.md
@@ -135,8 +135,56 @@ webarchitect <ruleset> [options]
 ### Available Options
 
 - `--verbose`: Shows detailed information about each validation, including what files are being checked, what rules are being applied, and the actual content found. Essential for debugging validation failures or understanding exactly what the tool is checking.
--`--json`: Outputs results in JSON format instead of human-readable text. Required for integrating webarchitect into automated systems, CI/CD pipelines, or other tools that need to programmatically process validation results.
--`--help`: Displays comprehensive usage information, available options, and examples. Use this command to see the most current information about the tool's capabilities.
+- `--json`: Outputs results in JSON format instead of human-readable text. Required for integrating webarchitect into automated systems, CI/CD pipelines, or other tools that need to programmatically process validation results.
+- `--var <key=value>`: Overrides a ruleset [template variable](#template-variables) for this run. Repeatable, e.g. `--var prefix=@myorg/ --var foo=bar`.
+- `--prefix <value>`: Shorthand for `--var prefix=<value>`, since the package-name prefix is the most common variable to override.
+- `--list`: Lists all available rulesets (bundled and in the current directory) and exits.
+- `--help`: Displays comprehensive usage information, available options, and examples. Use this command to see the most current information about the tool's capabilities.
+
+### Template variables
+
+Rulesets can declare **template variables** so a single ruleset can be reused across organizations or relaxed per-project without duplicating it. Variables are declared under a top-level `variables` block, referenced as `${name}` anywhere inside a rule, and overridden at the command line with `--var`/`--prefix`.
+
+The built-in `package`, `tool-ts`, and `package-svelte` rulesets use this to enforce the package-name prefix. They declare:
+
+```jsonc
+{
+  "name": "package",
+  "variables": {
+    "prefix": {
+      "default": "@canonical/",        // used when no override is supplied
+      "schema": { "type": "string" }   // optional: validates override values
+    }
+  },
+  "package-structure": {
+    "file": {
+      "name": "package.json",
+      "contains": {
+        "properties": {
+          "name": { "type": "string", "pattern": "^${prefix}" }
+        }
+      }
+    }
+  }
+}
+```
+
+By default this enforces that the package name starts with `@canonical/`. Consumers can override it:
+
+```bash
+# Require a different org prefix
+webarchitect library --prefix @myorg/
+
+# Drop the prefix requirement entirely (empty prefix → pattern "^", matches any name)
+webarchitect library --prefix ""
+```
+
+Resolution rules:
+
+- An override value always wins over the declared `default`.
+- If a variable declares a `schema`, the override value is validated against it (via JSON Schema) before substitution.
+- Overriding a variable that the ruleset does not declare is an error, as is referencing an undeclared `${name}` token inside a rule — both surface typos early.
+- Variables declared in a parent ruleset are inherited by rulesets that `extends` it.
 
 ### Ruleset Resolution Mechanism
 

--- a/packages/webarchitect/README.md
+++ b/packages/webarchitect/README.md
@@ -145,7 +145,7 @@ webarchitect <ruleset> [options]
 
 Rulesets can declare **template variables** so a single ruleset can be reused across organizations or relaxed per-project without duplicating it. Variables are declared under a top-level `variables` block, referenced as `${name}` anywhere inside a rule, and overridden at the command line with `--var`/`--prefix`.
 
-The built-in `package`, `tool-ts`, and `package-svelte` rulesets use this to enforce the package-name prefix. They declare:
+The built-in rulesets use this to enforce the package-name prefix: `package` and `tool-ts` declare a `prefix` variable, and `library`, `tool`, `package-react`, and `package-svelte` inherit it via `extends`. The declaration looks like:
 
 ```jsonc
 {
@@ -183,7 +183,7 @@ Resolution rules:
 
 - An override value always wins over the declared `default`.
 - If a variable declares a `schema`, the override value is validated against it (via JSON Schema) before substitution.
-- Overriding a variable that the ruleset does not declare is an error, as is referencing an undeclared `${name}` token inside a rule — both surface typos early.
+- Overriding a variable that the ruleset does not declare is an error, as is referencing an undeclared `${name}` token inside a rule — both surface typos early. This means `--prefix`/`--var prefix=…` only apply to the prefix-family rulesets above; passing them to a ruleset without a `prefix` variable (e.g. `base`, `assets`) is rejected.
 - Variables declared in a parent ruleset are inherited by rulesets that `extends` it.
 
 ### Ruleset Resolution Mechanism

--- a/packages/webarchitect/rulesets/package-svelte.ruleset.json
+++ b/packages/webarchitect/rulesets/package-svelte.ruleset.json
@@ -10,7 +10,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "pattern": "^@canonical/"
+            "pattern": "^${prefix}"
           },
           "version": {
             "type": "string"

--- a/packages/webarchitect/rulesets/package.ruleset.json
+++ b/packages/webarchitect/rulesets/package.ruleset.json
@@ -2,6 +2,12 @@
   "$schema": "https://raw.githubusercontent.com/canonical/pragma/refs/heads/main/packages/webarchitect/src/schema.json",
   "name": "package",
   "extends": ["base"],
+  "variables": {
+    "prefix": {
+      "default": "@canonical/",
+      "schema": { "type": "string" }
+    }
+  },
   "biome": {
     "file": {
       "name": "biome.json",
@@ -41,7 +47,8 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^${prefix}"
           },
           "version": {
             "type": "string"

--- a/packages/webarchitect/rulesets/tool-ts.ruleset.json
+++ b/packages/webarchitect/rulesets/tool-ts.ruleset.json
@@ -2,6 +2,12 @@
   "$schema": "https://raw.githubusercontent.com/canonical/pragma/refs/heads/main/packages/webarchitect/src/schema.json",
   "name": "tool-ts",
   "extends": ["base"],
+  "variables": {
+    "prefix": {
+      "default": "@canonical/",
+      "schema": { "type": "string" }
+    }
+  },
   "biome": {
     "file": {
       "name": "biome.json",
@@ -42,7 +48,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "pattern": "^@canonical/"
+            "pattern": "^${prefix}"
           },
           "version": {
             "type": "string"

--- a/packages/webarchitect/src/cli.ts
+++ b/packages/webarchitect/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import type { ErrorObject } from "ajv";
 import chalk from "chalk";
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { discoverAllRulesets } from "./lib/index.js";
 import type { ValidationResult } from "./types.js";
 import validate from "./validate.js";
@@ -280,7 +280,9 @@ function collectVariable(
 ): Record<string, string> {
   const separator = raw.indexOf("=");
   if (separator === -1) {
-    throw new Error(`Invalid --var '${raw}', expected key=value`);
+    // InvalidArgumentError lets Commander format and exit cleanly, rather than
+    // surfacing a raw stack trace from inside the option parser.
+    throw new InvalidArgumentError(`Expected key=value, received '${raw}'.`);
   }
   acc[raw.slice(0, separator)] = raw.slice(separator + 1);
   return acc;

--- a/packages/webarchitect/src/cli.ts
+++ b/packages/webarchitect/src/cli.ts
@@ -265,12 +265,40 @@ async function displayRulesetTree(): Promise<void> {
   }
 }
 
+/**
+ * Collects repeatable `--var key=value` options into a single record.
+ * Commander invokes this once per occurrence, threading the accumulator.
+ *
+ * @param raw - Raw `key=value` string from a single `--var` occurrence
+ * @param acc - Accumulator of previously parsed variable overrides
+ * @returns The accumulator with the new override added
+ * @throws Will throw if the value is missing an `=` separator
+ */
+function collectVariable(
+  raw: string,
+  acc: Record<string, string>,
+): Record<string, string> {
+  const separator = raw.indexOf("=");
+  if (separator === -1) {
+    throw new Error(`Invalid --var '${raw}', expected key=value`);
+  }
+  acc[raw.slice(0, separator)] = raw.slice(separator + 1);
+  return acc;
+}
+
 program
   .name("webarchitect")
   .argument("[ruleset]", "ruleset identifier, local path, or URL")
   .option("-v, --verbose", "show all validation results")
   .option("--json", "output results in JSON format")
   .option("--list", "list all available rulesets")
+  .option(
+    "--var <key=value>",
+    "override a ruleset template variable (repeatable)",
+    collectVariable,
+    {},
+  )
+  .option("--prefix <value>", "shortcut for --var prefix=<value>")
   .action(async (schemaArg, options) => {
     // Handle --list option
     if (options.list) {
@@ -287,7 +315,19 @@ program
       process.exit(1);
     }
     try {
-      const results = await validate(process.cwd(), schemaArg);
+      // Merge variable overrides; --prefix is sugar for --var prefix=<value>.
+      const variableOverrides: Record<string, string> = {
+        ...(options.var ?? {}),
+      };
+      if (options.prefix !== undefined) {
+        variableOverrides.prefix = options.prefix;
+      }
+
+      const results = await validate(
+        process.cwd(),
+        schemaArg,
+        variableOverrides,
+      );
 
       if (options.json) {
         formatJsonOutput(results);

--- a/packages/webarchitect/src/lib/index.ts
+++ b/packages/webarchitect/src/lib/index.ts
@@ -10,6 +10,7 @@ export { default as executeValidationRules } from "./executeValidationRules.js";
 export { default as listDirectory } from "./listDirectory.js";
 export { default as loadFullSchema } from "./loadFullSchema.js";
 export { default as resolveSchema } from "./resolveSchema.js";
+export { default as substituteVariables } from "./substituteVariables.js";
 export { default as validateDirectoryRule } from "./validateDirectoryRule.js";
 export { default as validateFileRule } from "./validateFileRule.js";
 export { default as validateRule } from "./validateRule.js";

--- a/packages/webarchitect/src/lib/loadFullSchema.test.ts
+++ b/packages/webarchitect/src/lib/loadFullSchema.test.ts
@@ -103,6 +103,31 @@ describe("loadFullSchema", () => {
     expect(result.extends).toBeUndefined();
   });
 
+  it("merges variables by key so a child keeps inherited variables", async () => {
+    const parent = {
+      name: "parent",
+      variables: {
+        prefix: { default: "@canonical/" },
+        suffix: { default: "-pkg" },
+      },
+    };
+    const child = {
+      name: "child",
+      extends: [join(tmp, "parent.ruleset.json")],
+      // Redeclares only `suffix`; `prefix` must still be inherited.
+      variables: { suffix: { default: "-lib" } },
+    };
+
+    writeFileSync(join(tmp, "parent.ruleset.json"), JSON.stringify(parent));
+    writeFileSync(join(tmp, "child.ruleset.json"), JSON.stringify(child));
+
+    const result = await loadFullSchema(join(tmp, "child.ruleset.json"));
+    expect(result.variables).toEqual({
+      prefix: { default: "@canonical/" },
+      suffix: { default: "-lib" },
+    });
+  });
+
   it("handles multiple extends", async () => {
     const base1 = {
       name: "base1",

--- a/packages/webarchitect/src/lib/loadFullSchema.ts
+++ b/packages/webarchitect/src/lib/loadFullSchema.ts
@@ -1,11 +1,13 @@
-import type { Schema } from "../types.js";
+import type { Schema, VariableDeclarations } from "../types.js";
 import resolveSchema from "./resolveSchema.js";
 
 /**
  * Loads a schema and recursively resolves all extended schemas.
  * Merges rules from parent schemas with child schemas, where child
- * rules override parent rules with the same name. Special properties
- * like $schema and name are preserved from the child schema.
+ * rules override parent rules with the same name. The `variables` block
+ * is merged by key (child variables override inherited ones) rather than
+ * replaced wholesale. Special properties like $schema and name are
+ * preserved from the child schema.
  *
  * @param schemaArg - Schema identifier (built-in name, file path, or URL)
  * @returns Promise that resolves to the fully merged schema with all extensions resolved
@@ -30,7 +32,22 @@ export default async function loadFullSchema(
       Object.assign(baseRules, rules);
     }
     const { $schema, name, extends: _, ...rules } = schema;
-    return Object.assign({}, baseRules, rules, { $schema, name });
+    const merged = Object.assign({}, baseRules, rules, {
+      $schema,
+      name,
+    }) as Schema;
+
+    // `variables` must merge by key (child overrides parent) rather than be
+    // wholesale-replaced by Object.assign, so a child ruleset can add or refine
+    // variables without dropping ones inherited from a parent ruleset.
+    const baseVariables = baseRules.variables as
+      | VariableDeclarations
+      | undefined;
+    if (baseVariables && schema.variables) {
+      merged.variables = { ...baseVariables, ...schema.variables };
+    }
+
+    return merged;
   }
   return schema;
 }

--- a/packages/webarchitect/src/lib/substituteVariables.test.ts
+++ b/packages/webarchitect/src/lib/substituteVariables.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { Schema } from "../types.js";
+import substituteVariables from "./substituteVariables.js";
+
+// Reads the resolved package name pattern out of a schema shaped like baseSchema().
+function namePattern(schema: Schema): string {
+  const rule = schema["package-structure"] as unknown as {
+    file: { contains: { properties: { name: { pattern: string } } } };
+  };
+  return rule.file.contains.properties.name.pattern;
+}
+
+describe("substituteVariables", () => {
+  const baseSchema = (): Schema => ({
+    name: "library",
+    variables: {
+      prefix: { default: "@canonical/", schema: { type: "string" } },
+    },
+    "package-structure": {
+      file: {
+        name: "package.json",
+        contains: {
+          type: "object",
+          properties: {
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: literal token resolved by substituteVariables
+            name: { type: "string", pattern: "^${prefix}" },
+          },
+        },
+      },
+    },
+  });
+
+  it("substitutes declared defaults when no override is provided", () => {
+    expect(namePattern(substituteVariables(baseSchema()))).toBe("^@canonical/");
+  });
+
+  it("lets overrides win over declared defaults", () => {
+    const result = substituteVariables(baseSchema(), { prefix: "@myorg/" });
+    expect(namePattern(result)).toBe("^@myorg/");
+  });
+
+  it("treats an empty prefix as no constraint (matches any name)", () => {
+    const result = substituteVariables(baseSchema(), { prefix: "" });
+    expect(namePattern(result)).toBe("^");
+    expect(/^/.test("anything")).toBe(true);
+  });
+
+  it("removes the variables block from the resolved schema", () => {
+    expect(substituteVariables(baseSchema()).variables).toBeUndefined();
+  });
+
+  it("does not mutate the input schema", () => {
+    const input = baseSchema();
+    substituteVariables(input, { prefix: "@myorg/" });
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: asserts the raw token is untouched
+    expect(namePattern(input)).toBe("^${prefix}");
+  });
+
+  it("throws when an override targets an undeclared variable", () => {
+    expect(() => substituteVariables(baseSchema(), { unknown: "x" })).toThrow(
+      /Unknown variable 'unknown'/,
+    );
+  });
+
+  it("throws when an override value fails its declared schema", () => {
+    const schema: Schema = {
+      name: "test",
+      variables: { count: { default: "1", schema: { pattern: "^[0-9]+$" } } },
+      rule: {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: literal token resolved by substituteVariables
+        file: { name: "package.json", contains: { title: "${count}" } },
+      },
+    };
+    expect(() => substituteVariables(schema, { count: "abc" })).toThrow(
+      /Invalid value 'abc' for variable 'count'/,
+    );
+  });
+
+  it("throws when a rule references an undeclared variable", () => {
+    const schema: Schema = {
+      name: "test",
+      rule: {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: literal token resolved by substituteVariables
+        file: { name: "package.json", contains: { title: "${missing}" } },
+      },
+    };
+    expect(() => substituteVariables(schema)).toThrow(
+      /Unknown template variable '\$\{missing\}'/,
+    );
+  });
+
+  it("returns the schema unchanged when there are no variables or tokens", () => {
+    const schema: Schema = {
+      name: "plain",
+      rule: { file: { name: "package.json", contains: { type: "object" } } },
+    };
+    expect(substituteVariables(schema)).toEqual(schema);
+  });
+});

--- a/packages/webarchitect/src/lib/substituteVariables.ts
+++ b/packages/webarchitect/src/lib/substituteVariables.ts
@@ -5,6 +5,16 @@ import ajv from "./ajv.js";
 const TOKEN_PATTERN = /\$\{([^}]+)\}/g;
 
 /**
+ * Formats a set of variable names for inclusion in error messages.
+ *
+ * @param names - Declared variable names
+ * @returns A comma-separated list, or "none" when empty
+ */
+function declaredList(names: string[]): string {
+  return names.join(", ") || "none";
+}
+
+/**
  * Replaces every `${name}` token in a string with its resolved value.
  * Throws if a token references a variable that was never declared, which
  * surfaces ruleset typos instead of silently leaving the placeholder in place.
@@ -17,9 +27,8 @@ const TOKEN_PATTERN = /\$\{([^}]+)\}/g;
 function replaceTokens(value: string, values: Record<string, string>): string {
   return value.replace(TOKEN_PATTERN, (_match, name: string) => {
     if (!(name in values)) {
-      const declared = Object.keys(values).join(", ") || "none";
       throw new Error(
-        `Unknown template variable '\${${name}}'. Declared variables: ${declared}`,
+        `Unknown template variable '\${${name}}'. Declared variables: ${declaredList(Object.keys(values))}`,
       );
     }
     return values[name];
@@ -72,9 +81,8 @@ function resolveValues(
   // Reject overrides that target undeclared variables (typo or wrong ruleset).
   for (const key of Object.keys(overrides)) {
     if (!(key in declarations)) {
-      const declared = Object.keys(declarations).join(", ") || "none";
       throw new Error(
-        `Unknown variable '${key}' provided via --var/--prefix. Declared variables: ${declared}`,
+        `Unknown variable '${key}' provided via --var/--prefix. Declared variables: ${declaredList(Object.keys(declarations))}`,
       );
     }
   }
@@ -83,6 +91,8 @@ function resolveValues(
   for (const [name, declaration] of Object.entries(declarations)) {
     const value = name in overrides ? overrides[name] : declaration.default;
 
+    // ajv.validate caches compiled schemas by object reference; fine here since
+    // this runs once per CLI invocation over a handful of small value schemas.
     if (declaration.schema && !ajv.validate(declaration.schema, value)) {
       throw new Error(
         `Invalid value '${value}' for variable '${name}': ${ajv.errorsText(ajv.errors)}`,
@@ -130,7 +140,7 @@ export default function substituteVariables(
   schema: Schema,
   overrides: Record<string, string> = {},
 ): Schema {
-  const declarations = (schema.variables ?? {}) as VariableDeclarations;
+  const declarations = schema.variables ?? {};
   const values = resolveValues(declarations, overrides);
 
   const { variables: _variables, ...rules } = schema;

--- a/packages/webarchitect/src/lib/substituteVariables.ts
+++ b/packages/webarchitect/src/lib/substituteVariables.ts
@@ -1,0 +1,138 @@
+import type { Schema, VariableDeclarations } from "../types.js";
+import ajv from "./ajv.js";
+
+// Matches `${name}` placeholders within rule strings.
+const TOKEN_PATTERN = /\$\{([^}]+)\}/g;
+
+/**
+ * Replaces every `${name}` token in a string with its resolved value.
+ * Throws if a token references a variable that was never declared, which
+ * surfaces ruleset typos instead of silently leaving the placeholder in place.
+ *
+ * @param value - String that may contain one or more `${name}` tokens
+ * @param values - Map of resolved variable names to their string values
+ * @returns The string with all tokens substituted
+ * @throws Will throw if a token references an undeclared variable
+ */
+function replaceTokens(value: string, values: Record<string, string>): string {
+  return value.replace(TOKEN_PATTERN, (_match, name: string) => {
+    if (!(name in values)) {
+      const declared = Object.keys(values).join(", ") || "none";
+      throw new Error(
+        `Unknown template variable '\${${name}}'. Declared variables: ${declared}`,
+      );
+    }
+    return values[name];
+  });
+}
+
+/**
+ * Recursively walks an arbitrary JSON value, substituting `${name}` tokens in
+ * every string it encounters. Returns a new value; the input is not mutated.
+ *
+ * @param value - Any JSON-compatible value (object, array, string, primitive)
+ * @param values - Map of resolved variable names to their string values
+ * @returns A structurally identical value with all string tokens substituted
+ */
+function deepSubstitute(
+  value: unknown,
+  values: Record<string, string>,
+): unknown {
+  if (typeof value === "string") {
+    return replaceTokens(value, values);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => deepSubstitute(item, values));
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        deepSubstitute(item, values),
+      ]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Resolves declared variables against CLI-provided overrides and validates the
+ * resulting values. Override values win over declared defaults, and any
+ * variable that declares a `schema` is validated against it using AJV.
+ *
+ * @param declarations - Variable declarations from the merged ruleset
+ * @param overrides - Variable values supplied via `--var` / `--prefix`
+ * @returns Map of variable name to its final, validated string value
+ * @throws Will throw if an override targets an undeclared variable or fails its schema
+ */
+function resolveValues(
+  declarations: VariableDeclarations,
+  overrides: Record<string, string>,
+): Record<string, string> {
+  // Reject overrides that target undeclared variables (typo or wrong ruleset).
+  for (const key of Object.keys(overrides)) {
+    if (!(key in declarations)) {
+      const declared = Object.keys(declarations).join(", ") || "none";
+      throw new Error(
+        `Unknown variable '${key}' provided via --var/--prefix. Declared variables: ${declared}`,
+      );
+    }
+  }
+
+  const values: Record<string, string> = {};
+  for (const [name, declaration] of Object.entries(declarations)) {
+    const value = name in overrides ? overrides[name] : declaration.default;
+
+    if (declaration.schema && !ajv.validate(declaration.schema, value)) {
+      throw new Error(
+        `Invalid value '${value}' for variable '${name}': ${ajv.errorsText(ajv.errors)}`,
+      );
+    }
+
+    values[name] = value;
+  }
+
+  return values;
+}
+
+/**
+ * Substitutes `${name}` template variables throughout a ruleset's rules.
+ * Variables are declared under the ruleset's `variables` block (with defaults
+ * and optional value schemas) and can be overridden at the command line. The
+ * returned schema has all tokens resolved and the `variables` block removed,
+ * leaving a plain ruleset ready for rule execution.
+ *
+ * Must run after `loadFullSchema` (so inherited variables and rules are merged)
+ * and before `executeValidationRules` (so rule regexes are compiled with their
+ * final values rather than raw `${name}` tokens).
+ *
+ * @param schema - Fully merged ruleset, optionally containing a `variables` block
+ * @param overrides - Variable values supplied via `--var` / `--prefix`
+ * @returns A new ruleset with tokens substituted and `variables` stripped
+ * @throws Will throw on undeclared overrides, failed value schemas, or unknown tokens
+ *
+ * @example
+ * ```typescript
+ * const schema = {
+ *   name: "library",
+ *   variables: { prefix: { default: "@canonical/" } },
+ *   "package-structure": {
+ *     file: { name: "package.json", contains: {
+ *       properties: { name: { type: "string", pattern: "^${prefix}" } }
+ *     } }
+ *   }
+ * };
+ * substituteVariables(schema, { prefix: "@myorg/" });
+ * // package name pattern becomes "^@myorg/"
+ * ```
+ */
+export default function substituteVariables(
+  schema: Schema,
+  overrides: Record<string, string> = {},
+): Schema {
+  const declarations = (schema.variables ?? {}) as VariableDeclarations;
+  const values = resolveValues(declarations, overrides);
+
+  const { variables: _variables, ...rules } = schema;
+  return deepSubstitute(rules, values) as Schema;
+}

--- a/packages/webarchitect/src/lib/validateFileRule.ts
+++ b/packages/webarchitect/src/lib/validateFileRule.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import type { ValidateFunction } from "ajv";
 import type { FileRule, ValidationResult } from "../types.js";
 import ajv from "./ajv.js";
 import describeSchema from "./describeSchema.js";
@@ -45,6 +46,18 @@ export default async function validateFileRule(
     schema: fileRule.contains,
   };
 
+  // Compile the rule schema up front, outside the file-read try below, so an
+  // invalid schema (e.g. a malformed regex produced by variable substitution)
+  // is reported clearly instead of being mislabeled as a file-read error.
+  let validate: ValidateFunction;
+  try {
+    validate = ajv.compile(fileRule.contains);
+  } catch (compileError) {
+    throw new Error(
+      `Invalid rule schema for '${ruleName}' validating ${fileRule.name}: ${(compileError as Error).message}`,
+    );
+  }
+
   try {
     const content = await readFile(filePath, "utf-8");
 
@@ -59,7 +72,6 @@ export default async function validateFileRule(
     }
 
     // Soft fail: return validation result
-    const validate = ajv.compile(fileRule.contains);
     const valid = validate(json);
 
     return [

--- a/packages/webarchitect/src/schema.json
+++ b/packages/webarchitect/src/schema.json
@@ -16,6 +16,25 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "List of other rulesets this one extends from"
+    },
+    "variables": {
+      "type": "object",
+      "description": "Template variables substituted as ${name} within rules and overridable via the CLI --var/--prefix flags",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string",
+            "description": "Value used when no override is provided"
+          },
+          "schema": {
+            "$ref": "http://json-schema.org/draft/2020-12/schema#",
+            "description": "Optional JSON Schema constraining override values"
+          }
+        },
+        "required": ["default"],
+        "additionalProperties": false
+      }
     }
   },
   "required": ["name"],

--- a/packages/webarchitect/src/types.ts
+++ b/packages/webarchitect/src/types.ts
@@ -20,12 +20,28 @@ export interface DirectoryRule {
 // Union type for rules
 export type Rule = { file: FileRule } | { directory: DirectoryRule };
 
+// Type for a single declared template variable
+export interface VariableDeclaration {
+  default: string; // Value used when no override is supplied
+  schema?: JSONSchema7; // Optional JSON Schema constraining override values
+}
+
+// Map of variable name to its declaration
+export type VariableDeclarations = Record<string, VariableDeclaration>;
+
 // Schema type with special properties and dynamic rule names
 export interface Schema {
   $schema?: string; // Optional meta-schema reference
   name: string; // Required schema name
   extends?: string[]; // Optional list of schemas to extend
-  [ruleName: string]: Rule | string | string[] | undefined; // Rules and special properties
+  variables?: VariableDeclarations; // Optional template variables substituted as ${name}
+  // Rules and special properties
+  [ruleName: string]:
+    | Rule
+    | string
+    | string[]
+    | VariableDeclarations
+    | undefined;
 }
 
 export interface ValidationResult {

--- a/packages/webarchitect/src/validate.test.ts
+++ b/packages/webarchitect/src/validate.test.ts
@@ -76,4 +76,43 @@ describe("validate", () => {
     expect(results[0].passed).toBe(false);
     expect(results[0].message).toContain("File not found");
   });
+
+  it("applies template variable overrides to rules", async () => {
+    writeFileSync(
+      join(tmp, "package.json"),
+      JSON.stringify({ name: "@myorg/test" }),
+    );
+
+    const schema = {
+      name: "prefixed",
+      variables: { prefix: { default: "@canonical/" } },
+      "pkg-name": {
+        file: {
+          name: "package.json",
+          contains: {
+            type: "object",
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: literal token resolved by substituteVariables
+            properties: { name: { type: "string", pattern: "^${prefix}" } },
+            required: ["name"],
+          },
+        },
+      },
+    };
+    const schemaPath = join(tmp, "prefixed.ruleset.json");
+    writeFileSync(schemaPath, JSON.stringify(schema));
+
+    // Default prefix rejects the @myorg/ name...
+    const withDefault = await validate(tmp, schemaPath);
+    expect(withDefault[0].passed).toBe(false);
+
+    // ...but an override accepts it.
+    const withOverride = await validate(tmp, schemaPath, {
+      prefix: "@myorg/",
+    });
+    expect(withOverride[0].passed).toBe(true);
+
+    // An empty prefix disables the constraint entirely.
+    const disabled = await validate(tmp, schemaPath, { prefix: "" });
+    expect(disabled[0].passed).toBe(true);
+  });
 });

--- a/packages/webarchitect/src/validate.ts
+++ b/packages/webarchitect/src/validate.ts
@@ -1,4 +1,8 @@
-import { executeValidationRules, loadFullSchema } from "./lib/index.js";
+import {
+  executeValidationRules,
+  loadFullSchema,
+  substituteVariables,
+} from "./lib/index.js";
 import type { ValidationResult } from "./types.js";
 
 /**
@@ -8,6 +12,7 @@ import type { ValidationResult } from "./types.js";
  *
  * @param projectPath - Path to the project directory to validate
  * @param schemaArg - Schema identifier: built-in name, file path, or URL
+ * @param variableOverrides - Template variable values supplied via `--var` / `--prefix`
  * @returns Promise that resolves to an array of validation results
  * @throws Will throw an error if schema cannot be loaded or is invalid
  *
@@ -19,12 +24,17 @@ import type { ValidationResult } from "./types.js";
  * // Check if validation passed
  * const passed = results.every(r => r.passed);
  * console.log(passed ? "All checks passed!" : "Some checks failed");
+ *
+ * // Override a ruleset's template variable
+ * await validate(process.cwd(), "library", { prefix: "@myorg/" });
  * ```
  */
 export default async function validate(
   projectPath: string,
   schemaArg: string,
+  variableOverrides: Record<string, string> = {},
 ): Promise<ValidationResult[]> {
   const schema = await loadFullSchema(schemaArg);
-  return executeValidationRules(projectPath, schema);
+  const resolved = substituteVariables(schema, variableOverrides);
+  return executeValidationRules(projectPath, resolved);
 }


### PR DESCRIPTION
## Done

- Added **template variables** to webarchitect rulesets: a top-level `variables` block (each with a `default` and an optional value `schema`), referenced as `${name}` anywhere inside a rule.
- New CLI flags: `--var key=value` (repeatable) and `--prefix <value>` (sugar for `--var prefix=<value>`).
- Substitution runs in `validate()` after inheritance is merged (`loadFullSchema`) and before rules execute, so resolved values — not raw `${…}` — reach AJV. Override values are validated against their declared `schema` via the existing AJV instance; undeclared overrides and unknown `${name}` tokens raise clear errors.
- Expressed the package-name prefix as `^${prefix}` (default `@canonical/`) in the `package` ruleset (inherited by `library`, `tool`, `package-react`) and in `tool-ts` / `package-svelte`. Consumers can now relax it (`--prefix ""` → pattern `^`, matches any name) instead of shipping an override ruleset.
- `loadFullSchema` merges the `variables` block by key (child overrides parent) instead of wholesale-replacing it, so a child ruleset can refine variables without dropping inherited ones.
- `validateFileRule` compiles the rule schema up front, so an invalid substituted regex is reported as a clear schema error rather than a misleading file-read error.
- Updated the mother schema (`src/schema.json`) and `Schema`/`VariableDeclaration` types.
- Documented the feature in `README.md` (new "Template variables" section + `--var`/`--prefix` options).
- Added unit tests (`substituteVariables.test.ts`, variable-inheritance test in `loadFullSchema.test.ts`) and end-to-end tests in `validate.test.ts`.

Fixes the need for downstream repos (e.g. `lit-relay`) to ship a custom override ruleset purely to relax the `@canonical/` name prefix.

## QA

1. `cd packages/webarchitect && bun install`
2. `bun run test` — 86 tests pass.
3. `bun run check` — biome + `tsc --noEmit` + the `tool-ts` self-check all pass.
4. Prefix override behaviour, from a temp dir containing a non-`@canonical/` `package.json` + a `biome.json` extending `@canonical/biome-config`:
   - `webarchitect library` → `package-structure` fails on the name pattern `^@canonical/`.
   - `webarchitect library --prefix @myorg/` → still fails for a `lit-relay`-style name.
   - `webarchitect library --prefix ""` → all rules pass (pattern becomes `^`).
   - `webarchitect library --var nope=1` → clear `Unknown variable 'nope'…` error.
   - `webarchitect package --var noequals` → clean Commander `argument is invalid` error (no stack trace).

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. (No build-script changes in this PR.)
- [ ] If this PR introduces a **new package**: first-time publish has been done manually… — N/A, no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — CLI/tooling change with no visual surface.

https://claude.ai/code/session_012bxc9tViWsYT6wW879SDE5

---
_Generated by [Claude Code](https://claude.ai/code/session_012bxc9tViWsYT6wW879SDE5)_