### PR TITLE
fix(ke-graphql): latent compiler correctness fixes (ancestor ordering + sh:in scoping)

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/compiler/build.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.test.ts
@@ -65,8 +65,10 @@ describe("build — class graph", () => {
     expect(output.classes.get(uri("B"))?.ancestors).toContain(uri("A"));
   });
 
-  it("dedupes a diamond hierarchy's shared ancestor", () => {
-    // A → {B, C}; both B and C → D. D must appear once in A's closure.
+  it("orders a diamond's closure most specific first, deduped", () => {
+    // A → {B, C}; both B and C → D. D (distance 2) appears once, and after
+    // the distance-1 parents B and C — the pre-order DFS would interleave it
+    // as [B, D, C], violating the "most specific first" ancestor contract.
     const extraction = makeExtraction({
       classes: [
         { uri: uri("A"), superclasses: [uri("B"), uri("C")] },
@@ -78,7 +80,31 @@ describe("build — class graph", () => {
     const { output } = build(extraction);
     const ancestors = output.classes.get(uri("A"))?.ancestors ?? [];
     expect(ancestors.filter((a) => a === uri("D"))).toHaveLength(1);
-    expect([...ancestors].sort()).toEqual([uri("B"), uri("C"), uri("D")]);
+    expect(ancestors).toEqual([uri("B"), uri("C"), uri("D")]);
+  });
+
+  it("orders a deeper diamond by ascending distance across two levels", () => {
+    // A → {B, C}; B → D; C → E; D,E → F. Distance-1 {B,C} precede
+    // distance-2 {D,E}, which precede distance-3 {F}; F is deduped.
+    const extraction = makeExtraction({
+      classes: [
+        { uri: uri("A"), superclasses: [uri("B"), uri("C")] },
+        { uri: uri("B"), superclasses: [uri("D")] },
+        { uri: uri("C"), superclasses: [uri("E")] },
+        { uri: uri("D"), superclasses: [uri("F")] },
+        { uri: uri("E"), superclasses: [uri("F")] },
+        { uri: uri("F"), superclasses: [] },
+      ],
+    });
+    const { output } = build(extraction);
+    const ancestors = output.classes.get(uri("A"))?.ancestors ?? [];
+    expect(ancestors).toEqual([
+      uri("B"),
+      uri("C"),
+      uri("D"),
+      uri("E"),
+      uri("F"),
+    ]);
   });
 
   it("dedupes a directly-repeated superclass", () => {

--- a/packages/runtime/ke-graphql/src/lib/compiler/build.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.ts
@@ -160,8 +160,39 @@ export default function build(
     return result;
   };
 
+  // The DFS yields the complete ancestor set, but in pre-order: a parent's
+  // whole chain is emitted before the next sibling parent, so in a diamond a
+  // grandparent can precede a not-yet-visited sibling parent. Re-walk the
+  // closure breadth-first to restore the "most specific first" contract
+  // (ancestors ordered by ascending distance from the class).
+  const orderByProximity = (
+    uri: string,
+    members: ReadonlySet<string>,
+  ): string[] => {
+    const ordered: string[] = [];
+    const seen = new Set<string>([uri]);
+    let frontier: string[] = [uri];
+    while (frontier.length > 0) {
+      const next: string[] = [];
+      for (const current of frontier) {
+        /* v8 ignore next -- current is the class itself or a known-class member, both of which carry a rawSuperclasses entry; the empty-array fallback is unreachable */
+        for (const parent of rawSuperclasses.get(current) ?? []) {
+          if (seen.has(parent) || !members.has(parent)) {
+            continue;
+          }
+          seen.add(parent);
+          ordered.push(parent);
+          next.push(parent);
+        }
+      }
+      frontier = next;
+    }
+    return ordered;
+  };
+
   for (const node of classes.values()) {
-    const ancestors = computeAncestors(node.uri, []);
+    const closure = computeAncestors(node.uri, []);
+    const ancestors = orderByProximity(node.uri, new Set(closure));
     classes.set(node.uri, { ...node, ancestors });
   }
 

--- a/packages/runtime/ke-graphql/src/lib/compiler/extract.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/extract.test.ts
@@ -295,14 +295,26 @@ describe("extract — SHACL direct constraints", () => {
         ]),
       ],
       [
-        "?path ?value WHERE",
+        "?targetClass ?path ?value WHERE",
         select([
-          // guard: missing path skipped
+          // guard: missing targetClass/path skipped
           { value: literal("x") },
           // guard: value neither literal nor NamedNode (blank) skipped
-          { path: named(`${EX}mode`), value: blank("_:b") },
-          { path: named(`${EX}mode`), value: literal("fast") },
-          { path: named(`${EX}mode`), value: named(`${EX}slow`) },
+          {
+            targetClass: named(`${EX}C`),
+            path: named(`${EX}mode`),
+            value: blank("_:b"),
+          },
+          {
+            targetClass: named(`${EX}C`),
+            path: named(`${EX}mode`),
+            value: literal("fast"),
+          },
+          {
+            targetClass: named(`${EX}C`),
+            path: named(`${EX}mode`),
+            value: named(`${EX}slow`),
+          },
         ]),
       ],
     ]);
@@ -313,6 +325,61 @@ describe("extract — SHACL direct constraints", () => {
     // non-numeric maxCount parses to undefined
     expect(c?.maxCount).toBeUndefined();
     expect(c?.inValues).toEqual(["fast", `${EX}slow`]);
+  });
+
+  it("scopes sh:in per (targetClass, property), not globally by path", async () => {
+    // A and B both constrain :status, with different sh:in lists. Keying by
+    // path alone merged them into one over-broad enum; keying by
+    // (targetClass, path) keeps each shape's enumeration its own.
+    const query = router([
+      [
+        "?targetClass ?path ?minCount ?maxCount ?inList",
+        select([
+          {
+            targetClass: named(`${EX}A`),
+            path: named(`${EX}status`),
+            inList: blank("_:la"),
+          },
+          {
+            targetClass: named(`${EX}B`),
+            path: named(`${EX}status`),
+            inList: blank("_:lb"),
+          },
+        ]),
+      ],
+      [
+        "?targetClass ?path ?value WHERE",
+        select([
+          {
+            targetClass: named(`${EX}A`),
+            path: named(`${EX}status`),
+            value: literal("active"),
+          },
+          {
+            targetClass: named(`${EX}A`),
+            path: named(`${EX}status`),
+            value: literal("inactive"),
+          },
+          {
+            targetClass: named(`${EX}B`),
+            path: named(`${EX}status`),
+            value: literal("open"),
+          },
+          {
+            targetClass: named(`${EX}B`),
+            path: named(`${EX}status`),
+            value: literal("closed"),
+          },
+        ]),
+      ],
+    ]);
+    const { output } = await extract(query, PREFIXES);
+    const byClass = (tc: string) =>
+      output.shaclConstraints.find(
+        (constraint) => constraint.targetClass === tc,
+      );
+    expect(byClass(`${EX}A`)?.inValues).toEqual(["active", "inactive"]);
+    expect(byClass(`${EX}B`)?.inValues).toEqual(["open", "closed"]);
   });
 
   it("omits inValues when no sh:in list is present", async () => {

--- a/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
@@ -307,11 +307,18 @@ export default async function extract(
     "Q7a shacl direct",
   );
 
-  // sh:in values are an RDF list; resolve them per constraint.
+  // sh:in values are an RDF list; resolve them per (targetClass, property) so
+  // two shapes that constrain the same property with different sh:in lists do
+  // not bleed into a single over-broad enumeration. The key uses the named
+  // targetClass + path (no blank-node identity to match across queries).
+  const shInKey = (targetClass: string, path: string): string =>
+    `${targetClass} ${path}`;
   const shIn = new Map<string, string[]>();
   const inListRows = await select(
     query,
-    `SELECT ?path ?value WHERE {
+    `SELECT ?targetClass ?path ?value WHERE {
+      ?shape <${SH_TARGET_CLASS}> ?targetClass ;
+             <${SH_PROPERTY}> ?propShape .
       ?propShape <${SH_PATH}> ?path ;
                  <${SH_IN}> ?list .
       ?list <${RDF_REST}>*/<${RDF_FIRST}> ?value .
@@ -320,14 +327,16 @@ export default async function extract(
     "Q7a sh:in values",
   );
   for (const row of inListRows) {
+    const targetClass = getNamedValue(row.targetClass);
     const path = getNamedValue(row.path);
     const value = getLiteralValue(row.value) ?? getNamedValue(row.value);
-    if (!path || value === undefined) {
+    if (!targetClass || !path || value === undefined) {
       continue;
     }
-    const values = shIn.get(path) ?? [];
+    const key = shInKey(targetClass, path);
+    const values = shIn.get(key) ?? [];
     values.push(value);
-    shIn.set(path, values);
+    shIn.set(key, values);
   }
 
   for (const row of directShaclRows) {
@@ -341,7 +350,7 @@ export default async function extract(
       property: path,
       minCount: getIntValue(row.minCount),
       maxCount: getIntValue(row.maxCount),
-      inValues: row.inList ? shIn.get(path) : undefined,
+      inValues: row.inList ? shIn.get(shInKey(targetClass, path)) : undefined,
     });
   }
 

--- a/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/extract.ts
@@ -312,7 +312,7 @@ export default async function extract(
   // not bleed into a single over-broad enumeration. The key uses the named
   // targetClass + path (no blank-node identity to match across queries).
   const shInKey = (targetClass: string, path: string): string =>
-    `${targetClass} ${path}`;
+    `${targetClass}\u0000${path}`;
   const shIn = new Map<string, string[]>();
   const inListRows = await select(
     query,


### PR DESCRIPTION
> Two latent correctness fixes in the `@canonical/ke-graphql` compiler passes, found by adversarial review of the merged stack (umbrella #658). **Base is `main`.**

## Done

**1. Pass 2 — ancestor closure ordering.** `computeAncestors` used a pre-order DFS, so a diamond (`A → {B,C}`, both `→ D`) yielded `[B, D, C]` — the distance-2 grandparent `D` ahead of the distance-1 sibling `C` — violating the documented "most specific first" contract (`types.ts`) that field-inheritance order relies on. The diamond unit test had masked it with `.sort()`. Now re-walks the closure breadth-first; the test asserts exact order, plus a two-level diamond case.

**2. Pass 1 — `sh:in` scoping.** `sh:in` values were resolved in a query keyed only by the property path, so two node shapes constraining the same property with different `sh:in` lists merged into one over-broad enumeration (surfaced by the V012 diagnostic). Now keyed by `(targetClass, path)` — both named nodes, so no blank-node identity is matched across queries — and the `sh:in` query carries each shape's `targetClass`.

Both were latent for existing ontologies (ancestor order affects emitted field order; `sh:in` affected only the V012 message text, since enums map to `String`), so no observable behavior change — but both are now correct.

## QA

```bash
cd packages/runtime/ke-graphql && bun run check && bun run test
```
biome + `tsc` + webarchitect green; **355 tests, 100/100/100/100**.

### PR readiness check

- [x] Label: `Bug 🐛`.
- [x] Conventional Commits title.
- [x] [Code standards](https://github.com/canonical/web-code-standards); colocated tests.
- [x] Scripts present.
- [x] `no visual change`.

## Screenshots

No visual change — compiler internals.

---
https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017euwRxoP8uiC5TiwnL2C6Z)_