### PR TITLE
chore(svelte-ds-app-launchpad): bump playwright to support resolute

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -158,10 +158,10 @@
       "name": "@canonical/storybook-config",
       "version": "0.29.0-experimental.0",
       "dependencies": {
-        "@canonical/ds-assets": "^0.27.1-experimental.0",
-        "@canonical/storybook-addon-shell-theme": "^0.27.1-experimental.0",
-        "@canonical/storybook-addon-utils": "^0.27.1-experimental.0",
-        "@canonical/styles-debug": "^0.27.1-experimental.0",
+        "@canonical/ds-assets": "^0.29.0-experimental.0",
+        "@canonical/storybook-addon-shell-theme": "^0.29.0-experimental.0",
+        "@canonical/storybook-addon-utils": "^0.29.0-experimental.0",
+        "@canonical/styles-debug": "^0.28.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-a11y": "^10.3.1",
         "@storybook/addon-docs": "^10.3.1",
@@ -173,8 +173,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config-react": "^0.28.0",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -216,11 +216,11 @@
       "name": "@canonical/typescript-config-react",
       "version": "0.28.0",
       "dependencies": {
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
+        "@canonical/typescript-config": "^0.28.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
@@ -231,11 +231,11 @@
       "name": "@canonical/typescript-config-svelte",
       "version": "0.28.0",
       "dependencies": {
-        "@canonical/typescript-config": "^0.21.0",
+        "@canonical/typescript-config": "^0.28.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.21.0",
+        "@canonical/biome-config": "^0.28.0",
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -340,9 +340,9 @@
       "version": "0.29.0-experimental.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
         "jsdom": "^28.1.0",
@@ -756,16 +756,16 @@
       "name": "@canonical/router-react",
       "version": "0.29.0-experimental.0",
       "dependencies": {
-        "@canonical/react-ssr": "^0.27.1-experimental.0",
-        "@canonical/router-core": "^0.27.1-experimental.0",
+        "@canonical/react-ssr": "^0.29.0-experimental.0",
+        "@canonical/router-core": "^0.29.0-experimental.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config-react": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.0",
@@ -787,16 +787,16 @@
         "serve-bun": "./dist/esm/bin/serve-bun.js",
       },
       "dependencies": {
-        "@canonical/utils": "^0.27.1-experimental.0",
+        "@canonical/utils": "^0.29.0-experimental.0",
         "htmlparser2": "^10.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config-react": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "@types/express": "^5.0.6",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -958,8 +958,8 @@
       "version": "0.29.0-experimental.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
@@ -984,9 +984,9 @@
       "version": "0.29.0-experimental.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "copyfiles": "^2.4.1",
         "storybook": "^10.3.1",
         "typescript": "^5.9.3",
@@ -1054,16 +1054,16 @@
       "name": "@canonical/storybook-addon-utils",
       "version": "0.29.0-experimental.0",
       "dependencies": {
-        "@canonical/styles-debug": "^0.27.1-experimental.0",
+        "@canonical/styles-debug": "^0.28.0",
         "@storybook/icons": "^2.0.1",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/router-core": "^0.27.1-experimental.0",
-        "@canonical/router-react": "^0.27.1-experimental.0",
-        "@canonical/styles": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/router-core": "^0.29.0-experimental.0",
+        "@canonical/router-react": "^0.29.0-experimental.0",
+        "@canonical/styles": "^0.28.0",
+        "@canonical/typescript-config-react": "^0.28.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1098,15 +1098,15 @@
       "name": "@canonical/storybook-helpers",
       "version": "0.29.0-experimental.0",
       "dependencies": {
-        "@canonical/ds-types": "^0.27.1-experimental.0",
+        "@canonical/ds-types": "^0.29.0-experimental.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config-react": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
@@ -1124,7 +1124,7 @@
       "version": "0.28.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
       },
       "peerDependencies": {
         "@canonical/design-tokens": ">=0.4.0",
@@ -1282,13 +1282,13 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.21.0",
+        "@canonical/biome-config": "^0.28.0",
         "@canonical/design-tokens": "^0.6.0",
-        "@canonical/storybook-config": "^0.21.0",
-        "@canonical/storybook-helpers": "^0.21.0",
-        "@canonical/svelte-ssr-test": "^0.21.0",
-        "@canonical/typescript-config-svelte": "^0.21.0",
-        "@canonical/webarchitect": "^0.21.0",
+        "@canonical/storybook-config": "^0.29.0-experimental.0",
+        "@canonical/storybook-helpers": "^0.29.0-experimental.0",
+        "@canonical/svelte-ssr-test": "^0.28.0",
+        "@canonical/typescript-config-svelte": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/addon-svelte-csf": "^5.0.11",
         "@sveltejs/package": "^2.5.7",
@@ -1296,7 +1296,7 @@
         "@types/bun": "^1.3.10",
         "@vitest/browser": "^4.0.18",
         "@vitest/browser-playwright": "^4.0.18",
-        "playwright": "^1.58.2",
+        "playwright": "^1.61.1",
         "storybook": "^10.3.1",
         "svelte-check": "^4.4.5",
         "typescript": "^5.9.3",
@@ -1349,8 +1349,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.21.0",
-        "@canonical/typescript-config": "^0.21.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config": "^0.28.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@types/jsdom": "^28.0.0",
         "typescript": "^5.9.3",
@@ -3309,9 +3309,9 @@
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
-    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
-    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
@@ -3821,6 +3821,8 @@
 
     "@canonical/react-hooks/@canonical/webarchitect": ["@canonical/webarchitect@0.22.0", "", { "dependencies": { "ajv": "^8.18.0", "chalk": "^5.6.2", "commander": "^14.0.3" }, "bin": { "webarchitect": "src/cli.ts" } }, "sha512-HoiqlMgF9PsVyQCPEvV4gREQEa/SpJeeJxKHglpfEez+pKAkmAlah1i37a55hHUYDAREHguxlktAJ0UYGAiqzQ=="],
 
+    "@canonical/svelte-ds-app-wpe/playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
     "@digitalbazaar/http-client/undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
 
     "@gar/promise-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
@@ -3884,6 +3886,8 @@
     "@nx/devkit/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "@nx/devkit/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@playwright/test/playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -4229,6 +4233,10 @@
 
     "@bundled-es-modules/glob/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
+    "@canonical/svelte-ds-app-wpe/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "@canonical/svelte-ds-app-wpe/playwright/playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -4262,6 +4270,10 @@
     "@npmcli/package-json/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "@nx/devkit/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "@playwright/test/playwright/playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/packages/svelte/ds-app-launchpad/package.json
+++ b/packages/svelte/ds-app-launchpad/package.json
@@ -77,7 +77,7 @@
     "@types/bun": "^1.3.10",
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
-    "playwright": "^1.58.2",
+    "playwright": "^1.61.1",
     "storybook": "^10.3.1",
     "svelte-check": "^4.4.5",
     "typescript": "^5.9.3",


### PR DESCRIPTION
Playwright support for resolute landed in 1.61

## Done

Update playwright to 1.61

## QA

- `bun run test:client`

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.
