### PR TITLE
feat(ke-graphql): compiler core + plugin [base main]

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/compiler/CompilationError.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/CompilationError.ts
@@ -1,0 +1,21 @@
+import type { Diagnostic } from "#shared";
+
+/**
+ * Thrown only when schema composition fails (C-series errors) — carries the
+ * full diagnostic list of the compilation, not just the fatal ones, so the
+ * consumer can report everything at once.
+ */
+export default class CompilationError extends Error {
+  readonly diagnostics: Diagnostic[];
+
+  constructor(diagnostics: Diagnostic[]) {
+    const errors = diagnostics.filter((d) => d.severity === "error");
+    super(
+      `ke-graphql: schema composition failed with ${errors.length} error(s):\n${errors
+        .map((d) => `  ${d.code}: ${d.message}`)
+        .join("\n")}`,
+    );
+    this.name = "CompilationError";
+    this.diagnostics = diagnostics;
+  }
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/artifact.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/artifact.ts
@@ -1,0 +1,113 @@
+// =============================================================================
+// The precompute artifact (Prisma-DMMF pattern): RawExtraction is the only
+// store-dependent pass output and is fully serializable. Build once with the
+// store; rebuild the executable schema anywhere in milliseconds — no Oxigraph,
+// no TTL parse, no SPARQL.
+//
+// `sourcesHash` keeps the artifact honest: it fingerprints the TTL inputs
+// (FNV-1a 64 — staleness detection, not security), and consumers fall back
+// to a live compile when it no longer matches the loaded sources.
+// =============================================================================
+
+import type { RawExtraction } from "#shared";
+import { ARTIFACT_VERSION } from "./constants.js";
+import type { SerializedExtraction } from "./types.js";
+
+/** FNV-1a 64-bit hash of a string. Deterministic, dependency-free, platform-free. */
+const hashFnv1a64 = (input: string, seed = 0xcbf29ce484222325n): bigint => {
+  const PRIME = 0x100000001b3n;
+  const MASK = 0xffffffffffffffffn;
+  let hash = seed;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= BigInt(input.charCodeAt(i));
+    hash = (hash * PRIME) & MASK;
+  }
+  return hash;
+};
+
+/**
+ * Fingerprint a set of source contents as a 16-character hex string
+ * (FNV-1a 64 — staleness detection, not security). Order-independent
+ * (sources are combined commutatively) so glob ordering differences don't
+ * churn the hash.
+ */
+export const hashSources = (contents: Iterable<string>): string => {
+  let combined = 0n;
+  for (const content of contents) {
+    combined ^= hashFnv1a64(content);
+  }
+  return combined.toString(16).padStart(16, "0");
+};
+
+/**
+ * Serialize a RawExtraction (plus the fingerprint of the sources it was
+ * built from) to the JSON artifact format — the input for artifact boots
+ * via compileFromExtraction.
+ */
+export const serializeExtraction = (
+  extraction: RawExtraction,
+  sourcesHash: string,
+): string =>
+  JSON.stringify(
+    {
+      version: ARTIFACT_VERSION,
+      sourcesHash,
+      classes: extraction.classes,
+      properties: extraction.properties,
+      inverses: extraction.inverses,
+      functionals: [...extraction.functionals],
+      datatypes: extraction.datatypes,
+      namespaces: [...extraction.namespaces],
+      shaclConstraints: extraction.shaclConstraints,
+      unions: extraction.unions,
+      instanceStats: [...extraction.instanceStats],
+      selfReferential: [...extraction.selfReferential],
+      functionalViolations: [...extraction.functionalViolations],
+      undeclaredPredicates: [...extraction.undeclaredPredicates],
+      annotations: [...extraction.annotations].map(([target, values]) => [
+        target,
+        [...values],
+      ]),
+      deepBlankNesting: extraction.deepBlankNesting,
+    } satisfies SerializedExtraction,
+    null,
+    0,
+  );
+
+/**
+ * Parse a serialized extraction artifact (JSON text or already-parsed
+ * object) back into a RawExtraction plus its sources fingerprint. Throws
+ * when the artifact's format version is not the supported one.
+ */
+export const deserializeExtraction = (
+  artifact: string | SerializedExtraction,
+): { extraction: RawExtraction; sourcesHash: string } => {
+  const parsed: SerializedExtraction =
+    typeof artifact === "string" ? JSON.parse(artifact) : artifact;
+  if (parsed.version !== ARTIFACT_VERSION) {
+    throw new Error(
+      `ke-graphql: extraction artifact version ${parsed.version} is not supported (expected ${ARTIFACT_VERSION}) — regenerate it`,
+    );
+  }
+  return {
+    sourcesHash: parsed.sourcesHash,
+    extraction: {
+      classes: parsed.classes,
+      properties: parsed.properties,
+      inverses: parsed.inverses,
+      functionals: new Set(parsed.functionals),
+      datatypes: parsed.datatypes,
+      namespaces: new Map(parsed.namespaces),
+      shaclConstraints: parsed.shaclConstraints,
+      unions: parsed.unions,
+      instanceStats: new Map(parsed.instanceStats),
+      selfReferential: new Set(parsed.selfReferential),
+      functionalViolations: new Set(parsed.functionalViolations),
+      undeclaredPredicates: new Set(parsed.undeclaredPredicates),
+      annotations: new Map(
+        parsed.annotations.map(([target, values]) => [target, new Map(values)]),
+      ),
+      deepBlankNesting: parsed.deepBlankNesting,
+    },
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/compiler/compile.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compile.ts
@@ -1,0 +1,28 @@
+import type { QueryFn } from "#shared";
+import extract from "./extract.js";
+import runPasses from "./runPasses.js";
+import type { CompilerResult, SchemaPluginOptions } from "./types.js";
+
+/**
+ * Run the full seven-pass pipeline against a query surface (ke
+ * PluginContext.query at plugin time, or createStoreQueryFn(store) directly).
+ *
+ * The schema is produced whenever composition succeeds — error diagnostics
+ * from earlier passes do not abort compilation (tsc model); only
+ * composition failure stops schema creation. The
+ * consumer decides its failure policy. Throws CompilationError only when
+ * composition fails.
+ *
+ * @note Impure — Pass 1 executes SPARQL queries against the store through
+ * the provided query function.
+ */
+export default async function compile(
+  query: QueryFn,
+  prefixes: Readonly<Record<string, string>>,
+  options: SchemaPluginOptions = {},
+): Promise<CompilerResult> {
+  const extracted = await extract(query, prefixes);
+  return runPasses(extracted.output, options, {
+    diagnostics: extracted.diagnostics,
+  });
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/compileFromExtraction.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compileFromExtraction.ts
@@ -1,0 +1,21 @@
+import { deserializeExtraction } from "./artifact.js";
+import runPasses from "./runPasses.js";
+import type {
+  CompilerResult,
+  SchemaPluginOptions,
+  SerializedExtraction,
+} from "./types.js";
+
+/**
+ * Rebuild the executable schema from a precomputed extraction artifact —
+ * Passes 2-7 only, pure JS, no store. validateSchema/printSchema are skipped
+ * by default (assumeValid): the artifact was validated when it was built.
+ */
+export default function compileFromExtraction(
+  artifact: string | SerializedExtraction,
+  options: SchemaPluginOptions = {},
+  { assumeValid = true }: { assumeValid?: boolean } = {},
+): CompilerResult {
+  const { extraction } = deserializeExtraction(artifact);
+  return runPasses(extraction, options, { skipValidation: assumeValid });
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/compose.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compose.test.ts
@@ -1,0 +1,290 @@
+import { GraphQLString } from "graphql";
+import { describe, expect, it } from "vitest";
+import type { InterfacePlan, MappedIR, NameMap, TypePlan } from "#shared";
+import compose from "./compose.js";
+import type { FieldPlan, SchemaPlan } from "./emit.js";
+import type { SchemaExtensionsInput } from "./types.js";
+
+const nameMap: NameMap = {
+  toGraphQL: () => undefined,
+  toOWL: () => undefined,
+  entries: () => [][Symbol.iterator](),
+};
+
+// Minimal MappedIR: buildTBoxSchema reads `ir` only inside resolver thunks,
+// none of which run during composition.
+const mapped = {
+  types: new Map(),
+  interfaces: new Map(),
+  unions: new Map(),
+  nameMap,
+  namespaces: new Map(),
+  ir: {
+    classes: new Map(),
+    properties: new Map(),
+    namespaces: new Map(),
+    extraction: {} as MappedIR["ir"]["extraction"],
+  },
+} as unknown as MappedIR;
+
+const emptyPlan = (over: Partial<SchemaPlan> = {}): SchemaPlan => ({
+  types: new Map(),
+  interfaces: new Map(),
+  unions: new Map(),
+  queryFields: new Map(),
+  mapped,
+  ...over,
+});
+
+const objectPlan = (name: string, fields: TypePlan["fields"]): TypePlan => ({
+  name,
+  interfaces: [],
+  fields,
+  embeddable: false,
+});
+
+const interfacePlan = (name: string): InterfacePlan => ({
+  name,
+  parents: [],
+  fields: new Map(),
+  embeddableOnly: false,
+});
+
+describe("compose validation failures (C003)", () => {
+  it("reports a validateSchema error and nulls the schema", () => {
+    // An object type with zero fields fails validateSchema ("must define one
+    // or more fields") without throwing during construction.
+    const plan = emptyPlan({
+      types: new Map([["Empty", objectPlan("Empty", new Map())]]),
+    });
+    const { output, diagnostics } = compose(plan);
+    expect(output.schema).toBeNull();
+    expect(output.sdl).toBe("");
+    const c003 = diagnostics.filter((d) => d.code === "C003");
+    expect(c003.length).toBeGreaterThan(0);
+    expect(c003[0]?.severity).toBe("error");
+    expect(c003.some((d) => /Empty/.test(d.message))).toBe(true);
+  });
+
+  it("skipValidation leaves the (unvalidated) schema and empty SDL", () => {
+    const plan = emptyPlan({
+      types: new Map([["Empty", objectPlan("Empty", new Map())]]),
+    });
+    const { output, diagnostics } = compose(plan, { skipValidation: true });
+    // No validation ran: the schema object is kept, SDL is not printed.
+    expect(output.schema).not.toBeNull();
+    expect(output.sdl).toBe("");
+    expect(diagnostics.filter((d) => d.code === "C003")).toHaveLength(0);
+  });
+
+  it("catches a thrown schema-construction error as C003", () => {
+    // A generated interface and a generated object type sharing a name make
+    // the GraphQLSchema constructor throw ("multiple types named …"); the
+    // throw is caught and surfaced as C003 with a null schema.
+    const plan = emptyPlan({
+      types: new Map([
+        [
+          "Dup",
+          objectPlan(
+            "Dup",
+            new Map([
+              [
+                "field",
+                {
+                  name: "field",
+                  type: {
+                    base: "String",
+                    kind: "scalar",
+                    list: false,
+                    nonNull: false,
+                  },
+                },
+              ],
+            ]),
+          ),
+        ],
+      ]),
+      interfaces: new Map([["Dup", interfacePlan("Dup")]]),
+    });
+    const { output, diagnostics } = compose(plan);
+    expect(output.schema).toBeNull();
+    const c003 = diagnostics.filter((d) => d.code === "C003");
+    expect(c003.length).toBeGreaterThan(0);
+    expect(c003.some((d) => /Dup/.test(d.message))).toBe(true);
+  });
+});
+
+const scalarField = (name: string, nonNull = false): FieldPlan => ({
+  name,
+  type: { base: "String", kind: "scalar", list: false, nonNull },
+});
+
+describe("compose full construction", () => {
+  it("builds unions, connections, args, and merges extensions", () => {
+    // ── interface Named { name: String } ──
+    const named: InterfacePlan = {
+      name: "Named",
+      parents: [],
+      fields: new Map([["name", scalarField("name")]]),
+      embeddableOnly: false,
+    };
+
+    // ── type Thing implements Named ──
+    const thingFields = new Map<string, FieldPlan>([
+      ["name", scalarField("name")],
+      // base resolves to no known type → findNamedType returns undefined and
+      // the type falls back to String (the ?? GraphQLString branch).
+      [
+        "mystery",
+        {
+          name: "mystery",
+          type: { base: "Missing", kind: "named", list: false, nonNull: false },
+        },
+      ],
+      // a connection whose base is also unknown → the edge node type uses the
+      // same String fallback inside getConnectionType.
+      [
+        "links",
+        {
+          name: "links",
+          type: {
+            base: "Missing",
+            kind: "connection",
+            list: false,
+            nonNull: true,
+          },
+          connectionArgs: true,
+        },
+      ],
+      // static args: one required, one optional, plus a bogus scalar type that
+      // exercises the SCALARS[...] ?? GraphQLString fallback.
+      [
+        "lookup",
+        {
+          name: "lookup",
+          type: { base: "String", kind: "scalar", list: false, nonNull: false },
+          args: {
+            id: { type: "ID", required: true },
+            q: { type: "String", required: false },
+            weird: { type: "Decimal" as "String", required: false },
+          },
+        },
+      ],
+    ]);
+    const thing: TypePlan = {
+      name: "Thing",
+      interfaces: ["Named"],
+      fields: thingFields,
+      embeddable: false,
+    };
+
+    // ── union Shape = Thing ──
+    const plan: SchemaPlan = emptyPlan({
+      types: new Map([["Thing", thing]]),
+      interfaces: new Map([["Named", named]]),
+      unions: new Map([["Shape", { name: "Shape", members: ["Thing"] }]]),
+      queryFields: new Map<string, FieldPlan>([
+        [
+          "thing",
+          {
+            name: "thing",
+            type: { base: "Thing", kind: "named", list: false, nonNull: false },
+          },
+        ],
+        [
+          "shape",
+          {
+            name: "shape",
+            type: { base: "Shape", kind: "named", list: false, nonNull: false },
+          },
+        ],
+      ]),
+    });
+
+    const ifaceSeen: Array<string | undefined> = [];
+    const extensions: SchemaExtensionsInput = (types) => {
+      // exercise the factory-form lookups: a generated interface, Node, and a
+      // miss (the iface ?? Node ?? undefined chain), plus a type lookup.
+      ifaceSeen.push(types.iface("Named")?.name);
+      ifaceSeen.push(types.iface("Node")?.name);
+      ifaceSeen.push(types.iface("Nope")?.name);
+      types.type("Thing");
+      return {
+        Thing: {
+          extra: { type: GraphQLString }, // new → merged
+          name: { type: GraphQLString }, // conflicts → C002
+        },
+        Query: {
+          newRoot: { type: GraphQLString }, // new → merged
+          thing: { type: GraphQLString }, // conflicts → C002
+        },
+      };
+    };
+
+    const { output, diagnostics } = compose(plan, { extensions });
+    expect(output.schema).not.toBeNull();
+    expect(output.sdl).toContain("union Shape = Thing");
+    expect(output.sdl).toContain("type Thing implements Named");
+    // connection + edge synthesized for the unknown base
+    expect(output.sdl).toContain("MissingConnection");
+
+    // factory lookups resolved as expected
+    expect(ifaceSeen).toEqual(["Named", "Node", undefined]);
+
+    // both conflicts surfaced; both new fields merged in
+    const c002 = diagnostics.filter((d) => d.code === "C002");
+    expect(c002.map((d) => d.message).sort()).toEqual([
+      "extension field Query.thing conflicts with a generated field",
+      "extension field Thing.name conflicts with a generated field",
+    ]);
+    expect(output.sdl).toContain("extra: String");
+    expect(output.sdl).toContain("newRoot: String");
+    // no C001: every extended type exists
+    expect(diagnostics.filter((d) => d.code === "C001")).toHaveLength(0);
+  });
+
+  it("surfaces a C002 extension conflict even under skipValidation", () => {
+    // The artifact-boot fast path skips validateSchema (which normally triggers
+    // the field thunks where conflicts are detected), but an extension field
+    // colliding with a generated one is still fatal and must surface.
+    const plan = emptyPlan({
+      types: new Map([
+        [
+          "Thing",
+          objectPlan("Thing", new Map([["name", scalarField("name")]])),
+        ],
+      ]),
+    });
+    const extensions: SchemaExtensionsInput = {
+      Thing: { name: { type: GraphQLString } },
+    };
+    const { diagnostics } = compose(plan, {
+      extensions,
+      skipValidation: true,
+    });
+    expect(
+      diagnostics.filter((d) => d.code === "C002").map((d) => d.message),
+    ).toContain("extension field Thing.name conflicts with a generated field");
+  });
+
+  it("C001 — object-form extension references an unknown type", () => {
+    const thing: TypePlan = {
+      name: "Thing",
+      interfaces: [],
+      fields: new Map([["name", scalarField("name")]]),
+      embeddable: false,
+    };
+    const extensions: SchemaExtensionsInput = {
+      Ghost: { extra: { type: GraphQLString } },
+    };
+    const { output, diagnostics } = compose(
+      emptyPlan({ types: new Map([["Thing", thing]]) }),
+      { extensions },
+    );
+    expect(output.schema).not.toBeNull();
+    expect(diagnostics.filter((d) => d.code === "C001")).toHaveLength(1);
+    expect(diagnostics.find((d) => d.code === "C001")?.message).toContain(
+      "Ghost",
+    );
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/compose.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compose.ts
@@ -1,0 +1,419 @@
+// =============================================================================
+// Pass 7 — Compose: SchemaPlan + TBox + extensions → GraphQLSchema
+//
+// The single place where graphql-js type objects are constructed (they are
+// immutable once constructed). Field thunks resolve circular references;
+// connection types are created on demand per base type; every interface and
+// union gets resolveType reading EntityValue.typename; extensions (object or
+// factory form) are validated (C001/C002); the composed schema runs
+// validateSchema (C003) and is printed to SDL for the Relay compiler.
+// =============================================================================
+
+import {
+  GraphQLBoolean,
+  GraphQLDeferDirective,
+  type GraphQLFieldConfig,
+  type GraphQLFieldConfigArgumentMap,
+  type GraphQLFieldConfigMap,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  type GraphQLNullableOutputType,
+  GraphQLObjectType,
+  type GraphQLOutputType,
+  type GraphQLScalarType,
+  GraphQLSchema,
+  GraphQLStreamDirective,
+  GraphQLString,
+  GraphQLUnionType,
+  printSchema,
+  specifiedDirectives,
+  validateSchema,
+} from "graphql";
+import {
+  CONNECTION_ARGS,
+  type CompilerContext,
+  type Diagnostic,
+  type EntityValue,
+  type PassResult,
+} from "#shared";
+import { buildTBoxSchema } from "#tbox";
+import type { FieldPlan, SchemaPlan, TypeRef } from "./emit.js";
+import type { SchemaExtensionsInput } from "./types.js";
+
+const PHASE = "compose";
+
+const SCALARS: Record<string, GraphQLScalarType> = {
+  String: GraphQLString,
+  Boolean: GraphQLBoolean,
+  Int: GraphQLInt,
+  Float: GraphQLFloat,
+  ID: GraphQLID,
+};
+
+/** Options for the composition pass (extensions, directives, validation). */
+export interface ComposeOptions {
+  extensions?: SchemaExtensionsInput;
+  incremental?: boolean;
+  /**
+   * Skip validateSchema + printSchema (artifact boots: the schema is a
+   * deterministic rebuild of an extraction that was validated when the
+   * artifact was produced; the SDL is a build artifact, not a runtime need).
+   */
+  skipValidation?: boolean;
+}
+
+/** Composition output: the schema (null on C003 failure) and its SDL. */
+export interface ComposedSchema {
+  schema: GraphQLSchema | null;
+  sdl: string;
+}
+
+/**
+ * Compose the executable GraphQLSchema from the SchemaPlan, the TBox schema,
+ * and consumer extensions (Pass 7). Extension conflicts surface as C001/C002
+ * diagnostics; validateSchema failures as C003. Pure construction — the
+ * resulting schema performs I/O only when executed.
+ */
+export default function compose(
+  plan: SchemaPlan,
+  options: ComposeOptions = {},
+): PassResult<ComposedSchema> {
+  const diagnostics: Diagnostic[] = [];
+
+  // ── shared structural types ──
+  const resolveTypename = (value: unknown): string | undefined =>
+    (value as EntityValue | undefined)?.typename;
+
+  const nodeInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
+    name: "Node",
+    fields: () => ({
+      id: { type: new GraphQLNonNull(GraphQLID) },
+      uri: { type: new GraphQLNonNull(GraphQLString) },
+    }),
+    resolveType: resolveTypename,
+  });
+
+  const pageInfo = new GraphQLObjectType({
+    name: "PageInfo",
+    fields: {
+      hasNextPage: { type: new GraphQLNonNull(GraphQLBoolean) },
+      hasPreviousPage: { type: new GraphQLNonNull(GraphQLBoolean) },
+      startCursor: { type: GraphQLString },
+      endCursor: { type: GraphQLString },
+    },
+  });
+
+  // ── registries with lazy construction ──
+  const objectTypes = new Map<string, GraphQLObjectType>();
+  const interfaceTypes = new Map<string, GraphQLInterfaceType>();
+  const unionTypes = new Map<string, GraphQLUnionType>();
+  const connectionTypes = new Map<string, GraphQLObjectType>();
+
+  const findNamedType = (name: string): GraphQLNullableOutputType | undefined =>
+    objectTypes.get(name) ??
+    interfaceTypes.get(name) ??
+    unionTypes.get(name) ??
+    (name === "Node" ? nodeInterface : undefined) ??
+    (name === "EntityMeta" ? tbox.entityMeta : undefined) ??
+    SCALARS[name];
+
+  const getConnectionType = (base: string): GraphQLObjectType => {
+    let connection = connectionTypes.get(`${base}Connection`);
+    if (connection) {
+      return connection;
+    }
+    const edge = new GraphQLObjectType({
+      name: `${base}Edge`,
+      fields: () => ({
+        node: {
+          type: new GraphQLNonNull(findNamedType(base) ?? GraphQLString),
+          resolve: (parent: { node: EntityValue }) => parent.node,
+        },
+        cursor: { type: new GraphQLNonNull(GraphQLString) },
+      }),
+    });
+    connection = new GraphQLObjectType({
+      name: `${base}Connection`,
+      fields: () => ({
+        edges: {
+          type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(edge))),
+        },
+        pageInfo: { type: new GraphQLNonNull(pageInfo) },
+      }),
+    });
+    connectionTypes.set(`${base}Connection`, connection);
+    return connection;
+  };
+
+  const buildOutputType = (ref: TypeRef): GraphQLOutputType => {
+    const base: GraphQLNullableOutputType =
+      ref.kind === "connection"
+        ? getConnectionType(ref.base)
+        : (findNamedType(ref.base) ?? GraphQLString);
+    if (ref.kind !== "connection" && ref.list) {
+      // List fields are always [T!]!: resolvers filter missing
+      // items rather than nulling them, and an empty list is the default.
+      return new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(base)));
+    }
+    return ref.nonNull ? new GraphQLNonNull(base) : base;
+  };
+
+  const buildArgs = (plan: FieldPlan): GraphQLFieldConfigArgumentMap => {
+    const args: GraphQLFieldConfigArgumentMap = {};
+    if (plan.connectionArgs) {
+      Object.assign(args, CONNECTION_ARGS);
+    }
+    for (const [name, spec] of Object.entries(plan.args ?? {})) {
+      const scalar = SCALARS[spec.type] ?? GraphQLString;
+      args[name] = {
+        type: spec.required ? new GraphQLNonNull(scalar) : scalar,
+      };
+    }
+    return args;
+  };
+
+  const buildFieldConfig = (
+    plan: FieldPlan,
+  ): GraphQLFieldConfig<EntityValue, CompilerContext> => ({
+    type: buildOutputType(plan.type),
+    args: buildArgs(plan),
+    resolve: plan.resolve,
+    description: plan.description,
+  });
+
+  const buildFieldsConfig = (
+    fields: Map<string, FieldPlan>,
+  ): GraphQLFieldConfigMap<EntityValue, CompilerContext> => {
+    const config: GraphQLFieldConfigMap<EntityValue, CompilerContext> = {};
+    for (const [name, plan] of fields) {
+      config[name] = buildFieldConfig(plan);
+    }
+    return config;
+  };
+
+  // ── TBox (needs the Node interface and the NodeConnection factory) ──
+  const tbox = buildTBoxSchema(plan.mapped, nodeInterface, () =>
+    getConnectionType("Node"),
+  );
+
+  // ── generated interfaces ──
+  for (const iface of plan.interfaces.values()) {
+    interfaceTypes.set(
+      iface.name,
+      new GraphQLInterfaceType({
+        name: iface.name,
+        description: iface.description,
+        interfaces: () =>
+          iface.parents
+            .map((p) => (p === "Node" ? nodeInterface : interfaceTypes.get(p)))
+            .filter((i): i is GraphQLInterfaceType => i !== undefined),
+        fields: () => buildFieldsConfig(iface.fields),
+        resolveType: resolveTypename,
+      }),
+    );
+  }
+
+  // ── generated unions ──
+  for (const union of plan.unions.values()) {
+    unionTypes.set(
+      union.name,
+      new GraphQLUnionType({
+        name: union.name,
+        types: () =>
+          union.members
+            .map((m) => objectTypes.get(m))
+            .filter((t): t is GraphQLObjectType => t !== undefined),
+        resolveType: resolveTypename,
+      }),
+    );
+  }
+
+  // ── extensions (validated below, merged into type construction) ──
+  const resolveExtensions = (
+    input: SchemaExtensionsInput | undefined,
+  ): Record<
+    string,
+    Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>>
+  > => {
+    if (!input) {
+      return {};
+    }
+    if (typeof input === "function") {
+      return input({
+        type: (name) => objectTypes.get(name),
+        iface: (name) =>
+          interfaceTypes.get(name) ??
+          (name === "Node" ? nodeInterface : undefined),
+      });
+    }
+    return input;
+  };
+
+  // Extension lookup is lazy (inside field thunks) so the factory form can
+  // reference generated types that exist by the time fields are resolved.
+  let extensionsCache:
+    | Record<
+        string,
+        Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>>
+      >
+    | undefined;
+  const getExtensionFields = (
+    typeName: string,
+  ): Record<string, GraphQLFieldConfig<EntityValue, CompilerContext>> => {
+    extensionsCache ??= resolveExtensions(options.extensions);
+    return extensionsCache[typeName] ?? {};
+  };
+
+  // ── generated object types ──
+  for (const type of plan.types.values()) {
+    objectTypes.set(
+      type.name,
+      new GraphQLObjectType<EntityValue, CompilerContext>({
+        name: type.name,
+        description: type.description,
+        interfaces: () =>
+          type.interfaces
+            .map((i) => (i === "Node" ? nodeInterface : interfaceTypes.get(i)))
+            .filter((i): i is GraphQLInterfaceType => i !== undefined),
+        fields: () => {
+          const generated = buildFieldsConfig(type.fields);
+          for (const [name, config] of Object.entries(
+            getExtensionFields(type.name),
+          )) {
+            if (generated[name]) {
+              diagnostics.push({
+                severity: "error",
+                code: "C002",
+                message: `extension field ${type.name}.${name} conflicts with a generated field`,
+                phase: PHASE,
+              });
+              continue;
+            }
+            generated[name] = config;
+          }
+          return generated;
+        },
+      }),
+    );
+  }
+
+  // C001 — extensions referencing unknown types (Query is always known).
+  extensionsCache ??= resolveExtensions(options.extensions);
+  for (const typeName of Object.keys(extensionsCache)) {
+    if (typeName !== "Query" && !plan.types.has(typeName)) {
+      diagnostics.push({
+        severity: "error",
+        code: "C001",
+        message: `extension references unknown type ${typeName}`,
+        phase: PHASE,
+      });
+    }
+  }
+
+  // ── Query ──
+  const queryType = new GraphQLObjectType<unknown, CompilerContext>({
+    name: "Query",
+    fields: () => {
+      const fields: GraphQLFieldConfigMap<unknown, CompilerContext> = {
+        ...tbox.queryFields,
+      };
+      for (const [name, fieldPlan] of plan.queryFields) {
+        fields[name] = buildFieldConfig(fieldPlan) as GraphQLFieldConfig<
+          unknown,
+          CompilerContext
+        >;
+      }
+      for (const [name, config] of Object.entries(
+        getExtensionFields("Query"),
+      )) {
+        if (fields[name]) {
+          diagnostics.push({
+            severity: "error",
+            code: "C002",
+            message: `extension field Query.${name} conflicts with a generated field`,
+            phase: PHASE,
+          });
+          continue;
+        }
+        fields[name] = config as GraphQLFieldConfig<unknown, CompilerContext>;
+      }
+      return fields;
+    },
+  });
+
+  // ── schema ──
+  // Embeddable-only interfaces and their implementors may be unreachable
+  // from Query; list every generated type explicitly so they are retained.
+  const allTypes = [
+    ...objectTypes.values(),
+    ...interfaceTypes.values(),
+    ...unionTypes.values(),
+    tbox.entityMeta,
+  ];
+
+  const directives = options.incremental
+    ? [...specifiedDirectives, GraphQLDeferDirective, GraphQLStreamDirective]
+    : [...specifiedDirectives];
+
+  let schema: GraphQLSchema | null = null;
+  let sdl = "";
+  try {
+    // GraphQLObjectType constructors validate names eagerly; field thunks
+    // run during validateSchema — both belong under the C003 umbrella so a
+    // bad name surfaces as a diagnostic, not a raw GraphQLError.
+    schema = new GraphQLSchema({
+      query: queryType,
+      types: allTypes,
+      directives,
+    });
+    if (!options.skipValidation) {
+      const validationErrors = validateSchema(schema);
+      for (const error of validationErrors) {
+        diagnostics.push({
+          severity: "error",
+          code: "C003",
+          message: error.message,
+          phase: PHASE,
+        });
+      }
+      if (validationErrors.length > 0) {
+        schema = null;
+      } else {
+        sdl = printSchema(schema);
+      }
+    } else if (options.extensions) {
+      // Skipping full validation (the artifact-boot fast path) must still honor
+      // the fatal C001/C002 contract. validateSchema normally triggers the
+      // field thunks where extension conflicts are detected; force them here so
+      // a C002 conflict surfaces as a diagnostic instead of silently dropping
+      // the extension field.
+      for (const type of [queryType, ...objectTypes.values()]) {
+        type.getFields();
+      }
+    }
+  } catch (error) {
+    // The only throw sites inside this try are graphql-js schema construction,
+    // validateSchema, and printSchema; all throw Error instances, so the
+    // non-Error else fallback below cannot be reached in practice.
+    let message: string;
+    /* v8 ignore else */
+    if (error instanceof Error) {
+      message = error.message;
+    } else {
+      message = String(error);
+    }
+    diagnostics.push({
+      severity: "error",
+      code: "C003",
+      message,
+      phase: PHASE,
+    });
+    schema = null;
+  }
+
+  return { output: { schema, sdl }, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.test.ts
@@ -1,0 +1,67 @@
+import type { Store } from "@canonical/ke";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MappedIR, NameMap, NamespaceInfo } from "#shared";
+import createContextFactory from "./createContextFactory.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const nameMap: NameMap = {
+  toGraphQL: () => undefined,
+  toOWL: () => undefined,
+  entries: () => [][Symbol.iterator](),
+};
+
+const namespaces = new Map<string, NamespaceInfo>();
+
+// Minimal MappedIR: the loaders read `mapped` only inside their batch
+// functions (never invoked here — no .load() call), so empty maps suffice.
+const mapped = {
+  types: new Map(),
+  interfaces: new Map(),
+  unions: new Map(),
+  nameMap,
+  namespaces,
+  ir: {
+    classes: new Map(),
+    properties: new Map(),
+    namespaces: new Map(),
+    extraction: {} as MappedIR["ir"]["extraction"],
+  },
+} as unknown as MappedIR;
+
+const store = {} as Store;
+
+describe("default runtime-warning handler", () => {
+  it("logs each distinct (property, value) coercion failure exactly once", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ctx = createContextFactory(mapped, {})(store);
+
+    ctx.warn({ property: "ex:count", value: "x", reason: "not an integer" });
+    // identical key — deduplicated, no second log
+    ctx.warn({ property: "ex:count", value: "x", reason: "not an integer" });
+    // distinct value — logged
+    ctx.warn({ property: "ex:count", value: "y", reason: "not an integer" });
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      'cannot coerce "x" on ex:count',
+    );
+    expect(String(warn.mock.calls[0]?.[0])).toContain("not an integer");
+  });
+
+  it("uses the supplied onRuntimeWarning handler when provided", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const seen: string[] = [];
+    const ctx = createContextFactory(mapped, {
+      onRuntimeWarning: (w) => seen.push(w.value),
+    })(store);
+
+    ctx.warn({ property: "ex:count", value: "z", reason: "nope" });
+    ctx.warn({ property: "ex:count", value: "z", reason: "nope" });
+
+    expect(seen).toEqual(["z", "z"]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/createContextFactory.ts
@@ -1,0 +1,95 @@
+import type { SPARQL, Store } from "@canonical/ke";
+import {
+  createEntityLoader,
+  createInverseLoader,
+  createListLoader,
+} from "#dataloader";
+import { createBoundedCache, DEFAULT_PROCESS_CACHE_SIZE } from "#hardening";
+import type {
+  EntityValue,
+  MappedIR,
+  QueryFn,
+  RuntimeWarningHandler,
+} from "#shared";
+import type { ContextFactory, SchemaPluginOptions } from "./types.js";
+
+/**
+ * Create the default runtime-warning handler: logs each distinct
+ * (property, value) coercion failure to the console exactly once.
+ *
+ * @note Impure — the returned handler writes to the console and tracks the
+ * warnings it has already reported.
+ */
+const createDefaultWarningHandler = (): RuntimeWarningHandler => {
+  const seen = new Set<string>();
+  return (warning) => {
+    const key = `${warning.property} ${warning.value}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    console.warn(
+      `[ke-graphql] cannot coerce "${warning.value}" on ${warning.property}: ${warning.reason}`,
+    );
+  };
+};
+
+/**
+ * Create the CompilerContext factory for a compiled MappedIR: each call
+ * produces a context with fresh DataLoaders ("request" mode) or loaders
+ * sharing process-lifetime caches ("process" mode), plus clearCache() to
+ * drop the shared caches.
+ *
+ * @note Impure — the produced contexts execute SPARQL queries against the
+ * store at resolve time, and clearCache() mutates the shared caches.
+ */
+export default function createContextFactory(
+  mapped: MappedIR,
+  options: SchemaPluginOptions,
+): ContextFactory {
+  // Process-lifetime loader caches (item: loaderCache "process"). Scoped to
+  // this CompilerResult: onReload recompiles and produces a new factory, so
+  // cache invalidation on data change is automatic. Bounded LRU (hardening) so
+  // ID enumeration can't grow them without limit.
+  const cacheSize = options.processCacheSize ?? DEFAULT_PROCESS_CACHE_SIZE;
+  const processCaches =
+    options.loaderCache === "process"
+      ? {
+          entity: createBoundedCache<string, Promise<EntityValue | null>>(
+            cacheSize,
+          ),
+          list: createBoundedCache<string, Promise<string[]>>(cacheSize),
+          inverse: createBoundedCache<string, Promise<string[]>>(cacheSize),
+        }
+      : undefined;
+
+  const factory: ContextFactory = Object.assign(
+    (store: Store | Promise<Store>) => {
+      // Lazy-store gate: ABox loaders await the store at query time; TBox
+      // resolvers read the frozen IR and never touch it.
+      const query: QueryFn = async (q) =>
+        (await Promise.resolve(store)).query(q as SPARQL<string>);
+      return {
+        entityLoader: createEntityLoader(query, mapped, processCaches?.entity),
+        listLoader: createListLoader(query, mapped, processCaches?.list),
+        inverseLoader: createInverseLoader(
+          query,
+          mapped,
+          processCaches?.inverse,
+        ),
+        nameMap: mapped.nameMap,
+        namespaces: mapped.namespaces,
+        store,
+        warn: options.onRuntimeWarning ?? createDefaultWarningHandler(),
+      };
+    },
+    {
+      clearCache(): void {
+        processCaches?.entity.clear();
+        processCaches?.list.clear();
+        processCaches?.inverse.clear();
+      },
+    },
+  );
+  return factory;
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/index.ts
@@ -1,14 +1,23 @@
 /**
- * The OWL → GraphQL compiler domain. This layer carries the extraction pass
- * (reading the ontology + instance data from the store into a raw extraction)
- * and the OWL→IR build pass, plus the store query adapter and the compiler
- * type contracts. The mapping and emission passes, the seven-pass
- * orchestration, the per-request context factory, and the artifact codec are
- * layered on top.
+ * The OWL → GraphQL compiler domain: the seven-pass pipeline (compile and
+ * its artifact-boot variant), the extraction artifact codec, the per-request
+ * context factory, and the compiler API type contracts. The shared vocabulary
+ * constants and IR type contracts it builds on live in the shared leaf and are
+ * re-exported here for the package's public surface.
  *
  * @module compiler
  */
 
 export type * from "#shared";
+export {
+  deserializeExtraction,
+  hashSources,
+  serializeExtraction,
+} from "./artifact.js";
+export { default as CompilationError } from "./CompilationError.js";
+export { default as compile } from "./compile.js";
+export { default as compileFromExtraction } from "./compileFromExtraction.js";
+export { ARTIFACT_VERSION } from "./constants.js";
+export { default as createContextFactory } from "./createContextFactory.js";
 export { default as createStoreQueryFn } from "./createStoreQueryFn.js";
 export type * from "./types.js";

--- a/packages/runtime/ke-graphql/src/lib/compiler/runPasses.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/runPasses.ts
@@ -1,0 +1,73 @@
+import type { Diagnostic, RawExtraction } from "#shared";
+import build from "./build.js";
+import CompilationError from "./CompilationError.js";
+import compose from "./compose.js";
+import createContextFactory from "./createContextFactory.js";
+import emit from "./emit.js";
+import map from "./map.js";
+import type { CompilerResult, SchemaPluginOptions } from "./types.js";
+import validate from "./validate.js";
+import wireRelay from "./wireRelay.js";
+
+/**
+ * Run Passes 2–7 over a RawExtraction and assemble the CompilerResult.
+ *
+ * Only Pass 7 (composition) errors prevent schema creation —
+ * C001/C002 extension conflicts and C003 validation failures throw a
+ * CompilationError; earlier error diagnostics surface in the list without
+ * aborting. Pure — every pass after extraction is store-free.
+ */
+export default function runPasses(
+  extraction: RawExtraction,
+  options: SchemaPluginOptions,
+  {
+    diagnostics: seed = [],
+    skipValidation = false,
+  }: { diagnostics?: Diagnostic[]; skipValidation?: boolean } = {},
+): CompilerResult {
+  const diagnostics: Diagnostic[] = [...seed];
+
+  const built = build(extraction, options.mappings);
+  diagnostics.push(...built.diagnostics);
+
+  const validated = validate(built.output);
+  diagnostics.push(...validated.diagnostics);
+
+  const mapped = map(validated.output, options);
+  diagnostics.push(...mapped.diagnostics);
+
+  const emitted = emit(mapped.output);
+  diagnostics.push(...emitted.diagnostics);
+
+  const relayed = options.relay === false ? emitted : wireRelay(emitted.output);
+  diagnostics.push(...(options.relay === false ? [] : relayed.diagnostics));
+
+  const composed = compose(relayed.output, {
+    extensions: options.extensions,
+    incremental: options.incremental,
+    skipValidation,
+  });
+  diagnostics.push(...composed.diagnostics);
+
+  // Only Pass 7 (composition) errors prevent schema creation —
+  // C001/C002 extension conflicts and C003 validation failures are fatal;
+  // earlier error diagnostics surface in the list without aborting.
+  const compositionErrors = composed.diagnostics.filter(
+    (d) => d.severity === "error",
+  );
+  if (!composed.output.schema || compositionErrors.length > 0) {
+    throw new CompilationError(diagnostics);
+  }
+
+  const factory = createContextFactory(mapped.output, options);
+  return {
+    schema: composed.output.schema,
+    sdl: composed.output.sdl,
+    diagnostics,
+    nameMap: mapped.output.nameMap,
+    mapped: mapped.output,
+    extraction,
+    createContext: factory,
+    clearLoaderCache: factory.clearCache,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/validate.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/validate.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ClassNode,
+  Diagnostic,
+  OntologyIR,
+  PropertyNode,
+  RangeSpec,
+} from "#shared";
+import validate from "./validate.js";
+
+const classNode = (
+  over: Partial<ClassNode> & Pick<ClassNode, "uri">,
+): ClassNode => ({
+  label: over.uri,
+  namespace: "ex",
+  superclasses: [],
+  ancestors: [],
+  subclasses: [],
+  isAbstract: false,
+  embeddable: false,
+  ownProperties: [],
+  allProperties: [],
+  ...over,
+});
+
+const scalarRange: RangeSpec = {
+  kind: "scalar",
+  xsd: "http://www.w3.org/2001/XMLSchema#string",
+  graphqlScalar: "String",
+};
+
+const property = (
+  over: Partial<PropertyNode> & Pick<PropertyNode, "uri">,
+): PropertyNode => ({
+  label: over.uri,
+  namespace: "ex",
+  kind: "datatype",
+  domains: ["http://example.org/Thing"],
+  range: scalarRange,
+  functional: false,
+  classCardinality: new Map(),
+  isAnnotation: false,
+  annotations: new Map(),
+  ...over,
+});
+
+const buildIR = (
+  properties: Map<string, PropertyNode>,
+  classes: Map<string, ClassNode> = new Map(),
+): OntologyIR =>
+  ({
+    classes,
+    properties,
+    namespaces: new Map(),
+    extraction: {
+      classes: [],
+      properties: [],
+      inverses: [],
+      functionals: new Set(),
+      datatypes: [],
+      namespaces: new Map(),
+      shaclConstraints: [],
+      unions: [],
+      instanceStats: new Map(),
+      selfReferential: new Set(),
+      functionalViolations: new Set(),
+      undeclaredPredicates: new Set(),
+      annotations: new Map(),
+      deepBlankNesting: false,
+    },
+  }) as unknown as OntologyIR;
+
+const codes = (diagnostics: Diagnostic[]): string[] =>
+  diagnostics.map((d) => d.code);
+
+describe("validate property diagnostics", () => {
+  it("B003 — unknown range mapped to String", () => {
+    const properties = new Map<string, PropertyNode>([
+      [
+        "http://example.org/p",
+        property({
+          uri: "http://example.org/p",
+          range: { kind: "unknown", raw: "http://example.org/Mystery" },
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(properties));
+    expect(codes(diagnostics)).toContain("B003");
+    expect(diagnostics.find((d) => d.code === "B003")?.message).toContain(
+      "Mystery",
+    );
+  });
+
+  it("B004 — inverse declares an unknown property", () => {
+    const properties = new Map<string, PropertyNode>([
+      [
+        "http://example.org/forward",
+        property({
+          uri: "http://example.org/forward",
+          inverse: "http://example.org/missing",
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(properties));
+    expect(codes(diagnostics)).toContain("B004");
+    // the inverse target is absent, so V003 does not also fire
+    expect(codes(diagnostics)).not.toContain("V003");
+  });
+
+  it("V003 — asymmetric owl:inverseOf between two declared properties", () => {
+    // a.inverse = b, but b is paired symmetrically with c → a is the only
+    // contradiction. All three inverse targets exist, so no B004 fires.
+    const properties = new Map<string, PropertyNode>([
+      [
+        "http://example.org/a",
+        property({
+          uri: "http://example.org/a",
+          kind: "object",
+          inverse: "http://example.org/b",
+        }),
+      ],
+      [
+        "http://example.org/b",
+        property({
+          uri: "http://example.org/b",
+          kind: "object",
+          inverse: "http://example.org/c",
+        }),
+      ],
+      [
+        "http://example.org/c",
+        property({
+          uri: "http://example.org/c",
+          kind: "object",
+          inverse: "http://example.org/b",
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(properties));
+    const v003 = diagnostics.filter((d) => d.code === "V003");
+    // exactly one asymmetry: a → b
+    expect(v003).toHaveLength(1);
+    expect(v003[0]?.message).toContain("a");
+    expect(diagnostics.filter((d) => d.code === "B004")).toHaveLength(0);
+  });
+
+  it("V013 — property declares multiple rdfs:domain classes", () => {
+    const properties = new Map<string, PropertyNode>([
+      [
+        "http://example.org/multi",
+        property({
+          uri: "http://example.org/multi",
+          domains: ["http://example.org/A", "http://example.org/B"],
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(properties));
+    expect(codes(diagnostics)).toContain("V013");
+    expect(diagnostics.find((d) => d.code === "V013")?.message).toContain(
+      "2 domains",
+    );
+  });
+});
+
+describe("validate class diagnostics", () => {
+  it("B002 — class references an unknown, non-standard superclass", () => {
+    // superclass is neither in the IR nor a standard vocabulary → B002
+    // (a standard-vocab parent would instead be V009).
+    const classes = new Map<string, ClassNode>([
+      [
+        "http://example.org/Sub",
+        classNode({
+          uri: "http://example.org/Sub",
+          superclasses: ["http://example.org/Ghost"],
+        }),
+      ],
+    ]);
+    const { diagnostics } = validate(buildIR(new Map(), classes));
+    expect(codes(diagnostics)).toContain("B002");
+    expect(codes(diagnostics)).not.toContain("V009");
+    expect(diagnostics.find((d) => d.code === "B002")?.message).toContain(
+      "Ghost",
+    );
+  });
+
+  it("V015 — class mapped abstract but has direct instances", () => {
+    const classes = new Map<string, ClassNode>([
+      [
+        "http://example.org/A",
+        classNode({ uri: "http://example.org/A", isAbstract: true }),
+      ],
+    ]);
+    const ir = buildIR(new Map(), classes);
+    // A custom mapping can force isAbstract while the data still has instances
+    // (the automatic heuristic only marks zero-instance classes abstract).
+    (
+      ir.extraction.instanceStats as Map<
+        string,
+        { total: number; named: number }
+      >
+    ).set("http://example.org/A", { total: 3, named: 3 });
+    const { diagnostics } = validate(ir);
+    expect(codes(diagnostics)).toContain("V015");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/validate.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/validate.ts
@@ -1,0 +1,249 @@
+// =============================================================================
+// Pass 3 — Validate: OntologyIR → OntologyIR (+ diagnostics)
+//
+// Pure. Reads the IR and the Pass 1 probes, emits the V-series diagnostics.
+// Never mutates the IR.
+// =============================================================================
+
+import {
+  type Diagnostic,
+  getLocalName,
+  type OntologyIR,
+  type PassResult,
+  XSD,
+} from "#shared";
+import isStandardVocab from "./isStandardVocab.js";
+
+const PHASE = "validate";
+
+/** A class is blank-node-only when it has instances but none are named. */
+const isBlankOnly = (ir: OntologyIR, classUri: string): boolean => {
+  const stats = ir.extraction.instanceStats.get(classUri);
+  return stats !== undefined && stats.total > 0 && stats.named === 0;
+};
+
+/**
+ * Validate the OntologyIR against the Pass 1 ABox probes (Pass 3): emits
+ * the V-series diagnostics (blank-node-only classes, domainless properties,
+ * asymmetric inverses, functional violations, SHACL specifics, …) without
+ * mutating the IR. Pure.
+ */
+export default function validate(ir: OntologyIR): PassResult<OntologyIR> {
+  const diagnostics: Diagnostic[] = [];
+  const push = (d: Omit<Diagnostic, "phase">) =>
+    diagnostics.push({ ...d, phase: PHASE });
+
+  for (const node of ir.classes.values()) {
+    // V001 — blank-node-only class
+    if (isBlankOnly(ir, node.uri)) {
+      push({
+        severity: "warning",
+        code: "V001",
+        message: `${getLocalName(node.uri)} instances are exclusively blank nodes — embeddable type`,
+        source: node.uri,
+      });
+    }
+    // V015 — class forced abstract (by mapping) yet has direct instances.
+    // Those instances' only asserted type is now an interface, so they cannot
+    // resolve and are filtered at runtime — the data contradicts the mapping.
+    // (The automatic abstract heuristic can't trigger this: it only marks a
+    // class abstract when it has zero instances.)
+    const abstractStats = ir.extraction.instanceStats.get(node.uri);
+    if (node.isAbstract && (abstractStats?.total ?? 0) > 0) {
+      push({
+        severity: "warning",
+        code: "V015",
+        message: `${getLocalName(node.uri)} is marked abstract but has ${abstractStats?.total} direct instance(s) — those instances will not resolve`,
+        source: node.uri,
+      });
+    }
+    // V016 — concrete class with subclasses (instantiable supertype). A field
+    // typed as this class can hold a subclass instance, but graphql-js calls
+    // no resolveType on a concrete object type, so the subclass's __typename
+    // and fields are unreachable through it. Mark it abstract if it has no
+    // direct instances; the interface+companion fix is a deferred option.
+    if (!node.isAbstract && !node.embeddable && node.subclasses.length > 0) {
+      push({
+        severity: "warning",
+        code: "V016",
+        message: `${getLocalName(node.uri)} is a concrete type with ${node.subclasses.length} subclass(es) — values returned through a ${getLocalName(node.uri)} field expose only its own fields, not the subclass's`,
+        source: node.uri,
+      });
+    }
+    // V009 — cross-vocabulary subClassOf
+    for (const parent of node.superclasses) {
+      if (!ir.classes.has(parent) && isStandardVocab(parent)) {
+        push({
+          severity: "warning",
+          code: "V009",
+          message: `${getLocalName(node.uri)} subClassOf standard-vocabulary ${parent} — treated as root class`,
+          source: node.uri,
+        });
+      } else if (!ir.classes.has(parent)) {
+        push({
+          severity: "warning",
+          code: "B002",
+          message: `${getLocalName(node.uri)} references unknown superclass ${parent}`,
+          source: node.uri,
+        });
+      }
+    }
+  }
+
+  for (const property of ir.properties.values()) {
+    // B002 — unknown domain
+    for (const domain of property.domains) {
+      if (!ir.classes.has(domain) && !isStandardVocab(domain)) {
+        push({
+          severity: "warning",
+          code: "B002",
+          message: `${getLocalName(property.uri)} has unknown domain ${domain}`,
+          source: property.uri,
+        });
+      }
+    }
+    // B003 — unknown range
+    if (property.range.kind === "unknown") {
+      push({
+        severity: "warning",
+        code: "B003",
+        message: `${getLocalName(property.uri)} has unknown range ${property.range.raw} — mapped to String`,
+        source: property.uri,
+      });
+    }
+    // B004 — unknown inverse
+    if (property.inverse && !ir.properties.has(property.inverse)) {
+      push({
+        severity: "warning",
+        code: "B004",
+        message: `${getLocalName(property.uri)} declares unknown inverse ${property.inverse}`,
+        source: property.uri,
+      });
+    }
+    // V002 — domainless
+    if (property.domains.length === 0 && !property.isAnnotation) {
+      push({
+        severity: "warning",
+        code: "V002",
+        message: `${getLocalName(property.uri)} has no rdfs:domain — assigned to all ${property.namespace}: classes`,
+        source: property.uri,
+      });
+    }
+    // V003 — conflicting inverse declarations (A declares inverse B while
+    // B declares inverse C). One-sided declarations are normal OWL and are
+    // silently completed in Pass 2 — only contradictions warrant a warning.
+    if (property.inverse) {
+      const other = ir.properties.get(property.inverse);
+      if (other && other.inverse !== property.uri) {
+        push({
+          severity: "warning",
+          code: "V003",
+          message: `asymmetric owl:inverseOf between ${getLocalName(property.uri)} and ${getLocalName(property.inverse)}`,
+          source: property.uri,
+        });
+      }
+    }
+    // V004 — self-referential assertions
+    if (ir.extraction.selfReferential.has(property.uri)) {
+      push({
+        severity: "warning",
+        code: "V004",
+        message: `${getLocalName(property.uri)} has a self-referential assertion in the data`,
+        source: property.uri,
+      });
+    }
+    // V005 — functional violations
+    if (ir.extraction.functionalViolations.has(property.uri)) {
+      push({
+        severity: "warning",
+        code: "V005",
+        message: `functional property ${getLocalName(property.uri)} has multiple values on some instance`,
+        source: property.uri,
+      });
+    }
+    // V006 — boolean range (data stores strings; resolver coerces)
+    if (
+      property.range.kind === "scalar" &&
+      property.range.xsd === `${XSD}boolean`
+    ) {
+      push({
+        severity: "info",
+        code: "V006",
+        message: `${getLocalName(property.uri)} is xsd:boolean — resolver coerces string literals`,
+        source: property.uri,
+      });
+    }
+    // V007 — annotation property routed to TBox
+    if (property.isAnnotation) {
+      push({
+        severity: "info",
+        code: "V007",
+        message: `annotation property ${getLocalName(property.uri)} routed to TBox schema`,
+        source: property.uri,
+      });
+    }
+    // V008 — custom datatype mapped to base scalar
+    if (property.range.kind === "scalar" && property.range.customDatatype) {
+      push({
+        severity: "info",
+        code: "V008",
+        message: `custom datatype ${getLocalName(property.range.customDatatype)} mapped to ${property.range.graphqlScalar}`,
+        source: property.uri,
+      });
+    }
+    // V010/V011/V012 — SHACL specifics
+    for (const [classUri, spec] of property.classCardinality) {
+      if (spec.omit) {
+        push({
+          severity: "warning",
+          code: "V010",
+          message: `${getLocalName(property.uri)} has sh:maxCount 0 on ${getLocalName(classUri)} — field omitted`,
+          source: property.uri,
+        });
+      }
+    }
+    const fromOr = ir.extraction.shaclConstraints.some(
+      (c) => c.property === property.uri && c.fromOr,
+    );
+    if (fromOr) {
+      push({
+        severity: "info",
+        code: "V011",
+        message: `${getLocalName(property.uri)} constrained via sh:or — most permissive interpretation applied`,
+        source: property.uri,
+      });
+    }
+    const inConstraint = ir.extraction.shaclConstraints.find(
+      (c) => c.property === property.uri && c.inValues?.length,
+    );
+    if (inConstraint) {
+      push({
+        severity: "info",
+        code: "V012",
+        message: `${getLocalName(property.uri)} has sh:in (${inConstraint.inValues?.join(", ")}) — mapped to String, enum deferred`,
+        source: property.uri,
+      });
+    }
+    // V013 — multi-domain
+    if (property.domains.length > 1) {
+      push({
+        severity: "warning",
+        code: "V013",
+        message: `${getLocalName(property.uri)} declares ${property.domains.length} domains — OWL means intersection; field generated on each`,
+        source: property.uri,
+      });
+    }
+  }
+
+  // V014 — undeclared ABox predicates
+  for (const predicate of ir.extraction.undeclaredPredicates) {
+    push({
+      severity: "info",
+      code: "V014",
+      message: `ABox predicate ${predicate} is not declared in any loaded TBox — no field generated`,
+      source: predicate,
+    });
+  }
+
+  return { output: ir, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.test.ts
@@ -1,0 +1,317 @@
+import type { GraphQLFieldResolver } from "graphql";
+import { describe, expect, it } from "vitest";
+import type {
+  CompilerContext,
+  EntityValue,
+  InterfacePlan,
+  MappedIR,
+  MappedType,
+  NameMap,
+  NamespaceInfo,
+  TypePlan,
+} from "#shared";
+import type { FieldPlan, SchemaPlan } from "./emit.js";
+import wireRelay from "./wireRelay.js";
+
+type Resolve = GraphQLFieldResolver<EntityValue, CompilerContext>;
+
+const nameMap: NameMap = {
+  toGraphQL: () => undefined,
+  toOWL: () => undefined,
+  entries: () => [][Symbol.iterator](),
+};
+
+const namespaces = new Map<string, NamespaceInfo>([
+  [
+    "ex",
+    {
+      prefix: "ex",
+      uri: "http://example.org/",
+      classCount: 0,
+      propertyCount: 0,
+    },
+  ],
+]);
+
+const listField = (
+  base: string,
+  kind: FieldPlan["type"]["kind"],
+): FieldPlan => ({
+  name: base,
+  type: { base, kind, list: true, nonNull: true },
+});
+
+const typePlan = (
+  over: Partial<TypePlan> & Pick<TypePlan, "name">,
+): TypePlan => ({
+  owlUri: `http://example.org/${over.name}`,
+  interfaces: [],
+  fields: new Map(),
+  embeddable: false,
+  ...over,
+});
+
+const ifacePlan = (
+  over: Partial<InterfacePlan> & Pick<InterfacePlan, "name">,
+): InterfacePlan => ({
+  owlUri: `http://example.org/${over.name}`,
+  parents: [],
+  fields: new Map(),
+  embeddableOnly: false,
+  ...over,
+});
+
+const mappedType = (name: string): MappedType => ({
+  owlUri: `http://example.org/${name}`,
+  graphqlName: name,
+  interfaces: [],
+  fields: new Map(),
+  embeddable: false,
+  namespace: "ex",
+  pluralName: `${name.toLowerCase()}s`,
+  singularName: name.toLowerCase(),
+});
+
+describe("wireRelay connection wrapping", () => {
+  it("wraps non-embeddable named lists and leaves embeddable/plain lists alone", () => {
+    const plain = typePlan({
+      name: "Plain",
+      embeddable: true,
+    });
+    const embeddableInterface = ifacePlan({
+      name: "EmbIface",
+      embeddableOnly: true,
+    });
+    const concreteInterface = ifacePlan({ name: "ConcIface" });
+
+    const host = typePlan({
+      name: "Host",
+      fields: new Map<string, FieldPlan>([
+        // base is a non-embeddable type → wrapped
+        ["entities", listField("Entity", "named")],
+        // base is an embeddable type → stays plain
+        ["plains", listField("Plain", "named")],
+        // base is an embeddable-only interface → stays plain
+        ["embs", listField("EmbIface", "named")],
+        // base is a concrete (non-embeddable) interface → wrapped
+        ["concs", listField("ConcIface", "named")],
+        // base resolves to neither a type nor an interface → wrapped
+        ["unknowns", listField("Mystery", "named")],
+        // not a list → untouched
+        [
+          "scalar",
+          {
+            name: "scalar",
+            type: {
+              base: "String",
+              kind: "scalar",
+              list: false,
+              nonNull: false,
+            },
+          },
+        ],
+        // a list but scalar kind → untouched
+        ["tags", listField("String", "scalar")],
+      ]),
+    });
+
+    const entity = typePlan({ name: "Entity" });
+
+    const plan: SchemaPlan = {
+      types: new Map([
+        ["Host", host],
+        ["Entity", entity],
+        ["Plain", plain],
+      ]),
+      interfaces: new Map([
+        ["EmbIface", embeddableInterface],
+        ["ConcIface", concreteInterface],
+      ]),
+      unions: new Map(),
+      queryFields: new Map(),
+      mapped: {
+        types: new Map([
+          ["Host", mappedType("Host")],
+          ["Entity", mappedType("Entity")],
+        ]),
+        interfaces: new Map(),
+        unions: new Map(),
+        nameMap,
+        namespaces,
+        ir: {
+          classes: new Map(),
+          properties: new Map(),
+          namespaces: new Map(),
+          extraction: {} as MappedIR["ir"]["extraction"],
+        },
+      } as unknown as MappedIR,
+    };
+
+    wireRelay(plan);
+    const fields = plan.types.get("Host")?.fields;
+    expect(fields?.get("entities")?.type.kind).toBe("connection");
+    expect(fields?.get("entities")?.connectionArgs).toBe(true);
+    expect(fields?.get("concs")?.type.kind).toBe("connection");
+    expect(fields?.get("unknowns")?.type.kind).toBe("connection");
+    // unchanged
+    expect(fields?.get("plains")?.type.kind).toBe("named");
+    expect(fields?.get("embs")?.type.kind).toBe("named");
+    expect(fields?.get("scalar")?.type.kind).toBe("scalar");
+    expect(fields?.get("tags")?.type.kind).toBe("scalar");
+  });
+});
+
+describe("wireRelay Node membership", () => {
+  it("skips embeddable-only interfaces but wires concrete ones", () => {
+    const embOnly = ifacePlan({ name: "EmbOnly", embeddableOnly: true });
+    const concrete = ifacePlan({ name: "Concrete" });
+
+    const plan: SchemaPlan = {
+      types: new Map(),
+      interfaces: new Map([
+        ["EmbOnly", embOnly],
+        ["Concrete", concrete],
+      ]),
+      unions: new Map(),
+      queryFields: new Map(),
+      mapped: {
+        types: new Map(),
+        interfaces: new Map(),
+        unions: new Map(),
+        nameMap,
+        namespaces,
+        ir: {
+          classes: new Map(),
+          properties: new Map(),
+          namespaces: new Map(),
+          extraction: {} as MappedIR["ir"]["extraction"],
+        },
+      } as unknown as MappedIR,
+    };
+
+    wireRelay(plan);
+    // embeddable-only interface: no structural fields, no Node parent
+    expect(plan.interfaces.get("EmbOnly")?.fields.has("id")).toBe(false);
+    expect(plan.interfaces.get("EmbOnly")?.parents).not.toContain("Node");
+    // concrete interface: id/uri/_meta injected, Node added
+    expect(plan.interfaces.get("Concrete")?.fields.has("id")).toBe(true);
+    expect(plan.interfaces.get("Concrete")?.parents).toContain("Node");
+  });
+});
+
+describe("wireRelay root query fields", () => {
+  const dummyCtx = {} as CompilerContext;
+
+  it("skips embeddable types, owlUri-less types, and types missing from the mapped IR", () => {
+    const plan: SchemaPlan = {
+      types: new Map([
+        // embeddable → skipped
+        ["Emb", typePlan({ name: "Emb", embeddable: true })],
+        // no owlUri → skipped
+        ["NoUri", typePlan({ name: "NoUri", owlUri: undefined })],
+        // owlUri present but absent from mapped.types → skipped (defensive)
+        ["Ghost", typePlan({ name: "Ghost" })],
+      ]),
+      interfaces: new Map(),
+      unions: new Map(),
+      queryFields: new Map(),
+      mapped: {
+        // intentionally empty: none of the above resolve here
+        types: new Map(),
+        interfaces: new Map(),
+        unions: new Map(),
+        nameMap,
+        namespaces,
+        ir: {
+          classes: new Map(),
+          properties: new Map(),
+          namespaces: new Map(),
+          extraction: {} as MappedIR["ir"]["extraction"],
+        },
+      } as unknown as MappedIR,
+    };
+
+    wireRelay(plan);
+    // only the node field exists; no per-type lookup/listing was added
+    expect([...plan.queryFields.keys()]).toEqual(["node"]);
+  });
+
+  const thingPlan = (): SchemaPlan => {
+    const plan: SchemaPlan = {
+      types: new Map([["Thing", typePlan({ name: "Thing" })]]),
+      interfaces: new Map(),
+      unions: new Map(),
+      queryFields: new Map(),
+      mapped: {
+        types: new Map([["Thing", mappedType("Thing")]]),
+        interfaces: new Map(),
+        unions: new Map(),
+        nameMap,
+        namespaces,
+        ir: {
+          classes: new Map(),
+          properties: new Map(),
+          namespaces: new Map(),
+          extraction: {} as MappedIR["ir"]["extraction"],
+        },
+      } as unknown as MappedIR,
+    };
+    wireRelay(plan);
+    return plan;
+  };
+
+  const resolverOf = (plan: SchemaPlan, name: string): Resolve => {
+    const resolve = plan.queryFields.get(name)?.resolve;
+    if (!resolve) {
+      throw new Error(`expected a resolver for query field ${name}`);
+    }
+    return resolve as Resolve;
+  };
+
+  it("node and singular resolvers return null when the id/uri arg is absent", async () => {
+    const plan = thingPlan();
+    const node = resolverOf(plan, "node");
+    const singular = resolverOf(plan, "thing");
+    expect(await node(undefined, {}, dummyCtx, {} as never)).toBeNull();
+    expect(await singular(undefined, {}, dummyCtx, {} as never)).toBeNull();
+  });
+
+  it("singular and listing resolvers fall back to the raw URI on an unknown prefix", async () => {
+    const plan = thingPlan();
+    const loaded: string[] = [];
+    const ctx = {
+      entityLoader: {
+        load: async (key: string) => {
+          loaded.push(key);
+          return null;
+        },
+        loadMany: async (keys: string[]) => {
+          loaded.push(...keys);
+          return keys.map(() => null);
+        },
+      },
+      // a URI with no registered namespace: toPrefixed leaves it unchanged and
+      // the subsequent toFull cannot expand it → the `?? uri` fallback fires.
+      listLoader: { load: async () => ["urn:unmapped"] },
+    } as unknown as CompilerContext;
+
+    // unknown prefix → toFull undefined → singular uses `?? args.uri`
+    await resolverOf(plan, "thing")(
+      undefined,
+      { uri: "zz:thing" },
+      ctx,
+      {} as never,
+    );
+    expect(loaded).toContain("zz:thing");
+
+    // listing → toFull undefined per window URI → `?? uri` fallback
+    const conn = (await resolverOf(plan, "things")(
+      undefined,
+      {},
+      ctx,
+      {} as never,
+    )) as { edges: unknown[] };
+    expect(loaded).toContain("urn:unmapped");
+    expect(conn.edges).toEqual([]);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/wireRelay.ts
@@ -1,0 +1,183 @@
+// =============================================================================
+// Pass 6 — Wire Relay: SchemaPlan → SchemaPlan
+//
+// Pure plan surgery (no graphql-js objects yet):
+// - id/uri/_meta on every non-embeddable type
+// - Node membership for non-embeddable types AND for generated interfaces
+//   whose concrete implementors are all non-embeddable (Relay @refetchable
+//   fragments on UIBlock need Node + id)
+// - list object fields → connections with the four pagination args
+// - root query fields: node(id), per-type lookup + listing
+// =============================================================================
+
+import { toFull, toPrefixed } from "#dataloader";
+import {
+  connectionFromPage,
+  paginateUriWindow,
+  unwrapEntities,
+} from "#resolver";
+import type {
+  CompilerContext,
+  Diagnostic,
+  EntityValue,
+  PassResult,
+} from "#shared";
+import type { FieldPlan, SchemaPlan } from "./emit.js";
+
+/** Create the Relay global-ID field plan (id: ID!). */
+const createIdField = (): FieldPlan => ({
+  name: "id",
+  type: { base: "ID", kind: "scalar", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent.uri,
+  description: "Relay global ID — the entity's prefixed URI.",
+});
+
+/** Create the uri field plan (uri: String!). */
+const createUriField = (): FieldPlan => ({
+  name: "uri",
+  type: { base: "String", kind: "scalar", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent.uri,
+});
+
+/** Create the _meta field plan (self-describing TBox access). */
+const createMetaField = (): FieldPlan => ({
+  name: "_meta",
+  type: { base: "EntityMeta", kind: "named", list: false, nonNull: true },
+  resolve: (parent: EntityValue) => parent,
+  description: "Self-describing TBox access for this entity.",
+});
+
+/**
+ * Wire the Relay server conventions into the SchemaPlan (Pass 6): Node
+ * membership with id/uri/_meta on non-embeddable types, connection-wrapping
+ * of list object fields, and the root node/lookup/listing query fields.
+ * Pure plan surgery — no graphql-js objects are constructed here.
+ */
+export default function wireRelay(plan: SchemaPlan): PassResult<SchemaPlan> {
+  const diagnostics: Diagnostic[] = [];
+  const { mapped } = plan;
+
+  // ── connections: every list field whose base is a named non-embeddable
+  //    type becomes a connection field with pagination args ──
+  const wrapConnections = (fields: Map<string, FieldPlan>) => {
+    for (const field of fields.values()) {
+      if (!field.type.list || field.type.kind !== "named") {
+        continue;
+      }
+      const targetType = plan.types.get(field.type.base);
+      const targetInterface = plan.interfaces.get(field.type.base);
+      const embeddableTarget =
+        targetType?.embeddable ??
+        (targetInterface ? targetInterface.embeddableOnly : false);
+      if (embeddableTarget) {
+        continue; // embedded lists stay plain lists
+      }
+      field.type = {
+        base: field.type.base,
+        kind: "connection",
+        list: false,
+        nonNull: true,
+      };
+      field.connectionArgs = true;
+    }
+  };
+
+  for (const type of plan.types.values()) {
+    wrapConnections(type.fields);
+  }
+  for (const iface of plan.interfaces.values()) {
+    wrapConnections(iface.fields);
+  }
+
+  // ── id/uri/_meta + Node membership ──
+  for (const type of plan.types.values()) {
+    if (type.embeddable) {
+      continue;
+    }
+    const structural = [createIdField(), createUriField(), createMetaField()];
+    const existing = type.fields;
+    type.fields = new Map([
+      ...structural.map((f): [string, FieldPlan] => [f.name, f]),
+      ...existing,
+    ]);
+    type.interfaces = ["Node", ...type.interfaces];
+  }
+  for (const iface of plan.interfaces.values()) {
+    if (iface.embeddableOnly) {
+      continue;
+    }
+    const structural = [createIdField(), createUriField(), createMetaField()];
+    iface.fields = new Map([
+      ...structural.map((f): [string, FieldPlan] => [f.name, f]),
+      ...iface.fields,
+    ]);
+    iface.parents = ["Node", ...iface.parents];
+  }
+
+  // ── root query fields ──
+  plan.queryFields.set("node", {
+    name: "node",
+    type: { base: "Node", kind: "named", list: false, nonNull: false },
+    args: { id: { type: "ID", required: true } },
+    resolve: async (_parent, args: { id?: string }, ctx: CompilerContext) => {
+      if (!args.id) {
+        return null;
+      }
+      const full = toFull(args.id, mapped.namespaces);
+      if (!full) {
+        return null; // unknown prefix
+      }
+      return ctx.entityLoader.load(full);
+    },
+    description: "Relay node resolution by prefixed-URI global ID.",
+  });
+
+  for (const type of plan.types.values()) {
+    if (type.embeddable || !type.owlUri) {
+      continue;
+    }
+    const mappedType = mapped.types.get(type.name);
+    if (!mappedType) {
+      continue;
+    }
+    const classUri = type.owlUri;
+
+    plan.queryFields.set(mappedType.singularName, {
+      name: mappedType.singularName,
+      type: { base: type.name, kind: "named", list: false, nonNull: false },
+      args: { uri: { type: "String", required: true } },
+      resolve: async (
+        _parent,
+        args: { uri?: string },
+        ctx: CompilerContext,
+      ) => {
+        if (!args.uri) {
+          return null;
+        }
+        const full = toFull(args.uri, mapped.namespaces) ?? args.uri;
+        return ctx.entityLoader.load(full);
+      },
+    });
+
+    plan.queryFields.set(mappedType.pluralName, {
+      name: mappedType.pluralName,
+      type: { base: type.name, kind: "connection", list: false, nonNull: true },
+      connectionArgs: true,
+      resolve: async (_parent, args, ctx: CompilerContext) => {
+        // Slice BEFORE hydration: cursors and pageInfo need only the
+        // (name-sorted) URI list; entities are loaded for the page alone.
+        const fullUris = await ctx.listLoader.load(classUri);
+        const prefixed = fullUris.map((uri) =>
+          toPrefixed(uri, mapped.namespaces),
+        );
+        const page = paginateUriWindow(prefixed, args);
+        const entities = await ctx.entityLoader.loadMany(
+          page.window.map((uri) => toFull(uri, mapped.namespaces) ?? uri),
+        );
+        return connectionFromPage(unwrapEntities(entities), page);
+      },
+    });
+  }
+
+  return { output: plan, diagnostics };
+}

--- a/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.test.ts
@@ -1,0 +1,318 @@
+// =============================================================================
+// Plugin integration: createSchemaPlugin via createStore, store.api,
+// sdlOutput writing, extensions (object + factory), standardVocabFields.
+// =============================================================================
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTestStore } from "@canonical/ke/testing";
+import { GraphQLString, graphql } from "graphql";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  compile,
+  createStoreQueryFn,
+  hashSources,
+  type SchemaPluginApi,
+  serializeExtraction,
+} from "#compiler";
+import type { EntityValue } from "#shared";
+import { MINIMAL_TTL, PREFIXES } from "#testing";
+import createSchemaPlugin from "./createSchemaPlugin.js";
+
+// A TTL whose compile emits diagnostics of every severity without failing
+// composition, plus at least one sourceless diagnostic so both arms of the
+// log line's `(source)` suffix are taken: V006 (info, boolean property),
+// V002 (warning, domainless property), three custom mappings onto one field
+// name (M001 error, non-fatal), and a union range (X003 info, sourceless).
+const DIAGNOSTIC_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:Thing a owl:Class ; rdfs:label "Thing" .
+ex:Other a owl:Class ; rdfs:label "Other" .
+ex:active a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:boolean ; rdfs:label "active" .
+ex:foo a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:string ; rdfs:label "foo" .
+ex:bar a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:string ; rdfs:label "bar" .
+ex:baz a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:string ; rdfs:label "baz" .
+ex:orphan a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "orphan" .
+ex:ref a owl:ObjectProperty ; rdfs:domain ex:Thing ; rdfs:range [ owl:unionOf ( ex:Thing ex:Other ) ] ; rdfs:label "ref" .
+ex:w a ex:Thing ; ex:active "true" ; ex:foo "f" ; ex:bar "b" ; ex:baz "z" .
+ex:o a ex:Other .
+`;
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+describe("createSchemaPlugin", () => {
+  it("compiles on onReady and exposes the api via store.api", async () => {
+    const plugin = createSchemaPlugin();
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    expect(api).toBeDefined();
+    expect(api?.schema.getType("Thing")).toBeDefined();
+    expect(api?.sdl).toContain("type Thing");
+    expect(api?.nameMap.toGraphQL("http://example.org/Thing")).toBe("Thing");
+
+    // request-time context takes the store (PluginContext is not retained)
+    const context = api?.createContext(store);
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ thing(uri: "ex:widget") { name } }`,
+      contextValue: context,
+    });
+    expect((result.data?.thing as { name: string }).name).toBe("Widget");
+  });
+
+  it("writes the SDL to sdlOutput", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ke-graphql-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const sdlPath = join(dir, "schema.graphql");
+    const plugin = createSchemaPlugin({ sdlOutput: sdlPath });
+    const { cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    expect(existsSync(sdlPath)).toBe(true);
+    expect(readFileSync(sdlPath, "utf-8")).toContain(
+      "type Thing implements Node",
+    );
+  });
+
+  it("registers extensions in object form on types and Query", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: {
+        Thing: {
+          shout: {
+            type: GraphQLString,
+            resolve: (source: EntityValue) => `${source.uri}!`,
+          },
+        },
+        Query: {
+          hello: { type: GraphQLString, resolve: () => "world" },
+        },
+      },
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ hello thing(uri: "ex:widget") { shout } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.hello).toBe("world");
+    expect((result.data?.thing as { shout: string }).shout).toBe("ex:widget!");
+  });
+
+  it("supports the extensions factory form receiving generated types", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: (types) => ({
+        Query: {
+          firstThing: {
+            type: types.type("Thing") as NonNullable<
+              ReturnType<typeof types.type>
+            >,
+            resolve: async (_source, _args, ctx) => {
+              const uris = await ctx.listLoader.load(
+                "http://example.org/Thing",
+              );
+              return uris[0] ? ctx.entityLoader.load(uris[0]) : null;
+            },
+          },
+        },
+      }),
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ firstThing { name } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.firstThing as { name: string }).name).toBe("Widget");
+  });
+
+  it("reports C001/C002 extension conflicts as composition errors", async () => {
+    const plugin = createSchemaPlugin({
+      extensions: {
+        NoSuchType: {
+          x: { type: GraphQLString },
+        },
+      },
+    });
+    await expect(
+      createTestStore({
+        ttl: MINIMAL_TTL,
+        prefixes: PREFIXES,
+        plugins: [plugin],
+      }),
+    ).rejects.toThrow(/C001|composition failed/);
+  });
+
+  it("generates instance-level standard-vocab fields", async () => {
+    const ttl = `${MINIMAL_TTL}
+      <http://example.org/widget> <http://www.w3.org/2000/01/rdf-schema#label> "The Widget"@en .
+    `;
+    const plugin = createSchemaPlugin({
+      standardVocabFields: {
+        Thing: { "http://www.w3.org/2000/01/rdf-schema#label": "label" },
+      },
+    });
+    const { store, cleanup } = await createTestStore({
+      ttl,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ thing(uri: "ex:widget") { label } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { label: string }).label).toBe("The Widget");
+  });
+
+  it("logs diagnostics to the matching console channel by severity", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    cleanups.push(() => {
+      error.mockRestore();
+      warn.mockRestore();
+      info.mockRestore();
+    });
+    const plugin = createSchemaPlugin({
+      mappings: {
+        "ex:foo": { graphqlName: "dup" },
+        "ex:bar": { graphqlName: "dup" },
+        "ex:baz": { graphqlName: "dup" },
+      },
+    });
+    const { cleanup } = await createTestStore({
+      ttl: DIAGNOSTIC_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("M001"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("V002"));
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("V006"));
+    // The "(source)" suffix is appended only when a diagnostic carries a
+    // source: V006 has one, the union diagnostic (X003) does not.
+    expect(info).toHaveBeenCalledWith(expect.stringMatching(/V006:.+\(.+\)$/));
+    expect(info).toHaveBeenCalledWith(expect.stringMatching(/X003:[^()]*$/));
+  });
+
+  it("boots from an extraction artifact given as a file path", async () => {
+    // Derive a fresh artifact (matching sourcesHash) from a live compile.
+    const probe = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+    });
+    cleanups.push(probe.cleanup);
+    const artifactJson = serializeExtraction(
+      (await compile(createStoreQueryFn(probe.store), PREFIXES)).extraction,
+      hashSources([MINIMAL_TTL]),
+    );
+    const dir = mkdtempSync(join(tmpdir(), "ke-graphql-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const artifactPath = join(dir, "extraction.json");
+    writeFileSync(artifactPath, artifactJson, "utf-8");
+
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [createSchemaPlugin({ extraction: artifactPath })],
+    });
+    cleanups.push(cleanup);
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    // Artifact boot skips printSchema — empty SDL is the fast-path marker.
+    expect(api?.sdl).toBe("");
+    expect(api?.schema.getType("Thing")).toBeDefined();
+  });
+
+  it("keeps using a fresh artifact across a reload (no fingerprint drift)", async () => {
+    const probe = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+    });
+    cleanups.push(probe.cleanup);
+    const artifactJson = serializeExtraction(
+      (await compile(createStoreQueryFn(probe.store), PREFIXES)).extraction,
+      hashSources([MINIMAL_TTL]),
+    );
+    const dir = mkdtempSync(join(tmpdir(), "ke-graphql-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const artifactPath = join(dir, "extraction.json");
+    writeFileSync(artifactPath, artifactJson, "utf-8");
+
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [createSchemaPlugin({ extraction: artifactPath })],
+    });
+    cleanups.push(cleanup);
+    // Cold boot uses the artifact (empty SDL = fast path).
+    expect(store.api<SchemaPluginApi>("ke-graphql")?.sdl).toBe("");
+    // ke re-invokes onLoad for every source on reload; the per-cycle reset
+    // keeps the fingerprint stable, so the artifact stays fresh (the old
+    // accumulating array would XOR to a drifted hash and force a live compile).
+    await store.reload({ force: true });
+    expect(store.api<SchemaPluginApi>("ke-graphql")?.sdl).toBe("");
+  });
+
+  it("recompiles on reload and keeps the api queryable", async () => {
+    const plugin = createSchemaPlugin();
+    const { store, cleanup } = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [plugin],
+    });
+    cleanups.push(cleanup);
+    await store.reload({ force: true });
+    const api = store.api<SchemaPluginApi>("ke-graphql");
+    expect(api?.schema.getType("Thing")).toBeDefined();
+    const result = await graphql({
+      schema: api?.schema as NonNullable<typeof api>["schema"],
+      source: `{ thing(uri: "ex:widget") { name } }`,
+      contextValue: api?.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { name: string }).name).toBe("Widget");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.ts
+++ b/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.ts
@@ -1,0 +1,159 @@
+// =============================================================================
+// ke plugin entry: onReady runs the compiler against the freshly loaded
+// store; onReload recompiles (note: with `cache:` configured, ke's reload()
+// short-circuits on a cache hit — pass { force: true } in dev flows).
+//
+// Failure policy: the schema is produced even through non-composition
+// errors (the tsc model — diagnostics never abort the pipeline); only a
+// CompilationError (composition failed) propagates and fails the boot. All
+// diagnostics are logged either way.
+// =============================================================================
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { definePlugin, type PluginContext, type SPARQL } from "@canonical/ke";
+import {
+  compile,
+  compileFromExtraction,
+  type Diagnostic,
+  deserializeExtraction,
+  hashSources,
+  type QueryFn,
+  type SchemaPluginApi,
+  type SchemaPluginOptions,
+  type SerializedExtraction,
+} from "./compiler/index.js";
+
+/**
+ * Log every diagnostic to the console at its severity's channel.
+ *
+ * @note Impure — writes to the console.
+ */
+const logDiagnostics = (diagnostics: Diagnostic[]): void => {
+  for (const d of diagnostics) {
+    const line = `[ke-graphql] ${d.code}: ${d.message}${d.source ? ` (${d.source})` : ""}`;
+    if (d.severity === "error") {
+      console.error(line);
+    } else if (d.severity === "warning") {
+      console.warn(line);
+    } else {
+      console.info(line);
+    }
+  }
+};
+
+/**
+ * Adapt a ke PluginContext to the QueryFn surface (string → branded SPARQL).
+ *
+ * @note Impure — the returned function executes SPARQL queries against the
+ * store behind the plugin context.
+ */
+const createPluginQueryFn =
+  (ctx: PluginContext): QueryFn =>
+  (query) =>
+    ctx.query(query as SPARQL<string>);
+
+/** Plugin-only options on top of SchemaPluginOptions. */
+export interface SchemaPluginExtra {
+  /**
+   * Precomputed extraction artifact (path or parsed) — boots the schema
+   * without Pass 1 when its sourcesHash matches the loaded TTL; falls back
+   * to a live compile (with a warning) when stale.
+   */
+  extraction?: string | SerializedExtraction;
+}
+
+/**
+ * Create the ke-graphql schema plugin: compiles the schema when the store is
+ * ready and recompiles on reload, registering the SchemaPluginApi under
+ * "ke-graphql".
+ *
+ * @note Impure — the plugin's lifecycle hooks query the store, may read the
+ * extraction artifact from disk, and may write the SDL output file.
+ *
+ * @example
+ * ```ts
+ * const graphql = createSchemaPlugin({ mappings, extensions });
+ * const store = await createStore({ sources, prefixes, plugins: [graphql] });
+ * const { schema, createContext } = store.api<SchemaPluginApi>("ke-graphql")!;
+ * ```
+ */
+export default function createSchemaPlugin(
+  options: SchemaPluginOptions & SchemaPluginExtra = {},
+) {
+  // Fingerprint the TTL sources as ke loads them — artifact freshness check.
+  const sourceContents: string[] = [];
+  return definePlugin<SchemaPluginApi>({
+    name: "ke-graphql",
+
+    onLoad(source) {
+      sourceContents.push(source.content);
+    },
+
+    async onReady(ctx) {
+      return compileForContext(ctx, options, sourceContents);
+    },
+
+    async onReload(ctx) {
+      return compileForContext(ctx, options, sourceContents);
+    },
+  });
+}
+
+/**
+ * Compile for a plugin lifecycle hook: boot from the extraction artifact
+ * when fresh, fall back to a live compile otherwise, then log diagnostics
+ * and write the SDL output when configured.
+ *
+ * @note Impure — reads the extraction artifact from disk, executes SPARQL
+ * queries on a live compile, logs to the console, and writes the SDL output
+ * file when configured.
+ */
+const compileForContext = async (
+  ctx: PluginContext,
+  options: SchemaPluginOptions & SchemaPluginExtra,
+  sourceContents: string[],
+): Promise<SchemaPluginApi> => {
+  let result: Awaited<ReturnType<typeof compile>> | undefined;
+
+  // Snapshot and reset the per-cycle source fingerprint. ke re-invokes onLoad
+  // for every source on each reload, so this accumulating array must be cleared
+  // each cycle or its XOR hash drifts across reloads and false-matches. An
+  // empty snapshot (a ke cache-hit boot, where the sources were never re-read)
+  // simply won't match a real artifact, so it falls back to a live compile.
+  const cycleSources = [...sourceContents];
+  sourceContents.length = 0;
+
+  if (options.extraction !== undefined) {
+    const artifact =
+      typeof options.extraction === "string"
+        ? (JSON.parse(
+            readFileSync(options.extraction, "utf-8"),
+          ) as SerializedExtraction)
+        : options.extraction;
+    const { sourcesHash } = deserializeExtraction(artifact);
+    const loadedHash = hashSources(cycleSources);
+    if (sourcesHash === loadedHash) {
+      result = compileFromExtraction(artifact, options);
+    } else {
+      console.warn(
+        `[ke-graphql] extraction artifact is stale (artifact ${sourcesHash}, sources ${loadedHash}) — falling back to a live compile. Regenerate it (pragma graphql build).`,
+      );
+    }
+  }
+
+  result ??= await compile(createPluginQueryFn(ctx), ctx.prefixes, options);
+  logDiagnostics(result.diagnostics);
+
+  if (options.sdlOutput) {
+    writeFileSync(options.sdlOutput, result.sdl, "utf-8");
+  }
+
+  return {
+    schema: result.schema,
+    diagnostics: result.diagnostics,
+    nameMap: result.nameMap,
+    sdl: result.sdl,
+    createContext: result.createContext,
+    clearLoaderCache: result.clearLoaderCache,
+  };
+};

--- a/packages/runtime/ke-graphql/src/lib/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/index.ts
@@ -1,12 +1,62 @@
 /**
  * The public library surface of @canonical/ke-graphql, composed from the
- * domain barrels. This layer exposes the hardening domain and the resolution
- * layer (URI prefixing and the Relay connection helpers); the compiler, ke
- * plugin, and execution helpers are layered on top.
+ * domain barrels: the compiler pipeline and its artifact codec, and the
+ * connection helpers. The internal cross-domain surface (loaders, vocabulary
+ * constants, resolver templates) is deliberately not re-exported. Local/static
+ * execution and the ke plugin are layered on top of this core.
  *
  * @module lib
  */
 
+export {
+  ARTIFACT_VERSION,
+  type CardinalitySpec,
+  type ClassNode,
+  CompilationError,
+  type CompilerContext,
+  type CompilerResult,
+  type ContextFactory,
+  type CustomMapping,
+  type CustomMappings,
+  compile,
+  compileFromExtraction,
+  createContextFactory,
+  createStoreQueryFn,
+  type Diagnostic,
+  type DiagnosticCode,
+  type DiagnosticSeverity,
+  deserializeExtraction,
+  type EntityValue,
+  hashSources,
+  type InstanceStats,
+  type MappedField,
+  type MappedInterface,
+  type MappedIR,
+  type MappedType,
+  type NameMap,
+  type NamespaceInfo,
+  type NonNullOverrides,
+  type OntologyIR,
+  type PassResult,
+  type PropertyNode,
+  type QueryFn,
+  type RangeSpec,
+  type RawExtraction,
+  type ResolverTemplate,
+  type RuntimeWarningHandler,
+  type SchemaExtensions,
+  type SchemaExtensionsInput,
+  type SchemaPluginApi,
+  type SchemaPluginOptions,
+  type SerializedExtraction,
+  serializeExtraction,
+  type TripleSet,
+  type TripleValue,
+} from "./compiler/index.js";
+export {
+  default as createSchemaPlugin,
+  type SchemaPluginExtra,
+} from "./createSchemaPlugin.js";
 export { toFull, toPrefixed } from "./dataloader/index.js";
 export {
   clampConnectionArgs,

--- a/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.test.ts
@@ -1,0 +1,572 @@
+// =============================================================================
+// TBox schema surface: Ontology, OntologyClass, OntologyProperty,
+// ClassProperty, EntityMeta lookups and edge cases.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import {
+  type GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  graphql,
+} from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import type {
+  ClassNode,
+  CompilerContext,
+  MappedIR,
+  NamespaceInfo,
+  OntologyIR,
+  PropertyNode,
+  RawExtraction,
+} from "#shared";
+import {
+  DS_REALISTIC_TTL,
+  INHERITANCE_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+  SHACL_TTL,
+} from "#testing";
+import buildTBoxSchema from "./buildTBoxSchema.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+interface Compiled {
+  result: CompilerResult;
+  schema: GraphQLSchema;
+  context: CompilerContext;
+}
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<Compiled> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, options);
+  return {
+    result,
+    schema: result.schema,
+    context: result.createContext(store),
+  };
+};
+
+const run = async (compiled: Compiled, source: string) =>
+  graphql({ schema: compiled.schema, source, contextValue: compiled.context });
+
+// A class-ranged property, an inverse pair, an undeclared (unknown) range,
+// and a domainless property — one fixture covering the range-kind branches
+// that are reachable through full compilation.
+const RANGE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix ext: <http://external.example/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Thing a owl:Class ; rdfs:label "Thing" .
+ex:Cat a owl:Class ; rdfs:label "Cat" .
+
+ex:rel a owl:ObjectProperty ; rdfs:domain ex:Thing ; rdfs:range ex:Cat .
+ex:weird a owl:ObjectProperty ; rdfs:domain ex:Thing ; rdfs:range ext:Mystery .
+ex:free a owl:DatatypeProperty ; rdfs:range xsd:string .
+
+ex:hasChild a owl:ObjectProperty ;
+  rdfs:domain ex:Thing ; rdfs:range ex:Cat ; owl:inverseOf ex:childOf .
+ex:childOf a owl:ObjectProperty ; rdfs:domain ex:Cat ; rdfs:range ex:Thing .
+
+ex:t1 a ex:Thing .
+ex:c1 a ex:Cat .
+`;
+
+describe("Ontology and lookups", () => {
+  it("lists ontologies with classes and properties", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologies {
+          prefix
+          namespace
+          label
+          classes { label }
+          properties { label kind functional namespace }
+        }
+        ontology(prefix: "ex") { prefix }
+        unknown: ontology(prefix: "zz") { prefix }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const ontologies = result.data?.ontologies as Array<
+      Record<string, unknown>
+    >;
+    const ex = ontologies.find((o) => o.prefix === "ex");
+    expect(ex?.namespace).toBe("http://example.org/");
+    expect((ex?.classes as unknown[]).length).toBe(1);
+    expect((ex?.properties as unknown[]).length).toBe(2);
+    expect((result.data?.ontology as { prefix: string }).prefix).toBe("ex");
+    expect(result.data?.unknown).toBeNull();
+  });
+
+  it("resolves ontologyProperty with scalar ranges and datatype kind", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyProperty(uri: "http://example.org/count") {
+          uri label kind functional range namespace
+          domain { label }
+          inverse { uri }
+        }
+        missing: ontologyProperty(uri: "http://example.org/nope") { uri }
+        prefixed: ontologyProperty(uri: "ex:count") { uri }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const property = result.data?.ontologyProperty as Record<string, unknown>;
+    expect(property.kind).toBe("DATATYPE");
+    expect(property.functional).toBe(true); // datatype default is singular
+    expect(property.range).toContain("integer");
+    expect((property.domain as { label: string }).label).toBe("Thing");
+    expect(property.inverse).toBeNull();
+    expect(result.data?.missing).toBeNull();
+    // Prefixed form resolves like ontologyClass does.
+    expect((result.data?.prefixed as { uri: string }).uri).toBe(
+      "http://example.org/count",
+    );
+  });
+
+  it("resolves class and unknown ranges, an inverse, and an absent domain", async () => {
+    const compiled = await setup(RANGE_TTL);
+    const result = await run(
+      compiled,
+      `{
+        rel: ontologyProperty(uri: "http://example.org/rel") {
+          range
+          domain { label }
+        }
+        weird: ontologyProperty(uri: "http://example.org/weird") { range }
+        domainless: ontologyProperty(uri: "http://example.org/free") {
+          domain { label }
+        }
+        inv: ontologyProperty(uri: "http://example.org/childOf") {
+          inverse { uri }
+          definition
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    // class range resolves to the member class URI.
+    const rel = result.data?.rel as Record<string, unknown>;
+    expect(rel.range).toBe("http://example.org/Cat");
+    expect((rel.domain as { label: string }).label).toBe("Thing");
+    // unknown range echoes the raw URI string.
+    expect((result.data?.weird as { range: string }).range).toBe(
+      "http://external.example/Mystery",
+    );
+    // a property with no rdfs:domain has a null domain.
+    expect((result.data?.domainless as { domain: unknown }).domain).toBeNull();
+    // an inverse pair exposes the inverse property; definition is absent here.
+    const inv = result.data?.inv as {
+      inverse: { uri: string };
+      definition: string | null;
+    };
+    expect(inv.inverse.uri).toBe("http://example.org/hasChild");
+    expect(inv.definition).toBeNull();
+  });
+
+  it("exposes class definition, namespace, and falls back through prefixed lookups", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL);
+    const result = await run(
+      compiled,
+      `{
+        byFull: ontologyClass(uri: "https://ds.canonical.com/Component") {
+          definition
+          namespace
+        }
+        byPrefixed: ontologyClass(uri: "ds:Component") { uri }
+        missingClass: ontologyClass(uri: "nope:Nope") { uri }
+        propByPrefixed: ontologyProperty(uri: "ds:name") { uri }
+        missingProp: ontologyProperty(uri: "nope:nope") { uri }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const cls = result.data?.byFull as Record<string, unknown>;
+    expect(cls.definition).toBe("A reusable UI component.");
+    expect(cls.namespace).toBe("ds");
+    // prefixed-form fallback resolves both class and property…
+    expect((result.data?.byPrefixed as { uri: string }).uri).toBe(
+      "https://ds.canonical.com/Component",
+    );
+    expect((result.data?.propByPrefixed as { uri: string }).uri).toBe(
+      "https://ds.canonical.com/name",
+    );
+    // …and an unmatched prefixed form falls through to null.
+    expect(result.data?.missingClass).toBeNull();
+    expect(result.data?.missingProp).toBeNull();
+  });
+
+  it("walks superclass chains on OntologyClass", async () => {
+    const compiled = await setup(INHERITANCE_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyClass(uri: "http://example.org/Widget") {
+          label
+          isAbstract
+          superclass { label }
+          superclasses { label }
+          subclasses { label }
+        }
+        root: ontologyClass(uri: "http://example.org/Entity") {
+          isAbstract
+          superclass { label }
+          subclasses { label }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const widget = result.data?.ontologyClass as Record<string, unknown>;
+    expect(widget.isAbstract).toBe(false);
+    expect((widget.superclass as { label: string }).label).toBe("Tangible");
+    expect(
+      (widget.superclasses as Array<{ label: string }>).map((c) => c.label),
+    ).toEqual(["Tangible", "Entity"]);
+    const root = result.data?.root as Record<string, unknown>;
+    expect(root.isAbstract).toBe(true);
+    expect(root.superclass).toBeNull();
+    expect(
+      (root.subclasses as Array<{ label: string }>).map((c) => c.label),
+    ).toEqual(["Tangible"]);
+  });
+
+  it("exposes per-class SHACL cardinality through ClassProperty", async () => {
+    const compiled = await setup(SHACL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyClass(uri: "http://example.org/Spec") {
+          properties {
+            property { label }
+            required
+            singular
+            inherited
+          }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const properties = (result.data?.ontologyClass as Record<string, unknown>)
+      .properties as Array<{
+      property: { label: string };
+      required: boolean;
+      singular: boolean;
+      inherited: boolean;
+    }>;
+    const root = properties.find((p) => p.property.label === "root");
+    expect(root?.required).toBe(true);
+    expect(root?.singular).toBe(true);
+    expect(root?.inherited).toBe(false);
+  });
+
+  it("returns annotation metadata through OntologyProperty", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL);
+    const result = await run(
+      compiled,
+      `{
+        ontologyProperty(uri: "https://ds.canonical.com/name") {
+          acceptanceCriteria
+          completionGuidance
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const property = result.data?.ontologyProperty as Record<string, unknown>;
+    expect(property.acceptanceCriteria).toBe(
+      "Must be a human-readable display name.",
+    );
+    expect(property.completionGuidance).toBeNull();
+  });
+});
+
+describe("EntityMeta edge cases", () => {
+  it("returns null for unknown field names", async () => {
+    const compiled = await setup(MINIMAL_TTL);
+    const result = await run(
+      compiled,
+      `{
+        thing(uri: "ex:widget") {
+          _meta { field(name: "doesNotExist") { required } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    expect(
+      (result.data?.thing as { _meta: { field: unknown } })._meta.field,
+    ).toBeNull();
+  });
+});
+
+describe("datatype list fields", () => {
+  it("resolves multi-valued datatype properties when forced to list", async () => {
+    const compiled = await setup(MINIMAL_TTL, {
+      mappings: { "ex:name": { singular: false, graphqlName: "names" } },
+    });
+    const result = await run(compiled, `{ thing(uri: "ex:widget") { names } }`);
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { names: string[] }).names).toEqual([
+      "Widget",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defensive branches reachable only from synthetic parent values: a union
+// range, ClassProperty rows pointing at unknown URIs, EntityMeta on an
+// unmapped typename, and an instances window whose URI cannot round-trip.
+// These states cannot be produced through normal compilation, so the schema
+// is built directly with hand-crafted IR and parents fed through extra root
+// fields wired to the returned object types.
+// ---------------------------------------------------------------------------
+
+const KNOWN = "urn:test#Known";
+const UNION_PROP = "urn:test#unionProp";
+const GHOST_PROP = "urn:test#ghostProp";
+
+const unionProperty: PropertyNode = {
+  uri: UNION_PROP,
+  label: "unionProp",
+  namespace: "t",
+  kind: "object",
+  domains: [KNOWN],
+  range: { kind: "union", name: "PetUnion", members: ["Cat", "Dog"] },
+  functional: false,
+  classCardinality: new Map(),
+  isAnnotation: false,
+  annotations: new Map(),
+};
+
+const knownClass: ClassNode = {
+  uri: KNOWN,
+  label: "Known",
+  namespace: "t",
+  superclasses: [],
+  ancestors: [],
+  subclasses: [],
+  isAbstract: false,
+  embeddable: false,
+  // GHOST_PROP has no PropertyNode → listClassProperties' `?? false` fires.
+  ownProperties: [UNION_PROP],
+  allProperties: [UNION_PROP, GHOST_PROP],
+};
+
+const buildSyntheticIR = (): MappedIR => {
+  const classes = new Map<string, ClassNode>([[KNOWN, knownClass]]);
+  const properties = new Map<string, PropertyNode>([
+    [UNION_PROP, unionProperty],
+  ]);
+  const namespaces = new Map<string, NamespaceInfo>([
+    ["t", { prefix: "t", uri: "urn:test#", classCount: 1, propertyCount: 1 }],
+  ]);
+  const ir: OntologyIR = {
+    classes,
+    properties,
+    namespaces,
+    // Only instanceStats is read by the TBox schema; an empty map drives the
+    // `?? 0` fallback in instanceCount.
+    extraction: { instanceStats: new Map() } as unknown as RawExtraction,
+  };
+  return {
+    ir,
+    classes,
+    properties,
+    namespaces,
+    types: new Map([
+      [
+        "Known",
+        {
+          owlUri: KNOWN,
+          graphqlName: "Known",
+          interfaces: [],
+          fields: new Map(),
+          embeddable: false,
+          namespace: "t",
+          pluralName: "knowns",
+          singularName: "known",
+        },
+      ],
+    ]),
+    interfaces: new Map(),
+    unions: new Map(),
+    nameMap: {
+      toGraphQL: () => undefined,
+      toOWL: (name: string) => (name === "Known" ? KNOWN : undefined),
+      entries: () => [],
+    },
+  } as unknown as MappedIR;
+};
+
+const buildSyntheticSchema = (): GraphQLSchema => {
+  const mapped = buildSyntheticIR();
+  const nodeInterface = {} as GraphQLInterfaceType;
+  const nodeConnection = () =>
+    new GraphQLObjectType({
+      name: "TestConnection",
+      fields: { _empty: { type: GraphQLString } },
+    });
+  const tbox = buildTBoxSchema(mapped, nodeInterface, nodeConnection);
+
+  const query = new GraphQLObjectType({
+    name: "Query",
+    fields: {
+      // union range branch
+      unionProp: {
+        type: tbox.ontologyProperty,
+        resolve: () => mapped.ir.properties.get(UNION_PROP),
+      },
+      // ClassProperty whose property is unknown → required/singular short to
+      // false (resolveCardinality never called) and inherited's `?? false`.
+      orphanProp: {
+        type: tbox.classProperty,
+        resolve: () => ({
+          propertyUri: GHOST_PROP,
+          classUri: "urn:test#NoClass",
+        }),
+      },
+      // ClassProperty with a known property but an unknown class → required/
+      // singular DO call resolveCardinality, whose `node?.ancestors ?? []`
+      // default fires because the class is absent.
+      orphanClassProp: {
+        type: tbox.classProperty,
+        resolve: () => ({
+          propertyUri: UNION_PROP,
+          classUri: "urn:test#NoClass",
+        }),
+      },
+      // EntityMeta with an unmapped typename
+      orphanMeta: {
+        type: tbox.entityMeta,
+        resolve: () => ({
+          uri: null,
+          typename: "NotAType",
+          triples: new Map(),
+        }),
+      },
+      // ClassNode with an empty stats map and a ghost own-property
+      knownClass: {
+        type: tbox.ontologyClass,
+        resolve: () => mapped.ir.classes.get(KNOWN),
+      },
+    },
+  });
+
+  return new GraphQLSchema({ query, types: [tbox.entityMeta] });
+};
+
+describe("TBox defensive branches (synthetic parents)", () => {
+  const orphanContext = {
+    // A bare token cannot be prefixed nor expanded → instances' `toFull ?? uri`.
+    listLoader: { load: async () => ["orphan"] },
+    entityLoader: { loadMany: async () => [null] },
+  } as unknown as CompilerContext;
+
+  it("joins union range members and reads the empty instanceCount fallback", async () => {
+    const schema = buildSyntheticSchema();
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{
+        unionProp { range }
+        knownClass {
+          namespace
+          instanceCount
+          properties { inherited }
+          instances(first: 5) { _empty }
+        }
+      }`,
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.unionProp as { range: string }).range).toBe(
+      "Cat | Dog",
+    );
+    const cls = result.data?.knownClass as Record<string, unknown>;
+    expect(cls.namespace).toBe("t");
+    // No stats entry for this class → instanceCount falls back to 0.
+    expect(cls.instanceCount).toBe(0);
+    // listClassProperties runs the annotation filter against GHOST_PROP (no
+    // PropertyNode → the `?? false` default keeps it) — both the union prop
+    // and the ghost survive, so the list has two entries. `property` is left
+    // unqueried because the ghost has no resolvable OntologyProperty.
+    const props = cls.properties as Array<{ inherited: boolean }>;
+    expect(props).toHaveLength(2);
+  });
+
+  it("reports false cardinality and inherited for a ClassProperty with unknown URIs", async () => {
+    const schema = buildSyntheticSchema();
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{ orphanProp { required singular inherited } }`,
+    });
+    expect(result.errors).toBeUndefined();
+    const cp = result.data?.orphanProp as Record<string, boolean>;
+    expect(cp.required).toBe(false);
+    expect(cp.singular).toBe(false);
+    // The class is unknown → ownProperties lookup yields the `?? false` default,
+    // so the property is reported as inherited.
+    expect(cp.inherited).toBe(true);
+  });
+
+  it("falls back to a known property's defaults when its class is unknown", async () => {
+    const schema = buildSyntheticSchema();
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{ orphanClassProp { required singular } }`,
+    });
+    expect(result.errors).toBeUndefined();
+    const cp = result.data?.orphanClassProp as Record<string, boolean>;
+    // resolveCardinality found no class node and no per-class spec → the kind
+    // default (object property → not singular, not required) applies.
+    expect(cp.required).toBe(false);
+    expect(cp.singular).toBe(false);
+  });
+
+  it("returns an empty field list for an unmapped EntityMeta typename", async () => {
+    const schema = buildSyntheticSchema();
+    // `fields` is queried alone: an unmapped typename yields no class node, so
+    // the resolver returns [] without touching the non-null `type` field.
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{ orphanMeta { fields { property { uri } } } }`,
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.orphanMeta as { fields: unknown[] }).fields).toEqual(
+      [],
+    );
+  });
+
+  it("nulls the non-null EntityMeta type for an unmapped typename", async () => {
+    const schema = buildSyntheticSchema();
+    // `type` is non-null; an unmapped typename resolves it to null, which
+    // bubbles a non-null violation and nulls the parent.
+    const result = await graphql({
+      schema,
+      contextValue: orphanContext,
+      source: `{ orphanMeta { type { uri } } }`,
+    });
+    expect(result.data?.orphanMeta).toBeNull();
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.ts
@@ -1,0 +1,394 @@
+// =============================================================================
+// TBox schema (hand-written): Ontology, OntologyClass,
+// ClassProperty, OntologyProperty, PropertyKind, EntityMeta.
+//
+// Value conventions:
+//   Ontology        → NamespaceInfo
+//   OntologyClass   → ClassNode (IR)
+//   OntologyProperty→ PropertyNode (IR)
+//   ClassProperty   → { propertyUri, classUri } (per-class scope)
+//   EntityMeta      → EntityValue (the ABox parent)
+//
+// Structural facts come from the frozen IR (resolver closures); only the
+// instances connection hits the loaders.
+// =============================================================================
+
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  type GraphQLFieldConfigMap,
+  GraphQLInt,
+  type GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql";
+import { toFull, toPrefixed } from "#dataloader";
+import {
+  connectionFromPage,
+  paginateUriWindow,
+  unwrapEntities,
+} from "#resolver";
+import {
+  type ClassNode,
+  CONNECTION_ARGS,
+  type CompilerContext,
+  type EntityValue,
+  type MappedIR,
+  type NamespaceInfo,
+  type PropertyNode,
+} from "#shared";
+
+interface ClassPropertyValue {
+  propertyUri: string;
+  classUri: string;
+}
+
+/**
+ * Get an annotation value on a property by the annotation property's local
+ * name suffix. Annotation values live on PropertyNode (extracted in Pass 1)
+ * — the TBox schema is fully store-free at request time. Matched by local
+ * name so the convention works for any namespace's annotation properties.
+ */
+const getAnnotationValue = (
+  property: PropertyNode,
+  localSuffix: string,
+): string | null => {
+  for (const [uri, value] of property.annotations) {
+    if (uri.endsWith(localSuffix)) {
+      return value;
+    }
+  }
+  return null;
+};
+
+/** The hand-written TBox types plus the root query fields that serve them. */
+export interface TBoxSchema {
+  ontology: GraphQLObjectType;
+  ontologyClass: GraphQLObjectType;
+  classProperty: GraphQLObjectType;
+  ontologyProperty: GraphQLObjectType;
+  entityMeta: GraphQLObjectType;
+  queryFields: GraphQLFieldConfigMap<unknown, CompilerContext>;
+}
+
+/**
+ * Build the hand-written TBox schema types (Ontology, OntologyClass,
+ * ClassProperty, OntologyProperty, EntityMeta) and their root query fields
+ * from the compiled IR. Resolvers read the frozen IR — only the instances
+ * connection touches the store, through the context's loaders.
+ */
+export default function buildTBoxSchema(
+  mapped: MappedIR,
+  nodeInterface: GraphQLInterfaceType,
+  nodeConnection: () => GraphQLObjectType,
+): TBoxSchema {
+  const { ir } = mapped;
+
+  const propertyKind = new GraphQLEnumType({
+    name: "PropertyKind",
+    values: {
+      DATATYPE: { value: "datatype" },
+      OBJECT: { value: "object" },
+      ANNOTATION: { value: "annotation" },
+    },
+  });
+
+  /** Per-class cardinality, consulting the class then its ancestors. */
+  const resolveCardinality = (property: PropertyNode, classUri: string) => {
+    const node = ir.classes.get(classUri);
+    for (const uri of [classUri, ...(node?.ancestors ?? [])]) {
+      const spec = property.classCardinality.get(uri);
+      if (spec) {
+        return spec;
+      }
+    }
+    return { singular: property.functional, required: false, omit: false };
+  };
+
+  const ontologyProperty: GraphQLObjectType = new GraphQLObjectType<
+    PropertyNode,
+    CompilerContext
+  >({
+    name: "OntologyProperty",
+    fields: () => ({
+      uri: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => p.uri,
+      },
+      label: { type: GraphQLString, resolve: (p) => p.label },
+      definition: { type: GraphQLString, resolve: (p) => p.definition },
+      domain: {
+        type: ontologyClass,
+        resolve: (p) => (p.domains[0] ? ir.classes.get(p.domains[0]) : null),
+      },
+      range: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => {
+          switch (p.range.kind) {
+            case "scalar":
+              return p.range.customDatatype ?? p.range.xsd;
+            case "class":
+              return p.range.uri;
+            case "union":
+              return p.range.members.join(" | ");
+            case "unknown":
+              return p.range.raw;
+          }
+        },
+      },
+      kind: { type: new GraphQLNonNull(propertyKind), resolve: (p) => p.kind },
+      functional: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (p) => p.functional,
+      },
+      inverse: {
+        type: ontologyProperty,
+        resolve: (p) => (p.inverse ? ir.properties.get(p.inverse) : null),
+      },
+      acceptanceCriteria: {
+        type: GraphQLString,
+        resolve: (p) => getAnnotationValue(p, "acceptanceCriteria"),
+      },
+      completionGuidance: {
+        type: GraphQLString,
+        resolve: (p) => getAnnotationValue(p, "completionGuidance"),
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (p) => p.namespace,
+      },
+    }),
+  });
+
+  const classProperty: GraphQLObjectType = new GraphQLObjectType<
+    ClassPropertyValue,
+    CompilerContext
+  >({
+    name: "ClassProperty",
+    description:
+      "Class-scoped view of a property: SHACL cardinality is a fact about a (class, property) pair.",
+    fields: () => ({
+      property: {
+        type: new GraphQLNonNull(ontologyProperty),
+        resolve: (cp) => ir.properties.get(cp.propertyUri),
+      },
+      required: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) => {
+          const property = ir.properties.get(cp.propertyUri);
+          return property
+            ? resolveCardinality(property, cp.classUri).required
+            : false;
+        },
+      },
+      singular: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) => {
+          const property = ir.properties.get(cp.propertyUri);
+          return property
+            ? resolveCardinality(property, cp.classUri).singular
+            : false;
+        },
+      },
+      inherited: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (cp) =>
+          !(
+            ir.classes
+              .get(cp.classUri)
+              ?.ownProperties.includes(cp.propertyUri) ?? false
+          ),
+      },
+    }),
+  });
+
+  const listClassProperties = (node: ClassNode): ClassPropertyValue[] =>
+    node.allProperties
+      .filter((uri) => !(ir.properties.get(uri)?.isAnnotation ?? false))
+      .map((propertyUri) => ({ propertyUri, classUri: node.uri }));
+
+  const ontologyClass: GraphQLObjectType = new GraphQLObjectType<
+    ClassNode,
+    CompilerContext
+  >({
+    name: "OntologyClass",
+    fields: () => ({
+      uri: { type: new GraphQLNonNull(GraphQLString), resolve: (c) => c.uri },
+      label: { type: GraphQLString, resolve: (c) => c.label },
+      definition: { type: GraphQLString, resolve: (c) => c.definition },
+      superclass: {
+        type: ontologyClass,
+        resolve: (c) =>
+          c.superclasses[0] ? ir.classes.get(c.superclasses[0]) : null,
+      },
+      superclasses: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (c) =>
+          c.ancestors
+            .map((uri) => ir.classes.get(uri))
+            .filter((n): n is ClassNode => n !== undefined),
+      },
+      subclasses: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (c) =>
+          c.subclasses
+            .map((uri) => ir.classes.get(uri))
+            .filter((n): n is ClassNode => n !== undefined),
+      },
+      properties: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(classProperty)),
+        ),
+        resolve: (c) => listClassProperties(c),
+      },
+      instances: {
+        type: new GraphQLNonNull(nodeConnection()),
+        args: CONNECTION_ARGS,
+        description:
+          "Named instances of this class (blank-node instances are embeddable and not standalone-resolvable).",
+        resolve: async (c, args, ctx) => {
+          const fullUris = await ctx.listLoader.load(c.uri);
+          const prefixed = fullUris.map((uri) =>
+            toPrefixed(uri, mapped.namespaces),
+          );
+          const page = paginateUriWindow(prefixed, args);
+          const entities = await ctx.entityLoader.loadMany(
+            page.window.map((uri) => toFull(uri, mapped.namespaces) ?? uri),
+          );
+          return connectionFromPage(unwrapEntities(entities), page);
+        },
+      },
+      instanceCount: {
+        type: new GraphQLNonNull(GraphQLInt),
+        description: "Count of NAMED instances (matches `instances`).",
+        resolve: (c) => ir.extraction.instanceStats.get(c.uri)?.named ?? 0,
+      },
+      isAbstract: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (c) => c.isAbstract,
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (c) => c.namespace,
+      },
+    }),
+  });
+
+  const ontology = new GraphQLObjectType<NamespaceInfo, CompilerContext>({
+    name: "Ontology",
+    fields: () => ({
+      prefix: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (n) => n.prefix,
+      },
+      namespace: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: (n) => n.uri,
+      },
+      label: { type: GraphQLString, resolve: (n) => n.prefix },
+      classes: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyClass)),
+        ),
+        resolve: (n) =>
+          [...ir.classes.values()].filter((c) => c.namespace === n.prefix),
+      },
+      properties: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ontologyProperty)),
+        ),
+        resolve: (n) =>
+          [...ir.properties.values()].filter((p) => p.namespace === n.prefix),
+      },
+    }),
+  });
+
+  const entityMeta = new GraphQLObjectType<EntityValue, CompilerContext>({
+    name: "EntityMeta",
+    description: "Self-describing TBox access attached to ABox types.",
+    fields: () => ({
+      type: {
+        type: new GraphQLNonNull(ontologyClass),
+        resolve: (parent) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          return classUri ? ir.classes.get(classUri) : null;
+        },
+      },
+      field: {
+        type: classProperty,
+        args: { name: { type: new GraphQLNonNull(GraphQLString) } },
+        resolve: (parent, args: { name: string }) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          const mappedType = mapped.types.get(parent.typename);
+          const field = mappedType?.fields.get(args.name);
+          if (!classUri || !field || !ir.properties.has(field.propertyUri)) {
+            return null;
+          }
+          return { propertyUri: field.propertyUri, classUri };
+        },
+      },
+      fields: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(classProperty)),
+        ),
+        resolve: (parent) => {
+          const classUri = mapped.nameMap.toOWL(parent.typename);
+          const node = classUri ? ir.classes.get(classUri) : undefined;
+          return node ? listClassProperties(node) : [];
+        },
+      },
+    }),
+  });
+
+  const queryFields: GraphQLFieldConfigMap<unknown, CompilerContext> = {
+    ontologies: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ontology))),
+      resolve: () => [...mapped.namespaces.values()],
+    },
+    ontology: {
+      type: ontology,
+      args: { prefix: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { prefix: string }) =>
+        mapped.namespaces.get(args.prefix) ?? null,
+    },
+    ontologyClass: {
+      type: ontologyClass,
+      args: { uri: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { uri: string }) =>
+        ir.classes.get(args.uri) ??
+        [...ir.classes.values()].find(
+          (c) => `${c.namespace}:${c.uri.split(/[#/]/).pop()}` === args.uri,
+        ) ??
+        null,
+    },
+    ontologyProperty: {
+      type: ontologyProperty,
+      args: { uri: { type: new GraphQLNonNull(GraphQLString) } },
+      resolve: (_parent, args: { uri: string }) =>
+        ir.properties.get(args.uri) ??
+        [...ir.properties.values()].find(
+          (p) => `${p.namespace}:${p.uri.split(/[#/]/).pop()}` === args.uri,
+        ) ??
+        null,
+    },
+  };
+
+  // The Node interface is referenced through nodeConnection (lazily); the
+  // parameter is accepted to make the dependency explicit at the call site.
+  void nodeInterface;
+
+  return {
+    ontology,
+    ontologyClass,
+    classProperty,
+    ontologyProperty,
+    entityMeta,
+    queryFields,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/tbox/index.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The TBox domain: the hand-written ontology-browsing schema (Ontology,
+ * OntologyClass, ClassProperty, OntologyProperty, EntityMeta) composed into
+ * every generated schema alongside the data types.
+ *
+ * @module tbox
+ */
+
+export {
+  default as buildTBoxSchema,
+  type TBoxSchema,
+} from "./buildTBoxSchema.js";

--- a/packages/runtime/ke-graphql/src/testing/integration/performance-features.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/performance-features.test.ts
@@ -1,0 +1,297 @@
+// =============================================================================
+// Performance features: extraction artifact (DMMF-style boot), lazy store,
+// process-lifetime loader cache, slice-before-hydrate pagination, store-free
+// TBox.
+// =============================================================================
+
+import type { SPARQL, Store } from "@canonical/ke";
+import { createTestStore } from "@canonical/ke/testing";
+import { graphql } from "graphql";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  compile,
+  compileFromExtraction,
+  createStoreQueryFn,
+  deserializeExtraction,
+  hashSources,
+  type SchemaPluginApi,
+  serializeExtraction,
+} from "#compiler";
+import { DS_REALISTIC_TTL, MINIMAL_TTL, PREFIXES } from "#testing";
+import createSchemaPlugin from "../../lib/createSchemaPlugin.js";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+  vi.restoreAllMocks();
+});
+
+const boot = async (ttl: string) => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  return store;
+};
+
+/** Wrap a store so SPARQL round-trips are countable. */
+const countingStore = (store: Store): { store: Store; count: () => number } => {
+  let queries = 0;
+  const wrapped: Store = {
+    ...store,
+    query: ((q: SPARQL<string>) => {
+      queries++;
+      return store.query(q);
+    }) as Store["query"],
+  };
+  return { store: wrapped, count: () => queries };
+};
+
+describe("extraction artifact (DMMF-style boot)", () => {
+  it("round-trips: serialized extraction rebuilds an executable schema", async () => {
+    const store = await boot(MINIMAL_TTL);
+    const live = await compile(createStoreQueryFn(store), PREFIXES);
+
+    const artifact = serializeExtraction(live.extraction, hashSources(["x"]));
+    const rebuilt = compileFromExtraction(artifact);
+
+    // assumeValid skips printSchema — the SDL is a build-time artifact
+    expect(rebuilt.sdl).toBe("");
+    expect(rebuilt.schema.getType("Thing")).toBeDefined();
+
+    const result = await graphql({
+      schema: rebuilt.schema,
+      source: `{ thing(uri: "ex:widget") { name count } _meta: ontologyClass(uri: "http://example.org/Thing") { label } }`,
+      contextValue: rebuilt.createContext(store),
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.thing as { name: string }).name).toBe("Widget");
+  });
+
+  it("preserves Sets/Maps through serialization", async () => {
+    const store = await boot(DS_REALISTIC_TTL);
+    const live = await compile(createStoreQueryFn(store), PREFIXES);
+    const { extraction } = deserializeExtraction(
+      serializeExtraction(live.extraction, "0"),
+    );
+    expect(extraction.functionals).toEqual(live.extraction.functionals);
+    expect(extraction.instanceStats).toEqual(live.extraction.instanceStats);
+    expect(extraction.annotations).toEqual(live.extraction.annotations);
+  });
+
+  it("rejects unknown artifact versions", () => {
+    expect(() =>
+      deserializeExtraction(JSON.stringify({ version: 99 })),
+    ).toThrow(/version 99/);
+  });
+
+  it("hashSources is order-independent and content-sensitive", () => {
+    expect(hashSources(["a", "b"])).toBe(hashSources(["b", "a"]));
+    expect(hashSources(["a"])).not.toBe(hashSources(["b"]));
+  });
+
+  it("plugin boots from a fresh artifact and falls back when stale", async () => {
+    // Build the artifact through the plugin so sourcesHash matches ke's load.
+    const probe = createSchemaPlugin();
+    const first = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [probe],
+    });
+    cleanups.push(first.cleanup);
+    // Recover the hash the plugin computed by re-deriving it from the file
+    // ke wrote: simplest faithful source is a second boot with the artifact.
+    const liveApi = first.store.api<SchemaPluginApi>("ke-graphql");
+    const ttlHash = hashSources([MINIMAL_TTL]);
+    const artifact = JSON.parse(
+      serializeExtraction(
+        (await compile(createStoreQueryFn(first.store), PREFIXES)).extraction,
+        ttlHash,
+      ),
+    );
+    expect(liveApi).toBeDefined();
+
+    const fresh = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [createSchemaPlugin({ extraction: artifact })],
+    });
+    cleanups.push(fresh.cleanup);
+    const freshApi = fresh.store.api<SchemaPluginApi>("ke-graphql");
+    // Artifact boot skips printSchema — that IS the fast path marker.
+    expect(freshApi?.sdl).toBe("");
+    expect(freshApi?.schema.getType("Thing")).toBeDefined();
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stale = await createTestStore({
+      ttl: MINIMAL_TTL,
+      prefixes: PREFIXES,
+      plugins: [
+        createSchemaPlugin({
+          extraction: { ...artifact, sourcesHash: "deadbeef" },
+        }),
+      ],
+    });
+    cleanups.push(stale.cleanup);
+    const staleApi = stale.store.api<SchemaPluginApi>("ke-graphql");
+    // Fallback = full live compile, SDL present again.
+    expect(staleApi?.sdl).toContain("type Thing");
+    expect(
+      warn.mock.calls.some(([message]) => String(message).includes("stale")),
+    ).toBe(true);
+  });
+});
+
+describe("lazy store (TBox needs no store)", () => {
+  it("answers TBox queries before the store resolves; ABox waits for it", async () => {
+    const store = await boot(MINIMAL_TTL);
+    const result = await compile(createStoreQueryFn(store), PREFIXES);
+
+    let releaseStore: (s: Store) => void = () => {};
+    const pending = new Promise<Store>((resolve) => {
+      releaseStore = resolve;
+    });
+    const ctx = result.createContext(pending);
+
+    // TBox: resolves while the store promise is still pending.
+    const tbox = await graphql({
+      schema: result.schema,
+      source: `{ ontologyClass(uri: "http://example.org/Thing") { label isAbstract properties { property { label } } } }`,
+      contextValue: ctx,
+    });
+    expect(tbox.errors).toBeUndefined();
+    expect((tbox.data?.ontologyClass as { label: string }).label).toBe("Thing");
+
+    // ABox: blocked until the store arrives.
+    const abox = graphql({
+      schema: result.schema,
+      source: `{ thing(uri: "ex:widget") { name } }`,
+      contextValue: ctx,
+    });
+    const raced = await Promise.race([
+      abox.then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r("pending"), 50)),
+    ]);
+    expect(raced).toBe("pending");
+
+    releaseStore(store);
+    const resolved = await abox;
+    expect(resolved.errors).toBeUndefined();
+    expect((resolved.data?.thing as { name: string }).name).toBe("Widget");
+  });
+});
+
+describe("loaderCache: process", () => {
+  it("shares entity/list caches across contexts and clears on demand", async () => {
+    const raw = await boot(MINIMAL_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(createStoreQueryFn(store), PREFIXES, {
+      loaderCache: "process",
+    });
+    const baseline = count();
+
+    const run = () =>
+      graphql({
+        schema: result.schema,
+        source: `{ things(first: 5) { edges { node { name } } } }`,
+        contextValue: result.createContext(store),
+      });
+
+    await run();
+    const afterFirst = count();
+    expect(afterFirst).toBeGreaterThan(baseline);
+
+    // A FRESH context hits the shared cache — zero new SPARQL.
+    await run();
+    expect(count()).toBe(afterFirst);
+
+    result.clearLoaderCache();
+    await run();
+    expect(count()).toBeGreaterThan(afterFirst);
+  });
+
+  it("request mode (default) re-queries per context", async () => {
+    const raw = await boot(MINIMAL_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(createStoreQueryFn(store), PREFIXES);
+    const run = () =>
+      graphql({
+        schema: result.schema,
+        source: `{ thing(uri: "ex:widget") { name } }`,
+        contextValue: result.createContext(store),
+      });
+    await run();
+    const afterFirst = count();
+    await run();
+    expect(count()).toBeGreaterThan(afterFirst);
+  });
+});
+
+describe("slice-before-hydrate listings", () => {
+  it("hydrates only the requested page and pages correctly via endCursor", async () => {
+    const raw = await boot(DS_REALISTIC_TTL);
+    const { store, count } = countingStore(raw);
+    const result = await compile(createStoreQueryFn(store), PREFIXES);
+
+    const page1 = await graphql({
+      schema: result.schema,
+      source: `{ tiers(first: 1) { edges { cursor node { id name } } pageInfo { hasNextPage endCursor } } }`,
+      contextValue: result.createContext(store),
+    });
+    expect(page1.errors).toBeUndefined();
+    void count();
+
+    // Page 2 of subcomponents-by-cursor on a 2-entity class: use modifiers
+    // (1 modifier) to assert the empty next page + pageInfo math.
+    const modifiers = await graphql({
+      schema: result.schema,
+      source: `{ modifiers(first: 1) { edges { cursor node { name } } pageInfo { hasNextPage } } }`,
+      contextValue: result.createContext(store),
+    });
+    const connection = modifiers.data?.modifiers as {
+      edges: Array<{ cursor: string }>;
+      pageInfo: { hasNextPage: boolean };
+    };
+    expect(connection.edges).toHaveLength(1);
+    expect(connection.pageInfo.hasNextPage).toBe(false);
+
+    const page2 = await graphql({
+      schema: result.schema,
+      source: `query($c: String) { modifiers(first: 1, after: $c) { edges { node { name } } pageInfo { hasPreviousPage } } }`,
+      variableValues: { c: connection.edges[0]?.cursor },
+      contextValue: result.createContext(store),
+    });
+    expect((page2.data?.modifiers as { edges: unknown[] }).edges).toHaveLength(
+      0,
+    );
+  });
+});
+
+describe("store-free TBox (tboxLoader removed)", () => {
+  it("serves class structure and annotations after the store is disposed", async () => {
+    const { store, cleanup } = await createTestStore({
+      ttl: DS_REALISTIC_TTL,
+      prefixes: PREFIXES,
+    });
+    const result = await compile(createStoreQueryFn(store), PREFIXES);
+    const ctx = result.createContext(store);
+    cleanup(); // disposes the store — TBox must not notice
+
+    const tbox = await graphql({
+      schema: result.schema,
+      source: `{
+        ontologyProperty(uri: "https://ds.canonical.com/name") { acceptanceCriteria }
+        ontologyClass(uri: "https://ds.canonical.com/Component") { isAbstract superclasses { label } }
+      }`,
+      contextValue: ctx,
+    });
+    expect(tbox.errors).toBeUndefined();
+    expect(
+      (tbox.data?.ontologyProperty as { acceptanceCriteria: string })
+        .acceptanceCriteria,
+    ).toBe("Must be a human-readable display name.");
+  });
+});

--- a/packages/runtime/ke-graphql/src/testing/integration/pipeline.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/pipeline.test.ts
@@ -1,0 +1,267 @@
+// =============================================================================
+// Pipeline tests (Passes 1–7) against fixture stores: schema shape,
+// diagnostics, golden SDL expectations.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import type { GraphQLObjectType } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import {
+  BLANK_NODES_TTL,
+  DOMAINLESS_TTL,
+  DS_REALISTIC_TTL,
+  EDGE_CASES_TTL,
+  INHERITANCE_TTL,
+  INVERSE_TTL,
+  MINIMAL_TTL,
+  PREFIXES,
+  SHACL_TTL,
+} from "#testing";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+const compileFixture = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<CompilerResult> => {
+  const { store, cleanup } = await createTestStore({
+    ttl,
+    prefixes: PREFIXES,
+  });
+  cleanups.push(cleanup);
+  return compile(createStoreQueryFn(store), PREFIXES, options);
+};
+
+const codes = (result: CompilerResult): string[] =>
+  result.diagnostics.map((d) => d.code);
+
+describe("minimal fixture", () => {
+  it("compiles one concrete type with root queries and Node membership", async () => {
+    const result = await compileFixture(MINIMAL_TTL);
+    expect(result.schema).toBeDefined();
+    const thing = result.schema.getType("Thing") as GraphQLObjectType;
+    expect(thing).toBeDefined();
+    const fields = thing.getFields();
+    // datatype properties default to singular
+    expect(String(fields.name?.type)).toBe("String");
+    expect(String(fields.count?.type)).toBe("Int");
+    // structural fields
+    expect(String(fields.id?.type)).toBe("ID!");
+    expect(String(fields.uri?.type)).toBe("String!");
+    expect(String(fields._meta?.type)).toBe("EntityMeta!");
+    expect(thing.getInterfaces().map((i) => i.name)).toContain("Node");
+    // root queries
+    const query = result.schema.getQueryType()?.getFields();
+    expect(query?.thing).toBeDefined();
+    expect(query?.things).toBeDefined();
+    expect(String(query?.things?.type)).toBe("ThingConnection!");
+    // connection fields carry the four pagination args
+    const argNames = query?.things?.args.map((a) => a.name).sort();
+    expect(argNames).toEqual(["after", "before", "first", "last"]);
+    expect(result.sdl).toContain("type Thing implements Node");
+  });
+});
+
+describe("inheritance fixture", () => {
+  it("generates the interface chain with inherited fields", async () => {
+    const result = await compileFixture(INHERITANCE_TTL);
+    expect(result.sdl).toContain("interface Entity implements Node");
+    expect(result.sdl).toContain("interface Tangible implements");
+    const widget = result.schema.getType("Widget") as GraphQLObjectType;
+    expect(
+      widget
+        .getInterfaces()
+        .map((i) => i.name)
+        .sort(),
+    ).toEqual(["Entity", "Node", "Tangible"]);
+    const fields = widget.getFields();
+    expect(fields.name).toBeDefined(); // inherited from Entity
+    expect(fields.weight).toBeDefined(); // inherited from Tangible
+    expect(fields.color).toBeDefined(); // own
+    // abstract classes produce no root queries
+    const query = result.schema.getQueryType()?.getFields();
+    expect(query?.entity).toBeUndefined();
+    expect(query?.widget).toBeDefined();
+  });
+});
+
+describe("inverse fixture", () => {
+  it("places one field per side with the irregular plural", async () => {
+    const result = await compileFixture(INVERSE_TTL);
+    const parent = result.schema.getType("Parent") as GraphQLObjectType;
+    const child = result.schema.getType("Child") as GraphQLObjectType;
+    // hasChild → children (has-strip + irregular plural), connection-wrapped
+    expect(String(parent.getFields().children?.type)).toBe("ChildConnection!");
+    // childOf is functional → singular
+    expect(String(child.getFields().childOf?.type)).toBe("Parent");
+    // no duplicated reverse fields
+    expect(parent.getFields().childOf).toBeUndefined();
+    expect(child.getFields().children).toBeUndefined();
+  });
+});
+
+describe("polymorphic flattening diagnostic (V016)", () => {
+  const SUPERTYPE_TTL = `
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Animal a owl:Class .
+ex:Dog a owl:Class ; rdfs:subClassOf ex:Animal .
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Animal ; rdfs:range xsd:string .
+ex:a1 a ex:Animal ; ex:name "Generic" .
+ex:d1 a ex:Dog ; ex:name "Rex" .
+`;
+
+  it("warns when a concrete class has subclasses (instantiable supertype)", async () => {
+    const result = await compileFixture(SUPERTYPE_TTL);
+    expect(codes(result)).toContain("V016");
+    // Animal keeps its direct instance, so it stays a concrete type.
+    expect(result.sdl).toContain("type Animal implements Node");
+  });
+
+  it("does not warn when the supertype is abstract (no direct instances)", async () => {
+    const result = await compileFixture(INHERITANCE_TTL);
+    expect(codes(result)).not.toContain("V016");
+  });
+});
+
+describe("blank nodes fixture", () => {
+  it("marks blank-only classes embeddable: no Node, plain list", async () => {
+    const result = await compileFixture(BLANK_NODES_TTL);
+    expect(codes(result)).toContain("V001");
+    const example = result.schema.getType("Example") as GraphQLObjectType;
+    expect(example.getInterfaces()).toHaveLength(0);
+    expect(example.getFields().id).toBeUndefined();
+    expect(example.getFields()._meta).toBeUndefined();
+    const standard = result.schema.getType("Standard") as GraphQLObjectType;
+    // plain list, not a connection
+    expect(String(standard.getFields().examples?.type)).toBe("[Example!]!");
+    // no root query for embeddable types
+    expect(result.schema.getQueryType()?.getFields().example).toBeUndefined();
+  });
+});
+
+describe("domainless fixture", () => {
+  it("assigns the property to every class in its namespace", async () => {
+    const result = await compileFixture(DOMAINLESS_TTL);
+    expect(codes(result)).toContain("V002");
+    const foo = result.schema.getType("Foo") as GraphQLObjectType;
+    const bar = result.schema.getType("Bar") as GraphQLObjectType;
+    expect(foo.getFields().description).toBeDefined();
+    expect(bar.getFields().description).toBeDefined();
+  });
+});
+
+describe("edge cases fixture", () => {
+  it("emits the expected V-series diagnostics", async () => {
+    const result = await compileFixture(EDGE_CASES_TTL);
+    const found = codes(result);
+    expect(found).toContain("V004"); // self-referential extends
+    expect(found).toContain("V005"); // functional violation on ex:rank
+    expect(found).toContain("V006"); // boolean range coercion note
+    expect(found).toContain("V007"); // annotation property routed to TBox
+    expect(found).toContain("V008"); // custom datatype → String
+    expect(found).toContain("V009"); // cross-vocabulary subClassOf
+    expect(found).toContain("V012"); // sh:in enum constraint
+    expect(found).toContain("V014"); // undeclared ABox predicate
+    // annotation property produces no ABox field
+    const item = result.schema.getType("Item") as GraphQLObjectType;
+    expect(item.getFields().guidance).toBeUndefined();
+    // custom datatype mapped to String
+    expect(String(item.getFields().ver?.type)).toBe("String");
+    // Category is a root class despite skos:Concept parentage
+    expect(result.schema.getType("Category")).toBeDefined();
+  });
+});
+
+describe("shacl fixture", () => {
+  it("resolves SHACL cardinality including sh:or and maxCount 0", async () => {
+    const result = await compileFixture(SHACL_TTL);
+    const found = codes(result);
+    expect(found).toContain("V010");
+    expect(found).toContain("V011");
+    const spec = result.schema.getType("Spec") as GraphQLObjectType;
+    // sh:maxCount 1 without owl:FunctionalProperty → singular
+    expect(String(spec.getFields().root?.type)).toBe("Hop");
+    // sh:maxCount 0 → field omitted
+    expect(spec.getFields().legacy).toBeUndefined();
+    const hop = result.schema.getType("Hop") as GraphQLObjectType;
+    // sh:or → both singular, both nullable
+    expect(String(hop.getFields().hopTarget?.type)).toBe("Spec");
+    expect(String(hop.getFields().hopSwitch?.type)).toBe("Sw");
+  });
+});
+
+describe("ds-realistic fixture", () => {
+  it("compiles the full hierarchy with synthetic inverses and overrides", async () => {
+    const result = await compileFixture(DS_REALISTIC_TTL, {
+      mappings: {
+        "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+        "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+        "ds:hasProperty": { graphqlName: "properties" },
+        "ds:hasModifier": { graphqlName: "modifiers" },
+        "ds:implementsBlock": { inverse: { graphqlName: "implementations" } },
+      },
+      nonNullOverrides: { Component: ["name"] },
+    });
+    expect(result.schema).toBeDefined();
+    const component = result.schema.getType("Component") as GraphQLObjectType;
+    const fields = component.getFields();
+    // abstract chain → interfaces
+    expect(
+      component
+        .getInterfaces()
+        .map((i) => i.name)
+        .sort(),
+    ).toEqual(["Entity", "Node", "UIBlock", "UIElement"]);
+    // non-null override
+    expect(String(fields.name?.type)).toBe("String!");
+    // custom-mapped names, connection-wrapped
+    expect(String(fields.modifierFamilies?.type)).toBe(
+      "ModifierFamilyConnection!",
+    );
+    expect(String(fields.subcomponents?.type)).toBe("SubcomponentConnection!");
+    // embedded blank-node list stays plain
+    expect(String(fields.properties?.type)).toBe("[Property!]!");
+    // synthetic inverse on the range type's concrete descendants
+    expect(String(fields.implementations?.type)).toBe(
+      "ImplementationObjectConnection!",
+    );
+    // ds:Property is embeddable: detected from blank-only instance stats
+    const property = result.schema.getType("Property") as GraphQLObjectType;
+    expect(property.getFields().id).toBeUndefined();
+  });
+});
+
+describe("failure modes", () => {
+  it("M003 reports unknown custom mappings", async () => {
+    const result = await compileFixture(MINIMAL_TTL, {
+      mappings: { "ex:doesNotExist": { graphqlName: "nope" } },
+    });
+    expect(codes(result)).toContain("M003");
+  });
+
+  it("relay: false produces a schema without Node wiring", async () => {
+    const result = await compileFixture(MINIMAL_TTL, { relay: false });
+    const thing = result.schema.getType("Thing") as GraphQLObjectType;
+    expect(thing.getFields().id).toBeUndefined();
+    expect(result.schema.getQueryType()?.getFields().node).toBeUndefined();
+  });
+
+  it("incremental: true adds the defer and stream directives", async () => {
+    const result = await compileFixture(MINIMAL_TTL, { incremental: true });
+    expect(result.schema.getDirective("defer")).toBeDefined();
+    expect(result.schema.getDirective("stream")).toBeDefined();
+  });
+});

--- a/packages/runtime/ke-graphql/src/testing/integration/queries.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/queries.test.ts
@@ -1,0 +1,296 @@
+// =============================================================================
+// Query execution against compiled schemas: resolution templates, node(),
+// pagination, _meta, coercion, dual-direction inverses.
+// =============================================================================
+
+import { createTestStore } from "@canonical/ke/testing";
+import { type GraphQLSchema, graphql } from "graphql";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CompilerResult, compile, createStoreQueryFn } from "#compiler";
+import type { CompilerContext } from "#shared";
+import {
+  BLANK_NODES_TTL,
+  DS_REALISTIC_TTL,
+  EDGE_CASES_TTL,
+  INVERSE_TTL,
+  PREFIXES,
+} from "#testing";
+
+type Cleanup = () => void;
+let cleanups: Cleanup[] = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups = [];
+});
+
+interface Compiled {
+  result: CompilerResult;
+  schema: GraphQLSchema;
+  context: CompilerContext;
+}
+
+const setup = async (
+  ttl: string,
+  options: Parameters<typeof compile>[2] = {},
+): Promise<Compiled> => {
+  const { store, cleanup } = await createTestStore({ ttl, prefixes: PREFIXES });
+  cleanups.push(cleanup);
+  const result = await compile(createStoreQueryFn(store), PREFIXES, options);
+  return {
+    result,
+    schema: result.schema,
+    context: result.createContext(store),
+  };
+};
+
+const run = async (
+  compiled: Compiled,
+  source: string,
+  variableValues?: Record<string, unknown>,
+) =>
+  graphql({
+    schema: compiled.schema,
+    source,
+    variableValues,
+    contextValue: compiled.context,
+  });
+
+describe("ds-realistic resolution", () => {
+  const options = {
+    mappings: {
+      "ds:hasModifierFamily": { graphqlName: "modifierFamilies" },
+      "ds:hasSubcomponent": { graphqlName: "subcomponents" },
+      "ds:hasProperty": { graphqlName: "properties" },
+      "ds:hasModifier": { graphqlName: "modifiers" },
+      "ds:implementsBlock": { inverse: { graphqlName: "implementations" } },
+    },
+  };
+
+  it("resolves a component with scalars, objects, and embedded blanks", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        component(uri: "ds:global.component.button") {
+          id
+          uri
+          name
+          summary
+          tier { name }
+          properties { name propertyType optional }
+          subcomponents(first: 10) { edges { node { name standalone parentComponent { name } } } }
+          implementations(first: 10) { edges { node { name } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const component = result.data?.component as Record<string, unknown>;
+    expect(component.id).toBe("ds:global.component.button");
+    expect(component.name).toBe("Button");
+    expect((component.tier as { name: string }).name).toBe("global");
+    // embedded blank node with boolean-as-string coercion
+    const properties = component.properties as Array<Record<string, unknown>>;
+    expect(properties).toHaveLength(1);
+    expect(properties[0]?.name).toBe("disabled");
+    expect(properties[0]?.optional).toBe(false);
+    // declared inverse pair: forward direction asserted in data
+    const subcomponents = component.subcomponents as {
+      edges: Array<{ node: Record<string, unknown> }>;
+    };
+    expect(subcomponents.edges).toHaveLength(1);
+    expect(subcomponents.edges[0]?.node.standalone).toBe(false);
+    expect(
+      (subcomponents.edges[0]?.node.parentComponent as { name: string }).name,
+    ).toBe("Button");
+    // synthetic inverse: reverse assertions found via the inverse loader
+    const implementations = component.implementations as {
+      edges: Array<{ node: { name: string } }>;
+    };
+    expect(implementations.edges.map((e) => e.node.name)).toEqual([
+      "react button",
+    ]);
+  });
+
+  it("resolves node() by prefixed-URI global ID with the most specific type", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        node(id: "ds:global.component.button") {
+          id
+          __typename
+          ... on Component { name }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const node = result.data?.node as Record<string, unknown>;
+    expect(node.__typename).toBe("Component");
+    expect(node.name).toBe("Button");
+  });
+
+  it("returns null for unknown prefixes and unknown URIs", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const unknownPrefix = await run(compiled, `{ node(id: "zz:nope") { id } }`);
+    expect(unknownPrefix.data?.node).toBeNull();
+    const unknownUri = await run(
+      compiled,
+      `{ node(id: "ds:does.not.exist") { id } }`,
+    );
+    expect(unknownUri.data?.node).toBeNull();
+  });
+
+  it("paginates listings with stable cursors", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const page1 = await run(
+      compiled,
+      `{ modifiers(first: 1) { edges { cursor node { name } } pageInfo { hasNextPage } } }`,
+    );
+    expect(page1.errors).toBeUndefined();
+    const modifiers = page1.data?.modifiers as {
+      edges: Array<{ cursor: string; node: { name: string } }>;
+      pageInfo: { hasNextPage: boolean };
+    };
+    expect(modifiers.edges).toHaveLength(1);
+    expect(modifiers.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it("rejects negative pagination arguments", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{ components(first: -1) { edges { cursor } } }`,
+    );
+    expect(result.errors?.[0]?.message).toContain("non-negative");
+  });
+
+  it("exposes _meta with class, fields, and per-class cardinality", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        component(uri: "ds:global.component.button") {
+          _meta {
+            type { uri label isAbstract superclasses { label } }
+            field(name: "name") { inherited property { label acceptanceCriteria } }
+            fields { property { label } }
+          }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const meta = (result.data?.component as Record<string, unknown>)
+      ._meta as Record<string, unknown>;
+    const type = meta.type as Record<string, unknown>;
+    expect(type.uri).toBe("https://ds.canonical.com/Component");
+    expect(type.isAbstract).toBe(false);
+    const field = meta.field as Record<string, unknown>;
+    expect(field.inherited).toBe(true); // ds:name declared on Entity
+    expect((field.property as Record<string, unknown>).acceptanceCriteria).toBe(
+      "Must be a human-readable display name.",
+    );
+    expect((meta.fields as unknown[]).length).toBeGreaterThan(3);
+  });
+
+  it("serves the TBox: ontologies, classes, instances", async () => {
+    const compiled = await setup(DS_REALISTIC_TTL, options);
+    const result = await run(
+      compiled,
+      `{
+        ontologies { prefix }
+        ontologyClass(uri: "https://ds.canonical.com/Component") {
+          label
+          isAbstract
+          instanceCount
+          instances(first: 5) { edges { node { id __typename } } }
+          properties { property { label } required singular inherited }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const prefixes = (result.data?.ontologies as Array<{ prefix: string }>).map(
+      (o) => o.prefix,
+    );
+    expect(prefixes).toContain("ds");
+    const cls = result.data?.ontologyClass as Record<string, unknown>;
+    expect(cls.instanceCount).toBe(1);
+    const instances = cls.instances as {
+      edges: Array<{ node: { id: string; __typename: string } }>;
+    };
+    expect(instances.edges[0]?.node.id).toBe("ds:global.component.button");
+    expect(instances.edges[0]?.node.__typename).toBe("Component");
+  });
+});
+
+describe("dual-direction inverse resolution", () => {
+  it("finds children even when only the reverse direction is asserted", async () => {
+    const compiled = await setup(INVERSE_TTL);
+    const result = await run(
+      compiled,
+      `{
+        parent(uri: "ex:p1") {
+          name
+          children(first: 10) { edges { node { uri childOf { name } } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const parent = result.data?.parent as Record<string, unknown>;
+    const children = parent.children as { edges: Array<{ node: unknown }> };
+    expect(children.edges).toHaveLength(2);
+  });
+});
+
+describe("embedded blank nodes", () => {
+  it("resolves embedded values inline with optional fields as null", async () => {
+    const compiled = await setup(BLANK_NODES_TTL);
+    const result = await run(
+      compiled,
+      `{ standard(uri: "ex:s1") { title examples { code language } } }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const examples = (result.data?.standard as Record<string, unknown>)
+      .examples as Array<Record<string, unknown>>;
+    expect(examples).toHaveLength(2);
+    const languages = examples.map((e) => e.language).sort();
+    expect(languages).toEqual([null, "typescript"].sort());
+  });
+});
+
+describe("coercion", () => {
+  it("coerces booleans, strips language tags, preserves empty strings", async () => {
+    const warnings: string[] = [];
+    const compiled = await setup(EDGE_CASES_TTL, {
+      onRuntimeWarning: (w) => warnings.push(w.reason),
+    });
+    const active = await run(compiled, `{ item(uri: "ex:i1") { active } }`);
+    expect((active.data?.item as { active: boolean }).active).toBe(true);
+    const label = await run(compiled, `{ item(uri: "ex:i3") { label } }`);
+    expect((label.data?.item as { label: string }).label).toBe("Tagged");
+    const summary = await run(compiled, `{ item(uri: "ex:i5") { summary } }`);
+    expect((summary.data?.item as { summary: string }).summary).toBe("");
+  });
+
+  it("self-referential chains resolve without infinite recursion", async () => {
+    const compiled = await setup(EDGE_CASES_TTL);
+    const result = await run(
+      compiled,
+      `{
+        item(uri: "ex:i2") {
+          uri
+          extends(first: 1) { edges { node { uri } } }
+        }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const item = result.data?.item as Record<string, unknown>;
+    const extendsConn = item.extends as {
+      edges: Array<{ node: { uri: string } }>;
+    };
+    // the chain terminates because resolution is per-level, not recursive
+    expect(extendsConn.edges[0]?.node.uri).toBe("ex:i2");
+  });
+});


### PR DESCRIPTION
> Re-opens the **core + plugin** delivery against `main` (the prior #676 was closed without merging). Stacks logically on #675 (map/emit) — until #675 lands, this PR's diff shows map/emit too; afterward it shows just core + plugin. **Base is `main`, so merging lands on `main` directly.**

## Done
The OWL→GraphQL library core + ke plugin: the `validate`/`wireRelay`/`compose` passes, the seven-pass orchestration (`compile`/`runPasses`/`createContextFactory`/artifact codec), the TBox introspection schema, `createSchemaPlugin`, and the pipeline/queries/performance integration suites. Includes the two adversarial-review fixes (artifact-freshness reset; C002 under `skipValidation`).

`bun run check && bun run test` → **290 tests, 100/100/100/100**.

- [x] `Feature 🎁`; Conventional Commits; code standards; colocated + integration tests; `no visual change`.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_