### PR TITLE
feat(ke-graphql): compiler cluster — orchestration, tbox, execution, plugin, integration

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import BidirectionalNameMap from "./BidirectionalNameMap.js";
+
+describe("BidirectionalNameMap", () => {
+  it("maps an OWL URI to a GraphQL name and back", () => {
+    const map = new BidirectionalNameMap();
+    map.set("http://ex.org/Component", "Component");
+    expect(map.toGraphQL("http://ex.org/Component")).toBe("Component");
+    expect(map.toOWL("Component")).toBe("http://ex.org/Component");
+  });
+
+  it("returns undefined for unknown URIs and names", () => {
+    const map = new BidirectionalNameMap();
+    expect(map.toGraphQL("http://ex.org/Missing")).toBeUndefined();
+    expect(map.toOWL("Missing")).toBeUndefined();
+  });
+
+  it("keeps the first writer for the reverse direction", () => {
+    const map = new BidirectionalNameMap();
+    map.set("http://ex.org/a", "name");
+    map.set("http://ex.org/b", "name");
+    // Forward direction follows the latest write for each URI...
+    expect(map.toGraphQL("http://ex.org/a")).toBe("name");
+    expect(map.toGraphQL("http://ex.org/b")).toBe("name");
+    // ...but the reverse keeps the first canonical OWL target.
+    expect(map.toOWL("name")).toBe("http://ex.org/a");
+  });
+
+  it("iterates every OWL URI / GraphQL name pair in insertion order", () => {
+    const map = new BidirectionalNameMap();
+    map.set("http://ex.org/A", "A");
+    map.set("http://ex.org/B", "B");
+    expect([...map.entries()]).toEqual([
+      ["http://ex.org/A", "A"],
+      ["http://ex.org/B", "B"],
+    ]);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.ts
@@ -1,0 +1,37 @@
+import type { NameMap } from "#shared";
+
+/**
+ * Bidirectional OWL URI ↔ GraphQL name map. Type names map globally; field
+ * names are scoped per type ("Component.tier") since the same property can
+ * surface on several types. For the reverse direction the first writer wins:
+ * a property mapped on several types keeps one canonical OWL target.
+ */
+export default class BidirectionalNameMap implements NameMap {
+  private readonly owlToGraphql = new Map<string, string>();
+  private readonly graphqlToOwl = new Map<string, string>();
+
+  /** Record a URI ↔ name pair (reverse direction: first writer wins). */
+  set(owlUri: string, graphqlName: string): void {
+    this.owlToGraphql.set(owlUri, graphqlName);
+    // First writer wins for the reverse direction: a property mapped on
+    // several types (inherited fields) keeps one canonical OWL target.
+    if (!this.graphqlToOwl.has(graphqlName)) {
+      this.graphqlToOwl.set(graphqlName, owlUri);
+    }
+  }
+
+  /** Look up the GraphQL name for an OWL URI. */
+  toGraphQL(uri: string): string | undefined {
+    return this.owlToGraphql.get(uri);
+  }
+
+  /** Look up the canonical OWL URI for a GraphQL name. */
+  toOWL(name: string): string | undefined {
+    return this.graphqlToOwl.get(name);
+  }
+
+  /** Iterate every (OWL URI, GraphQL name) pair. */
+  entries(): Iterable<[string, string]> {
+    return this.owlToGraphql.entries();
+  }
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/CompilationError.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/CompilationError.ts
@@ -1,0 +1,21 @@
+import type { Diagnostic } from "#shared";
+
+/**
+ * Thrown only when schema composition fails (C-series errors) — carries the
+ * full diagnostic list of the compilation, not just the fatal ones, so the
+ * consumer can report everything at once.
+ */
+export default class CompilationError extends Error {
+  readonly diagnostics: Diagnostic[];
+
+  constructor(diagnostics: Diagnostic[]) {
+    const errors = diagnostics.filter((d) => d.severity === "error");
+    super(
+      `ke-graphql: schema composition failed with ${errors.length} error(s):\n${errors
+        .map((d) => `  ${d.code}: ${d.message}`)
+        .join("\n")}`,
+    );
+    this.name = "CompilationError";
+    this.diagnostics = diagnostics;
+  }
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/artifact.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/artifact.ts
@@ -1,0 +1,113 @@
+// =============================================================================
+// The precompute artifact (Prisma-DMMF pattern): RawExtraction is the only
+// store-dependent pass output and is fully serializable. Build once with the
+// store; rebuild the executable schema anywhere in milliseconds — no Oxigraph,
+// no TTL parse, no SPARQL.
+//
+// `sourcesHash` keeps the artifact honest: it fingerprints the TTL inputs
+// (FNV-1a 64 — staleness detection, not security), and consumers fall back
+// to a live compile when it no longer matches the loaded sources.
+// =============================================================================
+
+import type { RawExtraction } from "#shared";
+import { ARTIFACT_VERSION } from "./constants.js";
+import type { SerializedExtraction } from "./types.js";
+
+/** FNV-1a 64-bit hash of a string. Deterministic, dependency-free, platform-free. */
+const hashFnv1a64 = (input: string, seed = 0xcbf29ce484222325n): bigint => {
+  const PRIME = 0x100000001b3n;
+  const MASK = 0xffffffffffffffffn;
+  let hash = seed;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= BigInt(input.charCodeAt(i));
+    hash = (hash * PRIME) & MASK;
+  }
+  return hash;
+};
+
+/**
+ * Fingerprint a set of source contents as a 16-character hex string
+ * (FNV-1a 64 — staleness detection, not security). Order-independent
+ * (sources are combined commutatively) so glob ordering differences don't
+ * churn the hash.
+ */
+export const hashSources = (contents: Iterable<string>): string => {
+  let combined = 0n;
+  for (const content of contents) {
+    combined ^= hashFnv1a64(content);
+  }
+  return combined.toString(16).padStart(16, "0");
+};
+
+/**
+ * Serialize a RawExtraction (plus the fingerprint of the sources it was
+ * built from) to the JSON artifact format — the input for artifact boots
+ * via compileFromExtraction.
+ */
+export const serializeExtraction = (
+  extraction: RawExtraction,
+  sourcesHash: string,
+): string =>
+  JSON.stringify(
+    {
+      version: ARTIFACT_VERSION,
+      sourcesHash,
+      classes: extraction.classes,
+      properties: extraction.properties,
+      inverses: extraction.inverses,
+      functionals: [...extraction.functionals],
+      datatypes: extraction.datatypes,
+      namespaces: [...extraction.namespaces],
+      shaclConstraints: extraction.shaclConstraints,
+      unions: extraction.unions,
+      instanceStats: [...extraction.instanceStats],
+      selfReferential: [...extraction.selfReferential],
+      functionalViolations: [...extraction.functionalViolations],
+      undeclaredPredicates: [...extraction.undeclaredPredicates],
+      annotations: [...extraction.annotations].map(([target, values]) => [
+        target,
+        [...values],
+      ]),
+      deepBlankNesting: extraction.deepBlankNesting,
+    } satisfies SerializedExtraction,
+    null,
+    0,
+  );
+
+/**
+ * Parse a serialized extraction artifact (JSON text or already-parsed
+ * object) back into a RawExtraction plus its sources fingerprint. Throws
+ * when the artifact's format version is not the supported one.
+ */
+export const deserializeExtraction = (
+  artifact: string | SerializedExtraction,
+): { extraction: RawExtraction; sourcesHash: string } => {
+  const parsed: SerializedExtraction =
+    typeof artifact === "string" ? JSON.parse(artifact) : artifact;
+  if (parsed.version !== ARTIFACT_VERSION) {
+    throw new Error(
+      `ke-graphql: extraction artifact version ${parsed.version} is not supported (expected ${ARTIFACT_VERSION}) — regenerate it`,
+    );
+  }
+  return {
+    sourcesHash: parsed.sourcesHash,
+    extraction: {
+      classes: parsed.classes,
+      properties: parsed.properties,
+      inverses: parsed.inverses,
+      functionals: new Set(parsed.functionals),
+      datatypes: parsed.datatypes,
+      namespaces: new Map(parsed.namespaces),
+      shaclConstraints: parsed.shaclConstraints,
+      unions: parsed.unions,
+      instanceStats: new Map(parsed.instanceStats),
+      selfReferential: new Set(parsed.selfReferential),
+      functionalViolations: new Set(parsed.functionalViolations),
+      undeclaredPredicates: new Set(parsed.undeclaredPredicates),
+      annotations: new Map(
+        parsed.annotations.map(([target, values]) => [target, new Map(values)]),
+      ),
+      deepBlankNesting: parsed.deepBlankNesting,
+    },
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/compiler/build.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.test.ts
@@ -1,0 +1,639 @@
+// =============================================================================
+// Pass 2 — Build unit tests. Crafted RawExtraction inputs drive the branches
+// the fixture pipeline does not reach: subClassOf cycles, every resolveRange
+// arm, the sh:or merge corners, asymmetric inverse completion, domainless
+// assignment, and standard-vocab namespace filtering.
+// =============================================================================
+
+import { describe, expect, it } from "vitest";
+import {
+  type RawExtraction,
+  type RawProperty,
+  type RawShaclConstraint,
+  XSD,
+} from "#shared";
+import build from "./build.js";
+
+const NS = "http://example.org/";
+const uri = (local: string) => `${NS}${local}`;
+
+/** A RawExtraction with empty defaults; spread in only the parts under test. */
+const makeExtraction = (
+  partial: Partial<RawExtraction> = {},
+): RawExtraction => ({
+  classes: [],
+  properties: [],
+  inverses: [],
+  functionals: new Set(),
+  datatypes: [],
+  namespaces: new Map([[NS, "ex"]]),
+  shaclConstraints: [],
+  unions: [],
+  instanceStats: new Map(),
+  selfReferential: new Set(),
+  functionalViolations: new Set(),
+  undeclaredPredicates: new Set(),
+  annotations: new Map(),
+  deepBlankNesting: false,
+  ...partial,
+});
+
+const datatypeProp = (
+  local: string,
+  overrides: Partial<RawProperty> = {},
+): RawProperty => ({
+  uri: uri(local),
+  kind: "datatype",
+  domains: [uri("Thing")],
+  ranges: [`${XSD}string`],
+  ...overrides,
+});
+
+describe("build — class graph", () => {
+  it("detects a subClassOf cycle and emits B001 with an empty ancestor set", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B")] },
+        { uri: uri("B"), superclasses: [uri("A")] },
+      ],
+    });
+    const { output, diagnostics } = build(extraction);
+    expect(diagnostics.map((d) => d.code)).toContain("B001");
+    // The cycle short-circuits the recursion so the stack never overflows;
+    // each class still records its direct parent as an ancestor.
+    expect(output.classes.get(uri("A"))?.ancestors).toContain(uri("B"));
+    expect(output.classes.get(uri("B"))?.ancestors).toContain(uri("A"));
+  });
+
+  it("dedupes a diamond hierarchy's shared ancestor", () => {
+    // A → {B, C}; both B and C → D. D must appear once in A's closure.
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B"), uri("C")] },
+        { uri: uri("B"), superclasses: [uri("D")] },
+        { uri: uri("C"), superclasses: [uri("D")] },
+        { uri: uri("D"), superclasses: [] },
+      ],
+    });
+    const { output } = build(extraction);
+    const ancestors = output.classes.get(uri("A"))?.ancestors ?? [];
+    expect(ancestors.filter((a) => a === uri("D"))).toHaveLength(1);
+    expect([...ancestors].sort()).toEqual([uri("B"), uri("C"), uri("D")]);
+  });
+
+  it("dedupes a directly-repeated superclass", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B"), uri("B")] },
+        { uri: uri("B"), superclasses: [] },
+      ],
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("A"))?.ancestors).toEqual([uri("B")]);
+  });
+
+  it("skips cross-vocabulary superclasses missing from the class map", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("Missing"), uri("B")] },
+        { uri: uri("B"), superclasses: [] },
+      ],
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("A"))?.ancestors).toEqual([uri("B")]);
+  });
+});
+
+describe("build — abstract and embeddable detection", () => {
+  it("marks a class with no instances and subclasses abstract", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Base"), superclasses: [] },
+        { uri: uri("Leaf"), superclasses: [uri("Base")] },
+      ],
+      instanceStats: new Map([[uri("Leaf"), { total: 1, named: 1 }]]),
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Base"))?.isAbstract).toBe(true);
+    expect(output.classes.get(uri("Leaf"))?.isAbstract).toBe(false);
+  });
+
+  it("marks a blank-only class embeddable", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Embed"), superclasses: [] }],
+      instanceStats: new Map([[uri("Embed"), { total: 2, named: 0 }]]),
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Embed"))?.embeddable).toBe(true);
+  });
+
+  it("honors custom abstract/embeddable mapping overrides", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      instanceStats: new Map([[uri("Thing"), { total: 3, named: 3 }]]),
+    });
+    const { output } = build(extraction, {
+      "ex:Thing": { abstract: true, embeddable: true },
+    });
+    expect(output.classes.get(uri("Thing"))?.isAbstract).toBe(true);
+    expect(output.classes.get(uri("Thing"))?.embeddable).toBe(true);
+  });
+});
+
+describe("build — resolveRange", () => {
+  const classes = [{ uri: uri("Thing"), superclasses: [] }];
+
+  it("resolves an anonymous range union by property", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("rel", { kind: "object", ranges: [] })],
+      unions: [{ property: uri("rel"), members: [uri("Thing")] }],
+    });
+    const { output } = build(extraction);
+    expect(output.properties.get(uri("rel"))?.range).toEqual({
+      kind: "union",
+      members: [uri("Thing")],
+    });
+  });
+
+  it("falls back to String when a property has no declared range", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("loose", { ranges: [] })],
+    });
+    expect(output(extraction, "loose").range).toEqual({
+      kind: "scalar",
+      xsd: `${XSD}string`,
+      graphqlScalar: "String",
+    });
+  });
+
+  it("resolves a custom datatype to its declared base scalar", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("v", { ranges: [uri("Version")] })],
+      datatypes: [{ uri: uri("Version"), baseType: `${XSD}integer` }],
+    });
+    expect(output(extraction, "v").range).toEqual({
+      kind: "scalar",
+      xsd: `${XSD}integer`,
+      graphqlScalar: "Int",
+      customDatatype: uri("Version"),
+    });
+  });
+
+  it("defaults a custom datatype with no base type to String", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("v", { ranges: [uri("Opaque")] })],
+      datatypes: [{ uri: uri("Opaque") }],
+    });
+    expect(output(extraction, "v").range).toEqual({
+      kind: "scalar",
+      xsd: `${XSD}string`,
+      graphqlScalar: "String",
+      customDatatype: uri("Opaque"),
+    });
+  });
+
+  it("maps a custom datatype with a non-scalar base to String", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [datatypeProp("v", { ranges: [uri("Weird")] })],
+      // base type is not in the XSD scalar table → falls back to String.
+      datatypes: [{ uri: uri("Weird"), baseType: uri("CustomBase") }],
+    });
+    expect(output(extraction, "v").range).toEqual({
+      kind: "scalar",
+      xsd: uri("CustomBase"),
+      graphqlScalar: "String",
+      customDatatype: uri("Weird"),
+    });
+  });
+
+  it("resolves a named union range", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Thing"), superclasses: [] },
+        { uri: uri("Other"), superclasses: [] },
+      ],
+      properties: [datatypeProp("u", { kind: "object", ranges: [uri("MyU")] })],
+      unions: [{ uri: uri("MyU"), members: [uri("Thing"), uri("Other")] }],
+    });
+    expect(output(extraction, "u").range).toEqual({
+      kind: "union",
+      name: "MyU",
+      members: [uri("Thing"), uri("Other")],
+    });
+  });
+
+  it("resolves a class range", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Thing"), superclasses: [] },
+        { uri: uri("Target"), superclasses: [] },
+      ],
+      properties: [
+        datatypeProp("rel", { kind: "object", ranges: [uri("Target")] }),
+      ],
+    });
+    expect(output(extraction, "rel").range).toEqual({
+      kind: "class",
+      uri: uri("Target"),
+    });
+  });
+
+  it("falls back to unknown for an unresolvable range", () => {
+    const extraction = makeExtraction({
+      classes,
+      properties: [
+        datatypeProp("rel", { kind: "object", ranges: [uri("Nowhere")] }),
+      ],
+    });
+    expect(output(extraction, "rel").range).toEqual({
+      kind: "unknown",
+      raw: uri("Nowhere"),
+    });
+  });
+
+  /** Helper: build and return the resolved PropertyNode for a local name. */
+  function output(extraction: RawExtraction, local: string) {
+    const prop = build(extraction).output.properties.get(uri(local));
+    if (!prop) {
+      throw new Error(`property ${local} missing`);
+    }
+    return prop;
+  }
+});
+
+describe("build — SHACL cardinality merge", () => {
+  /** Build with one class, one object property, and the given constraints. */
+  const withConstraints = (constraints: RawShaclConstraint[]) =>
+    build(
+      makeExtraction({
+        classes: [
+          { uri: uri("C"), superclasses: [] },
+          { uri: uri("Target"), superclasses: [] },
+        ],
+        properties: [
+          {
+            uri: uri("rel"),
+            kind: "object",
+            domains: [uri("C")],
+            ranges: [uri("Target")],
+          },
+        ],
+        instanceStats: new Map([[uri("C"), { total: 1, named: 1 }]]),
+        shaclConstraints: constraints,
+      }),
+    )
+      .output.properties.get(uri("rel"))
+      ?.classCardinality.get(uri("C"));
+
+  it("intersects a direct maxCount with a finite sh:or branch max", () => {
+    const card = withConstraints([
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 1,
+        maxCount: 2,
+      },
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        maxCount: 3,
+        fromOr: true,
+      },
+    ]);
+    // direct max 2, branch max 3 → most permissive across alternatives = 3.
+    expect(card?.singular).toBe(false);
+    // the unconstrained branch (min 0) lowers the merged minimum below 1.
+    expect(card?.required).toBe(false);
+  });
+
+  it("merges multiple direct constraints, intersecting their min and max counts", () => {
+    // Two direct constraints on the same property exercise the merge loop's
+    // second iteration, where the running min/max counts are already set.
+    const card = withConstraints([
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 1,
+        maxCount: 5,
+      },
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 2,
+        maxCount: 3,
+      },
+    ]);
+    // max of the minimums (2) and min of the maximums (3).
+    expect(card?.required).toBe(true);
+    expect(card?.singular).toBe(false);
+  });
+
+  it("applies a direct minCount-only constraint, leaving the max unbounded", () => {
+    // A direct constraint with minCount but no maxCount takes the false arm of
+    // the maxCount guard — required, but not singular.
+    const card = withConstraints([
+      { targetClass: uri("C"), property: uri("rel"), minCount: 1 },
+    ]);
+    expect(card?.required).toBe(true);
+    expect(card?.singular).toBe(false);
+  });
+
+  it("skips constraints belonging to a different property", () => {
+    // Two object properties; only ex:rel carries a constraint. The merge loop
+    // must skip the ex:other key when resolving ex:rel.
+    const { output } = build(
+      makeExtraction({
+        classes: [
+          { uri: uri("C"), superclasses: [] },
+          { uri: uri("Target"), superclasses: [] },
+        ],
+        properties: [
+          {
+            uri: uri("rel"),
+            kind: "object",
+            domains: [uri("C")],
+            ranges: [uri("Target")],
+          },
+          {
+            uri: uri("other"),
+            kind: "object",
+            domains: [uri("C")],
+            ranges: [uri("Target")],
+          },
+        ],
+        shaclConstraints: [
+          { targetClass: uri("C"), property: uri("other"), maxCount: 1 },
+        ],
+      }),
+    );
+    expect(output.properties.get(uri("rel"))?.classCardinality.size).toBe(0);
+    expect(
+      output.properties.get(uri("other"))?.classCardinality.get(uri("C"))
+        ?.singular,
+    ).toBe(true);
+  });
+
+  it("treats a direct maxCount with an unbounded sh:or branch as unbounded", () => {
+    const card = withConstraints([
+      { targetClass: uri("C"), property: uri("rel"), maxCount: 2 },
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 1,
+        fromOr: true,
+      },
+    ]);
+    // branch has no maxCount (unbounded) → keeps the direct max, stays 2;
+    // its minCount 1 makes the merged constraint required.
+    expect(card?.singular).toBe(false);
+    expect(card?.required).toBe(true);
+  });
+
+  it("keeps a finite-only sh:or branch maxCount when no direct max exists", () => {
+    const card = withConstraints([
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        maxCount: 1,
+        fromOr: true,
+      },
+    ]);
+    expect(card?.singular).toBe(true);
+  });
+
+  it("leaves cardinality unbounded when every sh:or branch is unbounded", () => {
+    const card = withConstraints([
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 1,
+        fromOr: true,
+      },
+      {
+        targetClass: uri("C"),
+        property: uri("rel"),
+        minCount: 0,
+        fromOr: true,
+      },
+    ]);
+    expect(card?.singular).toBe(false);
+    expect(card?.required).toBe(false);
+  });
+
+  it("skips a constraint whose targetClass is empty", () => {
+    const card = withConstraints([
+      { targetClass: "", property: uri("rel"), maxCount: 1, fromOr: true },
+    ]);
+    // No per-class entry is written for an empty target, but the singular
+    // signal still folds into the property default.
+    expect(card).toBeUndefined();
+    const prop = build(
+      makeExtraction({
+        classes: [{ uri: uri("C"), superclasses: [] }],
+        properties: [
+          {
+            uri: uri("rel"),
+            kind: "object",
+            domains: [uri("C")],
+            ranges: [],
+          },
+        ],
+        shaclConstraints: [
+          { targetClass: "", property: uri("rel"), maxCount: 1, fromOr: true },
+        ],
+      }),
+    ).output.properties.get(uri("rel"));
+    expect(prop?.functional).toBe(true);
+  });
+});
+
+describe("build — inverse pairs", () => {
+  it("auto-completes an asymmetric inverse declaration", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Parent"), superclasses: [] },
+        { uri: uri("Child"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("hasChild"),
+          kind: "object",
+          domains: [uri("Parent")],
+          ranges: [uri("Child")],
+        },
+        {
+          uri: uri("childOf"),
+          kind: "object",
+          domains: [uri("Child")],
+          ranges: [uri("Parent")],
+        },
+      ],
+      inverses: [{ property: uri("hasChild"), inverse: uri("childOf") }],
+    });
+    const { output } = build(extraction);
+    expect(output.properties.get(uri("hasChild"))?.inverse).toBe(
+      uri("childOf"),
+    );
+    // Reverse side completed even though only the forward direction declared it.
+    expect(output.properties.get(uri("childOf"))?.inverse).toBe(
+      uri("hasChild"),
+    );
+  });
+
+  it("ignores inverse declarations referencing unknown properties", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Parent"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("hasChild"),
+          kind: "object",
+          domains: [uri("Parent")],
+          ranges: [],
+        },
+      ],
+      inverses: [{ property: uri("ghost"), inverse: uri("phantom") }],
+    });
+    const { output } = build(extraction);
+    expect(output.properties.get(uri("hasChild"))?.inverse).toBeUndefined();
+  });
+});
+
+describe("build — property assignment", () => {
+  it("skips a property domain that is not a known class", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      properties: [
+        datatypeProp("p", { domains: [uri("Ghost"), uri("Thing")] }),
+      ],
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Thing"))?.ownProperties).toContain(uri("p"));
+  });
+
+  it("assigns a domainless property to same-namespace classes only", () => {
+    const OTHER = "http://other.test/";
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Foo"), superclasses: [] },
+        { uri: uri("Bar"), superclasses: [] },
+        { uri: `${OTHER}Far`, superclasses: [] },
+      ],
+      properties: [datatypeProp("desc", { domains: [] })],
+      namespaces: new Map([
+        [NS, "ex"],
+        [OTHER, "other"],
+      ]),
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Foo"))?.ownProperties).toContain(
+      uri("desc"),
+    );
+    expect(output.classes.get(uri("Bar"))?.ownProperties).toContain(
+      uri("desc"),
+    );
+    // A class in a different namespace does not receive the domainless property.
+    expect(output.classes.get(`${OTHER}Far`)?.ownProperties).not.toContain(
+      uri("desc"),
+    );
+  });
+
+  it("inherits an ancestor's property onto a subclass", () => {
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Base"), superclasses: [] },
+        { uri: uri("Leaf"), superclasses: [uri("Base")] },
+      ],
+      properties: [datatypeProp("p", { domains: [uri("Base")] })],
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get(uri("Leaf"))?.ownProperties).not.toContain(
+      uri("p"),
+    );
+    expect(output.classes.get(uri("Leaf"))?.allProperties).toContain(uri("p"));
+  });
+
+  it("dedupes an inherited property already declared on the subclass domain", () => {
+    // ex:p has both Base and Leaf as domains; Leaf also inherits it from Base.
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("Base"), superclasses: [] },
+        { uri: uri("Leaf"), superclasses: [uri("Base")] },
+      ],
+      properties: [datatypeProp("p", { domains: [uri("Base"), uri("Leaf")] })],
+    });
+    const { output } = build(extraction);
+    const all = output.classes.get(uri("Leaf"))?.allProperties ?? [];
+    expect(all.filter((p) => p === uri("p"))).toHaveLength(1);
+  });
+});
+
+describe("build — namespaces", () => {
+  it("excludes standard-vocabulary namespaces from the inventory", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      namespaces: new Map([
+        [NS, "ex"],
+        ["http://www.w3.org/2000/01/rdf-schema#", "rdfs"],
+      ]),
+    });
+    const { output } = build(extraction);
+    expect(output.namespaces.has("ex")).toBe(true);
+    expect(output.namespaces.has("rdfs")).toBe(false);
+  });
+
+  it("falls back to an empty prefix for an unregistered namespace", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: "http://other.test/Thing", superclasses: [] }],
+      namespaces: new Map(),
+    });
+    const { output } = build(extraction);
+    expect(output.classes.get("http://other.test/Thing")?.namespace).toBe("");
+  });
+});
+
+describe("build — custom mapping resolution", () => {
+  it("resolves a mapping keyed by prefixed name", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      properties: [datatypeProp("p", { ranges: [`${XSD}string`] })],
+    });
+    const { output } = build(extraction, { "ex:p": { singular: false } });
+    // datatype properties default singular; the prefixed mapping flips it.
+    expect(output.properties.get(uri("p"))?.functional).toBe(false);
+  });
+
+  it("resolves a mapping keyed by full IRI", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      properties: [datatypeProp("p", { ranges: [`${XSD}string`] })],
+    });
+    const { output } = build(extraction, { [uri("p")]: { singular: false } });
+    expect(output.properties.get(uri("p"))?.functional).toBe(false);
+  });
+});
+
+describe("build — annotation properties", () => {
+  it("routes annotation properties to the TBox, not class fields", () => {
+    const extraction = makeExtraction({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      properties: [
+        datatypeProp("note", { kind: "annotation", domains: [uri("Thing")] }),
+        datatypeProp("name", { domains: [uri("Thing")] }),
+      ],
+      annotations: new Map([[uri("name"), new Map([[uri("note"), "hi"]])]]),
+    });
+    const { output } = build(extraction);
+    const own = output.classes.get(uri("Thing"))?.ownProperties ?? [];
+    expect(own).toContain(uri("name"));
+    expect(own).not.toContain(uri("note"));
+    // The annotation value is attached to the targeted property node.
+    expect(
+      output.properties.get(uri("name"))?.annotations.get(uri("note")),
+    ).toBe("hi");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/build.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.ts
@@ -1,0 +1,388 @@
+// =============================================================================
+// Pass 2 — Build: RawExtraction → OntologyIR
+//
+// Pure. Constructs the typed class/property graph: transitive superclass
+// closure (with cycle detection), subclass inversion, abstract detection from
+// the Pass 1 instance stats, range resolution, SHACL cardinality (including
+// sh:or most-permissive merging), inverse pair symmetry, and property
+// inheritance.
+// =============================================================================
+
+import {
+  type CardinalitySpec,
+  type ClassNode,
+  type Diagnostic,
+  getLocalName,
+  type NamespaceInfo,
+  type OntologyIR,
+  type PassResult,
+  type PropertyNode,
+  type RangeSpec,
+  type RawExtraction,
+  type RawShaclConstraint,
+  type RawUnion,
+  XSD,
+  XSD_SCALARS,
+} from "#shared";
+import getNamespace from "./getNamespace.js";
+import isStandardVocab from "./isStandardVocab.js";
+import type { CustomMappings } from "./types.js";
+
+const PHASE = "build";
+
+/**
+ * Merge SHACL constraints for one (class, property) pair. Plain constraints
+ * intersect (most specific wins); sh:or branches union to the most
+ * permissive interpretation across alternatives.
+ */
+const mergeConstraints = (
+  constraints: RawShaclConstraint[],
+): { singular: boolean; required: boolean; omit: boolean } => {
+  const direct = constraints.filter((c) => !c.fromOr);
+  const branches = constraints.filter((c) => c.fromOr);
+
+  let minCount: number | undefined;
+  let maxCount: number | undefined;
+  for (const c of direct) {
+    if (c.minCount !== undefined) {
+      minCount = Math.max(minCount ?? 0, c.minCount);
+    }
+    if (c.maxCount !== undefined) {
+      maxCount = Math.min(maxCount ?? Number.POSITIVE_INFINITY, c.maxCount);
+    }
+  }
+  if (branches.length > 0) {
+    // Most permissive across branches: min of minCounts, max of maxCounts.
+    const branchMin = Math.min(...branches.map((c) => c.minCount ?? 0));
+    const branchMax = Math.max(
+      ...branches.map((c) => c.maxCount ?? Number.POSITIVE_INFINITY),
+    );
+    minCount = Math.min(minCount ?? branchMin, branchMin);
+    maxCount =
+      maxCount === undefined
+        ? branchMax === Number.POSITIVE_INFINITY
+          ? undefined
+          : branchMax
+        : Math.max(
+            maxCount,
+            branchMax === Number.POSITIVE_INFINITY ? maxCount : branchMax,
+          );
+  }
+
+  return {
+    singular: maxCount === 1,
+    required: (minCount ?? 0) >= 1,
+    omit: maxCount === 0,
+  };
+};
+
+/**
+ * Build the typed OntologyIR from a RawExtraction (Pass 2): class graph
+ * with ancestor closure and cycle detection (B001), abstract/embeddable
+ * detection, range resolution, SHACL cardinality merging, inverse-pair
+ * completion, and property inheritance. Pure.
+ */
+export default function build(
+  extraction: RawExtraction,
+  mappings: CustomMappings = {},
+): PassResult<OntologyIR> {
+  const diagnostics: Diagnostic[] = [];
+  const getPrefix = (uri: string): string =>
+    extraction.namespaces.get(getNamespace(uri)) ?? "";
+
+  // Custom mappings may be keyed by prefixed name (ds:tier) or full IRI.
+  const prefixedToFull = new Map<string, string>();
+  for (const [ns, prefix] of extraction.namespaces) {
+    prefixedToFull.set(prefix, ns);
+  }
+  const findMapping = (uri: string) => {
+    const direct = mappings[uri];
+    if (direct) {
+      return direct;
+    }
+    const prefix = getPrefix(uri);
+    return prefix ? mappings[`${prefix}:${getLocalName(uri)}`] : undefined;
+  };
+
+  // ── 1. class map ──
+  const classes = new Map<string, ClassNode>();
+  const rawSuperclasses = new Map<string, string[]>();
+  for (const raw of extraction.classes) {
+    rawSuperclasses.set(raw.uri, raw.superclasses);
+    classes.set(raw.uri, {
+      uri: raw.uri,
+      label: raw.label ?? getLocalName(raw.uri),
+      definition: raw.definition,
+      namespace: getPrefix(raw.uri),
+      superclasses: raw.superclasses,
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [],
+      allProperties: [],
+    });
+  }
+
+  // ── 2. transitive closure with cycle detection (B001) ──
+  const ancestorCache = new Map<string, string[]>();
+  const computeAncestors = (uri: string, trail: string[]): string[] => {
+    const cached = ancestorCache.get(uri);
+    if (cached) {
+      return cached;
+    }
+    if (trail.includes(uri)) {
+      diagnostics.push({
+        severity: "error",
+        code: "B001",
+        message: `subClassOf cycle: ${[...trail, uri].map(getLocalName).join(" → ")}`,
+        source: uri,
+        phase: PHASE,
+      });
+      return [];
+    }
+    const result: string[] = [];
+    /* v8 ignore next -- every uri reaching here is a known class, so it always has a rawSuperclasses entry; the empty-array fallback is unreachable */
+    for (const parent of rawSuperclasses.get(uri) ?? []) {
+      if (!classes.has(parent)) {
+        continue; // cross-vocabulary parents handled in Pass 3 (V009)
+      }
+      if (!result.includes(parent)) {
+        result.push(parent);
+      }
+      for (const ancestor of computeAncestors(parent, [...trail, uri])) {
+        if (!result.includes(ancestor)) {
+          result.push(ancestor);
+        }
+      }
+    }
+    ancestorCache.set(uri, result);
+    return result;
+  };
+
+  for (const node of classes.values()) {
+    const ancestors = computeAncestors(node.uri, []);
+    classes.set(node.uri, { ...node, ancestors });
+  }
+
+  // ── 3. invert subclass relationships ──
+  const subclassesOf = new Map<string, string[]>();
+  for (const node of classes.values()) {
+    for (const parent of node.superclasses) {
+      if (!classes.has(parent)) {
+        continue;
+      }
+      const children = subclassesOf.get(parent) ?? [];
+      children.push(node.uri);
+      subclassesOf.set(parent, children);
+    }
+  }
+
+  // ── 4. abstract + embeddable detection from instance stats ──
+  for (const node of classes.values()) {
+    const stats = extraction.instanceStats.get(node.uri);
+    const subclasses = subclassesOf.get(node.uri) ?? [];
+    const mapping = findMapping(node.uri);
+    const isAbstract =
+      mapping?.abstract ?? ((stats?.total ?? 0) === 0 && subclasses.length > 0);
+    // Embeddable: instances exist and none are named, or forced by mapping.
+    const embeddable =
+      mapping?.embeddable ??
+      (stats !== undefined && stats.total > 0 && stats.named === 0);
+    /* v8 ignore next -- node.uri was populated with its ancestors in the prior closure pass and is still present in the map, so the empty-array fallback is unreachable */
+    const ancestors = classes.get(node.uri)?.ancestors ?? [];
+    classes.set(node.uri, {
+      ...node,
+      ancestors,
+      subclasses,
+      isAbstract,
+      embeddable,
+    });
+  }
+
+  // ── 5. property map with range resolution ──
+  const datatypeByUri = new Map(extraction.datatypes.map((d) => [d.uri, d]));
+  const namedUnionByUri = new Map<string, RawUnion>();
+  const anonUnionByProperty = new Map<string, RawUnion>();
+  for (const union of extraction.unions) {
+    if (union.uri) {
+      namedUnionByUri.set(union.uri, union);
+    }
+    if (union.property) {
+      anonUnionByProperty.set(union.property, union);
+    }
+  }
+
+  const resolveRange = (propertyUri: string, ranges: string[]): RangeSpec => {
+    const anon = anonUnionByProperty.get(propertyUri);
+    if (anon) {
+      return { kind: "union", members: anon.members };
+    }
+    const range = ranges[0];
+    if (!range) {
+      // No declared range — safety net: treat as String.
+      return { kind: "scalar", xsd: `${XSD}string`, graphqlScalar: "String" };
+    }
+    const scalar = XSD_SCALARS[range];
+    if (scalar) {
+      return { kind: "scalar", xsd: range, graphqlScalar: scalar };
+    }
+    const custom = datatypeByUri.get(range);
+    if (custom) {
+      const base = custom.baseType ?? `${XSD}string`;
+      return {
+        kind: "scalar",
+        xsd: base,
+        graphqlScalar: XSD_SCALARS[base] ?? "String",
+        customDatatype: range,
+      };
+    }
+    const namedUnion = namedUnionByUri.get(range);
+    if (namedUnion) {
+      return {
+        kind: "union",
+        name: getLocalName(range),
+        members: namedUnion.members,
+      };
+    }
+    if (classes.has(range)) {
+      return { kind: "class", uri: range };
+    }
+    return { kind: "unknown", raw: range };
+  };
+
+  // ── 5a. SHACL cardinality per (class, property) ──
+  const constraintsByPair = new Map<string, RawShaclConstraint[]>();
+  for (const constraint of extraction.shaclConstraints) {
+    const key = `${constraint.targetClass} ${constraint.property}`;
+    const list = constraintsByPair.get(key) ?? [];
+    list.push(constraint);
+    constraintsByPair.set(key, list);
+  }
+
+  const properties = new Map<string, PropertyNode>();
+  for (const raw of extraction.properties) {
+    const classCardinality = new Map<string, CardinalitySpec>();
+    let shaclSingularAnywhere = false;
+    for (const [key, constraints] of constraintsByPair) {
+      const [targetClass, property] = key.split(" ");
+      if (property !== raw.uri) {
+        continue;
+      }
+      const merged = mergeConstraints(constraints);
+      shaclSingularAnywhere ||= merged.singular;
+      if (!targetClass) {
+        continue;
+      }
+      classCardinality.set(targetClass, {
+        singular: merged.singular,
+        required: merged.required,
+        omit: merged.omit,
+        source: "shacl",
+      });
+    }
+
+    // Cardinality precedence: custom > owl:FunctionalProperty > owl:cardinality
+    // (not present in current ontologies) > SHACL maxCount 1 > kind default.
+    // Datatype properties default to SINGULAR (multi-valued literals are the
+    // exception in RDF practice); only object properties default to list.
+    const mapping = findMapping(raw.uri);
+    const functional =
+      mapping?.singular ??
+      (extraction.functionals.has(raw.uri) ||
+        shaclSingularAnywhere ||
+        raw.kind !== "object");
+
+    properties.set(raw.uri, {
+      uri: raw.uri,
+      label: raw.label ?? getLocalName(raw.uri),
+      definition: raw.definition,
+      namespace: getPrefix(raw.uri),
+      kind: raw.kind,
+      domains: raw.domains,
+      range: resolveRange(raw.uri, raw.ranges),
+      functional,
+      classCardinality,
+      isAnnotation: raw.kind === "annotation",
+      annotations: extraction.annotations.get(raw.uri) ?? new Map(),
+    });
+  }
+
+  // ── 6. inverse pairs with symmetry verification (V003 in Pass 3) ──
+  for (const { property, inverse } of extraction.inverses) {
+    const forward = properties.get(property);
+    if (forward) {
+      properties.set(property, { ...forward, inverse });
+    }
+    const backward = properties.get(inverse);
+    if (backward && backward.inverse === undefined) {
+      // Auto-complete asymmetric declarations; Pass 3 reports V003.
+      properties.set(inverse, { ...backward, inverse: property });
+    }
+  }
+
+  // ── 7+8. assign properties to classes, compute inheritance ──
+  const ownProperties = new Map<string, string[]>();
+  for (const property of properties.values()) {
+    if (property.isAnnotation) {
+      continue; // annotation properties route to the TBox schema
+    }
+    for (const domain of property.domains) {
+      if (!classes.has(domain)) {
+        continue; // unknown domains reported in Pass 3 (B002)
+      }
+      const list = ownProperties.get(domain) ?? [];
+      list.push(property.uri);
+      ownProperties.set(domain, list);
+    }
+    if (property.domains.length === 0) {
+      // Domainless: assign to every class in the property's namespace.
+      for (const node of classes.values()) {
+        if (node.namespace === property.namespace) {
+          const list = ownProperties.get(node.uri) ?? [];
+          list.push(property.uri);
+          ownProperties.set(node.uri, list);
+        }
+      }
+    }
+  }
+
+  for (const node of classes.values()) {
+    const own = ownProperties.get(node.uri) ?? [];
+    const all = [...own];
+    for (const ancestor of node.ancestors) {
+      for (const inherited of ownProperties.get(ancestor) ?? []) {
+        if (!all.includes(inherited)) {
+          all.push(inherited);
+        }
+      }
+    }
+    classes.set(node.uri, {
+      ...node,
+      ownProperties: own,
+      allProperties: all,
+    });
+  }
+
+  // ── namespaces ──
+  const namespaces = new Map<string, NamespaceInfo>();
+  for (const [uri, prefix] of extraction.namespaces) {
+    if (isStandardVocab(uri)) {
+      continue;
+    }
+    namespaces.set(prefix, {
+      prefix,
+      uri,
+      classCount: [...classes.values()].filter((c) => c.namespace === prefix)
+        .length,
+      propertyCount: [...properties.values()].filter(
+        (p) => p.namespace === prefix,
+      ).length,
+    });
+  }
+
+  return {
+    output: { classes, properties, namespaces, extraction },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/compile.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compile.ts
@@ -1,0 +1,28 @@
+import type { QueryFn } from "#shared";
+import extract from "./extract.js";
+import runPasses from "./runPasses.js";
+import type { CompilerResult, SchemaPluginOptions } from "./types.js";
+
+/**
+ * Run the full seven-pass pipeline against a query surface (ke
+ * PluginContext.query at plugin time, or createStoreQueryFn(store) directly).
+ *
+ * The schema is produced whenever composition succeeds — error diagnostics
+ * from earlier passes do not abort compilation (tsc model); only
+ * composition failure stops schema creation. The
+ * consumer decides its failure policy. Throws CompilationError only when
+ * composition fails.
+ *
+ * @note Impure — Pass 1 executes SPARQL queries against the store through
+ * the provided query function.
+ */
+export default async function compile(
+  query: QueryFn,
+  prefixes: Readonly<Record<string, string>>,
+  options: SchemaPluginOptions = {},
+): Promise<CompilerResult> {
+  const extracted = await extract(query, prefixes);
+  return runPasses(extracted.output, options, {
+    diagnostics: extracted.diagnostics,
+  });
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/compileFromExtraction.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compileFromExtraction.ts
@@ -1,0 +1,21 @@
+import { deserializeExtraction } from "./artifact.js";
+import runPasses from "./runPasses.js";
+import type {
+  CompilerResult,
+  SchemaPluginOptions,
+  SerializedExtraction,
+} from "./types.js";
+
+/**
+ * Rebuild the executable schema from a precomputed extraction artifact —
+ * Passes 2-7 only, pure JS, no store. validateSchema/printSchema are skipped
+ * by default (assumeValid): the artifact was validated when it was built.
+ */
+export default function compileFromExtraction(
+  artifact: string | SerializedExtraction,
+  options: SchemaPluginOptions = {},
+  { assumeValid = true }: { assumeValid?: boolean } = {},
+): CompilerResult {
+  const { extraction } = deserializeExtraction(artifact);
+  return runPasses(extraction, options, { skipValidation: assumeValid });
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/compose.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compose.test.ts
@@ -1,0 +1,290 @@
+import { GraphQLString } from "graphql";
+import { describe, expect, it } from "vitest";
+import type { InterfacePlan, MappedIR, NameMap, TypePlan } from "#shared";
+import compose from "./compose.js";
+import type { FieldPlan, SchemaPlan } from "./emit.js";
+import type { SchemaExtensionsInput } from "./types.js";
+
+const nameMap: NameMap = {
+  toGraphQL: () => undefined,
+  toOWL: () => undefined,
+  entries: () => [][Symbol.iterator](),
+};
+
+// Minimal MappedIR: buildTBoxSchema reads `ir` only inside resolver thunks,
+// none of which run during composition.
+const mapped = {
+  types: new Map(),
+  interfaces: new Map(),
+  unions: new Map(),
+  nameMap,
+  namespaces: new Map(),
+  ir: {
+    classes: new Map(),
+    properties: new Map(),
+    namespaces: new Map(),
+    extraction: {} as MappedIR["ir"]["extraction"],
+  },
+} as unknown as MappedIR;
+
+const emptyPlan = (over: Partial<SchemaPlan> = {}): SchemaPlan => ({
+  types: new Map(),
+  interfaces: new Map(),
+  unions: new Map(),
+  queryFields: new Map(),
+  mapped,
+  ...over,
+});
+
+const objectPlan = (name: string, fields: TypePlan["fields"]): TypePlan => ({
+  name,
+  interfaces: [],
+  fields,
+  embeddable: false,
+});
+
+const interfacePlan = (name: string): InterfacePlan => ({
+  name,
+  parents: [],
+  fields: new Map(),
+  embeddableOnly: false,
+});
+
+describe("compose validation failures (C003)", () => {
+  it("reports a validateSchema error and nulls the schema", () => {
+    // An object type with zero fields fails validateSchema ("must define one
+    // or more fields") without throwing during construction.
+    const plan = emptyPlan({
+      types: new Map([["Empty", objectPlan("Empty", new Map())]]),
+    });
+    const { output, diagnostics } = compose(plan);
+    expect(output.schema).toBeNull();
+    expect(output.sdl).toBe("");
+    const c003 = diagnostics.filter((d) => d.code === "C003");
+    expect(c003.length).toBeGreaterThan(0);
+    expect(c003[0]?.severity).toBe("error");
+    expect(c003.some((d) => /Empty/.test(d.message))).toBe(true);
+  });
+
+  it("skipValidation leaves the (unvalidated) schema and empty SDL", () => {
+    const plan = emptyPlan({
+      types: new Map([["Empty", objectPlan("Empty", new Map())]]),
+    });
+    const { output, diagnostics } = compose(plan, { skipValidation: true });
+    // No validation ran: the schema object is kept, SDL is not printed.
+    expect(output.schema).not.toBeNull();
+    expect(output.sdl).toBe("");
+    expect(diagnostics.filter((d) => d.code === "C003")).toHaveLength(0);
+  });
+
+  it("catches a thrown schema-construction error as C003", () => {
+    // A generated interface and a generated object type sharing a name make
+    // the GraphQLSchema constructor throw ("multiple types named …"); the
+    // throw is caught and surfaced as C003 with a null schema.
+    const plan = emptyPlan({
+      types: new Map([
+        [
+          "Dup",
+          objectPlan(
+            "Dup",
+            new Map([
+              [
+                "field",
+                {
+                  name: "field",
+                  type: {
+                    base: "String",
+                    kind: "scalar",
+                    list: false,
+                    nonNull: false,
+                  },
+                },
+              ],
+            ]),
+          ),
+        ],
+      ]),
+      interfaces: new Map([["Dup", interfacePlan("Dup")]]),
+    });
+    const { output, diagnostics } = compose(plan);
+    expect(output.schema).toBeNull();
+    const c003 = diagnostics.filter((d) => d.code === "C003");
+    expect(c003.length).toBeGreaterThan(0);
+    expect(c003.some((d) => /Dup/.test(d.message))).toBe(true);
+  });
+});
+
+const scalarField = (name: string, nonNull = false): FieldPlan => ({
+  name,
+  type: { base: "String", kind: "scalar", list: false, nonNull },
+});
+
+describe("compose full construction", () => {
+  it("builds unions, connections, args, and merges extensions", () => {
+    // ── interface Named { name: String } ──
+    const named: InterfacePlan = {
+      name: "Named",
+      parents: [],
+      fields: new Map([["name", scalarField("name")]]),
+      embeddableOnly: false,
+    };
+
+    // ── type Thing implements Named ──
+    const thingFields = new Map<string, FieldPlan>([
+      ["name", scalarField("name")],
+      // base resolves to no known type → findNamedType returns undefined and
+      // the type falls back to String (the ?? GraphQLString branch).
+      [
+        "mystery",
+        {
+          name: "mystery",
+          type: { base: "Missing", kind: "named", list: false, nonNull: false },
+        },
+      ],
+      // a connection whose base is also unknown → the edge node type uses the
+      // same String fallback inside getConnectionType.
+      [
+        "links",
+        {
+          name: "links",
+          type: {
+            base: "Missing",
+            kind: "connection",
+            list: false,
+            nonNull: true,
+          },
+          connectionArgs: true,
+        },
+      ],
+      // static args: one required, one optional, plus a bogus scalar type that
+      // exercises the SCALARS[...] ?? GraphQLString fallback.
+      [
+        "lookup",
+        {
+          name: "lookup",
+          type: { base: "String", kind: "scalar", list: false, nonNull: false },
+          args: {
+            id: { type: "ID", required: true },
+            q: { type: "String", required: false },
+            weird: { type: "Decimal" as "String", required: false },
+          },
+        },
+      ],
+    ]);
+    const thing: TypePlan = {
+      name: "Thing",
+      interfaces: ["Named"],
+      fields: thingFields,
+      embeddable: false,
+    };
+
+    // ── union Shape = Thing ──
+    const plan: SchemaPlan = emptyPlan({
+      types: new Map([["Thing", thing]]),
+      interfaces: new Map([["Named", named]]),
+      unions: new Map([["Shape", { name: "Shape", members: ["Thing"] }]]),
+      queryFields: new Map<string, FieldPlan>([
+        [
+          "thing",
+          {
+            name: "thing",
+            type: { base: "Thing", kind: "named", list: false, nonNull: false },
+          },
+        ],
+        [
+          "shape",
+          {
+            name: "shape",
+            type: { base: "Shape", kind: "named", list: false, nonNull: false },
+          },
+        ],
+      ]),
+    });
+
+    const ifaceSeen: Array<string | undefined> = [];
+    const extensions: SchemaExtensionsInput = (types) => {
+      // exercise the factory-form lookups: a generated interface, Node, and a
+      // miss (the iface ?? Node ?? undefined chain), plus a type lookup.
+      ifaceSeen.push(types.iface("Named")?.name);
+      ifaceSeen.push(types.iface("Node")?.name);
+      ifaceSeen.push(types.iface("Nope")?.name);
+      types.type("Thing");
+      return {
+        Thing: {
+          extra: { type: GraphQLString }, // new → merged
+          name: { type: GraphQLString }, // conflicts → C002
+        },
+        Query: {
+          newRoot: { type: GraphQLString }, // new → merged
+          thing: { type: GraphQLString }, // conflicts → C002
+        },
+      };
+    };
+
+    const { output, diagnostics } = compose(plan, { extensions });
+    expect(output.schema).not.toBeNull();
+    expect(output.sdl).toContain("union Shape = Thing");
+    expect(output.sdl).toContain("type Thing implements Named");
+    // connection + edge synthesized for the unknown base
+    expect(output.sdl).toContain("MissingConnection");
+
+    // factory lookups resolved as expected
+    expect(ifaceSeen).toEqual(["Named", "Node", undefined]);
+
+    // both conflicts surfaced; both new fields merged in
+    const c002 = diagnostics.filter((d) => d.code === "C002");
+    expect(c002.map((d) => d.message).sort()).toEqual([
+      "extension field Query.thing conflicts with a generated field",
+      "extension field Thing.name conflicts with a generated field",
+    ]);
+    expect(output.sdl).toContain("extra: String");
+    expect(output.sdl).toContain("newRoot: String");
+    // no C001: every extended type exists
+    expect(diagnostics.filter((d) => d.code === "C001")).toHaveLength(0);
+  });
+
+  it("surfaces a C002 extension conflict even under skipValidation", () => {
+    // The artifact-boot fast path skips validateSchema (which normally triggers
+    // the field thunks where conflicts are detected), but an extension field
+    // colliding with a generated one is still fatal and must surface.
+    const plan = emptyPlan({
+      types: new Map([
+        [
+          "Thing",
+          objectPlan("Thing", new Map([["name", scalarField("name")]])),
+        ],
+      ]),
+    });
+    const extensions: SchemaExtensionsInput = {
+      Thing: { name: { type: GraphQLString } },
+    };
+    const { diagnostics } = compose(plan, {
+      extensions,
+      skipValidation: true,
+    });
+    expect(
+      diagnostics.filter((d) => d.code === "C002").map((d) => d.message),
+    ).toContain("extension field Thing.name conflicts with a generated field");
+  });
+
+  it("C001 — object-form extension references an unknown type", () => {
+    const thing: TypePlan = {
+      name: "Thing",
+      interfaces: [],
+      fields: new Map([["name", scalarField("name")]]),
+      embeddable: false,
+    };
+    const extensions: SchemaExtensionsInput = {
+      Ghost: { extra: { type: GraphQLString } },
+    };
+    const { output, diagnostics } = compose(
+      emptyPlan({ types: new Map([["Thing", thing]]) }),
+      { extensions },
+    );
+    expect(output.schema).not.toBeNull();
+    expect(diagnostics.filter((d) => d.code === "C001")).toHaveLength(1);
+    expect(diagnostics.find((d) => d.code === "C001")?.message).toContain(
+      "Ghost",
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/compose.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compose.ts
@@ -1,0 +1,419 @@
+// =============================================================================
+// Pass 7 — Compose: SchemaPlan + TBox + extensions → GraphQLSchema
+//
+// The single place where graphql-js type objects are constructed (they are
+// immutable once constructed). Field thunks resolve circular references;
+// connection types are created on demand per base type; every interface and
+// union gets resolveType reading EntityValue.typename; extensions (object or
+// factory form) are validated (C001/C002); the composed schema runs
+// validateSchema (C003) and is printed to SDL for the Relay compiler.
+// =============================================================================
+
+import {
+  GraphQLBoolean,
+  GraphQLDeferDirective,
+  type GraphQLFieldConfig,
+  type GraphQLFieldConfigArgumentMap,
+  type GraphQLFieldConfigMap,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  type GraphQLNullableOutputType,
+  GraphQLObjectType,
+  type GraphQLOutputType,
+  type GraphQLScalarType,
+  GraphQLSchema,
+  GraphQLStreamDirective,
+  GraphQLString,
+  GraphQLUnionType,
+  printSchema,
+  specifiedDirectives,
+  validateSchema,
+} from "graphql";
+import {
+  CONNECTION_ARGS,
+  type CompilerContext,
+  type Diagnostic,
+  type EntityValue,
+  type PassResult,
+} from "#shared";
+import { buildTBoxSchema } from "#tbox";
+import type { FieldPlan, SchemaPlan, TypeRef } from "./emit.js";
+import type { SchemaExtensionsInput } from "./types.js";
+
+const PHASE = "compose";
+
+const SCALARS: Record<string, GraphQLScalarType> = {
+  String: GraphQLString,
+  Boolean: GraphQLBoolean,
+  Int: GraphQLInt,
+  Float: GraphQLFloat,
+  ID: GraphQLID,
+};
+
+/** Options for the composition pass (extensions, directives, validation). */
+export interface ComposeOptions {
+  extensions?: SchemaExtensionsInput;
+  incremental?: boolean;
+  /**
+   * Skip validateSchema + printSchema (artifact boots: the schema is a
+   * deterministic rebuild of an extraction that was validated when the
+   * artifact was produced; the SDL is a build artifact, not a runtime need).
+   */
+  skipValidation?: boolean;
+}
+
+/** Composition output: the schema (null on C003 failure) and its SDL. */
+export interface ComposedSchema {
+  schema: GraphQLSchema | null;
+  sdl: string;
+}
+
+/**
+ * Compose the executable GraphQLSchema from the SchemaPlan, the TBox schema,
+ * and consumer extensions (Pass 7). Extension conflicts surface as C001/C002
+ * diagnostics; validateSchema failures as C003. Pure construction — the
+ * resulting schema performs I/O only when executed.
+ */
+export default function compose(
+  plan: SchemaPlan,
+  options: ComposeOptions = {},
+): PassResult<ComposedSchema> {
+  const diagnostics: Diagnostic[] = [];
+
+  // ── shared structural types ──
+  const resolveTypename = (value: unknown): string | undefined =>
+    (value as EntityValue | undefined)?.typename;
+
+  const nodeInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
+    name: "Node",
+    fields: () => ({
+      id: { type: new GraphQLNonNull(GraphQLID) },
+      uri: { type: new GraphQLNonNull(GraphQLString) },
+    }),
+    resolveType: resolveTypename,
+  });
+
+  const pageInfo = new GraphQLObjectType({
+    name: "PageInfo",
+    fields: {
+      hasNextPage: { type: new GraphQLNonNull(GraphQLBoolean) },
+      hasPreviousPage: { type: new GraphQLNonNull(GraphQLBoolean) },
+      startCursor: { type: GraphQLString },
+      endCursor: { type: GraphQLString },
+    },
+  });
+
+  // ── registries with lazy construction ──
+  const objectTypes = new Map<string, GraphQLObjectType>();
+  const interfaceTypes = new Map<string, GraphQLInterfaceType>();
+  const unionTypes = new Map<string, GraphQLUnionType>();
+  const connectionTypes = new Map<string, GraphQLObjectType>();
+
+  const findNamedType = (name: string): GraphQLNullableOutputType | undefined =>
+    objectTypes.get(name) ??
+    interfaceTypes.get(name) ??
+    unionTypes.get(name) ??
+    (name === "Node" ? nodeInterface : undefined) ??
+    (name === "EntityMeta" ? tbox.entityMeta : undefined) ??
+    SCALARS[name];
+
+  const getConnectionType = (base: string): GraphQLObjectType => {
+    let connection = connectionTypes.get(`${base}Connection`);
+    if (connection) {
+      return connection;
+    }
+    const edge = new GraphQLObjectType({
+      name: `${base}Edge`,
+      fields: () => ({
+        node: {
+          type: new GraphQLNonNull(findNamedType(base) ?? GraphQLString),
+          resolve: (parent: { node: EntityValue }) => parent.node,
+        },
+        cursor: { type: new GraphQLNonNull(GraphQLString) },
+      }),
+    });
+    connection = new GraphQLObjectType({
+      name: `${base}Connection`,
+      fields: () => ({
+        edges: {
+          type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(edge))),
+        },
+        pageInfo: { type: new GraphQLNonNull(pageInfo) },
+      }),
+    });
+    connectionTypes.set(`${base}Connection`, connection);
+    return connection;
+  };
+
+  const buildOutputType = (ref: TypeRef): GraphQLOutputType => {
+    const base: GraphQLNullableOutputType =
+      ref.kind === "connection"
+        ? getConnectionType(ref.base)
+        : (findNamedType(ref.base) ?? GraphQLString);
+    if (ref.kind !== "connection" && ref.list) {
+      // List fields are always [T!]!: resolvers filter missing
+      // items rather than nulling them, and an empty list is the default.
+      return new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(base)));
+    }
+    return ref.nonNull ? new GraphQLNonNull(base) : base;
+  };
+
+  const buildArgs = (plan: FieldPlan): GraphQLFieldConfigArgumentMap => {
+    const args: GraphQLFieldConfigArgumentMap = {};
+    if (plan.connectionArgs) {
+      Object.assign(args, CONNECTION_ARGS);
+    }
+    for (const [name, spec] of Object.entries(plan.args ?? {})) {
+      const scalar = SCALARS[spec.type] ?? GraphQLString;
+      args[name] = {
+        type: spec.required ? new GraphQLNonNull(scalar) : scalar,
+      };
+    }
+    return args;
+  };
+
+  const buildFieldConfig = (
+    plan: FieldPlan,
+  ): GraphQLFieldConfig<EntityValue, CompilerContext> => ({
+    type: buildOutputType(plan.type),
+    args: buildArgs(plan),
+    resolve: plan.resolve,
+    description: plan.description,
+  });
+
+  const buildFieldsConfig = (
+    fields: Map<string, FieldPlan>,
+  ): GraphQLFieldConfigMap<EntityValue, CompilerContext> => {
+    const config: GraphQLFieldConfigMap<EntityValue, CompilerContext> = {};
+    for (const [name, plan] of fields) {
+      config[name] = buildFieldConfig(plan);
+    }
+    return config;
+  };
+
+  // ── TBox (needs the Node interface and the NodeConnection factory) ──
+  const tbox = buildTBoxSchema(plan.mapped, nodeInterface, () =>
+    getConnectionType("Node"),
+  );
+
+  // ── generated interfaces ──
+  for (const iface of plan.interfaces.values()) {
+    interfaceTypes.set(
+      iface.name,
+      new GraphQLInterfaceType({
+        name: iface.name,
+        description: iface.description,
+        interfaces: () =>
+          iface.parents
+            .map((p) => (p === "Node" ? nodeInterface : interfaceTypes.get(p)))
+            .filter((i): i is GraphQLInterfaceType => i !== undefined),
+        fields: () => buildFieldsConfig(iface.fields),
+        resolveType: resolveTypename,
+      }),
+    );
+  }
+
+  // ── generated unions ──
+  for (const union of plan.unions.values()) {
+    unionTypes.set(
+      union.name,
+      new GraphQLUnionType({
+        name: union.name,
+        types: () =>
+          union.members
+            .map((m) => objectTypes.get(m))
+            .filter((t): t is GraphQLObjectType => t !== undefined),
+        resolveType: resolveTypename,
+      }),
+    );
+  }
+
+  // ── extensions (validated below, merged into type construction) ──
+  const resolveExtensions = (
+    input: SchemaExtensionsInput | undefined,
+  ): Record<
+    string,
+    Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>>
+  > => {
+    if (!input) {
+      return {};
+    }
+    if (typeof input === "function") {
+      return input({
+        type: (name) => objectTypes.get(name),
+        iface: (name) =>
+          interfaceTypes.get(name) ??
+          (name === "Node" ? nodeInterface : undefined),
+      });
+    }
+    return input;
+  };
+
+  // Extension lookup is lazy (inside field thunks) so the factory form can
+  // reference generated types that exist by the time fields are resolved.
+  let extensionsCache:
+    | Record<
+        string,
+        Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>>
+      >
+    | undefined;
+  const getExtensionFields = (
+    typeName: string,
+  ): Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>> => {
+    extensionsCache ??= resolveExtensions(options.extensions);
+    return extensionsCache[typeName] ?? {};
+  };
+
+  // ── generated object types ──
+  for (const type of plan.types.values()) {
+    objectTypes.set(
+      type.name,
+      new GraphQLObjectType<EntityValue, CompilerContext>({
+        name: type.name,
+        description: type.description,
+        interfaces: () =>
+          type.interfaces
+            .map((i) => (i === "Node" ? nodeInterface : interfaceTypes.get(i)))
+            .filter((i): i is GraphQLInterfaceType => i !== undefined),
+        fields: () => {
+          const generated = buildFieldsConfig(type.fields);
+          for (const [name, config] of Object.entries(
+            getExtensionFields(type.name),
+          )) {
+            if (generated[name]) {
+              diagnostics.push({
+                severity: "error",
+                code: "C002",
+                message: `extension field ${type.name}.${name} conflicts with a generated field`,
+                phase: PHASE,
+              });
+              continue;
+            }
+            generated[name] = config;
+          }
+          return generated;
+        },
+      }),
+    );
+  }
+
+  // C001 — extensions referencing unknown types (Query is always known).
+  extensionsCache ??= resolveExtensions(options.extensions);
+  for (const typeName of Object.keys(extensionsCache)) {
+    if (typeName !== "Query" && !plan.types.has(typeName)) {
+      diagnostics.push({
+        severity: "error",
+        code: "C001",
+        message: `extension references unknown type ${typeName}`,
+        phase: PHASE,
+      });
+    }
+  }
+
+  // ── Query ──
+  const queryType = new GraphQLObjectType<unknown, CompilerContext>({
+    name: "Query",
+    fields: () => {
+      const fields: GraphQLFieldConfigMap<unknown, CompilerContext> = {
+        ...tbox.queryFields,
+      };
+      for (const [name, fieldPlan] of plan.queryFields) {
+        fields[name] = buildFieldConfig(fieldPlan) as GraphQLFieldConfig<
+          unknown,
+          CompilerContext
+        >;
+      }
+      for (const [name, config] of Object.entries(
+        getExtensionFields("Query"),
+      )) {
+        if (fields[name]) {
+          diagnostics.push({
+            severity: "error",
+            code: "C002",
+            message: `extension field Query.${name} conflicts with a generated field`,
+            phase: PHASE,
+          });
+          continue;
+        }
+        fields[name] = config as GraphQLFieldConfig<unknown, CompilerContext>;
+      }
+      return fields;
+    },
+  });
+
+  // ── schema ──
+  // Embeddable-only interfaces and their implementors may be unreachable
+  // from Query; list every generated type explicitly so they are retained.
+  const allTypes = [
+    ...objectTypes.values(),
+    ...interfaceTypes.values(),
+    ...unionTypes.values(),
+    tbox.entityMeta,
+  ];
+
+  const directives = options.incremental
+    ? [...specifiedDirectives, GraphQLDeferDirective, GraphQLStreamDirective]
+    : [...specifiedDirectives];
+
+  let schema: GraphQLSchema | null = null;
+  let sdl = "";
+  try {
+    // GraphQLObjectType constructors validate names eagerly; field thunks
+    // run during validateSchema — both belong under the C003 umbrella so a
+    // bad name surfaces as a diagnostic, not a raw GraphQLError.
+    schema = new GraphQLSchema({
+      query: queryType,
+      types: allTypes,
+      directives,
+    });
+    if (!options.skipValidation) {
+      const validationErrors = validateSchema(schema);
+      for (const error of validationErrors) {
+        diagnostics.push({
+          severity: "error",
+          code: "C003",
+          message: error.message,
+          phase: PHASE,
+        });
+      }
+      if (validationErrors.length > 0) {
+        schema = null;
+      } else {
+        sdl = printSchema(schema);
+      }
+    } else if (options.extensions) {
+      // Skipping full validation (the artifact-boot fast path) must still honor
+      // the fatal C001/C002 contract. validateSchema normally triggers the
+      // field thunks where extension conflicts are detected; force them here so
+      // a C002 conflict surfaces as a diagnostic instead of silently dropping
+      // the extension field.
+      for (const type of [queryType, ...objectTypes.values()]) {
+        type.getFields();
+      }
+    }
+  } catch (error) {
+    // The only throw sites inside this try are graphql-js schema construction,
+    // validateSchema, and printSchema; all throw Error instances, so the
+    // non-Error else fallback below cannot be reached in practice.
+    let message: string;
+    /* v8 ignore else */
+    if (error instanceof Error) {
+      message = error.message;
+    } else {
+      message = String(error);
+    }
+    diagnostics.push({
+      severity: "error",
+      code: "C003",
+      message,
+      phase: PHASE,
+    });
+    schema = null;
+  }
+
+  return { output: { schema, sdl }, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/constants.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/constants.ts
@@ -1,0 +1,80 @@
+// =============================================================================
+// Compiler-only constants: the vocabulary IRIs and the artifact version used
+// solely inside the seven-pass pipeline. The dependency-free vocabulary base
+// shared across domains (namespace IRIs, rdf:type, rdfs:label, the XSD scalar
+// table, reserved names, connection args) lives in the shared leaf — imported
+// here to derive these compiler-internal IRIs without duplicating literals.
+//
+// Compiler queries use absolute IRIs so they work regardless of which prefixes
+// the consumer registered on the store.
+// =============================================================================
+
+import { OWL, RDF, RDFS, SH, SKOS, XSD } from "#shared";
+
+/** rdf:Property class IRI. */
+export const RDF_PROPERTY = `${RDF}Property`;
+/** rdf:first list predicate IRI. */
+export const RDF_FIRST = `${RDF}first`;
+/** rdf:rest list predicate IRI. */
+export const RDF_REST = `${RDF}rest`;
+/** rdf:nil list terminator IRI. */
+export const RDF_NIL = `${RDF}nil`;
+
+/** rdfs:comment predicate IRI. */
+export const RDFS_COMMENT = `${RDFS}comment`;
+/** rdfs:subClassOf predicate IRI. */
+export const RDFS_SUBCLASS_OF = `${RDFS}subClassOf`;
+/** rdfs:domain predicate IRI. */
+export const RDFS_DOMAIN = `${RDFS}domain`;
+/** rdfs:range predicate IRI. */
+export const RDFS_RANGE = `${RDFS}range`;
+/** rdfs:Datatype class IRI. */
+export const RDFS_DATATYPE = `${RDFS}Datatype`;
+
+/** owl:Class class IRI. */
+export const OWL_CLASS = `${OWL}Class`;
+/** owl:ObjectProperty class IRI. */
+export const OWL_OBJECT_PROPERTY = `${OWL}ObjectProperty`;
+/** owl:DatatypeProperty class IRI. */
+export const OWL_DATATYPE_PROPERTY = `${OWL}DatatypeProperty`;
+/** owl:AnnotationProperty class IRI. */
+export const OWL_ANNOTATION_PROPERTY = `${OWL}AnnotationProperty`;
+/** owl:FunctionalProperty class IRI. */
+export const OWL_FUNCTIONAL_PROPERTY = `${OWL}FunctionalProperty`;
+/** owl:inverseOf predicate IRI. */
+export const OWL_INVERSE_OF = `${OWL}inverseOf`;
+/** owl:unionOf predicate IRI. */
+export const OWL_UNION_OF = `${OWL}unionOf`;
+/** owl:onDatatype predicate IRI (custom datatype restriction base). */
+export const OWL_ON_DATATYPE = `${OWL}onDatatype`;
+/** owl:withRestrictions predicate IRI (custom datatype facet list). */
+export const OWL_WITH_RESTRICTIONS = `${OWL}withRestrictions`;
+
+/** skos:definition predicate IRI. */
+export const SKOS_DEFINITION = `${SKOS}definition`;
+
+/** sh:NodeShape class IRI. */
+export const SH_NODE_SHAPE = `${SH}NodeShape`;
+/** sh:targetClass predicate IRI. */
+export const SH_TARGET_CLASS = `${SH}targetClass`;
+/** sh:property predicate IRI. */
+export const SH_PROPERTY = `${SH}property`;
+/** sh:path predicate IRI. */
+export const SH_PATH = `${SH}path`;
+/** sh:minCount predicate IRI. */
+export const SH_MIN_COUNT = `${SH}minCount`;
+/** sh:maxCount predicate IRI. */
+export const SH_MAX_COUNT = `${SH}maxCount`;
+/** sh:or predicate IRI. */
+export const SH_OR = `${SH}or`;
+/** sh:in predicate IRI. */
+export const SH_IN = `${SH}in`;
+
+/** xsd:pattern facet IRI (custom datatype restrictions). */
+export const XSD_PATTERN = `${XSD}pattern`;
+
+/**
+ * Extraction artifact format version. Bumped on any breaking change to the
+ * serialized shape; deserialization rejects mismatched artifacts.
+ */
+export const ARTIFACT_VERSION = 1;

--- a/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.test.ts
@@ -1,0 +1,67 @@
+import type { Store } from "@canonical/ke";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MappedIR, NameMap, NamespaceInfo } from "#shared";
+import createContextFactory from "./createContextFactory.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const nameMap: NameMap = {
+  toGraphQL: () => undefined,
+  toOWL: () => undefined,
+  entries: () => [][Symbol.iterator](),
+};
+
+const namespaces = new Map<string, NamespaceInfo>();
+
+// Minimal MappedIR: the loaders read `mapped` only inside their batch
+// functions (never invoked here — no .load() call), so empty maps suffice.
+const mapped = {
+  types: new Map(),
+  interfaces: new Map(),
+  unions: new Map(),
+  nameMap,
+  namespaces,
+  ir: {
+    classes: new Map(),
+    properties: new Map(),
+    namespaces: new Map(),
+    extraction: {} as MappedIR["ir"]["extraction"],
+  },
+} as unknown as MappedIR;
+
+const store = {} as Store;
+
+describe("default runtime-warning handler", () => {
+  it("logs each distinct (property, value) coercion failure exactly once", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ctx = createContextFactory(mapped, {})(store);
+
+    ctx.warn({ property: "ex:count", value: "x", reason: "not an integer" });
+    // identical key — deduplicated, no second log
+    ctx.warn({ property: "ex:count", value: "x", reason: "not an integer" });
+    // distinct value — logged
+    ctx.warn({ property: "ex:count", value: "y", reason: "not an integer" });
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      'cannot coerce "x" on ex:count',
+    );
+    expect(String(warn.mock.calls[0]?.[0])).toContain("not an integer");
+  });
+
+  it("uses the supplied onRuntimeWarning handler when provided", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const seen: string[] = [];
+    const ctx = createContextFactory(mapped, {
+      onRuntimeWarning: (w) => seen.push(w.value),
+    })(store);
+
+    ctx.warn({ property: "ex:count", value: "z", reason: "nope" });
+    ctx.warn({ property: "ex:count", value: "z", reason: "nope" });
+
+    expect(seen).toEqual(["z", "z"]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.ts
@@ -1,0 +1,95 @@
+import type { SPARQL, Store } from "@canonical/ke";
+import {
+  createEntityLoader,
+  createInverseLoader,
+  createListLoader,
+} from "#dataloader";
+import { createBoundedCache, DEFAULT_PROCESS_CACHE_SIZE } from "#hardening";
+import type {
+  EntityValue,
+  MappedIR,
+  QueryFn,
+  RuntimeWarningHandler,
+} from "#shared";
+import type { ContextFactory, SchemaPluginOptions } from "./types.js";
+
+/**
+ * Create the default runtime-warning handler: logs each distinct
+ * (property, value) coercion failure to the console exactly once.
+ *
+ * @note Impure — the returned handler writes to the console and tracks the
+ * warnings it has already reported.
+ */
+const createDefaultWarningHandler = (): RuntimeWarningHandler => {
+  const seen = new Set<string>();
+  return (warning) => {
+    const key = `${warning.property} ${warning.value}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    console.warn(
+      `[ke-graphql] cannot coerce "${warning.value}" on ${warning.property}: ${warning.reason}`,
+    );
+  };
+};
+
+/**
+ * Create the CompilerContext factory for a compiled MappedIR: each call
+ * produces a context with fresh DataLoaders ("request" mode) or loaders
+ * sharing process-lifetime caches ("process" mode), plus clearCache() to
+ * drop the shared caches.
+ *
+ * @note Impure — the produced contexts execute SPARQL queries against the
+ * store at resolve time, and clearCache() mutates the shared caches.
+ */
+export default function createContextFactory(
+  mapped: MappedIR,
+  options: SchemaPluginOptions,
+): ContextFactory {
+  // Process-lifetime loader caches (item: loaderCache "process"). Scoped to
+  // this CompilerResult: onReload recompiles and produces a new factory, so
+  // cache invalidation on data change is automatic. Bounded LRU (hardening) so
+  // ID enumeration can't grow them without limit.
+  const cacheSize = options.processCacheSize ?? DEFAULT_PROCESS_CACHE_SIZE;
+  const processCaches =
+    options.loaderCache === "process"
+      ? {
+          entity: createBoundedCache<string, Promise<EntityValue | null>>(
+            cacheSize,
+          ),
+          list: createBoundedCache<string, Promise<string[]>>(cacheSize),
+          inverse: createBoundedCache<string, Promise<string[]>>(cacheSize),
+        }
+      : undefined;
+
+  const factory: ContextFactory = Object.assign(
+    (store: Store | Promise<Store>) => {
+      // Lazy-store gate: ABox loaders await the store at query time; TBox
+      // resolvers read the frozen IR and never touch it.
+      const query: QueryFn = async (q) =>
+        (await Promise.resolve(store)).query(q as SPARQL<string>);
+      return {
+        entityLoader: createEntityLoader(query, mapped, processCaches?.entity),
+        listLoader: createListLoader(query, mapped, processCaches?.list),
+        inverseLoader: createInverseLoader(
+          query,
+          mapped,
+          processCaches?.inverse,
+        ),
+        nameMap: mapped.nameMap,
+        namespaces: mapped.namespaces,
+        store,
+        warn: options.onRuntimeWarning ?? createDefaultWarningHandler(),
+      };
+    },
+    {
+      clearCache(): void {
+        processCaches?.entity.clear();
+        processCaches?.list.clear();
+        processCaches?.inverse.clear();
+      },
+    },
+  );
+  return factory;
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/createStoreQueryFn.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/createStoreQueryFn.ts
@@ -1,0 +1,13 @@
+import type { SPARQL, Store } from "@canonical/ke";
+import type { QueryFn } from "#shared";
+
+/**
+ * Adapt a ke Store to the QueryFn surface (string → branded SPARQL), for
+ * compiling directly against a store instead of a plugin context.
+ *
+ * @note Impure — the returned function executes SPARQL queries against the
+ * store.
+ */
+export default function createStoreQueryFn(store: Store): QueryFn {
+  return (query) => store.query(query as SPARQL<string>);
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/emit.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/emit.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ClassNode,
+  EntityValue,
+  MappedField,
+  MappedInterface,
+  MappedIR,
+  MappedType,
+  MappedUnion,
+  NameMap,
+  OntologyIR,
+  ResolverTemplate,
+} from "#shared";
+import emit from "./emit.js";
+
+const nameMap: NameMap = {
+  toGraphQL: () => undefined,
+  toOWL: () => undefined,
+  entries: () => [][Symbol.iterator](),
+};
+
+const classNode = (
+  over: Partial<ClassNode> & Pick<ClassNode, "uri">,
+): ClassNode => ({
+  label: over.uri,
+  namespace: "ex",
+  superclasses: [],
+  ancestors: [],
+  subclasses: [],
+  isAbstract: false,
+  embeddable: false,
+  ownProperties: [],
+  allProperties: [],
+  ...over,
+});
+
+const mappedInterface = (
+  over: Partial<MappedInterface> &
+    Pick<MappedInterface, "owlUri" | "graphqlName">,
+): MappedInterface => ({
+  parentInterfaces: [],
+  fields: new Map(),
+  ...over,
+});
+
+const buildMappedWithTypes = (
+  types: Map<string, MappedType>,
+  classes: Map<string, ClassNode>,
+  interfaces: Map<string, MappedInterface>,
+  unions: Map<string, MappedUnion>,
+): MappedIR =>
+  ({
+    types,
+    interfaces,
+    unions,
+    nameMap,
+    namespaces: new Map(),
+    ir: {
+      classes,
+      properties: new Map(),
+      namespaces: new Map(),
+      extraction: {} as OntologyIR["extraction"],
+    },
+  }) as unknown as MappedIR;
+
+const buildMapped = (
+  classes: Map<string, ClassNode>,
+  interfaces: Map<string, MappedInterface>,
+  unions: Map<string, MappedUnion>,
+): MappedIR => buildMappedWithTypes(new Map(), classes, interfaces, unions);
+
+const field = (
+  template: ResolverTemplate,
+  over: Partial<MappedField> = {},
+): MappedField => ({
+  owlUri: `http://example.org/${template}`,
+  graphqlName: template.replace(/-/g, ""),
+  type:
+    template === "datatype" || template === "datatype-list"
+      ? { kind: "scalar", name: "String" }
+      : { kind: "type", name: "Thing" },
+  nullable: true,
+  list: template.endsWith("list"),
+  resolverTemplate: template,
+  propertyUri: `http://example.org/${template}`,
+  shaclRequired: false,
+  nonNull: false,
+  ...over,
+});
+
+const typeWithFields = (fields: Map<string, MappedField>): MappedType => ({
+  owlUri: "http://example.org/Thing",
+  graphqlName: "Thing",
+  interfaces: [],
+  fields,
+  embeddable: false,
+  namespace: "ex",
+  pluralName: "things",
+  singularName: "thing",
+});
+
+describe("emit createResolver", () => {
+  it("instantiates a resolver for every template, including inverse and meta", () => {
+    const fields = new Map<string, MappedField>();
+    for (const template of [
+      "datatype",
+      "datatype-list",
+      "object-singular",
+      "object-list",
+      "embedded-singular",
+      "embedded-list",
+      "meta",
+    ] as ResolverTemplate[]) {
+      fields.set(template, field(template));
+    }
+    // inverse WITH an explicit inverseOf (left side of the ??)
+    fields.set(
+      "inverseExplicit",
+      field("inverse", {
+        graphqlName: "inverseExplicit",
+        inverseOf: "http://example.org/forward",
+      }),
+    );
+    // inverse WITHOUT inverseOf → falls back to propertyUri (right side of ??)
+    fields.set(
+      "inverseFallback",
+      field("inverse", {
+        graphqlName: "inverseFallback",
+        inverseOf: undefined,
+      }),
+    );
+
+    const types = new Map<string, MappedType>([
+      ["Thing", typeWithFields(fields)],
+    ]);
+    const result = emit(
+      buildMappedWithTypes(types, new Map(), new Map(), new Map()),
+    );
+    const planFields = result.output.types.get("Thing")?.fields;
+    expect(planFields?.size).toBe(fields.size);
+    for (const name of [
+      "datatype",
+      "datatypelist",
+      "objectsingular",
+      "objectlist",
+      "embeddedsingular",
+      "embeddedlist",
+      "inverseExplicit",
+      "inverseFallback",
+    ]) {
+      expect(typeof planFields?.get(name)?.resolve).toBe("function");
+    }
+    // the meta resolver returns the parent unchanged
+    const metaResolve = planFields?.get("meta")?.resolve;
+    const parent = { uri: "ex:x", typename: "Thing", triples: new Map() };
+    expect(
+      metaResolve?.(parent as EntityValue, {}, {} as never, {} as never),
+    ).toBe(parent);
+  });
+});
+
+describe("emit unions", () => {
+  it("emits one UnionPlan per mapped union", () => {
+    const unions = new Map<string, MappedUnion>([
+      ["Shape", { name: "Shape", members: ["Circle", "Square"] }],
+    ]);
+    const result = emit(buildMapped(new Map(), new Map(), unions));
+    expect(result.output.unions.get("Shape")?.members).toEqual([
+      "Circle",
+      "Square",
+    ]);
+  });
+});
+
+describe("emit areAllImplementorsEmbeddable (cycle-safe walk)", () => {
+  it("returns false (non-embeddableOnly) when the interface class is missing from the IR", () => {
+    // owlUri has no ClassNode → the walk's root lookup returns undefined.
+    const interfaces = new Map([
+      [
+        "Ghost",
+        mappedInterface({
+          owlUri: "http://example.org/Ghost",
+          graphqlName: "Ghost",
+        }),
+      ],
+    ]);
+    const result = emit(buildMapped(new Map(), interfaces, new Map()));
+    expect(result.output.interfaces.get("Ghost")?.embeddableOnly).toBe(false);
+  });
+
+  it("survives a subClassOf cycle without overflowing the stack", () => {
+    // A → B → A self-cycle: the visited-set guard short-circuits the revisit.
+    const classes = new Map<string, ClassNode>([
+      [
+        "http://example.org/A",
+        classNode({
+          uri: "http://example.org/A",
+          isAbstract: true,
+          subclasses: ["http://example.org/B"],
+        }),
+      ],
+      [
+        "http://example.org/B",
+        classNode({
+          uri: "http://example.org/B",
+          embeddable: true,
+          subclasses: ["http://example.org/A"],
+        }),
+      ],
+    ]);
+    const interfaces = new Map([
+      [
+        "A",
+        mappedInterface({ owlUri: "http://example.org/A", graphqlName: "A" }),
+      ],
+    ]);
+    const result = emit(buildMapped(classes, interfaces, new Map()));
+    // B is the only concrete implementor and it is embeddable → true.
+    expect(result.output.interfaces.get("A")?.embeddableOnly).toBe(true);
+  });
+
+  it("skips a subclass URI that is absent from the IR", () => {
+    // Iface's class lists a subclass that has no ClassNode → walk returns early.
+    const classes = new Map<string, ClassNode>([
+      [
+        "http://example.org/Iface",
+        classNode({
+          uri: "http://example.org/Iface",
+          isAbstract: true,
+          subclasses: ["http://example.org/Missing"],
+        }),
+      ],
+    ]);
+    const interfaces = new Map([
+      [
+        "Iface",
+        mappedInterface({
+          owlUri: "http://example.org/Iface",
+          graphqlName: "Iface",
+        }),
+      ],
+    ]);
+    const result = emit(buildMapped(classes, interfaces, new Map()));
+    // No concrete implementors reachable → not embeddable-only.
+    expect(result.output.interfaces.get("Iface")?.embeddableOnly).toBe(false);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/emit.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/emit.ts
@@ -1,0 +1,213 @@
+// =============================================================================
+// Pass 5 — Emit: MappedIR → SchemaPlan
+//
+// Pure. Produces *plans* (field descriptors with resolvers and string type
+// references), not graphql-js objects: graphql-js types are immutable, so
+// Pass 6 augments plans and Pass 7 constructs every GraphQL*Type exactly
+// once, with thunks for circular references.
+// =============================================================================
+
+import type { GraphQLFieldResolver } from "graphql";
+import {
+  createDatatypeListResolver,
+  createDatatypeResolver,
+  createEmbeddedListResolver,
+  createEmbeddedSingularResolver,
+  createInverseResolver,
+  createObjectListResolver,
+  createObjectSingularResolver,
+} from "#resolver";
+import type {
+  CompilerContext,
+  Diagnostic,
+  EntityValue,
+  MappedField,
+  MappedIR,
+  PassResult,
+} from "#shared";
+
+/** A reference to a (possibly not-yet-constructed) GraphQL type. */
+export interface TypeRef {
+  /** Scalar name, object/interface/union name, or connection base name. */
+  base: string;
+  kind: "scalar" | "named" | "connection";
+  list: boolean;
+  nonNull: boolean;
+}
+
+/** The plan for one GraphQL field: type reference, args, and resolver. */
+export interface FieldPlan {
+  name: string;
+  type: TypeRef;
+  /** Attach the four Relay connection args. */
+  connectionArgs?: boolean;
+  /** Static args spec: name → scalar type name + required flag. */
+  args?: Record<string, { type: "String" | "Int" | "ID"; required: boolean }>;
+  resolve?: GraphQLFieldResolver<EntityValue, CompilerContext>;
+  description?: string;
+}
+
+/** The plan for one GraphQL object type. */
+export interface TypePlan {
+  name: string;
+  owlUri?: string;
+  interfaces: string[];
+  fields: Map<string, FieldPlan>;
+  embeddable: boolean;
+  description?: string;
+}
+
+/** The plan for one GraphQL interface. */
+export interface InterfacePlan {
+  name: string;
+  owlUri?: string;
+  parents: string[];
+  fields: Map<string, FieldPlan>;
+  /** All concrete implementors are embeddable (no Node membership). */
+  embeddableOnly: boolean;
+  description?: string;
+}
+
+/** The plan for one GraphQL union. */
+export interface UnionPlan {
+  name: string;
+  members: string[];
+}
+
+/** Pass 5/6 output: every type, interface, union, and root field as a plan. */
+export interface SchemaPlan {
+  types: Map<string, TypePlan>;
+  interfaces: Map<string, InterfacePlan>;
+  unions: Map<string, UnionPlan>;
+  queryFields: Map<string, FieldPlan>;
+  mapped: MappedIR;
+}
+
+/** Build the TypeRef for a mapped field. */
+const buildTypeRef = (field: MappedField): TypeRef => ({
+  base: field.type.name,
+  kind: field.type.kind === "scalar" ? "scalar" : "named",
+  list: field.list,
+  nonNull: field.nonNull || !field.nullable,
+});
+
+/** Create the resolve function for a mapped field from its template. */
+const createResolver = (
+  field: MappedField,
+): GraphQLFieldResolver<EntityValue, CompilerContext> => {
+  switch (field.resolverTemplate) {
+    case "datatype":
+      return createDatatypeResolver(field);
+    case "datatype-list":
+      return createDatatypeListResolver(field);
+    case "object-singular":
+      return createObjectSingularResolver(field);
+    case "object-list":
+      return createObjectListResolver(field);
+    case "embedded-singular":
+      return createEmbeddedSingularResolver(field, field.type.name);
+    case "embedded-list":
+      return createEmbeddedListResolver(field, field.type.name);
+    case "inverse":
+      return createInverseResolver(field, field.inverseOf ?? field.propertyUri);
+    case "meta":
+      return (parent) => parent;
+  }
+};
+
+/**
+ * Emit the SchemaPlan from the MappedIR (Pass 5): one plan per type,
+ * interface, and union, with resolver instances attached to every field.
+ * Pure — no graphql-js objects are constructed here.
+ */
+export default function emit(mapped: MappedIR): PassResult<SchemaPlan> {
+  const diagnostics: Diagnostic[] = [];
+  const types = new Map<string, TypePlan>();
+  const interfaces = new Map<string, InterfacePlan>();
+  const unions = new Map<string, UnionPlan>();
+
+  const planFields = (
+    fields: ReadonlyMap<string, MappedField>,
+  ): Map<string, FieldPlan> => {
+    const plans = new Map<string, FieldPlan>();
+    for (const field of fields.values()) {
+      const description = mapped.ir.properties.get(
+        field.propertyUri,
+      )?.definition;
+      plans.set(field.graphqlName, {
+        name: field.graphqlName,
+        type: buildTypeRef(field),
+        resolve: createResolver(field),
+        description,
+      });
+    }
+    return plans;
+  };
+
+  for (const mappedInterface of mapped.interfaces.values()) {
+    const node = mapped.ir.classes.get(mappedInterface.owlUri);
+    interfaces.set(mappedInterface.graphqlName, {
+      name: mappedInterface.graphqlName,
+      owlUri: mappedInterface.owlUri,
+      parents: [...mappedInterface.parentInterfaces],
+      fields: planFields(mappedInterface.fields),
+      embeddableOnly: areAllImplementorsEmbeddable(
+        mapped,
+        mappedInterface.owlUri,
+      ),
+      description: node?.definition,
+    });
+  }
+
+  for (const mappedType of mapped.types.values()) {
+    const node = mapped.ir.classes.get(mappedType.owlUri);
+    types.set(mappedType.graphqlName, {
+      name: mappedType.graphqlName,
+      owlUri: mappedType.owlUri,
+      interfaces: [...mappedType.interfaces],
+      fields: planFields(mappedType.fields),
+      embeddable: mappedType.embeddable,
+      description: node?.definition,
+    });
+  }
+
+  for (const union of mapped.unions.values()) {
+    unions.set(union.name, { name: union.name, members: [...union.members] });
+  }
+
+  return {
+    output: { types, interfaces, unions, queryFields: new Map(), mapped },
+    diagnostics,
+  };
+}
+
+/** Are all concrete implementors of an interface embeddable? Cycle-safe walk. */
+const areAllImplementorsEmbeddable = (
+  mapped: MappedIR,
+  interfaceUri: string,
+): boolean => {
+  const node = mapped.ir.classes.get(interfaceUri);
+  if (!node) {
+    return false;
+  }
+  const concrete: boolean[] = [];
+  const visited = new Set<string>();
+  const walk = (uri: string) => {
+    if (visited.has(uri)) {
+      return; // subClassOf cycles (B001) must not overflow the stack
+    }
+    visited.add(uri);
+    const current = mapped.ir.classes.get(uri);
+    if (!current) {
+      return;
+    }
+    if (!current.isAbstract) {
+      concrete.push(current.embeddable);
+    }
+    for (const sub of current.subclasses) {
+      walk(sub);
+    }
+  };
+  walk(interfaceUri);
+  return concrete.length > 0 && concrete.every(Boolean);
+};

--- a/packages/runtime/ke-graphql/src/lib/compiler/extract.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/extract.test.ts
@@ -1,0 +1,531 @@
+// =============================================================================
+// Pass 1 — Extract unit tests. The only pass that touches the store, so it is
+// exercised two ways: a real fixture store for the happy path, and a crafted
+// QueryFn (the pass's sole dependency) for the term-shape guards and the
+// SPARQL failure modes a valid store cannot reproduce.
+// =============================================================================
+
+import type { QueryResult, SelectResult, Term } from "@canonical/ke";
+import { createTestStore } from "@canonical/ke/testing";
+import { afterEach, describe, expect, it } from "vitest";
+import { createStoreQueryFn } from "#compiler";
+import type { QueryFn } from "#shared";
+import { MINIMAL_TTL, PREFIXES } from "#testing";
+import extract from "./extract.js";
+
+const OWL = "http://www.w3.org/2002/07/owl#";
+const RDFS = "http://www.w3.org/2000/01/rdf-schema#";
+const XSD = "http://www.w3.org/2001/XMLSchema#";
+const EX = "http://example.org/";
+
+const named = (value: string): Term => ({ termType: "NamedNode", value });
+const literal = (
+  value: string,
+  extra: { datatype?: string; language?: string } = {},
+): Term => ({ termType: "Literal", value, ...extra });
+const blank = (value: string): Term => ({ termType: "BlankNode", value });
+
+const select = (rows: Record<string, Term>[]): SelectResult => ({
+  type: "select",
+  variables: rows[0] ? Object.keys(rows[0]) : [],
+  bindings: [],
+  termBindings: rows,
+});
+
+const EMPTY = select([]);
+
+/** A query result keyed by a fragment that uniquely identifies one query. */
+type Routes = Array<[fragment: string, result: QueryResult | (() => never)]>;
+
+/**
+ * Build a QueryFn that returns EMPTY for every query unless a route fragment
+ * matches; a function route throws (to exercise the select/catch paths).
+ */
+const router =
+  (routes: Routes): QueryFn =>
+  async (query: string) => {
+    for (const [fragment, result] of routes) {
+      if (query.includes(fragment)) {
+        if (typeof result === "function") {
+          return result();
+        }
+        return result;
+      }
+    }
+    return EMPTY;
+  };
+
+const NO_PREFIXES: Record<string, string> = {};
+
+describe("extract — real fixture store", () => {
+  let cleanup: (() => void) | undefined;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it("extracts classes, properties, namespaces, and stats end to end", async () => {
+    const store = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+    });
+    cleanup = store.cleanup;
+    const { output, diagnostics } = await extract(
+      createStoreQueryFn(store.store),
+      PREFIXES,
+    );
+    expect(output.classes.map((c) => c.uri)).toContain(`${EX}Thing`);
+    const thing = output.classes.find((c) => c.uri === `${EX}Thing`);
+    expect(thing?.label).toBe("Thing");
+    expect(thing?.definition).toBe("A concrete thing.");
+    expect(output.properties.map((p) => p.uri).sort()).toEqual([
+      `${EX}count`,
+      `${EX}name`,
+    ]);
+    expect(output.namespaces.get(EX)).toBe("ex");
+    expect(output.instanceStats.get(`${EX}Thing`)).toEqual({
+      total: 1,
+      named: 1,
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+describe("extract — select failure modes", () => {
+  it("emits E001 when a SELECT returns a non-select result", async () => {
+    const query = router([
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        { type: "ask", result: true },
+      ],
+    ]);
+    const { output, diagnostics } = await extract(query, PREFIXES);
+    expect(output.classes).toEqual([]);
+    const e001 = diagnostics.find(
+      (d) => d.code === "E001" && d.message.includes("expected SELECT"),
+    );
+    expect(e001?.severity).toBe("error");
+  });
+
+  it("emits E001 when a query throws", async () => {
+    const query = router([
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        () => {
+          throw new Error("boom");
+        },
+      ],
+    ]);
+    const { diagnostics } = await extract(query, PREFIXES);
+    expect(
+      diagnostics.some((d) => d.code === "E001" && d.message.includes("boom")),
+    ).toBe(true);
+  });
+
+  it("stringifies a non-Error thrown value", async () => {
+    const query: QueryFn = async (q: string) => {
+      if (q.includes("?class ?label ?definition ?comment ?superclass")) {
+        throw "plain string failure";
+      }
+      return EMPTY;
+    };
+    const { diagnostics } = await extract(query, PREFIXES);
+    expect(
+      diagnostics.some((d) => d.message.includes("plain string failure")),
+    ).toBe(true);
+  });
+});
+
+describe("extract — class rows", () => {
+  it("skips standard-vocabulary classes and collects superclasses once", async () => {
+    const query = router([
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        select([
+          // standard-vocab class is skipped
+          { class: named(`${OWL}Thing`) },
+          // non-NamedNode class is skipped
+          { class: blank("_:x") },
+          // comment used as the definition fallback; superclass deduped
+          {
+            class: named(`${EX}A`),
+            comment: literal("from comment"),
+            superclass: named(`${EX}Base`),
+          },
+          { class: named(`${EX}A`), superclass: named(`${EX}Base`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.classes).toHaveLength(1);
+    const a = output.classes[0];
+    expect(a?.uri).toBe(`${EX}A`);
+    expect(a?.definition).toBe("from comment");
+    expect(a?.superclasses).toEqual([`${EX}Base`]);
+  });
+});
+
+describe("extract — property rows", () => {
+  it("skips standard-vocab properties and resolves each kind", async () => {
+    const query = router([
+      [
+        "?prop ?kind ?label ?definition ?comment ?domain ?range",
+        select([
+          {
+            prop: named(`${RDFS}label`),
+            kind: named(`${OWL}DatatypeProperty`),
+          },
+          {
+            prop: named(`${EX}d`),
+            kind: named(`${OWL}DatatypeProperty`),
+            domain: named(`${EX}C`),
+            range: named(`${XSD}string`),
+          },
+          { prop: named(`${EX}a`), kind: named(`${OWL}AnnotationProperty`) },
+          { prop: named(`${EX}o`), kind: named(`${OWL}ObjectProperty`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const byUri = new Map(output.properties.map((p) => [p.uri, p]));
+    expect(byUri.has(`${RDFS}label`)).toBe(false);
+    expect(byUri.get(`${EX}d`)?.kind).toBe("datatype");
+    expect(byUri.get(`${EX}a`)?.kind).toBe("annotation");
+    expect(byUri.get(`${EX}o`)?.kind).toBe("object");
+    expect(byUri.get(`${EX}d`)?.domains).toEqual([`${EX}C`]);
+  });
+});
+
+describe("extract — inverses (Q3)", () => {
+  it("keeps fully-bound inverse pairs and drops partial rows", async () => {
+    const query = router([
+      [
+        "?prop ?inverse WHERE",
+        select([
+          { prop: named(`${EX}hasChild`), inverse: named(`${EX}childOf`) },
+          { prop: named(`${EX}lonely`) }, // missing inverse → dropped
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.inverses).toEqual([
+      { property: `${EX}hasChild`, inverse: `${EX}childOf` },
+    ]);
+  });
+});
+
+describe("extract — self-referential predicates (Q10)", () => {
+  it("collects named self-referential predicates and skips non-named rows", async () => {
+    const query = router([
+      [
+        "{ ?s ?p ?s }",
+        select([
+          { p: named(`${EX}extends`) },
+          { p: blank("_:anon") }, // non-NamedNode → skipped
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.selfReferential.has(`${EX}extends`)).toBe(true);
+    expect(output.selfReferential.size).toBe(1);
+  });
+});
+
+describe("extract — datatypes", () => {
+  it("skips standard-vocab datatypes", async () => {
+    const query = router([
+      [
+        "?dt ?base ?pattern",
+        select([
+          { dt: named(`${XSD}custom`), base: named(`${XSD}string`) },
+          {
+            dt: named(`${EX}Version`),
+            base: named(`${XSD}string`),
+            pattern: literal("\\d+"),
+          },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.datatypes).toHaveLength(1);
+    expect(output.datatypes[0]).toEqual({
+      uri: `${EX}Version`,
+      baseType: `${XSD}string`,
+      pattern: "\\d+",
+    });
+  });
+});
+
+describe("extract — namespace discovery", () => {
+  it("assigns a synthetic prefix and warns for an unregistered namespace", async () => {
+    const query = router([
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        select([{ class: named("http://unregistered.test/Foo") }]),
+      ],
+    ]);
+    // Pass an empty prefix map so the discovered namespace has no prefix.
+    const { output, diagnostics } = await extract(query, NO_PREFIXES);
+    expect(output.namespaces.get("http://unregistered.test/")).toBe("ns");
+    expect(
+      diagnostics.some(
+        (d) =>
+          d.severity === "warning" &&
+          d.message.includes("no registered prefix"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("extract — SHACL direct constraints", () => {
+  it("resolves sh:in values, skips guard rows, attaches inValues", async () => {
+    const query = router([
+      [
+        "?targetClass ?path ?minCount ?maxCount ?inList",
+        select([
+          // guard: missing path is skipped
+          { targetClass: named(`${EX}C`) },
+          {
+            targetClass: named(`${EX}C`),
+            path: named(`${EX}mode`),
+            minCount: literal("1"),
+            maxCount: literal("not-a-number"),
+            inList: named("_:list"),
+          },
+        ]),
+      ],
+      [
+        "?path ?value WHERE",
+        select([
+          // guard: missing path skipped
+          { value: literal("x") },
+          // guard: value neither literal nor NamedNode (blank) skipped
+          { path: named(`${EX}mode`), value: blank("_:b") },
+          { path: named(`${EX}mode`), value: literal("fast") },
+          { path: named(`${EX}mode`), value: named(`${EX}slow`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.shaclConstraints).toHaveLength(1);
+    const c = output.shaclConstraints[0];
+    expect(c?.minCount).toBe(1);
+    // non-numeric maxCount parses to undefined
+    expect(c?.maxCount).toBeUndefined();
+    expect(c?.inValues).toEqual(["fast", `${EX}slow`]);
+  });
+
+  it("omits inValues when no sh:in list is present", async () => {
+    const query = router([
+      [
+        "?targetClass ?path ?minCount ?maxCount ?inList",
+        select([{ targetClass: named(`${EX}C`), path: named(`${EX}p`) }]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.shaclConstraints[0]?.inValues).toBeUndefined();
+  });
+});
+
+describe("extract — SHACL sh:or branches", () => {
+  it("flags sh:or constraints and skips guard rows", async () => {
+    const query = router([
+      [
+        "?targetClass ?path ?minCount ?maxCount WHERE",
+        select([
+          { targetClass: named(`${EX}C`) }, // missing path → skipped
+          {
+            targetClass: named(`${EX}C`),
+            path: named(`${EX}hop`),
+            maxCount: literal("1"),
+          },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const fromOr = output.shaclConstraints.filter((c) => c.fromOr);
+    expect(fromOr).toHaveLength(1);
+    expect(fromOr[0]?.property).toBe(`${EX}hop`);
+  });
+});
+
+describe("extract — unions", () => {
+  it("collects named unions and skips member guard rows", async () => {
+    const query = router([
+      [
+        "?class ?member",
+        select([
+          { class: named(`${EX}U`) }, // missing member → skipped
+          { class: named(`${EX}U`), member: named(`${EX}A`) },
+          { class: named(`${EX}U`), member: named(`${EX}B`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const named1 = output.unions.find((u) => u.uri === `${EX}U`);
+    expect(named1?.members).toEqual([`${EX}A`, `${EX}B`]);
+  });
+
+  it("collects anonymous range unions and skips member guard rows", async () => {
+    const query = router([
+      [
+        "?property ?member",
+        select([
+          { member: named(`${EX}A`) }, // missing property → skipped
+          { property: named(`${EX}rel`), member: named(`${EX}A`) },
+          { property: named(`${EX}rel`), member: named(`${EX}B`) },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const anon = output.unions.find((u) => u.property === `${EX}rel`);
+    expect(anon?.members).toEqual([`${EX}A`, `${EX}B`]);
+  });
+});
+
+describe("extract — instance stats", () => {
+  it("skips rows with an unparseable total", async () => {
+    const query = router([
+      [
+        "(COUNT(?i) AS ?total)",
+        select([
+          { class: named(`${EX}A`), total: literal("oops") }, // skipped
+          { class: named(`${EX}B`), total: literal("3"), named: literal("2") },
+          // named missing → defaults to 0
+          { class: named(`${EX}C`), total: literal("1") },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.instanceStats.has(`${EX}A`)).toBe(false);
+    expect(output.instanceStats.get(`${EX}B`)).toEqual({ total: 3, named: 2 });
+    expect(output.instanceStats.get(`${EX}C`)).toEqual({ total: 1, named: 0 });
+  });
+});
+
+describe("extract — functional violations (Q11)", () => {
+  it("queries violations only when functional properties exist", async () => {
+    const query = router([
+      [
+        "<http://www.w3.org/2002/07/owl#FunctionalProperty> }",
+        select([
+          { prop: named(`${EX}rank`) },
+          { prop: blank("_:anon") }, // non-NamedNode → dropped from the set
+        ]),
+      ],
+      [
+        "?o1 != ?o2",
+        select([
+          { p: named(`${EX}rank`) },
+          { p: blank("_:anon") }, // non-NamedNode → not recorded
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.functionals.has(`${EX}rank`)).toBe(true);
+    expect(output.functionals.size).toBe(1);
+    expect(output.functionalViolations.has(`${EX}rank`)).toBe(true);
+    expect(output.functionalViolations.size).toBe(1);
+  });
+});
+
+describe("extract — undeclared predicates (Q12)", () => {
+  it("flags predicates in a known namespace that are missing from the TBox", async () => {
+    const query = router([
+      [
+        "SELECT DISTINCT ?p WHERE { ?s ?p ?o }",
+        select([
+          { p: named(`${EX}undeclared`) }, // in ex namespace, not a property
+          { p: named(`${RDFS}label`) }, // standard vocab → skipped
+          { p: blank("_:anon") }, // non-NamedNode → skipped
+          { p: named("http://foreign.test/pred") }, // unknown namespace → skipped
+        ]),
+      ],
+      [
+        "?class ?label ?definition ?comment ?superclass",
+        select([{ class: named(`${EX}Thing`) }]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.undeclaredPredicates.has(`${EX}undeclared`)).toBe(true);
+    expect(output.undeclaredPredicates.has(`${RDFS}label`)).toBe(false);
+    expect(output.undeclaredPredicates.has("http://foreign.test/pred")).toBe(
+      false,
+    );
+    expect(output.undeclaredPredicates.size).toBe(1);
+  });
+});
+
+describe("extract — annotation assertions", () => {
+  it("collects annotation values and skips non-literal guard rows", async () => {
+    const query = router([
+      [
+        "?prop ?kind ?label ?definition ?comment ?domain ?range",
+        select([
+          { prop: named(`${EX}note`), kind: named(`${OWL}AnnotationProperty`) },
+        ]),
+      ],
+      [
+        "?target ?prop ?value",
+        select([
+          // value is not a literal → skipped
+          {
+            target: named(`${EX}A`),
+            prop: named(`${EX}note`),
+            value: named(`${EX}X`),
+          },
+          {
+            target: named(`${EX}A`),
+            prop: named(`${EX}note`),
+            value: literal("hello"),
+          },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    expect(output.annotations.get(`${EX}A`)?.get(`${EX}note`)).toBe("hello");
+  });
+});
+
+describe("extract — depth guard", () => {
+  it("warns when blank nodes nest deeper than one level", async () => {
+    const query = router([["ASK", { type: "ask", result: true }]]);
+    const { output, diagnostics } = await extract(query, PREFIXES);
+    expect(output.deepBlankNesting).toBe(true);
+    expect(
+      diagnostics.some(
+        (d) => d.severity === "warning" && d.message.includes("nest deeper"),
+      ),
+    ).toBe(true);
+  });
+
+  it("emits E001 when the depth-guard ASK throws", async () => {
+    const query: QueryFn = async (q: string) => {
+      if (q.startsWith("ASK")) {
+        throw new Error("ask failed");
+      }
+      return EMPTY;
+    };
+    const { output, diagnostics } = await extract(query, PREFIXES);
+    expect(output.deepBlankNesting).toBe(false);
+    expect(
+      diagnostics.some(
+        (d) =>
+          d.code === "E001" && d.message.includes("depth guard: ask failed"),
+      ),
+    ).toBe(true);
+  });
+
+  it("stringifies a non-Error thrown by the depth guard", async () => {
+    const query: QueryFn = async (q: string) => {
+      if (q.startsWith("ASK")) {
+        throw 42;
+      }
+      return EMPTY;
+    };
+    const { diagnostics } = await extract(query, PREFIXES);
+    expect(diagnostics.some((d) => d.message.includes("depth guard: 42"))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
@@ -1,0 +1,579 @@
+// =============================================================================
+// Pass 1 — Extract: ke store → RawExtraction
+//
+// The only pass that touches the store. Twelve SPARQL queries: eight TBox
+// queries plus four ABox probes that keep Passes 2–7 pure. Queries use
+// absolute IRIs so they are independent of registered prefixes, and consume
+// ke's term-preserving results (termBindings) so that NamedNodes, literals,
+// and blank nodes are distinguishable.
+// =============================================================================
+
+import type { SelectResult, Term } from "@canonical/ke";
+import {
+  type Diagnostic,
+  type InstanceStats,
+  type PassResult,
+  type QueryFn,
+  type RawClass,
+  type RawDatatype,
+  type RawExtraction,
+  type RawProperty,
+  type RawPropertyKind,
+  type RawShaclConstraint,
+  type RawUnion,
+  RDF_TYPE,
+  RDFS_LABEL,
+} from "#shared";
+import {
+  OWL_ANNOTATION_PROPERTY,
+  OWL_CLASS,
+  OWL_DATATYPE_PROPERTY,
+  OWL_FUNCTIONAL_PROPERTY,
+  OWL_INVERSE_OF,
+  OWL_OBJECT_PROPERTY,
+  OWL_ON_DATATYPE,
+  OWL_UNION_OF,
+  OWL_WITH_RESTRICTIONS,
+  RDF_FIRST,
+  RDF_REST,
+  RDFS_COMMENT,
+  RDFS_DOMAIN,
+  RDFS_RANGE,
+  RDFS_SUBCLASS_OF,
+  SH_IN,
+  SH_MAX_COUNT,
+  SH_MIN_COUNT,
+  SH_OR,
+  SH_PATH,
+  SH_PROPERTY,
+  SH_TARGET_CLASS,
+  SKOS_DEFINITION,
+  XSD_PATTERN,
+} from "./constants.js";
+import getNamespace from "./getNamespace.js";
+import isStandardVocab from "./isStandardVocab.js";
+
+const PHASE = "extract";
+
+/**
+ * Run a SELECT and return its term-preserving rows, or [] plus an E001
+ * diagnostic when the query fails or returns a non-SELECT result.
+ *
+ * @note Impure — executes a SPARQL query against the store through the
+ * provided query function.
+ */
+const select = async (
+  query: QueryFn,
+  sparqlText: string,
+  diagnostics: Diagnostic[],
+  label: string,
+): Promise<SelectResult["termBindings"]> => {
+  try {
+    const result = await query(sparqlText);
+    if (result.type !== "select") {
+      diagnostics.push({
+        severity: "error",
+        code: "E001",
+        message: `${label}: expected SELECT result, got ${result.type}`,
+        phase: PHASE,
+      });
+      return [];
+    }
+    return result.termBindings;
+  } catch (error) {
+    diagnostics.push({
+      severity: "error",
+      code: "E001",
+      message: `${label}: ${error instanceof Error ? error.message : String(error)}`,
+      phase: PHASE,
+    });
+    return [];
+  }
+};
+
+/** Get a term's IRI when it is a NamedNode, undefined otherwise. */
+const getNamedValue = (term: Term | undefined): string | undefined =>
+  term?.termType === "NamedNode" ? term.value : undefined;
+
+/** Get a term's lexical value when it is a Literal, undefined otherwise. */
+const getLiteralValue = (term: Term | undefined): string | undefined =>
+  term?.termType === "Literal" ? term.value : undefined;
+
+/** Get a literal term parsed as a base-10 integer, undefined when not parseable. */
+const getIntValue = (term: Term | undefined): number | undefined => {
+  const value = getLiteralValue(term);
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+/**
+ * Extract the TBox structure and ABox probes from a ke store as a
+ * RawExtraction (Pass 1) — the only pipeline step that queries the store.
+ *
+ * @note Impure — executes the twelve extraction SPARQL queries against the
+ * store through the provided query function.
+ */
+export default async function extract(
+  query: QueryFn,
+  prefixes: Readonly<Record<string, string>>,
+): Promise<PassResult<RawExtraction>> {
+  const diagnostics: Diagnostic[] = [];
+
+  // ── Q1: classes with labels, definitions, superclasses ──
+  // Blank-node superclasses (owl:Restriction) are excluded with isIRI.
+  const classRows = await select(
+    query,
+    `SELECT ?class ?label ?definition ?comment ?superclass WHERE {
+      ?class <${RDF_TYPE}> <${OWL_CLASS}> .
+      FILTER(isIRI(?class))
+      OPTIONAL { ?class <${RDFS_LABEL}> ?label }
+      OPTIONAL { ?class <${SKOS_DEFINITION}> ?definition }
+      OPTIONAL { ?class <${RDFS_COMMENT}> ?comment }
+      OPTIONAL { ?class <${RDFS_SUBCLASS_OF}> ?superclass . FILTER(isIRI(?superclass)) }
+    }`,
+    diagnostics,
+    "Q1 classes",
+  );
+
+  const classMap = new Map<string, RawClass>();
+  for (const row of classRows) {
+    const uri = getNamedValue(row.class);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = classMap.get(uri) ?? { uri, superclasses: [] };
+    entry.label ??= getLiteralValue(row.label);
+    entry.definition ??=
+      getLiteralValue(row.definition) ?? getLiteralValue(row.comment);
+    const superclass = getNamedValue(row.superclass);
+    if (superclass && !entry.superclasses.includes(superclass)) {
+      entry.superclasses.push(superclass);
+    }
+    classMap.set(uri, entry);
+  }
+
+  // ── Q2: properties with kind, domains, ranges ──
+  const propertyRows = await select(
+    query,
+    `SELECT ?prop ?kind ?label ?definition ?comment ?domain ?range WHERE {
+      ?prop <${RDF_TYPE}> ?kind .
+      VALUES ?kind { <${OWL_OBJECT_PROPERTY}> <${OWL_DATATYPE_PROPERTY}> <${OWL_ANNOTATION_PROPERTY}> }
+      OPTIONAL { ?prop <${RDFS_LABEL}> ?label }
+      OPTIONAL { ?prop <${SKOS_DEFINITION}> ?definition }
+      OPTIONAL { ?prop <${RDFS_COMMENT}> ?comment }
+      OPTIONAL { ?prop <${RDFS_DOMAIN}> ?domain }
+      OPTIONAL { ?prop <${RDFS_RANGE}> ?range . FILTER(isIRI(?range)) }
+    }`,
+    diagnostics,
+    "Q2 properties",
+  );
+
+  const resolveKind = (kindUri: string | undefined): RawPropertyKind => {
+    if (kindUri === OWL_DATATYPE_PROPERTY) {
+      return "datatype";
+    }
+    if (kindUri === OWL_ANNOTATION_PROPERTY) {
+      return "annotation";
+    }
+    return "object";
+  };
+
+  const propertyMap = new Map<string, RawProperty>();
+  for (const row of propertyRows) {
+    const uri = getNamedValue(row.prop);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = propertyMap.get(uri) ?? {
+      uri,
+      kind: resolveKind(getNamedValue(row.kind)),
+      domains: [],
+      ranges: [],
+    };
+    entry.label ??= getLiteralValue(row.label);
+    entry.definition ??=
+      getLiteralValue(row.definition) ?? getLiteralValue(row.comment);
+    const domain = getNamedValue(row.domain);
+    if (domain && !entry.domains.includes(domain)) {
+      entry.domains.push(domain);
+    }
+    const range = getNamedValue(row.range);
+    if (range && !entry.ranges.includes(range)) {
+      entry.ranges.push(range);
+    }
+    propertyMap.set(uri, entry);
+  }
+
+  // ── Q3: inverse declarations ──
+  const inverseRows = await select(
+    query,
+    `SELECT ?prop ?inverse WHERE { ?prop <${OWL_INVERSE_OF}> ?inverse }`,
+    diagnostics,
+    "Q3 inverses",
+  );
+  const inverses = inverseRows.flatMap((row) => {
+    const property = getNamedValue(row.prop);
+    const inverse = getNamedValue(row.inverse);
+    return property && inverse ? [{ property, inverse }] : [];
+  });
+
+  // ── Q4: functional property markers ──
+  const functionalRows = await select(
+    query,
+    `SELECT ?prop WHERE { ?prop <${RDF_TYPE}> <${OWL_FUNCTIONAL_PROPERTY}> }`,
+    diagnostics,
+    "Q4 functionals",
+  );
+  const functionals = new Set(
+    functionalRows.flatMap((row) => getNamedValue(row.prop) ?? []),
+  );
+
+  // ── Q5: custom datatypes ──
+  // Keyed on the structural marker owl:onDatatype rather than the rdf:type:
+  // the published cs: ontology types its datatype `a owl:Datatype` (a
+  // non-standard term) while ds: uses `a rdfs:Datatype` — the restriction
+  // structure is what actually identifies a custom datatype. The
+  // owl:withRestrictions RDF list is walked with rdf:rest*/rdf:first so a
+  // pattern facet is found at any list position.
+  const datatypeRows = await select(
+    query,
+    `SELECT ?dt ?base ?pattern WHERE {
+      ?dt <${OWL_ON_DATATYPE}> ?base .
+      FILTER(isIRI(?dt))
+      OPTIONAL {
+        ?dt <${OWL_WITH_RESTRICTIONS}> ?list .
+        ?list <${RDF_REST}>*/<${RDF_FIRST}> ?restriction .
+        ?restriction <${XSD_PATTERN}> ?pattern .
+      }
+    }`,
+    diagnostics,
+    "Q5 datatypes",
+  );
+  const datatypeMap = new Map<string, RawDatatype>();
+  for (const row of datatypeRows) {
+    const uri = getNamedValue(row.dt);
+    if (!uri || isStandardVocab(uri)) {
+      continue;
+    }
+    const entry = datatypeMap.get(uri) ?? { uri };
+    entry.baseType ??= getNamedValue(row.base);
+    entry.pattern ??= getLiteralValue(row.pattern);
+    datatypeMap.set(uri, entry);
+  }
+
+  // ── Q6: namespace discovery (in code, from Q1+Q2, cross-referenced with
+  //        the store's registered prefixes) ──
+  const namespaces = new Map<string, string>();
+  const uriToPrefix = new Map<string, string>();
+  for (const [prefix, ns] of Object.entries(prefixes)) {
+    uriToPrefix.set(ns, prefix);
+  }
+  const discovered = new Set<string>();
+  for (const uri of [...classMap.keys(), ...propertyMap.keys()]) {
+    discovered.add(getNamespace(uri));
+  }
+  let anonymous = 0;
+  for (const ns of discovered) {
+    let prefix = uriToPrefix.get(ns);
+    if (!prefix) {
+      prefix = `ns${anonymous++ || ""}`;
+      diagnostics.push({
+        severity: "warning",
+        code: "E001",
+        message: `namespace ${ns} has no registered prefix — assigned synthetic "${prefix}". Register it in StoreConfig.prefixes: it drives the prefixed URIs used as Relay global IDs`,
+        source: ns,
+        phase: PHASE,
+      });
+    }
+    namespaces.set(ns, prefix);
+  }
+
+  // ── Q7a: direct SHACL cardinality constraints ──
+  const shaclConstraints: RawShaclConstraint[] = [];
+  const directShaclRows = await select(
+    query,
+    `SELECT ?targetClass ?path ?minCount ?maxCount ?inList WHERE {
+      ?shape <${SH_TARGET_CLASS}> ?targetClass ;
+             <${SH_PROPERTY}> ?propShape .
+      ?propShape <${SH_PATH}> ?path .
+      OPTIONAL { ?propShape <${SH_MIN_COUNT}> ?minCount }
+      OPTIONAL { ?propShape <${SH_MAX_COUNT}> ?maxCount }
+      OPTIONAL { ?propShape <${SH_IN}> ?inList }
+    }`,
+    diagnostics,
+    "Q7a shacl direct",
+  );
+
+  // sh:in values are an RDF list; resolve them per constraint.
+  const shIn = new Map<string, string[]>();
+  const inListRows = await select(
+    query,
+    `SELECT ?path ?value WHERE {
+      ?propShape <${SH_PATH}> ?path ;
+                 <${SH_IN}> ?list .
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?value .
+    }`,
+    diagnostics,
+    "Q7a sh:in values",
+  );
+  for (const row of inListRows) {
+    const path = getNamedValue(row.path);
+    const value = getLiteralValue(row.value) ?? getNamedValue(row.value);
+    if (!path || value === undefined) {
+      continue;
+    }
+    const values = shIn.get(path) ?? [];
+    values.push(value);
+    shIn.set(path, values);
+  }
+
+  for (const row of directShaclRows) {
+    const targetClass = getNamedValue(row.targetClass);
+    const path = getNamedValue(row.path);
+    if (!targetClass || !path) {
+      continue;
+    }
+    shaclConstraints.push({
+      targetClass,
+      property: path,
+      minCount: getIntValue(row.minCount),
+      maxCount: getIntValue(row.maxCount),
+      inValues: row.inList ? shIn.get(path) : undefined,
+    });
+  }
+
+  // ── Q7b: SHACL sh:or branches ──
+  // sh:or points at an RDF list of branch blank nodes; each branch carries
+  // its own sh:property shapes. The direct pattern in Q7a cannot see them.
+  const orShaclRows = await select(
+    query,
+    `SELECT ?targetClass ?path ?minCount ?maxCount WHERE {
+      ?shape <${SH_TARGET_CLASS}> ?targetClass ;
+             <${SH_OR}> ?orList .
+      ?orList <${RDF_REST}>*/<${RDF_FIRST}> ?branch .
+      ?branch <${SH_PROPERTY}> ?propShape .
+      ?propShape <${SH_PATH}> ?path .
+      OPTIONAL { ?propShape <${SH_MIN_COUNT}> ?minCount }
+      OPTIONAL { ?propShape <${SH_MAX_COUNT}> ?maxCount }
+    }`,
+    diagnostics,
+    "Q7b shacl sh:or",
+  );
+  for (const row of orShaclRows) {
+    const targetClass = getNamedValue(row.targetClass);
+    const path = getNamedValue(row.path);
+    if (!targetClass || !path) {
+      continue;
+    }
+    shaclConstraints.push({
+      targetClass,
+      property: path,
+      minCount: getIntValue(row.minCount),
+      maxCount: getIntValue(row.maxCount),
+      fromOr: true,
+    });
+  }
+
+  // ── Q8: union declarations (named classes and anonymous ranges) ──
+  const unions: RawUnion[] = [];
+  const namedUnionRows = await select(
+    query,
+    `SELECT ?class ?member WHERE {
+      ?class <${RDF_TYPE}> <${OWL_CLASS}> ;
+             <${OWL_UNION_OF}> ?list .
+      FILTER(isIRI(?class))
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?member .
+    }`,
+    diagnostics,
+    "Q8 named unions",
+  );
+  const namedUnions = new Map<string, string[]>();
+  for (const row of namedUnionRows) {
+    const uri = getNamedValue(row.class);
+    const member = getNamedValue(row.member);
+    if (!uri || !member) {
+      continue;
+    }
+    const members = namedUnions.get(uri) ?? [];
+    members.push(member);
+    namedUnions.set(uri, members);
+  }
+  for (const [uri, members] of namedUnions) {
+    unions.push({ uri, members });
+  }
+
+  const anonUnionRows = await select(
+    query,
+    `SELECT ?property ?member WHERE {
+      ?property <${RDFS_RANGE}> ?range .
+      FILTER(isBlank(?range))
+      ?range <${OWL_UNION_OF}> ?list .
+      ?list <${RDF_REST}>*/<${RDF_FIRST}> ?member .
+    }`,
+    diagnostics,
+    "Q8 anonymous unions",
+  );
+  const anonUnions = new Map<string, string[]>();
+  for (const row of anonUnionRows) {
+    const property = getNamedValue(row.property);
+    const member = getNamedValue(row.member);
+    if (!property || !member) {
+      continue;
+    }
+    const members = anonUnions.get(property) ?? [];
+    members.push(member);
+    anonUnions.set(property, members);
+  }
+  for (const [property, members] of anonUnions) {
+    unions.push({ property, members });
+  }
+
+  // ── Q9: instance stats per class (abstract + embeddable detection) ──
+  const statsRows = await select(
+    query,
+    `SELECT ?class (COUNT(?i) AS ?total) (SUM(IF(isBlank(?i), 0, 1)) AS ?named) WHERE {
+      ?i <${RDF_TYPE}> ?class .
+    } GROUP BY ?class`,
+    diagnostics,
+    "Q9 instance stats",
+  );
+  const instanceStats = new Map<string, InstanceStats>();
+  for (const row of statsRows) {
+    const uri = getNamedValue(row.class);
+    const total = getIntValue(row.total);
+    if (!uri || total === undefined) {
+      continue;
+    }
+    instanceStats.set(uri, { total, named: getIntValue(row.named) ?? 0 });
+  }
+
+  // ── Q10: self-referential assertions (V004) ──
+  const selfRows = await select(
+    query,
+    `SELECT DISTINCT ?p WHERE { ?s ?p ?s }`,
+    diagnostics,
+    "Q10 self-referential",
+  );
+  const selfReferential = new Set(
+    selfRows.flatMap((row) => getNamedValue(row.p) ?? []),
+  );
+
+  // ── Q11: functional property violations (V005) ──
+  const functionalViolations = new Set<string>();
+  if (functionals.size > 0) {
+    const values = [...functionals].map((uri) => `<${uri}>`).join(" ");
+    const violationRows = await select(
+      query,
+      `SELECT DISTINCT ?p WHERE {
+        VALUES ?p { ${values} }
+        ?s ?p ?o1 , ?o2 .
+        FILTER(?o1 != ?o2)
+      }`,
+      diagnostics,
+      "Q11 functional violations",
+    );
+    for (const row of violationRows) {
+      const uri = getNamedValue(row.p);
+      if (uri) {
+        functionalViolations.add(uri);
+      }
+    }
+  }
+
+  // ── Q12: undeclared ABox predicates (V014) ──
+  const predicateRows = await select(
+    query,
+    `SELECT DISTINCT ?p WHERE { ?s ?p ?o }`,
+    diagnostics,
+    "Q12 predicates",
+  );
+  const undeclaredPredicates = new Set<string>();
+  for (const row of predicateRows) {
+    const uri = getNamedValue(row.p);
+    if (!uri || isStandardVocab(uri) || propertyMap.has(uri)) {
+      continue;
+    }
+    // Predicates inside a declared namespace but missing from the TBox.
+    if (namespaces.has(getNamespace(uri))) {
+      undeclaredPredicates.add(uri);
+    }
+  }
+
+  // ── Annotation assertions (acceptanceCriteria/completionGuidance).
+  //    Extracted so the TBox schema is fully store-free at request time. ──
+  const annotations = new Map<string, Map<string, string>>();
+  const annotationProps = [...propertyMap.values()]
+    .filter((prop) => prop.kind === "annotation")
+    .map((prop) => prop.uri);
+  if (annotationProps.length > 0) {
+    const values = annotationProps.map((uri) => `<${uri}>`).join(" ");
+    const rows = await select(
+      query,
+      `SELECT ?target ?prop ?value WHERE {
+        VALUES ?prop { ${values} }
+        ?target ?prop ?value .
+      }`,
+      diagnostics,
+      "annotation assertions",
+    );
+    for (const row of rows) {
+      const target = getNamedValue(row.target);
+      const prop = getNamedValue(row.prop);
+      const value = getLiteralValue(row.value);
+      if (!target || !prop || value === undefined) {
+        continue;
+      }
+      const forTarget = annotations.get(target) ?? new Map<string, string>();
+      forTarget.set(prop, value);
+      annotations.set(target, forTarget);
+    }
+  }
+
+  // ── Depth guard: blank nodes whose objects are themselves blank ──
+  let deepBlankNesting = false;
+  try {
+    const deep = await query(
+      `ASK { ?a ?p ?b . ?b ?q ?c . FILTER(isBlank(?b) && isBlank(?c)) }`,
+    );
+    deepBlankNesting = deep.type === "ask" && deep.result;
+    if (deepBlankNesting) {
+      diagnostics.push({
+        severity: "warning",
+        code: "E001",
+        message:
+          "blank nodes nest deeper than 1 level in the store — the entity loader's single-hop blank-node closure will truncate them; extend the closure depth",
+        phase: PHASE,
+      });
+    }
+  } catch (error) {
+    diagnostics.push({
+      severity: "error",
+      code: "E001",
+      message: `depth guard: ${error instanceof Error ? error.message : String(error)}`,
+      phase: PHASE,
+    });
+  }
+
+  return {
+    output: {
+      classes: [...classMap.values()],
+      properties: [...propertyMap.values()],
+      inverses,
+      functionals,
+      datatypes: [...datatypeMap.values()],
+      namespaces,
+      shaclConstraints,
+      unions,
+      instanceStats,
+      selfReferential,
+      functionalViolations,
+      undeclaredPredicates,
+      annotations,
+      deepBlankNesting,
+    },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/getNamespace.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/getNamespace.ts
@@ -1,0 +1,6 @@
+/** Extract the namespace part of a URI (up to and including the last '#' or '/'). */
+export default function getNamespace(uri: string): string {
+  const hash = uri.lastIndexOf("#");
+  const slash = uri.lastIndexOf("/");
+  return uri.slice(0, Math.max(hash, slash) + 1);
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/index.ts
@@ -1,14 +1,23 @@
 /**
- * The OWL → GraphQL compiler domain. This layer carries the extraction pass
- * (reading the ontology + instance data from the store into a raw extraction)
- * and the OWL→IR build pass, plus the store query adapter and the compiler
- * type contracts. The mapping and emission passes, the seven-pass
- * orchestration, the per-request context factory, and the artifact codec are
- * layered on top.
+ * The OWL → GraphQL compiler domain: the seven-pass pipeline (compile and
+ * its artifact-boot variant), the extraction artifact codec, the per-request
+ * context factory, and the compiler API type contracts. The shared vocabulary
+ * constants and IR type contracts it builds on live in the shared leaf and are
+ * re-exported here for the package's public surface.
  *
  * @module compiler
  */
 
 export type * from "#shared";
+export {
+  deserializeExtraction,
+  hashSources,
+  serializeExtraction,
+} from "./artifact.js";
+export { default as CompilationError } from "./CompilationError.js";
+export { default as compile } from "./compile.js";
+export { default as compileFromExtraction } from "./compileFromExtraction.js";
+export { ARTIFACT_VERSION } from "./constants.js";
+export { default as createContextFactory } from "./createContextFactory.js";
 export { default as createStoreQueryFn } from "./createStoreQueryFn.js";
 export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/compiler/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/index.ts
@@ -1,0 +1,14 @@
+/**
+ * The OWL → GraphQL compiler domain. This layer carries the extraction pass
+ * (reading the ontology + instance data from the store into a raw extraction)
+ * and the OWL→IR build pass, plus the store query adapter and the compiler
+ * type contracts. The mapping and emission passes, the seven-pass
+ * orchestration, the per-request context factory, and the artifact codec are
+ * layered on top.
+ *
+ * @module compiler
+ */
+
+export type * from "#shared";
+export { default as createStoreQueryFn } from "./createStoreQueryFn.js";
+export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/compiler/isStandardVocab.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/isStandardVocab.ts
@@ -1,0 +1,9 @@
+import { STANDARD_NAMESPACES } from "#shared";
+
+/**
+ * Check whether a URI belongs to a standard vocabulary namespace
+ * (rdf/rdfs/owl/xsd/skos/sh) — such URIs never produce GraphQL types.
+ */
+export default function isStandardVocab(uri: string): boolean {
+  return STANDARD_NAMESPACES.some((ns) => uri.startsWith(ns));
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/map.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/map.test.ts
@@ -1,0 +1,1017 @@
+// =============================================================================
+// Pass 4 — Map unit tests. Drives the name-resolution corners (sanitization,
+// reserved collisions, unresolvable collisions), the field-type arms (class,
+// union with abstract-member expansion, unknown), field-name collisions,
+// synthetic inverse fields, standard-vocab fields, and union emission — none of
+// which the fixture pipeline exercises.
+// =============================================================================
+
+import { describe, expect, it } from "vitest";
+import {
+  type ClassNode,
+  type OntologyIR,
+  type PropertyNode,
+  type RawExtraction,
+  XSD,
+} from "#shared";
+import build from "./build.js";
+import map from "./map.js";
+
+const NS = "http://example.org/";
+const uri = (local: string) => `${NS}${local}`;
+
+const makeExtraction = (
+  partial: Partial<RawExtraction> = {},
+): RawExtraction => ({
+  classes: [],
+  properties: [],
+  inverses: [],
+  functionals: new Set(),
+  datatypes: [],
+  namespaces: new Map([[NS, "ex"]]),
+  shaclConstraints: [],
+  unions: [],
+  instanceStats: new Map(),
+  selfReferential: new Set(),
+  functionalViolations: new Set(),
+  undeclaredPredicates: new Set(),
+  annotations: new Map(),
+  deepBlankNesting: false,
+  ...partial,
+});
+
+/** Build a real OntologyIR from a crafted extraction. */
+const buildIR = (
+  partial: Partial<RawExtraction>,
+  mappings: Parameters<typeof build>[1] = {},
+): OntologyIR => build(makeExtraction(partial), mappings).output;
+
+const codes = (diagnostics: { code: string }[]) =>
+  diagnostics.map((d) => d.code);
+
+describe("map — type name resolution", () => {
+  it("sanitizes an illegal class local name and reports M002", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("My-Class"), superclasses: [] }],
+      instanceStats: new Map([[uri("My-Class"), { total: 1, named: 1 }]]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(codes(diagnostics)).toContain("M002");
+    expect(output.types.has("My_Class")).toBe(true);
+  });
+
+  it("namespace-prefixes a class colliding with a reserved name (M004)", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Query"), superclasses: [] }],
+      instanceStats: new Map([[uri("Query"), { total: 1, named: 1 }]]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(codes(diagnostics)).toContain("M004");
+    expect(output.types.has("ExQuery")).toBe(true);
+  });
+
+  it("reports M001 when two custom mappings force the same type name", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("A"), superclasses: [] },
+        { uri: uri("B"), superclasses: [] },
+      ],
+      instanceStats: new Map([
+        [uri("A"), { total: 1, named: 1 }],
+        [uri("B"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { diagnostics } = map(ir, {
+      mappings: {
+        "ex:A": { graphqlName: "Dup" },
+        "ex:B": { graphqlName: "Dup" },
+      },
+    });
+    expect(codes(diagnostics)).toContain("M001");
+  });
+});
+
+describe("map — field type specs", () => {
+  it("resolves a class-typed field to its GraphQL type name", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Doc"), superclasses: [] },
+        { uri: uri("Author"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("writtenBy"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Author")],
+        },
+      ],
+      // functional → singular field name "writtenBy".
+      functionals: new Set([uri("writtenBy")]),
+      instanceStats: new Map([
+        [uri("Doc"), { total: 1, named: 1 }],
+        [uri("Author"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Doc")?.fields.get("writtenBy");
+    expect(field?.type).toEqual({ kind: "type", name: "Author" });
+  });
+
+  it("expands an abstract union member to its concrete descendants", () => {
+    // Animal (abstract) has concrete Dog; the union over {Animal, Plant}
+    // expands Animal → Dog and keeps Plant directly.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Animal"), superclasses: [] },
+        { uri: uri("Dog"), superclasses: [uri("Animal")] },
+        { uri: uri("Plant"), superclasses: [] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      unions: [
+        { property: uri("subject"), members: [uri("Animal"), uri("Plant")] },
+      ],
+      functionals: new Set([uri("subject")]),
+      // Animal has no instances + a subclass → abstract; Dog/Plant concrete.
+      instanceStats: new Map([
+        [uri("Dog"), { total: 1, named: 1 }],
+        [uri("Plant"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    expect(field?.type.kind).toBe("union");
+    if (field?.type.kind === "union") {
+      expect([...field.type.members].sort()).toEqual(["Dog", "Plant"]);
+      // anonymous range → synthesized "<Prop>Union" name.
+      expect(field.type.name).toBe("SubjectUnion");
+    }
+  });
+
+  it("skips union members that are not known classes", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Cat"), superclasses: [] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      // ex:Ghost is not declared as a class → dropped from the union.
+      unions: [
+        { property: uri("subject"), members: [uri("Cat"), uri("Ghost")] },
+      ],
+      functionals: new Set([uri("subject")]),
+      instanceStats: new Map([
+        [uri("Cat"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    if (field?.type.kind === "union") {
+      expect([...field.type.members]).toEqual(["Cat"]);
+    } else {
+      throw new Error("expected a union field");
+    }
+  });
+
+  it("dedupes a concrete descendant reachable by two abstract paths", () => {
+    // A and B are both abstract supertypes of the concrete C (diamond). A
+    // union over {A, B} must list C only once.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("A"), superclasses: [] },
+        { uri: uri("B"), superclasses: [] },
+        { uri: uri("C"), superclasses: [uri("A"), uri("B")] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      unions: [{ property: uri("subject"), members: [uri("A"), uri("B")] }],
+      functionals: new Set([uri("subject")]),
+      instanceStats: new Map([
+        [uri("C"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    if (field?.type.kind === "union") {
+      expect([...field.type.members]).toEqual(["C"]);
+    } else {
+      throw new Error("expected a union field");
+    }
+  });
+
+  it("dedupes a concrete member that appears twice in a union", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Cat"), superclasses: [] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      // Cat listed twice → only one member survives.
+      unions: [{ property: uri("subject"), members: [uri("Cat"), uri("Cat")] }],
+      functionals: new Set([uri("subject")]),
+      instanceStats: new Map([
+        [uri("Cat"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    if (field?.type.kind === "union") {
+      expect([...field.type.members]).toEqual(["Cat"]);
+    } else {
+      throw new Error("expected a union field");
+    }
+  });
+
+  it("uses a named union's name and emits X002", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Cat"), superclasses: [] },
+        { uri: uri("Box"), superclasses: [] },
+        { uri: uri("Holder"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("holds"),
+          kind: "object",
+          domains: [uri("Holder")],
+          ranges: [uri("Contents")],
+        },
+      ],
+      unions: [{ uri: uri("Contents"), members: [uri("Cat"), uri("Box")] }],
+      instanceStats: new Map([
+        [uri("Cat"), { total: 1, named: 1 }],
+        [uri("Box"), { total: 1, named: 1 }],
+        [uri("Holder"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(output.unions.has("Contents")).toBe(true);
+    expect(codes(diagnostics)).toContain("X002");
+  });
+
+  it("emits X003 for an anonymous-range union", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Cat"), superclasses: [] },
+        { uri: uri("Box"), superclasses: [] },
+        { uri: uri("Holder"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("holds"),
+          kind: "object",
+          domains: [uri("Holder")],
+          ranges: [],
+        },
+      ],
+      unions: [{ property: uri("holds"), members: [uri("Cat"), uri("Box")] }],
+      instanceStats: new Map([
+        [uri("Cat"), { total: 1, named: 1 }],
+        [uri("Box"), { total: 1, named: 1 }],
+        [uri("Holder"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(output.unions.has("HoldsUnion")).toBe(true);
+    expect(codes(diagnostics)).toContain("X003");
+  });
+
+  it("falls back to String for an unknown range", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("rel"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Nowhere")],
+        },
+      ],
+      functionals: new Set([uri("rel")]),
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Doc")?.fields.get("rel");
+    expect(field?.type).toEqual({ kind: "scalar", name: "String" });
+  });
+
+  it("falls back to String when a class range has no resolved type name", () => {
+    // Hand-built IR: a property whose class range URI is absent from the class
+    // map, so resolveTypeNames never assigns it a name.
+    const doc: ClassNode = {
+      uri: uri("Doc"),
+      label: "Doc",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [uri("rel")],
+      allProperties: [uri("rel")],
+    };
+    const rel: PropertyNode = {
+      uri: uri("rel"),
+      label: "rel",
+      namespace: "ex",
+      kind: "object",
+      domains: [uri("Doc")],
+      range: { kind: "class", uri: uri("Phantom") },
+      functional: true,
+      classCardinality: new Map(),
+      isAnnotation: false,
+      annotations: new Map(),
+    };
+    const ir: OntologyIR = {
+      classes: new Map([[doc.uri, doc]]),
+      properties: new Map([[rel.uri, rel]]),
+      namespaces: new Map([
+        ["ex", { prefix: "ex", uri: NS, classCount: 1, propertyCount: 1 }],
+      ]),
+      extraction: makeExtraction(),
+    };
+    const { output } = map(ir);
+    const field = output.types.get("Doc")?.fields.get("rel");
+    expect(field?.type).toEqual({ kind: "scalar", name: "String" });
+  });
+});
+
+describe("map — concrete descendant collection", () => {
+  it("is cycle-safe and skips unknown subclasses", () => {
+    // Build with a subClassOf cycle: A ↔ B both abstract, union over them.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B")] },
+        { uri: uri("B"), superclasses: [uri("A")] },
+        { uri: uri("C"), superclasses: [uri("A")] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      unions: [{ property: uri("subject"), members: [uri("A")] }],
+      functionals: new Set([uri("subject")]),
+      instanceStats: new Map([
+        [uri("C"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    // A is abstract (no instances, has subclasses); the walk must terminate.
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    expect(field?.type.kind).toBe("union");
+  });
+});
+
+describe("map — field name collisions", () => {
+  it("renames a field colliding with a reserved field name", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("uri"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(codes(diagnostics)).toContain("M002");
+    // "uri" is reserved → namespace-prefixed to "exUri".
+    expect(output.types.get("Doc")?.fields.has("exUri")).toBe(true);
+  });
+
+  it("reports M001 when a renamed field collides with an existing field", () => {
+    // First property takes "dup"; second takes the prefixed form "exDup"; the
+    // third's "dup" collides → renamed to "exDup", which already exists → M001.
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("a"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+        {
+          uri: uri("b"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+        {
+          uri: uri("c"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { diagnostics } = map(ir, {
+      mappings: {
+        "ex:a": { graphqlName: "dup" },
+        "ex:b": { graphqlName: "exDup" },
+        "ex:c": { graphqlName: "dup" },
+      },
+    });
+    expect(codes(diagnostics)).toContain("M001");
+  });
+});
+
+describe("map — synthetic inverse fields", () => {
+  it("adds a synthetic inverse field on the range type", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Block"), superclasses: [] },
+        { uri: uri("Impl"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("implements"),
+          kind: "object",
+          domains: [uri("Impl")],
+          ranges: [uri("Block")],
+        },
+      ],
+      instanceStats: new Map([
+        [uri("Block"), { total: 1, named: 1 }],
+        [uri("Impl"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir, {
+      mappings: {
+        "ex:implements": { inverse: { graphqlName: "implementations" } },
+      },
+    });
+    const field = output.types.get("Block")?.fields.get("implementations");
+    expect(field?.resolverTemplate).toBe("inverse");
+    expect(field?.type).toEqual({ kind: "type", name: "Impl" });
+  });
+
+  it("falls back to Node when the synthetic inverse domain is unresolved", () => {
+    // Object property with a class range but NO domain — the synthetic field's
+    // type cannot resolve a domain type and falls back to Node.
+    const block: ClassNode = {
+      uri: uri("Block"),
+      label: "Block",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [],
+      allProperties: [],
+    };
+    const prop: PropertyNode = {
+      uri: uri("touches"),
+      label: "touches",
+      namespace: "ex",
+      kind: "object",
+      domains: [],
+      range: { kind: "class", uri: uri("Block") },
+      functional: false,
+      classCardinality: new Map(),
+      isAnnotation: false,
+      annotations: new Map(),
+    };
+    const ir: OntologyIR = {
+      classes: new Map([[block.uri, block]]),
+      properties: new Map([[prop.uri, prop]]),
+      namespaces: new Map([
+        ["ex", { prefix: "ex", uri: NS, classCount: 1, propertyCount: 1 }],
+      ]),
+      extraction: makeExtraction(),
+    };
+    const { output } = map(ir, {
+      mappings: { "ex:touches": { inverse: { graphqlName: "touchedBy" } } },
+    });
+    const field = output.types.get("Block")?.fields.get("touchedBy");
+    expect(field?.type).toEqual({ kind: "type", name: "Node" });
+  });
+
+  it("does not synthesize an inverse for a declared owl:inverseOf pair", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Parent"), superclasses: [] },
+        { uri: uri("Child"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("hasChild"),
+          kind: "object",
+          domains: [uri("Parent")],
+          ranges: [uri("Child")],
+        },
+        {
+          uri: uri("childOf"),
+          kind: "object",
+          domains: [uri("Child")],
+          ranges: [uri("Parent")],
+        },
+      ],
+      inverses: [{ property: uri("hasChild"), inverse: uri("childOf") }],
+      instanceStats: new Map([
+        [uri("Parent"), { total: 1, named: 1 }],
+        [uri("Child"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir, {
+      mappings: { "ex:hasChild": { inverse: { graphqlName: "kids" } } },
+    });
+    // The declared pair keeps its own forward field; no synthetic "kids".
+    expect(output.types.get("Child")?.fields.has("kids")).toBe(false);
+  });
+});
+
+describe("map — resolver templates", () => {
+  it("assigns the embedded-singular template to a functional embeddable range", () => {
+    // Card is embeddable (blank-only instances); a functional object property
+    // pointing at it yields a singular embedded field.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Doc"), superclasses: [] },
+        { uri: uri("Card"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("cover"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Card")],
+        },
+      ],
+      functionals: new Set([uri("cover")]),
+      instanceStats: new Map([
+        [uri("Doc"), { total: 1, named: 1 }],
+        [uri("Card"), { total: 2, named: 0 }],
+      ]),
+    });
+    const { output } = map(ir);
+    expect(output.types.get("Doc")?.fields.get("cover")?.resolverTemplate).toBe(
+      "embedded-singular",
+    );
+  });
+});
+
+describe("map — standard-vocab fields", () => {
+  it("adds opt-in instance-level standard-vocab fields", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir, {
+      standardVocabFields: {
+        Doc: { "http://www.w3.org/2000/01/rdf-schema#label": "rdfsLabel" },
+      },
+    });
+    const field = output.types.get("Doc")?.fields.get("rdfsLabel");
+    expect(field?.resolverTemplate).toBe("datatype");
+    expect(field?.type).toEqual({ kind: "scalar", name: "String" });
+  });
+
+  it("renames a standard-vocab field colliding with a reserved name", () => {
+    // The predicate is not a known property, so the rename's namespace lookup
+    // misses and falls back to the "x" prefix → "xId".
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output, diagnostics } = map(ir, {
+      standardVocabFields: {
+        Doc: { "http://www.w3.org/2000/01/rdf-schema#seeAlso": "id" },
+      },
+    });
+    expect(codes(diagnostics)).toContain("M002");
+    expect(output.types.get("Doc")?.fields.has("xId")).toBe(true);
+  });
+});
+
+describe("map — mappings on an unregistered namespace", () => {
+  it("returns no mapping when the class namespace prefix is empty", () => {
+    // The class lives in a namespace with no registered prefix → namespace "".
+    const FOREIGN = "http://foreign.test/";
+    const ir = buildIR(
+      {
+        classes: [{ uri: `${FOREIGN}Thing`, superclasses: [] }],
+        namespaces: new Map(),
+        instanceStats: new Map([[`${FOREIGN}Thing`, { total: 1, named: 1 }]]),
+      },
+      {},
+    );
+    // Supplying mappings forces findMapping past the direct lookup into the
+    // prefixed-key branch, where an empty namespace yields undefined.
+    const { output } = map(ir, {
+      mappings: { "ex:Unrelated": { graphqlName: "Nope" } },
+    });
+    expect(output.types.has("Thing")).toBe(true);
+  });
+});
+
+describe("map — defensive guards on a malformed IR", () => {
+  it("skips an allProperties entry that is annotation or missing", () => {
+    const doc: ClassNode = {
+      uri: uri("Doc"),
+      label: "Doc",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [uri("note"), uri("ghost")],
+      allProperties: [uri("note"), uri("ghost")],
+    };
+    const note: PropertyNode = {
+      uri: uri("note"),
+      label: "note",
+      namespace: "ex",
+      kind: "annotation",
+      domains: [uri("Doc")],
+      range: { kind: "scalar", xsd: `${XSD}string`, graphqlScalar: "String" },
+      functional: true,
+      classCardinality: new Map(),
+      isAnnotation: true,
+      annotations: new Map(),
+    };
+    const ir: OntologyIR = {
+      classes: new Map([[doc.uri, doc]]),
+      // ex:ghost is referenced by allProperties but absent from the map.
+      properties: new Map([[note.uri, note]]),
+      namespaces: new Map([
+        ["ex", { prefix: "ex", uri: NS, classCount: 1, propertyCount: 1 }],
+      ]),
+      extraction: makeExtraction(),
+    };
+    const { output } = map(ir);
+    // Neither the annotation nor the missing property produces a field.
+    expect(output.types.get("Doc")?.fields.size).toBe(0);
+  });
+
+  it("skips a dangling subclass when expanding an abstract union member", () => {
+    // Abstract A claims a subclass Gone that is absent from the class map; the
+    // descendant walk must terminate without throwing.
+    const a: ClassNode = {
+      uri: uri("A"),
+      label: "A",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [uri("Gone")],
+      isAbstract: true,
+      embeddable: false,
+      ownProperties: [],
+      allProperties: [],
+    };
+    const tag: ClassNode = {
+      uri: uri("Tag"),
+      label: "Tag",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [uri("subject")],
+      allProperties: [uri("subject")],
+    };
+    const subject: PropertyNode = {
+      uri: uri("subject"),
+      label: "subject",
+      namespace: "ex",
+      kind: "object",
+      domains: [uri("Tag")],
+      range: { kind: "union", members: [uri("A")] },
+      functional: true,
+      classCardinality: new Map(),
+      isAnnotation: false,
+      annotations: new Map(),
+    };
+    const ir: OntologyIR = {
+      classes: new Map([
+        [a.uri, a],
+        [tag.uri, tag],
+      ]),
+      properties: new Map([[subject.uri, subject]]),
+      namespaces: new Map([
+        ["ex", { prefix: "ex", uri: NS, classCount: 2, propertyCount: 1 }],
+      ]),
+      extraction: makeExtraction(),
+    };
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    // A is abstract with no resolvable concrete descendants → empty union.
+    if (field?.type.kind === "union") {
+      expect([...field.type.members]).toEqual([]);
+    } else {
+      throw new Error("expected a union field");
+    }
+  });
+});
+
+describe("map — interfaces", () => {
+  it("emits an interface with its abstract parent chain", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Entity"), superclasses: [] },
+        { uri: uri("Tangible"), superclasses: [uri("Entity")] },
+        { uri: uri("Widget"), superclasses: [uri("Tangible")] },
+      ],
+      // Entity + Tangible abstract (no instances, have subclasses); Widget
+      // concrete.
+      instanceStats: new Map([[uri("Widget"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    expect(output.interfaces.has("Entity")).toBe(true);
+    expect(output.interfaces.has("Tangible")).toBe(true);
+    // Tangible's parent interface chain includes the abstract Entity.
+    expect([
+      ...(output.interfaces.get("Tangible")?.parentInterfaces ?? []),
+    ]).toContain("Entity");
+    const widget = output.types.get("Widget");
+    expect([...(widget?.interfaces ?? [])].sort()).toEqual([
+      "Entity",
+      "Tangible",
+    ]);
+  });
+
+  it("does not list a non-abstract ancestor as a parent interface", () => {
+    // Animal is concrete (has its own instance) yet has a subclass; it must
+    // not appear in Dog's implemented-interface list.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Animal"), superclasses: [] },
+        { uri: uri("Dog"), superclasses: [uri("Animal")] },
+      ],
+      instanceStats: new Map([
+        [uri("Animal"), { total: 1, named: 1 }],
+        [uri("Dog"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    expect(output.types.get("Dog")?.interfaces ?? []).toHaveLength(0);
+  });
+});
+
+describe("map — mapping resolution by namespace", () => {
+  it("resolves a custom mapping by prefixed property key", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("title"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir, {
+      mappings: { "ex:title": { graphqlName: "heading" } },
+    });
+    expect(output.types.get("Doc")?.fields.has("heading")).toBe(true);
+  });
+});
+
+describe("map — cardinality and interface coverage", () => {
+  it("resolves a custom mapping keyed by full IRI", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      instanceStats: new Map([[uri("Thing"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir, {
+      mappings: { [uri("Thing")]: { graphqlName: "Renamed" } },
+    });
+    expect(output.types.has("Renamed")).toBe(true);
+  });
+
+  it("reads a per-class cardinality spec when one is present", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Spec"), superclasses: [] },
+        { uri: uri("Hop"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("root"),
+          kind: "object",
+          domains: [uri("Spec")],
+          ranges: [uri("Hop")],
+        },
+      ],
+      shaclConstraints: [
+        {
+          targetClass: uri("Spec"),
+          property: uri("root"),
+          minCount: 1,
+          maxCount: 1,
+        },
+      ],
+      instanceStats: new Map([[uri("Spec"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    // maxCount 1 → the per-class spec makes it a singular object field.
+    expect(output.types.get("Spec")?.fields.get("root")?.type.kind).toBe(
+      "type",
+    );
+  });
+
+  it("omits a field whose SHACL maxCount is 0 (V010)", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Item"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("legacy"),
+          kind: "datatype",
+          domains: [uri("Item")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      shaclConstraints: [
+        { targetClass: uri("Item"), property: uri("legacy"), maxCount: 0 },
+      ],
+      instanceStats: new Map([[uri("Item"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    expect(output.types.get("Item")?.fields.has("legacy")).toBe(false);
+  });
+
+  it("makes an embeddable type implement its all-embeddable interface", () => {
+    // Shape: no instances + a subclass → abstract interface. Box: its only
+    // concrete descendant, blank-node-only → embeddable. The interface is thus
+    // embeddable, so the embeddable Box DOES implement it.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Shape"), superclasses: [] },
+        { uri: uri("Box"), superclasses: [uri("Shape")] },
+      ],
+      properties: [
+        {
+          uri: uri("size"),
+          kind: "datatype",
+          domains: [uri("Box")],
+          ranges: [`${XSD}integer`],
+        },
+      ],
+      instanceStats: new Map([[uri("Box"), { total: 2, named: 0 }]]),
+    });
+    const { output } = map(ir);
+    expect(output.interfaces.has("Shape")).toBe(true);
+    expect(output.types.get("Box")?.interfaces).toContain("Shape");
+  });
+
+  it("drops the interface from an embeddable type when a sibling is named", () => {
+    // Adding a named (non-embeddable) Card under Shape makes the interface
+    // non-embeddable: the embeddable Box no longer implements it (it would have
+    // no uri/_meta), but the non-embeddable Card still does.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Shape"), superclasses: [] },
+        { uri: uri("Box"), superclasses: [uri("Shape")] },
+        { uri: uri("Card"), superclasses: [uri("Shape")] },
+      ],
+      properties: [
+        {
+          uri: uri("size"),
+          kind: "datatype",
+          domains: [uri("Box")],
+          ranges: [`${XSD}integer`],
+        },
+        {
+          uri: uri("label"),
+          kind: "datatype",
+          domains: [uri("Card")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      instanceStats: new Map([
+        [uri("Box"), { total: 2, named: 0 }], // embeddable
+        [uri("Card"), { total: 2, named: 2 }], // named → not embeddable
+      ]),
+    });
+    const { output } = map(ir);
+    expect(output.types.get("Box")?.interfaces ?? []).not.toContain("Shape");
+    expect(output.types.get("Card")?.interfaces).toContain("Shape");
+  });
+
+  it("picks templates by cardinality: datatype defaults singular, object list embedded", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Doc"), superclasses: [] },
+        { uri: uri("Meta"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("title"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+        {
+          uri: uri("meta"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Meta")],
+        },
+      ],
+      // Datatype properties default to singular (so `title` is a singular
+      // datatype field); the non-functional object to the blank-only (=>
+      // embeddable) Meta is a list → embedded-list (pluralized to `metas`).
+      instanceStats: new Map([
+        [uri("Doc"), { total: 1, named: 1 }],
+        [uri("Meta"), { total: 1, named: 0 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const fields = output.types.get("Doc")?.fields;
+    expect(fields?.get("title")?.resolverTemplate).toBe("datatype");
+    expect(fields?.get("metas")?.resolverTemplate).toBe("embedded-list");
+  });
+
+  it("uses the singular datatype template under a SHACL maxCount of 1", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("title"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      shaclConstraints: [
+        { targetClass: uri("Doc"), property: uri("title"), maxCount: 1 },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    // maxCount 1 → singular datatype template (not the list variant).
+    expect(output.types.get("Doc")?.fields.get("title")?.resolverTemplate).toBe(
+      "datatype",
+    );
+  });
+
+  it("resolves an object property with an unknown range as a String scalar (B003)", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("ref"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Ghost")],
+        },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    // Ghost is not a known class → the object range falls back to a String
+    // scalar, so the (pluralized, non-functional list) field resolves as a
+    // datatype-list of strings, not a connection.
+    const refs = output.types.get("Doc")?.fields.get("refs");
+    expect(refs?.type).toEqual({ kind: "scalar", name: "String" });
+    expect(refs?.resolverTemplate).toBe("datatype-list");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/map.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/map.ts
@@ -1,0 +1,505 @@
+// =============================================================================
+// Pass 4 — Map: OntologyIR → MappedIR
+//
+// Pure. OWL names → GraphQL names (custom overrides, has/is stripping, case
+// convention, pluralization, collision resolution), range → field type specs,
+// resolver template assignment, embeddable/interface interaction, synthetic
+// inverse fields, standard-vocab fields, non-null overrides.
+// =============================================================================
+
+import {
+  type ClassNode,
+  type Diagnostic,
+  type FieldTypeSpec,
+  getLocalName,
+  type MappedField,
+  type MappedInterface,
+  type MappedIR,
+  type MappedType,
+  type MappedUnion,
+  type OntologyIR,
+  type PassResult,
+  type PropertyNode,
+  RESERVED_FIELD_NAMES,
+  RESERVED_TYPE_NAMES,
+  type ResolverTemplate,
+} from "#shared";
+import BidirectionalNameMap from "./BidirectionalNameMap.js";
+import {
+  camelize,
+  pluralize,
+  sanitizeGraphQLName,
+  stripVerbPrefix,
+} from "./nameMap.js";
+import type { CustomMapping, SchemaPluginOptions } from "./types.js";
+
+const PHASE = "map";
+
+interface MapperState {
+  ir: OntologyIR;
+  options: SchemaPluginOptions;
+  diagnostics: Diagnostic[];
+  nameMap: BidirectionalNameMap;
+  typeNames: Map<string, string>; // class URI → resolved GraphQL type name
+}
+
+/** Find the custom mapping for a URI (full-IRI key first, prefixed key second). */
+const findMapping = (
+  state: MapperState,
+  uri: string,
+): CustomMapping | undefined => {
+  const direct = state.options.mappings?.[uri];
+  if (direct) {
+    return direct;
+  }
+  const ns =
+    state.ir.classes.get(uri)?.namespace ??
+    state.ir.properties.get(uri)?.namespace;
+  return ns
+    ? state.options.mappings?.[`${ns}:${getLocalName(uri)}`]
+    : undefined;
+};
+
+/** Resolve every class URI to its GraphQL type name with collision handling. */
+const resolveTypeNames = (state: MapperState): void => {
+  const taken = new Set<string>(RESERVED_TYPE_NAMES);
+  for (const node of state.ir.classes.values()) {
+    const custom = findMapping(state, node.uri)?.graphqlName;
+    let name = custom ?? getLocalName(node.uri);
+    const sanitized = sanitizeGraphQLName(name);
+    if (sanitized !== name) {
+      state.diagnostics.push({
+        severity: "warning",
+        code: "M002",
+        message: `class local name "${name}" is not a legal GraphQL name - sanitized to ${sanitized}`,
+        source: node.uri,
+        phase: PHASE,
+      });
+      name = sanitized;
+    }
+    if (taken.has(name) && !custom) {
+      // Rule 6a: prefix with PascalCase namespace prefix (M004 info).
+      const prefixed =
+        node.namespace.charAt(0).toUpperCase() + node.namespace.slice(1) + name;
+      state.diagnostics.push({
+        severity: "info",
+        code: "M004",
+        message: `type name ${name} collides with a reserved name — renamed to ${prefixed}`,
+        source: node.uri,
+        phase: PHASE,
+      });
+      name = prefixed;
+    }
+    if (taken.has(name)) {
+      state.diagnostics.push({
+        severity: "error",
+        code: "M001",
+        message: `type name ${name} (${node.uri}) collides and cannot be auto-resolved — add a custom mapping`,
+        source: node.uri,
+        phase: PHASE,
+      });
+    }
+    taken.add(name);
+    state.typeNames.set(node.uri, name);
+    state.nameMap.set(node.uri, name);
+  }
+};
+
+/** Compute the GraphQL field name for a property. */
+const computeFieldName = (
+  state: MapperState,
+  property: PropertyNode,
+  isList: boolean,
+): string => {
+  const custom = findMapping(state, property.uri)?.graphqlName;
+  if (custom) {
+    return custom;
+  }
+  let name = stripVerbPrefix(getLocalName(property.uri));
+  if (isList) {
+    name = pluralize(name);
+  }
+  return sanitizeGraphQLName(name);
+};
+
+/** Compute the GraphQL field type spec for a property's resolved range. */
+const computeFieldType = (
+  state: MapperState,
+  property: PropertyNode,
+): FieldTypeSpec => {
+  switch (property.range.kind) {
+    case "scalar":
+      return { kind: "scalar", name: property.range.graphqlScalar };
+    case "class": {
+      const name = state.typeNames.get(property.range.uri);
+      return name ? { kind: "type", name } : { kind: "scalar", name: "String" };
+    }
+    case "union": {
+      const name =
+        property.range.name ??
+        `${getLocalName(property.uri).charAt(0).toUpperCase()}${getLocalName(property.uri).slice(1)}Union`;
+      // Abstract members expand to concrete descendants.
+      const members: string[] = [];
+      for (const member of property.range.members) {
+        const node = state.ir.classes.get(member);
+        if (!node) {
+          continue;
+        }
+        if (node.isAbstract) {
+          for (const sub of collectConcreteDescendants(state.ir, node)) {
+            const subName = state.typeNames.get(sub);
+            if (subName && !members.includes(subName)) {
+              members.push(subName);
+            }
+          }
+        } else {
+          const memberName = state.typeNames.get(member);
+          if (memberName && !members.includes(memberName)) {
+            members.push(memberName);
+          }
+        }
+      }
+      return { kind: "union", name, members };
+    }
+    case "unknown":
+      return { kind: "scalar", name: "String" };
+  }
+};
+
+/** Collect the URIs of a class's concrete (non-abstract) descendants, cycle-safe. */
+const collectConcreteDescendants = (
+  ir: OntologyIR,
+  node: ClassNode,
+): string[] => {
+  const result: string[] = [];
+  const visited = new Set<string>();
+  const walk = (uri: string) => {
+    if (visited.has(uri)) {
+      return; // subClassOf cycles (B001) must not overflow the stack
+    }
+    visited.add(uri);
+    const current = ir.classes.get(uri);
+    if (!current) {
+      return;
+    }
+    if (!current.isAbstract) {
+      result.push(uri);
+    }
+    for (const sub of current.subclasses) {
+      walk(sub);
+    }
+  };
+  walk(node.uri);
+  return result;
+};
+
+/** Is the property's range an embeddable class? */
+const isEmbeddedRange = (state: MapperState, property: PropertyNode): boolean =>
+  property.range.kind === "class" &&
+  (state.ir.classes.get(property.range.uri)?.embeddable ?? false);
+
+/** Cardinality of a property on a specific class (per-class SHACL first). */
+const isSingularOn = (
+  property: PropertyNode,
+  classUri: string,
+  ancestors: readonly string[],
+): { singular: boolean; required: boolean; omit: boolean } => {
+  for (const uri of [classUri, ...ancestors]) {
+    const spec = property.classCardinality.get(uri);
+    if (spec) {
+      return spec;
+    }
+  }
+  return { singular: property.functional, required: false, omit: false };
+};
+
+/** Choose the resolver template for a field from its kind, cardinality, and type. */
+const chooseTemplate = (
+  property: PropertyNode,
+  singular: boolean,
+  embedded: boolean,
+  fieldType: FieldTypeSpec,
+): ResolverTemplate => {
+  // Decide from the RESOLVED type: an object property whose range fell back
+  // to String (unknown range, B003) must resolve its URI values as strings,
+  // not hand Connection shapes to a String field.
+  if (property.kind !== "object" || fieldType.kind === "scalar") {
+    return singular ? "datatype" : "datatype-list";
+  }
+  if (embedded) {
+    return singular ? "embedded-singular" : "embedded-list";
+  }
+  return singular ? "object-singular" : "object-list";
+};
+
+/** Build the MappedFields for one class (own + inherited). */
+const buildFields = (
+  state: MapperState,
+  node: ClassNode,
+  typeName: string,
+): Map<string, MappedField> => {
+  const fields = new Map<string, MappedField>();
+  const used = new Set<string>(node.embeddable ? [] : RESERVED_FIELD_NAMES);
+
+  const addField = (field: MappedField) => {
+    if (used.has(field.graphqlName)) {
+      // Rule 7: reserved/colliding field — namespace-prefix it.
+      const renamed = `${state.ir.properties.get(field.owlUri)?.namespace ?? "x"}${
+        field.graphqlName.charAt(0).toUpperCase() + field.graphqlName.slice(1)
+      }`;
+      state.diagnostics.push({
+        severity: "warning",
+        code: "M002",
+        message: `field ${typeName}.${field.graphqlName} collides with a reserved name — renamed to ${renamed}`,
+        source: field.owlUri,
+        phase: PHASE,
+      });
+      field = { ...field, graphqlName: renamed };
+    }
+    if (fields.has(field.graphqlName)) {
+      state.diagnostics.push({
+        severity: "error",
+        code: "M001",
+        message: `two properties map to ${typeName}.${field.graphqlName}`,
+        source: field.owlUri,
+        phase: PHASE,
+      });
+      return;
+    }
+    used.add(field.graphqlName);
+    fields.set(field.graphqlName, field);
+    state.nameMap.set(field.owlUri, field.graphqlName);
+  };
+
+  // Declared + inherited properties.
+  for (const propertyUri of node.allProperties) {
+    const property = state.ir.properties.get(propertyUri);
+    if (!property || property.isAnnotation) {
+      continue;
+    }
+    const { singular, omit } = isSingularOn(property, node.uri, node.ancestors);
+    if (omit) {
+      continue; // SHACL sh:maxCount 0 (V010)
+    }
+    const required = isSingularOn(property, node.uri, node.ancestors).required;
+    const embedded = isEmbeddedRange(state, property);
+    const list = !singular;
+    const name = computeFieldName(state, property, list);
+    const nonNull =
+      state.options.nonNullOverrides?.[typeName]?.includes(name) ?? false;
+    // Declared owl:inverseOf pair: the ABox may assert either direction, so
+    // each side resolves the union of forward + reverse assertions.
+    // List sides switch to the inverse template; singular sides keep their
+    // template but carry inverseOf for the reverse fallback.
+    const fieldType = computeFieldType(state, property);
+    const declaredInverse =
+      property.kind === "object" && fieldType.kind === "type" && !embedded
+        ? property.inverse
+        : undefined;
+    addField({
+      owlUri: property.uri,
+      graphqlName: name,
+      type: fieldType,
+      nullable: !nonNull,
+      list,
+      resolverTemplate:
+        declaredInverse && list
+          ? "inverse"
+          : chooseTemplate(property, singular, embedded, fieldType),
+      propertyUri: property.uri,
+      inverseOf: declaredInverse,
+      shaclRequired: required,
+      nonNull,
+    });
+  }
+
+  // Synthetic + declared inverse fields (Template 4).
+  for (const property of state.ir.properties.values()) {
+    if (property.kind !== "object" || property.range.kind !== "class") {
+      continue;
+    }
+    const rangeUri = property.range.uri;
+    const appliesHere =
+      rangeUri === node.uri || node.ancestors.includes(rangeUri);
+    if (!appliesHere) {
+      continue;
+    }
+    const synthetic = findMapping(state, property.uri)?.inverse;
+    const declared = property.inverse
+      ? state.ir.properties.get(property.inverse)
+      : undefined;
+    // Declared pairs: each side keeps its own forward field — the
+    // dual-direction union happens in the resolver, not via an extra field.
+    if (declared || !synthetic) {
+      continue;
+    }
+    const name = synthetic.graphqlName;
+    addField({
+      owlUri: `${property.uri}#inverse`,
+      graphqlName: name,
+      type: {
+        kind: "type",
+        name: state.typeNames.get(property.domains[0] ?? "") ?? "Node",
+      },
+      nullable: false,
+      list: true,
+      resolverTemplate: "inverse",
+      propertyUri: property.uri,
+      inverseOf: property.uri,
+      shaclRequired: false,
+      nonNull: true,
+    });
+  }
+
+  // Opt-in instance-level standard-vocab fields.
+  const vocabFields = state.options.standardVocabFields?.[typeName];
+  if (vocabFields) {
+    for (const [predicate, name] of Object.entries(vocabFields)) {
+      addField({
+        owlUri: predicate,
+        graphqlName: name,
+        type: { kind: "scalar", name: "String" },
+        nullable: true,
+        list: false,
+        resolverTemplate: "datatype",
+        propertyUri: predicate,
+        shaclRequired: false,
+        nonNull: false,
+      });
+    }
+  }
+
+  return fields;
+};
+
+/**
+ * An interface qualifies for embeddable implementors only when every
+ * concrete descendant is embeddable (no uri/_meta on the interface then).
+ */
+const isInterfaceEmbeddable = (ir: OntologyIR, node: ClassNode): boolean =>
+  collectConcreteDescendants(ir, node).every((uri) => {
+    /* v8 ignore next -- descendant URIs come from the class map, so the lookup always resolves and the false fallback is unreachable */
+    return ir.classes.get(uri)?.embeddable ?? false;
+  });
+
+/**
+ * Map the OntologyIR to the GraphQL-shaped MappedIR (Pass 4): resolved type
+ * and field names, field type specs, resolver template assignments, and the
+ * bidirectional name map. Pure.
+ */
+export default function map(
+  ir: OntologyIR,
+  options: SchemaPluginOptions = {},
+): PassResult<MappedIR> {
+  const diagnostics: Diagnostic[] = [];
+  const state: MapperState = {
+    ir,
+    options,
+    diagnostics,
+    nameMap: new BidirectionalNameMap(),
+    typeNames: new Map(),
+  };
+
+  // Report custom mappings that reference nothing (M003).
+  for (const key of Object.keys(options.mappings ?? {})) {
+    const full = ir.classes.has(key) || ir.properties.has(key);
+    const prefixed = [...ir.classes.values(), ...ir.properties.values()].some(
+      (n) => `${n.namespace}:${getLocalName(n.uri)}` === key,
+    );
+    if (!full && !prefixed) {
+      diagnostics.push({
+        severity: "warning",
+        code: "M003",
+        message: `custom mapping ${key} references no known class or property`,
+        source: key,
+        phase: PHASE,
+      });
+    }
+  }
+
+  resolveTypeNames(state);
+
+  const types = new Map<string, MappedType>();
+  const interfaces = new Map<string, MappedInterface>();
+  const unions = new Map<string, MappedUnion>();
+
+  for (const node of ir.classes.values()) {
+    const typeName = state.typeNames.get(node.uri);
+    /* v8 ignore next 3 -- resolveTypeNames assigns a name to every class in this same map, so a class without a resolved type name is unreachable */
+    if (!typeName) {
+      continue;
+    }
+    const fields = buildFields(state, node, typeName);
+    // Field-name reverse lookups are scoped per type and served from
+    // MappedType.fields (EntityMeta.field resolves through it) — the
+    // global NameMap carries type names plus a best-effort property entry.
+
+    if (node.isAbstract) {
+      const parentInterfaces = node.ancestors
+        .map((a) => state.typeNames.get(a))
+        .filter((n): n is string => n !== undefined)
+        .filter((n) => {
+          /* v8 ignore next -- every resolved type name was registered in the name map alongside its URI, so the reverse lookup always resolves and the empty-string fallback is unreachable */
+          const ownerUri = state.nameMap.toOWL(n) ?? "";
+          return ir.classes.get(ownerUri)?.isAbstract;
+        });
+      interfaces.set(typeName, {
+        owlUri: node.uri,
+        graphqlName: typeName,
+        parentInterfaces,
+        fields,
+      });
+      continue;
+    }
+
+    // Embeddable types implement an ancestor interface only when that
+    // interface itself is embeddable-safe (all implementors embeddable).
+    const implemented = node.ancestors
+      .map((a) => ir.classes.get(a))
+      .filter((a): a is ClassNode => Boolean(a?.isAbstract))
+      .filter((a) => !node.embeddable || isInterfaceEmbeddable(ir, a))
+      .map((a) => state.typeNames.get(a.uri))
+      .filter((n): n is string => n !== undefined);
+
+    types.set(typeName, {
+      owlUri: node.uri,
+      graphqlName: typeName,
+      interfaces: implemented,
+      fields,
+      embeddable: node.embeddable,
+      namespace: node.namespace,
+      singularName: camelize(typeName),
+      pluralName: pluralize(camelize(typeName)),
+    });
+  }
+
+  // Collect union specs from field types.
+  for (const container of [...types.values(), ...interfaces.values()]) {
+    for (const field of container.fields.values()) {
+      if (field.type.kind === "union" && !unions.has(field.type.name)) {
+        unions.set(field.type.name, {
+          name: field.type.name,
+          members: field.type.members,
+        });
+        diagnostics.push({
+          severity: "info",
+          code: field.type.name.endsWith("Union") ? "X003" : "X002",
+          message: `union ${field.type.name} = ${field.type.members.join(" | ")}`,
+          phase: PHASE,
+        });
+      }
+    }
+  }
+
+  return {
+    output: {
+      types,
+      interfaces,
+      unions,
+      nameMap: state.nameMap,
+      namespaces: ir.namespaces,
+      ir,
+    },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/nameMap.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/nameMap.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import BidirectionalNameMap from "./BidirectionalNameMap.js";
+import {
+  camelize,
+  pluralize,
+  sanitizeGraphQLName,
+  stripVerbPrefix,
+} from "./nameMap.js";
+
+describe("pluralize", () => {
+  it("applies the suffix rules", () => {
+    expect(pluralize("edge")).toBe("edges");
+    expect(pluralize("style")).toBe("styles");
+    expect(pluralize("category")).toBe("categories");
+    expect(pluralize("implementationLibrary")).toBe("implementationLibraries");
+    expect(pluralize("switch")).toBe("switches");
+    expect(pluralize("box")).toBe("boxes");
+  });
+
+  it("leaves names already ending in s unchanged", () => {
+    expect(pluralize("cases")).toBe("cases");
+    expect(pluralize("donts")).toBe("donts");
+    expect(pluralize("extends")).toBe("extends");
+  });
+
+  it("handles irregular plurals", () => {
+    expect(pluralize("child")).toBe("children");
+    expect(pluralize("person")).toBe("people");
+    expect(pluralize("grandChild")).toBe("grandChildren");
+  });
+
+  it("preserves the case of a capitalized irregular", () => {
+    expect(pluralize("Child")).toBe("Children");
+    expect(pluralize("Person")).toBe("People");
+  });
+});
+
+describe("stripVerbPrefix", () => {
+  it("strips has/is verb prefixes", () => {
+    expect(stripVerbPrefix("hasEdge")).toBe("edge");
+    expect(stripVerbPrefix("isDraft")).toBe("draft");
+    expect(stripVerbPrefix("hasModifierFamily")).toBe("modifierFamily");
+  });
+
+  it("leaves non-verb names alone", () => {
+    expect(stripVerbPrefix("name")).toBe("name");
+    expect(stripVerbPrefix("history")).toBe("history"); // not "has" + Word
+    expect(stripVerbPrefix("island")).toBe("island");
+  });
+});
+
+describe("sanitizeGraphQLName", () => {
+  it("replaces illegal characters and guards leading digits", () => {
+    expect(sanitizeGraphQLName("My-Class")).toBe("My_Class");
+    expect(sanitizeGraphQLName("has.thing")).toBe("has_thing");
+    expect(sanitizeGraphQLName("3d")).toBe("_3d");
+    expect(sanitizeGraphQLName("")).toBe("_");
+    expect(sanitizeGraphQLName("fine_Name0")).toBe("fine_Name0");
+  });
+});
+
+describe("camelize", () => {
+  it("lowercases the first character", () => {
+    expect(camelize("Component")).toBe("component");
+    expect(camelize("ImplementationLibrary")).toBe("implementationLibrary");
+  });
+});
+
+describe("BidirectionalNameMap", () => {
+  it("maps both directions with first-writer-wins reverse", () => {
+    const map = new BidirectionalNameMap();
+    map.set("https://ds.canonical.com/Component", "Component");
+    map.set("https://ds.canonical.com/name", "name");
+    map.set("http://pragma.canonical.com/codestandards#name", "name");
+    expect(map.toGraphQL("https://ds.canonical.com/Component")).toBe(
+      "Component",
+    );
+    expect(map.toOWL("Component")).toBe("https://ds.canonical.com/Component");
+    // first writer wins for the reverse direction
+    expect(map.toOWL("name")).toBe("https://ds.canonical.com/name");
+    expect([...map.entries()].length).toBe(3);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/nameMap.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/nameMap.ts
@@ -1,0 +1,82 @@
+// =============================================================================
+// The GraphQL naming rules: pluralization, casing, verb stripping, and
+// name sanitization. Grouped here because Pass 4 applies them together when
+// mapping OWL names to GraphQL names.
+// =============================================================================
+
+/** Irregular plurals the suffix rules cannot produce. */
+const IRREGULAR_PLURALS: Record<string, string> = {
+  child: "children",
+  person: "people",
+};
+
+/**
+ * Pluralize a camelCase field name:
+ *   a. irregulars (child → children)
+ *   b. already ends in 's' → unchanged (treated as plural: cases, donts)
+ *   c. consonant + 'y' → 'ies' (category → categories)
+ *   d. x/z/ch/sh → '+es' (switch → switches)
+ *   e. default → '+s' (edge → edges)
+ */
+export const pluralize = (name: string): string => {
+  // Preserve a camelCase prefix when the final word is irregular
+  // (hasChild → child; implementationChild → implementationChildren).
+  for (const [singular, plural] of Object.entries(IRREGULAR_PLURALS)) {
+    if (name.toLowerCase() === singular) {
+      return name[0] === name[0]?.toUpperCase()
+        ? plural.charAt(0).toUpperCase() + plural.slice(1)
+        : plural;
+    }
+    const suffix = singular.charAt(0).toUpperCase() + singular.slice(1);
+    if (name.endsWith(suffix)) {
+      return (
+        name.slice(0, -suffix.length) +
+        plural.charAt(0).toUpperCase() +
+        plural.slice(1)
+      );
+    }
+  }
+  if (name.endsWith("s")) {
+    return name;
+  }
+  if (/[^aeiou]y$/i.test(name)) {
+    return `${name.slice(0, -1)}ies`;
+  }
+  if (/(x|z|ch|sh)$/i.test(name)) {
+    return `${name}es`;
+  }
+  return `${name}s`;
+};
+
+/** Camelize a PascalCase type name (lowercase first letter) for root query fields. */
+export const camelize = (name: string): string =>
+  name.charAt(0).toLowerCase() + name.slice(1);
+
+/** Strip a leading "has"/"is" verb from a field name. */
+export const stripVerbPrefix = (name: string): string => {
+  for (const prefix of ["has", "is"]) {
+    if (
+      name.startsWith(prefix) &&
+      name.length > prefix.length &&
+      name[prefix.length] === name[prefix.length]?.toUpperCase()
+    ) {
+      const stripped = name.slice(prefix.length);
+      return stripped.charAt(0).toLowerCase() + stripped.slice(1);
+    }
+  }
+  return name;
+};
+
+/**
+ * Make a string a legal GraphQL name: [_a-zA-Z][_a-zA-Z0-9]*.
+ * Invalid characters (dots, dashes, unicode) become underscores; a leading
+ * digit gets an underscore prefix; an empty result becomes "_". Callers emit
+ * a diagnostic when the result differs from the input.
+ */
+export const sanitizeGraphQLName = (name: string): string => {
+  const cleaned = name.replace(/[^_a-zA-Z0-9]/g, "_");
+  if (cleaned.length === 0) {
+    return "_";
+  }
+  return /^[_a-zA-Z]/.test(cleaned) ? cleaned : `_${cleaned}`;
+};

--- a/packages/runtime/ke-graphql/src/lib/compiler/runPasses.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/runPasses.ts
@@ -1,0 +1,73 @@
+import type { Diagnostic, RawExtraction } from "#shared";
+import build from "./build.js";
+import CompilationError from "./CompilationError.js";
+import compose from "./compose.js";
+import createContextFactory from "./createContextFactory.js";
+import emit from "./emit.js";
+import map from "./map.js";
+import type { CompilerResult, SchemaPluginOptions } from "./types.js";
+import validate from "./validate.js";
+import wireRelay from "./wireRelay.js";
+
+/**
+ * Run Passes 2–7 over a RawExtraction and assemble the CompilerResult.
+ *
+ * Only Pass 7 (composition) errors prevent schema creation —
+ * C001/C002 extension conflicts and C003 validation failures throw a
+ * CompilationError; earlier error diagnostics surface in the list without
+ * aborting. Pure — every pass after extraction is store-free.
+ */
+export default function runPasses(
+  extraction: RawExtraction,
+  options: SchemaPluginOptions,
+  {
+    diagnostics: seed = [],
+    skipValidation = false,
+  }: { diagnostics?: Diagnostic[]; skipValidation?: boolean } = {},
+): CompilerResult {
+  const diagnostics: Diagnostic[] = [...seed];
+
+  const built = build(extraction, options.mappings);
+  diagnostics.push(...built.diagnostics);
+
+  const validated = validate(built.output);
+  diagnostics.push(...validated.diagnostics);
+
+  const mapped = map(validated.output, options);
+  diagnostics.push(...mapped.diagnostics);
+
+  const emitted = emit(mapped.output);
+  diagnostics.push(...emitted.diagnostics);
+
+  const relayed = options.relay === false ? emitted : wireRelay(emitted.output);
+  diagnostics.push(...(options.relay === false ? [] : relayed.diagnostics));
+
+  const composed = compose(relayed.output, {
+    extensions: options.extensions,
+    incremental: options.incremental,
+    skipValidation,
+  });
+  diagnostics.push(...composed.diagnostics);
+
+  // Only Pass 7 (composition) errors prevent schema creation —
+  // C001/C002 extension conflicts and C003 validation failures are fatal;
+  // earlier error diagnostics surface in the list without aborting.
+  const compositionErrors = composed.diagnostics.filter(
+    (d) => d.severity === "error",
+  );
+  if (!composed.output.schema || compositionErrors.length > 0) {
+    throw new CompilationError(diagnostics);
+  }
+
+  const factory = createContextFactory(mapped.output, options);
+  return {
+    schema: composed.output.schema,
+    sdl: composed.output.sdl,
+    diagnostics,
+    nameMap: mapped.output.nameMap,
+    mapped: mapped.output,
+    extraction,
+    createContext: factory,
+    clearLoaderCache: factory.clearCache,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/types.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/types.ts
@@ -1,0 +1,167 @@
+// =============================================================================
+// @canonical/ke-graphql — Compiler API type contracts
+//
+// The options and result shapes of the seven-pass pipeline's public entry
+// points (compile, the schema plugin, the artifact codec). The IR/value/
+// context contracts these build on live in the shared leaf (#shared) and are
+// re-exported from the compiler barrel for the package's public surface.
+// =============================================================================
+
+import type { Store } from "@canonical/ke";
+import type { GraphQLFieldConfig, GraphQLSchema } from "graphql";
+import type {
+  CompilerContext,
+  Diagnostic,
+  InstanceStats,
+  MappedIR,
+  NameMap,
+  RawExtraction,
+  RuntimeWarningHandler,
+} from "#shared";
+import type { ARTIFACT_VERSION } from "./constants.js";
+
+/**
+ * The JSON shape of a serialized extraction artifact: RawExtraction with its
+ * Maps and Sets flattened to arrays, plus the artifact format version and
+ * the fingerprint of the TTL sources it was built from.
+ */
+export interface SerializedExtraction {
+  version: typeof ARTIFACT_VERSION;
+  /** Combined fingerprint of the TTL sources the extraction was built from. */
+  sourcesHash: string;
+  classes: RawExtraction["classes"];
+  properties: RawExtraction["properties"];
+  inverses: RawExtraction["inverses"];
+  functionals: string[];
+  datatypes: RawExtraction["datatypes"];
+  namespaces: Array<[string, string]>;
+  shaclConstraints: RawExtraction["shaclConstraints"];
+  unions: RawExtraction["unions"];
+  instanceStats: Array<[string, InstanceStats]>;
+  selfReferential: string[];
+  functionalViolations: string[];
+  undeclaredPredicates: string[];
+  annotations: Array<[string, Array<[string, string]>]>;
+  deepBlankNesting: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Per-URI override of the generated mapping (rename, cardinality, shape). */
+export interface CustomMapping {
+  graphqlName?: string;
+  singular?: boolean;
+  abstract?: boolean;
+  embeddable?: boolean;
+  /** Synthesize an inverse field on the property's range type. */
+  inverse?: { graphqlName: string };
+}
+
+/** Custom mappings keyed by full IRI or prefixed name (e.g. "ds:tier"). */
+export type CustomMappings = Record<string, CustomMapping>;
+
+/** Per GraphQL type name: the field names promoted to non-null. */
+export type NonNullOverrides = Record<string, string[]>;
+
+/** Consumer-supplied extension fields, keyed by GraphQL type name. */
+export interface SchemaExtensions {
+  [typeName: string]: Record<
+    string,
+    // biome-ignore lint/suspicious/noExplicitAny: graphql-js field configs are consumer-typed
+    GraphQLFieldConfig<any, CompilerContext>
+  >;
+}
+
+/**
+ * Extensions may need the compiler-generated types (e.g. an `anatomy` field
+ * typed as the generated Specification). The factory form receives a lookup
+ * for generated types and interfaces by name.
+ */
+export type SchemaExtensionsInput =
+  | SchemaExtensions
+  | ((types: {
+      type(name: string): import("graphql").GraphQLObjectType | undefined;
+      iface(name: string): import("graphql").GraphQLInterfaceType | undefined;
+    }) => SchemaExtensions);
+
+/** Options accepted by the schema plugin and the compile entry points. */
+export interface SchemaPluginOptions {
+  mappings?: CustomMappings;
+  extensions?: SchemaExtensionsInput;
+  /** Wire the Node interface, global IDs, and connections. Default: true. */
+  relay?: boolean;
+  /** Add @defer/@stream directives to the schema. Default: false. */
+  incremental?: boolean;
+  /** File path for SDL output. */
+  sdlOutput?: string;
+  nonNullOverrides?: NonNullOverrides;
+  /**
+   * Opt-in instance-level standard-vocabulary fields.
+   * Per GraphQL type name: predicate URI → field name.
+   */
+  standardVocabFields?: Record<string, Record<string, string>>;
+  /** Resolver-time warnings (coercion failures). Default: console.warn, deduplicated. */
+  onRuntimeWarning?: RuntimeWarningHandler;
+  /**
+   * DataLoader cache scope. "request" (default): fresh caches per
+   * createContext call. "process": LRU caches shared across contexts for the
+   * lifetime of this CompilerResult — sound because the store is immutable
+   * between reloads, and onReload produces a new result (auto-invalidation).
+   * Bounded (see processCacheSize) so enumeration can't grow them without
+   * limit; failed batches are evicted, never memoized.
+   */
+  loaderCache?: "request" | "process";
+  /**
+   * Maximum entries per process-lifetime loader cache (LRU), used only when
+   * loaderCache is "process". Default: DEFAULT_PROCESS_CACHE_SIZE.
+   */
+  processCacheSize?: number;
+}
+
+/** Everything a successful compilation produces: schema, SDL, IR, context factory. */
+export interface CompilerResult {
+  schema: GraphQLSchema;
+  diagnostics: Diagnostic[];
+  nameMap: NameMap;
+  /** Empty when compiled from an artifact with assumeValid (printSchema skipped). */
+  sdl: string;
+  mapped: MappedIR;
+  /** The Pass 1 output — serializable via serializeExtraction (artifact boots). */
+  extraction: RawExtraction;
+  /**
+   * Fresh DataLoaders per call ("request" mode) or shared caches
+   * ("process" mode). Accepts a Promise for lazy-store boots: TBox
+   * queries answer before the store resolves; ABox loaders await it.
+   */
+  createContext(store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearLoaderCache(): void;
+}
+
+/** The API surface the plugin registers on the ke store under "ke-graphql". */
+export interface SchemaPluginApi {
+  schema: GraphQLSchema;
+  diagnostics: Diagnostic[];
+  nameMap: NameMap;
+  sdl: string;
+  /**
+   * Create a fresh CompilerContext (new DataLoaders each call). Takes the
+   * store as an argument: ke's PluginContext is scoped to its lifecycle
+   * hook and must not be retained for request-time queries.
+   */
+  createContext(store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearLoaderCache(): void;
+}
+
+/**
+ * Creates a fresh CompilerContext per call and exposes cache control for the
+ * "process" loader-cache mode.
+ */
+export interface ContextFactory {
+  (store: Store | Promise<Store>): CompilerContext;
+  /** Drop the shared caches ("process" mode); no-op otherwise. */
+  clearCache(): void;
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/validate.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/validate.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ClassNode,
+  Diagnostic,
+  OntologyIR,
+  PropertyNode,
+  RangeSpec,
+} from "#shared";
+import validate from "./validate.js";
+
+const classNode = (
+  over: Partial<ClassNode> & Pick<ClassNode, "uri">,
+): ClassNode => ({
+  label: over.uri,
+  namespace: "ex",
+  superclasses: [],
+  ancestors: [],
+  subclasses: [],
+  isAbstract: false,
+  embeddable: false,
+  ownProperties: [],
+  allProperties: [],
+  ...over,
+});
+
+const scalarRange: RangeSpec = {
+  kind: "scalar",
+  xsd: "http://www.w3.org/2001/XMLSchema#string",
+  graphqlScalar: "String",
+};
+
+const property = (
+  over: Partial<PropertyNode> & Pick<PropertyNode, "uri">,
+): PropertyNode => ({
+  label: over.uri,
+  namespace: "ex",
+  kind: "datatype",
+  domains: ["http://example.org/Thing"],
+  range: scalarRange,
+  functional: false,
+  classCardinality: new Map(),
+  isAnnotation: false,
+  annotations: new Map(),
+  ...over,
+});
+
+const buildIR = (
+  properties: Map<string, PropertyNode>,
+  classes: Map<string, ClassNode> = new Map(),
+): OntologyIR =>
+  ({
+    classes,
+    properties,
+    namespaces: new Map(),
+    extraction: {
+      classes: [],
+      properties: [],
+      inverses: [],
+      functionals: new Set(),
+      datatypes: [],
+      namespaces: new Map(),
+      shaclConstraints: [],
+      unions: [],
+      instanceStats: new Map(),
+      selfReferential: new Set(),
+      functionalViolations: new Set(),
+      undeclaredPredicates: new Set(),
+      annotations: new Map(),
+      deepBlankNesting: false,
+    },
+  }) as unknown as OntologyIR;
+
+const codes = (diagnostics: Diagnostic[]): string[] =>
+  diagnostics.map((d) => d.code);
+
+describe("validate property diagnostics", () => {
+  it("B003 — unknown range mapped to String", () => {
+    const properties = new Map<string, PropertyNode>([
+      [
+        "http://example.org/p",
+        property({
+          uri: "http://example.org/p",
+          range: { kind: "unknown", raw: "http://example.org/Mystery" },
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(properties));
+    expect(codes(diagnostics)).toContain("B003");
+    expect(diagnostics.find((d) => d.code === "B003")?.message).toContain(
+      "Mystery",
+    );
+  });
+
+  it("B004 — inverse declares an unknown property", () => {
+    const properties = new Map<string, PropertyNode>([
+      [
+        "http://example.org/forward",
+        property({
+          uri: "http://example.org/forward",
+          inverse: "http://example.org/missing",
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(properties));
+    expect(codes(diagnostics)).toContain("B004");
+    // the inverse target is absent, so V003 does not also fire
+    expect(codes(diagnostics)).not.toContain("V003");
+  });
+
+  it("V003 — asymmetric owl:inverseOf between two declared properties", () => {
+    // a.inverse = b, but b is paired symmetrically with c → a is the only
+    // contradiction. All three inverse targets exist, so no B004 fires.
+    const properties = new Map<string, PropertyNode>([
+      [
+        "http://example.org/a",
+        property({
+          uri: "http://example.org/a",
+          kind: "object",
+          inverse: "http://example.org/b",
+        }),
+      ],
+      [
+        "http://example.org/b",
+        property({
+          uri: "http://example.org/b",
+          kind: "object",
+          inverse: "http://example.org/c",
+        }),
+      ],
+      [
+        "http://example.org/c",
+        property({
+          uri: "http://example.org/c",
+          kind: "object",
+          inverse: "http://example.org/b",
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(properties));
+    const v003 = diagnostics.filter((d) => d.code === "V003");
+    // exactly one asymmetry: a → b
+    expect(v003).toHaveLength(1);
+    expect(v003[0]?.message).toContain("a");
+    expect(diagnostics.filter((d) => d.code === "B004")).toHaveLength(0);
+  });
+
+  it("V013 — property declares multiple rdfs:domain classes", () => {
+    const properties = new Map<string, PropertyNode>([
+      [
+        "http://example.org/multi",
+        property({
+          uri: "http://example.org/multi",
+          domains: ["http://example.org/A", "http://example.org/B"],
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(properties));
+    expect(codes(diagnostics)).toContain("V013");
+    expect(diagnostics.find((d) => d.code === "V013")?.message).toContain(
+      "2 domains",
+    );
+  });
+});
+
+describe("validate class diagnostics", () => {
+  it("B002 — class references an unknown, non-standard superclass", () => {
+    // superclass is neither in the IR nor a standard vocabulary → B002
+    // (a standard-vocab parent would instead be V009).
+    const classes = new Map<string, ClassNode>([
+      [
+        "http://example.org/Sub",
+        classNode({
+          uri: "http://example.org/Sub",
+          superclasses: ["http://example.org/Ghost"],
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(new Map(), classes));
+    expect(codes(diagnostics)).toContain("B002");
+    expect(codes(diagnostics)).not.toContain("V009");
+    expect(diagnostics.find((d) => d.code === "B002")?.message).toContain(
+      "Ghost",
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/validate.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/validate.ts
@@ -1,0 +1,249 @@
+// =============================================================================
+// Pass 3 — Validate: OntologyIR → OntologyIR (+ diagnostics)
+//
+// Pure. Reads the IR and the Pass 1 probes, emits the V-series diagnostics.
+// Never mutates the IR.
+// =============================================================================
+
+import {
+  type Diagnostic,
+  getLocalName,
+  type OntologyIR,
+  type PassResult,
+  XSD,
+} from "#shared";
+import isStandardVocab from "./isStandardVocab.js";
+
+const PHASE = "validate";
+
+/** A class is blank-node-only when it has instances but none are named. */
+const isBlankOnly = (ir: OntologyIR, classUri: string): boolean => {
+  const stats = ir.extraction.instanceStats.get(classUri);
+  return stats !== undefined && stats.total > 0 && stats.named === 0;
+};
+
+/**
+ * Validate the OntologyIR against the Pass 1 ABox probes (Pass 3): emits
+ * the V-series diagnostics (blank-node-only classes, domainless properties,
+ * asymmetric inverses, functional violations, SHACL specifics, …) without
+ * mutating the IR. Pure.
+ */
+export default function validate(ir: OntologyIR): PassResult<OntologyIR> {
+  const diagnostics: Diagnostic[] = [];
+  const push = (d: Omit<Diagnostic, "phase">) =>
+    diagnostics.push({ ...d, phase: PHASE });
+
+  for (const node of ir.classes.values()) {
+    // V001 — blank-node-only class
+    if (isBlankOnly(ir, node.uri)) {
+      push({
+        severity: "warning",
+        code: "V001",
+        message: `${getLocalName(node.uri)} instances are exclusively blank nodes — embeddable type`,
+        source: node.uri,
+      });
+    }
+    // V015 — class forced abstract (by mapping) yet has direct instances.
+    // Those instances' only asserted type is now an interface, so they cannot
+    // resolve and are filtered at runtime — the data contradicts the mapping.
+    // (The automatic abstract heuristic can't trigger this: it only marks a
+    // class abstract when it has zero instances.)
+    const abstractStats = ir.extraction.instanceStats.get(node.uri);
+    if (node.isAbstract && (abstractStats?.total ?? 0) > 0) {
+      push({
+        severity: "warning",
+        code: "V015",
+        message: `${getLocalName(node.uri)} is marked abstract but has ${abstractStats?.total} direct instance(s) — those instances will not resolve`,
+        source: node.uri,
+      });
+    }
+    // V016 — concrete class with subclasses (instantiable supertype). A field
+    // typed as this class can hold a subclass instance, but graphql-js calls
+    // no resolveType on a concrete object type, so the subclass's __typename
+    // and fields are unreachable through it. Mark it abstract if it has no
+    // direct instances; the interface+companion fix is a deferred option.
+    if (!node.isAbstract && !node.embeddable && node.subclasses.length > 0) {
+      push({
+        severity: "warning",
+        code: "V016",
+        message: `${getLocalName(node.uri)} is a concrete type with ${node.subclasses.length} subclass(es) — values returned through a ${getLocalName(node.uri)} field expose only its own fields, not the subclass's`,
+        source: node.uri,
+      });
+    }
+    // V009 — cross-vocabulary subClassOf
+    for (const parent of node.superclasses) {
+      if (!ir.classes.has(parent) && isStandardVocab(parent)) {
+        push({
+          severity: "warning",
+          code: "V009",
+          message: `${getLocalName(node.uri)} subClassOf standard-vocabulary ${parent} — treated as root class`,
+          source: node.uri,
+        });
+      } else if (!ir.classes.has(parent)) {
+        push({
+          severity: "warning",
+          code: "B002",
+          message: `${getLocalName(node.uri)} references unknown superclass ${parent}`,
+          source: node.uri,
+        });
+      }
+    }
+  }
+
+  for (const property of ir.properties.values()) {
+    // B002 — unknown domain
+    for (const domain of property.domains) {
+      if (!ir.classes.has(domain) && !isStandardVocab(domain)) {
+        push({
+          severity: "warning",
+          code: "B002",
+          message: `${getLocalName(property.uri)} has unknown domain ${domain}`,
+          source: property.uri,
+        });
+      }
+    }
+    // B003 — unknown range
+    if (property.range.kind === "unknown") {
+      push({
+        severity: "warning",
+        code: "B003",
+        message: `${getLocalName(property.uri)} has unknown range ${property.range.raw} — mapped to String`,
+        source: property.uri,
+      });
+    }
+    // B004 — unknown inverse
+    if (property.inverse && !ir.properties.has(property.inverse)) {
+      push({
+        severity: "warning",
+        code: "B004",
+        message: `${getLocalName(property.uri)} declares unknown inverse ${property.inverse}`,
+        source: property.uri,
+      });
+    }
+    // V002 — domainless
+    if (property.domains.length === 0 && !property.isAnnotation) {
+      push({
+        severity: "warning",
+        code: "V002",
+        message: `${getLocalName(property.uri)} has no rdfs:domain — assigned to all ${property.namespace}: classes`,
+        source: property.uri,
+      });
+    }
+    // V003 — conflicting inverse declarations (A declares inverse B while
+    // B declares inverse C). One-sided declarations are normal OWL and are
+    // silently completed in Pass 2 — only contradictions warrant a warning.
+    if (property.inverse) {
+      const other = ir.properties.get(property.inverse);
+      if (other && other.inverse !== property.uri) {
+        push({
+          severity: "warning",
+          code: "V003",
+          message: `asymmetric owl:inverseOf between ${getLocalName(property.uri)} and ${getLocalName(property.inverse)}`,
+          source: property.uri,
+        });
+      }
+    }
+    // V004 — self-referential assertions
+    if (ir.extraction.selfReferential.has(property.uri)) {
+      push({
+        severity: "warning",
+        code: "V004",
+        message: `${getLocalName(property.uri)} has a self-referential assertion in the data`,
+        source: property.uri,
+      });
+    }
+    // V005 — functional violations
+    if (ir.extraction.functionalViolations.has(property.uri)) {
+      push({
+        severity: "warning",
+        code: "V005",
+        message: `functional property ${getLocalName(property.uri)} has multiple values on some instance`,
+        source: property.uri,
+      });
+    }
+    // V006 — boolean range (data stores strings; resolver coerces)
+    if (
+      property.range.kind === "scalar" &&
+      property.range.xsd === `${XSD}boolean`
+    ) {
+      push({
+        severity: "info",
+        code: "V006",
+        message: `${getLocalName(property.uri)} is xsd:boolean — resolver coerces string literals`,
+        source: property.uri,
+      });
+    }
+    // V007 — annotation property routed to TBox
+    if (property.isAnnotation) {
+      push({
+        severity: "info",
+        code: "V007",
+        message: `annotation property ${getLocalName(property.uri)} routed to TBox schema`,
+        source: property.uri,
+      });
+    }
+    // V008 — custom datatype mapped to base scalar
+    if (property.range.kind === "scalar" && property.range.customDatatype) {
+      push({
+        severity: "info",
+        code: "V008",
+        message: `custom datatype ${getLocalName(property.range.customDatatype)} mapped to ${property.range.graphqlScalar}`,
+        source: property.uri,
+      });
+    }
+    // V010/V011/V012 — SHACL specifics
+    for (const [classUri, spec] of property.classCardinality) {
+      if (spec.omit) {
+        push({
+          severity: "warning",
+          code: "V010",
+          message: `${getLocalName(property.uri)} has sh:maxCount 0 on ${getLocalName(classUri)} — field omitted`,
+          source: property.uri,
+        });
+      }
+    }
+    const fromOr = ir.extraction.shaclConstraints.some(
+      (c) => c.property === property.uri && c.fromOr,
+    );
+    if (fromOr) {
+      push({
+        severity: "info",
+        code: "V011",
+        message: `${getLocalName(property.uri)} constrained via sh:or — most permissive interpretation applied`,
+        source: property.uri,
+      });
+    }
+    const inConstraint = ir.extraction.shaclConstraints.find(
+      (c) => c.property === property.uri && c.inValues?.length,
+    );
+    if (inConstraint) {
+      push({
+        severity: "info",
+        code: "V012",
+        message: `${getLocalName(property.uri)} has sh:in (${inConstraint.inValues?.join(", ")}) — mapped to String, enum deferred`,
+        source: property.uri,
+      });
+    }
+    // V013 — multi-domain
+    if (property.domains.length > 1) {
+      push({
+        severity: "warning",
+        code: "V013",
+        message: `${getLocalName(property.uri)} declares ${property.domains.length} domains — OWL means intersection; field generated on each`,
+        source: property.uri,
+      });
+    }
+  }
+
+  // V014 — undeclared ABox predicates
+  for (const predicate of ir.extraction.undeclaredPredicates) {
+    push({
+      severity: "info",
+      code: "V014",
+      message: `ABox predicate ${predicate} is not declared in any loaded TBox — no field generated`,
+      source: predicate,
+    });
+  }
+
+  return { output: ir, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.test.ts
@@ -1,0 +1,317 @@
+import type { GraphQLFieldResolver } from "graphql";
+import { describe, expect, it } from "vitest";
+import type {
+  CompilerContext,
+  EntityValue,
+  InterfacePlan,
+  MappedIR,
+  MappedType,
+  NameMap,
+  NamespaceInfo,
+  TypePlan,
+} from "#shared";
+import type { FieldPlan, SchemaPlan } from "./emit.js";
+import wireRelay from "./wireRelay.js";
+
+type Resolve = GraphQLFieldResolver<EntityValue, CompilerContext>;
+
+const nameMap: NameMap = {
+  toGraphQL: () => undefined,
+  toOWL: () => undefined,
+  entries: () => [][Symbol.iterator](),
+};
+
+const namespaces = new Map<string, NamespaceInfo>([
+  [
+    "ex",
+    {
+      prefix: "ex",
+      uri: "http://example.org/",
+      classCount: 0,
+      propertyCount: 0,
+    },
+  ],
+]);
+
+const listField = (
+  base: string,
+  kind: FieldPlan["type"]["kind"],
+): FieldPlan => ({
+  name: base,
+  type: { base, kind, list: true, nonNull: true },
+});
+
+const typePlan = (
+  over: Partial<TypePlan> & Pick<TypePlan, "name">,
+): TypePlan => ({
+  owlUri: `http://example.org/${over.name}`,
+  interfaces: [],
+  fields: new Map(),
+  embeddable: false,
+  ...over,
+});
+
+const ifacePlan = (
+  over: Partial<InterfacePlan> & Pick<InterfacePlan, "name">,
+): InterfacePlan => ({
+  owlUri: `http://example.org/${over.name}`,
+  parents: [],
+  fields: new Map(),
+  embeddableOnly: false,
+  ...over,
+});
+
+const mappedType = (name: string): MappedType => ({
+  owlUri: `http://example.org/${name}`,
+  graphqlName: name,
+  interfaces: [],
+  fields: new Map(),
+  embeddable: false,
+  namespace: "ex",
+  pluralName: `${name.toLowerCase()}s`,
+  singularName: name.toLowerCase(),
+});
+
+describe("wireRelay connection wrapping", () => {
+  it("wraps non-embeddable named lists and leaves embeddable/plain lists alone", () => {
+    const plain = typePlan({
+      name: "Plain",
+      embeddable: true,
+    });
+    const embeddableInterface = ifacePlan({
+      name: "EmbIface",
+      embeddableOnly: true,
+    });
+    const concreteInterface = ifacePlan({ name: "ConcIface" });
+
+    const host = typePlan({
+      name: "Host",
+      fields: new Map<string, FieldPlan>([
+        // base is a non-embeddable type → wrapped
+        ["entities", listField("Entity", "named")],
+        // base is an embeddable type → stays plain
+        ["plains", listField("Plain", "named")],
+        // base is an embeddable-only interface → stays plain
+        ["embs", listField("EmbIface", "named")],
+        // base is a concrete (non-embeddable) interface → wrapped
+        ["concs", listField("ConcIface", "named")],
+        // base resolves to neither a type nor an interface → wrapped
+        ["unknowns", listField("Mystery", "named")],
+        // not a list → untouched
+        [
+          "scalar",
+          {
+            name: "scalar",
+            type: {
+              base: "String",
+              kind: "scalar",
+              list: false,
+              nonNull: false,
+            },
+          },
+        ],
+        // a list but scalar kind → untouched
+        ["tags", listField("String", "scalar")],
+      ]),
+    });
+
+    const entity = typePlan({ name: "Entity" });
+
+    const plan: SchemaPlan = {
+      types: new Map([
+        ["Host", host],
+        ["Entity", entity],
+        ["Plain", plain],
+      ]),
+      interfaces: new Map([
+        ["EmbIface", embeddableInterface],
+        ["ConcIface", concreteInterface],
+      ]),
+      unions: new Map(),
+      queryFields: new Map(),
+      mapped: {
+        types: new Map([
+          ["Host", mappedType("Host")],
+          ["Entity", mappedType("Entity")],
+        ]),
+        interfaces: new Map(),
+        unions: new Map(),
+        nameMap,
+        namespaces,
+        ir: {
+          classes: new Map(),
+          properties: new Map(),
+          namespaces: new Map(),
+          extraction: {} as MappedIR["ir"]["extraction"],
+        },
+      } as unknown as MappedIR,
+    };
+
+    wireRelay(plan);
+    const fields = plan.types.get("Host")?.fields;
+    expect(fields?.get("entities")?.type.kind).toBe("connection");
+    expect(fields?.get("entities")?.connectionArgs).toBe(true);
+    expect(fields?.get("concs")?.type.kind).toBe("connection");
+    expect(fields?.get("unknowns")?.type.kind).toBe("connection");
+    // unchanged
+    expect(fields?.get("plains")?.type.kind).toBe("named");
+    expect(fields?.get("embs")?.type.kind).toBe("named");
+    expect(fields?.get("scalar")?.type.kind).toBe("scalar");
+    expect(fields?.get("tags")?.type.kind).toBe("scalar");
+  });
+});
+
+describe("wireRelay Node membership", () => {
+  it("skips embeddable-only interfaces but wires concrete ones", () => {
+    const embOnly = ifacePlan({ name: "EmbOnly", embeddableOnly: true });
+    const concrete = ifacePlan({ name: "Concrete" });
+
+    const plan: SchemaPlan = {
+      types: new Map(),
+      interfaces: new Map([
+        ["EmbOnly", embOnly],
+        ["Concrete", concrete],
+      ]),
+      unions: new Map(),
+      queryFields: new Map(),
+      mapped: {
+        types: new Map(),
+        interfaces: new Map(),
+        unions: new Map(),
+        nameMap,
+        namespaces,
+        ir: {
+          classes: new Map(),
+          properties: new Map(),
+          namespaces: new Map(),
+          extraction: {} as MappedIR["ir"]["extraction"],
+        },
+      } as unknown as MappedIR,
+    };
+
+    wireRelay(plan);
+    // embeddable-only interface: no structural fields, no Node parent
+    expect(plan.interfaces.get("EmbOnly")?.fields.has("id")).toBe(false);
+    expect(plan.interfaces.get("EmbOnly")?.parents).not.toContain("Node");
+    // concrete interface: id/uri/_meta injected, Node added
+    expect(plan.interfaces.get("Concrete")?.fields.has("id")).toBe(true);
+    expect(plan.interfaces.get("Concrete")?.parents).toContain("Node");
+  });
+});
+
+describe("wireRelay root query fields", () => {
+  const dummyCtx = {} as CompilerContext;
+
+  it("skips embeddable types, owlUri-less types, and types missing from the mapped IR", () => {
+    const plan: SchemaPlan = {
+      types: new Map([
+        // embeddable → skipped
+        ["Emb", typePlan({ name: "Emb", embeddable: true })],
+        // no owlUri → skipped
+        ["NoUri", typePlan({ name: "NoUri", owlUri: undefined })],
+        // owlUri present but absent from mapped.types → skipped (defensive)
+        ["Ghost", typePlan({ name: "Ghost" })],
+      ]),
+      interfaces: new Map(),
+      unions: new Map(),
+      queryFields: new Map(),
+      mapped: {
+        // intentionally empty: none of the above resolve here
+        types: new Map(),
+        interfaces: new Map(),
+        unions: new Map(),
+        nameMap,
+        namespaces,
+        ir: {
+          classes: new Map(),
+          properties: new Map(),
+          namespaces: new Map(),
+          extraction: {} as MappedIR["ir"]["extraction"],
+        },
+      } as unknown as MappedIR,
+    };
+
+    wireRelay(plan);
+    // only the node field exists; no per-type lookup/listing was added
+    expect([...plan.queryFields.keys()]).toEqual(["node"]);
+  });
+
+  const thingPlan = (): SchemaPlan => {
+    const plan: SchemaPlan = {
+      types: new Map([["Thing", typePlan({ name: "Thing" })]]),
+      interfaces: new Map(),
+      unions: new Map(),
+      queryFields: new Map(),
+      mapped: {
+        types: new Map([["Thing", mappedType("Thing")]]),
+        interfaces: new Map(),
+        unions: new Map(),
+        nameMap,
+        namespaces,
+        ir: {
+          classes: new Map(),
+          properties: new Map(),
+          namespaces: new Map(),
+          extraction: {} as MappedIR["ir"]["extraction"],
+        },
+      } as unknown as MappedIR,
+    };
+    wireRelay(plan);
+    return plan;
+  };
+
+  const resolverOf = (plan: SchemaPlan, name: string): Resolve => {
+    const resolve = plan.queryFields.get(name)?.resolve;
+    if (!resolve) {
+      throw new Error(`expected a resolver for query field ${name}`);
+    }
+    return resolve as Resolve;
+  };
+
+  it("node and singular resolvers return null when the id/uri arg is absent", async () => {
+    const plan = thingPlan();
+    const node = resolverOf(plan, "node");
+    const singular = resolverOf(plan, "thing");
+    expect(await node(undefined, {}, dummyCtx, {} as never)).toBeNull();
+    expect(await singular(undefined, {}, dummyCtx, {} as never)).toBeNull();
+  });
+
+  it("singular and listing resolvers fall back to the raw URI on an unknown prefix", async () => {
+    const plan = thingPlan();
+    const loaded: string[] = [];
+    const ctx = {
+      entityLoader: {
+        load: async (key: string) => {
+          loaded.push(key);
+          return null;
+        },
+        loadMany: async (keys: string[]) => {
+          loaded.push(...keys);
+          return keys.map(() => null);
+        },
+      },
+      // a URI with no registered namespace: toPrefixed leaves it unchanged and
+      // the subsequent toFull cannot expand it → the `?? uri` fallback fires.
+      listLoader: { load: async () => ["urn:unmapped"] },
+    } as unknown as CompilerContext;
+
+    // unknown prefix → toFull undefined → singular uses `?? args.uri`
+    await resolverOf(plan, "thing")(
+      undefined,
+      { uri: "zz:thing" },
+      ctx,
+      {} as never,
+    );
+    expect(loaded).toContain("zz:thing");
+
+    // listing → toFull undefined per window URI → `?? uri` fallback
+    const conn = (await resolverOf(plan, "things")(
+      undefined,
+      {},
+      ctx,
+      {} as never,
+    )) as { edges: unknown[] };
+    expect(loaded).toContain("urn:unmapped");
+    expect(conn.edges).toEqual([]);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.ts
@@ -1,0 +1,183 @@
+// =============================================================================
+// Pass 6 — Wire Relay: SchemaPlan → SchemaPlan
+//
+// Pure plan surgery (no graphql-js objects yet):
+// - id/uri/_meta on every non-embeddable type
+// - Node membership for non-embeddable types AND for generated interfaces
+//   whose concrete implementors are all non-embeddable (Relay @refetchable
+//   fragments on UIBlock need Node + id)
+// - list object fields → connections with the four pagination args
+// - root query fields: node(id), per-type lookup + listing
+// =============================================================================
+
+import { toFull, toPrefixed } from "#dataloader";
+import {
+  connectionFromPage,
+  paginateUriWindow,
+  unwrapEntities,
+} from "#resolver";
+import type {
+  CompilerContext,
+  Diagnostic,
+  EntityValue,
+  PassResult,
+} from "#shared";
+import type { FieldPlan, SchemaPlan } from "./emit.js";
+
+/** Create the Relay global-ID field plan (id: ID!). */
+const createIdField = (): FieldPlan => ({
+  name: "id",
+  type: { base: "ID", kind: "scalar", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent.uri,
+  description: "Relay global ID — the entity's prefixed URI.",
+});
+
+/** Create the uri field plan (uri: String!). */
+const createUriField = (): FieldPlan => ({
+  name: "uri",
+  type: { base: "String", kind: "scalar", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent.uri,
+});
+
+/** Create the _meta field plan (self-describing TBox access). */
+const createMetaField = (): FieldPlan => ({
+  name: "_meta",
+  type: { base: "EntityMeta", kind: "named", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent,
+  description: "Self-describing TBox access for this entity.",
+});
+
+/**
+ * Wire the Relay server conventions into the SchemaPlan (Pass 6): Node
+ * membership with id/uri/_meta on non-embeddable types, connection-wrapping
+ * of list object fields, and the root node/lookup/listing query fields.
+ * Pure plan surgery — no graphql-js objects are constructed here.
+ */
+export default function wireRelay(plan: SchemaPlan): PassResult<SchemaPlan> {
+  const diagnostics: Diagnostic[] = [];
+  const { mapped } = plan;
+
+  // ── connections: every list field whose base is a named non-embeddable
+  //    type becomes a connection field with pagination args ──
+  const wrapConnections = (fields: Map<string, FieldPlan>) => {
+    for (const field of fields.values()) {
+      if (!field.type.list || field.type.kind !== "named") {
+        continue;
+      }
+      const targetType = plan.types.get(field.type.base);
+      const targetInterface = plan.interfaces.get(field.type.base);
+      const embeddableTarget =
+        targetType?.embeddable ??
+        (targetInterface ? targetInterface.embeddableOnly : false);
+      if (embeddableTarget) {
+        continue; // embedded lists stay plain lists
+      }
+      field.type = {
+        base: field.type.base,
+        kind: "connection",
+        list: false,
+        nonNull: true,
+      };
+      field.connectionArgs = true;
+    }
+  };
+
+  for (const type of plan.types.values()) {
+    wrapConnections(type.fields);
+  }
+  for (const iface of plan.interfaces.values()) {
+    wrapConnections(iface.fields);
+  }
+
+  // ── id/uri/_meta + Node membership ──
+  for (const type of plan.types.values()) {
+    if (type.embeddable) {
+      continue;
+    }
+    const structural = [createIdField(), createUriField(), createMetaField()];
+    const existing = type.fields;
+    type.fields = new Map([
+      ...structural.map((f): [string, FieldPlan] => [f.name, f]),
+      ...existing,
+    ]);
+    type.interfaces = ["Node", ...type.interfaces];
+  }
+  for (const iface of plan.interfaces.values()) {
+    if (iface.embeddableOnly) {
+      continue;
+    }
+    const structural = [createIdField(), createUriField(), createMetaField()];
+    iface.fields = new Map([
+      ...structural.map((f): [string, FieldPlan] => [f.name, f]),
+      ...iface.fields,
+    ]);
+    iface.parents = ["Node", ...iface.parents];
+  }
+
+  // ── root query fields ──
+  plan.queryFields.set("node", {
+    name: "node",
+    type: { base: "Node", kind: "named", list: false, nonNull: false },
+    args: { id: { type: "ID", required: true } },
+    resolve: async (_parent, args: { id?: string }, ctx: CompilerContext) => {
+      if (!args.id) {
+        return null;
+      }
+      const full = toFull(args.id, mapped.namespaces);
+      if (!full) {
+        return null; // unknown prefix
+      }
+      return ctx.entityLoader.load(full);
+    },
+    description: "Relay node resolution by prefixed-URI global ID.",
+  });
+
+  for (const type of plan.types.values()) {
+    if (type.embeddable || !type.owlUri) {
+      continue;
+    }
+    const mappedType = mapped.types.get(type.name);
+    if (!mappedType) {
+      continue;
+    }
+    const classUri = type.owlUri;
+
+    plan.queryFields.set(mappedType.singularName, {
+      name: mappedType.singularName,
+      type: { base: type.name, kind: "named", list: false, nonNull: false },
+      args: { uri: { type: "String", required: true } },
+      resolve: async (
+        _parent,
+        args: { uri?: string },
+        ctx: CompilerContext,
+      ) => {
+        if (!args.uri) {
+          return null;
+        }
+        const full = toFull(args.uri, mapped.namespaces) ?? args.uri;
+        return ctx.entityLoader.load(full);
+      },
+    });
+
+    plan.queryFields.set(mappedType.pluralName, {
+      name: mappedType.pluralName,
+      type: { base: type.name, kind: "connection", list: false, nonNull: true },
+      connectionArgs: true,
+      resolve: async (_parent, args, ctx: CompilerContext) => {
+        // Slice BEFORE hydration: cursors and pageInfo need only the
+        // (name-sorted) URI list; entities are loaded for the page alone.
+        const fullUris = await ctx.listLoader.load(classUri);
+        const prefixed = fullUris.map((uri) =>
+          toPrefixed(uri, mapped.namespaces),
+        );
+        const page = paginateUriWindow(prefixed, args);
+        const entities = await ctx.entityLoader.loadMany(
+          page.window.map((uri) => toFull(uri, mapped.namespaces) ?? uri),
+        );
+        return connectionFromPage(unwrapEntities(entities), page);
+      },
+    });
+  }
+
+  return { output: plan, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.test.ts
@@ -1,0 +1,318 @@
+// =============================================================================
+// Plugin integration: createSchemaPlugin via createStore, store.api,
+// sdlOutput writing, extensions (object + factory), standardVocabFields.
+// =============================================================================
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTestStore } from "@canonical/ke/testing";
+import { GraphQLString, graphql } from "graphql";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  compile,
+  createStoreQueryFn,
+  hashSources,
+  type SchemaPluginApi,
+  serializeExtraction,
+} from "#compiler";
+import type { EntityValue } from "#shared";
+import { MINIMAL_TTL, PREFIXES } from "#testing";
+import createSchemaPlugin from "./createSchemaPlugin.js";
+
+// A TTL whose compile emits diagnostics of every severity without failing
+// composition, plus at least one sourceless diagnostic so both arms of the
+// log line's `(source)` suffix are taken: V006 (info, boolean property),
+// V002 (warning, domainless property), three custom mappings onto one field
+// name (M001 error, non-fatal), and a union range (X003 info, sourceless).
+const DIAGNOSTIC_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:Thing a owl:Class ; rdfs:label "Thing" .
+ex:Other a owl:Class ; rdfs:label "Other" .
+ex:active a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:boolean ; rdfs:label "active" .
+ex:foo a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:string ; rdfs:label "foo" .
+ex:bar a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:string ; rdfs:label "bar" .
+ex:baz a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:string ; rdfs:label "baz" .
+ex:orphan a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "orphan" .
+ex:ref a owl:ObjectProperty ; rdfs:domain ex:Thing ; rdfs:range [ owl:unionOf ( ex:Thing ex:Other ) ] ; rdfs:label "ref" .
+ex:w a ex:Thing ; ex:active "true" ; ex:foo "f" ; ex:bar "b" ; ex:baz "z" .
+ex:o a ex:Other .
+`;
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+describe("createSchemaPlugin", () => {
+  it("compiles on onReady and exposes the api via store.api", async () => {
+    const plugin = createSchemaPlugin();
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    expect(api).toBeDefined();
+    expect(api?.schema.getType("Thing")).toBeDefined();
+    expect(api?.sdl).toContain("type Thing");
+    expect(api?.nameMap.toGraphQL("http://example.org/Thing")).toBe("Thing");
+
+    // request-time context takes the store (PluginContext is not retained)
+    const context = api?.createContext(store);
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ thing(uri: "ex:widget") { name } }`,
+      contextValue: context,
+    });
+    expect((result.data?.thing as { name: string }).name).toBe("Widget");
+  });
+
+  it("writes the SDL to sdlOutput", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ke-graphql-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const sdlPath = join(dir, "schema.graphql");
+    const plugin = createSchemaPlugin({ sdlOutput: sdlPath });
+    const { cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    expect(existsSync(sdlPath)).toBe(true);
+    expect(readFileSync(sdlPath, "utf-8")).toContain(
+      "type Thing implements Node",
+    );
+  });
+
+  it("registers extensions in object form on types and Query", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: {
+        Thing: {
+          shout: {
+            type: GraphQLString,
+            resolve: (source: EntityValue) => `${source.uri}!`,
+          },
+        },
+        Query: {
+          hello: { type: GraphQLString, resolve: () => "world" },
+        },
+      },
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ hello thing(uri: "ex:widget") { shout } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.hello).toBe("world");
+    expect((result.data?.thing as { shout: string }).shout).toBe("ex:widget!");
+  });
+
+  it("supports the extensions factory form receiving generated types", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: (types) => ({
+        Query: {
+          firstThing: {
+            type: types.type("Thing") as NonNullable<
+              ReturnType<typeof types.type>
+            >,
+            resolve: async (_source, _args, ctx) => {
+              const uris = await ctx.listLoader.load(
+                "http://example.org/Thing",
+              );
+              return uris[0] ? ctx.entityLoader.load(uris[0]) : null;
+            },
+          },
+        },
+      }),
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ firstThing { name } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.firstThing as { name: string }).name).toBe("Widget");
+  });
+
+  it("reports C001/C002 extension conflicts as composition errors", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: {
+        NoSuchType: {
+          x: { type: GraphQLString },
+        },
+      },
+    });
+    await expect(
+      createTestStore({
+        ttl: MINIMAL_TTL,
+        prefixes: PREFIXES,
+        plugins: [plugin],
+      }),
+    ).rejects.toThrow(/C001|composition failed/);
+  });
+
+  it("generates instance-level standard-vocab fields", async () => {
+    const ttl = `${MINIMAL_TTL}
+      <http://example.org/widget> <http://www.w3.org/2000/01/rdf-schema#label> "The Widget"@en .
+    `;
+    const plugin = createSchemaPlugin({
+      standardVocabFields: {
+        Thing: { "http://www.w3.org/2000/01/rdf-schema#label": "label" },
+      },
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ thing(uri: "ex:widget") { label } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { label: string }).label).toBe("The Widget");
+  });
+
+  it("logs diagnostics to the matching console channel by severity", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    cleanups.push(() => {
+      error.mockRestore();
+      warn.mockRestore();
+      info.mockRestore();
+    });
+    const plugin = createSchemaPlugin({
+      mappings: {
+        "ex:foo": { graphqlName: "dup" },
+        "ex:bar": { graphqlName: "dup" },
+        "ex:baz": { graphqlName: "dup" },
+      },
+    });
+    const { cleanup } = await createTestStore({
+      ttl: DIAGNOSTIC_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("M001"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("V002"));
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("V006"));
+    // The "(source)" suffix is appended only when a diagnostic carries a
+    // source: V006 has one, the union diagnostic (X003) does not.
+    expect(info).toHaveBeenCalledWith(expect.stringMatching(/V006:.+\(.+\)$/));
+    expect(info).toHaveBeenCalledWith(expect.stringMatching(/X003:[^()]*$/));
+  });
+
+  it("boots from an extraction artifact given as a file path", async () => {
+    // Derive a fresh artifact (matching sourcesHash) from a live compile.
+    const probe = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+    });
+    cleanups.push(probe.cleanup);
+    const artifactJson = serializeExtraction(
+      (await compile(createStoreQueryFn(probe.store), PREFIXES)).extraction,
+      hashSources([MINIMAL_TTL]),
+    );
+    const dir = mkdtempSync(join(tmpdir(), "ke-graphql-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const artifactPath = join(dir, "extraction.json");
+    writeFileSync(artifactPath, artifactJson, "utf-8");
+
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [createSchemaPlugin({ extraction: artifactPath })],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    // Artifact boot skips printSchema — empty SDL is the fast-path marker.
+    expect(api?.sdl).toBe("");
+    expect(api?.schema.getType("Thing")).toBeDefined();
+  });
+
+  it("keeps using a fresh artifact across a reload (no fingerprint drift)", async () => {
+    const probe = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+    });
+    cleanups.push(probe.cleanup);
+    const artifactJson = serializeExtraction(
+      (await compile(createStoreQueryFn(probe.store), PREFIXES)).extraction,
+      hashSources([MINIMAL_TTL]),
+    );
+    const dir = mkdtempSync(join(tmpdir(), "ke-graphql-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const artifactPath = join(dir, "extraction.json");
+    writeFileSync(artifactPath, artifactJson, "utf-8");
+
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [createSchemaPlugin({ extraction: artifactPath })],
+    });
+    cleanups.push(cleanup);
+    // Cold boot uses the artifact (empty SDL = fast path).
+    expect(store.api<SchemaPluginApi>("ke-graphql")?.sdl).toBe("");
+    // ke re-invokes onLoad for every source on reload; the per-cycle reset
+    // keeps the fingerprint stable, so the artifact stays fresh (the old
+    // accumulating array would XOR to a drifted hash and force a live compile).
+    await store.reload({ force: true });
+    expect(store.api<SchemaPluginApi>("ke-graphql")?.sdl).toBe("");
+  });
+
+  it("recompiles on reload and keeps the api queryable", async () => {
+    const plugin = createSchemaPlugin();
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    await store.reload({ force: true });
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    expect(api?.schema.getType("Thing")).toBeDefined();
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ thing(uri: "ex:widget") { name } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { name: string }).name).toBe("Widget");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.ts
+++ b/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.ts
@@ -1,0 +1,159 @@
+// =============================================================================
+// ke plugin entry: onReady runs the compiler against the freshly loaded
+// store; onReload recompiles (note: with `cache:` configured, ke's reload()
+// short-circuits on a cache hit — pass { force: true } in dev flows).
+//
+// Failure policy: the schema is produced even through non-composition
+// errors (the tsc model — diagnostics never abort the pipeline); only a
+// CompilationError (composition failed) propagates and fails the boot. All
+// diagnostics are logged either way.
+// =============================================================================
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { definePlugin, type PluginContext, type SPARQL } from "@canonical/ke";
+import {
+  compile,
+  compileFromExtraction,
+  type Diagnostic,
+  deserializeExtraction,
+  hashSources,
+  type QueryFn,
+  type SchemaPluginApi,
+  type SchemaPluginOptions,
+  type SerializedExtraction,
+} from "./compiler/index.js";
+
+/**
+ * Log every diagnostic to the console at its severity's channel.
+ *
+ * @note Impure — writes to the console.
+ */
+const logDiagnostics = (diagnostics: Diagnostic[]): void => {
+  for (const d of diagnostics) {
+    const line = `[ke-graphql] ${d.code}: ${d.message}${d.source ? ` (${d.source})` : ""}`;
+    if (d.severity === "error") {
+      console.error(line);
+    } else if (d.severity === "warning") {
+      console.warn(line);
+    } else {
+      console.info(line);
+    }
+  }
+};
+
+/**
+ * Adapt a ke PluginContext to the QueryFn surface (string → branded SPARQL).
+ *
+ * @note Impure — the returned function executes SPARQL queries against the
+ * store behind the plugin context.
+ */
+const createPluginQueryFn =
+  (ctx: PluginContext): QueryFn =>
+  (query) =>
+    ctx.query(query as SPARQL<string>);
+
+/** Plugin-only options on top of SchemaPluginOptions. */
+export interface SchemaPluginExtra {
+  /**
+   * Precomputed extraction artifact (path or parsed) — boots the schema
+   * without Pass 1 when its sourcesHash matches the loaded TTL; falls back
+   * to a live compile (with a warning) when stale.
+   */
+  extraction?: string | SerializedExtraction;
+}
+
+/**
+ * Create the ke-graphql schema plugin: compiles the schema when the store is
+ * ready and recompiles on reload, registering the SchemaPluginApi under
+ * "ke-graphql".
+ *
+ * @note Impure — the plugin's lifecycle hooks query the store, may read the
+ * extraction artifact from disk, and may write the SDL output file.
+ *
+ * @example
+ * ```ts
+ * const graphql = createSchemaPlugin({ mappings, extensions });
+ * const store = await createStore({ sources, prefixes, plugins: [graphql] });
+ * const { schema, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+ * ```
+ */
+export default function createSchemaPlugin(
+  options: SchemaPluginOptions & SchemaPluginExtra = {},
+) {
+  // Fingerprint the TTL sources as ke loads them — artifact freshness check.
+  const sourceContents: string[] = [];
+  return definePlugin<SchemaPluginApi>({
+    name: "ke-graphql",
+
+    onLoad(source) {
+      sourceContents.push(source.content);
+    },
+
+    async onReady(ctx) {
+      return compileForContext(ctx, options, sourceContents);
+    },
+
+    async onReload(ctx) {
+      return compileForContext(ctx, options, sourceContents);
+    },
+  });
+}
+
+/**
+ * Compile for a plugin lifecycle hook: boot from the extraction artifact
+ * when fresh, fall back to a live compile otherwise, then log diagnostics
+ * and write the SDL output when configured.
+ *
+ * @note Impure — reads the extraction artifact from disk, executes SPARQL
+ * queries on a live compile, logs to the console, and writes the SDL output
+ * file when configured.
+ */
+const compileForContext = async (
+  ctx: PluginContext,
+  options: SchemaPluginOptions & SchemaPluginExtra,
+  sourceContents: string[],
+): Promise<SchemaPluginApi> => {
+  let result: Awaited<ReturnType<typeof compile>> | undefined;
+
+  // Snapshot and reset the per-cycle source fingerprint. ke re-invokes onLoad
+  // for every source on each reload, so this accumulating array must be cleared
+  // each cycle or its XOR hash drifts across reloads and false-matches. An
+  // empty snapshot (a ke cache-hit boot, where the sources were never re-read)
+  // simply won't match a real artifact, so it falls back to a live compile.
+  const cycleSources = [...sourceContents];
+  sourceContents.length = 0;
+
+  if (options.extraction !== undefined) {
+    const artifact =
+      typeof options.extraction === "string"
+        ? (JSON.parse(
+            readFileSync(options.extraction, "utf-8"),
+          ) as SerializedExtraction)
+        : options.extraction;
+    const { sourcesHash } = deserializeExtraction(artifact);
+    const loadedHash = hashSources(cycleSources);
+    if (sourcesHash === loadedHash) {
+      result = compileFromExtraction(artifact, options);
+    } else {
+      console.warn(
+        `[ke-graphql] extraction artifact is stale (artifact ${sourcesHash}, sources ${loadedHash}) — falling back to a live compile. Regenerate it (pragma graphql build).`,
+      );
+    }
+  }
+
+  result ??= await compile(createPluginQueryFn(ctx), ctx.prefixes, options);
+  logDiagnostics(result.diagnostics);
+
+  if (options.sdlOutput) {
+    writeFileSync(options.sdlOutput, result.sdl, "utf-8");
+  }
+
+  return {
+    schema: result.schema,
+    diagnostics: result.diagnostics,
+    nameMap: result.nameMap,
+    sdl: result.sdl,
+    createContext: result.createContext,
+    clearLoaderCache: result.clearLoaderCache,
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/execution/extractStatic.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/extractStatic.test.ts
@@ -1,0 +1,138 @@
+// =============================================================================
+// Path B static extraction: variable-type enumeration, embeddable-class skip,
+// and incremental drain-and-merge through extractStatic.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import type { CompilerContext } from "#shared";
+import {
+  BLANK_NODES_TTL,
+  DS_REALISTIC_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+} from "#testing";
+import extractStatic from "./extractStatic.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<{ result: CompilerResult; context: CompilerContext }> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, options);
+  return { result, context: result.createContext(store) };
+};
+
+describe("extractStatic variable enumeration", () => {
+  it("accepts every uri-shaped variable type and skips embeddable classes", async () => {
+    // BLANK_NODES_TTL has ex:Example as an embeddable (blank-node-only) class —
+    // listEntityUris must skip it and enumerate only the named ex:Standard.
+    const { result, context } = await setup(BLANK_NODES_TTL);
+    const results = await extractStatic({
+      schema: result.schema,
+      mapped: result.mapped,
+      context,
+      queries: [
+        {
+          name: "ByStringReq",
+          text: `query Q($uri: String!) { standard(uri: $uri) { title } }`,
+          variables: { uri: "String!" },
+        },
+        {
+          name: "ByString",
+          text: `query Q($uri: String) { standard(uri: $uri) { title } }`,
+          variables: { uri: "String" },
+        },
+        {
+          name: "ByIdReq",
+          text: `query Q($uri: ID!) { standard(uri: $uri) { title } }`,
+          variables: { uri: "ID!" },
+        },
+        {
+          name: "ById",
+          text: `query Q($uri: ID) { standard(uri: $uri) { title } }`,
+          variables: { uri: "ID" },
+        },
+      ],
+    });
+    // One named ex:Standard instance (ex:s1); the embeddable ex:Example is
+    // never enumerated, so every uri query yields exactly one keyed entry.
+    for (const prefix of ["ByStringReq", "ByString", "ByIdReq", "ById"]) {
+      const keyed = [...results.keys()].filter((k) =>
+        k.startsWith(`${prefix}:`),
+      );
+      expect(keyed).toEqual([`${prefix}:ex:s1`]);
+    }
+  });
+
+  it("rejects a uri variable whose declared type is missing", async () => {
+    // A key present with an undefined value drives the `?? ""` fallback, which
+    // is not a uri-shaped type — extractStatic must fail loudly.
+    const { result, context } = await setup(MINIMAL_TTL);
+    await expect(
+      extractStatic({
+        schema: result.schema,
+        mapped: result.mapped,
+        context,
+        queries: [
+          {
+            name: "Untyped",
+            text: `query Q($uri: String!) { thing(uri: $uri) { name } }`,
+            variables: { uri: undefined as unknown as string },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/non-enumerable/);
+  });
+});
+
+describe("extractStatic incremental drain-and-merge", () => {
+  it("merges a deferred result into one complete entry", async () => {
+    // An incremental schema + a @defer query make executeLocal return an
+    // IncrementalResults stream; extractStatic must drain and merge it.
+    const { result, context } = await setup(DS_REALISTIC_TTL, {
+      incremental: true,
+      mappings: {
+        "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+        "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+        "ds:hasProperty": { graphqlName: "properties" },
+        "ds:hasModifier": { graphqlName: "modifiers" },
+      },
+    });
+    const results = await extractStatic({
+      schema: result.schema,
+      mapped: result.mapped,
+      context,
+      queries: [
+        {
+          name: "Deferred",
+          text: `
+            query Deferred {
+              component(uri: "ds:global.component.button") {
+                name
+                ... on Component @defer(label: "summary") { summary }
+              }
+            }
+          `,
+        },
+      ],
+    });
+    const merged = results.get("Deferred");
+    expect(merged?.errors).toBeUndefined();
+    const component = merged?.data?.component as Record<string, unknown>;
+    expect(component.name).toBe("Button");
+    expect(component.summary).toBe("Primary action trigger.");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/execution/extractStatic.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/extractStatic.ts
@@ -1,0 +1,122 @@
+// =============================================================================
+// Path B — static extraction at build time.
+//
+// Runs every provided query against the compiled schema and returns the
+// results keyed by name (callers write them to disk as static JSON). Only
+// `uri`-typed variables are enumerable: for queries with a single required
+// `uri: String!` variable, every instance URI of the relevant classes is
+// substituted. Queries with other variables fail loudly rather than shipping
+// partial data. Incremental payloads are always drained and merged.
+// =============================================================================
+
+import type { ExecutionResult, GraphQLSchema } from "graphql";
+import { toPrefixed } from "#dataloader";
+import type { CompilerContext, MappedIR } from "#shared";
+import {
+  executeLocal,
+  isIncrementalResults,
+  mergeIncremental,
+} from "./incremental.js";
+
+/** One named query to extract, with optional variable definitions. */
+export interface StaticQuery {
+  name: string;
+  text: string;
+  /** Variable definitions: name → GraphQL type string (e.g. "String!"). */
+  variables?: Record<string, string>;
+}
+
+/** Arguments for extractStatic: schema, IR, context, and the query set. */
+export interface ExtractStaticOptions {
+  schema: GraphQLSchema;
+  mapped: MappedIR;
+  context: CompilerContext;
+  queries: StaticQuery[];
+}
+
+const isUriVariable = (type: string): boolean =>
+  type === "String!" || type === "String" || type === "ID!" || type === "ID";
+
+/**
+ * List all named instance URIs (prefixed) across all concrete classes.
+ *
+ * @note Impure — loads every class's instance list from the store through
+ * the context's list loader.
+ */
+const listEntityUris = async (
+  mapped: MappedIR,
+  context: CompilerContext,
+): Promise<string[]> => {
+  const uris: string[] = [];
+  for (const type of mapped.types.values()) {
+    if (type.embeddable) {
+      continue;
+    }
+    const instances = await context.listLoader.load(type.owlUri);
+    for (const full of instances) {
+      uris.push(toPrefixed(full, mapped.namespaces));
+    }
+  }
+  return uris;
+};
+
+/**
+ * Execute the provided query set against the compiled schema and return the
+ * results keyed by query name (queries with a single uri variable run once
+ * per instance URI, keyed "name:uri"). Incremental payloads are drained and
+ * merged. Throws on queries with non-enumerable variables rather than
+ * shipping partial data.
+ *
+ * @note Impure — executes every query against the store-backed context.
+ */
+export default async function extractStatic(
+  options: ExtractStaticOptions,
+): Promise<Map<string, ExecutionResult>> {
+  const results = new Map<string, ExecutionResult>();
+
+  const run = async (
+    key: string,
+    text: string,
+    variableValues?: Record<string, unknown>,
+  ) => {
+    const result = await executeLocal({
+      schema: options.schema,
+      source: text,
+      variableValues,
+      contextValue: options.context,
+    });
+    results.set(
+      key,
+      isIncrementalResults(result) ? await mergeIncremental(result) : result,
+    );
+  };
+
+  let entityUris: string[] | undefined;
+
+  for (const query of options.queries) {
+    const variableNames = Object.keys(query.variables ?? {});
+    if (variableNames.length === 0) {
+      await run(query.name, query.text);
+      continue;
+    }
+    const [name] = variableNames;
+    if (
+      variableNames.length === 1 &&
+      name === "uri" &&
+      isUriVariable(query.variables?.[name] ?? "")
+    ) {
+      entityUris ??= await listEntityUris(options.mapped, options.context);
+      for (const uri of entityUris) {
+        await run(`${query.name}:${uri}`, query.text, { uri });
+      }
+      continue;
+    }
+    throw new Error(
+      `extractStatic: query "${query.name}" has non-enumerable variables (${variableNames.join(
+        ", ",
+      )}) — static extraction supports only a single uri variable`,
+    );
+  }
+
+  return results;
+}

--- a/packages/runtime/ke-graphql/src/lib/execution/incremental.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/incremental.test.ts
@@ -1,0 +1,628 @@
+// =============================================================================
+// Execution paths: local execution, @defer incremental
+// delivery, drain-and-merge, the Relay format adapter, static extraction.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { parse } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import type { CompilerContext } from "#shared";
+import { DS_REALISTIC_TTL, MINIMAL_TTL, PREFIXES } from "#testing";
+import extractStatic from "./extractStatic.js";
+import {
+  executeLocal,
+  isIncrementalResults,
+  mergeIncremental,
+  relayFormatAdapter,
+} from "./incremental.js";
+import type {
+  IncrementalResults,
+  InitialIncrementalResult,
+  RelayLegacyPayload,
+  SubsequentIncrementalResult,
+} from "./types.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<{ result: CompilerResult; context: CompilerContext }> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, options);
+  return { result, context: result.createContext(store) };
+};
+
+const DEFERRED_QUERY = `
+  query ButtonQuery {
+    component(uri: "ds:global.component.button") {
+      name
+      ... DeferredSummary @defer(label: "summary")
+    }
+  }
+  fragment DeferredSummary on Component {
+    summary
+    tier { name }
+  }
+`;
+
+const dsOptions = {
+  incremental: true,
+  mappings: {
+    "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+    "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+    "ds:hasProperty": { graphqlName: "properties" },
+    "ds:hasModifier": { graphqlName: "modifiers" },
+  },
+};
+
+describe("executeLocal (in-process execution)", () => {
+  it("executes plain documents to a single result", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: `{ thing(uri: "ex:widget") { name count } }`,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors).toBeUndefined();
+      expect(execution.data?.thing).toEqual({ name: "Widget", count: 42 });
+    }
+  });
+
+  it("executes plain documents against an incremental schema (v17 forbids execute() there)", async () => {
+    const { result, context } = await setup(DS_REALISTIC_TTL, dsOptions);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: `{ component(uri: "ds:global.component.button") { name } }`,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors).toBeUndefined();
+      expect((execution.data?.component as Record<string, unknown>).name).toBe(
+        "Button",
+      );
+    }
+  });
+
+  it("uses a pre-parsed document and skips its own parse", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    const document = parse(`{ thing(uri: "ex:widget") { name } }`);
+    // The source is deliberately unparseable: if executeLocal honored the
+    // document it succeeds; if it re-parsed `source` it would error.
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: "this is not valid graphql",
+      document,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors).toBeUndefined();
+      expect(execution.data?.thing).toEqual({ name: "Widget" });
+    }
+  });
+
+  it("returns errors for syntax errors without throwing", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: "{ not valid graphql",
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("produces incremental results for @defer documents", async () => {
+    const { result, context } = await setup(DS_REALISTIC_TTL, dsOptions);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: DEFERRED_QUERY,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(true);
+    if (isIncrementalResults(execution)) {
+      const merged = await mergeIncremental(execution);
+      expect(merged.errors).toBeUndefined();
+      const component = merged.data?.component as Record<string, unknown>;
+      expect(component.name).toBe("Button");
+      expect(component.summary).toBe("Primary action trigger.");
+      expect((component.tier as { name: string }).name).toBe("global");
+    }
+  });
+});
+
+describe("relayFormatAdapter", () => {
+  it("translates v17 payloads to the Relay legacy shape", async () => {
+    const { result, context } = await setup(DS_REALISTIC_TTL, dsOptions);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: DEFERRED_QUERY,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(true);
+    if (!isIncrementalResults(execution)) {
+      return;
+    }
+    const payloads = [];
+    for await (const payload of relayFormatAdapter(execution)) {
+      payloads.push(payload);
+    }
+    // initial payload: plain data, no path
+    expect(payloads[0]?.path).toBeUndefined();
+    expect((payloads[0]?.data?.component as Record<string, unknown>).name).toBe(
+      "Button",
+    );
+    // deferred payload: path + label, is_final on the last
+    const deferred = payloads.slice(1);
+    expect(deferred.length).toBeGreaterThan(0);
+    const last = deferred[deferred.length - 1];
+    expect(last?.path).toEqual(["component"]);
+    expect(last?.label).toBe("summary");
+    expect(last?.extensions?.is_final).toBe(true);
+    expect((last?.data as Record<string, unknown>).summary).toBe(
+      "Primary action trigger.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit-level coverage of the merge/translate branches, driven by hand-crafted
+// v17 incremental payloads (the 2023 pending/incremental/completed shape).
+// ---------------------------------------------------------------------------
+
+const makeResults = (
+  initialResult: InitialIncrementalResult,
+  ...payloads: SubsequentIncrementalResult[]
+): IncrementalResults => ({
+  initialResult,
+  subsequentResults: (async function* () {
+    for (const payload of payloads) {
+      yield payload;
+    }
+  })(),
+});
+
+const collect = async (
+  gen: AsyncGenerator<RelayLegacyPayload, void, void>,
+): Promise<RelayLegacyPayload[]> => {
+  const out: RelayLegacyPayload[] = [];
+  for await (const payload of gen) {
+    out.push(payload);
+  }
+  return out;
+};
+
+describe("mergeIncremental (crafted payloads)", () => {
+  it("merges deferred-fragment data into the initial tree", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        {
+          data: { node: { name: "x" } },
+          pending: [{ id: "0", path: ["node"], label: "frag" }],
+        },
+        {
+          incremental: [{ id: "0", data: { extra: "y" } }],
+          completed: [{ id: "0" }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.errors).toBeUndefined();
+    expect(merged.data?.node).toEqual({ name: "x", extra: "y" });
+  });
+
+  it("pushes streamed items onto the array at the pending path", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        { data: { list: [0] }, pending: [{ id: "1", path: ["list"] }] },
+        { incremental: [{ id: "1", items: [1, 2] }], hasNext: true },
+        {
+          incremental: [{ id: "1", items: [3] }],
+          completed: [{ id: "1" }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.data?.list).toEqual([0, 1, 2, 3]);
+  });
+
+  it("collects errors from incremental entries and completed notices", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        {
+          data: { a: { keep: true }, b: null },
+          pending: [
+            { id: "0", path: ["a"], label: "fa" },
+            { id: "1", path: ["b"], label: "fb" },
+          ],
+        },
+        {
+          incremental: [
+            { id: "0", data: { added: 1 }, errors: [{ message: "partial" }] },
+          ],
+          completed: [{ id: "1", errors: [{ message: "fragment failed" }] }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.errors).toHaveLength(2);
+    expect(merged.data?.a).toEqual({ keep: true, added: 1 });
+  });
+
+  it("carries initial errors through and ignores unknown / null-data entries", async () => {
+    // data === null short-circuits the merge; an unknown id has no pending;
+    // the `?? null`/`?? []` defaults fire because data/pending are absent.
+    const merged = await mergeIncremental(
+      makeResults(
+        { errors: [{ message: "seed" }] },
+        { hasNext: true },
+        {
+          incremental: [{ id: "ghost", data: { ignored: true } }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.data).toBeNull();
+    expect(merged.errors).toHaveLength(1);
+  });
+
+  it("registers a pending announced in a subsequent payload", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        { data: { node: { name: "x" } } },
+        // pending "0" is announced here, not in the initial result.
+        {
+          pending: [{ id: "0", path: ["node"], label: "late" }],
+          incremental: [{ id: "0", data: { extra: "y" } }],
+          completed: [{ id: "0" }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.data?.node).toEqual({ name: "x", extra: "y" });
+  });
+
+  it("tolerates a pending path that walks through a non-object and a non-array items target", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        {
+          // ["scalar","deeper"] walks into a string → defensive bail-out;
+          // ["obj"] is an object, so items push finds a non-array container;
+          // ["leaf"] resolves fully to null → the final-cursor guard bails.
+          data: { scalar: "leaf", obj: { kind: "map" }, leaf: null },
+          pending: [
+            { id: "0", path: ["scalar", "deeper"] },
+            { id: "1", path: ["obj"] },
+            { id: "2", path: ["leaf"] },
+          ],
+        },
+        {
+          incremental: [
+            { id: "0", data: { unreached: true } },
+            { id: "1", items: [99] },
+            { id: "2", data: { alsoUnreached: true } },
+          ],
+          completed: [{ id: "0" }, { id: "1" }, { id: "2" }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.errors).toBeUndefined();
+    expect(merged.data?.scalar).toBe("leaf");
+    expect(merged.data?.obj).toEqual({ kind: "map" });
+    expect(merged.data?.leaf).toBeNull();
+  });
+});
+
+describe("relayFormatAdapter (crafted payloads)", () => {
+  it("emits the initial payload with errors, then a labelled deferred payload with is_final", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          {
+            data: { node: { name: "x" } },
+            errors: [{ message: "warn" }],
+            pending: [{ id: "0", path: ["node"], label: "frag" }],
+          },
+          {
+            incremental: [{ id: "0", data: { extra: "y" } }],
+            completed: [{ id: "0" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    expect(payloads[0]?.path).toBeUndefined();
+    expect(payloads[0]?.errors).toHaveLength(1);
+    const last = payloads[payloads.length - 1];
+    expect(last?.path).toEqual(["node"]);
+    expect(last?.label).toBe("frag");
+    expect(last?.data).toEqual({ extra: "y" });
+    expect(last?.extensions?.is_final).toBe(true);
+  });
+
+  it("indexes streamed items from the initial array length and flushes while hasNext", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          // No label on this pending → the label-omitting branches run.
+          { data: { list: ["a"] }, pending: [{ id: "1", path: ["list"] }] },
+          { incremental: [{ id: "1", items: ["b", "c"] }], hasNext: true },
+          {
+            incremental: [{ id: "1", items: ["d"] }],
+            completed: [{ id: "1" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const streamed = payloads.slice(1);
+    // initial array length is 1, so the first streamed item is index 1.
+    expect(streamed.map((p) => p.path)).toEqual([
+      ["list", 1],
+      ["list", 2],
+      ["list", 3],
+    ]);
+    expect(streamed.every((p) => p.label === undefined)).toBe(true);
+    expect(streamed[streamed.length - 1]?.extensions?.is_final).toBe(true);
+  });
+
+  it("translates a completed-only error and a null deferred payload, keeping path/label", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          {
+            data: { node: { name: "x" }, other: null },
+            pending: [
+              { id: "0", path: ["node"], label: "ok" },
+              { id: "1", path: ["other"], label: "bad" },
+            ],
+          },
+          {
+            // entry.data === null → relay still buffers a null-data payload.
+            incremental: [{ id: "0", data: null }],
+            hasNext: true,
+          },
+          {
+            completed: [{ id: "1", errors: [{ message: "fragment failed" }] }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const nullData = payloads.find((p) => p.label === "ok");
+    expect(nullData?.data).toBeNull();
+    const failed = payloads.find((p) => p.label === "bad");
+    expect(failed?.data).toBeNull();
+    expect(failed?.errors).toHaveLength(1);
+    expect(failed?.path).toEqual(["other"]);
+  });
+
+  it("flushes more than one trailing payload and marks only the last is_final", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          {
+            data: { a: {}, b: {} },
+            pending: [
+              { id: "0", path: ["a"] },
+              { id: "1", path: ["b"] },
+            ],
+          },
+          {
+            incremental: [
+              { id: "0", data: { x: 1 } },
+              { id: "1", data: { y: 2 } },
+            ],
+            completed: [{ id: "0" }, { id: "1" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const trailing = payloads.slice(1);
+    expect(trailing).toHaveLength(2);
+    expect(trailing[0]?.extensions?.is_final).toBeUndefined();
+    expect(trailing[1]?.extensions?.is_final).toBe(true);
+  });
+
+  it("emits a synthetic is_final payload when everything was flushed before the final notice", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { data: { node: {} }, pending: [{ id: "0", path: ["node"] }] },
+          // Flushed during hasNext: true …
+          { incremental: [{ id: "0", data: { x: 1 } }], hasNext: true },
+          // … the final payload carries only completed bookkeeping.
+          { completed: [{ id: "0" }], hasNext: false },
+        ),
+      ),
+    );
+    const last = payloads[payloads.length - 1];
+    expect(last?.data).toBeNull();
+    expect(last?.extensions?.is_final).toBe(true);
+    // The flushed deferred payload came before the synthetic final.
+    expect(payloads.some((p) => p.path?.[0] === "node")).toBe(true);
+  });
+
+  it("seeds the stream index at 0 when the initial result has no data and the path is absent", async () => {
+    // initialResult.data is undefined → the `?? null` default and the
+    // null-cursor guard in computeInitialIndex both run; index starts at 0.
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { pending: [{ id: "1", path: ["missing"] }] },
+          {
+            incremental: [{ id: "1", items: ["only"] }],
+            completed: [{ id: "1" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    expect(payloads[0]?.data).toBeNull();
+    const streamed = payloads.slice(1);
+    expect(streamed[0]?.path).toEqual(["missing", 0]);
+  });
+
+  it("seeds the stream index at 0 when the path leads to a non-array value", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          {
+            data: { box: { notAList: true } },
+            pending: [{ id: "1", path: ["box"] }],
+          },
+          {
+            incremental: [{ id: "1", items: ["x"] }],
+            completed: [{ id: "1" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    expect(payloads.slice(1)[0]?.path).toEqual(["box", 0]);
+  });
+
+  it("skips incremental entries whose id has no pending announcement", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { data: { node: {} } },
+          {
+            incremental: [{ id: "ghost", data: { ignored: true } }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    // Only the initial payload plus the synthetic is_final; nothing buffered.
+    const last = payloads[payloads.length - 1];
+    expect(last?.extensions?.is_final).toBe(true);
+    expect(
+      payloads.some((p) => (p.data as { ignored?: boolean })?.ignored),
+    ).toBe(false);
+  });
+
+  it("honors a pending announced in a subsequent payload, with labelled items and per-entry errors", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { data: { feed: ["seed"] } },
+          // The pending for "9" arrives in this subsequent payload, not the
+          // initial result — the subsequent-pending loop registers it.
+          {
+            pending: [{ id: "9", path: ["feed"], label: "stream" }],
+            incremental: [
+              { id: "9", items: ["one"], errors: [{ message: "item warn" }] },
+            ],
+            hasNext: true,
+          },
+          {
+            incremental: [
+              {
+                id: "9",
+                data: { tail: 1 },
+                errors: [{ message: "frag warn" }],
+              },
+            ],
+            completed: [{ id: "9" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const labelled = payloads.filter((p) => p.label === "stream");
+    expect(labelled.length).toBeGreaterThan(0);
+    // The deferred-data payload carried entry.errors through.
+    const withErrors = payloads.find((p) => p.errors !== undefined);
+    expect(withErrors?.errors).toHaveLength(1);
+    // The streamed item picked up the label too.
+    const item = payloads.find((p) => p.path?.[1] === 1);
+    expect(item?.label).toBe("stream");
+  });
+
+  it("emits a completed-error payload without path/label when the id was never announced", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { data: { node: {} } },
+          {
+            completed: [
+              { id: "unknown", errors: [{ message: "orphan failure" }] },
+            ],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const failed = payloads.find((p) => p.errors !== undefined);
+    expect(failed?.errors).toHaveLength(1);
+    expect(failed?.path).toBeUndefined();
+    expect(failed?.label).toBeUndefined();
+    expect(failed?.extensions?.is_final).toBe(true);
+  });
+});
+
+describe("extractStatic (build-time static extraction)", () => {
+  it("runs nullary queries once and uri queries per entity", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    const results = await extractStatic({
+      schema: result.schema,
+      mapped: result.mapped,
+      context,
+      queries: [
+        {
+          name: "AllThings",
+          text: `{ things(first: 10) { edges { node { name } } } }`,
+        },
+        {
+          name: "ThingQuery",
+          text: `query ThingQuery($uri: String!) { thing(uri: $uri) { name } }`,
+          variables: { uri: "String!" },
+        },
+      ],
+    });
+    expect(results.get("AllThings")).toBeDefined();
+    const perEntity = [...results.keys()].filter((k) =>
+      k.startsWith("ThingQuery:"),
+    );
+    expect(perEntity).toEqual(["ThingQuery:ex:widget"]);
+    const widget = results.get("ThingQuery:ex:widget");
+    expect((widget?.data?.thing as { name: string }).name).toBe("Widget");
+  });
+
+  it("fails loudly on non-enumerable variables", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    await expect(
+      extractStatic({
+        schema: result.schema,
+        mapped: result.mapped,
+        context,
+        queries: [
+          {
+            name: "Paginated",
+            text: `query P($after: String) { things(after: $after) { edges { cursor } } }`,
+            variables: { after: "String" },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/non-enumerable/);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/execution/incremental.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/incremental.ts
@@ -1,0 +1,283 @@
+// =============================================================================
+// Incremental delivery support, graphql v17.
+//
+// - executeLocal: graphql() for plain documents, experimentalExecuteIncrementally
+//   when the document uses @defer/@stream
+// - mergeIncremental: drain-and-merge fallback — folds every increment into
+//   one complete result (used by the handler for non-multipart clients and by
+//   Path B static extraction)
+// - relayFormatAdapter: translates v17's 2023 payload format
+//   (pending/id/incremental/completed) into Relay's legacy shape
+//   (path/label per payload, is_final extension)
+// =============================================================================
+
+import {
+  type DocumentNode,
+  type ExecutionResult,
+  execute,
+  experimentalExecuteIncrementally,
+  type GraphQLSchema,
+  parse,
+} from "graphql";
+import type { CompilerContext } from "#shared";
+import type {
+  IncrementalResults,
+  LocalExecutionResult,
+  PendingEntry,
+  RelayLegacyPayload,
+} from "./types.js";
+
+/** Distinguish an incremental result stream from a plain ExecutionResult. */
+export const isIncrementalResults = (
+  result: LocalExecutionResult,
+): result is IncrementalResults =>
+  "initialResult" in result && "subsequentResults" in result;
+
+/** Arguments for executeLocal: schema, source text, variables, and context. */
+export interface ExecuteLocalArgs {
+  schema: GraphQLSchema;
+  source: string;
+  /**
+   * Pre-parsed document. When provided (e.g. the HTTP handler's cached,
+   * already-validated document), executeLocal skips its own parse — avoiding
+   * a second parse of the same query text on the warm request path.
+   */
+  document?: DocumentNode;
+  variableValues?: Record<string, unknown> | null;
+  contextValue: CompilerContext;
+  operationName?: string | null;
+}
+
+const usesIncrementalDirectives = (source: string): boolean =>
+  source.includes("@defer") || source.includes("@stream");
+
+// graphql v17 RC's execute() throws on any schema that carries the @defer or
+// @stream directives — even for operations that use neither. Schemas compiled
+// with `incremental: true` must therefore always go through the experimental
+// executor (which still returns a plain ExecutionResult for plain operations).
+const schemaCarriesIncrementalDirectives = (schema: GraphQLSchema): boolean =>
+  schema.getDirective("defer") !== undefined ||
+  schema.getDirective("stream") !== undefined;
+
+/**
+ * Execute a query in-process (SSR prefetch, tests, scripts — no HTTP, no
+ * serialization). Documents using @defer/@stream go through the incremental
+ * executor and return an IncrementalResults stream; everything else returns
+ * a plain ExecutionResult. Syntax errors come back as an errors-only result,
+ * matching graphql().
+ *
+ * @note Impure — resolvers read the store through the context's loaders
+ * while the operation executes.
+ */
+export const executeLocal = async (
+  args: ExecuteLocalArgs,
+): Promise<LocalExecutionResult> => {
+  let document: DocumentNode;
+  if (args.document) {
+    document = args.document;
+  } else {
+    try {
+      document = parse(args.source);
+    } catch (error) {
+      return {
+        errors: [
+          // graphql() would produce the same shape for a syntax error.
+          error,
+        ],
+      } as ExecutionResult;
+    }
+  }
+  const executionArgs = {
+    schema: args.schema,
+    document,
+    variableValues: args.variableValues ?? undefined,
+    contextValue: args.contextValue,
+    operationName: args.operationName ?? undefined,
+  };
+  if (
+    usesIncrementalDirectives(args.source) ||
+    schemaCarriesIncrementalDirectives(args.schema)
+  ) {
+    return (await experimentalExecuteIncrementally(
+      executionArgs,
+    )) as LocalExecutionResult;
+  }
+  return execute(executionArgs);
+};
+
+const setAtPath = (
+  target: Record<string, unknown>,
+  path: ReadonlyArray<string | number>,
+  merge: (parent: Record<string, unknown> | unknown[]) => void,
+): void => {
+  // Walk to the container at `path`; tolerate missing segments (defensive).
+  let cursor: unknown = target;
+  for (const segment of path) {
+    if (cursor == null || typeof cursor !== "object") {
+      return;
+    }
+    cursor = (cursor as Record<string | number, unknown>)[segment];
+  }
+  if (cursor != null && typeof cursor === "object") {
+    merge(cursor as Record<string, unknown> | unknown[]);
+  }
+};
+
+/**
+ * Drain every increment and fold it into one complete ExecutionResult.
+ * Correctness-preserving fallback: streaming is lost, data is identical.
+ */
+export const mergeIncremental = async (
+  results: IncrementalResults,
+): Promise<ExecutionResult> => {
+  const { initialResult, subsequentResults } = results;
+  const data = (initialResult.data ?? null) as Record<string, unknown> | null;
+  const errors: unknown[] = [...(initialResult.errors ?? [])];
+  const pendingById = new Map<string, PendingEntry>();
+  for (const pending of initialResult.pending ?? []) {
+    pendingById.set(pending.id, pending);
+  }
+
+  for await (const payload of subsequentResults) {
+    for (const pending of payload.pending ?? []) {
+      pendingById.set(pending.id, pending);
+    }
+    for (const entry of payload.incremental ?? []) {
+      const pending = pendingById.get(entry.id);
+      if (!pending || data === null) {
+        continue;
+      }
+      const path = [...pending.path, ...(entry.subPath ?? [])];
+      if (entry.data !== undefined && entry.data !== null) {
+        setAtPath(data, path, (container) => {
+          Object.assign(container as Record<string, unknown>, entry.data);
+        });
+      }
+      if (entry.items) {
+        setAtPath(data, path, (container) => {
+          if (Array.isArray(container)) {
+            container.push(...(entry.items as unknown[]));
+          }
+        });
+      }
+      if (entry.errors) {
+        errors.push(...entry.errors);
+      }
+    }
+    for (const completed of payload.completed ?? []) {
+      if (completed.errors) {
+        errors.push(...completed.errors);
+      }
+    }
+  }
+
+  return errors.length > 0
+    ? ({ data, errors } as ExecutionResult)
+    : ({ data } as ExecutionResult);
+};
+
+/**
+ * Translate graphql v17 incremental results into Relay's legacy payload
+ * stream: the initial payload plain, then one payload per deferred fragment /
+ * streamed item with path + label, and is_final on the last payload.
+ *
+ * @experimental Coupled to the graphql v17 RC's 2023 incremental payload
+ * format (pending/incremental/completed) — the reason `graphql` is pinned
+ * exactly. May need adjustment when the RC payload shape changes.
+ */
+export async function* relayFormatAdapter(
+  results: IncrementalResults,
+): AsyncGenerator<RelayLegacyPayload, void, void> {
+  const pendingById = new Map<string, PendingEntry>();
+  const streamCounters = new Map<string, number>();
+  // @stream(initialCount: n): the first incremental item is list index n —
+  // seed each stream counter from the length of the array already delivered
+  // at the pending path in the initial result.
+  const computeInitialIndex = (pending: PendingEntry): number => {
+    let cursor: unknown = results.initialResult.data ?? null;
+    for (const segment of pending.path) {
+      if (cursor == null || typeof cursor !== "object") {
+        return 0;
+      }
+      cursor = (cursor as Record<string | number, unknown>)[segment];
+    }
+    return Array.isArray(cursor) ? cursor.length : 0;
+  };
+  for (const pending of results.initialResult.pending ?? []) {
+    pendingById.set(pending.id, pending);
+  }
+
+  yield {
+    data: (results.initialResult.data ?? null) as Record<
+      string,
+      unknown
+    > | null,
+    ...(results.initialResult.errors?.length
+      ? { errors: results.initialResult.errors }
+      : {}),
+  };
+
+  const buffered: RelayLegacyPayload[] = [];
+  for await (const payload of results.subsequentResults) {
+    for (const pending of payload.pending ?? []) {
+      pendingById.set(pending.id, pending);
+    }
+    for (const entry of payload.incremental ?? []) {
+      const pending = pendingById.get(entry.id);
+      if (!pending) {
+        continue;
+      }
+      if (entry.data !== undefined) {
+        buffered.push({
+          data: entry.data ?? null,
+          path: [...pending.path, ...(entry.subPath ?? [])],
+          ...(pending.label ? { label: pending.label } : {}),
+          ...(entry.errors?.length ? { errors: entry.errors } : {}),
+        });
+      }
+      for (const item of entry.items ?? []) {
+        const index =
+          streamCounters.get(entry.id) ?? computeInitialIndex(pending);
+        streamCounters.set(entry.id, index + 1);
+        buffered.push({
+          data: item as Record<string, unknown>,
+          path: [...pending.path, index],
+          ...(pending.label ? { label: pending.label } : {}),
+        });
+      }
+    }
+    // A deferred fragment that fails entirely is reported ONLY via
+    // completed[{id, errors}] — translate it so legacy clients see the error.
+    for (const completed of payload.completed ?? []) {
+      if (!completed.errors?.length) {
+        continue;
+      }
+      const pending = pendingById.get(completed.id);
+      buffered.push({
+        data: null,
+        errors: completed.errors,
+        ...(pending ? { path: pending.path } : {}),
+        ...(pending?.label ? { label: pending.label } : {}),
+      });
+    }
+    // Flush all but the last buffered payload; the final one needs is_final.
+    if (payload.hasNext) {
+      while (buffered.length > 0) {
+        yield buffered.shift() as RelayLegacyPayload;
+      }
+    }
+  }
+
+  while (buffered.length > 1) {
+    yield buffered.shift() as RelayLegacyPayload;
+  }
+  const last = buffered.shift();
+  if (last) {
+    yield { ...last, extensions: { ...last.extensions, is_final: true } };
+  } else {
+    // Everything was flushed while hasNext was still true (or the final
+    // payload carried only completed[] bookkeeping) — legacy Relay needs
+    // SOME payload with is_final or it treats the operation as incomplete.
+    yield { data: null, extensions: { is_final: true } };
+  }
+}

--- a/packages/runtime/ke-graphql/src/lib/execution/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/index.ts
@@ -1,0 +1,22 @@
+/**
+ * The execution domain: in-process query execution with incremental
+ * delivery, the Relay legacy-format adapter, build-time static
+ * extraction, and the persisted-query manifest builder.
+ *
+ * @module execution
+ */
+
+export type {
+  ExtractStaticOptions,
+  StaticQuery,
+} from "./extractStatic.js";
+export { default as extractStatic } from "./extractStatic.js";
+export {
+  type ExecuteLocalArgs,
+  executeLocal,
+  isIncrementalResults,
+  mergeIncremental,
+  relayFormatAdapter,
+} from "./incremental.js";
+export { createPersistedManifest, sha256Hex } from "./persisted.js";
+export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/execution/persisted.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/persisted.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createPersistedManifest, sha256Hex } from "./persisted.js";
+
+describe("persisted-query manifest", () => {
+  it("hashes with SHA-256 (Relay/Apollo convention)", async () => {
+    // echo -n "{ __typename }" | sha256sum
+    expect(await sha256Hex("{ __typename }")).toBe(
+      "7f56e67dd21ab3f30d1ff8b7bed08893f0a0db86449836189b361dd1e56ddb4b",
+    );
+  });
+
+  it("builds a manifest keyed by hash", async () => {
+    const a = "{ components(first: 1) { edges { cursor } } }";
+    const b = "{ ontologies { prefix } }";
+    const manifest = await createPersistedManifest([a, b]);
+    expect(Object.keys(manifest)).toHaveLength(2);
+    expect(manifest[await sha256Hex(a)]).toBe(a);
+    expect(manifest[await sha256Hex(b)]).toBe(b);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/execution/persisted.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/persisted.ts
@@ -1,0 +1,48 @@
+// =============================================================================
+// Persisted-query manifest: hash → query text, generated at build
+// time from the client's compiled operations (e.g. relay-compiler output).
+// In production the handler accepts only these (allowArbitraryQueries:
+// false), and — because the store is immutable between deploys — responses
+// become pure functions of (hash, variables): infinitely CDN-cacheable
+// until the next deploy.
+// =============================================================================
+
+/**
+ * Hash a string as lowercase SHA-256 hex — the Relay/Apollo persisted-query
+ * hash convention (SHA-256 of the exact operation text). Uses Web Crypto:
+ * platform-neutral (Node 18+, Bun, Workers).
+ */
+export const sha256Hex = async (text: string): Promise<string> => {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+/**
+ * Build a persisted-query manifest (SHA-256 hash → operation text) from
+ * operation texts. Feed the result to the handler:
+ *
+ * ```ts
+ * const manifest = await createPersistedManifest(operationTexts);
+ * createGraphQLHandler(schema, {
+ *   persistedQueries: {
+ *     get: (hash) => manifest[hash] ?? null,
+ *     allowArbitraryQueries: false,
+ *   },
+ *   ...
+ * });
+ * ```
+ */
+export const createPersistedManifest = async (
+  operations: Iterable<string>,
+): Promise<Record<string, string>> => {
+  const manifest: Record<string, string> = {};
+  for (const text of operations) {
+    manifest[await sha256Hex(text)] = text;
+  }
+  return manifest;
+};

--- a/packages/runtime/ke-graphql/src/lib/execution/types.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/types.ts
@@ -1,0 +1,66 @@
+// =============================================================================
+// Shared types for the execution domain: the graphql v17 incremental
+// delivery payload shapes and the Relay legacy payload they translate to.
+// Grouped here because executeLocal, the drain-and-merge fallback, the Relay
+// adapter, and the HTTP handler all exchange these shapes.
+//
+// The structural types mirror the v17 RC shapes rather than importing them:
+// the RC type surface is still settling, and this module is the single
+// place that would absorb a format change.
+// =============================================================================
+
+import type { ExecutionResult } from "graphql";
+
+/** A pending entry announcing a deferred fragment or stream (2023 format). */
+export interface PendingEntry {
+  id: string;
+  path: ReadonlyArray<string | number>;
+  label?: string;
+}
+
+/** One incremental delivery: deferred data or streamed items for a pending id. */
+export interface IncrementalEntry {
+  id: string;
+  data?: Record<string, unknown> | null;
+  items?: ReadonlyArray<unknown>;
+  subPath?: ReadonlyArray<string | number>;
+  errors?: ReadonlyArray<unknown>;
+}
+
+/** A completion notice for a pending id, with errors when the fragment failed. */
+export interface CompletedEntry {
+  id: string;
+  errors?: ReadonlyArray<unknown>;
+}
+
+/** The initial result of an incremental execution (data + pending list). */
+export interface InitialIncrementalResult extends ExecutionResult {
+  pending?: ReadonlyArray<PendingEntry>;
+  hasNext?: boolean;
+}
+
+/** A subsequent incremental payload (2023 format). */
+export interface SubsequentIncrementalResult {
+  pending?: ReadonlyArray<PendingEntry>;
+  incremental?: ReadonlyArray<IncrementalEntry>;
+  completed?: ReadonlyArray<CompletedEntry>;
+  hasNext: boolean;
+}
+
+/** An incremental execution: the initial result plus the payload stream. */
+export interface IncrementalResults {
+  initialResult: InitialIncrementalResult;
+  subsequentResults: AsyncGenerator<SubsequentIncrementalResult, void, void>;
+}
+
+/** What executeLocal returns: a plain result or an incremental stream. */
+export type LocalExecutionResult = ExecutionResult | IncrementalResults;
+
+/** A payload in Relay's legacy incremental shape (path/label, is_final). */
+export interface RelayLegacyPayload {
+  data?: Record<string, unknown> | null;
+  errors?: ReadonlyArray<unknown>;
+  path?: ReadonlyArray<string | number>;
+  label?: string;
+  extensions?: Record<string, unknown>;
+}

--- a/packages/runtime/ke-graphql/src/lib/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/index.ts
@@ -1,13 +1,76 @@
 /**
  * The public library surface of @canonical/ke-graphql, composed from the
- * domain barrels. This layer exposes the hardening domain and the resolution
- * layer (URI prefixing and the Relay connection helpers); the compiler, ke
- * plugin, and execution helpers are layered on top.
+ * domain barrels: the compiler pipeline and its artifact codec, the ke
+ * plugin, local/static execution, and the connection helpers. The internal
+ * cross-domain surface (loaders, vocabulary constants, resolver templates)
+ * is deliberately not re-exported.
  *
  * @module lib
  */
 
+export {
+  ARTIFACT_VERSION,
+  type CardinalitySpec,
+  type ClassNode,
+  CompilationError,
+  type CompilerContext,
+  type CompilerResult,
+  type ContextFactory,
+  type CustomMapping,
+  type CustomMappings,
+  compile,
+  compileFromExtraction,
+  createContextFactory,
+  createStoreQueryFn,
+  type Diagnostic,
+  type DiagnosticCode,
+  type DiagnosticSeverity,
+  deserializeExtraction,
+  type EntityValue,
+  hashSources,
+  type InstanceStats,
+  type MappedField,
+  type MappedInterface,
+  type MappedIR,
+  type MappedType,
+  type NameMap,
+  type NamespaceInfo,
+  type NonNullOverrides,
+  type OntologyIR,
+  type PassResult,
+  type PropertyNode,
+  type QueryFn,
+  type RangeSpec,
+  type RawExtraction,
+  type ResolverTemplate,
+  type RuntimeWarningHandler,
+  type SchemaExtensions,
+  type SchemaExtensionsInput,
+  type SchemaPluginApi,
+  type SchemaPluginOptions,
+  type SerializedExtraction,
+  serializeExtraction,
+  type TripleSet,
+  type TripleValue,
+} from "./compiler/index.js";
+export {
+  default as createSchemaPlugin,
+  type SchemaPluginExtra,
+} from "./createSchemaPlugin.js";
 export { toFull, toPrefixed } from "./dataloader/index.js";
+export {
+  createPersistedManifest,
+  executeLocal,
+  extractStatic,
+  type IncrementalResults,
+  isIncrementalResults,
+  type LocalExecutionResult,
+  mergeIncremental,
+  type RelayLegacyPayload,
+  relayFormatAdapter,
+  type StaticQuery,
+  sha256Hex,
+} from "./execution/index.js";
 export {
   clampConnectionArgs,
   createDepthLimitRule,

--- a/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.test.ts
@@ -1,0 +1,572 @@
+// =============================================================================
+// TBox schema surface: Ontology, OntologyClass, OntologyProperty,
+// ClassProperty, EntityMeta lookups and edge cases.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import {
+  type GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  graphql,
+} from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import type {
+  ClassNode,
+  CompilerContext,
+  MappedIR,
+  NamespaceInfo,
+  OntologyIR,
+  PropertyNode,
+  RawExtraction,
+} from "#shared";
+import {
+  DS_REALISTIC_TTL,
+  INHERITANCE_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+  SHACL_TTL,
+} from "#testing";
+import buildTBoxSchema from "./buildTBoxSchema.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+interface Compiled {
+  result: CompilerResult;
+  schema: GraphQLSchema;
+  context: CompilerContext;
+}
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<Compiled> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, options);
+  return {
+    result,
+    schema: result.schema,
+    context: result.createContext(store),
+  };
+};
+
+const run = async (compiled: Compiled, source: string) =>
+  graphql({ schema: compiled.schema, source, contextValue: compiled.context });
+
+// A class-ranged property, an inverse pair, an undeclared (unknown) range,
+// and a domainless property — one fixture covering the range-kind branches
+// that are reachable through full compilation.
+const RANGE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix ext: <http://external.example/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Thing a owl:Class ; rdfs:label "Thing" .
+ex:Cat a owl:Class ; rdfs:label "Cat" .
+
+ex:rel a owl:ObjectProperty ; rdfs:domain ex:Thing ; rdfs:range ex:Cat .
+ex:weird a owl:ObjectProperty ; rdfs:domain ex:Thing ; rdfs:range ext:Mystery .
+ex:free a owl:DatatypeProperty ; rdfs:range xsd:string .
+
+ex:hasChild a owl:ObjectProperty ;
+  rdfs:domain ex:Thing ; rdfs:range ex:Cat ; owl:inverseOf ex:childOf .
+ex:childOf a owl:ObjectProperty ; rdfs:domain ex:Cat ; rdfs:range ex:Thing .
+
+ex:t1 a ex:Thing .
+ex:c1 a ex:Cat .
+`;
+
+describe("Ontology and lookups", () => {
+  it("lists ontologies with classes and properties", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologies {
+          prefix
+          namespace
+          label
+          classes { label }
+          properties { label kind functional namespace }
+        }
+        ontology(prefix: "ex") { prefix }
+        unknown: ontology(prefix: "zz") { prefix }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const ontologies = result.data?.ontologies as Array<
+      Record<string, unknown>
+    >;
+    const ex = ontologies.find((o) => o.prefix === "ex");
+    expect(ex?.namespace).toBe("http://example.org/");
+    expect((ex?.classes as unknown[]).length).toBe(1);
+    expect((ex?.properties as unknown[]).length).toBe(2);
+    expect((result.data?.ontology as { prefix: string }).prefix).toBe("ex");
+    expect(result.data?.unknown).toBeNull();
+  });
+
+  it("resolves ontologyProperty with scalar ranges and datatype kind", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyProperty(uri: "http://example.org/count") {
+          uri label kind functional range namespace
+          domain { label }
+          inverse { uri }
+        }
+        missing: ontologyProperty(uri: "http://example.org/nope") { uri }
+        prefixed: ontologyProperty(uri: "ex:count") { uri }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const property = result.data?.ontologyProperty as Record<string, unknown>;
+    expect(property.kind).toBe("DATATYPE");
+    expect(property.functional).toBe(true); // datatype default is singular
+    expect(property.range).toContain("integer");
+    expect((property.domain as { label: string }).label).toBe("Thing");
+    expect(property.inverse).toBeNull();
+    expect(result.data?.missing).toBeNull();
+    // Prefixed form resolves like ontologyClass does.
+    expect((result.data?.prefixed as { uri: string }).uri).toBe(
+      "http://example.org/count",
+    );
+  });
+
+  it("resolves class and unknown ranges, an inverse, and an absent domain", async () => {
+    const compiled = await setup(RANGE_TTL);
+    const result = await run(
+      compiled,
+      `{
+        rel: ontologyProperty(uri: "http://example.org/rel") {
+          range
+          domain { label }
+        }
+        weird: ontologyProperty(uri: "http://example.org/weird") { range }
+        domainless: ontologyProperty(uri: "http://example.org/free") {
+          domain { label }
+        }
+        inv: ontologyProperty(uri: "http://example.org/childOf") {
+          inverse { uri }
+          definition
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    // class range resolves to the member class URI.
+    const rel = result.data?.rel as Record<string, unknown>;
+    expect(rel.range).toBe("http://example.org/Cat");
+    expect((rel.domain as { label: string }).label).toBe("Thing");
+    // unknown range echoes the raw URI string.
+    expect((result.data?.weird as { range: string }).range).toBe(
+      "http://external.example/Mystery",
+    );
+    // a property with no rdfs:domain has a null domain.
+    expect((result.data?.domainless as { domain: unknown }).domain).toBeNull();
+    // an inverse pair exposes the inverse property; definition is absent here.
+    const inv = result.data?.inv as {
+      inverse: { uri: string };
+      definition: string | null;
+    };
+    expect(inv.inverse.uri).toBe("http://example.org/hasChild");
+    expect(inv.definition).toBeNull();
+  });
+
+  it("exposes class definition, namespace, and falls back through prefixed lookups", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL);
+    const result = await run(
+      compiled,
+      `{
+        byFull: ontologyClass(uri: "https://ds.canonical.com/Component") {
+          definition
+          namespace
+        }
+        byPrefixed: ontologyClass(uri: "ds:Component") { uri }
+        missingClass: ontologyClass(uri: "nope:Nope") { uri }
+        propByPrefixed: ontologyProperty(uri: "ds:name") { uri }
+        missingProp: ontologyProperty(uri: "nope:nope") { uri }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const cls = result.data?.byFull as Record<string, unknown>;
+    expect(cls.definition).toBe("A reusable UI component.");
+    expect(cls.namespace).toBe("ds");
+    // prefixed-form fallback resolves both class and property…
+    expect((result.data?.byPrefixed as { uri: string }).uri).toBe(
+      "https://ds.canonical.com/Component",
+    );
+    expect((result.data?.propByPrefixed as { uri: string }).uri).toBe(
+      "https://ds.canonical.com/name",
+    );
+    // …and an unmatched prefixed form falls through to null.
+    expect(result.data?.missingClass).toBeNull();
+    expect(result.data?.missingProp).toBeNull();
+  });
+
+  it("walks superclass chains on OntologyClass", async () => {
+    const compiled = await setup(INHERITANCE_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyClass(uri: "http://example.org/Widget") {
+          label
+          isAbstract
+          superclass { label }
+          superclasses { label }
+          subclasses { label }
+        }
+        root: ontologyClass(uri: "http://example.org/Entity") {
+          isAbstract
+          superclass { label }
+          subclasses { label }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const widget = result.data?.ontologyClass as Record<string, unknown>;
+    expect(widget.isAbstract).toBe(false);
+    expect((widget.superclass as { label: string }).label).toBe("Tangible");
+    expect(
+      (widget.superclasses as Array<{ label: string }>).map((c) => c.label),
+    ).toEqual(["Tangible", "Entity"]);
+    const root = result.data?.root as Record<string, unknown>;
+    expect(root.isAbstract).toBe(true);
+    expect(root.superclass).toBeNull();
+    expect(
+      (root.subclasses as Array<{ label: string }>).map((c) => c.label),
+    ).toEqual(["Tangible"]);
+  });
+
+  it("exposes per-class SHACL cardinality through ClassProperty", async () => {
+    const compiled = await setup(SHACL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyClass(uri: "http://example.org/Spec") {
+          properties {
+            property { label }
+            required
+            singular
+            inherited
+          }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const properties = (result.data?.ontologyClass as Record<string, unknown>)
+      .properties as Array<{
+      property: { label: string };
+      required: boolean;
+      singular: boolean;
+      inherited: boolean;
+    }>;
+    const root = properties.find((p) => p.property.label === "root");
+    expect(root?.required).toBe(true);
+    expect(root?.singular).toBe(true);
+    expect(root?.inherited).toBe(false);
+  });
+
+  it("returns annotation metadata through OntologyProperty", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyProperty(uri: "https://ds.canonical.com/name") {
+          acceptanceCriteria
+          completionGuidance
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const property = result.data?.ontologyProperty as Record<string, unknown>;
+    expect(property.acceptanceCriteria).toBe(
+      "Must be a human-readable display name.",
+    );
+    expect(property.completionGuidance).toBeNull();
+  });
+});
+
+describe("EntityMeta edge cases", () => {
+  it("returns null for unknown field names", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        thing(uri: "ex:widget") {
+          _meta { field(name: "doesNotExist") { required } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    expect(
+      (result.data?.thing as { _meta: { field: unknown } })._meta.field,
+    ).toBeNull();
+  });
+});
+
+describe("datatype list fields", () => {
+  it("resolves multi-valued datatype properties when forced to list", async () => {
+    const compiled = await setup(MINIMAL_TTL, {
+      mappings: { "ex:name": { singular: false, graphqlName: "names" } },
+    });
+    const result = await run(compiled, `{ thing(uri: "ex:widget") { names } }`);
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { names: string[] }).names).toEqual([
+      "Widget",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defensive branches reachable only from synthetic parent values: a union
+// range, ClassProperty rows pointing at unknown URIs, EntityMeta on an
+// unmapped typename, and an instances window whose URI cannot round-trip.
+// These states cannot be produced through normal compilation, so the schema
+// is built directly with hand-crafted IR and parents fed through extra root
+// fields wired to the returned object types.
+// ---------------------------------------------------------------------------
+
+const KNOWN = "urn:test#Known";
+const UNION_PROP = "urn:test#unionProp";
+const GHOST_PROP = "urn:test#ghostProp";
+
+const unionProperty: PropertyNode = {
+  uri: UNION_PROP,
+  label: "unionProp",
+  namespace: "t",
+  kind: "object",
+  domains: [KNOWN],
+  range: { kind: "union", name: "PetUnion", members: ["Cat", "Dog"] },
+  functional: false,
+  classCardinality: new Map(),
+  isAnnotation: false,
+  annotations: new Map(),
+};
+
+const knownClass: ClassNode = {
+  uri: KNOWN,
+  label: "Known",
+  namespace: "t",
+  superclasses: [],
+  ancestors: [],
+  subclasses: [],
+  isAbstract: false,
+  embeddable: false,
+  // GHOST_PROP has no PropertyNode → listClassProperties' `?? false` fires.
+  ownProperties: [UNION_PROP],
+  allProperties: [UNION_PROP, GHOST_PROP],
+};
+
+const buildSyntheticIR = (): MappedIR => {
+  const classes = new Map<string, ClassNode>([[KNOWN, knownClass]]);
+  const properties = new Map<string, PropertyNode>([
+    [UNION_PROP, unionProperty],
+  ]);
+  const namespaces = new Map<string, NamespaceInfo>([
+    ["t", { prefix: "t", uri: "urn:test#", classCount: 1, propertyCount: 1 }],
+  ]);
+  const ir: OntologyIR = {
+    classes,
+    properties,
+    namespaces,
+    // Only instanceStats is read by the TBox schema; an empty map drives the
+    // `?? 0` fallback in instanceCount.
+    extraction: { instanceStats: new Map() } as unknown as RawExtraction,
+  };
+  return {
+    ir,
+    classes,
+    properties,
+    namespaces,
+    types: new Map([
+      [
+        "Known",
+        {
+          owlUri: KNOWN,
+          graphqlName: "Known",
+          interfaces: [],
+          fields: new Map(),
+          embeddable: false,
+          namespace: "t",
+          pluralName: "knowns",
+          singularName: "known",
+        },
+      ],
+    ]),
+    interfaces: new Map(),
+    unions: new Map(),
+    nameMap: {
+      toGraphQL: () => undefined,
+      toOWL: (name: string) => (name === "Known" ? KNOWN : undefined),
+      entries: () => [],
+    },
+  } as unknown as MappedIR;
+};
+
+const buildSyntheticSchema = (): GraphQLSchema => {
+  const mapped = buildSyntheticIR();
+  const nodeInterface = {} as GraphQLInterfaceType;
+  const nodeConnection = () =>
+    new GraphQLObjectType({
+      name: "TestConnection",
+      fields: { _empty: { type: GraphQLString } },
+    });
+  const tbox = buildTBoxSchema(mapped, nodeInterface, nodeConnection);
+
+  const query = new GraphQLObjectType({
+    name: "Query",
+    fields: {
+      // union range branch
+      unionProp: {
+        type: tbox.ontologyProperty,
+        resolve: () => mapped.ir.properties.get(UNION_PROP),
+      },
+      // ClassProperty whose property is unknown → required/singular short to
+      // false (resolveCardinality never called) and inherited's `?? false`.
+      orphanProp: {
+        type: tbox.classProperty,
+        resolve: () => ({
+          propertyUri: GHOST_PROP,
+          classUri: "urn:test#NoClass",
+        }),
+      },
+      // ClassProperty with a known property but an unknown class → required/
+      // singular DO call resolveCardinality, whose `node?.ancestors ?? []`
+      // default fires because the class is absent.
+      orphanClassProp: {
+        type: tbox.classProperty,
+        resolve: () => ({
+          propertyUri: UNION_PROP,
+          classUri: "urn:test#NoClass",
+        }),
+      },
+      // EntityMeta with an unmapped typename
+      orphanMeta: {
+        type: tbox.entityMeta,
+        resolve: () => ({
+          uri: null,
+          typename: "NotAType",
+          triples: new Map(),
+        }),
+      },
+      // ClassNode with an empty stats map and a ghost own-property
+      knownClass: {
+        type: tbox.ontologyClass,
+        resolve: () => mapped.ir.classes.get(KNOWN),
+      },
+    },
+  });
+
+  return new GraphQLSchema({ query, types: [tbox.entityMeta] });
+};
+
+describe("TBox defensive branches (synthetic parents)", () => {
+  const orphanContext = {
+    // A bare token cannot be prefixed nor expanded → instances' `toFull ?? uri`.
+    listLoader: { load: async () => ["orphan"] },
+    entityLoader: { loadMany: async () => [null] },
+  } as unknown as CompilerContext;
+
+  it("joins union range members and reads the empty instanceCount fallback", async () => {
+    const schema = buildSyntheticSchema();
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{
+        unionProp { range }
+        knownClass {
+          namespace
+          instanceCount
+          properties { inherited }
+          instances(first: 5) { _empty }
+        }
+      }`,
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.unionProp as { range: string }).range).toBe(
+      "Cat | Dog",
+    );
+    const cls = result.data?.knownClass as Record<string, unknown>;
+    expect(cls.namespace).toBe("t");
+    // No stats entry for this class → instanceCount falls back to 0.
+    expect(cls.instanceCount).toBe(0);
+    // listClassProperties runs the annotation filter against GHOST_PROP (no
+    // PropertyNode → the `?? false` default keeps it) — both the union prop
+    // and the ghost survive, so the list has two entries. `property` is left
+    // unqueried because the ghost has no resolvable OntologyProperty.
+    const props = cls.properties as Array<{ inherited: boolean }>;
+    expect(props).toHaveLength(2);
+  });
+
+  it("reports false cardinality and inherited for a ClassProperty with unknown URIs", async () => {
+    const schema = buildSyntheticSchema();
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{ orphanProp { required singular inherited } }`,
+    });
+    expect(result.errors).toBeUndefined();
+    const cp = result.data?.orphanProp as Record<string, boolean>;
+    expect(cp.required).toBe(false);
+    expect(cp.singular).toBe(false);
+    // The class is unknown → ownProperties lookup yields the `?? false` default,
+    // so the property is reported as inherited.
+    expect(cp.inherited).toBe(true);
+  });
+
+  it("falls back to a known property's defaults when its class is unknown", async () => {
+    const schema = buildSyntheticSchema();
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{ orphanClassProp { required singular } }`,
+    });
+    expect(result.errors).toBeUndefined();
+    const cp = result.data?.orphanClassProp as Record<string, boolean>;
+    // resolveCardinality found no class node and no per-class spec → the kind
+    // default (object property → not singular, not required) applies.
+    expect(cp.required).toBe(false);
+    expect(cp.singular).toBe(false);
+  });
+
+  it("returns an empty field list for an unmapped EntityMeta typename", async () => {
+    const schema = buildSyntheticSchema();
+    // `fields` is queried alone: an unmapped typename yields no class node, so
+    // the resolver returns [] without touching the non-null `type` field.
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{ orphanMeta { fields { property { uri } } } }`,
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.orphanMeta as { fields: unknown[] }).fields).toEqual(
+      [],
+    );
+  });
+
+  it("nulls the non-null EntityMeta type for an unmapped typename", async () => {
+    const schema = buildSyntheticSchema();
+    // `type` is non-null; an unmapped typename resolves it to null, which
+    // bubbles a non-null violation and nulls the parent.
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{ orphanMeta { type { uri } } }`,
+    });
+    expect(result.data?.orphanMeta).toBeNull();
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.ts
@@ -1,0 +1,394 @@
+// =============================================================================
+// TBox schema (hand-written): Ontology, OntologyClass,
+// ClassProperty, OntologyProperty, PropertyKind, EntityMeta.
+//
+// Value conventions:
+//   Ontology        → NamespaceInfo
+//   OntologyClass   → ClassNode (IR)
+//   OntologyProperty→ PropertyNode (IR)
+//   ClassProperty   → { propertyUri, classUri } (per-class scope)
+//   EntityMeta      → EntityValue (the ABox parent)
+//
+// Structural facts come from the frozen IR (resolver closures); only the
+// instances connection hits the loaders.
+// =============================================================================
+
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  type GraphQLFieldConfigMap,
+  GraphQLInt,
+  type GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql";
+import { toFull, toPrefixed } from "#dataloader";
+import {
+  connectionFromPage,
+  paginateUriWindow,
+  unwrapEntities,
+} from "#resolver";
+import {
+  type ClassNode,
+  CONNECTION_ARGS,
+  type CompilerContext,
+  type EntityValue,
+  type MappedIR,
+  type NamespaceInfo,
+  type PropertyNode,
+} from "#shared";
+
+interface ClassPropertyValue {
+  propertyUri: string;
+  classUri: string;
+}
+
+/**
+ * Get an annotation value on a property by the annotation property's local
+ * name suffix. Annotation values live on PropertyNode (extracted in Pass 1)
+ * — the TBox schema is fully store-free at request time. Matched by local
+ * name so the convention works for any namespace's annotation properties.
+ */
+const getAnnotationValue = (
+  property: PropertyNode,
+  localSuffix: string,
+): string | null => {
+  for (const [uri, value] of property.annotations) {
+    if (uri.endsWith(localSuffix)) {
+      return value;
+    }
+  }
+  return null;
+};
+
+/** The hand-written TBox types plus the root query fields that serve them. */
+export interface TBoxSchema {
+  ontology: GraphQLObjectType;
+  ontologyClass: GraphQLObjectType;
+  classProperty: GraphQLObjectType;
+  ontologyProperty: GraphQLObjectType;
+  entityMeta: GraphQLObjectType;
+  queryFields: GraphQLFieldConfigMap<unknown, CompilerContext>;
+}
+
+/**
+ * Build the hand-written TBox schema types (Ontology, OntologyClass,
+ * ClassProperty, OntologyProperty, EntityMeta) and their root query fields
+ * from the compiled IR. Resolvers read the frozen IR — only the instances
+ * connection touches the store, through the context's loaders.
+ */
+export default function buildTBoxSchema(
+  mapped: MappedIR,
+  nodeInterface: GraphQLInterfaceType,
+  nodeConnection: () => GraphQLObjectType,
+): TBoxSchema {
+  const { ir } = mapped;
+
+  const propertyKind = new GraphQLEnumType({
+    name: "PropertyKind",
+    values: {
+      DATATYPE: { value: "datatype" },
+      OBJECT: { value: "object" },
+      ANNOTATION: { value: "annotation" },
+    },
+  });
+
+  /** Per-class cardinality, consulting the class then its ancestors. */
+  const resolveCardinality = (property: PropertyNode, classUri: string) => {
+    const node = ir.classes.get(classUri);
+    for (const uri of [classUri, ...(node?.ancestors ?? [])]) {
+      const spec = property.classCardinality.get(uri);
+      if (spec) {
+        return spec;
+      }
+    }
+    return { singular: property.functional, required: false, omit: false };
+  };
+
+  const ontologyProperty: GraphQLObjectType = new GraphQLObjectType<
+    PropertyNode,
+    CompilerContext
+  >({
+    name: "OntologyProperty",
+    fields: () => ({
+      uri: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => p.uri,
+      },
+      label: { type: GraphQLString, resolve: (p) => p.label },
+      definition: { type: GraphQLString, resolve: (p) => p.definition },
+      domain: {
+        type: ontologyClass,
+        resolve: (p) => (p.domains[0] ? ir.classes.get(p.domains[0]) : null),
+      },
+      range: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => {
+          switch (p.range.kind) {
+            case "scalar":
+              return p.range.customDatatype ?? p.range.xsd;
+            case "class":
+              return p.range.uri;
+            case "union":
+              return p.range.members.join(" | ");
+            case "unknown":
+              return p.range.raw;
+          }
+        },
+      },
+      kind: { type: new GraphQLNonNull(propertyKind), resolve: (p) => p.kind },
+      functional: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (p) => p.functional,
+      },
+      inverse: {
+        type: ontologyProperty,
+        resolve: (p) => (p.inverse ? ir.properties.get(p.inverse) : null),
+      },
+      acceptanceCriteria: {
+        type: GraphQLString,
+        resolve: (p) => getAnnotationValue(p, "acceptanceCriteria"),
+      },
+      completionGuidance: {
+        type: GraphQLString,
+        resolve: (p) => getAnnotationValue(p, "completionGuidance"),
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => p.namespace,
+      },
+    }),
+  });
+
+  const classProperty: GraphQLObjectType = new GraphQLObjectType<
+    ClassPropertyValue,
+    CompilerContext
+  >({
+    name: "ClassProperty",
+    description:
+      "Class-scoped view of a property: SHACL cardinality is a fact about a (class, property) pair.",
+    fields: () => ({
+      property: {
+        type: new GraphQLNonNull(ontologyProperty),
+        resolve: (cp) => ir.properties.get(cp.propertyUri),
+      },
+      required: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) => {
+          const property = ir.properties.get(cp.propertyUri);
+          return property
+            ? resolveCardinality(property, cp.classUri).required
+            : false;
+        },
+      },
+      singular: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) => {
+          const property = ir.properties.get(cp.propertyUri);
+          return property
+            ? resolveCardinality(property, cp.classUri).singular
+            : false;
+        },
+      },
+      inherited: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) =>
+          !(
+            ir.classes
+              .get(cp.classUri)
+              ?.ownProperties.includes(cp.propertyUri) ?? false
+          ),
+      },
+    }),
+  });
+
+  const listClassProperties = (node: ClassNode): ClassPropertyValue[] =>
+    node.allProperties
+      .filter((uri) => !(ir.properties.get(uri)?.isAnnotation ?? false))
+      .map((propertyUri) => ({ propertyUri, classUri: node.uri }));
+
+  const ontologyClass: GraphQLObjectType = new GraphQLObjectType<
+    ClassNode,
+    CompilerContext
+  >({
+    name: "OntologyClass",
+    fields: () => ({
+      uri: { type: new GraphQLNonNull(GraphQLString), resolve: (c) => c.uri },
+      label: { type: GraphQLString, resolve: (c) => c.label },
+      definition: { type: GraphQLString, resolve: (c) => c.definition },
+      superclass: {
+        type: ontologyClass,
+        resolve: (c) =>
+          c.superclasses[0] ? ir.classes.get(c.superclasses[0]) : null,
+      },
+      superclasses: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (c) =>
+          c.ancestors
+            .map((uri) => ir.classes.get(uri))
+            .filter((n): n is ClassNode => n !== undefined),
+      },
+      subclasses: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (c) =>
+          c.subclasses
+            .map((uri) => ir.classes.get(uri))
+            .filter((n): n is ClassNode => n !== undefined),
+      },
+      properties: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(classProperty)),
+        ),
+        resolve: (c) => listClassProperties(c),
+      },
+      instances: {
+        type: new GraphQLNonNull(nodeConnection()),
+        args: CONNECTION_ARGS,
+        description:
+          "Named instances of this class (blank-node instances are embeddable and not standalone-resolvable).",
+        resolve: async (c, args, ctx) => {
+          const fullUris = await ctx.listLoader.load(c.uri);
+          const prefixed = fullUris.map((uri) =>
+            toPrefixed(uri, mapped.namespaces),
+          );
+          const page = paginateUriWindow(prefixed, args);
+          const entities = await ctx.entityLoader.loadMany(
+            page.window.map((uri) => toFull(uri, mapped.namespaces) ?? uri),
+          );
+          return connectionFromPage(unwrapEntities(entities), page);
+        },
+      },
+      instanceCount: {
+        type: new GraphQLNonNull(GraphQLInt),
+        description: "Count of NAMED instances (matches `instances`).",
+        resolve: (c) => ir.extraction.instanceStats.get(c.uri)?.named ?? 0,
+      },
+      isAbstract: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (c) => c.isAbstract,
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (c) => c.namespace,
+      },
+    }),
+  });
+
+  const ontology = new GraphQLObjectType<NamespaceInfo, CompilerContext>({
+    name: "Ontology",
+    fields: () => ({
+      prefix: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (n) => n.prefix,
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (n) => n.uri,
+      },
+      label: { type: GraphQLString, resolve: (n) => n.prefix },
+      classes: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (n) =>
+          [...ir.classes.values()].filter((c) => c.namespace === n.prefix),
+      },
+      properties: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyProperty)),
+        ),
+        resolve: (n) =>
+          [...ir.properties.values()].filter((p) => p.namespace === n.prefix),
+      },
+    }),
+  });
+
+  const entityMeta = new GraphQLObjectType<EntityValue, CompilerContext>({
+    name: "EntityMeta",
+    description: "Self-describing TBox access attached to ABox types.",
+    fields: () => ({
+      type: {
+        type: new GraphQLNonNull(ontologyClass),
+        resolve: (parent) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          return classUri ? ir.classes.get(classUri) : null;
+        },
+      },
+      field: {
+        type: classProperty,
+        args: { name: { type: new GraphQLNonNull(GraphQLString) } },
+        resolve: (parent, args: { name: string }) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          const mappedType = mapped.types.get(parent.typename);
+          const field = mappedType?.fields.get(args.name);
+          if (!classUri || !field || !ir.properties.has(field.propertyUri)) {
+            return null;
+          }
+          return { propertyUri: field.propertyUri, classUri };
+        },
+      },
+      fields: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(classProperty)),
+        ),
+        resolve: (parent) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          const node = classUri ? ir.classes.get(classUri) : undefined;
+          return node ? listClassProperties(node) : [];
+        },
+      },
+    }),
+  });
+
+  const queryFields: GraphQLFieldConfigMap<unknown, CompilerContext> = {
+    ontologies: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ontology))),
+      resolve: () => [...mapped.namespaces.values()],
+    },
+    ontology: {
+      type: ontology,
+      args: { prefix: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { prefix: string }) =>
+        mapped.namespaces.get(args.prefix) ?? null,
+    },
+    ontologyClass: {
+      type: ontologyClass,
+      args: { uri: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { uri: string }) =>
+        ir.classes.get(args.uri) ??
+        [...ir.classes.values()].find(
+          (c) => `${c.namespace}:${c.uri.split(/[#/]/).pop()}` === args.uri,
+        ) ??
+        null,
+    },
+    ontologyProperty: {
+      type: ontologyProperty,
+      args: { uri: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { uri: string }) =>
+        ir.properties.get(args.uri) ??
+        [...ir.properties.values()].find(
+          (p) => `${p.namespace}:${p.uri.split(/[#/]/).pop()}` === args.uri,
+        ) ??
+        null,
+    },
+  };
+
+  // The Node interface is referenced through nodeConnection (lazily); the
+  // parameter is accepted to make the dependency explicit at the call site.
+  void nodeInterface;
+
+  return {
+    ontology,
+    ontologyClass,
+    classProperty,
+    ontologyProperty,
+    entityMeta,
+    queryFields,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/tbox/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The TBox domain: the hand-written ontology-browsing schema (Ontology,
+ * OntologyClass, ClassProperty, OntologyProperty, EntityMeta) composed into
+ * every generated schema alongside the data types.
+ *
+ * @module tbox
+ */
+
+export {
+  default as buildTBoxSchema,
+  type TBoxSchema,
+} from "./buildTBoxSchema.js";

--- a/packages/runtime/ke-graphql/src/testing/integration/hardening.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/hardening.test.ts
@@ -1,0 +1,89 @@
+// =============================================================================
+// Hardening behaviors that need a compiled schema end-to-end: the forced-
+// abstract-with-instances guard (correctness C1 + V015) and the SPARQL
+// injection guard reaching through node(id:) to a null result.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { afterEach, describe, expect, it } from "vitest";
+import { compile, createStoreQueryFn } from "#compiler";
+import { executeLocal, isIncrementalResults } from "#execution";
+
+const PREFIXES = { ex: "http://example.org/" };
+
+// A class with a subclass AND a named instance of the parent itself — the only
+// shape that can trip the forced-abstract crash.
+const HIERARCHY_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Animal a owl:Class ; rdfs:label "Animal" .
+ex:Dog a owl:Class ; rdfs:subClassOf ex:Animal ; rdfs:label "Dog" .
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Animal ; rdfs:range xsd:string .
+
+ex:a1 a ex:Animal ; ex:name "Generic" .
+ex:d1 a ex:Dog ; ex:name "Rex" .
+`;
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const compileHierarchy = async () => {
+  const { store, cleanup } = await createTestStore({
+    ttl: HIERARCHY_TTL,
+    prefixes: PREFIXES,
+  });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, {
+    mappings: { "http://example.org/Animal": { abstract: true } },
+  });
+  return { result, store };
+};
+
+describe("forced abstract with direct instances (C1 + V015)", () => {
+  it("warns (V015) when the data contradicts an abstract mapping", async () => {
+    const { result } = await compileHierarchy();
+    expect(result.diagnostics.some((d) => d.code === "V015")).toBe(true);
+  });
+
+  it("filters the abstract-only instance instead of crashing resolveType", async () => {
+    const { result, store } = await compileHierarchy();
+    const context = result.createContext(store);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: `{ node(id: "ex:a1") { __typename } }`,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      // No "Abstract type ... resolved to a non-object type" error.
+      expect(execution.errors).toBeUndefined();
+      expect(execution.data?.node).toBeNull();
+    }
+  });
+
+  it("still resolves a concrete subclass instance to its concrete type", async () => {
+    const { result, store } = await compileHierarchy();
+    const context = result.createContext(store);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: `{ node(id: "ex:d1") { __typename } }`,
+      contextValue: context,
+    });
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors).toBeUndefined();
+      expect((execution.data?.node as { __typename: string }).__typename).toBe(
+        "Dog",
+      );
+    }
+  });
+});

--- a/packages/runtime/ke-graphql/src/testing/integration/performance-features.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/performance-features.test.ts
@@ -1,0 +1,297 @@
+// =============================================================================
+// Performance features: extraction artifact (DMMF-style boot), lazy store,
+// process-lifetime loader cache, slice-before-hydrate pagination, store-free
+// TBox.
+// =============================================================================
+
+import type { SPARQL, Store } from "@canonical/ke";
+import { createTestStore } from "@canonical/ke/testing";
+import { graphql } from "graphql";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  compile,
+  compileFromExtraction,
+  createStoreQueryFn,
+  deserializeExtraction,
+  hashSources,
+  type SchemaPluginApi,
+  serializeExtraction,
+} from "#compiler";
+import { DS_REALISTIC_TTL, MINIMAL_TTL, PREFIXES } from "#testing";
+import createSchemaPlugin from "../../lib/createSchemaPlugin.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+  vi.restoreAllMocks();
+});
+
+const boot = async (ttl: string) => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  return store;
+};
+
+/** Wrap a store so SPARQL round-trips are countable. */
+const countingStore = (store: Store): { store: Store; count: () => number } => {
+  let queries = 0;
+  const wrapped: Store = {
+    ...store,
+    query: ((q: SPARQL<string>) => {
+      queries++;
+      return store.query(q);
+    }) as Store["query"],
+  };
+  return { store: wrapped, count: () => queries };
+};
+
+describe("extraction artifact (DMMF-style boot)", () => {
+  it("round-trips: serialized extraction rebuilds an executable schema", async () => {
+    const store = await boot(MINIMAL_TTL);
+    const live = await compile(createStoreQueryFn(store), PREFIXES);
+
+    const artifact = serializeExtraction(live.extraction, hashSources(["x"]));
+    const rebuilt = compileFromExtraction(artifact);
+
+    // assumeValid skips printSchema — the SDL is a build-time artifact
+    expect(rebuilt.sdl).toBe("");
+    expect(rebuilt.schema.getType("Thing")).toBeDefined();
+
+    const result = await graphql({
+      schema: rebuilt.schema,
+      source: `{ thing(uri: "ex:widget") { name count } _meta: ontologyClass(uri: "http://example.org/Thing") { label } }`,
+      contextValue: rebuilt.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { name: string }).name).toBe("Widget");
+  });
+
+  it("preserves Sets/Maps through serialization", async () => {
+    const store = await boot(DS_REALISTIC_TTL);
+    const live = await compile(createStoreQueryFn(store), PREFIXES);
+    const { extraction } = deserializeExtraction(
+      serializeExtraction(live.extraction, "0"),
+    );
+    expect(extraction.functionals).toEqual(live.extraction.functionals);
+    expect(extraction.instanceStats).toEqual(live.extraction.instanceStats);
+    expect(extraction.annotations).toEqual(live.extraction.annotations);
+  });
+
+  it("rejects unknown artifact versions", () => {
+    expect(() =>
+      deserializeExtraction(JSON.stringify({ version: 99 })),
+    ).toThrow(/version 99/);
+  });
+
+  it("hashSources is order-independent and content-sensitive", () => {
+    expect(hashSources(["a", "b"])).toBe(hashSources(["b", "a"]));
+    expect(hashSources(["a"])).not.toBe(hashSources(["b"]));
+  });
+
+  it("plugin boots from a fresh artifact and falls back when stale", async () => {
+    // Build the artifact through the plugin so sourcesHash matches ke's load.
+    const probe = createSchemaPlugin();
+    const first = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [probe],
+    });
+    cleanups.push(first.cleanup);
+    // Recover the hash the plugin computed by re-deriving it from the file
+    // ke wrote: simplest faithful source is a second boot with the artifact.
+    const liveApi = first.store.api<SchemaPluginApi>("ke-graphql");
+    const ttlHash = hashSources([MINIMAL_TTL]);
+    const artifact = JSON.parse(
+      serializeExtraction(
+        (await compile(createStoreQueryFn(first.store), PREFIXES)).extraction,
+        ttlHash,
+      ),
+    );
+    expect(liveApi).toBeDefined();
+
+    const fresh = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [createSchemaPlugin({ extraction: artifact })],
+    });
+    cleanups.push(fresh.cleanup);
+    const freshApi = fresh.store.api<SchemaPluginApi>("ke-graphql");
+    // Artifact boot skips printSchema — that IS the fast path marker.
+    expect(freshApi?.sdl).toBe("");
+    expect(freshApi?.schema.getType("Thing")).toBeDefined();
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stale = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [
+        createSchemaPlugin({
+          extraction: { ...artifact, sourcesHash: "deadbeef" },
+        }),
+      ],
+    });
+    cleanups.push(stale.cleanup);
+    const staleApi = stale.store.api<SchemaPluginApi>("ke-graphql");
+    // Fallback = full live compile, SDL present again.
+    expect(staleApi?.sdl).toContain("type Thing");
+    expect(
+      warn.mock.calls.some(([message]) => String(message).includes("stale")),
+    ).toBe(true);
+  });
+});
+
+describe("lazy store (TBox needs no store)", () => {
+  it("answers TBox queries before the store resolves; ABox waits for it", async () => {
+    const store = await boot(MINIMAL_TTL);
+    const result = await compile(createStoreQueryFn(store), PREFIXES);
+
+    let releaseStore: (s: Store) => void = () => {};
+    const pending = new Promise<Store>((resolve) => {
+      releaseStore = resolve;
+    });
+    const ctx = result.createContext(pending);
+
+    // TBox: resolves while the store promise is still pending.
+    const tbox = await graphql({
+      schema: result.schema,
+      source: `{ ontologyClass(uri: "http://example.org/Thing") { label isAbstract properties { property { label } } } }`,
+      contextValue: ctx,
+    });
+    expect(tbox.errors).toBeUndefined();
+    expect((tbox.data?.ontologyClass as { label: string }).label).toBe("Thing");
+
+    // ABox: blocked until the store arrives.
+    const abox = graphql({
+      schema: result.schema,
+      source: `{ thing(uri: "ex:widget") { name } }`,
+      contextValue: ctx,
+    });
+    const raced = await Promise.race([
+      abox.then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r("pending"), 50)),
+    ]);
+    expect(raced).toBe("pending");
+
+    releaseStore(store);
+    const resolved = await abox;
+    expect(resolved.errors).toBeUndefined();
+    expect((resolved.data?.thing as { name: string }).name).toBe("Widget");
+  });
+});
+
+describe("loaderCache: process", () => {
+  it("shares entity/list caches across contexts and clears on demand", async () => {
+    const raw = await boot(MINIMAL_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(createStoreQueryFn(store), PREFIXES, {
+      loaderCache: "process",
+    });
+    const baseline = count();
+
+    const run = () =>
+      graphql({
+        schema: result.schema,
+        source: `{ things(first: 5) { edges { node { name } } } }`,
+        contextValue: result.createContext(store),
+      });
+
+    await run();
+    const afterFirst = count();
+    expect(afterFirst).toBeGreaterThan(baseline);
+
+    // A FRESH context hits the shared cache — zero new SPARQL.
+    await run();
+    expect(count()).toBe(afterFirst);
+
+    result.clearLoaderCache();
+    await run();
+    expect(count()).toBeGreaterThan(afterFirst);
+  });
+
+  it("request mode (default) re-queries per context", async () => {
+    const raw = await boot(MINIMAL_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(createStoreQueryFn(store), PREFIXES);
+    const run = () =>
+      graphql({
+        schema: result.schema,
+        source: `{ thing(uri: "ex:widget") { name } }`,
+        contextValue: result.createContext(store),
+      });
+    await run();
+    const afterFirst = count();
+    await run();
+    expect(count()).toBeGreaterThan(afterFirst);
+  });
+});
+
+describe("slice-before-hydrate listings", () => {
+  it("hydrates only the requested page and pages correctly via endCursor", async () => {
+    const raw = await boot(DS_REALISTIC_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(createStoreQueryFn(store), PREFIXES);
+
+    const page1 = await graphql({
+      schema: result.schema,
+      source: `{ tiers(first: 1) { edges { cursor node { id name } } pageInfo { hasNextPage endCursor } } }`,
+      contextValue: result.createContext(store),
+    });
+    expect(page1.errors).toBeUndefined();
+    void count();
+
+    // Page 2 of subcomponents-by-cursor on a 2-entity class: use modifiers
+    // (1 modifier) to assert the empty next page + pageInfo math.
+    const modifiers = await graphql({
+      schema: result.schema,
+      source: `{ modifiers(first: 1) { edges { cursor node { name } } pageInfo { hasNextPage } } }`,
+      contextValue: result.createContext(store),
+    });
+    const connection = modifiers.data?.modifiers as {
+      edges: Array<{ cursor: string }>;
+      pageInfo: { hasNextPage: boolean };
+    };
+    expect(connection.edges).toHaveLength(1);
+    expect(connection.pageInfo.hasNextPage).toBe(false);
+
+    const page2 = await graphql({
+      schema: result.schema,
+      source: `query($c: String) { modifiers(first: 1, after: $c) { edges { node { name } } pageInfo { hasPreviousPage } } }`,
+      variableValues: { c: connection.edges[0]?.cursor },
+      contextValue: result.createContext(store),
+    });
+    expect((page2.data?.modifiers as { edges: unknown[] }).edges).toHaveLength(
+      0,
+    );
+  });
+});
+
+describe("store-free TBox (tboxLoader removed)", () => {
+  it("serves class structure and annotations after the store is disposed", async () => {
+    const { store, cleanup } = await createTestStore({
+      ttl: DS_REALISTIC_TTL,
+      prefixes: PREFIXES,
+    });
+    const result = await compile(createStoreQueryFn(store), PREFIXES);
+    const ctx = result.createContext(store);
+    cleanup(); // disposes the store — TBox must not notice
+
+    const tbox = await graphql({
+      schema: result.schema,
+      source: `{
+        ontologyProperty(uri: "https://ds.canonical.com/name") { acceptanceCriteria }
+        ontologyClass(uri: "https://ds.canonical.com/Component") { isAbstract superclasses { label } }
+      }`,
+      contextValue: ctx,
+    });
+    expect(tbox.errors).toBeUndefined();
+    expect(
+      (tbox.data?.ontologyProperty as { acceptanceCriteria: string })
+        .acceptanceCriteria,
+    ).toBe("Must be a human-readable display name.");
+  });
+});

--- a/packages/runtime/ke-graphql/src/testing/integration/pipeline.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/pipeline.test.ts
@@ -1,0 +1,267 @@
+// =============================================================================
+// Pipeline tests (Passes 1–7) against fixture stores: schema shape,
+// diagnostics, golden SDL expectations.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import type { GraphQLObjectType } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import {
+  BLANK_NODES_TTL,
+  DOMAINLESS_TTL,
+  DS_REALISTIC_TTL,
+  EDGE_CASES_TTL,
+  INHERITANCE_TTL,
+  INVERSE_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+  SHACL_TTL,
+} from "#testing";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const compileFixture = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<CompilerResult> => {
+  const { store, cleanup } = await createTestStore({
+    ttl,
+    prefixes: PREFIXES,
+  });
+  cleanups.push(cleanup);
+  return compile(createStoreQueryFn(store), PREFIXES, options);
+};
+
+const codes = (result: CompilerResult): string[] =>
+  result.diagnostics.map((d) => d.code);
+
+describe("minimal fixture", () => {
+  it("compiles one concrete type with root queries and Node membership", async () => {
+    const result = await compileFixture(MINIMAL_TTL);
+    expect(result.schema).toBeDefined();
+    const thing = result.schema.getType("Thing") as GraphQLObjectType;
+    expect(thing).toBeDefined();
+    const fields = thing.getFields();
+    // datatype properties default to singular
+    expect(String(fields.name?.type)).toBe("String");
+    expect(String(fields.count?.type)).toBe("Int");
+    // structural fields
+    expect(String(fields.id?.type)).toBe("ID!");
+    expect(String(fields.uri?.type)).toBe("String!");
+    expect(String(fields._meta?.type)).toBe("EntityMeta!");
+    expect(thing.getInterfaces().map((i) => i.name)).toContain("Node");
+    // root queries
+    const query = result.schema.getQueryType()?.getFields();
+    expect(query?.thing).toBeDefined();
+    expect(query?.things).toBeDefined();
+    expect(String(query?.things?.type)).toBe("ThingConnection!");
+    // connection fields carry the four pagination args
+    const argNames = query?.things?.args.map((a) => a.name).sort();
+    expect(argNames).toEqual(["after", "before", "first", "last"]);
+    expect(result.sdl).toContain("type Thing implements Node");
+  });
+});
+
+describe("inheritance fixture", () => {
+  it("generates the interface chain with inherited fields", async () => {
+    const result = await compileFixture(INHERITANCE_TTL);
+    expect(result.sdl).toContain("interface Entity implements Node");
+    expect(result.sdl).toContain("interface Tangible implements");
+    const widget = result.schema.getType("Widget") as GraphQLObjectType;
+    expect(
+      widget
+        .getInterfaces()
+        .map((i) => i.name)
+        .sort(),
+    ).toEqual(["Entity", "Node", "Tangible"]);
+    const fields = widget.getFields();
+    expect(fields.name).toBeDefined(); // inherited from Entity
+    expect(fields.weight).toBeDefined(); // inherited from Tangible
+    expect(fields.color).toBeDefined(); // own
+    // abstract classes produce no root queries
+    const query = result.schema.getQueryType()?.getFields();
+    expect(query?.entity).toBeUndefined();
+    expect(query?.widget).toBeDefined();
+  });
+});
+
+describe("inverse fixture", () => {
+  it("places one field per side with the irregular plural", async () => {
+    const result = await compileFixture(INVERSE_TTL);
+    const parent = result.schema.getType("Parent") as GraphQLObjectType;
+    const child = result.schema.getType("Child") as GraphQLObjectType;
+    // hasChild → children (has-strip + irregular plural), connection-wrapped
+    expect(String(parent.getFields().children?.type)).toBe("ChildConnection!");
+    // childOf is functional → singular
+    expect(String(child.getFields().childOf?.type)).toBe("Parent");
+    // no duplicated reverse fields
+    expect(parent.getFields().childOf).toBeUndefined();
+    expect(child.getFields().children).toBeUndefined();
+  });
+});
+
+describe("polymorphic flattening diagnostic (V016)", () => {
+  const SUPERTYPE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Animal a owl:Class .
+ex:Dog a owl:Class ; rdfs:subClassOf ex:Animal .
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Animal ; rdfs:range xsd:string .
+ex:a1 a ex:Animal ; ex:name "Generic" .
+ex:d1 a ex:Dog ; ex:name "Rex" .
+`;
+
+  it("warns when a concrete class has subclasses (instantiable supertype)", async () => {
+    const result = await compileFixture(SUPERTYPE_TTL);
+    expect(codes(result)).toContain("V016");
+    // Animal keeps its direct instance, so it stays a concrete type.
+    expect(result.sdl).toContain("type Animal implements Node");
+  });
+
+  it("does not warn when the supertype is abstract (no direct instances)", async () => {
+    const result = await compileFixture(INHERITANCE_TTL);
+    expect(codes(result)).not.toContain("V016");
+  });
+});
+
+describe("blank nodes fixture", () => {
+  it("marks blank-only classes embeddable: no Node, plain list", async () => {
+    const result = await compileFixture(BLANK_NODES_TTL);
+    expect(codes(result)).toContain("V001");
+    const example = result.schema.getType("Example") as GraphQLObjectType;
+    expect(example.getInterfaces()).toHaveLength(0);
+    expect(example.getFields().id).toBeUndefined();
+    expect(example.getFields()._meta).toBeUndefined();
+    const standard = result.schema.getType("Standard") as GraphQLObjectType;
+    // plain list, not a connection
+    expect(String(standard.getFields().examples?.type)).toBe("[Example!]!");
+    // no root query for embeddable types
+    expect(result.schema.getQueryType()?.getFields().example).toBeUndefined();
+  });
+});
+
+describe("domainless fixture", () => {
+  it("assigns the property to every class in its namespace", async () => {
+    const result = await compileFixture(DOMAINLESS_TTL);
+    expect(codes(result)).toContain("V002");
+    const foo = result.schema.getType("Foo") as GraphQLObjectType;
+    const bar = result.schema.getType("Bar") as GraphQLObjectType;
+    expect(foo.getFields().description).toBeDefined();
+    expect(bar.getFields().description).toBeDefined();
+  });
+});
+
+describe("edge cases fixture", () => {
+  it("emits the expected V-series diagnostics", async () => {
+    const result = await compileFixture(EDGE_CASES_TTL);
+    const found = codes(result);
+    expect(found).toContain("V004"); // self-referential extends
+    expect(found).toContain("V005"); // functional violation on ex:rank
+    expect(found).toContain("V006"); // boolean range coercion note
+    expect(found).toContain("V007"); // annotation property routed to TBox
+    expect(found).toContain("V008"); // custom datatype → String
+    expect(found).toContain("V009"); // cross-vocabulary subClassOf
+    expect(found).toContain("V012"); // sh:in enum constraint
+    expect(found).toContain("V014"); // undeclared ABox predicate
+    // annotation property produces no ABox field
+    const item = result.schema.getType("Item") as GraphQLObjectType;
+    expect(item.getFields().guidance).toBeUndefined();
+    // custom datatype mapped to String
+    expect(String(item.getFields().ver?.type)).toBe("String");
+    // Category is a root class despite skos:Concept parentage
+    expect(result.schema.getType("Category")).toBeDefined();
+  });
+});
+
+describe("shacl fixture", () => {
+  it("resolves SHACL cardinality including sh:or and maxCount 0", async () => {
+    const result = await compileFixture(SHACL_TTL);
+    const found = codes(result);
+    expect(found).toContain("V010");
+    expect(found).toContain("V011");
+    const spec = result.schema.getType("Spec") as GraphQLObjectType;
+    // sh:maxCount 1 without owl:FunctionalProperty → singular
+    expect(String(spec.getFields().root?.type)).toBe("Hop");
+    // sh:maxCount 0 → field omitted
+    expect(spec.getFields().legacy).toBeUndefined();
+    const hop = result.schema.getType("Hop") as GraphQLObjectType;
+    // sh:or → both singular, both nullable
+    expect(String(hop.getFields().hopTarget?.type)).toBe("Spec");
+    expect(String(hop.getFields().hopSwitch?.type)).toBe("Sw");
+  });
+});
+
+describe("ds-realistic fixture", () => {
+  it("compiles the full hierarchy with synthetic inverses and overrides", async () => {
+    const result = await compileFixture(DS_REALISTIC_TTL, {
+      mappings: {
+        "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+        "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+        "ds:hasProperty": { graphqlName: "properties" },
+        "ds:hasModifier": { graphqlName: "modifiers" },
+        "ds:implementsBlock": { inverse: { graphqlName: "implementations" } },
+      },
+      nonNullOverrides: { Component: ["name"] },
+    });
+    expect(result.schema).toBeDefined();
+    const component = result.schema.getType("Component") as GraphQLObjectType;
+    const fields = component.getFields();
+    // abstract chain → interfaces
+    expect(
+      component
+        .getInterfaces()
+        .map((i) => i.name)
+        .sort(),
+    ).toEqual(["Entity", "Node", "UIBlock", "UIElement"]);
+    // non-null override
+    expect(String(fields.name?.type)).toBe("String!");
+    // custom-mapped names, connection-wrapped
+    expect(String(fields.modifierFamilies?.type)).toBe(
+      "ModifierFamilyConnection!",
+    );
+    expect(String(fields.subcomponents?.type)).toBe("SubcomponentConnection!");
+    // embedded blank-node list stays plain
+    expect(String(fields.properties?.type)).toBe("[Property!]!");
+    // synthetic inverse on the range type's concrete descendants
+    expect(String(fields.implementations?.type)).toBe(
+      "ImplementationObjectConnection!",
+    );
+    // ds:Property is embeddable: detected from blank-only instance stats
+    const property = result.schema.getType("Property") as GraphQLObjectType;
+    expect(property.getFields().id).toBeUndefined();
+  });
+});
+
+describe("failure modes", () => {
+  it("M003 reports unknown custom mappings", async () => {
+    const result = await compileFixture(MINIMAL_TTL, {
+      mappings: { "ex:doesNotExist": { graphqlName: "nope" } },
+    });
+    expect(codes(result)).toContain("M003");
+  });
+
+  it("relay: false produces a schema without Node wiring", async () => {
+    const result = await compileFixture(MINIMAL_TTL, { relay: false });
+    const thing = result.schema.getType("Thing") as GraphQLObjectType;
+    expect(thing.getFields().id).toBeUndefined();
+    expect(result.schema.getQueryType()?.getFields().node).toBeUndefined();
+  });
+
+  it("incremental: true adds the defer and stream directives", async () => {
+    const result = await compileFixture(MINIMAL_TTL, { incremental: true });
+    expect(result.schema.getDirective("defer")).toBeDefined();
+    expect(result.schema.getDirective("stream")).toBeDefined();
+  });
+});

--- a/packages/runtime/ke-graphql/src/testing/integration/queries.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/queries.test.ts
@@ -1,0 +1,296 @@
+// =============================================================================
+// Query execution against compiled schemas: resolution templates, node(),
+// pagination, _meta, coercion, dual-direction inverses.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { type GraphQLSchema, graphql } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import type { CompilerContext } from "#shared";
+import {
+  BLANK_NODES_TTL,
+  DS_REALISTIC_TTL,
+  EDGE_CASES_TTL,
+  INVERSE_TTL,
+  PREFIXES,
+} from "#testing";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+interface Compiled {
+  result: CompilerResult;
+  schema: GraphQLSchema;
+  context: CompilerContext;
+}
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<Compiled> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, options);
+  return {
+    result,
+    schema: result.schema,
+    context: result.createContext(store),
+  };
+};
+
+const run = async (
+  compiled: Compiled,
+  source: string,
+  variableValues?: Record<string, unknown>,
+) =>
+  graphql({
+    schema: compiled.schema,
+    source,
+    variableValues,
+    contextValue: compiled.context,
+  });
+
+describe("ds-realistic resolution", () => {
+  const options = {
+    mappings: {
+      "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+      "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+      "ds:hasProperty": { graphqlName: "properties" },
+      "ds:hasModifier": { graphqlName: "modifiers" },
+      "ds:implementsBlock": { inverse: { graphqlName: "implementations" } },
+    },
+  };
+
+  it("resolves a component with scalars, objects, and embedded blanks", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        component(uri: "ds:global.component.button") {
+          id
+          uri
+          name
+          summary
+          tier { name }
+          properties { name propertyType optional }
+          subcomponents(first: 10) { edges { node { name standalone parentComponent { name } } } }
+          implementations(first: 10) { edges { node { name } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const component = result.data?.component as Record<string, unknown>;
+    expect(component.id).toBe("ds:global.component.button");
+    expect(component.name).toBe("Button");
+    expect((component.tier as { name: string }).name).toBe("global");
+    // embedded blank node with boolean-as-string coercion
+    const properties = component.properties as Array<Record<string, unknown>>;
+    expect(properties).toHaveLength(1);
+    expect(properties[0]?.name).toBe("disabled");
+    expect(properties[0]?.optional).toBe(false);
+    // declared inverse pair: forward direction asserted in data
+    const subcomponents = component.subcomponents as {
+      edges: Array<{ node: Record<string, unknown> }>;
+    };
+    expect(subcomponents.edges).toHaveLength(1);
+    expect(subcomponents.edges[0]?.node.standalone).toBe(false);
+    expect(
+      (subcomponents.edges[0]?.node.parentComponent as { name: string }).name,
+    ).toBe("Button");
+    // synthetic inverse: reverse assertions found via the inverse loader
+    const implementations = component.implementations as {
+      edges: Array<{ node: { name: string } }>;
+    };
+    expect(implementations.edges.map((e) => e.node.name)).toEqual([
+      "react button",
+    ]);
+  });
+
+  it("resolves node() by prefixed-URI global ID with the most specific type", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        node(id: "ds:global.component.button") {
+          id
+          __typename
+          ... on Component { name }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const node = result.data?.node as Record<string, unknown>;
+    expect(node.__typename).toBe("Component");
+    expect(node.name).toBe("Button");
+  });
+
+  it("returns null for unknown prefixes and unknown URIs", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const unknownPrefix = await run(compiled, `{ node(id: "zz:nope") { id } }`);
+    expect(unknownPrefix.data?.node).toBeNull();
+    const unknownUri = await run(
+      compiled,
+      `{ node(id: "ds:does.not.exist") { id } }`,
+    );
+    expect(unknownUri.data?.node).toBeNull();
+  });
+
+  it("paginates listings with stable cursors", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const page1 = await run(
+      compiled,
+      `{ modifiers(first: 1) { edges { cursor node { name } } pageInfo { hasNextPage } } }`,
+    );
+    expect(page1.errors).toBeUndefined();
+    const modifiers = page1.data?.modifiers as {
+      edges: Array<{ cursor: string; node: { name: string } }>;
+      pageInfo: { hasNextPage: boolean };
+    };
+    expect(modifiers.edges).toHaveLength(1);
+    expect(modifiers.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it("rejects negative pagination arguments", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{ components(first: -1) { edges { cursor } } }`,
+    );
+    expect(result.errors?.[0]?.message).toContain("non-negative");
+  });
+
+  it("exposes _meta with class, fields, and per-class cardinality", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        component(uri: "ds:global.component.button") {
+          _meta {
+            type { uri label isAbstract superclasses { label } }
+            field(name: "name") { inherited property { label acceptanceCriteria } }
+            fields { property { label } }
+          }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const meta = (result.data?.component as Record<string, unknown>)
+      ._meta as Record<string, unknown>;
+    const type = meta.type as Record<string, unknown>;
+    expect(type.uri).toBe("https://ds.canonical.com/Component");
+    expect(type.isAbstract).toBe(false);
+    const field = meta.field as Record<string, unknown>;
+    expect(field.inherited).toBe(true); // ds:name declared on Entity
+    expect((field.property as Record<string, unknown>).acceptanceCriteria).toBe(
+      "Must be a human-readable display name.",
+    );
+    expect((meta.fields as unknown[]).length).toBeGreaterThan(3);
+  });
+
+  it("serves the TBox: ontologies, classes, instances", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        ontologies { prefix }
+        ontologyClass(uri: "https://ds.canonical.com/Component") {
+          label
+          isAbstract
+          instanceCount
+          instances(first: 5) { edges { node { id __typename } } }
+          properties { property { label } required singular inherited }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const prefixes = (result.data?.ontologies as Array<{ prefix: string }>).map(
+      (o) => o.prefix,
+    );
+    expect(prefixes).toContain("ds");
+    const cls = result.data?.ontologyClass as Record<string, unknown>;
+    expect(cls.instanceCount).toBe(1);
+    const instances = cls.instances as {
+      edges: Array<{ node: { id: string; __typename: string } }>;
+    };
+    expect(instances.edges[0]?.node.id).toBe("ds:global.component.button");
+    expect(instances.edges[0]?.node.__typename).toBe("Component");
+  });
+});
+
+describe("dual-direction inverse resolution", () => {
+  it("finds children even when only the reverse direction is asserted", async () => {
+    const compiled = await setup(INVERSE_TTL);
+    const result = await run(
+      compiled,
+      `{
+        parent(uri: "ex:p1") {
+          name
+          children(first: 10) { edges { node { uri childOf { name } } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const parent = result.data?.parent as Record<string, unknown>;
+    const children = parent.children as { edges: Array<{ node: unknown }> };
+    expect(children.edges).toHaveLength(2);
+  });
+});
+
+describe("embedded blank nodes", () => {
+  it("resolves embedded values inline with optional fields as null", async () => {
+    const compiled = await setup(BLANK_NODES_TTL);
+    const result = await run(
+      compiled,
+      `{ standard(uri: "ex:s1") { title examples { code language } } }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const examples = (result.data?.standard as Record<string, unknown>)
+      .examples as Array<Record<string, unknown>>;
+    expect(examples).toHaveLength(2);
+    const languages = examples.map((e) => e.language).sort();
+    expect(languages).toEqual([null, "typescript"].sort());
+  });
+});
+
+describe("coercion", () => {
+  it("coerces booleans, strips language tags, preserves empty strings", async () => {
+    const warnings: string[] = [];
+    const compiled = await setup(EDGE_CASES_TTL, {
+      onRuntimeWarning: (w) => warnings.push(w.reason),
+    });
+    const active = await run(compiled, `{ item(uri: "ex:i1") { active } }`);
+    expect((active.data?.item as { active: boolean }).active).toBe(true);
+    const label = await run(compiled, `{ item(uri: "ex:i3") { label } }`);
+    expect((label.data?.item as { label: string }).label).toBe("Tagged");
+    const summary = await run(compiled, `{ item(uri: "ex:i5") { summary } }`);
+    expect((summary.data?.item as { summary: string }).summary).toBe("");
+  });
+
+  it("self-referential chains resolve without infinite recursion", async () => {
+    const compiled = await setup(EDGE_CASES_TTL);
+    const result = await run(
+      compiled,
+      `{
+        item(uri: "ex:i2") {
+          uri
+          extends(first: 1) { edges { node { uri } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const item = result.data?.item as Record<string, unknown>;
+    const extendsConn = item.extends as {
+      edges: Array<{ node: { uri: string } }>;
+    };
+    // the chain terminates because resolution is per-level, not recursive
+    expect(extendsConn.edges[0]?.node.uri).toBe("ex:i2");
+  });
+});


### PR DESCRIPTION
> PR 5 of the `@canonical/ke-graphql` delivery stack (umbrella #658). **Stacked on #670** (map/emit). Next: `/http`, CLI, demo.

> **Intentionally larger than the ~4k target (~6k).** The remaining library is a genuinely interdependent unit: `compose` builds the TBox introspection from `tbox`, the seven-pass orchestration threads `execution`/`incremental`/`skipValidation` through the root barrel and the plugin options, and almost all of it is verified by **compiling a real ontology and querying it** — the integration suite. Carving it into smaller pieces would mean intermediate PRs whose coverage can't be honest until the whole pipeline exists. So it ships as one cohesive, fully-tested unit (this is the decomposition trade-off agreed for the cluster).

## Done

Completes the OWL→GraphQL library:

- **compiler:** the `validate`, `wireRelay`, and `compose` passes; the seven-pass orchestration (`compile`, `runPasses`); the per-request `createContextFactory`; and the extraction-artifact codec (`artifact`, `compileFromExtraction`).
- **tbox:** the self-describing TBox introspection schema — `Ontology`, `OntologyClass`, `OntologyProperty`, per-instance `_meta`.
- **execution:** in-process execution with graphql v17 incremental delivery, the Relay legacy-payload adapter, build-time static extraction, and the persisted-query manifest builder.
- **createSchemaPlugin:** the ke plugin entry that compiles on store-ready and exposes `{ schema, createContext }`.
- the **integration suite** (`src/testing/integration/`: pipeline, queries, performance-features, hardening) exercising the assembled pipeline end to end.

Completes the public library barrel.

## QA

```bash
cd packages/runtime/ke-graphql && bun run check && bun run test
```
biome + `tsc` + webarchitect green; **314 tests, 100/100/100/100** (threshold enforced). The integration suite compiles real ontologies and queries them — the only honest way to cover the assembled compiler, `validate`/`wireRelay`, the TBox resolvers, and incremental execution.

### PR readiness check

- [x] Label: `Feature 🎁`.
- [x] Conventional Commits title.
- [x] [Code standards](https://github.com/canonical/web-code-standards): `src/lib/{domain}` layout, per-domain barrels, `#`-subpath imports, colocated unit tests; integration tests in `src/testing/integration/`.
- [x] Scripts present.
- [x] `no visual change`.

## Screenshots

No visual change — runtime package, no UI.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_