### PR TITLE
feat(ds-global-form): required/optional marking, checkbox checkmark colour, choices columns

### DIFF
--- a/packages/react/ds-global-form/src/index.css
+++ b/packages/react/ds-global-form/src/index.css
@@ -104,6 +104,11 @@
   --form-label-color: var(--color-text);
   /* --form-label-padding-block:  … ; */ /* block padding for label  */
   /* --form-label-padding-inline: … ; */ /* inline padding for label */
+  /* Required marker (shown before the label of required fields in the default
+   * "required" indicator mode): */
+  /* --form-required-marker:       "*";                    */ /* marker glyph    */
+  /* --form-required-marker-gap:   0.25ch;                 */ /* gap after marker*/
+  /* --form-required-marker-color: var(--form-label-color);*/ /* marker colour   */
 
   /* ── Description ────────────────────────────────────────────────── */
 

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/Wrapper.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/Wrapper.tests.tsx
@@ -16,8 +16,15 @@ describe("withWrapper", () => {
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
-  it("renders the optional indicator", () => {
-    renderWithForm(<Text name="email" label="Email" isOptional />);
+  it("renders the optional indicator in optional-marking mode", () => {
+    renderWithForm(
+      <Text
+        name="email"
+        label="Email"
+        isOptional
+        requiredIndicator="optional"
+      />,
+    );
     expect(screen.getByText(/optional/)).toBeInTheDocument();
   });
 

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/Wrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/Wrapper.tsx
@@ -27,6 +27,7 @@ const Wrapper = <ComponentProps extends BaseInputProps>({
   description,
   label,
   isOptional,
+  requiredIndicator,
   registerProps: userRegisterProps,
   nestedRegisterProps,
   unregisterOnUnmount,
@@ -67,6 +68,7 @@ const Wrapper = <ComponentProps extends BaseInputProps>({
       <Label
         name={name}
         isOptional={isOptional}
+        requiredIndicator={requiredIndicator}
         tag={mockLabel ? "legend" : undefined}
         {...ariaProps.label}
       >

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/hooks/useFieldWrapper.ts
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/hooks/useFieldWrapper.ts
@@ -36,7 +36,9 @@ const useFieldWrapper = (
 
   const isError = !!fieldError;
 
-  const ariaProps = useFieldAriaProperties(name, isError);
+  // Optionality is the source of truth for required-ness (see `registerProps`
+  // below, which maps `!isOptional` to RHF's `required` rule).
+  const ariaProps = useFieldAriaProperties(name, isError, !isOptional);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Comparing the `name` suffices
   const registerProps = useMemo(() => {

--- a/packages/react/ds-global-form/src/lib/common/types.ts
+++ b/packages/react/ds-global-form/src/lib/common/types.ts
@@ -1,5 +1,6 @@
 import type React from "react";
 import type { RegisterOptions } from "react-hook-form";
+import type { RequiredIndicator } from "#lib/subcomponent/Field/Label/types.js";
 import type { BaseProps } from "#lib/subcomponent/types.js";
 
 // Field-composition machinery types, shared by `Wrapper` and `bindField` and by
@@ -36,6 +37,10 @@ export type WrapperProps<ComponentProps> = BaseWrapperProps<ComponentProps> & {
 
   /* Is the field optional */
   isOptional?: boolean;
+
+  /* Which convention marks required/optional fields in the label. Default:
+   * "required" (a "*" marker before the label of required fields). */
+  requiredIndicator?: RequiredIndicator;
 
   /* TODO */
   nestedRegisterProps?: RegisterOptions;

--- a/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.stories.tsx
@@ -25,22 +25,61 @@ export const Checked: Story = {
   args: { name: "subscribe_checked", label: "Checked" },
 };
 
-const IndeterminateHelper = () => {
+/**
+ * `indeterminate` is a DOM property (not an attribute), so it can't be passed
+ * as a prop — the helper sets it on the rendered input by `name` after mount.
+ */
+const IndeterminateField = ({
+  name,
+  label,
+  disabled,
+}: {
+  name: string;
+  label: string;
+  disabled?: boolean;
+}) => {
   useEffect(() => {
     const el = document.querySelector<HTMLInputElement>(
-      'input[name="subscribe_indeterminate"]',
+      `input[name="${name}"]`,
     );
     if (el) el.indeterminate = true;
-  }, []);
-  return <CheckboxField name="subscribe_indeterminate" label="Indeterminate" />;
+  }, [name]);
+  return <CheckboxField name={name} label={label} disabled={disabled} />;
 };
 
 export const Indeterminate: Story = {
   args: { name: "subscribe_indeterminate", label: "Indeterminate" },
   decorators: [decorators.form({ touchedFields: ["subscribe_indeterminate"] })],
-  render: () => <IndeterminateHelper />,
+  render: () => (
+    <IndeterminateField name="subscribe_indeterminate" label="Indeterminate" />
+  ),
 };
 
 export const Disabled: Story = {
   args: { name: "subscribe_disabled", label: "Disabled", disabled: true },
+};
+
+export const DisabledChecked: Story = {
+  decorators: [
+    decorators.form({ defaultValues: { subscribe_disabled_checked: true } }),
+  ],
+  args: {
+    name: "subscribe_disabled_checked",
+    label: "Disabled checked",
+    disabled: true,
+  },
+};
+
+export const DisabledIndeterminate: Story = {
+  args: { name: "subscribe_disabled_indeterminate", label: "Disabled" },
+  decorators: [
+    decorators.form({ touchedFields: ["subscribe_disabled_indeterminate"] }),
+  ],
+  render: () => (
+    <IndeterminateField
+      name="subscribe_disabled_indeterminate"
+      label="Disabled indeterminate"
+      disabled
+    />
+  ),
 };

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/ChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/ChoicesField.stories.tsx
@@ -4,12 +4,14 @@ import * as decorators from "storybook/decorators.js";
 import { ChoicesField } from "./index.js";
 
 // Field-tier stories run inside a form decorator (label/description/error +
-// react-hook-form state).
+// react-hook-form state). The grid decorator nests the form in a
+// `.grid.responsive`, so the form's subgrid has real column tracks for the
+// option cards to span via `--choices-span`.
 const meta = {
   title: "components/ChoicesField",
   component: ChoicesField,
   tags: ["autodocs"],
-  decorators: [decorators.form()],
+  decorators: [decorators.grid(), decorators.form()],
 } satisfies Meta<typeof ChoicesField>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/component/PhoneField/PhoneField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/PhoneField/PhoneField.stories.tsx
@@ -46,6 +46,21 @@ export const FlagDisplay: Story = {
   },
 };
 
+/**
+ * Opt into live display masking with `mask`: the national number is formatted
+ * with the selected country's mask as you type (here US `(###) ###-####`). The
+ * mask is cosmetic only — the submitted value is always raw digits, regardless
+ * of `mask`.
+ */
+export const Masked: Story = {
+  args: {
+    name: "phone_masked",
+    label: "Phone (masked)",
+    defaultCountry: "US",
+    mask: true,
+  },
+};
+
 export const Disabled: Story = {
   args: { name: "phone_disabled", label: "Phone (disabled)", disabled: true },
 };

--- a/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/SimpleChoices.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/SimpleChoices.tsx
@@ -21,16 +21,27 @@ export const SimpleChoices = ({
   isMultiple = false,
   disabled = false,
   layout = "inline",
+  columns,
   options,
   value,
   onChange,
 }: SimpleChoicesPresentationProps): React.ReactElement => {
   const type = isMultiple ? "checkbox" : "radio";
 
+  // In the "columns" layout the column count drives a CSS grid; the variable is
+  // unused (and so left unset) in the other layouts.
+  const layoutStyle =
+    layout === "columns" && columns
+      ? ({
+          ...style,
+          "--simple-choices-columns": columns,
+        } as React.CSSProperties)
+      : style;
+
   return (
     <fieldset
       id={id}
-      style={style}
+      style={layoutStyle}
       className={[componentCssClassName, layout, className]
         .filter(Boolean)
         .join(" ")}

--- a/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/SimpleChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/SimpleChoicesField.stories.tsx
@@ -54,9 +54,12 @@ export const StackedMultiple: Story = {
 
 /**
  * Column layout: options are laid out in a grid of equal-width columns, so each
- * option's width is column-based rather than sized to its content.
+ * option's width is column-based rather than sized to its content. Rendered in a
+ * `.grid.responsive` context (via the grid decorator) so the form's subgrid has
+ * real column tracks — matching how a form is laid out in a real page.
  */
 export const Columns: Story = {
+  decorators: [decorators.grid(), decorators.form()],
   args: {
     name: "select_columns",
     label: "Select a continent",
@@ -67,6 +70,7 @@ export const Columns: Story = {
 };
 
 export const ColumnsMultiple: Story = {
+  decorators: [decorators.grid(), decorators.form()],
   args: {
     name: "select_columns_multiple",
     label: "Select continents",

--- a/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/SimpleChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/SimpleChoicesField.stories.tsx
@@ -51,3 +51,28 @@ export const StackedMultiple: Story = {
     layout: "stacked",
   },
 };
+
+/**
+ * Column layout: options are laid out in a grid of equal-width columns, so each
+ * option's width is column-based rather than sized to its content.
+ */
+export const Columns: Story = {
+  args: {
+    name: "select_columns",
+    label: "Select a continent",
+    options: fixtures.continents,
+    layout: "columns",
+    columns: 3,
+  },
+};
+
+export const ColumnsMultiple: Story = {
+  args: {
+    name: "select_columns_multiple",
+    label: "Select continents",
+    options: fixtures.continents,
+    isMultiple: true,
+    layout: "columns",
+    columns: 2,
+  },
+};

--- a/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/styles.css
@@ -80,6 +80,7 @@
     & > input[type="checkbox"] {
       appearance: none;
       box-sizing: border-box;
+      position: relative;
       width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
       height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
       border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
@@ -90,13 +91,30 @@
         background-color 150ms ease,
         border-color 150ms ease;
 
+      /* Glyph as a masked pseudo-element so it takes the checkmark token
+       * (see CheckboxInput); the colour+mask live together under :checked so
+       * the unchecked box never paints a solid square. */
+      &::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        mask-repeat: no-repeat;
+        mask-position: center;
+        mask-size: 75%;
+        -webkit-mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        -webkit-mask-size: 75%;
+      }
+
       &:checked {
         background: var(--color-foreground-checkbox-selected);
         border-color: var(--color-foreground-checkbox-selected);
-        background-image: url("/icons/checkmark.svg#checkmark");
-        background-repeat: no-repeat;
-        background-position: center;
-        background-size: 75%;
+
+        &::before {
+          background-color: var(--color-foreground-checkbox-checkmark);
+          mask-image: url("/icons/checkmark.svg#checkmark");
+          -webkit-mask-image: url("/icons/checkmark.svg#checkmark");
+        }
       }
 
       &:hover:not(:disabled):not(:checked) {

--- a/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/styles.css
@@ -135,6 +135,18 @@
         border-color: var(--color-border-disabled);
         background-color: var(--color-foreground-checkbox-unselected-disabled);
       }
+
+      /* A checked+disabled box must keep the SELECTED (not unselected) disabled
+       * fill — the generic `:disabled` above would otherwise leave the checkmark
+       * on the unselected-disabled background. Matches CheckboxInput. */
+      &:checked:disabled {
+        background: var(--color-foreground-checkbox-selected-disabled);
+        border-color: var(--color-foreground-checkbox-selected-disabled);
+
+        &::before {
+          background-color: var(--color-foreground-checkbox-checkmark-disabled);
+        }
+      }
     }
   }
 }

--- a/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/styles.css
@@ -13,6 +13,15 @@
     flex-wrap: nowrap;
   }
 
+  /* Columns: a grid of equal-width columns. Each option fills its cell, so the
+   * option WIDTH is column-based rather than content-based. The column count
+   * comes from `--simple-choices-columns` (set from the `columns` prop). */
+  &.columns {
+    display: grid;
+    grid-template-columns: repeat(var(--simple-choices-columns, 2), 1fr);
+    gap: var(--form-group-gap) var(--container-gap-loose);
+  }
+
   /* Each option (common/Option, `.ds.option`) is styled here, scoped to this
    * group so the generic class cannot collide with options elsewhere. */
   & > .ds.option {

--- a/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/types.ts
+++ b/packages/react/ds-global-form/src/lib/component/SimpleChoicesField/types.ts
@@ -13,8 +13,19 @@ type AdditionalSimpleChoicesProps = OptionsProps & {
   /** Whether the input is disabled */
   disabled?: boolean;
 
-  /** Layout: "inline" wraps options horizontally, "stacked" puts each on its own line */
-  layout?: "inline" | "stacked";
+  /**
+   * Layout of the option group:
+   *  - "inline" (default): options wrap horizontally, each as wide as its content
+   *  - "stacked": one option per line
+   *  - "columns": a grid of equal-width columns (see {@link columns})
+   */
+  layout?: "inline" | "stacked" | "columns";
+
+  /**
+   * Number of equal-width columns when `layout="columns"`. Defaults to 2.
+   * Ignored in the other layouts.
+   */
+  columns?: number;
 
   /** Selected value (string for radios, string[] for checkboxes) */
   value?: string | string[];

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
@@ -140,7 +140,7 @@ export const ConditionalDisplay: Story = {
         name: "company",
         inputType: "text",
         label: "Company",
-        optional: true,
+        isOptional: true,
         condition: [
           ["email"],
           (values: string[]) => {

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
@@ -55,6 +55,49 @@ export const WithValidation: Story = {
   },
 };
 
+/**
+ * Default "required" marking: required fields get a "*" before the label (the
+ * marker is a CSS pseudo-element, so it stays out of the accessible name; the
+ * input carries `aria-required`).
+ */
+export const Required: Story = {
+  args: {
+    name: "required_field",
+    inputType: "text",
+    label: "Display name",
+  },
+};
+
+/**
+ * "optional" marking: the convention flips — optional fields are tagged
+ * "(optional)" after the label, and required fields are left unmarked.
+ */
+export const OptionalMarked: Story = {
+  args: {
+    name: "optional_field",
+    inputType: "text",
+    label: "Nickname",
+    isOptional: true,
+    requiredIndicator: "optional",
+  },
+};
+
+/**
+ * Error state: a required field that has been touched and left empty shows the
+ * field-error message and the `.danger` chrome (red border / focus ring).
+ */
+export const WithError: Story = {
+  decorators: [decorators.form({ touchedFields: ["email"] })],
+  args: {
+    name: "email",
+    inputType: "text",
+    label: "Email",
+    registerProps: {
+      required: { value: true, message: "Email is required" },
+    },
+  },
+};
+
 export const TypeTextarea: Story = {
   args: {
     name: "content",

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/CheckboxInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/CheckboxInput.stories.tsx
@@ -20,6 +20,44 @@ export const Checked: Story = {
   args: { name: "subscribe_checked", defaultChecked: true },
 };
 
+/**
+ * The indeterminate ("partially checked") state shows a minus glyph. It is a
+ * DOM property, not an attribute, so it can only be set on the element via a
+ * ref — there is no `indeterminate` prop to pass.
+ */
+export const Indeterminate: Story = {
+  args: { name: "subscribe_indeterminate" },
+  render: (args) => (
+    <CheckboxInput
+      {...args}
+      ref={(el) => {
+        if (el) el.indeterminate = true;
+      }}
+    />
+  ),
+};
+
 export const Disabled: Story = {
   args: { name: "subscribe_disabled", disabled: true },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    name: "subscribe_disabled_checked",
+    disabled: true,
+    defaultChecked: true,
+  },
+};
+
+/** The indeterminate glyph in the disabled state. */
+export const DisabledIndeterminate: Story = {
+  args: { name: "subscribe_disabled_indeterminate", disabled: true },
+  render: (args) => (
+    <CheckboxInput
+      {...args}
+      ref={(el) => {
+        if (el) el.indeterminate = true;
+      }}
+    />
+  ),
 };

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
@@ -1,6 +1,8 @@
 .ds.form-checkbox {
   appearance: none;
   box-sizing: border-box;
+  /* Positioning context for the masked checkmark/minus glyph (`::before`). */
+  position: relative;
   /* Align to the field edge like the label (no side margin by default), not to
    * the input's inner padding. Overridable via the shared variable. */
   margin-inline: var(--form-label-padding-inline, 0);
@@ -14,22 +16,44 @@
     background-color 150ms ease,
     border-color 150ms ease;
 
+  /* The glyph is a masked pseudo-element layered over the box, NOT a
+   * background-image: a background-image SVG can't be recoloured by CSS, so the
+   * checkmark would ignore the theme. Masking + `background-color` lets the
+   * glyph take the checkmark token (same technique as PasswordInput's eye
+   * icon). The box keeps its own `background` for the selected fill. */
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-color: var(--color-foreground-checkbox-checkmark);
+    mask-repeat: no-repeat;
+    mask-position: center;
+    mask-size: 75%;
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    -webkit-mask-size: 75%;
+  }
+
   &:checked {
+    position: relative;
     background: var(--color-foreground-checkbox-selected);
     border-color: var(--color-foreground-checkbox-selected);
-    background-image: url("/icons/checkmark.svg#checkmark");
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: 75%;
+
+    &::before {
+      mask-image: url("/icons/checkmark.svg#checkmark");
+      -webkit-mask-image: url("/icons/checkmark.svg#checkmark");
+    }
   }
 
   &:indeterminate {
+    position: relative;
     background: var(--color-foreground-checkbox-selected);
     border-color: var(--color-foreground-checkbox-selected);
-    background-image: url("/icons/minus.svg#minus");
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: 75%;
+
+    &::before {
+      mask-image: url("/icons/minus.svg#minus");
+      -webkit-mask-image: url("/icons/minus.svg#minus");
+    }
   }
 
   &:hover:not(:disabled):not(:checked):not(:indeterminate) {
@@ -62,5 +86,9 @@
   &:indeterminate:disabled {
     background: var(--color-foreground-checkbox-selected-disabled);
     border-color: var(--color-foreground-checkbox-selected-disabled);
+
+    &::before {
+      background-color: var(--color-foreground-checkbox-checkmark-disabled);
+    }
   }
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
@@ -20,12 +20,18 @@
    * background-image: a background-image SVG can't be recoloured by CSS, so the
    * checkmark would ignore the theme. Masking + `background-color` lets the
    * glyph take the checkmark token (same technique as PasswordInput's eye
-   * icon). The box keeps its own `background` for the selected fill. */
+   * icon). The box keeps its own `background` for the selected fill.
+   *
+   * IMPORTANT: only the :checked / :indeterminate rules give the ::before a
+   * `mask-image` AND a `background-color`. The base ::before sets geometry only
+   * — with no mask-image the mask is `none`, which means NO clipping, so a
+   * `background-color` here would paint the WHOLE box as a solid square in the
+   * unchecked state (visible under any theme where the checkmark colour differs
+   * from the box). So the paint lives with the mask, never on its own. */
   &::before {
     content: "";
     position: absolute;
     inset: 0;
-    background-color: var(--color-foreground-checkbox-checkmark);
     mask-repeat: no-repeat;
     mask-position: center;
     mask-size: 75%;
@@ -40,6 +46,7 @@
     border-color: var(--color-foreground-checkbox-selected);
 
     &::before {
+      background-color: var(--color-foreground-checkbox-checkmark);
       mask-image: url("/icons/checkmark.svg#checkmark");
       -webkit-mask-image: url("/icons/checkmark.svg#checkmark");
     }
@@ -51,6 +58,7 @@
     border-color: var(--color-foreground-checkbox-selected);
 
     &::before {
+      background-color: var(--color-foreground-checkbox-checkmark);
       mask-image: url("/icons/minus.svg#minus");
       -webkit-mask-image: url("/icons/minus.svg#minus");
     }

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.stories.tsx
@@ -23,6 +23,10 @@ export default meta;
 */
 type Story = StoryObj<typeof meta>;
 
+/**
+ * Default ("required") marking: a required field gets a "*" marker before the
+ * label, drawn as a CSS pseudo-element so it never enters the accessible name.
+ */
 export const Default: Story = {
   args: {
     name: "email",
@@ -30,11 +34,28 @@ export const Default: Story = {
   },
 };
 
-export const Optional: Story = {
+/**
+ * In the default ("required") mode an optional field carries no marker at all —
+ * only the required ones are tagged.
+ */
+export const OptionalNoMarker: Story = {
   args: {
     name: "name",
     children: "What is your name ?",
     isOptional: true,
+  },
+};
+
+/**
+ * The alternate ("optional") convention: optional fields are tagged
+ * "(optional)" after the label, required ones are left unmarked.
+ */
+export const OptionalMarked: Story = {
+  args: {
+    name: "name",
+    children: "What is your name ?",
+    isOptional: true,
+    requiredIndicator: "optional",
   },
 };
 

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tests.tsx
@@ -18,4 +18,46 @@ describe("Label component", () => {
     );
     expect(screen.getByText("Email")).toHaveClass("test-class");
   });
+
+  it("marks required fields (default mode) via data-required, not label text", () => {
+    render(<Component name="Email">Email</Component>);
+    const label = screen.getByText("Email");
+    // The "*" is a CSS ::before, so the accessible/queryable text is unchanged.
+    expect(label).toHaveAttribute("data-required");
+    expect(label).toHaveTextContent("Email");
+  });
+
+  it("does NOT mark optional fields in the default (required) mode", () => {
+    render(
+      <Component name="Email" isOptional>
+        Email
+      </Component>,
+    );
+    const label = screen.getByText("Email");
+    expect(label).not.toHaveAttribute("data-required");
+    expect(label).not.toHaveTextContent(/optional/i);
+  });
+
+  it("shows the (optional) suffix only in optional-marking mode", () => {
+    render(
+      <Component name="Email" isOptional requiredIndicator="optional">
+        Email
+      </Component>,
+    );
+    const label = screen.getByText(/Email/);
+    // No required marker in optional mode; the suffix is real, queryable text.
+    expect(label).not.toHaveAttribute("data-required");
+    expect(label).toHaveTextContent(/optional/i);
+  });
+
+  it("does not mark a required field in optional-marking mode", () => {
+    render(
+      <Component name="Email" requiredIndicator="optional">
+        Email
+      </Component>,
+    );
+    const label = screen.getByText("Email");
+    expect(label).not.toHaveAttribute("data-required");
+    expect(label).not.toHaveTextContent(/optional/i);
+  });
 });

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tsx
@@ -47,7 +47,9 @@ const Label = ({
         .join(" ")}
     >
       {children || name}
-      {showOptionalSuffix && <span> ({messages.optional()})</span>}
+      {showOptionalSuffix && (
+        <span className="optional"> ({messages.optional()})</span>
+      )}
     </Element>
   );
 };

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tsx
@@ -21,21 +21,33 @@ const Label = ({
   style,
   name,
   isOptional,
+  requiredIndicator = "required",
   messages = defaultMessages,
   htmlFor,
   tag: Element = "label",
 }: LabelProps): React.ReactElement => {
+  // "required" mode marks the required fields, "optional" marks the optional
+  // ones. The required marker (default "*") is drawn as a CSS `::before`
+  // pseudo-element keyed off `data-required`, NOT as text: that keeps it out of
+  // the label's accessible name (a screen reader would otherwise announce
+  // "asterisk Email" \u2014 the required state is conveyed by `aria-required` on the
+  // input instead). The "(optional)" suffix IS real text, since it's
+  // informational and belongs in the accessible name.
+  const markRequired = requiredIndicator === "required" && !isOptional;
+  const showOptionalSuffix = requiredIndicator === "optional" && isOptional;
+
   return (
     <Element
       id={id}
       style={style}
       htmlFor={Element === "label" ? htmlFor : undefined}
+      data-required={markRequired || undefined}
       className={[componentCssClassName, "p", className]
         .filter(Boolean)
         .join(" ")}
     >
       {children || name}
-      {isOptional && <span> ({messages.optional()})</span>}
+      {showOptionalSuffix && <span> ({messages.optional()})</span>}
     </Element>
   );
 };

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/styles.css
@@ -9,10 +9,19 @@
    * enters the accessible name — a screen reader announces the field's required
    * state from `aria-required` on the input, not an "asterisk". The marker glyph
    * and the gap after it are themeable; the gap stands in for the requested
-   * non-breaking space and, being a margin, never wraps away from the label. */
+   * non-breaking space and, being a margin, never wraps away from the label.
+   * Coloured with the form error/accent colour so it reads as a marker, not
+   * part of the label text. */
   &[data-required]::before {
     content: var(--form-required-marker, "*");
     margin-inline-end: var(--form-required-marker-gap, 0.25ch);
-    color: var(--color-text-error);
+    color: var(--form-required-marker-color, var(--form-error-color));
+  }
+
+  /* The "(optional)" suffix is a muted hint, visually subordinate to the label
+   * (which is bold) — not the same weight/colour as the label text. */
+  & > .optional {
+    font-weight: var(--font-weight-default, normal);
+    color: var(--color-text-muted);
   }
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/styles.css
@@ -5,7 +5,14 @@
    * input's inner padding. Overridable via the variable. */
   padding-inline: var(--form-label-padding-inline, 0);
 
-  & > .required {
+  /* Required marker. Drawn as a pseudo-element (NOT label text) so it never
+   * enters the accessible name — a screen reader announces the field's required
+   * state from `aria-required` on the input, not an "asterisk". The marker glyph
+   * and the gap after it are themeable; the gap stands in for the requested
+   * non-breaking space and, being a margin, never wraps away from the label. */
+  &[data-required]::before {
+    content: var(--form-required-marker, "*");
+    margin-inline-end: var(--form-required-marker-gap, 0.25ch);
     color: var(--color-text-error);
   }
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/styles.css
@@ -10,18 +10,17 @@
    * state from `aria-required` on the input, not an "asterisk". The marker glyph
    * and the gap after it are themeable; the gap stands in for the requested
    * non-breaking space and, being a margin, never wraps away from the label.
-   * Coloured with the form error/accent colour so it reads as a marker, not
-   * part of the label text. */
+   * Inherits the label colour by default (overridable via the variable). */
   &[data-required]::before {
     content: var(--form-required-marker, "*");
     margin-inline-end: var(--form-required-marker-gap, 0.25ch);
-    color: var(--form-required-marker-color, var(--form-error-color));
+    color: var(--form-required-marker-color, var(--form-label-color));
   }
 
   /* The "(optional)" suffix is a muted hint, visually subordinate to the label
    * (which is bold) — not the same weight/colour as the label text. */
   & > .optional {
-    font-weight: var(--font-weight-default, normal);
+    font-weight: var(--typography-text-primary-font-weight, normal);
     color: var(--color-text-muted);
   }
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/types.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/types.ts
@@ -3,8 +3,8 @@ import type React from "react";
 import type { JSX } from "react";
 
 export interface LabelMessages {
-  /* The optional message, shown after the label in the "optional" indicator
-   * mode (rendered as " (<optional>)"). */
+  /* The optional message (e.g. "optional"), shown in parentheses after the
+   * label in the "optional" indicator mode — i.e. ` (optional)`. */
   optional: () => string;
 }
 

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/types.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/types.ts
@@ -3,9 +3,20 @@ import type React from "react";
 import type { JSX } from "react";
 
 export interface LabelMessages {
-  /* The optional message */
+  /* The optional message, shown after the label in the "optional" indicator
+   * mode (rendered as " (<optional>)"). */
   optional: () => string;
 }
+
+/**
+ * How a field's required/optional state is signalled in the label:
+ *  - "required" (default): a marker (default "*") is shown BEFORE the label of
+ *    required fields, so the user scans for the marked ones.
+ *  - "optional": " (optional)" is shown AFTER the label of optional fields, so
+ *    the user scans for the unmarked (required) ones.
+ * The two are mutually exclusive conventions — pick one per form.
+ */
+export type RequiredIndicator = "required" | "optional";
 
 export interface LabelProps {
   /* A unique identifier for the Label */
@@ -22,6 +33,8 @@ export interface LabelProps {
   htmlFor?: string;
   /* Is the field optional */
   isOptional?: boolean;
+  /* Which convention marks required/optional fields. Default: "required". */
+  requiredIndicator?: RequiredIndicator;
   /* Custom messages */
   messages?: LabelMessages;
   /* The element to render as */

--- a/packages/react/ds-global-form/src/lib/utils/hooks/useFieldAriaProperties.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/utils/hooks/useFieldAriaProperties.tests.tsx
@@ -31,6 +31,20 @@ describe("useFieldAriaProperties", () => {
     expect(input["aria-invalid"]).toBe(false);
   });
 
+  it("sets aria-required from the required flag, independent of error state", () => {
+    // Required but not (yet) in error — aria-required must still be true.
+    const { result: required } = renderHook(() =>
+      useFieldAriaProperties("email", false, true),
+    );
+    expect(required.current.input["aria-required"]).toBe(true);
+
+    // Not required — aria-required is omitted (undefined), not false.
+    const { result: optional } = renderHook(() =>
+      useFieldAriaProperties("email", true, false),
+    );
+    expect(optional.current.input["aria-required"]).toBeUndefined();
+  });
+
   it("generates different IDs for different field names", () => {
     const { result: r1 } = renderHook(() =>
       useFieldAriaProperties("email", false),

--- a/packages/react/ds-global-form/src/lib/utils/hooks/useFieldAriaProperties.ts
+++ b/packages/react/ds-global-form/src/lib/utils/hooks/useFieldAriaProperties.ts
@@ -4,9 +4,14 @@ import { useId, useMemo } from "react";
  * Generates common ARIA properties for form field elements including input, label, description, and error state.
  * @param {string} name - The name of the field.
  * @param {boolean} isError - Indicates if the field is in an error state.
+ * @param {boolean} [isRequired] - Whether the field is required (drives `aria-required`, independent of error state).
  * @returns An object containing ARIA attributes for input, label, description, and error state.
  */
-const useFieldAriaProps = (name: string, isError: boolean) => {
+const useFieldAriaProps = (
+  name: string,
+  isError: boolean,
+  isRequired = false,
+) => {
   const uniqueId = useId();
   const props = useMemo(() => {
     const baseId = `${uniqueId}-${name}`;
@@ -23,6 +28,10 @@ const useFieldAriaProps = (name: string, isError: boolean) => {
           undefined,
         "aria-errormessage": isError ? errorId : undefined,
         "aria-invalid": isError,
+        // Required state is a property of the field's optionality, NOT its
+        // error state — set it whenever the field is required so assistive tech
+        // announces it before the user triggers a validation error.
+        "aria-required": isRequired || undefined,
       },
       label: {
         id: labelId,
@@ -34,7 +43,7 @@ const useFieldAriaProps = (name: string, isError: boolean) => {
         // role: "alert",
       },
     };
-  }, [name, isError, uniqueId]);
+  }, [name, isError, isRequired, uniqueId]);
   return props;
 };
 

--- a/packages/react/ds-global-form/src/storybook/decorators.tsx
+++ b/packages/react/ds-global-form/src/storybook/decorators.tsx
@@ -54,3 +54,18 @@ export const form = ({
     return <FormWrapper />;
   };
 };
+
+/**
+ * Wraps a story in a `.grid.responsive` context (the design-system 4/8/12-column
+ * responsive grid). A `.ds.form` is a `subgrid`, so it only resolves real column
+ * tracks when nested in a parent `.grid` — column-based field layouts (e.g.
+ * SimpleChoicesField's "columns", ChoicesField's `--choices-span`) need this to
+ * demonstrate correctly. Compose after `form()`: `[grid(), form()]`.
+ */
+export const grid =
+  () =>
+  (Story: React.ElementType): React.ReactElement => (
+    <div className="grid responsive">
+      <Story />
+    </div>
+  );


### PR DESCRIPTION
## Done

Field display & states for `ds-global-form` (5 related changes):

- **Proper required/optional field marking.** Two mutually-exclusive label conventions, chosen per field via a Label-level `requiredIndicator` prop forwarded through the Field wrapper:
  - `"required"` (default): a `*` marker before the label of **required** fields.
  - `"optional"`: ` (optional)` after the label of **optional** fields (prior behaviour).

  The required marker is a CSS `::before` pseudo-element keyed off `data-required`, **not** label text, so it never enters the field's accessible name (a screen reader would otherwise announce "asterisk Email"). Revives the previously-dead `.required` style. Marker glyph/gap/colour are themeable (`--form-required-marker`, `--form-required-marker-gap`, `--form-required-marker-color`); the gap stands in for the requested non-breaking space.
- **Accessibility:** `aria-required` is now set on the input from the field's optionality (independent of error state), so AT announces required before any validation error fires.
- **Required marker / optional suffix colour.** Marker inherits the label colour by default (`--form-required-marker-color` defaults to `--form-label-color`); the optional suffix is muted + normal weight so neither reads as plain label text.
- **Checkbox checkmark colour.** The checkmark/minus were `background-image` SVGs, which CSS can't recolour, so the glyph ignored the theme. Drawn now as a masked `::before` coloured by `--color-foreground-checkbox-checkmark` (and `…-checkmark-disabled`) — the previously-unused checkmark token is wired up. Same masking technique as PasswordInput's eye icon.
- **Checkbox indeterminate + disabled-state stories.** `Indeterminate` / `DisabledChecked` / `DisabledIndeterminate` on both CheckboxInput and CheckboxField (`indeterminate` is a DOM property, set via ref / mount helper).
- **Column-based width for SimpleChoicesField.** New `"columns"` layout lays options out in a CSS grid of equal-width columns (column count via a new `columns` prop, default 2, through `--simple-choices-columns`). Complements the existing `"inline"` / `"stacked"`.
- **Stories for the required/optional/error states** added at the **Label** and **Field-pattern** level only (not per input): Label indicator modes; Field `Required` / `OptionalMarked` / `WithError`.

## QA

- Storybook → `patterns/Field`: **Required** shows a red `*` before the label; **OptionalMarked** shows a muted `(optional)`; **WithError** shows the danger chrome + error message.
- `subcomponents/Field.Label`: Default (required `*`), OptionalNoMarker (no marker in required mode), OptionalMarked (muted suffix).
- `subcomponents/CheckboxInput` & `components/CheckboxField`: Checked / Indeterminate / Disabled* — the checkmark and minus glyphs are the themed (white-on-blue) colour, not raw black.
- `components/SimpleChoicesField` → **Columns** / **ColumnsMultiple**: options align in equal-width columns.
- Inspect a required input: it carries `aria-required="true"`; the `*` is **not** part of the accessible name.

Verified: `tsc` clean, full suite **236 passed**, `biome` clean, `build:storybook` succeeds.

### PR readiness check

- [x] Label: `Feature 🎁`
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] Package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [ ] New package: n/a.
- [ ] Requires visual testing (Chromatic) — has visual changes.

## Screenshots

_Visual states (required marker, themed checkmark, choices columns) are best reviewed via Chromatic / the built Storybook; jsdom can't render the masked glyphs or pseudo-element marker._

