### PR TITLE
feat(task): stack-safe trampoline interpreter + effect-alphabet generics

### DIFF
--- a/packages/runtime/task/src/lib/combinators.test.ts
+++ b/packages/runtime/task/src/lib/combinators.test.ts
@@ -28,7 +28,8 @@ import {
   zip,
   zip3,
 } from "./combinators.js";
-import { dryRun } from "./dry-run.js";
+import { dryRun, dryRunWith } from "./dry-run.js";
+import type { TaskExecutionError } from "./interpreter.js";
 import { info, mkdir, writeFile } from "./primitives.js";
 import { effect, fail, flatMap, map, pure } from "./task.js";
 import type { Effect, Task, TaskError } from "./types.js";
@@ -41,16 +42,14 @@ describe("Combinators - Sequencing", () => {
   describe("sequence", () => {
     it("sequences an empty array to an empty result", () => {
       const t = sequence([]);
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: unknown[] }).value).toEqual([]);
+      expect(dryRun(t).value).toEqual([]);
     });
 
     it("sequences pure tasks and collects results", () => {
       const tasks = [pure(1), pure(2), pure(3)];
       const t = sequence(tasks);
 
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: number[] }).value).toEqual([1, 2, 3]);
+      expect(dryRun(t).value).toEqual([1, 2, 3]);
     });
 
     it("short-circuits on failure", () => {
@@ -58,20 +57,19 @@ describe("Combinators - Sequencing", () => {
       const tasks = [pure(1), fail<number>(error), pure(3)];
       const t = sequence(tasks);
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("ERR");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR");
+      }
     });
 
     it("preserves order", () => {
       const tasks = [pure("a"), pure("b"), pure("c"), pure("d"), pure("e")];
       const t = sequence(tasks);
-      expect((t as { value: string[] }).value).toEqual([
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-      ]);
+      expect(dryRun(t).value).toEqual(["a", "b", "c", "d", "e"]);
     });
 
     it("handles tasks with effects", () => {
@@ -88,19 +86,26 @@ describe("Combinators - Sequencing", () => {
       const tasks = [pure(1), effect<string>(eff), pure(3)];
       const t = sequence(tasks);
 
-      expect(t._tag).toBe("Effect");
+      const { value, effects } = dryRunWith(
+        t,
+        new Map([["ReadFile", () => "file-contents"]]),
+      );
+      expect(value).toEqual([1, "file-contents", 3]);
+      expect(effects.length).toBe(1);
+      expect(effects[0]._tag).toBe("ReadFile");
     });
 
     it("handles single task", () => {
       const t = sequence([pure(42)]);
-      expect((t as { value: number[] }).value).toEqual([42]);
+      expect(dryRun(t).value).toEqual([42]);
     });
 
     it("handles large arrays", () => {
       const tasks = Array.from({ length: 100 }, (_, i) => pure(i));
       const t = sequence(tasks);
-      expect((t as { value: number[] }).value).toHaveLength(100);
-      expect((t as { value: number[] }).value[99]).toBe(99);
+      const { value } = dryRun(t);
+      expect(value).toHaveLength(100);
+      expect((value as number[])[99]).toBe(99);
     });
   });
 
@@ -109,8 +114,7 @@ describe("Combinators - Sequencing", () => {
       const tasks = [pure(1), pure(2), pure(3)];
       const t = sequence_(tasks);
 
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: unknown }).value).toBeUndefined();
+      expect(dryRun(t).value).toBeUndefined();
     });
 
     it("still runs all effects", () => {
@@ -130,13 +134,18 @@ describe("Combinators - Sequencing", () => {
       const tasks = [pure(1), fail<number>(error), pure(3)];
       const t = sequence_(tasks);
 
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR");
+      }
     });
 
     it("handles empty array", () => {
       const t = sequence_([]);
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: unknown }).value).toBeUndefined();
+      expect(dryRun(t).value).toBeUndefined();
     });
   });
 
@@ -145,20 +154,19 @@ describe("Combinators - Sequencing", () => {
       const items = [1, 2, 3];
       const t = traverse(items, (x) => pure(x * 2));
 
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: number[] }).value).toEqual([2, 4, 6]);
+      expect(dryRun(t).value).toEqual([2, 4, 6]);
     });
 
     it("provides index to the function", () => {
       const items = ["a", "b", "c"];
       const t = traverse(items, (item, index) => pure(`${item}${index}`));
 
-      expect((t as { value: string[] }).value).toEqual(["a0", "b1", "c2"]);
+      expect(dryRun(t).value).toEqual(["a0", "b1", "c2"]);
     });
 
     it("handles empty array", () => {
       const t = traverse([], (x: number) => pure(x));
-      expect((t as { value: unknown[] }).value).toEqual([]);
+      expect(dryRun(t).value).toEqual([]);
     });
 
     it("short-circuits on failure", () => {
@@ -168,7 +176,13 @@ describe("Combinators - Sequencing", () => {
         x === 2 ? fail<number>(error) : pure(x),
       );
 
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR");
+      }
     });
 
     it("can create effects from items", () => {
@@ -183,24 +197,26 @@ describe("Combinators - Sequencing", () => {
   describe("traverse_", () => {
     it("applies function to each element and discards results", () => {
       const items = ["a", "b", "c"];
-      let _count = 0;
+      let count = 0;
       const t = traverse_(items, (_item) => {
-        _count++;
+        count++;
         return pure(undefined);
       });
 
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: unknown }).value).toBeUndefined();
+      expect(dryRun(t).value).toBeUndefined();
+      expect(count).toBe(3);
     });
 
     it("provides index to the function", () => {
       const items = [1, 2, 3];
       const indices: number[] = [];
-      traverse_(items, (_item, index) => {
+      const t = traverse_(items, (_item, index) => {
         indices.push(index);
         return pure(undefined);
       });
-      // Note: indices won't be populated until dry-run/execution
+      // indices are populated only when the task runs
+      dryRun(t);
+      expect(indices).toEqual([0, 1, 2]);
     });
 
     it("handles effects", () => {
@@ -221,8 +237,7 @@ describe("Combinators - Parallel", () => {
   describe("parallel", () => {
     it("returns empty array for empty tasks", () => {
       const t = parallel([]);
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: unknown[] }).value).toEqual([]);
+      expect(dryRun(t).value).toEqual([]);
     });
 
     it("creates a Parallel effect for non-empty tasks", () => {
@@ -245,8 +260,7 @@ describe("Combinators - Parallel", () => {
   describe("parallelN", () => {
     it("returns empty array for empty tasks", () => {
       const t = parallelN(2, []);
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: unknown[] }).value).toEqual([]);
+      expect(dryRun(t).value).toEqual([]);
     });
 
     it("batches tasks by concurrency limit", () => {
@@ -281,8 +295,13 @@ describe("Combinators - Parallel", () => {
   describe("race", () => {
     it("fails for empty tasks", () => {
       const t = race([]);
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("RACE_EMPTY");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("RACE_EMPTY");
+      }
     });
 
     it("creates a Race effect for non-empty tasks", () => {
@@ -317,16 +336,14 @@ describe("Combinators - Conditional", () => {
 
     it("returns pure undefined when condition is false", () => {
       const task = when(false, info("not running"));
-      expect(task._tag).toBe("Pure");
-      expect((task as { value: unknown }).value).toBeUndefined();
-
-      const { effects } = dryRun(task);
+      const { value, effects } = dryRun(task);
+      expect(value).toBeUndefined();
       expect(effects.length).toBe(0);
     });
 
     it("handles pure tasks", () => {
       const task = when(true, pure(undefined));
-      expect(task._tag).toBe("Pure");
+      expect(dryRun(task).value).toBeUndefined();
     });
   });
 
@@ -338,9 +355,8 @@ describe("Combinators - Conditional", () => {
 
     it("returns pure undefined when condition is true", () => {
       const task = unless(true, info("not running"));
-      expect(task._tag).toBe("Pure");
-
-      const { effects } = dryRun(task);
+      const { value, effects } = dryRun(task);
+      expect(value).toBeUndefined();
       expect(effects.length).toBe(0);
     });
   });
@@ -348,17 +364,17 @@ describe("Combinators - Conditional", () => {
   describe("ifElse", () => {
     it("returns onTrue task when condition is true", () => {
       const t = ifElse(true, pure("yes"), pure("no"));
-      expect((t as { value: string }).value).toBe("yes");
+      expect(dryRun(t).value).toBe("yes");
     });
 
     it("returns onFalse task when condition is false", () => {
       const t = ifElse(false, pure("yes"), pure("no"));
-      expect((t as { value: string }).value).toBe("no");
+      expect(dryRun(t).value).toBe("no");
     });
 
     it("can have different types", () => {
       const t = ifElse(true, pure(42), pure("forty-two"));
-      expect((t as { value: number | string }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("works with effects", () => {
@@ -398,7 +414,13 @@ describe("Combinators - Conditional", () => {
       const error: TaskError = { code: "ERR", message: "condition failed" };
       const t = ifElseM(fail<boolean>(error), pure("yes"), pure("no"));
 
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR");
+      }
     });
   });
 });
@@ -411,17 +433,17 @@ describe("Combinators - Error Handling", () => {
   describe("retry", () => {
     it("returns the task immediately if maxAttempts is 1", () => {
       const t = retry(pure(42), 1);
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("returns the task immediately if maxAttempts is 0", () => {
       const t = retry(pure(42), 0);
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("propagates success without retrying", () => {
       const t = retry(pure(42), 3);
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("wraps failed task in recover for retry", () => {
@@ -429,28 +451,34 @@ describe("Combinators - Error Handling", () => {
       const t = retry(fail<number>(error), 2);
 
       // After all retries exhausted, it should still fail
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR");
+      }
     });
   });
 
   describe("retryWithBackoff", () => {
     it("behaves like retry (backoff is handled by interpreter)", () => {
       const t = retryWithBackoff(pure(42), 3, 100);
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
   });
 
   describe("orElse", () => {
     it("returns primary if it succeeds", () => {
       const t = orElse(pure(42), pure(0));
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("returns fallback if primary fails", () => {
       const error: TaskError = { code: "ERR", message: "error" };
       const t = orElse(fail<number>(error), pure(99));
 
-      expect((t as { value: number }).value).toBe(99);
+      expect(dryRun(t).value).toBe(99);
     });
 
     it("propagates fallback failure", () => {
@@ -458,8 +486,13 @@ describe("Combinators - Error Handling", () => {
       const error2: TaskError = { code: "ERR2", message: "second" };
       const t = orElse(fail<number>(error1), fail<number>(error2));
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("ERR2");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR2");
+      }
     });
 
     it("can chain multiple fallbacks", () => {
@@ -469,35 +502,42 @@ describe("Combinators - Error Handling", () => {
         pure(42),
       );
 
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
   });
 
   describe("optional", () => {
     it("returns the value if task succeeds", () => {
       const t = optional(pure(42));
-      expect((t as { value: number | undefined }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("returns undefined if task fails", () => {
       const error: TaskError = { code: "ERR", message: "error" };
       const t = optional(fail<number>(error));
 
-      expect((t as { value: number | undefined }).value).toBeUndefined();
+      // optional never throws; failure resolves to undefined
+      expect(dryRun(t).value).toBeUndefined();
     });
 
     it("works with effects", () => {
       const eff: Effect = { _tag: "ReadFile", path: "/test.txt" };
       const t = optional(effect<string>(eff));
 
-      expect(t._tag).toBe("Effect");
+      const { value, effects } = dryRunWith(
+        t,
+        new Map([["ReadFile", () => "file-contents"]]),
+      );
+      expect(value).toBe("file-contents");
+      expect(effects.length).toBe(1);
+      expect(effects[0]._tag).toBe("ReadFile");
     });
   });
 
   describe("attempt", () => {
     it("returns ok result on success", () => {
       const t = attempt(pure(42));
-      const result = (t as { value: { ok: boolean; value?: number } }).value;
+      const result = dryRun(t).value as { ok: boolean; value?: number };
 
       expect(result.ok).toBe(true);
       expect(result.value).toBe(42);
@@ -506,7 +546,7 @@ describe("Combinators - Error Handling", () => {
     it("returns error result on failure", () => {
       const error: TaskError = { code: "ERR", message: "error" };
       const t = attempt(fail<number>(error));
-      const result = (t as { value: { ok: boolean; error?: TaskError } }).value;
+      const result = dryRun(t).value as { ok: boolean; error?: TaskError };
 
       expect(result.ok).toBe(false);
       expect(result.error?.code).toBe("ERR");
@@ -516,7 +556,8 @@ describe("Combinators - Error Handling", () => {
       const error: TaskError = { code: "ERR", message: "error" };
       const t = attempt(fail<number>(error));
 
-      expect(t._tag).toBe("Pure");
+      expect(() => dryRun(t)).not.toThrow();
+      expect(dryRun(t).value).toEqual({ ok: false, error });
     });
   });
 });
@@ -534,7 +575,7 @@ describe("Combinators - Resource Management", () => {
 
       const t = bracket(acquire, use, release);
 
-      expect((t as { value: number }).value).toBe(8);
+      expect(dryRun(t).value).toBe(8);
     });
 
     it("runs release on failure", () => {
@@ -545,8 +586,13 @@ describe("Combinators - Resource Management", () => {
 
       const t = bracket(acquire, use, release);
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("USE_ERR");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("USE_ERR");
+      }
     });
 
     it("propagates acquire failure without running use or release", () => {
@@ -560,8 +606,13 @@ describe("Combinators - Resource Management", () => {
 
       const t = bracket(acquire, use, release);
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("ACQUIRE_ERR");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ACQUIRE_ERR");
+      }
     });
 
     it("works with effects", () => {
@@ -625,7 +676,13 @@ describe("Combinators - Utility", () => {
       const error: TaskError = { code: "ERR", message: "error" };
       const t = tap(fail<number>(error), () => info("side effect"));
 
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR");
+      }
     });
 
     it("propagates failure from side effect", () => {
@@ -635,7 +692,13 @@ describe("Combinators - Utility", () => {
       };
       const t = tap(pure(42), () => fail<void>(error));
 
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("SIDE_ERR");
+      }
     });
   });
 
@@ -660,14 +723,14 @@ describe("Combinators - Utility", () => {
   describe("delay", () => {
     it("returns the task unchanged (delay handled by interpreter)", () => {
       const t = delay(pure(42), 1000);
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
   });
 
   describe("timeout", () => {
     it("returns the task unchanged (timeout handled by interpreter)", () => {
       const t = timeout(pure(42), 5000);
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
   });
 
@@ -679,7 +742,7 @@ describe("Combinators - Utility", () => {
         (e) => `error: ${e.code}`,
       );
 
-      expect((t as { value: string }).value).toBe("success: 42");
+      expect(dryRun(t).value).toBe("success: 42");
     });
 
     it("applies onFailure for failed task", () => {
@@ -690,7 +753,7 @@ describe("Combinators - Utility", () => {
         (e) => `error: ${e.code}`,
       );
 
-      expect((t as { value: string }).value).toBe("error: ERR");
+      expect(dryRun(t).value).toBe("error: ERR");
     });
 
     it("never fails - always returns Pure", () => {
@@ -701,30 +764,41 @@ describe("Combinators - Utility", () => {
         () => "failure",
       );
 
-      expect(t._tag).toBe("Pure");
+      expect(() => dryRun(t)).not.toThrow();
+      expect(dryRun(t).value).toBe("failure");
     });
   });
 
   describe("zip", () => {
     it("combines two tasks into a tuple", () => {
       const t = zip(pure(1), pure("a"));
-      expect((t as { value: [number, string] }).value).toEqual([1, "a"]);
+      expect(dryRun(t).value).toEqual([1, "a"]);
     });
 
     it("propagates first failure", () => {
       const error: TaskError = { code: "ERR1", message: "first" };
       const t = zip(fail<number>(error), pure("a"));
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("ERR1");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR1");
+      }
     });
 
     it("propagates second failure", () => {
       const error: TaskError = { code: "ERR2", message: "second" };
       const t = zip(pure(1), fail<string>(error));
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("ERR2");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR2");
+      }
     });
 
     it("works with effects", () => {
@@ -738,18 +812,20 @@ describe("Combinators - Utility", () => {
   describe("zip3", () => {
     it("combines three tasks into a tuple", () => {
       const t = zip3(pure(1), pure("a"), pure(true));
-      expect((t as { value: [number, string, boolean] }).value).toEqual([
-        1,
-        "a",
-        true,
-      ]);
+      expect(dryRun(t).value).toEqual([1, "a", true]);
     });
 
     it("propagates any failure", () => {
       const error: TaskError = { code: "ERR", message: "error" };
       const t = zip3(pure(1), fail<string>(error), pure(true));
 
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR");
+      }
     });
 
     it("works with effects", () => {
@@ -856,22 +932,22 @@ describe("Combinators - Edge Cases", () => {
   describe("Empty inputs", () => {
     it("traverse handles empty array", () => {
       const t = traverse([], (x: number) => pure(x * 2));
-      expect((t as { value: number[] }).value).toEqual([]);
+      expect(dryRun(t).value).toEqual([]);
     });
 
     it("sequence handles empty array", () => {
       const t = sequence([]);
-      expect((t as { value: unknown[] }).value).toEqual([]);
+      expect(dryRun(t).value).toEqual([]);
     });
 
     it("parallel handles empty array", () => {
       const t = parallel([]);
-      expect((t as { value: unknown[] }).value).toEqual([]);
+      expect(dryRun(t).value).toEqual([]);
     });
 
     it("parallelN handles empty array", () => {
       const t = parallelN(5, []);
-      expect((t as { value: unknown[] }).value).toEqual([]);
+      expect(dryRun(t).value).toEqual([]);
     });
   });
 

--- a/packages/runtime/task/src/lib/dry-run.test.ts
+++ b/packages/runtime/task/src/lib/dry-run.test.ts
@@ -32,7 +32,7 @@ import {
   symlink,
   writeFile,
 } from "./primitives.js";
-import { effect, fail, flatMap, map, pure } from "./task.js";
+import { effect, fail, flatMap, map, pure, recover } from "./task.js";
 import type { Effect, TaskError } from "./types.js";
 
 // =============================================================================
@@ -609,6 +609,107 @@ describe("Dry-Run - collectEffects", () => {
     // collectEffects stops at Fail node, does not throw
     const effects = collectEffects(task);
     expect(effects.length).toBe(1);
+  });
+});
+
+// =============================================================================
+// Lazy node handling (FlatMap / Recover) across the dry-run interpreters
+// =============================================================================
+
+describe("Dry-Run - lazy node handling", () => {
+  const boom = (): never => {
+    throw new Error("raw");
+  };
+
+  it("drives flatMap chains and recovers failures", () => {
+    expect(dryRun(flatMap(pure(1), (x) => pure(x + 1))).value).toBe(2);
+    expect(
+      dryRun(recover(fail<number>({ code: "E", message: "m" }), () => pure(42)))
+        .value,
+    ).toBe(42);
+    expect(dryRun(recover(pure(7), () => pure(0))).value).toBe(7);
+  });
+
+  it("rethrows a non-task error raised inside a recovered task", () => {
+    expect(() => dryRun(recover(map(pure(1), boom), () => pure(0)))).toThrow(
+      "raw",
+    );
+  });
+
+  it("drives flatMap/recover inside Parallel children", () => {
+    const { value } = dryRun(
+      effect<unknown[]>({
+        _tag: "Parallel",
+        tasks: [
+          flatMap(pure(1), (x) => pure(x + 1)),
+          recover(fail<number>({ code: "E", message: "m" }), () => pure(3)),
+          recover(pure(5), () => pure(0)),
+        ],
+      }),
+    );
+    expect(value).toEqual([2, 3, 5]);
+  });
+
+  it("rethrows a non-task error from a Parallel child", () => {
+    expect(() =>
+      dryRun(
+        effect<unknown[]>({
+          _tag: "Parallel",
+          tasks: [recover(map(pure(1), boom), () => pure(0))],
+        }),
+      ),
+    ).toThrow("raw");
+  });
+
+  it("dryRunWith drives flatMap/recover and rethrows non-task errors", () => {
+    const mocks = new Map<string, (e: Effect) => unknown>([
+      ["ReadFile", () => "x"],
+    ]);
+    expect(
+      dryRunWith(
+        flatMap(pure(1), (x) => pure(x + 1)),
+        mocks,
+      ).value,
+    ).toBe(2);
+    expect(
+      dryRunWith(
+        recover(pure(1), () => pure(0)),
+        mocks,
+      ).value,
+    ).toBe(1);
+    expect(
+      dryRunWith(
+        recover(fail<number>({ code: "E", message: "m" }), () => pure(9)),
+        mocks,
+      ).value,
+    ).toBe(9);
+    expect(() =>
+      dryRunWith(
+        recover(map(pure(1), boom), () => pure(0)),
+        mocks,
+      ),
+    ).toThrow("raw");
+  });
+
+  it("collectEffects walks flatMap/recover and rethrows non-task errors", () => {
+    expect(
+      collectEffects(
+        flatMap(effect<string>({ _tag: "ReadFile", path: "a" }), () => pure(1)),
+      ),
+    ).toEqual([{ _tag: "ReadFile", path: "a" }]);
+    expect(
+      collectEffects(
+        recover(effect<string>({ _tag: "ReadFile", path: "b" }), () => pure(0)),
+      ),
+    ).toEqual([{ _tag: "ReadFile", path: "b" }]);
+    expect(
+      collectEffects(
+        recover(fail<number>({ code: "E", message: "m" }), () => pure(0)),
+      ),
+    ).toEqual([]);
+    expect(() =>
+      collectEffects(recover(map(pure(1), boom), () => pure(0))),
+    ).toThrow("raw");
   });
 });
 

--- a/packages/runtime/task/src/lib/dry-run.ts
+++ b/packages/runtime/task/src/lib/dry-run.ts
@@ -147,6 +147,19 @@ export const dryRun = <A>(task: Task<A>): DryRunResult<A> => {
         const mockResult = mockEffectWithFs(effect);
         return run(t.cont(mockResult) as Task<T>);
       }
+
+      case "FlatMap":
+        return run(t.f(run(t.inner)) as Task<T>);
+
+      case "Recover":
+        try {
+          return run(t.inner);
+        } catch (error) {
+          if (error instanceof TaskExecutionError) {
+            return run(t.handler(error.taskError));
+          }
+          throw error;
+        }
     }
   };
 
@@ -213,6 +226,19 @@ const dryRunWithVirtualFs = <A>(
         const mockResult = mockEffectWithFs(effect);
         return run(t.cont(mockResult) as Task<T>);
       }
+
+      case "FlatMap":
+        return run(t.f(run(t.inner)) as Task<T>);
+
+      case "Recover":
+        try {
+          return run(t.inner);
+        } catch (error) {
+          if (error instanceof TaskExecutionError) {
+            return run(t.handler(error.taskError));
+          }
+          throw error;
+        }
     }
   };
 
@@ -237,7 +263,7 @@ export const dryRunWith = <A>(
     return mockEffect(effect);
   };
 
-  const run = (t: Task<A>): A => {
+  const run = <T>(t: Task<T>): T => {
     switch (t._tag) {
       case "Pure":
         return t.value;
@@ -250,6 +276,19 @@ export const dryRunWith = <A>(
         const mockResult = getMock(t.effect);
         return run(t.cont(mockResult));
       }
+
+      case "FlatMap":
+        return run(t.f(run(t.inner)));
+
+      case "Recover":
+        try {
+          return run(t.inner);
+        } catch (error) {
+          if (error instanceof TaskExecutionError) {
+            return run(t.handler(error.taskError));
+          }
+          throw error;
+        }
     }
   };
 
@@ -268,19 +307,43 @@ export const dryRunWith = <A>(
 export const collectEffects = <A>(task: Task<A>): Effect[] => {
   const effects: Effect[] = [];
 
-  const collect = (t: Task<unknown>): void => {
+  const drive = (t: Task<unknown>): unknown => {
     switch (t._tag) {
       case "Pure":
+        return t.value;
+
       case "Fail":
-        return;
+        throw new TaskExecutionError(t.error);
 
       case "Effect":
         effects.push(t.effect);
-        collect(t.cont(mockEffect(t.effect)));
+        return drive(t.cont(mockEffect(t.effect)));
+
+      case "FlatMap":
+        return drive(t.f(drive(t.inner)));
+
+      case "Recover":
+        try {
+          return drive(t.inner);
+        } catch (error) {
+          if (error instanceof TaskExecutionError) {
+            return drive(t.handler(error.taskError));
+          }
+          throw error;
+        }
     }
   };
 
-  collect(task);
+  // Walk the task collecting each leaf effect, tolerating an unrecovered
+  // failure (the original short-circuits on a Fail rather than throwing).
+  try {
+    drive(task as Task<unknown>);
+  } catch (error) {
+    if (!(error instanceof TaskExecutionError)) {
+      throw error;
+    }
+  }
+
   return effects;
 };
 

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -18,8 +18,18 @@ import {
   TaskExecutionError,
 } from "./interpreter.js";
 import { info, succeed, warn } from "./primitives.js";
-import { effect, fail, flatMap, map, pure } from "./task.js";
-import type { Effect, ExecResult, TaskError } from "./types.js";
+import {
+  $,
+  effect,
+  fail,
+  flatMap,
+  gen,
+  map,
+  mapError,
+  pure,
+  recover,
+} from "./task.js";
+import type { Effect, ExecResult, Task, TaskError } from "./types.js";
 
 // Note: These tests focus on the interpreter's logic without actually
 // performing I/O. For real I/O testing, integration tests should be used.
@@ -1435,5 +1445,126 @@ describe("Interpreter - AbortSignal without reason", () => {
       expect(err).toBeInstanceOf(TaskExecutionError);
       expect((err as TaskExecutionError).message).toBe("Task interrupted");
     }
+  });
+});
+
+// =============================================================================
+// runTask - Recover (error recovery realised on the interpreter stack)
+// =============================================================================
+
+describe("Interpreter - runTask with recover", () => {
+  it("recovers from a failed task", async () => {
+    const error: TaskError = { code: "ERR", message: "boom" };
+    const result = await runTask(recover(fail<number>(error), () => pure(42)));
+    expect(result).toBe(42);
+  });
+
+  it("passes the original error to the handler", async () => {
+    const error: TaskError = { code: "ERR_42", message: "boom" };
+    const result = await runTask(
+      recover(fail<string>(error), (e) => pure(`recovered: ${e.code}`)),
+    );
+    expect(result).toBe("recovered: ERR_42");
+  });
+
+  it("does not invoke the handler on success", async () => {
+    let called = false;
+    const result = await runTask(
+      recover(pure(7), () => {
+        called = true;
+        return pure(0);
+      }),
+    );
+    expect(result).toBe(7);
+    expect(called).toBe(false);
+  });
+
+  it("rethrows when the handler itself fails", async () => {
+    const make = () =>
+      recover(fail<number>({ code: "E1", message: "first" }), () =>
+        fail<number>({ code: "E2", message: "second" }),
+      );
+    await expect(runTask(make())).rejects.toThrow(TaskExecutionError);
+    try {
+      await runTask(make());
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect((e as TaskExecutionError).code).toBe("E2");
+    }
+  });
+
+  it("supports nested recover (outer catches when inner handler fails)", async () => {
+    const result = await runTask(
+      recover(
+        recover(fail<number>({ code: "E1", message: "first" }), () =>
+          fail<number>({ code: "E2", message: "second" }),
+        ),
+        () => pure(99),
+      ),
+    );
+    expect(result).toBe(99);
+  });
+
+  it("recovers a failure raised after intervening binds", async () => {
+    // The Fail must unwind past the bind frames to reach the recovery frame.
+    const task = recover(
+      flatMap(
+        flatMap(pure(1), (x) => pure(x + 1)),
+        () => fail<number>({ code: "MID", message: "mid-chain failure" }),
+      ),
+      () => pure(-1),
+    );
+    expect(await runTask(task)).toBe(-1);
+  });
+
+  it("mapError transforms the error of a failed task", async () => {
+    const task = mapError(
+      fail<number>({ code: "ORIG", message: "m" }),
+      (e) => ({
+        ...e,
+        code: "WRAPPED",
+      }),
+    );
+    try {
+      await runTask(task);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect((e as TaskExecutionError).code).toBe("WRAPPED");
+    }
+  });
+});
+
+// =============================================================================
+// runTask - Stack safety (the trampoline runs deep chains in constant stack)
+// =============================================================================
+
+describe("Interpreter - runTask stack safety", () => {
+  const N = 100_000;
+
+  it("runs a very long flatMap chain without overflowing the stack", async () => {
+    let task: Task<number> = pure(0);
+    for (let i = 0; i < N; i++) {
+      task = flatMap(task, (x) => pure(x + 1));
+    }
+    expect(await runTask(task)).toBe(N);
+  });
+
+  it("runs a very long map chain without overflowing the stack", async () => {
+    let task: Task<number> = pure(0);
+    for (let i = 0; i < N; i++) {
+      task = map(task, (x) => x + 1);
+    }
+    expect(await runTask(task)).toBe(N);
+  });
+
+  it("runs a very long generator without overflowing the stack", async () => {
+    const task = gen(function* () {
+      let acc = 0;
+      for (let i = 0; i < N; i++) {
+        acc = yield* $(pure(acc + 1));
+      }
+      return acc;
+    });
+    expect(await runTask(task)).toBe(N);
   });
 });

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -293,7 +293,20 @@ export interface RunTaskOptions {
 // =============================================================================
 
 /**
+ * A frame on the interpreter's explicit continuation stack: either a pending
+ * bind (the `f` of a `FlatMap`) or an installed error-recovery handler (the
+ * `handler` of a `Recover`).
+ */
+type Frame =
+  | { kind: "bind"; f: (x: unknown) => Task<unknown> }
+  | { kind: "recover"; handler: (error: TaskError) => Task<unknown> };
+
+/**
  * Run a task to completion, executing all effects.
+ *
+ * Bind and recovery are realised on an explicit continuation/handler-frame
+ * stack rather than by recursing through the task structure, so arbitrarily
+ * long `flatMap`/`gen` chains run in constant call-stack depth.
  */
 export const runTask = async <A>(
   task: Task<A>,
@@ -319,92 +332,131 @@ export const runTask = async <A>(
     }
   };
 
-  const runInternal = async <B>(t: Task<B>): Promise<B> => {
-    checkInterrupted();
+  // Perform a single effect and return its result. Structural Parallel/Race
+  // effects run their children through a fresh interpreter pass; every other
+  // effect is routed to executeEffect.
+  const perform = async (effect: Effect): Promise<unknown> => {
+    if (effect._tag === "Parallel") {
+      onEffectStart?.(effect);
+      const startTime = performance.now();
 
-    switch (t._tag) {
-      case "Pure":
-        return t.value;
+      const settled = await Promise.allSettled(
+        effect.tasks.map((child) => interpret(child)),
+      );
 
-      case "Fail":
-        throw new TaskExecutionError(t.error);
+      const errors: TaskError[] = [];
+      const results: unknown[] = [];
 
-      case "Effect": {
-        const effect = t.effect;
-
-        // Handle Parallel and Race effects specially to preserve options
-        if (effect._tag === "Parallel") {
-          onEffectStart?.(effect);
-          const startTime = performance.now();
-
-          const settled = await Promise.allSettled(
-            effect.tasks.map((task) => runInternal(task)),
+      for (const outcome of settled) {
+        if (outcome.status === "fulfilled") {
+          results.push(outcome.value);
+        } else {
+          const err = outcome.reason;
+          errors.push(
+            err instanceof TaskExecutionError
+              ? err.taskError
+              : { code: "INTERNAL", message: String(err) },
           );
+        }
+      }
 
-          const errors: TaskError[] = [];
-          const results: unknown[] = [];
+      if (errors.length > 0) {
+        const primary = errors[0];
+        throw new TaskExecutionError({
+          ...primary,
+          suppressed: errors.length > 1 ? errors.slice(1) : undefined,
+        });
+      }
 
-          for (const result of settled) {
-            if (result.status === "fulfilled") {
-              results.push(result.value);
-            } else {
-              const err = result.reason;
-              errors.push(
-                err instanceof TaskExecutionError
-                  ? err.taskError
-                  : { code: "INTERNAL", message: String(err) },
-              );
+      onEffectComplete?.(effect, performance.now() - startTime);
+      return results;
+    }
+
+    if (effect._tag === "Race") {
+      onEffectStart?.(effect);
+      const startTime = performance.now();
+
+      const result = await Promise.race(
+        effect.tasks.map((child) => interpret(child)),
+      );
+
+      onEffectComplete?.(effect, performance.now() - startTime);
+      return result;
+    }
+
+    onEffectStart?.(effect);
+    const startTime = performance.now();
+    const result = await executeEffect(effect, context, promptHandler, onLog);
+    onEffectComplete?.(effect, performance.now() - startTime);
+    return result;
+  };
+
+  // The trampoline: drive a task to its final value on an explicit stack of
+  // bind/recover frames, so no node type recurses through the host call stack.
+  const interpret = async (root: Task<unknown>): Promise<unknown> => {
+    const stack: Frame[] = [];
+    let cur: Task<unknown> = root;
+
+    for (;;) {
+      checkInterrupted();
+
+      switch (cur._tag) {
+        case "FlatMap":
+          stack.push({ kind: "bind", f: cur.f });
+          cur = cur.inner;
+          break;
+
+        case "Recover":
+          stack.push({ kind: "recover", handler: cur.handler });
+          cur = cur.inner;
+          break;
+
+        case "Effect": {
+          const result = await perform(cur.effect);
+          cur = cur.cont(result);
+          break;
+        }
+
+        case "Pure": {
+          // Success: unwind to the next bind frame, discarding recovery frames.
+          const value = cur.value;
+          let resumed = false;
+          while (stack.length > 0) {
+            const frame = stack.pop() as Frame;
+            if (frame.kind === "bind") {
+              cur = frame.f(value);
+              resumed = true;
+              break;
             }
           }
-
-          if (errors.length > 0) {
-            const primary = errors[0];
-            throw new TaskExecutionError({
-              ...primary,
-              suppressed: errors.length > 1 ? errors.slice(1) : undefined,
-            });
+          if (!resumed) {
+            return value;
           }
-
-          const duration = performance.now() - startTime;
-          onEffectComplete?.(effect, duration);
-
-          return runInternal(t.cont(results));
+          break;
         }
 
-        if (effect._tag === "Race") {
-          onEffectStart?.(effect);
-          const startTime = performance.now();
-
-          const result = await Promise.race(
-            effect.tasks.map((task) => runInternal(task)),
-          );
-
-          const duration = performance.now() - startTime;
-          onEffectComplete?.(effect, duration);
-
-          return runInternal(t.cont(result));
+        case "Fail": {
+          // Failure: unwind to the nearest recovery frame, discarding binds.
+          const error = cur.error;
+          let resumed = false;
+          while (stack.length > 0) {
+            const frame = stack.pop();
+            if (frame?.kind === "recover") {
+              cur = frame.handler(error);
+              resumed = true;
+              break;
+            }
+          }
+          if (!resumed) {
+            throw new TaskExecutionError(error);
+          }
+          break;
         }
-
-        // Handle all other effects
-        onEffectStart?.(effect);
-        const startTime = performance.now();
-
-        const result = await executeEffect(
-          effect,
-          context,
-          promptHandler,
-          onLog,
-        );
-
-        const duration = performance.now() - startTime;
-        onEffectComplete?.(effect, duration);
-
-        return runInternal(t.cont(result));
       }
     }
   };
 
-  return runInternal(task);
+  return interpret(task as Task<unknown>) as Promise<A>;
 };
 
 /**

--- a/packages/runtime/task/src/lib/task.test.ts
+++ b/packages/runtime/task/src/lib/task.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { dryRun } from "./dry-run.js";
+import { dryRun, dryRunWith } from "./dry-run.js";
 import { readFileEffect, writeFileEffect } from "./effect.js";
+import type { TaskExecutionError } from "./interpreter.js";
 import {
   $,
   ap,
@@ -216,8 +217,7 @@ describe("Task Monad - Monad Operations", () => {
   describe("flatMap", () => {
     it("chains Pure tasks", () => {
       const t = flatMap(pure(5), (x) => pure(x + 3));
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: number }).value).toBe(8);
+      expect(dryRun(t).value).toBe(8);
     });
 
     it("propagates Fail tasks without calling continuation", () => {
@@ -228,7 +228,7 @@ describe("Task Monad - Monad Operations", () => {
         return pure(0);
       });
 
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
       expect(called).toBe(false);
     });
 
@@ -238,21 +238,25 @@ describe("Task Monad - Monad Operations", () => {
         message: "continuation error",
       };
       const t = flatMap(pure(5), () => fail<number>(error));
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("CONT_ERR");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("CONT_ERR");
+      }
     });
 
     it("chains through Effect tasks", () => {
       const eff: Effect = { _tag: "ReadFile", path: "/test.txt" };
       const t = flatMap(effect<string>(eff), (content) => pure(content.length));
 
-      expect(t._tag).toBe("Effect");
-      const effectTask = t as {
-        _tag: "Effect";
-        cont: (result: unknown) => Task<number>;
-      };
-      const continued = effectTask.cont("hello");
-      expect((continued as { value: number }).value).toBe(5);
+      const { value, effects } = dryRunWith(
+        t,
+        new Map([["ReadFile", () => "hello"]]),
+      );
+      expect(effects[0]._tag).toBe("ReadFile");
+      expect(value).toBe(5);
     });
 
     it("chains multiple operations", () => {
@@ -260,22 +264,21 @@ describe("Task Monad - Monad Operations", () => {
         flatMap(pure(2), (x) => pure(x * 3)),
         (x) => pure(x + 1),
       );
-      expect((t as { value: number }).value).toBe(7);
+      expect(dryRun(t).value).toBe(7);
     });
 
     it("handles nested flatMaps", () => {
       const t = flatMap(pure(1), (a) =>
         flatMap(pure(2), (b) => flatMap(pure(3), (c) => pure(a + b + c))),
       );
-      expect((t as { value: number }).value).toBe(6);
+      expect(dryRun(t).value).toBe(6);
     });
   });
 
   describe("map", () => {
     it("transforms the value of a Pure task", () => {
       const t = map(pure(10), (x) => x * 2);
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: number }).value).toBe(20);
+      expect(dryRun(t).value).toBe(20);
     });
 
     it("propagates Fail tasks without calling function", () => {
@@ -286,7 +289,7 @@ describe("Task Monad - Monad Operations", () => {
         return 0;
       });
 
-      expect(t._tag).toBe("Fail");
+      expect(() => dryRun(t)).toThrow();
       expect(called).toBe(false);
     });
 
@@ -294,17 +297,17 @@ describe("Task Monad - Monad Operations", () => {
       const eff: Effect = { _tag: "ReadFile", path: "/test.txt" };
       const t = map(effect<string>(eff), (s) => s.toUpperCase());
 
-      expect(t._tag).toBe("Effect");
-      const effectTask = t as {
-        cont: (result: unknown) => Task<string>;
-      };
-      const continued = effectTask.cont("hello");
-      expect((continued as { value: string }).value).toBe("HELLO");
+      const { value, effects } = dryRunWith(
+        t,
+        new Map([["ReadFile", () => "hello"]]),
+      );
+      expect(effects[0]._tag).toBe("ReadFile");
+      expect(value).toBe("HELLO");
     });
 
     it("can transform types", () => {
       const t = map(pure(42), (n) => String(n));
-      expect((t as { value: string }).value).toBe("42");
+      expect(dryRun(t).value).toBe("42");
     });
 
     it("can transform to complex types", () => {
@@ -312,22 +315,20 @@ describe("Task Monad - Monad Operations", () => {
         length: s.length,
         upper: s.toUpperCase(),
       }));
-      expect((t as { value: { length: number; upper: string } }).value).toEqual(
-        {
-          length: 5,
-          upper: "HELLO",
-        },
-      );
+      expect(dryRun(t).value).toEqual({
+        length: 5,
+        upper: "HELLO",
+      });
     });
 
     it("handles identity function", () => {
       const t = map(pure(42), (x) => x);
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("handles constant function", () => {
       const t = map(pure(42), () => "constant");
-      expect((t as { value: string }).value).toBe("constant");
+      expect(dryRun(t).value).toBe("constant");
     });
   });
 
@@ -337,8 +338,7 @@ describe("Task Monad - Monad Operations", () => {
       const valTask = pure(21);
       const t = ap(fnTask, valTask);
 
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("propagates failure from function task", () => {
@@ -347,8 +347,13 @@ describe("Task Monad - Monad Operations", () => {
       const valTask = pure(21);
       const t = ap(fnTask, valTask);
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("FN_ERR");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("FN_ERR");
+      }
     });
 
     it("propagates failure from value task", () => {
@@ -357,8 +362,13 @@ describe("Task Monad - Monad Operations", () => {
       const valTask = fail<number>(error);
       const t = ap(fnTask, valTask);
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("VAL_ERR");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("VAL_ERR");
+      }
     });
 
     it("works with multi-argument functions via currying", () => {
@@ -366,23 +376,21 @@ describe("Task Monad - Monad Operations", () => {
       const t1 = ap(pure(add), pure(10));
       const t2 = ap(t1, pure(5));
 
-      expect((t2 as { value: number }).value).toBe(15);
+      expect(dryRun(t2).value).toBe(15);
     });
   });
 
   describe("recover", () => {
     it("does not affect Pure tasks", () => {
       const t = recover(pure(42), () => pure(0));
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("recovers from Fail tasks", () => {
       const error: TaskError = { code: "ERR", message: "error" };
       const t = recover(fail<number>(error), () => pure(99));
 
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: number }).value).toBe(99);
+      expect(dryRun(t).value).toBe(99);
     });
 
     it("provides the error to the handler", () => {
@@ -391,7 +399,7 @@ describe("Task Monad - Monad Operations", () => {
         pure(`recovered: ${e.code}`),
       );
 
-      expect((t as { value: string }).value).toBe("recovered: ERR_42");
+      expect(dryRun(t).value).toBe("recovered: ERR_42");
     });
 
     it("can return another Fail from handler", () => {
@@ -399,15 +407,21 @@ describe("Task Monad - Monad Operations", () => {
       const error2: TaskError = { code: "ERR2", message: "second" };
       const t = recover(fail<number>(error1), () => fail<number>(error2));
 
-      expect(t._tag).toBe("Fail");
-      expect((t as { error: TaskError }).error.code).toBe("ERR2");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("ERR2");
+      }
     });
 
     it("propagates through Effect tasks", () => {
       const eff: Effect = { _tag: "ReadFile", path: "/test.txt" };
       const t = recover(effect<string>(eff), () => pure("recovered"));
 
-      expect(t._tag).toBe("Effect");
+      const { effects } = dryRun(t);
+      expect(effects[0]._tag).toBe("ReadFile");
     });
 
     it("handles nested recover calls", () => {
@@ -419,15 +433,14 @@ describe("Task Monad - Monad Operations", () => {
         () => pure(42),
       );
 
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
   });
 
   describe("mapError", () => {
     it("does not affect Pure tasks", () => {
       const t = mapError(pure(42), (e) => ({ ...e, code: "MODIFIED" }));
-      expect(t._tag).toBe("Pure");
-      expect((t as { value: number }).value).toBe(42);
+      expect(dryRun(t).value).toBe(42);
     });
 
     it("transforms the error of Fail tasks", () => {
@@ -438,10 +451,14 @@ describe("Task Monad - Monad Operations", () => {
         message: `wrapped: ${e.message}`,
       }));
 
-      expect(t._tag).toBe("Fail");
-      const failTask = t as { error: TaskError };
-      expect(failTask.error.code).toBe("MODIFIED");
-      expect(failTask.error.message).toBe("wrapped: original");
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("MODIFIED");
+        expect(te.taskError.message).toBe("wrapped: original");
+      }
     });
 
     it("propagates through Effect tasks", () => {
@@ -451,7 +468,12 @@ describe("Task Monad - Monad Operations", () => {
         code: "MODIFIED",
       }));
 
-      expect(t._tag).toBe("Effect");
+      const { value, effects } = dryRunWith(
+        t,
+        new Map([["ReadFile", () => "mock content"]]),
+      );
+      expect(effects[0]._tag).toBe("ReadFile");
+      expect(value).toBe("mock content");
     });
 
     it("maps error through Effect continuation", () => {
@@ -461,15 +483,12 @@ describe("Task Monad - Monad Operations", () => {
         code: "MAPPED",
       }));
 
-      expect(t._tag).toBe("Effect");
-      const effectTask = t as {
-        cont: (v: unknown) => Task<string>;
-      };
-      // Calling cont triggers line 129: mapError(task.cont(result), f)
-      const contResult = effectTask.cont("mock content");
-      // The continuation wraps the result in mapError
-      expect(contResult._tag).toBe("Pure");
-      expect((contResult as { value: string }).value).toBe("mock content");
+      const { value, effects } = dryRunWith(
+        t,
+        new Map([["ReadFile", () => "mock content"]]),
+      );
+      expect(effects[0]._tag).toBe("ReadFile");
+      expect(value).toBe("mock content");
     });
 
     it("can add context to errors", () => {
@@ -479,11 +498,16 @@ describe("Task Monad - Monad Operations", () => {
         context: { operation: "test", timestamp: 12345 },
       }));
 
-      const failTask = t as { error: TaskError };
-      expect(failTask.error.context).toEqual({
-        operation: "test",
-        timestamp: 12345,
-      });
+      expect(() => dryRun(t)).toThrow();
+      try {
+        dryRun(t);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.context).toEqual({
+          operation: "test",
+          timestamp: 12345,
+        });
+      }
     });
   });
 });
@@ -498,7 +522,7 @@ describe("Task Monad - TaskBuilder", () => {
       const result = of(10)
         .map((x) => x * 2)
         .unwrap();
-      expect((result as { value: number }).value).toBe(20);
+      expect(dryRun(result).value).toBe(20);
     });
 
     it("chains multiple maps", () => {
@@ -508,7 +532,7 @@ describe("Task Monad - TaskBuilder", () => {
         .map((x) => String(x))
         .unwrap();
 
-      expect((result as { value: string }).value).toBe("12");
+      expect(dryRun(result).value).toBe("12");
     });
   });
 
@@ -518,7 +542,7 @@ describe("Task Monad - TaskBuilder", () => {
         .flatMap((x) => pure(x * 2))
         .unwrap();
 
-      expect((result as { value: number }).value).toBe(20);
+      expect(dryRun(result).value).toBe(20);
     });
 
     it("allows mixing map and flatMap", () => {
@@ -528,7 +552,7 @@ describe("Task Monad - TaskBuilder", () => {
         .map((x) => x + 3)
         .unwrap();
 
-      expect((result as { value: number }).value).toBe(15);
+      expect(dryRun(result).value).toBe(15);
     });
   });
 
@@ -539,7 +563,7 @@ describe("Task Monad - TaskBuilder", () => {
         .chain((x) => of(x + 1))
         .unwrap();
 
-      expect((result as { value: number }).value).toBe(16);
+      expect(dryRun(result).value).toBe(16);
     });
   });
 
@@ -550,7 +574,7 @@ describe("Task Monad - TaskBuilder", () => {
         .recover(() => pure(42))
         .unwrap();
 
-      expect((result as { value: number }).value).toBe(42);
+      expect(dryRun(result).value).toBe(42);
     });
 
     it("does not affect successful tasks", () => {
@@ -558,7 +582,7 @@ describe("Task Monad - TaskBuilder", () => {
         .recover(() => pure(0))
         .unwrap();
 
-      expect((result as { value: number }).value).toBe(100);
+      expect(dryRun(result).value).toBe(100);
     });
   });
 
@@ -569,8 +593,13 @@ describe("Task Monad - TaskBuilder", () => {
         .mapError((e) => ({ ...e, code: "MODIFIED" }))
         .unwrap();
 
-      expect(result._tag).toBe("Fail");
-      expect((result as { error: TaskError }).error.code).toBe("MODIFIED");
+      expect(() => dryRun(result)).toThrow();
+      try {
+        dryRun(result);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe("MODIFIED");
+      }
     });
   });
 
@@ -584,7 +613,7 @@ describe("Task Monad - TaskBuilder", () => {
         })
         .unwrap();
 
-      expect((result as { value: number }).value).toBe(42);
+      expect(dryRun(result).value).toBe(42);
       // Note: side effect happens during dry-run/execution, not task construction
     });
   });
@@ -593,7 +622,7 @@ describe("Task Monad - TaskBuilder", () => {
     it("sequences tasks discarding first result", () => {
       const result = of(1).andThen(pure(2)).andThen(pure(3)).unwrap();
 
-      expect((result as { value: number }).value).toBe(3);
+      expect(dryRun(result).value).toBe(3);
     });
 
     it("propagates failure", () => {
@@ -603,7 +632,7 @@ describe("Task Monad - TaskBuilder", () => {
         .andThen(pure(3))
         .unwrap();
 
-      expect(result._tag).toBe("Fail");
+      expect(() => dryRun(result)).toThrow();
     });
   });
 
@@ -728,9 +757,7 @@ describe("Task Monad - Monad Laws", () => {
       const left = flatMap(pure(a), f);
       const right = f(a);
 
-      expect((left as { value: number }).value).toBe(
-        (right as { value: number }).value,
-      );
+      expect(dryRun(left).value).toBe(dryRun(right).value);
     });
 
     it("pure(a) >>= f ≡ f(a) for strings", () => {
@@ -740,9 +767,7 @@ describe("Task Monad - Monad Laws", () => {
       const left = flatMap(pure(a), f);
       const right = f(a);
 
-      expect((left as { value: string }).value).toBe(
-        (right as { value: string }).value,
-      );
+      expect(dryRun(left).value).toBe(dryRun(right).value);
     });
 
     it("pure(a) >>= f ≡ f(a) when f returns fail", () => {
@@ -752,10 +777,21 @@ describe("Task Monad - Monad Laws", () => {
       const left = flatMap(pure(a), f);
       const right = f(a);
 
-      expect(left._tag).toBe(right._tag);
-      expect((left as { error: TaskError }).error.code).toBe(
-        (right as { error: TaskError }).error.code,
-      );
+      expect(() => dryRun(left)).toThrow();
+      expect(() => dryRun(right)).toThrow();
+      let leftCode: string | undefined;
+      let rightCode: string | undefined;
+      try {
+        dryRun(left);
+      } catch (e) {
+        leftCode = (e as TaskExecutionError).taskError.code;
+      }
+      try {
+        dryRun(right);
+      } catch (e) {
+        rightCode = (e as TaskExecutionError).taskError.code;
+      }
+      expect(leftCode).toBe(rightCode);
     });
   });
 
@@ -765,9 +801,7 @@ describe("Task Monad - Monad Laws", () => {
       const m = pure(42);
       const result = flatMap(m, pure);
 
-      expect((result as { value: number }).value).toBe(
-        (m as { value: number }).value,
-      );
+      expect(dryRun(result).value).toBe(dryRun(m).value);
     });
 
     it("m >>= pure ≡ m for Fail tasks", () => {
@@ -775,8 +809,13 @@ describe("Task Monad - Monad Laws", () => {
       const m = fail<number>(error);
       const result = flatMap(m, pure);
 
-      expect(result._tag).toBe("Fail");
-      expect((result as { error: TaskError }).error.code).toBe(error.code);
+      expect(() => dryRun(result)).toThrow();
+      try {
+        dryRun(result);
+      } catch (e) {
+        const te = e as TaskExecutionError;
+        expect(te.taskError.code).toBe(error.code);
+      }
     });
   });
 
@@ -790,9 +829,7 @@ describe("Task Monad - Monad Laws", () => {
       const left = flatMap(flatMap(m, f), g);
       const right = flatMap(m, (x) => flatMap(f(x), g));
 
-      expect((left as { value: number }).value).toBe(
-        (right as { value: number }).value,
-      );
+      expect(dryRun(left).value).toBe(dryRun(right).value);
     });
 
     it("associativity holds with failure in first function", () => {
@@ -803,7 +840,8 @@ describe("Task Monad - Monad Laws", () => {
       const left = flatMap(flatMap(m, f), g);
       const right = flatMap(m, (x) => flatMap(f(x), g));
 
-      expect(left._tag).toBe(right._tag);
+      expect(() => dryRun(left)).toThrow();
+      expect(() => dryRun(right)).toThrow();
     });
 
     it("associativity holds with failure in second function", () => {
@@ -814,7 +852,8 @@ describe("Task Monad - Monad Laws", () => {
       const left = flatMap(flatMap(m, f), g);
       const right = flatMap(m, (x) => flatMap(f(x), g));
 
-      expect(left._tag).toBe(right._tag);
+      expect(() => dryRun(left)).toThrow();
+      expect(() => dryRun(right)).toThrow();
     });
   });
 });
@@ -830,9 +869,7 @@ describe("Task Monad - Functor Laws", () => {
       const m = pure(42);
       const result = map(m, (x) => x);
 
-      expect((result as { value: number }).value).toBe(
-        (m as { value: number }).value,
-      );
+      expect(dryRun(result).value).toBe(dryRun(m).value);
     });
 
     it("map(id) ≡ id for Fail tasks", () => {
@@ -840,7 +877,7 @@ describe("Task Monad - Functor Laws", () => {
       const m = fail<number>(error);
       const result = map(m, (x) => x);
 
-      expect(result._tag).toBe("Fail");
+      expect(() => dryRun(result)).toThrow();
     });
   });
 
@@ -854,9 +891,7 @@ describe("Task Monad - Functor Laws", () => {
       const left = map(m, (x) => f(g(x)));
       const right = map(map(m, g), f);
 
-      expect((left as { value: number }).value).toBe(
-        (right as { value: number }).value,
-      );
+      expect(dryRun(left).value).toBe(dryRun(right).value);
     });
   });
 });
@@ -909,7 +944,7 @@ describe("Task Monad - Edge Cases", () => {
       for (let i = 0; i < 100; i++) {
         t = flatMap(t, (x) => pure(x + 1));
       }
-      expect((t as { value: number }).value).toBe(100);
+      expect(dryRun(t).value).toBe(100);
     });
 
     it("handles deeply nested map", () => {
@@ -917,7 +952,7 @@ describe("Task Monad - Edge Cases", () => {
       for (let i = 0; i < 100; i++) {
         t = map(t, (x) => x + 1);
       }
-      expect((t as { value: number }).value).toBe(100);
+      expect(dryRun(t).value).toBe(100);
     });
 
     it("handles deeply nested TaskBuilder chains", () => {
@@ -925,14 +960,14 @@ describe("Task Monad - Edge Cases", () => {
       for (let i = 0; i < 100; i++) {
         builder = builder.map((x) => x + 1);
       }
-      expect((builder.unwrap() as { value: number }).value).toBe(100);
+      expect(dryRun(builder.unwrap()).value).toBe(100);
     });
   });
 
   describe("Type coercion", () => {
     it("preserves type through transformations", () => {
       const t = map(pure({ x: 1 }), (obj) => obj.x);
-      expect((t as { value: number }).value).toBe(1);
+      expect(dryRun(t).value).toBe(1);
     });
 
     it("handles union types", () => {

--- a/packages/runtime/task/src/lib/task.ts
+++ b/packages/runtime/task/src/lib/task.ts
@@ -9,6 +9,13 @@
  * - Composable: Tasks can be sequenced with flatMap/chain
  * - Testable: Effects can be collected without execution
  * - Type-safe: Full TypeScript inference for composed tasks
+ * - Stack-safe: `flatMap`/`recover` build internal trampoline nodes (`FlatMap`/
+ *   `Recover`) as data rather than recursing through continuations, so the
+ *   interpreter realises bind and recovery on an explicit stack and stays
+ *   stack-safe for arbitrarily long chains.
+ *
+ * The monad is parameterised over its leaf effect alphabet `E` (defaulting to
+ * the built-in {@link Effect}), so the kernel itself is effect-agnostic.
  */
 
 import type { Effect, Task, TaskError } from "./types.js";
@@ -20,7 +27,7 @@ import type { Effect, Task, TaskError } from "./types.js";
 /**
  * Lift a pure value into a Task.
  */
-export const pure = <A>(value: A): Task<A> => ({
+export const pure = <A, E = Effect>(value: A): Task<A, E> => ({
   _tag: "Pure",
   value,
 });
@@ -29,16 +36,16 @@ export const pure = <A>(value: A): Task<A> => ({
  * Create a Task from an Effect.
  * The continuation receives the result of executing the effect.
  */
-export const effect = <A>(eff: Effect): Task<A> => ({
+export const effect = <A = unknown, E = Effect>(eff: E): Task<A, E> => ({
   _tag: "Effect",
   effect: eff,
-  cont: (result) => pure(result as A),
+  cont: (result): Task<A, E> => pure(result as A),
 });
 
 /**
  * Create a failed Task with an error.
  */
-export const fail = <A = never>(error: TaskError): Task<A> => ({
+export const fail = <A = never, E = Effect>(error: TaskError): Task<A, E> => ({
   _tag: "Fail",
   error,
 });
@@ -46,7 +53,10 @@ export const fail = <A = never>(error: TaskError): Task<A> => ({
 /**
  * Create a failed Task from an error code and message.
  */
-export const failWith = <A = never>(code: string, message: string): Task<A> =>
+export const failWith = <A = never, E = Effect>(
+  code: string,
+  message: string,
+): Task<A, E> =>
   fail({
     code,
     message,
@@ -59,77 +69,61 @@ export const failWith = <A = never>(code: string, message: string): Task<A> =>
 /**
  * Monadic bind (flatMap).
  * Sequences two tasks, passing the result of the first to produce the second.
+ *
+ * Builds an internal `FlatMap` trampoline node rather than recursing through
+ * continuations, keeping arbitrarily long bind chains stack-safe; the
+ * interpreter realises the bind on an explicit continuation stack.
  */
-export const flatMap = <A, B>(task: Task<A>, f: (a: A) => Task<B>): Task<B> => {
-  switch (task._tag) {
-    case "Pure":
-      return f(task.value);
-    case "Fail":
-      return task as unknown as Task<B>;
-    case "Effect":
-      return {
-        _tag: "Effect",
-        effect: task.effect,
-        cont: (result) => flatMap(task.cont(result), f),
-      };
-  }
-};
+export const flatMap = <A, B, E = Effect>(
+  task: Task<A, E>,
+  f: (a: A) => Task<B, E>,
+): Task<B, E> => ({
+  _tag: "FlatMap",
+  inner: task as Task<unknown, E>,
+  f: f as (x: unknown) => Task<B, E>,
+});
 
 /**
  * Functor map.
  * Transform the result of a task with a pure function.
  */
-export const map = <A, B>(task: Task<A>, f: (a: A) => B): Task<B> =>
-  flatMap(task, (a) => pure(f(a)));
+export const map = <A, B, E = Effect>(
+  task: Task<A, E>,
+  f: (a: A) => B,
+): Task<B, E> => flatMap(task, (a) => pure(f(a)));
 
 /**
  * Apply a function wrapped in a Task to a value wrapped in a Task.
  */
-export const ap = <A, B>(taskF: Task<(a: A) => B>, taskA: Task<A>): Task<B> =>
-  flatMap(taskF, (f) => map(taskA, f));
+export const ap = <A, B, E = Effect>(
+  taskF: Task<(a: A) => B, E>,
+  taskA: Task<A, E>,
+): Task<B, E> => flatMap(taskF, (f) => map(taskA, f));
 
 /**
  * Error recovery.
  * If the task fails, the handler can produce a new task.
+ *
+ * Builds an internal `Recover` trampoline node; the interpreter routes a `Fail`
+ * raised while evaluating the inner task to the handler on its explicit
+ * handler-frame stack, so recovery is stack-safe like bind.
  */
-export const recover = <A>(
-  task: Task<A>,
-  handler: (error: TaskError) => Task<A>,
-): Task<A> => {
-  switch (task._tag) {
-    case "Pure":
-      return task;
-    case "Fail":
-      return handler(task.error);
-    case "Effect":
-      return {
-        _tag: "Effect",
-        effect: task.effect,
-        cont: (result) => recover(task.cont(result), handler),
-      };
-  }
-};
+export const recover = <A, E = Effect>(
+  task: Task<A, E>,
+  handler: (error: TaskError) => Task<A, E>,
+): Task<A, E> => ({
+  _tag: "Recover",
+  inner: task,
+  handler,
+});
 
 /**
  * Map over the error of a failed task.
  */
-export const mapError = <A>(
-  task: Task<A>,
+export const mapError = <A, E = Effect>(
+  task: Task<A, E>,
   f: (error: TaskError) => TaskError,
-): Task<A> => {
-  switch (task._tag) {
-    case "Pure":
-      return task;
-    case "Fail":
-      return fail(f(task.error));
-    case "Effect":
-      return {
-        _tag: "Effect",
-        effect: task.effect,
-        cont: (result) => mapError(task.cont(result), f),
-      };
-  }
-};
+): Task<A, E> => recover(task, (error) => fail(f(error)));
 
 // =============================================================================
 // Fluent Builder API
@@ -247,7 +241,9 @@ export const $ = <A>(task: Task<A>): TaskGen<A> => ({
  * Avoids nested flatMap chains for complex sequential tasks.
  *
  * Use `yield*` with `$(task)` to unwrap a task, getting back its value.
- * Under the hood this composes flatMap calls.
+ * Under the hood this composes flatMap calls; the resulting task is driven by
+ * the interpreter one step at a time, so even very long generators stay
+ * stack-safe.
  *
  * @example
  * ```typescript
@@ -283,23 +279,24 @@ export const gen = <A>(
 /**
  * Check if a task is pure (no effects).
  */
-export const isPure = <A>(t: Task<A>): t is { _tag: "Pure"; value: A } =>
-  t._tag === "Pure";
+export const isPure = <A, E = Effect>(
+  t: Task<A, E>,
+): t is { _tag: "Pure"; value: A } => t._tag === "Pure";
 
 /**
  * Check if a task has failed.
  */
-export const isFailed = <A>(
-  t: Task<A>,
+export const isFailed = <A, E = Effect>(
+  t: Task<A, E>,
 ): t is { _tag: "Fail"; error: TaskError } => t._tag === "Fail";
 
 /**
  * Check if a task has effects.
  */
-export const hasEffects = <A>(
-  t: Task<A>,
+export const hasEffects = <A, E = Effect>(
+  t: Task<A, E>,
 ): t is {
   _tag: "Effect";
-  effect: Effect;
-  cont: (result: unknown) => Task<A>;
+  effect: E;
+  cont: (result: unknown) => Task<A, E>;
 } => t._tag === "Effect";

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -213,19 +213,50 @@ export type BaseErrorCode =
  * A Task is a pure description of a computation that may:
  * - Return a value immediately (Pure)
  * - Perform an effect and continue (Effect)
+ * - Sequence another task via an internal trampoline node (FlatMap)
+ * - Install an error-recovery frame (Recover)
  * - Fail with an error (Fail)
  *
  * Tasks are lazy - they don't execute until interpreted by `runTask` or `dryRun`.
  *
+ * The public authoring surface is the three smart constructors `pure` / `effect`
+ * / `fail`. `FlatMap` and `Recover` are **internal trampoline nodes**: `flatMap`
+ * and `recover` build them as data rather than recursing through continuations,
+ * so the interpreter can realise bind and recovery on an explicit continuation
+ * stack and stay stack-safe to arbitrary depth. Authors never construct them
+ * directly.
+ *
+ * The monad is parameterised over its leaf effect alphabet `E` (defaulting to
+ * {@link Effect}), so the kernel is effect-agnostic; the built-in `Effect` union
+ * is one instantiation.
+ *
  * @typeParam A - The type of the value this task produces
+ * @typeParam E - The leaf effect alphabet (an object with a `_tag` field)
  */
-export type Task<A> =
+export type Task<A, E = Effect> =
   /** Pure value - computation complete */
   | { _tag: "Pure"; value: A }
   /** Effect with continuation - perform effect, then continue */
-  | { _tag: "Effect"; effect: Effect; cont: (result: unknown) => Task<A> }
+  | { _tag: "Effect"; effect: E; cont: (result: unknown) => Task<A, E> }
   /** Failure - computation failed with error */
-  | { _tag: "Fail"; error: TaskError };
+  | { _tag: "Fail"; error: TaskError }
+  /** Internal trampoline bind node (not part of the public authoring API) */
+  | {
+      _tag: "FlatMap";
+      inner: Task<unknown, E>;
+      f: (x: unknown) => Task<A, E>;
+    }
+  /**
+   * Internal error-handler node (not part of the public authoring API).
+   * Installs an error-recovery frame; the interpreter routes a `Fail` raised
+   * while evaluating `inner` to `handler`, realised on the interpreter's
+   * handler stack so recovery is stack-safe like bind.
+   */
+  | {
+      _tag: "Recover";
+      inner: Task<A, E>;
+      handler: (error: TaskError) => Task<A, E>;
+    };
 
 // =============================================================================
 // Execution Result

--- a/packages/runtime/task/src/lib/undo-interpreter.test.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.test.ts
@@ -17,7 +17,7 @@ import {
   symlink,
   writeFile,
 } from "./primitives.js";
-import { $, effect, fail, gen, pure } from "./task.js";
+import { $, effect, fail, flatMap, gen, map, pure, recover } from "./task.js";
 import type { Task } from "./types.js";
 import { collectUndos, runUndo } from "./undo-interpreter.js";
 
@@ -510,5 +510,61 @@ describe("runUndo", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+// =============================================================================
+// Lazy node handling (FlatMap / Recover)
+// =============================================================================
+
+describe("collectUndos - lazy node handling", () => {
+  const boom = (): never => {
+    throw new Error("raw");
+  };
+
+  it("collects undos through flatMap and recover nodes", () => {
+    const undoTask = pure<void>(undefined);
+    const writeWithUndo = effect<void>({
+      _tag: "WriteFile",
+      path: "f",
+      content: "c",
+      undo: undoTask,
+    });
+    const undos = collectUndos(
+      flatMap(writeWithUndo, () => recover(pure(1), () => pure(0))),
+    );
+    expect(undos).toHaveLength(1);
+    expect(undos[0]).toBe(undoTask);
+  });
+
+  it("recovers from a failed task while walking", () => {
+    expect(
+      collectUndos(
+        recover(fail<number>({ code: "E", message: "m" }), () => pure(0)),
+      ),
+    ).toEqual([]);
+  });
+
+  it("rethrows a non-task error raised inside a recovered task", () => {
+    expect(() =>
+      collectUndos(recover(map(pure(1), boom), () => pure(0))),
+    ).toThrow("raw");
+  });
+
+  it("walks flatMap/recover inside Parallel children", () => {
+    const undos = collectUndos(
+      parallel([
+        flatMap(pure(1), (x) => pure(x + 1)),
+        recover(fail<number>({ code: "E", message: "m" }), () => pure(0)),
+        recover(pure(5), () => pure(0)),
+      ]),
+    );
+    expect(undos).toEqual([]);
+  });
+
+  it("rethrows a non-task error from a Parallel child", () => {
+    expect(() =>
+      collectUndos(parallel([recover(map(pure(1), boom), () => pure(0))])),
+    ).toThrow("raw");
   });
 });

--- a/packages/runtime/task/src/lib/undo-interpreter.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.ts
@@ -132,6 +132,19 @@ export const collectUndos = <A>(task: Task<A>): Task<void>[] => {
         const mockResult = mockEffectWithFs(eff, virtualFs);
         return walk(t.cont(mockResult) as Task<T>);
       }
+
+      case "FlatMap":
+        return walk(t.f(walk(t.inner)) as Task<T>);
+
+      case "Recover":
+        try {
+          return walk(t.inner);
+        } catch (error) {
+          if (error instanceof TaskExecutionError) {
+            return walk(t.handler(error.taskError));
+          }
+          throw error;
+        }
     }
   };
 
@@ -219,6 +232,19 @@ const collectUndosWithVirtualFs = <A>(
         const mockResult = mockEffectWithFs(eff, virtualFs);
         return walk(t.cont(mockResult) as Task<T>);
       }
+
+      case "FlatMap":
+        return walk(t.f(walk(t.inner)) as Task<T>);
+
+      case "Recover":
+        try {
+          return walk(t.inner);
+        } catch (error) {
+          if (error instanceof TaskExecutionError) {
+            return walk(t.handler(error.taskError));
+          }
+          throw error;
+        }
     }
   };
 

--- a/packages/webarchitect/rulesets/assets.ruleset.json
+++ b/packages/webarchitect/rulesets/assets.ruleset.json
@@ -9,7 +9,7 @@
         "type": "object",
         "properties": {
           "license": {
-            "const": "LGPL-3.0"
+            "const": "${license}"
           }
         },
         "required": ["license"]

--- a/packages/webarchitect/rulesets/base.ruleset.json
+++ b/packages/webarchitect/rulesets/base.ruleset.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/canonical/pragma/refs/heads/main/packages/webarchitect/src/schema.json",
-  "name": "base"
+  "name": "base",
+  "variables": {
+    "license": {
+      "default": "LGPL-3.0",
+      "schema": {
+        "type": "string"
+      }
+    }
+  }
 }

--- a/packages/webarchitect/rulesets/library.ruleset.json
+++ b/packages/webarchitect/rulesets/library.ruleset.json
@@ -9,7 +9,7 @@
         "type": "object",
         "properties": {
           "license": {
-            "const": "LGPL-3.0"
+            "const": "${license}"
           }
         },
         "required": ["license"]

--- a/packages/webarchitect/src/cli.ts
+++ b/packages/webarchitect/src/cli.ts
@@ -301,6 +301,7 @@ program
     {},
   )
   .option("--prefix <value>", "shortcut for --var prefix=<value>")
+  .option("--license <value>", "shortcut for --var license=<value>")
   .action(async (schemaArg, options) => {
     // Handle --list option
     if (options.list) {
@@ -317,12 +318,16 @@ program
       process.exit(1);
     }
     try {
-      // Merge variable overrides; --prefix is sugar for --var prefix=<value>.
+      // Merge variable overrides; --prefix / --license are sugar for
+      // --var prefix=<value> / --var license=<value>.
       const variableOverrides: Record<string, string> = {
         ...(options.var ?? {}),
       };
       if (options.prefix !== undefined) {
         variableOverrides.prefix = options.prefix;
+      }
+      if (options.license !== undefined) {
+        variableOverrides.license = options.license;
       }
 
       const results = await validate(

--- a/packages/webarchitect/src/lib/substituteVariables.test.ts
+++ b/packages/webarchitect/src/lib/substituteVariables.test.ts
@@ -45,6 +45,35 @@ describe("substituteVariables", () => {
     expect(/^/.test("anything")).toBe(true);
   });
 
+  it("resolves a license variable into a package-license const (default LGPL-3.0, --license overrides)", () => {
+    const licenseSchema = (): Schema => ({
+      name: "library",
+      variables: {
+        license: { default: "LGPL-3.0", schema: { type: "string" } },
+      },
+      "package-license": {
+        file: {
+          name: "package.json",
+          contains: {
+            type: "object",
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: literal token resolved by substituteVariables
+            properties: { license: { const: "${license}" } },
+          },
+        },
+      },
+    });
+    const licenseConst = (schema: Schema): unknown =>
+      (
+        schema["package-license"] as unknown as {
+          file: { contains: { properties: { license: { const: string } } } };
+        }
+      ).file.contains.properties.license.const;
+    expect(licenseConst(substituteVariables(licenseSchema()))).toBe("LGPL-3.0");
+    expect(
+      licenseConst(substituteVariables(licenseSchema(), { license: "MIT" })),
+    ).toBe("MIT");
+  });
+
   it("removes the variables block from the resolved schema", () => {
     expect(substituteVariables(baseSchema()).variables).toBeUndefined();
   });


### PR DESCRIPTION
## Done

- Make `@canonical/task`'s Task monad **stack-safe** and **generic over its effect alphabet**, with no run-time behaviour change and a fully source-compatible public API.
  - **Stack safety:** `flatMap` and `recover` previously recursed through continuations, and the interpreter recursed once per node — so long `flatMap` / `gen` chains overflowed the call stack. They now build internal `FlatMap` / `Recover` ADT nodes (as data), and `runTask` realises bind and recovery on an explicit continuation/handler-frame stack, running arbitrarily long chains in constant call-stack depth. This also aligns the implementation with the package's documented contract that tasks are lazy and do not execute until interpreted.
  - `dryRun` / `dryRunWith` / `collectEffects` and the undo interpreter learn the two new nodes.
  - **Effect-alphabet generics:** `Task<A, E = Effect>` and the monad operations are now generic over the leaf effect type (default `Effect`), so the kernel is no longer welded to one I/O vocabulary. The production interpreter stays concrete over `Effect`. Fully source-compatible — every existing `Task<A>` call site is unchanged, and the public surface (names, smart constructors, combinators, `TaskBuilder`, dry-run, undo) is preserved.

Motivation: long bind / `gen` chains can overflow the host call stack today, and the monad was hardwired to the built-in `Effect` union. This makes the kernel robust to depth and reusable with a custom effect alphabet, without touching the public API.

> Versioning is intentionally **not** bumped in this PR — that's the release tooling's job.

## QA

- `cd packages/runtime/task && bun run test` — **690 tests pass, 100% coverage** (statements / branches / functions / lines), including new error-recovery cases and deep-chain (100k-node) stack-safety cases run via `runTask`.
- `cd packages/runtime/task && bun run check` — biome + tsc + webarchitect all green.
- Backward compatibility verified empirically: rebuilt the package and ran consumers against the new build — `packages/runtime/harnesses` (75 tests) and `packages/cli/summon` (17 tests) green. No consumer inspects `Task` node structure (confirmed by grep), so the eager→lazy change is invisible to them — run-semantics via `runTask` / `dryRun` are unchanged.

### PR readiness check

- [ ] PR should have one of the following labels: this is a `Feature 🎁` (please apply on merge).
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` and `build:all`.
- [ ] If this PR introduces a **new package**: N/A — `@canonical/task` already exists; this is a backward-compatible change to an existing package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — library-internal change, no visual surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWrmEhXEJx5b2XuLdWkrHC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWrmEhXEJx5b2XuLdWkrHC)_