### PR TITLE
fix(storybook-addon-utils): top-align the grid on the story root

### DIFF
--- a/packages/storybook/addon-utils/src/withUtilStyles.tsx
+++ b/packages/storybook/addon-utils/src/withUtilStyles.tsx
@@ -50,6 +50,12 @@ export const withUtilStyles = (
     root.classList.remove("grid", "responsive", "intrinsic");
     if (gridMode !== "none") {
       root.classList.add("grid", gridMode);
+      // The story root fills the preview height, so a grid there would stretch
+      // its (single) row and the story looks vertically centred. Top-align so
+      // rows take their natural height instead.
+      root.style.alignContent = "start";
+    } else {
+      root.style.removeProperty("align-content");
     }
   }, [gridMode]);
 


### PR DESCRIPTION
## Done

Fix the addon-utils **grid** so a single-row story doesn't render vertically stretched/centred.

The `grid` parameter (and toolbar toggle) adds `.grid` + the mode class to `#storybook-root`. Because the story root fills the preview height, a grid there stretches its (single) row to fill it, so the story content looks vertically centred rather than sitting at the top.

`withUtilStyles` now sets **`align-content: start`** on the root (inline) whenever a grid mode is active, and removes it when the grid is switched off. Rows take their natural (auto) height.

- Covers **both** `responsive` and `intrinsic` modes.
- Fixes it **once, in the addon**, for every consumer — previously each package would have had to add its own `#storybook-root.grid { align-content: start }` rule.
- Applied via inline style, mirroring how the effect already toggles the grid classes imperatively on the same element (the addon ships no stylesheet of its own).

## QA

- `bun run check` (biome + tsc) and `bun run test` pass; `bun run build` produces `dist` with the fix.
- Verified the built `dist/esm/withUtilStyles.js` contains the `alignContent` assignment.

### PR readiness check

- [x] Label: `Bug 🐛`
- [x] PR title follows Conventional Commits.
- [x] Package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [ ] Requires visual testing — changes grid-mode story layout (top-aligned).

## Related

- Supersedes the package-local workaround briefly added in #712 (ds-global-form); that local rule is being reverted since this addon fix is the real home.
