### PR TITLE
feat(ke-graphql): resolution layer — dataloaders + resolver

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/dataloader/createEntityLoader.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createEntityLoader.test.ts
@@ -1,0 +1,284 @@
+import type { QueryResult, Term } from "@canonical/ke";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ClassNode,
+  type MappedIR,
+  type NamespaceInfo,
+  type QueryFn,
+  RDF_TYPE,
+} from "#shared";
+import createEntityLoader from "./createEntityLoader.js";
+
+const NS = "https://ds.canonical.com/";
+
+const namespaces = new Map<string, NamespaceInfo>([
+  ["ds", { prefix: "ds", uri: NS, classCount: 0, propertyCount: 0 }],
+]);
+
+const named = (value: string): Term => ({ termType: "NamedNode", value });
+const literal = (value: string): Term => ({ termType: "Literal", value });
+const blank = (value: string): Term => ({ termType: "BlankNode", value });
+
+/** Minimal MappedIR exposing only what the entity loader reads. */
+const mappedFor = (classes: Map<string, ClassNode>): MappedIR =>
+  ({
+    ir: { classes },
+    nameMap: { toGraphQL: (uri: string) => getLocalName(uri) },
+    namespaces,
+  }) as unknown as MappedIR;
+
+const getLocalName = (uri: string) =>
+  uri.slice(Math.max(uri.lastIndexOf("#"), uri.lastIndexOf("/")) + 1);
+
+const concreteClass = (uri: string, ancestors: string[] = []): ClassNode =>
+  ({ uri, isAbstract: false, ancestors }) as unknown as ClassNode;
+
+const select = (termBindings: Record<string, Term>[]): QueryResult =>
+  ({
+    type: "select",
+    variables: [],
+    bindings: [],
+    termBindings,
+  }) as QueryResult;
+
+const construct = (
+  quads: { subject: Term; predicate: Term; object: Term }[],
+): QueryResult => ({ type: "construct", triples: [], quads }) as QueryResult;
+
+describe("createEntityLoader", () => {
+  it("evicts the keys of a failed batch and rethrows (no memoized failure)", async () => {
+    let calls = 0;
+    const query: QueryFn = vi.fn(async () => {
+      calls += 1;
+      throw new Error("store down");
+    });
+    const loader = createEntityLoader(query, mappedFor(new Map()), new Map());
+
+    await expect(loader.load(`${NS}thing`)).rejects.toThrow("store down");
+    // A second load re-queries (the failed key was cleared, never memoized).
+    await expect(loader.load(`${NS}thing`)).rejects.toThrow("store down");
+    expect(calls).toBe(2);
+  });
+
+  it("ignores a quad whose subject is neither NamedNode nor BlankNode", async () => {
+    // resolveTripleSet returns undefined for a Literal subject → skipped.
+    const query: QueryFn = async () =>
+      construct([
+        {
+          subject: literal("oops"),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Widget`),
+        },
+      ]);
+    const loader = createEntityLoader(
+      query,
+      mappedFor(new Map([[`${NS}Widget`, concreteClass(`${NS}Widget`)]])),
+    );
+    // No NamedNode subject row for the URI → missing entity.
+    expect(await loader.load(`${NS}thing`)).toBeNull();
+  });
+
+  it("skips a quad whose predicate is not a NamedNode", async () => {
+    const query: QueryFn = async () =>
+      construct([
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Widget`),
+        },
+        // Blank-node predicate → continue (predicate.termType !== "NamedNode").
+        {
+          subject: named(`${NS}thing`),
+          predicate: blank("p"),
+          object: literal("ignored"),
+        },
+      ]);
+    const loader = createEntityLoader(
+      query,
+      mappedFor(new Map([[`${NS}Widget`, concreteClass(`${NS}Widget`)]])),
+    );
+    const entity = await loader.load(`${NS}thing`);
+    expect(entity?.typename).toBe("Widget");
+    // Only the rdf:type triple survived; the blank-predicate quad was skipped.
+    expect([...(entity?.triples.keys() ?? [])]).toEqual([RDF_TYPE]);
+  });
+
+  it("materializes a fresh blank-node child set, literals, and uri values", async () => {
+    const query: QueryFn = async () =>
+      construct([
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Widget`),
+        },
+        // Blank-node object never seen as a subject → fresh set created (40-41).
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(`${NS}embed`),
+          object: blank("b1"),
+        },
+        {
+          subject: blank("b1"),
+          predicate: named(`${NS}label`),
+          object: literal("hi"),
+        },
+        // URI-valued object on the named subject.
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(`${NS}ref`),
+          object: named(`${NS}other`),
+        },
+        // Duplicate triple is deduped (seen).
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(`${NS}ref`),
+          object: named(`${NS}other`),
+        },
+      ]);
+    const loader = createEntityLoader(
+      query,
+      mappedFor(new Map([[`${NS}Widget`, concreteClass(`${NS}Widget`)]])),
+    );
+    const entity = await loader.load(`${NS}thing`);
+    const embed = entity?.triples.get(`${NS}embed`)?.[0];
+    expect(embed?.kind).toBe("blank");
+    // The blank child's own triples are populated through the shared set.
+    expect(
+      embed?.kind === "blank" && embed.triples.get(`${NS}label`)?.[0],
+    ).toEqual({
+      kind: "literal",
+      value: "hi",
+      datatype: undefined,
+      language: undefined,
+    });
+    expect(entity?.triples.get(`${NS}ref`)).toEqual([
+      { kind: "uri", value: `${NS}other` },
+    ]);
+  });
+
+  it("returns null for a URI with no concrete class assertion", async () => {
+    // Abstract class only → pickMostSpecificTypename yields undefined.
+    const query: QueryFn = async () =>
+      construct([
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Abstract`),
+        },
+      ]);
+    const abstractNode = {
+      uri: `${NS}Abstract`,
+      isAbstract: true,
+      ancestors: [],
+    } as unknown as ClassNode;
+    const loader = createEntityLoader(
+      query,
+      mappedFor(new Map([[`${NS}Abstract`, abstractNode]])),
+    );
+    expect(await loader.load(`${NS}thing`)).toBeNull();
+  });
+
+  it("treats an empty (select-shaped) result as all-missing", async () => {
+    const query: QueryFn = async () => select([]);
+    const loader = createEntityLoader(query, mappedFor(new Map()));
+    expect(await loader.load(`${NS}thing`)).toBeNull();
+  });
+
+  it("picks the deepest concrete class, ignoring shallower and unknown ones", async () => {
+    const query: QueryFn = async () =>
+      construct([
+        // Deepest concrete class first; shallower + unknown follow so the
+        // ancestors-depth comparison runs its false branch too.
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Deep`),
+        },
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Shallow`),
+        },
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Unknown`),
+        },
+      ]);
+    const classes = new Map([
+      [`${NS}Deep`, concreteClass(`${NS}Deep`, [`${NS}Shallow`, `${NS}Base`])],
+      [`${NS}Shallow`, concreteClass(`${NS}Shallow`, [`${NS}Base`])],
+    ]);
+    const loader = createEntityLoader(query, mappedFor(classes));
+    expect((await loader.load(`${NS}thing`))?.typename).toBe("Deep");
+  });
+
+  it("creates a fresh triple set for a blank-node subject seen before any object use", async () => {
+    // The blank node appears as a SUBJECT first (never yet seen as an object),
+    // so resolveTripleSet takes its create-fresh branch for blank subjects.
+    const query: QueryFn = async () =>
+      construct([
+        {
+          subject: blank("orphan"),
+          predicate: named(`${NS}label`),
+          object: literal("first"),
+        },
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Widget`),
+        },
+      ]);
+    const loader = createEntityLoader(
+      query,
+      mappedFor(new Map([[`${NS}Widget`, concreteClass(`${NS}Widget`)]])),
+    );
+    expect((await loader.load(`${NS}thing`))?.typename).toBe("Widget");
+  });
+
+  it("reuses an existing blank-node set when the same blank object recurs", async () => {
+    // The same blank node is referenced by two predicates, so the second
+    // conversion finds its set already present instead of creating a fresh one.
+    const query: QueryFn = async () =>
+      construct([
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(RDF_TYPE),
+          object: named(`${NS}Widget`),
+        },
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(`${NS}a`),
+          object: blank("shared"),
+        },
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(`${NS}b`),
+          object: blank("shared"),
+        },
+      ]);
+    const loader = createEntityLoader(
+      query,
+      mappedFor(new Map([[`${NS}Widget`, concreteClass(`${NS}Widget`)]])),
+    );
+    const entity = await loader.load(`${NS}thing`);
+    const a = entity?.triples.get(`${NS}a`)?.[0];
+    const b = entity?.triples.get(`${NS}b`)?.[0];
+    expect(a?.kind === "blank" && a.id).toBe("shared");
+    expect(b?.kind === "blank" && b.id).toBe("shared");
+  });
+
+  it("treats a URI with triples but no rdf:type as typeless (null)", async () => {
+    // No rdf:type predicate at all → typeUris falls back to [] (175).
+    const query: QueryFn = async () =>
+      construct([
+        {
+          subject: named(`${NS}thing`),
+          predicate: named(`${NS}label`),
+          object: literal("x"),
+        },
+      ]);
+    const loader = createEntityLoader(query, mappedFor(new Map()));
+    expect(await loader.load(`${NS}thing`)).toBeNull();
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/dataloader/createEntityLoader.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createEntityLoader.ts
@@ -1,0 +1,191 @@
+// =============================================================================
+// Entity loader. One batched CONSTRUCT fetches the requested entities'
+// triples AND the closure of their blank-node children in the same query —
+// blank-node labels are only consistent within a single result set (a
+// follow-up query per blank node is invalid SPARQL: labels are existential
+// variables, and VALUES may not contain blank nodes).
+//
+// Guards: ke classifies an empty CONSTRUCT result as { type: "select" }
+// (shape-based detection) — treated here as "all URIs missing". The closure
+// query produces one row per (?p,?o) x (?bp,?bo) combination, so identical
+// triples repeat — deduped by (subject, predicate, object identity).
+// =============================================================================
+
+import type { Quad, Term } from "@canonical/ke";
+import DataLoader from "dataloader";
+import { isSafeIri } from "#hardening";
+import {
+  type EntityValue,
+  type MappedIR,
+  type QueryFn,
+  RDF_TYPE,
+  type TripleSet,
+  type TripleValue,
+} from "#shared";
+import { toPrefixed } from "./uris.js";
+
+/** Separator that cannot occur in IRIs or well-formed literals. */
+const SEP = "\u0000";
+
+const convertToTripleValue = (
+  term: Term,
+  blankSets: Map<string, TripleSet>,
+): TripleValue => {
+  switch (term.termType) {
+    case "NamedNode":
+      return { kind: "uri", value: term.value };
+    case "BlankNode": {
+      let triples = blankSets.get(term.value);
+      if (!triples) {
+        triples = new Map();
+        blankSets.set(term.value, triples);
+      }
+      return { kind: "blank", id: term.value, triples };
+    }
+    case "Literal":
+      return {
+        kind: "literal",
+        value: term.value,
+        datatype: term.datatype,
+        language: term.language,
+      };
+  }
+};
+
+/** Pick the most specific class among rdf:type assertions via the IR. */
+const pickMostSpecificTypename = (
+  typeUris: string[],
+  mapped: MappedIR,
+): string | undefined => {
+  let best: string | undefined;
+  let bestDepth = -1;
+  for (const uri of typeUris) {
+    const node = mapped.ir.classes.get(uri);
+    // Only concrete classes are valid runtime typenames. Returning an abstract
+    // class's name makes graphql-js reject it in resolveType ("abstract type
+    // resolved to non-object type"), which nulls the whole field. An entity
+    // typed only as abstract classes resolves to undefined (filtered) instead.
+    if (!node || node.isAbstract) {
+      continue;
+    }
+    if (node.ancestors.length > bestDepth) {
+      bestDepth = node.ancestors.length;
+      best = uri;
+    }
+  }
+  return best ? mapped.nameMap.toGraphQL(best) : undefined;
+};
+
+/**
+ * Create the entity DataLoader: batches full-IRI keys into one CONSTRUCT
+ * (including the single-hop blank-node closure) and yields EntityValues, or
+ * null for missing/typeless URIs. An optional cacheMap shares the cache
+ * across contexts ("process" mode); failed batches evict their keys so
+ * errors are never memoized.
+ *
+ * @note Impure — the returned loader executes SPARQL queries against the
+ * store.
+ */
+export default function createEntityLoader(
+  query: QueryFn,
+  mapped: MappedIR,
+  cacheMap?: Map<string, Promise<EntityValue | null>>,
+): DataLoader<string, EntityValue | null> {
+  const loader: DataLoader<string, EntityValue | null> = new DataLoader(
+    (fullUris) =>
+      batch(fullUris).catch((error) => {
+        // A shared (process-lifetime) cache must not memoize failures:
+        // evict the keys of a failed batch before rethrowing.
+        for (const uri of fullUris) {
+          loader.clear(uri);
+        }
+        throw error;
+      }),
+    cacheMap ? { cacheMap } : undefined,
+  );
+  const batch = async (fullUris: ReadonlyArray<string>) => {
+    // Injection guard: only IRIs safe to interpolate into an IRIREF
+    // reach the query. An unsafe global ID is simply absent from VALUES and
+    // resolves to null (not found), never to injected SPARQL.
+    const values = fullUris
+      .filter(isSafeIri)
+      .map((uri) => `<${uri}>`)
+      .join(" ");
+    const result = await query(
+      `CONSTRUCT { ?s ?p ?o . ?o ?bp ?bo }
+       WHERE {
+         VALUES ?s { ${values} }
+         ?s ?p ?o .
+         OPTIONAL { ?o ?bp ?bo . FILTER(isBlank(?o)) }
+       }`,
+    );
+    // Empty CONSTRUCT results arrive select-shaped from ke.
+    const quads: Quad[] = result.type === "construct" ? result.quads : [];
+
+    // Group triples per subject; blank-node subjects fill the shared sets.
+    const bySubject = new Map<string, TripleSet>();
+    const blankSets = new Map<string, TripleSet>();
+    const seen = new Set<string>();
+
+    const resolveTripleSet = (subject: Term): TripleSet | undefined => {
+      if (subject.termType === "NamedNode") {
+        let set = bySubject.get(subject.value);
+        if (!set) {
+          set = new Map();
+          bySubject.set(subject.value, set);
+        }
+        return set;
+      }
+      if (subject.termType === "BlankNode") {
+        let set = blankSets.get(subject.value);
+        if (!set) {
+          set = new Map();
+          blankSets.set(subject.value, set);
+        }
+        return set;
+      }
+      return undefined;
+    };
+
+    const encodeTermKey = (term: Term): string =>
+      term.termType === "Literal"
+        ? `L:${term.value}${SEP}${term.datatype ?? ""}${SEP}${term.language ?? ""}`
+        : `${term.termType === "BlankNode" ? "B" : "N"}:${term.value}`;
+
+    for (const quad of quads) {
+      const set = resolveTripleSet(quad.subject);
+      if (!set || quad.predicate.termType !== "NamedNode") {
+        continue;
+      }
+      const key = `${encodeTermKey(quad.subject)}${SEP}${quad.predicate.value}${SEP}${encodeTermKey(quad.object)}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      const list = set.get(quad.predicate.value) ?? [];
+      list.push(convertToTripleValue(quad.object, blankSets));
+      set.set(quad.predicate.value, list);
+    }
+
+    return fullUris.map((uri) => {
+      const triples = bySubject.get(uri);
+      if (!triples) {
+        return null;
+      }
+      const typeUris = (triples.get(RDF_TYPE) ?? [])
+        .filter((v) => v.kind === "uri")
+        .map((v) => (v as { value: string }).value);
+      const typename = pickMostSpecificTypename(typeUris, mapped);
+      if (!typename) {
+        return null; // URI exists but has no known class assertion
+      }
+      return {
+        uri: toPrefixed(uri, mapped.namespaces),
+        typename,
+        triples,
+      } satisfies EntityValue;
+    });
+  };
+
+  return loader;
+}

--- a/packages/runtime/ke-graphql/src/lib/dataloader/createInverseLoader.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createInverseLoader.test.ts
@@ -1,0 +1,103 @@
+import type { QueryResult, Term } from "@canonical/ke";
+import { describe, expect, it, vi } from "vitest";
+import type { MappedIR, NamespaceInfo, QueryFn } from "#shared";
+import createInverseLoader from "./createInverseLoader.js";
+
+const NS = "https://ds.canonical.com/";
+
+const namespaces = new Map<string, NamespaceInfo>([
+  ["ds", { prefix: "ds", uri: NS, classCount: 0, propertyCount: 0 }],
+]);
+
+const named = (value: string): Term => ({ termType: "NamedNode", value });
+const literal = (value: string): Term => ({ termType: "Literal", value });
+
+const mapped = { namespaces } as unknown as MappedIR;
+
+const select = (termBindings: Record<string, Term>[]): QueryResult =>
+  ({
+    type: "select",
+    variables: [],
+    bindings: [],
+    termBindings,
+  }) as QueryResult;
+
+const ask = (): QueryResult => ({ type: "ask", result: true }) as QueryResult;
+
+const key = (property: string, object: string) => `${property} ${object}`;
+
+describe("createInverseLoader", () => {
+  it("evicts the keys of a failed batch and rethrows", async () => {
+    let calls = 0;
+    const query: QueryFn = vi.fn(async () => {
+      calls += 1;
+      throw new Error("store down");
+    });
+    const loader = createInverseLoader(query, mapped, new Map());
+
+    await expect(loader.load(key(`${NS}of`, "ds:x"))).rejects.toThrow(
+      "store down",
+    );
+    await expect(loader.load(key(`${NS}of`, "ds:x"))).rejects.toThrow(
+      "store down",
+    );
+    expect(calls).toBe(2);
+  });
+
+  it("skips SELECT bindings that are not all NamedNodes (each operand)", async () => {
+    const query: QueryFn = async () =>
+      select([
+        // A valid all-NamedNode row.
+        {
+          property: named(`${NS}of`),
+          object: named(`${NS}x`),
+          subject: named(`${NS}a`),
+        },
+        // property is a Literal → first operand of the || fails.
+        {
+          property: literal("nope"),
+          object: named(`${NS}x`),
+          subject: named(`${NS}b`),
+        },
+        // object is a Literal → second operand fails.
+        {
+          property: named(`${NS}of`),
+          object: literal("nope"),
+          subject: named(`${NS}c`),
+        },
+        // subject is a Literal → third operand fails.
+        {
+          property: named(`${NS}of`),
+          object: named(`${NS}x`),
+          subject: literal("nope"),
+        },
+      ]);
+    const loader = createInverseLoader(query, mapped);
+    // The prefixed object expands to the full IRI for byKey lookup.
+    expect(await loader.load(key(`${NS}of`, "ds:x"))).toEqual([`${NS}a`]);
+  });
+
+  it("returns an empty list for a non-select result", async () => {
+    // result.type !== "select" → byKey stays empty → the ?? [] fallback fires.
+    const query: QueryFn = async () => ask();
+    const loader = createInverseLoader(query, mapped);
+    expect(await loader.load(key(`${NS}of`, "ds:x"))).toEqual([]);
+  });
+
+  it("falls back to the raw object when its prefix is unknown (toFull undefined)", async () => {
+    const query: QueryFn = vi.fn(async (q: string) => {
+      // toFull("zz:thing") is undefined for an unregistered prefix → ?? object
+      // keeps "zz:thing" as the SPARQL object.
+      expect(q).toContain("<zz:thing>");
+      return select([
+        {
+          property: named(`${NS}of`),
+          object: named("zz:thing"),
+          subject: named(`${NS}a`),
+        },
+      ]);
+    });
+    const loader = createInverseLoader(query, mapped);
+    expect(await loader.load(key(`${NS}of`, "zz:thing"))).toEqual([`${NS}a`]);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/dataloader/createInverseLoader.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createInverseLoader.ts
@@ -1,0 +1,87 @@
+// =============================================================================
+// Inverse loader. Batches reverse-assertion lookups. Keys are encoded
+// as "<propertyUri> <objectFullUri>" strings (DataLoader cache keys must be
+// primitives without a custom cacheKeyFn).
+// =============================================================================
+
+import DataLoader from "dataloader";
+import type { MappedIR, QueryFn } from "#shared";
+import { toFull } from "./uris.js";
+
+/** Encode an inverse-loader cache key from its property and object parts. */
+const encodeInverseKey = (property: string, object: string): string =>
+  `${property} ${object}`;
+
+/**
+ * Create the inverse DataLoader: batches "<propertyUri> <objectUri>" keys
+ * into one SELECT over reverse assertions and yields the subject URIs
+ * pointing at each object. An optional cacheMap shares the cache across
+ * contexts ("process" mode); failed batches evict their keys so errors are
+ * never memoized.
+ *
+ * @note Impure — the returned loader executes SPARQL queries against the
+ * store.
+ */
+export default function createInverseLoader(
+  query: QueryFn,
+  mapped: MappedIR,
+  cacheMap?: Map<string, Promise<string[]>>,
+): DataLoader<string, string[]> {
+  const loader: DataLoader<string, string[]> = new DataLoader(
+    (keys) =>
+      batch(keys).catch((error) => {
+        for (const key of keys) {
+          loader.clear(key);
+        }
+        throw error;
+      }),
+    cacheMap ? { cacheMap } : undefined,
+  );
+  const batch = async (keys: ReadonlyArray<string>) => {
+    const pairs: string[] = [];
+    for (const key of keys) {
+      const space = key.indexOf(" ");
+      const property = key.slice(0, space);
+      const object = key.slice(space + 1);
+      // EntityValue.uri carries the prefixed form; expand for SPARQL.
+      const full = toFull(object, mapped.namespaces) ?? object;
+      pairs.push(`(<${property}> <${full}>)`);
+    }
+    const result = await query(
+      `SELECT ?property ?object ?subject WHERE {
+         VALUES (?property ?object) { ${pairs.join(" ")} }
+         ?subject ?property ?object .
+         FILTER(isIRI(?subject))
+       }
+       ORDER BY ?subject`,
+    );
+    const byKey = new Map<string, string[]>();
+    if (result.type === "select") {
+      for (const row of result.termBindings) {
+        const property = row.property;
+        const object = row.object;
+        const subject = row.subject;
+        if (
+          property?.termType !== "NamedNode" ||
+          object?.termType !== "NamedNode" ||
+          subject?.termType !== "NamedNode"
+        ) {
+          continue;
+        }
+        const key = encodeInverseKey(property.value, object.value);
+        const list = byKey.get(key) ?? [];
+        list.push(subject.value);
+        byKey.set(key, list);
+      }
+    }
+    return keys.map((key) => {
+      const space = key.indexOf(" ");
+      const property = key.slice(0, space);
+      const object = key.slice(space + 1);
+      const full = toFull(object, mapped.namespaces) ?? object;
+      return byKey.get(encodeInverseKey(property, full)) ?? [];
+    });
+  };
+
+  return loader;
+}

--- a/packages/runtime/ke-graphql/src/lib/dataloader/createListLoader.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createListLoader.test.ts
@@ -1,0 +1,126 @@
+import type { QueryResult, Term } from "@canonical/ke";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ClassNode,
+  type MappedIR,
+  type NamespaceInfo,
+  type QueryFn,
+  RDFS_LABEL,
+} from "#shared";
+import createListLoader from "./createListLoader.js";
+
+const NS = "https://ds.canonical.com/";
+
+const namespaces = new Map<string, NamespaceInfo>([
+  ["ds", { prefix: "ds", uri: NS, classCount: 0, propertyCount: 0 }],
+]);
+
+const named = (value: string): Term => ({ termType: "NamedNode", value });
+const literal = (value: string): Term => ({ termType: "Literal", value });
+
+const mappedFor = (classes: Map<string, ClassNode>): MappedIR =>
+  ({ ir: { classes }, namespaces }) as unknown as MappedIR;
+
+const classWith = (uri: string, allProperties: string[]): ClassNode =>
+  ({ uri, allProperties }) as unknown as ClassNode;
+
+const select = (termBindings: Record<string, Term>[]): QueryResult =>
+  ({
+    type: "select",
+    variables: [],
+    bindings: [],
+    termBindings,
+  }) as QueryResult;
+
+const ask = (): QueryResult => ({ type: "ask", result: true }) as QueryResult;
+
+describe("createListLoader", () => {
+  it("falls back to rdfs:label when the class has no local-name 'name' property", async () => {
+    // Class with a property whose local name is NOT "name" → RDFS_LABEL.
+    const classes = new Map([
+      [`${NS}Widget`, classWith(`${NS}Widget`, [`${NS}title`])],
+    ]);
+    const query: QueryFn = vi.fn(async (q: string) => {
+      // The paired VALUES must carry the rdfs:label name predicate.
+      expect(q).toContain(`<${RDFS_LABEL}>`);
+      return select([
+        { class: named(`${NS}Widget`), instance: named(`${NS}a`) },
+      ]);
+    });
+    const loader = createListLoader(query, mappedFor(classes));
+    expect(await loader.load(`${NS}Widget`)).toEqual([`${NS}a`]);
+  });
+
+  it("uses the class's own local-name 'name' property as the name predicate", async () => {
+    // A declared property whose local name is "name" wins over rdfs:label.
+    const classes = new Map([
+      [`${NS}Widget`, classWith(`${NS}Widget`, [`${NS}title`, `${NS}name`])],
+    ]);
+    const query: QueryFn = vi.fn(async (q: string) => {
+      expect(q).toContain(`<${NS}name>`);
+      return select([
+        { class: named(`${NS}Widget`), instance: named(`${NS}a`) },
+      ]);
+    });
+    const loader = createListLoader(query, mappedFor(classes));
+    expect(await loader.load(`${NS}Widget`)).toEqual([`${NS}a`]);
+  });
+
+  it("evicts the keys of a failed batch and rethrows", async () => {
+    let calls = 0;
+    const query: QueryFn = vi.fn(async () => {
+      calls += 1;
+      throw new Error("store down");
+    });
+    const loader = createListLoader(query, mappedFor(new Map()), new Map());
+
+    await expect(loader.load(`${NS}Widget`)).rejects.toThrow("store down");
+    await expect(loader.load(`${NS}Widget`)).rejects.toThrow("store down");
+    expect(calls).toBe(2);
+  });
+
+  it("skips a binding whose class/instance is not a NamedNode (each operand)", async () => {
+    const query: QueryFn = async () =>
+      select([
+        { class: named(`${NS}Widget`), instance: named(`${NS}a`) },
+        // class is a Literal → first operand of the || fails.
+        { class: literal("nope"), instance: named(`${NS}b`) },
+        // instance is a Literal → second operand fails.
+        { class: named(`${NS}Widget`), instance: literal("nope") },
+      ]);
+    // No class node registered → resolveNamePredicate takes the `if (node)`
+    // false path and falls back to rdfs:label as well.
+    const loader = createListLoader(query, mappedFor(new Map()));
+    expect(await loader.load(`${NS}Widget`)).toEqual([`${NS}a`]);
+  });
+
+  it("returns an empty list for non-select results and unknown classes", async () => {
+    const query: QueryFn = async () => ask();
+    const loader = createListLoader(query, mappedFor(new Map()));
+    expect(await loader.load(`${NS}Widget`)).toEqual([]);
+  });
+
+  it("dedupes rows duplicated by a multi-valued name", async () => {
+    const query: QueryFn = async () =>
+      select([
+        // Same (class, instance) repeated by two name values → second skipped.
+        {
+          class: named(`${NS}Widget`),
+          instance: named(`${NS}a`),
+          name: literal("Alpha"),
+        },
+        {
+          class: named(`${NS}Widget`),
+          instance: named(`${NS}a`),
+          name: literal("Alias"),
+        },
+        {
+          class: named(`${NS}Widget`),
+          instance: named(`${NS}b`),
+          name: literal("Beta"),
+        },
+      ]);
+    const loader = createListLoader(query, mappedFor(new Map()));
+    expect(await loader.load(`${NS}Widget`)).toEqual([`${NS}a`, `${NS}b`]);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/dataloader/createListLoader.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/createListLoader.ts
@@ -1,0 +1,97 @@
+// =============================================================================
+// List loader. Batches instance-of queries per class with a per-class
+// name predicate (paired VALUES) so the default name-sort works across
+// ontologies. Rows are deduplicated per instance (multi-valued names would
+// otherwise duplicate rows).
+// =============================================================================
+
+import DataLoader from "dataloader";
+import {
+  getLocalName,
+  type MappedIR,
+  type QueryFn,
+  RDF_TYPE,
+  RDFS_LABEL,
+} from "#shared";
+
+/**
+ * Resolve the name predicate for a class: a declared property in the class's
+ * own namespace with local name "name", else rdfs:label.
+ */
+const resolveNamePredicate = (mapped: MappedIR, classUri: string): string => {
+  const node = mapped.ir.classes.get(classUri);
+  if (node) {
+    for (const propertyUri of node.allProperties) {
+      if (getLocalName(propertyUri) === "name") {
+        return propertyUri;
+      }
+    }
+  }
+  return RDFS_LABEL;
+};
+
+/**
+ * Create the class-listing DataLoader: batches class URIs into one SELECT
+ * and yields each class's named instance URIs, name-sorted via the class's
+ * name predicate. An optional cacheMap shares the cache across contexts
+ * ("process" mode); failed batches evict their keys so errors are never
+ * memoized.
+ *
+ * @note Impure — the returned loader executes SPARQL queries against the
+ * store.
+ */
+export default function createListLoader(
+  query: QueryFn,
+  mapped: MappedIR,
+  cacheMap?: Map<string, Promise<string[]>>,
+): DataLoader<string, string[]> {
+  const loader: DataLoader<string, string[]> = new DataLoader(
+    (classUris) =>
+      batch(classUris).catch((error) => {
+        for (const uri of classUris) {
+          loader.clear(uri);
+        }
+        throw error;
+      }),
+    cacheMap ? { cacheMap } : undefined,
+  );
+  const batch = async (classUris: ReadonlyArray<string>) => {
+    const pairs = classUris
+      .map((uri) => `(<${uri}> <${resolveNamePredicate(mapped, uri)}>)`)
+      .join(" ");
+    const result = await query(
+      `SELECT ?class ?instance ?name WHERE {
+         VALUES (?class ?nameProp) { ${pairs} }
+         ?instance <${RDF_TYPE}> ?class .
+         FILTER(isIRI(?instance))
+         OPTIONAL { ?instance ?nameProp ?name }
+       }
+       ORDER BY LCASE(STR(?name)) ?instance`,
+    );
+    const byClass = new Map<string, string[]>();
+    if (result.type === "select") {
+      const seen = new Set<string>();
+      for (const row of result.termBindings) {
+        const classUri = row.class;
+        const instance = row.instance;
+        if (
+          classUri?.termType !== "NamedNode" ||
+          instance?.termType !== "NamedNode"
+        ) {
+          continue;
+        }
+        const key = `${classUri.value} ${instance.value}`;
+        if (seen.has(key)) {
+          continue; // multi-valued names duplicate rows
+        }
+        seen.add(key);
+        const list = byClass.get(classUri.value) ?? [];
+        list.push(instance.value);
+        byClass.set(classUri.value, list);
+      }
+    }
+    return classUris.map((uri) => byClass.get(uri) ?? []);
+  };
+
+  return loader;
+}

--- a/packages/runtime/ke-graphql/src/lib/dataloader/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The batched data-loading domain: the three per-request DataLoaders
+ * (entity, class listing, reverse assertions) and the prefixed-URI ↔ full
+ * IRI conversions they key on.
+ *
+ * @module dataloader
+ */
+
+export { default as createEntityLoader } from "./createEntityLoader.js";
+export { default as createInverseLoader } from "./createInverseLoader.js";
+export { default as createListLoader } from "./createListLoader.js";
+export { toFull, toPrefixed } from "./uris.js";

--- a/packages/runtime/ke-graphql/src/lib/dataloader/uris.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/uris.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { NamespaceInfo } from "#shared";
+import { toFull, toPrefixed } from "./uris.js";
+
+const namespaces = new Map<string, NamespaceInfo>([
+  [
+    "ds",
+    {
+      prefix: "ds",
+      uri: "https://ds.canonical.com/",
+      classCount: 0,
+      propertyCount: 0,
+    },
+  ],
+]);
+
+describe("toPrefixed / toFull", () => {
+  it("round-trips a prefixed URI", () => {
+    const full = "https://ds.canonical.com/global.component.button";
+    const prefixed = toPrefixed(full, namespaces);
+    expect(prefixed).toBe("ds:global.component.button");
+    expect(toFull(prefixed, namespaces)).toBe(full);
+  });
+
+  it("returns the input when no namespace matches", () => {
+    expect(toPrefixed("http://other.org/x", namespaces)).toBe(
+      "http://other.org/x",
+    );
+  });
+
+  it("returns undefined for unknown prefixes and prefixless ids", () => {
+    expect(toFull("zz:thing", namespaces)).toBeUndefined();
+    expect(toFull("no-colon-here", namespaces)).toBeUndefined();
+  });
+
+  it("passes through full IRIs", () => {
+    expect(toFull("https://ds.canonical.com/x", namespaces)).toBe(
+      "https://ds.canonical.com/x",
+    );
+  });
+
+  it("picks the longest matching namespace, order-independently (canonical IDs)", () => {
+    const entries: [string, NamespaceInfo][] = [
+      [
+        "base",
+        {
+          prefix: "base",
+          uri: "http://ex.org/",
+          classCount: 0,
+          propertyCount: 0,
+        },
+      ],
+      [
+        "sub",
+        {
+          prefix: "sub",
+          uri: "http://ex.org/sub/",
+          classCount: 0,
+          propertyCount: 0,
+        },
+      ],
+    ];
+    const nested = new Map(entries);
+    const reordered = new Map([...entries].reverse());
+    // The most specific (longest) namespace wins regardless of iteration order.
+    expect(toPrefixed("http://ex.org/sub/g1", nested)).toBe("sub:g1");
+    expect(toPrefixed("http://ex.org/sub/g1", reordered)).toBe("sub:g1");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/dataloader/uris.ts
+++ b/packages/runtime/ke-graphql/src/lib/dataloader/uris.ts
@@ -1,0 +1,56 @@
+// =============================================================================
+// Prefixed URI ↔ full IRI conversion. The prefixed form is the
+// public identity (global IDs, EntityValue.uri); full IRIs are the loader
+// keys and SPARQL currency.
+// =============================================================================
+
+import type { NamespaceInfo } from "#shared";
+
+/**
+ * Convert a full IRI to its prefixed form ("ds:button") using the compiled
+ * namespace inventory. Picks the LONGEST matching namespace so that nested
+ * namespaces (e.g. "http://x/" and "http://x/sub/") yield a stable, canonical
+ * prefixed form regardless of namespace discovery order — Relay global IDs and
+ * cursors depend on this being deterministic. Returns the input
+ * unchanged when no registered namespace matches.
+ */
+export const toPrefixed = (
+  fullUri: string,
+  namespaces: ReadonlyMap<string, NamespaceInfo>,
+): string => {
+  let best: string | undefined;
+  let bestLength = -1;
+  for (const ns of namespaces.values()) {
+    if (fullUri.startsWith(ns.uri) && ns.uri.length > bestLength) {
+      bestLength = ns.uri.length;
+      best = `${ns.prefix}:${fullUri.slice(ns.uri.length)}`;
+    }
+  }
+  return best ?? fullUri;
+};
+
+/**
+ * Convert a prefixed URI ("ds:button") to its full IRI using the compiled
+ * namespace inventory. Inputs that are already full IRIs pass through;
+ * returns undefined when the prefix is unknown (node() returns null then).
+ */
+export const toFull = (
+  prefixed: string,
+  namespaces: ReadonlyMap<string, NamespaceInfo>,
+): string | undefined => {
+  const colon = prefixed.indexOf(":");
+  if (colon === -1) {
+    return undefined;
+  }
+  const prefix = prefixed.slice(0, colon);
+  const rest = prefixed.slice(colon + 1);
+  const ns = namespaces.get(prefix);
+  if (ns) {
+    return `${ns.uri}${rest}`;
+  }
+  // Already a full IRI (contains "://" or another colon-bearing scheme).
+  if (rest.startsWith("//")) {
+    return prefixed;
+  }
+  return undefined;
+};

--- a/packages/runtime/ke-graphql/src/lib/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/index.ts
@@ -1,13 +1,13 @@
 /**
  * The public library surface of @canonical/ke-graphql, composed from the
- * domain barrels. This foundation layer exposes the hardening domain (the
- * SPARQL-injection guard, connection page-size clamp, query-depth rule,
- * bounded loader cache, and production error masking); the compiler, plugin,
- * execution, and connection helpers are layered on top.
+ * domain barrels. This layer exposes the hardening domain and the resolution
+ * layer (URI prefixing and the Relay connection helpers); the compiler, ke
+ * plugin, and execution helpers are layered on top.
  *
  * @module lib
  */
 
+export { toFull, toPrefixed } from "./dataloader/index.js";
 export {
   clampConnectionArgs,
   createDepthLimitRule,
@@ -18,3 +18,16 @@ export {
   MAX_PAGE_SIZE,
   maskError,
 } from "./hardening/index.js";
+export {
+  type Connection,
+  type ConnectionArgs,
+  connectionFromPage,
+  emptyConnection,
+  fromBase64,
+  isEntity,
+  paginateUriWindow,
+  toBase64,
+  toConnection,
+  type UriPage,
+  unwrapEntities,
+} from "./resolver/index.js";

--- a/packages/runtime/ke-graphql/src/lib/resolver/coerce.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/coerce.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { coerce, mapXsdToScalar } from "./coerce.js";
+
+const warnings: Array<{ reason: string }> = [];
+const warn = (w: { reason: string }) => warnings.push(w);
+
+describe("coerce", () => {
+  it("passes strings through", () => {
+    expect(coerce("hello", "String", "p", warn)).toBe("hello");
+    expect(coerce("", "String", "p", warn)).toBe("");
+  });
+
+  it("coerces boolean lexical forms", () => {
+    expect(coerce("true", "Boolean", "p", warn)).toBe(true);
+    expect(coerce("false", "Boolean", "p", warn)).toBe(false);
+    expect(coerce("1", "Boolean", "p", warn)).toBe(true);
+    expect(coerce("0", "Boolean", "p", warn)).toBe(false);
+  });
+
+  it("returns null + warning for non-coercible booleans", () => {
+    warnings.length = 0;
+    expect(coerce("maybe", "Boolean", "p", warn)).toBeNull();
+    expect(warnings[0]?.reason).toContain("Boolean");
+  });
+
+  it("coerces integers and floats, warning on garbage", () => {
+    expect(coerce("42", "Int", "p", warn)).toBe(42);
+    expect(coerce("-3", "Int", "p", warn)).toBe(-3);
+    expect(coerce("2.5", "Float", "p", warn)).toBe(2.5);
+    warnings.length = 0;
+    expect(coerce("abc", "Int", "p", warn)).toBeNull();
+    expect(coerce("abc", "Float", "p", warn)).toBeNull();
+    expect(warnings).toHaveLength(2);
+  });
+});
+
+describe("mapXsdToScalar", () => {
+  const XSD = "http://www.w3.org/2001/XMLSchema#";
+  it("maps xsd datatypes to scalars", () => {
+    expect(mapXsdToScalar(`${XSD}boolean`)).toBe("Boolean");
+    expect(mapXsdToScalar(`${XSD}integer`)).toBe("Int");
+    expect(mapXsdToScalar(`${XSD}int`)).toBe("Int");
+    expect(mapXsdToScalar(`${XSD}long`)).toBe("Int");
+    expect(mapXsdToScalar(`${XSD}float`)).toBe("Float");
+    expect(mapXsdToScalar(`${XSD}double`)).toBe("Float");
+    expect(mapXsdToScalar(`${XSD}decimal`)).toBe("Float");
+    expect(mapXsdToScalar(`${XSD}string`)).toBe("String");
+    expect(mapXsdToScalar(`${XSD}anyURI`)).toBe("String");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/resolver/coerce.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/coerce.ts
@@ -1,0 +1,73 @@
+// =============================================================================
+// Literal coercion: boolean-as-string, numeric parsing, language-tag
+// stripping. Runtime failures go to the context's warning channel.
+// =============================================================================
+
+import { type RuntimeWarningHandler, XSD } from "#shared";
+import type { ScalarName } from "./types.js";
+
+/**
+ * Coerce a literal's lexical value to the target GraphQL scalar: strings
+ * pass through, "true"/"false"/"1"/"0" become booleans, and numbers are
+ * parsed base-10. Returns null (plus a runtime warning through the provided
+ * handler) when the value cannot be coerced.
+ */
+export const coerce = (
+  value: string,
+  scalar: ScalarName,
+  property: string,
+  warn: RuntimeWarningHandler,
+): string | number | boolean | null => {
+  switch (scalar) {
+    case "String":
+      return value;
+    case "Boolean": {
+      if (value === "true" || value === "1") {
+        return true;
+      }
+      if (value === "false" || value === "0") {
+        return false;
+      }
+      warn({ property, value, reason: "not coercible to Boolean" });
+      return null;
+    }
+    case "Int": {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isNaN(parsed)) {
+        warn({ property, value, reason: "not coercible to Int" });
+        return null;
+      }
+      return parsed;
+    }
+    case "Float": {
+      const parsed = Number.parseFloat(value);
+      if (Number.isNaN(parsed)) {
+        warn({ property, value, reason: "not coercible to Float" });
+        return null;
+      }
+      return parsed;
+    }
+  }
+};
+
+/**
+ * Map an XSD datatype IRI to the GraphQL scalar it coerces to (boolean →
+ * Boolean, integer family → Int, decimal family → Float); anything else,
+ * including unknown datatypes, maps to String.
+ */
+export const mapXsdToScalar = (xsd: string): ScalarName => {
+  switch (xsd) {
+    case `${XSD}boolean`:
+      return "Boolean";
+    case `${XSD}integer`:
+    case `${XSD}int`:
+    case `${XSD}long`:
+      return "Int";
+    case `${XSD}float`:
+    case `${XSD}double`:
+    case `${XSD}decimal`:
+      return "Float";
+    default:
+      return "String";
+  }
+};

--- a/packages/runtime/ke-graphql/src/lib/resolver/connection.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/connection.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "#hardening";
+import {
+  connectionFromPage,
+  emptyConnection,
+  fromBase64,
+  isEntity,
+  paginateUriWindow,
+  toBase64,
+  toConnection,
+  unwrapEntities,
+} from "./connection.js";
+
+const items = (uris: string[]) => uris.map((uri) => ({ uri }));
+
+describe("toConnection", () => {
+  it("returns all items without arguments", () => {
+    const connection = toConnection(items(["b", "a", "c"]), {});
+    expect(connection.edges.map((e) => e.node.uri)).toEqual(["a", "b", "c"]);
+    expect(connection.pageInfo.hasNextPage).toBe(false);
+    expect(connection.pageInfo.hasPreviousPage).toBe(false);
+  });
+
+  it("paginates forward with first/after", () => {
+    const page1 = toConnection(items(["a", "b", "c"]), { first: 2 });
+    expect(page1.edges.map((e) => e.node.uri)).toEqual(["a", "b"]);
+    expect(page1.pageInfo.hasNextPage).toBe(true);
+    const page2 = toConnection(items(["a", "b", "c"]), {
+      first: 2,
+      after: page1.pageInfo.endCursor,
+    });
+    expect(page2.edges.map((e) => e.node.uri)).toEqual(["c"]);
+    expect(page2.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it("paginates backward with last/before", () => {
+    const lastPage = toConnection(items(["a", "b", "c"]), { last: 2 });
+    expect(lastPage.edges.map((e) => e.node.uri)).toEqual(["b", "c"]);
+    expect(lastPage.pageInfo.hasPreviousPage).toBe(true);
+    const before = toConnection(items(["a", "b", "c"]), {
+      last: 2,
+      before: toBase64("c"),
+    });
+    expect(before.edges.map((e) => e.node.uri)).toEqual(["a", "b"]);
+  });
+
+  it("throws on negative first/last (connection spec)", () => {
+    expect(() => toConnection(items(["a"]), { first: -1 })).toThrow(
+      /non-negative/,
+    );
+    expect(() => toConnection(items(["a"]), { last: -1 })).toThrow(
+      /non-negative/,
+    );
+  });
+
+  it("returns zero edges for last: 0 (not the whole list)", () => {
+    const connection = toConnection(items(["a", "b"]), { last: 0 });
+    expect(connection.edges).toHaveLength(0);
+  });
+
+  it("preserves upstream order when presorted", () => {
+    const connection = toConnection(items(["z", "a"]), {}, true);
+    expect(connection.edges.map((e) => e.node.uri)).toEqual(["z", "a"]);
+  });
+
+  it("ignores unknown cursors", () => {
+    const connection = toConnection(items(["a", "b"]), {
+      after: toBase64("nope"),
+    });
+    expect(connection.edges).toHaveLength(2);
+  });
+
+  it("ignores an unknown before cursor", () => {
+    const connection = toConnection(items(["a", "b"]), {
+      before: toBase64("nope"),
+    });
+    expect(connection.edges).toHaveLength(2);
+  });
+});
+
+describe("page-size hardening (clamp)", () => {
+  const many = (n: number) =>
+    items(
+      Array.from({ length: n }, (_, i) => `u${String(i).padStart(4, "0")}`),
+    );
+
+  it("imposes the default page size when neither first nor last is given", () => {
+    const connection = toConnection(many(200), {});
+    expect(connection.edges).toHaveLength(DEFAULT_PAGE_SIZE);
+    expect(connection.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it("caps an over-large first at the ceiling", () => {
+    expect(toConnection(many(200), { first: 10_000 }).edges).toHaveLength(
+      MAX_PAGE_SIZE,
+    );
+  });
+
+  it("clamps the URI window in paginateUriWindow as well", () => {
+    const uris = Array.from({ length: 200 }, (_, i) => `u${i}`);
+    expect(paginateUriWindow(uris, {}).window).toHaveLength(DEFAULT_PAGE_SIZE);
+    expect(paginateUriWindow(uris, { first: 10_000 }).window).toHaveLength(
+      MAX_PAGE_SIZE,
+    );
+  });
+});
+
+describe("paginateUriWindow", () => {
+  const uris = ["a", "b", "c", "d"];
+
+  it("trims the window at a before cursor", () => {
+    const page = paginateUriWindow(uris, { before: toBase64("c"), first: 10 });
+    expect(page.window).toEqual(["a", "b"]);
+    expect(page.hasNextPage).toBe(false);
+  });
+
+  it("ignores an unknown before cursor", () => {
+    const page = paginateUriWindow(uris, {
+      before: toBase64("zzz"),
+      first: 10,
+    });
+    expect(page.window).toEqual(uris);
+  });
+
+  it("ignores an unknown after cursor", () => {
+    const page = paginateUriWindow(uris, { after: toBase64("zzz"), first: 10 });
+    expect(page.window).toEqual(uris);
+  });
+
+  it("windows the tail with last (and reports a previous page)", () => {
+    const page = paginateUriWindow(uris, { last: 2 });
+    expect(page.window).toEqual(["c", "d"]);
+    expect(page.hasPreviousPage).toBe(true);
+  });
+
+  it("combines after and last", () => {
+    const page = paginateUriWindow(uris, { after: toBase64("a"), last: 2 });
+    expect(page.window).toEqual(["c", "d"]);
+    expect(page.hasPreviousPage).toBe(true);
+  });
+
+  it("throws on negative first/last (connection spec)", () => {
+    expect(() => paginateUriWindow(uris, { first: -1 })).toThrow(
+      /non-negative/,
+    );
+    expect(() => paginateUriWindow(uris, { last: -1 })).toThrow(/non-negative/);
+  });
+});
+
+describe("base64 platform-neutral fallback", () => {
+  it("round-trips via btoa/atob when Buffer is absent", () => {
+    const saved = globalThis.Buffer;
+    try {
+      // @ts-expect-error — force the non-Buffer (Workers/browser) branch.
+      globalThis.Buffer = undefined;
+      const encoded = toBase64("ds:global.component.button");
+      expect(fromBase64(encoded)).toBe("ds:global.component.button");
+      expect(fromBase64("!!!not-base64!!!")).toBe("");
+    } finally {
+      globalThis.Buffer = saved;
+    }
+  });
+});
+
+describe("helpers", () => {
+  it("base64 round-trips and tolerates garbage", () => {
+    expect(fromBase64(toBase64("ds:global.component.button"))).toBe(
+      "ds:global.component.button",
+    );
+    expect(typeof fromBase64("!!!")).toBe("string");
+  });
+
+  it("emptyConnection has the full pageInfo shape", () => {
+    const connection = emptyConnection();
+    expect(connection.edges).toEqual([]);
+    expect(connection.pageInfo.startCursor).toBeNull();
+  });
+
+  it("isEntity filters nulls and Errors from loadMany results", () => {
+    const entity = { uri: "x", typename: "T", triples: new Map() };
+    expect([entity, null, new Error("boom")].filter(isEntity)).toEqual([
+      entity,
+    ]);
+  });
+
+  it("unwrapEntities rethrows batch errors and drops nulls", () => {
+    const entity = { uri: "x", typename: "T", triples: new Map() };
+    expect(unwrapEntities([entity, null])).toEqual([entity]);
+    expect(() => unwrapEntities([entity, new Error("store down")])).toThrow(
+      "store down",
+    );
+  });
+
+  it("encodes a null uri as the empty-string cursor", () => {
+    // Embedded blank-node entities carry uri: null → toBase64("") cursor.
+    const page = { window: [], hasNextPage: false, hasPreviousPage: false };
+    const connection = connectionFromPage([{ uri: null }], page);
+    expect(connection.edges[0]?.cursor).toBe(toBase64(""));
+  });
+
+  it("yields null cursors for an empty hydrated page", () => {
+    const page = { window: [], hasNextPage: false, hasPreviousPage: false };
+    const connection = connectionFromPage([], page);
+    expect(connection.edges).toEqual([]);
+    expect(connection.pageInfo.startCursor).toBeNull();
+    expect(connection.pageInfo.endCursor).toBeNull();
+  });
+
+  it("sorts and cursors null uris (toConnection ?? '' fallbacks)", () => {
+    // Two null uris exercise both sides of the comparator's ?? "" fallbacks.
+    const connection = toConnection(
+      [{ uri: null }, { uri: null }, { uri: "a" }],
+      {},
+    );
+    expect(connection.edges.map((e) => e.node.uri)).toEqual([null, null, "a"]);
+    expect(connection.edges[0]?.cursor).toBe(toBase64(""));
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/resolver/connection.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/connection.ts
@@ -1,0 +1,213 @@
+// =============================================================================
+// Relay connection helpers.
+//
+// Cursor = base64(prefixed URI), opaque to clients. Items are sorted by URI
+// before slicing so cursors remain stable regardless of triple order or
+// Set-union order (root listings arrive name-sorted from the list loader and
+// keep that order). Per the Cursor Connections spec: negative first/last
+// throw, last: 0 yields zero edges.
+// =============================================================================
+
+import { GraphQLError } from "graphql";
+import { clampConnectionArgs } from "#hardening";
+import type { EntityValue } from "#shared";
+import type { Connection, ConnectionArgs, Sortable, UriPage } from "./types.js";
+
+/**
+ * Encode a string as base64. Platform-neutral (Workers/browsers have
+ * btoa/atob but no Buffer; Node has both) and Unicode-safe via TextEncoder.
+ */
+export const toBase64 = (value: string): string => {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "utf-8").toString("base64");
+  }
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+};
+
+/**
+ * Decode a base64 string (Unicode-safe, platform-neutral). Invalid input
+ * decodes to "" rather than throwing — cursors are client-supplied.
+ */
+export const fromBase64 = (value: string): string => {
+  try {
+    if (typeof Buffer !== "undefined") {
+      return Buffer.from(value, "base64").toString("utf-8");
+    }
+    const binary = atob(value);
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return "";
+  }
+};
+
+/** Build the canonical empty connection (no edges, no cursors). */
+export const emptyConnection = <T>(): Connection<T> => ({
+  edges: [],
+  pageInfo: {
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: null,
+    endCursor: null,
+  },
+});
+
+/** DataLoader.loadMany returns (V | Error)[]; keep only real entities. */
+export const isEntity = (
+  value: EntityValue | Error | null,
+): value is EntityValue =>
+  value !== null && !(value instanceof Error) && typeof value === "object";
+
+/**
+ * Unwrap a loadMany result: rethrow the first Error (a failed batch must
+ * surface as a GraphQL field error, not as an empty connection), drop nulls
+ * (missing or typeless entities are filtered).
+ */
+export const unwrapEntities = (
+  results: ReadonlyArray<EntityValue | Error | null>,
+): EntityValue[] => {
+  const firstError = results.find((r): r is Error => r instanceof Error);
+  if (firstError) {
+    throw firstError;
+  }
+  return results.filter(isEntity);
+};
+
+/**
+ * Run the full pagination algorithm on the URI LIST, before any hydration:
+ * cursors are base64(uri), hasNextPage is array math — entities are only
+ * needed for the page itself. Input must already be in display order
+ * (root listings arrive name-sorted from the list loader). Throws a
+ * GraphQLError on negative first/last.
+ */
+export const paginateUriWindow = (
+  uris: ReadonlyArray<string>,
+  args: ConnectionArgs,
+): UriPage => {
+  // Hardening: impose a default page size and cap an over-large one before
+  // any windowing (negatives pass through and are rejected below).
+  const page = clampConnectionArgs(args);
+  if (page.first != null && page.first < 0) {
+    throw new GraphQLError('Argument "first" must be a non-negative integer');
+  }
+  if (page.last != null && page.last < 0) {
+    throw new GraphQLError('Argument "last" must be a non-negative integer');
+  }
+  let start = 0;
+  let end = uris.length;
+  if (page.after) {
+    const idx = uris.indexOf(fromBase64(page.after));
+    if (idx !== -1) {
+      start = idx + 1;
+    }
+  }
+  if (page.before) {
+    const idx = uris.indexOf(fromBase64(page.before));
+    if (idx !== -1) {
+      end = Math.min(end, idx);
+    }
+  }
+  let hasNextPage = false;
+  let hasPreviousPage = false;
+  if (page.first != null && end - start > page.first) {
+    end = start + page.first;
+    hasNextPage = true;
+  }
+  if (page.last != null && end - start > page.last) {
+    start = end - page.last;
+    hasPreviousPage = true;
+  }
+  return { window: uris.slice(start, end), hasNextPage, hasPreviousPage };
+};
+
+/** Build a connection from an already-paginated, hydrated page. */
+export const connectionFromPage = <T extends Sortable>(
+  entities: T[],
+  page: UriPage,
+): Connection<T> => {
+  const edges = entities.map((node) => ({
+    node,
+    cursor: toBase64(node.uri ?? ""),
+  }));
+  return {
+    edges,
+    pageInfo: {
+      hasNextPage: page.hasNextPage,
+      hasPreviousPage: page.hasPreviousPage,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+};
+
+/**
+ * Build a Relay connection from a full in-memory list. O(n) — fine for the
+ * data scale (≤ ~1000 items per list). Throws a GraphQLError on negative
+ * first/last.
+ *
+ * @param presorted Skip the URI sort (root listings are name-sorted upstream).
+ */
+export const toConnection = <T extends Sortable>(
+  allItems: T[],
+  args: ConnectionArgs,
+  presorted = false,
+): Connection<T> => {
+  // Hardening: impose a default page size and cap an over-large one before
+  // slicing (negatives pass through and are rejected below).
+  const page = clampConnectionArgs(args);
+  if (page.first != null && page.first < 0) {
+    throw new GraphQLError('Argument "first" must be a non-negative integer');
+  }
+  if (page.last != null && page.last < 0) {
+    throw new GraphQLError('Argument "last" must be a non-negative integer');
+  }
+
+  let items = presorted
+    ? [...allItems]
+    : [...allItems].sort((a, b) => (a.uri ?? "").localeCompare(b.uri ?? ""));
+
+  if (page.after) {
+    const afterUri = fromBase64(page.after);
+    const idx = items.findIndex((i) => i.uri === afterUri);
+    if (idx !== -1) {
+      items = items.slice(idx + 1);
+    }
+  }
+  if (page.before) {
+    const beforeUri = fromBase64(page.before);
+    const idx = items.findIndex((i) => i.uri === beforeUri);
+    if (idx !== -1) {
+      items = items.slice(0, idx);
+    }
+  }
+
+  const hasNextPage = page.first != null && items.length > page.first;
+  const hasPreviousPage = page.last != null && items.length > page.last;
+
+  if (page.first != null) {
+    items = items.slice(0, page.first);
+  }
+  if (page.last != null) {
+    items = items.slice(Math.max(items.length - page.last, 0));
+  }
+
+  const edges = items.map((item) => ({
+    node: item,
+    cursor: toBase64(item.uri ?? ""),
+  }));
+
+  return {
+    edges,
+    pageInfo: {
+      hasNextPage,
+      hasPreviousPage,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/resolver/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/index.ts
@@ -1,0 +1,29 @@
+/**
+ * The resolver domain: literal coercion, the Relay connection/pagination
+ * helpers, the eight resolver templates the compiler instantiates per field,
+ * and the value shapes they exchange.
+ *
+ * @module resolver
+ */
+
+export { coerce, mapXsdToScalar } from "./coerce.js";
+export {
+  connectionFromPage,
+  emptyConnection,
+  fromBase64,
+  isEntity,
+  paginateUriWindow,
+  toBase64,
+  toConnection,
+  unwrapEntities,
+} from "./connection.js";
+export {
+  createDatatypeListResolver,
+  createDatatypeResolver,
+  createEmbeddedListResolver,
+  createEmbeddedSingularResolver,
+  createInverseResolver,
+  createObjectListResolver,
+  createObjectSingularResolver,
+} from "./templates.js";
+export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/resolver/templates.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/templates.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CompilerContext,
+  type EntityValue,
+  type FieldTypeSpec,
+  type MappedField,
+  RDF_TYPE,
+  type TripleSet,
+  type TripleValue,
+} from "#shared";
+import {
+  createDatatypeListResolver,
+  createDatatypeResolver,
+  createEmbeddedListResolver,
+  createEmbeddedSingularResolver,
+  createInverseResolver,
+  createObjectListResolver,
+  createObjectSingularResolver,
+} from "./templates.js";
+
+const NS = "https://ds.canonical.com/";
+
+const namespaces = new Map([
+  ["ds", { prefix: "ds", uri: NS, classCount: 0, propertyCount: 0 }],
+]);
+
+/** Build a MappedField with sensible defaults; override per test. */
+const field = (over: Partial<MappedField>): MappedField =>
+  ({
+    owlUri: `${NS}p`,
+    graphqlName: "p",
+    type: { kind: "scalar", name: "String" } as FieldTypeSpec,
+    nullable: true,
+    list: false,
+    resolverTemplate: "datatype",
+    propertyUri: `${NS}p`,
+    shaclRequired: false,
+    nonNull: false,
+    ...over,
+  }) as MappedField;
+
+const triples = (entries: [string, TripleValue[]][] = []): TripleSet =>
+  new Map(entries);
+
+const entity = (over: Partial<EntityValue>): EntityValue => ({
+  uri: "ds:thing",
+  typename: "Widget",
+  triples: triples(),
+  ...over,
+});
+
+/** Mock context whose loaders are plain spies. */
+const makeCtx = (over: Partial<CompilerContext> = {}): CompilerContext => {
+  const warn = vi.fn();
+  return {
+    entityLoader: {
+      load: vi.fn(async (uri: string) => entity({ uri })),
+      loadMany: vi.fn(async (uris: string[]) =>
+        uris.map((uri) => entity({ uri })),
+      ),
+    },
+    inverseLoader: { load: vi.fn(async () => [] as string[]) },
+    nameMap: { toGraphQL: (uri: string) => getLocalName(uri) },
+    namespaces,
+    warn,
+    ...over,
+  } as unknown as CompilerContext;
+};
+
+const getLocalName = (uri: string) =>
+  uri.slice(Math.max(uri.lastIndexOf("#"), uri.lastIndexOf("/")) + 1);
+
+const lit = (value: string, datatype?: string): TripleValue => ({
+  kind: "literal",
+  value,
+  datatype,
+});
+const uri = (value: string): TripleValue => ({ kind: "uri", value });
+const blankVal = (t: TripleSet): TripleValue => ({
+  kind: "blank",
+  id: "_:b",
+  triples: t,
+});
+
+const noArgs = {} as never;
+
+describe("createDatatypeResolver", () => {
+  it("returns null when there are no values", async () => {
+    const resolve = createDatatypeResolver(field({}));
+    expect(
+      await resolve(entity({}), noArgs, makeCtx(), {} as never),
+    ).toBeNull();
+  });
+
+  it("coerces the first literal to the field scalar", async () => {
+    const resolve = createDatatypeResolver(
+      field({ type: { kind: "scalar", name: "Int" } }),
+    );
+    const parent = entity({ triples: triples([[`${NS}p`, [lit("42")]]]) });
+    expect(await resolve(parent, noArgs, makeCtx(), {} as never)).toBe(42);
+  });
+
+  it("surfaces a URI value as a string on the B003 String fallback", async () => {
+    // Non-scalar field type → getScalarName returns "String".
+    const resolve = createDatatypeResolver(
+      field({ type: { kind: "type", name: "Thing" } }),
+    );
+    const parent = entity({ triples: triples([[`${NS}p`, [uri(`${NS}x`)]]]) });
+    expect(await resolve(parent, noArgs, makeCtx(), {} as never)).toBe(
+      `${NS}x`,
+    );
+  });
+
+  it("returns null for a URI value when the scalar is not String", async () => {
+    const resolve = createDatatypeResolver(
+      field({ type: { kind: "scalar", name: "Int" } }),
+    );
+    const parent = entity({ triples: triples([[`${NS}p`, [uri(`${NS}x`)]]]) });
+    expect(await resolve(parent, noArgs, makeCtx(), {} as never)).toBeNull();
+  });
+});
+
+describe("createDatatypeListResolver", () => {
+  it("returns [] when there are no values", async () => {
+    const resolve = createDatatypeListResolver(field({}));
+    expect(await resolve(entity({}), noArgs, makeCtx(), {} as never)).toEqual(
+      [],
+    );
+  });
+
+  it("coerces literals, surfaces String-fallback URIs, drops the rest", async () => {
+    const resolve = createDatatypeListResolver(
+      field({ type: { kind: "type", name: "Thing" } }),
+    );
+    const parent = entity({
+      triples: triples([
+        [`${NS}p`, [lit("a"), uri(`${NS}x`), blankVal(triples())]],
+      ]),
+    });
+    // String fallback: literal "a" and URI both surface; the blank is dropped.
+    expect(await resolve(parent, noArgs, makeCtx(), {} as never)).toEqual([
+      "a",
+      `${NS}x`,
+    ]);
+  });
+
+  it("drops uncoercible literals and non-String URIs", async () => {
+    const resolve = createDatatypeListResolver(
+      field({ type: { kind: "scalar", name: "Int" } }),
+    );
+    const parent = entity({
+      triples: triples([[`${NS}p`, [lit("notnum"), uri(`${NS}x`)]]]),
+    });
+    expect(await resolve(parent, noArgs, makeCtx(), {} as never)).toEqual([]);
+  });
+});
+
+describe("createObjectSingularResolver", () => {
+  it("loads the referenced entity from a URI value", async () => {
+    const resolve = createObjectSingularResolver(field({}));
+    const ctx = makeCtx();
+    const parent = entity({ triples: triples([[`${NS}p`, [uri(`${NS}x`)]]]) });
+    const result = (await resolve(
+      parent,
+      noArgs,
+      ctx,
+      {} as never,
+    )) as EntityValue;
+    expect(result.uri).toBe(`${NS}x`);
+    expect(ctx.entityLoader.load).toHaveBeenCalledWith(`${NS}x`);
+  });
+
+  it("falls back to the declared inverse assertion", async () => {
+    const resolve = createObjectSingularResolver(
+      field({ inverseOf: `${NS}fwd` }),
+    );
+    const ctx = makeCtx({
+      inverseLoader: { load: vi.fn(async () => [`${NS}back`]) },
+    } as Partial<CompilerContext>);
+    const parent = entity({ uri: "ds:thing", triples: triples() });
+    const result = (await resolve(
+      parent,
+      noArgs,
+      ctx,
+      {} as never,
+    )) as EntityValue;
+    expect(ctx.inverseLoader.load).toHaveBeenCalledWith(`${NS}fwd ds:thing`);
+    expect(result.uri).toBe(`${NS}back`);
+  });
+
+  it("returns null when the inverse yields nothing", async () => {
+    const resolve = createObjectSingularResolver(
+      field({ inverseOf: `${NS}fwd` }),
+    );
+    const ctx = makeCtx({
+      inverseLoader: { load: vi.fn(async () => [] as string[]) },
+    } as Partial<CompilerContext>);
+    const parent = entity({ uri: "ds:thing", triples: triples() });
+    expect(await resolve(parent, noArgs, ctx, {} as never)).toBeNull();
+  });
+
+  it("returns null with no URI value and no declared inverse", async () => {
+    const resolve = createObjectSingularResolver(field({}));
+    const parent = entity({ uri: "ds:thing", triples: triples() });
+    expect(await resolve(parent, noArgs, makeCtx(), {} as never)).toBeNull();
+  });
+
+  it("returns null when an inverse is declared but the parent has no uri", async () => {
+    const resolve = createObjectSingularResolver(
+      field({ inverseOf: `${NS}fwd` }),
+    );
+    const parent = entity({ uri: null, triples: triples() });
+    expect(await resolve(parent, noArgs, makeCtx(), {} as never)).toBeNull();
+  });
+});
+
+describe("createObjectListResolver", () => {
+  it("returns an empty connection when there are no values", async () => {
+    const resolve = createObjectListResolver(field({}));
+    const result = (await resolve(
+      entity({}),
+      noArgs,
+      makeCtx(),
+      {} as never,
+    )) as {
+      edges: unknown[];
+    };
+    expect(result.edges).toEqual([]);
+  });
+
+  it("paginates and hydrates URI values into a connection", async () => {
+    const resolve = createObjectListResolver(field({}));
+    const ctx = makeCtx();
+    const parent = entity({
+      triples: triples([
+        [`${NS}p`, [uri(`${NS}b`), uri(`${NS}a`), lit("ignored")]],
+      ]),
+    });
+    const result = (await resolve(
+      parent,
+      { first: 10 } as never,
+      ctx,
+      {} as never,
+    )) as {
+      edges: { node: EntityValue }[];
+    };
+    // Sorted by prefixed URI: ds:a, ds:b.
+    expect(result.edges.map((e) => e.node.uri)).toEqual([`${NS}a`, `${NS}b`]);
+  });
+
+  it("keeps a value verbatim when its prefix does not expand (toFull fallback)", async () => {
+    const resolve = createObjectListResolver(field({}));
+    const ctx = makeCtx();
+    // "zz:thing" has no registered namespace: toPrefixed leaves it, and
+    // toFull returns undefined → the loader key falls back to the raw value.
+    const parent = entity({
+      triples: triples([[`${NS}p`, [uri("zz:thing")]]]),
+    });
+    await resolve(parent, { first: 10 } as never, ctx, {} as never);
+    expect(ctx.entityLoader.loadMany).toHaveBeenCalledWith(["zz:thing"]);
+  });
+});
+
+describe("createInverseResolver", () => {
+  it("unions forward triples and reverse assertions, deduped", async () => {
+    const resolve = createInverseResolver(field({}), `${NS}fwd`);
+    const ctx = makeCtx({
+      inverseLoader: { load: vi.fn(async () => [`${NS}b`]) },
+    } as Partial<CompilerContext>);
+    const parent = entity({
+      uri: "ds:thing",
+      triples: triples([[`${NS}p`, [uri(`${NS}a`), lit("skip")]]]),
+    });
+    const result = (await resolve(
+      parent,
+      { first: 10 } as never,
+      ctx,
+      {} as never,
+    )) as {
+      edges: { node: EntityValue }[];
+    };
+    expect(result.edges.map((e) => e.node.uri)).toEqual([`${NS}a`, `${NS}b`]);
+    expect(ctx.inverseLoader.load).toHaveBeenCalledWith(`${NS}fwd ds:thing`);
+  });
+
+  it("uses only forward triples when the parent has no uri", async () => {
+    const resolve = createInverseResolver(field({}), `${NS}fwd`);
+    const ctx = makeCtx();
+    const parent = entity({
+      uri: null,
+      triples: triples([[`${NS}p`, [uri(`${NS}a`)]]]),
+    });
+    const result = (await resolve(
+      parent,
+      { first: 10 } as never,
+      ctx,
+      {} as never,
+    )) as {
+      edges: { node: EntityValue }[];
+    };
+    expect(result.edges.map((e) => e.node.uri)).toEqual([`${NS}a`]);
+    expect(ctx.inverseLoader.load).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty connection when the union is empty", async () => {
+    const resolve = createInverseResolver(field({}), `${NS}fwd`);
+    const parent = entity({ uri: null, triples: triples() });
+    const result = (await resolve(parent, noArgs, makeCtx(), {} as never)) as {
+      edges: unknown[];
+    };
+    expect(result.edges).toEqual([]);
+  });
+});
+
+describe("createEmbeddedListResolver", () => {
+  it("returns [] when there are no values", async () => {
+    const resolve = createEmbeddedListResolver(field({}), "Range");
+    expect(await resolve(entity({}), noArgs, makeCtx(), {} as never)).toEqual(
+      [],
+    );
+  });
+
+  it("materializes blank children, picking rdf:type or the range fallback", async () => {
+    const resolve = createEmbeddedListResolver(field({}), "Range");
+    const typed = triples([[RDF_TYPE, [uri(`${NS}Widget`)]]]);
+    const untyped = triples();
+    const parent = entity({
+      triples: triples([
+        [`${NS}p`, [blankVal(typed), blankVal(untyped), uri(`${NS}skip`)]],
+      ]),
+    });
+    const result = (await resolve(
+      parent,
+      noArgs,
+      makeCtx(),
+      {} as never,
+    )) as EntityValue[];
+    expect(result.map((e) => e.typename)).toEqual(["Widget", "Range"]);
+    expect(result.every((e) => e.uri === null)).toBe(true);
+  });
+
+  it("falls back to range when rdf:type is an unmapped URI", async () => {
+    const resolve = createEmbeddedListResolver(field({}), "Range");
+    // nameMap.toGraphQL returns "" for this; the resolver keeps scanning then
+    // falls back to the range typename.
+    const ctx = makeCtx({
+      nameMap: { toGraphQL: () => undefined },
+    } as Partial<CompilerContext>);
+    const t = triples([[RDF_TYPE, [uri(`${NS}Unknown`), lit("ignored")]]]);
+    const parent = entity({ triples: triples([[`${NS}p`, [blankVal(t)]]]) });
+    const result = (await resolve(
+      parent,
+      noArgs,
+      ctx,
+      {} as never,
+    )) as EntityValue[];
+    expect(result[0]?.typename).toBe("Range");
+  });
+});
+
+describe("createEmbeddedSingularResolver", () => {
+  it("returns null when there is no blank value", async () => {
+    const resolve = createEmbeddedSingularResolver(field({}), "Range");
+    const parent = entity({ triples: triples([[`${NS}p`, [uri(`${NS}x`)]]]) });
+    expect(await resolve(parent, noArgs, makeCtx(), {} as never)).toBeNull();
+  });
+
+  it("materializes the first blank child with its rdf:type typename", async () => {
+    const resolve = createEmbeddedSingularResolver(field({}), "Range");
+    const t = triples([[RDF_TYPE, [uri(`${NS}Widget`)]]]);
+    const parent = entity({ triples: triples([[`${NS}p`, [blankVal(t)]]]) });
+    const result = (await resolve(
+      parent,
+      noArgs,
+      makeCtx(),
+      {} as never,
+    )) as EntityValue;
+    expect(result.uri).toBeNull();
+    expect(result.typename).toBe("Widget");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/resolver/templates.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/templates.ts
@@ -1,0 +1,239 @@
+// =============================================================================
+// The eight resolver templates. Every generated field's resolve
+// function is an instantiation of one of these. Parents are EntityValues;
+// embedded blank-node children become EntityValues with uri: null and a
+// per-value typename derived from the blank node's rdf:type when present
+// (falling back to the field's declared range).
+// =============================================================================
+
+import type { GraphQLFieldResolver } from "graphql";
+import { toFull, toPrefixed } from "#dataloader";
+import {
+  type CompilerContext,
+  type EntityValue,
+  type MappedField,
+  RDF_TYPE,
+  type TripleSet,
+} from "#shared";
+import { coerce } from "./coerce.js";
+import {
+  connectionFromPage,
+  emptyConnection,
+  paginateUriWindow,
+  unwrapEntities,
+} from "./connection.js";
+import type { ConnectionArgs, ScalarName } from "./types.js";
+
+/**
+ * Paginate an object connection BEFORE hydration: sort the deduplicated URI
+ * list into cursor order, window it (page size clamped by the hardening
+ * domain), then hydrate only the page. This bounds the per-field hydration
+ * cost to the page size regardless of how many URIs the parent references —
+ * a nested `authors(first: 10)` loads 10 entities, not all of them.
+ *
+ * @note Impure — hydrates the page through the context's entity loader.
+ */
+const paginateAndHydrate = async (
+  fullUris: string[],
+  args: ConnectionArgs,
+  ctx: CompilerContext,
+) => {
+  const prefixed = [...new Set(fullUris)]
+    .map((uri) => toPrefixed(uri, ctx.namespaces))
+    .sort((a, b) => a.localeCompare(b));
+  const page = paginateUriWindow(prefixed, args);
+  const entities = await ctx.entityLoader.loadMany(
+    page.window.map((uri) => toFull(uri, ctx.namespaces) ?? uri),
+  );
+  return connectionFromPage(unwrapEntities(entities), page);
+};
+
+type Resolver = GraphQLFieldResolver<EntityValue, CompilerContext>;
+
+/** Get the scalar name a field coerces to (String for non-scalar fields). */
+const getScalarName = (field: MappedField): ScalarName =>
+  field.type.kind === "scalar" ? (field.type.name as ScalarName) : "String";
+
+/** Resolve an embedded value's typename: rdf:type when present, else the range. */
+const resolveEmbeddedTypename = (
+  triples: TripleSet,
+  fallback: string,
+  ctx: CompilerContext,
+): string => {
+  const typeTriples = triples.get(RDF_TYPE);
+  for (const t of typeTriples ?? []) {
+    if (t.kind === "uri") {
+      const name = ctx.nameMap.toGraphQL(t.value);
+      if (name) {
+        return name;
+      }
+    }
+  }
+  return fallback;
+};
+
+/**
+ * Create a Template 1 resolver (singular datatype field): coerces the first
+ * literal value to the field's scalar; URI values surface as strings on
+ * B003 String fallbacks.
+ */
+export const createDatatypeResolver = (field: MappedField): Resolver => {
+  const scalar = getScalarName(field);
+  return (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    if (!values?.length) {
+      return null;
+    }
+    const v = values[0];
+    if (v?.kind === "literal") {
+      return coerce(v.value, scalar, field.propertyUri, ctx.warn);
+    }
+    // Object property with an unknown range mapped to String (B003): the
+    // value is a URI — honor the "mapped to String" contract.
+    if (v?.kind === "uri" && scalar === "String") {
+      return v.value;
+    }
+    return null;
+  };
+};
+
+/**
+ * Create a Template 2 resolver (datatype list field): coerces every literal
+ * value, dropping the ones that fail coercion.
+ */
+export const createDatatypeListResolver = (field: MappedField): Resolver => {
+  const scalar = getScalarName(field);
+  return (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    if (!values?.length) {
+      return [];
+    }
+    return values
+      .map((v) => {
+        if (v.kind === "literal") {
+          return coerce(v.value, scalar, field.propertyUri, ctx.warn);
+        }
+        // B003 String fallback: URI values surface as their IRI strings.
+        if (v.kind === "uri" && scalar === "String") {
+          return v.value;
+        }
+        return null;
+      })
+      .filter((v) => v !== null);
+  };
+};
+
+/**
+ * Create a Template 3 resolver (singular object field): loads the referenced
+ * entity; declared inverse pairs fall back to the reverse assertion.
+ */
+export const createObjectSingularResolver = (field: MappedField): Resolver => {
+  return async (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    const v = values?.find((value) => value.kind === "uri");
+    if (v?.kind === "uri") {
+      return ctx.entityLoader.load(v.value);
+    }
+    // Declared inverse pair: fall back to the reverse assertion.
+    if (field.inverseOf && parent.uri) {
+      const reverse = await ctx.inverseLoader.load(
+        `${field.inverseOf} ${parent.uri}`,
+      );
+      if (reverse[0]) {
+        return ctx.entityLoader.load(reverse[0]);
+      }
+    }
+    return null;
+  };
+};
+
+/**
+ * Create a Template 5 resolver (object list field): loads every referenced
+ * entity and returns a Relay connection.
+ */
+export const createObjectListResolver = (field: MappedField): Resolver => {
+  return async (parent, args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    if (!values?.length) {
+      return emptyConnection();
+    }
+    const uris = values
+      .filter((v) => v.kind === "uri")
+      .map((v) => (v as { value: string }).value);
+    return paginateAndHydrate(uris, args as ConnectionArgs, ctx);
+  };
+};
+
+/**
+ * Create a Template 4 resolver (inverse fields — declared pairs and
+ * synthetic inverses): union of forward triples and reverse assertions,
+ * deduplicated by URI (an owl:inverseOf pair may be asserted in either
+ * direction; each side resolves the union of both), as a Relay connection.
+ */
+export const createInverseResolver = (
+  field: MappedField,
+  /** Encoded inverse key prefix: the forward property whose assertions point at the parent. */
+  forwardProperty: string,
+): Resolver => {
+  return async (parent, args, ctx) => {
+    const forward = (parent.triples.get(field.propertyUri) ?? [])
+      .filter((v) => v.kind === "uri")
+      .map((v) => (v as { value: string }).value);
+    const reverse = parent.uri
+      ? await ctx.inverseLoader.load(`${forwardProperty} ${parent.uri}`)
+      : [];
+    const uris = [...forward, ...reverse];
+    if (uris.length === 0) {
+      return emptyConnection();
+    }
+    return paginateAndHydrate(uris, args as ConnectionArgs, ctx);
+  };
+};
+
+/**
+ * Create a Template 7 resolver (embedded list field): materializes the
+ * parent's blank-node children as EntityValues with uri: null.
+ */
+export const createEmbeddedListResolver = (
+  field: MappedField,
+  rangeTypename: string,
+): Resolver => {
+  return (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    if (!values?.length) {
+      return [];
+    }
+    return values
+      .filter((v) => v.kind === "blank")
+      .map((v) => {
+        const blank = v as { triples: TripleSet };
+        return {
+          uri: null,
+          typename: resolveEmbeddedTypename(blank.triples, rangeTypename, ctx),
+          triples: blank.triples,
+        } satisfies EntityValue;
+      });
+  };
+};
+
+/**
+ * Create a Template 6 resolver (embedded singular field): materializes the
+ * parent's first blank-node child as an EntityValue with uri: null.
+ */
+export const createEmbeddedSingularResolver = (
+  field: MappedField,
+  rangeTypename: string,
+): Resolver => {
+  return (parent, _args, ctx) => {
+    const values = parent.triples.get(field.propertyUri);
+    const v = values?.find((value) => value.kind === "blank");
+    if (!v || v.kind !== "blank") {
+      return null;
+    }
+    return {
+      uri: null,
+      typename: resolveEmbeddedTypename(v.triples, rangeTypename, ctx),
+      triples: v.triples,
+    } satisfies EntityValue;
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/resolver/types.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/types.ts
@@ -1,0 +1,42 @@
+// =============================================================================
+// Shared types for the resolver domain: the Relay connection value shapes
+// every resolver template returns, the pagination argument contract, and the
+// scalar names the coercion helpers target. Grouped here because the
+// connection helpers, the resolver templates, and the compiler's Relay
+// wiring all exchange these shapes.
+// =============================================================================
+
+/** The four Relay pagination arguments accepted by connection fields. */
+export interface ConnectionArgs {
+  first?: number | null;
+  after?: string | null;
+  last?: number | null;
+  before?: string | null;
+}
+
+/** A Relay connection page: edges with cursors plus pageInfo. */
+export interface Connection<T> {
+  edges: Array<{ node: T; cursor: string }>;
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+}
+
+/** Anything carrying the URI identity used for cursor encoding and sorting. */
+export interface Sortable {
+  uri: string | null;
+}
+
+/** A paginated window over a URI list, computed before entity hydration. */
+export interface UriPage {
+  /** The page's URIs, in cursor domain (prefixed form). */
+  window: string[];
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+/** The GraphQL scalar names a literal can be coerced to. */
+export type ScalarName = "String" | "Boolean" | "Int" | "Float";


### PR DESCRIPTION
> PR 2 of the `@canonical/ke-graphql` delivery stack (umbrella #658). **Stacked on #667** (foundation) — review/merge that first. Next up: tbox + execution, then the compiler passes, `/http`, CLI, demo.

## Done

The **resolution layer** — how compiled fields fetch and shape data from the store:

- **`dataloader` domain:** batched DataLoaders over the triple store — the entity loader (one CONSTRUCT per batch, including the blank-node closure), the inverse-assertion loader (reverse `owl:inverseOf` lookups), and the class-listing loader (name-sorted instances per class) — plus the URI ↔ prefixed-name helpers. Failed batches evict their keys so errors are never memoized.
- **`resolver` domain:** the eight field-resolver templates (scalar, scalar-list, object, object-list, inverse, embedded singular/list), literal→scalar coercion, and the Relay cursor-connection helpers. Connections **paginate before hydrating** — a nested `authors(first: 10)` loads 10 entities, not all of them.

Extends the library barrel with the dataloader + resolver public surface (`toFull`/`toPrefixed`, the connection helpers). Both domains depend only on `shared` + `hardening` from #667 — a clean seam with no forward references.

## QA

```bash
cd packages/runtime/ke-graphql && bun run check && bun run test
```
biome + `tsc` + webarchitect green; **104 tests, 100/100/100/100 coverage** (threshold enforced). The colocated unit tests cover every loader/resolver code path directly — blank-node subject/object set creation and reuse, the class name-predicate vs `rdfs:label` fallback, and empty hydrated pages — so this layer hits 100% on its own unit tests without the integration suite (which lands with the compiler).

### PR readiness check

- [x] Label: `Feature 🎁`.
- [x] Conventional Commits title.
- [x] [Code standards](https://github.com/canonical/web-code-standards): `src/lib/{domain}` layout, per-domain barrels, `#`-subpath cross-domain imports, colocated name-matched unit tests.
- [x] Scripts present (unchanged from #667).
- [x] `no visual change`.

## Screenshots

No visual change — runtime package, no UI.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_