### PR TITLE
feat(svelte-ds-app-launchpad): allow SSR-opened dialogs

### DIFF
--- a/packages/svelte/ds-app-launchpad/.gitignore
+++ b/packages/svelte/ds-app-launchpad/.gitignore
@@ -1,0 +1,1 @@
+.vitest-attachments

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.ssr.test.ts
@@ -30,14 +30,17 @@ describe("Modal SSR", () => {
   });
 
   describe("attributes", () => {
-    it.each([
+    it.each<[string, unknown, string?]>([
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
-    ])("applies %s", (attribute, expected) => {
+      ["open", true, ""],
+    ])("applies %s", (attribute, set, expected) => {
       const page = render(Component, {
-        props: { ...baseProps, [attribute]: expected },
+        props: { ...baseProps, [attribute]: set },
       });
-      expect(componentLocator(page).getAttribute(attribute)).toBe(expected);
+      expect(componentLocator(page).getAttribute(attribute)).toBe(
+        expected ?? set,
+      );
     });
 
     it("applies classes", () => {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.stories.svelte
@@ -36,6 +36,8 @@
       }
     }, 1000);
   };
+
+  let open = $state(false);
 </script>
 
 <Story name="Default">
@@ -113,6 +115,30 @@
         <Modal.Content.Header>Timed Modal</Modal.Content.Header>
         <Modal.Content.Body>
           The modal will close automatically in {timeLeft} seconds.
+        </Modal.Content.Body>
+      </Modal.Content>
+    </Modal>
+  {/snippet}
+</Story>
+
+<Story
+  name="Controlled via bindable open prop"
+  argTypes={{ open: { control: false } }}
+>
+  {#snippet template({ children: __, trigger: _, open: ___, ...args })}
+    <!--
+    <script>
+      let open = $state(false);
+    </script>
+    -->
+
+    <p style="margin-block-end: 0.5rem;">Modal is {open ? "open" : "closed"}</p>
+    <Button onclick={() => (open = true)}>Show modal</Button>
+    <Modal bind:open {...args}>
+      <Modal.Content>
+        <Modal.Content.Header>Controlled Modal</Modal.Content.Header>
+        <Modal.Content.Body>
+          The modal is controlled via the bindable `open` prop.
         </Modal.Content.Body>
       </Modal.Content>
     </Modal>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.stories.svelte
@@ -2,7 +2,6 @@
   import { defineMeta } from "@storybook/addon-svelte-csf";
   import { Button } from "../Button/index.js";
   import { Modal } from "./index.js";
-  import type { ModalMethods } from "./types.js";
 
   const { Story } = defineMeta({
     title: "Components/Modal",
@@ -18,17 +17,17 @@
     },
   });
 
-  let modal = $state<ModalMethods>();
+  let open = $state(false);
   let interval: ReturnType<typeof setInterval> | null = null;
   let timeLeft = $state(0);
   const onclick = () => {
-    if (!modal) return;
-    modal.showModal();
+    if (interval) clearInterval(interval);
+    open = true;
     timeLeft = 5;
     interval = setInterval(() => {
       timeLeft -= 1;
       if (timeLeft <= 0) {
-        modal?.close();
+        open = false;
         if (interval) {
           clearInterval(interval);
           interval = null;
@@ -36,8 +35,6 @@
       }
     }, 1000);
   };
-
-  let open = $state(false);
 </script>
 
 <Story name="Default">
@@ -75,34 +72,40 @@
 </Story>
 
 <Story
-  name="Controlled via instance methods"
+  name="Controlled via bindable open prop"
   args={{ closeOnOutsideClick: false }}
+  argTypes={{ open: { control: false } }}
 >
-  {#snippet template({ children: __, trigger: _, ...args })}
+  {#snippet template({ children: _, trigger: __, open: ___, ...args })}
     <!-- 
-    let modal = $state<ModalMethods>();
-    let interval: ReturnType<typeof setInterval> | null = null;
-    let timeLeft = $state(0);
-    const onclick = () => {
-      if (!modal) return;
-      modal.showModal();
-      timeLeft = 5;
-      interval = setInterval(() => {
-        timeLeft -= 1;
-        if (timeLeft <= 0) {
-          modal?.close();
-          if (interval) {
-            clearInterval(interval);
-            interval = null;
-          }
-        }
-      }, 1000);
-    };
+      <script lang="ts">
+        let open = $state(false);
+        let interval: ReturnType<typeof setInterval> | null = null;
+        let timeLeft = $state(0);
+        const onclick = () => {
+          if (interval) clearInterval(interval);
+          open = true;
+          timeLeft = 5;
+          interval = setInterval(() => {
+            timeLeft -= 1;
+            if (timeLeft <= 0) {
+              open = false;
+              if (interval) {
+                clearInterval(interval);
+                interval = null;
+              }
+            }
+          }, 1000);
+        };
+      </script>
     -->
 
+    <p style="margin-block-end: 0.5rem;">
+      Modal is {open ? "open" : "closed"}
+    </p>
     <Button {onclick}>Show timed modal</Button>
     <Modal
-      bind:this={modal}
+      bind:open
       onclose={() => {
         if (interval) {
           clearInterval(interval);
@@ -115,30 +118,6 @@
         <Modal.Content.Header>Timed Modal</Modal.Content.Header>
         <Modal.Content.Body>
           The modal will close automatically in {timeLeft} seconds.
-        </Modal.Content.Body>
-      </Modal.Content>
-    </Modal>
-  {/snippet}
-</Story>
-
-<Story
-  name="Controlled via bindable open prop"
-  argTypes={{ open: { control: false } }}
->
-  {#snippet template({ children: __, trigger: _, open: ___, ...args })}
-    <!--
-    <script>
-      let open = $state(false);
-    </script>
-    -->
-
-    <p style="margin-block-end: 0.5rem;">Modal is {open ? "open" : "closed"}</p>
-    <Button onclick={() => (open = true)}>Show modal</Button>
-    <Modal bind:open {...args}>
-      <Modal.Content>
-        <Modal.Content.Header>Controlled Modal</Modal.Content.Header>
-        <Modal.Content.Body>
-          The modal is controlled via the bindable `open` prop.
         </Modal.Content.Body>
       </Modal.Content>
     </Modal>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { useIsMounted } from "../../useFunctions/index.js";
   import { isEventTargetInElement } from "../../utils/index.js";
-  import type { ModalMethods, ModalProps } from "./types.js";
+  import type { ModalProps } from "./types.js";
   import "./styles.css";
 
   const componentCssClassName = "ds modal";
@@ -19,14 +19,6 @@
     open = $bindable(),
     ...rest
   }: ModalProps = $props();
-
-  export const showModal: ModalMethods["showModal"] = () => {
-    open = true;
-  };
-
-  export const close: ModalMethods["close"] = () => {
-    open = false;
-  };
 
   const fallbackId = $props.id();
   const id = $derived(idProp || fallbackId);
@@ -104,32 +96,25 @@
   {...rest}
 >
   <div style="display: contents;" bind:this={contentWrapperRef}>
-    {@render children?.(id, close)}
+    {@render children?.(id, () => (open = false))}
   </div>
 </dialog>
 
 <!-- @component
-`Modal` provides a mechanism for displaying content overlaying the main application. 
+`Modal` provides a mechanism for displaying content overlaying the main application.
 
-Modal can be imperatively controlled by the following methods available on the component instance:
-- `showModal`: Shows the modal.
-- `close`: Closes the modal.
+Modal is declaratively controlled by default through the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) using `commandfor` and `command` attributes supplied via the `trigger` snippet. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) for more information.
 
-Modal is declaratively controlled by default through the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) using `commandfor` and `command` attributes supplied via the `trigger` snippet. Imperative methods remain available for cases where opening or closing must be orchestrated in code. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) for more information.
-
-Modal can also be controlled through the bindable `open` prop. With `bind:open` it stays in sync with the modal in both directions: setting it opens or closes the modal, and it updates to reflect changes made by invoker commands, `Escape`, or an outside click. Setting `open` during SSR renders the dialog open on page load without client-side JS, and it is upgraded to a true modal once hydrated.
+For cases where opening or closing must be orchestrated in code, Modal can be controlled through the bindable `open` prop. With `bind:open` it stays in sync with the modal in both directions: setting it opens or closes the modal, and it updates to reflect changes made by invoker commands, `Escape`, or an outside click. Setting `open` during SSR renders the dialog open on page load without client-side JS, and it is upgraded to a true modal once hydrated.
 
 ## Example Usage
 ```svelte
 <script lang="ts">
-  let modal = $state<ModalMethods>();
-  // Imperative controls on the component instance
-  $effect(() => modal?.showModal())
   let open = $state(false);
 </script>
 
 <p>Modal is {open ? "open" : "closed"}</p>
-<Modal bind:this={modal} bind:open>
+<Modal bind:open>
   {#snippet trigger(triggerProps)}
     <button {...triggerProps}>
       Open Modal

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
@@ -6,7 +6,9 @@
   import type { ModalProps } from "./types.js";
   import "./styles.css";
 
-  const componentCssClassName = "ds modal";
+  const componentCssClassNameBase = "modal";
+  const componentCssClassName = `ds ${componentCssClassNameBase}`;
+  const componentCssClassNameNonModalBackdrop = `ds ${componentCssClassNameBase}-non-modal-backdrop`;
 
   let {
     id: idProp,
@@ -63,7 +65,7 @@
 
 <!-- A non-modal dialog has no real `::backdrop` so we need to fake one. Can't be a pseudo-element, because a pseudo lives inside the dialog so `closeOnOutsideClick` wouldn't work. -->
 {#if initialOpen}
-  <div class={`${componentCssClassName}-non-modal-backdrop`}></div>
+  <div class={componentCssClassNameNonModalBackdrop}></div>
 {/if}
 <dialog
   {id}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
@@ -1,6 +1,7 @@
 <!-- @canonical/generator-ds 0.10.0-experimental.2 -->
 
 <script lang="ts">
+  import type { Attachment } from "svelte/attachments";
   import { useIsMounted } from "../../useFunctions/index.js";
   import { isEventTargetInElement } from "../../utils/index.js";
   import type { ModalMethods, ModalProps } from "./types.js";
@@ -15,23 +16,23 @@
     children,
     closeOnOutsideClick = true,
     onclick,
+    ontoggle: ontoggleProp,
+    open = $bindable(),
     ...rest
   }: ModalProps = $props();
 
-  let dialogRef = $state<HTMLDialogElement>();
+  export const showModal: ModalMethods["showModal"] = () => {
+    open = true;
+  };
+
+  export const close: ModalMethods["close"] = () => {
+    open = false;
+  };
 
   const fallbackId = $props.id();
   const id = $derived(idProp || fallbackId);
 
   const isMounted = useIsMounted();
-
-  export const showModal: ModalMethods["showModal"] = () => {
-    dialogRef?.showModal();
-  };
-
-  export const close: ModalMethods["close"] = () => {
-    dialogRef?.close();
-  };
 
   // Webkit doesn't support `closedby` attribute on dialog elements (https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy).
   // TODO(closedby): Remove this fallback when Webkit supports it.
@@ -48,8 +49,40 @@
       contentWrapperRef &&
       !isEventTargetInElement(e.target, contentWrapperRef)
     ) {
-      close();
+      open = false;
     }
+  };
+
+  // Capture the initial value of `open` for SSR paint. After hydration, the dialog's open attribute should never be set manually.
+  const initialOpen = open;
+
+  // Reflect the invoker commands, Escape, outside click changes back onto `open`.
+  const ontoggle: typeof ontoggleProp = (e) => {
+    ontoggleProp?.(e);
+    const newOpen = e.newState === "open";
+    if (newOpen !== open) open = newOpen;
+  };
+
+  const manageOpenState: Attachment<HTMLDialogElement> = (dialogEl) => {
+    // Suppress the transition on mount so that when we upgrade to modal the open fade doesn't play.
+    dialogEl.classList.add("no-transition");
+
+    // Map `open` changes to `showModal`/`close`. First run upgrades the dialog to modal if `open` is true.
+    $effect(() => {
+      if (open) {
+        if (dialogEl.open && !dialogEl.matches(":modal")) {
+          // `open === true` during SSR case
+          // `showModal` throws when called on open non-modal dialog so we need to close it first.
+          dialogEl.close();
+        }
+        dialogEl.showModal();
+      } else {
+        dialogEl.close();
+      }
+
+      // Re-enable the transition after the first sync so that later changes animate.
+      dialogEl.classList.remove("no-transition");
+    });
   };
 </script>
 
@@ -59,15 +92,20 @@
   "aria-haspopup": "dialog",
 })}
 
+<!-- A non-modal dialog has no real `::backdrop` so we need to fake one. Can't be a pseudo-element, because a pseudo lives inside the dialog so `closeOnOutsideClick` wouldn't work. -->
+{#if initialOpen}
+  <div class={`${componentCssClassName}-non-modal-backdrop`}></div>
+{/if}
 <dialog
-  bind:this={dialogRef}
   {id}
   class={[componentCssClassName, className]}
   closedby={closeOnOutsideClick ? "any" : "closerequest"}
   onclick={isClosedByFallbackNeeded ? fallbackOnclick : onclick}
+  {ontoggle}
+  open={initialOpen}
+  {@attach manageOpenState}
   {...rest}
 >
-  <!-- TODO(closedby): Remove this wrapper when Webkit supports closedby -->
   <div style="display: contents;" bind:this={contentWrapperRef}>
     {@render children?.(id, close)}
   </div>
@@ -82,15 +120,19 @@ Modal can be imperatively controlled by the following methods available on the c
 
 Modal is declaratively controlled by default through the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) using `commandfor` and `command` attributes supplied via the `trigger` snippet. Imperative methods remain available for cases where opening or closing must be orchestrated in code. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) for more information.
 
+Modal can also be controlled through the bindable `open` prop. With `bind:open` it stays in sync with the modal in both directions: setting it opens or closes the modal, and it updates to reflect changes made by invoker commands, `Escape`, or an outside click. Setting `open` during SSR renders the dialog open on page load without client-side JS, and it is upgraded to a true modal once hydrated.
+
 ## Example Usage
 ```svelte
 <script lang="ts">
   let modal = $state<ModalMethods>();
   // Imperative controls on the component instance
   $effect(() => modal?.showModal())
+  let open = $state(false);
 </script>
 
-<Modal bind:this={modal}>
+<p>Modal is {open ? "open" : "closed"}</p>
+<Modal bind:this={modal} bind:open>
   {#snippet trigger(triggerProps)}
     <button {...triggerProps}>
       Open Modal
@@ -122,5 +164,4 @@ Modal is declaratively controlled by default through the [Invoker Commands API](
   {/snippet}
 </Modal>
 ```
-
 -->

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
@@ -1,7 +1,6 @@
 <!-- @canonical/generator-ds 0.10.0-experimental.2 -->
 
 <script lang="ts">
-  import type { Attachment } from "svelte/attachments";
   import { useIsMounted } from "../../useFunctions/index.js";
   import { isEventTargetInElement } from "../../utils/index.js";
   import type { ModalMethods, ModalProps } from "./types.js";
@@ -53,36 +52,14 @@
     }
   };
 
-  // Capture the initial value of `open` for SSR paint. After hydration, the dialog's open attribute should never be set manually.
+  /** Capture the initial value of `open` for SSR paint. After hydration, the dialog's open attribute should never be set manually. */
   const initialOpen = open;
 
-  // Reflect the invoker commands, Escape, outside click changes back onto `open`.
+  /** Reflect the invoker commands, Escape, outside click changes back onto `open`. */
   const ontoggle: typeof ontoggleProp = (e) => {
     ontoggleProp?.(e);
     const newOpen = e.newState === "open";
     if (newOpen !== open) open = newOpen;
-  };
-
-  const manageOpenState: Attachment<HTMLDialogElement> = (dialogEl) => {
-    // Suppress the transition on mount so that when we upgrade to modal the open fade doesn't play.
-    dialogEl.classList.add("no-transition");
-
-    // Map `open` changes to `showModal`/`close`. First run upgrades the dialog to modal if `open` is true.
-    $effect(() => {
-      if (open) {
-        if (dialogEl.open && !dialogEl.matches(":modal")) {
-          // `open === true` during SSR case
-          // `showModal` throws when called on open non-modal dialog so we need to close it first.
-          dialogEl.close();
-        }
-        dialogEl.showModal();
-      } else {
-        dialogEl.close();
-      }
-
-      // Re-enable the transition after the first sync so that later changes animate.
-      dialogEl.classList.remove("no-transition");
-    });
   };
 </script>
 
@@ -103,7 +80,27 @@
   onclick={isClosedByFallbackNeeded ? fallbackOnclick : onclick}
   {ontoggle}
   open={initialOpen}
-  {@attach manageOpenState}
+  {@attach (dialogEl) => {
+    // Suppress the transition on mount so that when we upgrade to modal the open fade doesn't play.
+    dialogEl.classList.add("no-transition");
+
+    // Map `open` changes to `showModal`/`close`. First run upgrades the dialog to modal if `open` is true.
+    $effect(() => {
+      if (open) {
+        if (dialogEl.open && !dialogEl.matches(":modal")) {
+          // `open === true` during SSR case
+          // `showModal` throws when called on open non-modal dialog so we need to close it first.
+          dialogEl.close();
+        }
+        dialogEl.showModal();
+      } else {
+        dialogEl.close();
+      }
+
+      // Re-enable the transition after the first sync so that later changes animate.
+      dialogEl.classList.remove("no-transition");
+    });
+  }}
   {...rest}
 >
   <div style="display: contents;" bind:this={contentWrapperRef}>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
@@ -41,13 +41,6 @@
     isMounted.value && !("closedBy" in HTMLDialogElement.prototype),
   );
 
-  // TODO(Invoker Commands API): Remove this when Invoker Commands API is widely supported (https://caniuse.com/wf-invoker-commands)
-  const isInvokerCommandsFallbackNeeded = $derived(
-    isMounted.value &&
-      (!("commandForElement" in HTMLButtonElement.prototype) ||
-        !("command" in HTMLButtonElement.prototype)),
-  );
-
   const fallbackOnclick: typeof onclick = (e) => {
     onclick?.(e);
     if (
@@ -61,7 +54,6 @@
 </script>
 
 {@render trigger?.({
-  onclick: isInvokerCommandsFallbackNeeded ? showModal : undefined,
   commandfor: id,
   command: "show-modal",
   "aria-haspopup": "dialog",

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
@@ -1,6 +1,6 @@
 /* @canonical/generator-ds 0.10.0-experimental.5 */
 
-import type { ComponentProps } from "svelte";
+import { flushSync, type ComponentProps } from "svelte";
 import { describe, expect, it } from "vitest";
 import type { Locator } from "vitest/browser";
 import { userEvent } from "vitest/browser";
@@ -21,6 +21,23 @@ describe("Modal component", () => {
     children,
     trigger,
   } satisfies ComponentProps<typeof Component>;
+
+  function withOpen({
+    open: initialOpen,
+    ...extra
+  }: Partial<ComponentProps<typeof Component>> = {}) {
+    let open = $state(initialOpen);
+    return {
+      ...baseProps,
+      ...extra,
+      get open() {
+        return open;
+      },
+      set open(value) {
+        open = value;
+      },
+    };
+  }
 
   it("renders", async () => {
     const page = render(Component, { ...baseProps });
@@ -105,71 +122,104 @@ describe("Modal component", () => {
 
   describe("Opening the Modal", () => {
     it("is opened when `showModal` on the dialog element is called", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
+      expect(props.open).toBe(undefined);
 
       (componentLocator(page, true).element() as HTMLDialogElement).showModal();
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
       await expect.element(page.getByText(contentText)).toBeVisible();
+      await expect.poll(() => props.open).toBe(true);
     });
 
     it("is opened by trigger click", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
+      expect(props.open).toBe(undefined);
 
       await triggerLocator(page).click();
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
       await expect.element(page.getByText(contentText)).toBeVisible();
+      await expect.poll(() => props.open).toBe(true);
     });
 
     it("is opened by showModal() on the component instance", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
+      expect(props.open).toBe(undefined);
 
       const component = page.component as unknown as ModalMethods;
       component.showModal();
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
       await expect.element(page.getByText(contentText)).toBeVisible();
+      await expect.poll(() => props.open).toBe(true);
+    });
+
+    it("is opened by setting open to true", async () => {
+      const props = withOpen();
+      const page = render(Component, props);
+      await expect.element(componentLocator(page, true)).not.toBeVisible();
+      expect(props.open).toBe(undefined);
+
+      props.open = true;
+      await expect.element(componentLocator(page)).toBeVisible();
+      await expect.element(componentLocator(page)).toHaveAttribute("open");
+      await expect.element(page.getByText(contentText)).toBeVisible();
+      await expect.poll(() => props.open).toBe(true);
+    });
+
+    it("upgrades a server-rendered open dialog to a true modal on mount", async () => {
+      const props = withOpen({ open: true });
+      const page = render(Component, props);
+
+      await expect.element(componentLocator(page)).toBeVisible();
+      await expect.element(componentLocator(page)).toHaveAttribute("open");
+      await expect.element(page.getByText(contentText)).toBeVisible();
+      flushSync();
+      expect(componentLocator(page).element().matches(":modal")).toBe(true);
     });
   });
 
   describe("Closing the Modal", () => {
     it("is closed when `close` on the dialog element is called", async () => {
-      const page = render(Component, { ...baseProps });
+      const props = withOpen();
+      const page = render(Component, props);
       await showModal(page);
+      await expect.poll(() => props.open).toBe(true);
 
       (componentLocator(page).element() as HTMLDialogElement).close();
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
 
     it("is closed by close() supplied via children snippet", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await showModal(page);
+      await expect.poll(() => props.open).toBe(true);
 
       await page.getByRole("button", { name: closeButtonText }).click();
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
 
     it("is closed by close() on the component instance", async () => {
-      const page = render(Component, { ...baseProps });
+      const props = withOpen();
+      const page = render(Component, props);
       await showModal(page);
+      await expect.poll(() => props.open).toBe(true);
 
       const component = page.component as unknown as ModalMethods;
       component.close();
@@ -177,45 +227,61 @@ describe("Modal component", () => {
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
 
     it("is closed by clicking outside the modal when `closeOnOutsideClick` is true", async () => {
-      const page = render(Component, {
-        ...baseProps,
-        closeOnOutsideClick: true,
-      });
+      const props = withOpen({ closeOnOutsideClick: true });
+      const page = render(Component, props);
       await showModal(page);
+      await expect.poll(() => props.open).toBe(true);
 
       await componentLocator(page).click({ position: { x: 0, y: -10 } });
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
 
     it("is not closed by clicking outside the modal when `closeOnOutsideClick` is false", async () => {
-      const page = render(Component, {
-        ...baseProps,
-        closeOnOutsideClick: false,
-      });
+      const props = withOpen({ closeOnOutsideClick: false });
+      const page = render(Component, props);
       await showModal(page);
+      await expect.poll(() => props.open).toBe(true);
 
       await componentLocator(page).click({ position: { x: 0, y: -10 } });
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(true);
     });
 
     it("is closed by pressing Escape", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await showModal(page);
+      await expect.poll(() => props.open).toBe(true);
 
       await userEvent.keyboard("{Escape}");
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
+    });
+
+    it("is closed by setting open to false", async () => {
+      const props = withOpen();
+      const page = render(Component, props);
+      await showModal(page);
+      await expect.poll(() => props.open).toBe(true);
+
+      props.open = false;
+      await expect.element(componentLocator(page, true)).not.toBeVisible();
+      await expect
+        .element(componentLocator(page, true))
+        .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
   });
 
@@ -236,20 +302,6 @@ describe("Modal component", () => {
           }),
         )
         .toHaveAttribute("commandfor", modalId);
-    });
-
-    it("only adds onclick trigger fallback when invoker commands are unsupported", async () => {
-      const page = render(Component, { ...baseProps, trigger });
-      const supportsInvokerCommands =
-        "commandForElement" in HTMLButtonElement.prototype &&
-        "command" in HTMLButtonElement.prototype;
-      const triggerButton = triggerLocator(page).element() as HTMLButtonElement;
-
-      if (supportsInvokerCommands) {
-        expect(triggerButton.onclick).toBeNull();
-      } else {
-        expect(triggerButton.onclick).toBeTypeOf("function");
-      }
     });
   });
 });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
@@ -1,6 +1,6 @@
 /* @canonical/generator-ds 0.10.0-experimental.5 */
 
-import { flushSync, type ComponentProps } from "svelte";
+import { type ComponentProps, flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 import type { Locator } from "vitest/browser";
 import { userEvent } from "vitest/browser";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
@@ -14,7 +14,6 @@ import {
   trigger,
   triggerText,
 } from "./test.fixtures.svelte";
-import type { ModalMethods } from "./types.js";
 
 describe("Modal component", () => {
   const baseProps = {
@@ -147,20 +146,6 @@ describe("Modal component", () => {
       await expect.poll(() => props.open).toBe(true);
     });
 
-    it("is opened by showModal() on the component instance", async () => {
-      const props = withOpen();
-      const page = render(Component, props);
-      await expect.element(componentLocator(page, true)).not.toBeVisible();
-      expect(props.open).toBe(undefined);
-
-      const component = page.component as unknown as ModalMethods;
-      component.showModal();
-      await expect.element(componentLocator(page)).toBeVisible();
-      await expect.element(componentLocator(page)).toHaveAttribute("open");
-      await expect.element(page.getByText(contentText)).toBeVisible();
-      await expect.poll(() => props.open).toBe(true);
-    });
-
     it("is opened by setting open to true", async () => {
       const props = withOpen();
       const page = render(Component, props);
@@ -208,21 +193,6 @@ describe("Modal component", () => {
       await expect.poll(() => props.open).toBe(true);
 
       await page.getByRole("button", { name: closeButtonText }).click();
-      await expect.element(componentLocator(page, true)).not.toBeVisible();
-      await expect
-        .element(componentLocator(page, true))
-        .not.toHaveAttribute("open");
-      await expect.poll(() => props.open).toBe(false);
-    });
-
-    it("is closed by close() on the component instance", async () => {
-      const props = withOpen();
-      const page = render(Component, props);
-      await showModal(page);
-      await expect.poll(() => props.open).toBe(true);
-
-      const component = page.component as unknown as ModalMethods;
-      component.close();
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
@@ -318,7 +288,7 @@ function triggerLocator(page: RenderResult<typeof Component>): Locator {
 }
 
 async function showModal(page: RenderResult<typeof Component>): Promise<void> {
-  (page.component as unknown as ModalMethods).showModal();
+  (componentLocator(page, true).element() as HTMLDialogElement).showModal();
   await expect.element(componentLocator(page)).toBeVisible();
   await expect.element(componentLocator(page)).toHaveAttribute("open");
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/styles.css
@@ -3,7 +3,11 @@
   --dimension-width-modal: 38rem;
 
   position: fixed;
-  margin: auto;
+  inset: 0;
+  /* z-index on dialog is only relevant when opened as non-modal.
+  Modal dialogs are rendered on the top-layer anyways  */
+  /* TODO: Add z-index tokens */
+  z-index: 10;
   width: min(100vw, var(--dimension-width-modal));
 
   border: var(--lp-dimension-stroke-thickness-default) solid
@@ -17,11 +21,18 @@
     transition-duration: var(--lp-transition-duration-fast);
   }
 
+  &.no-transition {
+    &,
+    &::backdrop {
+      transition: none;
+    }
+  }
+
   &::backdrop {
     background-color: var(--lp-color-background-overlay);
   }
 
-  /* 
+  /*
       [open] is a fallback for Safari that doesn't support the `:open`.
 
       TODO(:open): Remove when Safari supports it (https://developer.mozilla.org/en-US/docs/Web/CSS/:open)
@@ -30,10 +41,29 @@
     &,
     &::backdrop {
       opacity: 1;
+    }
+  }
 
-      @starting-style {
+  /* Starting styles only for modal dialogs, so the SSR opened shows up immediately */
+  &:modal {
+    @starting-style {
+      &,
+      &::backdrop {
         opacity: 0;
       }
     }
+  }
+}
+
+.ds.modal-non-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: var(--lp-color-background-overlay);
+  display: none;
+  /* TODO: Add z-index tokens */
+  z-index: 10;
+
+  &:has(+ .ds.modal:is(:open, [open]):not(:modal)) {
+    display: block;
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/styles.css
@@ -3,6 +3,7 @@
   --dimension-width-modal: 38rem;
 
   position: fixed;
+  margin: auto;
   inset: 0;
   /* z-index on dialog is only relevant when opened as non-modal.
   Modal dialogs are rendered on the top-layer anyways  */
@@ -29,7 +30,10 @@
   }
 
   &::backdrop {
-    background-color: var(--lp-color-background-overlay);
+    background-color: var(
+      --modal-backdrop-color,
+      var(--lp-color-background-overlay)
+    );
   }
 
   /*
@@ -58,7 +62,10 @@
 .ds.modal-non-modal-backdrop {
   position: fixed;
   inset: 0;
-  background-color: var(--lp-color-background-overlay);
+  background-color: var(
+    --modal-backdrop-color,
+    var(--lp-color-background-overlay)
+  );
   display: none;
   /* TODO: Add z-index tokens */
   z-index: 10;

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/types.ts
@@ -11,8 +11,6 @@ import type { HTMLDialogAttributes } from "svelte/elements";
 type BaseProps = Omit<HTMLDialogAttributes, "open" | "children">;
 
 export type ModalTriggerProps = {
-  // TODO(Invoker Commands API): Remove `onclick` fallback when [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) support is widespread enough.
-  onclick?: () => void;
   commandfor: string;
   command: "show-modal";
   "aria-haspopup": "dialog";
@@ -26,7 +24,6 @@ export interface ModalProps extends BaseProps {
    * - `triggerProps`: Props to spread on the button element. It contains:
    *   - `commandfor`: The id of the dialog element. Setting it as `commandfor` associates the button with the dialog to open.
    *   - `command`: Always set to `"show-modal"` to indicate that the button opens a modal.
-   *   - `onclick`: An onclick handler that calls `dialog.showModal()`. Present only as a fallback for browsers that don't support [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API).
    *   - `aria-haspopup`: Always set to `"dialog"` to indicate that the button opens a dialog.
    */
   trigger?: Snippet<[triggerProps: ModalTriggerProps]>;

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/types.ts
@@ -44,8 +44,3 @@ export interface ModalProps extends BaseProps {
    */
   open?: BaseProps["open"];
 }
-
-export interface ModalMethods {
-  showModal: () => void;
-  close: () => void;
-}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/types.ts
@@ -3,12 +3,7 @@
 import type { Snippet } from "svelte";
 import type { HTMLDialogAttributes } from "svelte/elements";
 
-/*
- `open` is omitted, as from the [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#html-only_dialog):
- > Dialogs that are displayed using the open attribute are non-modal.
- > It is possible to toggle the display of the dialog by adding or removing the boolean `open` attribute, but it is not the recommended practice.
-*/
-type BaseProps = Omit<HTMLDialogAttributes, "open" | "children">;
+type BaseProps = Omit<HTMLDialogAttributes, "children">;
 
 export type ModalTriggerProps = {
   commandfor: string;
@@ -41,6 +36,13 @@ export interface ModalProps extends BaseProps {
    * - `close`: A function to close the modal.
    */
   children?: Snippet<[commandfor: string, close: () => void]>;
+  /**
+   * `open` serves two purposes:
+   * - As an SSR mechanism to render the modal already open without client-side JS.
+   *   Note: a dialog displayed this way is non-modal, so the component styles emulate a modal and, once hydrated, upgrade it to a real one.
+   * - As a two-way bindable prop once hydrated: setting it maps to `showModal()` / `close()`, and it is updated back to reflect the state change triggered by other means (e.g., invoker commands, Escape press, outside click).
+   */
+  open?: BaseProps["open"];
 }
 
 export interface ModalMethods {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.ssr.test.ts
@@ -52,14 +52,17 @@ describe("SidePanel SSR", () => {
   });
 
   describe("attributes", () => {
-    it.each([
+    it.each<[string, unknown, string?]>([
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
-    ])("applies %s", (attribute, expected) => {
+      ["open", true, ""],
+    ])("applies %s", (attribute, set, expected) => {
       const page = render(Component, {
-        props: { ...baseProps, [attribute]: expected },
+        props: { ...baseProps, [attribute]: set },
       });
-      expect(componentLocator(page).getAttribute(attribute)).toBe(expected);
+      expect(componentLocator(page).getAttribute(attribute)).toBe(
+        expected ?? set,
+      );
     });
 
     it("applies classes", () => {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.stories.svelte
@@ -36,6 +36,8 @@
       }
     }, 1000);
   };
+
+  let open = $state(false);
 </script>
 
 <Story name="Default">
@@ -104,6 +106,34 @@
         <SidePanel.Content.Header>Timed Side Panel</SidePanel.Content.Header>
         <SidePanel.Content.Body>
           This side panel closes automatically in {timeLeft} seconds.
+        </SidePanel.Content.Body>
+      </SidePanel.Content>
+    </SidePanel>
+  {/snippet}
+</Story>
+
+<Story
+  name="Controlled via bindable open prop"
+  argTypes={{ open: { control: false } }}
+>
+  {#snippet template({ children: __, trigger: _, open: ___, ...args })}
+    <!-- 
+    <script>
+      let open = $state(false);
+    </script>
+    -->
+
+    <p style="margin-block-end: 0.5rem;">
+      Side panel is {open ? "open" : "closed"}
+    </p>
+    <Button onclick={() => (open = true)}>Show side panel</Button>
+    <SidePanel bind:open {...args}>
+      <SidePanel.Content>
+        <SidePanel.Content.Header
+          >Controlled Side Panel</SidePanel.Content.Header
+        >
+        <SidePanel.Content.Body>
+          The side panel is controlled via the bindable `open` prop.
         </SidePanel.Content.Body>
       </SidePanel.Content>
     </SidePanel>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.stories.svelte
@@ -2,7 +2,6 @@
   import { defineMeta } from "@storybook/addon-svelte-csf";
   import { Button } from "../Button/index.js";
   import { SidePanel } from "./index.js";
-  import type { SidePanelMethods } from "./types.js";
 
   const { Story } = defineMeta({
     title: "Components/SidePanel",
@@ -18,17 +17,17 @@
     },
   });
 
-  let sidePanel = $state<SidePanelMethods>();
+  let open = $state(false);
   let interval: ReturnType<typeof setInterval> | null = null;
   let timeLeft = $state(0);
   const onclick = () => {
-    if (!sidePanel) return;
-    sidePanel.showModal();
+    if (interval) clearInterval(interval);
+    open = true;
     timeLeft = 5;
     interval = setInterval(() => {
       timeLeft -= 1;
       if (timeLeft <= 0) {
-        sidePanel?.close();
+        open = false;
         if (interval) {
           clearInterval(interval);
           interval = null;
@@ -36,8 +35,6 @@
       }
     }, 1000);
   };
-
-  let open = $state(false);
 </script>
 
 <Story name="Default">
@@ -66,34 +63,40 @@
 </Story>
 
 <Story
-  name="Controlled via instance methods"
+  name="Controlled via bindable open prop"
   args={{ closeOnOutsideClick: false }}
+  argTypes={{ open: { control: false } }}
 >
-  {#snippet template({ children: __, trigger: _, ...args })}
+  {#snippet template({ children: _, trigger: __, open: ___, ...args })}
     <!-- 
-    let sidePanel = $state<SidePanelMethods>();
-    let interval: ReturnType<typeof setInterval> | null = null;
-    let timeLeft = $state(0);
-    const onclick = () => {
-      if (!sidePanel) return;
-      sidePanel.showModal();
-      timeLeft = 5;
-      interval = setInterval(() => {
-        timeLeft -= 1;
-        if (timeLeft <= 0) {
-          sidePanel?.close();
-          if (interval) {
-            clearInterval(interval);
-            interval = null;
-          }
-        }
-      }, 1000);
-    };
+      <script lang="ts">
+        let open = $state(false);
+        let interval: ReturnType<typeof setInterval> | null = null;
+        let timeLeft = $state(0);
+        const onclick = () => {
+          if (interval) clearInterval(interval);
+          open = true;
+          timeLeft = 5;
+          interval = setInterval(() => {
+            timeLeft -= 1;
+            if (timeLeft <= 0) {
+              open = false;
+              if (interval) {
+                clearInterval(interval);
+                interval = null;
+              }
+            }
+          }, 1000);
+        };
+      </script>
     -->
 
+    <p style="margin-block-end: 0.5rem;">
+      Side panel is {open ? "open" : "closed"}
+    </p>
     <Button {onclick}>Show timed side panel</Button>
     <SidePanel
-      bind:this={sidePanel}
+      bind:open
       onclose={() => {
         if (interval) {
           clearInterval(interval);
@@ -106,34 +109,6 @@
         <SidePanel.Content.Header>Timed Side Panel</SidePanel.Content.Header>
         <SidePanel.Content.Body>
           This side panel closes automatically in {timeLeft} seconds.
-        </SidePanel.Content.Body>
-      </SidePanel.Content>
-    </SidePanel>
-  {/snippet}
-</Story>
-
-<Story
-  name="Controlled via bindable open prop"
-  argTypes={{ open: { control: false } }}
->
-  {#snippet template({ children: __, trigger: _, open: ___, ...args })}
-    <!-- 
-    <script>
-      let open = $state(false);
-    </script>
-    -->
-
-    <p style="margin-block-end: 0.5rem;">
-      Side panel is {open ? "open" : "closed"}
-    </p>
-    <Button onclick={() => (open = true)}>Show side panel</Button>
-    <SidePanel bind:open {...args}>
-      <SidePanel.Content>
-        <SidePanel.Content.Header
-          >Controlled Side Panel</SidePanel.Content.Header
-        >
-        <SidePanel.Content.Body>
-          The side panel is controlled via the bindable `open` prop.
         </SidePanel.Content.Body>
       </SidePanel.Content>
     </SidePanel>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { Modal } from "../Modal/index.js";
-  import type { SidePanelMethods, SidePanelProps } from "./types.js";
+  import type { SidePanelProps } from "./types.js";
   import "./styles.css";
 
   const componentCssClassName = "ds side-panel";
@@ -12,20 +12,9 @@
     open = $bindable(),
     ...rest
   }: SidePanelProps = $props();
-
-  let modalMethods = $state<SidePanelMethods>();
-
-  export const showModal: SidePanelMethods["showModal"] = () => {
-    modalMethods?.showModal();
-  };
-
-  export const close: SidePanelMethods["close"] = () => {
-    modalMethods?.close();
-  };
 </script>
 
 <Modal
-  bind:this={modalMethods}
   bind:open
   class={[componentCssClassName, className]}
   --modal-backdrop-color="transparent"

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte
@@ -7,7 +7,11 @@
 
   const componentCssClassName = "ds side-panel";
 
-  let { class: className, ...rest }: SidePanelProps = $props();
+  let {
+    class: className,
+    open = $bindable(),
+    ...rest
+  }: SidePanelProps = $props();
 
   let modalMethods = $state<SidePanelMethods>();
 
@@ -22,7 +26,9 @@
 
 <Modal
   bind:this={modalMethods}
+  bind:open
   class={[componentCssClassName, className]}
+  --modal-backdrop-color="transparent"
   {...rest}
 />
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte.test.ts
@@ -1,6 +1,6 @@
 /* @canonical/generator-ds 0.10.0-experimental.5 */
 
-import { flushSync, type ComponentProps } from "svelte";
+import { type ComponentProps, flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 import type { Locator } from "vitest/browser";
 import { userEvent } from "vitest/browser";

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte.test.ts
@@ -1,6 +1,6 @@
 /* @canonical/generator-ds 0.10.0-experimental.5 */
 
-import type { ComponentProps } from "svelte";
+import { flushSync, type ComponentProps } from "svelte";
 import { describe, expect, it } from "vitest";
 import type { Locator } from "vitest/browser";
 import { userEvent } from "vitest/browser";
@@ -21,6 +21,23 @@ describe("SidePanel component", () => {
     children,
     trigger,
   } satisfies ComponentProps<typeof Component>;
+
+  function withOpen({
+    open: initialOpen,
+    ...extra
+  }: Partial<ComponentProps<typeof Component>> = {}) {
+    let open = $state(initialOpen);
+    return {
+      ...baseProps,
+      ...extra,
+      get open() {
+        return open;
+      },
+      set open(value) {
+        open = value;
+      },
+    };
+  }
 
   it("renders", async () => {
     const page = render(Component, { ...baseProps });
@@ -107,71 +124,104 @@ describe("SidePanel component", () => {
 
   describe("Opening the SidePanel", () => {
     it("is opened when `showModal` on the dialog element is called", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
+      expect(props.open).toBe(undefined);
 
       (componentLocator(page, true).element() as HTMLDialogElement).showModal();
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
       await expect.element(page.getByText(contentText)).toBeVisible();
+      await expect.poll(() => props.open).toBe(true);
     });
 
     it("is opened by trigger click", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
+      expect(props.open).toBe(undefined);
 
       await triggerLocator(page).click();
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
       await expect.element(page.getByText(contentText)).toBeVisible();
+      await expect.poll(() => props.open).toBe(true);
     });
 
     it("is opened by showModal() on the component instance", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
+      expect(props.open).toBe(undefined);
 
       const component = page.component as unknown as SidePanelMethods;
       component.showModal();
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
       await expect.element(page.getByText(contentText)).toBeVisible();
+      await expect.poll(() => props.open).toBe(true);
+    });
+
+    it("is opened by setting open to true", async () => {
+      const props = withOpen();
+      const page = render(Component, props);
+      await expect.element(componentLocator(page, true)).not.toBeVisible();
+      expect(props.open).toBe(undefined);
+
+      props.open = true;
+      await expect.element(componentLocator(page)).toBeVisible();
+      await expect.element(componentLocator(page)).toHaveAttribute("open");
+      await expect.element(page.getByText(contentText)).toBeVisible();
+      await expect.poll(() => props.open).toBe(true);
+    });
+
+    it("upgrades a server-rendered open dialog to a true modal on mount", async () => {
+      const props = withOpen({ open: true });
+      const page = render(Component, props);
+
+      await expect.element(componentLocator(page)).toBeVisible();
+      await expect.element(componentLocator(page)).toHaveAttribute("open");
+      await expect.element(page.getByText(contentText)).toBeVisible();
+      flushSync();
+      expect(componentLocator(page).element().matches(":modal")).toBe(true);
     });
   });
 
   describe("Closing the SidePanel", () => {
     it("is closed when `close` on the dialog element is called", async () => {
-      const page = render(Component, { ...baseProps });
+      const props = withOpen();
+      const page = render(Component, props);
       await showSidePanel(page);
+      await expect.poll(() => props.open).toBe(true);
 
       (componentLocator(page).element() as HTMLDialogElement).close();
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
 
     it("is closed by close() supplied via children snippet", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await showSidePanel(page);
+      await expect.poll(() => props.open).toBe(true);
 
       await page.getByRole("button", { name: closeButtonText }).click();
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
 
     it("is closed by close() on the component instance", async () => {
-      const page = render(Component, { ...baseProps });
+      const props = withOpen();
+      const page = render(Component, props);
       await showSidePanel(page);
+      await expect.poll(() => props.open).toBe(true);
 
       const component = page.component as unknown as SidePanelMethods;
       component.close();
@@ -179,45 +229,61 @@ describe("SidePanel component", () => {
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
 
     it("is closed by clicking outside the side panel when `closeOnOutsideClick` is true", async () => {
-      const page = render(Component, {
-        ...baseProps,
-        closeOnOutsideClick: true,
-      });
+      const props = withOpen({ closeOnOutsideClick: true });
+      const page = render(Component, props);
       await showSidePanel(page);
+      await expect.poll(() => props.open).toBe(true);
 
       await componentLocator(page).click({ position: { x: -10, y: 10 } });
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
 
     it("is not closed by clicking outside the side panel when `closeOnOutsideClick` is false", async () => {
-      const page = render(Component, {
-        ...baseProps,
-        closeOnOutsideClick: false,
-      });
+      const props = withOpen({ closeOnOutsideClick: false });
+      const page = render(Component, props);
       await showSidePanel(page);
+      await expect.poll(() => props.open).toBe(true);
 
       await componentLocator(page).click({ position: { x: -10, y: 10 } });
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(true);
     });
 
     it("is closed by pressing Escape", async () => {
-      const page = render(Component, {
-        ...baseProps,
-      });
+      const props = withOpen();
+      const page = render(Component, props);
       await showSidePanel(page);
+      await expect.poll(() => props.open).toBe(true);
 
       await userEvent.keyboard("{Escape}");
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
         .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
+    });
+
+    it("is closed by setting open to false", async () => {
+      const props = withOpen();
+      const page = render(Component, props);
+      await showSidePanel(page);
+      await expect.poll(() => props.open).toBe(true);
+
+      props.open = false;
+      await expect.element(componentLocator(page, true)).not.toBeVisible();
+      await expect
+        .element(componentLocator(page, true))
+        .not.toHaveAttribute("open");
+      await expect.poll(() => props.open).toBe(false);
     });
   });
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte.test.ts
@@ -14,7 +14,6 @@ import {
   trigger,
   triggerText,
 } from "./test.fixtures.svelte";
-import type { SidePanelMethods } from "./types.js";
 
 describe("SidePanel component", () => {
   const baseProps = {
@@ -149,20 +148,6 @@ describe("SidePanel component", () => {
       await expect.poll(() => props.open).toBe(true);
     });
 
-    it("is opened by showModal() on the component instance", async () => {
-      const props = withOpen();
-      const page = render(Component, props);
-      await expect.element(componentLocator(page, true)).not.toBeVisible();
-      expect(props.open).toBe(undefined);
-
-      const component = page.component as unknown as SidePanelMethods;
-      component.showModal();
-      await expect.element(componentLocator(page)).toBeVisible();
-      await expect.element(componentLocator(page)).toHaveAttribute("open");
-      await expect.element(page.getByText(contentText)).toBeVisible();
-      await expect.poll(() => props.open).toBe(true);
-    });
-
     it("is opened by setting open to true", async () => {
       const props = withOpen();
       const page = render(Component, props);
@@ -210,21 +195,6 @@ describe("SidePanel component", () => {
       await expect.poll(() => props.open).toBe(true);
 
       await page.getByRole("button", { name: closeButtonText }).click();
-      await expect.element(componentLocator(page, true)).not.toBeVisible();
-      await expect
-        .element(componentLocator(page, true))
-        .not.toHaveAttribute("open");
-      await expect.poll(() => props.open).toBe(false);
-    });
-
-    it("is closed by close() on the component instance", async () => {
-      const props = withOpen();
-      const page = render(Component, props);
-      await showSidePanel(page);
-      await expect.poll(() => props.open).toBe(true);
-
-      const component = page.component as unknown as SidePanelMethods;
-      component.close();
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       await expect
         .element(componentLocator(page, true))
@@ -336,7 +306,7 @@ function triggerLocator(page: RenderResult<typeof Component>): Locator {
 async function showSidePanel(
   page: RenderResult<typeof Component>,
 ): Promise<void> {
-  (page.component as unknown as SidePanelMethods).showModal();
+  (componentLocator(page, true).element() as HTMLDialogElement).showModal();
   await expect.element(componentLocator(page)).toBeVisible();
   await expect.element(componentLocator(page)).toHaveAttribute("open");
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/styles.css
@@ -21,7 +21,10 @@
     */
   &:is(:open, [open]) {
     transform: translateX(0);
+  }
 
+  /* Starting styles only for modal dialogs, so the SSR opened shows up immediately */
+  &:modal {
     @starting-style {
       transform: translateX(100%);
     }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/types.ts
@@ -4,7 +4,4 @@ import type { ModalProps } from "../Modal/index.js";
 
 export type SidePanelProps = ModalProps;
 
-export type {
-  ModalMethods as SidePanelMethods,
-  ModalTriggerProps as SidePanelTriggerProps,
-} from "../Modal/index.js";
+export type { ModalTriggerProps as SidePanelTriggerProps } from "../Modal/index.js";


### PR DESCRIPTION
## Done

Adds support for rendering `Modal`/`SidePanel` dialogs already-open during SSR (non-modal `open` attribute), then upgrading them to a true modal after hydration while keeping a two-way `bind:open` API in sync with user-driven state changes (invoker commands, Escape, outside click).

**Changes:**
- Introduces a bindable `open` prop (two-way sync) on `Modal`, and forwards it through `SidePanel`.
- Adjusts dialog/backdrop transition behavior so SSR-opened (non-modal) dialogs paint immediately, while modal-open animations still work.
- Updates stories and tests to cover controlled `open` behavior and SSR upgrade behavior.
- Removes `showModal` and `close` component instance methods

**Drive-bys**:
- removes the invoker commands' fallback (already [supported in all major browsers](https://caniuse.com/wf-invoker-commands))
- adds `.vitest-attachments` to `.gitignore`.

## QA

- `bun run check && bun run vitest --run`.
- Verify Storybook for [`Modal`](https://698d9cc0a0decf9afb7a90cb-hjrvlvzlch.chromatic.com/?path=/docs/components-modal--docs) and [`SidePanel`](https://698d9cc0a0decf9afb7a90cb-hjrvlvzlch.chromatic.com/?path=/docs/components-sidepanel--docs).
- Import and use the components in a local project that supports SSR.
  - Provide `open: true` prop to `Modal` and `SidePanel` components.
  - Navigate to the page and verify that the dialogs are visible on page load. Verify that after JS kicks in, the dialogs are modal (e.g. focus can't be moved outside the dialogs)
  - Disable JS in your browser and refresh the page. Verify that the dialogs are visible on page load.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.
