### PR TITLE
feat(scripts): show npm provenance (OIDC) status in publish:status

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -970,9 +970,9 @@
       "version": "0.29.0-experimental.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1216,16 +1216,16 @@
       "name": "@canonical/summon-core",
       "version": "0.29.0-experimental.0",
       "dependencies": {
-        "@canonical/task": "^0.27.1-experimental.0",
-        "@canonical/utils": "^0.27.1-experimental.0",
+        "@canonical/task": "^0.29.0-experimental.0",
+        "@canonical/utils": "^0.29.0-experimental.0",
         "chalk": "^5.6.2",
         "ejs": "^5.0.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.28.0",
+        "@canonical/typescript-config": "^0.28.0",
+        "@canonical/webarchitect": "^0.29.0-experimental.0",
         "@types/bun": "^1.3.10",
         "@types/ejs": "^3.1.5",
         "@types/node": "^24.12.0",
@@ -1236,6 +1236,10 @@
     "packages/summon/monorepo": {
       "name": "@canonical/summon-monorepo",
       "version": "0.29.0-experimental.0",
+      "dependencies": {
+        "@canonical/summon-core": "^0.29.0-experimental.0",
+        "@canonical/task": "^0.29.0-experimental.0",
+      },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
         "@canonical/biome-config": "^0.28.0",
@@ -1245,10 +1249,6 @@
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
-      },
-      "peerDependencies": {
-        "@canonical/summon-core": "^0.18.0 || ^0.20.0",
-        "@canonical/task": "^0.18.0 || ^0.20.0",
       },
     },
     "packages/summon/package": {

--- a/packages/summon/monorepo/package.json
+++ b/packages/summon/monorepo/package.json
@@ -33,6 +33,10 @@
     "test:vitest": "vitest run --coverage",
     "test:vitest:watch": "vitest"
   },
+  "dependencies": {
+    "@canonical/summon-core": "^0.29.0-experimental.0",
+    "@canonical/task": "^0.29.0-experimental.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.4.9",
     "@canonical/biome-config": "^0.28.0",
@@ -42,9 +46,5 @@
     "@types/node": "^24.12.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "@canonical/summon-core": "^0.18.0 || ^0.20.0",
-    "@canonical/task": "^0.18.0 || ^0.20.0"
   }
 }

--- a/packages/summon/monorepo/src/templates/publish-status.ts.ejs
+++ b/packages/summon/monorepo/src/templates/publish-status.ts.ejs
@@ -3,7 +3,10 @@
  *
  * Reads workspace globs from the root package.json, resolves every
  * non-private package, and reports whether the local version is
- * published, outdated, or new.
+ * published, outdated, or new — and whether the latest published version
+ * carries an npm provenance attestation (published via OIDC trusted
+ * publishing with `--provenance`). All data is from the public registry,
+ * so no login is required.
  */
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -40,11 +43,19 @@ packages.sort((a, b) => a.name.localeCompare(b.name));
 const pad = Math.max(...packages.map((p) => `${p.name}@${p.version}`.length));
 
 for (const pkg of packages) {
-  let registry: string;
+  let registry = "unpublished";
+  // `dist.attestations.provenance` is present only when the latest version was
+  // published with OIDC `--provenance`. A single `npm view --json` gives both.
+  let provenance = "—";
   try {
-    registry = execSync(`npm view ${pkg.name} version 2>/dev/null`, {
+    const raw = execSync(`npm view ${pkg.name} --json 2>/dev/null`, {
       encoding: "utf8",
     }).trim();
+    const data = JSON.parse(raw);
+    registry = typeof data?.version === "string" ? data.version : "unpublished";
+    if (registry !== "unpublished") {
+      provenance = data?.dist?.attestations?.provenance ? "provenance" : "none";
+    }
   } catch {
     registry = "unpublished";
   }
@@ -57,5 +68,7 @@ for (const pkg of packages) {
       ? "published"
       : "outdated";
 
-  console.log(`${local.padEnd(pad)}  registry: ${registry.padEnd(12)}  ${status}`);
+  console.log(
+    `${local.padEnd(pad)}  registry: ${registry.padEnd(12)}  ${status.padEnd(11)}  ${provenance}`,
+  );
 }

--- a/scripts/publish-status.ts
+++ b/scripts/publish-status.ts
@@ -3,7 +3,14 @@
  * publish-status.ts
  *
  * Compares local workspace package versions against the npm registry.
- * Reports whether each package is published, outdated, new, or private.
+ * Reports whether each package is published, outdated, new, or private, and
+ * whether the latest published version carries an npm provenance attestation
+ * (i.e. was published via OIDC trusted publishing with `--provenance`).
+ *
+ * All data comes from the public registry (`npm view`), so no login is required.
+ * Note: npm exposes no public API for whether a *trusted publisher* is
+ * configured on a package; provenance on the latest version is the closest
+ * public, scriptable signal that OIDC publishing is actually in effect.
  *
  * Usage: bun scripts/publish-status.ts
  */
@@ -61,15 +68,19 @@ const NAME_W   = 52;
 const LOCAL_W  = 10;
 const STATUS_W = 12;
 const NPM_W    = 12;
+const PROV_W   = 14;
 
 const header = [
   BOLD + col("Package", NAME_W),
   col("Local", LOCAL_W),
   col("Status", STATUS_W),
-  col("npm", NPM_W) + RESET,
+  col("npm", NPM_W),
+  col("Provenance", PROV_W) + RESET,
 ].join("  ");
 
-const divider = "─".repeat(NAME_W + LOCAL_W + STATUS_W + NPM_W + 6);
+const divider = "─".repeat(
+  NAME_W + LOCAL_W + STATUS_W + NPM_W + PROV_W + 8,
+);
 
 console.log(`\n${header}`);
 console.log(divider);
@@ -78,28 +89,45 @@ let publishedCount = 0;
 let outdatedCount = 0;
 let newCount = 0;
 let privateCount = 0;
+let provenanceCount = 0;
 
-// Query npm registry in parallel for all public packages
+// What the public registry reports for a package's latest version.
+interface RegistryInfo {
+  version: string | null;
+  /** True when the latest version carries an npm provenance attestation. */
+  hasProvenance: boolean;
+}
+
+// Query npm registry in parallel for all public packages. A single `npm view
+// <pkg> --json` returns both the version and `dist.attestations` (provenance).
 const publicPackages = packages.filter((p) => !p.private);
-const registryVersions = await Promise.all(
-  publicPackages.map(async (pkg) => {
+const registryInfos = await Promise.all(
+  publicPackages.map(async (pkg): Promise<RegistryInfo> => {
     try {
-      const proc = Bun.spawn(["npm", "view", pkg.name, "version", "--json", "--prefer-online"], {
-        stdout: "pipe",
-        stderr: "ignore",
-      });
+      const proc = Bun.spawn(
+        ["npm", "view", pkg.name, "--json", "--prefer-online"],
+        { stdout: "pipe", stderr: "ignore" },
+      );
       const output = await new Response(proc.stdout).text();
       const code = await proc.exited;
-      if (code !== 0) return null;
-      return JSON.parse(output.trim()) as string;
+      if (code !== 0) return { version: null, hasProvenance: false };
+      const data = JSON.parse(output.trim());
+      // For a published package, `npm view --json` returns the latest version's
+      // manifest. `dist.attestations.provenance` is present only when the
+      // version was published with OIDC `--provenance`.
+      const version = typeof data?.version === "string" ? data.version : null;
+      const hasProvenance = Boolean(data?.dist?.attestations?.provenance);
+      return { version, hasProvenance };
     } catch {
-      return null;
+      return { version: null, hasProvenance: false };
     }
   }),
 );
 
-const registryMap = new Map<string, string | null>();
-publicPackages.forEach((pkg, i) => registryMap.set(pkg.name, registryVersions[i]));
+const registryMap = new Map<string, RegistryInfo>();
+publicPackages.forEach((pkg, i) => {
+  registryMap.set(pkg.name, registryInfos[i]);
+});
 
 for (const pkg of packages) {
   if (pkg.private) {
@@ -109,13 +137,18 @@ for (const pkg of packages) {
         DIM + col(pkg.name, NAME_W),
         col(pkg.version ?? "—", LOCAL_W),
         col("private", STATUS_W),
-        col("—", NPM_W) + RESET,
+        col("—", NPM_W),
+        col("—", PROV_W) + RESET,
       ].join("  "),
     );
     continue;
   }
 
-  const registryVersion = registryMap.get(pkg.name) ?? null;
+  const info = registryMap.get(pkg.name) ?? {
+    version: null,
+    hasProvenance: false,
+  };
+  const registryVersion = info.version;
   let statusLabel: string;
 
   if (!registryVersion) {
@@ -129,12 +162,24 @@ for (const pkg of packages) {
     statusLabel = YELLOW + col("outdated", STATUS_W) + RESET;
   }
 
+  // Provenance is only meaningful for an actually-published version.
+  let provLabel: string;
+  if (!registryVersion) {
+    provLabel = DIM + col("—", PROV_W) + RESET;
+  } else if (info.hasProvenance) {
+    provenanceCount++;
+    provLabel = GREEN + col("provenance ✓", PROV_W) + RESET;
+  } else {
+    provLabel = YELLOW + col("none", PROV_W) + RESET;
+  }
+
   console.log(
     [
       col(pkg.name, NAME_W),
       col(pkg.version ?? "—", LOCAL_W),
       statusLabel,
       CYAN + col(registryVersion ?? "—", NPM_W) + RESET,
+      provLabel,
     ].join("  "),
   );
 }
@@ -145,5 +190,6 @@ console.log(
   `${GREEN}${publishedCount} published${RESET}  ` +
   `${YELLOW}${outdatedCount} outdated${RESET}  ` +
   `${RED}${newCount} new${RESET}  ` +
-  `${DIM}${privateCount} private${RESET}\n`,
+  `${DIM}${privateCount} private${RESET}  ` +
+  `${GREEN}${provenanceCount} with provenance${RESET}\n`,
 );


### PR DESCRIPTION
## Done

Add a **Provenance** column to `bun run publish:status`, surfacing whether each package's latest published version was published via **OIDC trusted publishing** (`--provenance`) vs the legacy token path.

- Derived from the **public registry** — one `npm view <pkg> --json` per package now returns both version and `dist.attestations.provenance`. **No login required**, no extra network calls (folded into the existing query; `--prefer-online` preserved).
- Per package: `provenance ✓` / `none` / `—` (new/private); summary gains an `N with provenance` count.
- **Drive-by:** also update the summon monorepo generator template (`packages/summon/monorepo/src/templates/publish-status.ts.ejs`) so newly-scaffolded monorepos get the same provenance reporting.

Mirrors `canonical/design-tokens` PR #82.

### Why provenance (not "is a trusted publisher configured")

npm exposes **no public API** for whether a trusted publisher is *configured* on a package (private account setting, web-UI only). Provenance on the latest version is the closest **public, scriptable** signal that OIDC publishing is actually *in effect*.

Running it today shows **46 of pragma's packages already report `provenance ✓`** — confirming OIDC is live and the detection is correct.

## QA

- `bun run publish:status` renders the new column against the live registry (56 packages, 46 with provenance).
- `summon/monorepo`: `bun run check` clean, generator tests pass (22/22) — template change doesn't break generation.

### PR readiness check

- [x] PR title follows Conventional Commits.
- [x] `check` + generator tests pass; tooling/template-only change.

---

### Drive-by: fix summon-monorepo nx graph edge

This PR's build-matrix initially failed on a **pre-existing** CI bug unrelated to the provenance change. `@canonical/summon-monorepo` imports `@canonical/summon-core` and `@canonical/task` but declared them as `peerDependencies` pinned to `^0.18.0 || ^0.20.0`; those workspace packages are now `0.29.0-experimental.0`, so nx treated them as external and dropped the internal graph edge. `nx affected` then never built them, and `affected check` failed with `Cannot find module '@canonical/task'`.

Fixed by declaring them as real `dependencies` at `^0.29.0-experimental.0` (matching the working `@canonical/summon-application` pattern). Verified cold: `affected build:all/check/test` all pass.

— Claude Code
