### PR TITLE
fix(storybook): sidebar order + tier-scope stories to work-in-progress + docs

### DIFF
--- a/configs/storybook/src/previewConfig.ts
+++ b/configs/storybook/src/previewConfig.ts
@@ -19,6 +19,14 @@ type Preview = ReactPreview & SveltePreview & LitPreview;
  * stories not yet ready for their tier. Only top-level folders are listed;
  * every story is expected to be foldered, so no wildcard catch-all is needed.
  *
+ * NOTE: Storybook statically parses each package's own `preview.ts` for
+ * `storySort` and requires the order to be an inline literal there — an imported
+ * const is rejected — and it does not reliably merge `tags`/`parameters` spread
+ * from an imported preview (https://github.com/storybookjs/storybook/issues/31842).
+ * So the `storySort` below is not effective on its own; consuming packages must
+ * copy the order inline into their local `preview.ts`. It is kept here as the
+ * canonical reference for the tier order.
+ *
  * Color scheme toggling is handled by @canonical/storybook-addon-utils
  * which provides .light/.dark class toggling via its toolbar control.
  */

--- a/packages/react/ds-global-form/.storybook/preview.ts
+++ b/packages/react/ds-global-form/.storybook/preview.ts
@@ -4,10 +4,32 @@ import "./styles.css";
 
 const preview = {
   ...previewConfig,
+  // Storybook statically parses `preview.ts` for `storySort` and requires the
+  // order to be an inline literal — an imported const is rejected — and it does
+  // not reliably merge `tags`/`parameters` spread from an imported preview. So
+  // both `tags` and the `storySort` order are declared inline here rather than
+  // inherited from `@canonical/storybook-config`.
   // https://github.com/storybookjs/storybook/issues/31842
   tags: ["autodocs"],
-  // The sidebar story order (by ontology tier) is inherited from
-  // `@canonical/storybook-config`; no local override needed.
+  parameters: {
+    ...previewConfig.parameters,
+    options: {
+      storySort: {
+        order: [
+          // Keep Introduction first inside the Documentation folder.
+          "Documentation",
+          ["Introduction", "*"],
+          "subcomponents",
+          "components",
+          "groups",
+          "patterns",
+          "common",
+          "utils",
+          "_work_in_progress",
+        ],
+      },
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/InvisibleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/InvisibleWrapper.tsx
@@ -10,6 +10,8 @@ import { useFieldWrapper } from "./hooks/index.js";
  *
  * @param {WrapperProps<ComponentProps>} props - Component props including the Component to wrap and form-related props.
  * @returns {React.ReactElement} - Rendered wrapped component.
+ *
+ * `import { InvisibleWrapper } from "@canonical/react-ds-global-form";`
  */
 const InvisibleWrapper = <ComponentProps extends BaseInputProps>({
   name,

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/Wrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/Wrapper.tsx
@@ -16,6 +16,8 @@ const componentCssClassName = "ds field";
 /**
  * description of the Wrapper component
  * @returns {React.ReactElement} - Rendered Wrapper
+ *
+ * `import { Wrapper } from "@canonical/react-ds-global-form";`
  */
 const Wrapper = <ComponentProps extends BaseInputProps>({
   id,

--- a/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.tsx
@@ -6,6 +6,8 @@ import type { CheckboxFieldProps } from "./types.js";
 /**
  * CheckboxInput bound to react-hook-form, wrapped with field chrome
  * (label, description, error) and middleware/conditional-display support.
+ *
+ * `import { CheckboxField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<CheckboxFieldProps>(
   bindField<CheckboxFieldProps>(CheckboxInput, "native"),

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/Choices.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/Choices.tsx
@@ -12,6 +12,8 @@ const componentCssClassName = "ds form-choices";
  * out via `onChange` (a single value for radios, an array for checkboxes).
  * Each option is rendered by the `Option` subcomponent (common/Option).
  * @returns {React.ReactElement} - Rendered Choices
+ *
+ * `import { Choices } from "@canonical/react-ds-global-form";`
  */
 export const Choices = ({
   id,

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/ChoicesField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/ChoicesField.tsx
@@ -7,6 +7,8 @@ import type { ChoicesFieldProps } from "./types.js";
  * Choices bound to react-hook-form (controlled), wrapped with field
  * chrome. The label is mocked into the fieldset legend, as the "true" label is
  * rendered by the individual options.
+ *
+ * `import { ChoicesField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<ChoicesFieldProps>(
   bindField<ChoicesFieldProps>(Choices, "controlled"),

--- a/packages/react/ds-global-form/src/lib/component/ColorField/ColorField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ColorField/ColorField.stories.tsx
@@ -4,7 +4,7 @@ import { ColorField } from "./index.js";
 
 // Field-tier stories: the color input bound to react-hook-form, inside a form.
 const meta = {
-  title: "components/ColorField",
+  title: "_work_in_progress/component/ColorField",
   component: ColorField,
   tags: ["autodocs"],
   decorators: [decorators.form()],

--- a/packages/react/ds-global-form/src/lib/component/ComboboxField/ComboboxField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ComboboxField/ComboboxField.tsx
@@ -7,6 +7,8 @@ import type { ComboboxFieldProps } from "./types.js";
  * ComboboxInput bound to react-hook-form (controlled), wrapped with field chrome.
  * The single composite value is owned by the field; the presentational
  * ComboboxInput decomposes it across its input/list/chips internally.
+ *
+ * `import { ComboboxField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<ComboboxFieldProps>(
   bindField<ComboboxFieldProps>(ComboboxInput, "controlled"),

--- a/packages/react/ds-global-form/src/lib/component/DateField/DateField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/DateField/DateField.tsx
@@ -6,6 +6,8 @@ import type { DateFieldProps } from "./types.js";
 /**
  * Date input bound to react-hook-form, wrapped with field chrome
  * (label, description, error) and middleware/conditional-display support.
+ *
+ * `import { DateField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<DateFieldProps>(
   bindField<DateFieldProps>(DateInput, "native"),

--- a/packages/react/ds-global-form/src/lib/component/DateTimeField/DateTimeField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/DateTimeField/DateTimeField.tsx
@@ -6,6 +6,8 @@ import type { DateTimeFieldProps } from "./types.js";
 /**
  * DateTime input bound to react-hook-form, wrapped with field chrome
  * (label, description, error) and middleware/conditional-display support.
+ *
+ * `import { DateTimeField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<DateTimeFieldProps>(
   bindField<DateTimeFieldProps>(DateTimeInput, "native"),

--- a/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.tsx
@@ -7,6 +7,8 @@ import type { FileUploadFieldProps } from "./types.js";
  * FileUploadInput bound to react-hook-form (controlled), wrapped with field chrome.
  * The `defaultValue` preserves the registration default the original leaf set
  * in `useController` (`[]`).
+ *
+ * `import { FileUploadField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<FileUploadFieldProps>(
   bindField<FileUploadFieldProps>(FileUploadInput, "controlled", {

--- a/packages/react/ds-global-form/src/lib/component/HiddenField/HiddenField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/HiddenField/HiddenField.tsx
@@ -6,6 +6,8 @@ import type { HiddenFieldProps } from "./types.js";
 /**
  * HiddenInput bound to react-hook-form. Uses InvisibleWrapper so no label,
  * description, or error chrome is rendered.
+ *
+ * `import { HiddenField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<HiddenFieldProps>(
   bindField<HiddenFieldProps>(HiddenInput, "native"),

--- a/packages/react/ds-global-form/src/lib/component/NumberField/NumberField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/NumberField/NumberField.tsx
@@ -9,6 +9,8 @@ import type { NumberFieldProps } from "./types.js";
  * NumberInput bound to react-hook-form, wrapped with field chrome (label,
  * description, error) and middleware/conditional-display support. Collects a
  * numeric value with optional min/max/step and prefix/suffix units.
+ *
+ * `import { NumberField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<NumberFieldProps>(
   // `valueAsNumber` so RHF stores a number, not the string the native

--- a/packages/react/ds-global-form/src/lib/component/PasswordField/PasswordField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/PasswordField/PasswordField.tsx
@@ -9,6 +9,8 @@ import type { PasswordFieldProps } from "./types.js";
  * PasswordInput bound to react-hook-form, wrapped with field chrome (label,
  * description, error) and middleware/conditional-display support. Collects a
  * secret value, masked by default, with a reveal/mask toggle.
+ *
+ * `import { PasswordField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<PasswordFieldProps>(
   bindField<PasswordFieldProps>(PasswordInput, "native"),

--- a/packages/react/ds-global-form/src/lib/component/PhoneField/PhoneField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/PhoneField/PhoneField.tsx
@@ -12,6 +12,8 @@ import type { PhoneFieldProps } from "./types.js";
  * No static `defaultValue` is passed to `bindField`: the registration default
  * depends on `valueFormat`, which the binding cannot know statically, so the
  * presentational PhoneInput defaults defensively from an undefined initial value.
+ *
+ * `import { PhoneField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<PhoneFieldProps>(
   bindField<PhoneFieldProps>(PhoneInput, "controlled"),

--- a/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tsx
@@ -12,6 +12,8 @@ import type { RangeFieldProps } from "./types.js";
  * `RangeControl` for the full a11y / no-JS rationale; spec DE080).
  * `valueAsNumber` so the registered value is a number, not the string the
  * inputs report.
+ *
+ * `import { RangeField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<RangeFieldProps>(
   bindField<RangeFieldProps>(RangeControl, "native", {

--- a/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/RangeControl.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/common/RangeControl/RangeControl.tsx
@@ -52,6 +52,8 @@ function clampToSlider(raw: string, min: number, max: number): string {
  *    change. The number input typing back-fills the slider via local state.
  *
  * See pragma-adrs N.04 / spec DE080. @returns {ReactElement}
+ *
+ * `import { RangeControl } from "@canonical/react-ds-global-form";`
  */
 export const RangeControl = forwardRef<HTMLInputElement, RangeControlProps>(
   function RangeControl(

--- a/packages/react/ds-global-form/src/lib/component/RichChoicesField/RichChoices.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RichChoicesField/RichChoices.tsx
@@ -11,6 +11,8 @@ const componentCssClassName = "ds form-rich-choices";
  * out via `onChange` (a single value for radios, an array for checkboxes).
  * Each option is rendered by the `Option` subcomponent (common/Option).
  * @returns {React.ReactElement} - Rendered RichChoices
+ *
+ * `import { RichChoices } from "@canonical/react-ds-global-form";`
  */
 export const RichChoices = ({
   id,

--- a/packages/react/ds-global-form/src/lib/component/RichChoicesField/RichChoicesField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RichChoicesField/RichChoicesField.tsx
@@ -7,6 +7,8 @@ import type { RichChoicesFieldProps } from "./types.js";
  * RichChoices bound to react-hook-form (controlled), wrapped with field chrome.
  * The label is mocked into the fieldset legend, as the per-option labels are
  * rendered by the individual options.
+ *
+ * `import { RichChoicesField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<RichChoicesFieldProps>(
   bindField<RichChoicesFieldProps>(RichChoices, "controlled"),

--- a/packages/react/ds-global-form/src/lib/component/SelectField/SelectField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SelectField/SelectField.tsx
@@ -6,6 +6,8 @@ import type { SelectFieldProps } from "./types.js";
 /**
  * SelectInput bound to react-hook-form, wrapped with field chrome
  * (label, description, error) and middleware/conditional-display support.
+ *
+ * `import { SelectField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<SelectFieldProps>(
   bindField<SelectFieldProps>(SelectInput, "native"),

--- a/packages/react/ds-global-form/src/lib/component/TextField/TextField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/TextField/TextField.tsx
@@ -6,6 +6,8 @@ import type { TextFieldProps } from "./types.js";
 /**
  * TextInput bound to react-hook-form, wrapped with field chrome
  * (label, description, error) and middleware/conditional-display support.
+ *
+ * `import { TextField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<TextFieldProps>(
   bindField<TextFieldProps>(TextInput, "native"),

--- a/packages/react/ds-global-form/src/lib/component/TextareaField/TextareaField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/TextareaField/TextareaField.tsx
@@ -6,6 +6,8 @@ import type { TextareaFieldProps } from "./types.js";
 /**
  * TextareaInput bound to react-hook-form, wrapped with field chrome
  * (label, description, error) and middleware/conditional-display support.
+ *
+ * `import { TextareaField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<TextareaFieldProps>(
   bindField<TextareaFieldProps>(TextareaInput, "native"),

--- a/packages/react/ds-global-form/src/lib/component/TimeField/TimeField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/TimeField/TimeField.tsx
@@ -6,6 +6,8 @@ import type { TimeFieldProps } from "./types.js";
 /**
  * Time input bound to react-hook-form, wrapped with field chrome
  * (label, description, error) and middleware/conditional-display support.
+ *
+ * `import { TimeField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<TimeFieldProps>(
   bindField<TimeFieldProps>(TimeInput, "native"),

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.tsx
@@ -22,6 +22,8 @@ import type { FieldProps } from "./types.js";
 /**
  * description of the Field component
  * @returns {React.ReactElement} - Rendered Field
+ *
+ * `import { Field } from "@canonical/react-ds-global-form";`
  */
 const Field = ({
   inputType,

--- a/packages/react/ds-global-form/src/lib/pattern/Form/Form.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Form/Form.tsx
@@ -60,6 +60,8 @@ function InternalForm({
 /**
  * Public Form component that routes to the appropriate implementation
  * depending on whether external `methods` are provided.
+ *
+ * `import { Form } from "@canonical/react-ds-global-form";`
  */
 const Form = ({
   methods,

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/CheckboxInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/CheckboxInput.tsx
@@ -11,6 +11,8 @@ const componentCssClassName = "ds form-checkbox";
  * via the field tier, which spreads react-hook-form's `register()` result onto
  * it.
  * @returns {ReactElement} - Rendered Checkbox
+ *
+ * `import { CheckboxInput } from "@canonical/react-ds-global-form";`
  */
 export const CheckboxInput = forwardRef<HTMLInputElement, CheckboxInputProps>(
   function CheckboxInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/ColorInput/ColorInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ColorInput/ColorInput.stories.tsx
@@ -5,7 +5,7 @@ import { ColorInput } from "./ColorInput.js";
 // Presentational stories render the input directly, with no form decorator.
 // State is owned by the story via `useState` (controlled value/onChange).
 const meta = {
-  title: "subcomponents/ColorInput",
+  title: "_work_in_progress/subcomponent/ColorInput",
   component: ColorInput,
   tags: ["autodocs"],
   render: (args) => {

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/ComboboxInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/ComboboxInput.tsx
@@ -11,6 +11,8 @@ const componentCssClassName = "ds combobox";
  * Presentational combobox (controlled, no react-hook-form). Routes to the
  * single- or multiple-select implementation. The forwarded ref targets the
  * text input of the single-select variant.
+ *
+ * `import { ComboboxInput } from "@canonical/react-ds-global-form";`
  */
 export const ComboboxInput = forwardRef<HTMLInputElement, ComboboxInputProps>(
   function ComboboxInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/MultipleCombobox.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/MultipleCombobox.tsx
@@ -21,6 +21,8 @@ const componentCssClassName = "ds form-combobox";
  *
  * @param {ComboboxInputProps} props - The component props
  * @returns {React.ReactElement} - Rendered MultipleCombobox component
+ *
+ * `import { MultipleCombobox } from "@canonical/react-ds-global-form";`
  */
 const MultipleCombobox = ({
   id,

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/ResetButton/ResetButton.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/ResetButton/ResetButton.tsx
@@ -10,6 +10,8 @@ const componentCssClassName = "ds combobox-reset-button";
 /**
  * description of the ResetButton component
  * @returns {React.ReactElement} - Rendered ResetButton
+ *
+ * `import { ResetButton } from "@canonical/react-ds-global-form";`
  */
 const ResetButton = ({
   id,

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateInput/DateInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateInput/DateInput.tsx
@@ -17,6 +17,8 @@ const componentCssClassName = "ds input date chrome";
  * The `value` is always locale-independent ISO `yyyy-mm-dd`. To control the
  * displayed format you would need a custom (non-native) date control.
  * @returns {ReactElement} - Rendered DateInput
+ *
+ * `import { DateInput } from "@canonical/react-ds-global-form";`
  */
 export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
   function DateInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/DateTimeInput.tsx
@@ -17,6 +17,8 @@ const componentCssClassName = "ds input datetime chrome";
  * ISO `yyyy-mm-ddTHH:mm`. Controlling the display would require a custom
  * (non-native) control.
  * @returns {ReactElement} - Rendered DateTimeInput
+ *
+ * `import { DateTimeInput } from "@canonical/react-ds-global-form";`
  */
 export const DateTimeInput = forwardRef<HTMLInputElement, DateTimeInputProps>(
   function DateTimeInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Description/Description.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Description/Description.tsx
@@ -8,6 +8,8 @@ const componentCssClassName = "ds field-description";
 /**
  * description of the Description component
  * @returns {React.ReactElement} - Rendered Description
+ *
+ * `import { Description } from "@canonical/react-ds-global-form";`
  */
 const Description = ({
   id,

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Error/Error.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Error/Error.tsx
@@ -8,6 +8,8 @@ const componentCssClassName = "ds field-error";
 /**
  * description of the Error component
  * @returns {React.ReactElement} - Rendered Error
+ *
+ * `import { Error } from "@canonical/react-ds-global-form";`
  */
 const FieldError = ({
   id,

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tsx
@@ -13,6 +13,8 @@ const defaultMessages = {
 /**
  * description of the Label component
  * @returns {React.ReactElement} - Rendered Label
+ *
+ * `import { Label } from "@canonical/react-ds-global-form";`
  */
 const Label = ({
   id,

--- a/packages/react/ds-global-form/src/lib/subcomponent/FileUploadInput/FileUploadInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/FileUploadInput/FileUploadInput.tsx
@@ -10,6 +10,8 @@ const componentCssClassName = "ds input file-upload";
  * image preview. Controlled via `value`/`onChange` (no react-hook-form). The
  * field tier supplies the binding.
  * @returns {React.ReactElement} - Rendered FileUploadInput
+ *
+ * `import { FileUploadInput } from "@canonical/react-ds-global-form";`
  */
 export const FileUploadInput = ({
   id,

--- a/packages/react/ds-global-form/src/lib/subcomponent/HiddenInput/HiddenInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/HiddenInput/HiddenInput.tsx
@@ -6,6 +6,8 @@ const componentCssClassName = "ds form-hidden";
 /**
  * Presentational hidden input — pure markup, no react-hook-form.
  * @returns {ReactElement} - Rendered Hidden input
+ *
+ * `import { HiddenInput } from "@canonical/react-ds-global-form";`
  */
 export const HiddenInput = forwardRef<HTMLInputElement, HiddenInputProps>(
   function HiddenInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/NumberInput/NumberInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/NumberInput/NumberInput.tsx
@@ -14,6 +14,8 @@ const componentCssClassName = "ds input number chrome";
  * Usable standalone (controlled via `value`/`onChange`, or uncontrolled) or via
  * the field tier, which spreads react-hook-form's `register()` result onto it.
  * @returns {ReactElement} - Rendered NumberInput
+ *
+ * `import { NumberInput } from "@canonical/react-ds-global-form";`
  */
 export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
   function NumberInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/PasswordInput/PasswordInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/PasswordInput/PasswordInput.tsx
@@ -16,6 +16,8 @@ const componentCssClassName = "ds input password chrome";
  * Usable standalone (controlled via `value`/`onChange`, or uncontrolled) or via
  * the field tier, which spreads react-hook-form's `register()` result onto it.
  * @returns {ReactElement} - Rendered PasswordInput
+ *
+ * `import { PasswordInput } from "@canonical/react-ds-global-form";`
  */
 export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
   function PasswordInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/PhoneInput/PhoneInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/PhoneInput/PhoneInput.tsx
@@ -51,6 +51,8 @@ function countryLabel(
  * defaults defensively, so an undefined initial `value` renders the
  * `defaultCountry` with an empty number.
  * @returns {React.ReactElement} - Rendered Phone
+ *
+ * `import { PhoneInput } from "@canonical/react-ds-global-form";`
  */
 export const PhoneInput = ({
   id,

--- a/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/RadioInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/RadioInput.tsx
@@ -14,6 +14,8 @@ const componentCssClassName = "ds form-radio";
  * Usable standalone (controlled via `checked`/`onChange`, or uncontrolled) or
  * via a host that spreads its props onto it.
  * @returns {ReactElement} - Rendered RadioInput
+ *
+ * `import { RadioInput } from "@canonical/react-ds-global-form";`
  */
 export const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
   function RadioInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/RangeInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/RangeInput.tsx
@@ -10,6 +10,8 @@ const componentCssClassName = "ds range";
  * injects it via `bindField(..., { injectValue: true })`. The `<input>` itself
  * stays uncontrolled (driven by register / the consumer).
  * @returns {ReactElement} - Rendered Range
+ *
+ * `import { RangeInput } from "@canonical/react-ds-global-form";`
  */
 export const RangeInput = forwardRef<HTMLInputElement, RangeInputProps>(
   function RangeInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/SelectInput/SelectInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SelectInput/SelectInput.tsx
@@ -10,6 +10,8 @@ const componentCssClassName = "ds input select chrome";
  * Usable standalone (controlled via `value`/`onChange`, or uncontrolled) or via
  * the field tier, which spreads react-hook-form's `register()` result onto it.
  * @returns {ReactElement} - Rendered Select
+ *
+ * `import { SelectInput } from "@canonical/react-ds-global-form";`
  */
 export const SelectInput = forwardRef<HTMLSelectElement, SelectInputProps>(
   function SelectInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/TextInput/TextInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TextInput/TextInput.tsx
@@ -10,6 +10,8 @@ const componentCssClassName = "ds input text chrome";
  * Usable standalone (controlled via `value`/`onChange`, or uncontrolled) or via
  * the field tier, which spreads react-hook-form's `register()` result onto it.
  * @returns {ReactElement} - Rendered Text
+ *
+ * `import { TextInput } from "@canonical/react-ds-global-form";`
  */
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   function TextInput(

--- a/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/TextareaInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/TextareaInput.tsx
@@ -10,6 +10,8 @@ const componentCssClassName = "ds input textarea chrome";
  * Usable standalone (controlled via `value`/`onChange`, or uncontrolled) or via
  * the field tier, which spreads react-hook-form's `register()` result onto it.
  * @returns {ReactElement} - Rendered TextareaInput
+ *
+ * `import { TextareaInput } from "@canonical/react-ds-global-form";`
  */
 export const TextareaInput = forwardRef<
   HTMLTextAreaElement,

--- a/packages/react/ds-global-form/src/lib/subcomponent/TimeInput/TimeInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TimeInput/TimeInput.tsx
@@ -16,6 +16,8 @@ const componentCssClassName = "ds input time chrome";
  * there is no `hour12`/format lever for a native picker. The `value` is always
  * 24-hour ISO `HH:mm`. Forcing 12/24h would require a custom (non-native) control.
  * @returns {ReactElement} - Rendered TimeInput
+ *
+ * `import { TimeInput } from "@canonical/react-ds-global-form";`
  */
 export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
   function TimeInput(

--- a/packages/react/ds-global/.storybook/preview.ts
+++ b/packages/react/ds-global/.storybook/preview.ts
@@ -4,8 +4,32 @@ import "./styles.css";
 
 const preview = {
   ...previewConfig,
+  // Storybook statically parses `preview.ts` for `storySort` and requires the
+  // order to be an inline literal — an imported const is rejected — and it does
+  // not reliably merge `tags`/`parameters` spread from an imported preview. So
+  // both `tags` and the `storySort` order are declared inline here rather than
+  // inherited from `@canonical/storybook-config`.
   // https://github.com/storybookjs/storybook/issues/31842
   tags: ["autodocs"],
+  parameters: {
+    ...previewConfig.parameters,
+    options: {
+      storySort: {
+        order: [
+          // Keep Introduction first inside the Documentation folder.
+          "Documentation",
+          ["Introduction", "*"],
+          "subcomponents",
+          "components",
+          "groups",
+          "patterns",
+          "common",
+          "utils",
+          "_work_in_progress",
+        ],
+      },
+    },
+  },
 };
 
 export default preview;

--- a/packages/react/ds-global/src/docs/Welcome.mdx
+++ b/packages/react/ds-global/src/docs/Welcome.mdx
@@ -5,16 +5,20 @@ import { PackageInfo } from "@canonical/storybook-helpers";
 
 # Global Tier — React
 
-The foundational layer of Pragma. Every interface at Canonical shares these components — buttons, badges, cards, accordions, tooltips. This package is the React implementation of specifications defined in the Design System Ontology, a semantic knowledge graph that bridges design decisions to working code.
+The foundational layer of Pragma: the components every interface at Canonical
+shares. This package is the React implementation of specifications defined in
+the Design System Ontology — a semantic knowledge graph that bridges design
+decisions to working code. Each component's source carries an `@implements`
+annotation linking it back to its specification.
 
 ## Package
 
 <PackageInfo
   name="@canonical/react-ds-global"
-  version="0.11.0"
+  version="0.29.0"
   tier="global"
   framework="react"
-  status="stable"
+  status="experimental"
   dependencies={["@canonical/ds-assets", "@canonical/styles", "@canonical/utils"]}
   links={{
     source: "https://github.com/canonical/pragma/tree/main/packages/react/ds-global",
@@ -22,9 +26,76 @@ The foundational layer of Pragma. Every interface at Canonical shares these comp
   }}
 />
 
-## Architecture
+## Available components
 
-Components implement specifications from the Design System Ontology. Each source file contains an `@implements` annotation linking it to its semantic specification.
+These components are ready to use. Everything else in the sidebar sits under
+**\_work_in_progress** while it is reconciled against the ontology and Figma.
+
+| Component | Tier | What it does |
+| --- | --- | --- |
+| **Accordion** | Component | Vertically stacked, collapsible content built on native `<details>`. |
+| **Breadcrumbs** | Pattern | Navigational trail showing where a page sits in the information hierarchy. |
+| **Icon** | Component | Renders an SVG icon from `@canonical/ds-assets` by name. |
+| **InlineCode** | Component | Inline monospace code, using the `.code` baseline utility. |
+| **KeyboardKey** | Component | A single keyboard key rendered as a `<kbd>`. |
+| **KeyboardKeys** | Group | A group of `KeyboardKey`s forming a keystroke combination. |
+
+## Installation
+
+```bash
+bun add @canonical/react-ds-global
+```
+
+Requires React 19+, and `@canonical/styles` for the design tokens and baseline
+grid (imported once at your app root).
+
+## Usage
+
+```tsx
+import {
+  Accordion,
+  Breadcrumbs,
+  Icon,
+  InlineCode,
+  KeyboardKey,
+  KeyboardKeys,
+} from "@canonical/react-ds-global";
+import "@canonical/styles";
+
+function Example() {
+  return (
+    <>
+      <Breadcrumbs
+        items={[
+          { label: "Docs", url: "/docs" },
+          { label: "Global", url: "/docs/global", current: true },
+        ]}
+      />
+
+      <Accordion>
+        <Accordion.Item heading="Installing the CLI">
+          <p className="p">
+            Run <InlineCode>snap install juju</InlineCode>, then press{" "}
+            <KeyboardKeys>
+              <KeyboardKey keyValue="ctrl" />
+              <KeyboardKey keyValue="c" />
+            </KeyboardKeys>{" "}
+            to copy the output.
+          </p>
+        </Accordion.Item>
+      </Accordion>
+
+      <Icon icon="share" />
+    </>
+  );
+}
+```
+
+Components accept the standard HTML attributes of their underlying element and
+are routing-agnostic where they render links (pass your router's `Link` via the
+`LinkComponent` prop).
+
+## Architecture
 
 ```
 Design System Ontology (specifications)
@@ -33,55 +104,6 @@ Design System Ontology (specifications)
          ↓
 Your Application
 ```
-
-## Modifier System
-
-Components support orthogonal modifier families for systematic variation:
-
-```tsx
-// Importance: visual hierarchy
-<Button importance="primary">Main action</Button>
-<Button importance="secondary">Supporting action</Button>
-<Button importance="tertiary">Subtle action</Button>
-
-// Anticipation: expected outcome
-<Button anticipation="constructive">Save</Button>
-<Button anticipation="caution">Reset</Button>
-<Button anticipation="destructive">Delete</Button>
-
-// Combined
-<Button importance="primary" anticipation="destructive">
-  Delete Account
-</Button>
-```
-
-Each component with modifier support includes a **Matrix** story showing all combinations.
-
-## Installation
-
-```bash
-bun add @canonical/react-ds-global
-```
-
-Requires React 19+. Depends on `@canonical/styles` for CSS.
-
-## Usage
-
-```tsx
-import { Button, Badge, Card } from "@canonical/react-ds-global";
-import "@canonical/styles";
-
-function Example() {
-  return (
-    <Card>
-      <Badge>New</Badge>
-      <Button importance="primary">Submit</Button>
-    </Card>
-  );
-}
-```
-
-Components accept standard HTML attributes for their underlying elements.
 
 ## Links
 

--- a/packages/react/ds-global/src/lib/_work_in_progress/CategoriesSection/CategoriesSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/CategoriesSection/CategoriesSection.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import CategoriesSection from "./CategoriesSection.js";
 
 const meta: Meta<typeof CategoriesSection> = {
-  title: "_work_in_progress/CategoriesSection",
+  title: "_work_in_progress/other/CategoriesSection",
   component: CategoriesSection,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/CategoriesSection/common/Category/Category.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/CategoriesSection/common/Category/Category.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Category from "./Category.js";
 
 const meta: Meta<typeof Category> = {
-  title: "_work_in_progress/CategoriesSection.Category",
+  title: "_work_in_progress/other/CategoriesSection.Category",
   component: Category,
   tags: ["autodocs"],
 };

--- a/packages/react/ds-global/src/lib/_work_in_progress/ChatSection/ChatSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/ChatSection/ChatSection.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import ChatSection from "./ChatSection.js";
 
 const meta: Meta<typeof ChatSection> = {
-  title: "_work_in_progress/ChatSection",
+  title: "_work_in_progress/other/ChatSection",
   component: ChatSection,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/DescriptionSection/DescriptionSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/DescriptionSection/DescriptionSection.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import DescriptionSection from "./DescriptionSection.js";
 
 const meta: Meta<typeof DescriptionSection> = {
-  title: "_work_in_progress/DescriptionSection",
+  title: "_work_in_progress/other/DescriptionSection",
   component: DescriptionSection,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/GridTrial.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/GridTrial.stories.tsx
@@ -8,7 +8,7 @@ import { DescriptionSection } from "#lib/_work_in_progress/DescriptionSection/in
 import { IconSection } from "#lib/_work_in_progress/IconSection/index.js";
 
 const meta: Meta = {
-  title: "_work_in_progress/GridTrial",
+  title: "_work_in_progress/other/GridTrial",
   parameters: {
     layout: "fullscreen",
     grid: "responsive",

--- a/packages/react/ds-global/src/lib/_work_in_progress/IconSection/IconSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/IconSection/IconSection.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import IconSection from "./IconSection.js";
 
 const meta: Meta<typeof IconSection> = {
-  title: "_work_in_progress/IconSection",
+  title: "_work_in_progress/other/IconSection",
   component: IconSection,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/Label/Label.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Label/Label.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Label.js";
 
 const meta = {
-  title: "_work_in_progress/Label",
+  title: "_work_in_progress/other/Label",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/Link/Link.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Link/Link.stories.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import Component from "./Link.js";
 
 const meta = {
-  title: "_work_in_progress/Link",
+  title: "_work_in_progress/other/Link",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/Rule/Rule.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Rule/Rule.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Rule.js";
 
 const meta = {
-  title: "_work_in_progress/Rule",
+  title: "_work_in_progress/component/Rule",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global/src/lib/_work_in_progress/Section/Section.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Section/Section.stories.tsx
@@ -3,7 +3,7 @@ import { SECTION_SPACING } from "./constants.js";
 import Component from "./Section.js";
 
 const meta = {
-  title: "_work_in_progress/Section",
+  title: "_work_in_progress/component/Section",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/SkipLink/SkipLink.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/SkipLink/SkipLink.stories.tsx
@@ -17,7 +17,7 @@ const MainContents = () => (
 );
 
 const meta = {
-  title: "_work_in_progress/SkipLink",
+  title: "_work_in_progress/pattern/SkipLink",
   component: Component,
   parameters: {
     // SkipLink is hidden by default until it is focused, so we disable the snapshot test by default. The `Focused` story, hidden from the sidebar, forces the SkipLink to visible so it can be visually tested.

--- a/packages/react/ds-global/src/lib/_work_in_progress/TSection/TSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/TSection/TSection.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import TSection from "./TSection.js";
 
 const meta: Meta<typeof TSection> = {
-  title: "_work_in_progress/TSection",
+  title: "_work_in_progress/other/TSection",
   component: TSection,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/Typography.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Typography.stories.tsx
@@ -6,7 +6,7 @@
 // - should he have a separate Storybook package, that would group all stories from different sources?
 
 const meta = {
-  title: "_work_in_progress/Typography",
+  title: "_work_in_progress/other/Typography",
   parameters: { layout: "fullscreen" },
 };
 

--- a/packages/react/ds-global/src/lib/_work_in_progress/grid/ApplicationLayout/ApplicationLayout.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/grid/ApplicationLayout/ApplicationLayout.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ApplicationLayout } from "./ApplicationLayout.js";
 
 const meta: Meta<typeof ApplicationLayout> = {
-  title: "_work_in_progress/grid/ApplicationLayout",
+  title: "_work_in_progress/other/grid/ApplicationLayout",
   component: ApplicationLayout,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/grid/GridCard/GridCard.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/grid/GridCard/GridCard.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { GridCard } from "./GridCard.js";
 
 const meta: Meta<typeof GridCard> = {
-  title: "_work_in_progress/grid/GridCard",
+  title: "_work_in_progress/other/grid/GridCard",
   component: GridCard,
   tags: ["autodocs"],
 };

--- a/packages/react/ds-global/src/lib/_work_in_progress/grid/InnerGridDemo/InnerGridDemo.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/grid/InnerGridDemo/InnerGridDemo.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { InnerGridDemo } from "./InnerGridDemo.js";
 
 const meta: Meta<typeof InnerGridDemo> = {
-  title: "_work_in_progress/grid/InnerGridDemo",
+  title: "_work_in_progress/other/grid/InnerGridDemo",
   component: InnerGridDemo,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/_work_in_progress/grid/SettingsView/SettingsView.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/grid/SettingsView/SettingsView.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { SettingsView } from "./SettingsView.js";
 
 const meta: Meta<typeof SettingsView> = {
-  title: "_work_in_progress/grid/SettingsView",
+  title: "_work_in_progress/other/grid/SettingsView",
   component: SettingsView,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/component/Accordion/Accordion.tsx
+++ b/packages/react/ds-global/src/lib/component/Accordion/Accordion.tsx
@@ -15,6 +15,8 @@ const componentCssClassName = "ds accordion";
  * efficient way. Be wary that they can also hide content from users and are
  * not suitable when a user is meant to read all of the page content.
  *
+ * `import { Accordion } from "@canonical/react-ds-global";`
+ *
  * @implements dso:global.component.accordion
  */
 const Accordion = ({

--- a/packages/react/ds-global/src/lib/component/Announcement/Announcement.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Announcement/Announcement.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Announcement.js";
 
 const meta = {
-  title: "components/Announcement",
+  title: "_work_in_progress/component/Announcement",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global/src/lib/component/Badge/Badge.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Badge/Badge.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Badge.js";
 
 const meta = {
-  title: "components/Badge",
+  title: "_work_in_progress/component/Badge",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.tsx
@@ -16,6 +16,8 @@ const componentCssClassName = "ds breadcrumbs";
  * applications with multiple levels of hierarchy and are particularly useful
  * when users might arrive at deep pages through search or external links.
  *
+ * `import { Breadcrumbs } from "@canonical/react-ds-global";`
+ *
  * @implements ds:global.pattern.breadcrumbs
  */
 const Breadcrumbs = ({

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -5,7 +5,7 @@ import { fn } from "storybook/test";
 import Component from "./Button.js";
 
 const meta = {
-  title: "components/Button",
+  title: "_work_in_progress/component/Button",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/component/Card/Card.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/Card.stories.tsx
@@ -4,7 +4,7 @@ import Component from "./Card.js";
 import type { CardProps } from "./types.js";
 
 const meta = {
-  title: "components/Card",
+  title: "_work_in_progress/component/Card",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global/src/lib/component/Card/common/Content/Content.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Content/Content.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryFn } from "@storybook/react-vite";
 import Component from "./Content.js";
 
 const meta = {
-  title: "components/Card/Content",
+  title: "_work_in_progress/component/Card/Content",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Footer.js";
 
 const meta = {
-  title: "components/Card/Footer",
+  title: "_work_in_progress/component/Card/Footer",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/component/Card/common/Header/Header.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Header/Header.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Header.js";
 
 const meta = {
-  title: "components/Card/Header",
+  title: "_work_in_progress/component/Card/Header",
   component: Component,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/component/Card/common/Image/Image.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Image/Image.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Image.js";
 
 const meta = {
-  title: "components/Card/Image",
+  title: "_work_in_progress/component/Card/Image",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/component/Card/common/Thumbnail/Thumbnail.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Thumbnail/Thumbnail.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Thumbnail.js";
 
 const meta = {
-  title: "components/Card/Thumbnail",
+  title: "_work_in_progress/component/Card/Thumbnail",
   component: Component,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/ds-global/src/lib/component/Chip/Chip.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Chip/Chip.stories.tsx
@@ -4,7 +4,7 @@ import { fn } from "storybook/test";
 import Component from "./Chip.js";
 
 const meta = {
-  title: "components/Chip",
+  title: "_work_in_progress/component/Chip",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/component/Icon/Icon.tsx
+++ b/packages/react/ds-global/src/lib/component/Icon/Icon.tsx
@@ -10,6 +10,9 @@ const hasAccessibleName = (value: string | undefined): boolean =>
 
 /**
  * Icon component that renders SVG icons from @canonical/ds-assets
+ *
+ * `import { Icon } from "@canonical/react-ds-global";`
+ *
  * @implements ds:global.component.icon
  */
 const Icon = ({

--- a/packages/react/ds-global/src/lib/component/InlineCode/InlineCode.tsx
+++ b/packages/react/ds-global/src/lib/component/InlineCode/InlineCode.tsx
@@ -7,6 +7,8 @@ const componentCssClassName = "ds inline-code";
 /**
  * This component is used to display code inline or as a standalone block.
  *
+ * `import { InlineCode } from "@canonical/react-ds-global";`
+ *
  * @implements dso:global.component.inline_code
  */
 const InlineCode = ({

--- a/packages/react/ds-global/src/lib/component/KeyboardKey/KeyboardKey.tsx
+++ b/packages/react/ds-global/src/lib/component/KeyboardKey/KeyboardKey.tsx
@@ -14,6 +14,8 @@ const componentCssClassName = "ds keyboard-key";
  * instructional or reference content. It is non-interactive and purely
  * informational.
  *
+ * `import { KeyboardKey } from "@canonical/react-ds-global";`
+ *
  * @implements dso:global.component.keyboard_key
  */
 const KeyboardKey = ({

--- a/packages/react/ds-global/src/lib/component/Tile/Tile.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tile/Tile.stories.tsx
@@ -4,7 +4,7 @@ import Component from "./Tile.js";
 import Tile from "./Tile.js";
 
 const meta = {
-  title: "components/Tile",
+  title: "_work_in_progress/component/Tile",
   component: Component,
   tags: ["autodocs"],
   args: { onClick: fn() },

--- a/packages/react/ds-global/src/lib/component/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/Tooltip.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Component from "./Tooltip.js";
 
 const meta = {
-  title: "components/Tooltip",
+  title: "_work_in_progress/component/Tooltip",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
@@ -6,7 +6,7 @@ import type { BestPosition, WindowFitmentDirection } from "#lib/hooks/index.js";
 import Component from "./TooltipArea.js";
 
 const meta = {
-  title: "components/Tooltip/TooltipArea",
+  title: "_work_in_progress/component/Tooltip/TooltipArea",
   component: Component,
   // Add padding to all tooltips to allow their entire contents to be visible
   parameters: {

--- a/packages/react/ds-global/src/lib/component/Tooltip/withTooltip.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/withTooltip.stories.tsx
@@ -6,7 +6,7 @@ import { withTooltip } from "./index.js";
 type TooltipType = ReturnType<typeof withTooltip>;
 
 const meta = {
-  title: "components/Tooltip/withTooltip",
+  title: "_work_in_progress/component/Tooltip/withTooltip",
   parameters: {
     layout: "centered",
   },

--- a/packages/react/ds-global/src/lib/group/KeyboardKeys/KeyboardKeys.tsx
+++ b/packages/react/ds-global/src/lib/group/KeyboardKeys/KeyboardKeys.tsx
@@ -16,6 +16,9 @@ const componentCssClassName = "ds keyboard-keys";
  * single grouped keystroke.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/kbd#representing_keystrokes_within_an_input
+ *
+ * `import { KeyboardKeys } from "@canonical/react-ds-global";`
+ *
  * @implements dso:global.group.keyboard_keys
  */
 const KeyboardKeys = ({

--- a/packages/react/ds-global/src/lib/pattern/Timeline/Timeline.stories.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Timeline/Timeline.stories.tsx
@@ -3,7 +3,7 @@ import Component from "./Timeline.js";
 import Timeline from "./Timeline.js";
 
 const meta = {
-  title: "patterns/Timeline",
+  title: "_work_in_progress/pattern/Timeline",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;


### PR DESCRIPTION
## Sidebar order (storybookjs/storybook#31842)
The shared `storySort` never took effect: Storybook **statically parses each package's own `preview.ts`** for `storySort` and requires the order to be an **inline literal** (an imported const is rejected), and it doesn't reliably merge `tags`/`parameters` spread from an imported preview. Fix: declare the tier order **inline** in both `ds-global` and `ds-global-form` previews (mirroring how `tags: ["autodocs"]` was already re-declared locally), and **pin Introduction first** inside the Documentation folder.

## Scope stories to work-in-progress (titles only)
Only these appear in the ready sidebar tiers:
- **ds-global** — `components/`: Accordion, Breadcrumbs, Icon, InlineCode, KeyboardKey · `groups/`: KeyboardKeys
- **ds-global-form** — everything except ColorField / ColorInput

Every other story's **title** moves under `_work_in_progress/<type>/…` (`component`, `pattern`, or `other` for non-ontology items like the Sections/grid/Typography). **Only story titles change — no source files were moved**, so the public API and all imports are untouched.

## Component TSDoc import line
Each ready component's TSDoc now shows the consumer import as a backtick-wrapped line just before `@implements`, e.g. `import { Accordion } from "@canonical/react-ds-global";`. Applied to the ready ds-global components and all ds-global-form components/subcomponents (excluding ColorField/ColorInput).

## ds-global Introduction
Rewritten around the available components only (Accordion, Breadcrumbs, Icon, InlineCode, KeyboardKey, KeyboardKeys) with a real usage example; dropped stale references to now-WIP components.

## Verification
- config check ✓ · ds-global tsc/biome/webarchitect ✓ · **208 tests** ✓ · ds-global-form tsc/webarchitect ✓
- Storybook dev parses cleanly (no storySort error); sidebar shows `components` (Accordion, Breadcrumbs, Icon, InlineCode, KeyboardKey), `groups` (KeyboardKeys), `Documentation` (Introduction), and everything else under `_work_in_progress`.

> Note: 5 pre-existing biome warnings in ds-global-form (RichChoicesField story + two CSS specificity) are untouched and out of scope.