### PR TITLE
feat(ke-graphql): compiler map pass (OntologyIR → MappedIR)

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import BidirectionalNameMap from "./BidirectionalNameMap.js";
+
+describe("BidirectionalNameMap", () => {
+  it("maps an OWL URI to a GraphQL name and back", () => {
+    const map = new BidirectionalNameMap();
+    map.set("http://ex.org/Component", "Component");
+    expect(map.toGraphQL("http://ex.org/Component")).toBe("Component");
+    expect(map.toOWL("Component")).toBe("http://ex.org/Component");
+  });
+
+  it("returns undefined for unknown URIs and names", () => {
+    const map = new BidirectionalNameMap();
+    expect(map.toGraphQL("http://ex.org/Missing")).toBeUndefined();
+    expect(map.toOWL("Missing")).toBeUndefined();
+  });
+
+  it("keeps the first writer for the reverse direction", () => {
+    const map = new BidirectionalNameMap();
+    map.set("http://ex.org/a", "name");
+    map.set("http://ex.org/b", "name");
+    // Forward direction follows the latest write for each URI...
+    expect(map.toGraphQL("http://ex.org/a")).toBe("name");
+    expect(map.toGraphQL("http://ex.org/b")).toBe("name");
+    // ...but the reverse keeps the first canonical OWL target.
+    expect(map.toOWL("name")).toBe("http://ex.org/a");
+  });
+
+  it("iterates every OWL URI / GraphQL name pair in insertion order", () => {
+    const map = new BidirectionalNameMap();
+    map.set("http://ex.org/A", "A");
+    map.set("http://ex.org/B", "B");
+    expect([...map.entries()]).toEqual([
+      ["http://ex.org/A", "A"],
+      ["http://ex.org/B", "B"],
+    ]);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/BidirectionalNameMap.ts
@@ -1,0 +1,37 @@
+import type { NameMap } from "#shared";
+
+/**
+ * Bidirectional OWL URI ↔ GraphQL name map. Type names map globally; field
+ * names are scoped per type ("Component.tier") since the same property can
+ * surface on several types. For the reverse direction the first writer wins:
+ * a property mapped on several types keeps one canonical OWL target.
+ */
+export default class BidirectionalNameMap implements NameMap {
+  private readonly owlToGraphql = new Map<string, string>();
+  private readonly graphqlToOwl = new Map<string, string>();
+
+  /** Record a URI ↔ name pair (reverse direction: first writer wins). */
+  set(owlUri: string, graphqlName: string): void {
+    this.owlToGraphql.set(owlUri, graphqlName);
+    // First writer wins for the reverse direction: a property mapped on
+    // several types (inherited fields) keeps one canonical OWL target.
+    if (!this.graphqlToOwl.has(graphqlName)) {
+      this.graphqlToOwl.set(graphqlName, owlUri);
+    }
+  }
+
+  /** Look up the GraphQL name for an OWL URI. */
+  toGraphQL(uri: string): string | undefined {
+    return this.owlToGraphql.get(uri);
+  }
+
+  /** Look up the canonical OWL URI for a GraphQL name. */
+  toOWL(name: string): string | undefined {
+    return this.graphqlToOwl.get(name);
+  }
+
+  /** Iterate every (OWL URI, GraphQL name) pair. */
+  entries(): Iterable<[string, string]> {
+    return this.owlToGraphql.entries();
+  }
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/map.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/map.test.ts
@@ -1,0 +1,1017 @@
+// =============================================================================
+// Pass 4 — Map unit tests. Drives the name-resolution corners (sanitization,
+// reserved collisions, unresolvable collisions), the field-type arms (class,
+// union with abstract-member expansion, unknown), field-name collisions,
+// synthetic inverse fields, standard-vocab fields, and union emission — none of
+// which the fixture pipeline exercises.
+// =============================================================================
+
+import { describe, expect, it } from "vitest";
+import {
+  type ClassNode,
+  type OntologyIR,
+  type PropertyNode,
+  type RawExtraction,
+  XSD,
+} from "#shared";
+import build from "./build.js";
+import map from "./map.js";
+
+const NS = "http://example.org/";
+const uri = (local: string) => `${NS}${local}`;
+
+const makeExtraction = (
+  partial: Partial<RawExtraction> = {},
+): RawExtraction => ({
+  classes: [],
+  properties: [],
+  inverses: [],
+  functionals: new Set(),
+  datatypes: [],
+  namespaces: new Map([[NS, "ex"]]),
+  shaclConstraints: [],
+  unions: [],
+  instanceStats: new Map(),
+  selfReferential: new Set(),
+  functionalViolations: new Set(),
+  undeclaredPredicates: new Set(),
+  annotations: new Map(),
+  deepBlankNesting: false,
+  ...partial,
+});
+
+/** Build a real OntologyIR from a crafted extraction. */
+const buildIR = (
+  partial: Partial<RawExtraction>,
+  mappings: Parameters<typeof build>[1] = {},
+): OntologyIR => build(makeExtraction(partial), mappings).output;
+
+const codes = (diagnostics: { code: string }[]) =>
+  diagnostics.map((d) => d.code);
+
+describe("map — type name resolution", () => {
+  it("sanitizes an illegal class local name and reports M002", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("My-Class"), superclasses: [] }],
+      instanceStats: new Map([[uri("My-Class"), { total: 1, named: 1 }]]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(codes(diagnostics)).toContain("M002");
+    expect(output.types.has("My_Class")).toBe(true);
+  });
+
+  it("namespace-prefixes a class colliding with a reserved name (M004)", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Query"), superclasses: [] }],
+      instanceStats: new Map([[uri("Query"), { total: 1, named: 1 }]]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(codes(diagnostics)).toContain("M004");
+    expect(output.types.has("ExQuery")).toBe(true);
+  });
+
+  it("reports M001 when two custom mappings force the same type name", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("A"), superclasses: [] },
+        { uri: uri("B"), superclasses: [] },
+      ],
+      instanceStats: new Map([
+        [uri("A"), { total: 1, named: 1 }],
+        [uri("B"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { diagnostics } = map(ir, {
+      mappings: {
+        "ex:A": { graphqlName: "Dup" },
+        "ex:B": { graphqlName: "Dup" },
+      },
+    });
+    expect(codes(diagnostics)).toContain("M001");
+  });
+});
+
+describe("map — field type specs", () => {
+  it("resolves a class-typed field to its GraphQL type name", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Doc"), superclasses: [] },
+        { uri: uri("Author"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("writtenBy"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Author")],
+        },
+      ],
+      // functional → singular field name "writtenBy".
+      functionals: new Set([uri("writtenBy")]),
+      instanceStats: new Map([
+        [uri("Doc"), { total: 1, named: 1 }],
+        [uri("Author"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Doc")?.fields.get("writtenBy");
+    expect(field?.type).toEqual({ kind: "type", name: "Author" });
+  });
+
+  it("expands an abstract union member to its concrete descendants", () => {
+    // Animal (abstract) has concrete Dog; the union over {Animal, Plant}
+    // expands Animal → Dog and keeps Plant directly.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Animal"), superclasses: [] },
+        { uri: uri("Dog"), superclasses: [uri("Animal")] },
+        { uri: uri("Plant"), superclasses: [] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      unions: [
+        { property: uri("subject"), members: [uri("Animal"), uri("Plant")] },
+      ],
+      functionals: new Set([uri("subject")]),
+      // Animal has no instances + a subclass → abstract; Dog/Plant concrete.
+      instanceStats: new Map([
+        [uri("Dog"), { total: 1, named: 1 }],
+        [uri("Plant"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    expect(field?.type.kind).toBe("union");
+    if (field?.type.kind === "union") {
+      expect([...field.type.members].sort()).toEqual(["Dog", "Plant"]);
+      // anonymous range → synthesized "<Prop>Union" name.
+      expect(field.type.name).toBe("SubjectUnion");
+    }
+  });
+
+  it("skips union members that are not known classes", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Cat"), superclasses: [] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      // ex:Ghost is not declared as a class → dropped from the union.
+      unions: [
+        { property: uri("subject"), members: [uri("Cat"), uri("Ghost")] },
+      ],
+      functionals: new Set([uri("subject")]),
+      instanceStats: new Map([
+        [uri("Cat"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    if (field?.type.kind === "union") {
+      expect([...field.type.members]).toEqual(["Cat"]);
+    } else {
+      throw new Error("expected a union field");
+    }
+  });
+
+  it("dedupes a concrete descendant reachable by two abstract paths", () => {
+    // A and B are both abstract supertypes of the concrete C (diamond). A
+    // union over {A, B} must list C only once.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("A"), superclasses: [] },
+        { uri: uri("B"), superclasses: [] },
+        { uri: uri("C"), superclasses: [uri("A"), uri("B")] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      unions: [{ property: uri("subject"), members: [uri("A"), uri("B")] }],
+      functionals: new Set([uri("subject")]),
+      instanceStats: new Map([
+        [uri("C"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    if (field?.type.kind === "union") {
+      expect([...field.type.members]).toEqual(["C"]);
+    } else {
+      throw new Error("expected a union field");
+    }
+  });
+
+  it("dedupes a concrete member that appears twice in a union", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Cat"), superclasses: [] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      // Cat listed twice → only one member survives.
+      unions: [{ property: uri("subject"), members: [uri("Cat"), uri("Cat")] }],
+      functionals: new Set([uri("subject")]),
+      instanceStats: new Map([
+        [uri("Cat"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    if (field?.type.kind === "union") {
+      expect([...field.type.members]).toEqual(["Cat"]);
+    } else {
+      throw new Error("expected a union field");
+    }
+  });
+
+  it("uses a named union's name and emits X002", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Cat"), superclasses: [] },
+        { uri: uri("Box"), superclasses: [] },
+        { uri: uri("Holder"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("holds"),
+          kind: "object",
+          domains: [uri("Holder")],
+          ranges: [uri("Contents")],
+        },
+      ],
+      unions: [{ uri: uri("Contents"), members: [uri("Cat"), uri("Box")] }],
+      instanceStats: new Map([
+        [uri("Cat"), { total: 1, named: 1 }],
+        [uri("Box"), { total: 1, named: 1 }],
+        [uri("Holder"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(output.unions.has("Contents")).toBe(true);
+    expect(codes(diagnostics)).toContain("X002");
+  });
+
+  it("emits X003 for an anonymous-range union", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Cat"), superclasses: [] },
+        { uri: uri("Box"), superclasses: [] },
+        { uri: uri("Holder"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("holds"),
+          kind: "object",
+          domains: [uri("Holder")],
+          ranges: [],
+        },
+      ],
+      unions: [{ property: uri("holds"), members: [uri("Cat"), uri("Box")] }],
+      instanceStats: new Map([
+        [uri("Cat"), { total: 1, named: 1 }],
+        [uri("Box"), { total: 1, named: 1 }],
+        [uri("Holder"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(output.unions.has("HoldsUnion")).toBe(true);
+    expect(codes(diagnostics)).toContain("X003");
+  });
+
+  it("falls back to String for an unknown range", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("rel"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Nowhere")],
+        },
+      ],
+      functionals: new Set([uri("rel")]),
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    const field = output.types.get("Doc")?.fields.get("rel");
+    expect(field?.type).toEqual({ kind: "scalar", name: "String" });
+  });
+
+  it("falls back to String when a class range has no resolved type name", () => {
+    // Hand-built IR: a property whose class range URI is absent from the class
+    // map, so resolveTypeNames never assigns it a name.
+    const doc: ClassNode = {
+      uri: uri("Doc"),
+      label: "Doc",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [uri("rel")],
+      allProperties: [uri("rel")],
+    };
+    const rel: PropertyNode = {
+      uri: uri("rel"),
+      label: "rel",
+      namespace: "ex",
+      kind: "object",
+      domains: [uri("Doc")],
+      range: { kind: "class", uri: uri("Phantom") },
+      functional: true,
+      classCardinality: new Map(),
+      isAnnotation: false,
+      annotations: new Map(),
+    };
+    const ir: OntologyIR = {
+      classes: new Map([[doc.uri, doc]]),
+      properties: new Map([[rel.uri, rel]]),
+      namespaces: new Map([
+        ["ex", { prefix: "ex", uri: NS, classCount: 1, propertyCount: 1 }],
+      ]),
+      extraction: makeExtraction(),
+    };
+    const { output } = map(ir);
+    const field = output.types.get("Doc")?.fields.get("rel");
+    expect(field?.type).toEqual({ kind: "scalar", name: "String" });
+  });
+});
+
+describe("map — concrete descendant collection", () => {
+  it("is cycle-safe and skips unknown subclasses", () => {
+    // Build with a subClassOf cycle: A ↔ B both abstract, union over them.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B")] },
+        { uri: uri("B"), superclasses: [uri("A")] },
+        { uri: uri("C"), superclasses: [uri("A")] },
+        { uri: uri("Tag"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("subject"),
+          kind: "object",
+          domains: [uri("Tag")],
+          ranges: [],
+        },
+      ],
+      unions: [{ property: uri("subject"), members: [uri("A")] }],
+      functionals: new Set([uri("subject")]),
+      instanceStats: new Map([
+        [uri("C"), { total: 1, named: 1 }],
+        [uri("Tag"), { total: 1, named: 1 }],
+      ]),
+    });
+    // A is abstract (no instances, has subclasses); the walk must terminate.
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    expect(field?.type.kind).toBe("union");
+  });
+});
+
+describe("map — field name collisions", () => {
+  it("renames a field colliding with a reserved field name", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("uri"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output, diagnostics } = map(ir);
+    expect(codes(diagnostics)).toContain("M002");
+    // "uri" is reserved → namespace-prefixed to "exUri".
+    expect(output.types.get("Doc")?.fields.has("exUri")).toBe(true);
+  });
+
+  it("reports M001 when a renamed field collides with an existing field", () => {
+    // First property takes "dup"; second takes the prefixed form "exDup"; the
+    // third's "dup" collides → renamed to "exDup", which already exists → M001.
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("a"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+        {
+          uri: uri("b"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+        {
+          uri: uri("c"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { diagnostics } = map(ir, {
+      mappings: {
+        "ex:a": { graphqlName: "dup" },
+        "ex:b": { graphqlName: "exDup" },
+        "ex:c": { graphqlName: "dup" },
+      },
+    });
+    expect(codes(diagnostics)).toContain("M001");
+  });
+});
+
+describe("map — synthetic inverse fields", () => {
+  it("adds a synthetic inverse field on the range type", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Block"), superclasses: [] },
+        { uri: uri("Impl"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("implements"),
+          kind: "object",
+          domains: [uri("Impl")],
+          ranges: [uri("Block")],
+        },
+      ],
+      instanceStats: new Map([
+        [uri("Block"), { total: 1, named: 1 }],
+        [uri("Impl"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir, {
+      mappings: {
+        "ex:implements": { inverse: { graphqlName: "implementations" } },
+      },
+    });
+    const field = output.types.get("Block")?.fields.get("implementations");
+    expect(field?.resolverTemplate).toBe("inverse");
+    expect(field?.type).toEqual({ kind: "type", name: "Impl" });
+  });
+
+  it("falls back to Node when the synthetic inverse domain is unresolved", () => {
+    // Object property with a class range but NO domain — the synthetic field's
+    // type cannot resolve a domain type and falls back to Node.
+    const block: ClassNode = {
+      uri: uri("Block"),
+      label: "Block",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [],
+      allProperties: [],
+    };
+    const prop: PropertyNode = {
+      uri: uri("touches"),
+      label: "touches",
+      namespace: "ex",
+      kind: "object",
+      domains: [],
+      range: { kind: "class", uri: uri("Block") },
+      functional: false,
+      classCardinality: new Map(),
+      isAnnotation: false,
+      annotations: new Map(),
+    };
+    const ir: OntologyIR = {
+      classes: new Map([[block.uri, block]]),
+      properties: new Map([[prop.uri, prop]]),
+      namespaces: new Map([
+        ["ex", { prefix: "ex", uri: NS, classCount: 1, propertyCount: 1 }],
+      ]),
+      extraction: makeExtraction(),
+    };
+    const { output } = map(ir, {
+      mappings: { "ex:touches": { inverse: { graphqlName: "touchedBy" } } },
+    });
+    const field = output.types.get("Block")?.fields.get("touchedBy");
+    expect(field?.type).toEqual({ kind: "type", name: "Node" });
+  });
+
+  it("does not synthesize an inverse for a declared owl:inverseOf pair", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Parent"), superclasses: [] },
+        { uri: uri("Child"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("hasChild"),
+          kind: "object",
+          domains: [uri("Parent")],
+          ranges: [uri("Child")],
+        },
+        {
+          uri: uri("childOf"),
+          kind: "object",
+          domains: [uri("Child")],
+          ranges: [uri("Parent")],
+        },
+      ],
+      inverses: [{ property: uri("hasChild"), inverse: uri("childOf") }],
+      instanceStats: new Map([
+        [uri("Parent"), { total: 1, named: 1 }],
+        [uri("Child"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir, {
+      mappings: { "ex:hasChild": { inverse: { graphqlName: "kids" } } },
+    });
+    // The declared pair keeps its own forward field; no synthetic "kids".
+    expect(output.types.get("Child")?.fields.has("kids")).toBe(false);
+  });
+});
+
+describe("map — resolver templates", () => {
+  it("assigns the embedded-singular template to a functional embeddable range", () => {
+    // Card is embeddable (blank-only instances); a functional object property
+    // pointing at it yields a singular embedded field.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Doc"), superclasses: [] },
+        { uri: uri("Card"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("cover"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Card")],
+        },
+      ],
+      functionals: new Set([uri("cover")]),
+      instanceStats: new Map([
+        [uri("Doc"), { total: 1, named: 1 }],
+        [uri("Card"), { total: 2, named: 0 }],
+      ]),
+    });
+    const { output } = map(ir);
+    expect(output.types.get("Doc")?.fields.get("cover")?.resolverTemplate).toBe(
+      "embedded-singular",
+    );
+  });
+});
+
+describe("map — standard-vocab fields", () => {
+  it("adds opt-in instance-level standard-vocab fields", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir, {
+      standardVocabFields: {
+        Doc: { "http://www.w3.org/2000/01/rdf-schema#label": "rdfsLabel" },
+      },
+    });
+    const field = output.types.get("Doc")?.fields.get("rdfsLabel");
+    expect(field?.resolverTemplate).toBe("datatype");
+    expect(field?.type).toEqual({ kind: "scalar", name: "String" });
+  });
+
+  it("renames a standard-vocab field colliding with a reserved name", () => {
+    // The predicate is not a known property, so the rename's namespace lookup
+    // misses and falls back to the "x" prefix → "xId".
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output, diagnostics } = map(ir, {
+      standardVocabFields: {
+        Doc: { "http://www.w3.org/2000/01/rdf-schema#seeAlso": "id" },
+      },
+    });
+    expect(codes(diagnostics)).toContain("M002");
+    expect(output.types.get("Doc")?.fields.has("xId")).toBe(true);
+  });
+});
+
+describe("map — mappings on an unregistered namespace", () => {
+  it("returns no mapping when the class namespace prefix is empty", () => {
+    // The class lives in a namespace with no registered prefix → namespace "".
+    const FOREIGN = "http://foreign.test/";
+    const ir = buildIR(
+      {
+        classes: [{ uri: `${FOREIGN}Thing`, superclasses: [] }],
+        namespaces: new Map(),
+        instanceStats: new Map([[`${FOREIGN}Thing`, { total: 1, named: 1 }]]),
+      },
+      {},
+    );
+    // Supplying mappings forces findMapping past the direct lookup into the
+    // prefixed-key branch, where an empty namespace yields undefined.
+    const { output } = map(ir, {
+      mappings: { "ex:Unrelated": { graphqlName: "Nope" } },
+    });
+    expect(output.types.has("Thing")).toBe(true);
+  });
+});
+
+describe("map — defensive guards on a malformed IR", () => {
+  it("skips an allProperties entry that is annotation or missing", () => {
+    const doc: ClassNode = {
+      uri: uri("Doc"),
+      label: "Doc",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [uri("note"), uri("ghost")],
+      allProperties: [uri("note"), uri("ghost")],
+    };
+    const note: PropertyNode = {
+      uri: uri("note"),
+      label: "note",
+      namespace: "ex",
+      kind: "annotation",
+      domains: [uri("Doc")],
+      range: { kind: "scalar", xsd: `${XSD}string`, graphqlScalar: "String" },
+      functional: true,
+      classCardinality: new Map(),
+      isAnnotation: true,
+      annotations: new Map(),
+    };
+    const ir: OntologyIR = {
+      classes: new Map([[doc.uri, doc]]),
+      // ex:ghost is referenced by allProperties but absent from the map.
+      properties: new Map([[note.uri, note]]),
+      namespaces: new Map([
+        ["ex", { prefix: "ex", uri: NS, classCount: 1, propertyCount: 1 }],
+      ]),
+      extraction: makeExtraction(),
+    };
+    const { output } = map(ir);
+    // Neither the annotation nor the missing property produces a field.
+    expect(output.types.get("Doc")?.fields.size).toBe(0);
+  });
+
+  it("skips a dangling subclass when expanding an abstract union member", () => {
+    // Abstract A claims a subclass Gone that is absent from the class map; the
+    // descendant walk must terminate without throwing.
+    const a: ClassNode = {
+      uri: uri("A"),
+      label: "A",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [uri("Gone")],
+      isAbstract: true,
+      embeddable: false,
+      ownProperties: [],
+      allProperties: [],
+    };
+    const tag: ClassNode = {
+      uri: uri("Tag"),
+      label: "Tag",
+      namespace: "ex",
+      superclasses: [],
+      ancestors: [],
+      subclasses: [],
+      isAbstract: false,
+      embeddable: false,
+      ownProperties: [uri("subject")],
+      allProperties: [uri("subject")],
+    };
+    const subject: PropertyNode = {
+      uri: uri("subject"),
+      label: "subject",
+      namespace: "ex",
+      kind: "object",
+      domains: [uri("Tag")],
+      range: { kind: "union", members: [uri("A")] },
+      functional: true,
+      classCardinality: new Map(),
+      isAnnotation: false,
+      annotations: new Map(),
+    };
+    const ir: OntologyIR = {
+      classes: new Map([
+        [a.uri, a],
+        [tag.uri, tag],
+      ]),
+      properties: new Map([[subject.uri, subject]]),
+      namespaces: new Map([
+        ["ex", { prefix: "ex", uri: NS, classCount: 2, propertyCount: 1 }],
+      ]),
+      extraction: makeExtraction(),
+    };
+    const { output } = map(ir);
+    const field = output.types.get("Tag")?.fields.get("subject");
+    // A is abstract with no resolvable concrete descendants → empty union.
+    if (field?.type.kind === "union") {
+      expect([...field.type.members]).toEqual([]);
+    } else {
+      throw new Error("expected a union field");
+    }
+  });
+});
+
+describe("map — interfaces", () => {
+  it("emits an interface with its abstract parent chain", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Entity"), superclasses: [] },
+        { uri: uri("Tangible"), superclasses: [uri("Entity")] },
+        { uri: uri("Widget"), superclasses: [uri("Tangible")] },
+      ],
+      // Entity + Tangible abstract (no instances, have subclasses); Widget
+      // concrete.
+      instanceStats: new Map([[uri("Widget"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    expect(output.interfaces.has("Entity")).toBe(true);
+    expect(output.interfaces.has("Tangible")).toBe(true);
+    // Tangible's parent interface chain includes the abstract Entity.
+    expect([
+      ...(output.interfaces.get("Tangible")?.parentInterfaces ?? []),
+    ]).toContain("Entity");
+    const widget = output.types.get("Widget");
+    expect([...(widget?.interfaces ?? [])].sort()).toEqual([
+      "Entity",
+      "Tangible",
+    ]);
+  });
+
+  it("does not list a non-abstract ancestor as a parent interface", () => {
+    // Animal is concrete (has its own instance) yet has a subclass; it must
+    // not appear in Dog's implemented-interface list.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Animal"), superclasses: [] },
+        { uri: uri("Dog"), superclasses: [uri("Animal")] },
+      ],
+      instanceStats: new Map([
+        [uri("Animal"), { total: 1, named: 1 }],
+        [uri("Dog"), { total: 1, named: 1 }],
+      ]),
+    });
+    const { output } = map(ir);
+    expect(output.types.get("Dog")?.interfaces ?? []).toHaveLength(0);
+  });
+});
+
+describe("map — mapping resolution by namespace", () => {
+  it("resolves a custom mapping by prefixed property key", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("title"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir, {
+      mappings: { "ex:title": { graphqlName: "heading" } },
+    });
+    expect(output.types.get("Doc")?.fields.has("heading")).toBe(true);
+  });
+});
+
+describe("map — cardinality and interface coverage", () => {
+  it("resolves a custom mapping keyed by full IRI", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Thing"), superclasses: [] }],
+      instanceStats: new Map([[uri("Thing"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir, {
+      mappings: { [uri("Thing")]: { graphqlName: "Renamed" } },
+    });
+    expect(output.types.has("Renamed")).toBe(true);
+  });
+
+  it("reads a per-class cardinality spec when one is present", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Spec"), superclasses: [] },
+        { uri: uri("Hop"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("root"),
+          kind: "object",
+          domains: [uri("Spec")],
+          ranges: [uri("Hop")],
+        },
+      ],
+      shaclConstraints: [
+        {
+          targetClass: uri("Spec"),
+          property: uri("root"),
+          minCount: 1,
+          maxCount: 1,
+        },
+      ],
+      instanceStats: new Map([[uri("Spec"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    // maxCount 1 → the per-class spec makes it a singular object field.
+    expect(output.types.get("Spec")?.fields.get("root")?.type.kind).toBe(
+      "type",
+    );
+  });
+
+  it("omits a field whose SHACL maxCount is 0 (V010)", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Item"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("legacy"),
+          kind: "datatype",
+          domains: [uri("Item")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      shaclConstraints: [
+        { targetClass: uri("Item"), property: uri("legacy"), maxCount: 0 },
+      ],
+      instanceStats: new Map([[uri("Item"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    expect(output.types.get("Item")?.fields.has("legacy")).toBe(false);
+  });
+
+  it("makes an embeddable type implement its all-embeddable interface", () => {
+    // Shape: no instances + a subclass → abstract interface. Box: its only
+    // concrete descendant, blank-node-only → embeddable. The interface is thus
+    // embeddable, so the embeddable Box DOES implement it.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Shape"), superclasses: [] },
+        { uri: uri("Box"), superclasses: [uri("Shape")] },
+      ],
+      properties: [
+        {
+          uri: uri("size"),
+          kind: "datatype",
+          domains: [uri("Box")],
+          ranges: [`${XSD}integer`],
+        },
+      ],
+      instanceStats: new Map([[uri("Box"), { total: 2, named: 0 }]]),
+    });
+    const { output } = map(ir);
+    expect(output.interfaces.has("Shape")).toBe(true);
+    expect(output.types.get("Box")?.interfaces).toContain("Shape");
+  });
+
+  it("drops the interface from an embeddable type when a sibling is named", () => {
+    // Adding a named (non-embeddable) Card under Shape makes the interface
+    // non-embeddable: the embeddable Box no longer implements it (it would have
+    // no uri/_meta), but the non-embeddable Card still does.
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Shape"), superclasses: [] },
+        { uri: uri("Box"), superclasses: [uri("Shape")] },
+        { uri: uri("Card"), superclasses: [uri("Shape")] },
+      ],
+      properties: [
+        {
+          uri: uri("size"),
+          kind: "datatype",
+          domains: [uri("Box")],
+          ranges: [`${XSD}integer`],
+        },
+        {
+          uri: uri("label"),
+          kind: "datatype",
+          domains: [uri("Card")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      instanceStats: new Map([
+        [uri("Box"), { total: 2, named: 0 }], // embeddable
+        [uri("Card"), { total: 2, named: 2 }], // named → not embeddable
+      ]),
+    });
+    const { output } = map(ir);
+    expect(output.types.get("Box")?.interfaces ?? []).not.toContain("Shape");
+    expect(output.types.get("Card")?.interfaces).toContain("Shape");
+  });
+
+  it("picks templates by cardinality: datatype defaults singular, object list embedded", () => {
+    const ir = buildIR({
+      classes: [
+        { uri: uri("Doc"), superclasses: [] },
+        { uri: uri("Meta"), superclasses: [] },
+      ],
+      properties: [
+        {
+          uri: uri("title"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+        {
+          uri: uri("meta"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Meta")],
+        },
+      ],
+      // Datatype properties default to singular (so `title` is a singular
+      // datatype field); the non-functional object to the blank-only (=>
+      // embeddable) Meta is a list → embedded-list (pluralized to `metas`).
+      instanceStats: new Map([
+        [uri("Doc"), { total: 1, named: 1 }],
+        [uri("Meta"), { total: 1, named: 0 }],
+      ]),
+    });
+    const { output } = map(ir);
+    const fields = output.types.get("Doc")?.fields;
+    expect(fields?.get("title")?.resolverTemplate).toBe("datatype");
+    expect(fields?.get("metas")?.resolverTemplate).toBe("embedded-list");
+  });
+
+  it("uses the singular datatype template under a SHACL maxCount of 1", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("title"),
+          kind: "datatype",
+          domains: [uri("Doc")],
+          ranges: [`${XSD}string`],
+        },
+      ],
+      shaclConstraints: [
+        { targetClass: uri("Doc"), property: uri("title"), maxCount: 1 },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    // maxCount 1 → singular datatype template (not the list variant).
+    expect(output.types.get("Doc")?.fields.get("title")?.resolverTemplate).toBe(
+      "datatype",
+    );
+  });
+
+  it("resolves an object property with an unknown range as a String scalar (B003)", () => {
+    const ir = buildIR({
+      classes: [{ uri: uri("Doc"), superclasses: [] }],
+      properties: [
+        {
+          uri: uri("ref"),
+          kind: "object",
+          domains: [uri("Doc")],
+          ranges: [uri("Ghost")],
+        },
+      ],
+      instanceStats: new Map([[uri("Doc"), { total: 1, named: 1 }]]),
+    });
+    const { output } = map(ir);
+    // Ghost is not a known class → the object range falls back to a String
+    // scalar, so the (pluralized, non-functional list) field resolves as a
+    // datatype-list of strings, not a connection.
+    const refs = output.types.get("Doc")?.fields.get("refs");
+    expect(refs?.type).toEqual({ kind: "scalar", name: "String" });
+    expect(refs?.resolverTemplate).toBe("datatype-list");
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/map.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/map.ts
@@ -1,0 +1,505 @@
+// =============================================================================
+// Pass 4 — Map: OntologyIR → MappedIR
+//
+// Pure. OWL names → GraphQL names (custom overrides, has/is stripping, case
+// convention, pluralization, collision resolution), range → field type specs,
+// resolver template assignment, embeddable/interface interaction, synthetic
+// inverse fields, standard-vocab fields, non-null overrides.
+// =============================================================================
+
+import {
+  type ClassNode,
+  type Diagnostic,
+  type FieldTypeSpec,
+  getLocalName,
+  type MappedField,
+  type MappedInterface,
+  type MappedIR,
+  type MappedType,
+  type MappedUnion,
+  type OntologyIR,
+  type PassResult,
+  type PropertyNode,
+  RESERVED_FIELD_NAMES,
+  RESERVED_TYPE_NAMES,
+  type ResolverTemplate,
+} from "#shared";
+import BidirectionalNameMap from "./BidirectionalNameMap.js";
+import {
+  camelize,
+  pluralize,
+  sanitizeGraphQLName,
+  stripVerbPrefix,
+} from "./nameMap.js";
+import type { CustomMapping, SchemaPluginOptions } from "./types.js";
+
+const PHASE = "map";
+
+interface MapperState {
+  ir: OntologyIR;
+  options: SchemaPluginOptions;
+  diagnostics: Diagnostic[];
+  nameMap: BidirectionalNameMap;
+  typeNames: Map<string, string>; // class URI → resolved GraphQL type name
+}
+
+/** Find the custom mapping for a URI (full-IRI key first, prefixed key second). */
+const findMapping = (
+  state: MapperState,
+  uri: string,
+): CustomMapping | undefined => {
+  const direct = state.options.mappings?.[uri];
+  if (direct) {
+    return direct;
+  }
+  const ns =
+    state.ir.classes.get(uri)?.namespace ??
+    state.ir.properties.get(uri)?.namespace;
+  return ns
+    ? state.options.mappings?.[`${ns}:${getLocalName(uri)}`]
+    : undefined;
+};
+
+/** Resolve every class URI to its GraphQL type name with collision handling. */
+const resolveTypeNames = (state: MapperState): void => {
+  const taken = new Set<string>(RESERVED_TYPE_NAMES);
+  for (const node of state.ir.classes.values()) {
+    const custom = findMapping(state, node.uri)?.graphqlName;
+    let name = custom ?? getLocalName(node.uri);
+    const sanitized = sanitizeGraphQLName(name);
+    if (sanitized !== name) {
+      state.diagnostics.push({
+        severity: "warning",
+        code: "M002",
+        message: `class local name "${name}" is not a legal GraphQL name - sanitized to ${sanitized}`,
+        source: node.uri,
+        phase: PHASE,
+      });
+      name = sanitized;
+    }
+    if (taken.has(name) && !custom) {
+      // Rule 6a: prefix with PascalCase namespace prefix (M004 info).
+      const prefixed =
+        node.namespace.charAt(0).toUpperCase() + node.namespace.slice(1) + name;
+      state.diagnostics.push({
+        severity: "info",
+        code: "M004",
+        message: `type name ${name} collides with a reserved name — renamed to ${prefixed}`,
+        source: node.uri,
+        phase: PHASE,
+      });
+      name = prefixed;
+    }
+    if (taken.has(name)) {
+      state.diagnostics.push({
+        severity: "error",
+        code: "M001",
+        message: `type name ${name} (${node.uri}) collides and cannot be auto-resolved — add a custom mapping`,
+        source: node.uri,
+        phase: PHASE,
+      });
+    }
+    taken.add(name);
+    state.typeNames.set(node.uri, name);
+    state.nameMap.set(node.uri, name);
+  }
+};
+
+/** Compute the GraphQL field name for a property. */
+const computeFieldName = (
+  state: MapperState,
+  property: PropertyNode,
+  isList: boolean,
+): string => {
+  const custom = findMapping(state, property.uri)?.graphqlName;
+  if (custom) {
+    return custom;
+  }
+  let name = stripVerbPrefix(getLocalName(property.uri));
+  if (isList) {
+    name = pluralize(name);
+  }
+  return sanitizeGraphQLName(name);
+};
+
+/** Compute the GraphQL field type spec for a property's resolved range. */
+const computeFieldType = (
+  state: MapperState,
+  property: PropertyNode,
+): FieldTypeSpec => {
+  switch (property.range.kind) {
+    case "scalar":
+      return { kind: "scalar", name: property.range.graphqlScalar };
+    case "class": {
+      const name = state.typeNames.get(property.range.uri);
+      return name ? { kind: "type", name } : { kind: "scalar", name: "String" };
+    }
+    case "union": {
+      const name =
+        property.range.name ??
+        `${getLocalName(property.uri).charAt(0).toUpperCase()}${getLocalName(property.uri).slice(1)}Union`;
+      // Abstract members expand to concrete descendants.
+      const members: string[] = [];
+      for (const member of property.range.members) {
+        const node = state.ir.classes.get(member);
+        if (!node) {
+          continue;
+        }
+        if (node.isAbstract) {
+          for (const sub of collectConcreteDescendants(state.ir, node)) {
+            const subName = state.typeNames.get(sub);
+            if (subName && !members.includes(subName)) {
+              members.push(subName);
+            }
+          }
+        } else {
+          const memberName = state.typeNames.get(member);
+          if (memberName && !members.includes(memberName)) {
+            members.push(memberName);
+          }
+        }
+      }
+      return { kind: "union", name, members };
+    }
+    case "unknown":
+      return { kind: "scalar", name: "String" };
+  }
+};
+
+/** Collect the URIs of a class's concrete (non-abstract) descendants, cycle-safe. */
+const collectConcreteDescendants = (
+  ir: OntologyIR,
+  node: ClassNode,
+): string[] => {
+  const result: string[] = [];
+  const visited = new Set<string>();
+  const walk = (uri: string) => {
+    if (visited.has(uri)) {
+      return; // subClassOf cycles (B001) must not overflow the stack
+    }
+    visited.add(uri);
+    const current = ir.classes.get(uri);
+    if (!current) {
+      return;
+    }
+    if (!current.isAbstract) {
+      result.push(uri);
+    }
+    for (const sub of current.subclasses) {
+      walk(sub);
+    }
+  };
+  walk(node.uri);
+  return result;
+};
+
+/** Is the property's range an embeddable class? */
+const isEmbeddedRange = (state: MapperState, property: PropertyNode): boolean =>
+  property.range.kind === "class" &&
+  (state.ir.classes.get(property.range.uri)?.embeddable ?? false);
+
+/** Cardinality of a property on a specific class (per-class SHACL first). */
+const isSingularOn = (
+  property: PropertyNode,
+  classUri: string,
+  ancestors: readonly string[],
+): { singular: boolean; required: boolean; omit: boolean } => {
+  for (const uri of [classUri, ...ancestors]) {
+    const spec = property.classCardinality.get(uri);
+    if (spec) {
+      return spec;
+    }
+  }
+  return { singular: property.functional, required: false, omit: false };
+};
+
+/** Choose the resolver template for a field from its kind, cardinality, and type. */
+const chooseTemplate = (
+  property: PropertyNode,
+  singular: boolean,
+  embedded: boolean,
+  fieldType: FieldTypeSpec,
+): ResolverTemplate => {
+  // Decide from the RESOLVED type: an object property whose range fell back
+  // to String (unknown range, B003) must resolve its URI values as strings,
+  // not hand Connection shapes to a String field.
+  if (property.kind !== "object" || fieldType.kind === "scalar") {
+    return singular ? "datatype" : "datatype-list";
+  }
+  if (embedded) {
+    return singular ? "embedded-singular" : "embedded-list";
+  }
+  return singular ? "object-singular" : "object-list";
+};
+
+/** Build the MappedFields for one class (own + inherited). */
+const buildFields = (
+  state: MapperState,
+  node: ClassNode,
+  typeName: string,
+): Map<string, MappedField> => {
+  const fields = new Map<string, MappedField>();
+  const used = new Set<string>(node.embeddable ? [] : RESERVED_FIELD_NAMES);
+
+  const addField = (field: MappedField) => {
+    if (used.has(field.graphqlName)) {
+      // Rule 7: reserved/colliding field — namespace-prefix it.
+      const renamed = `${state.ir.properties.get(field.owlUri)?.namespace ?? "x"}${
+        field.graphqlName.charAt(0).toUpperCase() + field.graphqlName.slice(1)
+      }`;
+      state.diagnostics.push({
+        severity: "warning",
+        code: "M002",
+        message: `field ${typeName}.${field.graphqlName} collides with a reserved name — renamed to ${renamed}`,
+        source: field.owlUri,
+        phase: PHASE,
+      });
+      field = { ...field, graphqlName: renamed };
+    }
+    if (fields.has(field.graphqlName)) {
+      state.diagnostics.push({
+        severity: "error",
+        code: "M001",
+        message: `two properties map to ${typeName}.${field.graphqlName}`,
+        source: field.owlUri,
+        phase: PHASE,
+      });
+      return;
+    }
+    used.add(field.graphqlName);
+    fields.set(field.graphqlName, field);
+    state.nameMap.set(field.owlUri, field.graphqlName);
+  };
+
+  // Declared + inherited properties.
+  for (const propertyUri of node.allProperties) {
+    const property = state.ir.properties.get(propertyUri);
+    if (!property || property.isAnnotation) {
+      continue;
+    }
+    const { singular, omit } = isSingularOn(property, node.uri, node.ancestors);
+    if (omit) {
+      continue; // SHACL sh:maxCount 0 (V010)
+    }
+    const required = isSingularOn(property, node.uri, node.ancestors).required;
+    const embedded = isEmbeddedRange(state, property);
+    const list = !singular;
+    const name = computeFieldName(state, property, list);
+    const nonNull =
+      state.options.nonNullOverrides?.[typeName]?.includes(name) ?? false;
+    // Declared owl:inverseOf pair: the ABox may assert either direction, so
+    // each side resolves the union of forward + reverse assertions.
+    // List sides switch to the inverse template; singular sides keep their
+    // template but carry inverseOf for the reverse fallback.
+    const fieldType = computeFieldType(state, property);
+    const declaredInverse =
+      property.kind === "object" && fieldType.kind === "type" && !embedded
+        ? property.inverse
+        : undefined;
+    addField({
+      owlUri: property.uri,
+      graphqlName: name,
+      type: fieldType,
+      nullable: !nonNull,
+      list,
+      resolverTemplate:
+        declaredInverse && list
+          ? "inverse"
+          : chooseTemplate(property, singular, embedded, fieldType),
+      propertyUri: property.uri,
+      inverseOf: declaredInverse,
+      shaclRequired: required,
+      nonNull,
+    });
+  }
+
+  // Synthetic + declared inverse fields (Template 4).
+  for (const property of state.ir.properties.values()) {
+    if (property.kind !== "object" || property.range.kind !== "class") {
+      continue;
+    }
+    const rangeUri = property.range.uri;
+    const appliesHere =
+      rangeUri === node.uri || node.ancestors.includes(rangeUri);
+    if (!appliesHere) {
+      continue;
+    }
+    const synthetic = findMapping(state, property.uri)?.inverse;
+    const declared = property.inverse
+      ? state.ir.properties.get(property.inverse)
+      : undefined;
+    // Declared pairs: each side keeps its own forward field — the
+    // dual-direction union happens in the resolver, not via an extra field.
+    if (declared || !synthetic) {
+      continue;
+    }
+    const name = synthetic.graphqlName;
+    addField({
+      owlUri: `${property.uri}#inverse`,
+      graphqlName: name,
+      type: {
+        kind: "type",
+        name: state.typeNames.get(property.domains[0] ?? "") ?? "Node",
+      },
+      nullable: false,
+      list: true,
+      resolverTemplate: "inverse",
+      propertyUri: property.uri,
+      inverseOf: property.uri,
+      shaclRequired: false,
+      nonNull: true,
+    });
+  }
+
+  // Opt-in instance-level standard-vocab fields.
+  const vocabFields = state.options.standardVocabFields?.[typeName];
+  if (vocabFields) {
+    for (const [predicate, name] of Object.entries(vocabFields)) {
+      addField({
+        owlUri: predicate,
+        graphqlName: name,
+        type: { kind: "scalar", name: "String" },
+        nullable: true,
+        list: false,
+        resolverTemplate: "datatype",
+        propertyUri: predicate,
+        shaclRequired: false,
+        nonNull: false,
+      });
+    }
+  }
+
+  return fields;
+};
+
+/**
+ * An interface qualifies for embeddable implementors only when every
+ * concrete descendant is embeddable (no uri/_meta on the interface then).
+ */
+const isInterfaceEmbeddable = (ir: OntologyIR, node: ClassNode): boolean =>
+  collectConcreteDescendants(ir, node).every((uri) => {
+    /* v8 ignore next -- descendant URIs come from the class map, so the lookup always resolves and the false fallback is unreachable */
+    return ir.classes.get(uri)?.embeddable ?? false;
+  });
+
+/**
+ * Map the OntologyIR to the GraphQL-shaped MappedIR (Pass 4): resolved type
+ * and field names, field type specs, resolver template assignments, and the
+ * bidirectional name map. Pure.
+ */
+export default function map(
+  ir: OntologyIR,
+  options: SchemaPluginOptions = {},
+): PassResult<MappedIR> {
+  const diagnostics: Diagnostic[] = [];
+  const state: MapperState = {
+    ir,
+    options,
+    diagnostics,
+    nameMap: new BidirectionalNameMap(),
+    typeNames: new Map(),
+  };
+
+  // Report custom mappings that reference nothing (M003).
+  for (const key of Object.keys(options.mappings ?? {})) {
+    const full = ir.classes.has(key) || ir.properties.has(key);
+    const prefixed = [...ir.classes.values(), ...ir.properties.values()].some(
+      (n) => `${n.namespace}:${getLocalName(n.uri)}` === key,
+    );
+    if (!full && !prefixed) {
+      diagnostics.push({
+        severity: "warning",
+        code: "M003",
+        message: `custom mapping ${key} references no known class or property`,
+        source: key,
+        phase: PHASE,
+      });
+    }
+  }
+
+  resolveTypeNames(state);
+
+  const types = new Map<string, MappedType>();
+  const interfaces = new Map<string, MappedInterface>();
+  const unions = new Map<string, MappedUnion>();
+
+  for (const node of ir.classes.values()) {
+    const typeName = state.typeNames.get(node.uri);
+    /* v8 ignore next 3 -- resolveTypeNames assigns a name to every class in this same map, so a class without a resolved type name is unreachable */
+    if (!typeName) {
+      continue;
+    }
+    const fields = buildFields(state, node, typeName);
+    // Field-name reverse lookups are scoped per type and served from
+    // MappedType.fields (EntityMeta.field resolves through it) — the
+    // global NameMap carries type names plus a best-effort property entry.
+
+    if (node.isAbstract) {
+      const parentInterfaces = node.ancestors
+        .map((a) => state.typeNames.get(a))
+        .filter((n): n is string => n !== undefined)
+        .filter((n) => {
+          /* v8 ignore next -- every resolved type name was registered in the name map alongside its URI, so the reverse lookup always resolves and the empty-string fallback is unreachable */
+          const ownerUri = state.nameMap.toOWL(n) ?? "";
+          return ir.classes.get(ownerUri)?.isAbstract;
+        });
+      interfaces.set(typeName, {
+        owlUri: node.uri,
+        graphqlName: typeName,
+        parentInterfaces,
+        fields,
+      });
+      continue;
+    }
+
+    // Embeddable types implement an ancestor interface only when that
+    // interface itself is embeddable-safe (all implementors embeddable).
+    const implemented = node.ancestors
+      .map((a) => ir.classes.get(a))
+      .filter((a): a is ClassNode => Boolean(a?.isAbstract))
+      .filter((a) => !node.embeddable || isInterfaceEmbeddable(ir, a))
+      .map((a) => state.typeNames.get(a.uri))
+      .filter((n): n is string => n !== undefined);
+
+    types.set(typeName, {
+      owlUri: node.uri,
+      graphqlName: typeName,
+      interfaces: implemented,
+      fields,
+      embeddable: node.embeddable,
+      namespace: node.namespace,
+      singularName: camelize(typeName),
+      pluralName: pluralize(camelize(typeName)),
+    });
+  }
+
+  // Collect union specs from field types.
+  for (const container of [...types.values(), ...interfaces.values()]) {
+    for (const field of container.fields.values()) {
+      if (field.type.kind === "union" && !unions.has(field.type.name)) {
+        unions.set(field.type.name, {
+          name: field.type.name,
+          members: field.type.members,
+        });
+        diagnostics.push({
+          severity: "info",
+          code: field.type.name.endsWith("Union") ? "X003" : "X002",
+          message: `union ${field.type.name} = ${field.type.members.join(" | ")}`,
+          phase: PHASE,
+        });
+      }
+    }
+  }
+
+  return {
+    output: {
+      types,
+      interfaces,
+      unions,
+      nameMap: state.nameMap,
+      namespaces: ir.namespaces,
+      ir,
+    },
+    diagnostics,
+  };
+}

--- a/packages/runtime/ke-graphql/src/lib/compiler/nameMap.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/nameMap.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import BidirectionalNameMap from "./BidirectionalNameMap.js";
+import {
+  camelize,
+  pluralize,
+  sanitizeGraphQLName,
+  stripVerbPrefix,
+} from "./nameMap.js";
+
+describe("pluralize", () => {
+  it("applies the suffix rules", () => {
+    expect(pluralize("edge")).toBe("edges");
+    expect(pluralize("style")).toBe("styles");
+    expect(pluralize("category")).toBe("categories");
+    expect(pluralize("implementationLibrary")).toBe("implementationLibraries");
+    expect(pluralize("switch")).toBe("switches");
+    expect(pluralize("box")).toBe("boxes");
+  });
+
+  it("leaves names already ending in s unchanged", () => {
+    expect(pluralize("cases")).toBe("cases");
+    expect(pluralize("donts")).toBe("donts");
+    expect(pluralize("extends")).toBe("extends");
+  });
+
+  it("handles irregular plurals", () => {
+    expect(pluralize("child")).toBe("children");
+    expect(pluralize("person")).toBe("people");
+    expect(pluralize("grandChild")).toBe("grandChildren");
+  });
+
+  it("preserves the case of a capitalized irregular", () => {
+    expect(pluralize("Child")).toBe("Children");
+    expect(pluralize("Person")).toBe("People");
+  });
+});
+
+describe("stripVerbPrefix", () => {
+  it("strips has/is verb prefixes", () => {
+    expect(stripVerbPrefix("hasEdge")).toBe("edge");
+    expect(stripVerbPrefix("isDraft")).toBe("draft");
+    expect(stripVerbPrefix("hasModifierFamily")).toBe("modifierFamily");
+  });
+
+  it("leaves non-verb names alone", () => {
+    expect(stripVerbPrefix("name")).toBe("name");
+    expect(stripVerbPrefix("history")).toBe("history"); // not "has" + Word
+    expect(stripVerbPrefix("island")).toBe("island");
+  });
+});
+
+describe("sanitizeGraphQLName", () => {
+  it("replaces illegal characters and guards leading digits", () => {
+    expect(sanitizeGraphQLName("My-Class")).toBe("My_Class");
+    expect(sanitizeGraphQLName("has.thing")).toBe("has_thing");
+    expect(sanitizeGraphQLName("3d")).toBe("_3d");
+    expect(sanitizeGraphQLName("")).toBe("_");
+    expect(sanitizeGraphQLName("fine_Name0")).toBe("fine_Name0");
+  });
+});
+
+describe("camelize", () => {
+  it("lowercases the first character", () => {
+    expect(camelize("Component")).toBe("component");
+    expect(camelize("ImplementationLibrary")).toBe("implementationLibrary");
+  });
+});
+
+describe("BidirectionalNameMap", () => {
+  it("maps both directions with first-writer-wins reverse", () => {
+    const map = new BidirectionalNameMap();
+    map.set("https://ds.canonical.com/Component", "Component");
+    map.set("https://ds.canonical.com/name", "name");
+    map.set("http://pragma.canonical.com/codestandards#name", "name");
+    expect(map.toGraphQL("https://ds.canonical.com/Component")).toBe(
+      "Component",
+    );
+    expect(map.toOWL("Component")).toBe("https://ds.canonical.com/Component");
+    // first writer wins for the reverse direction
+    expect(map.toOWL("name")).toBe("https://ds.canonical.com/name");
+    expect([...map.entries()].length).toBe(3);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/nameMap.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/nameMap.ts
@@ -1,0 +1,82 @@
+// =============================================================================
+// The GraphQL naming rules: pluralization, casing, verb stripping, and
+// name sanitization. Grouped here because Pass 4 applies them together when
+// mapping OWL names to GraphQL names.
+// =============================================================================
+
+/** Irregular plurals the suffix rules cannot produce. */
+const IRREGULAR_PLURALS: Record<string, string> = {
+  child: "children",
+  person: "people",
+};
+
+/**
+ * Pluralize a camelCase field name:
+ *   a. irregulars (child → children)
+ *   b. already ends in 's' → unchanged (treated as plural: cases, donts)
+ *   c. consonant + 'y' → 'ies' (category → categories)
+ *   d. x/z/ch/sh → '+es' (switch → switches)
+ *   e. default → '+s' (edge → edges)
+ */
+export const pluralize = (name: string): string => {
+  // Preserve a camelCase prefix when the final word is irregular
+  // (hasChild → child; implementationChild → implementationChildren).
+  for (const [singular, plural] of Object.entries(IRREGULAR_PLURALS)) {
+    if (name.toLowerCase() === singular) {
+      return name[0] === name[0]?.toUpperCase()
+        ? plural.charAt(0).toUpperCase() + plural.slice(1)
+        : plural;
+    }
+    const suffix = singular.charAt(0).toUpperCase() + singular.slice(1);
+    if (name.endsWith(suffix)) {
+      return (
+        name.slice(0, -suffix.length) +
+        plural.charAt(0).toUpperCase() +
+        plural.slice(1)
+      );
+    }
+  }
+  if (name.endsWith("s")) {
+    return name;
+  }
+  if (/[^aeiou]y$/i.test(name)) {
+    return `${name.slice(0, -1)}ies`;
+  }
+  if (/(x|z|ch|sh)$/i.test(name)) {
+    return `${name}es`;
+  }
+  return `${name}s`;
+};
+
+/** Camelize a PascalCase type name (lowercase first letter) for root query fields. */
+export const camelize = (name: string): string =>
+  name.charAt(0).toLowerCase() + name.slice(1);
+
+/** Strip a leading "has"/"is" verb from a field name. */
+export const stripVerbPrefix = (name: string): string => {
+  for (const prefix of ["has", "is"]) {
+    if (
+      name.startsWith(prefix) &&
+      name.length > prefix.length &&
+      name[prefix.length] === name[prefix.length]?.toUpperCase()
+    ) {
+      const stripped = name.slice(prefix.length);
+      return stripped.charAt(0).toLowerCase() + stripped.slice(1);
+    }
+  }
+  return name;
+};
+
+/**
+ * Make a string a legal GraphQL name: [_a-zA-Z][_a-zA-Z0-9]*.
+ * Invalid characters (dots, dashes, unicode) become underscores; a leading
+ * digit gets an underscore prefix; an empty result becomes "_". Callers emit
+ * a diagnostic when the result differs from the input.
+ */
+export const sanitizeGraphQLName = (name: string): string => {
+  const cleaned = name.replace(/[^_a-zA-Z0-9]/g, "_");
+  if (cleaned.length === 0) {
+    return "_";
+  }
+  return /^[_a-zA-Z]/.test(cleaned) ? cleaned : `_${cleaned}`;
+};


### PR DESCRIPTION
> Split of #675 (map/emit) into two independent passes. The **map** pass. Base `main` (extract/build are on main). Pair: the emit PR. Merge both before the core (#678).

## Done
The **map pass** (`OntologyIR → MappedIR`): GraphQL type/field name resolution (illegal-character sanitization, reserved-name + collision handling), per-class SHACL cardinality, abstract-union member expansion to concrete descendants, embeddable-interface detection, and the resolver-template choice per field — plus the bidirectional OWL↔GraphQL name map.

`bun run check && bun run test` → **208 tests, 100/100/100/100** (unit-tested against crafted IRs; the 3 cases an adversarial review flagged as hollow are strengthened to assert real templates/types/interfaces).

- [x] `Feature 🎁`; Conventional Commits; code standards; colocated tests; `no visual change`.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_