### PR TITLE
feat(ke-graphql): OWL→GraphQL compiler core

### DIFF
--- a/packages/runtime/ke-graphql/README.md
+++ b/packages/runtime/ke-graphql/README.md
@@ -1,0 +1,408 @@
+# @canonical/ke-graphql
+
+OWL → GraphQL compiler for the [ke](../ke) triple store. Point it at a loaded store and it reads the ontology — classes, properties, domains and ranges, `subClassOf` chains, cardinality markers, SHACL shapes — and compiles a complete, executable `GraphQLSchema`: types, interfaces, field resolvers, batched data loading, and Relay server conventions. The ontology is the schema definition; there is nothing else to maintain.
+
+It is a compiler, not a middleware. OWL is not a database schema — a class with no instances should become an interface, an `owl:inverseOf` pair should produce one field per side rather than four, a blank-node-only class can't have a global ID. Mapping that faithfully takes semantic analysis, so the package is built like a compiler: seven passes over a typed intermediate representation, diagnostics with stable codes that never abort on the first problem, and a deterministic output you can snapshot. The full design rationale lives in the `A.10.COMPILER` architecture decision record (pragma-adrs, `session/A`).
+
+Like ke itself, the root export is a library, not a server: schema + resolvers + local execution, nothing that knows HTTP exists. The fetch handler and GraphiQL live behind the `./http` subpath, mirroring `@canonical/ke/http`.
+
+## Installation
+
+```bash
+bun add @canonical/ke-graphql
+```
+
+`graphql` (v17, pinned — see [Incremental delivery](#incremental-delivery-defer)) and `dataloader` come with it; `@canonical/ke` is a peer dependency.
+
+## Quick start
+
+The compiler runs as a ke plugin: when the store finishes loading, the schema is ready alongside it.
+
+```typescript
+import { createStore } from "@canonical/ke";
+import { createSchemaPlugin, type SchemaPluginApi } from "@canonical/ke-graphql";
+import { createGraphQLHandler } from "@canonical/ke-graphql/http";
+
+const graphql = createSchemaPlugin();
+
+const store = await createStore({
+  sources: ["./ontology.ttl", "./data/**/*.ttl"],
+  prefixes: { lib: "https://example.org/library/" }, // drives global IDs — register every domain prefix
+  plugins: [graphql],
+});
+
+const { schema, sdl, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+
+Bun.serve({
+  port: 4000,
+  fetch: createGraphQLHandler(schema, {
+    graphiql: true,
+    context: () => createContext(store),
+  }),
+});
+```
+
+Open `http://localhost:4000` and GraphiQL is talking to your ontology.
+
+## What gets generated
+
+Everything below is the compiler's actual output for this input — regenerate it any time with `pragma graphql build`.
+
+Given a small ontology and some data:
+
+```turtle
+@prefix lib: <https://example.org/library/> .
+
+lib:Work a owl:Class .
+lib:Book a owl:Class ; rdfs:subClassOf lib:Work .
+lib:Film a owl:Class ; rdfs:subClassOf lib:Work .
+lib:Author a owl:Class .
+lib:Review a owl:Class .
+
+lib:title     a owl:DatatypeProperty ; rdfs:domain lib:Work   ; rdfs:range xsd:string .
+lib:pageCount a owl:DatatypeProperty ; rdfs:domain lib:Book   ; rdfs:range xsd:integer .
+lib:inPrint   a owl:DatatypeProperty ; rdfs:domain lib:Book   ; rdfs:range xsd:boolean .
+lib:hasAuthor a owl:ObjectProperty   ; rdfs:domain lib:Work   ; rdfs:range lib:Author ;
+              owl:inverseOf lib:authored .
+lib:authored  a owl:ObjectProperty   ; rdfs:domain lib:Author ; rdfs:range lib:Work .
+lib:name      a owl:DatatypeProperty ; rdfs:domain lib:Author ; rdfs:range xsd:string .
+lib:hasReview a owl:ObjectProperty   ; rdfs:domain lib:Work   ; rdfs:range lib:Review .
+lib:rating    a owl:DatatypeProperty ; rdfs:domain lib:Review ; rdfs:range xsd:integer .
+lib:comment   a owl:DatatypeProperty ; rdfs:domain lib:Review ; rdfs:range xsd:string .
+
+lib:dune a lib:Book ;
+  lib:title "Dune" ; lib:pageCount 412 ; lib:inPrint "true" ;
+  lib:hasAuthor lib:herbert ;
+  lib:hasReview [ a lib:Review ; lib:rating 5 ] .
+lib:herbert a lib:Author ; lib:name "Frank Herbert" .
+```
+
+the compiler emits the following (fields lightly reordered for reading, Relay boilerplate and the TBox types elided — `pragma graphql build` regenerates the full file):
+
+```graphql
+interface Work implements Node {
+  id: ID!
+  uri: String!
+  _meta: EntityMeta!
+  title: String
+  authors(first: Int, after: String, last: Int, before: String): AuthorConnection!
+  reviews: [Review!]!
+}
+
+type Book implements Node & Work {
+  id: ID!                  # the prefixed URI: "lib:dune"
+  uri: String!
+  _meta: EntityMeta!
+  title: String
+  pageCount: Int
+  inPrint: Boolean         # data stores "true" as a string — the resolver coerces
+  authors(first: Int, after: String, last: Int, before: String): AuthorConnection!
+  reviews: [Review!]!      # plain list — Review instances are blank nodes
+}
+
+type Author implements Node {
+  id: ID!
+  uri: String!
+  _meta: EntityMeta!
+  name: String
+  authoreds(first: Int, after: String, last: Int, before: String): WorkConnection!
+}
+
+type Review {              # embeddable: no Node, no id — it lives inside its parent
+  rating: Int
+  comment: String
+}
+
+type Query {
+  node(id: ID!): Node
+  book(uri: String!): Book
+  books(first: Int, after: String, last: Int, before: String): BookConnection!
+  author(uri: String!): Author
+  authors(first: Int, after: String, last: Int, before: String): AuthorConnection!
+  film(uri: String!): Film
+  films(first: Int, after: String, last: Int, before: String): FilmConnection!
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+}
+```
+
+Reading the output back against the input shows most of the compiler's rules at once:
+
+- **`Work` became an interface.** It has subclasses and no direct instances, so it's abstract — and because all of its concrete implementors are full entities, the interface itself implements `Node`, which is what lets Relay refetch a fragment written against `Work`. (A class with subclasses *and* direct instances of its own stays a concrete type and earns a `V016` warning: a supertype-typed field can't surface its subclasses' fields. Force it abstract with `{ abstract: true }` when it has no direct instances; the interface-plus-companion-type alternative is a deferred item, A.10 §13.)
+- **`hasAuthor` became `authors`.** Field names strip a leading `has`/`is` verb; list fields are pluralized (`category → categories`, `child → children` — the pluralizer knows the irregulars).
+- **`reviews` is a plain list while `authors` is a connection.** `Review` instances are blank nodes: no URI means no global ID, no cursor, no standalone resolution. The compiler marks such classes *embeddable* and resolves them inline from the parent's own triples. Everything URI-addressable gets a paginated Relay connection instead.
+- **One field per side of the inverse pair, and direction doesn't matter.** `hasAuthor`/`authored` produce `Book.authors` and `Author.authoreds` — never the duplicates. At resolution time each side takes the union of forward and reverse assertions, so data written in either direction answers identically from both ends.
+- **`inPrint: Boolean` works even though the data says `"true"`.** Real-world TTL stores booleans as strings; the resolver coerces (`"true"/"false"/"1"/"0"`) and reports anything else through the runtime-warning channel instead of crashing the response.
+- **`id` is the prefixed URI**, not an opaque token. `node(id: "lib:dune")` works in GraphiQL, in URLs, and in the CLI alike.
+
+About `authoreds` — that's the pluralizer being mechanically right and ergonomically wrong. Which brings us to:
+
+## Custom mappings
+
+Mappings are the escape hatch for everything the ontology can't express ergonomically. Keys are full IRIs or prefixed names; values override one aspect each:
+
+```typescript
+const graphql = createSchemaPlugin({
+  mappings: {
+    // rename: fix the mechanical plural
+    "lib:authored": { graphqlName: "works" },
+
+    // cardinality: an object property that is singular in practice but
+    // carries no owl:FunctionalProperty or SHACL marker
+    "lib:hasPublisher": { singular: true },
+
+    // synthesize an inverse field on the RANGE type when the ontology
+    // declares no owl:inverseOf — no ontology change required, the
+    // resolver queries the forward assertions in reverse
+    "lib:cites": { inverse: { graphqlName: "citedBy" } },
+
+    // force embeddable/abstract when the loaded data can't reveal it
+    // (e.g. a blank-node-only class that happens to have zero instances
+    // in this particular dataset)
+    "lib:Annotation": { embeddable: true },
+  },
+});
+```
+
+A mapping that references nothing in the ontology produces an `M003` diagnostic rather than silently doing nothing.
+
+Names the compiler owns (`Node`, `Query`, `PageInfo`, the built-in scalars, …) are auto-resolved on collision by prefixing the namespace — a class named `lib:Node` becomes `LibNode` with an `M004` info diagnostic. Illegal GraphQL characters in local names are sanitized (`My-Class → My_Class`) with a warning.
+
+## Cardinality: how a property becomes singular or a list
+
+Precedence, highest first:
+
+1. custom mapping `{ singular }` override
+2. `owl:FunctionalProperty`
+3. SHACL `sh:maxCount 1` — per *(class, property)* pair, so the same property can be singular on one class and a list on another; `sh:or` branches merge to the most permissive interpretation, repeated shapes for one path merge as the SHACL conjunction
+4. kind default: **datatype and annotation properties are singular; object properties are lists.** (Multi-valued literals are the exception in RDF practice; opt a datatype property back into a list with `{ singular: false }`.)
+
+Nullability is deliberate and honest: `id` and `uri` are non-null, list and connection fields are non-null with empty defaults — and *everything else is nullable*, because OWL ontologies don't promise completeness. SHACL `sh:minCount` is **recorded** (queryable as `ClassProperty.required`) but never auto-promoted to GraphQL non-null: a single missing value would take down whole responses. Consumers who know their data promote specific fields via `nonNullOverrides: { Book: ["title"] }`.
+
+## The second schema: `_meta` and the ontology browser
+
+The compiler emits two connected schemas. Alongside the data types, a hand-written TBox schema exposes the ontology itself — and every generated type carries a `_meta: EntityMeta!` field bridging the two:
+
+```graphql
+{
+  book(uri: "lib:dune") {
+    title
+    _meta {
+      type { label definition superclasses { label } }      # the OWL class
+      fields {                                              # every applicable property
+        property { label range acceptanceCriteria }
+        required      # SHACL sh:minCount, for THIS class
+        singular
+        inherited     # declared on an ancestor vs Book itself
+      }
+    }
+  }
+  ontologyClass(uri: "https://example.org/library/Work") {
+    isAbstract
+    subclasses { label }
+    instances(first: 10) { edges { node { id } } }          # TBox → ABox hop
+  }
+}
+```
+
+This is what powers documentation UIs: "which fields *should* this entity have, which are required, what does good look like" — asked of the schema itself, in the same query as the data. The TBox resolvers read the compiler's frozen IR, **never the store**: ontology browsing works before the TTL finishes parsing and even against a disposed store, and it can't disagree with the schema's own shape because both came from the same compilation.
+
+## Diagnostics
+
+The compiler collects problems instead of aborting on the first one (the `tsc` model). Every diagnostic has a stable code:
+
+| Range | Meaning | Examples |
+|---|---|---|
+| `E001` | extraction/SPARQL failure | query failed, unregistered namespace (synthetic prefix assigned), blank nodes nested deeper than the loader's closure |
+| `B001–B004` | build references | `subClassOf` cycle, unknown domain/range/inverse |
+| `V001–V016` | data/ontology validation | blank-node-only class (`V001`), domainless property (`V002`), boolean-as-string (`V006`), SHACL `sh:maxCount 0` omission (`V010`), undeclared ABox predicate (`V014`), abstract mapping with direct instances (`V015`), concrete supertype flattening (`V016`) |
+| `M001–M004` | naming | unresolvable collision (`M001`, error), reserved-name rename (`M002`), unknown mapping (`M003`), auto-resolved type collision (`M004`) |
+| `X002–X003` | union emission | named / synthesized union created |
+| `C001–C003` | composition | extension targets unknown type, extension field conflict, `validateSchema` failure |
+
+Only **composition errors (`C00x`) prevent schema creation** — `compile()` then throws `CompilationError` carrying the complete diagnostic list. Everything else surfaces in `result.diagnostics` while the schema still builds; the consumer chooses its failure policy (the `pragma graphql check` command, for instance, fails CI on any error-severity diagnostic).
+
+## Plugin options
+
+```typescript
+createSchemaPlugin({
+  mappings,                          // CustomMappings (above)
+  extensions,                        // consumer fields — object or factory form (below)
+  relay: true,                       // Node/global IDs/connections/root queries (default true)
+  incremental: false,                // add @defer/@stream directives (below)
+  sdlOutput: "./schema.graphql",     // write the SDL on every (re)compile — feed relay-compiler
+  nonNullOverrides: { Book: ["title"] },
+  standardVocabFields: {             // opt-in instance-level rdfs:label/comment as fields —
+    Category: { "http://www.w3.org/2000/01/rdf-schema#label": "label" },
+  },                                 // by default only declared ontology properties become fields
+  loaderCache: "request",            // or "process" — see Performance
+  extraction: "./extraction.json",   // precomputed boot artifact — see Fast boot
+  onRuntimeWarning: (w) => log.warn(w),  // coercion failures at resolve time
+});
+```
+
+`onReload` recompiles when the store reloads — note that with ke's `cache:` configured, `store.reload()` short-circuits on a cache hit, so dev flows that edit TTL should call `reload({ force: true })`.
+
+## Extensions
+
+Domain-specific computed fields stay out of the compiler and in your code. The object form covers scalar-typed fields; the **factory form** receives the generated types, for extension fields typed as them:
+
+```typescript
+extensions: (types) => ({
+  Book: {
+    citation: {
+      type: GraphQLString,
+      resolve: (book) => formatCitation(book),       // book is an EntityValue
+    },
+  },
+  Query: {
+    search: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(SearchHitType))),
+      args: { query: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_s, args, ctx) => ctx.searchIndex.search(args.query),
+    },
+  },
+})
+```
+
+Extensions are validated at composition: an unknown type name is `C001`, a clash with a generated field is `C002` — both fatal, both reported together. Extension resolvers receive the `CompilerContext` (the loaders, the name map, the store escape hatch) and may stash their own state on it.
+
+## Serving over HTTP
+
+```typescript
+import { createGraphQLHandler } from "@canonical/ke-graphql/http";
+
+const handler = createGraphQLHandler(schema, {
+  context: (request) => createContext(store),   // fresh DataLoaders per request
+  graphiql: true,            // GET + Accept: text/html → GraphiQL (dev default)
+  cors: true,
+  introspection: true,       // default: dev on, production off
+  maxDepth: 12,              // built-in depth limit (default 20; 0 disables)
+  validationRules: [         // add your own rules on top (e.g. cost analysis)
+    createComplexityRule({ maximumComplexity: 1000, estimators: [...] }),
+  ],
+  persistedQueries: {        // strongest hardening: only build-time queries execute
+    get: (hash) => manifest[hash] ?? null,
+    allowArbitraryQueries: false,
+  },
+  hideFieldSuggestions: true,   // no "Did you mean…?" schema enumeration (prod default)
+  maskErrors: true,             // generic message for internal errors (prod default)
+  formatError: (e) => redact(e),
+  onOperation: ({ operation, duration, errors }) => metrics.record(...),
+});
+
+Bun.serve({ fetch: handler });   // or compose with other handlers by pathname
+```
+
+The handler is a plain `(Request) => Promise<Response>` — no framework, same composition pattern as `createSparqlHandler`. It implements GraphQL-over-HTTP (GET with query param, POST JSON, persisted-query extension), answers CORS preflight, honors `Accept` q-values, and serves nothing it wasn't asked to: the handler provides *seams*, the consumer provides *policy*. Build the persisted manifest from your client's compiled operations with `createPersistedManifest(operationTexts)` (SHA-256, the Relay/Apollo convention).
+
+**Built-in hardening defaults.** On top of those seams, the package ships a baseline production posture from its `hardening` domain (all named, exported, and tunable — never magic numbers buried in a resolver): every connection is page-size-clamped (`DEFAULT_PAGE_SIZE` 50, `MAX_PAGE_SIZE` 100), so a list is never unbounded and a client can't demand an oversized page; queries nested deeper than `maxDepth` (default `DEFAULT_MAX_QUERY_DEPTH`, 20) are rejected, bounding the recursion that cyclic types otherwise allow; IRIs that would break out of a SPARQL `IRIREF` are dropped before interpolation, so a crafted `node(id:)` resolves to `null` rather than injected SPARQL; and in production (`maskErrors`, default on) an unexpected internal error is returned as a generic message — store and SPARQL internals never reach the client, while deliberate validation/argument errors pass through. `loaderCache: "process"` uses bounded LRU caches (next section) so ID enumeration can't exhaust memory.
+
+GraphiQL's assets load as version-pinned UMD bundles from unpkg; air-gapped deployments supply their own page through the `graphiqlHtml` option.
+
+## Incremental delivery (`@defer`)
+
+`incremental: true` on the plugin adds the `@defer`/`@stream` directives (graphql v17 doesn't define them by default), and `incremental: true` on the handler streams deferred payloads as `multipart/mixed` to clients that accept it — everyone else gets a single, complete, drained-and-merged JSON response. Correctness can't be lost to a transport mismatch, only streaming.
+
+One ecosystem wrinkle this package absorbs for you: graphql v17 emits the 2023 incremental payload format (`pending`/`incremental`/`completed`), while Relay's network layer still consumes the legacy shape (`path`/`label` per payload, `is_final`). The `relayFormatAdapter` translates between them — used in-process for SSR and by the handler's `incrementalFormat: "relay-legacy"` option. This is also why `graphql` is **pinned exactly**: the adapter is coupled to the RC's payload format, and upgrades should be deliberate, snapshot-diffed events.
+
+## Executing without a server
+
+The compiled schema is a value and `graphql(schema, query, context)` is a function call — every serving mode is a thin shell over it:
+
+```typescript
+import { executeLocal, extractStatic } from "@canonical/ke-graphql";
+
+// In-process (SSR prefetch, tests, scripts) — no HTTP, no serialization.
+// One context per render pass: DataLoaders batch across every concurrent
+// Relay query in the same render.
+const result = await executeLocal({
+  schema,
+  source: `{ books(first: 24) { edges { node { title } } } }`,
+  contextValue: createContext(store),
+});
+
+// Build time (static sites, CDN): run the site's whole query set once,
+// ship the results as JSON. uri-typed variables are enumerated against
+// the store's own instance inventory; anything non-enumerable
+// (pagination cursors) fails loudly instead of shipping partial data.
+const artifacts = await extractStatic({
+  schema, mapped: result.mapped, context: createContext(store),
+  queries: [
+    { name: "AllBooks", text: "{ books(first: 500) { edges { node { id title } } } }" },
+    { name: "BookPage",
+      text: "query($uri: String!) { book(uri: $uri) { title authors(first: 10) { edges { node { name } } } } }",
+      variables: { uri: "String!" } },
+  ],
+});
+```
+
+## Fast boot: the extraction artifact
+
+Pass 1 (the SPARQL extraction) is the only part of compilation that needs the store — and its output is ~2 KiB of serializable JSON. Snapshot it at build time and every subsequent boot skips the store entirely:
+
+```bash
+pragma graphql build ./ontology.ttl "./data/**/*.ttl" \
+  --sdl schema.graphql --extraction extraction.json \
+  --prefix lib=https://example.org/library/
+```
+
+```typescript
+// boots the schema in ~10 ms — no Oxigraph, no TTL parse, no SPARQL
+createSchemaPlugin({ extraction: "./extraction.json" });
+
+// or with no store at all until the first data query:
+import { compileFromExtraction } from "@canonical/ke-graphql";
+const result = compileFromExtraction(artifactJson, { loaderCache: "process" });
+const storeReady = createStore({ sources, prefixes });   // not awaited!
+const ctx = result.createContext(storeReady);            // TBox answers now;
+                                                         // data queries await the store
+```
+
+The artifact embeds a `sourcesHash` fingerprint of the TTL it was built from. The plugin re-fingerprints the sources as ke loads them: match → fast boot; mismatch → a warning and a live compile. A stale artifact can cost you milliseconds, never wrong answers. `pragma graphql check` runs the same compile with no outputs and fails on error diagnostics — the CI gate that puts ontology changes under the same discipline as code.
+
+## Performance
+
+Measured by the committed benchmark (`bun run bench`, 250-entity graph):
+
+| Path | Cost |
+|---|---|
+| Schema boot from artifact (`compileFromExtraction`) | **~10 ms** — no store |
+| Live compile (Pass 1 + passes 2–7 + validate) | ~50–110 ms |
+| Detail page / `node()` with `loaderCache: "process"` | **~0.3 ms** |
+| Listing `first: 24` | **~0.7 ms** warm — pagination runs on the URI list; only the page hydrates |
+| TBox / ontology browsing | ~0.1 ms — store-free |
+
+`loaderCache: "process"` shares DataLoader caches across requests — sound because the store is immutable between reloads, and a reload produces a new compile (automatic invalidation). The shared caches are **bounded LRUs** (`processCacheSize`, default 10,000 entries each), so enumerating distinct IDs can't grow them without limit; evicted entries are simply re-queried, and failed batches are evicted, never memoized. The default `"request"` keeps the textbook per-request isolation.
+
+The ladder to zero: a warm process answers in microseconds; Lambda-style containers pay one ~80 ms boot per container with the artifact; Cloudflare Workers (WASM precompiled at deploy, TTL as ke inline sources — see `examples/cloudflare-worker`) cold-start in ~25–60 ms; and with persisted queries in front of a CDN, responses are pure functions of *(hash, variables)* until the next deploy — cacheable to 0 ms. For fully static deployments, `extractStatic` removes the runtime altogether.
+
+## Package boundary
+
+| Entry | Exports | Dependencies |
+|---|---|---|
+| `@canonical/ke-graphql` | `createSchemaPlugin`, `compile`, `compileFromExtraction`, `serializeExtraction`/`deserializeExtraction`/`hashSources`, `executeLocal`, `extractStatic`, `mergeIncremental`, `relayFormatAdapter`, `createPersistedManifest`, connection/pagination helpers, all IR + diagnostic types | `graphql` (pinned), `dataloader` |
+| `@canonical/ke-graphql/http` | `createGraphQLHandler`, `graphiqlHtml` | the root, plus platform-native fetch |
+
+Consumers that never serve — static extraction in CI, SSR-only processes, tests — never load a byte of HTTP or GraphiQL code.
+
+## Development
+
+```bash
+bun run demo     # GraphiQL on http://localhost:4000/graphql in under a second
+bun run test     # 98 tests over the ADR §12 fixture suite, with coverage gates
+bun run check    # biome + tsc + webarchitect
+bun run bench    # the numbers in this README
+```
+
+`bun run demo` boots `demo/server.ts` against `demo/graph.ttl` — the library
+ontology from this README with a few shelves of data — logging ke's load
+activity (sources, triple counts), the compiler diagnostics, and a ready-made
+`curl`. It serves GraphQL + GraphiQL with `@defer` enabled, so every example
+above can be pasted straight in. The folder is type-checked and linted with
+the package but ships nowhere: it is excluded from the build and the npm
+tarball.
+
+The intermediate representations (`RawExtraction`, `OntologyIR`, `MappedIR`) are exported public contracts, not internals — tooling can consume them the way Prisma generators consume the DMMF. The spec they implement is `A.10.COMPILER` (KG.01–KG.23) in the pragma-adrs repository; spec and implementation were hardened against each other, and the golden SDL there is this compiler's snapshot target.

--- a/packages/runtime/ke-graphql/biome.json
+++ b/packages/runtime/ke-graphql/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["**/src/**", "**/*.json"]
+  }
+}

--- a/packages/runtime/ke-graphql/docs/api.md
+++ b/packages/runtime/ke-graphql/docs/api.md
@@ -1,0 +1,175 @@
+# API reference — `@canonical/ke-graphql`
+
+Two entry points:
+
+- **`@canonical/ke-graphql`** — compiler, schema, resolvers, local execution (no HTTP).
+- **`@canonical/ke-graphql/http`** — the fetch handler and GraphiQL.
+
+Exhaustive types ship in the `.d.ts`; this document is the callable surface grouped by domain. See `docs/architecture.md` for the design and the `A.10.COMPILER` ADR (KG.01–KG.23) for rationale.
+
+---
+
+## Compiler
+
+### `compile(query, prefixes, options?)`
+```ts
+compile(query: QueryFn, prefixes: Readonly<Record<string,string>>, options?: SchemaPluginOptions): Promise<CompilerResult>
+```
+Run the full pipeline (Pass 1 executes SPARQL through `query`). Throws `CompilationError` only on composition failure; all other problems surface in `result.diagnostics`. Most consumers use `createSchemaPlugin` instead and never call this directly.
+
+### `compileFromExtraction(artifact, options?, { assumeValid? }?)`
+```ts
+compileFromExtraction(artifact: string | SerializedExtraction, options?: SchemaPluginOptions, opts?: { assumeValid?: boolean }): CompilerResult
+```
+Boot the schema from a precomputed extraction **without touching the store** (passes 2–7 only). `assumeValid` (default `true`) also skips `validateSchema`/SDL printing. Pair with `hashSources` to check freshness.
+
+### `createSchemaPlugin(options?)`
+```ts
+createSchemaPlugin(options?: SchemaPluginOptions & SchemaPluginExtra): Plugin<SchemaPluginApi>
+```
+The ke plugin. Compiles on `onReady`, recompiles on `onReload`, registers `SchemaPluginApi` under `"ke-graphql"`. `SchemaPluginExtra.extraction` boots from an artifact (path or parsed) when its `sourcesHash` matches the loaded TTL.
+
+```ts
+const graphql = createSchemaPlugin({ mappings: { "lib:authored": { graphqlName: "works" } } });
+const store = await createStore({ sources, prefixes, plugins: [graphql] });
+const { schema, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+```
+
+### `storeQueryFn(store)`
+```ts
+storeQueryFn(store: Store): QueryFn
+```
+Adapt a ke `Store` to the `QueryFn` the compiler expects.
+
+### `createContextFactory(mapped, options)`
+```ts
+createContextFactory(mapped: MappedIR, options: SchemaPluginOptions): ContextFactory
+```
+Build the per-request `CompilerContext` factory (fresh DataLoaders, or shared `"process"` caches). `factory(store)` → context; `factory.clearCache()` drops shared caches. Usually obtained as `result.createContext`.
+
+### `CompilationError`
+Thrown by `compile` when composition fails (`C00x`). Carries `.diagnostics: Diagnostic[]`.
+
+### Result & key option shapes
+- **`CompilerResult`** — `{ schema, sdl, diagnostics, nameMap, mapped, createContext, clearLoaderCache }`.
+- **`SchemaPluginApi`** — `{ schema, diagnostics, nameMap, sdl, createContext, clearLoaderCache }` (the `store.api("ke-graphql")` surface).
+- **`SchemaPluginOptions`** — `mappings`, `extensions`, `relay`, `incremental`, `sdlOutput`, `nonNullOverrides`, `standardVocabFields`, `onRuntimeWarning`, `loaderCache` (`"request"`|`"process"`), `processCacheSize`.
+- **`CustomMapping`** — `{ graphqlName?, singular?, abstract?, embeddable?, inverse?: { graphqlName } }`, keyed by IRI or prefixed name in `CustomMappings`.
+
+---
+
+## Artifact
+
+### `serializeExtraction(extraction, sourcesHash)` / `deserializeExtraction(artifact)`
+```ts
+serializeExtraction(extraction: RawExtraction, sourcesHash: string): string
+deserializeExtraction(artifact: string | SerializedExtraction): { extraction: RawExtraction; sourcesHash: string }
+```
+Codec for the boot artifact. `deserializeExtraction` throws if `version !== ARTIFACT_VERSION`.
+
+### `hashSources(contents)`
+```ts
+hashSources(contents: Iterable<string>): string
+```
+FNV-1a fingerprint of the loaded TTL sources — the freshness key for `compileFromExtraction`.
+
+### `ARTIFACT_VERSION`
+The artifact format version (a number); bump invalidates old artifacts.
+
+---
+
+## Local execution & incremental delivery
+
+### `executeLocal(args)`
+```ts
+executeLocal(args: { schema, source: string, document?: DocumentNode, variableValues?, contextValue: CompilerContext, operationName? }): Promise<LocalExecutionResult>
+```
+In-process execution (no HTTP). Plain documents return an `ExecutionResult`; `@defer`/`@stream` (or any incremental-capable schema) return `IncrementalResults`. Pass `document` to skip an internal parse.
+
+### `mergeIncremental(results)` / `isIncrementalResults(result)`
+Drain an `IncrementalResults` stream into one complete `{ data, errors }`; the type guard distinguishes a stream from a plain result.
+
+### `relayFormatAdapter(results)`
+```ts
+relayFormatAdapter(results: IncrementalResults): AsyncGenerator<RelayLegacyPayload>
+```
+Translate v17 incremental payloads to Relay's legacy `path`/`label`/`is_final` shape. **`@experimental`** — coupled to the graphql v17-RC payload format.
+
+### `extractStatic(options)`
+```ts
+extractStatic(options: { schema, mapped, context, queries: StaticQuery[] }): Promise<Map<string, ExecutionResult>>
+```
+KG.20 Path B: run a fixed query set, keyed by name (queries with a single `uri` variable run once per instance, keyed `"name:uri"`). Throws on non-enumerable variables.
+
+### `createPersistedManifest(operations)` / `sha256Hex(text)`
+```ts
+createPersistedManifest(operations: Iterable<string>): Promise<Record<string,string>>
+sha256Hex(text: string): Promise<string>
+```
+Build a `{ sha256 → query }` manifest from compiled client operations (Web Crypto; the Relay/Apollo persisted-query convention).
+
+---
+
+## Relay connection helpers
+
+```ts
+toConnection<T>(allItems: T[], args: ConnectionArgs, presorted?: boolean): Connection<T>
+paginateUriWindow(uris: readonly string[], args: ConnectionArgs): UriPage
+connectionFromPage<T>(entities: T[], page: UriPage): Connection<T>
+emptyConnection<T>(): Connection<T>
+toBase64(value: string): string         // cursor encode
+fromBase64(value: string): string       // cursor decode (tolerant — garbage → "")
+isEntity(v): v is EntityValue           // filter loadMany results
+unwrapEntities(results): EntityValue[]  // rethrow batch errors, drop nulls
+```
+`toConnection` runs the full Relay algorithm over an in-memory list; `paginateUriWindow` + `connectionFromPage` are the slice-before-hydrate pair (paginate the URI list, hydrate only the page). All page sizes are clamped by the hardening domain.
+
+---
+
+## Hardening
+
+```ts
+isSafeIri(iri: string): boolean
+clampConnectionArgs<T>(args: T, limits?: { defaultPageSize; maxPageSize }): T
+createDepthLimitRule(maxDepth: number): (ctx: ValidationContext) => ASTVisitor   // a graphql ValidationRule
+createBoundedCache<K,V>(maxSize: number): Map<K,V>                                // bounded LRU
+maskError(error: GraphQLError, mask: boolean): GraphQLFormattedError
+```
+Constants: `DEFAULT_PAGE_SIZE` (50), `MAX_PAGE_SIZE` (100), `DEFAULT_MAX_QUERY_DEPTH` (20), `DEFAULT_PROCESS_CACHE_SIZE` (10000). See `docs/architecture.md` §8.
+
+---
+
+## URI conversion
+
+```ts
+toPrefixed(fullUri: string, namespaces: ReadonlyMap<string, NamespaceInfo>): string         // longest-match → "lib:dune"
+toFull(prefixed: string, namespaces: ReadonlyMap<string, NamespaceInfo>): string | undefined // → full IRI, or undefined for unknown prefix
+```
+
+---
+
+## Types
+
+The exported IR and value types: `RawExtraction`, `OntologyIR`, `MappedIR`, `ClassNode`, `PropertyNode`, `MappedType`, `MappedInterface`, `MappedField`, `RangeSpec`, `CardinalitySpec`, `NameMap`, `NamespaceInfo`, `InstanceStats`, `EntityValue`, `TripleSet`, `TripleValue`, `Diagnostic`, `DiagnosticCode`, `DiagnosticSeverity`, `PassResult`, `QueryFn`, `ResolverTemplate`, `RuntimeWarningHandler`, `CompilerContext`, `ContextFactory`, `CompilerResult`, `SchemaPluginApi`, `SchemaPluginOptions`, `SchemaPluginExtra`, `CustomMapping`, `CustomMappings`, `NonNullOverrides`, `SchemaExtensions`, `SchemaExtensionsInput`, `SerializedExtraction`, `Connection`, `ConnectionArgs`, `UriPage`, `IncrementalResults`, `LocalExecutionResult`, `RelayLegacyPayload`, `StaticQuery`.
+
+---
+
+## `@canonical/ke-graphql/http`
+
+### `createGraphQLHandler(schema, options)`
+```ts
+createGraphQLHandler(schema: GraphQLSchema, options: GraphQLHandlerOptions): (request: Request) => Promise<Response>
+```
+A framework-free GraphQL-over-HTTP handler: GET (query param) / POST JSON, persisted-query extension, CORS preflight, `Accept` q-values, multipart incremental delivery.
+
+**`GraphQLHandlerOptions`** (every policy seam + the built-in hardening defaults):
+`context` (required, per-request `CompilerContext`), `graphiql`, `cors`, `maxQueryLength`, `maxDepth` (default `DEFAULT_MAX_QUERY_DEPTH`, 0 disables), `validationRules`, `introspection`, `persistedQueries` (`{ get, allowArbitraryQueries? }`), `hideFieldSuggestions`, `formatError`, `maskErrors` (default: production), `onOperation`, `incremental`, `incrementalFormat` (`"graphql17"`|`"relay-legacy"`), `graphiqlHtml`. Defaults are dev-vs-production aware (`NODE_ENV`; hardened where `process` is absent).
+
+### `graphiqlHtml(endpoint)`
+```ts
+graphiqlHtml(endpoint: string): string
+```
+The default GraphiQL page (version-pinned UMD assets from unpkg). Override via `GraphQLHandlerOptions.graphiqlHtml` for air-gapped/vendored deployments.
+
+### `OperationEvent`
+The `onOperation` payload: `{ operation, duration, errors, persisted }`.

--- a/packages/runtime/ke-graphql/docs/architecture.md
+++ b/packages/runtime/ke-graphql/docs/architecture.md
@@ -1,0 +1,89 @@
+# Architecture — `@canonical/ke-graphql`
+
+This is the design companion to the `A.10.COMPILER` ADR (pragma-adrs, `session/A`, decisions KG.01–KG.23). The README is the narrative introduction and `docs/api.md` is the export-by-export reference; this document explains *how the package is built and why*.
+
+## 1. What it is
+
+`@canonical/ke-graphql` is a **compiler**, not middleware. It reads an OWL/RDFS ontology (the TBox) plus its instance data (the ABox) from a [`@canonical/ke`](../../ke) triple store and emits an executable `GraphQLSchema` with resolvers. The mapping is not mechanical: a class with no instances should become an interface, an `owl:inverseOf` pair should produce one field per side rather than four, a blank-node-only class can't have a global ID. Faithful translation takes semantic analysis, so the package is structured like a compiler — passes over a typed intermediate representation, diagnostics with stable codes that never abort on the first problem, and deterministic output you can snapshot.
+
+```
+ke store ──► [ 7 passes ] ──► GraphQLSchema + resolvers ──► (local execution | /http handler)
+                  │
+                  └─ typed IRs: RawExtraction → OntologyIR → MappedIR → SchemaPlan
+```
+
+## 2. The seven passes
+
+Each pass is a pure function from one IR to the next (Pass 1 is the only one that touches the store). The pipeline lives in `src/lib/compiler/`.
+
+| Pass | File | In → Out | Responsibility |
+|---|---|---|---|
+| 1 Extract | `extract.ts` | store → `RawExtraction` | 12 SPARQL queries: TBox structure, SHACL shapes (incl. `sh:or`/`sh:in`), and ABox probes (instance counts, self-reference, functional violations, undeclared predicates, annotations). All store access happens here so passes 2–7 stay pure. |
+| 2 Build | `build.ts` | `RawExtraction` → `OntologyIR` | subClassOf closure, abstract/embeddable detection from instance stats, per-class cardinality with KG.17 precedence (custom > `owl:FunctionalProperty` > `owl:cardinality` > SHACL > kind default), range resolution. |
+| 3 Validate | `validate.ts` | `OntologyIR` → `OntologyIR` (+ diagnostics) | the V-series diagnostics (blank-node-only class, domainless property, asymmetric inverse, boolean-as-string, SHACL specifics, abstract-with-instances `V015`, supertype flattening `V016`). Never mutates the IR; never aborts. |
+| 4 Map | `map.ts` | `OntologyIR` → `MappedIR` | GraphQL naming rules (KG.09), collision auto-resolution (namespace prefixing), synthetic inverse field synthesis, the bidirectional name map. |
+| 5 Emit | `emit.ts` | `MappedIR` → `SchemaPlan` | a field plan + resolver per field (one of the eight resolver templates), because graphql-js type objects are immutable once constructed. |
+| 6 WireRelay | `wireRelay.ts` | `SchemaPlan` → `SchemaPlan` | the `Node` interface (id + uri) on types *and* qualifying interfaces, cursor connections, the `node(id:)` and per-type `<type>(uri:)` / listing root fields. |
+| 7 Compose | `compose.ts` | `SchemaPlan` → `GraphQLSchema` | the single construction point: builds every graphql-js type once, attaches the TBox schema and consumer extensions, runs `validateSchema`, prints the SDL. |
+
+`runPasses.ts` threads 2→7; `compile.ts` runs `extract` then `runPasses`. Splitting construction (Pass 5/6 plan, Pass 7 build) is deliberate — graphql-js objects can't be mutated after creation, so the plan accumulates intent and compose realizes it in one shot.
+
+## 3. The typed IRs
+
+The intermediate representations are exported public contracts (like Prisma's DMMF), not internals — tooling can consume them.
+
+- **`RawExtraction`** — the serializable result of Pass 1 (the twelve queries). It is the artifact boundary (§7).
+- **`OntologyIR`** — the typed ontology: `ClassNode` (ancestors, subclasses, `isAbstract`, `embeddable`) and `PropertyNode` (kind, domains, resolved `RangeSpec`, per-class `CardinalitySpec`).
+- **`MappedIR`** — GraphQL-shaped: `MappedType`/`MappedInterface`/`MappedField`, the `NameMap`, the namespace inventory.
+- **`SchemaPlan`** — field configs + resolvers awaiting construction.
+
+## 4. The OWL → GraphQL model
+
+- **Naming (KG.09).** Field names strip a leading `has`/`is`; list fields are pluralized (the pluralizer knows the irregulars). Illegal GraphQL names are sanitized; collisions are auto-resolved by namespace prefixing (diagnostic `M004`) or, if unresolvable, reported as `M001`.
+- **Cardinality (KG.17).** A property is singular when a custom mapping says so, else if `owl:FunctionalProperty`, else SHACL `maxCount 1`, else the kind default (datatype → singular, object → list). List items are always non-null (`[T!]!`).
+- **Embeddable types (KG.13).** A class whose instances are exclusively blank nodes has no URI, so no global ID, no cursor, no standalone resolution. It is emitted without `Node`/`id`/`_meta`, as a plain `[T!]!` list, and resolved inline from the parent's own triples — fetched in the parent's CONSTRUCT closure (a per-blank follow-up query is invalid SPARQL: blank-node labels are existential and not stable across result sets).
+- **Interfaces & abstract classes (KG.08).** A class with subclasses and *no direct instances* is abstract → an `interface`. If all of its concrete implementors are non-embeddable it implements `Node`, so a fragment written against the interface is Relay-refetchable. A class that is concrete *and* has subclasses stays a concrete type and earns `V016` (its supertype-typed fields flatten polymorphism); the interface-plus-companion alternative is deferred (ADR §13, DEF.01).
+- **Inverse pairs (KG.02).** `owl:inverseOf` produces one field per side, never the four-way duplication. At resolution each side takes the **union of forward and reverse assertions**, so data asserted in either direction answers identically from both ends. Synthetic inverses (a reverse field with no declared partner) are minted in Pass 4.
+- **Global IDs (KG.10).** The Relay `id` is the prefixed URI (`lib:dune`), not an opaque token — usable in GraphiQL, URLs, and the CLI. `toPrefixed` chooses the longest matching namespace so IDs are canonical and order-independent.
+- **Self-description (KG.03).** Every non-embeddable type carries `_meta: EntityMeta!`, exposing the class definition and per-field `ClassProperty` metadata (required/singular/inherited) read from the frozen IR.
+
+## 5. Runtime model
+
+- **The ke plugin (`createSchemaPlugin`).** Registered with `createStore`, it compiles on `onReady` and recompiles on `onReload`, exposing `{ schema, createContext, diagnostics, nameMap, sdl, clearLoaderCache }` under `store.api("ke-graphql")`. `onLoad` fingerprints the sources for artifact freshness.
+- **Resolution & DataLoader (KG.04).** A `CompilerContext` carries three batched loaders — entity (one CONSTRUCT with a `VALUES` clause + blank-node closure), list (one SELECT per class, name-sorted), inverse (one SELECT over reverse assertions). The eight resolver templates in `resolver/templates.ts` read the parent `EntityValue`'s `TripleSet` and dispatch to these loaders.
+- **Lazy store.** The context accepts `Store | Promise<Store>`; ABox loaders `await` it at query time, TBox resolvers never touch it. This lets the schema be ready before the store finishes loading.
+- **Local execution (KG.20).** `executeLocal` runs an operation in-process (SSR, tests, scripts) — `graphql()` for plain documents, `experimentalExecuteIncrementally` when the schema or document involves `@defer`/`@stream`. Path B (`extractStatic`) runs a fixed query set for fully static deployments.
+- **Incremental delivery (KG.21).** `graphql@17.0.0-rc.0`; the `incremental` compile option adds `@defer`/`@stream`; `relayFormatAdapter` translates v17's 2023 payload format to Relay's legacy `path`/`label`/`is_final` shape. A drain-and-merge fallback (`mergeIncremental`) means a format break can cost streaming, never correctness.
+
+## 6. Package boundary (KG.22)
+
+The root export is **schema + resolvers + local execution only** (`graphql` + `dataloader`). The fetch handler and GraphiQL live behind the **`@canonical/ke-graphql/http`** subpath (`createGraphQLHandler`, `graphiqlHtml`), mirroring `@canonical/ke/http`, so SSR/static/test consumers load no HTTP code. The handler is a plain `(Request) => Promise<Response>` — GraphQL-over-HTTP, CORS, persisted queries, multipart incremental — composing like any fetch handler.
+
+## 7. Performance model (KG.23)
+
+- **Extraction artifact** (DMMF pattern). `pragma graphql build` serializes Pass 1 to JSON with an FNV-1a `sourcesHash`. `compileFromExtraction` boots the schema from it without touching the store (~9 ms vs ~54 ms live), falling back to a live compile when the hash is stale.
+- **Store-free TBox.** `_meta`/Ontology/Class resolvers read the frozen IR; they answer even after the store is disposed (~0.13 ms).
+- **Slice-before-hydrate.** Every connection — root *and* nested — paginates the URI window first and hydrates only the page (24 entities, not 250).
+- **Loader caches.** `loaderCache: "request"` (default, per-request isolation) or `"process"` (shared across requests; sound because the store is immutable between reloads). Process caches are bounded LRUs (`processCacheSize`).
+
+The ladder: a warm process answers in microseconds; an artifact boot is ~80 ms per cold container; Cloudflare Workers (WASM precompiled, TTL as inline sources) cold-start in tens of ms; persisted queries behind a CDN make responses pure functions of *(hash, variables)*; `extractStatic` removes the runtime entirely.
+
+## 8. Hardening
+
+The `src/lib/hardening/` domain is the production-safety posture in one named place — tunable, exported, never magic numbers in a resolver:
+
+- `isSafeIri` — drops IRIs that would break out of a SPARQL `IRIREF`, so a crafted `node(id:)` resolves to null, not injected SPARQL (ke queries are read-only, but the guard closes cross-graph disclosure and cost amplification).
+- `clampConnectionArgs` (+ `DEFAULT_PAGE_SIZE`/`MAX_PAGE_SIZE`) — no connection is unbounded and no client can demand an oversized page; applied at both pagination choke points.
+- `createDepthLimitRule` (+ `DEFAULT_MAX_QUERY_DEPTH`) — bounds the recursion cyclic types allow.
+- `createBoundedCache` (+ `DEFAULT_PROCESS_CACHE_SIZE`) — the bounded LRU behind `"process"` mode.
+- `maskError` — replaces internal/unexpected error messages with a generic one in production; deliberate validation/argument errors pass through.
+
+The HTTP handler also defaults introspection and field-suggestions off in production (`process.env.NODE_ENV`, or always-on hardening where `process` is absent, e.g. Workers).
+
+## 9. Diagnostics
+
+The compiler collects problems instead of aborting (the `tsc` model). Codes are stable: `E001` (extraction), `B001–B004` (build references), `V001–V016` (data/ontology validation), `M001–M004` (naming), `X002–X003` (union emission), `C001–C003` (composition). **Only composition errors (`C00x`) prevent schema creation** — `compile()` then throws `CompilationError` with the full list. Everything else surfaces in `result.diagnostics` while the schema still builds; the consumer chooses its failure policy (`pragma graphql check` fails CI on any error-severity diagnostic).
+
+## 10. Delivery
+
+This package is being landed as a stack of focused PRs; the decomposition and dependency order are recorded in `A.10.COMPILER` §14.

--- a/packages/runtime/ke-graphql/examples/cloudflare-worker/README.md
+++ b/packages/runtime/ke-graphql/examples/cloudflare-worker/README.md
@@ -1,0 +1,20 @@
+# ke-graphql on Cloudflare Workers
+
+Cold isolate ≈ 25–60 ms: Workers precompile the Oxigraph WASM at deploy
+(instantiation ~1 ms), the extraction artifact skips Pass 1 entirely
+(schema in ~5–15 ms), and the store boots lazily — TBox/ontology queries
+answer before the TTL even finishes parsing.
+
+```sh
+pragma graphql build --sdl schema.graphql --extraction extraction.json <ttl sources>
+cp <your graph>.ttl graph.ttl
+wrangler deploy
+```
+
+Constraints: paid plan recommended (the wasm is a few MB; free tier's
+compressed size limit is tight), 128 MB isolate memory (fine ≤ ~100k
+triples), `nodejs_compat` flag required.
+
+For 0 ms: put the Cache API in front of persisted queries
+(`createPersistedManifest` + `allowArbitraryQueries: false`) — responses
+are pure functions of (hash, variables) until the next deploy.

--- a/packages/runtime/ke-graphql/examples/cloudflare-worker/worker.mjs
+++ b/packages/runtime/ke-graphql/examples/cloudflare-worker/worker.mjs
@@ -1,0 +1,33 @@
+// Cloudflare Worker serving the compiled graph (~25-60 ms cold isolate):
+// - the extraction artifact rebuilds the schema in ~5-15 ms (no Pass 1)
+// - TTL ships as inline sources (no filesystem on Workers)
+// - Oxigraph WASM is precompiled at deploy -> instantiation ~1 ms
+// - the store boots lazily: TBox queries answer before it resolves
+//
+// wrangler.toml needs: compatibility_flags = ["nodejs_compat"]
+// Generate the two imported artifacts with `pragma graphql build`.
+
+import { createStore } from "@canonical/ke";
+import { compileFromExtraction } from "@canonical/ke-graphql";
+import { createGraphQLHandler } from "@canonical/ke-graphql/http";
+import artifact from "./extraction.json";
+// Bundle the TTL as text (wrangler rule: type = "Text" for **/*.ttl)
+import ontologyTtl from "./graph.ttl";
+
+const result = compileFromExtraction(artifact, { loaderCache: "process" });
+
+// Lazy store: kicked off at isolate start, awaited only by ABox resolvers.
+const storeReady = createStore({
+  sources: [{ content: ontologyTtl, path: "bundle:graph.ttl" }],
+  prefixes: { ds: "https://ds.canonical.com/" },
+});
+
+const handler = createGraphQLHandler(result.schema, {
+  context: () => result.createContext(storeReady),
+  graphiql: false,
+  introspection: false,
+});
+
+export default {
+  fetch: (request) => handler(request),
+};

--- a/packages/runtime/ke-graphql/examples/cloudflare-worker/wrangler.toml
+++ b/packages/runtime/ke-graphql/examples/cloudflare-worker/wrangler.toml
@@ -1,0 +1,8 @@
+name = "ke-graphql-example"
+main = "worker.mjs"
+compatibility_date = "2026-06-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[rules]]
+type = "Text"
+globs = ["**/*.ttl"]

--- a/packages/runtime/ke-graphql/package.json
+++ b/packages/runtime/ke-graphql/package.json
@@ -1,0 +1,99 @@
+{
+  "name": "@canonical/ke-graphql",
+  "description": "OWL → GraphQL compiler for the ke triple store: typed IR, seven-pass pipeline, Relay conventions, incremental delivery",
+  "version": "0.27.1-experimental.0",
+  "type": "module",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "imports": {
+    "#compiler": {
+      "development": "./src/lib/compiler/index.ts",
+      "types": "./dist/types/lib/compiler/index.d.ts",
+      "default": "./dist/esm/lib/compiler/index.js"
+    },
+    "#dataloader": {
+      "development": "./src/lib/dataloader/index.ts",
+      "types": "./dist/types/lib/dataloader/index.d.ts",
+      "default": "./dist/esm/lib/dataloader/index.js"
+    },
+    "#hardening": {
+      "development": "./src/lib/hardening/index.ts",
+      "types": "./dist/types/lib/hardening/index.d.ts",
+      "default": "./dist/esm/lib/hardening/index.js"
+    },
+    "#resolver": {
+      "development": "./src/lib/resolver/index.ts",
+      "types": "./dist/types/lib/resolver/index.d.ts",
+      "default": "./dist/esm/lib/resolver/index.js"
+    },
+    "#tbox": {
+      "development": "./src/lib/tbox/index.ts",
+      "types": "./dist/types/lib/tbox/index.d.ts",
+      "default": "./dist/esm/lib/tbox/index.js"
+    },
+    "#testing": {
+      "development": "./src/testing/index.ts",
+      "types": "./src/testing/index.ts",
+      "default": "./src/testing/index.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun run build:package",
+    "build:all": "bun run build:package",
+    "build:package": "bun run build:package:tsc",
+    "build:package:tsc": "tsc -p tsconfig.build.json",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "test": "bun run test:vitest",
+    "test:vitest": "vitest run --coverage",
+    "test:vitest:watch": "vitest",
+    "check:webarchitect": "webarchitect library",
+    "bench": "bun run build && node scripts/bench.mjs"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.9",
+    "@canonical/biome-config": "^0.27.1-experimental.0",
+    "@canonical/ke": "^0.27.1-experimental.0",
+    "@canonical/typescript-config": "^0.27.1-experimental.0",
+    "@types/bun": "^1.3.10",
+    "@types/node": "^24.12.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18",
+    "@canonical/webarchitect": "^0.27.1-experimental.0"
+  },
+  "peerDependencies": {
+    "@canonical/ke": "^0.27.1-experimental.0"
+  },
+  "dependencies": {
+    "dataloader": "^2.2.3",
+    "graphql": "17.0.0-rc.0"
+  }
+}

--- a/packages/runtime/ke-graphql/scripts/bench.mjs
+++ b/packages/runtime/ke-graphql/scripts/bench.mjs
@@ -1,0 +1,106 @@
+// Cold-start + query-shape benchmark. Run after `bun run build`:
+//   node scripts/bench.mjs   (or bun scripts/bench.mjs)
+// Keeps the numbers in the ADR/README honest across changes.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const t0 = performance.now();
+const mark = (label, since) => {
+  const now = performance.now();
+  console.log(`${label.padEnd(44)} ${(now - since).toFixed(1).padStart(8)} ms`);
+  return now;
+};
+
+const N = 250;
+const ttl =
+  `
+@prefix ds: <https://ds.canonical.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ds:Entity a owl:Class . ds:UIElement a owl:Class ; rdfs:subClassOf ds:Entity .
+ds:UIBlock a owl:Class ; rdfs:subClassOf ds:UIElement .
+ds:Component a owl:Class ; rdfs:subClassOf ds:UIBlock .
+ds:Tier a owl:Class ; rdfs:subClassOf ds:Entity .
+ds:Property a owl:Class ; rdfs:subClassOf ds:Entity .
+ds:name a owl:DatatypeProperty ; rdfs:domain ds:Entity ; rdfs:range xsd:string .
+ds:summary a owl:DatatypeProperty ; rdfs:domain ds:Entity ; rdfs:range xsd:string .
+ds:tier a owl:ObjectProperty , owl:FunctionalProperty ; rdfs:domain ds:UIBlock ; rdfs:range ds:Tier .
+ds:hasProperty a owl:ObjectProperty ; rdfs:domain ds:UIBlock ; rdfs:range ds:Property .
+ds:propertyType a owl:DatatypeProperty ; rdfs:domain ds:Property ; rdfs:range xsd:string .
+ds:optional a owl:DatatypeProperty , owl:FunctionalProperty ; rdfs:domain ds:Property ; rdfs:range xsd:boolean .
+ds:global a ds:Tier ; ds:name "global" .
+` +
+  Array.from(
+    { length: N },
+    (_, i) => `
+ds:global.component.c${i} a ds:Component ; ds:name "C${i}" ; ds:summary "S${i}" ; ds:tier ds:global ;
+  ds:hasProperty [ a ds:Property ; ds:name "disabled" ; ds:propertyType "boolean" ; ds:optional "false" ] .`,
+  ).join("\n");
+
+let t = t0;
+const { createStore } = await import("@canonical/ke");
+const {
+  compile,
+  compileFromExtraction,
+  serializeExtraction,
+  hashSources,
+  storeQueryFn,
+  executeLocal,
+} = await import("../dist/esm/index.js");
+t = mark("import modules", t);
+
+const dir = mkdtempSync(join(tmpdir(), "kg-bench-"));
+const file = join(dir, "g.ttl");
+writeFileSync(file, ttl);
+const prefixes = { ds: "https://ds.canonical.com/" };
+const store = await createStore({ sources: [file], prefixes });
+t = mark(`createStore (WASM + ${N * 6 + 20} triples)`, t);
+
+const live = await compile(storeQueryFn(store), prefixes, {
+  mappings: { "ds:hasProperty": { graphqlName: "properties" } },
+});
+t = mark("compile() live (Pass 1 + 2-7 + validate)", t);
+
+const artifact = serializeExtraction(live.extraction, hashSources([ttl]));
+const result = compileFromExtraction(artifact, {
+  mappings: { "ds:hasProperty": { graphqlName: "properties" } },
+  loaderCache: "process",
+});
+t = mark("compileFromExtraction (artifact boot)", t);
+
+const run = (source) =>
+  executeLocal({
+    schema: result.schema,
+    source,
+    contextValue: result.createContext(store),
+  });
+
+const time = async (label, source, iters = 50) => {
+  await run(source); // warmup
+  const start = performance.now();
+  for (let i = 0; i < iters; i++) {
+    await run(source);
+  }
+  console.log(
+    `${label.padEnd(44)} ${((performance.now() - start) / iters).toFixed(2).padStart(8)} ms`,
+  );
+};
+
+await time(
+  "detail page (1 entity + tier + blanks)",
+  `{ component(uri: "ds:global.component.c42") { id name summary tier { name } properties { name optional } } }`,
+);
+await time(
+  `listing first:24 (slice-before-hydrate)`,
+  `{ components(first: 24) { edges { node { id name } } pageInfo { hasNextPage } } }`,
+);
+await time(
+  "TBox class + ClassProperties (store-free)",
+  `{ ontologyClass(uri: "https://ds.canonical.com/Component") { label properties { property { label } required } } }`,
+);
+console.log(
+  `${"TOTAL boot -> ready".padEnd(44)} ${(t - t0).toFixed(1).padStart(8)} ms`,
+);

--- a/packages/runtime/ke-graphql/src/index.ts
+++ b/packages/runtime/ke-graphql/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @canonical/ke-graphql — OWL → GraphQL compiler for the ke triple store.
+ *
+ * The root export is schema + resolvers + local execution only (KG.22):
+ * no server, no HTTP, no GraphiQL. The fetch handler lives behind the
+ * `@canonical/ke-graphql/http` subpath export.
+ *
+ * @example
+ * ```ts
+ * import { createStore } from "@canonical/ke";
+ * import { createSchemaPlugin, type SchemaPluginApi } from "@canonical/ke-graphql";
+ *
+ * const graphql = createSchemaPlugin();
+ * const store = await createStore({
+ *   sources: ["./ontology.ttl", "./data/*.ttl"],
+ *   prefixes: { ds: "https://ds.canonical.com/" },
+ *   plugins: [graphql],
+ * });
+ * const { schema, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+ * ```
+ *
+ * @module ke-graphql
+ */
+
+export * from "./lib/index.js";

--- a/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.ts
@@ -1,0 +1,37 @@
+import type { NameMap } from "./types.js";
+
+/**
+ * Bidirectional OWL URI ↔ GraphQL name map. Type names map globally; field
+ * names are scoped per type ("Component.tier") since the same property can
+ * surface on several types. For the reverse direction the first writer wins:
+ * a property mapped on several types keeps one canonical OWL target.
+ */
+export default class BidirectionalNameMap implements NameMap {
+  private readonly owlToGraphql = new Map<string, string>();
+  private readonly graphqlToOwl = new Map<string, string>();
+
+  /** Record a URI ↔ name pair (reverse direction: first writer wins). */
+  set(owlUri: string, graphqlName: string): void {
+    this.owlToGraphql.set(owlUri, graphqlName);
+    // First writer wins for the reverse direction: a property mapped on
+    // several types (inherited fields) keeps one canonical OWL target.
+    if (!this.graphqlToOwl.has(graphqlName)) {
+      this.graphqlToOwl.set(graphqlName, owlUri);
+    }
+  }
+
+  /** Look up the GraphQL name for an OWL URI. */
+  toGraphQL(uri: string): string | undefined {
+    return this.owlToGraphql.get(uri);
+  }
+
+  /** Look up the canonical OWL URI for a GraphQL name. */
+  toOWL(name: string): string | undefined {
+    return this.graphqlToOwl.get(name);
+  }
+
+  /** Iterate every (OWL URI, GraphQL name) pair. */
+  entries(): Iterable<[string, string]> {
+    return this.owlToGraphql.entries();
+  }
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/CompilationError.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/CompilationError.ts
@@ -1,0 +1,21 @@
+import type { Diagnostic } from "./types.js";
+
+/**
+ * Thrown only when schema composition fails (C-series errors) — carries the
+ * full diagnostic list of the compilation, not just the fatal ones, so the
+ * consumer can report everything at once.
+ */
+export default class CompilationError extends Error {
+  readonly diagnostics: Diagnostic[];
+
+  constructor(diagnostics: Diagnostic[]) {
+    const errors = diagnostics.filter((d) => d.severity === "error");
+    super(
+      `ke-graphql: schema composition failed with ${errors.length} error(s):\n${errors
+        .map((d) => `  ${d.code}: ${d.message}`)
+        .join("\n")}`,
+    );
+    this.name = "CompilationError";
+    this.diagnostics = diagnostics;
+  }
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/build.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.ts
@@ -1,0 +1,384 @@
+// =============================================================================
+// Pass 2 — Build: RawExtraction → OntologyIR
+//
+// Pure. Constructs the typed class/property graph: transitive superclass
+// closure (with cycle detection), subclass inversion, abstract detection from
+// the Pass 1 instance stats, range resolution, SHACL cardinality (including
+// sh:or most-permissive merging), inverse pair symmetry, and property
+// inheritance.
+// =============================================================================
+
+import { XSD, XSD_SCALARS } from "./constants.js";
+import getLocalName from "./getLocalName.js";
+import getNamespace from "./getNamespace.js";
+import isStandardVocab from "./isStandardVocab.js";
+import type {
+  CardinalitySpec,
+  ClassNode,
+  CustomMappings,
+  Diagnostic,
+  NamespaceInfo,
+  OntologyIR,
+  PassResult,
+  PropertyNode,
+  RangeSpec,
+  RawExtraction,
+  RawShaclConstraint,
+  RawUnion,
+} from "./types.js";
+
+const PHASE = "build";
+
+/**
+ * Merge SHACL constraints for one (class, property) pair. Plain constraints
+ * intersect (most specific wins); sh:or branches union to the most
+ * permissive interpretation across alternatives (§4.2 step 5a).
+ */
+const mergeConstraints = (
+  constraints: RawShaclConstraint[],
+): { singular: boolean; required: boolean; omit: boolean } => {
+  const direct = constraints.filter((c) => !c.fromOr);
+  const branches = constraints.filter((c) => c.fromOr);
+
+  let minCount: number | undefined;
+  let maxCount: number | undefined;
+  for (const c of direct) {
+    if (c.minCount !== undefined) {
+      minCount = Math.max(minCount ?? 0, c.minCount);
+    }
+    if (c.maxCount !== undefined) {
+      maxCount = Math.min(maxCount ?? Number.POSITIVE_INFINITY, c.maxCount);
+    }
+  }
+  if (branches.length > 0) {
+    // Most permissive across branches: min of minCounts, max of maxCounts.
+    const branchMin = Math.min(...branches.map((c) => c.minCount ?? 0));
+    const branchMax = Math.max(
+      ...branches.map((c) => c.maxCount ?? Number.POSITIVE_INFINITY),
+    );
+    minCount = Math.min(minCount ?? branchMin, branchMin);
+    maxCount =
+      maxCount === undefined
+        ? branchMax === Number.POSITIVE_INFINITY
+          ? undefined
+          : branchMax
+        : Math.max(
+            maxCount,
+            branchMax === Number.POSITIVE_INFINITY ? maxCount : branchMax,
+          );
+  }
+
+  return {
+    singular: maxCount === 1,
+    required: (minCount ?? 0) >= 1,
+    omit: maxCount === 0,
+  };
+};
+
+/**
+ * Build the typed OntologyIR from a RawExtraction (Pass 2): class graph
+ * with ancestor closure and cycle detection (B001), abstract/embeddable
+ * detection, range resolution, SHACL cardinality merging, inverse-pair
+ * completion, and property inheritance. Pure.
+ */
+export default function build(
+  extraction: RawExtraction,
+  mappings: CustomMappings = {},
+): PassResult<OntologyIR> {
+  const diagnostics: Diagnostic[] = [];
+  const getPrefix = (uri: string): string =>
+    extraction.namespaces.get(getNamespace(uri)) ?? "";
+
+  // Custom mappings may be keyed by prefixed name (ds:tier) or full IRI.
+  const prefixedToFull = new Map<string, string>();
+  for (const [ns, prefix] of extraction.namespaces) {
+    prefixedToFull.set(prefix, ns);
+  }
+  const findMapping = (uri: string) => {
+    const direct = mappings[uri];
+    if (direct) {
+      return direct;
+    }
+    const prefix = getPrefix(uri);
+    return prefix ? mappings[`${prefix}:${getLocalName(uri)}`] : undefined;
+  };
+
+  // ── 1. class map ──
+  const classes = new Map<string, ClassNode>();
+  const rawSuperclasses = new Map<string, string[]>();
+  for (const raw of extraction.classes) {
+    rawSuperclasses.set(raw.uri, raw.superclasses);
+    classes.set(raw.uri, {
+      uri: raw.uri,
+      label: raw.label ?? getLocalName(raw.uri),
+      definition: raw.definition,
+      namespace: getPrefix(raw.uri),
+      superclasses: raw.superclasses,
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [],
+      allProperties: [],
+    });
+  }
+
+  // ── 2. transitive closure with cycle detection (B001) ──
+  const ancestorCache = new Map<string, string[]>();
+  const computeAncestors = (uri: string, trail: string[]): string[] => {
+    const cached = ancestorCache.get(uri);
+    if (cached) {
+      return cached;
+    }
+    if (trail.includes(uri)) {
+      diagnostics.push({
+        severity: "error",
+        code: "B001",
+        message: `subClassOf cycle: ${[...trail, uri].map(getLocalName).join(" → ")}`,
+        source: uri,
+        phase: PHASE,
+      });
+      return [];
+    }
+    const result: string[] = [];
+    for (const parent of rawSuperclasses.get(uri) ?? []) {
+      if (!classes.has(parent)) {
+        continue; // cross-vocabulary parents handled in Pass 3 (V009)
+      }
+      if (!result.includes(parent)) {
+        result.push(parent);
+      }
+      for (const ancestor of computeAncestors(parent, [...trail, uri])) {
+        if (!result.includes(ancestor)) {
+          result.push(ancestor);
+        }
+      }
+    }
+    ancestorCache.set(uri, result);
+    return result;
+  };
+
+  for (const node of classes.values()) {
+    const ancestors = computeAncestors(node.uri, []);
+    classes.set(node.uri, { ...node, ancestors });
+  }
+
+  // ── 3. invert subclass relationships ──
+  const subclassesOf = new Map<string, string[]>();
+  for (const node of classes.values()) {
+    for (const parent of node.superclasses) {
+      if (!classes.has(parent)) {
+        continue;
+      }
+      const children = subclassesOf.get(parent) ?? [];
+      children.push(node.uri);
+      subclassesOf.set(parent, children);
+    }
+  }
+
+  // ── 4. abstract + embeddable detection from instance stats (KG.Q1, KG.13) ──
+  for (const node of classes.values()) {
+    const stats = extraction.instanceStats.get(node.uri);
+    const subclasses = subclassesOf.get(node.uri) ?? [];
+    const mapping = findMapping(node.uri);
+    const isAbstract =
+      mapping?.abstract ?? ((stats?.total ?? 0) === 0 && subclasses.length > 0);
+    // Embeddable: instances exist and none are named, or forced by mapping.
+    const embeddable =
+      mapping?.embeddable ??
+      (stats !== undefined && stats.total > 0 && stats.named === 0);
+    classes.set(node.uri, {
+      ...node,
+      ancestors: classes.get(node.uri)?.ancestors ?? [],
+      subclasses,
+      isAbstract,
+      embeddable,
+    });
+  }
+
+  // ── 5. property map with range resolution ──
+  const datatypeByUri = new Map(extraction.datatypes.map((d) => [d.uri, d]));
+  const namedUnionByUri = new Map<string, RawUnion>();
+  const anonUnionByProperty = new Map<string, RawUnion>();
+  for (const union of extraction.unions) {
+    if (union.uri) {
+      namedUnionByUri.set(union.uri, union);
+    }
+    if (union.property) {
+      anonUnionByProperty.set(union.property, union);
+    }
+  }
+
+  const resolveRange = (propertyUri: string, ranges: string[]): RangeSpec => {
+    const anon = anonUnionByProperty.get(propertyUri);
+    if (anon) {
+      return { kind: "union", members: anon.members };
+    }
+    const range = ranges[0];
+    if (!range) {
+      // No declared range — safety net: treat as String.
+      return { kind: "scalar", xsd: `${XSD}string`, graphqlScalar: "String" };
+    }
+    const scalar = XSD_SCALARS[range];
+    if (scalar) {
+      return { kind: "scalar", xsd: range, graphqlScalar: scalar };
+    }
+    const custom = datatypeByUri.get(range);
+    if (custom) {
+      const base = custom.baseType ?? `${XSD}string`;
+      return {
+        kind: "scalar",
+        xsd: base,
+        graphqlScalar: XSD_SCALARS[base] ?? "String",
+        customDatatype: range,
+      };
+    }
+    const namedUnion = namedUnionByUri.get(range);
+    if (namedUnion) {
+      return {
+        kind: "union",
+        name: getLocalName(range),
+        members: namedUnion.members,
+      };
+    }
+    if (classes.has(range)) {
+      return { kind: "class", uri: range };
+    }
+    return { kind: "unknown", raw: range };
+  };
+
+  // ── 5a. SHACL cardinality per (class, property) ──
+  const constraintsByPair = new Map<string, RawShaclConstraint[]>();
+  for (const constraint of extraction.shaclConstraints) {
+    const key = `${constraint.targetClass} ${constraint.property}`;
+    const list = constraintsByPair.get(key) ?? [];
+    list.push(constraint);
+    constraintsByPair.set(key, list);
+  }
+
+  const properties = new Map<string, PropertyNode>();
+  for (const raw of extraction.properties) {
+    const classCardinality = new Map<string, CardinalitySpec>();
+    let shaclSingularAnywhere = false;
+    for (const [key, constraints] of constraintsByPair) {
+      const [targetClass, property] = key.split(" ");
+      if (property !== raw.uri) {
+        continue;
+      }
+      const merged = mergeConstraints(constraints);
+      shaclSingularAnywhere ||= merged.singular;
+      if (!targetClass) {
+        continue;
+      }
+      classCardinality.set(targetClass, {
+        singular: merged.singular,
+        required: merged.required,
+        omit: merged.omit,
+        source: "shacl",
+      });
+    }
+
+    // KG.17 precedence: custom > owl:FunctionalProperty > owl:cardinality
+    // (not present in current ontologies) > SHACL maxCount 1 > kind default.
+    // Datatype properties default to SINGULAR (multi-valued literals are the
+    // exception in RDF practice); only object properties default to list.
+    const mapping = findMapping(raw.uri);
+    const functional =
+      mapping?.singular ??
+      (extraction.functionals.has(raw.uri) ||
+        shaclSingularAnywhere ||
+        raw.kind !== "object");
+
+    properties.set(raw.uri, {
+      uri: raw.uri,
+      label: raw.label ?? getLocalName(raw.uri),
+      definition: raw.definition,
+      namespace: getPrefix(raw.uri),
+      kind: raw.kind,
+      domains: raw.domains,
+      range: resolveRange(raw.uri, raw.ranges),
+      functional,
+      classCardinality,
+      isAnnotation: raw.kind === "annotation",
+      annotations: extraction.annotations.get(raw.uri) ?? new Map(),
+    });
+  }
+
+  // ── 6. inverse pairs with symmetry verification (V003 in Pass 3) ──
+  for (const { property, inverse } of extraction.inverses) {
+    const forward = properties.get(property);
+    if (forward) {
+      properties.set(property, { ...forward, inverse });
+    }
+    const backward = properties.get(inverse);
+    if (backward && backward.inverse === undefined) {
+      // Auto-complete asymmetric declarations; Pass 3 reports V003.
+      properties.set(inverse, { ...backward, inverse: property });
+    }
+  }
+
+  // ── 7+8. assign properties to classes, compute inheritance ──
+  const ownProperties = new Map<string, string[]>();
+  for (const property of properties.values()) {
+    if (property.isAnnotation) {
+      continue; // annotation properties route to the TBox schema (EC.07)
+    }
+    for (const domain of property.domains) {
+      if (!classes.has(domain)) {
+        continue; // unknown domains reported in Pass 3 (B002)
+      }
+      const list = ownProperties.get(domain) ?? [];
+      list.push(property.uri);
+      ownProperties.set(domain, list);
+    }
+    if (property.domains.length === 0) {
+      // Domainless (KG.14): assign to every class in the property's namespace.
+      for (const node of classes.values()) {
+        if (node.namespace === property.namespace) {
+          const list = ownProperties.get(node.uri) ?? [];
+          list.push(property.uri);
+          ownProperties.set(node.uri, list);
+        }
+      }
+    }
+  }
+
+  for (const node of classes.values()) {
+    const own = ownProperties.get(node.uri) ?? [];
+    const all = [...own];
+    for (const ancestor of node.ancestors) {
+      for (const inherited of ownProperties.get(ancestor) ?? []) {
+        if (!all.includes(inherited)) {
+          all.push(inherited);
+        }
+      }
+    }
+    classes.set(node.uri, {
+      ...node,
+      ownProperties: own,
+      allProperties: all,
+    });
+  }
+
+  // ── namespaces ──
+  const namespaces = new Map<string, NamespaceInfo>();
+  for (const [uri, prefix] of extraction.namespaces) {
+    if (isStandardVocab(uri)) {
+      continue;
+    }
+    namespaces.set(prefix, {
+      prefix,
+      uri,
+      classCount: [...classes.values()].filter((c) => c.namespace === prefix)
+        .length,
+      propertyCount: [...properties.values()].filter(
+        (p) => p.namespace === prefix,
+      ).length,
+    });
+  }
+
+  return {
+    output: { classes, properties, namespaces, extraction },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/compile.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compile.ts
@@ -1,0 +1,26 @@
+import extract from "./extract.js";
+import runPasses from "./runPasses.js";
+import type { CompilerResult, QueryFn, SchemaPluginOptions } from "./types.js";
+
+/**
+ * Run the full seven-pass pipeline against a query surface (ke
+ * PluginContext.query at plugin time, or storeQueryFn(store) directly).
+ *
+ * The schema is produced whenever composition succeeds — error diagnostics
+ * from earlier passes do not abort compilation (tsc model, §2.2); the
+ * consumer decides its failure policy. Throws CompilationError only when
+ * composition fails.
+ *
+ * @note Impure — Pass 1 executes SPARQL queries against the store through
+ * the provided query function.
+ */
+export default async function compile(
+  query: QueryFn,
+  prefixes: Readonly<Record<string, string>>,
+  options: SchemaPluginOptions = {},
+): Promise<CompilerResult> {
+  const extracted = await extract(query, prefixes);
+  return runPasses(extracted.output, options, {
+    diagnostics: extracted.diagnostics,
+  });
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/compose.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compose.ts
@@ -1,0 +1,387 @@
+// =============================================================================
+// Pass 7 — Compose: SchemaPlan + TBox + extensions → GraphQLSchema
+//
+// The single place where graphql-js type objects are constructed (they are
+// immutable — see ADR §4.5/§4.6). Field thunks resolve circular references;
+// connection types are created on demand per base type; every interface and
+// union gets resolveType reading EntityValue.typename; extensions (object or
+// factory form) are validated (C001/C002); the composed schema runs
+// validateSchema (C003) and is printed to SDL for the Relay compiler.
+// =============================================================================
+
+import {
+  GraphQLBoolean,
+  type GraphQLFieldConfig,
+  type GraphQLFieldConfigArgumentMap,
+  type GraphQLFieldConfigMap,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  type GraphQLNullableOutputType,
+  GraphQLObjectType,
+  type GraphQLOutputType,
+  type GraphQLScalarType,
+  GraphQLSchema,
+  GraphQLString,
+  GraphQLUnionType,
+  printSchema,
+  specifiedDirectives,
+  validateSchema,
+} from "graphql";
+import { buildTBoxSchema } from "#tbox";
+import { CONNECTION_ARGS } from "./constants.js";
+import type { FieldPlan, SchemaPlan, TypeRef } from "./emit.js";
+import type {
+  CompilerContext,
+  Diagnostic,
+  EntityValue,
+  PassResult,
+  SchemaExtensionsInput,
+} from "./types.js";
+
+const PHASE = "compose";
+
+const SCALARS: Record<string, GraphQLScalarType> = {
+  String: GraphQLString,
+  Boolean: GraphQLBoolean,
+  Int: GraphQLInt,
+  Float: GraphQLFloat,
+  ID: GraphQLID,
+};
+
+/** Options for the composition pass (extensions). */
+export interface ComposeOptions {
+  extensions?: SchemaExtensionsInput;
+}
+
+/** Composition output: the schema (null on C003 failure) and its SDL. */
+export interface ComposedSchema {
+  schema: GraphQLSchema | null;
+  sdl: string;
+}
+
+/**
+ * Compose the executable GraphQLSchema from the SchemaPlan, the TBox schema,
+ * and consumer extensions (Pass 7). Extension conflicts surface as C001/C002
+ * diagnostics; validateSchema failures as C003. Pure construction — the
+ * resulting schema performs I/O only when executed.
+ */
+export default function compose(
+  plan: SchemaPlan,
+  options: ComposeOptions = {},
+): PassResult<ComposedSchema> {
+  const diagnostics: Diagnostic[] = [];
+
+  // ── shared structural types ──
+  const resolveTypename = (value: unknown): string | undefined =>
+    (value as EntityValue | undefined)?.typename;
+
+  const nodeInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
+    name: "Node",
+    fields: () => ({
+      id: { type: new GraphQLNonNull(GraphQLID) },
+      uri: { type: new GraphQLNonNull(GraphQLString) },
+    }),
+    resolveType: resolveTypename,
+  });
+
+  const pageInfo = new GraphQLObjectType({
+    name: "PageInfo",
+    fields: {
+      hasNextPage: { type: new GraphQLNonNull(GraphQLBoolean) },
+      hasPreviousPage: { type: new GraphQLNonNull(GraphQLBoolean) },
+      startCursor: { type: GraphQLString },
+      endCursor: { type: GraphQLString },
+    },
+  });
+
+  // ── registries with lazy construction ──
+  const objectTypes = new Map<string, GraphQLObjectType>();
+  const interfaceTypes = new Map<string, GraphQLInterfaceType>();
+  const unionTypes = new Map<string, GraphQLUnionType>();
+  const connectionTypes = new Map<string, GraphQLObjectType>();
+
+  const findNamedType = (name: string): GraphQLNullableOutputType | undefined =>
+    objectTypes.get(name) ??
+    interfaceTypes.get(name) ??
+    unionTypes.get(name) ??
+    (name === "Node" ? nodeInterface : undefined) ??
+    (name === "EntityMeta" ? tbox.entityMeta : undefined) ??
+    SCALARS[name];
+
+  const getConnectionType = (base: string): GraphQLObjectType => {
+    let connection = connectionTypes.get(`${base}Connection`);
+    if (connection) {
+      return connection;
+    }
+    const edge = new GraphQLObjectType({
+      name: `${base}Edge`,
+      fields: () => ({
+        node: {
+          type: new GraphQLNonNull(findNamedType(base) ?? GraphQLString),
+          resolve: (parent: { node: EntityValue }) => parent.node,
+        },
+        cursor: { type: new GraphQLNonNull(GraphQLString) },
+      }),
+    });
+    connection = new GraphQLObjectType({
+      name: `${base}Connection`,
+      fields: () => ({
+        edges: {
+          type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(edge))),
+        },
+        pageInfo: { type: new GraphQLNonNull(pageInfo) },
+      }),
+    });
+    connectionTypes.set(`${base}Connection`, connection);
+    return connection;
+  };
+
+  const buildOutputType = (ref: TypeRef): GraphQLOutputType => {
+    const base: GraphQLNullableOutputType =
+      ref.kind === "connection"
+        ? getConnectionType(ref.base)
+        : (findNamedType(ref.base) ?? GraphQLString);
+    if (ref.kind !== "connection" && ref.list) {
+      // List fields are always [T!]! (KG.07): resolvers filter missing
+      // items rather than nulling them, and an empty list is the default.
+      return new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(base)));
+    }
+    return ref.nonNull ? new GraphQLNonNull(base) : base;
+  };
+
+  const buildArgs = (plan: FieldPlan): GraphQLFieldConfigArgumentMap => {
+    const args: GraphQLFieldConfigArgumentMap = {};
+    if (plan.connectionArgs) {
+      Object.assign(args, CONNECTION_ARGS);
+    }
+    for (const [name, spec] of Object.entries(plan.args ?? {})) {
+      const scalar = SCALARS[spec.type] ?? GraphQLString;
+      args[name] = {
+        type: spec.required ? new GraphQLNonNull(scalar) : scalar,
+      };
+    }
+    return args;
+  };
+
+  const buildFieldConfig = (
+    plan: FieldPlan,
+  ): GraphQLFieldConfig<EntityValue, CompilerContext> => ({
+    type: buildOutputType(plan.type),
+    args: buildArgs(plan),
+    resolve: plan.resolve,
+    description: plan.description,
+  });
+
+  const buildFieldsConfig = (
+    fields: Map<string, FieldPlan>,
+  ): GraphQLFieldConfigMap<EntityValue, CompilerContext> => {
+    const config: GraphQLFieldConfigMap<EntityValue, CompilerContext> = {};
+    for (const [name, plan] of fields) {
+      config[name] = buildFieldConfig(plan);
+    }
+    return config;
+  };
+
+  // ── TBox (needs the Node interface and the NodeConnection factory) ──
+  const tbox = buildTBoxSchema(plan.mapped, nodeInterface, () =>
+    getConnectionType("Node"),
+  );
+
+  // ── generated interfaces ──
+  for (const iface of plan.interfaces.values()) {
+    interfaceTypes.set(
+      iface.name,
+      new GraphQLInterfaceType({
+        name: iface.name,
+        description: iface.description,
+        interfaces: () =>
+          iface.parents
+            .map((p) => (p === "Node" ? nodeInterface : interfaceTypes.get(p)))
+            .filter((i): i is GraphQLInterfaceType => i !== undefined),
+        fields: () => buildFieldsConfig(iface.fields),
+        resolveType: resolveTypename,
+      }),
+    );
+  }
+
+  // ── generated unions ──
+  for (const union of plan.unions.values()) {
+    unionTypes.set(
+      union.name,
+      new GraphQLUnionType({
+        name: union.name,
+        types: () =>
+          union.members
+            .map((m) => objectTypes.get(m))
+            .filter((t): t is GraphQLObjectType => t !== undefined),
+        resolveType: resolveTypename,
+      }),
+    );
+  }
+
+  // ── extensions (validated below, merged into type construction) ──
+  const resolveExtensions = (
+    input: SchemaExtensionsInput | undefined,
+  ): Record<
+    string,
+    Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>>
+  > => {
+    if (!input) {
+      return {};
+    }
+    if (typeof input === "function") {
+      return input({
+        type: (name) => objectTypes.get(name),
+        iface: (name) =>
+          interfaceTypes.get(name) ??
+          (name === "Node" ? nodeInterface : undefined),
+      });
+    }
+    return input;
+  };
+
+  // Extension lookup is lazy (inside field thunks) so the factory form can
+  // reference generated types that exist by the time fields are resolved.
+  let extensionsCache:
+    | Record<
+        string,
+        Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>>
+      >
+    | undefined;
+  const getExtensionFields = (
+    typeName: string,
+  ): Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>> => {
+    extensionsCache ??= resolveExtensions(options.extensions);
+    return extensionsCache[typeName] ?? {};
+  };
+
+  // ── generated object types ──
+  for (const type of plan.types.values()) {
+    objectTypes.set(
+      type.name,
+      new GraphQLObjectType<EntityValue, CompilerContext>({
+        name: type.name,
+        description: type.description,
+        interfaces: () =>
+          type.interfaces
+            .map((i) => (i === "Node" ? nodeInterface : interfaceTypes.get(i)))
+            .filter((i): i is GraphQLInterfaceType => i !== undefined),
+        fields: () => {
+          const generated = buildFieldsConfig(type.fields);
+          for (const [name, config] of Object.entries(
+            getExtensionFields(type.name),
+          )) {
+            if (generated[name]) {
+              diagnostics.push({
+                severity: "error",
+                code: "C002",
+                message: `extension field ${type.name}.${name} conflicts with a generated field`,
+                phase: PHASE,
+              });
+              continue;
+            }
+            generated[name] = config;
+          }
+          return generated;
+        },
+      }),
+    );
+  }
+
+  // C001 — extensions referencing unknown types (Query is always known).
+  extensionsCache ??= resolveExtensions(options.extensions);
+  for (const typeName of Object.keys(extensionsCache)) {
+    if (typeName !== "Query" && !plan.types.has(typeName)) {
+      diagnostics.push({
+        severity: "error",
+        code: "C001",
+        message: `extension references unknown type ${typeName}`,
+        phase: PHASE,
+      });
+    }
+  }
+
+  // ── Query ──
+  const queryType = new GraphQLObjectType<unknown, CompilerContext>({
+    name: "Query",
+    fields: () => {
+      const fields: GraphQLFieldConfigMap<unknown, CompilerContext> = {
+        ...tbox.queryFields,
+      };
+      for (const [name, fieldPlan] of plan.queryFields) {
+        fields[name] = buildFieldConfig(fieldPlan) as GraphQLFieldConfig<
+          unknown,
+          CompilerContext
+        >;
+      }
+      for (const [name, config] of Object.entries(
+        getExtensionFields("Query"),
+      )) {
+        if (fields[name]) {
+          diagnostics.push({
+            severity: "error",
+            code: "C002",
+            message: `extension field Query.${name} conflicts with a generated field`,
+            phase: PHASE,
+          });
+          continue;
+        }
+        fields[name] = config as GraphQLFieldConfig<unknown, CompilerContext>;
+      }
+      return fields;
+    },
+  });
+
+  // ── schema ──
+  // Embeddable-only interfaces and their implementors may be unreachable
+  // from Query; list every generated type explicitly so they are retained.
+  const allTypes = [
+    ...objectTypes.values(),
+    ...interfaceTypes.values(),
+    ...unionTypes.values(),
+    tbox.entityMeta,
+  ];
+
+  const directives = [...specifiedDirectives];
+
+  let schema: GraphQLSchema | null = null;
+  let sdl = "";
+  try {
+    // GraphQLObjectType constructors validate names eagerly; field thunks
+    // run during validateSchema — both belong under the C003 umbrella so a
+    // bad name surfaces as a diagnostic, not a raw GraphQLError.
+    schema = new GraphQLSchema({
+      query: queryType,
+      types: allTypes,
+      directives,
+    });
+    const validationErrors = validateSchema(schema);
+    for (const error of validationErrors) {
+      diagnostics.push({
+        severity: "error",
+        code: "C003",
+        message: error.message,
+        phase: PHASE,
+      });
+    }
+    if (validationErrors.length > 0) {
+      schema = null;
+    } else {
+      sdl = printSchema(schema);
+    }
+  } catch (error) {
+    diagnostics.push({
+      severity: "error",
+      code: "C003",
+      message: error instanceof Error ? error.message : String(error),
+      phase: PHASE,
+    });
+    schema = null;
+  }
+
+  return { output: { schema, sdl }, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/constants.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/constants.ts
@@ -1,0 +1,156 @@
+// =============================================================================
+// Compiler domain constants: standard vocabulary IRIs, scalar mappings, and
+// reserved GraphQL names. Compiler queries use absolute IRIs so they work
+// regardless of which prefixes the consumer registered on the store.
+// =============================================================================
+
+import {
+  type GraphQLFieldConfigArgumentMap,
+  GraphQLInt,
+  GraphQLString,
+} from "graphql";
+
+/** RDF syntax namespace IRI. */
+export const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+/** RDF Schema namespace IRI. */
+export const RDFS = "http://www.w3.org/2000/01/rdf-schema#";
+/** OWL namespace IRI. */
+export const OWL = "http://www.w3.org/2002/07/owl#";
+/** XML Schema datatypes namespace IRI. */
+export const XSD = "http://www.w3.org/2001/XMLSchema#";
+/** SKOS namespace IRI. */
+export const SKOS = "http://www.w3.org/2004/02/skos/core#";
+/** SHACL namespace IRI. */
+export const SH = "http://www.w3.org/ns/shacl#";
+
+/** rdf:type predicate IRI. */
+export const RDF_TYPE = `${RDF}type`;
+/** rdf:Property class IRI. */
+export const RDF_PROPERTY = `${RDF}Property`;
+/** rdf:first list predicate IRI. */
+export const RDF_FIRST = `${RDF}first`;
+/** rdf:rest list predicate IRI. */
+export const RDF_REST = `${RDF}rest`;
+/** rdf:nil list terminator IRI. */
+export const RDF_NIL = `${RDF}nil`;
+
+/** rdfs:label predicate IRI. */
+export const RDFS_LABEL = `${RDFS}label`;
+/** rdfs:comment predicate IRI. */
+export const RDFS_COMMENT = `${RDFS}comment`;
+/** rdfs:subClassOf predicate IRI. */
+export const RDFS_SUBCLASS_OF = `${RDFS}subClassOf`;
+/** rdfs:domain predicate IRI. */
+export const RDFS_DOMAIN = `${RDFS}domain`;
+/** rdfs:range predicate IRI. */
+export const RDFS_RANGE = `${RDFS}range`;
+/** rdfs:Datatype class IRI. */
+export const RDFS_DATATYPE = `${RDFS}Datatype`;
+
+/** owl:Class class IRI. */
+export const OWL_CLASS = `${OWL}Class`;
+/** owl:ObjectProperty class IRI. */
+export const OWL_OBJECT_PROPERTY = `${OWL}ObjectProperty`;
+/** owl:DatatypeProperty class IRI. */
+export const OWL_DATATYPE_PROPERTY = `${OWL}DatatypeProperty`;
+/** owl:AnnotationProperty class IRI. */
+export const OWL_ANNOTATION_PROPERTY = `${OWL}AnnotationProperty`;
+/** owl:FunctionalProperty class IRI. */
+export const OWL_FUNCTIONAL_PROPERTY = `${OWL}FunctionalProperty`;
+/** owl:inverseOf predicate IRI. */
+export const OWL_INVERSE_OF = `${OWL}inverseOf`;
+/** owl:unionOf predicate IRI. */
+export const OWL_UNION_OF = `${OWL}unionOf`;
+/** owl:onDatatype predicate IRI (custom datatype restriction base). */
+export const OWL_ON_DATATYPE = `${OWL}onDatatype`;
+/** owl:withRestrictions predicate IRI (custom datatype facet list). */
+export const OWL_WITH_RESTRICTIONS = `${OWL}withRestrictions`;
+
+/** skos:definition predicate IRI. */
+export const SKOS_DEFINITION = `${SKOS}definition`;
+
+/** sh:NodeShape class IRI. */
+export const SH_NODE_SHAPE = `${SH}NodeShape`;
+/** sh:targetClass predicate IRI. */
+export const SH_TARGET_CLASS = `${SH}targetClass`;
+/** sh:property predicate IRI. */
+export const SH_PROPERTY = `${SH}property`;
+/** sh:path predicate IRI. */
+export const SH_PATH = `${SH}path`;
+/** sh:minCount predicate IRI. */
+export const SH_MIN_COUNT = `${SH}minCount`;
+/** sh:maxCount predicate IRI. */
+export const SH_MAX_COUNT = `${SH}maxCount`;
+/** sh:or predicate IRI. */
+export const SH_OR = `${SH}or`;
+/** sh:in predicate IRI. */
+export const SH_IN = `${SH}in`;
+
+/** xsd:pattern facet IRI (custom datatype restrictions). */
+export const XSD_PATTERN = `${XSD}pattern`;
+
+/**
+ * Namespaces that never produce GraphQL types. Loaded in ke for annotation
+ * resolution only.
+ */
+export const STANDARD_NAMESPACES = [RDF, RDFS, OWL, XSD, SKOS, SH];
+
+/**
+ * XSD datatype IRI → GraphQL scalar name. Datatypes missing from this map
+ * fall back to String (with a custom-datatype diagnostic where applicable).
+ */
+export const XSD_SCALARS: Record<
+  string,
+  "String" | "Boolean" | "Int" | "Float"
+> = {
+  [`${XSD}string`]: "String",
+  [`${XSD}boolean`]: "Boolean",
+  [`${XSD}integer`]: "Int",
+  [`${XSD}int`]: "Int",
+  [`${XSD}long`]: "Int",
+  [`${XSD}float`]: "Float",
+  [`${XSD}double`]: "Float",
+  [`${XSD}decimal`]: "Float",
+  [`${XSD}anyURI`]: "String",
+  [`${XSD}date`]: "String",
+  [`${XSD}dateTime`]: "String",
+};
+
+/** Names the compiler owns; generated type names may not take them (§4.4 rule 6). */
+export const RESERVED_TYPE_NAMES = new Set([
+  "Node",
+  "Query",
+  "PageInfo",
+  "EntityMeta",
+  "ClassProperty",
+  "Ontology",
+  "OntologyClass",
+  "OntologyProperty",
+  "PropertyKind",
+  // built-in scalars — a class named String would otherwise hit an
+  // uncontrolled duplicate-type failure instead of an M004 rename
+  "String",
+  "Boolean",
+  "Int",
+  "Float",
+  "ID",
+]);
+
+/** Field names the compiler owns on Node types (§4.4 rule 7). */
+export const RESERVED_FIELD_NAMES = new Set([
+  "id",
+  "uri",
+  "_meta",
+  "__typename",
+]);
+
+/**
+ * The four Relay connection pagination arguments (first/after/last/before),
+ * shared by every generated connection field and the TBox instances field.
+ */
+export const CONNECTION_ARGS: GraphQLFieldConfigArgumentMap = {
+  first: { type: GraphQLInt },
+  after: { type: GraphQLString },
+  last: { type: GraphQLInt },
+  before: { type: GraphQLString },
+};

--- a/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.ts
@@ -1,0 +1,96 @@
+import type { SPARQL, Store } from "@canonical/ke";
+import {
+  createEntityLoader,
+  createInverseLoader,
+  createListLoader,
+} from "#dataloader";
+import { createBoundedCache, DEFAULT_PROCESS_CACHE_SIZE } from "#hardening";
+import type {
+  ContextFactory,
+  EntityValue,
+  MappedIR,
+  QueryFn,
+  RuntimeWarningHandler,
+  SchemaPluginOptions,
+} from "./types.js";
+
+/**
+ * Create the default runtime-warning handler: logs each distinct
+ * (property, value) coercion failure to the console exactly once.
+ *
+ * @note Impure — the returned handler writes to the console and tracks the
+ * warnings it has already reported.
+ */
+const createDefaultWarningHandler = (): RuntimeWarningHandler => {
+  const seen = new Set<string>();
+  return (warning) => {
+    const key = `${warning.property} ${warning.value}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    console.warn(
+      `[ke-graphql] cannot coerce "${warning.value}" on ${warning.property}: ${warning.reason}`,
+    );
+  };
+};
+
+/**
+ * Create the CompilerContext factory for a compiled MappedIR: each call
+ * produces a context with fresh DataLoaders ("request" mode) or loaders
+ * sharing process-lifetime caches ("process" mode), plus clearCache() to
+ * drop the shared caches.
+ *
+ * @note Impure — the produced contexts execute SPARQL queries against the
+ * store at resolve time, and clearCache() mutates the shared caches.
+ */
+export default function createContextFactory(
+  mapped: MappedIR,
+  options: SchemaPluginOptions,
+): ContextFactory {
+  // Process-lifetime loader caches (item: loaderCache "process"). Scoped to
+  // this CompilerResult: onReload recompiles and produces a new factory, so
+  // cache invalidation on data change is automatic. Bounded LRU (hardening) so
+  // ID enumeration can't grow them without limit.
+  const cacheSize = options.processCacheSize ?? DEFAULT_PROCESS_CACHE_SIZE;
+  const processCaches =
+    options.loaderCache === "process"
+      ? {
+          entity: createBoundedCache<string, Promise<EntityValue | null>>(
+            cacheSize,
+          ),
+          list: createBoundedCache<string, Promise<string[]>>(cacheSize),
+          inverse: createBoundedCache<string, Promise<string[]>>(cacheSize),
+        }
+      : undefined;
+
+  const factory: ContextFactory = Object.assign(
+    (store: Store | Promise<Store>) => {
+      // Lazy-store gate: ABox loaders await the store at query time; TBox
+      // resolvers read the frozen IR and never touch it.
+      const query: QueryFn = async (q) =>
+        (await Promise.resolve(store)).query(q as SPARQL<string>);
+      return {
+        entityLoader: createEntityLoader(query, mapped, processCaches?.entity),
+        listLoader: createListLoader(query, mapped, processCaches?.list),
+        inverseLoader: createInverseLoader(
+          query,
+          mapped,
+          processCaches?.inverse,
+        ),
+        nameMap: mapped.nameMap,
+        namespaces: mapped.namespaces,
+        store,
+        warn: options.onRuntimeWarning ?? createDefaultWarningHandler(),
+      };
+    },
+    {
+      clearCache(): void {
+        processCaches?.entity.clear();
+        processCaches?.list.clear();
+        processCaches?.inverse.clear();
+      },
+    },
+  );
+  return factory;
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/emit.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/emit.ts
@@ -1,0 +1,213 @@
+// =============================================================================
+// Pass 5 — Emit: MappedIR → SchemaPlan
+//
+// Pure. Produces *plans* (field descriptors with resolvers and string type
+// references), not graphql-js objects: graphql-js types are immutable, so
+// Pass 6 augments plans and Pass 7 constructs every GraphQL*Type exactly
+// once, with thunks for circular references.
+// =============================================================================
+
+import type { GraphQLFieldResolver } from "graphql";
+import {
+  createDatatypeListResolver,
+  createDatatypeResolver,
+  createEmbeddedListResolver,
+  createEmbeddedSingularResolver,
+  createInverseResolver,
+  createObjectListResolver,
+  createObjectSingularResolver,
+} from "#resolver";
+import type {
+  CompilerContext,
+  Diagnostic,
+  EntityValue,
+  MappedField,
+  MappedIR,
+  PassResult,
+} from "./types.js";
+
+/** A reference to a (possibly not-yet-constructed) GraphQL type. */
+export interface TypeRef {
+  /** Scalar name, object/interface/union name, or connection base name. */
+  base: string;
+  kind: "scalar" | "named" | "connection";
+  list: boolean;
+  nonNull: boolean;
+}
+
+/** The plan for one GraphQL field: type reference, args, and resolver. */
+export interface FieldPlan {
+  name: string;
+  type: TypeRef;
+  /** Attach the four Relay connection args. */
+  connectionArgs?: boolean;
+  /** Static args spec: name → scalar type name + required flag. */
+  args?: Record<string, { type: "String" | "Int" | "ID"; required: boolean }>;
+  resolve?: GraphQLFieldResolver<EntityValue, CompilerContext>;
+  description?: string;
+}
+
+/** The plan for one GraphQL object type. */
+export interface TypePlan {
+  name: string;
+  owlUri?: string;
+  interfaces: string[];
+  fields: Map<string, FieldPlan>;
+  embeddable: boolean;
+  description?: string;
+}
+
+/** The plan for one GraphQL interface. */
+export interface InterfacePlan {
+  name: string;
+  owlUri?: string;
+  parents: string[];
+  fields: Map<string, FieldPlan>;
+  /** All concrete implementors are embeddable (no Node membership). */
+  embeddableOnly: boolean;
+  description?: string;
+}
+
+/** The plan for one GraphQL union. */
+export interface UnionPlan {
+  name: string;
+  members: string[];
+}
+
+/** Pass 5/6 output: every type, interface, union, and root field as a plan. */
+export interface SchemaPlan {
+  types: Map<string, TypePlan>;
+  interfaces: Map<string, InterfacePlan>;
+  unions: Map<string, UnionPlan>;
+  queryFields: Map<string, FieldPlan>;
+  mapped: MappedIR;
+}
+
+/** Build the TypeRef for a mapped field. */
+const buildTypeRef = (field: MappedField): TypeRef => ({
+  base: field.type.name,
+  kind: field.type.kind === "scalar" ? "scalar" : "named",
+  list: field.list,
+  nonNull: field.nonNull || !field.nullable,
+});
+
+/** Create the resolve function for a mapped field from its template. */
+const createResolver = (
+  field: MappedField,
+): GraphQLFieldResolver<EntityValue, CompilerContext> => {
+  switch (field.resolverTemplate) {
+    case "datatype":
+      return createDatatypeResolver(field);
+    case "datatype-list":
+      return createDatatypeListResolver(field);
+    case "object-singular":
+      return createObjectSingularResolver(field);
+    case "object-list":
+      return createObjectListResolver(field);
+    case "embedded-singular":
+      return createEmbeddedSingularResolver(field, field.type.name);
+    case "embedded-list":
+      return createEmbeddedListResolver(field, field.type.name);
+    case "inverse":
+      return createInverseResolver(field, field.inverseOf ?? field.propertyUri);
+    case "meta":
+      return (parent) => parent;
+  }
+};
+
+/**
+ * Emit the SchemaPlan from the MappedIR (Pass 5): one plan per type,
+ * interface, and union, with resolver instances attached to every field.
+ * Pure — no graphql-js objects are constructed here.
+ */
+export default function emit(mapped: MappedIR): PassResult<SchemaPlan> {
+  const diagnostics: Diagnostic[] = [];
+  const types = new Map<string, TypePlan>();
+  const interfaces = new Map<string, InterfacePlan>();
+  const unions = new Map<string, UnionPlan>();
+
+  const planFields = (
+    fields: ReadonlyMap<string, MappedField>,
+  ): Map<string, FieldPlan> => {
+    const plans = new Map<string, FieldPlan>();
+    for (const field of fields.values()) {
+      const description = mapped.ir.properties.get(
+        field.propertyUri,
+      )?.definition;
+      plans.set(field.graphqlName, {
+        name: field.graphqlName,
+        type: buildTypeRef(field),
+        resolve: createResolver(field),
+        description,
+      });
+    }
+    return plans;
+  };
+
+  for (const mappedInterface of mapped.interfaces.values()) {
+    const node = mapped.ir.classes.get(mappedInterface.owlUri);
+    interfaces.set(mappedInterface.graphqlName, {
+      name: mappedInterface.graphqlName,
+      owlUri: mappedInterface.owlUri,
+      parents: [...mappedInterface.parentInterfaces],
+      fields: planFields(mappedInterface.fields),
+      embeddableOnly: areAllImplementorsEmbeddable(
+        mapped,
+        mappedInterface.owlUri,
+      ),
+      description: node?.definition,
+    });
+  }
+
+  for (const mappedType of mapped.types.values()) {
+    const node = mapped.ir.classes.get(mappedType.owlUri);
+    types.set(mappedType.graphqlName, {
+      name: mappedType.graphqlName,
+      owlUri: mappedType.owlUri,
+      interfaces: [...mappedType.interfaces],
+      fields: planFields(mappedType.fields),
+      embeddable: mappedType.embeddable,
+      description: node?.definition,
+    });
+  }
+
+  for (const union of mapped.unions.values()) {
+    unions.set(union.name, { name: union.name, members: [...union.members] });
+  }
+
+  return {
+    output: { types, interfaces, unions, queryFields: new Map(), mapped },
+    diagnostics,
+  };
+}
+
+/** Are all concrete implementors of an interface embeddable? Cycle-safe walk. */
+const areAllImplementorsEmbeddable = (
+  mapped: MappedIR,
+  interfaceUri: string,
+): boolean => {
+  const node = mapped.ir.classes.get(interfaceUri);
+  if (!node) {
+    return false;
+  }
+  const concrete: boolean[] = [];
+  const visited = new Set<string>();
+  const walk = (uri: string) => {
+    if (visited.has(uri)) {
+      return; // subClassOf cycles (B001) must not overflow the stack
+    }
+    visited.add(uri);
+    const current = mapped.ir.classes.get(uri);
+    if (!current) {
+      return;
+    }
+    if (!current.isAbstract) {
+      concrete.push(current.embeddable);
+    }
+    for (const sub of current.subclasses) {
+      walk(sub);
+    }
+  };
+  walk(interfaceUri);
+  return concrete.length > 0 && concrete.every(Boolean);
+};

--- a/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
@@ -1,0 +1,579 @@
+// =============================================================================
+// Pass 1 — Extract: ke store → RawExtraction
+//
+// The only pass that touches the store. Twelve SPARQL queries: eight TBox
+// queries plus four ABox probes that keep Passes 2–7 pure. Queries use
+// absolute IRIs so they are independent of registered prefixes, and consume
+// ke's term-preserving results (termBindings) so that NamedNodes, literals,
+// and blank nodes are distinguishable.
+// =============================================================================
+
+import type { SelectResult, Term } from "@canonical/ke";
+import {
+  OWL_ANNOTATION_PROPERTY,
+  OWL_CLASS,
+  OWL_DATATYPE_PROPERTY,
+  OWL_FUNCTIONAL_PROPERTY,
+  OWL_INVERSE_OF,
+  OWL_OBJECT_PROPERTY,
+  OWL_ON_DATATYPE,
+  OWL_UNION_OF,
+  OWL_WITH_RESTRICTIONS,
+  RDF_FIRST,
+  RDF_REST,
+  RDF_TYPE,
+  RDFS_COMMENT,
+  RDFS_DOMAIN,
+  RDFS_LABEL,
+  RDFS_RANGE,
+  RDFS_SUBCLASS_OF,
+  SH_IN,
+  SH_MAX_COUNT,
+  SH_MIN_COUNT,
+  SH_OR,
+  SH_PATH,
+  SH_PROPERTY,
+  SH_TARGET_CLASS,
+  SKOS_DEFINITION,
+  XSD_PATTERN,
+} from "./constants.js";
+import getNamespace from "./getNamespace.js";
+import isStandardVocab from "./isStandardVocab.js";
+import type {
+  Diagnostic,
+  InstanceStats,
+  PassResult,
+  QueryFn,
+  RawClass,
+  RawDatatype,
+  RawExtraction,
+  RawProperty,
+  RawPropertyKind,
+  RawShaclConstraint,
+  RawUnion,
+} from "./types.js";
+
+const PHASE = "extract";
+
+/**
+ * Run a SELECT and return its term-preserving rows, or [] plus an E001
+ * diagnostic when the query fails or returns a non-SELECT result.
+ *
+ * @note Impure — executes a SPARQL query against the store through the
+ * provided query function.
+ */
+const select = async (
+  query: QueryFn,
+  sparqlText: string,
+  diagnostics: Diagnostic[],
+  label: string,
+): Promise<SelectResult["termBindings"]> => {
+  try {
+    const result = await query(sparqlText);
+    if (result.type !== "select") {
+      diagnostics.push({
+        severity: "error",
+        code: "E001",
+        message: `${label}: expected SELECT result, got ${result.type}`,
+        phase: PHASE,
+      });
+      return [];
+    }
+    return result.termBindings;
+  } catch (error) {
+    diagnostics.push({
+      severity: "error",
+      code: "E001",
+      message: `${label}: ${error instanceof Error ? error.message : String(error)}`,
+      phase: PHASE,
+    });
+    return [];
+  }
+};
+
+/** Get a term's IRI when it is a NamedNode, undefined otherwise. */
+const getNamedValue = (term: Term | undefined): string | undefined =>
+  term?.termType === "NamedNode" ? term.value : undefined;
+
+/** Get a term's lexical value when it is a Literal, undefined otherwise. */
+const getLiteralValue = (term: Term | undefined): string | undefined =>
+  term?.termType === "Literal" ? term.value : undefined;
+
+/** Get a literal term parsed as a base-10 integer, undefined when not parseable. */
+const getIntValue = (term: Term | undefined): number | undefined => {
+  const value = getLiteralValue(term);
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+/**
+ * Extract the TBox structure and ABox probes from a ke store as a
+ * RawExtraction (Pass 1) — the only pipeline step that queries the store.
+ *
+ * @note Impure — executes the twelve extraction SPARQL queries against the
+ * store through the provided query function.
+ */
+export default async function extract(
+  query: QueryFn,
+  prefixes: Readonly<Record<string, string>>,
+): Promise<PassResult<RawExtraction>> {
+  const diagnostics: Diagnostic[] = [];
+
+  // ── Q1: classes with labels, definitions, superclasses ──
+  // Blank-node superclasses (owl:Restriction) are excluded with isIRI.
+  const classRows = await select(
+    query,
+    `SELECT ?class ?label ?definition ?comment ?superclass WHERE {
+      ?class <${RDF_TYPE}> <${OWL_CLASS}> .
+      FILTER(isIRI(?class))
+      OPTIONAL { ?class <${RDFS_LABEL}> ?label }
+      OPTIONAL { ?class <${SKOS_DEFINITION}> ?definition }
+      OPTIONAL { ?class <${RDFS_COMMENT}> ?comment }
+      OPTIONAL { ?class <${RDFS_SUBCLASS_OF}> ?superclass . FILTER(isIRI(?superclass)) }
+    }`,
+    diagnostics,
+    "Q1 classes",
+  );
+
+  const classMap = new Map<string, RawClass>();
+  for (const row of classRows) {
+    const uri = getNamedValue(row.class);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = classMap.get(uri) ?? { uri, superclasses: [] };
+    entry.label ??= getLiteralValue(row.label);
+    entry.definition ??=
+      getLiteralValue(row.definition) ?? getLiteralValue(row.comment);
+    const superclass = getNamedValue(row.superclass);
+    if (superclass && !entry.superclasses.includes(superclass)) {
+      entry.superclasses.push(superclass);
+    }
+    classMap.set(uri, entry);
+  }
+
+  // ── Q2: properties with kind, domains, ranges ──
+  const propertyRows = await select(
+    query,
+    `SELECT ?prop ?kind ?label ?definition ?comment ?domain ?range WHERE {
+      ?prop <${RDF_TYPE}> ?kind .
+      VALUES ?kind { <${OWL_OBJECT_PROPERTY}> <${OWL_DATATYPE_PROPERTY}> <${OWL_ANNOTATION_PROPERTY}> }
+      OPTIONAL { ?prop <${RDFS_LABEL}> ?label }
+      OPTIONAL { ?prop <${SKOS_DEFINITION}> ?definition }
+      OPTIONAL { ?prop <${RDFS_COMMENT}> ?comment }
+      OPTIONAL { ?prop <${RDFS_DOMAIN}> ?domain }
+      OPTIONAL { ?prop <${RDFS_RANGE}> ?range . FILTER(isIRI(?range)) }
+    }`,
+    diagnostics,
+    "Q2 properties",
+  );
+
+  const resolveKind = (kindUri: string | undefined): RawPropertyKind => {
+    if (kindUri === OWL_DATATYPE_PROPERTY) {
+      return "datatype";
+    }
+    if (kindUri === OWL_ANNOTATION_PROPERTY) {
+      return "annotation";
+    }
+    return "object";
+  };
+
+  const propertyMap = new Map<string, RawProperty>();
+  for (const row of propertyRows) {
+    const uri = getNamedValue(row.prop);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = propertyMap.get(uri) ?? {
+      uri,
+      kind: resolveKind(getNamedValue(row.kind)),
+      domains: [],
+      ranges: [],
+    };
+    entry.label ??= getLiteralValue(row.label);
+    entry.definition ??=
+      getLiteralValue(row.definition) ?? getLiteralValue(row.comment);
+    const domain = getNamedValue(row.domain);
+    if (domain && !entry.domains.includes(domain)) {
+      entry.domains.push(domain);
+    }
+    const range = getNamedValue(row.range);
+    if (range && !entry.ranges.includes(range)) {
+      entry.ranges.push(range);
+    }
+    propertyMap.set(uri, entry);
+  }
+
+  // ── Q3: inverse declarations ──
+  const inverseRows = await select(
+    query,
+    `SELECT ?prop ?inverse WHERE { ?prop <${OWL_INVERSE_OF}> ?inverse }`,
+    diagnostics,
+    "Q3 inverses",
+  );
+  const inverses = inverseRows.flatMap((row) => {
+    const property = getNamedValue(row.prop);
+    const inverse = getNamedValue(row.inverse);
+    return property && inverse ? [{ property, inverse }] : [];
+  });
+
+  // ── Q4: functional property markers ──
+  const functionalRows = await select(
+    query,
+    `SELECT ?prop WHERE { ?prop <${RDF_TYPE}> <${OWL_FUNCTIONAL_PROPERTY}> }`,
+    diagnostics,
+    "Q4 functionals",
+  );
+  const functionals = new Set(
+    functionalRows.flatMap((row) => getNamedValue(row.prop) ?? []),
+  );
+
+  // ── Q5: custom datatypes ──
+  // Keyed on the structural marker owl:onDatatype rather than the rdf:type:
+  // the published cs: ontology types its datatype `a owl:Datatype` (a
+  // non-standard term) while ds: uses `a rdfs:Datatype` — the restriction
+  // structure is what actually identifies a custom datatype. The
+  // owl:withRestrictions RDF list is walked with rdf:rest*/rdf:first so a
+  // pattern facet is found at any list position.
+  const datatypeRows = await select(
+    query,
+    `SELECT ?dt ?base ?pattern WHERE {
+      ?dt <${OWL_ON_DATATYPE}> ?base .
+      FILTER(isIRI(?dt))
+      OPTIONAL {
+        ?dt <${OWL_WITH_RESTRICTIONS}> ?list .
+        ?list <${RDF_REST}>*/<${RDF_FIRST}> ?restriction .
+        ?restriction <${XSD_PATTERN}> ?pattern .
+      }
+    }`,
+    diagnostics,
+    "Q5 datatypes",
+  );
+  const datatypeMap = new Map<string, RawDatatype>();
+  for (const row of datatypeRows) {
+    const uri = getNamedValue(row.dt);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = datatypeMap.get(uri) ?? { uri };
+    entry.baseType ??= getNamedValue(row.base);
+    entry.pattern ??= getLiteralValue(row.pattern);
+    datatypeMap.set(uri, entry);
+  }
+
+  // ── Q6: namespace discovery (in code, from Q1+Q2, cross-referenced with
+  //        the store's registered prefixes) ──
+  const namespaces = new Map<string, string>();
+  const uriToPrefix = new Map<string, string>();
+  for (const [prefix, ns] of Object.entries(prefixes)) {
+    uriToPrefix.set(ns, prefix);
+  }
+  const discovered = new Set<string>();
+  for (const uri of [...classMap.keys(), ...propertyMap.keys()]) {
+    discovered.add(getNamespace(uri));
+  }
+  let anonymous = 0;
+  for (const ns of discovered) {
+    let prefix = uriToPrefix.get(ns);
+    if (!prefix) {
+      prefix = `ns${anonymous++ || ""}`;
+      diagnostics.push({
+        severity: "warning",
+        code: "E001",
+        message: `namespace ${ns} has no registered prefix — assigned synthetic "${prefix}". Register it in StoreConfig.prefixes: it drives global IDs (KG.10)`,
+        source: ns,
+        phase: PHASE,
+      });
+    }
+    namespaces.set(ns, prefix);
+  }
+
+  // ── Q7a: direct SHACL cardinality constraints ──
+  const shaclConstraints: RawShaclConstraint[] = [];
+  const directShaclRows = await select(
+    query,
+    `SELECT ?targetClass ?path ?minCount ?maxCount ?inList WHERE {
+      ?shape <${SH_TARGET_CLASS}> ?targetClass ;
+             <${SH_PROPERTY}> ?propShape .
+      ?propShape <${SH_PATH}> ?path .
+      OPTIONAL { ?propShape <${SH_MIN_COUNT}> ?minCount }
+      OPTIONAL { ?propShape <${SH_MAX_COUNT}> ?maxCount }
+      OPTIONAL { ?propShape <${SH_IN}> ?inList }
+    }`,
+    diagnostics,
+    "Q7a shacl direct",
+  );
+
+  // sh:in values are an RDF list; resolve them per constraint.
+  const shIn = new Map<string, string[]>();
+  const inListRows = await select(
+    query,
+    `SELECT ?path ?value WHERE {
+      ?propShape <${SH_PATH}> ?path ;
+                 <${SH_IN}> ?list .
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?value .
+    }`,
+    diagnostics,
+    "Q7a sh:in values",
+  );
+  for (const row of inListRows) {
+    const path = getNamedValue(row.path);
+    const value = getLiteralValue(row.value) ?? getNamedValue(row.value);
+    if (!path || value === undefined) {
+      continue;
+    }
+    const values = shIn.get(path) ?? [];
+    values.push(value);
+    shIn.set(path, values);
+  }
+
+  for (const row of directShaclRows) {
+    const targetClass = getNamedValue(row.targetClass);
+    const path = getNamedValue(row.path);
+    if (!targetClass || !path) {
+      continue;
+    }
+    shaclConstraints.push({
+      targetClass,
+      property: path,
+      minCount: getIntValue(row.minCount),
+      maxCount: getIntValue(row.maxCount),
+      inValues: row.inList ? shIn.get(path) : undefined,
+    });
+  }
+
+  // ── Q7b: SHACL sh:or branches ──
+  // sh:or points at an RDF list of branch blank nodes; each branch carries
+  // its own sh:property shapes. The direct pattern in Q7a cannot see them.
+  const orShaclRows = await select(
+    query,
+    `SELECT ?targetClass ?path ?minCount ?maxCount WHERE {
+      ?shape <${SH_TARGET_CLASS}> ?targetClass ;
+             <${SH_OR}> ?orList .
+      ?orList <${RDF_REST}>*/<${RDF_FIRST}> ?branch .
+      ?branch <${SH_PROPERTY}> ?propShape .
+      ?propShape <${SH_PATH}> ?path .
+      OPTIONAL { ?propShape <${SH_MIN_COUNT}> ?minCount }
+      OPTIONAL { ?propShape <${SH_MAX_COUNT}> ?maxCount }
+    }`,
+    diagnostics,
+    "Q7b shacl sh:or",
+  );
+  for (const row of orShaclRows) {
+    const targetClass = getNamedValue(row.targetClass);
+    const path = getNamedValue(row.path);
+    if (!targetClass || !path) {
+      continue;
+    }
+    shaclConstraints.push({
+      targetClass,
+      property: path,
+      minCount: getIntValue(row.minCount),
+      maxCount: getIntValue(row.maxCount),
+      fromOr: true,
+    });
+  }
+
+  // ── Q8: union declarations (named classes and anonymous ranges) ──
+  const unions: RawUnion[] = [];
+  const namedUnionRows = await select(
+    query,
+    `SELECT ?class ?member WHERE {
+      ?class <${RDF_TYPE}> <${OWL_CLASS}> ;
+             <${OWL_UNION_OF}> ?list .
+      FILTER(isIRI(?class))
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?member .
+    }`,
+    diagnostics,
+    "Q8 named unions",
+  );
+  const namedUnions = new Map<string, string[]>();
+  for (const row of namedUnionRows) {
+    const uri = getNamedValue(row.class);
+    const member = getNamedValue(row.member);
+    if (!uri || !member) {
+      continue;
+    }
+    const members = namedUnions.get(uri) ?? [];
+    members.push(member);
+    namedUnions.set(uri, members);
+  }
+  for (const [uri, members] of namedUnions) {
+    unions.push({ uri, members });
+  }
+
+  const anonUnionRows = await select(
+    query,
+    `SELECT ?property ?member WHERE {
+      ?property <${RDFS_RANGE}> ?range .
+      FILTER(isBlank(?range))
+      ?range <${OWL_UNION_OF}> ?list .
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?member .
+    }`,
+    diagnostics,
+    "Q8 anonymous unions",
+  );
+  const anonUnions = new Map<string, string[]>();
+  for (const row of anonUnionRows) {
+    const property = getNamedValue(row.property);
+    const member = getNamedValue(row.member);
+    if (!property || !member) {
+      continue;
+    }
+    const members = anonUnions.get(property) ?? [];
+    members.push(member);
+    anonUnions.set(property, members);
+  }
+  for (const [property, members] of anonUnions) {
+    unions.push({ property, members });
+  }
+
+  // ── Q9: instance stats per class (abstract + embeddable detection) ──
+  const statsRows = await select(
+    query,
+    `SELECT ?class (COUNT(?i) AS ?total) (SUM(IF(isBlank(?i), 0, 1)) AS ?named) WHERE {
+      ?i <${RDF_TYPE}> ?class .
+    } GROUP BY ?class`,
+    diagnostics,
+    "Q9 instance stats",
+  );
+  const instanceStats = new Map<string, InstanceStats>();
+  for (const row of statsRows) {
+    const uri = getNamedValue(row.class);
+    const total = getIntValue(row.total);
+    if (!uri || total === undefined) {
+      continue;
+    }
+    instanceStats.set(uri, { total, named: getIntValue(row.named) ?? 0 });
+  }
+
+  // ── Q10: self-referential assertions (V004) ──
+  const selfRows = await select(
+    query,
+    `SELECT DISTINCT ?p WHERE { ?s ?p ?s }`,
+    diagnostics,
+    "Q10 self-referential",
+  );
+  const selfReferential = new Set(
+    selfRows.flatMap((row) => getNamedValue(row.p) ?? []),
+  );
+
+  // ── Q11: functional property violations (V005) ──
+  const functionalViolations = new Set<string>();
+  if (functionals.size > 0) {
+    const values = [...functionals].map((uri) => `<${uri}>`).join(" ");
+    const violationRows = await select(
+      query,
+      `SELECT DISTINCT ?p WHERE {
+        VALUES ?p { ${values} }
+        ?s ?p ?o1 , ?o2 .
+        FILTER(?o1 != ?o2)
+      }`,
+      diagnostics,
+      "Q11 functional violations",
+    );
+    for (const row of violationRows) {
+      const uri = getNamedValue(row.p);
+      if (uri) {
+        functionalViolations.add(uri);
+      }
+    }
+  }
+
+  // ── Q12: undeclared ABox predicates (V014) ──
+  const predicateRows = await select(
+    query,
+    `SELECT DISTINCT ?p WHERE { ?s ?p ?o }`,
+    diagnostics,
+    "Q12 predicates",
+  );
+  const undeclaredPredicates = new Set<string>();
+  for (const row of predicateRows) {
+    const uri = getNamedValue(row.p);
+    if (!uri || isStandardVocab(uri) || propertyMap.has(uri)) {
+      continue;
+    }
+    // Predicates inside a declared namespace but missing from the TBox.
+    if (namespaces.has(getNamespace(uri))) {
+      undeclaredPredicates.add(uri);
+    }
+  }
+
+  // ── Annotation assertions (acceptanceCriteria/completionGuidance — EC.07).
+  //    Extracted so the TBox schema is fully store-free at request time. ──
+  const annotations = new Map<string, Map<string, string>>();
+  const annotationProps = [...propertyMap.values()]
+    .filter((prop) => prop.kind === "annotation")
+    .map((prop) => prop.uri);
+  if (annotationProps.length > 0) {
+    const values = annotationProps.map((uri) => `<${uri}>`).join(" ");
+    const rows = await select(
+      query,
+      `SELECT ?target ?prop ?value WHERE {
+        VALUES ?prop { ${values} }
+        ?target ?prop ?value .
+      }`,
+      diagnostics,
+      "annotation assertions",
+    );
+    for (const row of rows) {
+      const target = getNamedValue(row.target);
+      const prop = getNamedValue(row.prop);
+      const value = getLiteralValue(row.value);
+      if (!target || !prop || value === undefined) {
+        continue;
+      }
+      const forTarget = annotations.get(target) ?? new Map<string, string>();
+      forTarget.set(prop, value);
+      annotations.set(target, forTarget);
+    }
+  }
+
+  // ── Depth guard: blank nodes whose objects are themselves blank (§5.3) ──
+  let deepBlankNesting = false;
+  try {
+    const deep = await query(
+      `ASK { ?a ?p ?b . ?b ?q ?c . FILTER(isBlank(?b) && isBlank(?c)) }`,
+    );
+    deepBlankNesting = deep.type === "ask" && deep.result;
+    if (deepBlankNesting) {
+      diagnostics.push({
+        severity: "warning",
+        code: "E001",
+        message:
+          "blank nodes nest deeper than 1 level in the store — the entity loader's single-hop closure (§5.3) will truncate them; extend the closure depth",
+        phase: PHASE,
+      });
+    }
+  } catch (error) {
+    diagnostics.push({
+      severity: "error",
+      code: "E001",
+      message: `depth guard: ${error instanceof Error ? error.message : String(error)}`,
+      phase: PHASE,
+    });
+  }
+
+  return {
+    output: {
+      classes: [...classMap.values()],
+      properties: [...propertyMap.values()],
+      inverses,
+      functionals,
+      datatypes: [...datatypeMap.values()],
+      namespaces,
+      shaclConstraints,
+      unions,
+      instanceStats,
+      selfReferential,
+      functionalViolations,
+      undeclaredPredicates,
+      annotations,
+      deepBlankNesting,
+    },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/getLocalName.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/getLocalName.ts
@@ -1,0 +1,6 @@
+/** Extract the local name of a URI (the part after the last '#' or '/'). */
+export default function getLocalName(uri: string): string {
+  const hash = uri.lastIndexOf("#");
+  const slash = uri.lastIndexOf("/");
+  return uri.slice(Math.max(hash, slash) + 1);
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/getNamespace.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/getNamespace.ts
@@ -1,0 +1,6 @@
+/** Extract the namespace part of a URI (up to and including the last '#' or '/'). */
+export default function getNamespace(uri: string): string {
+  const hash = uri.lastIndexOf("#");
+  const slash = uri.lastIndexOf("/");
+  return uri.slice(0, Math.max(hash, slash) + 1);
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/hardening.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/hardening.test.ts
@@ -1,0 +1,85 @@
+// =============================================================================
+// Hardening behaviors that need a compiled schema end-to-end: the forced-
+// abstract-with-instances guard (correctness C1 + V015) and the SPARQL
+// injection guard reaching through node(id:) to a null result.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { graphql } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import compile from "./compile.js";
+import storeQueryFn from "./storeQueryFn.js";
+
+const PREFIXES = { ex: "http://example.org/" };
+
+// A class with a subclass AND a named instance of the parent itself — the only
+// shape that can trip the forced-abstract crash.
+const HIERARCHY_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Animal a owl:Class ; rdfs:label "Animal" .
+ex:Dog a owl:Class ; rdfs:subClassOf ex:Animal ; rdfs:label "Dog" .
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Animal ; rdfs:range xsd:string .
+
+ex:a1 a ex:Animal ; ex:name "Generic" .
+ex:d1 a ex:Dog ; ex:name "Rex" .
+`;
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const compileHierarchy = async () => {
+  const { store, cleanup } = await createTestStore({
+    ttl: HIERARCHY_TTL,
+    prefixes: PREFIXES,
+  });
+  cleanups.push(cleanup);
+  const result = await compile(storeQueryFn(store), PREFIXES, {
+    mappings: { "http://example.org/Animal": { abstract: true } },
+  });
+  return { result, store };
+};
+
+describe("forced abstract with direct instances (C1 + V015)", () => {
+  it("warns (V015) when the data contradicts an abstract mapping", async () => {
+    const { result } = await compileHierarchy();
+    expect(result.diagnostics.some((d) => d.code === "V015")).toBe(true);
+  });
+
+  it("filters the abstract-only instance instead of crashing resolveType", async () => {
+    const { result, store } = await compileHierarchy();
+    const context = result.createContext(store);
+    const execution = await graphql({
+      schema: result.schema,
+      source: `{ node(id: "ex:a1") { __typename } }`,
+      contextValue: context,
+    });
+    // No "Abstract type ... resolved to a non-object type" error.
+    expect(execution.errors).toBeUndefined();
+    expect(execution.data?.node).toBeNull();
+  });
+
+  it("still resolves a concrete subclass instance to its concrete type", async () => {
+    const { result, store } = await compileHierarchy();
+    const context = result.createContext(store);
+    const execution = await graphql({
+      schema: result.schema,
+      source: `{ node(id: "ex:d1") { __typename } }`,
+      contextValue: context,
+    });
+    expect(execution.errors).toBeUndefined();
+    expect((execution.data?.node as { __typename: string }).__typename).toBe(
+      "Dog",
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/index.ts
@@ -1,0 +1,15 @@
+/**
+ * The OWL → GraphQL compiler domain: the seven-pass pipeline (compile), the
+ * per-request context factory, the shared vocabulary constants, and every IR
+ * type contract.
+ *
+ * @module compiler
+ */
+
+export { default as CompilationError } from "./CompilationError.js";
+export { default as compile } from "./compile.js";
+export * from "./constants.js";
+export { default as createContextFactory } from "./createContextFactory.js";
+export { default as getLocalName } from "./getLocalName.js";
+export { default as storeQueryFn } from "./storeQueryFn.js";
+export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/compiler/isStandardVocab.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/isStandardVocab.ts
@@ -1,0 +1,9 @@
+import { STANDARD_NAMESPACES } from "./constants.js";
+
+/**
+ * Check whether a URI belongs to a standard vocabulary namespace
+ * (rdf/rdfs/owl/xsd/skos/sh) — such URIs never produce GraphQL types.
+ */
+export default function isStandardVocab(uri: string): boolean {
+  return STANDARD_NAMESPACES.some((ns) => uri.startsWith(ns));
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/map.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/map.ts
@@ -1,0 +1,501 @@
+// =============================================================================
+// Pass 4 — Map: OntologyIR → MappedIR
+//
+// Pure. OWL names → GraphQL names (custom overrides, has/is stripping, case
+// convention, pluralization, collision resolution), range → field type specs,
+// resolver template assignment, embeddable/interface interaction, synthetic
+// inverse fields, standard-vocab fields, non-null overrides.
+// =============================================================================
+
+import BidirectionalNameMap from "./BidirectionalNameMap.js";
+import { RESERVED_FIELD_NAMES, RESERVED_TYPE_NAMES } from "./constants.js";
+import getLocalName from "./getLocalName.js";
+import {
+  camelize,
+  pluralize,
+  sanitizeGraphQLName,
+  stripVerbPrefix,
+} from "./nameMap.js";
+import type {
+  ClassNode,
+  CustomMapping,
+  Diagnostic,
+  FieldTypeSpec,
+  MappedField,
+  MappedInterface,
+  MappedIR,
+  MappedType,
+  MappedUnion,
+  OntologyIR,
+  PassResult,
+  PropertyNode,
+  ResolverTemplate,
+  SchemaPluginOptions,
+} from "./types.js";
+
+const PHASE = "map";
+
+interface MapperState {
+  ir: OntologyIR;
+  options: SchemaPluginOptions;
+  diagnostics: Diagnostic[];
+  nameMap: BidirectionalNameMap;
+  typeNames: Map<string, string>; // class URI → resolved GraphQL type name
+}
+
+/** Find the custom mapping for a URI (full-IRI key first, prefixed key second). */
+const findMapping = (
+  state: MapperState,
+  uri: string,
+): CustomMapping | undefined => {
+  const direct = state.options.mappings?.[uri];
+  if (direct) {
+    return direct;
+  }
+  const ns =
+    state.ir.classes.get(uri)?.namespace ??
+    state.ir.properties.get(uri)?.namespace;
+  return ns
+    ? state.options.mappings?.[`${ns}:${getLocalName(uri)}`]
+    : undefined;
+};
+
+/** Resolve every class URI to its GraphQL type name with collision handling. */
+const resolveTypeNames = (state: MapperState): void => {
+  const taken = new Set<string>(RESERVED_TYPE_NAMES);
+  for (const node of state.ir.classes.values()) {
+    const custom = findMapping(state, node.uri)?.graphqlName;
+    let name = custom ?? getLocalName(node.uri);
+    const sanitized = sanitizeGraphQLName(name);
+    if (sanitized !== name) {
+      state.diagnostics.push({
+        severity: "warning",
+        code: "M002",
+        message: `class local name "${name}" is not a legal GraphQL name - sanitized to ${sanitized}`,
+        source: node.uri,
+        phase: PHASE,
+      });
+      name = sanitized;
+    }
+    if (taken.has(name) && !custom) {
+      // Rule 6a: prefix with PascalCase namespace prefix (M004 info).
+      const prefixed =
+        node.namespace.charAt(0).toUpperCase() + node.namespace.slice(1) + name;
+      state.diagnostics.push({
+        severity: "info",
+        code: "M004",
+        message: `type name ${name} collides with a reserved name — renamed to ${prefixed}`,
+        source: node.uri,
+        phase: PHASE,
+      });
+      name = prefixed;
+    }
+    if (taken.has(name)) {
+      state.diagnostics.push({
+        severity: "error",
+        code: "M001",
+        message: `type name ${name} (${node.uri}) collides and cannot be auto-resolved — add a custom mapping`,
+        source: node.uri,
+        phase: PHASE,
+      });
+    }
+    taken.add(name);
+    state.typeNames.set(node.uri, name);
+    state.nameMap.set(node.uri, name);
+  }
+};
+
+/** Compute the GraphQL field name for a property (§4.4 rules 1–5). */
+const computeFieldName = (
+  state: MapperState,
+  property: PropertyNode,
+  isList: boolean,
+): string => {
+  const custom = findMapping(state, property.uri)?.graphqlName;
+  if (custom) {
+    return custom;
+  }
+  let name = stripVerbPrefix(getLocalName(property.uri));
+  if (isList) {
+    name = pluralize(name);
+  }
+  return sanitizeGraphQLName(name);
+};
+
+/** Compute the GraphQL field type spec for a property's resolved range. */
+const computeFieldType = (
+  state: MapperState,
+  property: PropertyNode,
+): FieldTypeSpec => {
+  switch (property.range.kind) {
+    case "scalar":
+      return { kind: "scalar", name: property.range.graphqlScalar };
+    case "class": {
+      const name = state.typeNames.get(property.range.uri);
+      return name ? { kind: "type", name } : { kind: "scalar", name: "String" };
+    }
+    case "union": {
+      const name =
+        property.range.name ??
+        `${getLocalName(property.uri).charAt(0).toUpperCase()}${getLocalName(property.uri).slice(1)}Union`;
+      // Abstract members expand to concrete descendants (KG.16).
+      const members: string[] = [];
+      for (const member of property.range.members) {
+        const node = state.ir.classes.get(member);
+        if (!node) {
+          continue;
+        }
+        if (node.isAbstract) {
+          for (const sub of collectConcreteDescendants(state.ir, node)) {
+            const subName = state.typeNames.get(sub);
+            if (subName && !members.includes(subName)) {
+              members.push(subName);
+            }
+          }
+        } else {
+          const memberName = state.typeNames.get(member);
+          if (memberName && !members.includes(memberName)) {
+            members.push(memberName);
+          }
+        }
+      }
+      return { kind: "union", name, members };
+    }
+    case "unknown":
+      return { kind: "scalar", name: "String" };
+  }
+};
+
+/** Collect the URIs of a class's concrete (non-abstract) descendants, cycle-safe. */
+const collectConcreteDescendants = (
+  ir: OntologyIR,
+  node: ClassNode,
+): string[] => {
+  const result: string[] = [];
+  const visited = new Set<string>();
+  const walk = (uri: string) => {
+    if (visited.has(uri)) {
+      return; // subClassOf cycles (B001) must not overflow the stack
+    }
+    visited.add(uri);
+    const current = ir.classes.get(uri);
+    if (!current) {
+      return;
+    }
+    if (!current.isAbstract) {
+      result.push(uri);
+    }
+    for (const sub of current.subclasses) {
+      walk(sub);
+    }
+  };
+  walk(node.uri);
+  return result;
+};
+
+/** Is the property's range an embeddable class? */
+const isEmbeddedRange = (state: MapperState, property: PropertyNode): boolean =>
+  property.range.kind === "class" &&
+  (state.ir.classes.get(property.range.uri)?.embeddable ?? false);
+
+/** Cardinality of a property on a specific class (per-class SHACL first). */
+const isSingularOn = (
+  property: PropertyNode,
+  classUri: string,
+  ancestors: readonly string[],
+): { singular: boolean; required: boolean; omit: boolean } => {
+  for (const uri of [classUri, ...ancestors]) {
+    const spec = property.classCardinality.get(uri);
+    if (spec) {
+      return spec;
+    }
+  }
+  return { singular: property.functional, required: false, omit: false };
+};
+
+/** Choose the resolver template for a field from its kind, cardinality, and type. */
+const chooseTemplate = (
+  property: PropertyNode,
+  singular: boolean,
+  embedded: boolean,
+  fieldType: FieldTypeSpec,
+): ResolverTemplate => {
+  // Decide from the RESOLVED type: an object property whose range fell back
+  // to String (unknown range, B003) must resolve its URI values as strings,
+  // not hand Connection shapes to a String field.
+  if (property.kind !== "object" || fieldType.kind === "scalar") {
+    return singular ? "datatype" : "datatype-list";
+  }
+  if (embedded) {
+    return singular ? "embedded-singular" : "embedded-list";
+  }
+  return singular ? "object-singular" : "object-list";
+};
+
+/** Build the MappedFields for one class (own + inherited). */
+const buildFields = (
+  state: MapperState,
+  node: ClassNode,
+  typeName: string,
+): Map<string, MappedField> => {
+  const fields = new Map<string, MappedField>();
+  const used = new Set<string>(node.embeddable ? [] : RESERVED_FIELD_NAMES);
+
+  const addField = (field: MappedField) => {
+    if (used.has(field.graphqlName)) {
+      // Rule 7: reserved/colliding field — namespace-prefix it.
+      const renamed = `${state.ir.properties.get(field.owlUri)?.namespace ?? "x"}${
+        field.graphqlName.charAt(0).toUpperCase() + field.graphqlName.slice(1)
+      }`;
+      state.diagnostics.push({
+        severity: "warning",
+        code: "M002",
+        message: `field ${typeName}.${field.graphqlName} collides with a reserved name — renamed to ${renamed}`,
+        source: field.owlUri,
+        phase: PHASE,
+      });
+      field = { ...field, graphqlName: renamed };
+    }
+    if (fields.has(field.graphqlName)) {
+      state.diagnostics.push({
+        severity: "error",
+        code: "M001",
+        message: `two properties map to ${typeName}.${field.graphqlName}`,
+        source: field.owlUri,
+        phase: PHASE,
+      });
+      return;
+    }
+    used.add(field.graphqlName);
+    fields.set(field.graphqlName, field);
+    state.nameMap.set(field.owlUri, field.graphqlName);
+  };
+
+  // Declared + inherited properties.
+  for (const propertyUri of node.allProperties) {
+    const property = state.ir.properties.get(propertyUri);
+    if (!property || property.isAnnotation) {
+      continue;
+    }
+    const { singular, omit } = isSingularOn(property, node.uri, node.ancestors);
+    if (omit) {
+      continue; // SHACL sh:maxCount 0 (V010)
+    }
+    const required = isSingularOn(property, node.uri, node.ancestors).required;
+    const embedded = isEmbeddedRange(state, property);
+    const list = !singular;
+    const name = computeFieldName(state, property, list);
+    const nonNull =
+      state.options.nonNullOverrides?.[typeName]?.includes(name) ?? false;
+    // Declared owl:inverseOf pair: the ABox may assert either direction, so
+    // each side resolves the union of forward + reverse assertions (EC.05).
+    // List sides switch to the inverse template; singular sides keep their
+    // template but carry inverseOf for the reverse fallback.
+    const fieldType = computeFieldType(state, property);
+    const declaredInverse =
+      property.kind === "object" && fieldType.kind === "type" && !embedded
+        ? property.inverse
+        : undefined;
+    addField({
+      owlUri: property.uri,
+      graphqlName: name,
+      type: fieldType,
+      nullable: !nonNull,
+      list,
+      resolverTemplate:
+        declaredInverse && list
+          ? "inverse"
+          : chooseTemplate(property, singular, embedded, fieldType),
+      propertyUri: property.uri,
+      inverseOf: declaredInverse,
+      shaclRequired: required,
+      nonNull,
+    });
+  }
+
+  // Synthetic + declared inverse fields (Template 4).
+  for (const property of state.ir.properties.values()) {
+    if (property.kind !== "object" || property.range.kind !== "class") {
+      continue;
+    }
+    const rangeUri = property.range.uri;
+    const appliesHere =
+      rangeUri === node.uri || node.ancestors.includes(rangeUri);
+    if (!appliesHere) {
+      continue;
+    }
+    const synthetic = findMapping(state, property.uri)?.inverse;
+    const declared = property.inverse
+      ? state.ir.properties.get(property.inverse)
+      : undefined;
+    // Declared pairs: each side keeps its own forward field (EC.05) — the
+    // dual-direction union happens in the resolver, not via an extra field.
+    if (declared || !synthetic) {
+      continue;
+    }
+    const name = synthetic.graphqlName;
+    addField({
+      owlUri: `${property.uri}#inverse`,
+      graphqlName: name,
+      type: {
+        kind: "type",
+        name: state.typeNames.get(property.domains[0] ?? "") ?? "Node",
+      },
+      nullable: false,
+      list: true,
+      resolverTemplate: "inverse",
+      propertyUri: property.uri,
+      inverseOf: property.uri,
+      shaclRequired: false,
+      nonNull: true,
+    });
+  }
+
+  // Opt-in instance-level standard-vocab fields (EC.15).
+  const vocabFields = state.options.standardVocabFields?.[typeName];
+  if (vocabFields) {
+    for (const [predicate, name] of Object.entries(vocabFields)) {
+      addField({
+        owlUri: predicate,
+        graphqlName: name,
+        type: { kind: "scalar", name: "String" },
+        nullable: true,
+        list: false,
+        resolverTemplate: "datatype",
+        propertyUri: predicate,
+        shaclRequired: false,
+        nonNull: false,
+      });
+    }
+  }
+
+  return fields;
+};
+
+/**
+ * An interface qualifies for embeddable implementors only when every
+ * concrete descendant is embeddable (no uri/_meta on the interface then).
+ */
+const isInterfaceEmbeddable = (ir: OntologyIR, node: ClassNode): boolean =>
+  collectConcreteDescendants(ir, node).every(
+    (uri) => ir.classes.get(uri)?.embeddable ?? false,
+  );
+
+/**
+ * Map the OntologyIR to the GraphQL-shaped MappedIR (Pass 4): resolved type
+ * and field names, field type specs, resolver template assignments, and the
+ * bidirectional name map. Pure.
+ */
+export default function map(
+  ir: OntologyIR,
+  options: SchemaPluginOptions = {},
+): PassResult<MappedIR> {
+  const diagnostics: Diagnostic[] = [];
+  const state: MapperState = {
+    ir,
+    options,
+    diagnostics,
+    nameMap: new BidirectionalNameMap(),
+    typeNames: new Map(),
+  };
+
+  // Report custom mappings that reference nothing (M003).
+  for (const key of Object.keys(options.mappings ?? {})) {
+    const full = ir.classes.has(key) || ir.properties.has(key);
+    const prefixed = [...ir.classes.values(), ...ir.properties.values()].some(
+      (n) => `${n.namespace}:${getLocalName(n.uri)}` === key,
+    );
+    if (!full && !prefixed) {
+      diagnostics.push({
+        severity: "warning",
+        code: "M003",
+        message: `custom mapping ${key} references no known class or property`,
+        source: key,
+        phase: PHASE,
+      });
+    }
+  }
+
+  resolveTypeNames(state);
+
+  const types = new Map<string, MappedType>();
+  const interfaces = new Map<string, MappedInterface>();
+  const unions = new Map<string, MappedUnion>();
+
+  for (const node of ir.classes.values()) {
+    const typeName = state.typeNames.get(node.uri);
+    if (!typeName) {
+      continue;
+    }
+    const fields = buildFields(state, node, typeName);
+    // Field-name reverse lookups are scoped per type and served from
+    // MappedType.fields (EntityMeta.field resolves through it) — the
+    // global NameMap carries type names plus a best-effort property entry.
+
+    if (node.isAbstract) {
+      const parentInterfaces = node.ancestors
+        .map((a) => state.typeNames.get(a))
+        .filter((n): n is string => n !== undefined)
+        .filter(
+          (n) => ir.classes.get(state.nameMap.toOWL(n) ?? "")?.isAbstract,
+        );
+      interfaces.set(typeName, {
+        owlUri: node.uri,
+        graphqlName: typeName,
+        parentInterfaces,
+        fields,
+      });
+      continue;
+    }
+
+    // Embeddable types implement an ancestor interface only when that
+    // interface itself is embeddable-safe (all implementors embeddable).
+    const implemented = node.ancestors
+      .map((a) => ir.classes.get(a))
+      .filter((a): a is ClassNode => Boolean(a?.isAbstract))
+      .filter((a) => !node.embeddable || isInterfaceEmbeddable(ir, a))
+      .map((a) => state.typeNames.get(a.uri))
+      .filter((n): n is string => n !== undefined);
+
+    types.set(typeName, {
+      owlUri: node.uri,
+      graphqlName: typeName,
+      interfaces: implemented,
+      fields,
+      embeddable: node.embeddable,
+      namespace: node.namespace,
+      singularName: camelize(typeName),
+      pluralName: pluralize(camelize(typeName)),
+    });
+  }
+
+  // Collect union specs from field types.
+  for (const container of [...types.values(), ...interfaces.values()]) {
+    for (const field of container.fields.values()) {
+      if (field.type.kind === "union" && !unions.has(field.type.name)) {
+        unions.set(field.type.name, {
+          name: field.type.name,
+          members: field.type.members,
+        });
+        diagnostics.push({
+          severity: "info",
+          code: field.type.name.endsWith("Union") ? "X003" : "X002",
+          message: `union ${field.type.name} = ${field.type.members.join(" | ")}`,
+          phase: PHASE,
+        });
+      }
+    }
+  }
+
+  return {
+    output: {
+      types,
+      interfaces,
+      unions,
+      nameMap: state.nameMap,
+      namespaces: ir.namespaces,
+      ir,
+    },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/nameMap.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/nameMap.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import BidirectionalNameMap from "./BidirectionalNameMap.js";
+import {
+  camelize,
+  pluralize,
+  sanitizeGraphQLName,
+  stripVerbPrefix,
+} from "./nameMap.js";
+
+describe("pluralize (§4.4 rule 5)", () => {
+  it("applies the suffix rules", () => {
+    expect(pluralize("edge")).toBe("edges");
+    expect(pluralize("style")).toBe("styles");
+    expect(pluralize("category")).toBe("categories");
+    expect(pluralize("implementationLibrary")).toBe("implementationLibraries");
+    expect(pluralize("switch")).toBe("switches");
+    expect(pluralize("box")).toBe("boxes");
+  });
+
+  it("leaves names already ending in s unchanged", () => {
+    expect(pluralize("cases")).toBe("cases");
+    expect(pluralize("donts")).toBe("donts");
+    expect(pluralize("extends")).toBe("extends");
+  });
+
+  it("handles irregular plurals", () => {
+    expect(pluralize("child")).toBe("children");
+    expect(pluralize("person")).toBe("people");
+    expect(pluralize("grandChild")).toBe("grandChildren");
+  });
+});
+
+describe("stripVerbPrefix (§4.4 rule 3)", () => {
+  it("strips has/is verb prefixes", () => {
+    expect(stripVerbPrefix("hasEdge")).toBe("edge");
+    expect(stripVerbPrefix("isDraft")).toBe("draft");
+    expect(stripVerbPrefix("hasModifierFamily")).toBe("modifierFamily");
+  });
+
+  it("leaves non-verb names alone", () => {
+    expect(stripVerbPrefix("name")).toBe("name");
+    expect(stripVerbPrefix("history")).toBe("history"); // not "has" + Word
+    expect(stripVerbPrefix("island")).toBe("island");
+  });
+});
+
+describe("sanitizeGraphQLName", () => {
+  it("replaces illegal characters and guards leading digits", () => {
+    expect(sanitizeGraphQLName("My-Class")).toBe("My_Class");
+    expect(sanitizeGraphQLName("has.thing")).toBe("has_thing");
+    expect(sanitizeGraphQLName("3d")).toBe("_3d");
+    expect(sanitizeGraphQLName("")).toBe("_");
+    expect(sanitizeGraphQLName("fine_Name0")).toBe("fine_Name0");
+  });
+});
+
+describe("camelize", () => {
+  it("lowercases the first character", () => {
+    expect(camelize("Component")).toBe("component");
+    expect(camelize("ImplementationLibrary")).toBe("implementationLibrary");
+  });
+});
+
+describe("BidirectionalNameMap", () => {
+  it("maps both directions with first-writer-wins reverse", () => {
+    const map = new BidirectionalNameMap();
+    map.set("https://ds.canonical.com/Component", "Component");
+    map.set("https://ds.canonical.com/name", "name");
+    map.set("http://pragma.canonical.com/codestandards#name", "name");
+    expect(map.toGraphQL("https://ds.canonical.com/Component")).toBe(
+      "Component",
+    );
+    expect(map.toOWL("Component")).toBe("https://ds.canonical.com/Component");
+    // first writer wins for the reverse direction
+    expect(map.toOWL("name")).toBe("https://ds.canonical.com/name");
+    expect([...map.entries()].length).toBe(3);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/nameMap.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/nameMap.ts
@@ -1,0 +1,82 @@
+// =============================================================================
+// The §4.4 GraphQL naming rules: pluralization, casing, verb stripping, and
+// name sanitization. Grouped here because Pass 4 applies them together when
+// mapping OWL names to GraphQL names.
+// =============================================================================
+
+/** Irregular plurals the suffix rules cannot produce (§4.4 rule 5). */
+const IRREGULAR_PLURALS: Record<string, string> = {
+  child: "children",
+  person: "people",
+};
+
+/**
+ * Pluralize a camelCase field name (§4.4 rule 5):
+ *   a. irregulars (child → children)
+ *   b. already ends in 's' → unchanged (treated as plural: cases, donts)
+ *   c. consonant + 'y' → 'ies' (category → categories)
+ *   d. x/z/ch/sh → '+es' (switch → switches)
+ *   e. default → '+s' (edge → edges)
+ */
+export const pluralize = (name: string): string => {
+  // Preserve a camelCase prefix when the final word is irregular
+  // (hasChild → child; implementationChild → implementationChildren).
+  for (const [singular, plural] of Object.entries(IRREGULAR_PLURALS)) {
+    if (name.toLowerCase() === singular) {
+      return name[0] === name[0]?.toUpperCase()
+        ? plural.charAt(0).toUpperCase() + plural.slice(1)
+        : plural;
+    }
+    const suffix = singular.charAt(0).toUpperCase() + singular.slice(1);
+    if (name.endsWith(suffix)) {
+      return (
+        name.slice(0, -suffix.length) +
+        plural.charAt(0).toUpperCase() +
+        plural.slice(1)
+      );
+    }
+  }
+  if (name.endsWith("s")) {
+    return name;
+  }
+  if (/[^aeiou]y$/i.test(name)) {
+    return `${name.slice(0, -1)}ies`;
+  }
+  if (/(x|z|ch|sh)$/i.test(name)) {
+    return `${name}es`;
+  }
+  return `${name}s`;
+};
+
+/** Camelize a PascalCase type name (lowercase first letter) for root query fields. */
+export const camelize = (name: string): string =>
+  name.charAt(0).toLowerCase() + name.slice(1);
+
+/** Strip a leading "has"/"is" verb from a field name (§4.4 rule 3). */
+export const stripVerbPrefix = (name: string): string => {
+  for (const prefix of ["has", "is"]) {
+    if (
+      name.startsWith(prefix) &&
+      name.length > prefix.length &&
+      name[prefix.length] === name[prefix.length]?.toUpperCase()
+    ) {
+      const stripped = name.slice(prefix.length);
+      return stripped.charAt(0).toLowerCase() + stripped.slice(1);
+    }
+  }
+  return name;
+};
+
+/**
+ * Make a string a legal GraphQL name: [_a-zA-Z][_a-zA-Z0-9]*.
+ * Invalid characters (dots, dashes, unicode) become underscores; a leading
+ * digit gets an underscore prefix; an empty result becomes "_". Callers emit
+ * a diagnostic when the result differs from the input.
+ */
+export const sanitizeGraphQLName = (name: string): string => {
+  const cleaned = name.replace(/[^_a-zA-Z0-9]/g, "_");
+  if (cleaned.length === 0) {
+    return "_";
+  }
+  return /^[_a-zA-Z]/.test(cleaned) ? cleaned : `_${cleaned}`;
+};

--- a/packages/runtime/ke-graphql/src/lib/compiler/performance-features.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/performance-features.test.ts
@@ -1,0 +1,193 @@
+// =============================================================================
+// Performance features: lazy store, process-lifetime loader cache,
+// slice-before-hydrate pagination, store-free TBox.
+// =============================================================================
+
+import type { SPARQL, Store } from "@canonical/ke";
+import { createTestStore } from "@canonical/ke/testing";
+import { graphql } from "graphql";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DS_REALISTIC_TTL, MINIMAL_TTL, PREFIXES } from "#testing";
+import compile from "./compile.js";
+import storeQueryFn from "./storeQueryFn.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+  vi.restoreAllMocks();
+});
+
+const boot = async (ttl: string) => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  return store;
+};
+
+/** Wrap a store so SPARQL round-trips are countable. */
+const countingStore = (store: Store): { store: Store; count: () => number } => {
+  let queries = 0;
+  const wrapped: Store = {
+    ...store,
+    query: ((q: SPARQL<string>) => {
+      queries++;
+      return store.query(q);
+    }) as Store["query"],
+  };
+  return { store: wrapped, count: () => queries };
+};
+
+describe("lazy store (TBox needs no store)", () => {
+  it("answers TBox queries before the store resolves; ABox waits for it", async () => {
+    const store = await boot(MINIMAL_TTL);
+    const result = await compile(storeQueryFn(store), PREFIXES);
+
+    let releaseStore: (s: Store) => void = () => {};
+    const pending = new Promise<Store>((resolve) => {
+      releaseStore = resolve;
+    });
+    const ctx = result.createContext(pending);
+
+    // TBox: resolves while the store promise is still pending.
+    const tbox = await graphql({
+      schema: result.schema,
+      source: `{ ontologyClass(uri: "http://example.org/Thing") { label isAbstract properties { property { label } } } }`,
+      contextValue: ctx,
+    });
+    expect(tbox.errors).toBeUndefined();
+    expect((tbox.data?.ontologyClass as { label: string }).label).toBe("Thing");
+
+    // ABox: blocked until the store arrives.
+    const abox = graphql({
+      schema: result.schema,
+      source: `{ thing(uri: "ex:widget") { name } }`,
+      contextValue: ctx,
+    });
+    const raced = await Promise.race([
+      abox.then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r("pending"), 50)),
+    ]);
+    expect(raced).toBe("pending");
+
+    releaseStore(store);
+    const resolved = await abox;
+    expect(resolved.errors).toBeUndefined();
+    expect((resolved.data?.thing as { name: string }).name).toBe("Widget");
+  });
+});
+
+describe("loaderCache: process", () => {
+  it("shares entity/list caches across contexts and clears on demand", async () => {
+    const raw = await boot(MINIMAL_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(storeQueryFn(store), PREFIXES, {
+      loaderCache: "process",
+    });
+    const baseline = count();
+
+    const run = () =>
+      graphql({
+        schema: result.schema,
+        source: `{ things(first: 5) { edges { node { name } } } }`,
+        contextValue: result.createContext(store),
+      });
+
+    await run();
+    const afterFirst = count();
+    expect(afterFirst).toBeGreaterThan(baseline);
+
+    // A FRESH context hits the shared cache — zero new SPARQL.
+    await run();
+    expect(count()).toBe(afterFirst);
+
+    result.clearLoaderCache();
+    await run();
+    expect(count()).toBeGreaterThan(afterFirst);
+  });
+
+  it("request mode (default) re-queries per context", async () => {
+    const raw = await boot(MINIMAL_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(storeQueryFn(store), PREFIXES);
+    const run = () =>
+      graphql({
+        schema: result.schema,
+        source: `{ thing(uri: "ex:widget") { name } }`,
+        contextValue: result.createContext(store),
+      });
+    await run();
+    const afterFirst = count();
+    await run();
+    expect(count()).toBeGreaterThan(afterFirst);
+  });
+});
+
+describe("slice-before-hydrate listings", () => {
+  it("hydrates only the requested page and pages correctly via endCursor", async () => {
+    const raw = await boot(DS_REALISTIC_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(storeQueryFn(store), PREFIXES);
+
+    const page1 = await graphql({
+      schema: result.schema,
+      source: `{ tiers(first: 1) { edges { cursor node { id name } } pageInfo { hasNextPage endCursor } } }`,
+      contextValue: result.createContext(store),
+    });
+    expect(page1.errors).toBeUndefined();
+    void count();
+
+    // Page 2 of subcomponents-by-cursor on a 2-entity class: use modifiers
+    // (1 modifier) to assert the empty next page + pageInfo math.
+    const modifiers = await graphql({
+      schema: result.schema,
+      source: `{ modifiers(first: 1) { edges { cursor node { name } } pageInfo { hasNextPage } } }`,
+      contextValue: result.createContext(store),
+    });
+    const connection = modifiers.data?.modifiers as {
+      edges: Array<{ cursor: string }>;
+      pageInfo: { hasNextPage: boolean };
+    };
+    expect(connection.edges).toHaveLength(1);
+    expect(connection.pageInfo.hasNextPage).toBe(false);
+
+    const page2 = await graphql({
+      schema: result.schema,
+      source: `query($c: String) { modifiers(first: 1, after: $c) { edges { node { name } } pageInfo { hasPreviousPage } } }`,
+      variableValues: { c: connection.edges[0]?.cursor },
+      contextValue: result.createContext(store),
+    });
+    expect((page2.data?.modifiers as { edges: unknown[] }).edges).toHaveLength(
+      0,
+    );
+  });
+});
+
+describe("store-free TBox (tboxLoader removed)", () => {
+  it("serves class structure and annotations after the store is disposed", async () => {
+    const { store, cleanup } = await createTestStore({
+      ttl: DS_REALISTIC_TTL,
+      prefixes: PREFIXES,
+    });
+    const result = await compile(storeQueryFn(store), PREFIXES);
+    const ctx = result.createContext(store);
+    cleanup(); // disposes the store — TBox must not notice
+
+    const tbox = await graphql({
+      schema: result.schema,
+      source: `{
+        ontologyProperty(uri: "https://ds.canonical.com/name") { acceptanceCriteria }
+        ontologyClass(uri: "https://ds.canonical.com/Component") { isAbstract superclasses { label } }
+      }`,
+      contextValue: ctx,
+    });
+    expect(tbox.errors).toBeUndefined();
+    expect(
+      (tbox.data?.ontologyProperty as { acceptanceCriteria: string })
+        .acceptanceCriteria,
+    ).toBe("Must be a human-readable display name.");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/pipeline.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/pipeline.test.ts
@@ -1,0 +1,263 @@
+// =============================================================================
+// Pipeline tests (Passes 1–7) against fixture stores: schema shape,
+// diagnostics, golden SDL expectations (ADR §12).
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import type { GraphQLObjectType } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BLANK_NODES_TTL,
+  DOMAINLESS_TTL,
+  DS_REALISTIC_TTL,
+  EDGE_CASES_TTL,
+  INHERITANCE_TTL,
+  INVERSE_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+  SHACL_TTL,
+} from "#testing";
+import compile from "./compile.js";
+import storeQueryFn from "./storeQueryFn.js";
+import type { CompilerResult } from "./types.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const compileFixture = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<CompilerResult> => {
+  const { store, cleanup } = await createTestStore({
+    ttl,
+    prefixes: PREFIXES,
+  });
+  cleanups.push(cleanup);
+  return compile(storeQueryFn(store), PREFIXES, options);
+};
+
+const codes = (result: CompilerResult): string[] =>
+  result.diagnostics.map((d) => d.code);
+
+describe("minimal fixture (§12.2)", () => {
+  it("compiles one concrete type with root queries and Node membership", async () => {
+    const result = await compileFixture(MINIMAL_TTL);
+    expect(result.schema).toBeDefined();
+    const thing = result.schema.getType("Thing") as GraphQLObjectType;
+    expect(thing).toBeDefined();
+    const fields = thing.getFields();
+    // datatype properties default to singular
+    expect(String(fields.name?.type)).toBe("String");
+    expect(String(fields.count?.type)).toBe("Int");
+    // structural fields
+    expect(String(fields.id?.type)).toBe("ID!");
+    expect(String(fields.uri?.type)).toBe("String!");
+    expect(String(fields._meta?.type)).toBe("EntityMeta!");
+    expect(thing.getInterfaces().map((i) => i.name)).toContain("Node");
+    // root queries
+    const query = result.schema.getQueryType()?.getFields();
+    expect(query?.thing).toBeDefined();
+    expect(query?.things).toBeDefined();
+    expect(String(query?.things?.type)).toBe("ThingConnection!");
+    // connection fields carry the four pagination args
+    const argNames = query?.things?.args.map((a) => a.name).sort();
+    expect(argNames).toEqual(["after", "before", "first", "last"]);
+    expect(result.sdl).toContain("type Thing implements Node");
+  });
+});
+
+describe("inheritance fixture (§12.3)", () => {
+  it("generates the interface chain with inherited fields", async () => {
+    const result = await compileFixture(INHERITANCE_TTL);
+    expect(result.sdl).toContain("interface Entity implements Node");
+    expect(result.sdl).toContain("interface Tangible implements");
+    const widget = result.schema.getType("Widget") as GraphQLObjectType;
+    expect(
+      widget
+        .getInterfaces()
+        .map((i) => i.name)
+        .sort(),
+    ).toEqual(["Entity", "Node", "Tangible"]);
+    const fields = widget.getFields();
+    expect(fields.name).toBeDefined(); // inherited from Entity
+    expect(fields.weight).toBeDefined(); // inherited from Tangible
+    expect(fields.color).toBeDefined(); // own
+    // abstract classes produce no root queries
+    const query = result.schema.getQueryType()?.getFields();
+    expect(query?.entity).toBeUndefined();
+    expect(query?.widget).toBeDefined();
+  });
+});
+
+describe("inverse fixture (§12.4)", () => {
+  it("places one field per side with the irregular plural", async () => {
+    const result = await compileFixture(INVERSE_TTL);
+    const parent = result.schema.getType("Parent") as GraphQLObjectType;
+    const child = result.schema.getType("Child") as GraphQLObjectType;
+    // hasChild → children (has-strip + irregular plural), connection-wrapped
+    expect(String(parent.getFields().children?.type)).toBe("ChildConnection!");
+    // childOf is functional → singular
+    expect(String(child.getFields().childOf?.type)).toBe("Parent");
+    // no duplicated reverse fields (EC.05)
+    expect(parent.getFields().childOf).toBeUndefined();
+    expect(child.getFields().children).toBeUndefined();
+  });
+});
+
+describe("polymorphic flattening diagnostic (V016)", () => {
+  const SUPERTYPE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Animal a owl:Class .
+ex:Dog a owl:Class ; rdfs:subClassOf ex:Animal .
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Animal ; rdfs:range xsd:string .
+ex:a1 a ex:Animal ; ex:name "Generic" .
+ex:d1 a ex:Dog ; ex:name "Rex" .
+`;
+
+  it("warns when a concrete class has subclasses (instantiable supertype)", async () => {
+    const result = await compileFixture(SUPERTYPE_TTL);
+    expect(codes(result)).toContain("V016");
+    // Animal keeps its direct instance, so it stays a concrete type.
+    expect(result.sdl).toContain("type Animal implements Node");
+  });
+
+  it("does not warn when the supertype is abstract (no direct instances)", async () => {
+    const result = await compileFixture(INHERITANCE_TTL);
+    expect(codes(result)).not.toContain("V016");
+  });
+});
+
+describe("blank nodes fixture (§12.5)", () => {
+  it("marks blank-only classes embeddable: no Node, plain list", async () => {
+    const result = await compileFixture(BLANK_NODES_TTL);
+    expect(codes(result)).toContain("V001");
+    const example = result.schema.getType("Example") as GraphQLObjectType;
+    expect(example.getInterfaces()).toHaveLength(0);
+    expect(example.getFields().id).toBeUndefined();
+    expect(example.getFields()._meta).toBeUndefined();
+    const standard = result.schema.getType("Standard") as GraphQLObjectType;
+    // plain list, not a connection
+    expect(String(standard.getFields().examples?.type)).toBe("[Example!]!");
+    // no root query for embeddable types
+    expect(result.schema.getQueryType()?.getFields().example).toBeUndefined();
+  });
+});
+
+describe("domainless fixture (§12.6)", () => {
+  it("assigns the property to every class in its namespace (KG.14)", async () => {
+    const result = await compileFixture(DOMAINLESS_TTL);
+    expect(codes(result)).toContain("V002");
+    const foo = result.schema.getType("Foo") as GraphQLObjectType;
+    const bar = result.schema.getType("Bar") as GraphQLObjectType;
+    expect(foo.getFields().description).toBeDefined();
+    expect(bar.getFields().description).toBeDefined();
+  });
+});
+
+describe("edge cases fixture (§12.7)", () => {
+  it("emits the expected V-series diagnostics", async () => {
+    const result = await compileFixture(EDGE_CASES_TTL);
+    const found = codes(result);
+    expect(found).toContain("V004"); // self-referential extends
+    expect(found).toContain("V005"); // functional violation on ex:rank
+    expect(found).toContain("V006"); // boolean range coercion note
+    expect(found).toContain("V007"); // annotation property routed to TBox
+    expect(found).toContain("V008"); // custom datatype → String
+    expect(found).toContain("V009"); // cross-vocabulary subClassOf
+    expect(found).toContain("V012"); // sh:in enum constraint
+    expect(found).toContain("V014"); // undeclared ABox predicate
+    // annotation property produces no ABox field
+    const item = result.schema.getType("Item") as GraphQLObjectType;
+    expect(item.getFields().guidance).toBeUndefined();
+    // custom datatype mapped to String
+    expect(String(item.getFields().ver?.type)).toBe("String");
+    // Category is a root class despite skos:Concept parentage
+    expect(result.schema.getType("Category")).toBeDefined();
+  });
+});
+
+describe("shacl fixture (§12.10)", () => {
+  it("resolves SHACL cardinality including sh:or and maxCount 0", async () => {
+    const result = await compileFixture(SHACL_TTL);
+    const found = codes(result);
+    expect(found).toContain("V010");
+    expect(found).toContain("V011");
+    const spec = result.schema.getType("Spec") as GraphQLObjectType;
+    // sh:maxCount 1 without owl:FunctionalProperty → singular
+    expect(String(spec.getFields().root?.type)).toBe("Hop");
+    // sh:maxCount 0 → field omitted
+    expect(spec.getFields().legacy).toBeUndefined();
+    const hop = result.schema.getType("Hop") as GraphQLObjectType;
+    // sh:or → both singular, both nullable
+    expect(String(hop.getFields().hopTarget?.type)).toBe("Spec");
+    expect(String(hop.getFields().hopSwitch?.type)).toBe("Sw");
+  });
+});
+
+describe("ds-realistic fixture (§12.8)", () => {
+  it("compiles the full hierarchy with synthetic inverses and overrides", async () => {
+    const result = await compileFixture(DS_REALISTIC_TTL, {
+      mappings: {
+        "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+        "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+        "ds:hasProperty": { graphqlName: "properties" },
+        "ds:hasModifier": { graphqlName: "modifiers" },
+        "ds:implementsBlock": { inverse: { graphqlName: "implementations" } },
+      },
+      nonNullOverrides: { Component: ["name"] },
+    });
+    expect(result.schema).toBeDefined();
+    const component = result.schema.getType("Component") as GraphQLObjectType;
+    const fields = component.getFields();
+    // abstract chain → interfaces
+    expect(
+      component
+        .getInterfaces()
+        .map((i) => i.name)
+        .sort(),
+    ).toEqual(["Entity", "Node", "UIBlock", "UIElement"]);
+    // non-null override
+    expect(String(fields.name?.type)).toBe("String!");
+    // custom-mapped names, connection-wrapped
+    expect(String(fields.modifierFamilies?.type)).toBe(
+      "ModifierFamilyConnection!",
+    );
+    expect(String(fields.subcomponents?.type)).toBe("SubcomponentConnection!");
+    // embedded blank-node list stays plain
+    expect(String(fields.properties?.type)).toBe("[Property!]!");
+    // synthetic inverse on the range type's concrete descendants
+    expect(String(fields.implementations?.type)).toBe(
+      "ImplementationObjectConnection!",
+    );
+    // ds:Property is embeddable: detected from blank-only instance stats
+    const property = result.schema.getType("Property") as GraphQLObjectType;
+    expect(property.getFields().id).toBeUndefined();
+  });
+});
+
+describe("failure modes", () => {
+  it("M003 reports unknown custom mappings", async () => {
+    const result = await compileFixture(MINIMAL_TTL, {
+      mappings: { "ex:doesNotExist": { graphqlName: "nope" } },
+    });
+    expect(codes(result)).toContain("M003");
+  });
+
+  it("relay: false produces a schema without Node wiring", async () => {
+    const result = await compileFixture(MINIMAL_TTL, { relay: false });
+    const thing = result.schema.getType("Thing") as GraphQLObjectType;
+    expect(thing.getFields().id).toBeUndefined();
+    expect(result.schema.getQueryType()?.getFields().node).toBeUndefined();
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/queries.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/queries.test.ts
@@ -1,0 +1,297 @@
+// =============================================================================
+// Query execution against compiled schemas: resolution templates, node(),
+// pagination, _meta, coercion, dual-direction inverses (ADR §5, §12).
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { type GraphQLSchema, graphql } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BLANK_NODES_TTL,
+  DS_REALISTIC_TTL,
+  EDGE_CASES_TTL,
+  INVERSE_TTL,
+  PREFIXES,
+} from "#testing";
+import compile from "./compile.js";
+import storeQueryFn from "./storeQueryFn.js";
+import type { CompilerContext, CompilerResult } from "./types.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+interface Compiled {
+  result: CompilerResult;
+  schema: GraphQLSchema;
+  context: CompilerContext;
+}
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<Compiled> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(storeQueryFn(store), PREFIXES, options);
+  return {
+    result,
+    schema: result.schema,
+    context: result.createContext(store),
+  };
+};
+
+const run = async (
+  compiled: Compiled,
+  source: string,
+  variableValues?: Record<string, unknown>,
+) =>
+  graphql({
+    schema: compiled.schema,
+    source,
+    variableValues,
+    contextValue: compiled.context,
+  });
+
+describe("ds-realistic resolution", () => {
+  const options = {
+    mappings: {
+      "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+      "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+      "ds:hasProperty": { graphqlName: "properties" },
+      "ds:hasModifier": { graphqlName: "modifiers" },
+      "ds:implementsBlock": { inverse: { graphqlName: "implementations" } },
+    },
+  };
+
+  it("resolves a component with scalars, objects, and embedded blanks", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        component(uri: "ds:global.component.button") {
+          id
+          uri
+          name
+          summary
+          tier { name }
+          properties { name propertyType optional }
+          subcomponents(first: 10) { edges { node { name standalone parentComponent { name } } } }
+          implementations(first: 10) { edges { node { name } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const component = result.data?.component as Record<string, unknown>;
+    expect(component.id).toBe("ds:global.component.button");
+    expect(component.name).toBe("Button");
+    expect((component.tier as { name: string }).name).toBe("global");
+    // embedded blank node with boolean-as-string coercion (EC.03)
+    const properties = component.properties as Array<Record<string, unknown>>;
+    expect(properties).toHaveLength(1);
+    expect(properties[0]?.name).toBe("disabled");
+    expect(properties[0]?.optional).toBe(false);
+    // declared inverse pair: forward direction asserted in data
+    const subcomponents = component.subcomponents as {
+      edges: Array<{ node: Record<string, unknown> }>;
+    };
+    expect(subcomponents.edges).toHaveLength(1);
+    expect(subcomponents.edges[0]?.node.standalone).toBe(false);
+    expect(
+      (subcomponents.edges[0]?.node.parentComponent as { name: string }).name,
+    ).toBe("Button");
+    // synthetic inverse: reverse assertions found via the inverse loader
+    const implementations = component.implementations as {
+      edges: Array<{ node: { name: string } }>;
+    };
+    expect(implementations.edges.map((e) => e.node.name)).toEqual([
+      "react button",
+    ]);
+  });
+
+  it("resolves node() by prefixed-URI global ID with the most specific type", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        node(id: "ds:global.component.button") {
+          id
+          __typename
+          ... on Component { name }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const node = result.data?.node as Record<string, unknown>;
+    expect(node.__typename).toBe("Component");
+    expect(node.name).toBe("Button");
+  });
+
+  it("returns null for unknown prefixes and unknown URIs", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const unknownPrefix = await run(compiled, `{ node(id: "zz:nope") { id } }`);
+    expect(unknownPrefix.data?.node).toBeNull();
+    const unknownUri = await run(
+      compiled,
+      `{ node(id: "ds:does.not.exist") { id } }`,
+    );
+    expect(unknownUri.data?.node).toBeNull();
+  });
+
+  it("paginates listings with stable cursors", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const page1 = await run(
+      compiled,
+      `{ modifiers(first: 1) { edges { cursor node { name } } pageInfo { hasNextPage } } }`,
+    );
+    expect(page1.errors).toBeUndefined();
+    const modifiers = page1.data?.modifiers as {
+      edges: Array<{ cursor: string; node: { name: string } }>;
+      pageInfo: { hasNextPage: boolean };
+    };
+    expect(modifiers.edges).toHaveLength(1);
+    expect(modifiers.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it("rejects negative pagination arguments", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{ components(first: -1) { edges { cursor } } }`,
+    );
+    expect(result.errors?.[0]?.message).toContain("non-negative");
+  });
+
+  it("exposes _meta with class, fields, and per-class cardinality", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        component(uri: "ds:global.component.button") {
+          _meta {
+            type { uri label isAbstract superclasses { label } }
+            field(name: "name") { inherited property { label acceptanceCriteria } }
+            fields { property { label } }
+          }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const meta = (result.data?.component as Record<string, unknown>)
+      ._meta as Record<string, unknown>;
+    const type = meta.type as Record<string, unknown>;
+    expect(type.uri).toBe("https://ds.canonical.com/Component");
+    expect(type.isAbstract).toBe(false);
+    const field = meta.field as Record<string, unknown>;
+    expect(field.inherited).toBe(true); // ds:name declared on Entity
+    expect((field.property as Record<string, unknown>).acceptanceCriteria).toBe(
+      "Must be a human-readable display name.",
+    );
+    expect((meta.fields as unknown[]).length).toBeGreaterThan(3);
+  });
+
+  it("serves the TBox: ontologies, classes, instances", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        ontologies { prefix }
+        ontologyClass(uri: "https://ds.canonical.com/Component") {
+          label
+          isAbstract
+          instanceCount
+          instances(first: 5) { edges { node { id __typename } } }
+          properties { property { label } required singular inherited }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const prefixes = (result.data?.ontologies as Array<{ prefix: string }>).map(
+      (o) => o.prefix,
+    );
+    expect(prefixes).toContain("ds");
+    const cls = result.data?.ontologyClass as Record<string, unknown>;
+    expect(cls.instanceCount).toBe(1);
+    const instances = cls.instances as {
+      edges: Array<{ node: { id: string; __typename: string } }>;
+    };
+    expect(instances.edges[0]?.node.id).toBe("ds:global.component.button");
+    expect(instances.edges[0]?.node.__typename).toBe("Component");
+  });
+});
+
+describe("dual-direction inverse resolution (EC.05)", () => {
+  it("finds children even when only the reverse direction is asserted", async () => {
+    const compiled = await setup(INVERSE_TTL);
+    const result = await run(
+      compiled,
+      `{
+        parent(uri: "ex:p1") {
+          name
+          children(first: 10) { edges { node { uri childOf { name } } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const parent = result.data?.parent as Record<string, unknown>;
+    const children = parent.children as { edges: Array<{ node: unknown }> };
+    expect(children.edges).toHaveLength(2);
+  });
+});
+
+describe("embedded blank nodes (§12.5)", () => {
+  it("resolves embedded values inline with optional fields as null", async () => {
+    const compiled = await setup(BLANK_NODES_TTL);
+    const result = await run(
+      compiled,
+      `{ standard(uri: "ex:s1") { title examples { code language } } }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const examples = (result.data?.standard as Record<string, unknown>)
+      .examples as Array<Record<string, unknown>>;
+    expect(examples).toHaveLength(2);
+    const languages = examples.map((e) => e.language).sort();
+    expect(languages).toEqual([null, "typescript"].sort());
+  });
+});
+
+describe("coercion (EC.03, EC.06, EC.14)", () => {
+  it("coerces booleans, strips language tags, preserves empty strings", async () => {
+    const warnings: string[] = [];
+    const compiled = await setup(EDGE_CASES_TTL, {
+      onRuntimeWarning: (w) => warnings.push(w.reason),
+    });
+    const active = await run(compiled, `{ item(uri: "ex:i1") { active } }`);
+    expect((active.data?.item as { active: boolean }).active).toBe(true);
+    const label = await run(compiled, `{ item(uri: "ex:i3") { label } }`);
+    expect((label.data?.item as { label: string }).label).toBe("Tagged");
+    const summary = await run(compiled, `{ item(uri: "ex:i5") { summary } }`);
+    expect((summary.data?.item as { summary: string }).summary).toBe("");
+  });
+
+  it("self-referential chains resolve without infinite recursion (EC.04)", async () => {
+    const compiled = await setup(EDGE_CASES_TTL);
+    const result = await run(
+      compiled,
+      `{
+        item(uri: "ex:i2") {
+          uri
+          extends(first: 1) { edges { node { uri } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const item = result.data?.item as Record<string, unknown>;
+    const extendsConn = item.extends as {
+      edges: Array<{ node: { uri: string } }>;
+    };
+    // the chain terminates because resolution is per-level, not recursive
+    expect(extendsConn.edges[0]?.node.uri).toBe("ex:i2");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/runPasses.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/runPasses.ts
@@ -1,0 +1,72 @@
+import build from "./build.js";
+import CompilationError from "./CompilationError.js";
+import compose from "./compose.js";
+import createContextFactory from "./createContextFactory.js";
+import emit from "./emit.js";
+import map from "./map.js";
+import type {
+  CompilerResult,
+  Diagnostic,
+  RawExtraction,
+  SchemaPluginOptions,
+} from "./types.js";
+import validate from "./validate.js";
+import wireRelay from "./wireRelay.js";
+
+/**
+ * Run Passes 2–7 over a RawExtraction and assemble the CompilerResult.
+ *
+ * Per §2.2, only Pass 7 (composition) errors prevent schema creation —
+ * C001/C002 extension conflicts and C003 validation failures throw a
+ * CompilationError; earlier error diagnostics surface in the list without
+ * aborting. Pure — every pass after extraction is store-free.
+ */
+export default function runPasses(
+  extraction: RawExtraction,
+  options: SchemaPluginOptions,
+  { diagnostics: seed = [] }: { diagnostics?: Diagnostic[] } = {},
+): CompilerResult {
+  const diagnostics: Diagnostic[] = [...seed];
+
+  const built = build(extraction, options.mappings);
+  diagnostics.push(...built.diagnostics);
+
+  const validated = validate(built.output);
+  diagnostics.push(...validated.diagnostics);
+
+  const mapped = map(validated.output, options);
+  diagnostics.push(...mapped.diagnostics);
+
+  const emitted = emit(mapped.output);
+  diagnostics.push(...emitted.diagnostics);
+
+  const relayed = options.relay === false ? emitted : wireRelay(emitted.output);
+  diagnostics.push(...(options.relay === false ? [] : relayed.diagnostics));
+
+  const composed = compose(relayed.output, {
+    extensions: options.extensions,
+  });
+  diagnostics.push(...composed.diagnostics);
+
+  // §2.2: only Pass 7 (composition) errors prevent schema creation —
+  // C001/C002 extension conflicts and C003 validation failures are fatal;
+  // earlier error diagnostics surface in the list without aborting.
+  const compositionErrors = composed.diagnostics.filter(
+    (d) => d.severity === "error",
+  );
+  if (!composed.output.schema || compositionErrors.length > 0) {
+    throw new CompilationError(diagnostics);
+  }
+
+  const factory = createContextFactory(mapped.output, options);
+  return {
+    schema: composed.output.schema,
+    sdl: composed.output.sdl,
+    diagnostics,
+    nameMap: mapped.output.nameMap,
+    mapped: mapped.output,
+    extraction,
+    createContext: factory,
+    clearLoaderCache: factory.clearCache,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/storeQueryFn.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/storeQueryFn.ts
@@ -1,0 +1,13 @@
+import type { SPARQL, Store } from "@canonical/ke";
+import type { QueryFn } from "./types.js";
+
+/**
+ * Adapt a ke Store to the QueryFn surface (string → branded SPARQL), for
+ * compiling directly against a store instead of a plugin context.
+ *
+ * @note Impure — the returned function executes SPARQL queries against the
+ * store.
+ */
+export default function storeQueryFn(store: Store): QueryFn {
+  return (query) => store.query(query as SPARQL<string>);
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/types.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/types.ts
@@ -1,0 +1,579 @@
+// =============================================================================
+// @canonical/ke-graphql — Compiler type contracts
+//
+// The intermediate representations of the seven-pass pipeline specified in
+// the A.10.COMPILER ADR. Everything before the IR is extraction; everything
+// after it is emission. These types are a public contract (Prisma-DMMF
+// style): consumers can inspect RawExtraction, OntologyIR, and MappedIR.
+// =============================================================================
+
+import type { Store } from "@canonical/ke";
+import type DataLoader from "dataloader";
+import type { GraphQLFieldConfig, GraphQLSchema } from "graphql";
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+//
+// The compiler never aborts on the first error. Every pass returns its output
+// plus diagnostics; codes are stable and append-only (X001 is retired and
+// never reused).
+// ---------------------------------------------------------------------------
+
+/** Severity of a compiler diagnostic; only errors can prevent schema creation. */
+export type DiagnosticSeverity = "error" | "warning" | "info";
+
+/** Stable, append-only diagnostic codes emitted by the compiler passes. */
+export type DiagnosticCode =
+  // Extraction
+  | "E001" // SPARQL query failed
+  // Build
+  | "B001" // class cycle in subClassOf chain
+  | "B002" // property references unknown class in domain
+  | "B003" // property references unknown class/datatype in range
+  | "B004" // inverse property references unknown property
+  // Validation
+  | "V001" // blank-node-only class (embeddable)
+  | "V002" // property has no rdfs:domain (domainless)
+  | "V003" // asymmetric owl:inverseOf
+  | "V004" // self-referential relationship in ABox
+  | "V005" // functional property with multiple values in ABox
+  | "V006" // boolean-as-string mismatch
+  | "V007" // annotation property filtered from ABox schema
+  | "V008" // custom datatype mapped to base XSD type
+  | "V009" // cross-vocabulary subClassOf
+  | "V010" // SHACL sh:maxCount 0 — field omitted for a class
+  | "V011" // SHACL sh:or — most permissive interpretation applied
+  | "V012" // SHACL sh:in enum constraint — mapped to String
+  | "V013" // property declares multiple rdfs:domain classes
+  | "V014" // ABox predicate not declared in any loaded TBox
+  | "V015" // class forced abstract by mapping but has direct instances
+  | "V016" // concrete class with subclasses — polymorphic returns flattened
+  // Mapping
+  | "M001" // name collision after GraphQL name mapping
+  | "M002" // reserved GraphQL name conflict
+  | "M003" // custom mapping references unknown property/class
+  | "M004" // type name collision auto-resolved by namespace prefixing
+  // Emission
+  | "X002" // union type created for polymorphic range
+  | "X003" // union type synthesized from anonymous range
+  // Composition
+  | "C001" // extension references unknown type
+  | "C002" // extension field conflicts with generated field
+  | "C003"; // schema validation failed
+
+/** One problem (or notice) reported by a compiler pass. */
+export interface Diagnostic {
+  severity: DiagnosticSeverity;
+  code: DiagnosticCode;
+  message: string;
+  /** OWL URI that caused the diagnostic, when attributable. */
+  source?: string;
+  /** Compiler pass that emitted it. */
+  phase: string;
+}
+
+/** The uniform pass envelope: an output plus the diagnostics it produced. */
+export interface PassResult<T> {
+  output: T;
+  diagnostics: Diagnostic[];
+}
+
+// ---------------------------------------------------------------------------
+// Pass 1 output — RawExtraction
+//
+// Direct output of the twelve SPARQL queries. Includes the ABox probes
+// (instance stats, self-references, functional violations, undeclared
+// predicates) so that Passes 2–7 never touch the store.
+// ---------------------------------------------------------------------------
+
+/** A class row as extracted from the store (Pass 1, pre-IR). */
+export interface RawClass {
+  uri: string;
+  label?: string;
+  definition?: string;
+  /** Direct rdfs:subClassOf URIs (blank-node superclasses are filtered). */
+  superclasses: string[];
+}
+
+/** OWL property flavor: object, datatype, or annotation property. */
+export type RawPropertyKind = "object" | "datatype" | "annotation";
+
+/** A property row as extracted from the store (Pass 1, pre-IR). */
+export interface RawProperty {
+  uri: string;
+  label?: string;
+  definition?: string;
+  kind: RawPropertyKind;
+  /** rdfs:domain URIs (0 or more). */
+  domains: string[];
+  /** rdfs:range URIs (0 or more, usually 1). */
+  ranges: string[];
+}
+
+/** One owl:inverseOf declaration (property → its declared inverse). */
+export interface RawInverse {
+  property: string;
+  inverse: string;
+}
+
+/** A custom datatype declaration (owl:onDatatype restriction). */
+export interface RawDatatype {
+  uri: string;
+  /** The xsd: type it restricts (owl:onDatatype). */
+  baseType?: string;
+  /** xsd:pattern restriction value, when present. */
+  pattern?: string;
+}
+
+/** One SHACL cardinality/enum constraint on a (class, property) pair. */
+export interface RawShaclConstraint {
+  targetClass: string;
+  property: string;
+  minCount?: number;
+  maxCount?: number;
+  /** True when the constraint came from an sh:or branch (V011). */
+  fromOr?: boolean;
+  /** sh:in values, when present (V012). */
+  inValues?: string[];
+}
+
+/** An owl:unionOf declaration — named union class or anonymous range union. */
+export interface RawUnion {
+  /** URI if named union class; undefined if anonymous range. */
+  uri?: string;
+  /** Property URI if anonymous range; undefined if named class. */
+  property?: string;
+  members: string[];
+}
+
+/** Instance counts for one class: total assertions and named (non-blank). */
+export interface InstanceStats {
+  total: number;
+  named: number;
+}
+
+/**
+ * Pass 1 output: the complete, serializable result of the twelve SPARQL
+ * queries — the TBox structure plus the ABox probes that keep Passes 2–7
+ * pure.
+ */
+export interface RawExtraction {
+  classes: RawClass[];
+  properties: RawProperty[];
+  inverses: RawInverse[];
+  functionals: Set<string>;
+  datatypes: RawDatatype[];
+  /** namespace URI → prefix. */
+  namespaces: Map<string, string>;
+  shaclConstraints: RawShaclConstraint[];
+  unions: RawUnion[];
+
+  // ── ABox probes (keep later passes pure) ──
+  /** Per class URI: instance counts (total, named i.e. non-blank). */
+  instanceStats: Map<string, InstanceStats>;
+  /** Properties with at least one self-referential assertion (V004). */
+  selfReferential: Set<string>;
+  /** Functional properties with >1 value on some instance (V005). */
+  functionalViolations: Set<string>;
+  /** ABox predicates not declared in any loaded TBox (V014). */
+  undeclaredPredicates: Set<string>;
+  /**
+   * Annotation-property assertions: target URI -> (annotation property URI
+   * -> value). Extracted here so the TBox schema never touches the store
+   * (acceptanceCriteria/completionGuidance live on PropertyNode).
+   */
+  annotations: Map<string, Map<string, string>>;
+  /** True when some blank node's object is itself a blank node (§5.3 depth guard). */
+  deepBlankNesting: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Pass 2 output — OntologyIR
+// ---------------------------------------------------------------------------
+
+/** A discovered namespace: prefix, URI, and its class/property counts. */
+export interface NamespaceInfo {
+  prefix: string;
+  uri: string;
+  classCount: number;
+  propertyCount: number;
+}
+
+/** A class in the typed ontology IR (Pass 2 output). */
+export interface ClassNode {
+  uri: string;
+  label: string;
+  definition?: string;
+  /** Namespace prefix ('ds', 'cs', 'anatomy', …). */
+  namespace: string;
+  /** Direct parent classes (rdfs:subClassOf). */
+  superclasses: readonly string[];
+  /** Transitive superclass closure, most specific first. */
+  ancestors: readonly string[];
+  /** Direct subclasses. */
+  subclasses: readonly string[];
+  /** No direct instances + has subclasses (or custom override). */
+  isAbstract: boolean;
+  /**
+   * Instances are exclusively blank nodes (from Pass 1 instanceStats) or
+   * forced via custom mapping (KG.13). Embeddable types implement no Node
+   * interface and have no id/uri/_meta or root queries.
+   */
+  embeddable: boolean;
+  /** Properties whose rdfs:domain is this class. */
+  ownProperties: readonly string[];
+  /** Own + inherited properties, own first. */
+  allProperties: readonly string[];
+}
+
+/** Resolved cardinality for a (class, property) pair and where it came from. */
+export interface CardinalitySpec {
+  singular: boolean;
+  required: boolean;
+  omit: boolean;
+  source: "owl:FunctionalProperty" | "owl:cardinality" | "shacl" | "custom";
+}
+
+/** Property flavor carried through from extraction into the IR. */
+export type PropertyKind = RawPropertyKind;
+
+/** A property range resolved to a GraphQL scalar. */
+export interface ScalarRange {
+  kind: "scalar";
+  xsd: string;
+  graphqlScalar: "String" | "Boolean" | "Int" | "Float";
+  customDatatype?: string;
+}
+
+/** A property range resolved to a known class. */
+export interface ClassRange {
+  kind: "class";
+  uri: string;
+}
+
+/** A property range resolved to a union of classes. */
+export interface UnionRange {
+  kind: "union";
+  name?: string;
+  members: readonly string[];
+}
+
+/** A property range that resolved to nothing known (B003 → String). */
+export interface UnknownRange {
+  kind: "unknown";
+  raw: string;
+}
+
+/** The resolved range of a property: scalar, class, union, or unknown. */
+export type RangeSpec = ScalarRange | ClassRange | UnionRange | UnknownRange;
+
+/** A property in the typed ontology IR (Pass 2 output). */
+export interface PropertyNode {
+  uri: string;
+  label: string;
+  definition?: string;
+  namespace: string;
+  kind: PropertyKind;
+  domains: readonly string[];
+  range: RangeSpec;
+  /** Default cardinality (KG.17 precedence chain). True = singular. */
+  functional: boolean;
+  /** Per-class cardinality overrides (SHACL). Key: class URI. */
+  classCardinality: ReadonlyMap<string, CardinalitySpec>;
+  /** Inverse property URI when declared via owl:inverseOf. */
+  inverse?: string;
+  isAnnotation: boolean;
+  /** Annotation values targeting THIS property (annotation prop URI -> value). */
+  annotations: ReadonlyMap<string, string>;
+}
+
+/** Pass 2 output: the typed class/property graph plus namespace inventory. */
+export interface OntologyIR {
+  classes: ReadonlyMap<string, ClassNode>;
+  properties: ReadonlyMap<string, PropertyNode>;
+  namespaces: ReadonlyMap<string, NamespaceInfo>;
+  /** Carried through from Pass 1 for the validate/map passes. */
+  extraction: RawExtraction;
+}
+
+// ---------------------------------------------------------------------------
+// Pass 4 output — MappedIR
+// ---------------------------------------------------------------------------
+
+/** Which of the eight resolver templates a mapped field instantiates (§5.2). */
+export type ResolverTemplate =
+  | "datatype"
+  | "datatype-list"
+  | "object-singular"
+  | "object-list"
+  | "embedded-singular"
+  | "embedded-list"
+  | "inverse"
+  | "meta";
+
+/** The GraphQL type a mapped field resolves to: scalar, named type, or union. */
+export type FieldTypeSpec =
+  | { kind: "scalar"; name: string }
+  | { kind: "type"; name: string }
+  | { kind: "union"; name: string; members: readonly string[] };
+
+/** A GraphQL field mapped from an OWL property (Pass 4 output). */
+export interface MappedField {
+  owlUri: string;
+  graphqlName: string;
+  type: FieldTypeSpec;
+  nullable: boolean;
+  list: boolean;
+  resolverTemplate: ResolverTemplate;
+  propertyUri: string;
+  /** For inverse fields: the forward property whose assertions are reversed. */
+  inverseOf?: string;
+  /** SHACL sh:minCount >= 1 — informational, not auto-promoted (KG.15). */
+  shaclRequired: boolean;
+  /** Consumer-promoted via NonNullOverrides (KG.15 Tier 3). */
+  nonNull: boolean;
+}
+
+/** A GraphQL object type mapped from a concrete OWL class (Pass 4 output). */
+export interface MappedType {
+  owlUri: string;
+  graphqlName: string;
+  /** GraphQL interface names this type implements (ancestors). */
+  interfaces: readonly string[];
+  fields: ReadonlyMap<string, MappedField>;
+  embeddable: boolean;
+  namespace: string;
+  /** Pluralized root listing field name (e.g. "categories"). */
+  pluralName: string;
+  /** Singular root lookup field name (e.g. "category"). */
+  singularName: string;
+}
+
+/** A GraphQL interface mapped from an abstract OWL class (Pass 4 output). */
+export interface MappedInterface {
+  owlUri: string;
+  graphqlName: string;
+  parentInterfaces: readonly string[];
+  fields: ReadonlyMap<string, MappedField>;
+}
+
+/**
+ * Bidirectional OWL URI ↔ GraphQL name lookup. Type names map globally;
+ * field names are scoped per type ("Type.field").
+ */
+export interface NameMap {
+  /** OWL URI → GraphQL name. */
+  toGraphQL(uri: string): string | undefined;
+  /** GraphQL name → OWL URI. Field names are scoped per type: "Type.field". */
+  toOWL(name: string): string | undefined;
+  entries(): Iterable<[string, string]>;
+}
+
+/** A GraphQL union produced from an owl:unionOf range (Pass 4 output). */
+export interface MappedUnion {
+  name: string;
+  /** Concrete member type names (abstract members already expanded). */
+  members: readonly string[];
+}
+
+/** Pass 4 output: the complete GraphQL-shaped view of the ontology. */
+export interface MappedIR {
+  types: ReadonlyMap<string, MappedType>;
+  interfaces: ReadonlyMap<string, MappedInterface>;
+  unions: ReadonlyMap<string, MappedUnion>;
+  nameMap: NameMap;
+  namespaces: ReadonlyMap<string, NamespaceInfo>;
+  /** The OntologyIR, carried for resolver closures (meta fields, tbox). */
+  ir: OntologyIR;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver runtime values
+// ---------------------------------------------------------------------------
+
+/** A predicate URI → object values map for one entity. */
+export type TripleSet = Map<string, TripleValue[]>;
+
+/** One RDF object value: a URI reference, a literal, or a blank node. */
+export type TripleValue =
+  | { kind: "uri"; value: string }
+  | { kind: "literal"; value: string; datatype?: string; language?: string }
+  | { kind: "blank"; id: string; triples: TripleSet };
+
+/**
+ * The uniform parent value flowing through every resolver. Named entities
+ * carry their prefixed URI; embedded blank-node values carry uri: null.
+ */
+export interface EntityValue {
+  uri: string | null;
+  typename: string;
+  triples: TripleSet;
+}
+
+/** The decoded form of an inverse-loader cache key. */
+export interface InverseKey {
+  /** The forward OWL property URI whose assertions are reversed. */
+  property: string;
+  /** The entity (full IRI) being pointed at. */
+  object: string;
+}
+
+/**
+ * The per-request GraphQL context: the three DataLoaders, the name map, the
+ * store escape hatch, and the runtime warning channel. Extensions may stash
+ * their own state on it.
+ */
+export interface CompilerContext {
+  entityLoader: DataLoader<string, EntityValue | null>;
+  listLoader: DataLoader<string, string[]>;
+  inverseLoader: DataLoader<string, string[]>;
+  nameMap: NameMap;
+  /**
+   * The compiled namespace inventory — resolvers use it for full-IRI ↔
+   * prefixed-URI conversion (e.g. paginating an object connection by its
+   * cursor-stable prefixed form before hydration).
+   */
+  namespaces: ReadonlyMap<string, NamespaceInfo>;
+  /**
+   * The ke store (escape hatch for extensions). May be a Promise for
+   * lazy-store boots: ABox loaders await it; TBox resolvers never touch it.
+   */
+  store: Store | Promise<Store>;
+  /** Resolver-time warning channel (EC.03 coercion failures). */
+  warn: RuntimeWarningHandler;
+  /** Extension state (search index, back-link index, …) — consumer-owned. */
+  [key: string]: unknown;
+}
+
+/** Receives resolver-time warnings (e.g. literal coercion failures, EC.03). */
+export type RuntimeWarningHandler = (warning: {
+  property: string;
+  value: string;
+  reason: string;
+}) => void;
+
+/**
+ * Creates a fresh CompilerContext per call and exposes cache control for the
+ * "process" loader-cache mode.
+ */
+export interface ContextFactory {
+  (store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearCache(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Per-URI override of the generated mapping (rename, cardinality, shape). */
+export interface CustomMapping {
+  graphqlName?: string;
+  singular?: boolean;
+  abstract?: boolean;
+  embeddable?: boolean;
+  /** Synthesize an inverse field on the property's range type (KG.02). */
+  inverse?: { graphqlName: string };
+}
+
+/** Custom mappings keyed by full IRI or prefixed name (e.g. "ds:tier"). */
+export type CustomMappings = Record<string, CustomMapping>;
+
+/** Per GraphQL type name: the field names promoted to non-null (KG.15). */
+export type NonNullOverrides = Record<string, string[]>;
+
+/** Consumer-supplied extension fields, keyed by GraphQL type name. */
+export interface SchemaExtensions {
+  [typeName: string]: Record<
+    string,
+    // biome-ignore lint/suspicious/noExplicitAny: graphql-js field configs are consumer-typed
+    GraphQLFieldConfig<any, CompilerContext>
+  >;
+}
+
+/**
+ * Extensions may need the compiler-generated types (e.g. an `anatomy` field
+ * typed as the generated Specification). The factory form receives a lookup
+ * for generated types and interfaces by name.
+ */
+export type SchemaExtensionsInput =
+  | SchemaExtensions
+  | ((types: {
+      type(name: string): import("graphql").GraphQLObjectType | undefined;
+      iface(name: string): import("graphql").GraphQLInterfaceType | undefined;
+    }) => SchemaExtensions);
+
+/** Options accepted by the schema plugin and the compile entry points. */
+export interface SchemaPluginOptions {
+  mappings?: CustomMappings;
+  extensions?: SchemaExtensionsInput;
+  /** Wire the Node interface, global IDs, and connections. Default: true. */
+  relay?: boolean;
+  /** File path for SDL output. */
+  sdlOutput?: string;
+  nonNullOverrides?: NonNullOverrides;
+  /**
+   * Opt-in instance-level standard-vocabulary fields (EC.15).
+   * Per GraphQL type name: predicate URI → field name.
+   */
+  standardVocabFields?: Record<string, Record<string, string>>;
+  /** Resolver-time warnings (coercion failures). Default: console.warn, deduplicated. */
+  onRuntimeWarning?: RuntimeWarningHandler;
+  /**
+   * DataLoader cache scope. "request" (default): fresh caches per
+   * createContext call. "process": LRU caches shared across contexts for the
+   * lifetime of this CompilerResult — sound because the store is immutable
+   * between reloads, and onReload produces a new result (auto-invalidation).
+   * Bounded (see processCacheSize) so enumeration can't grow them without
+   * limit; failed batches are evicted, never memoized.
+   */
+  loaderCache?: "request" | "process";
+  /**
+   * Maximum entries per process-lifetime loader cache (LRU), used only when
+   * loaderCache is "process". Default: DEFAULT_PROCESS_CACHE_SIZE.
+   */
+  processCacheSize?: number;
+}
+
+/** Everything a successful compilation produces: schema, SDL, IR, context factory. */
+export interface CompilerResult {
+  schema: GraphQLSchema;
+  diagnostics: Diagnostic[];
+  nameMap: NameMap;
+  sdl: string;
+  mapped: MappedIR;
+  /** The Pass 1 output, carried on every CompilerResult. */
+  extraction: RawExtraction;
+  /**
+   * Fresh DataLoaders per call ("request" mode) or shared caches
+   * ("process" mode). Accepts a Promise for lazy-store boots: TBox
+   * queries answer before the store resolves; ABox loaders await it.
+   */
+  createContext(store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearLoaderCache(): void;
+}
+
+/** The API surface the plugin registers on the ke store under "ke-graphql". */
+export interface SchemaPluginApi {
+  schema: GraphQLSchema;
+  diagnostics: Diagnostic[];
+  nameMap: NameMap;
+  sdl: string;
+  /**
+   * Create a fresh CompilerContext (new DataLoaders each call). Takes the
+   * store as an argument: ke's PluginContext is scoped to its lifecycle
+   * hook and must not be retained for request-time queries.
+   */
+  createContext(store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearLoaderCache(): void;
+}
+
+/**
+ * The query surface the compiler needs. Satisfied by both ke's
+ * PluginContext.query (compile time) and Store.query (request time).
+ */
+export type QueryFn = (
+  query: string,
+) => Promise<import("@canonical/ke").QueryResult>;

--- a/packages/runtime/ke-graphql/src/lib/compiler/validate.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/validate.ts
@@ -1,0 +1,245 @@
+// =============================================================================
+// Pass 3 — Validate: OntologyIR → OntologyIR (+ diagnostics)
+//
+// Pure. Reads the IR and the Pass 1 probes, emits the V-series diagnostics.
+// Never mutates the IR.
+// =============================================================================
+
+import { XSD } from "./constants.js";
+import getLocalName from "./getLocalName.js";
+import isStandardVocab from "./isStandardVocab.js";
+import type { Diagnostic, OntologyIR, PassResult } from "./types.js";
+
+const PHASE = "validate";
+
+/** A class is blank-node-only when it has instances but none are named. */
+const isBlankOnly = (ir: OntologyIR, classUri: string): boolean => {
+  const stats = ir.extraction.instanceStats.get(classUri);
+  return stats !== undefined && stats.total > 0 && stats.named === 0;
+};
+
+/**
+ * Validate the OntologyIR against the Pass 1 ABox probes (Pass 3): emits
+ * the V-series diagnostics (blank-node-only classes, domainless properties,
+ * asymmetric inverses, functional violations, SHACL specifics, …) without
+ * mutating the IR. Pure.
+ */
+export default function validate(ir: OntologyIR): PassResult<OntologyIR> {
+  const diagnostics: Diagnostic[] = [];
+  const push = (d: Omit<Diagnostic, "phase">) =>
+    diagnostics.push({ ...d, phase: PHASE });
+
+  for (const node of ir.classes.values()) {
+    // V001 — blank-node-only class
+    if (isBlankOnly(ir, node.uri)) {
+      push({
+        severity: "warning",
+        code: "V001",
+        message: `${getLocalName(node.uri)} instances are exclusively blank nodes — embeddable type`,
+        source: node.uri,
+      });
+    }
+    // V015 — class forced abstract (by mapping) yet has direct instances.
+    // Those instances' only asserted type is now an interface, so they cannot
+    // resolve and are filtered at runtime — the data contradicts the mapping.
+    // (The automatic abstract heuristic can't trigger this: it only marks a
+    // class abstract when it has zero instances.)
+    const abstractStats = ir.extraction.instanceStats.get(node.uri);
+    if (node.isAbstract && (abstractStats?.total ?? 0) > 0) {
+      push({
+        severity: "warning",
+        code: "V015",
+        message: `${getLocalName(node.uri)} is marked abstract but has ${abstractStats?.total} direct instance(s) — those instances will not resolve`,
+        source: node.uri,
+      });
+    }
+    // V016 — concrete class with subclasses (instantiable supertype). A field
+    // typed as this class can hold a subclass instance, but graphql-js calls
+    // no resolveType on a concrete object type, so the subclass's __typename
+    // and fields are unreachable through it. Mark it abstract if it has no
+    // direct instances; the interface+companion fix is deferred (A.10 §13).
+    if (!node.isAbstract && !node.embeddable && node.subclasses.length > 0) {
+      push({
+        severity: "warning",
+        code: "V016",
+        message: `${getLocalName(node.uri)} is a concrete type with ${node.subclasses.length} subclass(es) — values returned through a ${getLocalName(node.uri)} field expose only its own fields, not the subclass's`,
+        source: node.uri,
+      });
+    }
+    // V009 — cross-vocabulary subClassOf
+    for (const parent of node.superclasses) {
+      if (!ir.classes.has(parent) && isStandardVocab(parent)) {
+        push({
+          severity: "warning",
+          code: "V009",
+          message: `${getLocalName(node.uri)} subClassOf standard-vocabulary ${parent} — treated as root class`,
+          source: node.uri,
+        });
+      } else if (!ir.classes.has(parent)) {
+        push({
+          severity: "warning",
+          code: "B002",
+          message: `${getLocalName(node.uri)} references unknown superclass ${parent}`,
+          source: node.uri,
+        });
+      }
+    }
+  }
+
+  for (const property of ir.properties.values()) {
+    // B002 — unknown domain
+    for (const domain of property.domains) {
+      if (!ir.classes.has(domain) && !isStandardVocab(domain)) {
+        push({
+          severity: "warning",
+          code: "B002",
+          message: `${getLocalName(property.uri)} has unknown domain ${domain}`,
+          source: property.uri,
+        });
+      }
+    }
+    // B003 — unknown range
+    if (property.range.kind === "unknown") {
+      push({
+        severity: "warning",
+        code: "B003",
+        message: `${getLocalName(property.uri)} has unknown range ${property.range.raw} — mapped to String`,
+        source: property.uri,
+      });
+    }
+    // B004 — unknown inverse
+    if (property.inverse && !ir.properties.has(property.inverse)) {
+      push({
+        severity: "warning",
+        code: "B004",
+        message: `${getLocalName(property.uri)} declares unknown inverse ${property.inverse}`,
+        source: property.uri,
+      });
+    }
+    // V002 — domainless
+    if (property.domains.length === 0 && !property.isAnnotation) {
+      push({
+        severity: "warning",
+        code: "V002",
+        message: `${getLocalName(property.uri)} has no rdfs:domain — assigned to all ${property.namespace}: classes`,
+        source: property.uri,
+      });
+    }
+    // V003 — conflicting inverse declarations (A declares inverse B while
+    // B declares inverse C). One-sided declarations are normal OWL and are
+    // silently completed in Pass 2 — only contradictions warrant a warning.
+    if (property.inverse) {
+      const other = ir.properties.get(property.inverse);
+      if (other && other.inverse !== property.uri) {
+        push({
+          severity: "warning",
+          code: "V003",
+          message: `asymmetric owl:inverseOf between ${getLocalName(property.uri)} and ${getLocalName(property.inverse)}`,
+          source: property.uri,
+        });
+      }
+    }
+    // V004 — self-referential assertions
+    if (ir.extraction.selfReferential.has(property.uri)) {
+      push({
+        severity: "warning",
+        code: "V004",
+        message: `${getLocalName(property.uri)} has a self-referential assertion in the data`,
+        source: property.uri,
+      });
+    }
+    // V005 — functional violations
+    if (ir.extraction.functionalViolations.has(property.uri)) {
+      push({
+        severity: "warning",
+        code: "V005",
+        message: `functional property ${getLocalName(property.uri)} has multiple values on some instance`,
+        source: property.uri,
+      });
+    }
+    // V006 — boolean range (data stores strings; resolver coerces)
+    if (
+      property.range.kind === "scalar" &&
+      property.range.xsd === `${XSD}boolean`
+    ) {
+      push({
+        severity: "info",
+        code: "V006",
+        message: `${getLocalName(property.uri)} is xsd:boolean — resolver coerces string literals`,
+        source: property.uri,
+      });
+    }
+    // V007 — annotation property routed to TBox
+    if (property.isAnnotation) {
+      push({
+        severity: "info",
+        code: "V007",
+        message: `annotation property ${getLocalName(property.uri)} routed to TBox schema`,
+        source: property.uri,
+      });
+    }
+    // V008 — custom datatype mapped to base scalar
+    if (property.range.kind === "scalar" && property.range.customDatatype) {
+      push({
+        severity: "info",
+        code: "V008",
+        message: `custom datatype ${getLocalName(property.range.customDatatype)} mapped to ${property.range.graphqlScalar}`,
+        source: property.uri,
+      });
+    }
+    // V010/V011/V012 — SHACL specifics
+    for (const [classUri, spec] of property.classCardinality) {
+      if (spec.omit) {
+        push({
+          severity: "warning",
+          code: "V010",
+          message: `${getLocalName(property.uri)} has sh:maxCount 0 on ${getLocalName(classUri)} — field omitted`,
+          source: property.uri,
+        });
+      }
+    }
+    const fromOr = ir.extraction.shaclConstraints.some(
+      (c) => c.property === property.uri && c.fromOr,
+    );
+    if (fromOr) {
+      push({
+        severity: "info",
+        code: "V011",
+        message: `${getLocalName(property.uri)} constrained via sh:or — most permissive interpretation applied`,
+        source: property.uri,
+      });
+    }
+    const inConstraint = ir.extraction.shaclConstraints.find(
+      (c) => c.property === property.uri && c.inValues?.length,
+    );
+    if (inConstraint) {
+      push({
+        severity: "info",
+        code: "V012",
+        message: `${getLocalName(property.uri)} has sh:in (${inConstraint.inValues?.join(", ")}) — mapped to String, enum deferred`,
+        source: property.uri,
+      });
+    }
+    // V013 — multi-domain
+    if (property.domains.length > 1) {
+      push({
+        severity: "warning",
+        code: "V013",
+        message: `${getLocalName(property.uri)} declares ${property.domains.length} domains — OWL means intersection; field generated on each`,
+        source: property.uri,
+      });
+    }
+  }
+
+  // V014 — undeclared ABox predicates
+  for (const predicate of ir.extraction.undeclaredPredicates) {
+    push({
+      severity: "info",
+      code: "V014",
+      message: `ABox predicate ${predicate} is not declared in any loaded TBox — no field generated`,
+      source: predicate,
+    });
+  }
+
+  return { output: ir, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.ts
@@ -1,0 +1,183 @@
+// =============================================================================
+// Pass 6 — Wire Relay: SchemaPlan → SchemaPlan
+//
+// Pure plan surgery (no graphql-js objects yet):
+// - id/uri/_meta on every non-embeddable type
+// - Node membership for non-embeddable types AND for generated interfaces
+//   whose concrete implementors are all non-embeddable (Relay @refetchable
+//   fragments on UIBlock need Node + id)
+// - list object fields → connections with the four pagination args
+// - root query fields: node(id), per-type lookup + listing
+// =============================================================================
+
+import { toFull, toPrefixed } from "#dataloader";
+import {
+  connectionFromPage,
+  paginateUriWindow,
+  unwrapEntities,
+} from "#resolver";
+import type { FieldPlan, SchemaPlan } from "./emit.js";
+import type {
+  CompilerContext,
+  Diagnostic,
+  EntityValue,
+  PassResult,
+} from "./types.js";
+
+/** Create the Relay global-ID field plan (id: ID!). */
+const createIdField = (): FieldPlan => ({
+  name: "id",
+  type: { base: "ID", kind: "scalar", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent.uri,
+  description: "Relay global ID — the entity's prefixed URI (KG.10).",
+});
+
+/** Create the uri field plan (uri: String!). */
+const createUriField = (): FieldPlan => ({
+  name: "uri",
+  type: { base: "String", kind: "scalar", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent.uri,
+});
+
+/** Create the _meta field plan (self-describing TBox access, KG.03). */
+const createMetaField = (): FieldPlan => ({
+  name: "_meta",
+  type: { base: "EntityMeta", kind: "named", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent,
+  description: "Self-describing TBox access for this entity (KG.03).",
+});
+
+/**
+ * Wire the Relay server conventions into the SchemaPlan (Pass 6): Node
+ * membership with id/uri/_meta on non-embeddable types, connection-wrapping
+ * of list object fields, and the root node/lookup/listing query fields.
+ * Pure plan surgery — no graphql-js objects are constructed here.
+ */
+export default function wireRelay(plan: SchemaPlan): PassResult<SchemaPlan> {
+  const diagnostics: Diagnostic[] = [];
+  const { mapped } = plan;
+
+  // ── connections: every list field whose base is a named non-embeddable
+  //    type becomes a connection field with pagination args ──
+  const wrapConnections = (fields: Map<string, FieldPlan>) => {
+    for (const field of fields.values()) {
+      if (!field.type.list || field.type.kind !== "named") {
+        continue;
+      }
+      const targetType = plan.types.get(field.type.base);
+      const targetInterface = plan.interfaces.get(field.type.base);
+      const embeddableTarget =
+        targetType?.embeddable ??
+        (targetInterface ? targetInterface.embeddableOnly : false);
+      if (embeddableTarget) {
+        continue; // embedded lists stay plain lists (KG.13)
+      }
+      field.type = {
+        base: field.type.base,
+        kind: "connection",
+        list: false,
+        nonNull: true,
+      };
+      field.connectionArgs = true;
+    }
+  };
+
+  for (const type of plan.types.values()) {
+    wrapConnections(type.fields);
+  }
+  for (const iface of plan.interfaces.values()) {
+    wrapConnections(iface.fields);
+  }
+
+  // ── id/uri/_meta + Node membership ──
+  for (const type of plan.types.values()) {
+    if (type.embeddable) {
+      continue;
+    }
+    const structural = [createIdField(), createUriField(), createMetaField()];
+    const existing = type.fields;
+    type.fields = new Map([
+      ...structural.map((f): [string, FieldPlan] => [f.name, f]),
+      ...existing,
+    ]);
+    type.interfaces = ["Node", ...type.interfaces];
+  }
+  for (const iface of plan.interfaces.values()) {
+    if (iface.embeddableOnly) {
+      continue;
+    }
+    const structural = [createIdField(), createUriField(), createMetaField()];
+    iface.fields = new Map([
+      ...structural.map((f): [string, FieldPlan] => [f.name, f]),
+      ...iface.fields,
+    ]);
+    iface.parents = ["Node", ...iface.parents];
+  }
+
+  // ── root query fields ──
+  plan.queryFields.set("node", {
+    name: "node",
+    type: { base: "Node", kind: "named", list: false, nonNull: false },
+    args: { id: { type: "ID", required: true } },
+    resolve: async (_parent, args: { id?: string }, ctx: CompilerContext) => {
+      if (!args.id) {
+        return null;
+      }
+      const full = toFull(args.id, mapped.namespaces);
+      if (!full) {
+        return null; // unknown prefix
+      }
+      return ctx.entityLoader.load(full);
+    },
+    description: "Relay node resolution by prefixed-URI global ID.",
+  });
+
+  for (const type of plan.types.values()) {
+    if (type.embeddable || !type.owlUri) {
+      continue;
+    }
+    const mappedType = mapped.types.get(type.name);
+    if (!mappedType) {
+      continue;
+    }
+    const classUri = type.owlUri;
+
+    plan.queryFields.set(mappedType.singularName, {
+      name: mappedType.singularName,
+      type: { base: type.name, kind: "named", list: false, nonNull: false },
+      args: { uri: { type: "String", required: true } },
+      resolve: async (
+        _parent,
+        args: { uri?: string },
+        ctx: CompilerContext,
+      ) => {
+        if (!args.uri) {
+          return null;
+        }
+        const full = toFull(args.uri, mapped.namespaces) ?? args.uri;
+        return ctx.entityLoader.load(full);
+      },
+    });
+
+    plan.queryFields.set(mappedType.pluralName, {
+      name: mappedType.pluralName,
+      type: { base: type.name, kind: "connection", list: false, nonNull: true },
+      connectionArgs: true,
+      resolve: async (_parent, args, ctx: CompilerContext) => {
+        // Slice BEFORE hydration: cursors and pageInfo need only the
+        // (name-sorted) URI list; entities are loaded for the page alone.
+        const fullUris = await ctx.listLoader.load(classUri);
+        const prefixed = fullUris.map((uri) =>
+          toPrefixed(uri, mapped.namespaces),
+        );
+        const page = paginateUriWindow(prefixed, args);
+        const entities = await ctx.entityLoader.loadMany(
+          page.window.map((uri) => toFull(uri, mapped.namespaces) ?? uri),
+        );
+        return connectionFromPage(unwrapEntities(entities), page);
+      },
+    });
+  }
+
+  return { output: plan, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.test.ts
@@ -1,0 +1,174 @@
+// =============================================================================
+// Plugin integration (§9): createSchemaPlugin via createStore, store.api,
+// sdlOutput writing, extensions (object + factory), standardVocabFields.
+// =============================================================================
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTestStore } from "@canonical/ke/testing";
+import { GraphQLString, graphql } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import type { EntityValue, SchemaPluginApi } from "#compiler";
+import { MINIMAL_TTL, PREFIXES } from "#testing";
+import createSchemaPlugin from "./createSchemaPlugin.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+describe("createSchemaPlugin (§9)", () => {
+  it("compiles on onReady and exposes the api via store.api", async () => {
+    const plugin = createSchemaPlugin();
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    expect(api).toBeDefined();
+    expect(api?.schema.getType("Thing")).toBeDefined();
+    expect(api?.sdl).toContain("type Thing");
+    expect(api?.nameMap.toGraphQL("http://example.org/Thing")).toBe("Thing");
+
+    // request-time context takes the store (PluginContext is not retained)
+    const context = api?.createContext(store);
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ thing(uri: "ex:widget") { name } }`,
+      contextValue: context,
+    });
+    expect((result.data?.thing as { name: string }).name).toBe("Widget");
+  });
+
+  it("writes the SDL to sdlOutput", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ke-graphql-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const sdlPath = join(dir, "schema.graphql");
+    const plugin = createSchemaPlugin({ sdlOutput: sdlPath });
+    const { cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    expect(existsSync(sdlPath)).toBe(true);
+    expect(readFileSync(sdlPath, "utf-8")).toContain(
+      "type Thing implements Node",
+    );
+  });
+
+  it("registers extensions in object form on types and Query", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: {
+        Thing: {
+          shout: {
+            type: GraphQLString,
+            resolve: (source: EntityValue) => `${source.uri}!`,
+          },
+        },
+        Query: {
+          hello: { type: GraphQLString, resolve: () => "world" },
+        },
+      },
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ hello thing(uri: "ex:widget") { shout } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.hello).toBe("world");
+    expect((result.data?.thing as { shout: string }).shout).toBe("ex:widget!");
+  });
+
+  it("supports the extensions factory form receiving generated types", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: (types) => ({
+        Query: {
+          firstThing: {
+            type: types.type("Thing") as NonNullable<
+              ReturnType<typeof types.type>
+            >,
+            resolve: async (_source, _args, ctx) => {
+              const uris = await ctx.listLoader.load(
+                "http://example.org/Thing",
+              );
+              return uris[0] ? ctx.entityLoader.load(uris[0]) : null;
+            },
+          },
+        },
+      }),
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ firstThing { name } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.firstThing as { name: string }).name).toBe("Widget");
+  });
+
+  it("reports C001/C002 extension conflicts as composition errors", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: {
+        NoSuchType: {
+          x: { type: GraphQLString },
+        },
+      },
+    });
+    await expect(
+      createTestStore({
+        ttl: MINIMAL_TTL,
+        prefixes: PREFIXES,
+        plugins: [plugin],
+      }),
+    ).rejects.toThrow(/C001|composition failed/);
+  });
+
+  it("generates instance-level standard-vocab fields (EC.15)", async () => {
+    const ttl = `${MINIMAL_TTL}
+      <http://example.org/widget> <http://www.w3.org/2000/01/rdf-schema#label> "The Widget"@en .
+    `;
+    const plugin = createSchemaPlugin({
+      standardVocabFields: {
+        Thing: { "http://www.w3.org/2000/01/rdf-schema#label": "label" },
+      },
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ thing(uri: "ex:widget") { label } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { label: string }).label).toBe("The Widget");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.ts
+++ b/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.ts
@@ -1,0 +1,105 @@
+// =============================================================================
+// ke plugin entry (§9): onReady runs the compiler against the freshly loaded
+// store; onReload recompiles (note: with `cache:` configured, ke's reload()
+// short-circuits on a cache hit — pass { force: true } in dev flows).
+//
+// Failure policy: the schema is produced through non-composition errors
+// (§2.2); only a CompilationError (composition failed) propagates and fails
+// the boot. All diagnostics are logged either way.
+// =============================================================================
+
+import { writeFileSync } from "node:fs";
+import { definePlugin, type PluginContext, type SPARQL } from "@canonical/ke";
+import {
+  compile,
+  type Diagnostic,
+  type QueryFn,
+  type SchemaPluginApi,
+  type SchemaPluginOptions,
+} from "./compiler/index.js";
+
+/**
+ * Log every diagnostic to the console at its severity's channel.
+ *
+ * @note Impure — writes to the console.
+ */
+const logDiagnostics = (diagnostics: Diagnostic[]): void => {
+  for (const d of diagnostics) {
+    const line = `[ke-graphql] ${d.code}: ${d.message}${d.source ? ` (${d.source})` : ""}`;
+    if (d.severity === "error") {
+      console.error(line);
+    } else if (d.severity === "warning") {
+      console.warn(line);
+    } else {
+      console.info(line);
+    }
+  }
+};
+
+/**
+ * Adapt a ke PluginContext to the QueryFn surface (string → branded SPARQL).
+ *
+ * @note Impure — the returned function executes SPARQL queries against the
+ * store behind the plugin context.
+ */
+const createPluginQueryFn =
+  (ctx: PluginContext): QueryFn =>
+  (query) =>
+    ctx.query(query as SPARQL<string>);
+
+/**
+ * Create the ke-graphql schema plugin: compiles the schema when the store is
+ * ready and recompiles on reload, registering the SchemaPluginApi under
+ * "ke-graphql".
+ *
+ * @note Impure — the plugin's lifecycle hooks query the store and may write
+ * the SDL output file.
+ *
+ * @example
+ * ```ts
+ * const graphql = createSchemaPlugin({ mappings, extensions });
+ * const store = await createStore({ sources, prefixes, plugins: [graphql] });
+ * const { schema, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+ * ```
+ */
+export default function createSchemaPlugin(options: SchemaPluginOptions = {}) {
+  return definePlugin<SchemaPluginApi>({
+    name: "ke-graphql",
+
+    async onReady(ctx) {
+      return compileForContext(ctx, options);
+    },
+
+    async onReload(ctx) {
+      return compileForContext(ctx, options);
+    },
+  });
+}
+
+/**
+ * Compile for a plugin lifecycle hook: run a live compile, then log
+ * diagnostics and write the SDL output when configured.
+ *
+ * @note Impure — executes SPARQL queries on the store, logs to the console,
+ * and writes the SDL output file when configured.
+ */
+const compileForContext = async (
+  ctx: PluginContext,
+  options: SchemaPluginOptions,
+): Promise<SchemaPluginApi> => {
+  const result = await compile(createPluginQueryFn(ctx), ctx.prefixes, options);
+  logDiagnostics(result.diagnostics);
+
+  if (options.sdlOutput) {
+    writeFileSync(options.sdlOutput, result.sdl, "utf-8");
+  }
+
+  return {
+    schema: result.schema,
+    diagnostics: result.diagnostics,
+    nameMap: result.nameMap,
+    sdl: result.sdl,
+    createContext: result.createContext,
+    clearLoaderCache: result.clearLoaderCache,
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/dataloader/createEntityLoader.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createEntityLoader.ts
@@ -1,0 +1,191 @@
+// =============================================================================
+// Entity loader (§5.3). One batched CONSTRUCT fetches the requested entities'
+// triples AND the closure of their blank-node children in the same query —
+// blank-node labels are only consistent within a single result set (a
+// follow-up query per blank node is invalid SPARQL: labels are existential
+// variables, and VALUES may not contain blank nodes).
+//
+// Guards: ke classifies an empty CONSTRUCT result as { type: "select" }
+// (shape-based detection) — treated here as "all URIs missing". The closure
+// query produces one row per (?p,?o) x (?bp,?bo) combination, so identical
+// triples repeat — deduped by (subject, predicate, object identity).
+// =============================================================================
+
+import type { Quad, Term } from "@canonical/ke";
+import DataLoader from "dataloader";
+import {
+  type EntityValue,
+  type MappedIR,
+  type QueryFn,
+  RDF_TYPE,
+  type TripleSet,
+  type TripleValue,
+} from "#compiler";
+import { isSafeIri } from "#hardening";
+import { toPrefixed } from "./uris.js";
+
+/** Separator that cannot occur in IRIs or well-formed literals. */
+const SEP = "\u0000";
+
+const convertToTripleValue = (
+  term: Term,
+  blankSets: Map<string, TripleSet>,
+): TripleValue => {
+  switch (term.termType) {
+    case "NamedNode":
+      return { kind: "uri", value: term.value };
+    case "BlankNode": {
+      let triples = blankSets.get(term.value);
+      if (!triples) {
+        triples = new Map();
+        blankSets.set(term.value, triples);
+      }
+      return { kind: "blank", id: term.value, triples };
+    }
+    case "Literal":
+      return {
+        kind: "literal",
+        value: term.value,
+        datatype: term.datatype,
+        language: term.language,
+      };
+  }
+};
+
+/** Pick the most specific class among rdf:type assertions via the IR. */
+const pickMostSpecificTypename = (
+  typeUris: string[],
+  mapped: MappedIR,
+): string | undefined => {
+  let best: string | undefined;
+  let bestDepth = -1;
+  for (const uri of typeUris) {
+    const node = mapped.ir.classes.get(uri);
+    // Only concrete classes are valid runtime typenames. Returning an abstract
+    // class's name makes graphql-js reject it in resolveType ("abstract type
+    // resolved to non-object type"), which nulls the whole field. An entity
+    // typed only as abstract classes resolves to undefined (filtered) instead.
+    if (!node || node.isAbstract) {
+      continue;
+    }
+    if (node.ancestors.length > bestDepth) {
+      bestDepth = node.ancestors.length;
+      best = uri;
+    }
+  }
+  return best ? mapped.nameMap.toGraphQL(best) : undefined;
+};
+
+/**
+ * Create the entity DataLoader: batches full-IRI keys into one CONSTRUCT
+ * (including the single-hop blank-node closure) and yields EntityValues, or
+ * null for missing/typeless URIs. An optional cacheMap shares the cache
+ * across contexts ("process" mode); failed batches evict their keys so
+ * errors are never memoized.
+ *
+ * @note Impure — the returned loader executes SPARQL queries against the
+ * store.
+ */
+export default function createEntityLoader(
+  query: QueryFn,
+  mapped: MappedIR,
+  cacheMap?: Map<string, Promise<EntityValue | null>>,
+): DataLoader<string, EntityValue | null> {
+  const loader: DataLoader<string, EntityValue | null> = new DataLoader(
+    (fullUris) =>
+      batch(fullUris).catch((error) => {
+        // A shared (process-lifetime) cache must not memoize failures:
+        // evict the keys of a failed batch before rethrowing.
+        for (const uri of fullUris) {
+          loader.clear(uri);
+        }
+        throw error;
+      }),
+    cacheMap ? { cacheMap } : undefined,
+  );
+  const batch = async (fullUris: ReadonlyArray<string>) => {
+    // Injection guard (KG.19): only IRIs safe to interpolate into an IRIREF
+    // reach the query. An unsafe global ID is simply absent from VALUES and
+    // resolves to null (not found), never to injected SPARQL.
+    const values = fullUris
+      .filter(isSafeIri)
+      .map((uri) => `<${uri}>`)
+      .join(" ");
+    const result = await query(
+      `CONSTRUCT { ?s ?p ?o . ?o ?bp ?bo }
+       WHERE {
+         VALUES ?s { ${values} }
+         ?s ?p ?o .
+         OPTIONAL { ?o ?bp ?bo . FILTER(isBlank(?o)) }
+       }`,
+    );
+    // Empty CONSTRUCT results arrive select-shaped from ke.
+    const quads: Quad[] = result.type === "construct" ? result.quads : [];
+
+    // Group triples per subject; blank-node subjects fill the shared sets.
+    const bySubject = new Map<string, TripleSet>();
+    const blankSets = new Map<string, TripleSet>();
+    const seen = new Set<string>();
+
+    const resolveTripleSet = (subject: Term): TripleSet | undefined => {
+      if (subject.termType === "NamedNode") {
+        let set = bySubject.get(subject.value);
+        if (!set) {
+          set = new Map();
+          bySubject.set(subject.value, set);
+        }
+        return set;
+      }
+      if (subject.termType === "BlankNode") {
+        let set = blankSets.get(subject.value);
+        if (!set) {
+          set = new Map();
+          blankSets.set(subject.value, set);
+        }
+        return set;
+      }
+      return undefined;
+    };
+
+    const encodeTermKey = (term: Term): string =>
+      term.termType === "Literal"
+        ? `L:${term.value}${SEP}${term.datatype ?? ""}${SEP}${term.language ?? ""}`
+        : `${term.termType === "BlankNode" ? "B" : "N"}:${term.value}`;
+
+    for (const quad of quads) {
+      const set = resolveTripleSet(quad.subject);
+      if (!set || quad.predicate.termType !== "NamedNode") {
+        continue;
+      }
+      const key = `${encodeTermKey(quad.subject)}${SEP}${quad.predicate.value}${SEP}${encodeTermKey(quad.object)}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      const list = set.get(quad.predicate.value) ?? [];
+      list.push(convertToTripleValue(quad.object, blankSets));
+      set.set(quad.predicate.value, list);
+    }
+
+    return fullUris.map((uri) => {
+      const triples = bySubject.get(uri);
+      if (!triples) {
+        return null;
+      }
+      const typeUris = (triples.get(RDF_TYPE) ?? [])
+        .filter((v) => v.kind === "uri")
+        .map((v) => (v as { value: string }).value);
+      const typename = pickMostSpecificTypename(typeUris, mapped);
+      if (!typename) {
+        return null; // URI exists but has no known class assertion
+      }
+      return {
+        uri: toPrefixed(uri, mapped.namespaces),
+        typename,
+        triples,
+      } satisfies EntityValue;
+    });
+  };
+
+  return loader;
+}

--- a/packages/runtime/ke-graphql/src/lib/dataloader/createInverseLoader.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createInverseLoader.ts
@@ -1,0 +1,87 @@
+// =============================================================================
+// Inverse loader (§5.3). Batches reverse-assertion lookups. Keys are encoded
+// as "<propertyUri> <objectFullUri>" strings (DataLoader cache keys must be
+// primitives without a custom cacheKeyFn).
+// =============================================================================
+
+import DataLoader from "dataloader";
+import type { MappedIR, QueryFn } from "#compiler";
+import { toFull } from "./uris.js";
+
+/** Encode an inverse-loader cache key from its property and object parts. */
+const encodeInverseKey = (property: string, object: string): string =>
+  `${property} ${object}`;
+
+/**
+ * Create the inverse DataLoader: batches "<propertyUri> <objectUri>" keys
+ * into one SELECT over reverse assertions and yields the subject URIs
+ * pointing at each object. An optional cacheMap shares the cache across
+ * contexts ("process" mode); failed batches evict their keys so errors are
+ * never memoized.
+ *
+ * @note Impure — the returned loader executes SPARQL queries against the
+ * store.
+ */
+export default function createInverseLoader(
+  query: QueryFn,
+  mapped: MappedIR,
+  cacheMap?: Map<string, Promise<string[]>>,
+): DataLoader<string, string[]> {
+  const loader: DataLoader<string, string[]> = new DataLoader(
+    (keys) =>
+      batch(keys).catch((error) => {
+        for (const key of keys) {
+          loader.clear(key);
+        }
+        throw error;
+      }),
+    cacheMap ? { cacheMap } : undefined,
+  );
+  const batch = async (keys: ReadonlyArray<string>) => {
+    const pairs: string[] = [];
+    for (const key of keys) {
+      const space = key.indexOf(" ");
+      const property = key.slice(0, space);
+      const object = key.slice(space + 1);
+      // EntityValue.uri carries the prefixed form; expand for SPARQL.
+      const full = toFull(object, mapped.namespaces) ?? object;
+      pairs.push(`(<${property}> <${full}>)`);
+    }
+    const result = await query(
+      `SELECT ?property ?object ?subject WHERE {
+         VALUES (?property ?object) { ${pairs.join(" ")} }
+         ?subject ?property ?object .
+         FILTER(isIRI(?subject))
+       }
+       ORDER BY ?subject`,
+    );
+    const byKey = new Map<string, string[]>();
+    if (result.type === "select") {
+      for (const row of result.termBindings) {
+        const property = row.property;
+        const object = row.object;
+        const subject = row.subject;
+        if (
+          property?.termType !== "NamedNode" ||
+          object?.termType !== "NamedNode" ||
+          subject?.termType !== "NamedNode"
+        ) {
+          continue;
+        }
+        const key = encodeInverseKey(property.value, object.value);
+        const list = byKey.get(key) ?? [];
+        list.push(subject.value);
+        byKey.set(key, list);
+      }
+    }
+    return keys.map((key) => {
+      const space = key.indexOf(" ");
+      const property = key.slice(0, space);
+      const object = key.slice(space + 1);
+      const full = toFull(object, mapped.namespaces) ?? object;
+      return byKey.get(encodeInverseKey(property, full)) ?? [];
+    });
+  };
+
+  return loader;
+}

--- a/packages/runtime/ke-graphql/src/lib/dataloader/createListLoader.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createListLoader.ts
@@ -1,0 +1,97 @@
+// =============================================================================
+// List loader (§5.3). Batches instance-of queries per class with a per-class
+// name predicate (paired VALUES) so the default name-sort works across
+// ontologies. Rows are deduplicated per instance (multi-valued names would
+// otherwise duplicate rows).
+// =============================================================================
+
+import DataLoader from "dataloader";
+import {
+  getLocalName,
+  type MappedIR,
+  type QueryFn,
+  RDF_TYPE,
+  RDFS_LABEL,
+} from "#compiler";
+
+/**
+ * Resolve the name predicate for a class: a declared property in the class's
+ * own namespace with local name "name", else rdfs:label.
+ */
+const resolveNamePredicate = (mapped: MappedIR, classUri: string): string => {
+  const node = mapped.ir.classes.get(classUri);
+  if (node) {
+    for (const propertyUri of node.allProperties) {
+      if (getLocalName(propertyUri) === "name") {
+        return propertyUri;
+      }
+    }
+  }
+  return RDFS_LABEL;
+};
+
+/**
+ * Create the class-listing DataLoader: batches class URIs into one SELECT
+ * and yields each class's named instance URIs, name-sorted via the class's
+ * name predicate. An optional cacheMap shares the cache across contexts
+ * ("process" mode); failed batches evict their keys so errors are never
+ * memoized.
+ *
+ * @note Impure — the returned loader executes SPARQL queries against the
+ * store.
+ */
+export default function createListLoader(
+  query: QueryFn,
+  mapped: MappedIR,
+  cacheMap?: Map<string, Promise<string[]>>,
+): DataLoader<string, string[]> {
+  const loader: DataLoader<string, string[]> = new DataLoader(
+    (classUris) =>
+      batch(classUris).catch((error) => {
+        for (const uri of classUris) {
+          loader.clear(uri);
+        }
+        throw error;
+      }),
+    cacheMap ? { cacheMap } : undefined,
+  );
+  const batch = async (classUris: ReadonlyArray<string>) => {
+    const pairs = classUris
+      .map((uri) => `(<${uri}> <${resolveNamePredicate(mapped, uri)}>)`)
+      .join(" ");
+    const result = await query(
+      `SELECT ?class ?instance ?name WHERE {
+         VALUES (?class ?nameProp) { ${pairs} }
+         ?instance <${RDF_TYPE}> ?class .
+         FILTER(isIRI(?instance))
+         OPTIONAL { ?instance ?nameProp ?name }
+       }
+       ORDER BY LCASE(STR(?name)) ?instance`,
+    );
+    const byClass = new Map<string, string[]>();
+    if (result.type === "select") {
+      const seen = new Set<string>();
+      for (const row of result.termBindings) {
+        const classUri = row.class;
+        const instance = row.instance;
+        if (
+          classUri?.termType !== "NamedNode" ||
+          instance?.termType !== "NamedNode"
+        ) {
+          continue;
+        }
+        const key = `${classUri.value} ${instance.value}`;
+        if (seen.has(key)) {
+          continue; // multi-valued names duplicate rows
+        }
+        seen.add(key);
+        const list = byClass.get(classUri.value) ?? [];
+        list.push(instance.value);
+        byClass.set(classUri.value, list);
+      }
+    }
+    return classUris.map((uri) => byClass.get(uri) ?? []);
+  };
+
+  return loader;
+}

--- a/packages/runtime/ke-graphql/src/lib/dataloader/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The batched data-loading domain: the three per-request DataLoaders
+ * (entity, class listing, reverse assertions) and the prefixed-URI ↔ full
+ * IRI conversions they key on.
+ *
+ * @module dataloader
+ */
+
+export { default as createEntityLoader } from "./createEntityLoader.js";
+export { default as createInverseLoader } from "./createInverseLoader.js";
+export { default as createListLoader } from "./createListLoader.js";
+export { toFull, toPrefixed } from "./uris.js";

--- a/packages/runtime/ke-graphql/src/lib/dataloader/uris.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/uris.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { NamespaceInfo } from "#compiler";
+import { toFull, toPrefixed } from "./uris.js";
+
+const namespaces = new Map<string, NamespaceInfo>([
+  [
+    "ds",
+    {
+      prefix: "ds",
+      uri: "https://ds.canonical.com/",
+      classCount: 0,
+      propertyCount: 0,
+    },
+  ],
+]);
+
+describe("toPrefixed / toFull (KG.10)", () => {
+  it("round-trips a prefixed URI", () => {
+    const full = "https://ds.canonical.com/global.component.button";
+    const prefixed = toPrefixed(full, namespaces);
+    expect(prefixed).toBe("ds:global.component.button");
+    expect(toFull(prefixed, namespaces)).toBe(full);
+  });
+
+  it("returns the input when no namespace matches", () => {
+    expect(toPrefixed("http://other.org/x", namespaces)).toBe(
+      "http://other.org/x",
+    );
+  });
+
+  it("returns undefined for unknown prefixes and prefixless ids", () => {
+    expect(toFull("zz:thing", namespaces)).toBeUndefined();
+    expect(toFull("no-colon-here", namespaces)).toBeUndefined();
+  });
+
+  it("passes through full IRIs", () => {
+    expect(toFull("https://ds.canonical.com/x", namespaces)).toBe(
+      "https://ds.canonical.com/x",
+    );
+  });
+
+  it("picks the longest matching namespace, order-independently (canonical IDs)", () => {
+    const entries: [string, NamespaceInfo][] = [
+      [
+        "base",
+        {
+          prefix: "base",
+          uri: "http://ex.org/",
+          classCount: 0,
+          propertyCount: 0,
+        },
+      ],
+      [
+        "sub",
+        {
+          prefix: "sub",
+          uri: "http://ex.org/sub/",
+          classCount: 0,
+          propertyCount: 0,
+        },
+      ],
+    ];
+    const nested = new Map(entries);
+    const reordered = new Map([...entries].reverse());
+    // The most specific (longest) namespace wins regardless of iteration order.
+    expect(toPrefixed("http://ex.org/sub/g1", nested)).toBe("sub:g1");
+    expect(toPrefixed("http://ex.org/sub/g1", reordered)).toBe("sub:g1");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/dataloader/uris.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/uris.ts
@@ -1,0 +1,56 @@
+// =============================================================================
+// Prefixed URI ↔ full IRI conversion (KG.10). The prefixed form is the
+// public identity (global IDs, EntityValue.uri); full IRIs are the loader
+// keys and SPARQL currency.
+// =============================================================================
+
+import type { NamespaceInfo } from "#compiler";
+
+/**
+ * Convert a full IRI to its prefixed form ("ds:button") using the compiled
+ * namespace inventory. Picks the LONGEST matching namespace so that nested
+ * namespaces (e.g. "http://x/" and "http://x/sub/") yield a stable, canonical
+ * prefixed form regardless of namespace discovery order — Relay global IDs and
+ * cursors depend on this being deterministic (KG.10). Returns the input
+ * unchanged when no registered namespace matches.
+ */
+export const toPrefixed = (
+  fullUri: string,
+  namespaces: ReadonlyMap<string, NamespaceInfo>,
+): string => {
+  let best: string | undefined;
+  let bestLength = -1;
+  for (const ns of namespaces.values()) {
+    if (fullUri.startsWith(ns.uri) && ns.uri.length > bestLength) {
+      bestLength = ns.uri.length;
+      best = `${ns.prefix}:${fullUri.slice(ns.uri.length)}`;
+    }
+  }
+  return best ?? fullUri;
+};
+
+/**
+ * Convert a prefixed URI ("ds:button") to its full IRI using the compiled
+ * namespace inventory. Inputs that are already full IRIs pass through;
+ * returns undefined when the prefix is unknown (node() returns null then).
+ */
+export const toFull = (
+  prefixed: string,
+  namespaces: ReadonlyMap<string, NamespaceInfo>,
+): string | undefined => {
+  const colon = prefixed.indexOf(":");
+  if (colon === -1) {
+    return undefined;
+  }
+  const prefix = prefixed.slice(0, colon);
+  const rest = prefixed.slice(colon + 1);
+  const ns = namespaces.get(prefix);
+  if (ns) {
+    return `${ns.uri}${rest}`;
+  }
+  // Already a full IRI (contains "://" or another colon-bearing scheme).
+  if (rest.startsWith("//")) {
+    return prefixed;
+  }
+  return undefined;
+};

--- a/packages/runtime/ke-graphql/src/lib/hardening/clampConnectionArgs.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/clampConnectionArgs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import clampConnectionArgs from "./clampConnectionArgs.js";
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "./constants.js";
+
+describe("clampConnectionArgs (page-size hardening)", () => {
+  it("imposes the default page size when neither first nor last is given", () => {
+    expect(clampConnectionArgs({})).toEqual({ first: DEFAULT_PAGE_SIZE });
+    // `after`/`before` alone still count as "no page bound supplied".
+    expect(clampConnectionArgs({ after: "cur" })).toEqual({
+      after: "cur",
+      first: DEFAULT_PAGE_SIZE,
+    });
+  });
+
+  it("caps an over-large first/last at the ceiling", () => {
+    expect(clampConnectionArgs({ first: 10_000 }).first).toBe(MAX_PAGE_SIZE);
+    expect(clampConnectionArgs({ last: 10_000 }).last).toBe(MAX_PAGE_SIZE);
+  });
+
+  it("leaves in-range values untouched", () => {
+    expect(clampConnectionArgs({ first: 10 }).first).toBe(10);
+    expect(clampConnectionArgs({ last: 5 })).toEqual({ last: 5 });
+  });
+
+  it("passes negatives through unchanged (rejected downstream, not masked)", () => {
+    expect(clampConnectionArgs({ first: -1 }).first).toBe(-1);
+    expect(clampConnectionArgs({ last: -3 }).last).toBe(-3);
+  });
+
+  it("honors explicit limits", () => {
+    const limits = { defaultPageSize: 3, maxPageSize: 9 };
+    expect(clampConnectionArgs({}, limits)).toEqual({ first: 3 });
+    expect(clampConnectionArgs({ first: 100 }, limits).first).toBe(9);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/clampConnectionArgs.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/clampConnectionArgs.ts
@@ -1,0 +1,39 @@
+// =============================================================================
+// Connection page-size clamp. A connection must never return an unbounded
+// list, and a client must never be able to demand an arbitrarily large page.
+// This is applied at the two pagination choke points (paginateUriWindow and
+// toConnection) so every connection — root, nested, and TBox — is bounded.
+// =============================================================================
+
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "./constants.js";
+
+/**
+ * Clamp a connection's page size: apply the default `first` when the client
+ * gave neither `first` nor `last`, and cap a too-large `first`/`last` at the
+ * ceiling (`{ defaultPageSize, maxPageSize }`, defaulting to the hardening
+ * constants). Negative values pass through unchanged — the connection helpers
+ * reject those with a GraphQLError, which this must not mask. Returns a new
+ * args object; the input is not mutated.
+ */
+export default function clampConnectionArgs<
+  T extends { first?: number | null; last?: number | null },
+>(
+  args: T,
+  limits: { defaultPageSize: number; maxPageSize: number } = {
+    defaultPageSize: DEFAULT_PAGE_SIZE,
+    maxPageSize: MAX_PAGE_SIZE,
+  },
+): T {
+  // No page bound supplied → impose the default page size.
+  if (args.first == null && args.last == null) {
+    return { ...args, first: limits.defaultPageSize };
+  }
+  let { first, last } = args;
+  if (first != null && first > limits.maxPageSize) {
+    first = limits.maxPageSize;
+  }
+  if (last != null && last > limits.maxPageSize) {
+    last = limits.maxPageSize;
+  }
+  return { ...args, first, last };
+}

--- a/packages/runtime/ke-graphql/src/lib/hardening/constants.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/constants.ts
@@ -1,0 +1,37 @@
+// =============================================================================
+// Hardening defaults. These are the package's production-safety knobs in one
+// named place (the hardening domain), not magic numbers scattered through the
+// handler and resolvers. The HTTP handler and connection helpers read them;
+// consumers can override at their call sites.
+// =============================================================================
+
+/**
+ * Page size applied to a connection when the client supplies neither `first`
+ * nor `last`. A connection must never return an unbounded list — this is the
+ * floor of DoS protection.
+ */
+export const DEFAULT_PAGE_SIZE = 50;
+
+/**
+ * Hard ceiling on `first`/`last`. A client asking for more is clamped down to
+ * this — it bounds both the hydration cost and the response size regardless
+ * of what the client requests.
+ */
+export const MAX_PAGE_SIZE = 100;
+
+/**
+ * Default maximum selection-set nesting depth enforced by the HTTP handler's
+ * depth-limit rule. High enough to admit the standard introspection query,
+ * low enough to reject the unbounded recursion that cyclic types
+ * (work → authors → works → authors → …) otherwise allow.
+ */
+export const DEFAULT_MAX_QUERY_DEPTH = 20;
+
+/**
+ * Default maximum entries per process-lifetime loader cache (LRU) when
+ * `loaderCache: "process"` is used. Bounds memory: enumerating distinct entity
+ * IDs (misses are cached too) can't grow the caches without limit. Evicted
+ * entries are simply re-queried — the store is immutable between reloads, so
+ * eviction never returns stale data.
+ */
+export const DEFAULT_PROCESS_CACHE_SIZE = 10_000;

--- a/packages/runtime/ke-graphql/src/lib/hardening/createBoundedCache.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/createBoundedCache.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import createBoundedCache from "./createBoundedCache.js";
+
+describe("createBoundedCache (bounded LRU)", () => {
+  it("evicts the least-recently-used entry past the size limit", () => {
+    const cache = createBoundedCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3); // over capacity → evict "a"
+    expect(cache.has("a")).toBe(false);
+    expect(cache.has("b")).toBe(true);
+    expect(cache.has("c")).toBe(true);
+    expect(cache.size).toBe(2);
+  });
+
+  it("get() refreshes recency, protecting an entry from eviction", () => {
+    const cache = createBoundedCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    expect(cache.get("a")).toBe(1); // "a" is now most-recent; "b" is LRU
+    cache.set("c", 3); // evicts "b", not "a"
+    expect(cache.has("a")).toBe(true);
+    expect(cache.has("b")).toBe(false);
+  });
+
+  it("behaves as a normal Map within the limit", () => {
+    const cache = createBoundedCache<string, number>(10);
+    cache.set("a", 1);
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("missing")).toBeUndefined();
+    cache.delete("a");
+    expect(cache.has("a")).toBe(false);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/createBoundedCache.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/createBoundedCache.ts
@@ -1,0 +1,51 @@
+// =============================================================================
+// Bounded LRU for the process-lifetime loader caches. The "process" loaderCache
+// mode shares DataLoader caches across requests; without a bound, a client
+// enumerating distinct entity IDs (misses are cached too) grows the maps
+// without limit. This caps them — past the size limit, inserting evicts the
+// least-recently-used key, and an eviction merely re-queries (still correct,
+// since the store is immutable between reloads).
+// =============================================================================
+
+// Map subclass with LRU eviction. get()/set() refresh recency by re-inserting
+// (Map preserves insertion order), so the first key is always the LRU one.
+class BoundedCache<K, V> extends Map<K, V> {
+  readonly #maxSize: number;
+
+  constructor(maxSize: number) {
+    super();
+    this.#maxSize = maxSize;
+  }
+
+  get(key: K): V | undefined {
+    if (!super.has(key)) {
+      return undefined;
+    }
+    const value = super.get(key) as V;
+    super.delete(key);
+    super.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): this {
+    super.delete(key);
+    super.set(key, value);
+    if (super.size > this.#maxSize) {
+      const lru = super.keys().next().value;
+      if (lru !== undefined) {
+        super.delete(lru);
+      }
+    }
+    return this;
+  }
+}
+
+/**
+ * Create a bounded, least-recently-used Map: once it exceeds `maxSize`
+ * entries, inserting evicts the least-recently-used key; get() and set()
+ * refresh recency. Backs the process-lifetime loader caches so "process" mode
+ * bounds memory instead of growing without limit.
+ */
+export default function createBoundedCache<K, V>(maxSize: number): Map<K, V> {
+  return new BoundedCache<K, V>(maxSize);
+}

--- a/packages/runtime/ke-graphql/src/lib/hardening/createDepthLimitRule.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/createDepthLimitRule.test.ts
@@ -1,0 +1,41 @@
+import { buildSchema, parse, validate } from "graphql";
+import { describe, expect, it } from "vitest";
+import createDepthLimitRule from "./createDepthLimitRule.js";
+
+const schema = buildSchema(`
+  type Query { node: Node }
+  type Node { name: String, child: Node }
+`);
+
+const depthErrors = (query: string, maxDepth: number) =>
+  validate(schema, parse(query), [createDepthLimitRule(maxDepth)]);
+
+describe("createDepthLimitRule", () => {
+  it("passes operations within the limit", () => {
+    // node(1) name(2) => depth 2
+    expect(depthErrors(`{ node { name } }`, 3)).toHaveLength(0);
+  });
+
+  it("rejects operations exceeding the limit", () => {
+    // node(1) child(2) child(3) name(4) => depth 4
+    const errors = depthErrors(`{ node { child { child { name } } } }`, 2);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toMatch(/maximum depth of 2/);
+  });
+
+  it("counts through inline fragments without adding a level", () => {
+    // node(1) name(2) — the inline fragment is transparent => depth 2
+    expect(depthErrors(`{ node { ... on Node { name } } }`, 2)).toHaveLength(0);
+  });
+
+  it("resolves named fragment spreads", () => {
+    const query = `{ node { ...F } } fragment F on Node { child { child { name } } }`;
+    // node(1) child(2) child(3) name(4) => depth 4 > 2
+    expect(depthErrors(query, 2)).toHaveLength(1);
+  });
+
+  it("guards fragment cycles without infinite recursion", () => {
+    const query = `{ node { ...F } } fragment F on Node { child { ...F } }`;
+    expect(() => depthErrors(query, 50)).not.toThrow();
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/createDepthLimitRule.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/createDepthLimitRule.ts
@@ -1,0 +1,85 @@
+// =============================================================================
+// Query-depth validation rule. graphql-js ships no depth limit, so a schema
+// with cyclic types (work → authors → works → authors → …) accepts arbitrarily
+// nested operations. This rule rejects any operation whose selection-set
+// nesting exceeds maxDepth, resolving named fragment spreads (with a cycle
+// guard) and inline fragments — neither of which adds a level of its own.
+// =============================================================================
+
+import {
+  type ASTVisitor,
+  type FragmentDefinitionNode,
+  GraphQLError,
+  Kind,
+  type SelectionSetNode,
+  type ValidationContext,
+} from "graphql";
+
+/**
+ * Create a validation rule that fails any operation nested deeper than
+ * `maxDepth` selection sets. A leaf field is depth 1; `{ a { b } }` is depth
+ * 2. Fragment spreads and inline fragments are transparent to the count.
+ */
+export default function createDepthLimitRule(
+  maxDepth: number,
+): (context: ValidationContext) => ASTVisitor {
+  return (context) => {
+    const fragments = new Map<string, FragmentDefinitionNode>();
+    for (const def of context.getDocument().definitions) {
+      if (def.kind === Kind.FRAGMENT_DEFINITION) {
+        fragments.set(def.name.value, def);
+      }
+    }
+
+    const depthOf = (
+      selectionSet: SelectionSetNode | undefined,
+      seenFragments: ReadonlySet<string>,
+    ): number => {
+      if (!selectionSet) {
+        return 0;
+      }
+      let deepest = 0;
+      for (const selection of selectionSet.selections) {
+        if (selection.kind === Kind.FIELD) {
+          const below = depthOf(selection.selectionSet, seenFragments);
+          deepest = Math.max(deepest, 1 + below);
+        } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+          // Inline fragments do not add a level — their selections sit at the
+          // current depth.
+          deepest = Math.max(
+            deepest,
+            depthOf(selection.selectionSet, seenFragments),
+          );
+        } else {
+          // Fragment spread: expand the named fragment, guarding cycles.
+          const name = selection.name.value;
+          if (seenFragments.has(name)) {
+            continue;
+          }
+          const fragment = fragments.get(name);
+          if (fragment) {
+            deepest = Math.max(
+              deepest,
+              depthOf(fragment.selectionSet, new Set([...seenFragments, name])),
+            );
+          }
+        }
+      }
+      return deepest;
+    };
+
+    return {
+      OperationDefinition(node) {
+        const depth = depthOf(node.selectionSet, new Set());
+        if (depth > maxDepth) {
+          context.reportError(
+            new GraphQLError(
+              `Query exceeds maximum depth of ${maxDepth} (depth ${depth})`,
+              { nodes: [node] },
+            ),
+          );
+        }
+      },
+    };
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/hardening/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/index.ts
@@ -1,0 +1,23 @@
+/**
+ * The hardening domain: the package's production-safety posture in one named
+ * place — the IRI-injection guard for SPARQL interpolation, connection
+ * page-size clamping, the query-depth validation rule, the bounded loader
+ * cache, and production error masking. Defaults live in ./constants; the HTTP
+ * handler, the connection helpers, and the context factory consume these so
+ * the policy is discoverable and tunable, never a magic number lurking in a
+ * resolver.
+ *
+ * @module hardening
+ */
+
+export { default as clampConnectionArgs } from "./clampConnectionArgs.js";
+export {
+  DEFAULT_MAX_QUERY_DEPTH,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_PROCESS_CACHE_SIZE,
+  MAX_PAGE_SIZE,
+} from "./constants.js";
+export { default as createBoundedCache } from "./createBoundedCache.js";
+export { default as createDepthLimitRule } from "./createDepthLimitRule.js";
+export { default as isSafeIri } from "./isSafeIri.js";
+export { default as maskError } from "./maskError.js";

--- a/packages/runtime/ke-graphql/src/lib/hardening/isSafeIri.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/isSafeIri.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import isSafeIri from "./isSafeIri.js";
+
+describe("isSafeIri (SPARQL IRIREF injection guard)", () => {
+  it("accepts well-formed IRIs with legal punctuation", () => {
+    for (const iri of [
+      "http://example.org/Thing",
+      "https://ds.canonical.com/global.component.button",
+      "http://ex.org/path?q=1#frag",
+      "urn:uuid:1234-5678",
+    ]) {
+      expect(isSafeIri(iri)).toBe(true);
+    }
+  });
+
+  it("rejects IRIs carrying an IRIREF-illegal character", () => {
+    for (const iri of [
+      "http://ex.org/x> } UNION { ?s ?p ?o } #", // the injection breakout
+      "http://ex.org/a b", // space
+      "http://ex.org/x\ty", // control character (tab)
+      "http://ex.org/<x>",
+      'http://ex.org/"x"',
+      "http://ex.org/{x}",
+      "http://ex.org/x|y",
+      "http://ex.org/x^y",
+      "http://ex.org/x`y",
+      "http://ex.org/x\\y",
+      "",
+    ]) {
+      expect(isSafeIri(iri)).toBe(false);
+    }
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/isSafeIri.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/isSafeIri.ts
@@ -1,0 +1,39 @@
+// =============================================================================
+// IRI-injection guard. Loaders interpolate full IRIs into SPARQL as `<${iri}>`
+// (e.g. VALUES ?s { <...> }). The IRI ultimately derives from client input
+// (node(id:) / <type>(uri:) arguments), so an IRI carrying an IRIREF-illegal
+// character -- `>` above all -- would terminate the IRIREF early and inject
+// the remainder as SPARQL graph patterns. ke queries are read-only, so the
+// blast radius is cross-graph disclosure and query-cost amplification rather
+// than mutation, but it is still reachable unauthenticated.
+//
+// Per the SPARQL grammar an IRIREF is '<' ([^<>"{}|^`\]-[#x00-#x20])* '>'.
+// A well-formed IRI never contains any of those characters, so rejecting them
+// closes the injection without affecting any legitimate identifier. Legal IRI
+// punctuation (#, /, :, ?, %, ...) is deliberately NOT rejected.
+// =============================================================================
+
+// Code points forbidden inside a SPARQL IRIREF: <, >, ", {, }, |, ^, backtick,
+// backslash (control characters and space are handled by the <= 0x20 test).
+const FORBIDDEN = new Set([
+  0x3c, 0x3e, 0x22, 0x7b, 0x7d, 0x7c, 0x5e, 0x60, 0x5c,
+]);
+
+/**
+ * Report whether an IRI is safe to interpolate into a SPARQL `<...>` IRIREF --
+ * i.e. it is non-empty and contains no IRIREF-illegal character. Callers
+ * filter unsafe IRIs out of the query (an unsafe global ID then resolves to
+ * "not found", never to injected SPARQL).
+ */
+export default function isSafeIri(iri: string): boolean {
+  if (iri.length === 0) {
+    return false;
+  }
+  for (let i = 0; i < iri.length; i++) {
+    const code = iri.charCodeAt(i);
+    if (code <= 0x20 || FORBIDDEN.has(code)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/runtime/ke-graphql/src/lib/hardening/maskError.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/maskError.test.ts
@@ -1,0 +1,35 @@
+import { GraphQLError } from "graphql";
+import { describe, expect, it } from "vitest";
+import maskError from "./maskError.js";
+
+describe("maskError (production error masking)", () => {
+  it("masks an internal error (wrapping a non-GraphQL throw) when enabled", () => {
+    const internal = new GraphQLError("connection refused: db://secret@host", {
+      originalError: new Error("connection refused: db://secret@host"),
+    });
+    const formatted = maskError(internal, true);
+    expect(formatted.message).toBe("Internal server error");
+    expect(formatted.extensions?.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+
+  it("passes the original message through when masking is disabled", () => {
+    const internal = new GraphQLError("boom", {
+      originalError: new Error("boom"),
+    });
+    expect(maskError(internal, false).message).toBe("boom");
+  });
+
+  it("never masks a deliberate client-facing GraphQLError", () => {
+    // Validation-style error: no originalError.
+    expect(
+      maskError(new GraphQLError("Cannot query field x"), true).message,
+    ).toBe("Cannot query field x");
+    // An error that wraps another GraphQLError is still client-facing.
+    const wrapping = new GraphQLError("Argument first must be non-negative", {
+      originalError: new GraphQLError("Argument first must be non-negative"),
+    });
+    expect(maskError(wrapping, true).message).toBe(
+      "Argument first must be non-negative",
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/maskError.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/maskError.ts
@@ -1,0 +1,36 @@
+// =============================================================================
+// Production error masking. An unexpected throw inside a resolver (a store
+// error, a bug) bubbles up wrapped in a GraphQLError whose `originalError` is
+// the underlying Error — and its message can leak SPARQL fragments or store
+// internals to the client. In production those messages are replaced with a
+// generic one, while deliberate client-facing GraphQLErrors (validation, our
+// own throws — which carry no non-GraphQL originalError) pass through.
+// =============================================================================
+
+import { GraphQLError, type GraphQLFormattedError } from "graphql";
+
+/**
+ * Format a GraphQL execution error, masking internal/unexpected errors when
+ * `mask` is set. An error is "internal" when it wraps a non-GraphQLError
+ * `originalError` (a thrown runtime error): its message becomes generic
+ * (locations/path retained, `extensions.code = "INTERNAL_SERVER_ERROR"`).
+ * Deliberate GraphQLErrors pass through unchanged via `toJSON()`.
+ */
+export default function maskError(
+  error: GraphQLError,
+  mask: boolean,
+): GraphQLFormattedError {
+  if (
+    mask &&
+    error.originalError &&
+    !(error.originalError instanceof GraphQLError)
+  ) {
+    return {
+      message: "Internal server error",
+      ...(error.locations ? { locations: error.locations } : {}),
+      ...(error.path ? { path: error.path } : {}),
+      extensions: { code: "INTERNAL_SERVER_ERROR" },
+    };
+  }
+  return error.toJSON();
+}

--- a/packages/runtime/ke-graphql/src/lib/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/index.ts
@@ -1,0 +1,74 @@
+/**
+ * The public library surface of @canonical/ke-graphql, composed from the
+ * domain barrels: the compiler pipeline and its artifact codec, the ke
+ * plugin, local/static execution, and the connection helpers. The internal
+ * cross-domain surface (loaders, vocabulary constants, resolver templates)
+ * is deliberately not re-exported.
+ *
+ * @module lib
+ */
+
+export {
+  type CardinalitySpec,
+  type ClassNode,
+  CompilationError,
+  type CompilerContext,
+  type CompilerResult,
+  type ContextFactory,
+  type CustomMapping,
+  type CustomMappings,
+  compile,
+  createContextFactory,
+  type Diagnostic,
+  type DiagnosticCode,
+  type DiagnosticSeverity,
+  type EntityValue,
+  type InstanceStats,
+  type MappedField,
+  type MappedInterface,
+  type MappedIR,
+  type MappedType,
+  type NameMap,
+  type NamespaceInfo,
+  type NonNullOverrides,
+  type OntologyIR,
+  type PassResult,
+  type PropertyNode,
+  type QueryFn,
+  type RangeSpec,
+  type RawExtraction,
+  type ResolverTemplate,
+  type RuntimeWarningHandler,
+  type SchemaExtensions,
+  type SchemaExtensionsInput,
+  type SchemaPluginApi,
+  type SchemaPluginOptions,
+  storeQueryFn,
+  type TripleSet,
+  type TripleValue,
+} from "./compiler/index.js";
+export { default as createSchemaPlugin } from "./createSchemaPlugin.js";
+export { toFull, toPrefixed } from "./dataloader/index.js";
+export {
+  clampConnectionArgs,
+  createDepthLimitRule,
+  DEFAULT_MAX_QUERY_DEPTH,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_PROCESS_CACHE_SIZE,
+  isSafeIri,
+  MAX_PAGE_SIZE,
+  maskError,
+} from "./hardening/index.js";
+export {
+  type Connection,
+  type ConnectionArgs,
+  connectionFromPage,
+  emptyConnection,
+  fromBase64,
+  isEntity,
+  paginateUriWindow,
+  toBase64,
+  toConnection,
+  type UriPage,
+  unwrapEntities,
+} from "./resolver/index.js";

--- a/packages/runtime/ke-graphql/src/lib/resolver/coerce.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/coerce.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { coerce, mapXsdToScalar } from "./coerce.js";
+
+const warnings: Array<{ reason: string }> = [];
+const warn = (w: { reason: string }) => warnings.push(w);
+
+describe("coerce (EC.03)", () => {
+  it("passes strings through", () => {
+    expect(coerce("hello", "String", "p", warn)).toBe("hello");
+    expect(coerce("", "String", "p", warn)).toBe("");
+  });
+
+  it("coerces boolean lexical forms", () => {
+    expect(coerce("true", "Boolean", "p", warn)).toBe(true);
+    expect(coerce("false", "Boolean", "p", warn)).toBe(false);
+    expect(coerce("1", "Boolean", "p", warn)).toBe(true);
+    expect(coerce("0", "Boolean", "p", warn)).toBe(false);
+  });
+
+  it("returns null + warning for non-coercible booleans", () => {
+    warnings.length = 0;
+    expect(coerce("maybe", "Boolean", "p", warn)).toBeNull();
+    expect(warnings[0]?.reason).toContain("Boolean");
+  });
+
+  it("coerces integers and floats, warning on garbage", () => {
+    expect(coerce("42", "Int", "p", warn)).toBe(42);
+    expect(coerce("-3", "Int", "p", warn)).toBe(-3);
+    expect(coerce("2.5", "Float", "p", warn)).toBe(2.5);
+    warnings.length = 0;
+    expect(coerce("abc", "Int", "p", warn)).toBeNull();
+    expect(coerce("abc", "Float", "p", warn)).toBeNull();
+    expect(warnings).toHaveLength(2);
+  });
+});
+
+describe("mapXsdToScalar", () => {
+  const XSD = "http://www.w3.org/2001/XMLSchema#";
+  it("maps xsd datatypes to scalars", () => {
+    expect(mapXsdToScalar(`${XSD}boolean`)).toBe("Boolean");
+    expect(mapXsdToScalar(`${XSD}integer`)).toBe("Int");
+    expect(mapXsdToScalar(`${XSD}int`)).toBe("Int");
+    expect(mapXsdToScalar(`${XSD}long`)).toBe("Int");
+    expect(mapXsdToScalar(`${XSD}float`)).toBe("Float");
+    expect(mapXsdToScalar(`${XSD}double`)).toBe("Float");
+    expect(mapXsdToScalar(`${XSD}decimal`)).toBe("Float");
+    expect(mapXsdToScalar(`${XSD}string`)).toBe("String");
+    expect(mapXsdToScalar(`${XSD}anyURI`)).toBe("String");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/resolver/coerce.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/coerce.ts
@@ -1,0 +1,73 @@
+// =============================================================================
+// Literal coercion: boolean-as-string (EC.03), numeric parsing, language-tag
+// stripping (EC.06). Runtime failures go to the context's warning channel.
+// =============================================================================
+
+import { type RuntimeWarningHandler, XSD } from "#compiler";
+import type { ScalarName } from "./types.js";
+
+/**
+ * Coerce a literal's lexical value to the target GraphQL scalar: strings
+ * pass through, "true"/"false"/"1"/"0" become booleans, and numbers are
+ * parsed base-10. Returns null (plus a runtime warning through the provided
+ * handler) when the value cannot be coerced.
+ */
+export const coerce = (
+  value: string,
+  scalar: ScalarName,
+  property: string,
+  warn: RuntimeWarningHandler,
+): string | number | boolean | null => {
+  switch (scalar) {
+    case "String":
+      return value;
+    case "Boolean": {
+      if (value === "true" || value === "1") {
+        return true;
+      }
+      if (value === "false" || value === "0") {
+        return false;
+      }
+      warn({ property, value, reason: "not coercible to Boolean" });
+      return null;
+    }
+    case "Int": {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isNaN(parsed)) {
+        warn({ property, value, reason: "not coercible to Int" });
+        return null;
+      }
+      return parsed;
+    }
+    case "Float": {
+      const parsed = Number.parseFloat(value);
+      if (Number.isNaN(parsed)) {
+        warn({ property, value, reason: "not coercible to Float" });
+        return null;
+      }
+      return parsed;
+    }
+  }
+};
+
+/**
+ * Map an XSD datatype IRI to the GraphQL scalar it coerces to (boolean →
+ * Boolean, integer family → Int, decimal family → Float); anything else,
+ * including unknown datatypes, maps to String.
+ */
+export const mapXsdToScalar = (xsd: string): ScalarName => {
+  switch (xsd) {
+    case `${XSD}boolean`:
+      return "Boolean";
+    case `${XSD}integer`:
+    case `${XSD}int`:
+    case `${XSD}long`:
+      return "Int";
+    case `${XSD}float`:
+    case `${XSD}double`:
+    case `${XSD}decimal`:
+      return "Float";
+    default:
+      return "String";
+  }
+};

--- a/packages/runtime/ke-graphql/src/lib/resolver/connection.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/connection.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "#hardening";
+import {
+  emptyConnection,
+  fromBase64,
+  isEntity,
+  paginateUriWindow,
+  toBase64,
+  toConnection,
+  unwrapEntities,
+} from "./connection.js";
+
+const items = (uris: string[]) => uris.map((uri) => ({ uri }));
+
+describe("toConnection (§5.4, KG.18)", () => {
+  it("returns all items without arguments", () => {
+    const connection = toConnection(items(["b", "a", "c"]), {});
+    expect(connection.edges.map((e) => e.node.uri)).toEqual(["a", "b", "c"]);
+    expect(connection.pageInfo.hasNextPage).toBe(false);
+    expect(connection.pageInfo.hasPreviousPage).toBe(false);
+  });
+
+  it("paginates forward with first/after", () => {
+    const page1 = toConnection(items(["a", "b", "c"]), { first: 2 });
+    expect(page1.edges.map((e) => e.node.uri)).toEqual(["a", "b"]);
+    expect(page1.pageInfo.hasNextPage).toBe(true);
+    const page2 = toConnection(items(["a", "b", "c"]), {
+      first: 2,
+      after: page1.pageInfo.endCursor,
+    });
+    expect(page2.edges.map((e) => e.node.uri)).toEqual(["c"]);
+    expect(page2.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it("paginates backward with last/before", () => {
+    const lastPage = toConnection(items(["a", "b", "c"]), { last: 2 });
+    expect(lastPage.edges.map((e) => e.node.uri)).toEqual(["b", "c"]);
+    expect(lastPage.pageInfo.hasPreviousPage).toBe(true);
+    const before = toConnection(items(["a", "b", "c"]), {
+      last: 2,
+      before: toBase64("c"),
+    });
+    expect(before.edges.map((e) => e.node.uri)).toEqual(["a", "b"]);
+  });
+
+  it("throws on negative first/last (connection spec)", () => {
+    expect(() => toConnection(items(["a"]), { first: -1 })).toThrow(
+      /non-negative/,
+    );
+    expect(() => toConnection(items(["a"]), { last: -1 })).toThrow(
+      /non-negative/,
+    );
+  });
+
+  it("returns zero edges for last: 0 (not the whole list)", () => {
+    const connection = toConnection(items(["a", "b"]), { last: 0 });
+    expect(connection.edges).toHaveLength(0);
+  });
+
+  it("preserves upstream order when presorted", () => {
+    const connection = toConnection(items(["z", "a"]), {}, true);
+    expect(connection.edges.map((e) => e.node.uri)).toEqual(["z", "a"]);
+  });
+
+  it("ignores unknown cursors", () => {
+    const connection = toConnection(items(["a", "b"]), {
+      after: toBase64("nope"),
+    });
+    expect(connection.edges).toHaveLength(2);
+  });
+});
+
+describe("page-size hardening (clamp)", () => {
+  const many = (n: number) =>
+    items(
+      Array.from({ length: n }, (_, i) => `u${String(i).padStart(4, "0")}`),
+    );
+
+  it("imposes the default page size when neither first nor last is given", () => {
+    const connection = toConnection(many(200), {});
+    expect(connection.edges).toHaveLength(DEFAULT_PAGE_SIZE);
+    expect(connection.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it("caps an over-large first at the ceiling", () => {
+    expect(toConnection(many(200), { first: 10_000 }).edges).toHaveLength(
+      MAX_PAGE_SIZE,
+    );
+  });
+
+  it("clamps the URI window in paginateUriWindow as well", () => {
+    const uris = Array.from({ length: 200 }, (_, i) => `u${i}`);
+    expect(paginateUriWindow(uris, {}).window).toHaveLength(DEFAULT_PAGE_SIZE);
+    expect(paginateUriWindow(uris, { first: 10_000 }).window).toHaveLength(
+      MAX_PAGE_SIZE,
+    );
+  });
+});
+
+describe("helpers", () => {
+  it("base64 round-trips and tolerates garbage", () => {
+    expect(fromBase64(toBase64("ds:global.component.button"))).toBe(
+      "ds:global.component.button",
+    );
+    expect(typeof fromBase64("!!!")).toBe("string");
+  });
+
+  it("emptyConnection has the full pageInfo shape", () => {
+    const connection = emptyConnection();
+    expect(connection.edges).toEqual([]);
+    expect(connection.pageInfo.startCursor).toBeNull();
+  });
+
+  it("isEntity filters nulls and Errors from loadMany results", () => {
+    const entity = { uri: "x", typename: "T", triples: new Map() };
+    expect([entity, null, new Error("boom")].filter(isEntity)).toEqual([
+      entity,
+    ]);
+  });
+
+  it("unwrapEntities rethrows batch errors and drops nulls", () => {
+    const entity = { uri: "x", typename: "T", triples: new Map() };
+    expect(unwrapEntities([entity, null])).toEqual([entity]);
+    expect(() => unwrapEntities([entity, new Error("store down")])).toThrow(
+      "store down",
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/resolver/connection.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/connection.ts
@@ -1,0 +1,213 @@
+// =============================================================================
+// Relay connection helpers (KG.18).
+//
+// Cursor = base64(prefixed URI), opaque to clients. Items are sorted by URI
+// before slicing so cursors remain stable regardless of triple order or
+// Set-union order (root listings arrive name-sorted from the list loader and
+// keep that order). Per the Cursor Connections spec: negative first/last
+// throw, last: 0 yields zero edges.
+// =============================================================================
+
+import { GraphQLError } from "graphql";
+import type { EntityValue } from "#compiler";
+import { clampConnectionArgs } from "#hardening";
+import type { Connection, ConnectionArgs, Sortable, UriPage } from "./types.js";
+
+/**
+ * Encode a string as base64. Platform-neutral (Workers/browsers have
+ * btoa/atob but no Buffer; Node has both) and Unicode-safe via TextEncoder.
+ */
+export const toBase64 = (value: string): string => {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "utf-8").toString("base64");
+  }
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+};
+
+/**
+ * Decode a base64 string (Unicode-safe, platform-neutral). Invalid input
+ * decodes to "" rather than throwing — cursors are client-supplied.
+ */
+export const fromBase64 = (value: string): string => {
+  try {
+    if (typeof Buffer !== "undefined") {
+      return Buffer.from(value, "base64").toString("utf-8");
+    }
+    const binary = atob(value);
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return "";
+  }
+};
+
+/** Build the canonical empty connection (no edges, no cursors). */
+export const emptyConnection = <T>(): Connection<T> => ({
+  edges: [],
+  pageInfo: {
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: null,
+    endCursor: null,
+  },
+});
+
+/** DataLoader.loadMany returns (V | Error)[]; keep only real entities. */
+export const isEntity = (
+  value: EntityValue | Error | null,
+): value is EntityValue =>
+  value !== null && !(value instanceof Error) && typeof value === "object";
+
+/**
+ * Unwrap a loadMany result: rethrow the first Error (a failed batch must
+ * surface as a GraphQL field error, not as an empty connection), drop nulls
+ * (missing or typeless entities are filtered, KG.07).
+ */
+export const unwrapEntities = (
+  results: ReadonlyArray<EntityValue | Error | null>,
+): EntityValue[] => {
+  const firstError = results.find((r): r is Error => r instanceof Error);
+  if (firstError) {
+    throw firstError;
+  }
+  return results.filter(isEntity);
+};
+
+/**
+ * Run the full pagination algorithm on the URI LIST, before any hydration:
+ * cursors are base64(uri), hasNextPage is array math — entities are only
+ * needed for the page itself. Input must already be in display order
+ * (root listings arrive name-sorted from the list loader). Throws a
+ * GraphQLError on negative first/last.
+ */
+export const paginateUriWindow = (
+  uris: ReadonlyArray<string>,
+  args: ConnectionArgs,
+): UriPage => {
+  // Hardening: impose a default page size and cap an over-large one before
+  // any windowing (negatives pass through and are rejected below).
+  const page = clampConnectionArgs(args);
+  if (page.first != null && page.first < 0) {
+    throw new GraphQLError('Argument "first" must be a non-negative integer');
+  }
+  if (page.last != null && page.last < 0) {
+    throw new GraphQLError('Argument "last" must be a non-negative integer');
+  }
+  let start = 0;
+  let end = uris.length;
+  if (page.after) {
+    const idx = uris.indexOf(fromBase64(page.after));
+    if (idx !== -1) {
+      start = idx + 1;
+    }
+  }
+  if (page.before) {
+    const idx = uris.indexOf(fromBase64(page.before));
+    if (idx !== -1) {
+      end = Math.min(end, idx);
+    }
+  }
+  let hasNextPage = false;
+  let hasPreviousPage = false;
+  if (page.first != null && end - start > page.first) {
+    end = start + page.first;
+    hasNextPage = true;
+  }
+  if (page.last != null && end - start > page.last) {
+    start = end - page.last;
+    hasPreviousPage = true;
+  }
+  return { window: uris.slice(start, end), hasNextPage, hasPreviousPage };
+};
+
+/** Build a connection from an already-paginated, hydrated page. */
+export const connectionFromPage = <T extends Sortable>(
+  entities: T[],
+  page: UriPage,
+): Connection<T> => {
+  const edges = entities.map((node) => ({
+    node,
+    cursor: toBase64(node.uri ?? ""),
+  }));
+  return {
+    edges,
+    pageInfo: {
+      hasNextPage: page.hasNextPage,
+      hasPreviousPage: page.hasPreviousPage,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+};
+
+/**
+ * Build a Relay connection from a full in-memory list. O(n) — fine for the
+ * data scale (≤ ~1000 items per list). Throws a GraphQLError on negative
+ * first/last.
+ *
+ * @param presorted Skip the URI sort (root listings are name-sorted upstream).
+ */
+export const toConnection = <T extends Sortable>(
+  allItems: T[],
+  args: ConnectionArgs,
+  presorted = false,
+): Connection<T> => {
+  // Hardening: impose a default page size and cap an over-large one before
+  // slicing (negatives pass through and are rejected below).
+  const page = clampConnectionArgs(args);
+  if (page.first != null && page.first < 0) {
+    throw new GraphQLError('Argument "first" must be a non-negative integer');
+  }
+  if (page.last != null && page.last < 0) {
+    throw new GraphQLError('Argument "last" must be a non-negative integer');
+  }
+
+  let items = presorted
+    ? [...allItems]
+    : [...allItems].sort((a, b) => (a.uri ?? "").localeCompare(b.uri ?? ""));
+
+  if (page.after) {
+    const afterUri = fromBase64(page.after);
+    const idx = items.findIndex((i) => i.uri === afterUri);
+    if (idx !== -1) {
+      items = items.slice(idx + 1);
+    }
+  }
+  if (page.before) {
+    const beforeUri = fromBase64(page.before);
+    const idx = items.findIndex((i) => i.uri === beforeUri);
+    if (idx !== -1) {
+      items = items.slice(0, idx);
+    }
+  }
+
+  const hasNextPage = page.first != null && items.length > page.first;
+  const hasPreviousPage = page.last != null && items.length > page.last;
+
+  if (page.first != null) {
+    items = items.slice(0, page.first);
+  }
+  if (page.last != null) {
+    items = items.slice(Math.max(items.length - page.last, 0));
+  }
+
+  const edges = items.map((item) => ({
+    node: item,
+    cursor: toBase64(item.uri ?? ""),
+  }));
+
+  return {
+    edges,
+    pageInfo: {
+      hasNextPage,
+      hasPreviousPage,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/resolver/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/index.ts
@@ -1,0 +1,29 @@
+/**
+ * The resolver domain: literal coercion, the Relay connection/pagination
+ * helpers, the eight resolver templates the compiler instantiates per field,
+ * and the value shapes they exchange.
+ *
+ * @module resolver
+ */
+
+export { coerce, mapXsdToScalar } from "./coerce.js";
+export {
+  connectionFromPage,
+  emptyConnection,
+  fromBase64,
+  isEntity,
+  paginateUriWindow,
+  toBase64,
+  toConnection,
+  unwrapEntities,
+} from "./connection.js";
+export {
+  createDatatypeListResolver,
+  createDatatypeResolver,
+  createEmbeddedListResolver,
+  createEmbeddedSingularResolver,
+  createInverseResolver,
+  createObjectListResolver,
+  createObjectSingularResolver,
+} from "./templates.js";
+export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/resolver/templates.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/templates.ts
@@ -1,0 +1,238 @@
+// =============================================================================
+// The eight resolver templates (§5.2). Every generated field's resolve
+// function is an instantiation of one of these. Parents are EntityValues;
+// embedded blank-node children become EntityValues with uri: null and a
+// per-value typename derived from the blank node's rdf:type when present
+// (falling back to the field's declared range).
+// =============================================================================
+
+import type { GraphQLFieldResolver } from "graphql";
+import {
+  type CompilerContext,
+  type EntityValue,
+  type MappedField,
+  RDF_TYPE,
+  type TripleSet,
+} from "#compiler";
+import { toFull, toPrefixed } from "#dataloader";
+import { coerce } from "./coerce.js";
+import {
+  connectionFromPage,
+  emptyConnection,
+  paginateUriWindow,
+  unwrapEntities,
+} from "./connection.js";
+import type { ConnectionArgs, ScalarName } from "./types.js";
+
+/**
+ * Paginate an object connection BEFORE hydration: sort the deduplicated URI
+ * list into cursor order, window it (page size clamped by the hardening
+ * domain), then hydrate only the page. This bounds the per-field hydration
+ * cost to the page size regardless of how many URIs the parent references —
+ * a nested `authors(first: 10)` loads 10 entities, not all of them.
+ *
+ * @note Impure — hydrates the page through the context's entity loader.
+ */
+const paginateAndHydrate = async (
+  fullUris: string[],
+  args: ConnectionArgs,
+  ctx: CompilerContext,
+) => {
+  const prefixed = [...new Set(fullUris)]
+    .map((uri) => toPrefixed(uri, ctx.namespaces))
+    .sort((a, b) => a.localeCompare(b));
+  const page = paginateUriWindow(prefixed, args);
+  const entities = await ctx.entityLoader.loadMany(
+    page.window.map((uri) => toFull(uri, ctx.namespaces) ?? uri),
+  );
+  return connectionFromPage(unwrapEntities(entities), page);
+};
+
+type Resolver = GraphQLFieldResolver<EntityValue, CompilerContext>;
+
+/** Get the scalar name a field coerces to (String for non-scalar fields). */
+const getScalarName = (field: MappedField): ScalarName =>
+  field.type.kind === "scalar" ? (field.type.name as ScalarName) : "String";
+
+/** Resolve an embedded value's typename: rdf:type when present, else the range. */
+const resolveEmbeddedTypename = (
+  triples: TripleSet,
+  fallback: string,
+  ctx: CompilerContext,
+): string => {
+  const typeTriples = triples.get(RDF_TYPE);
+  for (const t of typeTriples ?? []) {
+    if (t.kind === "uri") {
+      const name = ctx.nameMap.toGraphQL(t.value);
+      if (name) {
+        return name;
+      }
+    }
+  }
+  return fallback;
+};
+
+/**
+ * Create a Template 1 resolver (singular datatype field): coerces the first
+ * literal value to the field's scalar; URI values surface as strings on
+ * B003 String fallbacks.
+ */
+export const createDatatypeResolver = (field: MappedField): Resolver => {
+  const scalar = getScalarName(field);
+  return (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    if (!values?.length) {
+      return null;
+    }
+    const v = values[0];
+    if (v?.kind === "literal") {
+      return coerce(v.value, scalar, field.propertyUri, ctx.warn);
+    }
+    // Object property with an unknown range mapped to String (B003): the
+    // value is a URI — honor the "mapped to String" contract.
+    if (v?.kind === "uri" && scalar === "String") {
+      return v.value;
+    }
+    return null;
+  };
+};
+
+/**
+ * Create a Template 2 resolver (datatype list field): coerces every literal
+ * value, dropping the ones that fail coercion (KG.07).
+ */
+export const createDatatypeListResolver = (field: MappedField): Resolver => {
+  const scalar = getScalarName(field);
+  return (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    if (!values?.length) {
+      return [];
+    }
+    return values
+      .map((v) => {
+        if (v.kind === "literal") {
+          return coerce(v.value, scalar, field.propertyUri, ctx.warn);
+        }
+        // B003 String fallback: URI values surface as their IRI strings.
+        if (v.kind === "uri" && scalar === "String") {
+          return v.value;
+        }
+        return null;
+      })
+      .filter((v) => v !== null);
+  };
+};
+
+/**
+ * Create a Template 3 resolver (singular object field): loads the referenced
+ * entity; declared inverse pairs fall back to the reverse assertion (EC.05).
+ */
+export const createObjectSingularResolver = (field: MappedField): Resolver => {
+  return async (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    const v = values?.find((value) => value.kind === "uri");
+    if (v?.kind === "uri") {
+      return ctx.entityLoader.load(v.value);
+    }
+    // Declared inverse pair: fall back to the reverse assertion (EC.05).
+    if (field.inverseOf && parent.uri) {
+      const reverse = await ctx.inverseLoader.load(
+        `${field.inverseOf} ${parent.uri}`,
+      );
+      if (reverse[0]) {
+        return ctx.entityLoader.load(reverse[0]);
+      }
+    }
+    return null;
+  };
+};
+
+/**
+ * Create a Template 5 resolver (object list field): loads every referenced
+ * entity and returns a Relay connection.
+ */
+export const createObjectListResolver = (field: MappedField): Resolver => {
+  return async (parent, args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    if (!values?.length) {
+      return emptyConnection();
+    }
+    const uris = values
+      .filter((v) => v.kind === "uri")
+      .map((v) => (v as { value: string }).value);
+    return paginateAndHydrate(uris, args as ConnectionArgs, ctx);
+  };
+};
+
+/**
+ * Create a Template 4 resolver (inverse fields — declared pairs and
+ * synthetic inverses): union of forward triples and reverse assertions,
+ * deduplicated by URI (EC.05 direction rule), as a Relay connection.
+ */
+export const createInverseResolver = (
+  field: MappedField,
+  /** Encoded inverse key prefix: the forward property whose assertions point at the parent. */
+  forwardProperty: string,
+): Resolver => {
+  return async (parent, args, ctx) => {
+    const forward = (parent.triples.get(field.propertyUri) ?? [])
+      .filter((v) => v.kind === "uri")
+      .map((v) => (v as { value: string }).value);
+    const reverse = parent.uri
+      ? await ctx.inverseLoader.load(`${forwardProperty} ${parent.uri}`)
+      : [];
+    const uris = [...forward, ...reverse];
+    if (uris.length === 0) {
+      return emptyConnection();
+    }
+    return paginateAndHydrate(uris, args as ConnectionArgs, ctx);
+  };
+};
+
+/**
+ * Create a Template 7 resolver (embedded list field): materializes the
+ * parent's blank-node children as EntityValues with uri: null.
+ */
+export const createEmbeddedListResolver = (
+  field: MappedField,
+  rangeTypename: string,
+): Resolver => {
+  return (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    if (!values?.length) {
+      return [];
+    }
+    return values
+      .filter((v) => v.kind === "blank")
+      .map((v) => {
+        const blank = v as { triples: TripleSet };
+        return {
+          uri: null,
+          typename: resolveEmbeddedTypename(blank.triples, rangeTypename, ctx),
+          triples: blank.triples,
+        } satisfies EntityValue;
+      });
+  };
+};
+
+/**
+ * Create a Template 6 resolver (embedded singular field): materializes the
+ * parent's first blank-node child as an EntityValue with uri: null.
+ */
+export const createEmbeddedSingularResolver = (
+  field: MappedField,
+  rangeTypename: string,
+): Resolver => {
+  return (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    const v = values?.find((value) => value.kind === "blank");
+    if (!v || v.kind !== "blank") {
+      return null;
+    }
+    return {
+      uri: null,
+      typename: resolveEmbeddedTypename(v.triples, rangeTypename, ctx),
+      triples: v.triples,
+    } satisfies EntityValue;
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/resolver/types.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/types.ts
@@ -1,0 +1,42 @@
+// =============================================================================
+// Shared types for the resolver domain: the Relay connection value shapes
+// every resolver template returns, the pagination argument contract, and the
+// scalar names the coercion helpers target. Grouped here because the
+// connection helpers, the resolver templates, and the compiler's Relay
+// wiring all exchange these shapes.
+// =============================================================================
+
+/** The four Relay pagination arguments accepted by connection fields. */
+export interface ConnectionArgs {
+  first?: number | null;
+  after?: string | null;
+  last?: number | null;
+  before?: string | null;
+}
+
+/** A Relay connection page: edges with cursors plus pageInfo. */
+export interface Connection<T> {
+  edges: Array<{ node: T; cursor: string }>;
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+}
+
+/** Anything carrying the URI identity used for cursor encoding and sorting. */
+export interface Sortable {
+  uri: string | null;
+}
+
+/** A paginated window over a URI list, computed before entity hydration. */
+export interface UriPage {
+  /** The page's URIs, in cursor domain (prefixed form). */
+  window: string[];
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+/** The GraphQL scalar names a literal can be coerced to. */
+export type ScalarName = "String" | "Boolean" | "Int" | "Float";

--- a/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.test.ts
@@ -1,0 +1,225 @@
+// =============================================================================
+// TBox schema surface (§1.6/§11.4): Ontology, OntologyClass, OntologyProperty,
+// ClassProperty, EntityMeta lookups and edge cases.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { type GraphQLSchema, graphql } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type CompilerContext,
+  type CompilerResult,
+  compile,
+  storeQueryFn,
+} from "#compiler";
+import {
+  DS_REALISTIC_TTL,
+  INHERITANCE_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+  SHACL_TTL,
+} from "#testing";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+interface Compiled {
+  result: CompilerResult;
+  schema: GraphQLSchema;
+  context: CompilerContext;
+}
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<Compiled> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(storeQueryFn(store), PREFIXES, options);
+  return {
+    result,
+    schema: result.schema,
+    context: result.createContext(store),
+  };
+};
+
+const run = async (compiled: Compiled, source: string) =>
+  graphql({ schema: compiled.schema, source, contextValue: compiled.context });
+
+describe("Ontology and lookups", () => {
+  it("lists ontologies with classes and properties", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologies {
+          prefix
+          namespace
+          label
+          classes { label }
+          properties { label kind functional namespace }
+        }
+        ontology(prefix: "ex") { prefix }
+        unknown: ontology(prefix: "zz") { prefix }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const ontologies = result.data?.ontologies as Array<
+      Record<string, unknown>
+    >;
+    const ex = ontologies.find((o) => o.prefix === "ex");
+    expect(ex?.namespace).toBe("http://example.org/");
+    expect((ex?.classes as unknown[]).length).toBe(1);
+    expect((ex?.properties as unknown[]).length).toBe(2);
+    expect((result.data?.ontology as { prefix: string }).prefix).toBe("ex");
+    expect(result.data?.unknown).toBeNull();
+  });
+
+  it("resolves ontologyProperty with scalar ranges and datatype kind", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyProperty(uri: "http://example.org/count") {
+          uri label kind functional range namespace
+          domain { label }
+          inverse { uri }
+        }
+        missing: ontologyProperty(uri: "http://example.org/nope") { uri }
+        prefixed: ontologyProperty(uri: "ex:count") { uri }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const property = result.data?.ontologyProperty as Record<string, unknown>;
+    expect(property.kind).toBe("DATATYPE");
+    expect(property.functional).toBe(true); // datatype default is singular
+    expect(property.range).toContain("integer");
+    expect((property.domain as { label: string }).label).toBe("Thing");
+    expect(property.inverse).toBeNull();
+    expect(result.data?.missing).toBeNull();
+    // Prefixed form resolves like ontologyClass does.
+    expect((result.data?.prefixed as { uri: string }).uri).toBe(
+      "http://example.org/count",
+    );
+  });
+
+  it("walks superclass chains on OntologyClass", async () => {
+    const compiled = await setup(INHERITANCE_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyClass(uri: "http://example.org/Widget") {
+          label
+          isAbstract
+          superclass { label }
+          superclasses { label }
+          subclasses { label }
+        }
+        root: ontologyClass(uri: "http://example.org/Entity") {
+          isAbstract
+          superclass { label }
+          subclasses { label }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const widget = result.data?.ontologyClass as Record<string, unknown>;
+    expect(widget.isAbstract).toBe(false);
+    expect((widget.superclass as { label: string }).label).toBe("Tangible");
+    expect(
+      (widget.superclasses as Array<{ label: string }>).map((c) => c.label),
+    ).toEqual(["Tangible", "Entity"]);
+    const root = result.data?.root as Record<string, unknown>;
+    expect(root.isAbstract).toBe(true);
+    expect(root.superclass).toBeNull();
+    expect(
+      (root.subclasses as Array<{ label: string }>).map((c) => c.label),
+    ).toEqual(["Tangible"]);
+  });
+
+  it("exposes per-class SHACL cardinality through ClassProperty", async () => {
+    const compiled = await setup(SHACL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyClass(uri: "http://example.org/Spec") {
+          properties {
+            property { label }
+            required
+            singular
+            inherited
+          }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const properties = (result.data?.ontologyClass as Record<string, unknown>)
+      .properties as Array<{
+      property: { label: string };
+      required: boolean;
+      singular: boolean;
+      inherited: boolean;
+    }>;
+    const root = properties.find((p) => p.property.label === "root");
+    expect(root?.required).toBe(true);
+    expect(root?.singular).toBe(true);
+    expect(root?.inherited).toBe(false);
+  });
+
+  it("returns annotation metadata through OntologyProperty", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyProperty(uri: "https://ds.canonical.com/name") {
+          acceptanceCriteria
+          completionGuidance
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const property = result.data?.ontologyProperty as Record<string, unknown>;
+    expect(property.acceptanceCriteria).toBe(
+      "Must be a human-readable display name.",
+    );
+    expect(property.completionGuidance).toBeNull();
+  });
+});
+
+describe("EntityMeta edge cases", () => {
+  it("returns null for unknown field names", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        thing(uri: "ex:widget") {
+          _meta { field(name: "doesNotExist") { required } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    expect(
+      (result.data?.thing as { _meta: { field: unknown } })._meta.field,
+    ).toBeNull();
+  });
+});
+
+describe("datatype list fields", () => {
+  it("resolves multi-valued datatype properties when forced to list", async () => {
+    const compiled = await setup(MINIMAL_TTL, {
+      mappings: { "ex:name": { singular: false, graphqlName: "names" } },
+    });
+    const result = await run(compiled, `{ thing(uri: "ex:widget") { names } }`);
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { names: string[] }).names).toEqual([
+      "Widget",
+    ]);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.ts
@@ -1,0 +1,394 @@
+// =============================================================================
+// TBox schema (hand-written, §1.6/§11.4): Ontology, OntologyClass,
+// ClassProperty, OntologyProperty, PropertyKind, EntityMeta.
+//
+// Value conventions:
+//   Ontology        → NamespaceInfo
+//   OntologyClass   → ClassNode (IR)
+//   OntologyProperty→ PropertyNode (IR)
+//   ClassProperty   → { propertyUri, classUri } (per-class scope)
+//   EntityMeta      → EntityValue (the ABox parent)
+//
+// Structural facts come from the frozen IR (resolver closures); only the
+// instances connection hits the loaders.
+// =============================================================================
+
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  type GraphQLFieldConfigMap,
+  GraphQLInt,
+  type GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql";
+import {
+  type ClassNode,
+  CONNECTION_ARGS,
+  type CompilerContext,
+  type EntityValue,
+  type MappedIR,
+  type NamespaceInfo,
+  type PropertyNode,
+} from "#compiler";
+import { toFull, toPrefixed } from "#dataloader";
+import {
+  connectionFromPage,
+  paginateUriWindow,
+  unwrapEntities,
+} from "#resolver";
+
+interface ClassPropertyValue {
+  propertyUri: string;
+  classUri: string;
+}
+
+/**
+ * Get an annotation value on a property by the annotation property's local
+ * name suffix. Annotation values live on PropertyNode (extracted in Pass 1)
+ * — the TBox schema is fully store-free at request time. Matched by local
+ * name so the convention works for any namespace's annotation properties.
+ */
+const getAnnotationValue = (
+  property: PropertyNode,
+  localSuffix: string,
+): string | null => {
+  for (const [uri, value] of property.annotations) {
+    if (uri.endsWith(localSuffix)) {
+      return value;
+    }
+  }
+  return null;
+};
+
+/** The hand-written TBox types plus the root query fields that serve them. */
+export interface TBoxSchema {
+  ontology: GraphQLObjectType;
+  ontologyClass: GraphQLObjectType;
+  classProperty: GraphQLObjectType;
+  ontologyProperty: GraphQLObjectType;
+  entityMeta: GraphQLObjectType;
+  queryFields: GraphQLFieldConfigMap<unknown, CompilerContext>;
+}
+
+/**
+ * Build the hand-written TBox schema types (Ontology, OntologyClass,
+ * ClassProperty, OntologyProperty, EntityMeta) and their root query fields
+ * from the compiled IR. Resolvers read the frozen IR — only the instances
+ * connection touches the store, through the context's loaders.
+ */
+export default function buildTBoxSchema(
+  mapped: MappedIR,
+  nodeInterface: GraphQLInterfaceType,
+  nodeConnection: () => GraphQLObjectType,
+): TBoxSchema {
+  const { ir } = mapped;
+
+  const propertyKind = new GraphQLEnumType({
+    name: "PropertyKind",
+    values: {
+      DATATYPE: { value: "datatype" },
+      OBJECT: { value: "object" },
+      ANNOTATION: { value: "annotation" },
+    },
+  });
+
+  /** Per-class cardinality, consulting the class then its ancestors. */
+  const resolveCardinality = (property: PropertyNode, classUri: string) => {
+    const node = ir.classes.get(classUri);
+    for (const uri of [classUri, ...(node?.ancestors ?? [])]) {
+      const spec = property.classCardinality.get(uri);
+      if (spec) {
+        return spec;
+      }
+    }
+    return { singular: property.functional, required: false, omit: false };
+  };
+
+  const ontologyProperty: GraphQLObjectType = new GraphQLObjectType<
+    PropertyNode,
+    CompilerContext
+  >({
+    name: "OntologyProperty",
+    fields: () => ({
+      uri: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => p.uri,
+      },
+      label: { type: GraphQLString, resolve: (p) => p.label },
+      definition: { type: GraphQLString, resolve: (p) => p.definition },
+      domain: {
+        type: ontologyClass,
+        resolve: (p) => (p.domains[0] ? ir.classes.get(p.domains[0]) : null),
+      },
+      range: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => {
+          switch (p.range.kind) {
+            case "scalar":
+              return p.range.customDatatype ?? p.range.xsd;
+            case "class":
+              return p.range.uri;
+            case "union":
+              return p.range.members.join(" | ");
+            case "unknown":
+              return p.range.raw;
+          }
+        },
+      },
+      kind: { type: new GraphQLNonNull(propertyKind), resolve: (p) => p.kind },
+      functional: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (p) => p.functional,
+      },
+      inverse: {
+        type: ontologyProperty,
+        resolve: (p) => (p.inverse ? ir.properties.get(p.inverse) : null),
+      },
+      acceptanceCriteria: {
+        type: GraphQLString,
+        resolve: (p) => getAnnotationValue(p, "acceptanceCriteria"),
+      },
+      completionGuidance: {
+        type: GraphQLString,
+        resolve: (p) => getAnnotationValue(p, "completionGuidance"),
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => p.namespace,
+      },
+    }),
+  });
+
+  const classProperty: GraphQLObjectType = new GraphQLObjectType<
+    ClassPropertyValue,
+    CompilerContext
+  >({
+    name: "ClassProperty",
+    description:
+      "Class-scoped view of a property: SHACL cardinality is a fact about a (class, property) pair.",
+    fields: () => ({
+      property: {
+        type: new GraphQLNonNull(ontologyProperty),
+        resolve: (cp) => ir.properties.get(cp.propertyUri),
+      },
+      required: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) => {
+          const property = ir.properties.get(cp.propertyUri);
+          return property
+            ? resolveCardinality(property, cp.classUri).required
+            : false;
+        },
+      },
+      singular: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) => {
+          const property = ir.properties.get(cp.propertyUri);
+          return property
+            ? resolveCardinality(property, cp.classUri).singular
+            : false;
+        },
+      },
+      inherited: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) =>
+          !(
+            ir.classes
+              .get(cp.classUri)
+              ?.ownProperties.includes(cp.propertyUri) ?? false
+          ),
+      },
+    }),
+  });
+
+  const listClassProperties = (node: ClassNode): ClassPropertyValue[] =>
+    node.allProperties
+      .filter((uri) => !(ir.properties.get(uri)?.isAnnotation ?? false))
+      .map((propertyUri) => ({ propertyUri, classUri: node.uri }));
+
+  const ontologyClass: GraphQLObjectType = new GraphQLObjectType<
+    ClassNode,
+    CompilerContext
+  >({
+    name: "OntologyClass",
+    fields: () => ({
+      uri: { type: new GraphQLNonNull(GraphQLString), resolve: (c) => c.uri },
+      label: { type: GraphQLString, resolve: (c) => c.label },
+      definition: { type: GraphQLString, resolve: (c) => c.definition },
+      superclass: {
+        type: ontologyClass,
+        resolve: (c) =>
+          c.superclasses[0] ? ir.classes.get(c.superclasses[0]) : null,
+      },
+      superclasses: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (c) =>
+          c.ancestors
+            .map((uri) => ir.classes.get(uri))
+            .filter((n): n is ClassNode => n !== undefined),
+      },
+      subclasses: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (c) =>
+          c.subclasses
+            .map((uri) => ir.classes.get(uri))
+            .filter((n): n is ClassNode => n !== undefined),
+      },
+      properties: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(classProperty)),
+        ),
+        resolve: (c) => listClassProperties(c),
+      },
+      instances: {
+        type: new GraphQLNonNull(nodeConnection()),
+        args: CONNECTION_ARGS,
+        description:
+          "Named instances of this class (blank-node instances are embeddable and not standalone-resolvable).",
+        resolve: async (c, args, ctx) => {
+          const fullUris = await ctx.listLoader.load(c.uri);
+          const prefixed = fullUris.map((uri) =>
+            toPrefixed(uri, mapped.namespaces),
+          );
+          const page = paginateUriWindow(prefixed, args);
+          const entities = await ctx.entityLoader.loadMany(
+            page.window.map((uri) => toFull(uri, mapped.namespaces) ?? uri),
+          );
+          return connectionFromPage(unwrapEntities(entities), page);
+        },
+      },
+      instanceCount: {
+        type: new GraphQLNonNull(GraphQLInt),
+        description: "Count of NAMED instances (matches `instances`).",
+        resolve: (c) => ir.extraction.instanceStats.get(c.uri)?.named ?? 0,
+      },
+      isAbstract: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (c) => c.isAbstract,
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (c) => c.namespace,
+      },
+    }),
+  });
+
+  const ontology = new GraphQLObjectType<NamespaceInfo, CompilerContext>({
+    name: "Ontology",
+    fields: () => ({
+      prefix: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (n) => n.prefix,
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (n) => n.uri,
+      },
+      label: { type: GraphQLString, resolve: (n) => n.prefix },
+      classes: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (n) =>
+          [...ir.classes.values()].filter((c) => c.namespace === n.prefix),
+      },
+      properties: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyProperty)),
+        ),
+        resolve: (n) =>
+          [...ir.properties.values()].filter((p) => p.namespace === n.prefix),
+      },
+    }),
+  });
+
+  const entityMeta = new GraphQLObjectType<EntityValue, CompilerContext>({
+    name: "EntityMeta",
+    description: "Self-describing TBox access attached to ABox types (KG.03).",
+    fields: () => ({
+      type: {
+        type: new GraphQLNonNull(ontologyClass),
+        resolve: (parent) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          return classUri ? ir.classes.get(classUri) : null;
+        },
+      },
+      field: {
+        type: classProperty,
+        args: { name: { type: new GraphQLNonNull(GraphQLString) } },
+        resolve: (parent, args: { name: string }) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          const mappedType = mapped.types.get(parent.typename);
+          const field = mappedType?.fields.get(args.name);
+          if (!classUri || !field || !ir.properties.has(field.propertyUri)) {
+            return null;
+          }
+          return { propertyUri: field.propertyUri, classUri };
+        },
+      },
+      fields: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(classProperty)),
+        ),
+        resolve: (parent) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          const node = classUri ? ir.classes.get(classUri) : undefined;
+          return node ? listClassProperties(node) : [];
+        },
+      },
+    }),
+  });
+
+  const queryFields: GraphQLFieldConfigMap<unknown, CompilerContext> = {
+    ontologies: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ontology))),
+      resolve: () => [...mapped.namespaces.values()],
+    },
+    ontology: {
+      type: ontology,
+      args: { prefix: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { prefix: string }) =>
+        mapped.namespaces.get(args.prefix) ?? null,
+    },
+    ontologyClass: {
+      type: ontologyClass,
+      args: { uri: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { uri: string }) =>
+        ir.classes.get(args.uri) ??
+        [...ir.classes.values()].find(
+          (c) => `${c.namespace}:${c.uri.split(/[#/]/).pop()}` === args.uri,
+        ) ??
+        null,
+    },
+    ontologyProperty: {
+      type: ontologyProperty,
+      args: { uri: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { uri: string }) =>
+        ir.properties.get(args.uri) ??
+        [...ir.properties.values()].find(
+          (p) => `${p.namespace}:${p.uri.split(/[#/]/).pop()}` === args.uri,
+        ) ??
+        null,
+    },
+  };
+
+  // The Node interface is referenced through nodeConnection (lazily); the
+  // parameter is accepted to make the dependency explicit at the call site.
+  void nodeInterface;
+
+  return {
+    ontology,
+    ontologyClass,
+    classProperty,
+    ontologyProperty,
+    entityMeta,
+    queryFields,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/tbox/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The TBox domain: the hand-written ontology-browsing schema (Ontology,
+ * OntologyClass, ClassProperty, OntologyProperty, EntityMeta) composed into
+ * every generated schema alongside the data types.
+ *
+ * @module tbox
+ */
+
+export {
+  default as buildTBoxSchema,
+  type TBoxSchema,
+} from "./buildTBoxSchema.js";

--- a/packages/runtime/ke-graphql/src/testing/fixtures.ts
+++ b/packages/runtime/ke-graphql/src/testing/fixtures.ts
@@ -1,0 +1,305 @@
+/**
+ * Self-contained TTL fixtures for the compiler/pipeline/execution tests
+ * (ADR §12). Each constant is a complete document — TBox + ABox together —
+ * that exercises one specific compiler behavior, kept minimal by design;
+ * `PREFIXES` is the prefix map the fixture stores share. They live in one
+ * file so a test can pull whichever scenario it needs from a single import.
+ * Internal test data only: excluded from the build, never shipped in dist.
+ */
+
+export const PREFIXES = {
+  ex: "http://example.org/",
+  ds: "https://ds.canonical.com/",
+  cs: "http://pragma.canonical.com/codestandards#",
+};
+
+/** §12.2 — happy path: one class, two properties, one instance. */
+export const MINIMAL_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:Thing a owl:Class ;
+  rdfs:label "Thing" ;
+  skos:definition "A concrete thing." .
+
+ex:name a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:string ;
+  rdfs:label "name" .
+
+ex:count a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:integer ;
+  rdfs:label "count" .
+
+ex:widget a ex:Thing ;
+  ex:name "Widget" ;
+  ex:count 42 .
+`;
+
+/** §12.3 — class hierarchy and interface generation. */
+export const INHERITANCE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Entity a owl:Class ; rdfs:label "Entity" .
+ex:Tangible a owl:Class ; rdfs:subClassOf ex:Entity ; rdfs:label "Tangible" .
+ex:Widget a owl:Class ; rdfs:subClassOf ex:Tangible ; rdfs:label "Widget" .
+ex:Gadget a owl:Class ; rdfs:subClassOf ex:Tangible ; rdfs:label "Gadget" .
+
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Entity ; rdfs:range xsd:string .
+ex:weight a owl:DatatypeProperty ; rdfs:domain ex:Tangible ; rdfs:range xsd:integer .
+ex:color a owl:DatatypeProperty ; rdfs:domain ex:Widget ; rdfs:range xsd:string .
+
+ex:w1 a ex:Widget ; ex:name "Alpha" ; ex:weight 10 ; ex:color "red" .
+ex:g1 a ex:Gadget ; ex:name "Beta" ; ex:weight 5 .
+`;
+
+/** §12.4 — inverse pair: forward/inverse placement, irregular plural. */
+export const INVERSE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Parent a owl:Class ; rdfs:label "Parent" .
+ex:Child a owl:Class ; rdfs:label "Child" .
+
+ex:hasChild a owl:ObjectProperty ;
+  rdfs:domain ex:Parent ; rdfs:range ex:Child ;
+  owl:inverseOf ex:childOf .
+
+ex:childOf a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ex:Child ; rdfs:range ex:Parent .
+
+ex:name a owl:DatatypeProperty ;
+  rdfs:domain ex:Parent ; rdfs:range xsd:string .
+
+# Data asserts ONLY the childOf direction — hasChild resolution must find
+# the children via the reverse assertions (EC.05 dual-direction rule).
+ex:p1 a ex:Parent ; ex:name "Alice" .
+ex:c1 a ex:Child ; ex:childOf ex:p1 .
+ex:c2 a ex:Child ; ex:childOf ex:p1 .
+`;
+
+/** §12.5 — embedded blank-node types. */
+export const BLANK_NODES_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Standard a owl:Class ; rdfs:label "Standard" .
+ex:Example a owl:Class ; rdfs:label "Example" .
+
+ex:title a owl:DatatypeProperty ; rdfs:domain ex:Standard ; rdfs:range xsd:string .
+ex:hasExample a owl:ObjectProperty ; rdfs:domain ex:Standard ; rdfs:range ex:Example .
+ex:code a owl:DatatypeProperty ; rdfs:domain ex:Example ; rdfs:range xsd:string .
+ex:language a owl:DatatypeProperty ; rdfs:domain ex:Example ; rdfs:range xsd:string .
+
+ex:s1 a ex:Standard ;
+  ex:title "Use const" ;
+  ex:hasExample [
+    a ex:Example ;
+    ex:code "const x = 1;" ;
+    ex:language "typescript"
+  ] , [
+    a ex:Example ;
+    ex:code "const y = 2;"
+  ] .
+`;
+
+/** §12.6 — domainless property (KG.14). */
+export const DOMAINLESS_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Foo a owl:Class ; rdfs:label "Foo" .
+ex:Bar a owl:Class ; rdfs:label "Bar" .
+
+ex:label a owl:DatatypeProperty ; rdfs:domain ex:Foo ; rdfs:range xsd:string .
+ex:description a owl:DatatypeProperty ; rdfs:range xsd:string .
+
+ex:f1 a ex:Foo ; ex:label "foo" ; ex:description "a foo" .
+ex:b1 a ex:Bar ; ex:description "a bar" .
+`;
+
+/** §12.7 — synthetic triggers for the V-series diagnostics. */
+export const EDGE_CASES_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+# EC.03 — boolean-as-string
+ex:Item a owl:Class .
+ex:active a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range xsd:boolean .
+ex:i1 a ex:Item ; ex:active "true" .
+
+# EC.04 — self-referential relationship
+ex:extends a owl:ObjectProperty ; rdfs:domain ex:Item ; rdfs:range ex:Item .
+ex:i2 a ex:Item ; ex:extends ex:i2 .
+
+# EC.06 — language-tagged literal
+ex:label a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range xsd:string .
+ex:i3 a ex:Item ; ex:label "Tagged"@en .
+
+# EC.07 — annotation property on rdf:Property
+ex:guidance a owl:AnnotationProperty ; rdfs:domain rdf:Property ; rdfs:range xsd:string .
+ex:active ex:guidance "Must be boolean" .
+
+# EC.08 — custom datatype
+ex:Version a rdfs:Datatype ; owl:onDatatype xsd:string .
+ex:ver a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range ex:Version .
+ex:i4 a ex:Item ; ex:ver "1.0.0" .
+
+# EC.13 — cross-vocabulary subClassOf
+ex:Category a owl:Class ; rdfs:subClassOf skos:Concept .
+ex:c1 a ex:Category .
+
+# EC.14 — empty string value
+ex:summary a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range xsd:string .
+ex:i5 a ex:Item ; ex:summary "" .
+
+# V012 — SHACL sh:in enum constraint
+ex:ItemShape a sh:NodeShape ;
+  sh:targetClass ex:Item ;
+  sh:property [
+    sh:path ex:mode ;
+    sh:in ("fast" "slow" "auto") ;
+  ] .
+ex:mode a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range xsd:string .
+
+# V014 / EC.16 — ABox predicate not declared in the TBox
+ex:i6 a ex:Item ; ex:undeclaredThing "x" .
+
+# V005 — functional property with multiple values
+ex:rank a owl:DatatypeProperty , owl:FunctionalProperty ;
+  rdfs:domain ex:Item ; rdfs:range xsd:integer .
+ex:i7 a ex:Item ; ex:rank 1 , 2 .
+`;
+
+/** §12.10 — SHACL cardinality, sh:or XOR, maxCount 0. */
+export const SHACL_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:Spec a owl:Class . ex:Hop a owl:Class . ex:Sw a owl:Class .
+
+ex:root a owl:ObjectProperty ; rdfs:domain ex:Spec ; rdfs:range ex:Hop .
+ex:hopTarget a owl:ObjectProperty ; rdfs:domain ex:Hop ; rdfs:range ex:Spec .
+ex:hopSwitch a owl:ObjectProperty ; rdfs:domain ex:Hop ; rdfs:range ex:Sw .
+ex:legacy a owl:DatatypeProperty ; rdfs:domain ex:Spec ; rdfs:range xsd:string .
+
+ex:SpecShape a sh:NodeShape ; sh:targetClass ex:Spec ;
+  sh:property [ sh:path ex:root ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path ex:legacy ; sh:maxCount 0 ] .
+
+ex:HopShape a sh:NodeShape ; sh:targetClass ex:Hop ;
+  sh:or (
+    [ sh:property [ sh:path ex:hopTarget ; sh:minCount 1 ; sh:maxCount 1 ] ;
+      sh:property [ sh:path ex:hopSwitch ; sh:maxCount 0 ] ]
+    [ sh:property [ sh:path ex:hopTarget ; sh:maxCount 0 ] ;
+      sh:property [ sh:path ex:hopSwitch ; sh:minCount 1 ; sh:maxCount 1 ] ]
+  ) .
+
+ex:s1 a ex:Spec . ex:h1 a ex:Hop . ex:sw1 a ex:Sw .
+`;
+
+/** §12.8 — realistic ds: subset: hierarchy, inverses, blank nodes, booleans. */
+export const DS_REALISTIC_TTL = `
+@prefix ds: <https://ds.canonical.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ds:Entity a owl:Class ; rdfs:label "Entity" .
+ds:UIElement a owl:Class ; rdfs:subClassOf ds:Entity ; rdfs:label "UIElement" .
+ds:UIBlock a owl:Class ; rdfs:subClassOf ds:UIElement ; rdfs:label "UIBlock" .
+ds:Component a owl:Class ; rdfs:subClassOf ds:UIBlock ; rdfs:label "Component" ;
+  skos:definition "A reusable UI component." .
+ds:Subcomponent a owl:Class ; rdfs:subClassOf ds:UIBlock ; rdfs:label "Subcomponent" .
+ds:Modifier a owl:Class ; rdfs:subClassOf ds:UIElement ; rdfs:label "Modifier" .
+ds:ModifierFamily a owl:Class ; rdfs:subClassOf ds:UIElement ; rdfs:label "ModifierFamily" .
+ds:Tier a owl:Class ; rdfs:subClassOf ds:Entity ; rdfs:label "Tier" .
+ds:Property a owl:Class ; rdfs:subClassOf ds:Entity ; rdfs:label "Property" .
+ds:ImplementationObject a owl:Class ; rdfs:subClassOf ds:Entity ; rdfs:label "ImplementationObject" .
+
+ds:name a owl:DatatypeProperty ; rdfs:domain ds:Entity ; rdfs:range xsd:string ;
+  rdfs:label "name" ; skos:definition "Display name." .
+ds:summary a owl:DatatypeProperty ; rdfs:domain ds:Entity ; rdfs:range xsd:string .
+ds:tier a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:UIBlock ; rdfs:range ds:Tier .
+ds:hasModifierFamily a owl:ObjectProperty ;
+  rdfs:domain ds:UIBlock ; rdfs:range ds:ModifierFamily .
+ds:hasSubcomponent a owl:ObjectProperty ;
+  rdfs:domain ds:Component ; rdfs:range ds:Subcomponent ;
+  owl:inverseOf ds:parentComponent .
+ds:parentComponent a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:Subcomponent ; rdfs:range ds:Component .
+ds:modifierFamily a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:Modifier ; rdfs:range ds:ModifierFamily ;
+  owl:inverseOf ds:hasModifier .
+ds:hasModifier a owl:ObjectProperty ;
+  rdfs:domain ds:ModifierFamily ; rdfs:range ds:Modifier .
+ds:hasProperty a owl:ObjectProperty ;
+  rdfs:domain ds:UIBlock ; rdfs:range ds:Property .
+ds:propertyType a owl:DatatypeProperty ; rdfs:domain ds:Property ; rdfs:range xsd:string .
+ds:optional a owl:DatatypeProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:Property ; rdfs:range xsd:boolean .
+ds:standalone a owl:DatatypeProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:Subcomponent ; rdfs:range xsd:boolean .
+ds:implementsBlock a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:ImplementationObject ; rdfs:range ds:UIBlock .
+
+ds:acceptanceCriteria a owl:AnnotationProperty ;
+  rdfs:domain <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> ;
+  rdfs:range xsd:string .
+ds:name ds:acceptanceCriteria "Must be a human-readable display name." .
+
+ds:global a ds:Tier ; ds:name "global" .
+
+ds:global.component.button a ds:Component ;
+  ds:name "Button" ;
+  ds:summary "Primary action trigger." ;
+  ds:tier ds:global ;
+  ds:hasModifierFamily ds:modifier_family.importance ;
+  ds:hasSubcomponent ds:global.subcomponent.button_icon ;
+  ds:hasProperty [
+    a ds:Property ;
+    ds:name "disabled" ;
+    ds:propertyType "boolean" ;
+    ds:optional "false"
+  ] .
+
+ds:global.subcomponent.button_icon a ds:Subcomponent ;
+  ds:name "Button.Icon" ;
+  ds:tier ds:global ;
+  ds:parentComponent ds:global.component.button ;
+  ds:standalone "false" .
+
+ds:modifier_family.importance a ds:ModifierFamily ;
+  ds:name "importance" .
+
+ds:mod_importance_primary a ds:Modifier ;
+  ds:name "primary" ;
+  ds:modifierFamily ds:modifier_family.importance .
+
+ds:react_button a ds:ImplementationObject ;
+  ds:name "react button" ;
+  ds:implementsBlock ds:global.component.button .
+`;

--- a/packages/runtime/ke-graphql/src/testing/index.ts
+++ b/packages/runtime/ke-graphql/src/testing/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal test-support surface: the shared TTL fixtures the compiler,
+ * pipeline, execution, and handler tests compile against. Reachable through
+ * the `#testing` subpath alias. Excluded from the build — nothing in dist
+ * imports it, and it is never published.
+ *
+ * @module testing
+ */
+
+export {
+  BLANK_NODES_TTL,
+  DOMAINLESS_TTL,
+  DS_REALISTIC_TTL,
+  EDGE_CASES_TTL,
+  INHERITANCE_TTL,
+  INVERSE_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+  SHACL_TTL,
+} from "./fixtures.js";

--- a/packages/runtime/ke-graphql/tsconfig.build.json
+++ b/packages/runtime/ke-graphql/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/testing/**"]
+}

--- a/packages/runtime/ke-graphql/tsconfig.json
+++ b/packages/runtime/ke-graphql/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@canonical/typescript-config",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["node", "@types/bun"],
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "customConditions": ["development"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/runtime/ke-graphql/vitest.config.ts
+++ b/packages/runtime/ke-graphql/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: [
+        "**/index.ts",
+        "**/*.test.ts",
+        "**/*.d.ts",
+        "**/types.ts",
+        "src/testing/**",
+        "src/http/graphiqlHtml.ts",
+      ],
+      thresholds: {
+        statements: 87,
+        branches: 71,
+        functions: 88,
+        lines: 87,
+      },
+    },
+  },
+});


### PR DESCRIPTION
> Part of the `@canonical/ke-graphql` delivery stack (umbrella #658), stacked on #664. **This PR is being sub-split** into ≤4k-line pieces (shared types/constants, hardening, the resolution layer, the compiler passes) and its tests reorganized (unit tests name-matched to source; integration tests moved to `src/testing/integration/`) — it will be superseded by the smaller PRs shortly.

## Done

The **`@canonical/ke-graphql` compiler core** — a seven-pass OWL→GraphQL compiler over `@canonical/ke`:
- Reads an OWL/RDFS ontology + its instance data from the triple store and emits an executable `GraphQLSchema` + resolvers, exposed through a ke plugin (`createSchemaPlugin` → `{ schema, createContext }`).
- Typed intermediate representations + stable, non-aborting diagnostics.
- Relay server conventions: prefixed-URI global IDs, cursor connections, self-describing `_meta`, blank-node-only "embeddable" types, and union-of-forward-and-reverse resolution for `owl:inverseOf` pairs.
- A first-class `hardening` domain: SPARQL-injection guard, connection page-size clamp, query-depth limit, bounded loader cache, production error masking.
- `docs/architecture.md` + `docs/api.md`.

Standards-compliant: `src/lib/{domain}` + per-domain barrels, `#`-subpath cross-domain imports (dist-safe conditional mapping), colocated unit tests.

## QA

```bash
cd packages/runtime/ke-graphql && bun run check && bun run test && bun run build
```
biome + tsc + webarchitect green; clean build; the dist root entry imports under plain Node.

### PR readiness check
- [x] `Feature 🎁`; Conventional Commits title; [code standards](https://github.com/canonical/web-code-standards); scripts present; `no visual change`.
- [ ] New package — first publish + OIDC is a maintainer step at merge.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z