### PR TITLE
feat(pragma-cli): graphql serve + config-driven build/check over semantic packages

### DIFF
--- a/packages/cli/pragma/src/domains/graphql/commands/build.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/build.test.ts
@@ -181,13 +181,15 @@ describe("graphql build command", () => {
     expect(printed).toContain("C003");
   });
 
-  it("throws structured error when sources are missing", async () => {
+  it("throws a structured error when explicit sources match nothing", async () => {
     const ctx = makeCtx();
 
-    await expect(buildCommand.execute({}, ctx)).rejects.toMatchObject({
+    await expect(
+      buildCommand.execute({ sources: ["no-such-*.ttl"] }, ctx),
+    ).rejects.toMatchObject({
       code: "INVALID_INPUT",
       recovery: {
-        message: "Provide at least one TTL file or glob pattern.",
+        message: "No files matched the given paths or glob patterns.",
       },
     });
   });

--- a/packages/cli/pragma/src/domains/graphql/commands/build.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/build.ts
@@ -7,10 +7,9 @@ import {
   createOutputResult,
 } from "@canonical/cli-core";
 import { serializeExtraction } from "@canonical/ke-graphql";
-import { PragmaError } from "#error";
 import { selectFormatter } from "../../shared/formatters.js";
 import { reportFormatters } from "../formatters/index.js";
-import { parsePrefixes } from "../helpers/index.js";
+import { gatherSources, parsePrefixes } from "../helpers/index.js";
 import { compileSchema } from "../operations/index.js";
 import type { GraphqlCompileReport } from "../types.js";
 
@@ -37,10 +36,10 @@ const buildCommand: CommandDefinition = {
   parameters: [
     {
       name: "sources",
-      description: "TTL source files or glob patterns",
+      description:
+        "TTL files or globs (default: the configured semantic packages)",
       type: "multiselect",
       positional: true,
-      required: true,
     },
     {
       name: "sdl",
@@ -68,15 +67,10 @@ const buildCommand: CommandDefinition = {
     ],
   },
   async execute(params, ctx): Promise<CommandResult> {
-    const sources = readStringArray(params.sources);
-    if (sources.length === 0) {
-      throw PragmaError.invalidInput("sources", "(empty)", {
-        recovery: {
-          message: "Provide at least one TTL file or glob pattern.",
-        },
-      });
-    }
-
+    const sources = await gatherSources(
+      readStringArray(params.sources),
+      ctx.cwd,
+    );
     const prefixes = parsePrefixes(readStringArray(params.prefix));
     const outcome = await compileSchema({ sources, prefixes, cwd: ctx.cwd });
     const format = selectFormatter(ctx, reportFormatters);

--- a/packages/cli/pragma/src/domains/graphql/commands/build.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/build.ts
@@ -8,13 +8,11 @@ import {
 } from "@canonical/cli-core";
 import { serializeExtraction } from "@canonical/ke-graphql";
 import { selectFormatter } from "../../shared/formatters.js";
+import { DEFAULT_EXTRACTION_PATH, DEFAULT_SDL_PATH } from "../constants.js";
 import { reportFormatters } from "../formatters/index.js";
 import { gatherSources, parsePrefixes } from "../helpers/index.js";
 import { compileSchema } from "../operations/index.js";
 import type { GraphqlCompileReport } from "../types.js";
-
-const DEFAULT_SDL_PATH = "./schema.graphql";
-const DEFAULT_EXTRACTION_PATH = "./extraction.json";
 
 /** Narrow an unknown param to a string array. */
 function readStringArray(value: unknown): string[] {

--- a/packages/cli/pragma/src/domains/graphql/commands/check.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/check.test.ts
@@ -126,13 +126,15 @@ describe("graphql check command", () => {
     expect(parsed.artifacts).toBeUndefined();
   });
 
-  it("throws structured error when sources are missing", async () => {
+  it("throws a structured error when explicit sources match nothing", async () => {
     const ctx = makeCtx();
 
-    await expect(checkCommand.execute({}, ctx)).rejects.toMatchObject({
+    await expect(
+      checkCommand.execute({ sources: ["no-such-*.ttl"] }, ctx),
+    ).rejects.toMatchObject({
       code: "INVALID_INPUT",
       recovery: {
-        message: "Provide at least one TTL file or glob pattern.",
+        message: "No files matched the given paths or glob patterns.",
       },
     });
   });

--- a/packages/cli/pragma/src/domains/graphql/commands/check.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/check.ts
@@ -4,10 +4,9 @@ import {
   createExitResult,
   createOutputResult,
 } from "@canonical/cli-core";
-import { PragmaError } from "#error";
 import { selectFormatter } from "../../shared/formatters.js";
 import { reportFormatters } from "../formatters/index.js";
-import { parsePrefixes } from "../helpers/index.js";
+import { gatherSources, parsePrefixes } from "../helpers/index.js";
 import { compileSchema } from "../operations/index.js";
 import type { GraphqlCompileReport } from "../types.js";
 
@@ -31,10 +30,10 @@ const checkCommand: CommandDefinition = {
   parameters: [
     {
       name: "sources",
-      description: "TTL source files or glob patterns",
+      description:
+        "TTL files or globs (default: the configured semantic packages)",
       type: "multiselect",
       positional: true,
-      required: true,
     },
     {
       name: "prefix",
@@ -49,15 +48,10 @@ const checkCommand: CommandDefinition = {
     ],
   },
   async execute(params, ctx): Promise<CommandResult> {
-    const sources = readStringArray(params.sources);
-    if (sources.length === 0) {
-      throw PragmaError.invalidInput("sources", "(empty)", {
-        recovery: {
-          message: "Provide at least one TTL file or glob pattern.",
-        },
-      });
-    }
-
+    const sources = await gatherSources(
+      readStringArray(params.sources),
+      ctx.cwd,
+    );
     const prefixes = parsePrefixes(readStringArray(params.prefix));
     const outcome = await compileSchema({ sources, prefixes, cwd: ctx.cwd });
 

--- a/packages/cli/pragma/src/domains/graphql/commands/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/index.ts
@@ -2,3 +2,4 @@
 
 export { default as buildCommand } from "./build.js";
 export { default as checkCommand } from "./check.js";
+export { default as serveCommand } from "./serve.js";

--- a/packages/cli/pragma/src/domains/graphql/commands/serve.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/serve.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { PragmaContext } from "../../shared/context.js";
+import serveCommand, { readPort } from "./serve.js";
+
+describe("readPort", () => {
+  it("parses a valid port", () => {
+    expect(readPort("4001")).toBe(4001);
+  });
+
+  it("falls back to the default for non-string values", () => {
+    expect(readPort(undefined)).toBe(4000);
+    expect(readPort(4001)).toBe(4000);
+  });
+
+  it("falls back to the default for out-of-range or unparseable values", () => {
+    expect(readPort("0")).toBe(4000);
+    expect(readPort("70000")).toBe(4000);
+    expect(readPort("not-a-port")).toBe(4000);
+  });
+});
+
+describe("graphql serve command", () => {
+  const ctx = { cwd: process.cwd() } as PragmaContext;
+  const original = (globalThis as Record<string, unknown>).Bun;
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).Bun = original;
+  });
+
+  it("requires the Bun runtime", async () => {
+    (globalThis as Record<string, unknown>).Bun = undefined;
+
+    await expect(serveCommand.execute({}, ctx)).rejects.toMatchObject({
+      code: "STORE_ERROR",
+      recovery: {
+        message: "Run the compiled `pragma` binary or use `bun run`.",
+      },
+    });
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/commands/serve.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/serve.ts
@@ -4,13 +4,12 @@ import {
   createOutputResult,
 } from "@canonical/cli-core";
 import { PragmaError } from "#error";
+import { DEFAULT_PORT } from "../constants.js";
 import { gatherSources, parsePrefixes } from "../helpers/index.js";
 import routeGraphql from "../helpers/routeGraphql.js";
 import createSchemaServer, {
   type SchemaServer,
 } from "../operations/createSchemaServer.js";
-
-const DEFAULT_PORT = 4000;
 
 /** Narrow an unknown param to a string array. */
 function readStringArray(value: unknown): string[] {

--- a/packages/cli/pragma/src/domains/graphql/commands/serve.ts
+++ b/packages/cli/pragma/src/domains/graphql/commands/serve.ts
@@ -1,0 +1,132 @@
+import {
+  type CommandDefinition,
+  type CommandResult,
+  createOutputResult,
+} from "@canonical/cli-core";
+import { PragmaError } from "#error";
+import { gatherSources, parsePrefixes } from "../helpers/index.js";
+import routeGraphql from "../helpers/routeGraphql.js";
+import createSchemaServer, {
+  type SchemaServer,
+} from "../operations/createSchemaServer.js";
+
+const DEFAULT_PORT = 4000;
+
+/** Narrow an unknown param to a string array. */
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+/** Parse the --port flag, falling back to the default on anything invalid. */
+export function readPort(value: unknown): number {
+  if (typeof value !== "string") {
+    return DEFAULT_PORT;
+  }
+  const port = Number.parseInt(value, 10);
+  return Number.isInteger(port) && port > 0 && port < 65536
+    ? port
+    : DEFAULT_PORT;
+}
+
+/**
+ * Listen on `port` and block until the process is interrupted, then stop
+ * the server and dispose the store.
+ *
+ * @note Impure — opens a network listener and registers signal handlers.
+ */
+/* v8 ignore start -- the live Bun.serve listener and signal loop run under `pragma graphql serve`, not unit tests */
+async function listen(server: SchemaServer, port: number): Promise<void> {
+  const httpServer = Bun.serve({
+    port,
+    fetch: (request) => routeGraphql(request, server.handler, port),
+  });
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      httpServer.stop();
+      server.dispose();
+      resolve();
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}
+/* v8 ignore stop */
+
+/**
+ * Builds the `pragma graphql serve` command definition.
+ *
+ * Compiles the configured ontologies (or explicit TTL sources) and serves
+ * a local GraphQL + GraphiQL endpoint until interrupted. With no positional
+ * sources it serves every TTL across the semantic packages in
+ * `pragma.config.json`.
+ */
+const serveCommand: CommandDefinition = {
+  path: ["graphql", "serve"],
+  description:
+    "Serve a local GraphQL + GraphiQL endpoint over the configured ontologies",
+  parameters: [
+    {
+      name: "sources",
+      description:
+        "TTL files or globs to serve (default: the configured semantic packages)",
+      type: "multiselect",
+      positional: true,
+    },
+    {
+      name: "port",
+      description: `Port to listen on (default ${DEFAULT_PORT})`,
+      type: "string",
+    },
+    {
+      name: "prefix",
+      description: "Ontology prefix as name=namespace (repeatable)",
+      type: "multiselect",
+    },
+  ],
+  meta: {
+    examples: [
+      "pragma graphql serve",
+      "pragma graphql serve ontology.ttl --port 4001",
+    ],
+  },
+  async execute(params, ctx): Promise<CommandResult> {
+    if (typeof Bun === "undefined") {
+      throw PragmaError.storeError(
+        "`pragma graphql serve` requires the Bun runtime.",
+        {
+          recovery: {
+            message: "Run the compiled `pragma` binary or use `bun run`.",
+          },
+        },
+      );
+    }
+
+    const sources = await gatherSources(
+      readStringArray(params.sources),
+      ctx.cwd,
+    );
+    const prefixes = parsePrefixes(readStringArray(params.prefix));
+    const port = readPort(params.port);
+
+    const server = await createSchemaServer({ sources, prefixes });
+    const errorCount = server.diagnostics.filter(
+      (d) => d.severity === "error",
+    ).length;
+    process.stdout.write(
+      `[ke-graphql] schema compiled — ${server.diagnostics.length} diagnostic(s)${
+        errorCount > 0 ? `, ${errorCount} error(s)` : ""
+      }\n[ke-graphql] GraphiQL on http://localhost:${port}/graphql (Ctrl-C to stop)\n`,
+    );
+
+    await listen(server, port);
+
+    return createOutputResult(
+      { port, diagnostics: server.diagnostics },
+      { plain: () => `Stopped the graphql server on port ${port}.` },
+    );
+  },
+};
+
+export default serveCommand;

--- a/packages/cli/pragma/src/domains/graphql/constants.ts
+++ b/packages/cli/pragma/src/domains/graphql/constants.ts
@@ -1,0 +1,10 @@
+/** Default port `pragma graphql serve` listens on. */
+const DEFAULT_PORT = 4000;
+
+/** Default output path for the SDL written by `pragma graphql build`. */
+const DEFAULT_SDL_PATH = "./schema.graphql";
+
+/** Default output path for the extraction artifact written by `pragma graphql build`. */
+const DEFAULT_EXTRACTION_PATH = "./extraction.json";
+
+export { DEFAULT_EXTRACTION_PATH, DEFAULT_PORT, DEFAULT_SDL_PATH };

--- a/packages/cli/pragma/src/domains/graphql/helpers/gatherSources.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/gatherSources.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GRAPHQL_CLEAN_TTL } from "#testing";
+import resolveConfiguredGraphs from "../../shared/resolveConfiguredGraphs.js";
+import gatherSources from "./gatherSources.js";
+
+vi.mock("../../shared/resolveConfiguredGraphs.js", () => ({
+  default: vi.fn(),
+}));
+
+const mockResolve = vi.mocked(resolveConfiguredGraphs);
+
+describe("gatherSources", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pragma-gather-"));
+    writeFileSync(join(dir, "a.ttl"), GRAPHQL_CLEAN_TTL);
+    writeFileSync(join(dir, "b.ttl"), GRAPHQL_CLEAN_TTL);
+    mockResolve.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads explicit files into inline sources, ignoring the config", async () => {
+    const sources = await gatherSources(["a.ttl"], dir);
+
+    expect(sources).toEqual([
+      {
+        content: GRAPHQL_CLEAN_TTL,
+        format: "turtle",
+        path: join(dir, "a.ttl"),
+      },
+    ]);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it("expands glob patterns", async () => {
+    const sources = await gatherSources(["*.ttl"], dir);
+
+    expect(sources.map((source) => source.path).sort()).toEqual([
+      join(dir, "a.ttl"),
+      join(dir, "b.ttl"),
+    ]);
+  });
+
+  it("throws when explicit sources match nothing", async () => {
+    await expect(gatherSources(["none-*.ttl"], dir)).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+      recovery: {
+        message: "No files matched the given paths or glob patterns.",
+      },
+    });
+  });
+
+  it("falls back to the configured package graphs when no sources are given", async () => {
+    mockResolve.mockResolvedValue([
+      {
+        path: "definitions/ontology.ttl",
+        content: GRAPHQL_CLEAN_TTL,
+        format: "turtle",
+      },
+    ]);
+
+    const sources = await gatherSources([], dir);
+
+    expect(mockResolve).toHaveBeenCalledWith(dir);
+    expect(sources).toEqual([
+      {
+        content: GRAPHQL_CLEAN_TTL,
+        format: "turtle",
+        path: "definitions/ontology.ttl",
+      },
+    ]);
+  });
+
+  it("throws when no sources are given and no packages resolve", async () => {
+    mockResolve.mockResolvedValue([]);
+
+    await expect(gatherSources([], dir)).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+      recovery: {
+        message:
+          "No TTL sources given and no semantic packages resolved. Pass TTL files or globs, or configure `packages` in pragma.config.json and install them.",
+      },
+    });
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/helpers/gatherSources.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/gatherSources.ts
@@ -1,0 +1,58 @@
+/**
+ * Resolve the TTL sources for a graphql command.
+ *
+ * When positional paths or globs are given they win; otherwise the sources
+ * are the union of every configured semantic package's graphs (the
+ * `pragma.config.json` packages, falling back to the defaults). Either way
+ * the result is a list of ke `InlineSource`s (content + provenance path),
+ * so the compiler and the dev server load the exact same bytes.
+ *
+ * @note Impure — reads files and resolves packages from disk.
+ *
+ * @param positional - Explicit TTL file paths or glob patterns (may be empty).
+ * @param cwd - Working directory for file and config resolution.
+ * @returns In-memory TTL sources to compile or serve.
+ * @throws PragmaError (INVALID_INPUT) when nothing resolves.
+ */
+
+import { readFileSync } from "node:fs";
+import type { InlineSource } from "@canonical/ke";
+import { PragmaError } from "#error";
+import resolveConfiguredGraphs from "../../shared/resolveConfiguredGraphs.js";
+import resolveSourceFiles from "./resolveSourceFiles.js";
+
+export default async function gatherSources(
+  positional: readonly string[],
+  cwd: string,
+): Promise<InlineSource[]> {
+  if (positional.length > 0) {
+    const files = resolveSourceFiles([...positional], cwd);
+    if (files.length === 0) {
+      throw PragmaError.invalidInput("sources", positional.join(", "), {
+        recovery: {
+          message: "No files matched the given paths or glob patterns.",
+        },
+      });
+    }
+    return files.map((path) => ({
+      content: readFileSync(path, "utf-8"),
+      format: "turtle" as const,
+      path,
+    }));
+  }
+
+  const graphs = await resolveConfiguredGraphs(cwd);
+  if (graphs.length === 0) {
+    throw PragmaError.invalidInput("sources", "(none)", {
+      recovery: {
+        message:
+          "No TTL sources given and no semantic packages resolved. Pass TTL files or globs, or configure `packages` in pragma.config.json and install them.",
+      },
+    });
+  }
+  return graphs.map((graph) => ({
+    content: graph.content,
+    format: graph.format,
+    path: graph.path,
+  }));
+}

--- a/packages/cli/pragma/src/domains/graphql/helpers/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/index.ts
@@ -1,4 +1,6 @@
 /** @module Barrel for graphql helpers. */
 
+export { default as gatherSources } from "./gatherSources.js";
 export { default as parsePrefixes } from "./parsePrefixes.js";
 export { default as resolveSourceFiles } from "./resolveSourceFiles.js";
+export { default as routeGraphql } from "./routeGraphql.js";

--- a/packages/cli/pragma/src/domains/graphql/helpers/routeGraphql.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/routeGraphql.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import routeGraphql from "./routeGraphql.js";
+
+describe("routeGraphql", () => {
+  it("delegates /graphql to the handler", async () => {
+    const handler = vi.fn(() => new Response("handled"));
+    const request = new Request("http://localhost:4000/graphql");
+
+    const response = await routeGraphql(request, handler, 4000);
+
+    expect(handler).toHaveBeenCalledWith(request);
+    expect(await response.text()).toBe("handled");
+  });
+
+  it("redirects / to /graphql", async () => {
+    const handler = vi.fn();
+
+    const response = await routeGraphql(
+      new Request("http://localhost:4000/"),
+      handler,
+      4000,
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:4000/graphql",
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("404s any other path", async () => {
+    const handler = vi.fn();
+
+    const response = await routeGraphql(
+      new Request("http://localhost:4000/favicon.ico"),
+      handler,
+      4000,
+    );
+
+    expect(response.status).toBe(404);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/helpers/routeGraphql.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/routeGraphql.ts
@@ -1,0 +1,28 @@
+/**
+ * Route an incoming request for the graphql dev server: `/graphql` to the
+ * GraphQL + GraphiQL handler, `/` to a redirect there, and everything else
+ * to 404. Mounting is intentionally the host's job, which keeps the handler
+ * itself path-agnostic.
+ *
+ * @param request - The incoming fetch Request.
+ * @param handler - The GraphQL fetch handler for `/graphql`.
+ * @param port - The listen port, used to build the root redirect target.
+ * @returns The response (or a promise of one) for the route.
+ */
+
+type GraphQLHandler = (request: Request) => Response | Promise<Response>;
+
+export default function routeGraphql(
+  request: Request,
+  handler: GraphQLHandler,
+  port: number,
+): Response | Promise<Response> {
+  const { pathname } = new URL(request.url);
+  if (pathname === "/graphql") {
+    return handler(request);
+  }
+  if (pathname === "/") {
+    return Response.redirect(`http://localhost:${port}/graphql`, 302);
+  }
+  return new Response(null, { status: 404 });
+}

--- a/packages/cli/pragma/src/domains/graphql/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/index.ts
@@ -1,21 +1,24 @@
 /**
  * @module GraphQL domain barrel.
  *
- * Compiles TTL ontologies into GraphQL schema artifacts via the
- * ke-graphql pipeline. Commands boot their own ke store from explicit
- * TTL sources, so they run on the store-skip pipeline path.
+ * Compiles TTL ontologies into GraphQL schema artifacts via the ke-graphql
+ * pipeline, and serves them locally. Commands boot their own ke store —
+ * from explicit TTL sources or, when none are given, the semantic packages
+ * configured in `pragma.config.json` — so they run on the store-skip
+ * pipeline path.
  */
 
 import type { CommandDefinition } from "@canonical/cli-core";
-import { buildCommand, checkCommand } from "./commands/index.js";
+import { buildCommand, checkCommand, serveCommand } from "./commands/index.js";
 
 /**
  * Returns all command definitions for the graphql domain.
  *
- * @returns An array of command definitions (`graphql build`, `graphql check`).
+ * @returns The `graphql build`, `graphql check`, and `graphql serve`
+ *   command definitions.
  */
 export function commands(): CommandDefinition[] {
-  return [buildCommand, checkCommand];
+  return [buildCommand, checkCommand, serveCommand];
 }
 
 export { compileSchema } from "./operations/index.js";

--- a/packages/cli/pragma/src/domains/graphql/operations/compileSchema.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/compileSchema.test.ts
@@ -1,8 +1,5 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { hashSources } from "@canonical/ke-graphql";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   EX_NAMESPACE,
   GRAPHQL_CLEAN_TTL,
@@ -14,60 +11,47 @@ import compileSchema from "./compileSchema.js";
 
 const PREFIXES = { ...PREFIX_MAP, ex: EX_NAMESPACE };
 
+const inline = (content: string, path: string) => ({
+  content,
+  format: "turtle" as const,
+  path,
+});
+
 describe("compileSchema", () => {
-  let dir: string;
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "pragma-graphql-compile-"));
-    writeFileSync(join(dir, "clean.ttl"), GRAPHQL_CLEAN_TTL);
-    writeFileSync(join(dir, "error.ttl"), GRAPHQL_ERROR_TTL);
-    writeFileSync(join(dir, "fatal.ttl"), GRAPHQL_FATAL_TTL);
-  });
-
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("compiles a clean ontology into SDL", async () => {
     const outcome = await compileSchema({
-      sources: ["clean.ttl"],
+      sources: [inline(GRAPHQL_CLEAN_TTL, "clean.ttl")],
       prefixes: PREFIXES,
-      cwd: dir,
     });
 
     expect(outcome.status).toBe("ok");
     expect(outcome.compiled?.sdl).toContain("type Thing");
     expect(outcome.diagnostics).toEqual([]);
-    expect(outcome.files).toEqual([join(dir, "clean.ttl")]);
+    expect(outcome.files).toEqual(["clean.ttl"]);
   });
 
-  it("hashes the exact raw file contents", async () => {
+  it("hashes the exact raw source contents", async () => {
     const outcome = await compileSchema({
-      sources: ["clean.ttl"],
+      sources: [inline(GRAPHQL_CLEAN_TTL, "clean.ttl")],
       prefixes: PREFIXES,
-      cwd: dir,
     });
 
-    const raw = readFileSync(join(dir, "clean.ttl"), "utf-8");
-    expect(outcome.sourcesHash).toBe(hashSources([raw]));
+    expect(outcome.sourcesHash).toBe(hashSources([GRAPHQL_CLEAN_TTL]));
   });
 
-  it("resolves glob patterns to source files", async () => {
+  it("labels a source without a path as 'inline'", async () => {
     const outcome = await compileSchema({
-      sources: ["clean*.ttl"],
+      sources: [{ content: GRAPHQL_CLEAN_TTL, format: "turtle" }],
       prefixes: PREFIXES,
-      cwd: dir,
     });
 
-    expect(outcome.status).toBe("ok");
-    expect(outcome.files).toEqual([join(dir, "clean.ttl")]);
+    expect(outcome.files).toEqual(["inline"]);
   });
 
   it("surfaces error diagnostics without failing the compile", async () => {
     const outcome = await compileSchema({
-      sources: ["error.ttl"],
+      sources: [inline(GRAPHQL_ERROR_TTL, "error.ttl")],
       prefixes: PREFIXES,
-      cwd: dir,
     });
 
     expect(outcome.status).toBe("ok");
@@ -81,9 +65,8 @@ describe("compileSchema", () => {
 
   it("converts CompilationError into a failed result with diagnostics", async () => {
     const outcome = await compileSchema({
-      sources: ["fatal.ttl"],
+      sources: [inline(GRAPHQL_FATAL_TTL, "fatal.ttl")],
       prefixes: PREFIXES,
-      cwd: dir,
     });
 
     expect(outcome.status).toBe("failed");
@@ -95,24 +78,17 @@ describe("compileSchema", () => {
     ).toBe(true);
   });
 
-  it("throws structured error when no sources resolve", async () => {
+  it("throws a structured error when given no sources", async () => {
     await expect(
-      compileSchema({
-        sources: ["missing.ttl"],
-        prefixes: PREFIXES,
-        cwd: dir,
-      }),
+      compileSchema({ sources: [], prefixes: PREFIXES }),
     ).rejects.toMatchObject({ code: "INVALID_INPUT" });
   });
 
-  it("throws structured error on invalid TTL syntax", async () => {
-    writeFileSync(join(dir, "broken.ttl"), "this is not turtle .");
-
+  it("throws a structured error on invalid TTL syntax", async () => {
     await expect(
       compileSchema({
-        sources: ["broken.ttl"],
+        sources: [inline("this is not turtle .", "broken.ttl")],
         prefixes: PREFIXES,
-        cwd: dir,
       }),
     ).rejects.toMatchObject({ code: "STORE_ERROR" });
   });

--- a/packages/cli/pragma/src/domains/graphql/operations/compileSchema.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/compileSchema.ts
@@ -1,5 +1,4 @@
-import { readFileSync } from "node:fs";
-import { createStore } from "@canonical/ke";
+import { createStore, type InlineSource } from "@canonical/ke";
 import {
   CompilationError,
   type CompilerResult,
@@ -9,15 +8,14 @@ import {
   hashSources,
 } from "@canonical/ke-graphql";
 import { PragmaError } from "#error";
-import { resolveSourceFiles } from "../helpers/index.js";
 
 export interface CompileSchemaOptions {
-  /** TTL file paths or glob patterns, resolved from `cwd`. */
-  readonly sources: readonly string[];
+  /** In-memory TTL sources (content + provenance path) to compile. */
+  readonly sources: readonly InlineSource[];
   /** Prefix map handed to both the ke store and the compiler. */
   readonly prefixes: Readonly<Record<string, string>>;
-  /** Working directory for resolving relative source paths. */
-  readonly cwd: string;
+  /** Working directory, passed through to the store (unused for inline). */
+  readonly cwd?: string;
 }
 
 export interface CompileSchemaResult {
@@ -25,7 +23,7 @@ export interface CompileSchemaResult {
   readonly status: "ok" | "failed";
   /** All compiler diagnostics, including those carried by a CompilationError. */
   readonly diagnostics: readonly Diagnostic[];
-  /** Resolved absolute TTL file paths that were loaded. */
+  /** Provenance paths of the sources that were loaded. */
   readonly files: readonly string[];
   /** Fingerprint of the raw source contents (matches ke's onLoad hashing). */
   readonly sourcesHash: string;
@@ -34,42 +32,42 @@ export interface CompileSchemaResult {
 }
 
 /**
- * Compile TTL sources into a GraphQL schema via the ke-graphql pipeline.
+ * Compile in-memory TTL sources into a GraphQL schema via the ke-graphql
+ * pipeline.
  *
- * Resolves source patterns, hashes the raw file contents (the exact bytes
- * ke loads, so the artifact's `sourcesHash` matches what
- * `createSchemaPlugin` computes from ke's onLoad), boots a throwaway ke
- * store, and runs the compiler. A {@link CompilationError} (schema
- * composition failed) is converted into a `"failed"` result carrying its
- * diagnostics; the store is always disposed.
+ * Hashes the raw source contents (the exact bytes ke loads, so the
+ * artifact's `sourcesHash` matches what `createSchemaPlugin` computes from
+ * ke's onLoad), boots a throwaway ke store, and runs the compiler. A
+ * {@link CompilationError} (schema composition failed) is converted into a
+ * `"failed"` result carrying its diagnostics; the store is always disposed.
  *
- * @note Impure — reads filesystem and boots a ke store (WASM + TTL).
+ * @note Impure — boots a ke store (WASM + TTL).
  *
- * @param options - Sources, prefixes, and working directory.
+ * @param options - In-memory sources and prefixes.
  * @returns The compile outcome with diagnostics, files, and sources hash.
- * @throws PragmaError with code `INVALID_INPUT` when no sources resolve.
+ * @throws PragmaError with code `INVALID_INPUT` when given no sources.
  * @throws PragmaError with code `STORE_ERROR` when the store fails to load.
  */
 export default async function compileSchema(
   options: CompileSchemaOptions,
 ): Promise<CompileSchemaResult> {
-  const files = resolveSourceFiles(options.sources, options.cwd);
+  const { sources } = options;
 
-  if (files.length === 0) {
-    throw PragmaError.invalidInput("sources", options.sources.join(", "), {
+  if (sources.length === 0) {
+    throw PragmaError.invalidInput("sources", "(empty)", {
       recovery: {
-        message: "Provide at least one existing TTL file or glob pattern.",
+        message: "Provide at least one TTL source.",
       },
     });
   }
 
-  const contents = files.map((file) => readFileSync(file, "utf-8"));
-  const sourcesHash = hashSources(contents);
+  const sourcesHash = hashSources(sources.map((source) => source.content));
+  const files = sources.map((source) => source.path ?? "inline");
 
   let store: Awaited<ReturnType<typeof createStore>>;
   try {
     store = await createStore({
-      sources: [...files],
+      sources: [...sources],
       prefixes: options.prefixes,
       cwd: options.cwd,
     });

--- a/packages/cli/pragma/src/domains/graphql/operations/createSchemaServer.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/createSchemaServer.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { EX_NAMESPACE, GRAPHQL_CLEAN_TTL } from "#testing";
+import { PREFIX_MAP } from "../../shared/prefixes.js";
+import createSchemaServer, { type SchemaServer } from "./createSchemaServer.js";
+
+const PREFIXES = { ...PREFIX_MAP, ex: EX_NAMESPACE };
+
+describe("createSchemaServer", () => {
+  let server: SchemaServer | undefined;
+
+  afterEach(() => {
+    server?.dispose();
+    server = undefined;
+  });
+
+  it("compiles inline sources and serves an introspectable schema", async () => {
+    server = await createSchemaServer({
+      sources: [
+        { content: GRAPHQL_CLEAN_TTL, format: "turtle", path: "clean.ttl" },
+      ],
+      prefixes: PREFIXES,
+    });
+
+    const response = await server.handler(
+      new Request("http://localhost/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query: "{ __schema { queryType { name } } }",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data?: { __schema?: { queryType?: { name?: string } } };
+    };
+    expect(body.data?.__schema?.queryType?.name).toBe("Query");
+    expect(Array.isArray(server.diagnostics)).toBe(true);
+  });
+
+  it("throws a STORE_ERROR on invalid TTL", async () => {
+    await expect(
+      createSchemaServer({
+        sources: [{ content: "not turtle .", format: "turtle", path: "x.ttl" }],
+        prefixes: PREFIXES,
+      }),
+    ).rejects.toMatchObject({ code: "STORE_ERROR" });
+  });
+});

--- a/packages/cli/pragma/src/domains/graphql/operations/createSchemaServer.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/createSchemaServer.ts
@@ -1,0 +1,75 @@
+/**
+ * Boot a persistent ke store over in-memory TTL sources with the
+ * ke-graphql schema plugin attached, and build the `/http` fetch handler
+ * (GraphiQL + GraphQL, CORS, incremental delivery) over the compiled
+ * schema. The caller owns the returned `dispose`.
+ *
+ * @note Impure — boots a ke store (WASM + TTL) and compiles the schema.
+ */
+
+import { createStore, type InlineSource, type Plugin } from "@canonical/ke";
+import {
+  createSchemaPlugin,
+  type Diagnostic,
+  type SchemaPluginApi,
+} from "@canonical/ke-graphql";
+import { createGraphQLHandler } from "@canonical/ke-graphql/http";
+import { PragmaError } from "#error";
+
+export interface CreateSchemaServerOptions {
+  /** In-memory TTL sources to load into the store. */
+  readonly sources: readonly InlineSource[];
+  /** Prefix map handed to both the ke store and the compiler. */
+  readonly prefixes: Readonly<Record<string, string>>;
+}
+
+export interface SchemaServer {
+  /** Runtime-neutral fetch handler over the compiled schema. */
+  readonly handler: ReturnType<typeof createGraphQLHandler>;
+  /** Compiler diagnostics produced while building the schema. */
+  readonly diagnostics: readonly Diagnostic[];
+  /** Releases the underlying ke store. */
+  readonly dispose: () => void;
+}
+
+export default async function createSchemaServer(
+  options: CreateSchemaServerOptions,
+): Promise<SchemaServer> {
+  const plugin = createSchemaPlugin({ incremental: true });
+
+  let store: Awaited<ReturnType<typeof createStore>>;
+  try {
+    store = await createStore({
+      sources: [...options.sources],
+      prefixes: options.prefixes,
+      // biome-ignore lint/suspicious/noExplicitAny: Plugin generic variance
+      plugins: [plugin as Plugin<any>],
+    });
+  } catch (error) {
+    throw PragmaError.storeError(
+      error instanceof Error ? error.message : String(error),
+      { recovery: { message: "Check the TTL syntax of the sources." } },
+    );
+  }
+
+  const api = store.api<SchemaPluginApi>("ke-graphql");
+  if (!api) {
+    store.dispose();
+    throw PragmaError.storeError("ke-graphql plugin did not register its API", {
+      recovery: { message: "This is an internal error; please report it." },
+    });
+  }
+
+  const handler = createGraphQLHandler(api.schema, {
+    context: () => api.createContext(store),
+    graphiql: true,
+    cors: true,
+    incremental: true,
+  });
+
+  return {
+    handler,
+    diagnostics: api.diagnostics,
+    dispose: () => store.dispose(),
+  };
+}

--- a/packages/cli/pragma/src/domains/graphql/operations/index.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/index.ts
@@ -5,3 +5,8 @@ export type {
   CompileSchemaResult,
 } from "./compileSchema.js";
 export { default as compileSchema } from "./compileSchema.js";
+export type {
+  CreateSchemaServerOptions,
+  SchemaServer,
+} from "./createSchemaServer.js";
+export { default as createSchemaServer } from "./createSchemaServer.js";

--- a/packages/cli/pragma/src/domains/shared/mergeAndParseRefs.test.ts
+++ b/packages/cli/pragma/src/domains/shared/mergeAndParseRefs.test.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RawPackageEntry } from "../refs/operations/parseRef.js";
+import { mergeAndParseRefs } from "./mergeAndParseRefs.js";
+import { DEFAULT_PACKAGES } from "./packages.js";
+
+const DEFAULT_NAMES = DEFAULT_PACKAGES.map((entry) =>
+  typeof entry === "string" ? entry : entry.name,
+);
+
+function writeGlobalRefs(
+  xdgDir: string,
+  packages: ReadonlyArray<RawPackageEntry>,
+): void {
+  const dir = join(xdgDir, "pragma");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "refs.json"), JSON.stringify({ packages }));
+}
+
+describe("mergeAndParseRefs", () => {
+  let tmpDir: string;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pragma-merge-refs-"));
+    // Point XDG_CONFIG_HOME to our temp dir so readGlobalRefs() resolves there
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns parsed defaults when config and global refs are absent", () => {
+    const refs = mergeAndParseRefs(undefined);
+    expect(refs.map((ref) => ref.pkg)).toEqual(DEFAULT_NAMES);
+    expect(refs.every((ref) => ref.kind === "git")).toBe(true);
+  });
+
+  it("treats an explicitly empty config list as not configured", () => {
+    expect(mergeAndParseRefs([])).toEqual(mergeAndParseRefs(undefined));
+  });
+
+  it("falls back to global refs when the config list is empty", () => {
+    writeGlobalRefs(tmpDir, [
+      { name: "@canonical/design-system", source: "file:///tmp/ds" },
+    ]);
+
+    const refs = mergeAndParseRefs([]);
+
+    expect(refs.map((ref) => ref.pkg)).toEqual(DEFAULT_NAMES);
+    expect(refs.at(0)).toEqual({
+      kind: "file",
+      pkg: "@canonical/design-system",
+      path: "/tmp/ds",
+    });
+  });
+
+  it("merges global refs over defaults by package name", () => {
+    writeGlobalRefs(tmpDir, [
+      { name: "@canonical/design-system", source: "file:///tmp/ds" },
+      "@acme/extra",
+    ]);
+
+    const refs = mergeAndParseRefs(undefined);
+
+    expect(refs.map((ref) => ref.pkg)).toEqual([
+      ...DEFAULT_NAMES,
+      "@acme/extra",
+    ]);
+    expect(refs.at(0)?.kind).toBe("file");
+    expect(refs.at(-1)).toEqual({ kind: "npm", pkg: "@acme/extra" });
+  });
+
+  it("replaces defaults and global refs with a non-empty config list", () => {
+    writeGlobalRefs(tmpDir, ["@acme/global-only"]);
+
+    const refs = mergeAndParseRefs([
+      { name: "@acme/only", source: "file:///tmp/only" },
+    ]);
+
+    expect(refs).toEqual([
+      { kind: "file", pkg: "@acme/only", path: "/tmp/only" },
+    ]);
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/mergeAndParseRefs.ts
+++ b/packages/cli/pragma/src/domains/shared/mergeAndParseRefs.ts
@@ -1,0 +1,44 @@
+import {
+  type PackageRef,
+  parsePackageEntry,
+  type RawPackageEntry,
+} from "../refs/operations/parseRef.js";
+import readGlobalRefs from "../refs/operations/readGlobalRefs.js";
+import { DEFAULT_PACKAGES } from "./packages.js";
+
+/**
+ * Merge config packages, global refs, and the built-in defaults into a
+ * final parsed `PackageRef` array.
+ *
+ * Priority: config `packages` > global `refs.json` > hardcoded defaults.
+ * A non-empty config list is a full replacement — only the listed packages
+ * resolve. An empty or absent list means "not configured": global refs are
+ * merged over the defaults by package name, so a global entry for
+ * "@canonical/foo" overrides the default entry for the same package.
+ *
+ * Kept free of store imports so config-only consumers (e.g.
+ * `resolveConfiguredGraphs`) can merge refs without loading the ke/WASM
+ * runtime.
+ *
+ * @note Impure — reads global refs from `~/.config/pragma/refs.json`.
+ *
+ * @param configPackages - The `packages` field from `pragma.config.json`.
+ * @returns Parsed refs ready for the loader chain.
+ * @throws PragmaError with code CONFIG_ERROR when an entry is malformed.
+ */
+export function mergeAndParseRefs(
+  configPackages?: ReadonlyArray<RawPackageEntry>,
+): PackageRef[] {
+  // A non-empty config list replaces the package set entirely.
+  if (configPackages && configPackages.length > 0) {
+    return configPackages.map((entry) => parsePackageEntry(entry));
+  }
+
+  // Empty or absent → merge global refs over the defaults, keyed by name.
+  const merged = new Map<string, RawPackageEntry>();
+  for (const entry of [...DEFAULT_PACKAGES, ...readGlobalRefs()]) {
+    const name = typeof entry === "string" ? entry : entry.name;
+    merged.set(name, entry);
+  }
+  return [...merged.values()].map((entry) => parsePackageEntry(entry));
+}

--- a/packages/cli/pragma/src/domains/shared/resolveConfiguredGraphs.test.ts
+++ b/packages/cli/pragma/src/domains/shared/resolveConfiguredGraphs.test.ts
@@ -1,0 +1,27 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import resolveConfiguredGraphs from "./resolveConfiguredGraphs.js";
+
+describe("resolveConfiguredGraphs", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pragma-rcg-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("resolves the default semantic packages' TTL graphs", async () => {
+    // No pragma.config.json in the temp dir → mergeAndParseRefs falls back to
+    // the default packages, which resolve from node_modules in the workspace.
+    const graphs = await resolveConfiguredGraphs(dir);
+
+    expect(graphs.length).toBeGreaterThan(0);
+    expect(graphs[0]).toMatchObject({ format: "turtle" });
+    expect(typeof graphs[0]?.content).toBe("string");
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/resolveConfiguredGraphs.ts
+++ b/packages/cli/pragma/src/domains/shared/resolveConfiguredGraphs.ts
@@ -2,8 +2,9 @@
  * Resolve every TTL graph from the semantically-configured packages.
  *
  * Reads `pragma.config.json`, merges its `packages` with the global refs
- * and the built-in defaults (a project entry replaces the list, otherwise
- * the defaults apply), resolves each package through the loader chain
+ * and the built-in defaults (a non-empty `packages` list replaces the set
+ * entirely; an empty or absent list falls back to global refs merged over
+ * the defaults), resolves each package through the loader chain
  * (local > git > bundled), and returns the union of their definitions/ and
  * data/ graph content — the same discovery the runtime store performs at
  * boot, minus the store.
@@ -20,7 +21,7 @@ import {
   createGitLoader,
   createLocalLoader,
 } from "./loaders/index.js";
-import { mergeAndParseRefs } from "./runtime.js";
+import { mergeAndParseRefs } from "./mergeAndParseRefs.js";
 import {
   type GraphContent,
   resolveSemanticPackages,

--- a/packages/cli/pragma/src/domains/shared/resolveConfiguredGraphs.ts
+++ b/packages/cli/pragma/src/domains/shared/resolveConfiguredGraphs.ts
@@ -1,0 +1,40 @@
+/**
+ * Resolve every TTL graph from the semantically-configured packages.
+ *
+ * Reads `pragma.config.json`, merges its `packages` with the global refs
+ * and the built-in defaults (a project entry replaces the list, otherwise
+ * the defaults apply), resolves each package through the loader chain
+ * (local > git > bundled), and returns the union of their definitions/ and
+ * data/ graph content — the same discovery the runtime store performs at
+ * boot, minus the store.
+ *
+ * @note Impure — reads config and package files from disk.
+ *
+ * @param cwd - Working directory used to locate `pragma.config.json`.
+ * @returns The TTL graph content of every resolved package.
+ */
+
+import { readConfig } from "#config";
+import {
+  createBundledLoader,
+  createGitLoader,
+  createLocalLoader,
+} from "./loaders/index.js";
+import { mergeAndParseRefs } from "./runtime.js";
+import {
+  type GraphContent,
+  resolveSemanticPackages,
+} from "./semanticPackage.js";
+
+export default async function resolveConfiguredGraphs(
+  cwd: string,
+): Promise<GraphContent[]> {
+  const config = readConfig(cwd);
+  const refs = mergeAndParseRefs(config.packages);
+  const packages = await resolveSemanticPackages(refs, [
+    createLocalLoader(),
+    createGitLoader(),
+    createBundledLoader(),
+  ]);
+  return packages.flatMap((pkg) => pkg.graphs);
+}

--- a/packages/cli/pragma/src/domains/shared/runtime.ts
+++ b/packages/cli/pragma/src/domains/shared/runtime.ts
@@ -76,7 +76,7 @@ export async function bootPragma(options?: {
  * Merging is by package name — a project entry for "@canonical/foo"
  * overrides the global entry for the same package.
  */
-function mergeAndParseRefs(
+export function mergeAndParseRefs(
   projectPackages?: ReadonlyArray<RawPackageEntry>,
 ): PackageRef[] {
   const globalEntries = readGlobalRefs();

--- a/packages/cli/pragma/src/domains/shared/runtime.ts
+++ b/packages/cli/pragma/src/domains/shared/runtime.ts
@@ -10,14 +10,8 @@
 
 import type { SourceSpec } from "@canonical/ke";
 import { readConfig } from "#config";
-import {
-  type PackageRef,
-  parsePackageEntry,
-  type RawPackageEntry,
-} from "../refs/operations/parseRef.js";
-import readGlobalRefs from "../refs/operations/readGlobalRefs.js";
 import { bootStore } from "./bootStore.js";
-import { DEFAULT_PACKAGES } from "./packages.js";
+import { mergeAndParseRefs } from "./mergeAndParseRefs.js";
 import type { PragmaRuntime } from "./types/index.js";
 
 export type { PragmaRuntime } from "./types/index.js";
@@ -43,7 +37,8 @@ export async function bootPragma(options?: {
   const cwd = options?.cwd ?? process.cwd();
   const config = readConfig(cwd);
 
-  // Merge package refs: project overrides global, both override defaults.
+  // Merge package refs: a non-empty config list replaces global refs and
+  // defaults; otherwise global refs merge over the defaults.
   const refs = options?.sources
     ? undefined
     : mergeAndParseRefs(config.packages);
@@ -62,59 +57,4 @@ export async function bootPragma(options?: {
     packages,
     dispose: () => store.dispose(),
   };
-}
-
-// ---------------------------------------------------------------------------
-// Ref merging
-// ---------------------------------------------------------------------------
-
-/**
- * Merge global refs, project config packages, and defaults into a final
- * parsed PackageRef array.
- *
- * Priority: project packages > global refs > hardcoded defaults.
- * Merging is by package name — a project entry for "@canonical/foo"
- * overrides the global entry for the same package.
- */
-export function mergeAndParseRefs(
-  projectPackages?: ReadonlyArray<RawPackageEntry>,
-): PackageRef[] {
-  const globalEntries = readGlobalRefs();
-
-  // If neither project nor global defines packages, return undefined
-  // so resolvePackages() uses hardcoded defaults.
-  if (
-    (!projectPackages || projectPackages.length === 0) &&
-    globalEntries.length === 0
-  ) {
-    return DEFAULT_PACKAGES.map((pkg) => parsePackageEntry(pkg));
-  }
-
-  // Build a name → entry map, global first, project overrides.
-  const merged = new Map<string, RawPackageEntry>();
-
-  // Start with defaults (lowest priority)
-  for (const entry of DEFAULT_PACKAGES) {
-    const name = typeof entry === "string" ? entry : entry.name;
-    merged.set(name, entry);
-  }
-
-  // Global overrides defaults
-  for (const entry of globalEntries) {
-    const name = typeof entry === "string" ? entry : entry.name;
-    merged.set(name, entry);
-  }
-
-  // Project overrides global
-  if (projectPackages) {
-    // When project explicitly declares packages, it's a full replacement
-    // of the package list — clear defaults and global, use project only.
-    merged.clear();
-    for (const entry of projectPackages) {
-      const name = typeof entry === "string" ? entry : entry.name;
-      merged.set(name, entry);
-    }
-  }
-
-  return [...merged.values()].map(parsePackageEntry);
 }


### PR DESCRIPTION
> Follow-on to the `@canonical/ke-graphql` stack (umbrella #658). Builds directly on the graphql CLI domain from #674 — which is already on `main` (it landed cumulatively with #673). **Base is `main`.**

## Done

- **`pragma graphql serve`** — compiles the configured ontologies and serves a local GraphQL + GraphiQL endpoint (the `@canonical/ke-graphql/http` fetch handler over a persistent ke store, via `Bun.serve`) until interrupted. With no positional sources it serves **every TTL across the semantic packages in `pragma.config.json`** — the same `definitions/` + `data/` discovery the runtime store performs at boot, so a future token package is picked up automatically.
- **Config-driven `build`/`check`** — when no TTL files or globs are given, they compile the configured packages instead of erroring.
- Source gathering is unified in a new `gatherSources` helper (explicit files/globs, or the configured package graphs via a new shared `resolveConfiguredGraphs`), and `compileSchema` now takes in-memory ke `InlineSource`s so the file- and package-resolution paths share one compile.

### Relation to #674

#674 introduced the `pragma graphql build`/`check` domain; that code is **already on `main`** (it landed cumulatively when #673 merged). This PR **extends those exact files** (`build.ts`, `check.ts`, `compileSchema.ts`) and adds the `serve` command. **#674 is therefore superseded and should be closed** — it is not a separate pending change.

## QA

```bash
cd packages/cli/pragma && bun run check && bun run test
```
biome + `tsc` + webarchitect green; **1080 tests pass**, coverage thresholds met. A real `pragma graphql build` with no args compiled **234 package TTLs** into a 1179-line SDL.

### PR readiness check

- [x] Label: `Feature 🎁`.
- [x] Conventional Commits title.
- [x] [Code standards](https://github.com/canonical/web-code-standards): graphql domain, colocated tests, helpers/operations/commands split.
- [x] `check`, `check:fix`, `test` present.
- [x] `no visual change`.

## Screenshots

No visual change — CLI commands + a local dev server, no shipped UI.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_