### PR TITLE
docs: adopt canonical-agents knowledge-base convention (ds-global-form)

### DIFF
--- a/.kb/agents.md
+++ b/.kb/agents.md
@@ -1,0 +1,43 @@
+# Preface
+
+This repository follows strict conventions for organizing agent-oriented knowledge documents, and this document is required reading for any agent that wants to read or write these.
+
+Read the top-level `.kb/agents.md` before continuing below.
+
+
+# Overview
+
+Every directory in this repository, including the root, may have its own `AGENTS.md` file and `.kb/` subdirectory. The AGENTS.md file provides a general view for the directory, while more specific information is found in `.kb/*.md` files with dashed lowercase names (e.g. `.kb/special-relativity.md`).
+
+The design of this structure has the following key goals:
+
+- **Mechanical** - Agents are the main actors reading and writing the knowledge base.
+- **Generic** - Benefits any agentic workflow, no matter the editor or platform.
+- **Distilled** - Avoids the use of verbose task or plan logs that pollute the context window.
+- **Hierarchical** - Avoids excessive information in a single place that also pollutes the context window.
+- **Human** - Information is readily available and reviewable in a friendly format.
+
+
+# Important
+
+- Read local `AGENTS.md` files upon navigating directories.
+- Keep the `.kb/*.md` files updated whenever there is something relevant to be documented or updated.
+- Follow the header conventions outlined below. Only the _Preface_ header is required, and the other headers should be omitted if empty or trivial.
+
+
+# Headers
+
+Every header used across the `.kb/*.md` files in this repository MUST be documented here to maintain semantic standardizations.
+
+- _Preface_ - A brief introduction outlining the scope and relevance of a specific `*.md` file. This section MUST be at the top of every `.kb/*.md` file so agents can easily grep for it, and the last line of this section MUST be "Read the top-level `.kb/agents.md` file before continuing below." so rules are followed.
+- _Overview_ - High-level summary of the directory, subsystem or knowledge base layout at large. Do NOT use this to list files or directories.
+- _Important_ - Essential directives for the agent outlining critical constraints, behaviors, or rules.
+- _Headers_ - Global registry of header definitions, uniquely hosted at the root `.kb/agents.md` (this file). Do NOT use this header in any other document.
+- _Architecture_ - Structural design details or boundary explanations for a given component. Only use this for software architecture concepts, NOT for directory outlining. Also avoid using this as a code reference (keep that in the code itself).
+- _Directory_ - Only in `AGENTS.md` files, it briefly outlines the contents and structure of the directory the `AGENTS.md` file is in, and potentially nested small directories that do not justify their own `AGENTS.md` file. For `.kb/*.md` files, use _Documents_ instead.
+- _Documents_ - Only in `AGENTS.md` files, it outlines the content of `.kb/*.md` files and also immediately nested `AGENTS.md` child files, to aid agent navigation. It MUST be the last section in the file. It's okay to also mention such filenames inline when they are relevant elsewhere in the text.
+
+For the _Directory_ and _Documents_ listings, format items as a dashed list starting with the file or directory name surrounded by backticks, a dash, and then a brief description:
+```
+- `filename` - Terse summary.
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,12 @@
-# AGENTS.md — Working on a Pragma PR
+# Preface
 
-Guidance for AI agents (and humans) contributing to `canonical/pragma`. For deeper
-setup and monorepo mechanics see [`old/CONTRIBUTING.md`](old/CONTRIBUTING.md); this
-file is the PR workflow contract.
+`canonical/pragma` is a Bun/Lerna monorepo of design-system packages. This file is
+the **PR workflow contract** for agents and humans contributing here: toolchain,
+commit/branch conventions, the pre-push gate, and PR mechanics. Read it before
+opening a PR against this repo; skip it for tasks that don't touch this repo. Deeper
+setup and monorepo mechanics live in [`old/CONTRIBUTING.md`](old/CONTRIBUTING.md).
+
+Read the top-level `.kb/agents.md` file before continuing below.
 
 ## Toolchain
 
@@ -167,3 +171,8 @@ build-excluded folder if the alias points at story/dev-only code.
   automated workflow cannot publish future versions. Beware: merging a new package does
   not make it releasable on its own. See
   [`docs/how-to-guides/PUBLISH_A_PACKAGE.md`](docs/how-to-guides/PUBLISH_A_PACKAGE.md).
+
+# Documents
+
+- `.kb/agents.md` - General rules for reading and writing the knowledge base.
+- `packages/react/ds-global-form/AGENTS.md` - The React form package (`@canonical/react-ds-global-form`): tier architecture, field/RHF machinery, and Storybook conventions.

--- a/packages/react/ds-global-form/.kb/architecture.md
+++ b/packages/react/ds-global-form/.kb/architecture.md
@@ -1,0 +1,116 @@
+# Preface
+
+The tier architecture of `@canonical/react-ds-global-form`, the machinery every
+field is composed from, and the field-level conventions (required/optional marking,
+error state, input chrome). Read this before adding or moving an input, field, or
+pattern, or before touching the `common/` machinery. For Storybook see
+`.kb/storybook.md`.
+
+Read the top-level `.kb/agents.md` file before continuing below.
+
+# Overview
+
+`src/lib/` is organised in ontology tiers plus two non-tier support folders. Each
+tier may only depend *downward*; the machinery in `common/` is depended on by all
+tiers but depends on none of them.
+
+- `subcomponent/` — presentational inputs, **no** react-hook-form. One folder per
+  input (`TextInput`, `CheckboxInput`, `SelectInput`, `PhoneInput`, …) plus the field
+  chrome `Field/{Label,Description,Error}`. May import only shared types.
+- `component/` — the RHF-bound `*Field` wrappers, one per input (`TextField`,
+  `CheckboxField`, `RangeField`, …), each built by composing `common/` + a
+  `subcomponent/` input.
+- `pattern/` — `Field` (a discriminated-union switch that routes an `inputType` to
+  the right `*Field`, with a custom passthrough) and `Form` (the `FormProvider`
+  wrapper). This tier is the public surface.
+- `common/` — the machinery: `bindField/`, `Wrapper/` (+ `withWrapper`), and the
+  shared prop types (`BaseInputProps`, `InputProps<T>`, `WrapperProps<T>`).
+- `utils/` — `hooks/` (`useFieldAriaProperties`, `useFieldError`), `middleware/`
+  (REST options/validation), and `countries/` (phone dial codes + masks).
+
+**Public surface:** `src/lib/index.ts` exports only `pattern/*` and
+`utils/middleware/*`. The `component/` and `subcomponent/` tiers are internal —
+consumers reach inputs through `<Field inputType="…">` or `<Form>`, never by deep
+import. Renaming a `*Field` is therefore not a breaking change.
+
+# Architecture
+
+## The composition machinery
+
+Every `*Field` is `withWrapper(bindField(Input, mode, options?))`.
+
+`bindField<P>(Presentational, mode, options?)` (`common/bindField/bindField.ts`)
+turns a presentational input into an RHF-bound one. `BindMode` is `"native" |
+"controlled"`:
+
+- `"native"` — spreads `register(name, registerProps)` onto the input (uncontrolled;
+  the default for most inputs).
+- `"controlled"` — lifts `useController()` and passes `value`/`onChange`/`onBlur`/
+  `ref`, for inputs that need a live value (e.g. Color, FileUpload).
+
+`BindFieldOptions`:
+
+- `registerDefaults?: RegisterOptions` — merged *under* the consumer's
+  `registerProps` (`{ ...registerDefaults, ...registerProps }`), so the consumer
+  always wins. Example: `RangeField` passes `{ valueAsNumber: true }` so RHF stores a
+  number, not the string the input reports.
+- `injectValue?: boolean` — supplies a live `value` prop via a watch (Range's
+  `<output>`).
+- `defaultValue?` — the registration default in controlled mode.
+
+`withWrapper(Component, options?, Wrapper?)` wraps the bound field in the field
+chrome. `Wrapper` (`common/Wrapper/Wrapper.tsx`) renders `.ds.field` (a subgrid,
+gains `.danger` on error) containing the `<Label>` and a `.payload` div
+(description + input + error message), and threads the aria props from
+`useFieldWrapper` onto the input.
+
+## Required / optional marking
+
+`isOptional` is the source of truth. `useFieldWrapper` maps `!isOptional` to an RHF
+`required` rule *and* to `aria-required` on the input (independent of error state).
+The visual marker is chosen by the Label-level `requiredIndicator` prop, forwarded
+from the field:
+
+- `"required"` (default) — required fields get a `*` marker rendered as a CSS
+  `::before` pseudo-element keyed off a `data-required` attribute, so it stays out of
+  the accessible name (the required semantic is carried by `aria-required`). Colour
+  defaults to the label colour via `--form-required-marker-color`.
+- `"optional"` — optional fields get a muted ` (optional)` **text** suffix (real
+  text, so it belongs in the accessible name).
+
+## Input chrome + error state
+
+The shared `.ds.input.chrome` rule (`src/index.css`) provides border, height, and
+**block** padding. **Inline** padding lives on the text-bearing leaf, single-sourced:
+composite wrappers (text/number/password/phone) put it on their inner `<input>`;
+direct-chrome inputs (date/time/datetime/select/textarea) set it on the element
+itself; `.ds.input.chrome` never sets inline padding (that would double it).
+
+Error state is applied by the Wrapper, not the input: on an RHF error the `.ds.field`
+container gains `.danger`, and inputs style themselves red via the ancestor selector
+`.danger > .payload .ds.input.chrome` (Color/FileUpload re-implement it on their own
+`.color-trigger` / `.drop-zone`). Controls without a chrome border (checkbox, radio,
+range slider) show the error only through the `FieldError` message.
+
+The checkbox checkmark is a masked pseudo-element, not a `background-image` SVG (which
+CSS can't recolour): `::before` with `mask-image` + `background-color:
+var(--color-foreground-checkbox-checkmark)`, with the colour+mask set together only
+under `:checked`/`:indeterminate` so the unchecked box paints nothing.
+
+## The `#lib/*` import alias
+
+Package-internal cross-tier imports use `#lib/*` (e.g.
+`#lib/common/bindField/index.js`) instead of deep relative paths. `package.json`
+`imports` maps it with a **publish-safe conditional map**:
+
+```jsonc
+"#lib/*": {
+  "development": "./src/lib/*",   // local dev (source)
+  "types":       "./dist/types/lib/*",
+  "default":     "./dist/esm/lib/*" // published runtime
+}
+```
+
+This resolves correctly at every stage (source during dev, `dist` when published), so
+a shipped tarball doesn't break. It requires `customConditions: ["development"]` in
+tsconfig and matching `resolve.conditions` in the Vite/Storybook config.

--- a/packages/react/ds-global-form/.kb/storybook.md
+++ b/packages/react/ds-global-form/.kb/storybook.md
@@ -1,0 +1,60 @@
+# Preface
+
+Storybook conventions for `@canonical/react-ds-global-form`: the decorators, the
+per-tier story shape, and how field state (touched, error) is set up. Read this
+before adding or changing a `*.stories.tsx` here. For the component architecture see
+`.kb/architecture.md`.
+
+Read the top-level `.kb/agents.md` file before continuing below.
+
+# Overview
+
+Stories live next to their component as `*.stories.tsx`. Shared Storybook helpers are
+in `src/storybook/` and imported via the `storybook/*` alias (from
+`@canonical/storybook-config`), e.g. `import * as decorators from
+"storybook/decorators.js"`. Fixtures (option lists) are in
+`storybook/fixtures.options.js`.
+
+# Architecture
+
+## Per-tier story shape
+
+- **`subcomponent/` (presentational inputs)** render **bare** — no form decorator,
+  no Wrapper. They demonstrate the input's own markup/states (Default, Disabled,
+  Checked, …). Titled `subcomponents/<Name>`.
+- **`component/` (`*Field`)** always run inside the `form()` decorator (they are
+  react-hook-form-bound and need a `FormProvider`). Titled `components/<Name>`.
+- **`pattern/`** (`Field`, `Form`) also use `form()`. Titled `patterns/<Name>`.
+
+## Decorators (`src/storybook/decorators.tsx`)
+
+- **`form(options?)`** — wraps the story in `FormProvider` + `<form class="ds form
+  subgrid">` with `useForm({ mode: "onChange" })` and emits state to the form-state
+  addon. Options: `defaultValues`, `className`, and `touchedFields: string[]` — the
+  listed fields are marked touched (via `setValue(..., { shouldTouch: true })`) so
+  validation errors surface immediately (react-hook-form has no `defaultTouched`).
+- **`grid()`** — wraps the story in `.grid.responsive` (the 4/8/12-column design-system
+  grid). `.ds.form` is a `subgrid`, so column-based field layouts (ChoicesField's
+  `--choices-span`, SimpleChoicesField's `"columns"`) only resolve real column tracks
+  inside a parent `.grid`. Compose grid-outside-form: `decorators: [grid(), form()]`.
+
+## Showing the error state
+
+Error state is owned by the field Wrapper (it adds `.danger` when react-hook-form
+reports an error), so it is a **field-tier** concern:
+
+- On a `*Field`, an error story renders the field inside `form({ touchedFields:
+  [name] })` with a validation rule that fails for the (empty) value — so RHF reports
+  the error, the Wrapper adds `.danger`, and the `FieldError` message shows. Prefer a
+  shared factory over hand-rolling each one. Note a field with a non-empty registered
+  default (e.g. ColorField's `#000000`) needs a `validate` rule, not a bare
+  `required`, since `required` can never fail for it.
+- A presentational subcomponent has no Wrapper, so its error story reproduces the
+  `<div class="ds field danger"><div class="payload">…</div></div>` ancestor context
+  via a decorator (plus a `FieldError` message) — showing the visual error layer the
+  subcomponent owns without faking RHF state.
+
+> Note: the shared error-story helpers (`errorStory()` and the `danger()` decorator)
+> and the per-component `WithError` / `ErrorState` stories land via a separate PR; this
+> section describes the intended convention. Until then, `form()` + `touchedFields`
+> is the mechanism for a field error story.

--- a/packages/react/ds-global-form/AGENTS.md
+++ b/packages/react/ds-global-form/AGENTS.md
@@ -1,0 +1,32 @@
+# Preface
+
+`@canonical/react-ds-global-form` is the React form package: presentational inputs,
+react-hook-form-bound fields, and a polymorphic `Field`/`Form` pattern. Read this
+before adding or changing a form input, field, or story here — the tier layout and
+composition machinery are non-obvious. Skip it for work outside this package.
+
+Read the top-level `.kb/agents.md` file before continuing below.
+
+# Overview
+
+The package is organised in ontology tiers under `src/lib/`: `subcomponent/`
+(presentational inputs, no react-hook-form), `component/` (the RHF-bound `*Field`
+wrappers), and `pattern/` (the public `Field` switch + `Form`). Two non-tier folders
+support them: `common/` (the `bindField` + `Wrapper` machinery every field is built
+from) and `utils/` (hooks, middleware, phone-country data). The public surface is
+deliberately small — only `pattern/*` and `utils/middleware/*` are exported. See
+`.kb/architecture.md` for the tiers, the composition pattern, and the field
+conventions; `.kb/storybook.md` for the story decorators and helpers.
+
+# Directory
+
+- `src/lib/` - The tiered library (see `.kb/architecture.md`).
+- `src/storybook/` - Storybook decorators and the `errorStory` factory (see `.kb/storybook.md`).
+- `src/testing/` - Test helpers (`renderWithForm`).
+- `src/index.css` - Package token catalog + the shared `.ds.input.chrome` / `.ds.field` rules.
+- `.storybook/` - Storybook config (uses `@canonical/storybook-config`).
+
+# Documents
+
+- `.kb/architecture.md` - Tier structure, dependency direction, the `bindField` + `withWrapper` composition, the required/optional and error-state field conventions, and the `#lib/*` import alias.
+- `.kb/storybook.md` - The `form` / `grid` / `danger` decorators, the `errorStory()` factory, and the per-tier story conventions (bare subcomponents; `form()`-wrapped fields; `WithError` vs `ErrorState`).


### PR DESCRIPTION
## Done

Adopt the **canonical-agents** knowledge-base convention (`~/code/cn/canonical-agents`): `AGENTS.md` files act as terse indexes, with detailed knowledge in `.kb/*.md` topic files that use standardized headers and live hierarchically, close to what they document.

Scoped to the area of our recent form work:

- **Seed the required rules file** at the repo root: `.kb/agents.md`, copied verbatim from the canonical-agents repository (this is the file every `AGENTS.md` Preface must cross-link to).
- **Make the top-level `AGENTS.md` convention-compliant** — add the required `Preface` (ending with the mandated `Read the top-level .kb/agents.md …` line) and a `Documents` section (last, per the convention). The existing PR-workflow content is preserved unchanged.
- **Document the `ds-global-form` React form package** where the knowledge belongs:
  - `packages/react/ds-global-form/AGENTS.md` — the package index (Preface, Overview, Directory, Documents).
  - `.kb/architecture.md` — the ontology tiers + dependency direction, the `bindField` + `withWrapper` composition, the required/optional + error-state field conventions, and the `#lib/*` publish-safe import alias.
  - `.kb/storybook.md` — the `form` / `grid` decorators, the per-tier story shape, and how field error state is set up.

This captures the architecture established across the recent form PRs (tier restructure, field machinery, required/error conventions) in the durable, reviewable format the convention prescribes — instead of it living only in PR history.

## QA

- Convention compliance checked: every `.kb/*.md` has a `Preface` ending with the exact cross-link line; both `AGENTS.md` files start with `Preface` and end with `Documents`.
- **Docs only** — no code, no build/test/Storybook impact (the root `check`/`test` gate does not touch these markdown files).
- Content verified against the code on `main` (tiers, `bindField` signature/modes, public exports, `#lib/*` conditional map).

### PR readiness check

- [x] Label: `Documentation 📝`
- [x] PR title follows Conventional Commits.
- [x] Docs-only; no package scripts affected.
- [x] `no visual change` — markdown only (skip Chromatic).
