### PR TITLE
feat(ke-graphql): compiler emit pass (MappedIR → GraphQL type plans)

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/compiler/emit.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/emit.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ClassNode,
+  EntityValue,
+  MappedField,
+  MappedInterface,
+  MappedIR,
+  MappedType,
+  MappedUnion,
+  NameMap,
+  OntologyIR,
+  ResolverTemplate,
+} from "#shared";
+import emit from "./emit.js";
+
+const nameMap: NameMap = {
+  toGraphQL: () => undefined,
+  toOWL: () => undefined,
+  entries: () => [][Symbol.iterator](),
+};
+
+const classNode = (
+  over: Partial<ClassNode> & Pick<ClassNode, "uri">,
+): ClassNode => ({
+  label: over.uri,
+  namespace: "ex",
+  superclasses: [],
+  ancestors: [],
+  subclasses: [],
+  isAbstract: false,
+  embeddable: false,
+  ownProperties: [],
+  allProperties: [],
+  ...over,
+});
+
+const mappedInterface = (
+  over: Partial<MappedInterface> &
+    Pick<MappedInterface, "owlUri" | "graphqlName">,
+): MappedInterface => ({
+  parentInterfaces: [],
+  fields: new Map(),
+  ...over,
+});
+
+const buildMappedWithTypes = (
+  types: Map<string, MappedType>,
+  classes: Map<string, ClassNode>,
+  interfaces: Map<string, MappedInterface>,
+  unions: Map<string, MappedUnion>,
+): MappedIR =>
+  ({
+    types,
+    interfaces,
+    unions,
+    nameMap,
+    namespaces: new Map(),
+    ir: {
+      classes,
+      properties: new Map(),
+      namespaces: new Map(),
+      extraction: {} as OntologyIR["extraction"],
+    },
+  }) as unknown as MappedIR;
+
+const buildMapped = (
+  classes: Map<string, ClassNode>,
+  interfaces: Map<string, MappedInterface>,
+  unions: Map<string, MappedUnion>,
+): MappedIR => buildMappedWithTypes(new Map(), classes, interfaces, unions);
+
+const field = (
+  template: ResolverTemplate,
+  over: Partial<MappedField> = {},
+): MappedField => ({
+  owlUri: `http://example.org/${template}`,
+  graphqlName: template.replace(/-/g, ""),
+  type:
+    template === "datatype" || template === "datatype-list"
+      ? { kind: "scalar", name: "String" }
+      : { kind: "type", name: "Thing" },
+  nullable: true,
+  list: template.endsWith("list"),
+  resolverTemplate: template,
+  propertyUri: `http://example.org/${template}`,
+  shaclRequired: false,
+  nonNull: false,
+  ...over,
+});
+
+const typeWithFields = (fields: Map<string, MappedField>): MappedType => ({
+  owlUri: "http://example.org/Thing",
+  graphqlName: "Thing",
+  interfaces: [],
+  fields,
+  embeddable: false,
+  namespace: "ex",
+  pluralName: "things",
+  singularName: "thing",
+});
+
+describe("emit createResolver", () => {
+  it("instantiates a resolver for every template, including inverse and meta", () => {
+    const fields = new Map<string, MappedField>();
+    for (const template of [
+      "datatype",
+      "datatype-list",
+      "object-singular",
+      "object-list",
+      "embedded-singular",
+      "embedded-list",
+      "meta",
+    ] as ResolverTemplate[]) {
+      fields.set(template, field(template));
+    }
+    // inverse WITH an explicit inverseOf (left side of the ??)
+    fields.set(
+      "inverseExplicit",
+      field("inverse", {
+        graphqlName: "inverseExplicit",
+        inverseOf: "http://example.org/forward",
+      }),
+    );
+    // inverse WITHOUT inverseOf → falls back to propertyUri (right side of ??)
+    fields.set(
+      "inverseFallback",
+      field("inverse", {
+        graphqlName: "inverseFallback",
+        inverseOf: undefined,
+      }),
+    );
+
+    const types = new Map<string, MappedType>([
+      ["Thing", typeWithFields(fields)],
+    ]);
+    const result = emit(
+      buildMappedWithTypes(types, new Map(), new Map(), new Map()),
+    );
+    const planFields = result.output.types.get("Thing")?.fields;
+    expect(planFields?.size).toBe(fields.size);
+    for (const name of [
+      "datatype",
+      "datatypelist",
+      "objectsingular",
+      "objectlist",
+      "embeddedsingular",
+      "embeddedlist",
+      "inverseExplicit",
+      "inverseFallback",
+    ]) {
+      expect(typeof planFields?.get(name)?.resolve).toBe("function");
+    }
+    // the meta resolver returns the parent unchanged
+    const metaResolve = planFields?.get("meta")?.resolve;
+    const parent = { uri: "ex:x", typename: "Thing", triples: new Map() };
+    expect(
+      metaResolve?.(parent as EntityValue, {}, {} as never, {} as never),
+    ).toBe(parent);
+  });
+});
+
+describe("emit unions", () => {
+  it("emits one UnionPlan per mapped union", () => {
+    const unions = new Map<string, MappedUnion>([
+      ["Shape", { name: "Shape", members: ["Circle", "Square"] }],
+    ]);
+    const result = emit(buildMapped(new Map(), new Map(), unions));
+    expect(result.output.unions.get("Shape")?.members).toEqual([
+      "Circle",
+      "Square",
+    ]);
+  });
+});
+
+describe("emit areAllImplementorsEmbeddable (cycle-safe walk)", () => {
+  it("returns false (non-embeddableOnly) when the interface class is missing from the IR", () => {
+    // owlUri has no ClassNode → the walk's root lookup returns undefined.
+    const interfaces = new Map([
+      [
+        "Ghost",
+        mappedInterface({
+          owlUri: "http://example.org/Ghost",
+          graphqlName: "Ghost",
+        }),
+      ],
+    ]);
+    const result = emit(buildMapped(new Map(), interfaces, new Map()));
+    expect(result.output.interfaces.get("Ghost")?.embeddableOnly).toBe(false);
+  });
+
+  it("survives a subClassOf cycle without overflowing the stack", () => {
+    // A → B → A self-cycle: the visited-set guard short-circuits the revisit.
+    const classes = new Map<string, ClassNode>([
+      [
+        "http://example.org/A",
+        classNode({
+          uri: "http://example.org/A",
+          isAbstract: true,
+          subclasses: ["http://example.org/B"],
+        }),
+      ],
+      [
+        "http://example.org/B",
+        classNode({
+          uri: "http://example.org/B",
+          embeddable: true,
+          subclasses: ["http://example.org/A"],
+        }),
+      ],
+    ]);
+    const interfaces = new Map([
+      [
+        "A",
+        mappedInterface({ owlUri: "http://example.org/A", graphqlName: "A" }),
+      ],
+    ]);
+    const result = emit(buildMapped(classes, interfaces, new Map()));
+    // B is the only concrete implementor and it is embeddable → true.
+    expect(result.output.interfaces.get("A")?.embeddableOnly).toBe(true);
+  });
+
+  it("skips a subclass URI that is absent from the IR", () => {
+    // Iface's class lists a subclass that has no ClassNode → walk returns early.
+    const classes = new Map<string, ClassNode>([
+      [
+        "http://example.org/Iface",
+        classNode({
+          uri: "http://example.org/Iface",
+          isAbstract: true,
+          subclasses: ["http://example.org/Missing"],
+        }),
+      ],
+    ]);
+    const interfaces = new Map([
+      [
+        "Iface",
+        mappedInterface({
+          owlUri: "http://example.org/Iface",
+          graphqlName: "Iface",
+        }),
+      ],
+    ]);
+    const result = emit(buildMapped(classes, interfaces, new Map()));
+    // No concrete implementors reachable → not embeddable-only.
+    expect(result.output.interfaces.get("Iface")?.embeddableOnly).toBe(false);
+  });
+});

--- a/packages/runtime/ke-graphql/src/lib/compiler/emit.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/emit.ts
@@ -1,0 +1,213 @@
+// =============================================================================
+// Pass 5 — Emit: MappedIR → SchemaPlan
+//
+// Pure. Produces *plans* (field descriptors with resolvers and string type
+// references), not graphql-js objects: graphql-js types are immutable, so
+// Pass 6 augments plans and Pass 7 constructs every GraphQL*Type exactly
+// once, with thunks for circular references.
+// =============================================================================
+
+import type { GraphQLFieldResolver } from "graphql";
+import {
+  createDatatypeListResolver,
+  createDatatypeResolver,
+  createEmbeddedListResolver,
+  createEmbeddedSingularResolver,
+  createInverseResolver,
+  createObjectListResolver,
+  createObjectSingularResolver,
+} from "#resolver";
+import type {
+  CompilerContext,
+  Diagnostic,
+  EntityValue,
+  MappedField,
+  MappedIR,
+  PassResult,
+} from "#shared";
+
+/** A reference to a (possibly not-yet-constructed) GraphQL type. */
+export interface TypeRef {
+  /** Scalar name, object/interface/union name, or connection base name. */
+  base: string;
+  kind: "scalar" | "named" | "connection";
+  list: boolean;
+  nonNull: boolean;
+}
+
+/** The plan for one GraphQL field: type reference, args, and resolver. */
+export interface FieldPlan {
+  name: string;
+  type: TypeRef;
+  /** Attach the four Relay connection args. */
+  connectionArgs?: boolean;
+  /** Static args spec: name → scalar type name + required flag. */
+  args?: Record<string, { type: "String" | "Int" | "ID"; required: boolean }>;
+  resolve?: GraphQLFieldResolver<EntityValue, CompilerContext>;
+  description?: string;
+}
+
+/** The plan for one GraphQL object type. */
+export interface TypePlan {
+  name: string;
+  owlUri?: string;
+  interfaces: string[];
+  fields: Map<string, FieldPlan>;
+  embeddable: boolean;
+  description?: string;
+}
+
+/** The plan for one GraphQL interface. */
+export interface InterfacePlan {
+  name: string;
+  owlUri?: string;
+  parents: string[];
+  fields: Map<string, FieldPlan>;
+  /** All concrete implementors are embeddable (no Node membership). */
+  embeddableOnly: boolean;
+  description?: string;
+}
+
+/** The plan for one GraphQL union. */
+export interface UnionPlan {
+  name: string;
+  members: string[];
+}
+
+/** Pass 5/6 output: every type, interface, union, and root field as a plan. */
+export interface SchemaPlan {
+  types: Map<string, TypePlan>;
+  interfaces: Map<string, InterfacePlan>;
+  unions: Map<string, UnionPlan>;
+  queryFields: Map<string, FieldPlan>;
+  mapped: MappedIR;
+}
+
+/** Build the TypeRef for a mapped field. */
+const buildTypeRef = (field: MappedField): TypeRef => ({
+  base: field.type.name,
+  kind: field.type.kind === "scalar" ? "scalar" : "named",
+  list: field.list,
+  nonNull: field.nonNull || !field.nullable,
+});
+
+/** Create the resolve function for a mapped field from its template. */
+const createResolver = (
+  field: MappedField,
+): GraphQLFieldResolver<EntityValue, CompilerContext> => {
+  switch (field.resolverTemplate) {
+    case "datatype":
+      return createDatatypeResolver(field);
+    case "datatype-list":
+      return createDatatypeListResolver(field);
+    case "object-singular":
+      return createObjectSingularResolver(field);
+    case "object-list":
+      return createObjectListResolver(field);
+    case "embedded-singular":
+      return createEmbeddedSingularResolver(field, field.type.name);
+    case "embedded-list":
+      return createEmbeddedListResolver(field, field.type.name);
+    case "inverse":
+      return createInverseResolver(field, field.inverseOf ?? field.propertyUri);
+    case "meta":
+      return (parent) => parent;
+  }
+};
+
+/**
+ * Emit the SchemaPlan from the MappedIR (Pass 5): one plan per type,
+ * interface, and union, with resolver instances attached to every field.
+ * Pure — no graphql-js objects are constructed here.
+ */
+export default function emit(mapped: MappedIR): PassResult<SchemaPlan> {
+  const diagnostics: Diagnostic[] = [];
+  const types = new Map<string, TypePlan>();
+  const interfaces = new Map<string, InterfacePlan>();
+  const unions = new Map<string, UnionPlan>();
+
+  const planFields = (
+    fields: ReadonlyMap<string, MappedField>,
+  ): Map<string, FieldPlan> => {
+    const plans = new Map<string, FieldPlan>();
+    for (const field of fields.values()) {
+      const description = mapped.ir.properties.get(
+        field.propertyUri,
+      )?.definition;
+      plans.set(field.graphqlName, {
+        name: field.graphqlName,
+        type: buildTypeRef(field),
+        resolve: createResolver(field),
+        description,
+      });
+    }
+    return plans;
+  };
+
+  for (const mappedInterface of mapped.interfaces.values()) {
+    const node = mapped.ir.classes.get(mappedInterface.owlUri);
+    interfaces.set(mappedInterface.graphqlName, {
+      name: mappedInterface.graphqlName,
+      owlUri: mappedInterface.owlUri,
+      parents: [...mappedInterface.parentInterfaces],
+      fields: planFields(mappedInterface.fields),
+      embeddableOnly: areAllImplementorsEmbeddable(
+        mapped,
+        mappedInterface.owlUri,
+      ),
+      description: node?.definition,
+    });
+  }
+
+  for (const mappedType of mapped.types.values()) {
+    const node = mapped.ir.classes.get(mappedType.owlUri);
+    types.set(mappedType.graphqlName, {
+      name: mappedType.graphqlName,
+      owlUri: mappedType.owlUri,
+      interfaces: [...mappedType.interfaces],
+      fields: planFields(mappedType.fields),
+      embeddable: mappedType.embeddable,
+      description: node?.definition,
+    });
+  }
+
+  for (const union of mapped.unions.values()) {
+    unions.set(union.name, { name: union.name, members: [...union.members] });
+  }
+
+  return {
+    output: { types, interfaces, unions, queryFields: new Map(), mapped },
+    diagnostics,
+  };
+}
+
+/** Are all concrete implementors of an interface embeddable? Cycle-safe walk. */
+const areAllImplementorsEmbeddable = (
+  mapped: MappedIR,
+  interfaceUri: string,
+): boolean => {
+  const node = mapped.ir.classes.get(interfaceUri);
+  if (!node) {
+    return false;
+  }
+  const concrete: boolean[] = [];
+  const visited = new Set<string>();
+  const walk = (uri: string) => {
+    if (visited.has(uri)) {
+      return; // subClassOf cycles (B001) must not overflow the stack
+    }
+    visited.add(uri);
+    const current = mapped.ir.classes.get(uri);
+    if (!current) {
+      return;
+    }
+    if (!current.isAbstract) {
+      concrete.push(current.embeddable);
+    }
+    for (const sub of current.subclasses) {
+      walk(sub);
+    }
+  };
+  walk(interfaceUri);
+  return concrete.length > 0 && concrete.every(Boolean);
+};


### PR DESCRIPTION
> Split of #675 (map/emit) into two independent passes. The **emit** pass. Base `main` — independent of the map pass (it consumes the `MappedIR` contract from `#shared`, not map's code). Pair: the map PR (#680). Merge both before the core (#678).

## Done
The **emit pass** (`MappedIR → GraphQL type plans`): builds the GraphQL object/interface/union type plans and scalars from the `MappedIR`, selecting the resolver for each field.

`bun run check && bun run test` → **165 tests, 100/100/100/100** (unit-tested against a hand-crafted `MappedIR`).

- [x] `Feature 🎁`; Conventional Commits; code standards; colocated tests; `no visual change`.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_