### PR TITLE
feat(ds-global-form): SwitchInput + SwitchField

### DIFF
--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
@@ -1,5 +1,5 @@
-/* Toggle field layout: an optional heading and a description stacked above a
- * control row where the input sits inline with its label. */
+/* Toggle field layout, top to bottom: an optional heading, a control row where
+ * the input sits inline with its label, then the description and any error. */
 .ds.field.field-toggle {
   display: flex;
   flex-direction: column;
@@ -11,21 +11,25 @@
     padding: 0;
   }
 
-  /* Control row: input then inline label, aligned on the text baseline. */
+  /* Control row: the input sits at the start of the label's first line, so a
+     multi-line (sentence) label wraps below the input rather than centring on
+     it. */
   & > .field-toggle-control {
     display: flex;
     flex-direction: row;
     align-items: baseline;
     column-gap: var(--form-field-inline-gap);
 
-    /* The inline control label reads as regular body text, not the bold
-       heading-style weight the field label uses by default. It takes the
-       remaining width so long labels wrap beside the control rather than
-       pushing it. */
+    /* The control label is often a full clickable sentence, so it reads as
+       regular body prose (not the bold heading weight the field label uses by
+       default): normal weight, left-aligned, pointer cursor, and it takes the
+       remaining width so it wraps beside the control instead of pushing it. */
     & > .ds.field-label {
       flex: 1;
       min-width: 0;
       font-weight: var(--typography-text-primary-font-weight);
+      text-align: start;
+      cursor: pointer;
     }
   }
 }

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
@@ -1,0 +1,28 @@
+/* Toggle field layout: an optional heading and a description stacked above a
+ * control row where the input sits inline with its label. */
+.ds.field.field-toggle {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--form-group-gap);
+
+  /* The heading is a mock label (a <legend>): reset the fieldset default so it
+     flows like the other block children. */
+  & > .field-toggle-heading {
+    padding: 0;
+  }
+
+  /* Control row: input then inline label, aligned on the text baseline. */
+  & > .field-toggle-control {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    column-gap: var(--form-field-inline-gap);
+
+    /* The label takes the remaining width so long labels wrap beside the
+       control rather than pushing it. */
+    & > .ds.field-label {
+      flex: 1;
+      min-width: 0;
+    }
+  }
+}

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
@@ -18,11 +18,14 @@
     align-items: baseline;
     column-gap: var(--form-field-inline-gap);
 
-    /* The label takes the remaining width so long labels wrap beside the
-       control rather than pushing it. */
+    /* The inline control label reads as regular body text, not the bold
+       heading-style weight the field label uses by default. It takes the
+       remaining width so long labels wrap beside the control rather than
+       pushing it. */
     & > .ds.field-label {
       flex: 1;
       min-width: 0;
+      font-weight: var(--typography-text-primary-font-weight);
     }
   }
 }

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
@@ -92,11 +92,8 @@ const ToggleWrapper = <ComponentProps extends BaseInputProps>({
         </Label>
       )}
 
-      {description && (
-        <Description {...ariaProps.description}>{description}</Description>
-      )}
-
-      {/* The control and its inline true label, side by side. */}
+      {/* The control and its inline true label, side by side. The label is
+          often a full sentence, so it wraps as prose beside the control. */}
       <div className="field-toggle-control">
         <Component {...componentProps} />
         <Label
@@ -108,6 +105,11 @@ const ToggleWrapper = <ComponentProps extends BaseInputProps>({
           {inlineLabel}
         </Label>
       </div>
+
+      {/* Description sits after the control on toggle fields. */}
+      {description && (
+        <Description {...ariaProps.description}>{description}</Description>
+      )}
 
       {isError && (
         <FieldError {...ariaProps.error}>

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
@@ -1,0 +1,125 @@
+import type React from "react";
+import { useMemo } from "react";
+import { states } from "#lib/constants.js";
+import {
+  Description,
+  Error as FieldError,
+  Label,
+} from "#lib/subcomponent/Field/index.js";
+import type { BaseInputProps, WrapperProps } from "../types.js";
+import { useFieldWrapper } from "./hooks/index.js";
+import "./styles.css";
+import "./ToggleWrapper.css";
+
+const componentCssClassName = "ds field field-toggle";
+
+/**
+ * Field wrapper for toggle inputs (checkbox, switch), where the control sits
+ * inline beside its label instead of stacked below it.
+ *
+ * Two label slots:
+ * - `controlLabel` — the inline label beside the control; it carries the real
+ *   `htmlFor` binding. Falls back to `label` when omitted, so a uniform field
+ *   map (`{ label, name, inputType }`) still produces a properly labelled
+ *   control.
+ * - `label` — an optional heading rendered above the control (and description).
+ *   It only shows as a heading when `controlLabel` is also set; otherwise it is
+ *   used as the inline control label.
+ *
+ * @returns {React.ReactElement} - Rendered toggle field
+ *
+ * `import { ToggleWrapper } from "@canonical/react-ds-global-form";`
+ */
+const ToggleWrapper = <ComponentProps extends BaseInputProps>({
+  id,
+  className,
+  style,
+
+  name,
+  Component,
+  description,
+  label,
+  controlLabel,
+  isOptional,
+  requiredIndicator,
+  registerProps: userRegisterProps,
+  nestedRegisterProps,
+  unregisterOnUnmount,
+
+  ...otherProps
+}: WrapperProps<ComponentProps>): React.ReactElement => {
+  // The inline label (beside the control) always carries the htmlFor binding;
+  // the heading only appears when a distinct controlLabel was supplied.
+  const inlineLabel = controlLabel ?? label;
+  const headingLabel = controlLabel && label ? label : undefined;
+
+  if (process.env.NODE_ENV !== "production" && inlineLabel === undefined) {
+    console.warn(
+      `Toggle field "${name}" has no label. Provide \`label\` (and optionally \`controlLabel\`) so the control has an accessible name.`,
+    );
+  }
+
+  const { fieldError, isError, ariaProps, registerProps } = useFieldWrapper(
+    name,
+    {
+      label: inlineLabel,
+      isOptional,
+      userRegisterProps,
+      nestedRegisterProps,
+      unregisterOnUnmount,
+    },
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: comparing name suffices
+  const componentProps = useMemo(
+    () => ({
+      name,
+      registerProps,
+      ...ariaProps.input,
+      ...otherProps,
+    }),
+    [name, registerProps, ariaProps.input],
+  ) as unknown as ComponentProps;
+
+  return (
+    <div
+      id={id}
+      style={style}
+      className={[componentCssClassName, className, isError && states.Danger]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {/* Optional heading above the control (mock label — no htmlFor). */}
+      {headingLabel && (
+        <Label name={name} tag="legend" className="field-toggle-heading">
+          {headingLabel}
+        </Label>
+      )}
+
+      {description && (
+        <Description {...ariaProps.description}>{description}</Description>
+      )}
+
+      {/* The control and its inline true label, side by side. */}
+      <div className="field-toggle-control">
+        <Component {...componentProps} />
+        <Label
+          name={name}
+          isOptional={isOptional}
+          requiredIndicator={requiredIndicator}
+          {...ariaProps.label}
+        >
+          {inlineLabel}
+        </Label>
+      </div>
+
+      {isError && (
+        <FieldError {...ariaProps.error}>
+          {fieldError?.message?.toString()}
+        </FieldError>
+      )}
+    </div>
+  );
+};
+
+export default ToggleWrapper;

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
@@ -49,15 +49,11 @@ const ToggleWrapper = <ComponentProps extends BaseInputProps>({
   ...otherProps
 }: WrapperProps<ComponentProps>): React.ReactElement => {
   // The inline label (beside the control) always carries the htmlFor binding;
-  // the heading only appears when a distinct controlLabel was supplied.
+  // the heading only appears when a distinct controlLabel was supplied. At
+  // least one of `label`/`controlLabel` is guaranteed by the type of the toggle
+  // field props, so no runtime check is needed here.
   const inlineLabel = controlLabel ?? label;
   const headingLabel = controlLabel && label ? label : undefined;
-
-  if (process.env.NODE_ENV !== "production" && inlineLabel === undefined) {
-    console.warn(
-      `Toggle field "${name}" has no label. Provide \`label\` (and optionally \`controlLabel\`) so the control has an accessible name.`,
-    );
-  }
 
   const { fieldError, isError, ariaProps, registerProps } = useFieldWrapper(
     name,

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
@@ -1,5 +1,4 @@
 import type React from "react";
-import { useMemo } from "react";
 import { states } from "#lib/constants.js";
 import {
   Description,
@@ -66,16 +65,14 @@ const ToggleWrapper = <ComponentProps extends BaseInputProps>({
     },
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: comparing name suffices
-  const componentProps = useMemo(
-    () => ({
-      name,
-      registerProps,
-      ...ariaProps.input,
-      ...otherProps,
-    }),
-    [name, registerProps, ariaProps.input],
-  ) as unknown as ComponentProps;
+  // Computed inline (not memoised) so `...otherProps` — disabled, onChange,
+  // etc. — never goes stale between renders.
+  const componentProps = {
+    name,
+    registerProps,
+    ...ariaProps.input,
+    ...otherProps,
+  } as unknown as ComponentProps;
 
   return (
     <div

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/index.ts
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/index.ts
@@ -4,4 +4,5 @@ export { default as InvisibleWrapper } from "./InvisibleWrapper.js";
 export { default as ToggleWrapper } from "./ToggleWrapper.js";
 export * from "./types.js";
 export { default as Wrapper } from "./Wrapper.js";
+export { default as withToggleWrapper } from "./withToggleWrapper.js";
 export { default as withWrapper } from "./withWrapper.js";

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/index.ts
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/index.ts
@@ -1,6 +1,7 @@
 /* @canonical/generator-ds 0.9.0-experimental.4 */
 
 export { default as InvisibleWrapper } from "./InvisibleWrapper.js";
+export { default as ToggleWrapper } from "./ToggleWrapper.js";
 export * from "./types.js";
 export { default as Wrapper } from "./Wrapper.js";
 export { default as withWrapper } from "./withWrapper.js";

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/withToggleWrapper.ts
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/withToggleWrapper.ts
@@ -1,0 +1,37 @@
+import type { ComponentType, FC } from "react";
+import type {
+  BaseInputProps,
+  ToggleLabelProps,
+  WrapperProps,
+} from "../types.js";
+import ToggleWrapper from "./ToggleWrapper.js";
+import withWrapper from "./withWrapper.js";
+
+/**
+ * Public props of a toggle field: everything the wrapper accepts, but with the
+ * optional `label`/`controlLabel` replaced by the "at least one" union so a
+ * label-less toggle is a compile error.
+ */
+type ToggleWrapperProps<ComponentProps extends BaseInputProps> = Omit<
+  WrapperProps<ComponentProps>,
+  "Component" | "label" | "controlLabel"
+> &
+  ToggleLabelProps;
+
+/**
+ * Field HOC for toggle inputs (checkbox, switch). Like `withWrapper`, but bakes
+ * in `ToggleWrapper` (control inline with its label) and types the result to
+ * require at least one of `label`/`controlLabel`. Applying the label constraint
+ * here — in the HOC's return type — keeps it out of the shared `withWrapper`
+ * generics, which would otherwise widen the union back to all-optional.
+ *
+ * `import { withToggleWrapper } from "@canonical/react-ds-global-form";`
+ */
+const withToggleWrapper = <ComponentProps extends BaseInputProps>(
+  Component: ComponentType<ComponentProps>,
+): FC<ToggleWrapperProps<ComponentProps>> =>
+  withWrapper<ComponentProps>(Component, undefined, ToggleWrapper) as FC<
+    ToggleWrapperProps<ComponentProps>
+  >;
+
+export default withToggleWrapper;

--- a/packages/react/ds-global-form/src/lib/common/types.ts
+++ b/packages/react/ds-global-form/src/lib/common/types.ts
@@ -23,6 +23,29 @@ export type InputProps<
   AdditionalComponentProps extends Record<string, any> = {},
 > = BaseInputProps & AdditionalComponentProps;
 
+/**
+ * At least one of `label`/`controlLabel` — the toggle-field label requirement,
+ * expressed as a union so a label-less toggle is a compile error rather than a
+ * runtime check.
+ */
+export type ToggleLabelProps =
+  | { label: string; controlLabel?: string }
+  | { label?: string; controlLabel: string };
+
+/**
+ * Props for toggle fields (checkbox, switch), which render the control inline
+ * with its label via the ToggleWrapper. On top of the usual input props they
+ * add `controlLabel` (the inline label beside the control) and require at least
+ * one of `label`/`controlLabel`. `label` alone is the inline label (the
+ * field-map case); `label` + `controlLabel` renders `label` as a heading above
+ * and `controlLabel` inline.
+ */
+export type ToggleFieldProps<
+  // biome-ignore lint/complexity/noBannedTypes: toggle inputs may add no extra props
+  // biome-ignore lint/suspicious/noExplicitAny: presentational prop shapes vary
+  AdditionalComponentProps extends Record<string, any> = {},
+> = InputProps<AdditionalComponentProps> & ToggleLabelProps;
+
 export type BaseWrapperProps<ComponentProps> = BaseProps & {
   /* The input to render */
   Component: React.ComponentType<ComponentProps>;

--- a/packages/react/ds-global-form/src/lib/common/types.ts
+++ b/packages/react/ds-global-form/src/lib/common/types.ts
@@ -35,6 +35,12 @@ export type WrapperProps<ComponentProps> = BaseWrapperProps<ComponentProps> & {
   /* The name of input labelled */
   label?: string;
 
+  /* Toggle fields (checkbox, switch) only: the inline label rendered beside the
+   * control, which carries the real `htmlFor` binding. When omitted it falls
+   * back to `label`; when both are set, `label` becomes the heading above and
+   * `controlLabel` the inline control label. */
+  controlLabel?: string;
+
   /* Is the field optional */
   isOptional?: boolean;
 

--- a/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.tests.tsx
@@ -5,34 +5,34 @@ import { CheckboxField } from "./index.js";
 
 describe("CheckboxField", () => {
   it("renders a checkbox input", () => {
-    renderWithForm(<CheckboxField name="agree" />);
+    renderWithForm(<CheckboxField name="agree" label="Agree" />);
     expect(screen.getByRole("checkbox")).toBeInTheDocument();
   });
 
   it("registers with react-hook-form", () => {
-    renderWithForm(<CheckboxField name="agree" />);
+    renderWithForm(<CheckboxField name="agree" label="Agree" />);
     expect(screen.getByRole("checkbox")).toHaveAttribute("name", "agree");
   });
 
   it("applies the component class", () => {
-    renderWithForm(<CheckboxField name="agree" />);
+    renderWithForm(<CheckboxField name="agree" label="Agree" />);
     expect(screen.getByRole("checkbox")).toHaveClass("form-checkbox");
   });
 
   it("supports disabled state", () => {
-    renderWithForm(<CheckboxField name="agree" disabled />);
+    renderWithForm(<CheckboxField name="agree" label="Agree" disabled />);
     expect(screen.getByRole("checkbox")).toBeDisabled();
   });
 
   it("supports default checked via form defaultValues", () => {
-    renderWithForm(<CheckboxField name="agree" />, {
+    renderWithForm(<CheckboxField name="agree" label="Agree" />, {
       formProps: { defaultValues: { agree: true } },
     });
     expect(screen.getByRole("checkbox")).toBeChecked();
   });
 
   it("toggles on click", () => {
-    renderWithForm(<CheckboxField name="agree" />);
+    renderWithForm(<CheckboxField name="agree" label="Agree" />);
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox).not.toBeChecked();
     fireEvent.click(checkbox);

--- a/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.tsx
@@ -1,18 +1,19 @@
 import bindField from "#lib/common/bindField/index.js";
-import ToggleWrapper from "#lib/common/Wrapper/ToggleWrapper.js";
-import withWrapper from "#lib/common/Wrapper/withWrapper.js";
+import type { InputProps } from "#lib/common/types.js";
+import withToggleWrapper from "#lib/common/Wrapper/withToggleWrapper.js";
+import type { CheckboxInputProps } from "#lib/subcomponent/CheckboxInput/index.js";
 import { CheckboxInput } from "#lib/subcomponent/CheckboxInput/index.js";
-import type { CheckboxFieldProps } from "./types.js";
+
+type CheckboxInputFieldProps = InputProps<CheckboxInputProps>;
 
 /**
  * CheckboxInput bound to react-hook-form, wrapped with the toggle field chrome
  * (inline label, optional heading, description, error) and
- * middleware/conditional-display support.
+ * middleware/conditional-display support. Requires at least one of
+ * `label`/`controlLabel`.
  *
  * `import { CheckboxField } from "@canonical/react-ds-global-form";`
  */
-export default withWrapper<CheckboxFieldProps>(
-  bindField<CheckboxFieldProps>(CheckboxInput, "native"),
-  undefined,
-  ToggleWrapper,
+export default withToggleWrapper<CheckboxInputFieldProps>(
+  bindField<CheckboxInputFieldProps>(CheckboxInput, "native"),
 );

--- a/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.tsx
@@ -1,14 +1,18 @@
 import bindField from "#lib/common/bindField/index.js";
+import ToggleWrapper from "#lib/common/Wrapper/ToggleWrapper.js";
 import withWrapper from "#lib/common/Wrapper/withWrapper.js";
 import { CheckboxInput } from "#lib/subcomponent/CheckboxInput/index.js";
 import type { CheckboxFieldProps } from "./types.js";
 
 /**
- * CheckboxInput bound to react-hook-form, wrapped with field chrome
- * (label, description, error) and middleware/conditional-display support.
+ * CheckboxInput bound to react-hook-form, wrapped with the toggle field chrome
+ * (inline label, optional heading, description, error) and
+ * middleware/conditional-display support.
  *
  * `import { CheckboxField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<CheckboxFieldProps>(
   bindField<CheckboxFieldProps>(CheckboxInput, "native"),
+  undefined,
+  ToggleWrapper,
 );

--- a/packages/react/ds-global-form/src/lib/component/CheckboxField/types.ts
+++ b/packages/react/ds-global-form/src/lib/component/CheckboxField/types.ts
@@ -1,5 +1,8 @@
-import type { InputProps } from "#lib/common/types.js";
+import type { ToggleFieldProps } from "#lib/common/types.js";
 import type { CheckboxInputProps } from "#lib/subcomponent/CheckboxInput/index.js";
 
-/** Props for the react-hook-form-bound Checkbox field (presentational + binding). */
-export type CheckboxFieldProps = InputProps<CheckboxInputProps>;
+/**
+ * Props for the react-hook-form-bound Checkbox field (presentational +
+ * binding). A toggle field: requires at least one of `label`/`controlLabel`.
+ */
+export type CheckboxFieldProps = ToggleFieldProps<CheckboxInputProps>;

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.stories.tsx
@@ -68,12 +68,24 @@ export const WithHeading: Story = {
   },
 };
 
-/** Heading, description, then the toggle with its inline label. */
+/** Heading, the toggle with its inline label, then the description below. */
 export const WithDescription: Story = {
   args: {
     name: "notifications_described",
     label: "Notifications",
     controlLabel: "Email updates",
     description: "Send me product updates and security alerts.",
+  },
+};
+
+/**
+ * The control label is often a full sentence to click, not a short word. It
+ * wraps as prose beside the toggle, which stays aligned to its first line.
+ */
+export const SentenceLabel: Story = {
+  args: {
+    name: "terms",
+    label:
+      "I agree to the terms of service and acknowledge that my data will be processed in line with the privacy policy.",
   },
 };

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.stories.tsx
@@ -47,10 +47,33 @@ export const DisabledChecked: Story = {
   },
 };
 
+/**
+ * With only `label`, it is used as the inline label beside the toggle — the
+ * shape a uniform field map produces. No heading is rendered.
+ */
+export const InlineLabelOnly: Story = {
+  args: { name: "notifications_inline", label: "Enable email notifications" },
+};
+
+/**
+ * Providing both `label` and `controlLabel` renders the full toggle layout: the
+ * `label` becomes a heading above, and `controlLabel` is the inline label
+ * beside the toggle (which carries the `htmlFor` binding).
+ */
+export const WithHeading: Story = {
+  args: {
+    name: "notifications_heading",
+    label: "Notifications",
+    controlLabel: "Email updates",
+  },
+};
+
+/** Heading, description, then the toggle with its inline label. */
 export const WithDescription: Story = {
   args: {
     name: "notifications_described",
-    label: "Email notifications",
+    label: "Notifications",
+    controlLabel: "Email updates",
     description: "Send me product updates and security alerts.",
   },
 };

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as decorators from "storybook/decorators.js";
+import { SwitchField } from "./index.js";
+
+// Field-tier stories run inside a form decorator (label/description/error +
+// react-hook-form state).
+const meta = {
+  title: "components/SwitchField",
+  component: SwitchField,
+  tags: ["autodocs"],
+  decorators: [decorators.form()],
+} satisfies Meta<typeof SwitchField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { name: "notifications", label: "Notifications" },
+};
+
+export const Checked: Story = {
+  decorators: [
+    decorators.form({ defaultValues: { notifications_checked: true } }),
+  ],
+  args: { name: "notifications_checked", label: "Checked" },
+};
+
+export const Disabled: Story = {
+  args: {
+    name: "notifications_disabled",
+    label: "Disabled",
+    disabled: true,
+  },
+};
+
+export const DisabledChecked: Story = {
+  decorators: [
+    decorators.form({
+      defaultValues: { notifications_disabled_checked: true },
+    }),
+  ],
+  args: {
+    name: "notifications_disabled_checked",
+    label: "Disabled checked",
+    disabled: true,
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    name: "notifications_described",
+    label: "Email notifications",
+    description: "Send me product updates and security alerts.",
+  },
+};

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tests.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithForm } from "../../../testing/renderWithForm.js";
+import { SwitchField } from "./index.js";
+
+describe("SwitchField", () => {
+  it("renders a switch input", () => {
+    renderWithForm(<SwitchField name="notify" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+  });
+
+  it("registers with react-hook-form", () => {
+    renderWithForm(<SwitchField name="notify" />);
+    expect(screen.getByRole("switch")).toHaveAttribute("name", "notify");
+  });
+
+  it("applies the component class", () => {
+    renderWithForm(<SwitchField name="notify" />);
+    expect(screen.getByRole("switch")).toHaveClass("form-switch");
+  });
+
+  it("supports disabled state", () => {
+    renderWithForm(<SwitchField name="notify" disabled />);
+    expect(screen.getByRole("switch")).toBeDisabled();
+  });
+
+  it("supports default checked via form defaultValues", () => {
+    renderWithForm(<SwitchField name="notify" />, {
+      formProps: { defaultValues: { notify: true } },
+    });
+    expect(screen.getByRole("switch")).toBeChecked();
+  });
+
+  it("toggles on click", () => {
+    renderWithForm(<SwitchField name="notify" />);
+    const toggle = screen.getByRole("switch");
+    expect(toggle).not.toBeChecked();
+    fireEvent.click(toggle);
+    expect(toggle).toBeChecked();
+  });
+});

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tests.tsx
@@ -5,34 +5,34 @@ import { SwitchField } from "./index.js";
 
 describe("SwitchField", () => {
   it("renders a switch input", () => {
-    renderWithForm(<SwitchField name="notify" />);
+    renderWithForm(<SwitchField name="notify" label="Notify" />);
     expect(screen.getByRole("switch")).toBeInTheDocument();
   });
 
   it("registers with react-hook-form", () => {
-    renderWithForm(<SwitchField name="notify" />);
+    renderWithForm(<SwitchField name="notify" label="Notify" />);
     expect(screen.getByRole("switch")).toHaveAttribute("name", "notify");
   });
 
   it("applies the component class", () => {
-    renderWithForm(<SwitchField name="notify" />);
+    renderWithForm(<SwitchField name="notify" label="Notify" />);
     expect(screen.getByRole("switch")).toHaveClass("form-switch");
   });
 
   it("supports disabled state", () => {
-    renderWithForm(<SwitchField name="notify" disabled />);
+    renderWithForm(<SwitchField name="notify" label="Notify" disabled />);
     expect(screen.getByRole("switch")).toBeDisabled();
   });
 
   it("supports default checked via form defaultValues", () => {
-    renderWithForm(<SwitchField name="notify" />, {
+    renderWithForm(<SwitchField name="notify" label="Notify" />, {
       formProps: { defaultValues: { notify: true } },
     });
     expect(screen.getByRole("switch")).toBeChecked();
   });
 
   it("toggles on click", () => {
-    renderWithForm(<SwitchField name="notify" />);
+    renderWithForm(<SwitchField name="notify" label="Notify" />);
     const toggle = screen.getByRole("switch");
     expect(toggle).not.toBeChecked();
     fireEvent.click(toggle);

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
@@ -1,18 +1,19 @@
 import bindField from "#lib/common/bindField/index.js";
-import ToggleWrapper from "#lib/common/Wrapper/ToggleWrapper.js";
-import withWrapper from "#lib/common/Wrapper/withWrapper.js";
+import type { InputProps } from "#lib/common/types.js";
+import withToggleWrapper from "#lib/common/Wrapper/withToggleWrapper.js";
+import type { SwitchInputProps } from "#lib/subcomponent/SwitchInput/index.js";
 import { SwitchInput } from "#lib/subcomponent/SwitchInput/index.js";
-import type { SwitchFieldProps } from "./types.js";
+
+type SwitchInputFieldProps = InputProps<SwitchInputProps>;
 
 /**
  * SwitchInput bound to react-hook-form, wrapped with the toggle field chrome
  * (inline label, optional heading, description, error) and
- * middleware/conditional-display support.
+ * middleware/conditional-display support. Requires at least one of
+ * `label`/`controlLabel`.
  *
  * `import { SwitchField } from "@canonical/react-ds-global-form";`
  */
-export default withWrapper<SwitchFieldProps>(
-  bindField<SwitchFieldProps>(SwitchInput, "native"),
-  undefined,
-  ToggleWrapper,
+export default withToggleWrapper<SwitchInputFieldProps>(
+  bindField<SwitchInputFieldProps>(SwitchInput, "native"),
 );

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
@@ -1,0 +1,14 @@
+import bindField from "#lib/common/bindField/index.js";
+import withWrapper from "#lib/common/Wrapper/withWrapper.js";
+import { SwitchInput } from "#lib/subcomponent/SwitchInput/index.js";
+import type { SwitchFieldProps } from "./types.js";
+
+/**
+ * SwitchInput bound to react-hook-form, wrapped with field chrome
+ * (label, description, error) and middleware/conditional-display support.
+ *
+ * `import { SwitchField } from "@canonical/react-ds-global-form";`
+ */
+export default withWrapper<SwitchFieldProps>(
+  bindField<SwitchFieldProps>(SwitchInput, "native"),
+);

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
@@ -1,14 +1,18 @@
 import bindField from "#lib/common/bindField/index.js";
+import ToggleWrapper from "#lib/common/Wrapper/ToggleWrapper.js";
 import withWrapper from "#lib/common/Wrapper/withWrapper.js";
 import { SwitchInput } from "#lib/subcomponent/SwitchInput/index.js";
 import type { SwitchFieldProps } from "./types.js";
 
 /**
- * SwitchInput bound to react-hook-form, wrapped with field chrome
- * (label, description, error) and middleware/conditional-display support.
+ * SwitchInput bound to react-hook-form, wrapped with the toggle field chrome
+ * (inline label, optional heading, description, error) and
+ * middleware/conditional-display support.
  *
  * `import { SwitchField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<SwitchFieldProps>(
   bindField<SwitchFieldProps>(SwitchInput, "native"),
+  undefined,
+  ToggleWrapper,
 );

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/index.ts
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/index.ts
@@ -1,0 +1,2 @@
+export { default as SwitchField } from "./SwitchField.js";
+export type { SwitchFieldProps } from "./types.js";

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/types.ts
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/types.ts
@@ -1,0 +1,5 @@
+import type { InputProps } from "#lib/common/types.js";
+import type { SwitchInputProps } from "#lib/subcomponent/SwitchInput/index.js";
+
+/** Props for the react-hook-form-bound Switch field (presentational + binding). */
+export type SwitchFieldProps = InputProps<SwitchInputProps>;

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/types.ts
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/types.ts
@@ -1,5 +1,8 @@
-import type { InputProps } from "#lib/common/types.js";
+import type { ToggleFieldProps } from "#lib/common/types.js";
 import type { SwitchInputProps } from "#lib/subcomponent/SwitchInput/index.js";
 
-/** Props for the react-hook-form-bound Switch field (presentational + binding). */
-export type SwitchFieldProps = InputProps<SwitchInputProps>;
+/**
+ * Props for the react-hook-form-bound Switch field (presentational + binding).
+ * A toggle field: requires at least one of `label`/`controlLabel`.
+ */
+export type SwitchFieldProps = ToggleFieldProps<SwitchInputProps>;

--- a/packages/react/ds-global-form/src/lib/component/index.ts
+++ b/packages/react/ds-global-form/src/lib/component/index.ts
@@ -14,6 +14,7 @@ export * from "./PhoneField/index.js";
 export * from "./RangeField/index.js";
 export * from "./RichChoicesField/index.js";
 export * from "./SelectField/index.js";
+export * from "./SwitchField/index.js";
 export * from "./TextareaField/index.js";
 export * from "./TextField/index.js";
 export * from "./TimeField/index.js";

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.tsx
@@ -14,6 +14,7 @@ import { PhoneField } from "#lib/component/PhoneField/index.js";
 import { RangeField } from "#lib/component/RangeField/index.js";
 import { RichChoicesField } from "#lib/component/RichChoicesField/index.js";
 import { SelectField } from "#lib/component/SelectField/index.js";
+import { SwitchField } from "#lib/component/SwitchField/index.js";
 import { TextareaField } from "#lib/component/TextareaField/index.js";
 import { TextField } from "#lib/component/TextField/index.js";
 import { TimeField } from "#lib/component/TimeField/index.js";
@@ -35,6 +36,8 @@ const Field = ({
       return <TextareaField {...props} />;
     case "checkbox":
       return <CheckboxField {...props} />;
+    case "switch":
+      return <SwitchField {...props} />;
     case "range":
       return <RangeField {...props} />;
     case "select":

--- a/packages/react/ds-global-form/src/lib/pattern/Field/types.ts
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/types.ts
@@ -13,6 +13,7 @@ import type { PhoneFieldProps } from "#lib/component/PhoneField/index.js";
 import type { RangeFieldProps } from "#lib/component/RangeField/index.js";
 import type { RichChoicesFieldProps } from "#lib/component/RichChoicesField/index.js";
 import type { SelectFieldProps } from "#lib/component/SelectField/index.js";
+import type { SwitchFieldProps } from "#lib/component/SwitchField/index.js";
 import type { TextareaFieldProps } from "#lib/component/TextareaField/index.js";
 import type { TextFieldProps } from "#lib/component/TextField/index.js";
 import type { TimeFieldProps } from "#lib/component/TimeField/index.js";
@@ -46,6 +47,7 @@ export type FieldProps =
   | ({ inputType: "password" } & PasswordFieldProps)
   | ({ inputType: "number" } & NumberFieldProps)
   | ({ inputType: "checkbox" } & CheckboxFieldProps)
+  | ({ inputType: "switch" } & SwitchFieldProps)
   | ({ inputType: "hidden" } & HiddenFieldProps)
   | ({ inputType: "range" } & RangeFieldProps)
   | ({ inputType: "select" } & SelectFieldProps)

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.ssr.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.ssr.tests.tsx
@@ -1,0 +1,17 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SwitchInput } from "./SwitchInput.js";
+
+// Proves the presentational input renders to static HTML with no client
+// runtime / form context — the server-rendered floor for progressive
+// enhancement.
+describe("SwitchInput (SSR)", () => {
+  it("renders to static HTML without a form context", () => {
+    const html = renderToString(<SwitchInput name="notify" />);
+    expect(html).toContain("<input");
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain('role="switch"');
+    expect(html).toContain('name="notify"');
+    expect(html).toContain("ds form-switch");
+  });
+});

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SwitchInput } from "./SwitchInput.js";
+
+// Presentational stories render the input directly, with no form decorator.
+const meta = {
+  title: "subcomponents/SwitchInput",
+  component: SwitchInput,
+  tags: ["autodocs"],
+} satisfies Meta<typeof SwitchInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { name: "notifications" },
+};
+
+export const Checked: Story = {
+  args: { name: "notifications_checked", defaultChecked: true },
+};
+
+export const Disabled: Story = {
+  args: { name: "notifications_disabled", disabled: true },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    name: "notifications_disabled_checked",
+    disabled: true,
+    defaultChecked: true,
+  },
+};

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.tests.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SwitchInput } from "./SwitchInput.js";
+
+// These tests render the presentational input with NO FormProvider, proving it
+// is usable standalone (outside of a <Form>).
+describe("SwitchInput (presentational)", () => {
+  it("renders a switch without a form context", () => {
+    render(<SwitchInput name="notify" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+  });
+
+  it("renders as a checkbox input under the hood", () => {
+    render(<SwitchInput name="notify" />);
+    expect(screen.getByRole("switch")).toHaveAttribute("type", "checkbox");
+  });
+
+  it("applies the component class", () => {
+    render(<SwitchInput name="notify" />);
+    expect(screen.getByRole("switch")).toHaveClass("form-switch");
+  });
+
+  it("is controllable via checked/onChange", () => {
+    const onChange = vi.fn();
+    render(<SwitchInput name="notify" checked onChange={onChange} />);
+    expect(screen.getByRole("switch")).toBeChecked();
+  });
+
+  it("forwards a ref to the underlying input", () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<SwitchInput name="notify" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it("supports the disabled state", () => {
+    render(<SwitchInput name="notify" disabled />);
+    expect(screen.getByRole("switch")).toBeDisabled();
+  });
+});

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.tests.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { SwitchInput } from "./SwitchInput.js";
@@ -24,7 +24,10 @@ describe("SwitchInput (presentational)", () => {
   it("is controllable via checked/onChange", () => {
     const onChange = vi.fn();
     render(<SwitchInput name="notify" checked onChange={onChange} />);
-    expect(screen.getByRole("switch")).toBeChecked();
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toBeChecked();
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it("forwards a ref to the underlying input", () => {

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.tsx
@@ -24,12 +24,15 @@ export const SwitchInput = forwardRef<HTMLInputElement, SwitchInputProps>(
       <input
         id={id}
         style={style}
-        type="checkbox"
-        // biome-ignore lint/a11y/useAriaPropsForRole: a native checkbox exposes its checked state to the a11y tree, so role="switch" needs no explicit aria-checked.
-        role="switch"
         className={[componentCssClassName, className].filter(Boolean).join(" ")}
         ref={ref}
         {...nativeProps}
+        // `type`/`role` are the fixed switch semantics: spread `nativeProps`
+        // BEFORE them so they can never be overridden (belt-and-suspenders with
+        // omitting the keys from SwitchInputProps).
+        type="checkbox"
+        // biome-ignore lint/a11y/useAriaPropsForRole: a native checkbox exposes its checked state to the a11y tree, so role="switch" needs no explicit aria-checked.
+        role="switch"
       />
     );
   },

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type ReactElement } from "react";
+import type { SwitchInputProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds form-switch";
+
+/**
+ * Presentational switch input — pure markup, no react-hook-form.
+ *
+ * A switch is a checkbox with `role="switch"`, styled as a sliding toggle.
+ * Usable standalone (controlled via `checked`/`onChange`, or uncontrolled) or
+ * via the field tier, which spreads react-hook-form's `register()` result onto
+ * it. Do not use directly in a form — use SwitchField instead.
+ * @returns {ReactElement} - Rendered Switch
+ *
+ * `import { SwitchInput } from "@canonical/react-ds-global-form";`
+ */
+export const SwitchInput = forwardRef<HTMLInputElement, SwitchInputProps>(
+  function SwitchInput(
+    { id, className, style, ...nativeProps },
+    ref,
+  ): ReactElement {
+    return (
+      <input
+        id={id}
+        style={style}
+        type="checkbox"
+        // biome-ignore lint/a11y/useAriaPropsForRole: a native checkbox exposes its checked state to the a11y tree, so role="switch" needs no explicit aria-checked.
+        role="switch"
+        className={[componentCssClassName, className].filter(Boolean).join(" ")}
+        ref={ref}
+        {...nativeProps}
+      />
+    );
+  },
+);
+
+export default SwitchInput;

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/index.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/index.ts
@@ -1,0 +1,2 @@
+export { default as SwitchInput } from "./SwitchInput.js";
+export type { SwitchInputProps } from "./types.js";

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
@@ -1,0 +1,89 @@
+/* A switch is a checkbox (role="switch") styled as a sliding pill toggle.
+ * The track is the <input> box; the knob is a `::before` pseudo-element that
+ * slides from left (off) to right (on). Colours come from the switch token
+ * channel; the geometry is in baseline multiples. */
+.ds.form-switch {
+  /* Geometry, all derived from the track size and a 1px inset. */
+  --switch-track-width: calc(var(--space-baseline) * 4); /* 32px — 4bU */
+  --switch-track-height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+  --switch-knob-inset: 1px;
+  --switch-knob-size: calc(
+    var(--switch-track-height) -
+    (var(--switch-knob-inset) * 2)
+  );
+
+  appearance: none;
+  box-sizing: border-box;
+  position: relative;
+
+  /* Align to the field edge like the label, not the input's inner padding. */
+  margin-inline: var(--form-label-padding-inline, 0);
+
+  /* Track: a 2:1 pill. */
+  width: var(--switch-track-width);
+  height: var(--switch-track-height);
+  border: var(--dimension-stroke-thickness-medium) solid transparent;
+  border-radius: var(--dimension-radius-full);
+  background: var(--color-foreground-switch-unselected);
+  cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease;
+
+  /* Knob: a circle inset from the track edges, sliding on the inline axis. */
+  &::before {
+    content: "";
+    position: absolute;
+    inset-block: var(--switch-knob-inset);
+    inset-inline-start: var(--switch-knob-inset);
+    width: var(--switch-knob-size);
+    height: var(--switch-knob-size);
+    border-radius: var(--dimension-radius-full);
+    background: var(--color-foreground-switch-knob);
+    transition: translate 150ms ease;
+  }
+
+  &:checked {
+    background: var(--color-foreground-switch-selected);
+
+    &::before {
+      /* Slide to the far edge: the space left over after the knob and both
+         insets are removed from the track width. */
+      translate: calc(
+          var(--switch-track-width) -
+          var(--switch-knob-size) -
+          (var(--switch-knob-inset) * 2)
+        )
+        0;
+    }
+  }
+
+  &:hover:not(:disabled):not(:checked) {
+    background: var(--color-foreground-switch-unselected);
+    filter: brightness(0.95);
+  }
+
+  &:checked:hover:not(:disabled) {
+    background: var(--color-foreground-switch-selected);
+    filter: brightness(0.9);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-focusRing);
+    box-shadow: 0 0 0 1px var(--color-focusRing);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background: var(--color-foreground-switch-unselected-disabled);
+
+    &::before {
+      background: var(--color-foreground-switch-knob-disabled);
+    }
+  }
+
+  &:checked:disabled {
+    background: var(--color-foreground-switch-selected-disabled);
+  }
+}

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
@@ -19,16 +19,16 @@
   /* Align to the field edge like the label, not the input's inner padding. */
   margin-inline: var(--form-label-padding-inline, 0);
 
-  /* Track: a 2:1 pill. */
+  /* Track: a 2:1 pill. No border, so the width/height are the exact track box
+     and the absolutely-positioned knob is measured against the same box (a
+     border under `box-sizing: border-box` would shrink the padding box the knob
+     is anchored to, throwing off the inset and slide). */
   width: var(--switch-track-width);
   height: var(--switch-track-height);
-  border: var(--dimension-stroke-thickness-medium) solid transparent;
   border-radius: var(--dimension-radius-full);
   background: var(--color-foreground-switch-unselected);
   cursor: pointer;
-  transition:
-    background-color 150ms ease,
-    border-color 150ms ease;
+  transition: background-color 150ms ease;
 
   /* Knob: a circle inset from the track edges, sliding on the inline axis. */
   &::before {
@@ -70,7 +70,6 @@
 
   &:focus-visible {
     outline: none;
-    border-color: var(--color-focusRing);
     box-shadow: 0 0 0 1px var(--color-focusRing);
   }
 

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/types.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/types.ts
@@ -1,6 +1,11 @@
 import type React from "react";
 
-type NativeCheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
-
-/** Props for the presentational Switch input (no react-hook-form). */
-export type SwitchInputProps = NativeCheckboxProps;
+/**
+ * Props for the presentational Switch input (no react-hook-form). `type` and
+ * `role` are fixed by the component (`checkbox` / `switch`) and omitted here so
+ * a consumer cannot override the switch semantics.
+ */
+export type SwitchInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type" | "role"
+>;

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/types.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/types.ts
@@ -1,0 +1,6 @@
+import type React from "react";
+
+type NativeCheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+/** Props for the presentational Switch input (no react-hook-form). */
+export type SwitchInputProps = NativeCheckboxProps;

--- a/packages/react/ds-global-form/src/lib/subcomponent/index.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/index.ts
@@ -32,6 +32,8 @@ export type { RangeInputProps } from "./RangeInput/index.js";
 export { RangeInput } from "./RangeInput/index.js";
 export type { SelectInputProps } from "./SelectInput/index.js";
 export { SelectInput } from "./SelectInput/index.js";
+export type { SwitchInputProps } from "./SwitchInput/index.js";
+export { SwitchInput } from "./SwitchInput/index.js";
 export type { TextareaInputProps } from "./TextareaInput/index.js";
 export { TextareaInput } from "./TextareaInput/index.js";
 export type { TextInputProps, TextInputType } from "./TextInput/index.js";


### PR DESCRIPTION
## Done

Adds the **Switch** form components and reworks how **toggle fields** (checkbox, switch) lay out their labels, in `@canonical/react-ds-global-form`.

- **`SwitchInput`** (subcomponent) — presentational toggle: a native `<input type="checkbox" role="switch">` styled as a sliding pill. Colours from the switch token channel (`--color-foreground-switch-selected/-unselected/-knob` + disabled variants); geometry in baseline multiples (32×16 track, 1px knob inset). Usable standalone; not for direct form use.
- **`SwitchField`** (component) — `SwitchInput` bound to react-hook-form with field chrome, via the new toggle HOC.
- **Field router** — `inputType: "switch"` added to the `FieldProps` union and the `Field` switch statement, so `<Field inputType="switch" … />` resolves to `SwitchField`.
- **`ToggleWrapper`** — a dedicated field wrapper for checkbox/switch that renders the control **inline with its label** (instead of stacked). Layout top-to-bottom: optional heading → control row (input + inline label) → description → error. Two label slots: `controlLabel` (the inline label, which carries the `htmlFor`; falls back to `label`) and `label` (an optional heading, shown only when `controlLabel` is also set). The control label reads as clickable body prose, so a full-sentence label wraps beside the toggle.
- **`withToggleWrapper`** — one HOC that bakes in `ToggleWrapper` and, in its return type, requires at least one of `label`/`controlLabel` — so a label-less toggle is a **compile error**, not a runtime check. Both `CheckboxField` and `SwitchField` now use it and stay one-liners.
- Drive-by: **`CheckboxField`** adopts the same inline-label toggle layout.

The on-disk ontology specs (`switch_input.ttl`, `switch_field.ttl`) are still `needs:definition` stubs, so anatomy/tokens follow Figma (WIP/Core — Switch field / Switch input) and the existing Checkbox pattern.

## QA

- In the `@canonical/react-ds-global-form` Storybook:
  - **subcomponents/SwitchInput** — toggle the `Checked`/`Disabled` stories; confirm the knob slides fully to the right edge (1px inset both ends) and the disabled colours apply.
  - **components/SwitchField** — check `InlineLabelOnly` (label only → inline label, no heading), `WithHeading` (label heading + inline `controlLabel`), `WithDescription` (description renders **below** the control), and `SentenceLabel` (long clickable label wraps beside the toggle, which stays aligned to the first line).
  - **components/CheckboxField** — confirm the checkbox now sits inline with its label.
  - Clicking the control label toggles the control (real `htmlFor`), and keyboard focus shows a ring.
- Types: `<SwitchField name="x" />` (no label) is a compile error; `label` or `controlLabel` alone compiles.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.
- [ ] If this PR introduces a **new package**: … — N/A, no new package (adds to existing `@canonical/react-ds-global-form`).
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic. — N/A, this PR changes component visuals; Chromatic should run.

## Screenshots

_Storybook `components/SwitchField` and `subcomponents/SwitchInput` render the toggle in its off/on/disabled and inline-label/heading/sentence-label variants; see the QA stories above._
