### PR TITLE
fix(ds-global-form): clear all selections on multiple-combobox reset

### DIFF
--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/ComboboxInput.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/ComboboxInput.tests.tsx
@@ -1,12 +1,148 @@
-// ComboboxInput tests are blocked by ResetButton importing Button from
-// @canonical/react-ds-global, which fails to resolve in vitest.
-// TODO: fix once ds-global exports are resolvable in test environment.
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { ComboboxField } from "#lib/component/ComboboxField/index.js";
+import type { Option } from "../types.js";
+import { ComboboxInput } from "./ComboboxInput.js";
 
-import { describe, it } from "vitest";
+const fruits: Option[] = [
+  { value: "apple", label: "Apple" },
+  { value: "banana", label: "Banana" },
+  { value: "cherry", label: "Cherry" },
+];
 
-describe("ComboboxInput", () => {
-  it.todo("renders an input (blocked: ds-global resolution)");
-  it.todo("shows options when typing");
-  it.todo("supports disabled state");
-  it.todo("multiple mode renders an input");
+/**
+ * The visible selection is the set of chips (`button.chip` inside
+ * `.selected-items`). Query them directly rather than by text — the dropdown
+ * list also renders each option as `<li role="option">`, so a plain text query
+ * would conflate a selected chip with an available option.
+ */
+const chipLabels = (container: HTMLElement): string[] =>
+  Array.from(container.querySelectorAll(".selected-items .chip")).map((chip) =>
+    (chip.textContent ?? "").replace("×", "").trim(),
+  );
+
+describe("ComboboxInput (presentational)", () => {
+  it("renders an input", () => {
+    render(<ComboboxInput options={fruits} />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("renders chips for each value in multiple mode", () => {
+    const { container } = render(
+      <ComboboxInput
+        isMultiple
+        options={fruits}
+        value={["apple", "banana", "cherry"]}
+      />,
+    );
+    expect(chipLabels(container)).toEqual(["Apple", "Banana", "Cherry"]);
+  });
+
+  it("supports the disabled state", () => {
+    render(<ComboboxInput options={fruits} disabled />);
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
+});
+
+/**
+ * A form harness that both renders the field and exposes the values captured on
+ * submit, so a test can assert the react-hook-form state — not just the DOM.
+ * The DOM alone is insufficient here: the reset bug was a re-sync effect
+ * resurrecting cleared chips from a stale RHF value, so the field value is the
+ * thing under test.
+ */
+function ComboboxFormHarness({
+  onSubmit,
+  extraButton,
+}: {
+  onSubmit: (values: Record<string, unknown>) => void;
+  extraButton?: React.ReactNode;
+}) {
+  const methods = useForm({
+    defaultValues: { fruit: ["apple", "banana", "cherry"] },
+  });
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)}>
+        <ComboboxField
+          name="fruit"
+          label="Fruit"
+          isMultiple
+          isOptional
+          options={fruits}
+        />
+        {extraButton}
+        <button type="submit">Submit</button>
+      </form>
+    </FormProvider>
+  );
+}
+
+describe("ComboboxField (multiple) reset", () => {
+  it("clears ALL selected chips when the reset button is clicked", () => {
+    const { container } = render(<ComboboxFormHarness onSubmit={() => {}} />);
+
+    // All three defaultValues render as chips.
+    expect(chipLabels(container)).toEqual(["Apple", "Banana", "Cherry"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
+
+    // Not one, not the last — every chip is gone.
+    expect(chipLabels(container)).toEqual([]);
+  });
+
+  it("clears the react-hook-form value (does not revert to defaultValues)", async () => {
+    const onSubmit = vi.fn();
+    const { container } = render(<ComboboxFormHarness onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
+    // Submit the form element directly — the fields carry no validation rules,
+    // so the empty selection is valid and handleSubmit invokes the callback.
+    const form = container.querySelector("form");
+    if (!form) throw new Error("form not rendered");
+    fireEvent.submit(form);
+
+    // react-hook-form's handleSubmit resolves asynchronously.
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    // Emitting [] (not undefined) is what stops RHF falling back to the
+    // defaultValue array and resurrecting the chips on the next render.
+    expect(onSubmit.mock.calls[0]?.[0]).toEqual({ fruit: [] });
+  });
+
+  it("stays cleared after a parent re-render (the effect cannot resurrect it)", async () => {
+    // A parent re-render re-runs the value→selectedItems sync effect. With the
+    // old write-only effect + onChange(undefined), that re-supplied the default
+    // array and repopulated the chips. Assert on the form value, not just the
+    // DOM: in jsdom the synchronous setSelectedItems([]) clears the chips even
+    // on the buggy code, so the resurrection only shows through the RHF value.
+    const onSubmit = vi.fn();
+    function Wrapper() {
+      const [, forceRender] = useState(0);
+      return (
+        <ComboboxFormHarness
+          onSubmit={onSubmit}
+          extraButton={
+            <button type="button" onClick={() => forceRender((n) => n + 1)}>
+              Re-render
+            </button>
+          }
+        />
+      );
+    }
+    const { container } = render(<Wrapper />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
+    fireEvent.click(screen.getByRole("button", { name: "Re-render" }));
+
+    expect(chipLabels(container)).toEqual([]);
+
+    const form = container.querySelector("form");
+    if (!form) throw new Error("form not rendered");
+    fireEvent.submit(form);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0]?.[0]).toEqual({ fruit: [] });
+  });
 });

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/MultipleCombobox.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/MultipleCombobox.tsx
@@ -53,12 +53,13 @@ const MultipleCombobox = ({
     [convertValueToItem, options, valueKey],
   );
 
-  // Initialise selectedItems from the controlled value on mount / when it changes
+  // Keep selectedItems in sync with the controlled value — on mount and on every
+  // change. Must clear as well as populate: an empty/undefined `value` (e.g. after
+  // reset) has to drive `selectedItems` back to [], otherwise a later re-render
+  // that re-supplies the previous array would resurrect the cleared chips.
   useEffect(() => {
-    const values = value as string[] | undefined;
-    if (values && values.length > 0) {
-      setSelectedItems(convertValuesToItems(values));
-    }
+    const values = (value as string[] | undefined) ?? [];
+    setSelectedItems(values.length > 0 ? convertValuesToItems(values) : []);
   }, [value, convertValuesToItems]);
 
   // Downshift's useMultipleSelection hook for managing multiple selections
@@ -72,8 +73,11 @@ const MultipleCombobox = ({
     onSelectedItemsChange: ({ selectedItems: newSelectedItems }) => {
       if (newSelectedItems) {
         setSelectedItems(newSelectedItems);
+        // Emit [] (never undefined) when the list empties: with a react-hook-form
+        // Controller that has a defaultValue, onChange(undefined) reverts the field
+        // to that default, resurrecting the removed chips. [] clears cleanly.
         const newValue = newSelectedItems.map((item) => item[valueKey]);
-        onChange?.(newValue.length > 0 ? (newValue as string[]) : undefined);
+        onChange?.(newValue as string[]);
       }
     },
   });
@@ -115,11 +119,13 @@ const MultipleCombobox = ({
     itemToString: convertItemToString,
   });
 
-  // Reset function to clear selections and input
+  // Reset function to clear selections and input. Emits [] (not undefined) so a
+  // react-hook-form Controller with a defaultValue stores the cleared state
+  // rather than falling back to its default and repopulating the chips.
   const resetSelection = useCallback(() => {
     setSelectedItems([]);
     setInputValue("");
-    onChange?.(undefined);
+    onChange?.([]);
   }, [onChange, setInputValue]);
 
   return (


### PR DESCRIPTION
## Done

- Fix the multiple-select Combobox reset (✕): it cleared only the last selection, not all of them.
  - Root cause: the reset handler and the empty-list path emitted `onChange(undefined)`. With a react-hook-form `Controller` that has a `defaultValue`, setting the field to `undefined` reverts it to that default array on the next render; the `value → selectedItems` sync effect (which only ever populated, never cleared) then repopulated the chips.
  - Emit `[]` instead of `undefined` on both the reset and the empty-list paths so RHF stores the cleared state; make the sync effect clear as well as populate so an empty value reinforces the empty selection.
- Add a real regression test — the test file was previously `it.todo` stubs. Renders the RHF-bound `ComboboxField` with three default selections, clicks reset, and asserts **both** that no chips remain **and** that the submitted form value is `[]` (not the resurrected default). Verified by mutation: the value assertions fail against the pre-fix code.

Fixes the "combobox multiple ✕ only resets the last item" bug.

## QA

1. Open Storybook → `subcomponents/ComboboxInput` → the multiple-select story (or any `ComboboxField` with `isMultiple` bound to a form with default selections).
2. Select several options — they render as chips.
3. Click the ✕ reset button.
4. **Expected:** all chips clear (not just the last one), and the form value becomes `[]`.
5. Removing chips one by one down to zero also leaves the value at `[]` (no resurrection on the next render).

### PR readiness check

- [x] PR should have one of the following labels: `Bug 🐛`.
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] All packages define the required scripts in `package.json` (`check`, `check:fix`, `test`, `build`).
- [ ] N/A — no new package.
- [x] No visual change — `no visual change` label added (logic-only fix; no CSS/DOM structure change).

## Screenshots

N/A — behavioural fix, no visual change.

---

**Note on date/time Canonical icons:** this PR was originally scoped to also swap the browser-default date/time indicator icons for Canonical ones. That work is blocked upstream (no calendar/clock glyph exists in `@canonical/ds-assets`, and the swap is Chromium-only — Firefox has no equivalent pseudo-element), so it is split out into a tracking issue and not included here.
