### PR TITLE
fix(storybook-addon-utils): force autodocs pages to the light scheme

### DIFF
--- a/packages/storybook/addon-utils/src/forceLightDocs.ts
+++ b/packages/storybook/addon-utils/src/forceLightDocs.ts
@@ -1,0 +1,24 @@
+// Storybook renders autodocs into `#storybook-docs` (Storybook 10; `.sbdocs` is
+// the content wrapper), in the SAME preview document as the canvas
+// (`#storybook-root`). The design-system tokens use `color-scheme: light dark`
+// + `light-dark()`, so with no explicit scheme they follow the OS. On docs
+// pages the scheme toolbar is not available (it is registered for the `story`
+// view mode only) and no `.light`/`.dark` class is applied to the document — so
+// on a dark-mode OS the docs render dark inside Storybook's light docs chrome,
+// a mismatch.
+//
+// Force `color-scheme: light` on the docs root so autodocs are always light,
+// independent of the OS or the canvas theme toggle. Scoped to the docs root, so
+// the canvas (`#storybook-root`) stays fully theme-toggleable.
+//
+// Injected once, at preview module load, so every consumer of this addon gets
+// it without any per-project CSS.
+
+const STYLE_ID = "ds-utils-force-light-docs";
+
+if (typeof document !== "undefined" && !document.getElementById(STYLE_ID)) {
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = "#storybook-docs, .sbdocs { color-scheme: light; }";
+  document.head.appendChild(style);
+}

--- a/packages/storybook/addon-utils/src/preview.ts
+++ b/packages/storybook/addon-utils/src/preview.ts
@@ -2,6 +2,8 @@ import type { ProjectAnnotations, Renderer } from "storybook/internal/types";
 
 import "@canonical/styles/fonts";
 import "@canonical/styles-debug";
+// Force autodocs pages to render in the light scheme (see forceLightDocs.ts).
+import "./forceLightDocs.js";
 
 import {
   KEY_BASELINE,


### PR DESCRIPTION
## Done

Make **autodocs pages always render in the light scheme**, in every storybook that uses the addon.

**Why they weren't.** Storybook renders autodocs into `#storybook-docs` (`.sbdocs` content wrapper), in the same preview document as the canvas (`#storybook-root`). The design-system tokens use `color-scheme: light dark` + `light-dark()`, so without an explicit scheme they **follow the OS**. On docs pages the scheme toolbar isn't available (it's registered for the `story` view mode only) and no `.light`/`.dark` class is applied to the document — so on a dark-mode OS the docs render dark inside Storybook's light docs chrome, a mismatch (the "dark blocks, light page" issue).

**Fix.** The addon's preview injects a small always-on style that sets `color-scheme: light` on the docs root (`#storybook-docs, .sbdocs`). Autodocs are now always light regardless of OS or the canvas theme toggle; the canvas stays fully theme-toggleable. Injected once at preview load, so every consumer of the addon inherits it — no per-project CSS.

## QA

- `bun run check` (biome + tsc) and `bun run test` pass for the addon; `bun run build` produces `dist` with the fix.
- **Verified end-to-end:** built a consumer storybook (`ds-global-form`) against the rebuilt addon and confirmed the injected style (`ds-utils-force-light-docs` → `#storybook-docs, .sbdocs { color-scheme: light }`) is present in its built preview bundle.

### PR readiness check

- [x] Label: `Bug 🐛`
- [x] PR title follows Conventional Commits.
- [x] Package defines `check`, `check:fix`, `test`, `build`, `build:all`.
- [ ] Requires visual testing — changes autodocs page appearance (forced light).

## Notes

- Reverse-engineered against Storybook 10.3.3: canvas (`#storybook-root`) and docs (`#storybook-docs`) share one preview document; the scheme is otherwise applied by the `withUtilStyles` decorator toggling `.light`/`.dark` on `document.documentElement`, which the docs chrome doesn't get.
- Separate from the addon grid-align fix (#714); both touch this addon but are unrelated.
