### PR TITLE
feat(ke-graphql): library foundation — scaffold, shared + hardening, docs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -930,6 +930,28 @@
         "vitest": "^4.0.18",
       },
     },
+    "packages/runtime/ke-graphql": {
+      "name": "@canonical/ke-graphql",
+      "version": "0.27.1-experimental.0",
+      "dependencies": {
+        "dataloader": "^2.2.3",
+        "graphql": "17.0.0-rc.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.4.9",
+        "@canonical/biome-config": "^0.27.1-experimental.0",
+        "@canonical/ke": "^0.27.1-experimental.0",
+        "@canonical/typescript-config": "^0.27.1-experimental.0",
+        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@types/bun": "^1.3.10",
+        "@types/node": "^24.12.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
+      },
+      "peerDependencies": {
+        "@canonical/ke": "^0.27.1-experimental.0",
+      },
+    },
     "packages/runtime/router": {
       "name": "@canonical/router-core",
       "version": "0.27.1-experimental.0",
@@ -1479,6 +1501,8 @@
     "@canonical/harnesses": ["@canonical/harnesses@workspace:packages/runtime/harnesses"],
 
     "@canonical/ke": ["@canonical/ke@workspace:packages/runtime/ke"],
+
+    "@canonical/ke-graphql": ["@canonical/ke-graphql@workspace:packages/runtime/ke-graphql"],
 
     "@canonical/launchpad-design-tokens": ["@canonical/launchpad-design-tokens@1.1.1", "", {}, "sha512-rOrV4TxC9bOyA4DlgxNAwssFfsA/h5XHPqM0plmYbaODodd7EakntM3ZOSHnoNqViskxieVSc7TEbZY+JyFHoA=="],
 
@@ -2436,6 +2460,8 @@
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
+    "dataloader": ["dataloader@2.2.3", "", {}, "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA=="],
+
     "dateformat": ["dateformat@3.0.3", "", {}, "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -2688,7 +2714,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
+    "graphql": ["graphql@17.0.0-rc.0", "", {}, "sha512-cQpxqmx0r8JOp4fH6CCDPZxV4Eh2e33Q4uWDzCL8JLsKb2FUMwKOC2Gzo+khYaLL1Ui9hQdhNwTm6YlbmkHHQQ=="],
 
     "handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
 
@@ -4023,6 +4049,8 @@
     "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "msw/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "msw/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
     "n3/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 

--- a/packages/runtime/ke-graphql/README.md
+++ b/packages/runtime/ke-graphql/README.md
@@ -1,0 +1,408 @@
+# @canonical/ke-graphql
+
+OWL → GraphQL compiler for the [ke](../ke) triple store. Point it at a loaded store and it reads the ontology — classes, properties, domains and ranges, `subClassOf` chains, cardinality markers, SHACL shapes — and compiles a complete, executable `GraphQLSchema`: types, interfaces, field resolvers, batched data loading, and Relay server conventions. The ontology is the schema definition; there is nothing else to maintain.
+
+It is a compiler, not a middleware. OWL is not a database schema — a class with no instances should become an interface, an `owl:inverseOf` pair should produce one field per side rather than four, a blank-node-only class can't have a global ID. Mapping that faithfully takes semantic analysis, so the package is built like a compiler: seven passes over a typed intermediate representation, diagnostics with stable codes that never abort on the first problem, and a deterministic output you can snapshot. `docs/architecture.md` is the full design rationale.
+
+Like ke itself, the root export is a library, not a server: schema + resolvers + local execution, nothing that knows HTTP exists. The fetch handler and GraphiQL live behind the `./http` subpath, mirroring `@canonical/ke/http`.
+
+## Installation
+
+```bash
+bun add @canonical/ke-graphql
+```
+
+`graphql` (v17, pinned — see [Incremental delivery](#incremental-delivery-defer)) and `dataloader` come with it; `@canonical/ke` is a peer dependency.
+
+## Quick start
+
+The compiler runs as a ke plugin: when the store finishes loading, the schema is ready alongside it.
+
+```typescript
+import { createStore } from "@canonical/ke";
+import { createSchemaPlugin, type SchemaPluginApi } from "@canonical/ke-graphql";
+import { createGraphQLHandler } from "@canonical/ke-graphql/http";
+
+const graphql = createSchemaPlugin();
+
+const store = await createStore({
+  sources: ["./ontology.ttl", "./data/**/*.ttl"],
+  prefixes: { lib: "https://example.org/library/" }, // drives global IDs — register every domain prefix
+  plugins: [graphql],
+});
+
+const { schema, sdl, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+
+Bun.serve({
+  port: 4000,
+  fetch: createGraphQLHandler(schema, {
+    graphiql: true,
+    context: () => createContext(store),
+  }),
+});
+```
+
+Open `http://localhost:4000` and GraphiQL is talking to your ontology.
+
+## What gets generated
+
+Everything below is the compiler's actual output for this input — regenerate it any time with `pragma graphql build`.
+
+Given a small ontology and some data:
+
+```turtle
+@prefix lib: <https://example.org/library/> .
+
+lib:Work a owl:Class .
+lib:Book a owl:Class ; rdfs:subClassOf lib:Work .
+lib:Film a owl:Class ; rdfs:subClassOf lib:Work .
+lib:Author a owl:Class .
+lib:Review a owl:Class .
+
+lib:title     a owl:DatatypeProperty ; rdfs:domain lib:Work   ; rdfs:range xsd:string .
+lib:pageCount a owl:DatatypeProperty ; rdfs:domain lib:Book   ; rdfs:range xsd:integer .
+lib:inPrint   a owl:DatatypeProperty ; rdfs:domain lib:Book   ; rdfs:range xsd:boolean .
+lib:hasAuthor a owl:ObjectProperty   ; rdfs:domain lib:Work   ; rdfs:range lib:Author ;
+              owl:inverseOf lib:authored .
+lib:authored  a owl:ObjectProperty   ; rdfs:domain lib:Author ; rdfs:range lib:Work .
+lib:name      a owl:DatatypeProperty ; rdfs:domain lib:Author ; rdfs:range xsd:string .
+lib:hasReview a owl:ObjectProperty   ; rdfs:domain lib:Work   ; rdfs:range lib:Review .
+lib:rating    a owl:DatatypeProperty ; rdfs:domain lib:Review ; rdfs:range xsd:integer .
+lib:comment   a owl:DatatypeProperty ; rdfs:domain lib:Review ; rdfs:range xsd:string .
+
+lib:dune a lib:Book ;
+  lib:title "Dune" ; lib:pageCount 412 ; lib:inPrint "true" ;
+  lib:hasAuthor lib:herbert ;
+  lib:hasReview [ a lib:Review ; lib:rating 5 ] .
+lib:herbert a lib:Author ; lib:name "Frank Herbert" .
+```
+
+the compiler emits the following (fields lightly reordered for reading, Relay boilerplate and the TBox types elided — `pragma graphql build` regenerates the full file):
+
+```graphql
+interface Work implements Node {
+  id: ID!
+  uri: String!
+  _meta: EntityMeta!
+  title: String
+  authors(first: Int, after: String, last: Int, before: String): AuthorConnection!
+  reviews: [Review!]!
+}
+
+type Book implements Node & Work {
+  id: ID!                  # the prefixed URI: "lib:dune"
+  uri: String!
+  _meta: EntityMeta!
+  title: String
+  pageCount: Int
+  inPrint: Boolean         # data stores "true" as a string — the resolver coerces
+  authors(first: Int, after: String, last: Int, before: String): AuthorConnection!
+  reviews: [Review!]!      # plain list — Review instances are blank nodes
+}
+
+type Author implements Node {
+  id: ID!
+  uri: String!
+  _meta: EntityMeta!
+  name: String
+  authoreds(first: Int, after: String, last: Int, before: String): WorkConnection!
+}
+
+type Review {              # embeddable: no Node, no id — it lives inside its parent
+  rating: Int
+  comment: String
+}
+
+type Query {
+  node(id: ID!): Node
+  book(uri: String!): Book
+  books(first: Int, after: String, last: Int, before: String): BookConnection!
+  author(uri: String!): Author
+  authors(first: Int, after: String, last: Int, before: String): AuthorConnection!
+  film(uri: String!): Film
+  films(first: Int, after: String, last: Int, before: String): FilmConnection!
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+}
+```
+
+Reading the output back against the input shows most of the compiler's rules at once:
+
+- **`Work` became an interface.** It has subclasses and no direct instances, so it's abstract — and because all of its concrete implementors are full entities, the interface itself implements `Node`, which is what lets Relay refetch a fragment written against `Work`. (A class with subclasses *and* direct instances of its own stays a concrete type and earns a `V016` warning: a supertype-typed field can't surface its subclasses' fields. Force it abstract with `{ abstract: true }` when it has no direct instances; the interface-plus-companion-type alternative is a deferred option.)
+- **`hasAuthor` became `authors`.** Field names strip a leading `has`/`is` verb; list fields are pluralized (`category → categories`, `child → children` — the pluralizer knows the irregulars).
+- **`reviews` is a plain list while `authors` is a connection.** `Review` instances are blank nodes: no URI means no global ID, no cursor, no standalone resolution. The compiler marks such classes *embeddable* and resolves them inline from the parent's own triples. Everything URI-addressable gets a paginated Relay connection instead.
+- **One field per side of the inverse pair, and direction doesn't matter.** `hasAuthor`/`authored` produce `Book.authors` and `Author.authoreds` — never the duplicates. At resolution time each side takes the union of forward and reverse assertions, so data written in either direction answers identically from both ends.
+- **`inPrint: Boolean` works even though the data says `"true"`.** Real-world TTL stores booleans as strings; the resolver coerces (`"true"/"false"/"1"/"0"`) and reports anything else through the runtime-warning channel instead of crashing the response.
+- **`id` is the prefixed URI**, not an opaque token. `node(id: "lib:dune")` works in GraphiQL, in URLs, and in the CLI alike.
+
+About `authoreds` — that's the pluralizer being mechanically right and ergonomically wrong. Which brings us to:
+
+## Custom mappings
+
+Mappings are the escape hatch for everything the ontology can't express ergonomically. Keys are full IRIs or prefixed names; values override one aspect each:
+
+```typescript
+const graphql = createSchemaPlugin({
+  mappings: {
+    // rename: fix the mechanical plural
+    "lib:authored": { graphqlName: "works" },
+
+    // cardinality: an object property that is singular in practice but
+    // carries no owl:FunctionalProperty or SHACL marker
+    "lib:hasPublisher": { singular: true },
+
+    // synthesize an inverse field on the RANGE type when the ontology
+    // declares no owl:inverseOf — no ontology change required, the
+    // resolver queries the forward assertions in reverse
+    "lib:cites": { inverse: { graphqlName: "citedBy" } },
+
+    // force embeddable/abstract when the loaded data can't reveal it
+    // (e.g. a blank-node-only class that happens to have zero instances
+    // in this particular dataset)
+    "lib:Annotation": { embeddable: true },
+  },
+});
+```
+
+A mapping that references nothing in the ontology produces an `M003` diagnostic rather than silently doing nothing.
+
+Names the compiler owns (`Node`, `Query`, `PageInfo`, the built-in scalars, …) are auto-resolved on collision by prefixing the namespace — a class named `lib:Node` becomes `LibNode` with an `M004` info diagnostic. Illegal GraphQL characters in local names are sanitized (`My-Class → My_Class`) with a warning.
+
+## Cardinality: how a property becomes singular or a list
+
+Precedence, highest first:
+
+1. custom mapping `{ singular }` override
+2. `owl:FunctionalProperty`
+3. SHACL `sh:maxCount 1` — per *(class, property)* pair, so the same property can be singular on one class and a list on another; `sh:or` branches merge to the most permissive interpretation, repeated shapes for one path merge as the SHACL conjunction
+4. kind default: **datatype and annotation properties are singular; object properties are lists.** (Multi-valued literals are the exception in RDF practice; opt a datatype property back into a list with `{ singular: false }`.)
+
+Nullability is deliberate and honest: `id` and `uri` are non-null, list and connection fields are non-null with empty defaults — and *everything else is nullable*, because OWL ontologies don't promise completeness. SHACL `sh:minCount` is **recorded** (queryable as `ClassProperty.required`) but never auto-promoted to GraphQL non-null: a single missing value would take down whole responses. Consumers who know their data promote specific fields via `nonNullOverrides: { Book: ["title"] }`.
+
+## The second schema: `_meta` and the ontology browser
+
+The compiler emits two connected schemas. Alongside the data types, a hand-written TBox schema exposes the ontology itself — and every generated type carries a `_meta: EntityMeta!` field bridging the two:
+
+```graphql
+{
+  book(uri: "lib:dune") {
+    title
+    _meta {
+      type { label definition superclasses { label } }      # the OWL class
+      fields {                                              # every applicable property
+        property { label range acceptanceCriteria }
+        required      # SHACL sh:minCount, for THIS class
+        singular
+        inherited     # declared on an ancestor vs Book itself
+      }
+    }
+  }
+  ontologyClass(uri: "https://example.org/library/Work") {
+    isAbstract
+    subclasses { label }
+    instances(first: 10) { edges { node { id } } }          # TBox → ABox hop
+  }
+}
+```
+
+This is what powers documentation UIs: "which fields *should* this entity have, which are required, what does good look like" — asked of the schema itself, in the same query as the data. The TBox resolvers read the compiler's frozen IR, **never the store**: ontology browsing works before the TTL finishes parsing and even against a disposed store, and it can't disagree with the schema's own shape because both came from the same compilation.
+
+## Diagnostics
+
+The compiler collects problems instead of aborting on the first one (the `tsc` model). Every diagnostic has a stable code:
+
+| Range | Meaning | Examples |
+|---|---|---|
+| `E001` | extraction/SPARQL failure | query failed, unregistered namespace (synthetic prefix assigned), blank nodes nested deeper than the loader's closure |
+| `B001–B004` | build references | `subClassOf` cycle, unknown domain/range/inverse |
+| `V001–V016` | data/ontology validation | blank-node-only class (`V001`), domainless property (`V002`), boolean-as-string (`V006`), SHACL `sh:maxCount 0` omission (`V010`), undeclared ABox predicate (`V014`), abstract mapping with direct instances (`V015`), concrete supertype flattening (`V016`) |
+| `M001–M004` | naming | unresolvable collision (`M001`, error), reserved-name rename (`M002`), unknown mapping (`M003`), auto-resolved type collision (`M004`) |
+| `X002–X003` | union emission | named / synthesized union created |
+| `C001–C003` | composition | extension targets unknown type, extension field conflict, `validateSchema` failure |
+
+Only **composition errors (`C00x`) prevent schema creation** — `compile()` then throws `CompilationError` carrying the complete diagnostic list. Everything else surfaces in `result.diagnostics` while the schema still builds; the consumer chooses its failure policy (the `pragma graphql check` command, for instance, fails CI on any error-severity diagnostic).
+
+## Plugin options
+
+```typescript
+createSchemaPlugin({
+  mappings,                          // CustomMappings (above)
+  extensions,                        // consumer fields — object or factory form (below)
+  relay: true,                       // Node/global IDs/connections/root queries (default true)
+  incremental: false,                // add @defer/@stream directives (below)
+  sdlOutput: "./schema.graphql",     // write the SDL on every (re)compile — feed relay-compiler
+  nonNullOverrides: { Book: ["title"] },
+  standardVocabFields: {             // opt-in instance-level rdfs:label/comment as fields —
+    Category: { "http://www.w3.org/2000/01/rdf-schema#label": "label" },
+  },                                 // by default only declared ontology properties become fields
+  loaderCache: "request",            // or "process" — see Performance
+  extraction: "./extraction.json",   // precomputed boot artifact — see Fast boot
+  onRuntimeWarning: (w) => log.warn(w),  // coercion failures at resolve time
+});
+```
+
+`onReload` recompiles when the store reloads — note that with ke's `cache:` configured, `store.reload()` short-circuits on a cache hit, so dev flows that edit TTL should call `reload({ force: true })`.
+
+## Extensions
+
+Domain-specific computed fields stay out of the compiler and in your code. The object form covers scalar-typed fields; the **factory form** receives the generated types, for extension fields typed as them:
+
+```typescript
+extensions: (types) => ({
+  Book: {
+    citation: {
+      type: GraphQLString,
+      resolve: (book) => formatCitation(book),       // book is an EntityValue
+    },
+  },
+  Query: {
+    search: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(SearchHitType))),
+      args: { query: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_s, args, ctx) => ctx.searchIndex.search(args.query),
+    },
+  },
+})
+```
+
+Extensions are validated at composition: an unknown type name is `C001`, a clash with a generated field is `C002` — both fatal, both reported together. Extension resolvers receive the `CompilerContext` (the loaders, the name map, the store escape hatch) and may stash their own state on it.
+
+## Serving over HTTP
+
+```typescript
+import { createGraphQLHandler } from "@canonical/ke-graphql/http";
+
+const handler = createGraphQLHandler(schema, {
+  context: (request) => createContext(store),   // fresh DataLoaders per request
+  graphiql: true,            // GET + Accept: text/html → GraphiQL (dev default)
+  cors: true,
+  introspection: true,       // default: dev on, production off
+  maxDepth: 12,              // built-in depth limit (default 20; 0 disables)
+  validationRules: [         // add your own rules on top (e.g. cost analysis)
+    createComplexityRule({ maximumComplexity: 1000, estimators: [...] }),
+  ],
+  persistedQueries: {        // strongest hardening: only build-time queries execute
+    get: (hash) => manifest[hash] ?? null,
+    allowArbitraryQueries: false,
+  },
+  hideFieldSuggestions: true,   // no "Did you mean…?" schema enumeration (prod default)
+  maskErrors: true,             // generic message for internal errors (prod default)
+  formatError: (e) => redact(e),
+  onOperation: ({ operation, duration, errors }) => metrics.record(...),
+});
+
+Bun.serve({ fetch: handler });   // or compose with other handlers by pathname
+```
+
+The handler is a plain `(Request) => Promise<Response>` — no framework, same composition pattern as `createSparqlHandler`. It implements GraphQL-over-HTTP (GET with query param, POST JSON, persisted-query extension), answers CORS preflight, honors `Accept` q-values, and serves nothing it wasn't asked to: the handler provides *seams*, the consumer provides *policy*. Build the persisted manifest from your client's compiled operations with `createPersistedManifest(operationTexts)` (SHA-256, the Relay/Apollo convention).
+
+**Built-in hardening defaults.** On top of those seams, the package ships a baseline production posture from its `hardening` domain (all named, exported, and tunable — never magic numbers buried in a resolver): every connection is page-size-clamped (`DEFAULT_PAGE_SIZE` 50, `MAX_PAGE_SIZE` 100), so a list is never unbounded and a client can't demand an oversized page; queries nested deeper than `maxDepth` (default `DEFAULT_MAX_QUERY_DEPTH`, 20) are rejected, bounding the recursion that cyclic types otherwise allow; IRIs that would break out of a SPARQL `IRIREF` are dropped before interpolation, so a crafted `node(id:)` resolves to `null` rather than injected SPARQL; and in production (`maskErrors`, default on) an unexpected internal error is returned as a generic message — store and SPARQL internals never reach the client, while deliberate validation/argument errors pass through. `loaderCache: "process"` uses bounded LRU caches (next section) so ID enumeration can't exhaust memory.
+
+GraphiQL's assets load as version-pinned UMD bundles from unpkg; air-gapped deployments supply their own page through the `graphiqlHtml` option.
+
+## Incremental delivery (`@defer`)
+
+`incremental: true` on the plugin adds the `@defer`/`@stream` directives (graphql v17 doesn't define them by default), and `incremental: true` on the handler streams deferred payloads as `multipart/mixed` to clients that accept it — everyone else gets a single, complete, drained-and-merged JSON response. Correctness can't be lost to a transport mismatch, only streaming.
+
+One ecosystem wrinkle this package absorbs for you: graphql v17 emits the 2023 incremental payload format (`pending`/`incremental`/`completed`), while Relay's network layer still consumes the legacy shape (`path`/`label` per payload, `is_final`). The `relayFormatAdapter` translates between them — used in-process for SSR and by the handler's `incrementalFormat: "relay-legacy"` option. This is also why `graphql` is **pinned exactly**: the adapter is coupled to the RC's payload format, and upgrades should be deliberate, snapshot-diffed events.
+
+## Executing without a server
+
+The compiled schema is a value and `graphql(schema, query, context)` is a function call — every serving mode is a thin shell over it:
+
+```typescript
+import { executeLocal, extractStatic } from "@canonical/ke-graphql";
+
+// In-process (SSR prefetch, tests, scripts) — no HTTP, no serialization.
+// One context per render pass: DataLoaders batch across every concurrent
+// Relay query in the same render.
+const result = await executeLocal({
+  schema,
+  source: `{ books(first: 24) { edges { node { title } } } }`,
+  contextValue: createContext(store),
+});
+
+// Build time (static sites, CDN): run the site's whole query set once,
+// ship the results as JSON. uri-typed variables are enumerated against
+// the store's own instance inventory; anything non-enumerable
+// (pagination cursors) fails loudly instead of shipping partial data.
+const artifacts = await extractStatic({
+  schema, mapped: result.mapped, context: createContext(store),
+  queries: [
+    { name: "AllBooks", text: "{ books(first: 500) { edges { node { id title } } } }" },
+    { name: "BookPage",
+      text: "query($uri: String!) { book(uri: $uri) { title authors(first: 10) { edges { node { name } } } } }",
+      variables: { uri: "String!" } },
+  ],
+});
+```
+
+## Fast boot: the extraction artifact
+
+Pass 1 (the SPARQL extraction) is the only part of compilation that needs the store — and its output is ~2 KiB of serializable JSON. Snapshot it at build time and every subsequent boot skips the store entirely:
+
+```bash
+pragma graphql build ./ontology.ttl "./data/**/*.ttl" \
+  --sdl schema.graphql --extraction extraction.json \
+  --prefix lib=https://example.org/library/
+```
+
+```typescript
+// boots the schema in ~10 ms — no Oxigraph, no TTL parse, no SPARQL
+createSchemaPlugin({ extraction: "./extraction.json" });
+
+// or with no store at all until the first data query:
+import { compileFromExtraction } from "@canonical/ke-graphql";
+const result = compileFromExtraction(artifactJson, { loaderCache: "process" });
+const storeReady = createStore({ sources, prefixes });   // not awaited!
+const ctx = result.createContext(storeReady);            // TBox answers now;
+                                                         // data queries await the store
+```
+
+The artifact embeds a `sourcesHash` fingerprint of the TTL it was built from. The plugin re-fingerprints the sources as ke loads them: match → fast boot; mismatch → a warning and a live compile. A stale artifact can cost you milliseconds, never wrong answers. `pragma graphql check` runs the same compile with no outputs and fails on error diagnostics — the CI gate that puts ontology changes under the same discipline as code.
+
+## Performance
+
+Measured by the committed benchmark (`bun run bench`, 250-entity graph):
+
+| Path | Cost |
+|---|---|
+| Schema boot from artifact (`compileFromExtraction`) | **~10 ms** — no store |
+| Live compile (Pass 1 + passes 2–7 + validate) | ~50–110 ms |
+| Detail page / `node()` with `loaderCache: "process"` | **~0.3 ms** |
+| Listing `first: 24` | **~0.7 ms** warm — pagination runs on the URI list; only the page hydrates |
+| TBox / ontology browsing | ~0.1 ms — store-free |
+
+`loaderCache: "process"` shares DataLoader caches across requests — sound because the store is immutable between reloads, and a reload produces a new compile (automatic invalidation). The shared caches are **bounded LRUs** (`processCacheSize`, default 10,000 entries each), so enumerating distinct IDs can't grow them without limit; evicted entries are simply re-queried, and failed batches are evicted, never memoized. The default `"request"` keeps the textbook per-request isolation.
+
+The ladder to zero: a warm process answers in microseconds; Lambda-style containers pay one ~80 ms boot per container with the artifact; Cloudflare Workers (WASM precompiled at deploy, TTL as ke inline sources — see `examples/cloudflare-worker`) cold-start in ~25–60 ms; and with persisted queries in front of a CDN, responses are pure functions of *(hash, variables)* until the next deploy — cacheable to 0 ms. For fully static deployments, `extractStatic` removes the runtime altogether.
+
+## Package boundary
+
+| Entry | Exports | Dependencies |
+|---|---|---|
+| `@canonical/ke-graphql` | `createSchemaPlugin`, `compile`, `compileFromExtraction`, `serializeExtraction`/`deserializeExtraction`/`hashSources`, `executeLocal`, `extractStatic`, `mergeIncremental`, `relayFormatAdapter`, `createPersistedManifest`, connection/pagination helpers, all IR + diagnostic types | `graphql` (pinned), `dataloader` |
+| `@canonical/ke-graphql/http` | `createGraphQLHandler`, `graphiqlHtml` | the root, plus platform-native fetch |
+
+Consumers that never serve — static extraction in CI, SSR-only processes, tests — never load a byte of HTTP or GraphiQL code.
+
+## Development
+
+```bash
+bun run demo     # GraphiQL on http://localhost:4000/graphql in under a second
+bun run test     # the fixture-suite tests, with coverage gates
+bun run check    # biome + tsc + webarchitect
+bun run bench    # the numbers in this README
+```
+
+`bun run demo` boots `demo/server.ts` against `demo/graph.ttl` — the library
+ontology from this README with a few shelves of data — logging ke's load
+activity (sources, triple counts), the compiler diagnostics, and a ready-made
+`curl`. It serves GraphQL + GraphiQL with `@defer` enabled, so every example
+above can be pasted straight in. The folder is type-checked and linted with
+the package but ships nowhere: it is excluded from the build and the npm
+tarball.
+
+The intermediate representations (`RawExtraction`, `OntologyIR`, `MappedIR`) are exported public contracts, not internals — tooling can consume them the way Prisma generators consume the DMMF. They are pinned by the golden-SDL snapshot in the test suite, so changes to the emitted shape are caught.

--- a/packages/runtime/ke-graphql/biome.json
+++ b/packages/runtime/ke-graphql/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["**/src/**", "**/demo/**", "**/*.json"]
+  }
+}

--- a/packages/runtime/ke-graphql/docs/api.md
+++ b/packages/runtime/ke-graphql/docs/api.md
@@ -1,0 +1,175 @@
+# API reference — `@canonical/ke-graphql`
+
+Two entry points:
+
+- **`@canonical/ke-graphql`** — compiler, schema, resolvers, local execution (no HTTP).
+- **`@canonical/ke-graphql/http`** — the fetch handler and GraphiQL.
+
+Exhaustive types ship in the `.d.ts`; this document is the callable surface grouped by domain. See `docs/architecture.md` for the design and rationale.
+
+---
+
+## Compiler
+
+### `compile(query, prefixes, options?)`
+```ts
+compile(query: QueryFn, prefixes: Readonly<Record<string,string>>, options?: SchemaPluginOptions): Promise<CompilerResult>
+```
+Run the full pipeline (Pass 1 executes SPARQL through `query`). Throws `CompilationError` only on composition failure; all other problems surface in `result.diagnostics`. Most consumers use `createSchemaPlugin` instead and never call this directly.
+
+### `compileFromExtraction(artifact, options?, { assumeValid? }?)`
+```ts
+compileFromExtraction(artifact: string | SerializedExtraction, options?: SchemaPluginOptions, opts?: { assumeValid?: boolean }): CompilerResult
+```
+Boot the schema from a precomputed extraction **without touching the store** (passes 2–7 only). `assumeValid` (default `true`) also skips `validateSchema`/SDL printing. Pair with `hashSources` to check freshness.
+
+### `createSchemaPlugin(options?)`
+```ts
+createSchemaPlugin(options?: SchemaPluginOptions & SchemaPluginExtra): Plugin<SchemaPluginApi>
+```
+The ke plugin. Compiles on `onReady`, recompiles on `onReload`, registers `SchemaPluginApi` under `"ke-graphql"`. `SchemaPluginExtra.extraction` boots from an artifact (path or parsed) when its `sourcesHash` matches the loaded TTL.
+
+```ts
+const graphql = createSchemaPlugin({ mappings: { "lib:authored": { graphqlName: "works" } } });
+const store = await createStore({ sources, prefixes, plugins: [graphql] });
+const { schema, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+```
+
+### `storeQueryFn(store)`
+```ts
+storeQueryFn(store: Store): QueryFn
+```
+Adapt a ke `Store` to the `QueryFn` the compiler expects.
+
+### `createContextFactory(mapped, options)`
+```ts
+createContextFactory(mapped: MappedIR, options: SchemaPluginOptions): ContextFactory
+```
+Build the per-request `CompilerContext` factory (fresh DataLoaders, or shared `"process"` caches). `factory(store)` → context; `factory.clearCache()` drops shared caches. Usually obtained as `result.createContext`.
+
+### `CompilationError`
+Thrown by `compile` when composition fails (`C00x`). Carries `.diagnostics: Diagnostic[]`.
+
+### Result & key option shapes
+- **`CompilerResult`** — `{ schema, sdl, diagnostics, nameMap, mapped, createContext, clearLoaderCache }`.
+- **`SchemaPluginApi`** — `{ schema, diagnostics, nameMap, sdl, createContext, clearLoaderCache }` (the `store.api("ke-graphql")` surface).
+- **`SchemaPluginOptions`** — `mappings`, `extensions`, `relay`, `incremental`, `sdlOutput`, `nonNullOverrides`, `standardVocabFields`, `onRuntimeWarning`, `loaderCache` (`"request"`|`"process"`), `processCacheSize`.
+- **`CustomMapping`** — `{ graphqlName?, singular?, abstract?, embeddable?, inverse?: { graphqlName } }`, keyed by IRI or prefixed name in `CustomMappings`.
+
+---
+
+## Artifact
+
+### `serializeExtraction(extraction, sourcesHash)` / `deserializeExtraction(artifact)`
+```ts
+serializeExtraction(extraction: RawExtraction, sourcesHash: string): string
+deserializeExtraction(artifact: string | SerializedExtraction): { extraction: RawExtraction; sourcesHash: string }
+```
+Codec for the boot artifact. `deserializeExtraction` throws if `version !== ARTIFACT_VERSION`.
+
+### `hashSources(contents)`
+```ts
+hashSources(contents: Iterable<string>): string
+```
+FNV-1a fingerprint of the loaded TTL sources — the freshness key for `compileFromExtraction`.
+
+### `ARTIFACT_VERSION`
+The artifact format version (a number); bump invalidates old artifacts.
+
+---
+
+## Local execution & incremental delivery
+
+### `executeLocal(args)`
+```ts
+executeLocal(args: { schema, source: string, document?: DocumentNode, variableValues?, contextValue: CompilerContext, operationName? }): Promise<LocalExecutionResult>
+```
+In-process execution (no HTTP). Plain documents return an `ExecutionResult`; `@defer`/`@stream` (or any incremental-capable schema) return `IncrementalResults`. Pass `document` to skip an internal parse.
+
+### `mergeIncremental(results)` / `isIncrementalResults(result)`
+Drain an `IncrementalResults` stream into one complete `{ data, errors }`; the type guard distinguishes a stream from a plain result.
+
+### `relayFormatAdapter(results)`
+```ts
+relayFormatAdapter(results: IncrementalResults): AsyncGenerator<RelayLegacyPayload>
+```
+Translate v17 incremental payloads to Relay's legacy `path`/`label`/`is_final` shape. **`@experimental`** — coupled to the graphql v17-RC payload format.
+
+### `extractStatic(options)`
+```ts
+extractStatic(options: { schema, mapped, context, queries: StaticQuery[] }): Promise<Map<string, ExecutionResult>>
+```
+Build-time static extraction: run a fixed query set, keyed by name (queries with a single `uri` variable run once per instance, keyed `"name:uri"`). Throws on non-enumerable variables.
+
+### `createPersistedManifest(operations)` / `sha256Hex(text)`
+```ts
+createPersistedManifest(operations: Iterable<string>): Promise<Record<string,string>>
+sha256Hex(text: string): Promise<string>
+```
+Build a `{ sha256 → query }` manifest from compiled client operations (Web Crypto; the Relay/Apollo persisted-query convention).
+
+---
+
+## Relay connection helpers
+
+```ts
+toConnection<T>(allItems: T[], args: ConnectionArgs, presorted?: boolean): Connection<T>
+paginateUriWindow(uris: readonly string[], args: ConnectionArgs): UriPage
+connectionFromPage<T>(entities: T[], page: UriPage): Connection<T>
+emptyConnection<T>(): Connection<T>
+toBase64(value: string): string         // cursor encode
+fromBase64(value: string): string       // cursor decode (tolerant — garbage → "")
+isEntity(v): v is EntityValue           // filter loadMany results
+unwrapEntities(results): EntityValue[]  // rethrow batch errors, drop nulls
+```
+`toConnection` runs the full Relay algorithm over an in-memory list; `paginateUriWindow` + `connectionFromPage` are the slice-before-hydrate pair (paginate the URI list, hydrate only the page). All page sizes are clamped by the hardening domain.
+
+---
+
+## Hardening
+
+```ts
+isSafeIri(iri: string): boolean
+clampConnectionArgs<T>(args: T, limits?: { defaultPageSize; maxPageSize }): T
+createDepthLimitRule(maxDepth: number): (ctx: ValidationContext) => ASTVisitor   // a graphql ValidationRule
+createBoundedCache<K,V>(maxSize: number): Map<K,V>                                // bounded LRU
+maskError(error: GraphQLError, mask: boolean): GraphQLFormattedError
+```
+Constants: `DEFAULT_PAGE_SIZE` (50), `MAX_PAGE_SIZE` (100), `DEFAULT_MAX_QUERY_DEPTH` (20), `DEFAULT_PROCESS_CACHE_SIZE` (10000). See the Hardening section of `docs/architecture.md`.
+
+---
+
+## URI conversion
+
+```ts
+toPrefixed(fullUri: string, namespaces: ReadonlyMap<string, NamespaceInfo>): string         // longest-match → "lib:dune"
+toFull(prefixed: string, namespaces: ReadonlyMap<string, NamespaceInfo>): string | undefined // → full IRI, or undefined for unknown prefix
+```
+
+---
+
+## Types
+
+The exported IR and value types: `RawExtraction`, `OntologyIR`, `MappedIR`, `ClassNode`, `PropertyNode`, `MappedType`, `MappedInterface`, `MappedField`, `RangeSpec`, `CardinalitySpec`, `NameMap`, `NamespaceInfo`, `InstanceStats`, `EntityValue`, `TripleSet`, `TripleValue`, `Diagnostic`, `DiagnosticCode`, `DiagnosticSeverity`, `PassResult`, `QueryFn`, `ResolverTemplate`, `RuntimeWarningHandler`, `CompilerContext`, `ContextFactory`, `CompilerResult`, `SchemaPluginApi`, `SchemaPluginOptions`, `SchemaPluginExtra`, `CustomMapping`, `CustomMappings`, `NonNullOverrides`, `SchemaExtensions`, `SchemaExtensionsInput`, `SerializedExtraction`, `Connection`, `ConnectionArgs`, `UriPage`, `IncrementalResults`, `LocalExecutionResult`, `RelayLegacyPayload`, `StaticQuery`.
+
+---
+
+## `@canonical/ke-graphql/http`
+
+### `createGraphQLHandler(schema, options)`
+```ts
+createGraphQLHandler(schema: GraphQLSchema, options: GraphQLHandlerOptions): (request: Request) => Promise<Response>
+```
+A framework-free GraphQL-over-HTTP handler: GET (query param) / POST JSON, persisted-query extension, CORS preflight, `Accept` q-values, multipart incremental delivery.
+
+**`GraphQLHandlerOptions`** (every policy seam + the built-in hardening defaults):
+`context` (required, per-request `CompilerContext`), `graphiql`, `cors`, `maxQueryLength`, `maxDepth` (default `DEFAULT_MAX_QUERY_DEPTH`, 0 disables), `validationRules`, `introspection`, `persistedQueries` (`{ get, allowArbitraryQueries? }`), `hideFieldSuggestions`, `formatError`, `maskErrors` (default: production), `onOperation`, `incremental`, `incrementalFormat` (`"graphql17"`|`"relay-legacy"`), `graphiqlHtml`. Defaults are dev-vs-production aware (`NODE_ENV`; hardened where `process` is absent).
+
+### `graphiqlHtml(endpoint)`
+```ts
+graphiqlHtml(endpoint: string): string
+```
+The default GraphiQL page (version-pinned UMD assets from unpkg). Override via `GraphQLHandlerOptions.graphiqlHtml` for air-gapped/vendored deployments.
+
+### `OperationEvent`
+The `onOperation` payload: `{ operation, duration, errors, persisted }`.

--- a/packages/runtime/ke-graphql/docs/architecture.md
+++ b/packages/runtime/ke-graphql/docs/architecture.md
@@ -1,0 +1,89 @@
+# Architecture — `@canonical/ke-graphql`
+
+The README is the narrative introduction and `docs/api.md` is the export-by-export reference; this document explains *how the package is built and why*.
+
+## 1. What it is
+
+`@canonical/ke-graphql` is a **compiler**, not middleware. It reads an OWL/RDFS ontology (the TBox) plus its instance data (the ABox) from a [`@canonical/ke`](../../ke) triple store and emits an executable `GraphQLSchema` with resolvers. The mapping is not mechanical: a class with no instances should become an interface, an `owl:inverseOf` pair should produce one field per side rather than four, a blank-node-only class can't have a global ID. Faithful translation takes semantic analysis, so the package is structured like a compiler — passes over a typed intermediate representation, diagnostics with stable codes that never abort on the first problem, and deterministic output you can snapshot.
+
+```
+ke store ──► [ 7 passes ] ──► GraphQLSchema + resolvers ──► (local execution | /http handler)
+                  │
+                  └─ typed IRs: RawExtraction → OntologyIR → MappedIR → SchemaPlan
+```
+
+## 2. The seven passes
+
+Each pass is a pure function from one IR to the next (Pass 1 is the only one that touches the store). The pipeline lives in `src/lib/compiler/`.
+
+| Pass | File | In → Out | Responsibility |
+|---|---|---|---|
+| 1 Extract | `extract.ts` | store → `RawExtraction` | 12 SPARQL queries: TBox structure, SHACL shapes (incl. `sh:or`/`sh:in`), and ABox probes (instance counts, self-reference, functional violations, undeclared predicates, annotations). All store access happens here so passes 2–7 stay pure. |
+| 2 Build | `build.ts` | `RawExtraction` → `OntologyIR` | subClassOf closure, abstract/embeddable detection from instance stats, per-class cardinality by precedence (custom > `owl:FunctionalProperty` > `owl:cardinality` > SHACL > kind default), range resolution. |
+| 3 Validate | `validate.ts` | `OntologyIR` → `OntologyIR` (+ diagnostics) | the V-series diagnostics (blank-node-only class, domainless property, asymmetric inverse, boolean-as-string, SHACL specifics, abstract-with-instances `V015`, supertype flattening `V016`). Never mutates the IR; never aborts. |
+| 4 Map | `map.ts` | `OntologyIR` → `MappedIR` | GraphQL naming rules, collision auto-resolution (namespace prefixing), synthetic inverse field synthesis, the bidirectional name map. |
+| 5 Emit | `emit.ts` | `MappedIR` → `SchemaPlan` | a field plan + resolver per field (one of the eight resolver templates), because graphql-js type objects are immutable once constructed. |
+| 6 WireRelay | `wireRelay.ts` | `SchemaPlan` → `SchemaPlan` | the `Node` interface (id + uri) on types *and* qualifying interfaces, cursor connections, the `node(id:)` and per-type `<type>(uri:)` / listing root fields. |
+| 7 Compose | `compose.ts` | `SchemaPlan` → `GraphQLSchema` | the single construction point: builds every graphql-js type once, attaches the TBox schema and consumer extensions, runs `validateSchema`, prints the SDL. |
+
+`runPasses.ts` threads 2→7; `compile.ts` runs `extract` then `runPasses`. Splitting construction (Pass 5/6 plan, Pass 7 build) is deliberate — graphql-js objects can't be mutated after creation, so the plan accumulates intent and compose realizes it in one shot.
+
+## 3. The typed IRs
+
+The intermediate representations are exported public contracts (like Prisma's DMMF), not internals — tooling can consume them.
+
+- **`RawExtraction`** — the serializable result of Pass 1 (the twelve queries). It is the artifact boundary (see the performance model below).
+- **`OntologyIR`** — the typed ontology: `ClassNode` (ancestors, subclasses, `isAbstract`, `embeddable`) and `PropertyNode` (kind, domains, resolved `RangeSpec`, per-class `CardinalitySpec`).
+- **`MappedIR`** — GraphQL-shaped: `MappedType`/`MappedInterface`/`MappedField`, the `NameMap`, the namespace inventory.
+- **`SchemaPlan`** — field configs + resolvers awaiting construction.
+
+## 4. The OWL → GraphQL model
+
+- **Naming.** Field names strip a leading `has`/`is`; list fields are pluralized (the pluralizer knows the irregulars). Illegal GraphQL names are sanitized; collisions are auto-resolved by namespace prefixing (diagnostic `M004`) or, if unresolvable, reported as `M001`.
+- **Cardinality.** A property is singular when a custom mapping says so, else if `owl:FunctionalProperty`, else SHACL `maxCount 1`, else the kind default (datatype → singular, object → list). List items are always non-null (`[T!]!`).
+- **Embeddable types.** A class whose instances are exclusively blank nodes has no URI, so no global ID, no cursor, no standalone resolution. It is emitted without `Node`/`id`/`_meta`, as a plain `[T!]!` list, and resolved inline from the parent's own triples — fetched in the parent's CONSTRUCT closure (a per-blank follow-up query is invalid SPARQL: blank-node labels are existential and not stable across result sets).
+- **Interfaces & abstract classes.** A class with subclasses and *no direct instances* is abstract → an `interface`. If all of its concrete implementors are non-embeddable it implements `Node`, so a fragment written against the interface is Relay-refetchable. A class that is concrete *and* has subclasses stays a concrete type and earns `V016` (its supertype-typed fields flatten polymorphism); the interface-plus-companion alternative is a deferred option.
+- **Inverse pairs.** `owl:inverseOf` produces one field per side, never the four-way duplication. At resolution each side takes the **union of forward and reverse assertions**, so data asserted in either direction answers identically from both ends. Synthetic inverses (a reverse field with no declared partner) are minted in Pass 4.
+- **Global IDs.** The Relay `id` is the prefixed URI (`lib:dune`), not an opaque token — usable in GraphiQL, URLs, and the CLI. `toPrefixed` chooses the longest matching namespace so IDs are canonical and order-independent.
+- **Self-description.** Every non-embeddable type carries `_meta: EntityMeta!`, exposing the class definition and per-field `ClassProperty` metadata (required/singular/inherited) read from the frozen IR.
+
+## 5. Runtime model
+
+- **The ke plugin (`createSchemaPlugin`).** Registered with `createStore`, it compiles on `onReady` and recompiles on `onReload`, exposing `{ schema, createContext, diagnostics, nameMap, sdl, clearLoaderCache }` under `store.api("ke-graphql")`. `onLoad` fingerprints the sources for artifact freshness.
+- **Resolution & DataLoader.** A `CompilerContext` carries three batched loaders — entity (one CONSTRUCT with a `VALUES` clause + blank-node closure), list (one SELECT per class, name-sorted), inverse (one SELECT over reverse assertions). The eight resolver templates in `resolver/templates.ts` read the parent `EntityValue`'s `TripleSet` and dispatch to these loaders.
+- **Lazy store.** The context accepts `Store | Promise<Store>`; ABox loaders `await` it at query time, TBox resolvers never touch it. This lets the schema be ready before the store finishes loading.
+- **Local execution.** `executeLocal` runs an operation in-process (SSR, tests, scripts) — `graphql()` for plain documents, `experimentalExecuteIncrementally` when the schema or document involves `@defer`/`@stream`. Path B (`extractStatic`) runs a fixed query set for fully static deployments.
+- **Incremental delivery.** `graphql@17.0.0-rc.0`; the `incremental` compile option adds `@defer`/`@stream`; `relayFormatAdapter` translates v17's 2023 payload format to Relay's legacy `path`/`label`/`is_final` shape. A drain-and-merge fallback (`mergeIncremental`) means a format break can cost streaming, never correctness.
+
+## 6. Package boundary
+
+The root export is **schema + resolvers + local execution only** (`graphql` + `dataloader`). The fetch handler and GraphiQL live behind the **`@canonical/ke-graphql/http`** subpath (`createGraphQLHandler`, `graphiqlHtml`), mirroring `@canonical/ke/http`, so SSR/static/test consumers load no HTTP code. The handler is a plain `(Request) => Promise<Response>` — GraphQL-over-HTTP, CORS, persisted queries, multipart incremental — composing like any fetch handler.
+
+## 7. Performance model
+
+- **Extraction artifact** (DMMF pattern). `pragma graphql build` serializes Pass 1 to JSON with an FNV-1a `sourcesHash`. `compileFromExtraction` boots the schema from it without touching the store (~9 ms vs ~54 ms live), falling back to a live compile when the hash is stale.
+- **Store-free TBox.** `_meta`/Ontology/Class resolvers read the frozen IR; they answer even after the store is disposed (~0.13 ms).
+- **Slice-before-hydrate.** Every connection — root *and* nested — paginates the URI window first and hydrates only the page (24 entities, not 250).
+- **Loader caches.** `loaderCache: "request"` (default, per-request isolation) or `"process"` (shared across requests; sound because the store is immutable between reloads). Process caches are bounded LRUs (`processCacheSize`).
+
+The ladder: a warm process answers in microseconds; an artifact boot is ~80 ms per cold container; Cloudflare Workers (WASM precompiled, TTL as inline sources) cold-start in tens of ms; persisted queries behind a CDN make responses pure functions of *(hash, variables)*; `extractStatic` removes the runtime entirely.
+
+## 8. Hardening
+
+The `src/lib/hardening/` domain is the production-safety posture in one named place — tunable, exported, never magic numbers in a resolver:
+
+- `isSafeIri` — drops IRIs that would break out of a SPARQL `IRIREF`, so a crafted `node(id:)` resolves to null, not injected SPARQL (ke queries are read-only, but the guard closes cross-graph disclosure and cost amplification).
+- `clampConnectionArgs` (+ `DEFAULT_PAGE_SIZE`/`MAX_PAGE_SIZE`) — no connection is unbounded and no client can demand an oversized page; applied at both pagination choke points.
+- `createDepthLimitRule` (+ `DEFAULT_MAX_QUERY_DEPTH`) — bounds the recursion cyclic types allow.
+- `createBoundedCache` (+ `DEFAULT_PROCESS_CACHE_SIZE`) — the bounded LRU behind `"process"` mode.
+- `maskError` — replaces internal/unexpected error messages with a generic one in production; deliberate validation/argument errors pass through.
+
+The HTTP handler also defaults introspection and field-suggestions off in production (`process.env.NODE_ENV`, or always-on hardening where `process` is absent, e.g. Workers).
+
+## 9. Diagnostics
+
+The compiler collects problems instead of aborting (the `tsc` model). Codes are stable: `E001` (extraction), `B001–B004` (build references), `V001–V016` (data/ontology validation), `M001–M004` (naming), `X002–X003` (union emission), `C001–C003` (composition). **Only composition errors (`C00x`) prevent schema creation** — `compile()` then throws `CompilationError` with the full list. Everything else surfaces in `result.diagnostics` while the schema still builds; the consumer chooses its failure policy (`pragma graphql check` fails CI on any error-severity diagnostic).
+
+## 10. Delivery
+
+This package is being landed as a stack of focused PRs, decomposed in dependency order so each builds on the last.

--- a/packages/runtime/ke-graphql/package.json
+++ b/packages/runtime/ke-graphql/package.json
@@ -1,0 +1,114 @@
+{
+  "name": "@canonical/ke-graphql",
+  "description": "OWL → GraphQL compiler for the ke triple store: typed IR, seven-pass pipeline, Relay conventions, incremental delivery",
+  "version": "0.27.1-experimental.0",
+  "type": "module",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    },
+    "./http": {
+      "types": "./dist/types/http/index.d.ts",
+      "import": "./dist/esm/http/index.js"
+    }
+  },
+  "imports": {
+    "#compiler": {
+      "development": "./src/lib/compiler/index.ts",
+      "types": "./dist/types/lib/compiler/index.d.ts",
+      "default": "./dist/esm/lib/compiler/index.js"
+    },
+    "#dataloader": {
+      "development": "./src/lib/dataloader/index.ts",
+      "types": "./dist/types/lib/dataloader/index.d.ts",
+      "default": "./dist/esm/lib/dataloader/index.js"
+    },
+    "#execution": {
+      "development": "./src/lib/execution/index.ts",
+      "types": "./dist/types/lib/execution/index.d.ts",
+      "default": "./dist/esm/lib/execution/index.js"
+    },
+    "#hardening": {
+      "development": "./src/lib/hardening/index.ts",
+      "types": "./dist/types/lib/hardening/index.d.ts",
+      "default": "./dist/esm/lib/hardening/index.js"
+    },
+    "#resolver": {
+      "development": "./src/lib/resolver/index.ts",
+      "types": "./dist/types/lib/resolver/index.d.ts",
+      "default": "./dist/esm/lib/resolver/index.js"
+    },
+    "#shared": {
+      "development": "./src/lib/shared/index.ts",
+      "types": "./dist/types/lib/shared/index.d.ts",
+      "default": "./dist/esm/lib/shared/index.js"
+    },
+    "#tbox": {
+      "development": "./src/lib/tbox/index.ts",
+      "types": "./dist/types/lib/tbox/index.d.ts",
+      "default": "./dist/esm/lib/tbox/index.js"
+    },
+    "#testing": {
+      "development": "./src/testing/index.ts",
+      "types": "./src/testing/index.ts",
+      "default": "./src/testing/index.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun run build:package",
+    "build:all": "bun run build:package",
+    "build:package": "bun run build:package:tsc",
+    "build:package:tsc": "tsc -p tsconfig.build.json",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "test": "bun run test:vitest",
+    "test:vitest": "vitest run --coverage",
+    "test:vitest:watch": "vitest",
+    "check:webarchitect": "webarchitect library",
+    "bench": "bun run build && node scripts/bench.mjs",
+    "demo": "bun demo/server.ts"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.9",
+    "@canonical/biome-config": "^0.27.1-experimental.0",
+    "@canonical/ke": "^0.27.1-experimental.0",
+    "@canonical/typescript-config": "^0.27.1-experimental.0",
+    "@types/bun": "^1.3.10",
+    "@types/node": "^24.12.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18",
+    "@canonical/webarchitect": "^0.27.1-experimental.0"
+  },
+  "peerDependencies": {
+    "@canonical/ke": "^0.27.1-experimental.0"
+  },
+  "dependencies": {
+    "dataloader": "^2.2.3",
+    "graphql": "17.0.0-rc.0"
+  }
+}

--- a/packages/runtime/ke-graphql/src/index.ts
+++ b/packages/runtime/ke-graphql/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @canonical/ke-graphql — OWL → GraphQL compiler for the ke triple store.
+ *
+ * The root export is schema + resolvers + local execution only:
+ * no server, no HTTP, no GraphiQL. The fetch handler lives behind the
+ * `@canonical/ke-graphql/http` subpath export, so consumers that only
+ * need the schema never load HTTP code.
+ *
+ * @example
+ * ```ts
+ * import { createStore } from "@canonical/ke";
+ * import { createSchemaPlugin, type SchemaPluginApi } from "@canonical/ke-graphql";
+ *
+ * const graphql = createSchemaPlugin();
+ * const store = await createStore({
+ *   sources: ["./ontology.ttl", "./data/*.ttl"],
+ *   prefixes: { ds: "https://ds.canonical.com/" },
+ *   plugins: [graphql],
+ * });
+ * const { schema, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+ * ```
+ *
+ * @module ke-graphql
+ */
+
+export * from "./lib/index.js";

--- a/packages/runtime/ke-graphql/src/lib/hardening/clampConnectionArgs.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/clampConnectionArgs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import clampConnectionArgs from "./clampConnectionArgs.js";
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "./constants.js";
+
+describe("clampConnectionArgs (page-size hardening)", () => {
+  it("imposes the default page size when neither first nor last is given", () => {
+    expect(clampConnectionArgs({})).toEqual({ first: DEFAULT_PAGE_SIZE });
+    // `after`/`before` alone still count as "no page bound supplied".
+    expect(clampConnectionArgs({ after: "cur" })).toEqual({
+      after: "cur",
+      first: DEFAULT_PAGE_SIZE,
+    });
+  });
+
+  it("caps an over-large first/last at the ceiling", () => {
+    expect(clampConnectionArgs({ first: 10_000 }).first).toBe(MAX_PAGE_SIZE);
+    expect(clampConnectionArgs({ last: 10_000 }).last).toBe(MAX_PAGE_SIZE);
+  });
+
+  it("leaves in-range values untouched", () => {
+    expect(clampConnectionArgs({ first: 10 }).first).toBe(10);
+    expect(clampConnectionArgs({ last: 5 })).toEqual({ last: 5 });
+  });
+
+  it("passes negatives through unchanged (rejected downstream, not masked)", () => {
+    expect(clampConnectionArgs({ first: -1 }).first).toBe(-1);
+    expect(clampConnectionArgs({ last: -3 }).last).toBe(-3);
+  });
+
+  it("honors explicit limits", () => {
+    const limits = { defaultPageSize: 3, maxPageSize: 9 };
+    expect(clampConnectionArgs({}, limits)).toEqual({ first: 3 });
+    expect(clampConnectionArgs({ first: 100 }, limits).first).toBe(9);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/clampConnectionArgs.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/clampConnectionArgs.ts
@@ -1,0 +1,39 @@
+// =============================================================================
+// Connection page-size clamp. A connection must never return an unbounded
+// list, and a client must never be able to demand an arbitrarily large page.
+// This is applied at the two pagination choke points (paginateUriWindow and
+// toConnection) so every connection — root, nested, and TBox — is bounded.
+// =============================================================================
+
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "./constants.js";
+
+/**
+ * Clamp a connection's page size: apply the default `first` when the client
+ * gave neither `first` nor `last`, and cap a too-large `first`/`last` at the
+ * ceiling (`{ defaultPageSize, maxPageSize }`, defaulting to the hardening
+ * constants). Negative values pass through unchanged — the connection helpers
+ * reject those with a GraphQLError, which this must not mask. Returns a new
+ * args object; the input is not mutated.
+ */
+export default function clampConnectionArgs<
+  T extends { first?: number | null; last?: number | null },
+>(
+  args: T,
+  limits: { defaultPageSize: number; maxPageSize: number } = {
+    defaultPageSize: DEFAULT_PAGE_SIZE,
+    maxPageSize: MAX_PAGE_SIZE,
+  },
+): T {
+  // No page bound supplied → impose the default page size.
+  if (args.first == null && args.last == null) {
+    return { ...args, first: limits.defaultPageSize };
+  }
+  let { first, last } = args;
+  if (first != null && first > limits.maxPageSize) {
+    first = limits.maxPageSize;
+  }
+  if (last != null && last > limits.maxPageSize) {
+    last = limits.maxPageSize;
+  }
+  return { ...args, first, last };
+}

--- a/packages/runtime/ke-graphql/src/lib/hardening/constants.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/constants.ts
@@ -1,0 +1,37 @@
+// =============================================================================
+// Hardening defaults. These are the package's production-safety knobs in one
+// named place (the hardening domain), not magic numbers scattered through the
+// handler and resolvers. The HTTP layer and connection helpers read them;
+// consumers can override at their call sites.
+// =============================================================================
+
+/**
+ * Page size applied to a connection when the client supplies neither `first`
+ * nor `last`. A connection must never return an unbounded list — this is the
+ * floor of DoS protection.
+ */
+export const DEFAULT_PAGE_SIZE = 50;
+
+/**
+ * Hard ceiling on `first`/`last`. A client asking for more is clamped down to
+ * this — it bounds both the hydration cost and the response size regardless
+ * of what the client requests.
+ */
+export const MAX_PAGE_SIZE = 100;
+
+/**
+ * Default maximum selection-set nesting depth enforced by the HTTP layer's
+ * depth-limit rule. High enough to admit the standard introspection query,
+ * low enough to reject the unbounded recursion that cyclic types
+ * (work → authors → works → authors → …) otherwise allow.
+ */
+export const DEFAULT_MAX_QUERY_DEPTH = 20;
+
+/**
+ * Default maximum entries per process-lifetime loader cache (LRU) when
+ * `loaderCache: "process"` is used. Bounds memory: enumerating distinct entity
+ * IDs (misses are cached too) can't grow the caches without limit. Evicted
+ * entries are simply re-queried — the store is immutable between reloads, so
+ * eviction never returns stale data.
+ */
+export const DEFAULT_PROCESS_CACHE_SIZE = 10_000;

--- a/packages/runtime/ke-graphql/src/lib/hardening/createBoundedCache.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/createBoundedCache.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import createBoundedCache from "./createBoundedCache.js";
+
+describe("createBoundedCache (bounded LRU)", () => {
+  it("evicts the least-recently-used entry past the size limit", () => {
+    const cache = createBoundedCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3); // over capacity → evict "a"
+    expect(cache.has("a")).toBe(false);
+    expect(cache.has("b")).toBe(true);
+    expect(cache.has("c")).toBe(true);
+    expect(cache.size).toBe(2);
+  });
+
+  it("get() refreshes recency, protecting an entry from eviction", () => {
+    const cache = createBoundedCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    expect(cache.get("a")).toBe(1); // "a" is now most-recent; "b" is LRU
+    cache.set("c", 3); // evicts "b", not "a"
+    expect(cache.has("a")).toBe(true);
+    expect(cache.has("b")).toBe(false);
+  });
+
+  it("behaves as a normal Map within the limit", () => {
+    const cache = createBoundedCache<string, number>(10);
+    cache.set("a", 1);
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("missing")).toBeUndefined();
+    cache.delete("a");
+    expect(cache.has("a")).toBe(false);
+  });
+
+  it("does not evict when the LRU key is undefined (cannot distinguish from empty)", () => {
+    const cache = createBoundedCache<undefined, number>(1);
+    cache.set(undefined, 1); // LRU key is literally undefined
+    cache.set("x" as unknown as undefined, 2); // over capacity
+    // The eviction guard skips an undefined first key, so nothing is removed.
+    expect(cache.has(undefined)).toBe(true);
+    expect(cache.size).toBe(2);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/createBoundedCache.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/createBoundedCache.ts
@@ -1,0 +1,52 @@
+// =============================================================================
+// Bounded LRU for the process-lifetime loader caches. The "process" loaderCache
+// mode shares DataLoader caches across requests; without a bound, a client
+// enumerating distinct entity IDs (misses are cached too) grows the maps
+// without limit. This caps them — past the size limit, inserting evicts the
+// least-recently-used key, and an eviction merely re-queries (still correct,
+// since the store is immutable between reloads).
+// =============================================================================
+
+// Map subclass with LRU eviction. get()/set() refresh recency by re-inserting
+// (Map preserves insertion order), so the first key is always the LRU one.
+class BoundedCache<K, V> extends Map<K, V> {
+  readonly #maxSize: number;
+
+  constructor(maxSize: number) {
+    super();
+    this.#maxSize = maxSize;
+  }
+
+  /** @note Impure — mutates LRU recency order (a read promotes the key to most-recent). */
+  get(key: K): V | undefined {
+    if (!super.has(key)) {
+      return undefined;
+    }
+    const value = super.get(key) as V;
+    super.delete(key);
+    super.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): this {
+    super.delete(key);
+    super.set(key, value);
+    if (super.size > this.#maxSize) {
+      const lru = super.keys().next().value;
+      if (lru !== undefined) {
+        super.delete(lru);
+      }
+    }
+    return this;
+  }
+}
+
+/**
+ * Create a bounded, least-recently-used Map: once it exceeds `maxSize`
+ * entries, inserting evicts the least-recently-used key; get() and set()
+ * refresh recency. Backs the process-lifetime loader caches so "process" mode
+ * bounds memory instead of growing without limit.
+ */
+export default function createBoundedCache<K, V>(maxSize: number): Map<K, V> {
+  return new BoundedCache<K, V>(maxSize);
+}

--- a/packages/runtime/ke-graphql/src/lib/hardening/createDepthLimitRule.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/createDepthLimitRule.test.ts
@@ -1,0 +1,48 @@
+import { buildSchema, parse, validate } from "graphql";
+import { describe, expect, it } from "vitest";
+import createDepthLimitRule from "./createDepthLimitRule.js";
+
+const schema = buildSchema(`
+  type Query { node: Node }
+  type Node { name: String, child: Node }
+`);
+
+const depthErrors = (query: string, maxDepth: number) =>
+  validate(schema, parse(query), [createDepthLimitRule(maxDepth)]);
+
+describe("createDepthLimitRule", () => {
+  it("passes operations within the limit", () => {
+    // node(1) name(2) => depth 2
+    expect(depthErrors(`{ node { name } }`, 3)).toHaveLength(0);
+  });
+
+  it("rejects operations exceeding the limit", () => {
+    // node(1) child(2) child(3) name(4) => depth 4
+    const errors = depthErrors(`{ node { child { child { name } } } }`, 2);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toMatch(/maximum depth of 2/);
+  });
+
+  it("counts through inline fragments without adding a level", () => {
+    // node(1) name(2) — the inline fragment is transparent => depth 2
+    expect(depthErrors(`{ node { ... on Node { name } } }`, 2)).toHaveLength(0);
+  });
+
+  it("resolves named fragment spreads", () => {
+    const query = `{ node { ...F } } fragment F on Node { child { child { name } } }`;
+    // node(1) child(2) child(3) name(4) => depth 4 > 2
+    expect(depthErrors(query, 2)).toHaveLength(1);
+  });
+
+  it("guards fragment cycles without infinite recursion", () => {
+    const query = `{ node { ...F } } fragment F on Node { child { ...F } }`;
+    expect(() => depthErrors(query, 50)).not.toThrow();
+  });
+
+  it("ignores a spread to an undefined fragment", () => {
+    // No fragment definition for `Missing` — the depth rule runs in isolation
+    // (no KnownFragmentNames rule), so the spread contributes no depth.
+    // node(1) name(2) => depth 2, within the limit.
+    expect(depthErrors(`{ node { name ...Missing } }`, 2)).toHaveLength(0);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/createDepthLimitRule.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/createDepthLimitRule.ts
@@ -1,0 +1,85 @@
+// =============================================================================
+// Query-depth validation rule. graphql-js ships no depth limit, so a schema
+// with cyclic types (work → authors → works → authors → …) accepts arbitrarily
+// nested operations. This rule rejects any operation whose selection-set
+// nesting exceeds maxDepth, resolving named fragment spreads (with a cycle
+// guard) and inline fragments — neither of which adds a level of its own.
+// =============================================================================
+
+import {
+  type ASTVisitor,
+  type FragmentDefinitionNode,
+  GraphQLError,
+  Kind,
+  type SelectionSetNode,
+  type ValidationContext,
+} from "graphql";
+
+/**
+ * Create a validation rule that fails any operation nested deeper than
+ * `maxDepth` selection sets. A leaf field is depth 1; `{ a { b } }` is depth
+ * 2. Fragment spreads and inline fragments are transparent to the count.
+ */
+export default function createDepthLimitRule(
+  maxDepth: number,
+): (context: ValidationContext) => ASTVisitor {
+  return (context) => {
+    const fragments = new Map<string, FragmentDefinitionNode>();
+    for (const def of context.getDocument().definitions) {
+      if (def.kind === Kind.FRAGMENT_DEFINITION) {
+        fragments.set(def.name.value, def);
+      }
+    }
+
+    const depthOf = (
+      selectionSet: SelectionSetNode | undefined,
+      seenFragments: ReadonlySet<string>,
+    ): number => {
+      if (!selectionSet) {
+        return 0;
+      }
+      let deepest = 0;
+      for (const selection of selectionSet.selections) {
+        if (selection.kind === Kind.FIELD) {
+          const below = depthOf(selection.selectionSet, seenFragments);
+          deepest = Math.max(deepest, 1 + below);
+        } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+          // Inline fragments do not add a level — their selections sit at the
+          // current depth.
+          deepest = Math.max(
+            deepest,
+            depthOf(selection.selectionSet, seenFragments),
+          );
+        } else {
+          // Fragment spread: expand the named fragment, guarding cycles.
+          const name = selection.name.value;
+          if (seenFragments.has(name)) {
+            continue;
+          }
+          const fragment = fragments.get(name);
+          if (fragment) {
+            deepest = Math.max(
+              deepest,
+              depthOf(fragment.selectionSet, new Set([...seenFragments, name])),
+            );
+          }
+        }
+      }
+      return deepest;
+    };
+
+    return {
+      OperationDefinition(node) {
+        const depth = depthOf(node.selectionSet, new Set());
+        if (depth > maxDepth) {
+          context.reportError(
+            new GraphQLError(
+              `Query exceeds maximum depth of ${maxDepth} (depth ${depth})`,
+              { nodes: [node] },
+            ),
+          );
+        }
+      },
+    };
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/hardening/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/index.ts
@@ -1,0 +1,23 @@
+/**
+ * The hardening domain: the package's production-safety posture in one named
+ * place — the IRI-injection guard for SPARQL interpolation, connection
+ * page-size clamping, the query-depth validation rule, the bounded loader
+ * cache, and production error masking. Defaults live in ./constants; the HTTP
+ * layer, the connection helpers, and the context factory consume these so
+ * the policy is discoverable and tunable, never a magic number lurking in a
+ * resolver.
+ *
+ * @module hardening
+ */
+
+export { default as clampConnectionArgs } from "./clampConnectionArgs.js";
+export {
+  DEFAULT_MAX_QUERY_DEPTH,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_PROCESS_CACHE_SIZE,
+  MAX_PAGE_SIZE,
+} from "./constants.js";
+export { default as createBoundedCache } from "./createBoundedCache.js";
+export { default as createDepthLimitRule } from "./createDepthLimitRule.js";
+export { default as isSafeIri } from "./isSafeIri.js";
+export { default as maskError } from "./maskError.js";

--- a/packages/runtime/ke-graphql/src/lib/hardening/isSafeIri.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/isSafeIri.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import isSafeIri from "./isSafeIri.js";
+
+describe("isSafeIri (SPARQL IRIREF injection guard)", () => {
+  it("accepts well-formed IRIs with legal punctuation", () => {
+    for (const iri of [
+      "http://example.org/Thing",
+      "https://ds.canonical.com/global.component.button",
+      "http://ex.org/path?q=1#frag",
+      "urn:uuid:1234-5678",
+    ]) {
+      expect(isSafeIri(iri)).toBe(true);
+    }
+  });
+
+  it("rejects IRIs carrying an IRIREF-illegal character", () => {
+    for (const iri of [
+      "http://ex.org/x> } UNION { ?s ?p ?o } #", // the injection breakout
+      "http://ex.org/a b", // space
+      "http://ex.org/x\ty", // control character (tab)
+      "http://ex.org/<x>",
+      'http://ex.org/"x"',
+      "http://ex.org/{x}",
+      "http://ex.org/x|y",
+      "http://ex.org/x^y",
+      "http://ex.org/x`y",
+      "http://ex.org/x\\y",
+      "",
+    ]) {
+      expect(isSafeIri(iri)).toBe(false);
+    }
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/isSafeIri.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/isSafeIri.ts
@@ -1,0 +1,39 @@
+// =============================================================================
+// IRI-injection guard. Loaders interpolate full IRIs into SPARQL as `<${iri}>`
+// (e.g. VALUES ?s { <...> }). The IRI ultimately derives from client input
+// (node(id:) / <type>(uri:) arguments), so an IRI carrying an IRIREF-illegal
+// character -- `>` above all -- would terminate the IRIREF early and inject
+// the remainder as SPARQL graph patterns. ke queries are read-only, so the
+// blast radius is cross-graph disclosure and query-cost amplification rather
+// than mutation, but it is still reachable unauthenticated.
+//
+// Per the SPARQL grammar an IRIREF is '<' ([^<>"{}|^`\]-[#x00-#x20])* '>'.
+// A well-formed IRI never contains any of those characters, so rejecting them
+// closes the injection without affecting any legitimate identifier. Legal IRI
+// punctuation (#, /, :, ?, %, ...) is deliberately NOT rejected.
+// =============================================================================
+
+// Code points forbidden inside a SPARQL IRIREF: <, >, ", {, }, |, ^, backtick,
+// backslash (control characters and space are handled by the <= 0x20 test).
+const FORBIDDEN = new Set([
+  0x3c, 0x3e, 0x22, 0x7b, 0x7d, 0x7c, 0x5e, 0x60, 0x5c,
+]);
+
+/**
+ * Report whether an IRI is safe to interpolate into a SPARQL `<...>` IRIREF --
+ * i.e. it is non-empty and contains no IRIREF-illegal character. Callers
+ * filter unsafe IRIs out of the query (an unsafe global ID then resolves to
+ * "not found", never to injected SPARQL).
+ */
+export default function isSafeIri(iri: string): boolean {
+  if (iri.length === 0) {
+    return false;
+  }
+  for (let i = 0; i < iri.length; i++) {
+    const code = iri.charCodeAt(i);
+    if (code <= 0x20 || FORBIDDEN.has(code)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/runtime/ke-graphql/src/lib/hardening/maskError.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/maskError.test.ts
@@ -1,0 +1,49 @@
+import { GraphQLError, parse } from "graphql";
+import { describe, expect, it } from "vitest";
+import maskError from "./maskError.js";
+
+describe("maskError (production error masking)", () => {
+  it("masks an internal error (wrapping a non-GraphQL throw) when enabled", () => {
+    const internal = new GraphQLError("connection refused: db://secret@host", {
+      originalError: new Error("connection refused: db://secret@host"),
+    });
+    const formatted = maskError(internal, true);
+    expect(formatted.message).toBe("Internal server error");
+    expect(formatted.extensions?.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+
+  it("retains locations and path on a masked internal error", () => {
+    const node = parse(`{ a { b } }`).definitions[0];
+    const internal = new GraphQLError("connection refused: db://secret@host", {
+      nodes: node,
+      path: ["a", "b"],
+      originalError: new Error("connection refused: db://secret@host"),
+    });
+    const formatted = maskError(internal, true);
+    expect(formatted.message).toBe("Internal server error");
+    expect(formatted.locations).toEqual([{ line: 1, column: 1 }]);
+    expect(formatted.path).toEqual(["a", "b"]);
+    expect(formatted.extensions?.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+
+  it("passes the original message through when masking is disabled", () => {
+    const internal = new GraphQLError("boom", {
+      originalError: new Error("boom"),
+    });
+    expect(maskError(internal, false).message).toBe("boom");
+  });
+
+  it("never masks a deliberate client-facing GraphQLError", () => {
+    // Validation-style error: no originalError.
+    expect(
+      maskError(new GraphQLError("Cannot query field x"), true).message,
+    ).toBe("Cannot query field x");
+    // An error that wraps another GraphQLError is still client-facing.
+    const wrapping = new GraphQLError("Argument first must be non-negative", {
+      originalError: new GraphQLError("Argument first must be non-negative"),
+    });
+    expect(maskError(wrapping, true).message).toBe(
+      "Argument first must be non-negative",
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/hardening/maskError.ts
+++ b/packages/runtime/ke-graphql/src/lib/hardening/maskError.ts
@@ -1,0 +1,36 @@
+// =============================================================================
+// Production error masking. An unexpected throw inside a resolver (a store
+// error, a bug) bubbles up wrapped in a GraphQLError whose `originalError` is
+// the underlying Error — and its message can leak SPARQL fragments or store
+// internals to the client. In production those messages are replaced with a
+// generic one, while deliberate client-facing GraphQLErrors (validation, our
+// own throws — which carry no non-GraphQL originalError) pass through.
+// =============================================================================
+
+import { GraphQLError, type GraphQLFormattedError } from "graphql";
+
+/**
+ * Format a GraphQL execution error, masking internal/unexpected errors when
+ * `mask` is set. An error is "internal" when it wraps a non-GraphQLError
+ * `originalError` (a thrown runtime error): its message becomes generic
+ * (locations/path retained, `extensions.code = "INTERNAL_SERVER_ERROR"`).
+ * Deliberate GraphQLErrors pass through unchanged via `toJSON()`.
+ */
+export default function maskError(
+  error: GraphQLError,
+  mask: boolean,
+): GraphQLFormattedError {
+  if (
+    mask &&
+    error.originalError &&
+    !(error.originalError instanceof GraphQLError)
+  ) {
+    return {
+      message: "Internal server error",
+      ...(error.locations ? { locations: error.locations } : {}),
+      ...(error.path ? { path: error.path } : {}),
+      extensions: { code: "INTERNAL_SERVER_ERROR" },
+    };
+  }
+  return error.toJSON();
+}

--- a/packages/runtime/ke-graphql/src/lib/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/index.ts
@@ -1,0 +1,20 @@
+/**
+ * The public library surface of @canonical/ke-graphql, composed from the
+ * domain barrels. This foundation layer exposes the hardening domain (the
+ * SPARQL-injection guard, connection page-size clamp, query-depth rule,
+ * bounded loader cache, and production error masking); the compiler, plugin,
+ * execution, and connection helpers are layered on top.
+ *
+ * @module lib
+ */
+
+export {
+  clampConnectionArgs,
+  createDepthLimitRule,
+  DEFAULT_MAX_QUERY_DEPTH,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_PROCESS_CACHE_SIZE,
+  isSafeIri,
+  MAX_PAGE_SIZE,
+  maskError,
+} from "./hardening/index.js";

--- a/packages/runtime/ke-graphql/src/lib/shared/constants.ts
+++ b/packages/runtime/ke-graphql/src/lib/shared/constants.ts
@@ -1,0 +1,102 @@
+// =============================================================================
+// Shared vocabulary, scalar, and structural constants. These are the
+// dependency-free building blocks consumed across domains — standard
+// vocabulary IRIs, the XSD → GraphQL scalar table, reserved GraphQL names, and
+// the Relay connection arguments. They live here (the shared leaf) rather than
+// in the compiler so that the loader, resolver, and TBox domains depend on a
+// leaf instead of importing values back from their orchestrator.
+//
+// Queries use absolute IRIs so they work regardless of which prefixes the
+// consumer registered on the store.
+// =============================================================================
+
+import {
+  type GraphQLFieldConfigArgumentMap,
+  GraphQLInt,
+  GraphQLString,
+} from "graphql";
+
+/** RDF syntax namespace IRI. */
+export const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+/** RDF Schema namespace IRI. */
+export const RDFS = "http://www.w3.org/2000/01/rdf-schema#";
+/** OWL namespace IRI. */
+export const OWL = "http://www.w3.org/2002/07/owl#";
+/** XML Schema datatypes namespace IRI. */
+export const XSD = "http://www.w3.org/2001/XMLSchema#";
+/** SKOS namespace IRI. */
+export const SKOS = "http://www.w3.org/2004/02/skos/core#";
+/** SHACL namespace IRI. */
+export const SH = "http://www.w3.org/ns/shacl#";
+
+/** rdf:type predicate IRI. */
+export const RDF_TYPE = `${RDF}type`;
+
+/** rdfs:label predicate IRI. */
+export const RDFS_LABEL = `${RDFS}label`;
+
+/**
+ * Namespaces that never produce GraphQL types. Loaded in ke for annotation
+ * resolution only.
+ */
+export const STANDARD_NAMESPACES = [RDF, RDFS, OWL, XSD, SKOS, SH];
+
+/**
+ * XSD datatype IRI → GraphQL scalar name. Datatypes missing from this map
+ * fall back to String (with a custom-datatype diagnostic where applicable).
+ */
+export const XSD_SCALARS: Record<
+  string,
+  "String" | "Boolean" | "Int" | "Float"
+> = {
+  [`${XSD}string`]: "String",
+  [`${XSD}boolean`]: "Boolean",
+  [`${XSD}integer`]: "Int",
+  [`${XSD}int`]: "Int",
+  [`${XSD}long`]: "Int",
+  [`${XSD}float`]: "Float",
+  [`${XSD}double`]: "Float",
+  [`${XSD}decimal`]: "Float",
+  [`${XSD}anyURI`]: "String",
+  [`${XSD}date`]: "String",
+  [`${XSD}dateTime`]: "String",
+};
+
+/** Names the compiler owns; generated type names may not take them. */
+export const RESERVED_TYPE_NAMES = new Set([
+  "Node",
+  "Query",
+  "PageInfo",
+  "EntityMeta",
+  "ClassProperty",
+  "Ontology",
+  "OntologyClass",
+  "OntologyProperty",
+  "PropertyKind",
+  // built-in scalars — a class named String would otherwise hit an
+  // uncontrolled duplicate-type failure instead of an M004 rename
+  "String",
+  "Boolean",
+  "Int",
+  "Float",
+  "ID",
+]);
+
+/** Field names the compiler owns on Node types. */
+export const RESERVED_FIELD_NAMES = new Set([
+  "id",
+  "uri",
+  "_meta",
+  "__typename",
+]);
+
+/**
+ * The four Relay connection pagination arguments (first/after/last/before),
+ * shared by every generated connection field and the TBox instances field.
+ */
+export const CONNECTION_ARGS: GraphQLFieldConfigArgumentMap = {
+  first: { type: GraphQLInt },
+  after: { type: GraphQLString },
+  last: { type: GraphQLInt },
+  before: { type: GraphQLString },
+};

--- a/packages/runtime/ke-graphql/src/lib/shared/getLocalName.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/shared/getLocalName.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import getLocalName from "./getLocalName.js";
+
+describe("getLocalName", () => {
+  it("takes the part after the last hash", () => {
+    expect(getLocalName("http://www.w3.org/2000/01/rdf-schema#label")).toBe(
+      "label",
+    );
+  });
+
+  it("takes the part after the last slash", () => {
+    expect(getLocalName("https://ds.canonical.com/Component")).toBe(
+      "Component",
+    );
+  });
+
+  it("prefers the hash when both a hash and a slash are present", () => {
+    expect(getLocalName("http://ex.org/path#frag")).toBe("frag");
+  });
+
+  it("returns the whole string when neither separator is present", () => {
+    expect(getLocalName("bareword")).toBe("bareword");
+  });
+
+  it("returns an empty string when the separator is the last character", () => {
+    expect(getLocalName("http://ex.org/")).toBe("");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/shared/getLocalName.ts
+++ b/packages/runtime/ke-graphql/src/lib/shared/getLocalName.ts
@@ -1,0 +1,6 @@
+/** Extract the local name of a URI (the part after the last '#' or '/'). */
+export default function getLocalName(uri: string): string {
+  const hash = uri.lastIndexOf("#");
+  const slash = uri.lastIndexOf("/");
+  return uri.slice(Math.max(hash, slash) + 1);
+}

--- a/packages/runtime/ke-graphql/src/lib/shared/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/shared/index.ts
@@ -1,0 +1,28 @@
+/**
+ * The shared leaf domain: the dependency-free surface the other domains build
+ * on — standard vocabulary IRIs, the XSD → GraphQL scalar table, reserved
+ * GraphQL names, the Relay connection arguments, the local-name helper, and
+ * every IR/value/context type contract of the seven-pass pipeline. It imports
+ * only `graphql`, `dataloader`, and `@canonical/ke` (types), never another
+ * domain, so loaders, resolvers, and the TBox can depend on it without a cycle.
+ *
+ * @module shared
+ */
+
+export {
+  CONNECTION_ARGS,
+  OWL,
+  RDF,
+  RDF_TYPE,
+  RDFS,
+  RDFS_LABEL,
+  RESERVED_FIELD_NAMES,
+  RESERVED_TYPE_NAMES,
+  SH,
+  SKOS,
+  STANDARD_NAMESPACES,
+  XSD,
+  XSD_SCALARS,
+} from "./constants.js";
+export { default as getLocalName } from "./getLocalName.js";
+export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/shared/types.ts
+++ b/packages/runtime/ke-graphql/src/lib/shared/types.ts
@@ -1,0 +1,476 @@
+// =============================================================================
+// @canonical/ke-graphql — Shared type contracts
+//
+// The intermediate representations of the seven-pass pipeline (extract →
+// build → validate → map → emit → wire-relay → compose), plus the resolver
+// runtime values and the per-request context. Everything before the IR is
+// extraction; everything after it is emission. These types are a public
+// contract (Prisma-DMMF style): consumers can inspect RawExtraction,
+// OntologyIR, and MappedIR.
+//
+// They live in the shared leaf (not the compiler) so the loader, resolver, and
+// TBox domains can depend on them without importing back from their
+// orchestrator.
+// =============================================================================
+
+import type { Store } from "@canonical/ke";
+import type DataLoader from "dataloader";
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+//
+// The compiler never aborts on the first error. Every pass returns its output
+// plus diagnostics; codes are stable and append-only (X001 is retired and
+// never reused).
+// ---------------------------------------------------------------------------
+
+/** Severity of a compiler diagnostic; only errors can prevent schema creation. */
+export type DiagnosticSeverity = "error" | "warning" | "info";
+
+/** Stable, append-only diagnostic codes emitted by the compiler passes. */
+export type DiagnosticCode =
+  // Extraction
+  | "E001" // SPARQL query failed
+  // Build
+  | "B001" // class cycle in subClassOf chain
+  | "B002" // property references unknown class in domain
+  | "B003" // property references unknown class/datatype in range
+  | "B004" // inverse property references unknown property
+  // Validation
+  | "V001" // blank-node-only class (embeddable)
+  | "V002" // property has no rdfs:domain (domainless)
+  | "V003" // asymmetric owl:inverseOf
+  | "V004" // self-referential relationship in ABox
+  | "V005" // functional property with multiple values in ABox
+  | "V006" // boolean-as-string mismatch
+  | "V007" // annotation property filtered from ABox schema
+  | "V008" // custom datatype mapped to base XSD type
+  | "V009" // cross-vocabulary subClassOf
+  | "V010" // SHACL sh:maxCount 0 — field omitted for a class
+  | "V011" // SHACL sh:or — most permissive interpretation applied
+  | "V012" // SHACL sh:in enum constraint — mapped to String
+  | "V013" // property declares multiple rdfs:domain classes
+  | "V014" // ABox predicate not declared in any loaded TBox
+  | "V015" // class forced abstract by mapping but has direct instances
+  | "V016" // concrete class with subclasses — polymorphic returns flattened
+  // Mapping
+  | "M001" // name collision after GraphQL name mapping
+  | "M002" // reserved GraphQL name conflict
+  | "M003" // custom mapping references unknown property/class
+  | "M004" // type name collision auto-resolved by namespace prefixing
+  // Emission
+  | "X002" // union type created for polymorphic range
+  | "X003" // union type synthesized from anonymous range
+  // Composition
+  | "C001" // extension references unknown type
+  | "C002" // extension field conflicts with generated field
+  | "C003"; // schema validation failed
+
+/** One problem (or notice) reported by a compiler pass. */
+export interface Diagnostic {
+  severity: DiagnosticSeverity;
+  code: DiagnosticCode;
+  message: string;
+  /** OWL URI that caused the diagnostic, when attributable. */
+  source?: string;
+  /** Compiler pass that emitted it. */
+  phase: string;
+}
+
+/** The uniform pass envelope: an output plus the diagnostics it produced. */
+export interface PassResult<T> {
+  output: T;
+  diagnostics: Diagnostic[];
+}
+
+// ---------------------------------------------------------------------------
+// Pass 1 output — RawExtraction
+//
+// Direct output of the twelve SPARQL queries. Includes the ABox probes
+// (instance stats, self-references, functional violations, undeclared
+// predicates) so that Passes 2–7 never touch the store.
+// ---------------------------------------------------------------------------
+
+/** A class row as extracted from the store (Pass 1, pre-IR). */
+export interface RawClass {
+  uri: string;
+  label?: string;
+  definition?: string;
+  /** Direct rdfs:subClassOf URIs (blank-node superclasses are filtered). */
+  superclasses: string[];
+}
+
+/** OWL property flavor: object, datatype, or annotation property. */
+export type RawPropertyKind = "object" | "datatype" | "annotation";
+
+/** A property row as extracted from the store (Pass 1, pre-IR). */
+export interface RawProperty {
+  uri: string;
+  label?: string;
+  definition?: string;
+  kind: RawPropertyKind;
+  /** rdfs:domain URIs (0 or more). */
+  domains: string[];
+  /** rdfs:range URIs (0 or more, usually 1). */
+  ranges: string[];
+}
+
+/** One owl:inverseOf declaration (property → its declared inverse). */
+export interface RawInverse {
+  property: string;
+  inverse: string;
+}
+
+/** A custom datatype declaration (owl:onDatatype restriction). */
+export interface RawDatatype {
+  uri: string;
+  /** The xsd: type it restricts (owl:onDatatype). */
+  baseType?: string;
+  /** xsd:pattern restriction value, when present. */
+  pattern?: string;
+}
+
+/** One SHACL cardinality/enum constraint on a (class, property) pair. */
+export interface RawShaclConstraint {
+  targetClass: string;
+  property: string;
+  minCount?: number;
+  maxCount?: number;
+  /** True when the constraint came from an sh:or branch (V011). */
+  fromOr?: boolean;
+  /** sh:in values, when present (V012). */
+  inValues?: string[];
+}
+
+/** An owl:unionOf declaration — named union class or anonymous range union. */
+export interface RawUnion {
+  /** URI if named union class; undefined if anonymous range. */
+  uri?: string;
+  /** Property URI if anonymous range; undefined if named class. */
+  property?: string;
+  members: string[];
+}
+
+/** Instance counts for one class: total assertions and named (non-blank). */
+export interface InstanceStats {
+  total: number;
+  named: number;
+}
+
+/**
+ * Pass 1 output: the complete, serializable result of the twelve SPARQL
+ * queries — the TBox structure plus the ABox probes that keep Passes 2–7
+ * pure.
+ */
+export interface RawExtraction {
+  classes: RawClass[];
+  properties: RawProperty[];
+  inverses: RawInverse[];
+  functionals: Set<string>;
+  datatypes: RawDatatype[];
+  /** namespace URI → prefix. */
+  namespaces: Map<string, string>;
+  shaclConstraints: RawShaclConstraint[];
+  unions: RawUnion[];
+
+  // ── ABox probes (keep later passes pure) ──
+  /** Per class URI: instance counts (total, named i.e. non-blank). */
+  instanceStats: Map<string, InstanceStats>;
+  /** Properties with at least one self-referential assertion (V004). */
+  selfReferential: Set<string>;
+  /** Functional properties with >1 value on some instance (V005). */
+  functionalViolations: Set<string>;
+  /** ABox predicates not declared in any loaded TBox (V014). */
+  undeclaredPredicates: Set<string>;
+  /**
+   * Annotation-property assertions: target URI -> (annotation property URI
+   * -> value). Extracted here so the TBox schema never touches the store
+   * (acceptanceCriteria/completionGuidance live on PropertyNode).
+   */
+  annotations: Map<string, Map<string, string>>;
+  /** True when some blank node's object is itself a blank node. The entity
+   * loader fetches only a single-hop blank-node closure, so deeper nesting
+   * would be truncated. */
+  deepBlankNesting: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Pass 2 output — OntologyIR
+// ---------------------------------------------------------------------------
+
+/** A discovered namespace: prefix, URI, and its class/property counts. */
+export interface NamespaceInfo {
+  prefix: string;
+  uri: string;
+  classCount: number;
+  propertyCount: number;
+}
+
+/** A class in the typed ontology IR (Pass 2 output). */
+export interface ClassNode {
+  uri: string;
+  label: string;
+  definition?: string;
+  /** Namespace prefix ('ds', 'cs', 'anatomy', …). */
+  namespace: string;
+  /** Direct parent classes (rdfs:subClassOf). */
+  superclasses: readonly string[];
+  /** Transitive superclass closure, most specific first. */
+  ancestors: readonly string[];
+  /** Direct subclasses. */
+  subclasses: readonly string[];
+  /** No direct instances + has subclasses (or custom override). */
+  isAbstract: boolean;
+  /**
+   * Instances are exclusively blank nodes (from Pass 1 instanceStats) or
+   * forced via custom mapping. Embeddable types implement no Node
+   * interface and have no id/uri/_meta or root queries.
+   */
+  embeddable: boolean;
+  /** Properties whose rdfs:domain is this class. */
+  ownProperties: readonly string[];
+  /** Own + inherited properties, own first. */
+  allProperties: readonly string[];
+}
+
+/** Resolved cardinality for a (class, property) pair and where it came from. */
+export interface CardinalitySpec {
+  singular: boolean;
+  required: boolean;
+  omit: boolean;
+  source: "owl:FunctionalProperty" | "owl:cardinality" | "shacl" | "custom";
+}
+
+/** Property flavor carried through from extraction into the IR. */
+export type PropertyKind = RawPropertyKind;
+
+/** A property range resolved to a GraphQL scalar. */
+export interface ScalarRange {
+  kind: "scalar";
+  xsd: string;
+  graphqlScalar: "String" | "Boolean" | "Int" | "Float";
+  customDatatype?: string;
+}
+
+/** A property range resolved to a known class. */
+export interface ClassRange {
+  kind: "class";
+  uri: string;
+}
+
+/** A property range resolved to a union of classes. */
+export interface UnionRange {
+  kind: "union";
+  name?: string;
+  members: readonly string[];
+}
+
+/** A property range that resolved to nothing known (B003 → String). */
+export interface UnknownRange {
+  kind: "unknown";
+  raw: string;
+}
+
+/** The resolved range of a property: scalar, class, union, or unknown. */
+export type RangeSpec = ScalarRange | ClassRange | UnionRange | UnknownRange;
+
+/** A property in the typed ontology IR (Pass 2 output). */
+export interface PropertyNode {
+  uri: string;
+  label: string;
+  definition?: string;
+  namespace: string;
+  kind: PropertyKind;
+  domains: readonly string[];
+  range: RangeSpec;
+  /**
+   * Default cardinality. True = singular. Resolved by precedence:
+   * custom mapping > owl:FunctionalProperty > owl:cardinality > SHACL
+   * maxCount 1 > kind default (datatype → singular, object → list).
+   */
+  functional: boolean;
+  /** Per-class cardinality overrides (SHACL). Key: class URI. */
+  classCardinality: ReadonlyMap<string, CardinalitySpec>;
+  /** Inverse property URI when declared via owl:inverseOf. */
+  inverse?: string;
+  isAnnotation: boolean;
+  /** Annotation values targeting THIS property (annotation prop URI -> value). */
+  annotations: ReadonlyMap<string, string>;
+}
+
+/** Pass 2 output: the typed class/property graph plus namespace inventory. */
+export interface OntologyIR {
+  classes: ReadonlyMap<string, ClassNode>;
+  properties: ReadonlyMap<string, PropertyNode>;
+  namespaces: ReadonlyMap<string, NamespaceInfo>;
+  /** Carried through from Pass 1 for the validate/map passes. */
+  extraction: RawExtraction;
+}
+
+// ---------------------------------------------------------------------------
+// Pass 4 output — MappedIR
+// ---------------------------------------------------------------------------
+
+/** Which of the eight resolver templates a mapped field instantiates. */
+export type ResolverTemplate =
+  | "datatype"
+  | "datatype-list"
+  | "object-singular"
+  | "object-list"
+  | "embedded-singular"
+  | "embedded-list"
+  | "inverse"
+  | "meta";
+
+/** The GraphQL type a mapped field resolves to: scalar, named type, or union. */
+export type FieldTypeSpec =
+  | { kind: "scalar"; name: string }
+  | { kind: "type"; name: string }
+  | { kind: "union"; name: string; members: readonly string[] };
+
+/** A GraphQL field mapped from an OWL property (Pass 4 output). */
+export interface MappedField {
+  owlUri: string;
+  graphqlName: string;
+  type: FieldTypeSpec;
+  nullable: boolean;
+  list: boolean;
+  resolverTemplate: ResolverTemplate;
+  propertyUri: string;
+  /** For inverse fields: the forward property whose assertions are reversed. */
+  inverseOf?: string;
+  /** SHACL sh:minCount >= 1 — informational, not auto-promoted to non-null. */
+  shaclRequired: boolean;
+  /** Consumer-promoted to non-null via the NonNullOverrides option. */
+  nonNull: boolean;
+}
+
+/** A GraphQL object type mapped from a concrete OWL class (Pass 4 output). */
+export interface MappedType {
+  owlUri: string;
+  graphqlName: string;
+  /** GraphQL interface names this type implements (ancestors). */
+  interfaces: readonly string[];
+  fields: ReadonlyMap<string, MappedField>;
+  embeddable: boolean;
+  namespace: string;
+  /** Pluralized root listing field name (e.g. "categories"). */
+  pluralName: string;
+  /** Singular root lookup field name (e.g. "category"). */
+  singularName: string;
+}
+
+/** A GraphQL interface mapped from an abstract OWL class (Pass 4 output). */
+export interface MappedInterface {
+  owlUri: string;
+  graphqlName: string;
+  parentInterfaces: readonly string[];
+  fields: ReadonlyMap<string, MappedField>;
+}
+
+/**
+ * Bidirectional OWL URI ↔ GraphQL name lookup. Type names map globally;
+ * field names are scoped per type ("Type.field").
+ */
+export interface NameMap {
+  /** OWL URI → GraphQL name. */
+  toGraphQL(uri: string): string | undefined;
+  /** GraphQL name → OWL URI. Field names are scoped per type: "Type.field". */
+  toOWL(name: string): string | undefined;
+  entries(): Iterable<[string, string]>;
+}
+
+/** A GraphQL union produced from an owl:unionOf range (Pass 4 output). */
+export interface MappedUnion {
+  name: string;
+  /** Concrete member type names (abstract members already expanded). */
+  members: readonly string[];
+}
+
+/** Pass 4 output: the complete GraphQL-shaped view of the ontology. */
+export interface MappedIR {
+  types: ReadonlyMap<string, MappedType>;
+  interfaces: ReadonlyMap<string, MappedInterface>;
+  unions: ReadonlyMap<string, MappedUnion>;
+  nameMap: NameMap;
+  namespaces: ReadonlyMap<string, NamespaceInfo>;
+  /** The OntologyIR, carried for resolver closures (meta fields, tbox). */
+  ir: OntologyIR;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver runtime values
+// ---------------------------------------------------------------------------
+
+/** A predicate URI → object values map for one entity. */
+export type TripleSet = Map<string, TripleValue[]>;
+
+/** One RDF object value: a URI reference, a literal, or a blank node. */
+export type TripleValue =
+  | { kind: "uri"; value: string }
+  | { kind: "literal"; value: string; datatype?: string; language?: string }
+  | { kind: "blank"; id: string; triples: TripleSet };
+
+/**
+ * The uniform parent value flowing through every resolver. Named entities
+ * carry their prefixed URI; embedded blank-node values carry uri: null.
+ */
+export interface EntityValue {
+  uri: string | null;
+  typename: string;
+  triples: TripleSet;
+}
+
+/** The decoded form of an inverse-loader cache key. */
+export interface InverseKey {
+  /** The forward OWL property URI whose assertions are reversed. */
+  property: string;
+  /** The entity (full IRI) being pointed at. */
+  object: string;
+}
+
+/**
+ * The per-request GraphQL context: the three DataLoaders, the name map, the
+ * store escape hatch, and the runtime warning channel. Extensions may stash
+ * their own state on it.
+ */
+export interface CompilerContext {
+  entityLoader: DataLoader<string, EntityValue | null>;
+  listLoader: DataLoader<string, string[]>;
+  inverseLoader: DataLoader<string, string[]>;
+  nameMap: NameMap;
+  /**
+   * The compiled namespace inventory — resolvers use it for full-IRI ↔
+   * prefixed-URI conversion (e.g. paginating an object connection by its
+   * cursor-stable prefixed form before hydration).
+   */
+  namespaces: ReadonlyMap<string, NamespaceInfo>;
+  /**
+   * The ke store (escape hatch for extensions). May be a Promise for
+   * lazy-store boots: ABox loaders await it; TBox resolvers never touch it.
+   */
+  store: Store | Promise<Store>;
+  /** Resolver-time warning channel (e.g. literal coercion failures). */
+  warn: RuntimeWarningHandler;
+  /** Extension state (search index, back-link index, …) — consumer-owned. */
+  [key: string]: unknown;
+}
+
+/** Receives resolver-time warnings (e.g. literal coercion failures). */
+export type RuntimeWarningHandler = (warning: {
+  property: string;
+  value: string;
+  reason: string;
+}) => void;
+
+// ---------------------------------------------------------------------------
+// Query surface
+// ---------------------------------------------------------------------------
+
+/**
+ * The query surface the compiler needs. Satisfied by both ke's
+ * PluginContext.query (compile time) and Store.query (request time).
+ */
+export type QueryFn = (
+  query: string,
+) => Promise<import("@canonical/ke").QueryResult>;

--- a/packages/runtime/ke-graphql/src/testing/fixtures.ts
+++ b/packages/runtime/ke-graphql/src/testing/fixtures.ts
@@ -1,0 +1,306 @@
+/**
+ * Self-contained TTL fixtures for the compiler/pipeline/execution tests
+ * Each constant is a complete document — TBox + ABox together —
+ * that exercises one specific compiler behavior, kept minimal by design;
+ * `PREFIXES` is the prefix map the fixture stores share. They live in one
+ * file so a test can pull whichever scenario it needs from a single import.
+ * Internal test data only: excluded from the build, never shipped in dist.
+ */
+
+export const PREFIXES = {
+  ex: "http://example.org/",
+  ds: "https://ds.canonical.com/",
+  cs: "http://pragma.canonical.com/codestandards#",
+};
+
+/** Happy path: one class, two properties, one instance. */
+export const MINIMAL_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:Thing a owl:Class ;
+  rdfs:label "Thing" ;
+  skos:definition "A concrete thing." .
+
+ex:name a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:string ;
+  rdfs:label "name" .
+
+ex:count a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:integer ;
+  rdfs:label "count" .
+
+ex:widget a ex:Thing ;
+  ex:name "Widget" ;
+  ex:count 42 .
+`;
+
+/** Class hierarchy and interface generation. */
+export const INHERITANCE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Entity a owl:Class ; rdfs:label "Entity" .
+ex:Tangible a owl:Class ; rdfs:subClassOf ex:Entity ; rdfs:label "Tangible" .
+ex:Widget a owl:Class ; rdfs:subClassOf ex:Tangible ; rdfs:label "Widget" .
+ex:Gadget a owl:Class ; rdfs:subClassOf ex:Tangible ; rdfs:label "Gadget" .
+
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Entity ; rdfs:range xsd:string .
+ex:weight a owl:DatatypeProperty ; rdfs:domain ex:Tangible ; rdfs:range xsd:integer .
+ex:color a owl:DatatypeProperty ; rdfs:domain ex:Widget ; rdfs:range xsd:string .
+
+ex:w1 a ex:Widget ; ex:name "Alpha" ; ex:weight 10 ; ex:color "red" .
+ex:g1 a ex:Gadget ; ex:name "Beta" ; ex:weight 5 .
+`;
+
+/** Inverse pair: forward/inverse placement, irregular plural. */
+export const INVERSE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Parent a owl:Class ; rdfs:label "Parent" .
+ex:Child a owl:Class ; rdfs:label "Child" .
+
+ex:hasChild a owl:ObjectProperty ;
+  rdfs:domain ex:Parent ; rdfs:range ex:Child ;
+  owl:inverseOf ex:childOf .
+
+ex:childOf a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ex:Child ; rdfs:range ex:Parent .
+
+ex:name a owl:DatatypeProperty ;
+  rdfs:domain ex:Parent ; rdfs:range xsd:string .
+
+# Data asserts ONLY the childOf direction — hasChild resolution must find
+# the children via the reverse assertions (the dual-direction inverse rule:
+# each side resolves the union of forward and reverse assertions).
+ex:p1 a ex:Parent ; ex:name "Alice" .
+ex:c1 a ex:Child ; ex:childOf ex:p1 .
+ex:c2 a ex:Child ; ex:childOf ex:p1 .
+`;
+
+/** Embedded blank-node types. */
+export const BLANK_NODES_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Standard a owl:Class ; rdfs:label "Standard" .
+ex:Example a owl:Class ; rdfs:label "Example" .
+
+ex:title a owl:DatatypeProperty ; rdfs:domain ex:Standard ; rdfs:range xsd:string .
+ex:hasExample a owl:ObjectProperty ; rdfs:domain ex:Standard ; rdfs:range ex:Example .
+ex:code a owl:DatatypeProperty ; rdfs:domain ex:Example ; rdfs:range xsd:string .
+ex:language a owl:DatatypeProperty ; rdfs:domain ex:Example ; rdfs:range xsd:string .
+
+ex:s1 a ex:Standard ;
+  ex:title "Use const" ;
+  ex:hasExample [
+    a ex:Example ;
+    ex:code "const x = 1;" ;
+    ex:language "typescript"
+  ] , [
+    a ex:Example ;
+    ex:code "const y = 2;"
+  ] .
+`;
+
+/** Domainless property (no rdfs:domain — assigned to every class in its namespace). */
+export const DOMAINLESS_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Foo a owl:Class ; rdfs:label "Foo" .
+ex:Bar a owl:Class ; rdfs:label "Bar" .
+
+ex:label a owl:DatatypeProperty ; rdfs:domain ex:Foo ; rdfs:range xsd:string .
+ex:description a owl:DatatypeProperty ; rdfs:range xsd:string .
+
+ex:f1 a ex:Foo ; ex:label "foo" ; ex:description "a foo" .
+ex:b1 a ex:Bar ; ex:description "a bar" .
+`;
+
+/** Synthetic triggers for the V-series diagnostics. */
+export const EDGE_CASES_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+# boolean-as-string
+ex:Item a owl:Class .
+ex:active a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range xsd:boolean .
+ex:i1 a ex:Item ; ex:active "true" .
+
+# self-referential relationship
+ex:extends a owl:ObjectProperty ; rdfs:domain ex:Item ; rdfs:range ex:Item .
+ex:i2 a ex:Item ; ex:extends ex:i2 .
+
+# language-tagged literal
+ex:label a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range xsd:string .
+ex:i3 a ex:Item ; ex:label "Tagged"@en .
+
+# annotation property on rdf:Property
+ex:guidance a owl:AnnotationProperty ; rdfs:domain rdf:Property ; rdfs:range xsd:string .
+ex:active ex:guidance "Must be boolean" .
+
+# custom datatype
+ex:Version a rdfs:Datatype ; owl:onDatatype xsd:string .
+ex:ver a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range ex:Version .
+ex:i4 a ex:Item ; ex:ver "1.0.0" .
+
+# cross-vocabulary subClassOf
+ex:Category a owl:Class ; rdfs:subClassOf skos:Concept .
+ex:c1 a ex:Category .
+
+# empty string value
+ex:summary a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range xsd:string .
+ex:i5 a ex:Item ; ex:summary "" .
+
+# V012 — SHACL sh:in enum constraint
+ex:ItemShape a sh:NodeShape ;
+  sh:targetClass ex:Item ;
+  sh:property [
+    sh:path ex:mode ;
+    sh:in ("fast" "slow" "auto") ;
+  ] .
+ex:mode a owl:DatatypeProperty ; rdfs:domain ex:Item ; rdfs:range xsd:string .
+
+# V014 — ABox predicate not declared in the TBox
+ex:i6 a ex:Item ; ex:undeclaredThing "x" .
+
+# V005 — functional property with multiple values
+ex:rank a owl:DatatypeProperty , owl:FunctionalProperty ;
+  rdfs:domain ex:Item ; rdfs:range xsd:integer .
+ex:i7 a ex:Item ; ex:rank 1 , 2 .
+`;
+
+/** SHACL cardinality, sh:or XOR, maxCount 0. */
+export const SHACL_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:Spec a owl:Class . ex:Hop a owl:Class . ex:Sw a owl:Class .
+
+ex:root a owl:ObjectProperty ; rdfs:domain ex:Spec ; rdfs:range ex:Hop .
+ex:hopTarget a owl:ObjectProperty ; rdfs:domain ex:Hop ; rdfs:range ex:Spec .
+ex:hopSwitch a owl:ObjectProperty ; rdfs:domain ex:Hop ; rdfs:range ex:Sw .
+ex:legacy a owl:DatatypeProperty ; rdfs:domain ex:Spec ; rdfs:range xsd:string .
+
+ex:SpecShape a sh:NodeShape ; sh:targetClass ex:Spec ;
+  sh:property [ sh:path ex:root ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path ex:legacy ; sh:maxCount 0 ] .
+
+ex:HopShape a sh:NodeShape ; sh:targetClass ex:Hop ;
+  sh:or (
+    [ sh:property [ sh:path ex:hopTarget ; sh:minCount 1 ; sh:maxCount 1 ] ;
+      sh:property [ sh:path ex:hopSwitch ; sh:maxCount 0 ] ]
+    [ sh:property [ sh:path ex:hopTarget ; sh:maxCount 0 ] ;
+      sh:property [ sh:path ex:hopSwitch ; sh:minCount 1 ; sh:maxCount 1 ] ]
+  ) .
+
+ex:s1 a ex:Spec . ex:h1 a ex:Hop . ex:sw1 a ex:Sw .
+`;
+
+/** Realistic ds: subset: hierarchy, inverses, blank nodes, booleans. */
+export const DS_REALISTIC_TTL = `
+@prefix ds: <https://ds.canonical.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ds:Entity a owl:Class ; rdfs:label "Entity" .
+ds:UIElement a owl:Class ; rdfs:subClassOf ds:Entity ; rdfs:label "UIElement" .
+ds:UIBlock a owl:Class ; rdfs:subClassOf ds:UIElement ; rdfs:label "UIBlock" .
+ds:Component a owl:Class ; rdfs:subClassOf ds:UIBlock ; rdfs:label "Component" ;
+  skos:definition "A reusable UI component." .
+ds:Subcomponent a owl:Class ; rdfs:subClassOf ds:UIBlock ; rdfs:label "Subcomponent" .
+ds:Modifier a owl:Class ; rdfs:subClassOf ds:UIElement ; rdfs:label "Modifier" .
+ds:ModifierFamily a owl:Class ; rdfs:subClassOf ds:UIElement ; rdfs:label "ModifierFamily" .
+ds:Tier a owl:Class ; rdfs:subClassOf ds:Entity ; rdfs:label "Tier" .
+ds:Property a owl:Class ; rdfs:subClassOf ds:Entity ; rdfs:label "Property" .
+ds:ImplementationObject a owl:Class ; rdfs:subClassOf ds:Entity ; rdfs:label "ImplementationObject" .
+
+ds:name a owl:DatatypeProperty ; rdfs:domain ds:Entity ; rdfs:range xsd:string ;
+  rdfs:label "name" ; skos:definition "Display name." .
+ds:summary a owl:DatatypeProperty ; rdfs:domain ds:Entity ; rdfs:range xsd:string .
+ds:tier a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:UIBlock ; rdfs:range ds:Tier .
+ds:hasModifierFamily a owl:ObjectProperty ;
+  rdfs:domain ds:UIBlock ; rdfs:range ds:ModifierFamily .
+ds:hasSubcomponent a owl:ObjectProperty ;
+  rdfs:domain ds:Component ; rdfs:range ds:Subcomponent ;
+  owl:inverseOf ds:parentComponent .
+ds:parentComponent a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:Subcomponent ; rdfs:range ds:Component .
+ds:modifierFamily a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:Modifier ; rdfs:range ds:ModifierFamily ;
+  owl:inverseOf ds:hasModifier .
+ds:hasModifier a owl:ObjectProperty ;
+  rdfs:domain ds:ModifierFamily ; rdfs:range ds:Modifier .
+ds:hasProperty a owl:ObjectProperty ;
+  rdfs:domain ds:UIBlock ; rdfs:range ds:Property .
+ds:propertyType a owl:DatatypeProperty ; rdfs:domain ds:Property ; rdfs:range xsd:string .
+ds:optional a owl:DatatypeProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:Property ; rdfs:range xsd:boolean .
+ds:standalone a owl:DatatypeProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:Subcomponent ; rdfs:range xsd:boolean .
+ds:implementsBlock a owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:domain ds:ImplementationObject ; rdfs:range ds:UIBlock .
+
+ds:acceptanceCriteria a owl:AnnotationProperty ;
+  rdfs:domain <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> ;
+  rdfs:range xsd:string .
+ds:name ds:acceptanceCriteria "Must be a human-readable display name." .
+
+ds:global a ds:Tier ; ds:name "global" .
+
+ds:global.component.button a ds:Component ;
+  ds:name "Button" ;
+  ds:summary "Primary action trigger." ;
+  ds:tier ds:global ;
+  ds:hasModifierFamily ds:modifier_family.importance ;
+  ds:hasSubcomponent ds:global.subcomponent.button_icon ;
+  ds:hasProperty [
+    a ds:Property ;
+    ds:name "disabled" ;
+    ds:propertyType "boolean" ;
+    ds:optional "false"
+  ] .
+
+ds:global.subcomponent.button_icon a ds:Subcomponent ;
+  ds:name "Button.Icon" ;
+  ds:tier ds:global ;
+  ds:parentComponent ds:global.component.button ;
+  ds:standalone "false" .
+
+ds:modifier_family.importance a ds:ModifierFamily ;
+  ds:name "importance" .
+
+ds:mod_importance_primary a ds:Modifier ;
+  ds:name "primary" ;
+  ds:modifierFamily ds:modifier_family.importance .
+
+ds:react_button a ds:ImplementationObject ;
+  ds:name "react button" ;
+  ds:implementsBlock ds:global.component.button .
+`;

--- a/packages/runtime/ke-graphql/src/testing/index.ts
+++ b/packages/runtime/ke-graphql/src/testing/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal test-support surface: the shared TTL fixtures the compiler,
+ * pipeline, execution, and handler tests compile against. Reachable through
+ * the `#testing` subpath alias. Excluded from the build — nothing in dist
+ * imports it, and it is never published.
+ *
+ * @module testing
+ */
+
+export {
+  BLANK_NODES_TTL,
+  DOMAINLESS_TTL,
+  DS_REALISTIC_TTL,
+  EDGE_CASES_TTL,
+  INHERITANCE_TTL,
+  INVERSE_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+  SHACL_TTL,
+} from "./fixtures.js";

--- a/packages/runtime/ke-graphql/tsconfig.build.json
+++ b/packages/runtime/ke-graphql/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/testing/**"]
+}

--- a/packages/runtime/ke-graphql/tsconfig.json
+++ b/packages/runtime/ke-graphql/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@canonical/typescript-config",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["node", "@types/bun"],
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "customConditions": ["development"]
+  },
+  "include": ["src/**/*.ts", "demo/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/runtime/ke-graphql/vitest.config.ts
+++ b/packages/runtime/ke-graphql/vitest.config.ts
@@ -13,12 +13,16 @@ export default defineConfig({
         "**/*.test.ts",
         "**/*.d.ts",
         "**/types.ts",
+        "**/constants.ts",
         "src/testing/**",
         "src/http/graphiqlHtml.ts",
       ],
-      // Coverage thresholds are enforced once the library is fully assembled
-      // (see the PR that completes the compiler). Earlier layers in the stack
-      // ship partial slices whose untested lines are covered downstream.
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
     },
   },
 });

--- a/packages/runtime/ke-graphql/vitest.config.ts
+++ b/packages/runtime/ke-graphql/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: [
+        "**/index.ts",
+        "**/*.test.ts",
+        "**/*.d.ts",
+        "**/types.ts",
+        "src/testing/**",
+        "src/http/graphiqlHtml.ts",
+      ],
+      // Coverage thresholds are enforced once the library is fully assembled
+      // (see the PR that completes the compiler). Earlier layers in the stack
+      // ship partial slices whose untested lines are covered downstream.
+    },
+  },
+});


### PR DESCRIPTION
> First PR in the `@canonical/ke-graphql` delivery stack (umbrella #658, supersedes the monolithic #666). The library is landed as a sequence of ≤4k-line stacked PRs, partitioned by dependency seam; each builds green on its base and the union equals the umbrella branch. Subsequent PRs (loaders → resolver → tbox/execution → compiler passes → `/http` → CLI → demo) stack on this one.

## Done

The **`@canonical/ke-graphql` package foundation** — everything the rest of the library stacks on:

- **Package scaffold:** manifest, `tsconfig` (+ build config), `biome.json`, `vitest` config, and the `#`-subpath import map with dist-safe conditional exports (`development` → source, `types`/`default` → built `.d.ts`/`.js`).
- **`shared` domain (leaf):** the cross-domain types, the RDF/RDFS/OWL/SKOS vocabulary constants, and `getLocalName`. Internal — surfaced to consumers later through the compiler barrel.
- **`hardening` domain (leaf):** the security/robustness seams used throughout the runtime — `isSafeIri` (SPARQL IRIREF injection guard), `clampConnectionArgs` (connection page-size clamp with sensible default/ceiling), `createDepthLimitRule` (query-depth limit), `createBoundedCache` (bounded LRU for the process-lifetime loader caches), and `maskError` (production error masking). Fully unit-tested.
- **Reference docs:** `docs/architecture.md` (the seven-pass design) and `docs/api.md` (the full API surface).
- The testing fixtures scaffold (`#testing`) the downstream suites compile against.

Both domains are dependency-free leaves, so this layer builds and its hardening suite passes at 100% on its own. The root library barrel currently exports only `hardening`; later PRs extend it as their domains land.

## QA

```bash
cd packages/runtime/ke-graphql && bun run check && bun run test && bun run build
```
biome + `tsc` + webarchitect green; 21 hardening/shared tests pass; clean build emitting ESM + d.ts.

> **Coverage thresholds** are intentionally not enforced in this PR. A partial slice of the package cannot reach 100% (e.g. `shared` utilities are exercised by the dataloader/compiler suites that land downstream). The `thresholds: 100/100/100/100` gate is restored by the PR that completes the compiler, at which point the full package is covered. Every domain ships its own colocated unit tests as it lands.

### PR readiness check

- [x] PR has a label: `Feature 🎁`.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] The code follows the [code standards](https://github.com/canonical/web-code-standards): `src/lib/{domain}` layout, per-domain barrels, `#`-subpath cross-domain imports, colocated name-matched unit tests.
- [x] `check`, `check:fix`, `test`, `build`, `build:all` present in `package.json`.
- [ ] **New package** — first-time publish + OIDC trusted-publisher setup is a maintainer step, handled when the stack merges.
- [x] `no visual change` (non-visual runtime package).

## Screenshots

No visual change — a backend/runtime package with no UI surface.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_