### PR TITLE
feat(ds-global): add Spinner subcomponent

### DIFF
--- a/packages/react/ds-global/README.md
+++ b/packages/react/ds-global/README.md
@@ -57,6 +57,39 @@ import "@canonical/styles";
 
 `@canonical/styles` provides the global design tokens (colour, spacing, typography). Each component in this package co-locates its own component-level tokens in a `styles.css` file next to the component source. These component tokens reference the global tokens from `@canonical/design-tokens` and are included automatically when the component is imported.
 
+## Icon assets
+
+Components that render an icon — `Icon`, `Spinner`, and any component with an
+icon affordance (e.g. the `Accordion` caret) — reference SVGs from
+`@canonical/ds-assets` **at runtime**, not from the JavaScript bundle. Each
+glyph is fetched by URL, e.g. `/icons/spinner.svg#spinner`.
+
+Your application must therefore **serve the `@canonical/ds-assets` icons at
+`/icons`**. In most setups this means copying (or symlinking) the package's
+`icons/` directory into the app's static/public directory so the files are
+reachable at `/icons/*.svg`. If the icons are not served, icon-rendering
+components mount but appear empty (the SVG `<use>` resolves to nothing).
+
+If you serve the icons from a different path:
+
+- **`Icon` and `Spinner`** accept a `rootPath` prop (default `/icons`) to
+  override the location per instance:
+
+  ```tsx
+  <Spinner rootPath="/assets/icons" />
+  ```
+
+  There is currently no global default — the override is per component
+  instance.
+
+- **CSS-referenced icons** (such as the `Accordion` caret) are fixed at
+  `/icons` in the stylesheet and cannot be redirected via a prop. Serve the
+  icons at `/icons`, or override the relevant component CSS custom property in
+  your own styles.
+
+A single global source of truth for the icon root is planned; until then,
+serving the assets at `/icons` is the path of least resistance.
+
 ## Storybook
 
 Each component includes Storybook stories demonstrating usage patterns and variants:

--- a/packages/react/ds-global/src/lib/index.ts
+++ b/packages/react/ds-global/src/lib/index.ts
@@ -23,4 +23,5 @@ export * from "./component/Tile/index.js";
 export * from "./component/Tooltip/index.js";
 export * from "./group/KeyboardKeys/index.js";
 export * from "./pattern/Timeline/index.js";
+export * from "./subcomponent/Spinner/index.js";
 export type * from "./types/index.js";

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.ssr.tests.tsx
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.ssr.tests.tsx
@@ -1,0 +1,31 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import Component from "./Spinner.js";
+
+describe("Spinner SSR", () => {
+  it("doesn't throw", () => {
+    expect(() => {
+      renderToString(<Component />);
+    }).not.toThrow();
+  });
+
+  it("renders the spinner icon", () => {
+    const html = renderToString(<Component />);
+    expect(html).toContain("<svg");
+    expect(html).toContain('href="/icons/spinner.svg#spinner"');
+  });
+
+  it("applies className", () => {
+    const html = renderToString(<Component className="test-class" />);
+    expect(html).toContain(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="ds spinner test-class" aria-hidden="true"><use href="/icons/spinner.svg#spinner"></use></svg>',
+    );
+  });
+
+  it("renders a named image when aria-label is provided", () => {
+    const html = renderToString(<Component aria-label="Loading" />);
+    expect(html).toContain('role="img"');
+    expect(html).toContain('aria-label="Loading"');
+    expect(html).not.toContain("aria-hidden");
+  });
+});

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.stories.tsx
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Component from "./Spinner.js";
+
+const meta = {
+  title: "subcomponents/Spinner",
+  component: Component,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Component>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sized: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The spinner is sized relative to the `font-size` of its container, like any icon.",
+      },
+    },
+  },
+  render: (args) => (
+    <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+      <span style={{ fontSize: "1rem" }}>
+        <Component {...args} />
+      </span>
+      <span style={{ fontSize: "2rem" }}>
+        <Component {...args} />
+      </span>
+      <span style={{ fontSize: "3rem" }}>
+        <Component {...args} />
+      </span>
+    </div>
+  ),
+};
+
+export const Labelled: Story = {
+  args: {
+    "aria-label": "Loading",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When the spinner is the only indication that work is in progress, give it an `aria-label` so it is announced as a named image. Inside a control that already announces its busy state, leave it decorative (the default).",
+      },
+    },
+  },
+};

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.stories.tsx
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.stories.tsx
@@ -30,8 +30,10 @@ export const Default: Story = {
 };
 
 /**
- * The spinner scales with the `font-size` of its container (like any icon), so
- * it lines up with adjacent text. Override `--spinner-size` to resize directly.
+ * The spinner's size is consumed from the text: it tracks the `font-size` of
+ * its container, so it lines up with adjacent text at any scale. (Override
+ * `--spinner-size`, or `--icon-size` globally, only when you need a size that
+ * is decoupled from the text.)
  */
 export const Sized: Story = {
   render: (args) => (
@@ -39,10 +41,10 @@ export const Sized: Story = {
       <span style={{ fontSize: "1rem" }}>
         <Component {...args} />
       </span>
-      <span style={{ fontSize: "1.5rem" }}>
+      <span style={{ fontSize: "2rem" }}>
         <Component {...args} />
       </span>
-      <span style={{ fontSize: "2rem" }}>
+      <span style={{ fontSize: "3rem" }}>
         <Component {...args} />
       </span>
     </div>

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.stories.tsx
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.stories.tsx
@@ -5,48 +5,46 @@ const meta = {
   title: "subcomponents/Spinner",
   component: Component,
   tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "An indeterminate activity indicator: the `spinner` icon rotating continuously. It is decorative by default (`aria-hidden`); pass an `aria-label` when the spinner is the only signal that work is in progress, so it is announced as a named image. Inside a control that already announces its busy state (e.g. a submitting Button), leave it decorative.",
+      },
+    },
+  },
 } satisfies Meta<typeof Component>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-
-export const Sized: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "The spinner is sized relative to the `font-size` of its container, like any icon.",
-      },
-    },
+/**
+ * The default spinner. It is decorative unless labelled — set `aria-label`
+ * (shown here) to expose it as a named image for standalone loading states.
+ */
+export const Default: Story = {
+  args: {
+    "aria-label": "Loading",
   },
+};
+
+/**
+ * The spinner scales with the `font-size` of its container (like any icon), so
+ * it lines up with adjacent text. Override `--spinner-size` to resize directly.
+ */
+export const Sized: Story = {
   render: (args) => (
     <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
       <span style={{ fontSize: "1rem" }}>
         <Component {...args} />
       </span>
-      <span style={{ fontSize: "2rem" }}>
+      <span style={{ fontSize: "1.5rem" }}>
         <Component {...args} />
       </span>
-      <span style={{ fontSize: "3rem" }}>
+      <span style={{ fontSize: "2rem" }}>
         <Component {...args} />
       </span>
     </div>
   ),
-};
-
-export const Labelled: Story = {
-  args: {
-    "aria-label": "Loading",
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "When the spinner is the only indication that work is in progress, give it an `aria-label` so it is announced as a named image. Inside a control that already announces its busy state, leave it decorative (the default).",
-      },
-    },
-  },
 };

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.tests.tsx
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.tests.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Component from "./Spinner.js";
+
+describe("Spinner subcomponent", () => {
+  it("renders the spinner icon", () => {
+    const { container } = render(<Component />);
+    expect(container.querySelector("use")).toHaveAttribute(
+      "href",
+      "/icons/spinner.svg#spinner",
+    );
+  });
+
+  it("applies the spinner class", () => {
+    const { container } = render(<Component />);
+    expect(container.querySelector("svg")).toHaveClass("ds", "spinner");
+  });
+
+  it("is decorative by default", () => {
+    const { container } = render(<Component />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    expect(svg).not.toHaveAttribute("role");
+  });
+
+  it("exposes a named image when aria-label is provided", () => {
+    render(<Component aria-label="Loading" />);
+    const svg = screen.getByRole("img", { name: "Loading" });
+    expect(svg).not.toHaveAttribute("aria-hidden");
+  });
+
+  it("treats an empty aria-label as decorative", () => {
+    const { container } = render(
+      // biome-ignore lint/a11y/useValidAriaValues: deliberately exercising the empty-label degenerate input
+      <Component aria-label="" />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    expect(svg).not.toHaveAttribute("role");
+  });
+
+  it("honours an explicit role", () => {
+    render(<Component role="presentation" />);
+    const svg = screen.getByRole("presentation");
+    expect(svg).not.toHaveAttribute("aria-hidden");
+  });
+
+  it("merges a consumer className alongside the spinner class", () => {
+    const { container } = render(<Component className="test-class" />);
+    expect(container.querySelector("svg")).toHaveClass("spinner", "test-class");
+  });
+
+  it("resolves the icon from a custom rootPath", () => {
+    const { container } = render(<Component rootPath="/assets/icons" />);
+    expect(container.querySelector("use")).toHaveAttribute(
+      "href",
+      "/assets/icons/spinner.svg#spinner",
+    );
+  });
+});

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.tsx
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from "react";
+import type { SpinnerProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds spinner";
+
+/** An empty or whitespace-only label provides no accessible name. */
+const hasAccessibleName = (value: string | undefined): boolean =>
+  typeof value === "string" && value.trim() !== "";
+
+/**
+ * An indeterminate activity indicator: the `spinner` icon (the Canonical
+ * "circle of friends") rotating continuously to signal that work is in
+ * progress. Mirrors `Icon`'s rendering and accessibility model — decorative by
+ * default, exposed as a named `img` when given an `aria-label`/`aria-labelledby`
+ * — and adds the continuous rotation, which pauses under `prefers-reduced-motion`.
+ *
+ * The glyph is referenced from `@canonical/ds-assets` at runtime
+ * (`${rootPath}/spinner.svg#spinner`, default `/icons`), not bundled — the
+ * consuming app must serve those SVGs at that path, or the spinner renders
+ * empty. If the app serves icons from a different location, pass `rootPath`
+ * (per instance; there is no global default yet). See the package README
+ * ("Icon assets").
+ *
+ * `import { Spinner } from "@canonical/react-ds-global";`
+ *
+ * @implements ds:global.subcomponent.spinner
+ */
+const Spinner = ({
+  className,
+  rootPath = "/icons",
+  role,
+  ...props
+}: SpinnerProps): ReactElement => {
+  // Decorative by default and hidden from assistive technology; providing an
+  // accessible name (or an explicit role) exposes it as a named image instead.
+  // An empty label counts as decorative, mirroring the `alt=""` convention.
+  const isLabelled =
+    hasAccessibleName(props["aria-label"]) ||
+    hasAccessibleName(props["aria-labelledby"]);
+
+  return (
+    // biome-ignore lint/a11y/noSvgWithoutTitle: decorative spinners render aria-hidden="true"; labelled spinners render role="img" with an aria-label/aria-labelledby (computed at runtime)
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      role={role ?? (isLabelled ? "img" : undefined)}
+      aria-hidden={isLabelled || role ? undefined : true}
+      {...props}
+    >
+      <use href={`${rootPath}/spinner.svg#spinner`} />
+    </svg>
+  );
+};
+
+export default Spinner;

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/index.ts
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/index.ts
@@ -1,0 +1,2 @@
+export { default as Spinner } from "./Spinner.js";
+export type * from "./types.js";

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/styles.css
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/styles.css
@@ -1,0 +1,39 @@
+/**
+ * Spinner styles
+ * @implements dso:global.subcomponent.spinner
+ *
+ * The Spinner renders the `spinner` glyph and rotates it continuously. The
+ * rotation is a linear, infinite animation so the motion reads as steady
+ * rather than eased.
+ */
+
+/* A full 0→360deg turn. Keep it a full turn: Chromatic freezes infinite
+   animations at the last frame of the cycle, so a complete rotation lands on
+   360deg (visually identical to 0deg) and the snapshot stays deterministic. A
+   partial arc here would make visual tests flaky. */
+@keyframes ds-spinner-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.ds.spinner {
+  /* A continuous spinner wants a longer, linear cycle than the eased
+     transition tokens describe. `--motion-duration-slow` is the closest
+     ratified value today; expose `--spinner-duration` so a consumer can tune
+     the cycle without overriding the whole animation. */
+  --spinner-duration: var(--motion-duration-slow, 0.4s);
+
+  animation: ds-spinner-rotate var(--spinner-duration) linear infinite;
+}
+
+/* Honour users who have asked for reduced motion: hold the icon still rather
+   than spinning it. The spinner remains visible as a static activity glyph. */
+@media (prefers-reduced-motion: reduce) {
+  .ds.spinner {
+    animation: none;
+  }
+}

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/styles.css
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/styles.css
@@ -21,24 +21,24 @@
 }
 
 .ds.spinner {
-  /* Sized like an icon: scales with the container `font-size`, so a spinner
-     next to text matches the text height. Consumers override `--spinner-size`
-     (or the surrounding font-size) to resize. */
-  --spinner-size: 1em;
-
-  /* A continuous spinner wants a much longer, linear cycle than the eased
-     transition tokens describe (the fastest of which, `--motion-duration-slow`,
-     is 0.4s — frantic for a loop). One second per turn reads as steady; expose
-     `--spinner-duration` so a consumer can tune it. There is no ratified motion
-     token this long yet, so the default is a literal. */
-  --spinner-duration: 1s;
-
   display: inline-block;
   vertical-align: middle;
-  width: var(--spinner-size);
-  height: var(--spinner-size);
 
-  animation: ds-spinner-rotate var(--spinner-duration) linear infinite;
+  /* Sized from the text: the `1em` base makes the spinner track the container
+     `font-size`, so it matches adjacent text. The cascade is, in order:
+     `--spinner-size` (per-instance override) → `--icon-size` (the shared icon
+     convention, so a global icon-size tweak also sizes spinners) → `1em`. No
+     value is hard-declared here, so `:root`/ancestor overrides win. */
+  width: var(--spinner-size, var(--icon-size, 1em));
+  height: var(--spinner-size, var(--icon-size, 1em));
+
+  /* A continuous spinner wants a much longer, linear cycle than the eased
+     transition tokens describe (the fastest, `--motion-duration-slow`, is 0.4s
+     — frantic for a loop). Default to ~1s/turn via a `var()` fallback (not a
+     hard declaration) so a consumer can retune the cycle from `:root` or an
+     ancestor with `--spinner-duration`. There is no ratified motion token this
+     long yet, hence the literal fallback. */
+  animation: ds-spinner-rotate var(--spinner-duration, 1s) linear infinite;
 }
 
 /* Honour users who have asked for reduced motion: hold the icon still rather

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/styles.css
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/styles.css
@@ -21,11 +21,22 @@
 }
 
 .ds.spinner {
-  /* A continuous spinner wants a longer, linear cycle than the eased
-     transition tokens describe. `--motion-duration-slow` is the closest
-     ratified value today; expose `--spinner-duration` so a consumer can tune
-     the cycle without overriding the whole animation. */
-  --spinner-duration: var(--motion-duration-slow, 0.4s);
+  /* Sized like an icon: scales with the container `font-size`, so a spinner
+     next to text matches the text height. Consumers override `--spinner-size`
+     (or the surrounding font-size) to resize. */
+  --spinner-size: 1em;
+
+  /* A continuous spinner wants a much longer, linear cycle than the eased
+     transition tokens describe (the fastest of which, `--motion-duration-slow`,
+     is 0.4s — frantic for a loop). One second per turn reads as steady; expose
+     `--spinner-duration` so a consumer can tune it. There is no ratified motion
+     token this long yet, so the default is a literal. */
+  --spinner-duration: 1s;
+
+  display: inline-block;
+  vertical-align: middle;
+  width: var(--spinner-size);
+  height: var(--spinner-size);
 
   animation: ds-spinner-rotate var(--spinner-duration) linear infinite;
 }

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/types.ts
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/types.ts
@@ -1,0 +1,17 @@
+import type { SVGAttributes } from "react";
+
+/**
+ * The Spinner has no props of its own beyond those of the underlying icon
+ * `<svg>`: it always renders the `spinner` icon and animates it. The `icon`
+ * name is fixed, so it is not part of the public surface.
+ *
+ * Like `Icon`, the Spinner is decorative by default (`aria-hidden="true"`).
+ * Pass an `aria-label` (or `aria-labelledby`) when the spinner is the only
+ * indication that work is in progress; it is then exposed as a named `img`.
+ * When the spinner sits inside a control that already announces its busy
+ * state (e.g. a submitting Button), leave it decorative.
+ */
+export interface SpinnerProps extends SVGAttributes<HTMLOrSVGElement> {
+  /** Root path to the icons (default: /icons). Must be exposed to the user. */
+  rootPath?: string;
+}


### PR DESCRIPTION
## Done

- Add a **Spinner** subcomponent to `@canonical/react-ds-global`: the `spinner` icon (the Canonical "circle of friends") rotating continuously to signal indeterminate progress.
  - First member of the ds-global `subcomponent/` tier. Free-standing (no single parent) — it is intended to be composed by other components, starting with a loading Button. Titled `subcomponents/Spinner`.
  - **Mirrors** `Icon`'s `<svg><use href="/icons/spinner.svg#spinner">` rendering and accessibility model (decorative `aria-hidden` by default; a named `role="img"` when given an `aria-label`/`aria-labelledby`) rather than wrapping `Icon`. This keeps the class a clean `ds spinner` (no `ds icon` bleed-through) and its ontology identity uncoupled from Icon.
  - Rotation is a **linear, infinite** CSS animation driven by a motion token (`--motion-duration-slow`, overridable via `--spinner-duration`), and **pauses under `prefers-reduced-motion`**.
  - **Chromatic determinism:** the keyframe is a full `0→360deg` turn, so Chromatic's default (freeze at the last frame of the cycle) lands on a frame identical to 0deg — deterministic, live Storybook still spins for humans. A CSS comment guards against reducing it to a partial arc.
- Document the **runtime icon-asset dependency**: the glyph is fetched from `@canonical/ds-assets` at runtime, not bundled.
  - Spinner TSDoc explains it and points to the README.
  - New **"Icon assets"** section in the package README: assets must be served at `/icons`; `Icon`/`Spinner` accept a per-instance `rootPath` override; CSS-referenced icons (e.g. the Accordion caret) are fixed at `/icons`. Notes a global icon-root single-source-of-truth is planned.
- Export `Spinner` from the package barrel.

Implements `ds:global.subcomponent.spinner`.

## QA

1. `cd packages/react/ds-global && bun run storybook` → **subcomponents / Spinner**.
2. `Default` spins continuously (linear, ~constant speed).
3. `Sized` shows it scaling with `font-size` (1rem / 2rem / 3rem).
4. `Labelled` exposes it as a named image (`aria-label="Loading"`); the default is decorative (`aria-hidden`).
5. Enable OS "reduce motion" → the spinner holds still (no rotation) but stays visible.
6. Ensure the app serves `@canonical/ds-assets` icons at `/icons` — otherwise the glyph renders empty (documented in the README).

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁`.
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] All packages define the required scripts in `package.json` (`check`, `check:fix`, `test`, `build`).
- [ ] N/A — no new package.
- [ ] Visual testing applies — Chromatic runs (the spinner is a visual component; snapshots are deterministic by the full-turn keyframe).

## Screenshots

_Storybook: `subcomponents/Spinner` — Default (spinning), Sized (1/2/3rem), Labelled. Chromatic will attach the visual baseline._
