### PR TITLE
feat(pragma-cli): graphql domain — build/check commands for ke-graphql

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -275,6 +275,7 @@
         "@canonical/design-system": "^0.1.2",
         "@canonical/harnesses": "^0.27.1-experimental.0",
         "@canonical/ke": "^0.27.1-experimental.0",
+        "@canonical/ke-graphql": "^0.27.1-experimental.0",
         "@canonical/summon-component": "^0.27.1-experimental.0",
         "@canonical/summon-core": "^0.27.1-experimental.0",
         "@canonical/summon-package": "^0.27.1-experimental.0",

--- a/packages/cli/pragma/package.json
+++ b/packages/cli/pragma/package.json
@@ -77,6 +77,7 @@
     "@canonical/design-system": "^0.1.2",
     "@canonical/harnesses": "^0.27.1-experimental.0",
     "@canonical/ke": "^0.27.1-experimental.0",
+    "@canonical/ke-graphql": "^0.27.1-experimental.0",
     "@canonical/summon-component": "^0.27.1-experimental.0",
     "@canonical/summon-core": "^0.27.1-experimental.0",
     "@canonical/summon-package": "^0.27.1-experimental.0",

--- a/packages/cli/pragma/src/domains/graphql/commands/build.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/build.test.ts
@@ -1,0 +1,194 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CommandDefinition } from "@canonical/cli-core";
+import { hashSources } from "@canonical/ke-graphql";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EX_PREFIX_ENTRY,
+  GRAPHQL_CLEAN_TTL,
+  GRAPHQL_ERROR_TTL,
+  GRAPHQL_FATAL_TTL,
+} from "#testing";
+import type { PragmaContext } from "../../shared/context.js";
+import type { GraphqlCompileReport } from "../types.js";
+import buildCommand from "./build.js";
+
+let dir: string;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pragma-graphql-build-"));
+  writeFileSync(join(dir, "clean.ttl"), GRAPHQL_CLEAN_TTL);
+  writeFileSync(join(dir, "error.ttl"), GRAPHQL_ERROR_TTL);
+  writeFileSync(join(dir, "fatal.ttl"), GRAPHQL_FATAL_TTL);
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function makeCtx(overrides: Partial<PragmaContext> = {}): PragmaContext {
+  return {
+    cwd: dir,
+    globalFlags: { llm: false, format: "text" as const, verbose: false },
+    store: {} as PragmaContext["store"],
+    config: { tier: undefined, channel: "normal" },
+    ...overrides,
+  } as PragmaContext;
+}
+
+async function executeOutput(
+  cmd: CommandDefinition,
+  params: Record<string, unknown>,
+  ctx: PragmaContext,
+): Promise<{ value: GraphqlCompileReport; text: string }> {
+  const result = await cmd.execute(params, ctx);
+  expect(result.tag).toBe("output");
+  if (result.tag !== "output") throw new Error("Expected output result");
+  return {
+    value: result.value as GraphqlCompileReport,
+    text: result.render.plain(result.value),
+  };
+}
+
+describe("graphql build command", () => {
+  it("writes the SDL and extraction artifacts to the default paths", async () => {
+    const ctx = makeCtx();
+    const { value } = await executeOutput(
+      buildCommand,
+      { sources: ["clean.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    const sdl = readFileSync(join(dir, "schema.graphql"), "utf-8");
+    expect(sdl).toContain("type Thing");
+
+    const artifact = JSON.parse(
+      readFileSync(join(dir, "extraction.json"), "utf-8"),
+    ) as { version: number; sourcesHash: string };
+    expect(artifact.version).toBe(1);
+
+    const raw = readFileSync(join(dir, "clean.ttl"), "utf-8");
+    expect(artifact.sourcesHash).toBe(hashSources([raw]));
+    expect(value.artifacts).toEqual({
+      sdl: join(dir, "schema.graphql"),
+      extraction: join(dir, "extraction.json"),
+    });
+  });
+
+  it("writes artifacts to custom --sdl and --extraction paths", async () => {
+    const ctx = makeCtx();
+    await executeOutput(
+      buildCommand,
+      {
+        sources: ["clean.ttl"],
+        prefix: [EX_PREFIX_ENTRY],
+        sdl: "out/api.graphql",
+        extraction: "out/api-extraction.json",
+      },
+      ctx,
+    );
+
+    expect(readFileSync(join(dir, "out", "api.graphql"), "utf-8")).toContain(
+      "type Thing",
+    );
+    expect(
+      JSON.parse(
+        readFileSync(join(dir, "out", "api-extraction.json"), "utf-8"),
+      ),
+    ).toMatchObject({ version: 1 });
+  });
+
+  it("renders plain output with a summary and artifact paths", async () => {
+    const ctx = makeCtx();
+    const { text } = await executeOutput(
+      buildCommand,
+      { sources: ["clean.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(text).toContain("1 source file: 0 errors, 0 warnings, 0 info");
+    expect(text).toContain(`Wrote ${join(dir, "schema.graphql")}`);
+    expect(text).toContain(`Wrote ${join(dir, "extraction.json")}`);
+  });
+
+  it("prints error diagnostics but still writes artifacts", async () => {
+    const ctx = makeCtx();
+    const { text } = await executeOutput(
+      buildCommand,
+      { sources: ["error.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(text).toContain("M001");
+    expect(text).toContain("1 error");
+    expect(existsSync(join(dir, "schema.graphql"))).toBe(true);
+    expect(existsSync(join(dir, "extraction.json"))).toBe(true);
+  });
+
+  it("renders llm output", async () => {
+    const ctx = makeCtx({
+      globalFlags: { llm: true, format: "text" as const, verbose: false },
+    });
+    const { text } = await executeOutput(
+      buildCommand,
+      { sources: ["clean.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(text).toContain("## GraphQL Compile");
+    expect(text).toContain("**Summary:**");
+  });
+
+  it("renders json output", async () => {
+    const ctx = makeCtx({
+      globalFlags: { llm: false, format: "json" as const, verbose: false },
+    });
+    const { text } = await executeOutput(
+      buildCommand,
+      { sources: ["clean.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    const parsed = JSON.parse(text) as GraphqlCompileReport;
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.files).toEqual([join(dir, "clean.ttl")]);
+  });
+
+  it("exits non-zero and writes no artifacts when compilation fails", async () => {
+    const ctx = makeCtx();
+    const result = await buildCommand.execute(
+      { sources: ["fatal.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(result.tag).toBe("exit");
+    if (result.tag !== "exit") throw new Error("Expected exit result");
+    expect(result.code).toBe(1);
+    expect(existsSync(join(dir, "schema.graphql"))).toBe(false);
+    expect(existsSync(join(dir, "extraction.json"))).toBe(false);
+
+    const printed = stdoutSpy.mock.calls.map((call) => call[0]).join("");
+    expect(printed).toContain("C003");
+  });
+
+  it("throws structured error when sources are missing", async () => {
+    const ctx = makeCtx();
+
+    await expect(buildCommand.execute({}, ctx)).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+      recovery: {
+        message: "Provide at least one TTL file or glob pattern.",
+      },
+    });
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/commands/build.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/build.ts
@@ -1,0 +1,125 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import {
+  type CommandDefinition,
+  type CommandResult,
+  createExitResult,
+  createOutputResult,
+} from "@canonical/cli-core";
+import { serializeExtraction } from "@canonical/ke-graphql";
+import { PragmaError } from "#error";
+import { selectFormatter } from "../../shared/formatters.js";
+import { reportFormatters } from "../formatters/index.js";
+import { parsePrefixes } from "../helpers/index.js";
+import { compileSchema } from "../operations/index.js";
+import type { GraphqlCompileReport } from "../types.js";
+
+const DEFAULT_SDL_PATH = "./schema.graphql";
+const DEFAULT_EXTRACTION_PATH = "./extraction.json";
+
+/** Narrow an unknown param to a string array. */
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+/**
+ * Builds the `pragma graphql build` command definition.
+ *
+ * Compiles TTL sources into a GraphQL schema, writes the SDL and the
+ * extraction artifact, and prints all compiler diagnostics. Exits
+ * non-zero when schema composition fails.
+ */
+const buildCommand: CommandDefinition = {
+  path: ["graphql", "build"],
+  description: "Compile TTL sources into GraphQL schema artifacts",
+  parameters: [
+    {
+      name: "sources",
+      description: "TTL source files or glob patterns",
+      type: "multiselect",
+      positional: true,
+      required: true,
+    },
+    {
+      name: "sdl",
+      description: "Output path for the GraphQL SDL",
+      type: "string",
+      default: DEFAULT_SDL_PATH,
+    },
+    {
+      name: "extraction",
+      description: "Output path for the extraction artifact",
+      type: "string",
+      default: DEFAULT_EXTRACTION_PATH,
+    },
+    {
+      name: "prefix",
+      description: "Ontology prefix as name=namespace (repeatable)",
+      type: "multiselect",
+    },
+  ],
+  meta: {
+    examples: [
+      "pragma graphql build ontology.ttl",
+      'pragma graphql build "data/*.ttl" --sdl out/schema.graphql --extraction out/extraction.json',
+      "pragma graphql build ontology.ttl --prefix ds=https://ds.canonical.com/",
+    ],
+  },
+  async execute(params, ctx): Promise<CommandResult> {
+    const sources = readStringArray(params.sources);
+    if (sources.length === 0) {
+      throw PragmaError.invalidInput("sources", "(empty)", {
+        recovery: {
+          message: "Provide at least one TTL file or glob pattern.",
+        },
+      });
+    }
+
+    const prefixes = parsePrefixes(readStringArray(params.prefix));
+    const outcome = await compileSchema({ sources, prefixes, cwd: ctx.cwd });
+    const format = selectFormatter(ctx, reportFormatters);
+
+    if (outcome.status === "failed" || !outcome.compiled) {
+      const report: GraphqlCompileReport = {
+        diagnostics: outcome.diagnostics,
+        files: outcome.files,
+        sourcesHash: outcome.sourcesHash,
+      };
+      process.stdout.write(`${format(report)}\n`);
+      return createExitResult(1);
+    }
+
+    const sdlPath = resolve(
+      ctx.cwd,
+      typeof params.sdl === "string" ? params.sdl : DEFAULT_SDL_PATH,
+    );
+    const extractionPath = resolve(
+      ctx.cwd,
+      typeof params.extraction === "string"
+        ? params.extraction
+        : DEFAULT_EXTRACTION_PATH,
+    );
+
+    mkdirSync(dirname(sdlPath), { recursive: true });
+    writeFileSync(sdlPath, outcome.compiled.sdl, "utf-8");
+    mkdirSync(dirname(extractionPath), { recursive: true });
+    writeFileSync(
+      extractionPath,
+      serializeExtraction(outcome.compiled.extraction, outcome.sourcesHash),
+      "utf-8",
+    );
+
+    const report: GraphqlCompileReport = {
+      diagnostics: outcome.diagnostics,
+      files: outcome.files,
+      sourcesHash: outcome.sourcesHash,
+      artifacts: { sdl: sdlPath, extraction: extractionPath },
+    };
+
+    return createOutputResult(report, { plain: format });
+  },
+};
+
+export default buildCommand;

--- a/packages/cli/pragma/src/domains/graphql/commands/check.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/check.test.ts
@@ -1,0 +1,139 @@
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EX_PREFIX_ENTRY,
+  GRAPHQL_CLEAN_TTL,
+  GRAPHQL_ERROR_TTL,
+  GRAPHQL_FATAL_TTL,
+} from "#testing";
+import type { PragmaContext } from "../../shared/context.js";
+import type { GraphqlCompileReport } from "../types.js";
+import checkCommand from "./check.js";
+
+let dir: string;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pragma-graphql-check-"));
+  writeFileSync(join(dir, "clean.ttl"), GRAPHQL_CLEAN_TTL);
+  writeFileSync(join(dir, "error.ttl"), GRAPHQL_ERROR_TTL);
+  writeFileSync(join(dir, "fatal.ttl"), GRAPHQL_FATAL_TTL);
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function makeCtx(overrides: Partial<PragmaContext> = {}): PragmaContext {
+  return {
+    cwd: dir,
+    globalFlags: { llm: false, format: "text" as const, verbose: false },
+    store: {} as PragmaContext["store"],
+    config: { tier: undefined, channel: "normal" },
+    ...overrides,
+  } as PragmaContext;
+}
+
+function printedOutput(): string {
+  return stdoutSpy.mock.calls.map((call) => call[0]).join("");
+}
+
+describe("graphql check command", () => {
+  it("passes a clean ontology with a summary line", async () => {
+    const ctx = makeCtx();
+    const result = await checkCommand.execute(
+      { sources: ["clean.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(result.tag).toBe("output");
+    if (result.tag !== "output") throw new Error("Expected output result");
+    const text = result.render.plain(result.value);
+    expect(text).toContain("1 source file: 0 errors, 0 warnings, 0 info");
+  });
+
+  it("exits non-zero and prints diagnostics on error diagnostics", async () => {
+    const ctx = makeCtx();
+    const result = await checkCommand.execute(
+      { sources: ["error.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(result.tag).toBe("exit");
+    if (result.tag !== "exit") throw new Error("Expected exit result");
+    expect(result.code).toBe(1);
+
+    const printed = printedOutput();
+    expect(printed).toContain("M001");
+    expect(printed).toContain("error");
+    expect(printed).toContain("1 error, 2 warnings, 0 info");
+  });
+
+  it("exits non-zero when compilation fails entirely", async () => {
+    const ctx = makeCtx();
+    const result = await checkCommand.execute(
+      { sources: ["fatal.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(result.tag).toBe("exit");
+    if (result.tag !== "exit") throw new Error("Expected exit result");
+    expect(result.code).toBe(1);
+    expect(printedOutput()).toContain("C003");
+  });
+
+  it("passes with warnings when prefixes are not registered", async () => {
+    const ctx = makeCtx();
+    const result = await checkCommand.execute({ sources: ["clean.ttl"] }, ctx);
+
+    expect(result.tag).toBe("output");
+    if (result.tag !== "output") throw new Error("Expected output result");
+    const text = result.render.plain(result.value);
+    expect(text).toContain("1 warning");
+    expect(text).toContain("0 errors");
+  });
+
+  it("writes no artifacts", async () => {
+    const ctx = makeCtx();
+    const before = readdirSync(dir).sort();
+    await checkCommand.execute(
+      { sources: ["clean.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(readdirSync(dir).sort()).toEqual(before);
+  });
+
+  it("renders json output", async () => {
+    const ctx = makeCtx({
+      globalFlags: { llm: false, format: "json" as const, verbose: false },
+    });
+    const result = await checkCommand.execute(
+      { sources: ["clean.ttl"], prefix: [EX_PREFIX_ENTRY] },
+      ctx,
+    );
+
+    expect(result.tag).toBe("output");
+    if (result.tag !== "output") throw new Error("Expected output result");
+    const parsed = JSON.parse(
+      result.render.plain(result.value),
+    ) as GraphqlCompileReport;
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.artifacts).toBeUndefined();
+  });
+
+  it("throws structured error when sources are missing", async () => {
+    const ctx = makeCtx();
+
+    await expect(checkCommand.execute({}, ctx)).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+      recovery: {
+        message: "Provide at least one TTL file or glob pattern.",
+      },
+    });
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/commands/check.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/check.ts
@@ -1,0 +1,87 @@
+import {
+  type CommandDefinition,
+  type CommandResult,
+  createExitResult,
+  createOutputResult,
+} from "@canonical/cli-core";
+import { PragmaError } from "#error";
+import { selectFormatter } from "../../shared/formatters.js";
+import { reportFormatters } from "../formatters/index.js";
+import { parsePrefixes } from "../helpers/index.js";
+import { compileSchema } from "../operations/index.js";
+import type { GraphqlCompileReport } from "../types.js";
+
+/** Narrow an unknown param to a string array. */
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+/**
+ * Builds the `pragma graphql check` command definition.
+ *
+ * Runs the same compile as `graphql build` but writes no artifacts —
+ * a CI gate. Prints all compiler diagnostics and exits non-zero when
+ * compilation fails or any error-severity diagnostic is produced.
+ */
+const checkCommand: CommandDefinition = {
+  path: ["graphql", "check"],
+  description: "Compile TTL sources and fail on error diagnostics",
+  parameters: [
+    {
+      name: "sources",
+      description: "TTL source files or glob patterns",
+      type: "multiselect",
+      positional: true,
+      required: true,
+    },
+    {
+      name: "prefix",
+      description: "Ontology prefix as name=namespace (repeatable)",
+      type: "multiselect",
+    },
+  ],
+  meta: {
+    examples: [
+      "pragma graphql check ontology.ttl",
+      'pragma graphql check "data/*.ttl" --prefix ds=https://ds.canonical.com/',
+    ],
+  },
+  async execute(params, ctx): Promise<CommandResult> {
+    const sources = readStringArray(params.sources);
+    if (sources.length === 0) {
+      throw PragmaError.invalidInput("sources", "(empty)", {
+        recovery: {
+          message: "Provide at least one TTL file or glob pattern.",
+        },
+      });
+    }
+
+    const prefixes = parsePrefixes(readStringArray(params.prefix));
+    const outcome = await compileSchema({ sources, prefixes, cwd: ctx.cwd });
+
+    const report: GraphqlCompileReport = {
+      diagnostics: outcome.diagnostics,
+      files: outcome.files,
+      sourcesHash: outcome.sourcesHash,
+    };
+
+    const hasErrors =
+      outcome.status === "failed" ||
+      outcome.diagnostics.some((d) => d.severity === "error");
+
+    if (hasErrors) {
+      process.stdout.write(
+        `${selectFormatter(ctx, reportFormatters)(report)}\n`,
+      );
+      return createExitResult(1);
+    }
+
+    return createOutputResult(report, {
+      plain: selectFormatter(ctx, reportFormatters),
+    });
+  },
+};
+
+export default checkCommand;

--- a/packages/cli/pragma/src/domains/graphql/commands/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/index.ts
@@ -1,0 +1,4 @@
+/** @module Barrel for graphql command builders. */
+
+export { default as buildCommand } from "./build.js";
+export { default as checkCommand } from "./check.js";

--- a/packages/cli/pragma/src/domains/graphql/formatters/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/formatters/index.ts
@@ -1,0 +1,3 @@
+/** @module Barrel for graphql formatters. */
+
+export { default as reportFormatters } from "./report.js";

--- a/packages/cli/pragma/src/domains/graphql/formatters/report.ts
+++ b/packages/cli/pragma/src/domains/graphql/formatters/report.ts
@@ -1,0 +1,78 @@
+import type { Diagnostic } from "@canonical/ke-graphql";
+import chalk from "chalk";
+import type { Formatters } from "../../shared/formatters.js";
+import type { GraphqlCompileReport } from "../types.js";
+
+/** Count diagnostics of one severity. */
+function countSeverity(
+  diagnostics: readonly Diagnostic[],
+  severity: Diagnostic["severity"],
+): number {
+  return diagnostics.filter((d) => d.severity === severity).length;
+}
+
+/** Pluralize a count: `1 error`, `2 errors`. */
+function plural(count: number, word: string): string {
+  return `${count} ${word}${count !== 1 ? "s" : ""}`;
+}
+
+/** One-line summary of diagnostic counts and compiled sources. */
+function summaryLine(report: GraphqlCompileReport): string {
+  const errors = countSeverity(report.diagnostics, "error");
+  const warnings = countSeverity(report.diagnostics, "warning");
+  const infos = countSeverity(report.diagnostics, "info");
+  return `${plural(report.files.length, "source file")}: ${plural(errors, "error")}, ${plural(warnings, "warning")}, ${infos} info`;
+}
+
+function colorSeverity(severity: Diagnostic["severity"]): string {
+  if (severity === "error") return chalk.red(severity);
+  if (severity === "warning") return chalk.yellow(severity);
+  return chalk.dim(severity);
+}
+
+/**
+ * Formatters for `pragma graphql build` and `pragma graphql check` output.
+ *
+ * - **plain**: one line per diagnostic (severity, code, message, source),
+ *   a summary line with counts, and `Wrote <path>` lines for artifacts.
+ * - **llm**: condensed Markdown under a `## GraphQL Compile` heading.
+ * - **json**: serialized {@link GraphqlCompileReport} as indented JSON.
+ */
+const formatters: Formatters<GraphqlCompileReport> = {
+  plain(report) {
+    const lines = report.diagnostics.map(
+      (d) =>
+        `${colorSeverity(d.severity)} ${chalk.bold(d.code)}: ${d.message}${d.source ? ` (${d.source})` : ""}`,
+    );
+    lines.push(summaryLine(report));
+    if (report.artifacts) {
+      lines.push(`Wrote ${report.artifacts.sdl}`);
+      lines.push(`Wrote ${report.artifacts.extraction}`);
+    }
+    return lines.join("\n");
+  },
+
+  llm(report) {
+    const lines = ["## GraphQL Compile", ""];
+    for (const d of report.diagnostics) {
+      lines.push(
+        `- **${d.severity}** \`${d.code}\`: ${d.message}${d.source ? ` (\`${d.source}\`)` : ""}`,
+      );
+    }
+    if (report.diagnostics.length > 0) {
+      lines.push("");
+    }
+    lines.push(`**Summary:** ${summaryLine(report)}`);
+    if (report.artifacts) {
+      lines.push(`**SDL:** \`${report.artifacts.sdl}\``);
+      lines.push(`**Extraction:** \`${report.artifacts.extraction}\``);
+    }
+    return lines.join("\n");
+  },
+
+  json(report) {
+    return JSON.stringify(report, null, 2);
+  },
+};
+
+export default formatters;

--- a/packages/cli/pragma/src/domains/graphql/helpers/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/index.ts
@@ -1,0 +1,4 @@
+/** @module Barrel for graphql helpers. */
+
+export { default as parsePrefixes } from "./parsePrefixes.js";
+export { default as resolveSourceFiles } from "./resolveSourceFiles.js";

--- a/packages/cli/pragma/src/domains/graphql/helpers/parsePrefixes.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/parsePrefixes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { PREFIX_MAP } from "../../shared/prefixes.js";
+import parsePrefixes from "./parsePrefixes.js";
+
+describe("parsePrefixes", () => {
+  it("returns the default prefix map for no entries", () => {
+    const prefixes = parsePrefixes([]);
+    expect(prefixes).toEqual(PREFIX_MAP);
+  });
+
+  it("merges entries on top of the defaults", () => {
+    const prefixes = parsePrefixes(["ex=http://example.org/"]);
+    expect(prefixes.ex).toBe("http://example.org/");
+    expect(prefixes.ds).toBe(PREFIX_MAP.ds);
+  });
+
+  it("lets entries override default prefixes", () => {
+    const prefixes = parsePrefixes(["ds=http://other.example/"]);
+    expect(prefixes.ds).toBe("http://other.example/");
+  });
+
+  it("splits on the first equals sign only", () => {
+    const prefixes = parsePrefixes(["ex=http://example.org/?q=1"]);
+    expect(prefixes.ex).toBe("http://example.org/?q=1");
+  });
+
+  it("throws structured error for an entry without equals sign", () => {
+    expect(() => parsePrefixes(["nonsense"])).toThrowError(
+      expect.objectContaining({ code: "INVALID_INPUT" }),
+    );
+  });
+
+  it("throws structured error for an entry without a name", () => {
+    expect(() => parsePrefixes(["=http://example.org/"])).toThrowError(
+      expect.objectContaining({ code: "INVALID_INPUT" }),
+    );
+  });
+
+  it("throws structured error for an entry without a namespace", () => {
+    expect(() => parsePrefixes(["ex="])).toThrowError(
+      expect.objectContaining({ code: "INVALID_INPUT" }),
+    );
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/helpers/parsePrefixes.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/parsePrefixes.ts
@@ -1,0 +1,38 @@
+import { PragmaError } from "#error";
+import { PREFIX_MAP } from "../../shared/prefixes.js";
+
+/**
+ * Parse repeated `--prefix name=namespace` entries into a prefix map.
+ *
+ * User-supplied prefixes are merged on top of pragma's default
+ * {@link PREFIX_MAP}, so `ds:` and the W3C vocabularies stay available
+ * unless explicitly overridden.
+ *
+ * @param entries - Raw `name=namespace` strings from the CLI.
+ * @returns The merged prefix map for store creation and compilation.
+ * @throws PragmaError with code `INVALID_INPUT` when an entry is malformed.
+ */
+export default function parsePrefixes(
+  entries: readonly string[],
+): Record<string, string> {
+  const prefixes: Record<string, string> = { ...PREFIX_MAP };
+
+  for (const entry of entries) {
+    const separator = entry.indexOf("=");
+    const name = separator === -1 ? "" : entry.slice(0, separator).trim();
+    const namespace = separator === -1 ? "" : entry.slice(separator + 1).trim();
+
+    if (!name || !namespace) {
+      throw PragmaError.invalidInput("prefix", entry, {
+        recovery: {
+          message:
+            "Use name=namespace, e.g. --prefix ds=https://ds.canonical.com/.",
+        },
+      });
+    }
+
+    prefixes[name] = namespace;
+  }
+
+  return prefixes;
+}

--- a/packages/cli/pragma/src/domains/graphql/helpers/resolveSourceFiles.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/resolveSourceFiles.test.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import resolveSourceFiles from "./resolveSourceFiles.js";
+
+describe("resolveSourceFiles", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pragma-graphql-sources-"));
+    writeFileSync(join(dir, "a.ttl"), "# a");
+    writeFileSync(join(dir, "b.ttl"), "# b");
+    writeFileSync(join(dir, "notes.txt"), "ignore me");
+    mkdirSync(join(dir, "nested"));
+    writeFileSync(join(dir, "nested", "c.ttl"), "# c");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("resolves relative literal paths against cwd", () => {
+    const files = resolveSourceFiles(["a.ttl"], dir);
+    expect(files).toEqual([join(dir, "a.ttl")]);
+  });
+
+  it("keeps absolute literal paths", () => {
+    const files = resolveSourceFiles([join(dir, "b.ttl")], dir);
+    expect(files).toEqual([join(dir, "b.ttl")]);
+  });
+
+  it("skips missing literal paths", () => {
+    const files = resolveSourceFiles(["missing.ttl"], dir);
+    expect(files).toEqual([]);
+  });
+
+  it("expands glob patterns", () => {
+    const files = resolveSourceFiles(["*.ttl"], dir);
+    expect(files.sort()).toEqual([join(dir, "a.ttl"), join(dir, "b.ttl")]);
+  });
+
+  it("expands recursive glob patterns", () => {
+    const files = resolveSourceFiles(["**/*.ttl"], dir);
+    expect(files.sort()).toEqual([
+      join(dir, "a.ttl"),
+      join(dir, "b.ttl"),
+      join(dir, "nested", "c.ttl"),
+    ]);
+  });
+
+  it("combines multiple patterns in order", () => {
+    const files = resolveSourceFiles(["b.ttl", "nested/*.ttl"], dir);
+    expect(files).toEqual([join(dir, "b.ttl"), join(dir, "nested", "c.ttl")]);
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/helpers/resolveSourceFiles.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/resolveSourceFiles.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolve TTL source patterns to absolute file paths.
+ *
+ * Mirrors ke's own source resolution (wildcard detection + `globSync`,
+ * literal paths checked for existence) so the files the CLI reads and
+ * hashes are exactly the files `createStore` loads.
+ *
+ * @note Impure — reads filesystem to expand globs and check existence.
+ */
+
+import { existsSync, globSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Expand file paths and glob patterns into absolute file paths.
+ *
+ * @param patterns - Literal paths or glob patterns (`*`, `?`, `[`).
+ * @param cwd - Base directory for resolving relative patterns.
+ * @returns Absolute paths of all matched, existing files.
+ */
+export default function resolveSourceFiles(
+  patterns: readonly string[],
+  cwd: string,
+): string[] {
+  const files: string[] = [];
+
+  for (const pattern of patterns) {
+    if (
+      pattern.includes("*") ||
+      pattern.includes("?") ||
+      pattern.includes("[")
+    ) {
+      for (const file of globSync(pattern, { cwd })) {
+        files.push(resolve(cwd, file));
+      }
+    } else {
+      const absPath = resolve(cwd, pattern);
+      if (existsSync(absPath)) {
+        files.push(absPath);
+      }
+    }
+  }
+
+  return files;
+}

--- a/packages/cli/pragma/src/domains/graphql/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @module GraphQL domain barrel.
+ *
+ * Compiles TTL ontologies into GraphQL schema artifacts via the
+ * ke-graphql pipeline. Commands boot their own ke store from explicit
+ * TTL sources, so they run on the store-skip pipeline path.
+ */
+
+import type { CommandDefinition } from "@canonical/cli-core";
+import { buildCommand, checkCommand } from "./commands/index.js";
+
+/**
+ * Returns all command definitions for the graphql domain.
+ *
+ * @returns An array of command definitions (`graphql build`, `graphql check`).
+ */
+export function commands(): CommandDefinition[] {
+  return [buildCommand, checkCommand];
+}
+
+export { compileSchema } from "./operations/index.js";

--- a/packages/cli/pragma/src/domains/graphql/operations/compileSchema.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/compileSchema.test.ts
@@ -1,0 +1,119 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hashSources } from "@canonical/ke-graphql";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  EX_NAMESPACE,
+  GRAPHQL_CLEAN_TTL,
+  GRAPHQL_ERROR_TTL,
+  GRAPHQL_FATAL_TTL,
+} from "#testing";
+import { PREFIX_MAP } from "../../shared/prefixes.js";
+import compileSchema from "./compileSchema.js";
+
+const PREFIXES = { ...PREFIX_MAP, ex: EX_NAMESPACE };
+
+describe("compileSchema", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pragma-graphql-compile-"));
+    writeFileSync(join(dir, "clean.ttl"), GRAPHQL_CLEAN_TTL);
+    writeFileSync(join(dir, "error.ttl"), GRAPHQL_ERROR_TTL);
+    writeFileSync(join(dir, "fatal.ttl"), GRAPHQL_FATAL_TTL);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("compiles a clean ontology into SDL", async () => {
+    const outcome = await compileSchema({
+      sources: ["clean.ttl"],
+      prefixes: PREFIXES,
+      cwd: dir,
+    });
+
+    expect(outcome.status).toBe("ok");
+    expect(outcome.compiled?.sdl).toContain("type Thing");
+    expect(outcome.diagnostics).toEqual([]);
+    expect(outcome.files).toEqual([join(dir, "clean.ttl")]);
+  });
+
+  it("hashes the exact raw file contents", async () => {
+    const outcome = await compileSchema({
+      sources: ["clean.ttl"],
+      prefixes: PREFIXES,
+      cwd: dir,
+    });
+
+    const raw = readFileSync(join(dir, "clean.ttl"), "utf-8");
+    expect(outcome.sourcesHash).toBe(hashSources([raw]));
+  });
+
+  it("resolves glob patterns to source files", async () => {
+    const outcome = await compileSchema({
+      sources: ["clean*.ttl"],
+      prefixes: PREFIXES,
+      cwd: dir,
+    });
+
+    expect(outcome.status).toBe("ok");
+    expect(outcome.files).toEqual([join(dir, "clean.ttl")]);
+  });
+
+  it("surfaces error diagnostics without failing the compile", async () => {
+    const outcome = await compileSchema({
+      sources: ["error.ttl"],
+      prefixes: PREFIXES,
+      cwd: dir,
+    });
+
+    expect(outcome.status).toBe("ok");
+    expect(outcome.compiled).toBeDefined();
+    expect(
+      outcome.diagnostics.some(
+        (d) => d.severity === "error" && d.code === "M001",
+      ),
+    ).toBe(true);
+  });
+
+  it("converts CompilationError into a failed result with diagnostics", async () => {
+    const outcome = await compileSchema({
+      sources: ["fatal.ttl"],
+      prefixes: PREFIXES,
+      cwd: dir,
+    });
+
+    expect(outcome.status).toBe("failed");
+    expect(outcome.compiled).toBeUndefined();
+    expect(
+      outcome.diagnostics.some(
+        (d) => d.severity === "error" && d.code === "C003",
+      ),
+    ).toBe(true);
+  });
+
+  it("throws structured error when no sources resolve", async () => {
+    await expect(
+      compileSchema({
+        sources: ["missing.ttl"],
+        prefixes: PREFIXES,
+        cwd: dir,
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+  });
+
+  it("throws structured error on invalid TTL syntax", async () => {
+    writeFileSync(join(dir, "broken.ttl"), "this is not turtle .");
+
+    await expect(
+      compileSchema({
+        sources: ["broken.ttl"],
+        prefixes: PREFIXES,
+        cwd: dir,
+      }),
+    ).rejects.toMatchObject({ code: "STORE_ERROR" });
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/operations/compileSchema.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/compileSchema.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from "node:fs";
+import { createStore } from "@canonical/ke";
+import {
+  CompilationError,
+  type CompilerResult,
+  compile,
+  createStoreQueryFn,
+  type Diagnostic,
+  hashSources,
+} from "@canonical/ke-graphql";
+import { PragmaError } from "#error";
+import { resolveSourceFiles } from "../helpers/index.js";
+
+export interface CompileSchemaOptions {
+  /** TTL file paths or glob patterns, resolved from `cwd`. */
+  readonly sources: readonly string[];
+  /** Prefix map handed to both the ke store and the compiler. */
+  readonly prefixes: Readonly<Record<string, string>>;
+  /** Working directory for resolving relative source paths. */
+  readonly cwd: string;
+}
+
+export interface CompileSchemaResult {
+  /** `"ok"` when a schema was produced, `"failed"` when composition aborted. */
+  readonly status: "ok" | "failed";
+  /** All compiler diagnostics, including those carried by a CompilationError. */
+  readonly diagnostics: readonly Diagnostic[];
+  /** Resolved absolute TTL file paths that were loaded. */
+  readonly files: readonly string[];
+  /** Fingerprint of the raw source contents (matches ke's onLoad hashing). */
+  readonly sourcesHash: string;
+  /** Full compiler output; absent when compilation failed. */
+  readonly compiled?: CompilerResult;
+}
+
+/**
+ * Compile TTL sources into a GraphQL schema via the ke-graphql pipeline.
+ *
+ * Resolves source patterns, hashes the raw file contents (the exact bytes
+ * ke loads, so the artifact's `sourcesHash` matches what
+ * `createSchemaPlugin` computes from ke's onLoad), boots a throwaway ke
+ * store, and runs the compiler. A {@link CompilationError} (schema
+ * composition failed) is converted into a `"failed"` result carrying its
+ * diagnostics; the store is always disposed.
+ *
+ * @note Impure — reads filesystem and boots a ke store (WASM + TTL).
+ *
+ * @param options - Sources, prefixes, and working directory.
+ * @returns The compile outcome with diagnostics, files, and sources hash.
+ * @throws PragmaError with code `INVALID_INPUT` when no sources resolve.
+ * @throws PragmaError with code `STORE_ERROR` when the store fails to load.
+ */
+export default async function compileSchema(
+  options: CompileSchemaOptions,
+): Promise<CompileSchemaResult> {
+  const files = resolveSourceFiles(options.sources, options.cwd);
+
+  if (files.length === 0) {
+    throw PragmaError.invalidInput("sources", options.sources.join(", "), {
+      recovery: {
+        message: "Provide at least one existing TTL file or glob pattern.",
+      },
+    });
+  }
+
+  const contents = files.map((file) => readFileSync(file, "utf-8"));
+  const sourcesHash = hashSources(contents);
+
+  let store: Awaited<ReturnType<typeof createStore>>;
+  try {
+    store = await createStore({
+      sources: [...files],
+      prefixes: options.prefixes,
+      cwd: options.cwd,
+    });
+  } catch (error) {
+    throw PragmaError.storeError(
+      error instanceof Error ? error.message : String(error),
+      {
+        recovery: {
+          message: "Check the TTL syntax of the provided sources.",
+        },
+      },
+    );
+  }
+
+  try {
+    const compiled = await compile(createStoreQueryFn(store), options.prefixes);
+    return {
+      status: "ok",
+      diagnostics: compiled.diagnostics,
+      files,
+      sourcesHash,
+      compiled,
+    };
+  } catch (error) {
+    if (error instanceof CompilationError) {
+      return {
+        status: "failed",
+        diagnostics: error.diagnostics,
+        files,
+        sourcesHash,
+      };
+    }
+    throw error;
+  } finally {
+    store.dispose();
+  }
+}

--- a/packages/cli/pragma/src/domains/graphql/operations/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/index.ts
@@ -1,0 +1,7 @@
+/** @module Barrel for graphql operations. */
+
+export type {
+  CompileSchemaOptions,
+  CompileSchemaResult,
+} from "./compileSchema.js";
+export { default as compileSchema } from "./compileSchema.js";

--- a/packages/cli/pragma/src/domains/graphql/types.ts
+++ b/packages/cli/pragma/src/domains/graphql/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Type definitions for the graphql domain.
+ *
+ * The compile report is the shared output shape for `graphql build` and
+ * `graphql check`: the full diagnostic list plus source and artifact
+ * metadata, rendered by the report formatters.
+ */
+
+import type { Diagnostic } from "@canonical/ke-graphql";
+
+/** Artifact paths written by `pragma graphql build`. */
+export interface GraphqlArtifacts {
+  /** Absolute path of the written GraphQL SDL file. */
+  readonly sdl: string;
+  /** Absolute path of the written extraction artifact. */
+  readonly extraction: string;
+}
+
+/** Output shape rendered by `graphql build` and `graphql check`. */
+export interface GraphqlCompileReport {
+  /** All compiler diagnostics (errors, warnings, info). */
+  readonly diagnostics: readonly Diagnostic[];
+  /** Resolved absolute TTL file paths that were compiled. */
+  readonly files: readonly string[];
+  /** Combined fingerprint of the raw TTL source contents. */
+  readonly sourcesHash: string;
+  /** Written artifact paths (present only for a successful `build`). */
+  readonly artifacts?: GraphqlArtifacts;
+}

--- a/packages/cli/pragma/src/pipeline/collectCommands.ts
+++ b/packages/cli/pragma/src/pipeline/collectCommands.ts
@@ -4,6 +4,7 @@ import { commands as configCommands } from "../domains/config/index.js";
 import { commands as createCommands } from "../domains/create/index.js";
 import { doctorCommand } from "../domains/doctor/commands/index.js";
 import { commands as graphCommands } from "../domains/graph/index.js";
+import { commands as graphqlCommands } from "../domains/graphql/index.js";
 import { infoCommand, upgradeCommand } from "../domains/info/index.js";
 import {
   buildCapabilitiesCommand,
@@ -41,6 +42,7 @@ export default function collectCommands(
     ...blockCommands(ctx),
     ...ontologyCommands(ctx),
     ...graphCommands(ctx),
+    ...graphqlCommands(),
     ...skillCommands(ctx),
     doctorCommand,
     infoCommand,

--- a/packages/cli/pragma/src/pipeline/resolveCommandKind.ts
+++ b/packages/cli/pragma/src/pipeline/resolveCommandKind.ts
@@ -14,6 +14,7 @@ const STORE_SKIP_COMMANDS = new Set([
   "update-refs",
   "capabilities",
   "trace",
+  "graphql",
 ]);
 
 function findCommandArg(argv: readonly string[]): string | undefined {

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -1,5 +1,6 @@
 import type { GlobalFlags } from "@canonical/cli-core";
 import { CommanderError } from "commander";
+import { commands as graphqlCommands } from "../domains/graphql/index.js";
 import { buildCapabilitiesCommand } from "../domains/llm/index.js";
 import { commands as refsCommands } from "../domains/refs/index.js";
 import { commands as setupCommands } from "../domains/setup/index.js";
@@ -149,6 +150,7 @@ async function runStoreSkip(
     ...setupCommands(),
     ...refsCommands(),
     ...traceCommands(),
+    ...graphqlCommands(),
     buildCapabilitiesCommand(),
   ];
   const program = createProgram(commands, stubCtx);

--- a/packages/cli/pragma/src/testing/graphqlFixtures.ts
+++ b/packages/cli/pragma/src/testing/graphqlFixtures.ts
@@ -1,0 +1,72 @@
+/**
+ * TTL fixtures for graphql domain tests.
+ *
+ * Three compile outcomes: a clean ontology (no diagnostics), an ontology
+ * with an unresolvable field-name collision (M001 error diagnostic, schema
+ * still composes), and an ontology whose reserved `__` field name fails
+ * schema composition entirely (C003 → CompilationError).
+ */
+
+/** Namespace used by all graphql fixtures. */
+export const EX_NAMESPACE = "http://example.org/";
+
+/** `--prefix` entry registering {@link EX_NAMESPACE}. */
+export const EX_PREFIX_ENTRY = `ex=${EX_NAMESPACE}`;
+
+const prefixBlock = `@prefix ex: <${EX_NAMESPACE}> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .`;
+
+/** Compiles to `type Thing` with zero diagnostics. */
+export const GRAPHQL_CLEAN_TTL = `${prefixBlock}
+
+ex:Thing a owl:Class ;
+  rdfs:label "Thing" .
+
+ex:name a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:string ;
+  rdfs:label "name" .
+
+ex:widget a ex:Thing ;
+  ex:name "Widget" .
+`;
+
+/**
+ * Produces an M001 error diagnostic (three properties collapse to
+ * `Thing.name` and the namespace-prefixed rename collides too), but the
+ * schema still composes — no CompilationError.
+ */
+export const GRAPHQL_ERROR_TTL = `${prefixBlock}
+
+ex:Thing a owl:Class ;
+  rdfs:label "Thing" .
+
+ex:name a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:string .
+
+ex:hasName a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:string .
+
+ex:isName a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:string .
+`;
+
+/**
+ * Fails schema composition (C003): `__bad` survives name sanitization but
+ * `__` is reserved by GraphQL introspection, so compile() throws
+ * CompilationError.
+ */
+export const GRAPHQL_FATAL_TTL = `${prefixBlock}
+
+ex:Thing a owl:Class ;
+  rdfs:label "Thing" .
+
+ex:__bad a owl:DatatypeProperty ;
+  rdfs:domain ex:Thing ;
+  rdfs:range xsd:string .
+`;

--- a/packages/cli/pragma/src/testing/index.ts
+++ b/packages/cli/pragma/src/testing/index.ts
@@ -3,6 +3,13 @@ export type { CommandResult } from "./cli.js";
 export { runCommand } from "./cli.js";
 export { default as createTestMcpClient } from "./createTestMcpClient.js";
 export { DS_ALL_TTL, DS_ONTOLOGY_TTL, DS_TIERS_TTL } from "./dsFixtures.js";
+export {
+  EX_NAMESPACE,
+  EX_PREFIX_ENTRY,
+  GRAPHQL_CLEAN_TTL,
+  GRAPHQL_ERROR_TTL,
+  GRAPHQL_FATAL_TTL,
+} from "./graphqlFixtures.js";
 export type { PragmaTestStoreOptions } from "./store.js";
 export { createTestStore } from "./store.js";
 export type { TestMcpClientResult } from "./types.js";


### PR DESCRIPTION
> PR 7 of the `@canonical/ke-graphql` delivery stack (umbrella #658). **Stacked on #672** (/http). Final PR (demo) is #673.

## Done

The **`pragma graphql` CLI domain** in `@canonical/pragma` — ahead-of-time schema tooling over `@canonical/ke-graphql`:

- **`pragma graphql build`** — compiles the ontology and writes the SDL + the extraction artifact (the fast-boot input the schema plugin verifies).
- **`pragma graphql check`** — compiles and reports diagnostics (the V/B/M/C/X-series codes) without emitting, as a CI gate.
- The graphql command domain: commands, formatters, helpers (prefix parsing, source-file resolution), and the `compileSchema` operation — wired into the CLI pipeline.

## QA

```bash
cd packages/cli/pragma && bun run check && bun run test
```
biome + `tsc` + webarchitect green; **1065 tests pass** (2 pre-existing skips). The consumer resolves `@canonical/ke-graphql` through the workspace.

### PR readiness check

- [x] Label: `Feature 🎁`.
- [x] Conventional Commits title.
- [x] [Code standards](https://github.com/canonical/web-code-standards): graphql domain under `src/domains/graphql/`, colocated tests, helpers/operations/formatters split.
- [x] `check`, `check:fix`, `test` present.
- [x] `no visual change`.

## Screenshots

No visual change — CLI commands, no UI.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_