### PR TITLE
feat(ke-graphql): compiler extract + build passes (OWL → IR)

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/compiler/build.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.test.ts
@@ -1,0 +1,639 @@
+// =============================================================================
+// Pass 2 — Build unit tests. Crafted RawExtraction inputs drive the branches
+// the fixture pipeline does not reach: subClassOf cycles, every resolveRange
+// arm, the sh:or merge corners, asymmetric inverse completion, domainless
+// assignment, and standard-vocab namespace filtering.
+// =============================================================================
+
+import { describe, expect, it } from "vitest";
+import {
+  type RawExtraction,
+  type RawProperty,
+  type RawShaclConstraint,
+  XSD,
+} from "#shared";
+import build from "./build.js";
+
+const NS = "http://example.org/";
+const uri = (local: string) => `${NS}${local}`;
+
+/** A RawExtraction with empty defaults; spread in only the parts under test. */
+const makeExtraction = (
+  partial: Partial<RawExtraction> = {},
+): RawExtraction => ({
+  classes: [],
+  properties: [],
+  inverses: [],
+  functionals: new Set(),
+  datatypes: [],
+  namespaces: new Map([[NS, "ex"]]),
+  shaclConstraints: [],
+  unions: [],
+  instanceStats: new Map(),
+  selfReferential: new Set(),
+  functionalViolations: new Set(),
+  undeclaredPredicates: new Set(),
+  annotations: new Map(),
+  deepBlankNesting: false,
+  ...partial,
+});
+
+const datatypeProp = (
+  local: string,
+  overrides: Partial<RawProperty> = {},
+): RawProperty => ({
+  uri: uri(local),
+  kind: "datatype",
+  domains: [uri("Thing")],
+  ranges: [`${XSD}string`],
+  ...overrides,
+});
+
+describe("build — class graph", () => {
+  it("detects a subClassOf cycle and emits B001 with an empty ancestor set", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B")] },
+        { uri: uri("B"), superclasses: [uri("A")] },
+      ],
+    });
+    const { output, diagnostics } = build(extraction);
+    expect(diagnostics.map((d) => d.code)).toContain("B001");
+    // The cycle short-circuits the recursion so the stack never overflows;
+    // each class still records its direct parent as an ancestor.
+    expect(output.classes.get(uri("A"))?.ancestors).toContain(uri("B"));
+    expect(output.classes.get(uri("B"))?.ancestors).toContain(uri("A"));
+  });
+
+  it("dedupes a diamond hierarchy's shared ancestor", () => {
+    // A → {B, C}; both B and C → D. D must appear once in A's closure.
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B"), uri("C")] },
+        { uri: uri("B"), superclasses: [uri("D")] },
+        { uri: uri("C"), superclasses: [uri("D")] },
+        { uri: uri("D"), superclasses: [] },
+      ],
+    });
+    const { output } = build(extraction);
+    const ancestors = output.classes.get(uri("A"))?.ancestors ?? [];
+    expect(ancestors.filter((a) => a === uri("D"))).toHaveLength(1);
+    expect([...ancestors].sort()).toEqual([uri("B"), uri("C"), uri("D")]);
+  });
+
+  it("dedupes a directly-repeated superclass", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B"), uri("B")] },
+        { uri: uri("B"), superclasses: [] },
+      ],
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("A"))?.ancestors).toEqual([uri("B")]);
+  });
+
+  it("skips cross-vocabulary superclasses missing from the class map", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("Missing"), uri("B")] },
+        { uri: uri("B"), superclasses: [] },
+      ],
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("A"))?.ancestors).toEqual([uri("B")]);
+  });
+});
+
+describe("build — abstract and embeddable detection", () => {
+  it("marks a class with no instances and subclasses abstract", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Base"), superclasses: [] },
+        { uri: uri("Leaf"), superclasses: [uri("Base")] },
+      ],
+      instanceStats: new Map([[uri("Leaf"), { total: 1, named: 1 }]]),
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Base"))?.isAbstract).toBe(true);
+    expect(output.classes.get(uri("Leaf"))?.isAbstract).toBe(false);
+  });
+
+  it("marks a blank-only class embeddable", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Embed"), superclasses: [] }],
+      instanceStats: new Map([[uri("Embed"), { total: 2, named: 0 }]]),
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Embed"))?.embeddable).toBe(true);
+  });
+
+  it("honors custom abstract/embeddable mapping overrides", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      instanceStats: new Map([[uri("Thing"), { total: 3, named: 3 }]]),
+    });
+    const { output } = build(extraction, {
+      "ex:Thing": { abstract: true, embeddable: true },
+    });
+    expect(output.classes.get(uri("Thing"))?.isAbstract).toBe(true);
+    expect(output.classes.get(uri("Thing"))?.embeddable).toBe(true);
+  });
+});
+
+describe("build — resolveRange", () => {
+  const classes = [{ uri: uri("Thing"), superclasses: [] }];
+
+  it("resolves an anonymous range union by property", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("rel", { kind: "object", ranges: [] })],
+      unions: [{ property: uri("rel"), members: [uri("Thing")] }],
+    });
+    const { output } = build(extraction);
+    expect(output.properties.get(uri("rel"))?.range).toEqual({
+      kind: "union",
+      members: [uri("Thing")],
+    });
+  });
+
+  it("falls back to String when a property has no declared range", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("loose", { ranges: [] })],
+    });
+    expect(output(extraction, "loose").range).toEqual({
+      kind: "scalar",
+      xsd: `${XSD}string`,
+      graphqlScalar: "String",
+    });
+  });
+
+  it("resolves a custom datatype to its declared base scalar", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("v", { ranges: [uri("Version")] })],
+      datatypes: [{ uri: uri("Version"), baseType: `${XSD}integer` }],
+    });
+    expect(output(extraction, "v").range).toEqual({
+      kind: "scalar",
+      xsd: `${XSD}integer`,
+      graphqlScalar: "Int",
+      customDatatype: uri("Version"),
+    });
+  });
+
+  it("defaults a custom datatype with no base type to String", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("v", { ranges: [uri("Opaque")] })],
+      datatypes: [{ uri: uri("Opaque") }],
+    });
+    expect(output(extraction, "v").range).toEqual({
+      kind: "scalar",
+      xsd: `${XSD}string`,
+      graphqlScalar: "String",
+      customDatatype: uri("Opaque"),
+    });
+  });
+
+  it("maps a custom datatype with a non-scalar base to String", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("v", { ranges: [uri("Weird")] })],
+      // base type is not in the XSD scalar table → falls back to String.
+      datatypes: [{ uri: uri("Weird"), baseType: uri("CustomBase") }],
+    });
+    expect(output(extraction, "v").range).toEqual({
+      kind: "scalar",
+      xsd: uri("CustomBase"),
+      graphqlScalar: "String",
+      customDatatype: uri("Weird"),
+    });
+  });
+
+  it("resolves a named union range", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Thing"), superclasses: [] },
+        { uri: uri("Other"), superclasses: [] },
+      ],
+      properties: [datatypeProp("u", { kind: "object", ranges: [uri("MyU")] })],
+      unions: [{ uri: uri("MyU"), members: [uri("Thing"), uri("Other")] }],
+    });
+    expect(output(extraction, "u").range).toEqual({
+      kind: "union",
+      name: "MyU",
+      members: [uri("Thing"), uri("Other")],
+    });
+  });
+
+  it("resolves a class range", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Thing"), superclasses: [] },
+        { uri: uri("Target"), superclasses: [] },
+      ],
+      properties: [
+        datatypeProp("rel", { kind: "object", ranges: [uri("Target")] }),
+      ],
+    });
+    expect(output(extraction, "rel").range).toEqual({
+      kind: "class",
+      uri: uri("Target"),
+    });
+  });
+
+  it("falls back to unknown for an unresolvable range", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [
+        datatypeProp("rel", { kind: "object", ranges: [uri("Nowhere")] }),
+      ],
+    });
+    expect(output(extraction, "rel").range).toEqual({
+      kind: "unknown",
+      raw: uri("Nowhere"),
+    });
+  });
+
+  /** Helper: build and return the resolved PropertyNode for a local name. */
+  function output(extraction: RawExtraction, local: string) {
+    const prop = build(extraction).output.properties.get(uri(local));
+    if (!prop) {
+      throw new Error(`property ${local} missing`);
+    }
+    return prop;
+  }
+});
+
+describe("build — SHACL cardinality merge", () => {
+  /** Build with one class, one object property, and the given constraints. */
+  const withConstraints = (constraints: RawShaclConstraint[]) =>
+    build(
+      makeExtraction({
+        classes: [
+          { uri: uri("C"), superclasses: [] },
+          { uri: uri("Target"), superclasses: [] },
+        ],
+        properties: [
+          {
+            uri: uri("rel"),
+            kind: "object",
+            domains: [uri("C")],
+            ranges: [uri("Target")],
+          },
+        ],
+        instanceStats: new Map([[uri("C"), { total: 1, named: 1 }]]),
+        shaclConstraints: constraints,
+      }),
+    )
+      .output.properties.get(uri("rel"))
+      ?.classCardinality.get(uri("C"));
+
+  it("intersects a direct maxCount with a finite sh:or branch max", () => {
+    const card = withConstraints([
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 1,
+        maxCount: 2,
+      },
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        maxCount: 3,
+        fromOr: true,
+      },
+    ]);
+    // direct max 2, branch max 3 → most permissive across alternatives = 3.
+    expect(card?.singular).toBe(false);
+    // the unconstrained branch (min 0) lowers the merged minimum below 1.
+    expect(card?.required).toBe(false);
+  });
+
+  it("merges multiple direct constraints, intersecting their min and max counts", () => {
+    // Two direct constraints on the same property exercise the merge loop's
+    // second iteration, where the running min/max counts are already set.
+    const card = withConstraints([
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 1,
+        maxCount: 5,
+      },
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 2,
+        maxCount: 3,
+      },
+    ]);
+    // max of the minimums (2) and min of the maximums (3).
+    expect(card?.required).toBe(true);
+    expect(card?.singular).toBe(false);
+  });
+
+  it("applies a direct minCount-only constraint, leaving the max unbounded", () => {
+    // A direct constraint with minCount but no maxCount takes the false arm of
+    // the maxCount guard — required, but not singular.
+    const card = withConstraints([
+      { targetClass: uri("C"), property: uri("rel"), minCount: 1 },
+    ]);
+    expect(card?.required).toBe(true);
+    expect(card?.singular).toBe(false);
+  });
+
+  it("skips constraints belonging to a different property", () => {
+    // Two object properties; only ex:rel carries a constraint. The merge loop
+    // must skip the ex:other key when resolving ex:rel.
+    const { output } = build(
+      makeExtraction({
+        classes: [
+          { uri: uri("C"), superclasses: [] },
+          { uri: uri("Target"), superclasses: [] },
+        ],
+        properties: [
+          {
+            uri: uri("rel"),
+            kind: "object",
+            domains: [uri("C")],
+            ranges: [uri("Target")],
+          },
+          {
+            uri: uri("other"),
+            kind: "object",
+            domains: [uri("C")],
+            ranges: [uri("Target")],
+          },
+        ],
+        shaclConstraints: [
+          { targetClass: uri("C"), property: uri("other"), maxCount: 1 },
+        ],
+      }),
+    );
+    expect(output.properties.get(uri("rel"))?.classCardinality.size).toBe(0);
+    expect(
+      output.properties.get(uri("other"))?.classCardinality.get(uri("C"))
+        ?.singular,
+    ).toBe(true);
+  });
+
+  it("treats a direct maxCount with an unbounded sh:or branch as unbounded", () => {
+    const card = withConstraints([
+      { targetClass: uri("C"), property: uri("rel"), maxCount: 2 },
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 1,
+        fromOr: true,
+      },
+    ]);
+    // branch has no maxCount (unbounded) → keeps the direct max, stays 2;
+    // its minCount 1 makes the merged constraint required.
+    expect(card?.singular).toBe(false);
+    expect(card?.required).toBe(true);
+  });
+
+  it("keeps a finite-only sh:or branch maxCount when no direct max exists", () => {
+    const card = withConstraints([
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        maxCount: 1,
+        fromOr: true,
+      },
+    ]);
+    expect(card?.singular).toBe(true);
+  });
+
+  it("leaves cardinality unbounded when every sh:or branch is unbounded", () => {
+    const card = withConstraints([
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 1,
+        fromOr: true,
+      },
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 0,
+        fromOr: true,
+      },
+    ]);
+    expect(card?.singular).toBe(false);
+    expect(card?.required).toBe(false);
+  });
+
+  it("skips a constraint whose targetClass is empty", () => {
+    const card = withConstraints([
+      { targetClass: "", property: uri("rel"), maxCount: 1, fromOr: true },
+    ]);
+    // No per-class entry is written for an empty target, but the singular
+    // signal still folds into the property default.
+    expect(card).toBeUndefined();
+    const prop = build(
+      makeExtraction({
+        classes: [{ uri: uri("C"), superclasses: [] }],
+        properties: [
+          {
+            uri: uri("rel"),
+            kind: "object",
+            domains: [uri("C")],
+            ranges: [],
+          },
+        ],
+        shaclConstraints: [
+          { targetClass: "", property: uri("rel"), maxCount: 1, fromOr: true },
+        ],
+      }),
+    ).output.properties.get(uri("rel"));
+    expect(prop?.functional).toBe(true);
+  });
+});
+
+describe("build — inverse pairs", () => {
+  it("auto-completes an asymmetric inverse declaration", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Parent"), superclasses: [] },
+        { uri: uri("Child"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("hasChild"),
+          kind: "object",
+          domains: [uri("Parent")],
+          ranges: [uri("Child")],
+        },
+        {
+          uri: uri("childOf"),
+          kind: "object",
+          domains: [uri("Child")],
+          ranges: [uri("Parent")],
+        },
+      ],
+      inverses: [{ property: uri("hasChild"), inverse: uri("childOf") }],
+    });
+    const { output } = build(extraction);
+    expect(output.properties.get(uri("hasChild"))?.inverse).toBe(
+      uri("childOf"),
+    );
+    // Reverse side completed even though only the forward direction declared it.
+    expect(output.properties.get(uri("childOf"))?.inverse).toBe(
+      uri("hasChild"),
+    );
+  });
+
+  it("ignores inverse declarations referencing unknown properties", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Parent"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("hasChild"),
+          kind: "object",
+          domains: [uri("Parent")],
+          ranges: [],
+        },
+      ],
+      inverses: [{ property: uri("ghost"), inverse: uri("phantom") }],
+    });
+    const { output } = build(extraction);
+    expect(output.properties.get(uri("hasChild"))?.inverse).toBeUndefined();
+  });
+});
+
+describe("build — property assignment", () => {
+  it("skips a property domain that is not a known class", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      properties: [
+        datatypeProp("p", { domains: [uri("Ghost"), uri("Thing")] }),
+      ],
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Thing"))?.ownProperties).toContain(uri("p"));
+  });
+
+  it("assigns a domainless property to same-namespace classes only", () => {
+    const OTHER = "http://other.test/";
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Foo"), superclasses: [] },
+        { uri: uri("Bar"), superclasses: [] },
+        { uri: `${OTHER}Far`, superclasses: [] },
+      ],
+      properties: [datatypeProp("desc", { domains: [] })],
+      namespaces: new Map([
+        [NS, "ex"],
+        [OTHER, "other"],
+      ]),
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Foo"))?.ownProperties).toContain(
+      uri("desc"),
+    );
+    expect(output.classes.get(uri("Bar"))?.ownProperties).toContain(
+      uri("desc"),
+    );
+    // A class in a different namespace does not receive the domainless property.
+    expect(output.classes.get(`${OTHER}Far`)?.ownProperties).not.toContain(
+      uri("desc"),
+    );
+  });
+
+  it("inherits an ancestor's property onto a subclass", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Base"), superclasses: [] },
+        { uri: uri("Leaf"), superclasses: [uri("Base")] },
+      ],
+      properties: [datatypeProp("p", { domains: [uri("Base")] })],
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Leaf"))?.ownProperties).not.toContain(
+      uri("p"),
+    );
+    expect(output.classes.get(uri("Leaf"))?.allProperties).toContain(uri("p"));
+  });
+
+  it("dedupes an inherited property already declared on the subclass domain", () => {
+    // ex:p has both Base and Leaf as domains; Leaf also inherits it from Base.
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Base"), superclasses: [] },
+        { uri: uri("Leaf"), superclasses: [uri("Base")] },
+      ],
+      properties: [datatypeProp("p", { domains: [uri("Base"), uri("Leaf")] })],
+    });
+    const { output } = build(extraction);
+    const all = output.classes.get(uri("Leaf"))?.allProperties ?? [];
+    expect(all.filter((p) => p === uri("p"))).toHaveLength(1);
+  });
+});
+
+describe("build — namespaces", () => {
+  it("excludes standard-vocabulary namespaces from the inventory", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      namespaces: new Map([
+        [NS, "ex"],
+        ["http://www.w3.org/2000/01/rdf-schema#", "rdfs"],
+      ]),
+    });
+    const { output } = build(extraction);
+    expect(output.namespaces.has("ex")).toBe(true);
+    expect(output.namespaces.has("rdfs")).toBe(false);
+  });
+
+  it("falls back to an empty prefix for an unregistered namespace", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: "http://other.test/Thing", superclasses: [] }],
+      namespaces: new Map(),
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get("http://other.test/Thing")?.namespace).toBe("");
+  });
+});
+
+describe("build — custom mapping resolution", () => {
+  it("resolves a mapping keyed by prefixed name", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      properties: [datatypeProp("p", { ranges: [`${XSD}string`] })],
+    });
+    const { output } = build(extraction, { "ex:p": { singular: false } });
+    // datatype properties default singular; the prefixed mapping flips it.
+    expect(output.properties.get(uri("p"))?.functional).toBe(false);
+  });
+
+  it("resolves a mapping keyed by full IRI", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      properties: [datatypeProp("p", { ranges: [`${XSD}string`] })],
+    });
+    const { output } = build(extraction, { [uri("p")]: { singular: false } });
+    expect(output.properties.get(uri("p"))?.functional).toBe(false);
+  });
+});
+
+describe("build — annotation properties", () => {
+  it("routes annotation properties to the TBox, not class fields", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      properties: [
+        datatypeProp("note", { kind: "annotation", domains: [uri("Thing")] }),
+        datatypeProp("name", { domains: [uri("Thing")] }),
+      ],
+      annotations: new Map([[uri("name"), new Map([[uri("note"), "hi"]])]]),
+    });
+    const { output } = build(extraction);
+    const own = output.classes.get(uri("Thing"))?.ownProperties ?? [];
+    expect(own).toContain(uri("name"));
+    expect(own).not.toContain(uri("note"));
+    // The annotation value is attached to the targeted property node.
+    expect(
+      output.properties.get(uri("name"))?.annotations.get(uri("note")),
+    ).toBe("hi");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/build.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.ts
@@ -1,0 +1,388 @@
+// =============================================================================
+// Pass 2 — Build: RawExtraction → OntologyIR
+//
+// Pure. Constructs the typed class/property graph: transitive superclass
+// closure (with cycle detection), subclass inversion, abstract detection from
+// the Pass 1 instance stats, range resolution, SHACL cardinality (including
+// sh:or most-permissive merging), inverse pair symmetry, and property
+// inheritance.
+// =============================================================================
+
+import {
+  type CardinalitySpec,
+  type ClassNode,
+  type Diagnostic,
+  getLocalName,
+  type NamespaceInfo,
+  type OntologyIR,
+  type PassResult,
+  type PropertyNode,
+  type RangeSpec,
+  type RawExtraction,
+  type RawShaclConstraint,
+  type RawUnion,
+  XSD,
+  XSD_SCALARS,
+} from "#shared";
+import getNamespace from "./getNamespace.js";
+import isStandardVocab from "./isStandardVocab.js";
+import type { CustomMappings } from "./types.js";
+
+const PHASE = "build";
+
+/**
+ * Merge SHACL constraints for one (class, property) pair. Plain constraints
+ * intersect (most specific wins); sh:or branches union to the most
+ * permissive interpretation across alternatives.
+ */
+const mergeConstraints = (
+  constraints: RawShaclConstraint[],
+): { singular: boolean; required: boolean; omit: boolean } => {
+  const direct = constraints.filter((c) => !c.fromOr);
+  const branches = constraints.filter((c) => c.fromOr);
+
+  let minCount: number | undefined;
+  let maxCount: number | undefined;
+  for (const c of direct) {
+    if (c.minCount !== undefined) {
+      minCount = Math.max(minCount ?? 0, c.minCount);
+    }
+    if (c.maxCount !== undefined) {
+      maxCount = Math.min(maxCount ?? Number.POSITIVE_INFINITY, c.maxCount);
+    }
+  }
+  if (branches.length > 0) {
+    // Most permissive across branches: min of minCounts, max of maxCounts.
+    const branchMin = Math.min(...branches.map((c) => c.minCount ?? 0));
+    const branchMax = Math.max(
+      ...branches.map((c) => c.maxCount ?? Number.POSITIVE_INFINITY),
+    );
+    minCount = Math.min(minCount ?? branchMin, branchMin);
+    maxCount =
+      maxCount === undefined
+        ? branchMax === Number.POSITIVE_INFINITY
+          ? undefined
+          : branchMax
+        : Math.max(
+            maxCount,
+            branchMax === Number.POSITIVE_INFINITY ? maxCount : branchMax,
+          );
+  }
+
+  return {
+    singular: maxCount === 1,
+    required: (minCount ?? 0) >= 1,
+    omit: maxCount === 0,
+  };
+};
+
+/**
+ * Build the typed OntologyIR from a RawExtraction (Pass 2): class graph
+ * with ancestor closure and cycle detection (B001), abstract/embeddable
+ * detection, range resolution, SHACL cardinality merging, inverse-pair
+ * completion, and property inheritance. Pure.
+ */
+export default function build(
+  extraction: RawExtraction,
+  mappings: CustomMappings = {},
+): PassResult<OntologyIR> {
+  const diagnostics: Diagnostic[] = [];
+  const getPrefix = (uri: string): string =>
+    extraction.namespaces.get(getNamespace(uri)) ?? "";
+
+  // Custom mappings may be keyed by prefixed name (ds:tier) or full IRI.
+  const prefixedToFull = new Map<string, string>();
+  for (const [ns, prefix] of extraction.namespaces) {
+    prefixedToFull.set(prefix, ns);
+  }
+  const findMapping = (uri: string) => {
+    const direct = mappings[uri];
+    if (direct) {
+      return direct;
+    }
+    const prefix = getPrefix(uri);
+    return prefix ? mappings[`${prefix}:${getLocalName(uri)}`] : undefined;
+  };
+
+  // ── 1. class map ──
+  const classes = new Map<string, ClassNode>();
+  const rawSuperclasses = new Map<string, string[]>();
+  for (const raw of extraction.classes) {
+    rawSuperclasses.set(raw.uri, raw.superclasses);
+    classes.set(raw.uri, {
+      uri: raw.uri,
+      label: raw.label ?? getLocalName(raw.uri),
+      definition: raw.definition,
+      namespace: getPrefix(raw.uri),
+      superclasses: raw.superclasses,
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [],
+      allProperties: [],
+    });
+  }
+
+  // ── 2. transitive closure with cycle detection (B001) ──
+  const ancestorCache = new Map<string, string[]>();
+  const computeAncestors = (uri: string, trail: string[]): string[] => {
+    const cached = ancestorCache.get(uri);
+    if (cached) {
+      return cached;
+    }
+    if (trail.includes(uri)) {
+      diagnostics.push({
+        severity: "error",
+        code: "B001",
+        message: `subClassOf cycle: ${[...trail, uri].map(getLocalName).join(" → ")}`,
+        source: uri,
+        phase: PHASE,
+      });
+      return [];
+    }
+    const result: string[] = [];
+    /* v8 ignore next -- every uri reaching here is a known class, so it always has a rawSuperclasses entry; the empty-array fallback is unreachable */
+    for (const parent of rawSuperclasses.get(uri) ?? []) {
+      if (!classes.has(parent)) {
+        continue; // cross-vocabulary parents handled in Pass 3 (V009)
+      }
+      if (!result.includes(parent)) {
+        result.push(parent);
+      }
+      for (const ancestor of computeAncestors(parent, [...trail, uri])) {
+        if (!result.includes(ancestor)) {
+          result.push(ancestor);
+        }
+      }
+    }
+    ancestorCache.set(uri, result);
+    return result;
+  };
+
+  for (const node of classes.values()) {
+    const ancestors = computeAncestors(node.uri, []);
+    classes.set(node.uri, { ...node, ancestors });
+  }
+
+  // ── 3. invert subclass relationships ──
+  const subclassesOf = new Map<string, string[]>();
+  for (const node of classes.values()) {
+    for (const parent of node.superclasses) {
+      if (!classes.has(parent)) {
+        continue;
+      }
+      const children = subclassesOf.get(parent) ?? [];
+      children.push(node.uri);
+      subclassesOf.set(parent, children);
+    }
+  }
+
+  // ── 4. abstract + embeddable detection from instance stats ──
+  for (const node of classes.values()) {
+    const stats = extraction.instanceStats.get(node.uri);
+    const subclasses = subclassesOf.get(node.uri) ?? [];
+    const mapping = findMapping(node.uri);
+    const isAbstract =
+      mapping?.abstract ?? ((stats?.total ?? 0) === 0 && subclasses.length > 0);
+    // Embeddable: instances exist and none are named, or forced by mapping.
+    const embeddable =
+      mapping?.embeddable ??
+      (stats !== undefined && stats.total > 0 && stats.named === 0);
+    /* v8 ignore next -- node.uri was populated with its ancestors in the prior closure pass and is still present in the map, so the empty-array fallback is unreachable */
+    const ancestors = classes.get(node.uri)?.ancestors ?? [];
+    classes.set(node.uri, {
+      ...node,
+      ancestors,
+      subclasses,
+      isAbstract,
+      embeddable,
+    });
+  }
+
+  // ── 5. property map with range resolution ──
+  const datatypeByUri = new Map(extraction.datatypes.map((d) => [d.uri, d]));
+  const namedUnionByUri = new Map<string, RawUnion>();
+  const anonUnionByProperty = new Map<string, RawUnion>();
+  for (const union of extraction.unions) {
+    if (union.uri) {
+      namedUnionByUri.set(union.uri, union);
+    }
+    if (union.property) {
+      anonUnionByProperty.set(union.property, union);
+    }
+  }
+
+  const resolveRange = (propertyUri: string, ranges: string[]): RangeSpec => {
+    const anon = anonUnionByProperty.get(propertyUri);
+    if (anon) {
+      return { kind: "union", members: anon.members };
+    }
+    const range = ranges[0];
+    if (!range) {
+      // No declared range — safety net: treat as String.
+      return { kind: "scalar", xsd: `${XSD}string`, graphqlScalar: "String" };
+    }
+    const scalar = XSD_SCALARS[range];
+    if (scalar) {
+      return { kind: "scalar", xsd: range, graphqlScalar: scalar };
+    }
+    const custom = datatypeByUri.get(range);
+    if (custom) {
+      const base = custom.baseType ?? `${XSD}string`;
+      return {
+        kind: "scalar",
+        xsd: base,
+        graphqlScalar: XSD_SCALARS[base] ?? "String",
+        customDatatype: range,
+      };
+    }
+    const namedUnion = namedUnionByUri.get(range);
+    if (namedUnion) {
+      return {
+        kind: "union",
+        name: getLocalName(range),
+        members: namedUnion.members,
+      };
+    }
+    if (classes.has(range)) {
+      return { kind: "class", uri: range };
+    }
+    return { kind: "unknown", raw: range };
+  };
+
+  // ── 5a. SHACL cardinality per (class, property) ──
+  const constraintsByPair = new Map<string, RawShaclConstraint[]>();
+  for (const constraint of extraction.shaclConstraints) {
+    const key = `${constraint.targetClass} ${constraint.property}`;
+    const list = constraintsByPair.get(key) ?? [];
+    list.push(constraint);
+    constraintsByPair.set(key, list);
+  }
+
+  const properties = new Map<string, PropertyNode>();
+  for (const raw of extraction.properties) {
+    const classCardinality = new Map<string, CardinalitySpec>();
+    let shaclSingularAnywhere = false;
+    for (const [key, constraints] of constraintsByPair) {
+      const [targetClass, property] = key.split(" ");
+      if (property !== raw.uri) {
+        continue;
+      }
+      const merged = mergeConstraints(constraints);
+      shaclSingularAnywhere ||= merged.singular;
+      if (!targetClass) {
+        continue;
+      }
+      classCardinality.set(targetClass, {
+        singular: merged.singular,
+        required: merged.required,
+        omit: merged.omit,
+        source: "shacl",
+      });
+    }
+
+    // Cardinality precedence: custom > owl:FunctionalProperty > owl:cardinality
+    // (not present in current ontologies) > SHACL maxCount 1 > kind default.
+    // Datatype properties default to SINGULAR (multi-valued literals are the
+    // exception in RDF practice); only object properties default to list.
+    const mapping = findMapping(raw.uri);
+    const functional =
+      mapping?.singular ??
+      (extraction.functionals.has(raw.uri) ||
+        shaclSingularAnywhere ||
+        raw.kind !== "object");
+
+    properties.set(raw.uri, {
+      uri: raw.uri,
+      label: raw.label ?? getLocalName(raw.uri),
+      definition: raw.definition,
+      namespace: getPrefix(raw.uri),
+      kind: raw.kind,
+      domains: raw.domains,
+      range: resolveRange(raw.uri, raw.ranges),
+      functional,
+      classCardinality,
+      isAnnotation: raw.kind === "annotation",
+      annotations: extraction.annotations.get(raw.uri) ?? new Map(),
+    });
+  }
+
+  // ── 6. inverse pairs with symmetry verification (V003 in Pass 3) ──
+  for (const { property, inverse } of extraction.inverses) {
+    const forward = properties.get(property);
+    if (forward) {
+      properties.set(property, { ...forward, inverse });
+    }
+    const backward = properties.get(inverse);
+    if (backward && backward.inverse === undefined) {
+      // Auto-complete asymmetric declarations; Pass 3 reports V003.
+      properties.set(inverse, { ...backward, inverse: property });
+    }
+  }
+
+  // ── 7+8. assign properties to classes, compute inheritance ──
+  const ownProperties = new Map<string, string[]>();
+  for (const property of properties.values()) {
+    if (property.isAnnotation) {
+      continue; // annotation properties route to the TBox schema
+    }
+    for (const domain of property.domains) {
+      if (!classes.has(domain)) {
+        continue; // unknown domains reported in Pass 3 (B002)
+      }
+      const list = ownProperties.get(domain) ?? [];
+      list.push(property.uri);
+      ownProperties.set(domain, list);
+    }
+    if (property.domains.length === 0) {
+      // Domainless: assign to every class in the property's namespace.
+      for (const node of classes.values()) {
+        if (node.namespace === property.namespace) {
+          const list = ownProperties.get(node.uri) ?? [];
+          list.push(property.uri);
+          ownProperties.set(node.uri, list);
+        }
+      }
+    }
+  }
+
+  for (const node of classes.values()) {
+    const own = ownProperties.get(node.uri) ?? [];
+    const all = [...own];
+    for (const ancestor of node.ancestors) {
+      for (const inherited of ownProperties.get(ancestor) ?? []) {
+        if (!all.includes(inherited)) {
+          all.push(inherited);
+        }
+      }
+    }
+    classes.set(node.uri, {
+      ...node,
+      ownProperties: own,
+      allProperties: all,
+    });
+  }
+
+  // ── namespaces ──
+  const namespaces = new Map<string, NamespaceInfo>();
+  for (const [uri, prefix] of extraction.namespaces) {
+    if (isStandardVocab(uri)) {
+      continue;
+    }
+    namespaces.set(prefix, {
+      prefix,
+      uri,
+      classCount: [...classes.values()].filter((c) => c.namespace === prefix)
+        .length,
+      propertyCount: [...properties.values()].filter(
+        (p) => p.namespace === prefix,
+      ).length,
+    });
+  }
+
+  return {
+    output: { classes, properties, namespaces, extraction },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/constants.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/constants.ts
@@ -1,0 +1,80 @@
+// =============================================================================
+// Compiler-only constants: the vocabulary IRIs and the artifact version used
+// solely inside the seven-pass pipeline. The dependency-free vocabulary base
+// shared across domains (namespace IRIs, rdf:type, rdfs:label, the XSD scalar
+// table, reserved names, connection args) lives in the shared leaf — imported
+// here to derive these compiler-internal IRIs without duplicating literals.
+//
+// Compiler queries use absolute IRIs so they work regardless of which prefixes
+// the consumer registered on the store.
+// =============================================================================
+
+import { OWL, RDF, RDFS, SH, SKOS, XSD } from "#shared";
+
+/** rdf:Property class IRI. */
+export const RDF_PROPERTY = `${RDF}Property`;
+/** rdf:first list predicate IRI. */
+export const RDF_FIRST = `${RDF}first`;
+/** rdf:rest list predicate IRI. */
+export const RDF_REST = `${RDF}rest`;
+/** rdf:nil list terminator IRI. */
+export const RDF_NIL = `${RDF}nil`;
+
+/** rdfs:comment predicate IRI. */
+export const RDFS_COMMENT = `${RDFS}comment`;
+/** rdfs:subClassOf predicate IRI. */
+export const RDFS_SUBCLASS_OF = `${RDFS}subClassOf`;
+/** rdfs:domain predicate IRI. */
+export const RDFS_DOMAIN = `${RDFS}domain`;
+/** rdfs:range predicate IRI. */
+export const RDFS_RANGE = `${RDFS}range`;
+/** rdfs:Datatype class IRI. */
+export const RDFS_DATATYPE = `${RDFS}Datatype`;
+
+/** owl:Class class IRI. */
+export const OWL_CLASS = `${OWL}Class`;
+/** owl:ObjectProperty class IRI. */
+export const OWL_OBJECT_PROPERTY = `${OWL}ObjectProperty`;
+/** owl:DatatypeProperty class IRI. */
+export const OWL_DATATYPE_PROPERTY = `${OWL}DatatypeProperty`;
+/** owl:AnnotationProperty class IRI. */
+export const OWL_ANNOTATION_PROPERTY = `${OWL}AnnotationProperty`;
+/** owl:FunctionalProperty class IRI. */
+export const OWL_FUNCTIONAL_PROPERTY = `${OWL}FunctionalProperty`;
+/** owl:inverseOf predicate IRI. */
+export const OWL_INVERSE_OF = `${OWL}inverseOf`;
+/** owl:unionOf predicate IRI. */
+export const OWL_UNION_OF = `${OWL}unionOf`;
+/** owl:onDatatype predicate IRI (custom datatype restriction base). */
+export const OWL_ON_DATATYPE = `${OWL}onDatatype`;
+/** owl:withRestrictions predicate IRI (custom datatype facet list). */
+export const OWL_WITH_RESTRICTIONS = `${OWL}withRestrictions`;
+
+/** skos:definition predicate IRI. */
+export const SKOS_DEFINITION = `${SKOS}definition`;
+
+/** sh:NodeShape class IRI. */
+export const SH_NODE_SHAPE = `${SH}NodeShape`;
+/** sh:targetClass predicate IRI. */
+export const SH_TARGET_CLASS = `${SH}targetClass`;
+/** sh:property predicate IRI. */
+export const SH_PROPERTY = `${SH}property`;
+/** sh:path predicate IRI. */
+export const SH_PATH = `${SH}path`;
+/** sh:minCount predicate IRI. */
+export const SH_MIN_COUNT = `${SH}minCount`;
+/** sh:maxCount predicate IRI. */
+export const SH_MAX_COUNT = `${SH}maxCount`;
+/** sh:or predicate IRI. */
+export const SH_OR = `${SH}or`;
+/** sh:in predicate IRI. */
+export const SH_IN = `${SH}in`;
+
+/** xsd:pattern facet IRI (custom datatype restrictions). */
+export const XSD_PATTERN = `${XSD}pattern`;
+
+/**
+ * Extraction artifact format version. Bumped on any breaking change to the
+ * serialized shape; deserialization rejects mismatched artifacts.
+ */
+export const ARTIFACT_VERSION = 1;

--- a/packages/runtime/ke-graphql/src/lib/compiler/createStoreQueryFn.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/createStoreQueryFn.ts
@@ -1,0 +1,13 @@
+import type { SPARQL, Store } from "@canonical/ke";
+import type { QueryFn } from "#shared";
+
+/**
+ * Adapt a ke Store to the QueryFn surface (string → branded SPARQL), for
+ * compiling directly against a store instead of a plugin context.
+ *
+ * @note Impure — the returned function executes SPARQL queries against the
+ * store.
+ */
+export default function createStoreQueryFn(store: Store): QueryFn {
+  return (query) => store.query(query as SPARQL<string>);
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/extract.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/extract.test.ts
@@ -1,0 +1,531 @@
+// =============================================================================
+// Pass 1 — Extract unit tests. The only pass that touches the store, so it is
+// exercised two ways: a real fixture store for the happy path, and a crafted
+// QueryFn (the pass's sole dependency) for the term-shape guards and the
+// SPARQL failure modes a valid store cannot reproduce.
+// =============================================================================
+
+import type { QueryResult, SelectResult, Term } from "@canonical/ke";
+import { createTestStore } from "@canonical/ke/testing";
+import { afterEach, describe, expect, it } from "vitest";
+import { createStoreQueryFn } from "#compiler";
+import type { QueryFn } from "#shared";
+import { MINIMAL_TTL, PREFIXES } from "#testing";
+import extract from "./extract.js";
+
+const OWL = "http://www.w3.org/2002/07/owl#";
+const RDFS = "http://www.w3.org/2000/01/rdf-schema#";
+const XSD = "http://www.w3.org/2001/XMLSchema#";
+const EX = "http://example.org/";
+
+const named = (value: string): Term => ({ termType: "NamedNode", value });
+const literal = (
+  value: string,
+  extra: { datatype?: string; language?: string } = {},
+): Term => ({ termType: "Literal", value, ...extra });
+const blank = (value: string): Term => ({ termType: "BlankNode", value });
+
+const select = (rows: Record<string, Term>[]): SelectResult => ({
+  type: "select",
+  variables: rows[0] ? Object.keys(rows[0]) : [],
+  bindings: [],
+  termBindings: rows,
+});
+
+const EMPTY = select([]);
+
+/** A query result keyed by a fragment that uniquely identifies one query. */
+type Routes = Array<[fragment: string, result: QueryResult | (() => never)]>;
+
+/**
+ * Build a QueryFn that returns EMPTY for every query unless a route fragment
+ * matches; a function route throws (to exercise the select/catch paths).
+ */
+const router =
+  (routes: Routes): QueryFn =>
+  async (query: string) => {
+    for (const [fragment, result] of routes) {
+      if (query.includes(fragment)) {
+        if (typeof result === "function") {
+          return result();
+        }
+        return result;
+      }
+    }
+    return EMPTY;
+  };
+
+const NO_PREFIXES: Record<string, string> = {};
+
+describe("extract — real fixture store", () => {
+  let cleanup: (() => void) | undefined;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it("extracts classes, properties, namespaces, and stats end to end", async () => {
+    const store = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+    });
+    cleanup = store.cleanup;
+    const { output, diagnostics } = await extract(
+      createStoreQueryFn(store.store),
+      PREFIXES,
+    );
+    expect(output.classes.map((c) => c.uri)).toContain(`${EX}Thing`);
+    const thing = output.classes.find((c) => c.uri === `${EX}Thing`);
+    expect(thing?.label).toBe("Thing");
+    expect(thing?.definition).toBe("A concrete thing.");
+    expect(output.properties.map((p) => p.uri).sort()).toEqual([
+      `${EX}count`,
+      `${EX}name`,
+    ]);
+    expect(output.namespaces.get(EX)).toBe("ex");
+    expect(output.instanceStats.get(`${EX}Thing`)).toEqual({
+      total: 1,
+      named: 1,
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+describe("extract — select failure modes", () => {
+  it("emits E001 when a SELECT returns a non-select result", async () => {
+    const query = router([
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        { type: "ask", result: true },
+      ],
+    ]);
+    const { output, diagnostics } = await extract(query, PREFIXES);
+    expect(output.classes).toEqual([]);
+    const e001 = diagnostics.find(
+      (d) => d.code === "E001" && d.message.includes("expected SELECT"),
+    );
+    expect(e001?.severity).toBe("error");
+  });
+
+  it("emits E001 when a query throws", async () => {
+    const query = router([
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        () => {
+          throw new Error("boom");
+        },
+      ],
+    ]);
+    const { diagnostics } = await extract(query, PREFIXES);
+    expect(
+      diagnostics.some((d) => d.code === "E001" && d.message.includes("boom")),
+    ).toBe(true);
+  });
+
+  it("stringifies a non-Error thrown value", async () => {
+    const query: QueryFn = async (q: string) => {
+      if (q.includes("?class ?label ?definition ?comment ?superclass")) {
+        throw "plain string failure";
+      }
+      return EMPTY;
+    };
+    const { diagnostics } = await extract(query, PREFIXES);
+    expect(
+      diagnostics.some((d) => d.message.includes("plain string failure")),
+    ).toBe(true);
+  });
+});
+
+describe("extract — class rows", () => {
+  it("skips standard-vocabulary classes and collects superclasses once", async () => {
+    const query = router([
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        select([
+          // standard-vocab class is skipped
+          { class: named(`${OWL}Thing`) },
+          // non-NamedNode class is skipped
+          { class: blank("_:x") },
+          // comment used as the definition fallback; superclass deduped
+          {
+            class: named(`${EX}A`),
+            comment: literal("from comment"),
+            superclass: named(`${EX}Base`),
+          },
+          { class: named(`${EX}A`), superclass: named(`${EX}Base`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.classes).toHaveLength(1);
+    const a = output.classes[0];
+    expect(a?.uri).toBe(`${EX}A`);
+    expect(a?.definition).toBe("from comment");
+    expect(a?.superclasses).toEqual([`${EX}Base`]);
+  });
+});
+
+describe("extract — property rows", () => {
+  it("skips standard-vocab properties and resolves each kind", async () => {
+    const query = router([
+      [
+        "?prop ?kind ?label ?definition ?comment ?domain ?range",
+        select([
+          {
+            prop: named(`${RDFS}label`),
+            kind: named(`${OWL}DatatypeProperty`),
+          },
+          {
+            prop: named(`${EX}d`),
+            kind: named(`${OWL}DatatypeProperty`),
+            domain: named(`${EX}C`),
+            range: named(`${XSD}string`),
+          },
+          { prop: named(`${EX}a`), kind: named(`${OWL}AnnotationProperty`) },
+          { prop: named(`${EX}o`), kind: named(`${OWL}ObjectProperty`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const byUri = new Map(output.properties.map((p) => [p.uri, p]));
+    expect(byUri.has(`${RDFS}label`)).toBe(false);
+    expect(byUri.get(`${EX}d`)?.kind).toBe("datatype");
+    expect(byUri.get(`${EX}a`)?.kind).toBe("annotation");
+    expect(byUri.get(`${EX}o`)?.kind).toBe("object");
+    expect(byUri.get(`${EX}d`)?.domains).toEqual([`${EX}C`]);
+  });
+});
+
+describe("extract — inverses (Q3)", () => {
+  it("keeps fully-bound inverse pairs and drops partial rows", async () => {
+    const query = router([
+      [
+        "?prop ?inverse WHERE",
+        select([
+          { prop: named(`${EX}hasChild`), inverse: named(`${EX}childOf`) },
+          { prop: named(`${EX}lonely`) }, // missing inverse → dropped
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.inverses).toEqual([
+      { property: `${EX}hasChild`, inverse: `${EX}childOf` },
+    ]);
+  });
+});
+
+describe("extract — self-referential predicates (Q10)", () => {
+  it("collects named self-referential predicates and skips non-named rows", async () => {
+    const query = router([
+      [
+        "{ ?s ?p ?s }",
+        select([
+          { p: named(`${EX}extends`) },
+          { p: blank("_:anon") }, // non-NamedNode → skipped
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.selfReferential.has(`${EX}extends`)).toBe(true);
+    expect(output.selfReferential.size).toBe(1);
+  });
+});
+
+describe("extract — datatypes", () => {
+  it("skips standard-vocab datatypes", async () => {
+    const query = router([
+      [
+        "?dt ?base ?pattern",
+        select([
+          { dt: named(`${XSD}custom`), base: named(`${XSD}string`) },
+          {
+            dt: named(`${EX}Version`),
+            base: named(`${XSD}string`),
+            pattern: literal("\\d+"),
+          },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.datatypes).toHaveLength(1);
+    expect(output.datatypes[0]).toEqual({
+      uri: `${EX}Version`,
+      baseType: `${XSD}string`,
+      pattern: "\\d+",
+    });
+  });
+});
+
+describe("extract — namespace discovery", () => {
+  it("assigns a synthetic prefix and warns for an unregistered namespace", async () => {
+    const query = router([
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        select([{ class: named("http://unregistered.test/Foo") }]),
+      ],
+    ]);
+    // Pass an empty prefix map so the discovered namespace has no prefix.
+    const { output, diagnostics } = await extract(query, NO_PREFIXES);
+    expect(output.namespaces.get("http://unregistered.test/")).toBe("ns");
+    expect(
+      diagnostics.some(
+        (d) =>
+          d.severity === "warning" &&
+          d.message.includes("no registered prefix"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("extract — SHACL direct constraints", () => {
+  it("resolves sh:in values, skips guard rows, attaches inValues", async () => {
+    const query = router([
+      [
+        "?targetClass ?path ?minCount ?maxCount ?inList",
+        select([
+          // guard: missing path is skipped
+          { targetClass: named(`${EX}C`) },
+          {
+            targetClass: named(`${EX}C`),
+            path: named(`${EX}mode`),
+            minCount: literal("1"),
+            maxCount: literal("not-a-number"),
+            inList: named("_:list"),
+          },
+        ]),
+      ],
+      [
+        "?path ?value WHERE",
+        select([
+          // guard: missing path skipped
+          { value: literal("x") },
+          // guard: value neither literal nor NamedNode (blank) skipped
+          { path: named(`${EX}mode`), value: blank("_:b") },
+          { path: named(`${EX}mode`), value: literal("fast") },
+          { path: named(`${EX}mode`), value: named(`${EX}slow`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.shaclConstraints).toHaveLength(1);
+    const c = output.shaclConstraints[0];
+    expect(c?.minCount).toBe(1);
+    // non-numeric maxCount parses to undefined
+    expect(c?.maxCount).toBeUndefined();
+    expect(c?.inValues).toEqual(["fast", `${EX}slow`]);
+  });
+
+  it("omits inValues when no sh:in list is present", async () => {
+    const query = router([
+      [
+        "?targetClass ?path ?minCount ?maxCount ?inList",
+        select([{ targetClass: named(`${EX}C`), path: named(`${EX}p`) }]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.shaclConstraints[0]?.inValues).toBeUndefined();
+  });
+});
+
+describe("extract — SHACL sh:or branches", () => {
+  it("flags sh:or constraints and skips guard rows", async () => {
+    const query = router([
+      [
+        "?targetClass ?path ?minCount ?maxCount WHERE",
+        select([
+          { targetClass: named(`${EX}C`) }, // missing path → skipped
+          {
+            targetClass: named(`${EX}C`),
+            path: named(`${EX}hop`),
+            maxCount: literal("1"),
+          },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const fromOr = output.shaclConstraints.filter((c) => c.fromOr);
+    expect(fromOr).toHaveLength(1);
+    expect(fromOr[0]?.property).toBe(`${EX}hop`);
+  });
+});
+
+describe("extract — unions", () => {
+  it("collects named unions and skips member guard rows", async () => {
+    const query = router([
+      [
+        "?class ?member",
+        select([
+          { class: named(`${EX}U`) }, // missing member → skipped
+          { class: named(`${EX}U`), member: named(`${EX}A`) },
+          { class: named(`${EX}U`), member: named(`${EX}B`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const named1 = output.unions.find((u) => u.uri === `${EX}U`);
+    expect(named1?.members).toEqual([`${EX}A`, `${EX}B`]);
+  });
+
+  it("collects anonymous range unions and skips member guard rows", async () => {
+    const query = router([
+      [
+        "?property ?member",
+        select([
+          { member: named(`${EX}A`) }, // missing property → skipped
+          { property: named(`${EX}rel`), member: named(`${EX}A`) },
+          { property: named(`${EX}rel`), member: named(`${EX}B`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const anon = output.unions.find((u) => u.property === `${EX}rel`);
+    expect(anon?.members).toEqual([`${EX}A`, `${EX}B`]);
+  });
+});
+
+describe("extract — instance stats", () => {
+  it("skips rows with an unparseable total", async () => {
+    const query = router([
+      [
+        "(COUNT(?i) AS ?total)",
+        select([
+          { class: named(`${EX}A`), total: literal("oops") }, // skipped
+          { class: named(`${EX}B`), total: literal("3"), named: literal("2") },
+          // named missing → defaults to 0
+          { class: named(`${EX}C`), total: literal("1") },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.instanceStats.has(`${EX}A`)).toBe(false);
+    expect(output.instanceStats.get(`${EX}B`)).toEqual({ total: 3, named: 2 });
+    expect(output.instanceStats.get(`${EX}C`)).toEqual({ total: 1, named: 0 });
+  });
+});
+
+describe("extract — functional violations (Q11)", () => {
+  it("queries violations only when functional properties exist", async () => {
+    const query = router([
+      [
+        "<http://www.w3.org/2002/07/owl#FunctionalProperty> }",
+        select([
+          { prop: named(`${EX}rank`) },
+          { prop: blank("_:anon") }, // non-NamedNode → dropped from the set
+        ]),
+      ],
+      [
+        "?o1 != ?o2",
+        select([
+          { p: named(`${EX}rank`) },
+          { p: blank("_:anon") }, // non-NamedNode → not recorded
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.functionals.has(`${EX}rank`)).toBe(true);
+    expect(output.functionals.size).toBe(1);
+    expect(output.functionalViolations.has(`${EX}rank`)).toBe(true);
+    expect(output.functionalViolations.size).toBe(1);
+  });
+});
+
+describe("extract — undeclared predicates (Q12)", () => {
+  it("flags predicates in a known namespace that are missing from the TBox", async () => {
+    const query = router([
+      [
+        "SELECT DISTINCT ?p WHERE { ?s ?p ?o }",
+        select([
+          { p: named(`${EX}undeclared`) }, // in ex namespace, not a property
+          { p: named(`${RDFS}label`) }, // standard vocab → skipped
+          { p: blank("_:anon") }, // non-NamedNode → skipped
+          { p: named("http://foreign.test/pred") }, // unknown namespace → skipped
+        ]),
+      ],
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        select([{ class: named(`${EX}Thing`) }]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.undeclaredPredicates.has(`${EX}undeclared`)).toBe(true);
+    expect(output.undeclaredPredicates.has(`${RDFS}label`)).toBe(false);
+    expect(output.undeclaredPredicates.has("http://foreign.test/pred")).toBe(
+      false,
+    );
+    expect(output.undeclaredPredicates.size).toBe(1);
+  });
+});
+
+describe("extract — annotation assertions", () => {
+  it("collects annotation values and skips non-literal guard rows", async () => {
+    const query = router([
+      [
+        "?prop ?kind ?label ?definition ?comment ?domain ?range",
+        select([
+          { prop: named(`${EX}note`), kind: named(`${OWL}AnnotationProperty`) },
+        ]),
+      ],
+      [
+        "?target ?prop ?value",
+        select([
+          // value is not a literal → skipped
+          {
+            target: named(`${EX}A`),
+            prop: named(`${EX}note`),
+            value: named(`${EX}X`),
+          },
+          {
+            target: named(`${EX}A`),
+            prop: named(`${EX}note`),
+            value: literal("hello"),
+          },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.annotations.get(`${EX}A`)?.get(`${EX}note`)).toBe("hello");
+  });
+});
+
+describe("extract — depth guard", () => {
+  it("warns when blank nodes nest deeper than one level", async () => {
+    const query = router([["ASK", { type: "ask", result: true }]]);
+    const { output, diagnostics } = await extract(query, PREFIXES);
+    expect(output.deepBlankNesting).toBe(true);
+    expect(
+      diagnostics.some(
+        (d) => d.severity === "warning" && d.message.includes("nest deeper"),
+      ),
+    ).toBe(true);
+  });
+
+  it("emits E001 when the depth-guard ASK throws", async () => {
+    const query: QueryFn = async (q: string) => {
+      if (q.startsWith("ASK")) {
+        throw new Error("ask failed");
+      }
+      return EMPTY;
+    };
+    const { output, diagnostics } = await extract(query, PREFIXES);
+    expect(output.deepBlankNesting).toBe(false);
+    expect(
+      diagnostics.some(
+        (d) =>
+          d.code === "E001" && d.message.includes("depth guard: ask failed"),
+      ),
+    ).toBe(true);
+  });
+
+  it("stringifies a non-Error thrown by the depth guard", async () => {
+    const query: QueryFn = async (q: string) => {
+      if (q.startsWith("ASK")) {
+        throw 42;
+      }
+      return EMPTY;
+    };
+    const { diagnostics } = await extract(query, PREFIXES);
+    expect(diagnostics.some((d) => d.message.includes("depth guard: 42"))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
@@ -1,0 +1,579 @@
+// =============================================================================
+// Pass 1 — Extract: ke store → RawExtraction
+//
+// The only pass that touches the store. Twelve SPARQL queries: eight TBox
+// queries plus four ABox probes that keep Passes 2–7 pure. Queries use
+// absolute IRIs so they are independent of registered prefixes, and consume
+// ke's term-preserving results (termBindings) so that NamedNodes, literals,
+// and blank nodes are distinguishable.
+// =============================================================================
+
+import type { SelectResult, Term } from "@canonical/ke";
+import {
+  type Diagnostic,
+  type InstanceStats,
+  type PassResult,
+  type QueryFn,
+  type RawClass,
+  type RawDatatype,
+  type RawExtraction,
+  type RawProperty,
+  type RawPropertyKind,
+  type RawShaclConstraint,
+  type RawUnion,
+  RDF_TYPE,
+  RDFS_LABEL,
+} from "#shared";
+import {
+  OWL_ANNOTATION_PROPERTY,
+  OWL_CLASS,
+  OWL_DATATYPE_PROPERTY,
+  OWL_FUNCTIONAL_PROPERTY,
+  OWL_INVERSE_OF,
+  OWL_OBJECT_PROPERTY,
+  OWL_ON_DATATYPE,
+  OWL_UNION_OF,
+  OWL_WITH_RESTRICTIONS,
+  RDF_FIRST,
+  RDF_REST,
+  RDFS_COMMENT,
+  RDFS_DOMAIN,
+  RDFS_RANGE,
+  RDFS_SUBCLASS_OF,
+  SH_IN,
+  SH_MAX_COUNT,
+  SH_MIN_COUNT,
+  SH_OR,
+  SH_PATH,
+  SH_PROPERTY,
+  SH_TARGET_CLASS,
+  SKOS_DEFINITION,
+  XSD_PATTERN,
+} from "./constants.js";
+import getNamespace from "./getNamespace.js";
+import isStandardVocab from "./isStandardVocab.js";
+
+const PHASE = "extract";
+
+/**
+ * Run a SELECT and return its term-preserving rows, or [] plus an E001
+ * diagnostic when the query fails or returns a non-SELECT result.
+ *
+ * @note Impure — executes a SPARQL query against the store through the
+ * provided query function.
+ */
+const select = async (
+  query: QueryFn,
+  sparqlText: string,
+  diagnostics: Diagnostic[],
+  label: string,
+): Promise<SelectResult["termBindings"]> => {
+  try {
+    const result = await query(sparqlText);
+    if (result.type !== "select") {
+      diagnostics.push({
+        severity: "error",
+        code: "E001",
+        message: `${label}: expected SELECT result, got ${result.type}`,
+        phase: PHASE,
+      });
+      return [];
+    }
+    return result.termBindings;
+  } catch (error) {
+    diagnostics.push({
+      severity: "error",
+      code: "E001",
+      message: `${label}: ${error instanceof Error ? error.message : String(error)}`,
+      phase: PHASE,
+    });
+    return [];
+  }
+};
+
+/** Get a term's IRI when it is a NamedNode, undefined otherwise. */
+const getNamedValue = (term: Term | undefined): string | undefined =>
+  term?.termType === "NamedNode" ? term.value : undefined;
+
+/** Get a term's lexical value when it is a Literal, undefined otherwise. */
+const getLiteralValue = (term: Term | undefined): string | undefined =>
+  term?.termType === "Literal" ? term.value : undefined;
+
+/** Get a literal term parsed as a base-10 integer, undefined when not parseable. */
+const getIntValue = (term: Term | undefined): number | undefined => {
+  const value = getLiteralValue(term);
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+/**
+ * Extract the TBox structure and ABox probes from a ke store as a
+ * RawExtraction (Pass 1) — the only pipeline step that queries the store.
+ *
+ * @note Impure — executes the twelve extraction SPARQL queries against the
+ * store through the provided query function.
+ */
+export default async function extract(
+  query: QueryFn,
+  prefixes: Readonly<Record<string, string>>,
+): Promise<PassResult<RawExtraction>> {
+  const diagnostics: Diagnostic[] = [];
+
+  // ── Q1: classes with labels, definitions, superclasses ──
+  // Blank-node superclasses (owl:Restriction) are excluded with isIRI.
+  const classRows = await select(
+    query,
+    `SELECT ?class ?label ?definition ?comment ?superclass WHERE {
+      ?class <${RDF_TYPE}> <${OWL_CLASS}> .
+      FILTER(isIRI(?class))
+      OPTIONAL { ?class <${RDFS_LABEL}> ?label }
+      OPTIONAL { ?class <${SKOS_DEFINITION}> ?definition }
+      OPTIONAL { ?class <${RDFS_COMMENT}> ?comment }
+      OPTIONAL { ?class <${RDFS_SUBCLASS_OF}> ?superclass . FILTER(isIRI(?superclass)) }
+    }`,
+    diagnostics,
+    "Q1 classes",
+  );
+
+  const classMap = new Map<string, RawClass>();
+  for (const row of classRows) {
+    const uri = getNamedValue(row.class);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = classMap.get(uri) ?? { uri, superclasses: [] };
+    entry.label ??= getLiteralValue(row.label);
+    entry.definition ??=
+      getLiteralValue(row.definition) ?? getLiteralValue(row.comment);
+    const superclass = getNamedValue(row.superclass);
+    if (superclass && !entry.superclasses.includes(superclass)) {
+      entry.superclasses.push(superclass);
+    }
+    classMap.set(uri, entry);
+  }
+
+  // ── Q2: properties with kind, domains, ranges ──
+  const propertyRows = await select(
+    query,
+    `SELECT ?prop ?kind ?label ?definition ?comment ?domain ?range WHERE {
+      ?prop <${RDF_TYPE}> ?kind .
+      VALUES ?kind { <${OWL_OBJECT_PROPERTY}> <${OWL_DATATYPE_PROPERTY}> <${OWL_ANNOTATION_PROPERTY}> }
+      OPTIONAL { ?prop <${RDFS_LABEL}> ?label }
+      OPTIONAL { ?prop <${SKOS_DEFINITION}> ?definition }
+      OPTIONAL { ?prop <${RDFS_COMMENT}> ?comment }
+      OPTIONAL { ?prop <${RDFS_DOMAIN}> ?domain }
+      OPTIONAL { ?prop <${RDFS_RANGE}> ?range . FILTER(isIRI(?range)) }
+    }`,
+    diagnostics,
+    "Q2 properties",
+  );
+
+  const resolveKind = (kindUri: string | undefined): RawPropertyKind => {
+    if (kindUri === OWL_DATATYPE_PROPERTY) {
+      return "datatype";
+    }
+    if (kindUri === OWL_ANNOTATION_PROPERTY) {
+      return "annotation";
+    }
+    return "object";
+  };
+
+  const propertyMap = new Map<string, RawProperty>();
+  for (const row of propertyRows) {
+    const uri = getNamedValue(row.prop);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = propertyMap.get(uri) ?? {
+      uri,
+      kind: resolveKind(getNamedValue(row.kind)),
+      domains: [],
+      ranges: [],
+    };
+    entry.label ??= getLiteralValue(row.label);
+    entry.definition ??=
+      getLiteralValue(row.definition) ?? getLiteralValue(row.comment);
+    const domain = getNamedValue(row.domain);
+    if (domain && !entry.domains.includes(domain)) {
+      entry.domains.push(domain);
+    }
+    const range = getNamedValue(row.range);
+    if (range && !entry.ranges.includes(range)) {
+      entry.ranges.push(range);
+    }
+    propertyMap.set(uri, entry);
+  }
+
+  // ── Q3: inverse declarations ──
+  const inverseRows = await select(
+    query,
+    `SELECT ?prop ?inverse WHERE { ?prop <${OWL_INVERSE_OF}> ?inverse }`,
+    diagnostics,
+    "Q3 inverses",
+  );
+  const inverses = inverseRows.flatMap((row) => {
+    const property = getNamedValue(row.prop);
+    const inverse = getNamedValue(row.inverse);
+    return property && inverse ? [{ property, inverse }] : [];
+  });
+
+  // ── Q4: functional property markers ──
+  const functionalRows = await select(
+    query,
+    `SELECT ?prop WHERE { ?prop <${RDF_TYPE}> <${OWL_FUNCTIONAL_PROPERTY}> }`,
+    diagnostics,
+    "Q4 functionals",
+  );
+  const functionals = new Set(
+    functionalRows.flatMap((row) => getNamedValue(row.prop) ?? []),
+  );
+
+  // ── Q5: custom datatypes ──
+  // Keyed on the structural marker owl:onDatatype rather than the rdf:type:
+  // the published cs: ontology types its datatype `a owl:Datatype` (a
+  // non-standard term) while ds: uses `a rdfs:Datatype` — the restriction
+  // structure is what actually identifies a custom datatype. The
+  // owl:withRestrictions RDF list is walked with rdf:rest*/rdf:first so a
+  // pattern facet is found at any list position.
+  const datatypeRows = await select(
+    query,
+    `SELECT ?dt ?base ?pattern WHERE {
+      ?dt <${OWL_ON_DATATYPE}> ?base .
+      FILTER(isIRI(?dt))
+      OPTIONAL {
+        ?dt <${OWL_WITH_RESTRICTIONS}> ?list .
+        ?list <${RDF_REST}>*/<${RDF_FIRST}> ?restriction .
+        ?restriction <${XSD_PATTERN}> ?pattern .
+      }
+    }`,
+    diagnostics,
+    "Q5 datatypes",
+  );
+  const datatypeMap = new Map<string, RawDatatype>();
+  for (const row of datatypeRows) {
+    const uri = getNamedValue(row.dt);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = datatypeMap.get(uri) ?? { uri };
+    entry.baseType ??= getNamedValue(row.base);
+    entry.pattern ??= getLiteralValue(row.pattern);
+    datatypeMap.set(uri, entry);
+  }
+
+  // ── Q6: namespace discovery (in code, from Q1+Q2, cross-referenced with
+  //        the store's registered prefixes) ──
+  const namespaces = new Map<string, string>();
+  const uriToPrefix = new Map<string, string>();
+  for (const [prefix, ns] of Object.entries(prefixes)) {
+    uriToPrefix.set(ns, prefix);
+  }
+  const discovered = new Set<string>();
+  for (const uri of [...classMap.keys(), ...propertyMap.keys()]) {
+    discovered.add(getNamespace(uri));
+  }
+  let anonymous = 0;
+  for (const ns of discovered) {
+    let prefix = uriToPrefix.get(ns);
+    if (!prefix) {
+      prefix = `ns${anonymous++ || ""}`;
+      diagnostics.push({
+        severity: "warning",
+        code: "E001",
+        message: `namespace ${ns} has no registered prefix — assigned synthetic "${prefix}". Register it in StoreConfig.prefixes: it drives the prefixed URIs used as Relay global IDs`,
+        source: ns,
+        phase: PHASE,
+      });
+    }
+    namespaces.set(ns, prefix);
+  }
+
+  // ── Q7a: direct SHACL cardinality constraints ──
+  const shaclConstraints: RawShaclConstraint[] = [];
+  const directShaclRows = await select(
+    query,
+    `SELECT ?targetClass ?path ?minCount ?maxCount ?inList WHERE {
+      ?shape <${SH_TARGET_CLASS}> ?targetClass ;
+             <${SH_PROPERTY}> ?propShape .
+      ?propShape <${SH_PATH}> ?path .
+      OPTIONAL { ?propShape <${SH_MIN_COUNT}> ?minCount }
+      OPTIONAL { ?propShape <${SH_MAX_COUNT}> ?maxCount }
+      OPTIONAL { ?propShape <${SH_IN}> ?inList }
+    }`,
+    diagnostics,
+    "Q7a shacl direct",
+  );
+
+  // sh:in values are an RDF list; resolve them per constraint.
+  const shIn = new Map<string, string[]>();
+  const inListRows = await select(
+    query,
+    `SELECT ?path ?value WHERE {
+      ?propShape <${SH_PATH}> ?path ;
+                 <${SH_IN}> ?list .
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?value .
+    }`,
+    diagnostics,
+    "Q7a sh:in values",
+  );
+  for (const row of inListRows) {
+    const path = getNamedValue(row.path);
+    const value = getLiteralValue(row.value) ?? getNamedValue(row.value);
+    if (!path || value === undefined) {
+      continue;
+    }
+    const values = shIn.get(path) ?? [];
+    values.push(value);
+    shIn.set(path, values);
+  }
+
+  for (const row of directShaclRows) {
+    const targetClass = getNamedValue(row.targetClass);
+    const path = getNamedValue(row.path);
+    if (!targetClass || !path) {
+      continue;
+    }
+    shaclConstraints.push({
+      targetClass,
+      property: path,
+      minCount: getIntValue(row.minCount),
+      maxCount: getIntValue(row.maxCount),
+      inValues: row.inList ? shIn.get(path) : undefined,
+    });
+  }
+
+  // ── Q7b: SHACL sh:or branches ──
+  // sh:or points at an RDF list of branch blank nodes; each branch carries
+  // its own sh:property shapes. The direct pattern in Q7a cannot see them.
+  const orShaclRows = await select(
+    query,
+    `SELECT ?targetClass ?path ?minCount ?maxCount WHERE {
+      ?shape <${SH_TARGET_CLASS}> ?targetClass ;
+             <${SH_OR}> ?orList .
+      ?orList <${RDF_REST}>*/<${RDF_FIRST}> ?branch .
+      ?branch <${SH_PROPERTY}> ?propShape .
+      ?propShape <${SH_PATH}> ?path .
+      OPTIONAL { ?propShape <${SH_MIN_COUNT}> ?minCount }
+      OPTIONAL { ?propShape <${SH_MAX_COUNT}> ?maxCount }
+    }`,
+    diagnostics,
+    "Q7b shacl sh:or",
+  );
+  for (const row of orShaclRows) {
+    const targetClass = getNamedValue(row.targetClass);
+    const path = getNamedValue(row.path);
+    if (!targetClass || !path) {
+      continue;
+    }
+    shaclConstraints.push({
+      targetClass,
+      property: path,
+      minCount: getIntValue(row.minCount),
+      maxCount: getIntValue(row.maxCount),
+      fromOr: true,
+    });
+  }
+
+  // ── Q8: union declarations (named classes and anonymous ranges) ──
+  const unions: RawUnion[] = [];
+  const namedUnionRows = await select(
+    query,
+    `SELECT ?class ?member WHERE {
+      ?class <${RDF_TYPE}> <${OWL_CLASS}> ;
+             <${OWL_UNION_OF}> ?list .
+      FILTER(isIRI(?class))
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?member .
+    }`,
+    diagnostics,
+    "Q8 named unions",
+  );
+  const namedUnions = new Map<string, string[]>();
+  for (const row of namedUnionRows) {
+    const uri = getNamedValue(row.class);
+    const member = getNamedValue(row.member);
+    if (!uri || !member) {
+      continue;
+    }
+    const members = namedUnions.get(uri) ?? [];
+    members.push(member);
+    namedUnions.set(uri, members);
+  }
+  for (const [uri, members] of namedUnions) {
+    unions.push({ uri, members });
+  }
+
+  const anonUnionRows = await select(
+    query,
+    `SELECT ?property ?member WHERE {
+      ?property <${RDFS_RANGE}> ?range .
+      FILTER(isBlank(?range))
+      ?range <${OWL_UNION_OF}> ?list .
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?member .
+    }`,
+    diagnostics,
+    "Q8 anonymous unions",
+  );
+  const anonUnions = new Map<string, string[]>();
+  for (const row of anonUnionRows) {
+    const property = getNamedValue(row.property);
+    const member = getNamedValue(row.member);
+    if (!property || !member) {
+      continue;
+    }
+    const members = anonUnions.get(property) ?? [];
+    members.push(member);
+    anonUnions.set(property, members);
+  }
+  for (const [property, members] of anonUnions) {
+    unions.push({ property, members });
+  }
+
+  // ── Q9: instance stats per class (abstract + embeddable detection) ──
+  const statsRows = await select(
+    query,
+    `SELECT ?class (COUNT(?i) AS ?total) (SUM(IF(isBlank(?i), 0, 1)) AS ?named) WHERE {
+      ?i <${RDF_TYPE}> ?class .
+    } GROUP BY ?class`,
+    diagnostics,
+    "Q9 instance stats",
+  );
+  const instanceStats = new Map<string, InstanceStats>();
+  for (const row of statsRows) {
+    const uri = getNamedValue(row.class);
+    const total = getIntValue(row.total);
+    if (!uri || total === undefined) {
+      continue;
+    }
+    instanceStats.set(uri, { total, named: getIntValue(row.named) ?? 0 });
+  }
+
+  // ── Q10: self-referential assertions (V004) ──
+  const selfRows = await select(
+    query,
+    `SELECT DISTINCT ?p WHERE { ?s ?p ?s }`,
+    diagnostics,
+    "Q10 self-referential",
+  );
+  const selfReferential = new Set(
+    selfRows.flatMap((row) => getNamedValue(row.p) ?? []),
+  );
+
+  // ── Q11: functional property violations (V005) ──
+  const functionalViolations = new Set<string>();
+  if (functionals.size > 0) {
+    const values = [...functionals].map((uri) => `<${uri}>`).join(" ");
+    const violationRows = await select(
+      query,
+      `SELECT DISTINCT ?p WHERE {
+        VALUES ?p { ${values} }
+        ?s ?p ?o1 , ?o2 .
+        FILTER(?o1 != ?o2)
+      }`,
+      diagnostics,
+      "Q11 functional violations",
+    );
+    for (const row of violationRows) {
+      const uri = getNamedValue(row.p);
+      if (uri) {
+        functionalViolations.add(uri);
+      }
+    }
+  }
+
+  // ── Q12: undeclared ABox predicates (V014) ──
+  const predicateRows = await select(
+    query,
+    `SELECT DISTINCT ?p WHERE { ?s ?p ?o }`,
+    diagnostics,
+    "Q12 predicates",
+  );
+  const undeclaredPredicates = new Set<string>();
+  for (const row of predicateRows) {
+    const uri = getNamedValue(row.p);
+    if (!uri || isStandardVocab(uri) || propertyMap.has(uri)) {
+      continue;
+    }
+    // Predicates inside a declared namespace but missing from the TBox.
+    if (namespaces.has(getNamespace(uri))) {
+      undeclaredPredicates.add(uri);
+    }
+  }
+
+  // ── Annotation assertions (acceptanceCriteria/completionGuidance).
+  //    Extracted so the TBox schema is fully store-free at request time. ──
+  const annotations = new Map<string, Map<string, string>>();
+  const annotationProps = [...propertyMap.values()]
+    .filter((prop) => prop.kind === "annotation")
+    .map((prop) => prop.uri);
+  if (annotationProps.length > 0) {
+    const values = annotationProps.map((uri) => `<${uri}>`).join(" ");
+    const rows = await select(
+      query,
+      `SELECT ?target ?prop ?value WHERE {
+        VALUES ?prop { ${values} }
+        ?target ?prop ?value .
+      }`,
+      diagnostics,
+      "annotation assertions",
+    );
+    for (const row of rows) {
+      const target = getNamedValue(row.target);
+      const prop = getNamedValue(row.prop);
+      const value = getLiteralValue(row.value);
+      if (!target || !prop || value === undefined) {
+        continue;
+      }
+      const forTarget = annotations.get(target) ?? new Map<string, string>();
+      forTarget.set(prop, value);
+      annotations.set(target, forTarget);
+    }
+  }
+
+  // ── Depth guard: blank nodes whose objects are themselves blank ──
+  let deepBlankNesting = false;
+  try {
+    const deep = await query(
+      `ASK { ?a ?p ?b . ?b ?q ?c . FILTER(isBlank(?b) && isBlank(?c)) }`,
+    );
+    deepBlankNesting = deep.type === "ask" && deep.result;
+    if (deepBlankNesting) {
+      diagnostics.push({
+        severity: "warning",
+        code: "E001",
+        message:
+          "blank nodes nest deeper than 1 level in the store — the entity loader's single-hop blank-node closure will truncate them; extend the closure depth",
+        phase: PHASE,
+      });
+    }
+  } catch (error) {
+    diagnostics.push({
+      severity: "error",
+      code: "E001",
+      message: `depth guard: ${error instanceof Error ? error.message : String(error)}`,
+      phase: PHASE,
+    });
+  }
+
+  return {
+    output: {
+      classes: [...classMap.values()],
+      properties: [...propertyMap.values()],
+      inverses,
+      functionals,
+      datatypes: [...datatypeMap.values()],
+      namespaces,
+      shaclConstraints,
+      unions,
+      instanceStats,
+      selfReferential,
+      functionalViolations,
+      undeclaredPredicates,
+      annotations,
+      deepBlankNesting,
+    },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/getNamespace.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/getNamespace.ts
@@ -1,0 +1,6 @@
+/** Extract the namespace part of a URI (up to and including the last '#' or '/'). */
+export default function getNamespace(uri: string): string {
+  const hash = uri.lastIndexOf("#");
+  const slash = uri.lastIndexOf("/");
+  return uri.slice(0, Math.max(hash, slash) + 1);
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/index.ts
@@ -1,0 +1,14 @@
+/**
+ * The OWL → GraphQL compiler domain. This layer carries the extraction pass
+ * (reading the ontology + instance data from the store into a raw extraction)
+ * and the OWL→IR build pass, plus the store query adapter and the compiler
+ * type contracts. The mapping and emission passes, the seven-pass
+ * orchestration, the per-request context factory, and the artifact codec are
+ * layered on top.
+ *
+ * @module compiler
+ */
+
+export type * from "#shared";
+export { default as createStoreQueryFn } from "./createStoreQueryFn.js";
+export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/compiler/isStandardVocab.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/isStandardVocab.ts
@@ -1,0 +1,9 @@
+import { STANDARD_NAMESPACES } from "#shared";
+
+/**
+ * Check whether a URI belongs to a standard vocabulary namespace
+ * (rdf/rdfs/owl/xsd/skos/sh) — such URIs never produce GraphQL types.
+ */
+export default function isStandardVocab(uri: string): boolean {
+  return STANDARD_NAMESPACES.some((ns) => uri.startsWith(ns));
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/types.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/types.ts
@@ -1,0 +1,167 @@
+// =============================================================================
+// @canonical/ke-graphql — Compiler API type contracts
+//
+// The options and result shapes of the seven-pass pipeline's public entry
+// points (compile, the schema plugin, the artifact codec). The IR/value/
+// context contracts these build on live in the shared leaf (#shared) and are
+// re-exported from the compiler barrel for the package's public surface.
+// =============================================================================
+
+import type { Store } from "@canonical/ke";
+import type { GraphQLFieldConfig, GraphQLSchema } from "graphql";
+import type {
+  CompilerContext,
+  Diagnostic,
+  InstanceStats,
+  MappedIR,
+  NameMap,
+  RawExtraction,
+  RuntimeWarningHandler,
+} from "#shared";
+import type { ARTIFACT_VERSION } from "./constants.js";
+
+/**
+ * The JSON shape of a serialized extraction artifact: RawExtraction with its
+ * Maps and Sets flattened to arrays, plus the artifact format version and
+ * the fingerprint of the TTL sources it was built from.
+ */
+export interface SerializedExtraction {
+  version: typeof ARTIFACT_VERSION;
+  /** Combined fingerprint of the TTL sources the extraction was built from. */
+  sourcesHash: string;
+  classes: RawExtraction["classes"];
+  properties: RawExtraction["properties"];
+  inverses: RawExtraction["inverses"];
+  functionals: string[];
+  datatypes: RawExtraction["datatypes"];
+  namespaces: Array<[string, string]>;
+  shaclConstraints: RawExtraction["shaclConstraints"];
+  unions: RawExtraction["unions"];
+  instanceStats: Array<[string, InstanceStats]>;
+  selfReferential: string[];
+  functionalViolations: string[];
+  undeclaredPredicates: string[];
+  annotations: Array<[string, Array<[string, string]>]>;
+  deepBlankNesting: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Per-URI override of the generated mapping (rename, cardinality, shape). */
+export interface CustomMapping {
+  graphqlName?: string;
+  singular?: boolean;
+  abstract?: boolean;
+  embeddable?: boolean;
+  /** Synthesize an inverse field on the property's range type. */
+  inverse?: { graphqlName: string };
+}
+
+/** Custom mappings keyed by full IRI or prefixed name (e.g. "ds:tier"). */
+export type CustomMappings = Record<string, CustomMapping>;
+
+/** Per GraphQL type name: the field names promoted to non-null. */
+export type NonNullOverrides = Record<string, string[]>;
+
+/** Consumer-supplied extension fields, keyed by GraphQL type name. */
+export interface SchemaExtensions {
+  [typeName: string]: Record<
+    string,
+    // biome-ignore lint/suspicious/noExplicitAny: graphql-js field configs are consumer-typed
+    GraphQLFieldConfig<any, CompilerContext>
+  >;
+}
+
+/**
+ * Extensions may need the compiler-generated types (e.g. an `anatomy` field
+ * typed as the generated Specification). The factory form receives a lookup
+ * for generated types and interfaces by name.
+ */
+export type SchemaExtensionsInput =
+  | SchemaExtensions
+  | ((types: {
+      type(name: string): import("graphql").GraphQLObjectType | undefined;
+      iface(name: string): import("graphql").GraphQLInterfaceType | undefined;
+    }) => SchemaExtensions);
+
+/** Options accepted by the schema plugin and the compile entry points. */
+export interface SchemaPluginOptions {
+  mappings?: CustomMappings;
+  extensions?: SchemaExtensionsInput;
+  /** Wire the Node interface, global IDs, and connections. Default: true. */
+  relay?: boolean;
+  /** Add @defer/@stream directives to the schema. Default: false. */
+  incremental?: boolean;
+  /** File path for SDL output. */
+  sdlOutput?: string;
+  nonNullOverrides?: NonNullOverrides;
+  /**
+   * Opt-in instance-level standard-vocabulary fields.
+   * Per GraphQL type name: predicate URI → field name.
+   */
+  standardVocabFields?: Record<string, Record<string, string>>;
+  /** Resolver-time warnings (coercion failures). Default: console.warn, deduplicated. */
+  onRuntimeWarning?: RuntimeWarningHandler;
+  /**
+   * DataLoader cache scope. "request" (default): fresh caches per
+   * createContext call. "process": LRU caches shared across contexts for the
+   * lifetime of this CompilerResult — sound because the store is immutable
+   * between reloads, and onReload produces a new result (auto-invalidation).
+   * Bounded (see processCacheSize) so enumeration can't grow them without
+   * limit; failed batches are evicted, never memoized.
+   */
+  loaderCache?: "request" | "process";
+  /**
+   * Maximum entries per process-lifetime loader cache (LRU), used only when
+   * loaderCache is "process". Default: DEFAULT_PROCESS_CACHE_SIZE.
+   */
+  processCacheSize?: number;
+}
+
+/** Everything a successful compilation produces: schema, SDL, IR, context factory. */
+export interface CompilerResult {
+  schema: GraphQLSchema;
+  diagnostics: Diagnostic[];
+  nameMap: NameMap;
+  /** Empty when compiled from an artifact with assumeValid (printSchema skipped). */
+  sdl: string;
+  mapped: MappedIR;
+  /** The Pass 1 output — serializable via serializeExtraction (artifact boots). */
+  extraction: RawExtraction;
+  /**
+   * Fresh DataLoaders per call ("request" mode) or shared caches
+   * ("process" mode). Accepts a Promise for lazy-store boots: TBox
+   * queries answer before the store resolves; ABox loaders await it.
+   */
+  createContext(store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearLoaderCache(): void;
+}
+
+/** The API surface the plugin registers on the ke store under "ke-graphql". */
+export interface SchemaPluginApi {
+  schema: GraphQLSchema;
+  diagnostics: Diagnostic[];
+  nameMap: NameMap;
+  sdl: string;
+  /**
+   * Create a fresh CompilerContext (new DataLoaders each call). Takes the
+   * store as an argument: ke's PluginContext is scoped to its lifecycle
+   * hook and must not be retained for request-time queries.
+   */
+  createContext(store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearLoaderCache(): void;
+}
+
+/**
+ * Creates a fresh CompilerContext per call and exposes cache control for the
+ * "process" loader-cache mode.
+ */
+export interface ContextFactory {
+  (store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearCache(): void;
+}


### PR DESCRIPTION
> PR 3 of the `@canonical/ke-graphql` delivery stack (umbrella #658). **Stacked on #668** (resolution layer). Next: the mapping/emission passes, then the compiler cluster (compose + tbox + execution + orchestration + integration suite), then `/http`, CLI, demo.

## Done

The first two compiler passes — **OWL/RDFS → typed intermediate representation**:

- **`extract` (pass 1):** reads the ontology + instance data from the triple store into a typed `RawExtraction` — classes and their superclasses, datatype/object properties with domains/ranges, SHACL constraints, annotation properties, and per-class instance statistics — emitting stable diagnostics for malformed input rather than throwing.
- **`build` (pass 2):** folds the raw extraction into the `OntologyIR` — transitive subclass closure, cardinality merge (direct constraints intersected with `sh:or` branch alternatives), domainless-property assignment across a namespace, and asymmetric `owl:inverseOf` completion.

Plus the store→`QueryFn` adapter (`createStoreQueryFn`), the compiler type contracts, and the vocabulary helpers (`getNamespace`, `isStandardVocab`). The compiler barrel is staged to the surface available so far; the mapping/emission passes and orchestration extend it.

## QA

```bash
cd packages/runtime/ke-graphql && bun run check && bun run test
```
biome + `tsc` + webarchitect green; **160 tests, 100/100/100/100** (threshold enforced). Both passes are unit-tested against hand-crafted extractions and a real test store — no dependency on the assembled compiler.

### PR readiness check

- [x] Label: `Feature 🎁`.
- [x] Conventional Commits title.
- [x] [Code standards](https://github.com/canonical/web-code-standards): `src/lib/{domain}` layout, per-domain barrel, `#`-subpath cross-domain imports, colocated name-matched unit tests.
- [x] Scripts present.
- [x] `no visual change`.

## Screenshots

No visual change — runtime package, no UI.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_