### PR TITLE
feat(ke-graphql): local + incremental execution

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/execution/extractStatic.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/extractStatic.test.ts
@@ -1,0 +1,138 @@
+// =============================================================================
+// Path B static extraction: variable-type enumeration, embeddable-class skip,
+// and incremental drain-and-merge through extractStatic.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import type { CompilerContext } from "#shared";
+import {
+  BLANK_NODES_TTL,
+  DS_REALISTIC_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+} from "#testing";
+import extractStatic from "./extractStatic.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<{ result: CompilerResult; context: CompilerContext }> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, options);
+  return { result, context: result.createContext(store) };
+};
+
+describe("extractStatic variable enumeration", () => {
+  it("accepts every uri-shaped variable type and skips embeddable classes", async () => {
+    // BLANK_NODES_TTL has ex:Example as an embeddable (blank-node-only) class —
+    // listEntityUris must skip it and enumerate only the named ex:Standard.
+    const { result, context } = await setup(BLANK_NODES_TTL);
+    const results = await extractStatic({
+      schema: result.schema,
+      mapped: result.mapped,
+      context,
+      queries: [
+        {
+          name: "ByStringReq",
+          text: `query Q($uri: String!) { standard(uri: $uri) { title } }`,
+          variables: { uri: "String!" },
+        },
+        {
+          name: "ByString",
+          text: `query Q($uri: String) { standard(uri: $uri) { title } }`,
+          variables: { uri: "String" },
+        },
+        {
+          name: "ByIdReq",
+          text: `query Q($uri: ID!) { standard(uri: $uri) { title } }`,
+          variables: { uri: "ID!" },
+        },
+        {
+          name: "ById",
+          text: `query Q($uri: ID) { standard(uri: $uri) { title } }`,
+          variables: { uri: "ID" },
+        },
+      ],
+    });
+    // One named ex:Standard instance (ex:s1); the embeddable ex:Example is
+    // never enumerated, so every uri query yields exactly one keyed entry.
+    for (const prefix of ["ByStringReq", "ByString", "ByIdReq", "ById"]) {
+      const keyed = [...results.keys()].filter((k) =>
+        k.startsWith(`${prefix}:`),
+      );
+      expect(keyed).toEqual([`${prefix}:ex:s1`]);
+    }
+  });
+
+  it("rejects a uri variable whose declared type is missing", async () => {
+    // A key present with an undefined value drives the `?? ""` fallback, which
+    // is not a uri-shaped type — extractStatic must fail loudly.
+    const { result, context } = await setup(MINIMAL_TTL);
+    await expect(
+      extractStatic({
+        schema: result.schema,
+        mapped: result.mapped,
+        context,
+        queries: [
+          {
+            name: "Untyped",
+            text: `query Q($uri: String!) { thing(uri: $uri) { name } }`,
+            variables: { uri: undefined as unknown as string },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/non-enumerable/);
+  });
+});
+
+describe("extractStatic incremental drain-and-merge", () => {
+  it("merges a deferred result into one complete entry", async () => {
+    // An incremental schema + a @defer query make executeLocal return an
+    // IncrementalResults stream; extractStatic must drain and merge it.
+    const { result, context } = await setup(DS_REALISTIC_TTL, {
+      incremental: true,
+      mappings: {
+        "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+        "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+        "ds:hasProperty": { graphqlName: "properties" },
+        "ds:hasModifier": { graphqlName: "modifiers" },
+      },
+    });
+    const results = await extractStatic({
+      schema: result.schema,
+      mapped: result.mapped,
+      context,
+      queries: [
+        {
+          name: "Deferred",
+          text: `
+            query Deferred {
+              component(uri: "ds:global.component.button") {
+                name
+                ... on Component @defer(label: "summary") { summary }
+              }
+            }
+          `,
+        },
+      ],
+    });
+    const merged = results.get("Deferred");
+    expect(merged?.errors).toBeUndefined();
+    const component = merged?.data?.component as Record<string, unknown>;
+    expect(component.name).toBe("Button");
+    expect(component.summary).toBe("Primary action trigger.");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/execution/extractStatic.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/extractStatic.ts
@@ -1,0 +1,122 @@
+// =============================================================================
+// Path B — static extraction at build time.
+//
+// Runs every provided query against the compiled schema and returns the
+// results keyed by name (callers write them to disk as static JSON). Only
+// `uri`-typed variables are enumerable: for queries with a single required
+// `uri: String!` variable, every instance URI of the relevant classes is
+// substituted. Queries with other variables fail loudly rather than shipping
+// partial data. Incremental payloads are always drained and merged.
+// =============================================================================
+
+import type { ExecutionResult, GraphQLSchema } from "graphql";
+import { toPrefixed } from "#dataloader";
+import type { CompilerContext, MappedIR } from "#shared";
+import {
+  executeLocal,
+  isIncrementalResults,
+  mergeIncremental,
+} from "./incremental.js";
+
+/** One named query to extract, with optional variable definitions. */
+export interface StaticQuery {
+  name: string;
+  text: string;
+  /** Variable definitions: name → GraphQL type string (e.g. "String!"). */
+  variables?: Record<string, string>;
+}
+
+/** Arguments for extractStatic: schema, IR, context, and the query set. */
+export interface ExtractStaticOptions {
+  schema: GraphQLSchema;
+  mapped: MappedIR;
+  context: CompilerContext;
+  queries: StaticQuery[];
+}
+
+const isUriVariable = (type: string): boolean =>
+  type === "String!" || type === "String" || type === "ID!" || type === "ID";
+
+/**
+ * List all named instance URIs (prefixed) across all concrete classes.
+ *
+ * @note Impure — loads every class's instance list from the store through
+ * the context's list loader.
+ */
+const listEntityUris = async (
+  mapped: MappedIR,
+  context: CompilerContext,
+): Promise<string[]> => {
+  const uris: string[] = [];
+  for (const type of mapped.types.values()) {
+    if (type.embeddable) {
+      continue;
+    }
+    const instances = await context.listLoader.load(type.owlUri);
+    for (const full of instances) {
+      uris.push(toPrefixed(full, mapped.namespaces));
+    }
+  }
+  return uris;
+};
+
+/**
+ * Execute the provided query set against the compiled schema and return the
+ * results keyed by query name (queries with a single uri variable run once
+ * per instance URI, keyed "name:uri"). Incremental payloads are drained and
+ * merged. Throws on queries with non-enumerable variables rather than
+ * shipping partial data.
+ *
+ * @note Impure — executes every query against the store-backed context.
+ */
+export default async function extractStatic(
+  options: ExtractStaticOptions,
+): Promise<Map<string, ExecutionResult>> {
+  const results = new Map<string, ExecutionResult>();
+
+  const run = async (
+    key: string,
+    text: string,
+    variableValues?: Record<string, unknown>,
+  ) => {
+    const result = await executeLocal({
+      schema: options.schema,
+      source: text,
+      variableValues,
+      contextValue: options.context,
+    });
+    results.set(
+      key,
+      isIncrementalResults(result) ? await mergeIncremental(result) : result,
+    );
+  };
+
+  let entityUris: string[] | undefined;
+
+  for (const query of options.queries) {
+    const variableNames = Object.keys(query.variables ?? {});
+    if (variableNames.length === 0) {
+      await run(query.name, query.text);
+      continue;
+    }
+    const [name] = variableNames;
+    if (
+      variableNames.length === 1 &&
+      name === "uri" &&
+      isUriVariable(query.variables?.[name] ?? "")
+    ) {
+      entityUris ??= await listEntityUris(options.mapped, options.context);
+      for (const uri of entityUris) {
+        await run(`${query.name}:${uri}`, query.text, { uri });
+      }
+      continue;
+    }
+    throw new Error(
+      `extractStatic: query "${query.name}" has non-enumerable variables (${variableNames.join(
+        ", ",
+      )}) — static extraction supports only a single uri variable`,
+    );
+  }
+
+  return results;
+}

--- a/packages/runtime/ke-graphql/src/lib/execution/incremental.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/incremental.test.ts
@@ -1,0 +1,628 @@
+// =============================================================================
+// Execution paths: local execution, @defer incremental
+// delivery, drain-and-merge, the Relay format adapter, static extraction.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { parse } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import type { CompilerContext } from "#shared";
+import { DS_REALISTIC_TTL, MINIMAL_TTL, PREFIXES } from "#testing";
+import extractStatic from "./extractStatic.js";
+import {
+  executeLocal,
+  isIncrementalResults,
+  mergeIncremental,
+  relayFormatAdapter,
+} from "./incremental.js";
+import type {
+  IncrementalResults,
+  InitialIncrementalResult,
+  RelayLegacyPayload,
+  SubsequentIncrementalResult,
+} from "./types.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<{ result: CompilerResult; context: CompilerContext }> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, options);
+  return { result, context: result.createContext(store) };
+};
+
+const DEFERRED_QUERY = `
+  query ButtonQuery {
+    component(uri: "ds:global.component.button") {
+      name
+      ... DeferredSummary @defer(label: "summary")
+    }
+  }
+  fragment DeferredSummary on Component {
+    summary
+    tier { name }
+  }
+`;
+
+const dsOptions = {
+  incremental: true,
+  mappings: {
+    "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+    "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+    "ds:hasProperty": { graphqlName: "properties" },
+    "ds:hasModifier": { graphqlName: "modifiers" },
+  },
+};
+
+describe("executeLocal (in-process execution)", () => {
+  it("executes plain documents to a single result", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: `{ thing(uri: "ex:widget") { name count } }`,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors).toBeUndefined();
+      expect(execution.data?.thing).toEqual({ name: "Widget", count: 42 });
+    }
+  });
+
+  it("executes plain documents against an incremental schema (v17 forbids execute() there)", async () => {
+    const { result, context } = await setup(DS_REALISTIC_TTL, dsOptions);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: `{ component(uri: "ds:global.component.button") { name } }`,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors).toBeUndefined();
+      expect((execution.data?.component as Record<string, unknown>).name).toBe(
+        "Button",
+      );
+    }
+  });
+
+  it("uses a pre-parsed document and skips its own parse", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    const document = parse(`{ thing(uri: "ex:widget") { name } }`);
+    // The source is deliberately unparseable: if executeLocal honored the
+    // document it succeeds; if it re-parsed `source` it would error.
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: "this is not valid graphql",
+      document,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors).toBeUndefined();
+      expect(execution.data?.thing).toEqual({ name: "Widget" });
+    }
+  });
+
+  it("returns errors for syntax errors without throwing", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: "{ not valid graphql",
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("produces incremental results for @defer documents", async () => {
+    const { result, context } = await setup(DS_REALISTIC_TTL, dsOptions);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: DEFERRED_QUERY,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(true);
+    if (isIncrementalResults(execution)) {
+      const merged = await mergeIncremental(execution);
+      expect(merged.errors).toBeUndefined();
+      const component = merged.data?.component as Record<string, unknown>;
+      expect(component.name).toBe("Button");
+      expect(component.summary).toBe("Primary action trigger.");
+      expect((component.tier as { name: string }).name).toBe("global");
+    }
+  });
+});
+
+describe("relayFormatAdapter", () => {
+  it("translates v17 payloads to the Relay legacy shape", async () => {
+    const { result, context } = await setup(DS_REALISTIC_TTL, dsOptions);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: DEFERRED_QUERY,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(true);
+    if (!isIncrementalResults(execution)) {
+      return;
+    }
+    const payloads = [];
+    for await (const payload of relayFormatAdapter(execution)) {
+      payloads.push(payload);
+    }
+    // initial payload: plain data, no path
+    expect(payloads[0]?.path).toBeUndefined();
+    expect((payloads[0]?.data?.component as Record<string, unknown>).name).toBe(
+      "Button",
+    );
+    // deferred payload: path + label, is_final on the last
+    const deferred = payloads.slice(1);
+    expect(deferred.length).toBeGreaterThan(0);
+    const last = deferred[deferred.length - 1];
+    expect(last?.path).toEqual(["component"]);
+    expect(last?.label).toBe("summary");
+    expect(last?.extensions?.is_final).toBe(true);
+    expect((last?.data as Record<string, unknown>).summary).toBe(
+      "Primary action trigger.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit-level coverage of the merge/translate branches, driven by hand-crafted
+// v17 incremental payloads (the 2023 pending/incremental/completed shape).
+// ---------------------------------------------------------------------------
+
+const makeResults = (
+  initialResult: InitialIncrementalResult,
+  ...payloads: SubsequentIncrementalResult[]
+): IncrementalResults => ({
+  initialResult,
+  subsequentResults: (async function* () {
+    for (const payload of payloads) {
+      yield payload;
+    }
+  })(),
+});
+
+const collect = async (
+  gen: AsyncGenerator<RelayLegacyPayload, void, void>,
+): Promise<RelayLegacyPayload[]> => {
+  const out: RelayLegacyPayload[] = [];
+  for await (const payload of gen) {
+    out.push(payload);
+  }
+  return out;
+};
+
+describe("mergeIncremental (crafted payloads)", () => {
+  it("merges deferred-fragment data into the initial tree", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        {
+          data: { node: { name: "x" } },
+          pending: [{ id: "0", path: ["node"], label: "frag" }],
+        },
+        {
+          incremental: [{ id: "0", data: { extra: "y" } }],
+          completed: [{ id: "0" }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.errors).toBeUndefined();
+    expect(merged.data?.node).toEqual({ name: "x", extra: "y" });
+  });
+
+  it("pushes streamed items onto the array at the pending path", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        { data: { list: [0] }, pending: [{ id: "1", path: ["list"] }] },
+        { incremental: [{ id: "1", items: [1, 2] }], hasNext: true },
+        {
+          incremental: [{ id: "1", items: [3] }],
+          completed: [{ id: "1" }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.data?.list).toEqual([0, 1, 2, 3]);
+  });
+
+  it("collects errors from incremental entries and completed notices", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        {
+          data: { a: { keep: true }, b: null },
+          pending: [
+            { id: "0", path: ["a"], label: "fa" },
+            { id: "1", path: ["b"], label: "fb" },
+          ],
+        },
+        {
+          incremental: [
+            { id: "0", data: { added: 1 }, errors: [{ message: "partial" }] },
+          ],
+          completed: [{ id: "1", errors: [{ message: "fragment failed" }] }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.errors).toHaveLength(2);
+    expect(merged.data?.a).toEqual({ keep: true, added: 1 });
+  });
+
+  it("carries initial errors through and ignores unknown / null-data entries", async () => {
+    // data === null short-circuits the merge; an unknown id has no pending;
+    // the `?? null`/`?? []` defaults fire because data/pending are absent.
+    const merged = await mergeIncremental(
+      makeResults(
+        { errors: [{ message: "seed" }] },
+        { hasNext: true },
+        {
+          incremental: [{ id: "ghost", data: { ignored: true } }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.data).toBeNull();
+    expect(merged.errors).toHaveLength(1);
+  });
+
+  it("registers a pending announced in a subsequent payload", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        { data: { node: { name: "x" } } },
+        // pending "0" is announced here, not in the initial result.
+        {
+          pending: [{ id: "0", path: ["node"], label: "late" }],
+          incremental: [{ id: "0", data: { extra: "y" } }],
+          completed: [{ id: "0" }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.data?.node).toEqual({ name: "x", extra: "y" });
+  });
+
+  it("tolerates a pending path that walks through a non-object and a non-array items target", async () => {
+    const merged = await mergeIncremental(
+      makeResults(
+        {
+          // ["scalar","deeper"] walks into a string → defensive bail-out;
+          // ["obj"] is an object, so items push finds a non-array container;
+          // ["leaf"] resolves fully to null → the final-cursor guard bails.
+          data: { scalar: "leaf", obj: { kind: "map" }, leaf: null },
+          pending: [
+            { id: "0", path: ["scalar", "deeper"] },
+            { id: "1", path: ["obj"] },
+            { id: "2", path: ["leaf"] },
+          ],
+        },
+        {
+          incremental: [
+            { id: "0", data: { unreached: true } },
+            { id: "1", items: [99] },
+            { id: "2", data: { alsoUnreached: true } },
+          ],
+          completed: [{ id: "0" }, { id: "1" }, { id: "2" }],
+          hasNext: false,
+        },
+      ),
+    );
+    expect(merged.errors).toBeUndefined();
+    expect(merged.data?.scalar).toBe("leaf");
+    expect(merged.data?.obj).toEqual({ kind: "map" });
+    expect(merged.data?.leaf).toBeNull();
+  });
+});
+
+describe("relayFormatAdapter (crafted payloads)", () => {
+  it("emits the initial payload with errors, then a labelled deferred payload with is_final", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          {
+            data: { node: { name: "x" } },
+            errors: [{ message: "warn" }],
+            pending: [{ id: "0", path: ["node"], label: "frag" }],
+          },
+          {
+            incremental: [{ id: "0", data: { extra: "y" } }],
+            completed: [{ id: "0" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    expect(payloads[0]?.path).toBeUndefined();
+    expect(payloads[0]?.errors).toHaveLength(1);
+    const last = payloads[payloads.length - 1];
+    expect(last?.path).toEqual(["node"]);
+    expect(last?.label).toBe("frag");
+    expect(last?.data).toEqual({ extra: "y" });
+    expect(last?.extensions?.is_final).toBe(true);
+  });
+
+  it("indexes streamed items from the initial array length and flushes while hasNext", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          // No label on this pending → the label-omitting branches run.
+          { data: { list: ["a"] }, pending: [{ id: "1", path: ["list"] }] },
+          { incremental: [{ id: "1", items: ["b", "c"] }], hasNext: true },
+          {
+            incremental: [{ id: "1", items: ["d"] }],
+            completed: [{ id: "1" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const streamed = payloads.slice(1);
+    // initial array length is 1, so the first streamed item is index 1.
+    expect(streamed.map((p) => p.path)).toEqual([
+      ["list", 1],
+      ["list", 2],
+      ["list", 3],
+    ]);
+    expect(streamed.every((p) => p.label === undefined)).toBe(true);
+    expect(streamed[streamed.length - 1]?.extensions?.is_final).toBe(true);
+  });
+
+  it("translates a completed-only error and a null deferred payload, keeping path/label", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          {
+            data: { node: { name: "x" }, other: null },
+            pending: [
+              { id: "0", path: ["node"], label: "ok" },
+              { id: "1", path: ["other"], label: "bad" },
+            ],
+          },
+          {
+            // entry.data === null → relay still buffers a null-data payload.
+            incremental: [{ id: "0", data: null }],
+            hasNext: true,
+          },
+          {
+            completed: [{ id: "1", errors: [{ message: "fragment failed" }] }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const nullData = payloads.find((p) => p.label === "ok");
+    expect(nullData?.data).toBeNull();
+    const failed = payloads.find((p) => p.label === "bad");
+    expect(failed?.data).toBeNull();
+    expect(failed?.errors).toHaveLength(1);
+    expect(failed?.path).toEqual(["other"]);
+  });
+
+  it("flushes more than one trailing payload and marks only the last is_final", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          {
+            data: { a: {}, b: {} },
+            pending: [
+              { id: "0", path: ["a"] },
+              { id: "1", path: ["b"] },
+            ],
+          },
+          {
+            incremental: [
+              { id: "0", data: { x: 1 } },
+              { id: "1", data: { y: 2 } },
+            ],
+            completed: [{ id: "0" }, { id: "1" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const trailing = payloads.slice(1);
+    expect(trailing).toHaveLength(2);
+    expect(trailing[0]?.extensions?.is_final).toBeUndefined();
+    expect(trailing[1]?.extensions?.is_final).toBe(true);
+  });
+
+  it("emits a synthetic is_final payload when everything was flushed before the final notice", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { data: { node: {} }, pending: [{ id: "0", path: ["node"] }] },
+          // Flushed during hasNext: true …
+          { incremental: [{ id: "0", data: { x: 1 } }], hasNext: true },
+          // … the final payload carries only completed bookkeeping.
+          { completed: [{ id: "0" }], hasNext: false },
+        ),
+      ),
+    );
+    const last = payloads[payloads.length - 1];
+    expect(last?.data).toBeNull();
+    expect(last?.extensions?.is_final).toBe(true);
+    // The flushed deferred payload came before the synthetic final.
+    expect(payloads.some((p) => p.path?.[0] === "node")).toBe(true);
+  });
+
+  it("seeds the stream index at 0 when the initial result has no data and the path is absent", async () => {
+    // initialResult.data is undefined → the `?? null` default and the
+    // null-cursor guard in computeInitialIndex both run; index starts at 0.
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { pending: [{ id: "1", path: ["missing"] }] },
+          {
+            incremental: [{ id: "1", items: ["only"] }],
+            completed: [{ id: "1" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    expect(payloads[0]?.data).toBeNull();
+    const streamed = payloads.slice(1);
+    expect(streamed[0]?.path).toEqual(["missing", 0]);
+  });
+
+  it("seeds the stream index at 0 when the path leads to a non-array value", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          {
+            data: { box: { notAList: true } },
+            pending: [{ id: "1", path: ["box"] }],
+          },
+          {
+            incremental: [{ id: "1", items: ["x"] }],
+            completed: [{ id: "1" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    expect(payloads.slice(1)[0]?.path).toEqual(["box", 0]);
+  });
+
+  it("skips incremental entries whose id has no pending announcement", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { data: { node: {} } },
+          {
+            incremental: [{ id: "ghost", data: { ignored: true } }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    // Only the initial payload plus the synthetic is_final; nothing buffered.
+    const last = payloads[payloads.length - 1];
+    expect(last?.extensions?.is_final).toBe(true);
+    expect(
+      payloads.some((p) => (p.data as { ignored?: boolean })?.ignored),
+    ).toBe(false);
+  });
+
+  it("honors a pending announced in a subsequent payload, with labelled items and per-entry errors", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { data: { feed: ["seed"] } },
+          // The pending for "9" arrives in this subsequent payload, not the
+          // initial result — the subsequent-pending loop registers it.
+          {
+            pending: [{ id: "9", path: ["feed"], label: "stream" }],
+            incremental: [
+              { id: "9", items: ["one"], errors: [{ message: "item warn" }] },
+            ],
+            hasNext: true,
+          },
+          {
+            incremental: [
+              {
+                id: "9",
+                data: { tail: 1 },
+                errors: [{ message: "frag warn" }],
+              },
+            ],
+            completed: [{ id: "9" }],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const labelled = payloads.filter((p) => p.label === "stream");
+    expect(labelled.length).toBeGreaterThan(0);
+    // The deferred-data payload carried entry.errors through.
+    const withErrors = payloads.find((p) => p.errors !== undefined);
+    expect(withErrors?.errors).toHaveLength(1);
+    // The streamed item picked up the label too.
+    const item = payloads.find((p) => p.path?.[1] === 1);
+    expect(item?.label).toBe("stream");
+  });
+
+  it("emits a completed-error payload without path/label when the id was never announced", async () => {
+    const payloads = await collect(
+      relayFormatAdapter(
+        makeResults(
+          { data: { node: {} } },
+          {
+            completed: [
+              { id: "unknown", errors: [{ message: "orphan failure" }] },
+            ],
+            hasNext: false,
+          },
+        ),
+      ),
+    );
+    const failed = payloads.find((p) => p.errors !== undefined);
+    expect(failed?.errors).toHaveLength(1);
+    expect(failed?.path).toBeUndefined();
+    expect(failed?.label).toBeUndefined();
+    expect(failed?.extensions?.is_final).toBe(true);
+  });
+});
+
+describe("extractStatic (build-time static extraction)", () => {
+  it("runs nullary queries once and uri queries per entity", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    const results = await extractStatic({
+      schema: result.schema,
+      mapped: result.mapped,
+      context,
+      queries: [
+        {
+          name: "AllThings",
+          text: `{ things(first: 10) { edges { node { name } } } }`,
+        },
+        {
+          name: "ThingQuery",
+          text: `query ThingQuery($uri: String!) { thing(uri: $uri) { name } }`,
+          variables: { uri: "String!" },
+        },
+      ],
+    });
+    expect(results.get("AllThings")).toBeDefined();
+    const perEntity = [...results.keys()].filter((k) =>
+      k.startsWith("ThingQuery:"),
+    );
+    expect(perEntity).toEqual(["ThingQuery:ex:widget"]);
+    const widget = results.get("ThingQuery:ex:widget");
+    expect((widget?.data?.thing as { name: string }).name).toBe("Widget");
+  });
+
+  it("fails loudly on non-enumerable variables", async () => {
+    const { result, context } = await setup(MINIMAL_TTL);
+    await expect(
+      extractStatic({
+        schema: result.schema,
+        mapped: result.mapped,
+        context,
+        queries: [
+          {
+            name: "Paginated",
+            text: `query P($after: String) { things(after: $after) { edges { cursor } } }`,
+            variables: { after: "String" },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/non-enumerable/);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/execution/incremental.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/incremental.ts
@@ -1,0 +1,283 @@
+// =============================================================================
+// Incremental delivery support, graphql v17.
+//
+// - executeLocal: graphql() for plain documents, experimentalExecuteIncrementally
+//   when the document uses @defer/@stream
+// - mergeIncremental: drain-and-merge fallback — folds every increment into
+//   one complete result (used by the handler for non-multipart clients and by
+//   Path B static extraction)
+// - relayFormatAdapter: translates v17's 2023 payload format
+//   (pending/id/incremental/completed) into Relay's legacy shape
+//   (path/label per payload, is_final extension)
+// =============================================================================
+
+import {
+  type DocumentNode,
+  type ExecutionResult,
+  execute,
+  experimentalExecuteIncrementally,
+  type GraphQLSchema,
+  parse,
+} from "graphql";
+import type { CompilerContext } from "#shared";
+import type {
+  IncrementalResults,
+  LocalExecutionResult,
+  PendingEntry,
+  RelayLegacyPayload,
+} from "./types.js";
+
+/** Distinguish an incremental result stream from a plain ExecutionResult. */
+export const isIncrementalResults = (
+  result: LocalExecutionResult,
+): result is IncrementalResults =>
+  "initialResult" in result && "subsequentResults" in result;
+
+/** Arguments for executeLocal: schema, source text, variables, and context. */
+export interface ExecuteLocalArgs {
+  schema: GraphQLSchema;
+  source: string;
+  /**
+   * Pre-parsed document. When provided (e.g. the HTTP handler's cached,
+   * already-validated document), executeLocal skips its own parse — avoiding
+   * a second parse of the same query text on the warm request path.
+   */
+  document?: DocumentNode;
+  variableValues?: Record<string, unknown> | null;
+  contextValue: CompilerContext;
+  operationName?: string | null;
+}
+
+const usesIncrementalDirectives = (source: string): boolean =>
+  source.includes("@defer") || source.includes("@stream");
+
+// graphql v17 RC's execute() throws on any schema that carries the @defer or
+// @stream directives — even for operations that use neither. Schemas compiled
+// with `incremental: true` must therefore always go through the experimental
+// executor (which still returns a plain ExecutionResult for plain operations).
+const schemaCarriesIncrementalDirectives = (schema: GraphQLSchema): boolean =>
+  schema.getDirective("defer") !== undefined ||
+  schema.getDirective("stream") !== undefined;
+
+/**
+ * Execute a query in-process (SSR prefetch, tests, scripts — no HTTP, no
+ * serialization). Documents using @defer/@stream go through the incremental
+ * executor and return an IncrementalResults stream; everything else returns
+ * a plain ExecutionResult. Syntax errors come back as an errors-only result,
+ * matching graphql().
+ *
+ * @note Impure — resolvers read the store through the context's loaders
+ * while the operation executes.
+ */
+export const executeLocal = async (
+  args: ExecuteLocalArgs,
+): Promise<LocalExecutionResult> => {
+  let document: DocumentNode;
+  if (args.document) {
+    document = args.document;
+  } else {
+    try {
+      document = parse(args.source);
+    } catch (error) {
+      return {
+        errors: [
+          // graphql() would produce the same shape for a syntax error.
+          error,
+        ],
+      } as ExecutionResult;
+    }
+  }
+  const executionArgs = {
+    schema: args.schema,
+    document,
+    variableValues: args.variableValues ?? undefined,
+    contextValue: args.contextValue,
+    operationName: args.operationName ?? undefined,
+  };
+  if (
+    usesIncrementalDirectives(args.source) ||
+    schemaCarriesIncrementalDirectives(args.schema)
+  ) {
+    return (await experimentalExecuteIncrementally(
+      executionArgs,
+    )) as LocalExecutionResult;
+  }
+  return execute(executionArgs);
+};
+
+const setAtPath = (
+  target: Record<string, unknown>,
+  path: ReadonlyArray<string | number>,
+  merge: (parent: Record<string, unknown> | unknown[]) => void,
+): void => {
+  // Walk to the container at `path`; tolerate missing segments (defensive).
+  let cursor: unknown = target;
+  for (const segment of path) {
+    if (cursor == null || typeof cursor !== "object") {
+      return;
+    }
+    cursor = (cursor as Record<string | number, unknown>)[segment];
+  }
+  if (cursor != null && typeof cursor === "object") {
+    merge(cursor as Record<string, unknown> | unknown[]);
+  }
+};
+
+/**
+ * Drain every increment and fold it into one complete ExecutionResult.
+ * Correctness-preserving fallback: streaming is lost, data is identical.
+ */
+export const mergeIncremental = async (
+  results: IncrementalResults,
+): Promise<ExecutionResult> => {
+  const { initialResult, subsequentResults } = results;
+  const data = (initialResult.data ?? null) as Record<string, unknown> | null;
+  const errors: unknown[] = [...(initialResult.errors ?? [])];
+  const pendingById = new Map<string, PendingEntry>();
+  for (const pending of initialResult.pending ?? []) {
+    pendingById.set(pending.id, pending);
+  }
+
+  for await (const payload of subsequentResults) {
+    for (const pending of payload.pending ?? []) {
+      pendingById.set(pending.id, pending);
+    }
+    for (const entry of payload.incremental ?? []) {
+      const pending = pendingById.get(entry.id);
+      if (!pending || data === null) {
+        continue;
+      }
+      const path = [...pending.path, ...(entry.subPath ?? [])];
+      if (entry.data !== undefined && entry.data !== null) {
+        setAtPath(data, path, (container) => {
+          Object.assign(container as Record<string, unknown>, entry.data);
+        });
+      }
+      if (entry.items) {
+        setAtPath(data, path, (container) => {
+          if (Array.isArray(container)) {
+            container.push(...(entry.items as unknown[]));
+          }
+        });
+      }
+      if (entry.errors) {
+        errors.push(...entry.errors);
+      }
+    }
+    for (const completed of payload.completed ?? []) {
+      if (completed.errors) {
+        errors.push(...completed.errors);
+      }
+    }
+  }
+
+  return errors.length > 0
+    ? ({ data, errors } as ExecutionResult)
+    : ({ data } as ExecutionResult);
+};
+
+/**
+ * Translate graphql v17 incremental results into Relay's legacy payload
+ * stream: the initial payload plain, then one payload per deferred fragment /
+ * streamed item with path + label, and is_final on the last payload.
+ *
+ * @experimental Coupled to the graphql v17 RC's 2023 incremental payload
+ * format (pending/incremental/completed) — the reason `graphql` is pinned
+ * exactly. May need adjustment when the RC payload shape changes.
+ */
+export async function* relayFormatAdapter(
+  results: IncrementalResults,
+): AsyncGenerator<RelayLegacyPayload, void, void> {
+  const pendingById = new Map<string, PendingEntry>();
+  const streamCounters = new Map<string, number>();
+  // @stream(initialCount: n): the first incremental item is list index n —
+  // seed each stream counter from the length of the array already delivered
+  // at the pending path in the initial result.
+  const computeInitialIndex = (pending: PendingEntry): number => {
+    let cursor: unknown = results.initialResult.data ?? null;
+    for (const segment of pending.path) {
+      if (cursor == null || typeof cursor !== "object") {
+        return 0;
+      }
+      cursor = (cursor as Record<string | number, unknown>)[segment];
+    }
+    return Array.isArray(cursor) ? cursor.length : 0;
+  };
+  for (const pending of results.initialResult.pending ?? []) {
+    pendingById.set(pending.id, pending);
+  }
+
+  yield {
+    data: (results.initialResult.data ?? null) as Record<
+      string,
+      unknown
+    > | null,
+    ...(results.initialResult.errors?.length
+      ? { errors: results.initialResult.errors }
+      : {}),
+  };
+
+  const buffered: RelayLegacyPayload[] = [];
+  for await (const payload of results.subsequentResults) {
+    for (const pending of payload.pending ?? []) {
+      pendingById.set(pending.id, pending);
+    }
+    for (const entry of payload.incremental ?? []) {
+      const pending = pendingById.get(entry.id);
+      if (!pending) {
+        continue;
+      }
+      if (entry.data !== undefined) {
+        buffered.push({
+          data: entry.data ?? null,
+          path: [...pending.path, ...(entry.subPath ?? [])],
+          ...(pending.label ? { label: pending.label } : {}),
+          ...(entry.errors?.length ? { errors: entry.errors } : {}),
+        });
+      }
+      for (const item of entry.items ?? []) {
+        const index =
+          streamCounters.get(entry.id) ?? computeInitialIndex(pending);
+        streamCounters.set(entry.id, index + 1);
+        buffered.push({
+          data: item as Record<string, unknown>,
+          path: [...pending.path, index],
+          ...(pending.label ? { label: pending.label } : {}),
+        });
+      }
+    }
+    // A deferred fragment that fails entirely is reported ONLY via
+    // completed[{id, errors}] — translate it so legacy clients see the error.
+    for (const completed of payload.completed ?? []) {
+      if (!completed.errors?.length) {
+        continue;
+      }
+      const pending = pendingById.get(completed.id);
+      buffered.push({
+        data: null,
+        errors: completed.errors,
+        ...(pending ? { path: pending.path } : {}),
+        ...(pending?.label ? { label: pending.label } : {}),
+      });
+    }
+    // Flush all but the last buffered payload; the final one needs is_final.
+    if (payload.hasNext) {
+      while (buffered.length > 0) {
+        yield buffered.shift() as RelayLegacyPayload;
+      }
+    }
+  }
+
+  while (buffered.length > 1) {
+    yield buffered.shift() as RelayLegacyPayload;
+  }
+  const last = buffered.shift();
+  if (last) {
+    yield { ...last, extensions: { ...last.extensions, is_final: true } };
+  } else {
+    // Everything was flushed while hasNext was still true (or the final
+    // payload carried only completed[] bookkeeping) — legacy Relay needs
+    // SOME payload with is_final or it treats the operation as incomplete.
+    yield { data: null, extensions: { is_final: true } };
+  }
+}

--- a/packages/runtime/ke-graphql/src/lib/execution/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/index.ts
@@ -1,0 +1,22 @@
+/**
+ * The execution domain: in-process query execution with incremental
+ * delivery, the Relay legacy-format adapter, build-time static
+ * extraction, and the persisted-query manifest builder.
+ *
+ * @module execution
+ */
+
+export type {
+  ExtractStaticOptions,
+  StaticQuery,
+} from "./extractStatic.js";
+export { default as extractStatic } from "./extractStatic.js";
+export {
+  type ExecuteLocalArgs,
+  executeLocal,
+  isIncrementalResults,
+  mergeIncremental,
+  relayFormatAdapter,
+} from "./incremental.js";
+export { createPersistedManifest, sha256Hex } from "./persisted.js";
+export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/execution/persisted.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/persisted.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createPersistedManifest, sha256Hex } from "./persisted.js";
+
+describe("persisted-query manifest", () => {
+  it("hashes with SHA-256 (Relay/Apollo convention)", async () => {
+    // echo -n "{ __typename }" | sha256sum
+    expect(await sha256Hex("{ __typename }")).toBe(
+      "7f56e67dd21ab3f30d1ff8b7bed08893f0a0db86449836189b361dd1e56ddb4b",
+    );
+  });
+
+  it("builds a manifest keyed by hash", async () => {
+    const a = "{ components(first: 1) { edges { cursor } } }";
+    const b = "{ ontologies { prefix } }";
+    const manifest = await createPersistedManifest([a, b]);
+    expect(Object.keys(manifest)).toHaveLength(2);
+    expect(manifest[await sha256Hex(a)]).toBe(a);
+    expect(manifest[await sha256Hex(b)]).toBe(b);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/execution/persisted.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/persisted.ts
@@ -1,0 +1,48 @@
+// =============================================================================
+// Persisted-query manifest: hash → query text, generated at build
+// time from the client's compiled operations (e.g. relay-compiler output).
+// In production the handler accepts only these (allowArbitraryQueries:
+// false), and — because the store is immutable between deploys — responses
+// become pure functions of (hash, variables): infinitely CDN-cacheable
+// until the next deploy.
+// =============================================================================
+
+/**
+ * Hash a string as lowercase SHA-256 hex — the Relay/Apollo persisted-query
+ * hash convention (SHA-256 of the exact operation text). Uses Web Crypto:
+ * platform-neutral (Node 18+, Bun, Workers).
+ */
+export const sha256Hex = async (text: string): Promise<string> => {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+/**
+ * Build a persisted-query manifest (SHA-256 hash → operation text) from
+ * operation texts. Feed the result to the handler:
+ *
+ * ```ts
+ * const manifest = await createPersistedManifest(operationTexts);
+ * createGraphQLHandler(schema, {
+ *   persistedQueries: {
+ *     get: (hash) => manifest[hash] ?? null,
+ *     allowArbitraryQueries: false,
+ *   },
+ *   ...
+ * });
+ * ```
+ */
+export const createPersistedManifest = async (
+  operations: Iterable<string>,
+): Promise<Record<string, string>> => {
+  const manifest: Record<string, string> = {};
+  for (const text of operations) {
+    manifest[await sha256Hex(text)] = text;
+  }
+  return manifest;
+};

--- a/packages/runtime/ke-graphql/src/lib/execution/types.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/types.ts
@@ -1,0 +1,66 @@
+// =============================================================================
+// Shared types for the execution domain: the graphql v17 incremental
+// delivery payload shapes and the Relay legacy payload they translate to.
+// Grouped here because executeLocal, the drain-and-merge fallback, the Relay
+// adapter, and the HTTP handler all exchange these shapes.
+//
+// The structural types mirror the v17 RC shapes rather than importing them:
+// the RC type surface is still settling, and this module is the single
+// place that would absorb a format change.
+// =============================================================================
+
+import type { ExecutionResult } from "graphql";
+
+/** A pending entry announcing a deferred fragment or stream (2023 format). */
+export interface PendingEntry {
+  id: string;
+  path: ReadonlyArray<string | number>;
+  label?: string;
+}
+
+/** One incremental delivery: deferred data or streamed items for a pending id. */
+export interface IncrementalEntry {
+  id: string;
+  data?: Record<string, unknown> | null;
+  items?: ReadonlyArray<unknown>;
+  subPath?: ReadonlyArray<string | number>;
+  errors?: ReadonlyArray<unknown>;
+}
+
+/** A completion notice for a pending id, with errors when the fragment failed. */
+export interface CompletedEntry {
+  id: string;
+  errors?: ReadonlyArray<unknown>;
+}
+
+/** The initial result of an incremental execution (data + pending list). */
+export interface InitialIncrementalResult extends ExecutionResult {
+  pending?: ReadonlyArray<PendingEntry>;
+  hasNext?: boolean;
+}
+
+/** A subsequent incremental payload (2023 format). */
+export interface SubsequentIncrementalResult {
+  pending?: ReadonlyArray<PendingEntry>;
+  incremental?: ReadonlyArray<IncrementalEntry>;
+  completed?: ReadonlyArray<CompletedEntry>;
+  hasNext: boolean;
+}
+
+/** An incremental execution: the initial result plus the payload stream. */
+export interface IncrementalResults {
+  initialResult: InitialIncrementalResult;
+  subsequentResults: AsyncGenerator<SubsequentIncrementalResult, void, void>;
+}
+
+/** What executeLocal returns: a plain result or an incremental stream. */
+export type LocalExecutionResult = ExecutionResult | IncrementalResults;
+
+/** A payload in Relay's legacy incremental shape (path/label, is_final). */
+export interface RelayLegacyPayload {
+  data?: Record<string, unknown> | null;
+  errors?: ReadonlyArray<unknown>;
+  path?: ReadonlyArray<string | number>;
+  label?: string;
+  extensions?: Record<string, unknown>;
+}

--- a/packages/runtime/ke-graphql/src/lib/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/index.ts
@@ -1,9 +1,9 @@
 /**
  * The public library surface of @canonical/ke-graphql, composed from the
- * domain barrels: the compiler pipeline and its artifact codec, and the
- * connection helpers. The internal cross-domain surface (loaders, vocabulary
- * constants, resolver templates) is deliberately not re-exported. Local/static
- * execution and the ke plugin are layered on top of this core.
+ * domain barrels: the compiler pipeline and its artifact codec, the ke
+ * plugin, local/static execution, and the connection helpers. The internal
+ * cross-domain surface (loaders, vocabulary constants, resolver templates)
+ * is deliberately not re-exported.
  *
  * @module lib
  */
@@ -58,6 +58,19 @@ export {
   type SchemaPluginExtra,
 } from "./createSchemaPlugin.js";
 export { toFull, toPrefixed } from "./dataloader/index.js";
+export {
+  createPersistedManifest,
+  executeLocal,
+  extractStatic,
+  type IncrementalResults,
+  isIncrementalResults,
+  type LocalExecutionResult,
+  mergeIncremental,
+  type RelayLegacyPayload,
+  relayFormatAdapter,
+  type StaticQuery,
+  sha256Hex,
+} from "./execution/index.js";
 export {
   clampConnectionArgs,
   createDepthLimitRule,

--- a/packages/runtime/ke-graphql/src/testing/integration/hardening.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/hardening.test.ts
@@ -1,0 +1,89 @@
+// =============================================================================
+// Hardening behaviors that need a compiled schema end-to-end: the forced-
+// abstract-with-instances guard (correctness C1 + V015) and the SPARQL
+// injection guard reaching through node(id:) to a null result.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { afterEach, describe, expect, it } from "vitest";
+import { compile, createStoreQueryFn } from "#compiler";
+import { executeLocal, isIncrementalResults } from "#execution";
+
+const PREFIXES = { ex: "http://example.org/" };
+
+// A class with a subclass AND a named instance of the parent itself — the only
+// shape that can trip the forced-abstract crash.
+const HIERARCHY_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Animal a owl:Class ; rdfs:label "Animal" .
+ex:Dog a owl:Class ; rdfs:subClassOf ex:Animal ; rdfs:label "Dog" .
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Animal ; rdfs:range xsd:string .
+
+ex:a1 a ex:Animal ; ex:name "Generic" .
+ex:d1 a ex:Dog ; ex:name "Rex" .
+`;
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const compileHierarchy = async () => {
+  const { store, cleanup } = await createTestStore({
+    ttl: HIERARCHY_TTL,
+    prefixes: PREFIXES,
+  });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, {
+    mappings: { "http://example.org/Animal": { abstract: true } },
+  });
+  return { result, store };
+};
+
+describe("forced abstract with direct instances (C1 + V015)", () => {
+  it("warns (V015) when the data contradicts an abstract mapping", async () => {
+    const { result } = await compileHierarchy();
+    expect(result.diagnostics.some((d) => d.code === "V015")).toBe(true);
+  });
+
+  it("filters the abstract-only instance instead of crashing resolveType", async () => {
+    const { result, store } = await compileHierarchy();
+    const context = result.createContext(store);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: `{ node(id: "ex:a1") { __typename } }`,
+      contextValue: context,
+    });
+    expect(isIncrementalResults(execution)).toBe(false);
+    if (!isIncrementalResults(execution)) {
+      // No "Abstract type ... resolved to a non-object type" error.
+      expect(execution.errors).toBeUndefined();
+      expect(execution.data?.node).toBeNull();
+    }
+  });
+
+  it("still resolves a concrete subclass instance to its concrete type", async () => {
+    const { result, store } = await compileHierarchy();
+    const context = result.createContext(store);
+    const execution = await executeLocal({
+      schema: result.schema,
+      source: `{ node(id: "ex:d1") { __typename } }`,
+      contextValue: context,
+    });
+    if (!isIncrementalResults(execution)) {
+      expect(execution.errors).toBeUndefined();
+      expect((execution.data?.node as { __typename: string }).__typename).toBe(
+        "Dog",
+      );
+    }
+  });
+});


### PR DESCRIPTION
> Split of the former cluster #671. Part 5b of 2. **Stacked on #676** (core + plugin). Followed by `/http`, CLI, demo.

## Done

The **execution domain** — split out of the core because it's the one domain genuinely independent of the compiler passes:

- **`executeLocal`** — in-process execution (SSR/tests/scripts) with graphql v17 incremental delivery (`@defer`/`@stream`).
- **`relayFormatAdapter`** — translates v17 incremental payloads to Relay's legacy multipart shape.
- **`extractStatic`** — build-time static-query extraction (Path B).
- **`createPersistedManifest` / `sha256Hex`** — the persisted-query manifest builder.
- the **hardening** integration suite (which exercises `executeLocal`).

Adds the execution surface to the public library barrel, completing it.

## QA

```bash
cd packages/runtime/ke-graphql && bun run check && bun run test
```
biome + `tsc` + webarchitect green; **322 tests, 100/100/100/100** (the full library).

### PR readiness check
- [x] `Feature 🎁`; Conventional Commits; [code standards](https://github.com/canonical/web-code-standards); colocated tests; `no visual change`.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_