### PR TITLE
docs(svelte-ds-app-launchpad): Add a manually wired modal trigger story

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.stories.svelte
@@ -118,3 +118,29 @@
     </Modal>
   {/snippet}
 </Story>
+
+<Story name="With a manually wired trigger">
+  {#snippet template({ children: _, trigger: __, ...args })}
+    <Button command="show-modal" commandfor="my-modal" aria-haspopup="dialog"
+      >Show modal</Button
+    >
+    <Modal {...args} id="my-modal">
+      <Modal.Content>
+        <Modal.Content.Header>
+          Modal with a manually wired trigger
+          <Modal.Content.Header.CloseButton
+            commandfor="my-modal"
+            command="close"
+          />
+        </Modal.Content.Header>
+        <Modal.Content.Body>
+          Modal can be wired to a trigger manually by using the <code
+            >commandfor</code
+          >
+          and
+          <code>command</code> attributes.
+        </Modal.Content.Body>
+      </Modal.Content>
+    </Modal>
+  {/snippet}
+</Story>


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

Fixes [list issues/bugs if needed]

## QA

- [Add QA steps]

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [ ] The code follows the appropriate [code standards](https://github.com/canonical/code-standards)
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify.
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

[if relevant, include a screenshot or screen capture]
