### PR TITLE
feat(webarchitect): add --license parameter (defaults to LGPL-3.0)

### DIFF
--- a/packages/webarchitect/rulesets/assets.ruleset.json
+++ b/packages/webarchitect/rulesets/assets.ruleset.json
@@ -9,7 +9,7 @@
         "type": "object",
         "properties": {
           "license": {
-            "const": "LGPL-3.0"
+            "const": "${license}"
           }
         },
         "required": ["license"]

--- a/packages/webarchitect/rulesets/base.ruleset.json
+++ b/packages/webarchitect/rulesets/base.ruleset.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/canonical/pragma/refs/heads/main/packages/webarchitect/src/schema.json",
-  "name": "base"
+  "name": "base",
+  "variables": {
+    "license": {
+      "default": "LGPL-3.0",
+      "schema": {
+        "type": "string"
+      }
+    }
+  }
 }

--- a/packages/webarchitect/rulesets/library.ruleset.json
+++ b/packages/webarchitect/rulesets/library.ruleset.json
@@ -9,7 +9,7 @@
         "type": "object",
         "properties": {
           "license": {
-            "const": "LGPL-3.0"
+            "const": "${license}"
           }
         },
         "required": ["license"]

--- a/packages/webarchitect/src/cli.ts
+++ b/packages/webarchitect/src/cli.ts
@@ -301,6 +301,7 @@ program
     {},
   )
   .option("--prefix <value>", "shortcut for --var prefix=<value>")
+  .option("--license <value>", "shortcut for --var license=<value>")
   .action(async (schemaArg, options) => {
     // Handle --list option
     if (options.list) {
@@ -317,12 +318,16 @@ program
       process.exit(1);
     }
     try {
-      // Merge variable overrides; --prefix is sugar for --var prefix=<value>.
+      // Merge variable overrides; --prefix / --license are sugar for
+      // --var prefix=<value> / --var license=<value>.
       const variableOverrides: Record<string, string> = {
         ...(options.var ?? {}),
       };
       if (options.prefix !== undefined) {
         variableOverrides.prefix = options.prefix;
+      }
+      if (options.license !== undefined) {
+        variableOverrides.license = options.license;
       }
 
       const results = await validate(

--- a/packages/webarchitect/src/lib/substituteVariables.test.ts
+++ b/packages/webarchitect/src/lib/substituteVariables.test.ts
@@ -45,6 +45,35 @@ describe("substituteVariables", () => {
     expect(/^/.test("anything")).toBe(true);
   });
 
+  it("resolves a license variable into a package-license const (default LGPL-3.0, --license overrides)", () => {
+    const licenseSchema = (): Schema => ({
+      name: "library",
+      variables: {
+        license: { default: "LGPL-3.0", schema: { type: "string" } },
+      },
+      "package-license": {
+        file: {
+          name: "package.json",
+          contains: {
+            type: "object",
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: literal token resolved by substituteVariables
+            properties: { license: { const: "${license}" } },
+          },
+        },
+      },
+    });
+    const licenseConst = (schema: Schema): unknown =>
+      (
+        schema["package-license"] as unknown as {
+          file: { contains: { properties: { license: { const: string } } } };
+        }
+      ).file.contains.properties.license.const;
+    expect(licenseConst(substituteVariables(licenseSchema()))).toBe("LGPL-3.0");
+    expect(
+      licenseConst(substituteVariables(licenseSchema(), { license: "MIT" })),
+    ).toBe("MIT");
+  });
+
   it("removes the variables block from the resolved schema", () => {
     expect(substituteVariables(baseSchema()).variables).toBeUndefined();
   });


### PR DESCRIPTION
## Done

- Add a `--license` parameter to `webarchitect`, mirroring the existing `--prefix` namespace parameter, so a consumer can validate a package licensed under something other than the previously hardcoded `LGPL-3.0`.
  - `base.ruleset.json` declares a `license` template variable (default `LGPL-3.0`), inherited by every ruleset that extends `base`.
  - The `library` and `assets` `package-license` rules now check `${license}` instead of a hardcoded const (`LGPL-3.0` remains the default). The GPL-licensed `tool` / `tool-ts` rulesets are intentionally left hardcoded.
  - `cli.ts` adds `--license <value>` as sugar for `--var license=<value>`.

Motivation: the `package-license` rule hardcoded the expected SPDX as a const, so a consumer could not validate a differently-licensed package. This parameterizes it the same way the namespace is parameterized via `--prefix`. Backward-compatible — default behaviour (require `LGPL-3.0`) is unchanged.

> Versioning is intentionally **not** bumped in this PR — that's the release tooling's job.

## QA

- `cd packages/webarchitect && bun run test` — `substituteVariables.test.ts` covers default → `LGPL-3.0` and `--license MIT` override → `MIT`.
- From a package directory: `webarchitect library --license MIT` validates an MIT `package.json`; `webarchitect library` (no flag) still requires `LGPL-3.0`.
- `cd packages/webarchitect && bun run check` is green (biome + tsc).

### PR readiness check

- [ ] PR should have one of the following labels: this is a `Feature 🎁` (please apply on merge).
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.
- [ ] If this PR introduces a **new package**: N/A — `webarchitect` already exists; this is a backward-compatible feature addition.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — CLI-only change, no visual surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWrmEhXEJx5b2XuLdWkrHC