### PR TITLE
feat(react-ds-global-form): RangeField synced number + slider (DE080)

### DIFF
--- a/packages/react/ds-global-form/src/index.css
+++ b/packages/react/ds-global-form/src/index.css
@@ -134,6 +134,15 @@
 /* ── .ds.input.chrome — shared input chrome ─────────────────────────
  * Applied on native <textarea>/<select> directly, and on the
  * composite .ds.input.text wrapper for <input> + prefix/suffix.
+ *
+ * Inline padding is deliberately NOT set here. On composite wrappers the
+ * text-bearing leaf is the inner <input>, which carries its own
+ * `padding-inline`; if the wrapper ALSO had it the text would be inset twice
+ * (and prefix/suffix would sit off the edge). So the inline padding lives on
+ * the leaf in every case: the inner <input> for composite inputs (text,
+ * number, password, phone …), and the element itself for the direct-chrome
+ * inputs (date, time, datetime, select, textarea), which set it locally.
+ * Only the block padding (baseline-grid height) is shared here.
  */
 .ds.input.chrome {
   display: block;
@@ -142,7 +151,6 @@
   /* Explicit height snapped to baseline grid — border-box includes border */
   height: var(--form-input-height);
   padding-block: var(--form-input-padding-block);
-  padding-inline: var(--form-input-padding-inline);
 
   /* Base border */
   border: var(--form-input-border-width) solid var(--form-input-border-color);

--- a/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.stories.tsx
@@ -16,3 +16,17 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: { name: "volume", label: "Volume", min: 0, max: 100 },
 };
+
+export const Stepped: Story = {
+  args: { name: "volume", label: "Volume", min: 0, max: 100, step: 10 },
+};
+
+export const CustomSliderLabel: Story = {
+  args: {
+    name: "volume",
+    label: "Volume",
+    min: 0,
+    max: 100,
+    sliderLabel: "Volume (slider)",
+  },
+};

--- a/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithForm } from "../../../testing/renderWithForm.js";
@@ -22,6 +22,18 @@ describe("RangeField", () => {
     expect(slider).toHaveAttribute("aria-label");
     // The slider must NOT carry the field name (it would double-submit).
     expect(slider).not.toHaveAttribute("name");
+  });
+
+  it("derives the slider aria-label from the field name when none is given", () => {
+    renderWithForm(
+      <RangeField name="volume" label="Volume" min={0} max={100} />,
+    );
+    // A generic "Slider" would make every RangeField's slider indistinguishable
+    // to assistive tech; the default is field-specific.
+    expect(screen.getByRole("slider")).toHaveAttribute(
+      "aria-label",
+      "volume (slider)",
+    );
   });
 
   it("forwards min/max/step to both controls", () => {
@@ -51,7 +63,9 @@ describe("RangeField", () => {
         </FormProvider>
       );
     }
-    renderWithForm(<Host />);
+    // Host already provides its own FormProvider + <form>, so render plainly
+    // rather than double-wrapping with renderWithForm.
+    render(<Host />);
     fireEvent.change(screen.getByRole("slider"), { target: { value: "42" } });
     // The number input mirrors the slider.
     expect(screen.getByLabelText("Volume")).toHaveValue(42);

--- a/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tests.tsx
@@ -1,28 +1,74 @@
-import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
 import { renderWithForm } from "../../../testing/renderWithForm.js";
 import { RangeField } from "./index.js";
 
 describe("RangeField", () => {
-  it("renders a range input", () => {
-    renderWithForm(<RangeField name="volume" min={0} max={100} />);
-    expect(screen.getByRole("slider")).toBeInTheDocument();
+  it("renders a canonical number input as the labelled control", () => {
+    renderWithForm(
+      <RangeField name="volume" label="Volume" min={0} max={100} />,
+    );
+    const number = screen.getByLabelText("Volume");
+    expect(number).toHaveAttribute("type", "number");
+    expect(number).toHaveAttribute("name", "volume");
   });
 
-  it("registers with react-hook-form", () => {
-    renderWithForm(<RangeField name="volume" min={0} max={100} />);
-    expect(screen.getByRole("slider")).toHaveAttribute("name", "volume");
-  });
-
-  it("renders an output element", () => {
-    renderWithForm(<RangeField name="volume" min={0} max={100} />);
-    expect(screen.getByRole("status")).toBeInTheDocument();
-  });
-
-  it("respects min and max", () => {
-    renderWithForm(<RangeField name="volume" min={0} max={100} />);
+  it("renders a mirroring slider with its own aria-label (no name)", () => {
+    renderWithForm(
+      <RangeField name="volume" label="Volume" min={0} max={100} />,
+    );
     const slider = screen.getByRole("slider");
-    expect(slider).toHaveAttribute("min", "0");
-    expect(slider).toHaveAttribute("max", "100");
+    expect(slider).toHaveAttribute("aria-label");
+    // The slider must NOT carry the field name (it would double-submit).
+    expect(slider).not.toHaveAttribute("name");
+  });
+
+  it("forwards min/max/step to both controls", () => {
+    renderWithForm(
+      <RangeField name="volume" label="Volume" min={0} max={100} step={5} />,
+    );
+    for (const control of [
+      screen.getByLabelText("Volume"),
+      screen.getByRole("slider"),
+    ]) {
+      expect(control).toHaveAttribute("min", "0");
+      expect(control).toHaveAttribute("max", "100");
+      expect(control).toHaveAttribute("step", "5");
+    }
+  });
+
+  it("syncs slider → number (write-through) and registers a number", async () => {
+    const onSubmit = vi.fn();
+    function Host() {
+      const methods = useForm();
+      return (
+        <FormProvider {...methods}>
+          <form onSubmit={methods.handleSubmit(onSubmit)}>
+            <RangeField name="volume" label="Volume" min={0} max={100} />
+            <button type="submit">submit</button>
+          </form>
+        </FormProvider>
+      );
+    }
+    renderWithForm(<Host />);
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "42" } });
+    // The number input mirrors the slider.
+    expect(screen.getByLabelText("Volume")).toHaveValue(42);
+    fireEvent.click(screen.getByRole("button", { name: "submit" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const submitted = onSubmit.mock.calls[0][0] as { volume: unknown };
+    expect(submitted.volume).toBe(42);
+    expect(typeof submitted.volume).toBe("number");
+  });
+
+  it("syncs number → slider", () => {
+    renderWithForm(
+      <RangeField name="volume" label="Volume" min={0} max={100} />,
+    );
+    fireEvent.change(screen.getByLabelText("Volume"), {
+      target: { value: "73" },
+    });
+    expect(screen.getByRole("slider")).toHaveValue("73");
   });
 });

--- a/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tsx
@@ -1,12 +1,20 @@
 import bindField from "#lib/common/bindField/index.js";
 import withWrapper from "#lib/common/Wrapper/withWrapper.js";
-import { RangeInput } from "#lib/subcomponent/RangeInput/index.js";
+import { RangeControl } from "./common/index.js";
 import type { RangeFieldProps } from "./types.js";
 
 /**
- * RangeInput bound to react-hook-form. The live field value is injected into
- * the presentational `<output>` via bindField's `injectValue`.
+ * A numeric field offering both precise entry and a slider for one value.
+ *
+ * The CANONICAL control is the number input — it carries the field `name`/`id`,
+ * takes the react-hook-form binding, and is the target of the field's real
+ * `<label for>`. The slider is a JS-only mirror that writes through to it (see
+ * `RangeControl` for the full a11y / no-JS rationale; spec DE080).
+ * `valueAsNumber` so the registered value is a number, not the string the
+ * inputs report.
  */
 export default withWrapper<RangeFieldProps>(
-  bindField<RangeFieldProps>(RangeInput, "native", { injectValue: true }),
+  bindField<RangeFieldProps>(RangeControl, "native", {
+    registerDefaults: { valueAsNumber: true },
+  }),
 );

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/RangeControl.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/RangeControl.tsx
@@ -12,6 +12,17 @@ import "./styles.css";
 const componentCssClassName = "ds range-control";
 
 /**
+ * A range input can't represent "empty", so the slider mirror is clamped to a
+ * valid number — `min` when the source is blank/non-numeric/out of range.
+ * @returns {string} the clamped value as a string
+ */
+function clampToSlider(raw: string, min: number, max: number): string {
+  const n = Number.parseFloat(raw);
+  if (Number.isNaN(n)) return String(min);
+  return String(Math.min(Math.max(n, min), max));
+}
+
+/**
  * Presentational range control: a canonical NUMBER input paired with a slider
  * that mirrors it. Pure markup, no react-hook-form.
  *
@@ -50,7 +61,7 @@ export const RangeControl = forwardRef<HTMLInputElement, RangeControlProps>(
       min,
       max,
       step,
-      sliderLabel = "Slider",
+      sliderLabel,
       onChange,
       ...numberProps
     },
@@ -59,16 +70,24 @@ export const RangeControl = forwardRef<HTMLInputElement, RangeControlProps>(
     const numberRef = useRef<HTMLInputElement | null>(null);
     // Slider is client-only: no-JS users see just the canonical number input.
     const [mounted, setMounted] = useState(false);
+
     // Mirror of the current value used to drive the (controlled) slider.
+    const initial =
+      numberProps.value ?? numberProps.defaultValue ?? String(min);
     const [sliderValue, setSliderValue] = useState<string>(
-      numberProps.value != null
-        ? String(numberProps.value)
-        : numberProps.defaultValue != null
-          ? String(numberProps.defaultValue)
-          : "",
+      clampToSlider(String(initial), min, max),
     );
 
-    useEffect(() => setMounted(true), []);
+    // On mount, seed the slider from the number input's actual DOM value: in the
+    // react-hook-form `register()` path the initial value comes from RHF
+    // `defaultValues` applied to the node, which the props above don't see.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only sync — re-running on min/max changes would clobber the user's current value.
+    useEffect(() => {
+      setMounted(true);
+      if (numberRef.current?.value) {
+        setSliderValue(clampToSlider(numberRef.current.value, min, max));
+      }
+    }, []);
 
     // Compose the forwarded RHF ref with our local ref to the number input.
     const setNumberRef = (node: HTMLInputElement | null) => {
@@ -77,14 +96,20 @@ export const RangeControl = forwardRef<HTMLInputElement, RangeControlProps>(
       else if (ref) ref.current = node;
     };
 
+    // The slider's accessible name: explicit `sliderLabel`, else derived from the
+    // field `name` so multiple RangeFields aren't all just "Slider".
+    const resolvedSliderLabel =
+      sliderLabel ??
+      (numberProps.name ? `${numberProps.name} (slider)` : "Slider");
+
     const handleNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
-      setSliderValue(e.target.value);
+      setSliderValue(clampToSlider(e.target.value, min, max));
       onChange?.(e);
     };
 
     const handleSliderChange = (e: ChangeEvent<HTMLInputElement>) => {
       const next = e.target.value;
-      setSliderValue(next);
+      setSliderValue(clampToSlider(next, min, max));
       // Write through to the canonical number input so react-hook-form (bound to
       // it) sees the change: set the value via the native setter and dispatch a
       // real `input` event, which React/RHF listen for.
@@ -119,7 +144,7 @@ export const RangeControl = forwardRef<HTMLInputElement, RangeControlProps>(
           <input
             type="range"
             className="ds range range-slider"
-            aria-label={sliderLabel}
+            aria-label={resolvedSliderLabel}
             min={min}
             max={max}
             step={step}

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/RangeControl.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/RangeControl.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { NumberInput } from "#lib/subcomponent/NumberInput/index.js";
 import type { RangeControlProps } from "./types.js";
 import "./styles.css";
 
@@ -129,12 +130,16 @@ export const RangeControl = forwardRef<HTMLInputElement, RangeControlProps>(
         style={style}
         className={[componentCssClassName, className].filter(Boolean).join(" ")}
       >
-        <input
+        {/* Compose the real NumberInput (wrapper + inner <input class="p">) so
+            the number gets the exact chrome + baseline + inline-padding of every
+            other field, instead of a hand-rolled bare input. `id`/`ref` forward
+            to the inner <input> (the labelable, registered, write-through node);
+            `range-number` lands on the wrapper for sizing/order. */}
+        <NumberInput
           {...numberProps}
           id={id}
           ref={setNumberRef}
-          type="number"
-          className="ds input number chrome range-number p"
+          className="range-number"
           min={min}
           max={max}
           step={step}

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/RangeControl.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/RangeControl.tsx
@@ -1,0 +1,136 @@
+import {
+  type ChangeEvent,
+  forwardRef,
+  type ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import type { RangeControlProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds range-control";
+
+/**
+ * Presentational range control: a canonical NUMBER input paired with a slider
+ * that mirrors it. Pure markup, no react-hook-form.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS SHAPE (do NOT "simplify" without re-checking the a11y/no-JS contract)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Two visible controls drive ONE value. WCAG (SC 1.3.1 / 3.3.2 / 4.1.2): a
+ * `<label for>` can only associate with ONE input, so we do NOT try to make the
+ * slider and the number "share" a label. Instead:
+ *
+ *  - The NUMBER input is CANONICAL: it carries the field `name`/`id`, takes the
+ *    react-hook-form `register()` binding, and is the labelable target of the
+ *    field's real `<label for>` (1:1, programmatically correct). It is the
+ *    no-JS baseline — a user can type an exact value and submit it with scripts
+ *    disabled.
+ *  - The SLIDER is a JS-ONLY enhancement: it is mounted only after hydration
+ *    (`mounted` flag), so with no JS the user is shown ONLY the working number
+ *    input — never a dead/misleading slider that can't sync (there is no native,
+ *    no-JS way to keep two editable inputs in sync, nor to render a range's live
+ *    value as text). The slider carries no `name` (it must not double-submit)
+ *    and gets its own `aria-label` so screen-reader users can tell the two
+ *    controls apart.
+ *  - Sync: dragging the slider writes through to the number input by setting its
+ *    value via the native value setter and dispatching a real `input` event, so
+ *    react-hook-form (which is registered on the number input) observes the
+ *    change. The number input typing back-fills the slider via local state.
+ *
+ * See pragma-adrs N.04 / spec DE080. @returns {ReactElement}
+ */
+export const RangeControl = forwardRef<HTMLInputElement, RangeControlProps>(
+  function RangeControl(
+    {
+      id,
+      className,
+      style,
+      min,
+      max,
+      step,
+      sliderLabel = "Slider",
+      onChange,
+      ...numberProps
+    },
+    ref,
+  ): ReactElement {
+    const numberRef = useRef<HTMLInputElement | null>(null);
+    // Slider is client-only: no-JS users see just the canonical number input.
+    const [mounted, setMounted] = useState(false);
+    // Mirror of the current value used to drive the (controlled) slider.
+    const [sliderValue, setSliderValue] = useState<string>(
+      numberProps.value != null
+        ? String(numberProps.value)
+        : numberProps.defaultValue != null
+          ? String(numberProps.defaultValue)
+          : "",
+    );
+
+    useEffect(() => setMounted(true), []);
+
+    // Compose the forwarded RHF ref with our local ref to the number input.
+    const setNumberRef = (node: HTMLInputElement | null) => {
+      numberRef.current = node;
+      if (typeof ref === "function") ref(node);
+      else if (ref) ref.current = node;
+    };
+
+    const handleNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
+      setSliderValue(e.target.value);
+      onChange?.(e);
+    };
+
+    const handleSliderChange = (e: ChangeEvent<HTMLInputElement>) => {
+      const next = e.target.value;
+      setSliderValue(next);
+      // Write through to the canonical number input so react-hook-form (bound to
+      // it) sees the change: set the value via the native setter and dispatch a
+      // real `input` event, which React/RHF listen for.
+      const node = numberRef.current;
+      if (node) {
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          "value",
+        )?.set;
+        setter?.call(node, next);
+        node.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+    };
+
+    return (
+      <div
+        style={style}
+        className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      >
+        <input
+          {...numberProps}
+          id={id}
+          ref={setNumberRef}
+          type="number"
+          className="ds input number chrome range-number p"
+          min={min}
+          max={max}
+          step={step}
+          onChange={handleNumberChange}
+        />
+        {mounted && (
+          <input
+            type="range"
+            className="ds range range-slider"
+            aria-label={sliderLabel}
+            min={min}
+            max={max}
+            step={step}
+            value={sliderValue}
+            disabled={numberProps.disabled}
+            onChange={handleSliderChange}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+export default RangeControl;

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/index.ts
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/index.ts
@@ -1,0 +1,2 @@
+export { default as RangeControl } from "./RangeControl.js";
+export type { RangeControlProps } from "./types.js";

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/styles.css
@@ -11,14 +11,19 @@
   align-items: center;
   gap: var(--form-group-gap);
 
-  /* The number input reuses the text-input chrome; no spinner arrows — the
-   * slider is the coarse control, the number is for precise entry. Fixed,
-   * non-flexing width so the slider takes the slack, and ordered last so it
-   * paints at the inline-end. */
+  /* `.range-number` is the NumberInput WRAPPER (a <div>). Size/order the whole
+   * control here: fixed, non-flexing width so the slider takes the slack, and
+   * ordered last so it paints at the inline-end. */
   & > .range-number {
     order: 1;
     flex: 0 0 var(--form-range-number-width, 5rem);
     width: var(--form-range-number-width, 5rem);
+  }
+
+  /* Spinner removal targets the INNER <input> (the wrapper is a <div>, which
+   * has no spinner): the slider is the coarse control, the number is for
+   * precise entry, so no native steppers. */
+  & > .range-number > input {
     appearance: textfield;
     -moz-appearance: textfield;
 

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/styles.css
@@ -1,0 +1,24 @@
+/* A canonical number input stacked with its mirroring slider (the slider is
+ * appended on hydration). */
+.ds.range-control {
+  display: flex;
+  flex-direction: column;
+  gap: var(--form-group-gap);
+
+  /* The number input reuses the text-input chrome; no spinner arrows — the
+   * slider is the coarse control, the number is for precise entry. */
+  & > .range-number {
+    appearance: textfield;
+    -moz-appearance: textfield;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      appearance: none;
+      margin: 0;
+    }
+  }
+
+  & > .range-slider {
+    width: 100%;
+  }
+}

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/styles.css
@@ -1,13 +1,18 @@
-/* A canonical number input stacked with its mirroring slider (the slider is
- * appended on hydration). */
+/* A canonical number input beside its mirroring slider (the slider is appended
+ * on hydration). The number sits to the side at a fixed width for precise
+ * entry; the slider flexes to fill the remaining track. */
 .ds.range-control {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
   gap: var(--form-group-gap);
 
   /* The number input reuses the text-input chrome; no spinner arrows — the
-   * slider is the coarse control, the number is for precise entry. */
+   * slider is the coarse control, the number is for precise entry. Fixed,
+   * non-flexing width so the slider takes the slack. */
   & > .range-number {
+    flex: 0 0 var(--form-range-number-width, 5rem);
+    width: var(--form-range-number-width, 5rem);
     appearance: textfield;
     -moz-appearance: textfield;
 
@@ -18,7 +23,9 @@
     }
   }
 
+  /* The slider flexes to fill whatever space the number input leaves. */
   & > .range-slider {
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
   }
 }

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/styles.css
@@ -1,6 +1,10 @@
 /* A canonical number input beside its mirroring slider (the slider is appended
- * on hydration). The number sits to the side at a fixed width for precise
- * entry; the slider flexes to fill the remaining track. */
+ * on hydration). The number sits at the inline-END (right in LTR, left in RTL)
+ * at a fixed width for precise entry; the slider flexes to fill the rest.
+ *
+ * The number input is kept FIRST in the DOM (it is the canonical, labelled,
+ * no-JS control, so it must lead in source order); we move it visually to the
+ * inline-end with `order`, which follows the writing direction automatically. */
 .ds.range-control {
   display: flex;
   flex-direction: row;
@@ -9,8 +13,10 @@
 
   /* The number input reuses the text-input chrome; no spinner arrows — the
    * slider is the coarse control, the number is for precise entry. Fixed,
-   * non-flexing width so the slider takes the slack. */
+   * non-flexing width so the slider takes the slack, and ordered last so it
+   * paints at the inline-end. */
   & > .range-number {
+    order: 1;
     flex: 0 0 var(--form-range-number-width, 5rem);
     width: var(--form-range-number-width, 5rem);
     appearance: textfield;

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/types.ts
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/types.ts
@@ -1,0 +1,16 @@
+import type React from "react";
+
+type NativeInputAttrs = React.InputHTMLAttributes<HTMLInputElement>;
+
+/**
+ * Props for the presentational Range control (no react-hook-form). The field
+ * tier binds the NUMBER input (the canonical, registered control) by spreading
+ * react-hook-form's `register()` result here; the slider is a JS-only mirror.
+ */
+export type RangeControlProps = NativeInputAttrs & {
+  /**
+   * Accessible label for the slider sub-control. The visible field label is on
+   * the number input (the canonical control); the slider needs its own name.
+   */
+  sliderLabel?: string;
+};

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/types.ts
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/types.ts
@@ -1,6 +1,9 @@
 import type React from "react";
 
-type NativeInputAttrs = React.InputHTMLAttributes<HTMLInputElement>;
+type NativeInputAttrs = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "min" | "max"
+>;
 
 /**
  * Props for the presentational Range control (no react-hook-form). The field
@@ -9,8 +12,20 @@ type NativeInputAttrs = React.InputHTMLAttributes<HTMLInputElement>;
  */
 export type RangeControlProps = NativeInputAttrs & {
   /**
+   * Lower bound, required as a number. Both the number input and the slider
+   * share it, so the two controls represent the same range (an omitted `min`
+   * would leave the number unbounded while the slider fell back to 0).
+   */
+  min: number;
+
+  /** Upper bound, required as a number — shared by both controls (see {@link min}). */
+  max: number;
+
+  /**
    * Accessible label for the slider sub-control. The visible field label is on
-   * the number input (the canonical control); the slider needs its own name.
+   * the number input (the canonical control); the slider needs its own name so
+   * assistive tech can tell sliders apart across a form. Defaults to a name
+   * derived from the field `name` (e.g. `"volume (slider)"`).
    */
   sliderLabel?: string;
 };

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/index.ts
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./RangeControl/index.js";

--- a/packages/react/ds-global-form/src/lib/component/RangeField/types.ts
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/types.ts
@@ -1,5 +1,5 @@
 import type { InputProps } from "#lib/common/types.js";
-import type { RangeInputProps } from "#lib/subcomponent/RangeInput/index.js";
+import type { RangeControlProps } from "./common/index.js";
 
-/** Props for the react-hook-form-bound Range field. */
-export type RangeFieldProps = InputProps<RangeInputProps>;
+/** Props for the react-hook-form-bound Range field (number + synced slider). */
+export type RangeFieldProps = InputProps<RangeControlProps>;

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
@@ -1,7 +1,9 @@
 .ds.form-checkbox {
   appearance: none;
   box-sizing: border-box;
-  margin-inline: var(--form-input-padding-inline);
+  /* Align to the field edge like the label (no side margin by default), not to
+   * the input's inner padding. Overridable via the shared variable. */
+  margin-inline: var(--form-label-padding-inline, 0);
   width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
   height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
   border: var(--dimension-stroke-thickness-medium) solid var(--color-border);

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateInput/styles.css
@@ -4,6 +4,10 @@
  */
 
 .ds.input.date {
+  /* This element IS the text-bearing leaf, so it carries the inline padding
+   * (`.ds.input.chrome` provides only the block padding). */
+  padding-inline: var(--form-input-padding-inline);
+
   /* Suppress native calendar picker inconsistencies across browsers */
   &::-webkit-inner-spin-button {
     display: none;

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/styles.css
@@ -4,6 +4,10 @@
  */
 
 .ds.input.datetime {
+  /* This element IS the text-bearing leaf, so it carries the inline padding
+   * (`.ds.input.chrome` provides only the block padding). */
+  padding-inline: var(--form-input-padding-inline);
+
   /* Suppress native calendar/clock picker inconsistencies across browsers */
   &::-webkit-inner-spin-button {
     display: none;

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Description/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Description/styles.css
@@ -1,4 +1,6 @@
 .ds.field-description {
   color: var(--form-description-color);
-  padding-inline: var(--form-input-padding-inline);
+  /* Align to the field edge like the label (no side padding by default), not
+   * to the input's inner padding. Overridable via the shared variable. */
+  padding-inline: var(--form-label-padding-inline, 0);
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Error/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Error/styles.css
@@ -1,4 +1,6 @@
 .ds.field-error {
   color: var(--form-error-color);
-  padding-inline: var(--form-input-padding-inline);
+  /* Align to the field edge like the label (no side padding by default), not
+   * to the input's inner padding. Overridable via the shared variable. */
+  padding-inline: var(--form-label-padding-inline, 0);
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/styles.css
@@ -1,26 +1,40 @@
 .ds.range {
   appearance: none;
   width: 100%;
-  height: var(--space-baseline); /* 8px — 1bU */
-  background: var(--color-foreground-slider-track);
-  /* The bar is a flat track, no outline — strip the UA border that some
-   * engines keep on a range input even after `appearance: none`. */
+  /* Element box is as tall as the THUMB (16px), so the thumb and its focus
+   * ring are never clipped in a flex row; the visible 8px track is painted by
+   * the track pseudo-elements below, vertically centred within this box. */
+  height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+  background: transparent;
   border: none;
-  border-radius: var(--dimension-radius-small);
   outline: none;
   cursor: pointer;
 
-  /* Firefox draws the track via its own pseudo-element, which carries its own
-   * UA border — zero it so the track matches the flat WebKit rendering. */
-  &::-moz-range-track {
+  /* WebKit/Chromium paints the bar via this pseudo-element, which keeps a UA
+   * border even after `appearance: none` on the element — THIS is the visible
+   * border. Style the track here: flat, no border, 8px tall. */
+  &::-webkit-slider-runnable-track {
+    height: var(--space-baseline); /* 8px — 1bU */
+    background: var(--color-foreground-slider-track);
     border: none;
-    background: transparent;
+    border-radius: var(--dimension-radius-small);
+  }
+
+  /* Firefox draws the track via its own pseudo-element with its own UA border —
+   * zero it and paint the flat track here to match WebKit. */
+  &::-moz-range-track {
+    height: var(--space-baseline); /* 8px — 1bU */
+    background: var(--color-foreground-slider-track);
+    border: none;
+    border-radius: var(--dimension-radius-small);
   }
 
   &::-webkit-slider-thumb {
     appearance: none;
     width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
     height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+    /* Re-centre the 16px thumb on the 8px runnable-track: (8 − 16) / 2 = −4px. */
+    margin-top: calc((var(--space-baseline) - var(--space-baseline) * 2) / 2);
     border-radius: 50%;
     background: var(--color-foreground-slider-progress);
     border: none;
@@ -49,8 +63,16 @@
   }
 
   &:disabled {
-    background: var(--color-foreground-slider-track-disabled);
     cursor: not-allowed;
+
+    /* Track colour lives on the pseudo-elements (the element box is transparent). */
+    &::-webkit-slider-runnable-track {
+      background: var(--color-foreground-slider-track-disabled);
+    }
+
+    &::-moz-range-track {
+      background: var(--color-foreground-slider-track-disabled);
+    }
 
     &::-webkit-slider-thumb {
       background: var(--color-foreground-slider-progress-disabled);

--- a/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/styles.css
@@ -3,9 +3,19 @@
   width: 100%;
   height: var(--space-baseline); /* 8px — 1bU */
   background: var(--color-foreground-slider-track);
+  /* The bar is a flat track, no outline — strip the UA border that some
+   * engines keep on a range input even after `appearance: none`. */
+  border: none;
   border-radius: var(--dimension-radius-small);
   outline: none;
   cursor: pointer;
+
+  /* Firefox draws the track via its own pseudo-element, which carries its own
+   * UA border — zero it so the track matches the flat WebKit rendering. */
+  &::-moz-range-track {
+    border: none;
+    background: transparent;
+  }
 
   &::-webkit-slider-thumb {
     appearance: none;

--- a/packages/react/ds-global-form/src/lib/subcomponent/SelectInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SelectInput/styles.css
@@ -5,5 +5,9 @@
   background-repeat: no-repeat;
   background-position: right var(--form-input-padding-inline) center;
   background-size: 1em;
+  /* This element IS the text-bearing leaf, so it carries the inline padding
+   * (`.ds.input.chrome` provides only the block padding). The end side leaves
+   * room for the chevron. */
+  padding-inline-start: var(--form-input-padding-inline);
   padding-inline-end: calc(var(--form-input-padding-inline) * 2 + 1em);
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/styles.css
@@ -1,4 +1,8 @@
 .ds.input.textarea {
+  /* This element IS the text-bearing leaf, so it carries the inline padding
+   * (`.ds.input.chrome` provides only the block padding). */
+  padding-inline: var(--form-input-padding-inline);
+
   /* Combine chrome padding with baseline engine nudges */
   padding-block-start: calc(
     var(--form-input-padding-block) +

--- a/packages/react/ds-global-form/src/lib/subcomponent/TimeInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TimeInput/styles.css
@@ -4,6 +4,10 @@
  */
 
 .ds.input.time {
+  /* This element IS the text-bearing leaf, so it carries the inline padding
+   * (`.ds.input.chrome` provides only the block padding). */
+  padding-inline: var(--form-input-padding-inline);
+
   /* Suppress native clock picker inconsistencies across browsers */
   &::-webkit-inner-spin-button {
     display: none;


### PR DESCRIPTION
## Done

**RangeField gains a slider synced with a canonical number input** (per spec **DE080**). One value, two controls, accessible and no-JS-safe. **Stacked on #703.**

The composite lives at `component/RangeField/common/RangeControl/`:

- **Number input is canonical** — carries the field `name`/`id`, takes the react-hook-form binding, and is the target of the field's **real `<label for>`** (1:1, programmatically correct — no fieldset/legend gymnastics). It's the **no-JS baseline**: a user can type an exact value and submit it with scripts off. `valueAsNumber` so the registered value is a number.
- **Slider is a JS-only mirror** — mounted only after hydration, so a no-JS user sees **only the working number input** (never a dead/unsyncable slider). It carries **no `name`** (must not double-submit) and has its own `aria-label`. Dragging writes through to the number input (native value setter + dispatched `input` event → RHF observes it); typing in the number back-fills the slider.
- A **clear in-code rationale block** documents the WCAG basis (SC 1.3.1 / 3.3.2 / 4.1.2) and the no-JS contract, so the structure isn't "simplified" into an inaccessible form later.

> Why number-canonical (not the slider, not a fieldset+legend of co-equal inputs): a `<label for>` binds 1:1, so with the number as the single canonical control the real field label associates correctly and the slider is a pure enhancement. There is no native, no-JS way to keep two editable inputs in sync or to render a range's live value as text — hence the slider is JS-only and the number is the floor.

The pure `RangeInput` subcomponent (slider + `<output>`) is **unchanged** and remains available standalone.

## QA

- `bun run check:ts` clean; `bun run test` → 59 files / 213 pass / 1 skip / 4 todo (+5: canonical number labelled control, slider mirror w/ aria-label & no name, min/max/step on both, slider→number write-through registering a **number**, number→slider sync); `bun run check` passes; `build:storybook` succeeds.

### PR readiness check
- [x] Label **`Feature 🎁`**.
- [x] Conventional Commits title; code standards (CS.NAMING.1, `#lib`, barrel-only index); required scripts; no new package.
- [ ] Visual change — new RangeField composite (number + slider) — Chromatic should review.

## Screenshots
_Stories: Default, Stepped, CustomSliderLabel — number input + synced slider._
