### PR TITLE
chore(react-ds-global-form): retitle stories by ontology tier + sidebar order

### DIFF
--- a/packages/react/ds-global-form/.storybook/preview.ts
+++ b/packages/react/ds-global-form/.storybook/preview.ts
@@ -10,11 +10,13 @@ const preview = {
     ...previewConfig.parameters,
     options: {
       ...previewConfig.parameters?.options,
-      // Sidebar order by ontology tier (N.04): docs first, then the tiers, then
+      // Sidebar order by ontology tier (N.04): the Documentation folder first
+      // (Introduction, then Getting Started, then Guides), then the tiers, then
       // the non-tier machinery (common/utils) last.
       storySort: {
         order: [
-          "Getting Started",
+          "Documentation",
+          ["Introduction", "Getting Started", "Guides"],
           "subcomponents",
           "components",
           "patterns",

--- a/packages/react/ds-global-form/.storybook/preview.ts
+++ b/packages/react/ds-global-form/.storybook/preview.ts
@@ -6,6 +6,25 @@ const preview = {
   ...previewConfig,
   // https://github.com/storybookjs/storybook/issues/31842
   tags: ["autodocs"],
+  parameters: {
+    ...previewConfig.parameters,
+    options: {
+      ...previewConfig.parameters?.options,
+      // Sidebar order by ontology tier (N.04): docs first, then the tiers, then
+      // the non-tier machinery (common/utils) last.
+      storySort: {
+        order: [
+          "Getting Started",
+          "subcomponents",
+          "components",
+          "patterns",
+          "common",
+          "utils",
+          "*",
+        ],
+      },
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-global-form/src/lib/Form/Form.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/Form/Form.stories.tsx
@@ -21,7 +21,7 @@ import type { FieldProps } from "../fields/types.js";
  * ```
  */
 const meta = {
-  title: "Form",
+  title: "patterns/Form",
   parameters: { grid: "intrinsic" },
   decorators: [decorators.form()],
 } satisfies Meta;

--- a/packages/react/ds-global-form/src/lib/Welcome.mdx
+++ b/packages/react/ds-global-form/src/lib/Welcome.mdx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 import { PackageInfo } from "@canonical/storybook-helpers";
 
-<Meta title="Introduction" />
+<Meta title="Documentation/Introduction" />
 
 # Form Components — React
 

--- a/packages/react/ds-global-form/src/lib/docs/CreatingCustomFields.mdx
+++ b/packages/react/ds-global-form/src/lib/docs/CreatingCustomFields.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Guides/Creating Custom Fields" />
+<Meta title="Documentation/Guides/Creating Custom Fields" />
 
 # Creating Custom Fields
 

--- a/packages/react/ds-global-form/src/lib/docs/CreatingMiddleware.mdx
+++ b/packages/react/ds-global-form/src/lib/docs/CreatingMiddleware.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Guides/Creating Middleware" />
+<Meta title="Documentation/Guides/Creating Middleware" />
 
 # Creating Middleware
 

--- a/packages/react/ds-global-form/src/lib/docs/GettingStarted.mdx
+++ b/packages/react/ds-global-form/src/lib/docs/GettingStarted.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas } from "@storybook/addon-docs/blocks";
 import * as Stories from "./GettingStarted.stories";
 
-<Meta title="Getting Started" />
+<Meta title="Documentation/Getting Started" />
 
 # Getting Started with Forms
 

--- a/packages/react/ds-global-form/src/lib/docs/GettingStarted.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/docs/GettingStarted.stories.tsx
@@ -6,7 +6,7 @@ import Field from "../fields/Field.js";
 const noop = (data: Record<string, unknown>) => console.log(data);
 
 const meta = {
-  title: "Getting Started/Examples",
+  title: "Documentation/Getting Started/Examples",
   parameters: { layout: "padded" },
   decorators: [
     (Story) => (

--- a/packages/react/ds-global-form/src/lib/docs/WrapperPattern.mdx
+++ b/packages/react/ds-global-form/src/lib/docs/WrapperPattern.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Guides/The Wrapper Pattern" />
+<Meta title="Documentation/Guides/The Wrapper Pattern" />
 
 # The Wrapper Pattern
 

--- a/packages/react/ds-global-form/src/lib/fields/Checkbox/CheckboxField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Checkbox/CheckboxField.stories.tsx
@@ -6,7 +6,7 @@ import { CheckboxField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/Checkbox",
+  title: "components/CheckboxField",
   component: CheckboxField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Choices/ChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Choices/ChoicesField.stories.tsx
@@ -6,7 +6,7 @@ import { ChoicesField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/Choices",
+  title: "components/ChoicesField",
   component: ChoicesField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Color/ColorField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Color/ColorField.stories.tsx
@@ -4,7 +4,7 @@ import { ColorField } from "./index.js";
 
 // Field-tier stories: the color input bound to react-hook-form, inside a form.
 const meta = {
-  title: "Fields/Color",
+  title: "components/ColorField",
   component: ColorField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Combobox/ComboboxField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Combobox/ComboboxField.stories.tsx
@@ -5,7 +5,7 @@ import { ComboboxField } from "./index.js";
 
 // Field-tier stories: the combobox bound to react-hook-form, inside a form.
 const meta = {
-  title: "Fields/Combobox",
+  title: "components/ComboboxField",
   component: ComboboxField,
   tags: ["autodocs"],
   decorators: [

--- a/packages/react/ds-global-form/src/lib/fields/Date/DateInputField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Date/DateInputField.stories.tsx
@@ -5,7 +5,7 @@ import { DateInputField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/Date",
+  title: "components/DateInputField",
   component: DateInputField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Date/DateTimeInputField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Date/DateTimeInputField.stories.tsx
@@ -5,7 +5,7 @@ import { DateTimeInputField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/DateTime",
+  title: "components/DateTimeInputField",
   component: DateTimeInputField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Date/TimeInputField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Date/TimeInputField.stories.tsx
@@ -5,7 +5,7 @@ import { TimeInputField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/Time",
+  title: "components/TimeInputField",
   component: TimeInputField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Field.stories.tsx
@@ -12,7 +12,7 @@ import Component from "./Field.js";
 // import type { StoryFn } from '@storybook/react-vite'
 
 const meta = {
-  title: "Field",
+  title: "patterns/Field",
   component: Component,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/FileUpload/FileUploadField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/FileUpload/FileUploadField.stories.tsx
@@ -4,7 +4,7 @@ import { FileUploadField } from "./index.js";
 
 // Field-tier stories: the file upload bound to react-hook-form, inside a form.
 const meta = {
-  title: "Fields/FileUpload",
+  title: "components/FileUploadField",
   component: FileUploadField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Hidden/HiddenField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Hidden/HiddenField.stories.tsx
@@ -3,7 +3,7 @@ import * as decorators from "storybook/decorators.js";
 import { HiddenField } from "./index.js";
 
 const meta = {
-  title: "Fields/Hidden",
+  title: "components/HiddenField",
   component: HiddenField,
   tags: ["autodocs"],
   decorators: [

--- a/packages/react/ds-global-form/src/lib/fields/Phone/PhoneField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Phone/PhoneField.stories.tsx
@@ -4,7 +4,7 @@ import { PhoneField } from "./index.js";
 
 // Field-tier stories: the phone input bound to react-hook-form, inside a form.
 const meta = {
-  title: "Fields/Phone",
+  title: "components/PhoneField",
   component: PhoneField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Range/RangeField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Range/RangeField.stories.tsx
@@ -3,7 +3,7 @@ import * as decorators from "storybook/decorators.js";
 import { RangeField } from "./index.js";
 
 const meta = {
-  title: "Fields/Range",
+  title: "components/RangeField",
   component: RangeField,
   tags: ["autodocs"],
   decorators: [decorators.form({ defaultValues: { volume: 50 } })],

--- a/packages/react/ds-global-form/src/lib/fields/Select/SelectField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Select/SelectField.stories.tsx
@@ -6,7 +6,7 @@ import { SelectField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/Select",
+  title: "components/SelectField",
   component: SelectField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/SimpleChoices/SimpleChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/SimpleChoices/SimpleChoicesField.stories.tsx
@@ -6,7 +6,7 @@ import { SimpleChoicesField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/SimpleChoices",
+  title: "components/SimpleChoicesField",
   component: SimpleChoicesField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Text/TextField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Text/TextField.stories.tsx
@@ -5,7 +5,7 @@ import { TextField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/Text",
+  title: "components/TextField",
   component: TextField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/Textarea/TextareaField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/Textarea/TextareaField.stories.tsx
@@ -5,7 +5,7 @@ import { TextareaField } from "./index.js";
 // Field-tier stories run inside a form decorator (label/description/error +
 // react-hook-form state).
 const meta = {
-  title: "Fields/Textarea",
+  title: "components/TextareaField",
   component: TextareaField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/fields/common/Description/Description.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/common/Description/Description.stories.tsx
@@ -9,7 +9,7 @@ import Component from "./Description.js";
 // import type { StoryFn } from '@storybook/react-vite'
 
 const meta = {
-  title: "common/Wrapper/Description",
+  title: "subcomponents/Field.Description",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global-form/src/lib/fields/common/Error/Error.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/common/Error/Error.stories.tsx
@@ -9,7 +9,7 @@ import Component from "./Error.js";
 // import type { StoryFn } from '@storybook/react-vite'
 
 const meta = {
-  title: "common/Wrapper/Error",
+  title: "subcomponents/Field.Error",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global-form/src/lib/fields/common/Label/Label.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/fields/common/Label/Label.stories.tsx
@@ -9,7 +9,7 @@ import Component from "./Label.js";
 // import type { StoryFn } from '@storybook/react-vite'
 
 const meta = {
-  title: "common/Wrapper/Label",
+  title: "subcomponents/Field.Label",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global-form/src/lib/inputs/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Checkbox/Checkbox.stories.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from "./Checkbox.js";
 
 // Presentational stories render the input directly, with no form decorator.
 const meta = {
-  title: "Inputs/Checkbox",
+  title: "subcomponents/CheckboxInput",
   component: Checkbox,
   tags: ["autodocs"],
 } satisfies Meta<typeof Checkbox>;

--- a/packages/react/ds-global-form/src/lib/inputs/Color/Color.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Color/Color.stories.tsx
@@ -5,7 +5,7 @@ import { Color } from "./Color.js";
 // Presentational stories render the input directly, with no form decorator.
 // State is owned by the story via `useState` (controlled value/onChange).
 const meta = {
-  title: "Inputs/Color",
+  title: "subcomponents/ColorInput",
   component: Color,
   tags: ["autodocs"],
   render: (args) => {

--- a/packages/react/ds-global-form/src/lib/inputs/Combobox/Combobox.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Combobox/Combobox.stories.tsx
@@ -6,7 +6,7 @@ import { Combobox } from "./Combobox.js";
 
 // Presentational stories: the combobox is controlled directly, no form.
 const meta = {
-  title: "Inputs/Combobox",
+  title: "subcomponents/ComboboxInput",
   component: Combobox,
   tags: ["autodocs"],
 } satisfies Meta<typeof Combobox>;

--- a/packages/react/ds-global-form/src/lib/inputs/Combobox/common/List/List.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Combobox/common/List/List.stories.tsx
@@ -12,7 +12,7 @@ import Component from "./List.js";
 // import type { StoryFn } from '@storybook/react-vite'
 
 const meta = {
-  title: "Field/inputs/Combobox/common/List",
+  title: "subcomponents/ComboboxInput/List",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global-form/src/lib/inputs/Combobox/common/ResetButton/ResetButton.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Combobox/common/ResetButton/ResetButton.stories.tsx
@@ -9,7 +9,7 @@ import Component from "./ResetButton.js";
 // import type { StoryFn } from '@storybook/react-vite'
 
 const meta = {
-  title: "Field/inputs/Combobox/common/ResetButton",
+  title: "subcomponents/ComboboxInput/ResetButton",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global-form/src/lib/inputs/Date/DateInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Date/DateInput.stories.tsx
@@ -3,7 +3,7 @@ import { DateInput } from "./DateInput.js";
 
 // Presentational stories render the input directly, with no form decorator.
 const meta = {
-  title: "Inputs/Date",
+  title: "subcomponents/DateInput",
   component: DateInput,
   tags: ["autodocs"],
 } satisfies Meta<typeof DateInput>;

--- a/packages/react/ds-global-form/src/lib/inputs/Date/DateTimeInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Date/DateTimeInput.stories.tsx
@@ -3,7 +3,7 @@ import { DateTimeInput } from "./DateTimeInput.js";
 
 // Presentational stories render the input directly, with no form decorator.
 const meta = {
-  title: "Inputs/DateTime",
+  title: "subcomponents/DateTimeInput",
   component: DateTimeInput,
   tags: ["autodocs"],
 } satisfies Meta<typeof DateTimeInput>;

--- a/packages/react/ds-global-form/src/lib/inputs/Date/TimeInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Date/TimeInput.stories.tsx
@@ -3,7 +3,7 @@ import { TimeInput } from "./TimeInput.js";
 
 // Presentational stories render the input directly, with no form decorator.
 const meta = {
-  title: "Inputs/Time",
+  title: "subcomponents/TimeInput",
   component: TimeInput,
   tags: ["autodocs"],
 } satisfies Meta<typeof TimeInput>;

--- a/packages/react/ds-global-form/src/lib/inputs/FileUpload/FileUpload.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/FileUpload/FileUpload.stories.tsx
@@ -4,7 +4,7 @@ import { FileUpload } from "./FileUpload.js";
 
 // Presentational stories: the file upload is controlled directly, no form.
 const meta = {
-  title: "Inputs/FileUpload",
+  title: "subcomponents/FileUploadInput",
   component: FileUpload,
   tags: ["autodocs"],
 } satisfies Meta<typeof FileUpload>;

--- a/packages/react/ds-global-form/src/lib/inputs/Hidden/Hidden.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Hidden/Hidden.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Hidden } from "./Hidden.js";
 
 const meta = {
-  title: "Inputs/Hidden",
+  title: "subcomponents/HiddenInput",
   component: Hidden,
   tags: ["autodocs"],
   parameters: { chromatic: { disableSnapshot: true } },

--- a/packages/react/ds-global-form/src/lib/inputs/Phone/Phone.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Phone/Phone.stories.tsx
@@ -5,7 +5,7 @@ import type { PhoneValue } from "./types.js";
 
 // Presentational stories: the phone input is controlled directly, no form.
 const meta = {
-  title: "Inputs/Phone",
+  title: "subcomponents/PhoneInput",
   component: Phone,
   tags: ["autodocs"],
 } satisfies Meta<typeof Phone>;

--- a/packages/react/ds-global-form/src/lib/inputs/Range/Range.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Range/Range.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Range } from "./Range.js";
 
 const meta = {
-  title: "Inputs/Range",
+  title: "subcomponents/RangeInput",
   component: Range,
   tags: ["autodocs"],
 } satisfies Meta<typeof Range>;

--- a/packages/react/ds-global-form/src/lib/inputs/Select/Select.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Select/Select.stories.tsx
@@ -4,7 +4,7 @@ import { Select } from "./Select.js";
 
 // Presentational stories render the input directly, with no form decorator.
 const meta = {
-  title: "Inputs/Select",
+  title: "subcomponents/SelectInput",
   component: Select,
   tags: ["autodocs"],
 } satisfies Meta<typeof Select>;

--- a/packages/react/ds-global-form/src/lib/inputs/Text/Text.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Text/Text.stories.tsx
@@ -3,7 +3,7 @@ import { Text } from "./Text.js";
 
 // Presentational stories render the input directly, with no form decorator.
 const meta = {
-  title: "Inputs/Text",
+  title: "subcomponents/TextInput",
   component: Text,
   tags: ["autodocs"],
 } satisfies Meta<typeof Text>;

--- a/packages/react/ds-global-form/src/lib/inputs/Textarea/Textarea.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/inputs/Textarea/Textarea.stories.tsx
@@ -3,7 +3,7 @@ import { Textarea } from "./Textarea.js";
 
 // Presentational stories render the input directly, with no form decorator.
 const meta = {
-  title: "Inputs/Textarea",
+  title: "subcomponents/TextareaInput",
   component: Textarea,
   tags: ["autodocs"],
 } satisfies Meta<typeof Textarea>;

--- a/packages/react/ds-global-form/src/lib/middleware/middleware.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/middleware/middleware.stories.tsx
@@ -9,7 +9,7 @@ import { Field } from "../fields/index.js";
 import * as middleware from "./index.js";
 
 const meta = {
-  title: "middleware",
+  title: "utils/middleware",
   decorators: [decorators.form()],
   component: Field,
   parameters: {

--- a/packages/react/ds-global-form/vite.config.ts
+++ b/packages/react/ds-global-form/vite.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     tsconfigPaths: true,
+    // Resolve the `#lib/*` self-imports against `src` in dev/build/test by
+    // selecting the `development` condition of the package `imports` map (see
+    // pragma-adrs N.05 CS.IMPORTS.1). Without this, the bundler falls through to
+    // the `default` condition (`./dist/esm/lib/*`), which only exists after a
+    // package build — breaking Storybook/Vitest against live source.
+    conditions: ["development", "import", "module", "browser", "default"],
   },
   build: {
     // include sourcemaps for easier debugging


### PR DESCRIPTION
## Done

Stage 2 of the `ds-global-form` restructure (pragma-adrs **N.04**). **Story metadata + Storybook config only** — no component code changes. Rebased onto `main` after #697 merged; base is now `main`.

- **Retitled every story to `[tier]/[Name]{Input|Field}`**, matching the design-system ontology tiers (full Input/Field suffix on the leaf):
  - `Fields/*` → `components/*Field`; `Inputs/*` → `subcomponents/*Input`
  - Field chrome → `subcomponents/Field.{Description,Error,Label}`; Combobox internals → `subcomponents/ComboboxInput/{List,ResetButton}`
  - `Field` → `patterns/Field`; `Form` → `patterns/Form`; `middleware` → `utils/middleware`; `Wrapper` → `common/Wrapper`
- **Conflated all documentation under a top-level `Documentation` folder** (pinned first), with **Guides as a subfolder** and **Introduction** inside it:
  - `Introduction` → `Documentation/Introduction`
  - `Getting Started` (+ `…/Examples`) → `Documentation/Getting Started`
  - `Guides/*` → `Documentation/Guides/*`
- **Added a `storySort`** to `.storybook/preview.ts` (merged into the shared storybook-config): **Documentation** (Introduction → Getting Started → Guides) → subcomponents → components → patterns → common → utils.
- **`fix`: resolve the `#lib` `development` condition in Vite/Storybook.** The conditional `#lib` imports map merged in #697 relies on the `development` condition for dev tooling; Vite/Rolldown (Storybook build + Vitest) don't select it by default and fell through to `default → ./dist/esm/lib/*` (only present after a build), so `build:storybook` failed to resolve `#lib` against live source. Added `resolve.conditions` to `vite.config.ts`. (Completes the publish-safety work; code standard N.05 CS.IMPORTS.1.)

## QA

- `cd packages/react/ds-global-form`
- `bun run check:ts` → clean.
- `bun run test` → 45 files pass / 1 skipped, 176 tests pass / 4 todo.
- `bun run build:storybook` → **builds successfully** with `dist/` absent (proves `#lib` resolves against `src` in the bundler); every story loads under its new title; sidebar follows the tier order with `Documentation` first.

### PR readiness check

- [x] Label: **`Maintenance 🔨`** (+ a `fix` commit for the Vite condition).
- [x] Conventional Commits title.
- [x] Code standards followed.
- [x] `check`, `check:fix`, `test`, `build`, `build:all` defined.
- [x] No new package.
- [x] `no visual change` to component renders — only Storybook titles/order + a dev-resolution config fix.

## Screenshots

N/A — Storybook sidebar reorganisation + a build-config fix; component renders unchanged.
