### PR TITLE
docs(ds-global-form): CSS imports, react-hook-form guide, runnable Form examples

### DIFF
--- a/packages/react/ds-global-form/README.md
+++ b/packages/react/ds-global-form/README.md
@@ -59,6 +59,39 @@ function ContactForm() {
 }
 ```
 
+### Form modes
+
+`Form` wraps its children in a react-hook-form `FormProvider` and works in two modes:
+
+- **Internal mode** (above) — pass `onSubmit`, and optionally `defaultValues` and a
+  validation `mode`; `Form` creates the `useForm` instance for you. Best for a
+  self-contained form.
+- **External mode** — create the `useForm` instance yourself and pass it as
+  `methods`. Because you own it, you can read `formState` (e.g. `isSubmitting`) and
+  call its methods (`reset`, `setValue`, `watch`, …). Use this for async submits,
+  shared state, or multi-step forms.
+
+  ```tsx
+  import { useForm } from "react-hook-form";
+
+  const methods = useForm({ mode: "onBlur", defaultValues: { email: "" } });
+  const { reset, formState: { isSubmitting } } = methods;
+
+  <Form methods={methods} onSubmit={async (data) => { await save(data); reset(); }}>
+    <Field name="email" inputType="email" label="Email" />
+    <button type="submit" disabled={isSubmitting}>Send</button>
+  </Form>;
+  ```
+
+  When you pass `methods`, `Form`'s own `defaultValues`/`mode` props are ignored —
+  configure those on your `useForm` call.
+
+This library is a thin layer over [react-hook-form](https://react-hook-form.com/)
+(`^7.71`): validation rules (`registerProps`), `formState`, submission, field
+arrays, and schema resolvers are all RHF's API. See the **Getting Started** guide
+in Storybook for a full walkthrough with runnable examples, and the
+[react-hook-form docs](https://react-hook-form.com/docs) for the complete surface.
+
 ## Field Switch Pattern
 
 The `Field` component uses `inputType` to select the appropriate input component:

--- a/packages/react/ds-global-form/src/docs/GettingStarted.mdx
+++ b/packages/react/ds-global-form/src/docs/GettingStarted.mdx
@@ -45,29 +45,74 @@ A form needs a grid parent, a `Form` wrapper, and one or more `Field` components
 
 `Form` wraps children in a react-hook-form [`FormProvider`](https://react-hook-form.com/docs/formprovider). It has two modes:
 
-**Internal mode** (simple) — `Form` creates its own `useForm` instance:
+**Internal mode** (simple) — `Form` creates its own `useForm` instance. Pass
+`onSubmit`, and optionally `defaultValues` and a validation `mode`. Use this for
+a self-contained form where you don't need direct access to the form state.
 
 ```tsx
-<Form onSubmit={handleSubmit} defaultValues={{ name: "" }} mode="onBlur">
-  {/* fields */}
+<Form
+  onSubmit={handleSubmit}
+  defaultValues={{ name: "Ada", email: "" }}
+  mode="onBlur"
+>
+  <Field name="name" inputType="text" label="Full name" />
+  <Field
+    name="email"
+    inputType="text"
+    label="Email address"
+    registerProps={{ required: "Email is required" }}
+  />
+  <Button type="submit">Send</Button>
 </Form>
 ```
 
-**External mode** (advanced) — you provide your own `useForm` methods for scenarios like shared state or multi-step forms:
+<Canvas of={Stories.InternalMode} />
+
+**External mode** (advanced) — you create the `useForm` instance and pass it as
+`methods`. Because you own it, you can read `formState` (e.g. `isSubmitting`) and
+call its methods (`reset`, `setValue`, `watch`, …). Reach for this when a submit
+is async, when the form state is shared across components, or for multi-step /
+wizard forms that keep one instance across steps.
 
 ```tsx
 import { useForm } from "react-hook-form";
 
-function MultiStepForm() {
-  const methods = useForm({ defaultValues: { step1: "", step2: "" } });
+function SignupForm() {
+  const methods = useForm({
+    mode: "onBlur",
+    defaultValues: { name: "", email: "" },
+  });
+  const {
+    reset,
+    formState: { isSubmitting },
+  } = methods;
+
+  const onSubmit = async (data) => {
+    await api.createUser(data); // your async call
+    reset(); // clear back to defaultValues after success
+  };
 
   return (
-    <Form onSubmit={handleSubmit} methods={methods}>
-      {/* fields */}
+    <Form methods={methods} onSubmit={onSubmit}>
+      <Field name="name" inputType="text" label="Full name" />
+      <Field
+        name="email"
+        inputType="text"
+        label="Email address"
+        registerProps={{ required: "Email is required" }}
+      />
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? "Saving…" : "Send"}
+      </Button>
     </Form>
   );
 }
 ```
+
+<Canvas of={Stories.ExternalMode} />
+
+When you pass `methods`, `Form`'s own `defaultValues` and `mode` props are
+ignored — configure those on your `useForm` call instead.
 
 ## Understanding react-hook-form
 
@@ -114,76 +159,12 @@ what the form is doing. The fields you will reach for most:
 
 ### Validation rules (`registerProps`)
 
-Each `Field` accepts a `registerProps` object passed straight to RHF's `register`.
-It is RHF's [validation rules](https://react-hook-form.com/docs/useform/register),
-not a bespoke API: `required`, `min`, `max`, `minLength`, `maxLength`, `pattern`,
-`validate` (a function, or an object of named validators — sync or async, each
-returning `true` or an error message), plus value transforms `valueAsNumber`,
-`valueAsDate`, and `setValueAs`.
-
-```tsx
-<Field
-  name="age"
-  inputType="text"
-  label="Age"
-  registerProps={{
-    required: "Age is required",
-    min: { value: 18, message: "Must be 18 or older" },
-    valueAsNumber: true,
-    validate: (v) => v < 130 || "That doesn't look right",
-  }}
-/>
-```
-
-> This library maps the `isOptional` prop to a `required` rule for you, so a
-> field is required by default. Pass `isOptional` to make it optional, or set
-> your own `required` message via `registerProps`.
-
-### Full example: submit, async, reset
-
-Use **external mode** to reach the methods you need beyond a single field —
-`formState` for `isSubmitting`, and `reset` after a successful submit:
-
-```tsx
-import { useForm } from "react-hook-form";
-import { Form, Field } from "@canonical/react-ds-global-form";
-
-type Values = { name: string; email: string };
-
-function SignupForm() {
-  const methods = useForm<Values>({
-    mode: "onBlur",
-    defaultValues: { name: "", email: "" },
-  });
-  const {
-    reset,
-    formState: { isSubmitting },
-  } = methods;
-
-  const onSubmit = async (data: Values) => {
-    await api.createUser(data); // your async call
-    reset(); // clear back to defaultValues
-  };
-
-  return (
-    <Form methods={methods} onSubmit={onSubmit}>
-      <Field name="name" inputType="text" label="Name" />
-      <Field
-        name="email"
-        inputType="text"
-        label="Email"
-        registerProps={{
-          required: "Email is required",
-          pattern: { value: /^[^@]+@[^@]+$/, message: "Enter a valid email" },
-        }}
-      />
-      <button type="submit" disabled={isSubmitting}>
-        {isSubmitting ? "Saving…" : "Sign up"}
-      </button>
-    </Form>
-  );
-}
-```
+A `Field`'s `registerProps` is RHF's
+[validation rules](https://react-hook-form.com/docs/useform/register) object,
+passed straight to `register`: `required`, `min`, `max`, `minLength`,
+`maxLength`, `pattern`, and `validate`, plus the value transforms `valueAsNumber`,
+`valueAsDate`, and `setValueAs`. See [Validation](#validation) below for a live
+example.
 
 ### Schema validation (optional)
 

--- a/packages/react/ds-global-form/src/docs/GettingStarted.mdx
+++ b/packages/react/ds-global-form/src/docs/GettingStarted.mdx
@@ -10,10 +10,26 @@ The form system provides a `Form` wrapper and a `Field` router that handle form 
 ## Installation
 
 ```bash
-bun add @canonical/react-ds-global-form
+bun add @canonical/react-ds-global-form @canonical/styles
 ```
 
-The form package depends on `@canonical/react-ds-global` and `@canonical/styles`. No additional CSS imports are required beyond the global `@canonical/styles` import.
+### Import the styles
+
+Two stylesheets are required, imported in your application's root stylesheet:
+
+```css
+/* 1. The global Pragma styles — CSS reset, typography baseline, and the design
+      tokens (colour, spacing, surfaces, states) every component reads. */
+@import url("@canonical/styles");
+
+/* 2. The form styles — input chrome, field layout, and per-component styles. */
+@import url("@canonical/react-ds-global-form/dist/esm/index.css");
+```
+
+Both are needed: the form stylesheet styles the inputs and field layout, but it
+consumes the design tokens defined by the global `@canonical/styles` — without
+the global import the form renders unstyled (missing colours, spacing, and the
+grid). The form package also builds on `@canonical/react-ds-global`.
 
 ## Basic form
 
@@ -52,6 +68,160 @@ function MultiStepForm() {
   );
 }
 ```
+
+## Understanding react-hook-form
+
+This library is a thin layer over [react-hook-form](https://react-hook-form.com/)
+(RHF, `^7.71`). `Form` provides the [`FormProvider`](https://react-hook-form.com/docs/formprovider)
+and `Field` calls [`register`](https://react-hook-form.com/docs/useform/register)
+for you — but **the form state, validation, submission, and everything beyond a
+single field is react-hook-form's API, not this library's.** To build a real
+form you should read the RHF docs; this section is a map of the surface you will
+use, with the pieces this library already wires up called out.
+
+> This library re-exports nothing from RHF. Import RHF hooks
+> (`useForm`, `useFormContext`, `useController`, `useFieldArray`) directly from
+> `"react-hook-form"`.
+
+### `useForm` — the form instance
+
+You only call `useForm` yourself in **external mode** (passing `methods` to
+`Form`); in internal mode `Form` calls it for you from its `defaultValues`/`mode`
+props. Its most-used options ([full reference](https://react-hook-form.com/docs/useform)):
+
+- `mode` — when validation first runs: `"onSubmit"` (default), `"onBlur"`,
+  `"onChange"`, `"onTouched"`, or `"all"`.
+- `defaultValues` — the initial values (an object, or an async function that
+  returns one). Also what `reset()` restores to.
+- `values` — externally-controlled values that re-sync the form when they change.
+- `resolver` — plug in schema validation (zod/yup/valibot…); see below.
+- `reValidateMode`, `criteriaMode`, `shouldUnregister`, `delayError` — finer control.
+
+`useForm` returns the **methods object** (also what `useFormContext()` returns
+inside a `Form`): `register`, `handleSubmit`, `watch`, `getValues`, `setValue`,
+`reset`, `resetField`, `setError`, `clearErrors`, `trigger`, `setFocus`,
+`unregister`, `getFieldState`, `control`, and `formState`.
+
+### `formState` — reacting to the form
+
+[`formState`](https://react-hook-form.com/docs/useform/formstate) is how you read
+what the form is doing. The fields you will reach for most:
+
+- `errors` — per-field validation errors (this library renders these for you).
+- `isSubmitting` — true while an async `onSubmit` runs (disable the submit button).
+- `isValid` / `isDirty` — whether the form passes validation / differs from defaults.
+- `isSubmitSuccessful`, `submitCount`, `touchedFields`, `dirtyFields`.
+
+### Validation rules (`registerProps`)
+
+Each `Field` accepts a `registerProps` object passed straight to RHF's `register`.
+It is RHF's [validation rules](https://react-hook-form.com/docs/useform/register),
+not a bespoke API: `required`, `min`, `max`, `minLength`, `maxLength`, `pattern`,
+`validate` (a function, or an object of named validators — sync or async, each
+returning `true` or an error message), plus value transforms `valueAsNumber`,
+`valueAsDate`, and `setValueAs`.
+
+```tsx
+<Field
+  name="age"
+  inputType="text"
+  label="Age"
+  registerProps={{
+    required: "Age is required",
+    min: { value: 18, message: "Must be 18 or older" },
+    valueAsNumber: true,
+    validate: (v) => v < 130 || "That doesn't look right",
+  }}
+/>
+```
+
+> This library maps the `isOptional` prop to a `required` rule for you, so a
+> field is required by default. Pass `isOptional` to make it optional, or set
+> your own `required` message via `registerProps`.
+
+### Full example: submit, async, reset
+
+Use **external mode** to reach the methods you need beyond a single field —
+`formState` for `isSubmitting`, and `reset` after a successful submit:
+
+```tsx
+import { useForm } from "react-hook-form";
+import { Form, Field } from "@canonical/react-ds-global-form";
+
+type Values = { name: string; email: string };
+
+function SignupForm() {
+  const methods = useForm<Values>({
+    mode: "onBlur",
+    defaultValues: { name: "", email: "" },
+  });
+  const {
+    reset,
+    formState: { isSubmitting },
+  } = methods;
+
+  const onSubmit = async (data: Values) => {
+    await api.createUser(data); // your async call
+    reset(); // clear back to defaultValues
+  };
+
+  return (
+    <Form methods={methods} onSubmit={onSubmit}>
+      <Field name="name" inputType="text" label="Name" />
+      <Field
+        name="email"
+        inputType="text"
+        label="Email"
+        registerProps={{
+          required: "Email is required",
+          pattern: { value: /^[^@]+@[^@]+$/, message: "Enter a valid email" },
+        }}
+      />
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? "Saving…" : "Sign up"}
+      </button>
+    </Form>
+  );
+}
+```
+
+### Schema validation (optional)
+
+For a single source of truth you can validate against a schema instead of
+per-field rules, via a `resolver`. This needs two extra packages —
+`@hookform/resolvers` and a schema library such as `zod` — which are **not**
+bundled with this library:
+
+```bash
+bun add @hookform/resolvers zod
+```
+
+```tsx
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const schema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Enter a valid email"),
+});
+
+const methods = useForm({
+  resolver: zodResolver(schema),
+  defaultValues: { name: "", email: "" },
+});
+// <Form methods={methods} …> — no per-field registerProps needed
+```
+
+### Beyond the basics
+
+For repeating groups of fields (e.g. a list of contacts) use RHF's
+[`useFieldArray`](https://react-hook-form.com/docs/usefieldarray); for
+custom/controlled inputs use [`useController`](https://react-hook-form.com/docs/usecontroller)
+(this library already uses it internally for controlled fields — see
+[Creating Custom Fields](?path=/docs/global-form-guides-creating-custom-fields--docs)).
+When in doubt, the [react-hook-form documentation](https://react-hook-form.com/docs)
+is the authoritative reference for everything the form can do.
 
 ## The Field component
 

--- a/packages/react/ds-global-form/src/docs/GettingStarted.stories.tsx
+++ b/packages/react/ds-global-form/src/docs/GettingStarted.stories.tsx
@@ -28,14 +28,10 @@ function SubmittedValues({ data }: { data: Record<string, unknown> | null }) {
 
 const meta = {
   title: "Documentation/Getting Started/Examples",
-  parameters: { layout: "padded" },
-  decorators: [
-    (Story) => (
-      <div className="grid responsive">
-        <Story />
-      </div>
-    ),
-  ],
+  // `grid: "responsive"` (from @canonical/storybook-addon-utils) renders each
+  // example inside a `.grid.responsive` so the form's subgrid resolves its
+  // columns — and the grid mode stays switchable from the toolbar.
+  parameters: { layout: "padded", grid: "responsive" },
 } satisfies Meta;
 
 export default meta;

--- a/packages/react/ds-global-form/src/docs/GettingStarted.stories.tsx
+++ b/packages/react/ds-global-form/src/docs/GettingStarted.stories.tsx
@@ -1,9 +1,30 @@
 import { Button } from "@canonical/react-ds-global";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { type FieldValues, useForm } from "react-hook-form";
 import Field from "#lib/pattern/Field/Field.js";
 import Form from "#lib/pattern/Form/Form.js";
 
 const noop = (data: Record<string, unknown>) => console.log(data);
+
+/** Small readout so the examples visibly show the submitted values. */
+function SubmittedValues({ data }: { data: Record<string, unknown> | null }) {
+  if (!data) return null;
+  return (
+    <pre
+      style={{
+        marginBlockStart: "1rem",
+        padding: "0.75rem",
+        background: "var(--color-background-neutral-subtle, #f4f4f4)",
+        borderRadius: "0.25rem",
+        fontSize: "0.85em",
+        overflowX: "auto",
+      }}
+    >
+      Submitted: {JSON.stringify(data, null, 2)}
+    </pre>
+  );
+}
 
 const meta = {
   title: "Documentation/Getting Started/Examples",
@@ -40,6 +61,81 @@ export const BasicForm: Story = {
       <Button type="submit">Send</Button>
     </Form>
   ),
+};
+
+export const InternalMode: Story = {
+  name: "Form — internal mode",
+  render: () => {
+    const [submitted, setSubmitted] = useState<Record<string, unknown> | null>(
+      null,
+    );
+    // `Form` owns the useForm instance — pass onSubmit, and optionally
+    // defaultValues and a validation mode. Simplest for a self-contained form.
+    return (
+      <>
+        <Form
+          onSubmit={setSubmitted}
+          defaultValues={{ name: "Ada", email: "" }}
+          mode="onBlur"
+        >
+          <Field name="name" inputType="text" label="Full name" />
+          <Field
+            name="email"
+            inputType="text"
+            label="Email address"
+            registerProps={{ required: "Email is required" }}
+          />
+          <Button type="submit">Send</Button>
+        </Form>
+        <SubmittedValues data={submitted} />
+      </>
+    );
+  },
+};
+
+export const ExternalMode: Story = {
+  name: "Form — external mode",
+  render: () => {
+    const [submitted, setSubmitted] = useState<Record<string, unknown> | null>(
+      null,
+    );
+    // You own the useForm instance, so you can read `formState` (e.g.
+    // `isSubmitting`) and call methods like `reset` — useful for async submits,
+    // shared/multi-step state, or a "reset" button.
+    const methods = useForm<FieldValues>({
+      mode: "onBlur",
+      defaultValues: { name: "", email: "" },
+    });
+    const {
+      reset,
+      formState: { isSubmitting },
+    } = methods;
+
+    const onSubmit = async (data: Record<string, unknown>) => {
+      // Simulate an async request so `isSubmitting` is observable.
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      setSubmitted(data);
+      reset(); // clear back to defaultValues after a successful submit
+    };
+
+    return (
+      <>
+        <Form methods={methods} onSubmit={onSubmit}>
+          <Field name="name" inputType="text" label="Full name" />
+          <Field
+            name="email"
+            inputType="text"
+            label="Email address"
+            registerProps={{ required: "Email is required" }}
+          />
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Saving…" : "Send"}
+          </Button>
+        </Form>
+        <SubmittedValues data={submitted} />
+      </>
+    );
+  },
 };
 
 export const InputTypes: Story = {

--- a/packages/react/ds-global-form/src/docs/Welcome.mdx
+++ b/packages/react/ds-global-form/src/docs/Welcome.mdx
@@ -94,9 +94,16 @@ import { Form, Field } from "@canonical/react-ds-global-form";
 
 Forms require a `.grid` parent — `Form` renders as a subgrid and inherits the column structure. See [Getting Started](?path=/docs/global-form-getting-started--docs) for the full walkthrough.
 
-## Validation
+## Built on react-hook-form
 
-Validation integrates with [react-hook-form](https://react-hook-form.com/) through the [`registerProps`](https://react-hook-form.com/docs/useform/register) prop. Error states apply a `.danger` CSS class that shifts the input border to the error colour. See [Getting Started](?path=/docs/global-form-getting-started--docs) for details.
+This package is a thin layer over [react-hook-form](https://react-hook-form.com/)
+(`^7.71`): `Form` provides the `FormProvider`, `Field` calls `register`, and
+everything beyond a single field — form state, validation, submission — is
+react-hook-form's API. Validation uses the [`registerProps`](https://react-hook-form.com/docs/useform/register)
+prop, and error states apply a `.danger` CSS class that shifts the input border to
+the error colour. The [Getting Started](?path=/docs/global-form-getting-started--docs)
+guide covers both `Form` modes (internal and external) and how to use the
+react-hook-form API for a full working form.
 
 ## Middleware
 
@@ -105,10 +112,21 @@ Middleware wraps input components to add cross-cutting behaviour — fetching op
 ## Installation
 
 ```bash
-bun add @canonical/react-ds-global-form
+bun add @canonical/react-ds-global-form @canonical/styles
 ```
 
-Requires `@canonical/react-ds-global` and `@canonical/styles` as peer dependencies.
+Then import **both** stylesheets in your application's root stylesheet — the
+global Pragma styles (which define the design tokens the form reads) and the form
+styles:
+
+```css
+@import url("@canonical/styles");
+@import url("@canonical/react-ds-global-form/dist/esm/index.css");
+```
+
+Without the global `@canonical/styles` import the form renders unstyled. The
+package also builds on `@canonical/react-ds-global`. See
+[Getting Started](?path=/docs/global-form-getting-started--docs) for the details.
 
 ## Documentation
 

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/ChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/ChoicesField.stories.tsx
@@ -54,12 +54,13 @@ export const StackedMultiple: Story = {
 
 /**
  * Column layout: options are laid out in a grid of equal-width columns, so each
- * option's width is column-based rather than sized to its content. Rendered in a
- * `.grid.responsive` context (via the grid decorator) so the form's subgrid has
- * real column tracks — matching how a form is laid out in a real page.
+ * option's width is column-based rather than sized to its content. The
+ * `grid: "responsive"` parameter (from @canonical/storybook-addon-utils) renders
+ * the story in a `.grid.responsive` context so the form's subgrid has real column
+ * tracks — matching how a form is laid out in a real page.
  */
 export const Columns: Story = {
-  decorators: [decorators.grid(), decorators.form()],
+  parameters: { grid: "responsive" },
   args: {
     name: "select_columns",
     label: "Select a continent",
@@ -70,7 +71,7 @@ export const Columns: Story = {
 };
 
 export const ColumnsMultiple: Story = {
-  decorators: [decorators.grid(), decorators.form()],
+  parameters: { grid: "responsive" },
   args: {
     name: "select_columns_multiple",
     label: "Select continents",

--- a/packages/react/ds-global-form/src/lib/component/RichChoicesField/RichChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RichChoicesField/RichChoicesField.stories.tsx
@@ -4,14 +4,16 @@ import * as decorators from "storybook/decorators.js";
 import { RichChoicesField } from "./index.js";
 
 // Field-tier stories run inside a form decorator (label/description/error +
-// react-hook-form state). The grid decorator nests the form in a
-// `.grid.responsive`, so the form's subgrid has real column tracks for the
-// option cards to span via `--rich-choices-span`.
+// react-hook-form state). The `grid: "responsive"` parameter (from
+// @canonical/storybook-addon-utils) puts the story root in a `.grid.responsive`,
+// so the form's subgrid has real column tracks for the option cards to span via
+// `--rich-choices-span` — and the grid mode stays switchable from the toolbar.
 const meta = {
   title: "components/RichChoicesField",
   component: RichChoicesField,
   tags: ["autodocs"],
-  decorators: [decorators.grid(), decorators.form()],
+  parameters: { grid: "responsive" },
+  decorators: [decorators.form()],
 } satisfies Meta<typeof RichChoicesField>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/storybook/decorators.tsx
+++ b/packages/react/ds-global-form/src/storybook/decorators.tsx
@@ -54,18 +54,3 @@ export const form = ({
     return <FormWrapper />;
   };
 };
-
-/**
- * Wraps a story in a `.grid.responsive` context (the design-system 4/8/12-column
- * responsive grid). A `.ds.form` is a `subgrid`, so it only resolves real column
- * tracks when nested in a parent `.grid` — column-based field layouts (e.g.
- * ChoicesField's "columns", RichChoicesField's `--rich-choices-span`) need this
- * to demonstrate correctly. Compose after `form()`: `[grid(), form()]`.
- */
-export const grid =
-  () =>
-  (Story: React.ElementType): React.ReactElement => (
-    <div className="grid responsive">
-      <Story />
-    </div>
-  );


### PR DESCRIPTION
## Done

Documentation + Storybook improvements for the form package.

**CSS imports (the original gap).** The Getting Started guide wrongly said *"No additional CSS imports are required beyond the global `@canonical/styles` import,"* and the Introduction gave no CSS instructions at all. Both now document the **two required stylesheets** and why both are needed:

```css
@import url("@canonical/styles");                             /* global tokens, reset, typography */
@import url("@canonical/react-ds-global-form/dist/esm/index.css"); /* form input chrome + layout */
```

The form stylesheet consumes the design tokens defined by the global styles, so without the global import the form renders unstyled. (This matches what the README already stated; the MDX had drifted.)

**react-hook-form.** New guidance making explicit that this package is a thin layer over react-hook-form (`^7.71`) and that a full working form uses RHF's own API. Added to Getting Started (an "Understanding react-hook-form" section mapping `useForm` options, the methods object, `formState`, and `registerProps` validation rules) and surfaced in the Introduction. Includes optional schema-validation via a resolver (`@hookform/resolvers` + `zod`), clearly flagged as **not bundled**.

**Runnable internal / external Form examples.** Added live `Form — internal mode` and `Form — external mode` stories, embedded as `<Canvas>` in the guide, so both modes are shown working — external mode demonstrates owning `useForm`, `isSubmitting` button state, `reset()`, and a submitted-values readout. The README's Usage section now documents both modes too.

**Grid parameter migration (drive-by).** Replaced the local `grid()` story decorator with the `grid: "responsive"` **parameter** from `@canonical/storybook-addon-utils` — it applies the grid to the story root (no wrapper div) and adds a toolbar toggle, which is nicer for exploring column-based layouts. Migrated RichChoicesField, ChoicesField's column stories, and the Getting Started examples; removed the now-unused decorator. (The Form pattern stories already used this pattern.)

De-duplicated throughout: each concept (CSS import, form modes, validation rules, `isOptional`) has a single canonical home; cross-references point between them instead of repeating.

## QA

- RHF API details verified against the **installed `react-hook-form@7.71.2` type definitions** (the website blocks fetching): `UseFormProps`, `UseFormReturn`, `FormState`, `RegisterOptions`.
- `bun run check` (tsc + biome + structure) passes; `build:storybook` succeeds (the new Canvas stories and the `grid` parameter render).
- Docs + Storybook config only — no library runtime/API change.
- Rebased onto latest `main`.

### PR readiness check

- [x] Label: `Documentation 📝`
- [x] PR title follows Conventional Commits.
- [x] Package scripts unaffected; `check`/`test`/`build` all defined.
- [x] `no visual change` — MDX prose + story-decorator swap (no rendered-component change).

## Notes

- Uses the current `simple-choices`/`choices` / `ChoicesField`/`RichChoicesField` names as they are on `main` (the choices rename merged in #711).
- The `zod` example is gated behind an explicit install step since `@hookform/resolvers`/`zod` are not dependencies of this package.


- The grid parameter stretched a single-row story to full height; that is fixed centrally in the addon itself (#714), not per-package.
