### PR TITLE
fix(ds-global): story polish — accordion heading/caret, surface stories, core-api notes

### DIFF
--- a/packages/react/ds-global/src/lib/component/Accordion/Accordion.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Accordion/Accordion.stories.tsx
@@ -51,32 +51,20 @@ export const SingleItem: Story = {
 };
 
 /**
- * The `heading` prop takes a node, so the consumer owns heading semantics and
- * chooses the level appropriate for the page's document outline.
+ * The `heading` prop takes a node, so the consumer owns the heading semantics.
+ * Only two type tokens are used: plain text (and any heading element) renders
+ * at the text-primary body tier, while an `<h6>` renders at the heading-6 tier.
  */
-export const HeadingLevels: Story = {
+export const Heading: Story = {
   render: () => (
     <Component>
-      <Component.Item heading={<h1>Level 1 heading</h1>}>
-        <p className="p">This item's heading is an h1.</p>
+      <Component.Item heading="Plain text heading (text-primary)">
+        <p className="p">A plain-text heading renders at the body tier.</p>
       </Component.Item>
-      <Component.Item heading={<h2>Level 2 heading</h2>}>
-        <p className="p">This item's heading is an h2.</p>
-      </Component.Item>
-      <Component.Item heading={<h3>Level 3 heading</h3>}>
-        <p className="p">This item's heading is an h3.</p>
-      </Component.Item>
-      <Component.Item heading={<h4>Level 4 heading</h4>}>
-        <p className="p">This item's heading is an h4.</p>
-      </Component.Item>
-      <Component.Item heading={<h5>Level 5 heading</h5>}>
-        <p className="p">This item's heading is an h5.</p>
-      </Component.Item>
-      <Component.Item heading={<h6>Level 6 heading</h6>}>
+      <Component.Item heading={<h6>Element heading (heading-6)</h6>}>
         <p className="p">
-          This item's heading is an h6. Each level renders at its own heading
-          tier in the type scale; the chevron aligns to the first text line so
-          it stays put across sizes.
+          An <code className="code">&lt;h6&gt;</code> heading renders at the
+          heading-6 tier and contributes to the document outline.
         </p>
       </Component.Item>
     </Component>
@@ -91,19 +79,36 @@ export const HeadingLevels: Story = {
 export const OnSurfaces: Story = {
   render: () => (
     // `.surface` re-channels the foreground tokens but does not set its own
-    // background, so each wrapper's background is hard-coded here from the
-    // matching layer token to make the levels visible.
-    <div style={{ display: "grid", gap: "var(--dimension-300)" }}>
+    // background, so each wrapper's background is hard-coded from the matching
+    // layer token. Wrappers pad only on the block axis (no inline padding) so
+    // the nesting reads as stacked surface bands, not nested boxes.
+    <div
+      className="surface"
+      style={{
+        paddingBlock: "var(--dimension-200)",
+        background: "var(--color-background)",
+      }}
+    >
+      <Component>
+        <Component.Item heading="On a surface" expanded>
+          <p className="p">Header background at the base surface level.</p>
+        </Component.Item>
+        <Component.Item heading="Second item">
+          <p className="p">Content.</p>
+        </Component.Item>
+      </Component>
+
       <div
         className="surface"
         style={{
-          padding: "var(--dimension-200)",
-          background: "var(--color-background)",
+          marginBlockStart: "var(--dimension-200)",
+          paddingBlock: "var(--dimension-200)",
+          background: "var(--color-background-layer2)",
         }}
       >
         <Component>
-          <Component.Item heading="On a surface" expanded>
-            <p className="p">Header background at the base surface level.</p>
+          <Component.Item heading="On surface layer 2" expanded>
+            <p className="p">Header background steps to layer 2.</p>
           </Component.Item>
           <Component.Item heading="Second item">
             <p className="p">Content.</p>
@@ -114,36 +119,18 @@ export const OnSurfaces: Story = {
           className="surface"
           style={{
             marginBlockStart: "var(--dimension-200)",
-            padding: "var(--dimension-200)",
-            background: "var(--color-background-layer2)",
+            paddingBlock: "var(--dimension-200)",
+            background: "var(--color-background-layer3)",
           }}
         >
           <Component>
-            <Component.Item heading="On surface layer 2" expanded>
-              <p className="p">Header background steps to layer 2.</p>
+            <Component.Item heading="On surface layer 3" expanded>
+              <p className="p">Header background steps to layer 3.</p>
             </Component.Item>
             <Component.Item heading="Second item">
               <p className="p">Content.</p>
             </Component.Item>
           </Component>
-
-          <div
-            className="surface"
-            style={{
-              marginBlockStart: "var(--dimension-200)",
-              padding: "var(--dimension-200)",
-              background: "var(--color-background-layer3)",
-            }}
-          >
-            <Component>
-              <Component.Item heading="On surface layer 3" expanded>
-                <p className="p">Header background steps to layer 3.</p>
-              </Component.Item>
-              <Component.Item heading="Second item">
-                <p className="p">Content.</p>
-              </Component.Item>
-            </Component>
-          </div>
         </div>
       </div>
     </div>

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
@@ -105,69 +105,32 @@
 }
 
 /* The consumer supplies the heading content — plain text by default (rendered
-   as body copy) or an optional heading element (h1–h6), which renders at its
-   matching typography-heading tier (the real type scale). */
+   as the text-primary body tier) or an <h6>, which renders at the heading-6
+   tier. Only those two type tokens are allowed on the accordion heading; any
+   other heading element is normalised to the text-primary body tier. */
 .ds.accordion-item > .header > .heading {
   flex: 1;
   min-width: 0;
 
-  /* Default: body copy for plain-text headings. */
+  /* Default: body copy (text-primary) for plain text and any heading element. */
   font-family: var(--typography-text-primary-font-family);
   font-size: var(--typography-text-primary-font-size);
   font-weight: var(--typography-text-primary-font-weight);
   line-height: var(--typography-text-primary-line-height);
   letter-spacing: var(--typography-text-primary-letter-spacing);
 
-  & :is(h1, h2, h3, h4, h5, h6) {
+  /* Normalise every heading element except <h6> down to the inherited body
+     tier. <h6> is left untouched so the base h6 tier from
+     @canonical/styles-typography applies (correct heading-6 tokens, including
+     the baseline-snapped line-height) — no heading-6 tokens are restated here. */
+  & :is(h1, h2, h3, h4, h5) {
     margin: 0;
-  }
-
-  & h1 {
-    font-family: var(--typography-heading-1-font-family);
-    font-size: var(--typography-heading-1-font-size);
-    font-weight: var(--typography-heading-1-font-weight);
-    line-height: var(--typography-heading-1-line-height);
-    letter-spacing: var(--typography-heading-1-letter-spacing);
-  }
-
-  & h2 {
-    font-family: var(--typography-heading-2-font-family);
-    font-size: var(--typography-heading-2-font-size);
-    font-weight: var(--typography-heading-2-font-weight);
-    line-height: var(--typography-heading-2-line-height);
-    letter-spacing: var(--typography-heading-2-letter-spacing);
-  }
-
-  & h3 {
-    font-family: var(--typography-heading-3-font-family);
-    font-size: var(--typography-heading-3-font-size);
-    font-weight: var(--typography-heading-3-font-weight);
-    line-height: var(--typography-heading-3-line-height);
-    letter-spacing: var(--typography-heading-3-letter-spacing);
-  }
-
-  & h4 {
-    font-family: var(--typography-heading-4-font-family);
-    font-size: var(--typography-heading-4-font-size);
-    font-weight: var(--typography-heading-4-font-weight);
-    line-height: var(--typography-heading-4-line-height);
-    letter-spacing: var(--typography-heading-4-letter-spacing);
-  }
-
-  & h5 {
-    font-family: var(--typography-heading-5-font-family);
-    font-size: var(--typography-heading-5-font-size);
-    font-weight: var(--typography-heading-5-font-weight);
-    line-height: var(--typography-heading-5-line-height);
-    letter-spacing: var(--typography-heading-5-letter-spacing);
+    font: inherit;
+    letter-spacing: inherit;
   }
 
   & h6 {
-    font-family: var(--typography-heading-6-font-family);
-    font-size: var(--typography-heading-6-font-size);
-    font-weight: var(--typography-heading-6-font-weight);
-    line-height: var(--typography-heading-6-line-height);
-    letter-spacing: var(--typography-heading-6-letter-spacing);
+    margin: 0;
   }
 }
 
@@ -182,16 +145,22 @@
   transition: transform var(--motion-duration-fast)
     var(--motion-easing-standard);
 
+  /* Chevron glyph from the Canonical icon set, masked so it can take the theme
+     icon colour (same technique as CheckboxInput's checkmark). */
   &::before {
     content: "";
     display: block;
     width: 100%;
     height: 100%;
     background-color: var(--accordion-item-color-icon);
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='currentColor' d='M4.47 5.47a.75.75 0 0 1 1.06 0L8 7.94l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06z'/%3E%3C/svg%3E");
+    mask-image: url("/icons/chevron-down.svg#chevron-down");
     mask-repeat: no-repeat;
     mask-position: center;
     mask-size: contain;
+    -webkit-mask-image: url("/icons/chevron-down.svg#chevron-down");
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    -webkit-mask-size: contain;
   }
 }
 

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -53,6 +53,8 @@ export const ManyLevels: Story = {
 
 /**
  * Breadcrumbs using a custom separator character.
+ *
+ * Note: the `separator` prop is not part of the core api.
  */
 export const CustomSeparator: Story = {
   args: {
@@ -81,6 +83,9 @@ export const WithCustomAriaLabel: Story = {
 /**
  * Breadcrumbs with a custom item component.
  * Demonstrates the switch pattern for custom rendering.
+ *
+ * Note: this story is not part of the core api — it illustrates a userland
+ * pattern (rendering items through a custom component), not a supported prop.
  */
 const CustomItem = ({
   label,

--- a/packages/react/ds-global/src/lib/component/Card/Card.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/Card.stories.tsx
@@ -12,11 +12,10 @@ const meta = {
 export default meta;
 
 /**
- * A typical blog-style card: a full-bleed image above a padded content block.
+ * The base card. The core api is `Card.Content` — a padded content section.
  */
 export const Default: StoryFn<CardProps> = (props) => (
   <Component {...props} style={{ maxWidth: "24rem" }}>
-    <Component.Image src="https://assets.ubuntu.com/v1/5ce214a4-rpi.png" />
     <Component.Content>
       <h3>Build a bare-metal cloud on a Raspberry Pi cluster with MAAS</h3>
       <p className="p">
@@ -29,9 +28,30 @@ export const Default: StoryFn<CardProps> = (props) => (
 );
 
 /**
+ * A full-bleed image above the content block.
+ *
+ * Note: `Card.Image` is not part of the core api.
+ */
+export const WithImage: StoryFn<CardProps> = (props) => (
+  <Component {...props} style={{ maxWidth: "24rem" }}>
+    <Component.Image src="https://assets.ubuntu.com/v1/5ce214a4-rpi.png" />
+    <Component.Content>
+      <h3>Build a bare-metal cloud on a Raspberry Pi cluster with MAAS</h3>
+      <p className="p">
+        The Raspberry Pi 4 is a great option to run a cluster on, and
+        provisioning is easy with <a href="https://maas.io">MAAS</a>.
+      </p>
+    </Component.Content>
+  </Component>
+);
+
+/**
  * A card with a header, content and footer. Only the content-bearing sections
  * pad themselves; the card frame applies no general padding and the image
  * bleeds edge to edge. Dividers separate adjacent sections.
+ *
+ * Note: `Card.Header`, `Card.Image` and `Card.Footer` are not part of the core
+ * api — the base card only has `Card.Content`.
  */
 export const HeaderContentFooter: StoryFn<CardProps> = (props) => (
   <Component {...props} style={{ maxWidth: "24rem" }}>
@@ -56,6 +76,8 @@ export const HeaderContentFooter: StoryFn<CardProps> = (props) => (
 /**
  * A compact horizontal card: a fixed-size thumbnail beside a title and excerpt,
  * as used in blog sidebars and related-content lists.
+ *
+ * Note: `Card.Thumbnail` is not part of the core api.
  */
 export const WithThumbnail: StoryFn<CardProps> = (props) => (
   <Component {...props} style={{ maxWidth: "28rem" }}>
@@ -141,13 +163,23 @@ export const OnSurfaces: StoryFn<CardProps> = () => {
     </Component>
   );
 
+  // Surface wrappers pad only on the block axis (no inline padding), so the
+  // nesting reads as stacked surface bands rather than nested card boxes.
   return (
-    <div style={{ display: "grid", gap: "var(--dimension-300)" }}>
+    <div
+      className="surface"
+      style={{
+        paddingBlock: "var(--dimension-200)",
+        background: "var(--color-background)",
+      }}
+    >
+      {card}
       <div
         className="surface"
         style={{
-          padding: "var(--dimension-200)",
-          background: "var(--color-background)",
+          marginBlockStart: "var(--dimension-200)",
+          paddingBlock: "var(--dimension-200)",
+          background: "var(--color-background-layer2)",
         }}
       >
         {card}
@@ -155,21 +187,11 @@ export const OnSurfaces: StoryFn<CardProps> = () => {
           className="surface"
           style={{
             marginBlockStart: "var(--dimension-200)",
-            padding: "var(--dimension-200)",
-            background: "var(--color-background-layer2)",
+            paddingBlock: "var(--dimension-200)",
+            background: "var(--color-background-layer3)",
           }}
         >
           {card}
-          <div
-            className="surface"
-            style={{
-              marginBlockStart: "var(--dimension-200)",
-              padding: "var(--dimension-200)",
-              background: "var(--color-background-layer3)",
-            }}
-          >
-            {card}
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

Small story/polish fixes on existing ds-global components. **Stacked on #722** (`feat/ds-global-form-switch`) — review/merge that first.

- **Accordion heading tokens** — only the `text-primary` body tier and the `heading-6` tier are allowed on the accordion heading. Dropped the h1–h5 tier rules (any heading element other than `<h6>` now normalises to `text-primary`), and replaced the `HeadingLevels` story with a `Heading` story showing just the two allowed variants.
- **Accordion caret** — sourced from the Canonical icon set (`/icons/chevron-down.svg#chevron-down`, masked so it takes the theme icon colour) instead of an inline data-URI SVG.
- **Surface stories** (Card + Accordion `OnSurfaces`) — the nested surface wrappers now pad on the block axis only (no inline padding), so the nesting reads as stacked surface bands rather than nested card/accordion boxes.
- **Core-api notes + Card story order** — added "not part of the core api" notes to Breadcrumbs' custom `separator`/`Component` and to Card's `Image`/`Header`/`Footer`/`Thumbnail` (the base card only has `Content`); reordered the Card stories so the core Content-only `Default` comes first, then `WithImage`, then the multi-section examples.

## QA

- ds-global Storybook:
  - **components/Accordion → Heading** — plain-text heading renders at the body tier; the `<h6>` item renders at the heading-6 tier. No h1–h5 sizes appear.
  - **components/Accordion** — the caret is the Canonical chevron (right when closed, down when open); `/icons/chevron-down.svg` serves (200).
  - **components/Accordion → OnSurfaces** and **components/Card → OnSurfaces** — the three surface levels read as stacked bands (no inline padding boxing them in), backgrounds step layer 1 → 2 → 3.
  - **components/Card** — `Default` (Content only) is first; `WithImage`/`HeaderContentFooter`/`WithThumbnail` docs carry the non-core notes.
  - **components/Breadcrumbs → CustomSeparator / WithCustomComponent** — docs note the props are not part of the core api.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build`, `build:all`.
- [ ] If this PR introduces a **new package**: … — N/A, no new package.
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic. — N/A, this PR changes story visuals; Chromatic should run.

## Screenshots

_See the QA stories above — the accordion caret, heading tiers, and stacked-band surface stories are the visible changes._
