### PR TITLE
feat(ds-global): overlay hooks — useDisclosure, useContextualMenu, arrow offset

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -622,6 +622,7 @@
       "version": "0.29.1",
       "dependencies": {
         "@canonical/ds-assets": "^0.29.0",
+        "@canonical/react-hooks": "^0.29.0",
         "@canonical/storybook-config": "^0.29.1",
         "@canonical/styles": "^0.29.0",
         "@canonical/utils": "^0.29.0",
@@ -728,8 +729,8 @@
       "name": "@canonical/react-hooks",
       "version": "0.29.0",
       "dependencies": {
-        "@canonical/ds-types": "^0.27.1-experimental.0",
-        "@canonical/utils": "^0.27.1-experimental.0",
+        "@canonical/ds-types": "^0.29.0",
+        "@canonical/utils": "^0.29.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
@@ -1179,15 +1180,15 @@
       "name": "@canonical/summon-application",
       "version": "0.29.0",
       "dependencies": {
-        "@canonical/summon-core": "^0.29.0",
-        "@canonical/task": "^0.29.0",
-        "@canonical/utils": "^0.29.0",
+        "@canonical/summon-core": "^0.27.1-experimental.0",
+        "@canonical/task": "^0.27.1-experimental.0",
+        "@canonical/utils": "^0.27.1-experimental.0",
         "typescript": "^5.9.3",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.29.0",
-        "@canonical/webarchitect": "^0.29.0",
+        "@canonical/biome-config": "^0.27.1-experimental.0",
+        "@canonical/webarchitect": "^0.27.1-experimental.0",
         "@types/node": "^24.12.0",
         "vitest": "^4.0.18",
       },
@@ -1209,8 +1210,8 @@
         "vitest": "^4.0.18",
       },
       "peerDependencies": {
-        "@canonical/summon-core": "^0.29.0",
-        "@canonical/task": "^0.29.0",
+        "@canonical/summon-core": "^0.18.0 || ^0.20.0",
+        "@canonical/task": "^0.18.0 || ^0.20.0",
       },
     },
     "packages/summon/core": {

--- a/packages/react/ds-global/package.json
+++ b/packages/react/ds-global/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@canonical/ds-assets": "^0.29.0",
+    "@canonical/react-hooks": "^0.29.0",
     "@canonical/storybook-config": "^0.29.1",
     "@canonical/styles": "^0.29.0",
     "@canonical/utils": "^0.29.0",

--- a/packages/react/ds-global/src/lib/hooks/index.ts
+++ b/packages/react/ds-global/src/lib/hooks/index.ts
@@ -1,4 +1,6 @@
+export * from "./useContextualMenu/index.js";
 export * from "./useDelayedToggle/index.js";
+export * from "./useDisclosure/index.js";
 export * from "./usePopup/index.js";
 export * from "./useResizeObserver/index.js";
 export * from "./useWindowDimensions/index.js";

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/index.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export { default as useContextualMenu } from "./useContextualMenu.js";

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
@@ -1,0 +1,96 @@
+import type { _Item, Item } from "@canonical/ds-types";
+import type {
+  ItemProps,
+  MenuGroupPropsResult,
+  MenuItemPropsResult,
+  MenuProps,
+  MenuPropsResult,
+  UseNavigationTreeResult,
+} from "@canonical/react-hooks";
+import type {
+  UseDisclosureProps,
+  UseDisclosureResult,
+} from "../useDisclosure/index.js";
+
+/**
+ * A menu item that may carry a right-aligned slot (e.g. a badge or keyboard
+ * shortcut) in addition to the base navigation fields. The slot is an optional
+ * extension that survives tree annotation.
+ */
+export interface MenuItem
+  extends Item<React.ComponentType<{ item: MenuItem }>> {
+  /** Content rendered right-aligned within the item, such as a badge or shortcut. */
+  slot?: React.ReactNode;
+  /** Icon rendered left of the label. */
+  icon?: React.ReactNode;
+  /** Child items — a group's items, or a future submenu's entries. */
+  items?: MenuItem[];
+}
+
+export interface UseContextualMenuProps
+  extends Omit<UseDisclosureProps, "mode"> {
+  /**
+   * The menu tree. The root's children are groups; each group's children are
+   * the menu items (menu -> group -> item). One level of items is supported now;
+   * deeper nesting is reserved for submenus.
+   */
+  root: MenuItem;
+  /** Whether arrow keys wrap at the first/last item. Defaults to false. */
+  wrap?: boolean;
+  /** Type-ahead reset timeout in milliseconds. */
+  typeAheadTimeout?: number;
+}
+
+/** Options for the menu/group ARIA prop-getters. */
+export interface MenuAriaOptions {
+  /** Accessible name for the element. */
+  label?: string;
+  /** Id of an element that labels this one. */
+  labelledBy?: string;
+  /** A ref to compose with the menu's internal keyboard ref (menu container only). */
+  ref?: React.Ref<HTMLElement>;
+}
+
+/**
+ * The contextual menu combines a click disclosure (open state, positioning,
+ * dismissal) with a navigation tree (roving keyboard focus, type-ahead, and
+ * cross-group arrow traversal via a `stateReducer`) and menu ARIA wiring.
+ */
+export interface UseContextualMenuResult
+  extends Pick<
+      UseDisclosureResult,
+      | "isOpen"
+      | "open"
+      | "close"
+      | "toggle"
+      | "targetRef"
+      | "popupRef"
+      | "popupPositionStyle"
+      | "popupId"
+      | "bestPosition"
+      | "arrowOffset"
+    >,
+    Pick<
+      UseNavigationTreeResult<MenuItem>,
+      | "annotatedRoot"
+      | "index"
+      | "highlightedItems"
+      | "highlightItem"
+      | "selectItem"
+    > {
+  /**
+   * Prop-getter for the menu trigger element. Drives the disclosure (open state,
+   * positioning, dismissal) and carries the menu ARIA wiring
+   * (`aria-haspopup`/`aria-expanded`/`aria-controls`).
+   */
+  getTriggerProps: () => Record<string, unknown>;
+  /**
+   * Prop-getter for the `role="menu"` container element. Merges the navigation
+   * container props (keyboard handler, ref) with the menu ARIA preset.
+   */
+  getMenuProps: (opts?: MenuAriaOptions) => MenuProps & MenuPropsResult;
+  /** Prop-getter for a `role="group"` element. */
+  getGroupProps: (opts?: MenuAriaOptions) => MenuGroupPropsResult;
+  /** Prop-getter for a `role="menuitem"` element. */
+  getItemProps: (item: _Item<MenuItem>) => ItemProps & MenuItemPropsResult;
+}

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.tests.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.tests.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type BestPosition,
+  useWindowFitment,
+} from "../useWindowFitment/index.js";
+import { useContextualMenu } from "./index.js";
+import type { MenuItem } from "./types.js";
+
+// Mock only the leaf positioning hook; the navigation tree and cross-group
+// reducer run for real so composition is genuinely exercised.
+vi.mock("../useWindowFitment/index.js");
+
+const menu: MenuItem = {
+  key: "menu",
+  items: [
+    {
+      key: "group-a",
+      items: [
+        { key: "a1", label: "A one", url: "/a1" },
+        { key: "a2", label: "A two", url: "/a2" },
+      ],
+    },
+    {
+      key: "group-b",
+      items: [{ key: "b1", label: "B one", url: "/b1" }],
+    },
+  ],
+};
+
+describe("useContextualMenu", () => {
+  const mockBestPosition: BestPosition = {
+    positionName: "bottom",
+    position: { top: 0, left: 0 },
+    fits: true,
+    autoFitOffset: { top: 0, left: 0 },
+  };
+
+  beforeEach(() => {
+    vi.mocked(useWindowFitment).mockReturnValue({
+      targetRef: { current: null },
+      popupRef: { current: null },
+      bestPosition: mockBestPosition,
+      popupPositionStyle: {},
+      arrowOffset: { axis: "x", offset: 0 },
+    });
+  });
+
+  it("exposes disclosure, navigation, and positioning surface", () => {
+    const { result } = renderHook(() => useContextualMenu({ root: menu }));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.getTriggerProps).toBeInstanceOf(Function);
+    expect(result.current.getMenuProps).toBeInstanceOf(Function);
+    expect(result.current.getItemProps).toBeInstanceOf(Function);
+    expect(result.current.arrowOffset).toEqual({ axis: "x", offset: 0 });
+    expect(result.current.index).toBeDefined();
+  });
+
+  it("the trigger carries click-disclosure ARIA wiring", () => {
+    const { result } = renderHook(() => useContextualMenu({ root: menu }));
+    const triggerProps = result.current.getTriggerProps();
+    expect(triggerProps["aria-expanded"]).toBe(false);
+  });
+
+  it("opens and closes via the imperative controls", () => {
+    const { result } = renderHook(() => useContextualMenu({ root: menu }));
+
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => result.current.close());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("passes positioning props through to useWindowFitment", () => {
+    renderHook(() =>
+      useContextualMenu({ root: menu, preferredDirections: ["bottom"] }),
+    );
+    expect(vi.mocked(useWindowFitment)).toHaveBeenCalledWith(
+      expect.objectContaining({ preferredDirections: ["bottom"] }),
+    );
+  });
+
+  it("crosses group boundaries on ArrowDown through the composed hook", () => {
+    // Regression: the cross-group reducer must operate on the tree's own item
+    // instances (via the highlighted path), not a separately-annotated index —
+    // otherwise reference checks never match and the behaviour silently no-ops.
+    const { result } = renderHook(() => useContextualMenu({ root: menu }));
+
+    // Highlight the last item of group A.
+    const a2 = result.current.index["/a2"];
+    expect(a2).toBeDefined();
+    act(() => result.current.highlightItem(a2));
+    expect(result.current.highlightedItems.at(-1)?.key).toBe("a2");
+
+    // ArrowDown at the group edge should move into group B's first item.
+    // biome-ignore lint/suspicious/noExplicitAny: minimal keyboard event for the menu handler
+    const arrowDownEvent = {
+      key: "ArrowDown",
+      preventDefault: () => {},
+    } as any;
+    act(() => {
+      result.current.getMenuProps().onKeyDown?.(arrowDownEvent);
+    });
+    expect(result.current.highlightedItems.at(-1)?.key).toBe("b1");
+  });
+});

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
@@ -1,0 +1,142 @@
+import type { _Item } from "@canonical/ds-types";
+import {
+  getMenuProps as getMenuAriaProps,
+  getMenuGroupProps,
+  getMenuItemProps,
+  useNavigationTree,
+} from "@canonical/react-hooks";
+import { createCrossGroupStateReducer } from "@canonical/utils";
+import { useCallback, useEffect, useMemo } from "react";
+import { useDisclosure } from "../useDisclosure/index.js";
+import type {
+  MenuItem,
+  UseContextualMenuProps,
+  UseContextualMenuResult,
+} from "./types.js";
+
+/**
+ * Drives a contextual menu: a click-triggered, positioned popup listing grouped
+ * menu items with full keyboard support.
+ *
+ * Positioning, open state, outside-click and Escape dismissal come from
+ * {@link useDisclosure} in `click` mode. Roving focus, type-ahead, and ARIA
+ * wiring come from `useNavigationTree`. Vertical arrow keys cross group
+ * boundaries through a `stateReducer`, so the shared navigation machinery stays
+ * menu-agnostic.
+ *
+ * @param root The menu tree (menu -> group -> item).
+ * @param wrap Whether arrow keys wrap at the first/last item.
+ * @param typeAheadTimeout Type-ahead reset timeout in milliseconds.
+ * @param props Forwarded to the underlying disclosure (positioning, callbacks).
+ * @returns The open state, positioning, and menu prop-getters.
+ */
+const useContextualMenu = ({
+  root,
+  wrap = false,
+  typeAheadTimeout,
+  ...props
+}: UseContextualMenuProps): UseContextualMenuResult => {
+  const {
+    isOpen,
+    open,
+    close,
+    toggle,
+    targetRef,
+    popupRef,
+    popupPositionStyle,
+    popupId,
+    bestPosition,
+    arrowOffset,
+    getToggleProps: getDisclosureToggleProps,
+  } = useDisclosure({ ...props, mode: "click" });
+
+  // The cross-group reducer operates on state.highlightedItems (the tree's own
+  // instances), so it needs no external index — avoiding the instance mismatch
+  // that a separately-annotated tree would introduce.
+  const stateReducer = useMemo(
+    () => createCrossGroupStateReducer<MenuItem>(),
+    [],
+  );
+
+  const nav = useNavigationTree<MenuItem>({
+    root,
+    focus: "roving",
+    wrap,
+    typeAheadTimeout,
+    // The cross-group boundary rule lives here, not in the shared reducer.
+    stateReducer,
+  });
+
+  // The disclosure owns the open state (it drives positioning and dismissal);
+  // mirror it into the navigation tree so roving focus follows open/close.
+  useEffect(() => {
+    if (isOpen) nav.openMenu();
+    else nav.closeMenu();
+  }, [isOpen, nav.openMenu, nav.closeMenu]);
+
+  // The trigger must drive the DISCLOSURE (the source of truth for open) while
+  // keeping the disclosure's click/keyboard handlers. The tree's toggle is not
+  // used for open/close here.
+  const getTriggerProps = useCallback(
+    () => ({
+      "aria-haspopup": "menu" as const,
+      "aria-expanded": isOpen,
+      "aria-controls": popupId,
+      ...getDisclosureToggleProps(),
+    }),
+    [isOpen, popupId, getDisclosureToggleProps],
+  );
+
+  // Menu-role ARIA getters, composing the base navigation prop-getters (for
+  // roving tabindex + refs) with the contextual-menu ARIA presets.
+  const getMenuProps = useCallback(
+    (opts?: {
+      label?: string;
+      labelledBy?: string;
+      ref?: React.Ref<HTMLElement>;
+    }) => ({
+      // Compose the positioning ref (if provided) with the navigation menu ref.
+      ...nav.getMenuProps(opts?.ref ? { ref: opts.ref } : undefined),
+      ...getMenuAriaProps(nav, opts),
+    }),
+    [nav],
+  );
+
+  const getGroupProps = useCallback(
+    (opts?: { label?: string; labelledBy?: string }) =>
+      getMenuGroupProps(nav, opts),
+    [nav],
+  );
+
+  const getItemProps = useCallback(
+    (item: _Item<MenuItem>) => ({
+      ...nav.getItemProps(item),
+      ...getMenuItemProps(nav, item),
+    }),
+    [nav],
+  );
+
+  return {
+    isOpen,
+    open,
+    close,
+    toggle,
+    targetRef,
+    popupRef,
+    popupPositionStyle,
+    popupId,
+    bestPosition,
+    arrowOffset,
+    annotatedRoot: nav.annotatedRoot,
+    index: nav.index,
+    highlightedItems: nav.highlightedItems,
+    highlightItem: nav.highlightItem,
+    selectItem: nav.selectItem,
+    getTriggerProps,
+    getMenuProps,
+    getGroupProps,
+    getItemProps,
+  };
+};
+
+export default useContextualMenu;

--- a/packages/react/ds-global/src/lib/hooks/useDisclosure/index.ts
+++ b/packages/react/ds-global/src/lib/hooks/useDisclosure/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export { default as useDisclosure } from "./useDisclosure.js";

--- a/packages/react/ds-global/src/lib/hooks/useDisclosure/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useDisclosure/types.ts
@@ -1,0 +1,119 @@
+import type {
+  CSSProperties,
+  FocusEventHandler,
+  KeyboardEventHandler,
+  PointerEventHandler,
+  RefObject,
+} from "react";
+import type { UseDelayedToggleProps } from "../useDelayedToggle/index.js";
+import type {
+  UseWindowFitmentProps,
+  UseWindowFitmentResult,
+} from "../useWindowFitment/index.js";
+
+/**
+ * How the disclosure is triggered.
+ * - `hover`: opens on pointer-enter / focus, closes on pointer-leave / blur,
+ *   with a delay. Suits tooltips and other non-interactive overlays. There is
+ *   no native HTML primitive for this; the hook owns the open state.
+ * - `click`: toggles on click, closes on outside-click and Escape, and returns
+ *   focus to the trigger on close. Suits popovers, menus, and dropdowns. This
+ *   mode is complementary to a native `<details>`/`<summary>` (or a
+ *   `<button aria-expanded>` + panel), which provides the no-JS baseline while
+ *   the hook layers on positioning and dismissal after hydration.
+ */
+export type DisclosureMode = "hover" | "click";
+
+export interface UseDisclosureProps
+  extends UseWindowFitmentProps,
+    UseDelayedToggleProps {
+  /** How the disclosure opens and closes. Defaults to `hover`. */
+  mode?: DisclosureMode;
+  /** An override for the open state. When boolean, the hook is controlled. */
+  isOpen?: boolean;
+  /** Called when the popup is shown. */
+  onShow?: (event?: Event) => void;
+  /** Called when the popup is hidden. */
+  onHide?: (event?: Event) => void;
+  /**
+   * Whether the popup closes when the Escape key is pressed. Defaults to true.
+   */
+  closeOnEscape?: boolean;
+  /**
+   * Whether a `click` disclosure closes when a pointer-down occurs outside the
+   * trigger and content. Ignored in `hover` mode. Defaults to true.
+   */
+  closeOnOutsideClick?: boolean;
+  /**
+   * Whether a `click` disclosure returns focus to the trigger when it closes.
+   * Ignored in `hover` mode. Defaults to true.
+   */
+  returnFocus?: boolean;
+  /** Called when the pointer enters the trigger (`hover` mode). */
+  onEnter?: PointerEventHandler;
+  /** Called when the pointer leaves the trigger (`hover` mode). */
+  onLeave?: PointerEventHandler;
+  /** Called when the trigger is focused. */
+  onFocus?: FocusEventHandler;
+  /** Called when the trigger loses focus. */
+  onBlur?: FocusEventHandler;
+}
+
+/**
+ * Props to spread onto the trigger element. The trigger is whatever the
+ * component chooses to render (a `<button>`, a `<summary>`, a `<span>`); the
+ * hook stays element-agnostic.
+ */
+export interface DisclosureToggleProps {
+  /** Reflects the open state for assistive tech (`click` mode). */
+  "aria-expanded"?: boolean;
+  /** Points at the content element (`click` mode). */
+  "aria-controls"?: string;
+  /** Associates the trigger with its description (`hover` mode). */
+  "aria-describedby"?: string;
+  onClick?: (event: React.MouseEvent) => void;
+  onKeyDown?: KeyboardEventHandler;
+  onPointerEnter?: PointerEventHandler;
+  onPointerLeave?: PointerEventHandler;
+  onFocus?: FocusEventHandler;
+  onBlur?: FocusEventHandler;
+}
+
+/** Props to spread onto the content (popup) element. */
+export interface DisclosureContentProps {
+  /** Stable id, matched by the trigger's `aria-controls` / `aria-describedby`. */
+  id: string;
+  /** Hidden from layout and assistive tech while closed. */
+  hidden?: boolean;
+  onPointerEnter?: PointerEventHandler;
+  onPointerLeave?: PointerEventHandler;
+}
+
+export type DisableableElement = HTMLElement & {
+  disabled: boolean;
+};
+
+export interface UseDisclosureResult extends UseWindowFitmentResult {
+  /** Whether the disclosure is currently open. */
+  isOpen: boolean;
+  /** Whether the trigger is currently focused. */
+  isFocused: boolean;
+  /** Imperatively open the disclosure. */
+  open: () => void;
+  /** Imperatively close the disclosure. */
+  close: () => void;
+  /** Imperatively toggle the disclosure. */
+  toggle: () => void;
+  /** A ref to attach to the trigger element. */
+  targetRef: RefObject<HTMLDivElement | null>;
+  /** A ref to attach to the content (popup) element. */
+  popupRef: RefObject<HTMLDivElement | null>;
+  /** The style object to apply to the content element. */
+  popupPositionStyle: CSSProperties;
+  /** A stable id for the content element (associates trigger and content). */
+  popupId: string;
+  /** Prop-getter for the trigger element. */
+  getToggleProps: () => DisclosureToggleProps;
+  /** Prop-getter for the content (popup) element. */
+  getContentProps: () => DisclosureContentProps;
+}

--- a/packages/react/ds-global/src/lib/hooks/useDisclosure/useDisclosure.tests.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useDisclosure/useDisclosure.tests.tsx
@@ -1,0 +1,270 @@
+import { act, renderHook } from "@testing-library/react";
+import type { CSSProperties } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDelayedToggle } from "../useDelayedToggle/index.js";
+import {
+  type BestPosition,
+  useWindowFitment,
+} from "../useWindowFitment/index.js";
+import { useDisclosure } from "./index.js";
+
+vi.mock("../useDelayedToggle/index.js");
+vi.mock("../useWindowFitment/index.js");
+
+describe("useDisclosure", () => {
+  const mockTargetRef = { current: document.createElement("div") };
+  const mockPopupRef = { current: document.createElement("div") };
+
+  const mockBestPosition: BestPosition = {
+    positionName: "bottom",
+    position: { top: 10, left: 20 },
+    fits: true,
+    autoFitOffset: { top: 0, left: 0 },
+  };
+
+  const mockPopupPositionStyle: CSSProperties = {
+    top: 10,
+    left: 20,
+    maxWidth: "300px",
+  };
+
+  beforeEach(() => {
+    vi.mocked(useDelayedToggle).mockReturnValue({
+      flag: false,
+      activate: vi.fn(),
+      deactivate: vi.fn(),
+    });
+    vi.mocked(useWindowFitment).mockReturnValue({
+      targetRef: mockTargetRef,
+      popupRef: mockPopupRef,
+      bestPosition: mockBestPosition,
+      popupPositionStyle: mockPopupPositionStyle,
+    });
+  });
+
+  it("should return initial state, controls, and prop-getters", () => {
+    const { result } = renderHook(() => useDisclosure({}));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.isFocused).toBe(false);
+    expect(result.current.targetRef).toBe(mockTargetRef);
+    expect(result.current.popupRef).toBe(mockPopupRef);
+    expect(result.current.bestPosition).toBe(mockBestPosition);
+    expect(result.current.popupPositionStyle).toEqual(mockPopupPositionStyle);
+    expect(result.current.popupId).toBeDefined();
+
+    expect(result.current.open).toBeInstanceOf(Function);
+    expect(result.current.close).toBeInstanceOf(Function);
+    expect(result.current.toggle).toBeInstanceOf(Function);
+    expect(result.current.getToggleProps).toBeInstanceOf(Function);
+    expect(result.current.getContentProps).toBeInstanceOf(Function);
+  });
+
+  it("should honour the isOpen prop override", () => {
+    const { result } = renderHook(() => useDisclosure({ isOpen: true }));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  describe("hover mode (default)", () => {
+    it("exposes pointer and describedby wiring on the trigger", () => {
+      const { result } = renderHook(() => useDisclosure({ mode: "hover" }));
+      const toggleProps = result.current.getToggleProps();
+
+      expect(toggleProps["aria-describedby"]).toBe(result.current.popupId);
+      expect(toggleProps["aria-expanded"]).toBeUndefined();
+      expect(toggleProps.onPointerEnter).toBeInstanceOf(Function);
+      expect(toggleProps.onPointerLeave).toBeInstanceOf(Function);
+    });
+
+    it("opens on pointer-enter and closes on pointer-leave", () => {
+      const activate = vi.fn();
+      const deactivate = vi.fn();
+      vi.mocked(useDelayedToggle).mockReturnValue({
+        flag: false,
+        activate,
+        deactivate,
+      });
+
+      const { result } = renderHook(() => useDisclosure({ mode: "hover" }));
+
+      act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to PointerEvent
+        result.current.getToggleProps().onPointerEnter?.({} as any);
+      });
+      expect(activate).toHaveBeenCalledOnce();
+
+      act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to PointerEvent
+        result.current.getToggleProps().onPointerLeave?.({} as any);
+      });
+      expect(deactivate).toHaveBeenCalledOnce();
+    });
+
+    it("opens on focus (keyboard parity)", () => {
+      const activate = vi.fn();
+      vi.mocked(useDelayedToggle).mockReturnValue({
+        flag: false,
+        activate,
+        deactivate: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useDisclosure({ mode: "hover" }));
+      act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to FocusEvent
+        result.current.getToggleProps().onFocus?.({} as any);
+      });
+
+      expect(activate).toHaveBeenCalledOnce();
+      expect(result.current.isFocused).toBe(true);
+    });
+
+    it("does not open on hover if the trigger is disabled", () => {
+      const activate = vi.fn();
+      vi.mocked(useDelayedToggle).mockReturnValue({
+        flag: false,
+        activate,
+        deactivate: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useDisclosure({ mode: "hover" }));
+      act(() => {
+        result.current
+          .getToggleProps()
+          // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to PointerEvent
+          .onPointerEnter?.({ target: { disabled: true } } as any);
+      });
+
+      expect(activate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("click mode", () => {
+    it("exposes expanded/controls wiring on the trigger", () => {
+      const { result } = renderHook(() => useDisclosure({ mode: "click" }));
+      const toggleProps = result.current.getToggleProps();
+
+      expect(toggleProps["aria-expanded"]).toBe(false);
+      expect(toggleProps["aria-controls"]).toBe(result.current.popupId);
+      expect(toggleProps["aria-describedby"]).toBeUndefined();
+      expect(toggleProps.onClick).toBeInstanceOf(Function);
+      expect(toggleProps.onKeyDown).toBeInstanceOf(Function);
+    });
+
+    it("does not open on focus alone", () => {
+      const activate = vi.fn();
+      vi.mocked(useDelayedToggle).mockReturnValue({
+        flag: false,
+        activate,
+        deactivate: vi.fn(),
+      });
+
+      const { result } = renderHook(() => useDisclosure({ mode: "click" }));
+      act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to FocusEvent
+        result.current.getToggleProps().onFocus?.({} as any);
+      });
+
+      expect(activate).not.toHaveBeenCalled();
+      expect(result.current.isFocused).toBe(true);
+    });
+
+    it("toggles open and shut on click (synchronously, no timer)", () => {
+      const { result } = renderHook(() => useDisclosure({ mode: "click" }));
+
+      act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to MouseEvent
+        result.current.getToggleProps().onClick?.({ target: {} } as any);
+      });
+      expect(result.current.isOpen).toBe(true);
+
+      act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to MouseEvent
+        result.current.getToggleProps().onClick?.({ target: {} } as any);
+      });
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it("opens on ArrowDown when closed", () => {
+      const { result } = renderHook(() => useDisclosure({ mode: "click" }));
+      const preventDefault = vi.fn();
+      act(() => {
+        result.current.getToggleProps().onKeyDown?.({
+          key: "ArrowDown",
+          preventDefault,
+          // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to KeyboardEvent
+        } as any);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+      expect(preventDefault).toHaveBeenCalledOnce();
+    });
+
+    it("closes on outside pointer-down when open", () => {
+      const { result } = renderHook(() => useDisclosure({ mode: "click" }));
+
+      // Open it first.
+      act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to MouseEvent
+        result.current.getToggleProps().onClick?.({ target: {} } as any);
+      });
+      expect(result.current.isOpen).toBe(true);
+
+      // A pointer-down outside the trigger and popup closes it.
+      act(() => {
+        const event = new Event("pointerdown", { bubbles: true });
+        Object.defineProperty(event, "target", { value: document.body });
+        document.dispatchEvent(event);
+      });
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it("does not close on pointer-down inside the trigger or popup", () => {
+      const { result } = renderHook(() => useDisclosure({ mode: "click" }));
+
+      // Open it, then a pointer-down inside the popup must not close it.
+      act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: firing a test event without conforming to MouseEvent
+        result.current.getToggleProps().onClick?.({ target: {} } as any);
+      });
+      expect(result.current.isOpen).toBe(true);
+
+      act(() => {
+        const event = new Event("pointerdown", { bubbles: true });
+        Object.defineProperty(event, "target", { value: mockPopupRef.current });
+        document.dispatchEvent(event);
+      });
+      expect(result.current.isOpen).toBe(true);
+    });
+  });
+
+  it("closes a controlled-open click disclosure when Escape is pressed", () => {
+    // A controlled `isOpen: true` registers the Escape listener without relying
+    // on useDelayedToggle's internal state.
+    const onHide = vi.fn();
+    renderHook(() => useDisclosure({ mode: "click", isOpen: true, onHide }));
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(onHide).toHaveBeenCalledOnce();
+  });
+
+  it("marks content hidden while closed and visible while open", () => {
+    const { result, rerender } = renderHook(
+      ({ isOpen }) => useDisclosure({ isOpen }),
+      { initialProps: { isOpen: false } },
+    );
+    expect(result.current.getContentProps().hidden).toBe(true);
+
+    rerender({ isOpen: true });
+    expect(result.current.getContentProps().hidden).toBe(false);
+  });
+
+  it("passes props through to useWindowFitment with the resolved isOpen", () => {
+    renderHook(() => useDisclosure({ preferredDirections: ["top"] }));
+    expect(vi.mocked(useWindowFitment)).toHaveBeenCalledWith({
+      preferredDirections: ["top"],
+      isOpen: false,
+    });
+  });
+});

--- a/packages/react/ds-global/src/lib/hooks/useDisclosure/useDisclosure.ts
+++ b/packages/react/ds-global/src/lib/hooks/useDisclosure/useDisclosure.ts
@@ -1,0 +1,288 @@
+import {
+  type FocusEventHandler,
+  type KeyboardEventHandler,
+  type MouseEvent,
+  type PointerEventHandler,
+  useCallback,
+  useEffect,
+  useId,
+  useState,
+} from "react";
+import { useDelayedToggle } from "../useDelayedToggle/index.js";
+import { useWindowFitment } from "../useWindowFitment/index.js";
+import type {
+  DisableableElement,
+  DisclosureContentProps,
+  DisclosureToggleProps,
+  UseDisclosureProps,
+  UseDisclosureResult,
+} from "./types.js";
+
+/**
+ * Manages the open state, positioning, and accessibility wiring of a disclosure
+ * (a popup revealed by a trigger). The hook is headless and element-agnostic:
+ * it renders nothing and returns prop-getters the consumer spreads onto whichever
+ * trigger and content elements it chooses to render.
+ *
+ * In `hover` mode the popup opens on pointer-enter / focus and closes on
+ * pointer-leave / blur, with a delay — suited to tooltips. In `click` mode it
+ * toggles on click, closes on outside-click and Escape, and returns focus to the
+ * trigger on close — suited to popovers, menus, and dropdowns, layered over a
+ * native `<details>` or `<button aria-expanded>` baseline.
+ *
+ * @param mode How the disclosure opens and closes. Defaults to `hover`.
+ * @param isOpen An override for the open state; when boolean, the hook is controlled.
+ * @param deactivateDelay Delay in milliseconds before closing (`hover` mode).
+ * @param activateDelay Delay in milliseconds before opening (`hover` mode).
+ * @param onEnter Called when the pointer enters the trigger (`hover` mode).
+ * @param onLeave Called when the pointer leaves the trigger (`hover` mode).
+ * @param onFocus Called when the trigger is focused.
+ * @param onBlur Called when the trigger loses focus.
+ * @param onShow Called when the popup is shown.
+ * @param onHide Called when the popup is hidden.
+ * @param closeOnEscape Whether Escape closes the popup. Defaults to true.
+ * @param closeOnOutsideClick Whether an outside pointer-down closes a `click` popup. Defaults to true.
+ * @param returnFocus Whether closing a `click` popup returns focus to the trigger. Defaults to true.
+ * @param props Forwarded to the useWindowFitment hook.
+ * @returns The open state, imperative controls, positioning refs and style, and prop-getters.
+ */
+const useDisclosure = ({
+  mode = "hover",
+  isOpen: isOpenProp,
+  deactivateDelay,
+  activateDelay,
+  onEnter,
+  onLeave,
+  onFocus,
+  onBlur,
+  onShow,
+  onHide,
+  closeOnEscape = true,
+  closeOnOutsideClick = true,
+  returnFocus = true,
+  ...props
+}: UseDisclosureProps): UseDisclosureResult => {
+  const isServer = typeof window === "undefined";
+  const isClick = mode === "click";
+  const [isFocused, setIsFocused] = useState(false);
+  // Click disclosures open/close synchronously; hover disclosures use the timer.
+  const [isOpenClick, setIsOpenClick] = useState(false);
+  const popupId = useId();
+
+  const {
+    flag: isOpenHover,
+    deactivate: scheduleClose,
+    activate: scheduleOpen,
+  } = useDelayedToggle({
+    activateDelay,
+    deactivateDelay,
+    onActivate: onShow,
+    onDeactivate: onHide,
+  });
+
+  const isOpenInternal = isClick ? isOpenClick : isOpenHover;
+  // A boolean override makes the hook controlled; otherwise the internal state wins.
+  const isOpen = typeof isOpenProp === "boolean" ? isOpenProp : isOpenInternal;
+
+  const { targetRef, popupRef, bestPosition, popupPositionStyle, arrowOffset } =
+    useWindowFitment({
+      ...props,
+      isOpen,
+    });
+
+  const open = useCallback(() => {
+    if (isServer) return;
+    if (isClick) {
+      setIsOpenClick(true);
+      onShow?.();
+    } else {
+      scheduleOpen(new Event("open"));
+    }
+  }, [scheduleOpen, isServer, isClick, onShow]);
+
+  const close = useCallback(() => {
+    if (isServer) return;
+    if (isClick) {
+      setIsOpenClick(false);
+      onHide?.();
+      // Return focus to the trigger whenever a click disclosure closes —
+      // outside-click, Escape, toggle, or an explicit close() all route here.
+      // @note Impure — moves DOM focus.
+      if (returnFocus) targetRef.current?.focus();
+    } else {
+      scheduleClose(new Event("close"));
+    }
+  }, [scheduleClose, isServer, isClick, onHide, returnFocus, targetRef]);
+
+  const toggle = useCallback(() => {
+    if (isOpen) close();
+    else open();
+  }, [isOpen, open, close]);
+
+  const isDisabled = useCallback((el: DisableableElement) => el?.disabled, []);
+
+  const handleTriggerEnter: PointerEventHandler = useCallback(
+    (event) => {
+      if (isServer || isDisabled(event.target as DisableableElement)) return;
+      open();
+      onEnter?.(event);
+    },
+    [open, onEnter, isServer, isDisabled],
+  );
+
+  const handleTriggerLeave: PointerEventHandler = useCallback(
+    (event) => {
+      if (isServer || isDisabled(event.target as DisableableElement)) return;
+      close();
+      onLeave?.(event);
+    },
+    [close, onLeave, isServer, isDisabled],
+  );
+
+  const handleTriggerFocus: FocusEventHandler = useCallback(
+    (event) => {
+      if (isServer) return;
+      setIsFocused(true);
+      // Focus reveals a hover disclosure (keyboard parity); a click disclosure
+      // opens only on an explicit click, so focus alone must not open it.
+      if (!isClick) open();
+      onFocus?.(event);
+    },
+    [open, onFocus, isServer, isClick],
+  );
+
+  const handleTriggerBlur: FocusEventHandler = useCallback(
+    (event) => {
+      if (isServer) return;
+      setIsFocused(false);
+      if (!isClick) close();
+      onBlur?.(event);
+    },
+    [close, onBlur, isServer, isClick],
+  );
+
+  const handleTriggerClick = useCallback(
+    (event: MouseEvent) => {
+      if (isServer || isDisabled(event.target as DisableableElement)) return;
+      toggle();
+    },
+    [toggle, isServer, isDisabled],
+  );
+
+  const handleTriggerKeyDown: KeyboardEventHandler = useCallback(
+    (event) => {
+      if (isServer || !isClick) return;
+      // Space and Enter activate the trigger; ArrowDown opens the popup so
+      // keyboard users can move into it without toggling it shut.
+      if (event.key === " " || event.key === "Enter") {
+        event.preventDefault();
+        toggle();
+      } else if (event.key === "ArrowDown" && !isOpen) {
+        event.preventDefault();
+        open();
+      }
+    },
+    [isClick, isOpen, toggle, open, isServer],
+  );
+
+  // Close on Escape. `close()` handles return-focus for click disclosures.
+  useEffect(() => {
+    if (isServer || !closeOnEscape || !isOpen) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [close, closeOnEscape, isOpen, isServer]);
+
+  // Close a click disclosure when a pointer-down lands outside trigger and content.
+  useEffect(() => {
+    if (isServer || !isClick || !closeOnOutsideClick || !isOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const node = event.target as Node | null;
+      if (!node) return;
+      if (
+        targetRef.current?.contains(node) ||
+        popupRef.current?.contains(node)
+      ) {
+        return;
+      }
+      close();
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [
+    isServer,
+    isClick,
+    closeOnOutsideClick,
+    isOpen,
+    close,
+    targetRef,
+    popupRef,
+  ]);
+
+  const getToggleProps = useCallback((): DisclosureToggleProps => {
+    if (isClick) {
+      return {
+        "aria-expanded": isOpen,
+        "aria-controls": popupId,
+        onClick: handleTriggerClick,
+        onKeyDown: handleTriggerKeyDown,
+        onFocus: handleTriggerFocus,
+        onBlur: handleTriggerBlur,
+      };
+    }
+    return {
+      "aria-describedby": popupId,
+      onPointerEnter: handleTriggerEnter,
+      onPointerLeave: handleTriggerLeave,
+      onFocus: handleTriggerFocus,
+      onBlur: handleTriggerBlur,
+    };
+  }, [
+    isClick,
+    isOpen,
+    popupId,
+    handleTriggerClick,
+    handleTriggerKeyDown,
+    handleTriggerEnter,
+    handleTriggerLeave,
+    handleTriggerFocus,
+    handleTriggerBlur,
+  ]);
+
+  const getContentProps = useCallback((): DisclosureContentProps => {
+    const contentProps: DisclosureContentProps = {
+      id: popupId,
+      hidden: !isOpen,
+    };
+    // Hover popups keep the pointer handlers so moving onto the popup keeps it open.
+    if (!isClick) {
+      contentProps.onPointerEnter = handleTriggerEnter;
+      contentProps.onPointerLeave = handleTriggerLeave;
+    }
+    return contentProps;
+  }, [popupId, isOpen, isClick, handleTriggerEnter, handleTriggerLeave]);
+
+  return {
+    isOpen,
+    isFocused,
+    open,
+    close,
+    toggle,
+    targetRef,
+    popupRef,
+    popupPositionStyle,
+    popupId,
+    bestPosition,
+    arrowOffset,
+    getToggleProps,
+    getContentProps,
+  };
+};
+
+export default useDisclosure;

--- a/packages/react/ds-global/src/lib/hooks/usePopup/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/usePopup/types.ts
@@ -29,9 +29,9 @@ export interface UsePopupProps
   closeOnEscape?: boolean;
 }
 
-export type DisableableElement = HTMLElement & {
-  disabled: boolean;
-};
+// Re-export the canonical definition from useDisclosure to avoid a duplicate
+// export from the hooks barrel.
+export type { DisableableElement } from "../useDisclosure/index.js";
 
 export interface UsePopupResult extends UseWindowFitmentResult {
   /**

--- a/packages/react/ds-global/src/lib/hooks/usePopup/usePopup.ts
+++ b/packages/react/ds-global/src/lib/hooks/usePopup/usePopup.ts
@@ -1,137 +1,46 @@
-import {
-  type FocusEventHandler,
-  type PointerEventHandler,
-  useCallback,
-  useEffect,
-  useId,
-  useState,
-} from "react";
-import { useDelayedToggle } from "../useDelayedToggle/index.js";
-import { useWindowFitment } from "../useWindowFitment/index.js";
-import type {
-  DisableableElement,
-  UsePopupProps,
-  UsePopupResult,
-} from "./types.js";
+import { useDisclosure } from "../useDisclosure/index.js";
+import type { UsePopupProps, UsePopupResult } from "./types.js";
+
+const noop = () => {};
 
 /**
- * Manages the state of a popup.
- * @param isOpen An override for the open state.
- * @param deactivateDelay The delay in milliseconds before setting the flag to false.
- * @param activateDelay The delay in milliseconds before setting the flag to true.
- * @param onEnter A callback to be called when the mouse enters the target element.
- * @param onLeave A callback to be called when the mouse leaves the target element.
- * @param onFocus A callback to be called when the target element is focused.
- * @param onBlur A callback to be called when the target element loses focus.
- * @param onShow A callback to be called when the popup is shown.
- * @param onHide A callback to be called when the popup is hidden.
- * @param closeOnEscape Whether the popup should close when the escape key is pressed. Defaults to true.
- * @param props The props to be passed to the useWindowFitment hook.
+ * Manages the state of a hover popup.
+ *
+ * @deprecated Use {@link useDisclosure} with `mode: "hover"` instead. `usePopup`
+ * is a thin backwards-compatible wrapper retained for existing tooltip consumers
+ * and will be removed once they migrate.
+ *
+ * @param props The props for the underlying disclosure.
  * @returns The current state of the popup, and event handlers for the target element.
  */
-const usePopup = ({
-  isOpen: isOpenProp,
-  deactivateDelay,
-  activateDelay,
-  onEnter,
-  onLeave,
-  onFocus,
-  onBlur,
-  onShow,
-  onHide,
-  closeOnEscape = true,
-  ...props
-}: UsePopupProps): UsePopupResult => {
-  const isServer = typeof window === "undefined";
-  const [isFocused, setIsFocused] = useState(false);
-  const popupId = useId();
-
+const usePopup = (props: UsePopupProps): UsePopupResult => {
   const {
-    flag: isOpenHook,
-    deactivate: close,
-    activate: open,
-  } = useDelayedToggle({
-    activateDelay,
-    deactivateDelay,
-    onActivate: onShow,
-    onDeactivate: onHide,
-  });
+    isOpen,
+    isFocused,
+    targetRef,
+    popupRef,
+    popupPositionStyle,
+    popupId,
+    bestPosition,
+    getToggleProps,
+  } = useDisclosure({ ...props, mode: "hover" });
 
-  // Apply open override
-  const isOpen = typeof isOpenProp === "boolean" ? isOpenProp : isOpenHook;
-
-  const { targetRef, popupRef, bestPosition, popupPositionStyle } =
-    useWindowFitment({
-      ...props,
-      isOpen: isOpen,
-    });
-
-  const handleTriggerFocus: FocusEventHandler = useCallback(
-    (event) => {
-      if (isServer) return;
-      setIsFocused(true);
-      open(event.nativeEvent);
-      if (onFocus) onFocus(event);
-    },
-    [open, onFocus, isServer],
-  );
-
-  const handleTriggerBlur: FocusEventHandler = useCallback(
-    (event) => {
-      if (isServer) return;
-      setIsFocused(false);
-      close(event.nativeEvent);
-      if (onBlur) onBlur(event);
-    },
-    [close, onBlur, isServer],
-  );
-
-  const isDisabled = useCallback((el: DisableableElement) => el?.disabled, []);
-
-  const handleTriggerEnter: PointerEventHandler = useCallback(
-    (event) => {
-      if (isServer || isDisabled(event.target as DisableableElement)) return;
-      open(event.nativeEvent);
-      if (onEnter) onEnter(event);
-    },
-    [open, onEnter, isServer, isDisabled],
-  );
-
-  const handleTriggerLeave: PointerEventHandler = useCallback(
-    (event) => {
-      if (isServer || isDisabled(event.target as DisableableElement)) return;
-      close(event.nativeEvent);
-      if (onLeave) onLeave(event);
-    },
-    [close, onLeave, isServer, isDisabled],
-  );
-
-  useEffect(() => {
-    if (isServer || !closeOnEscape || !isOpen) return;
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") close(event);
-    };
-
-    document.addEventListener("keydown", handleEscape);
-
-    return () => {
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [close, closeOnEscape, isOpen, isServer]);
+  // Adapt the element-agnostic prop-getter back to the legacy named handlers
+  // that TooltipArea and withTooltip still consume.
+  const toggleProps = getToggleProps();
 
   return {
-    handleTriggerBlur,
-    handleTriggerEnter,
-    handleTriggerFocus,
-    handleTriggerLeave,
-    isFocused,
     isOpen,
-    popupId,
-    popupRef,
+    isFocused,
     targetRef,
-    bestPosition,
+    popupRef,
     popupPositionStyle,
+    popupId,
+    bestPosition,
+    handleTriggerEnter: toggleProps.onPointerEnter ?? noop,
+    handleTriggerLeave: toggleProps.onPointerLeave ?? noop,
+    handleTriggerFocus: toggleProps.onFocus ?? noop,
+    handleTriggerBlur: toggleProps.onBlur ?? noop,
   };
 };
 

--- a/packages/react/ds-global/src/lib/hooks/useWindowFitment/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useWindowFitment/types.ts
@@ -65,6 +65,14 @@ export interface UseWindowFitmentResult {
    * The style object to be applied to the popup element.
    */
   popupPositionStyle: CSSProperties;
+  /**
+   * The offset, in pixels, needed to keep an arrow pointing at the target's
+   * centre, along the cross-axis of the current placement (horizontal for
+   * `top`/`bottom`, vertical for `left`/`right`). Zero when the popup is
+   * centred on the target. Optional to consume: popups without an arrow ignore
+   * it. `undefined` until a position has been measured.
+   */
+  arrowOffset?: ArrowOffset;
   //
   // /**
   //  * The distance, in pixels, between the target and the popup.
@@ -77,6 +85,17 @@ export type RelativePosition = {
   top: number;
   left: number;
 };
+
+/**
+ * The displacement of an arrow from the centre of a popup edge so it points at
+ * the target. `axis` names which dimension the `offset` applies to: `x` shifts
+ * the arrow horizontally (for `top`/`bottom` placements), `y` vertically (for
+ * `left`/`right`).
+ */
+export interface ArrowOffset {
+  axis: "x" | "y";
+  offset: number;
+}
 
 export interface BestPosition {
   position: RelativePosition;

--- a/packages/react/ds-global/src/lib/hooks/useWindowFitment/useWindowFitment.tests.ts
+++ b/packages/react/ds-global/src/lib/hooks/useWindowFitment/useWindowFitment.tests.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { computeArrowOffset } from "./useWindowFitment.js";
+
+/** Build a minimal DOMRect-like object for the fields computeArrowOffset reads. */
+const makeRect = (
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+): DOMRect =>
+  ({
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+describe("computeArrowOffset", () => {
+  it("returns zero on the x axis when a top/bottom popup is centred on the target", () => {
+    // Target centre x = 150; popup centre x = 150 → aligned.
+    const target = makeRect(100, 0, 100, 20);
+    const popup = makeRect(50, 30, 200, 40);
+
+    expect(computeArrowOffset("bottom", target, popup)).toEqual({
+      axis: "x",
+      offset: 0,
+    });
+    expect(computeArrowOffset("top", target, popup)).toEqual({
+      axis: "x",
+      offset: 0,
+    });
+  });
+
+  it("shifts the arrow toward a target left of the popup centre", () => {
+    // Target centre x = 60; popup centre x = 150 → arrow shifts -90.
+    const target = makeRect(40, 0, 40, 20);
+    const popup = makeRect(50, 30, 200, 40);
+
+    expect(computeArrowOffset("bottom", target, popup)).toEqual({
+      axis: "x",
+      offset: -90,
+    });
+  });
+
+  it("shifts the arrow toward a target right of the popup centre", () => {
+    // Target centre x = 240; popup centre x = 150 → arrow shifts +90.
+    const target = makeRect(220, 0, 40, 20);
+    const popup = makeRect(50, 30, 200, 40);
+
+    expect(computeArrowOffset("bottom", target, popup)).toEqual({
+      axis: "x",
+      offset: 90,
+    });
+  });
+
+  it("clamps the offset to the popup half-extent so the arrow stays on the edge", () => {
+    // Target centre x = 500; popup centre x = 150; raw offset 350, half-extent 100.
+    const target = makeRect(480, 0, 40, 20);
+    const popup = makeRect(50, 30, 200, 40);
+
+    expect(computeArrowOffset("bottom", target, popup)).toEqual({
+      axis: "x",
+      offset: 100,
+    });
+  });
+
+  it("uses the y axis for left/right placements", () => {
+    // Target centre y = 100; popup centre y = 60 → arrow shifts +40 on y.
+    const target = makeRect(0, 80, 20, 40);
+    const popup = makeRect(30, 10, 40, 100);
+
+    expect(computeArrowOffset("right", target, popup)).toEqual({
+      axis: "y",
+      offset: 40,
+    });
+    expect(computeArrowOffset("left", target, popup)).toEqual({
+      axis: "y",
+      offset: 40,
+    });
+  });
+});

--- a/packages/react/ds-global/src/lib/hooks/useWindowFitment/useWindowFitment.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useWindowFitment/useWindowFitment.tsx
@@ -8,12 +8,48 @@ import {
 import { useResizeObserver } from "../useResizeObserver/index.js";
 import { useWindowDimensions } from "../useWindowDimensions/index.js";
 import type {
+  ArrowOffset,
   BestPosition,
   RelativePosition,
   UseWindowFitmentProps,
   UseWindowFitmentResult,
   WindowFitmentDirection,
 } from "./types.js";
+
+/**
+ * Compute the cross-axis displacement needed to keep an arrow pointing at the
+ * target's centre for a given placement. The arrow sits at the popup edge
+ * centre by default; this returns how far to shift it so it aligns with the
+ * target centre, clamped to the popup's half-extent so it never leaves the edge.
+ * @param direction The side of the target the popup is placed on.
+ * @param targetRect The bounding client rect of the target element.
+ * @param popupRect The bounding client rect of the popup element.
+ * @returns The arrow axis and offset in pixels.
+ */
+export const computeArrowOffset = (
+  direction: WindowFitmentDirection,
+  targetRect: DOMRect,
+  popupRect: DOMRect,
+): ArrowOffset => {
+  const isVerticalPlacement = direction === "top" || direction === "bottom";
+  const axis = isVerticalPlacement ? "x" : "y";
+
+  const targetCentre = isVerticalPlacement
+    ? targetRect.left + targetRect.width / 2
+    : targetRect.top + targetRect.height / 2;
+  const popupCentre = isVerticalPlacement
+    ? popupRect.left + popupRect.width / 2
+    : popupRect.top + popupRect.height / 2;
+
+  const halfExtent = isVerticalPlacement
+    ? popupRect.width / 2
+    : popupRect.height / 2;
+
+  const rawOffset = targetCentre - popupCentre;
+  const clampedOffset = Math.max(-halfExtent, Math.min(halfExtent, rawOffset));
+
+  return { axis, offset: clampedOffset };
+};
 
 const useWindowFitment = ({
   preferredDirections = ["top", "bottom", "left", "right"],
@@ -248,6 +284,28 @@ const useWindowFitment = ({
     isServer,
   ]);
 
+  /**
+   * The arrow offset that keeps an arrow pointing at the target centre, computed
+   * for every placement (not only when auto-fit clamps). Consumers without an
+   * arrow ignore it.
+   */
+  const arrowOffset: ArrowOffset | undefined = useMemo(() => {
+    if (
+      isServer ||
+      !bestPosition ||
+      !targetRef.current ||
+      !popupRef.current ||
+      !targetSize ||
+      !popupSize
+    )
+      return;
+    return computeArrowOffset(
+      bestPosition.positionName,
+      targetRef.current.getBoundingClientRect(),
+      popupRef.current.getBoundingClientRect(),
+    );
+  }, [bestPosition, isServer, targetSize, popupSize]);
+
   /** Notify the consumer when the best position changes. */
   useEffect(() => {
     if (bestPosition?.positionName !== prevBestPosition.current?.positionName) {
@@ -294,6 +352,7 @@ const useWindowFitment = ({
     popupRef,
     bestPosition,
     popupPositionStyle,
+    arrowOffset,
   };
 };
 

--- a/packages/react/hooks/src/lib/useNavigationTree/aria/getMenuGroupProps.ts
+++ b/packages/react/hooks/src/lib/useNavigationTree/aria/getMenuGroupProps.ts
@@ -1,0 +1,24 @@
+import type { Item } from "@canonical/ds-types";
+import type { UseNavigationTreeResult } from "../types.js";
+import type { MenuGroupPropsResult } from "./types.js";
+
+/**
+ * Build ARIA props for a contextual-menu group element (`role="group"`).
+ *
+ * Groups partition a menu's items. Provide a `label` for an accessible name, or
+ * `labelledBy` to reference a visible group heading.
+ *
+ * @param _nav Navigation hook result (unused, reserved for future use).
+ * @param opts Accessible label or labelledby reference for the group.
+ * @returns ARIA attributes to spread on the group element.
+ */
+export default function getMenuGroupProps<T extends Item = Item>(
+  _nav: UseNavigationTreeResult<T>,
+  opts: { label?: string; labelledBy?: string } = {},
+): MenuGroupPropsResult {
+  return {
+    role: "group",
+    ...(opts.label ? { "aria-label": opts.label } : {}),
+    ...(opts.labelledBy ? { "aria-labelledby": opts.labelledBy } : {}),
+  };
+}

--- a/packages/react/hooks/src/lib/useNavigationTree/aria/getMenuItemProps.ts
+++ b/packages/react/hooks/src/lib/useNavigationTree/aria/getMenuItemProps.ts
@@ -1,0 +1,43 @@
+import type { _Item, Item } from "@canonical/ds-types";
+import type { UseNavigationTreeResult } from "../types.js";
+import type { MenuItemPropsResult } from "./types.js";
+
+/**
+ * Build ARIA props for a contextual-menu item element (`role="menuitem"`).
+ *
+ * The highlighted item is the single roving tab stop (`tabIndex` 0); the rest
+ * are `-1`. An item with children is a submenu trigger, gaining `aria-haspopup`
+ * and `aria-expanded`. Disabled items are marked `aria-disabled`.
+ *
+ * @param nav Navigation hook result for reading roving/highlight state.
+ * @param item The annotated menu item.
+ * @returns ARIA attributes to spread on the item element.
+ */
+export default function getMenuItemProps<T extends Item = Item>(
+  nav: UseNavigationTreeResult<T>,
+  item: _Item<T>,
+): MenuItemPropsResult {
+  const status = nav.getNodeStatus(item);
+  const hasChildren = !!item.items?.length;
+  // A menu has a single roving tab stop. The highlighted item wins; only when
+  // nothing is highlighted does the selected tail item take the tab stop, so two
+  // items never both become tabbable.
+  const highlightedTail = nav.highlightedItems.at(-1);
+  const isRovingTarget = highlightedTail ? status.highlighted : status.selected;
+
+  const result: MenuItemPropsResult = {
+    role: "menuitem",
+    tabIndex: isRovingTarget ? 0 : -1,
+  };
+
+  if (hasChildren) {
+    result["aria-haspopup"] = true;
+    result["aria-expanded"] = nav.isOpen && status.inHighlightedBranch;
+  }
+
+  if (item.disabled) {
+    result["aria-disabled"] = true;
+  }
+
+  return result;
+}

--- a/packages/react/hooks/src/lib/useNavigationTree/aria/getMenuProps.ts
+++ b/packages/react/hooks/src/lib/useNavigationTree/aria/getMenuProps.ts
@@ -1,0 +1,24 @@
+import type { Item } from "@canonical/ds-types";
+import type { UseNavigationTreeResult } from "../types.js";
+import type { MenuPropsResult } from "./types.js";
+
+/**
+ * Build ARIA props for a contextual-menu container element (`role="menu"`).
+ *
+ * Unlike a menubar, a contextual menu is always a vertical `menu`. Provide a
+ * `label` for an accessible name, or `labelledBy` to reference the trigger.
+ *
+ * @param _nav Navigation hook result (unused, reserved for future use).
+ * @param opts Accessible label or labelledby reference for the menu.
+ * @returns ARIA attributes to spread on the menu container element.
+ */
+export default function getMenuProps<T extends Item = Item>(
+  _nav: UseNavigationTreeResult<T>,
+  opts: { label?: string; labelledBy?: string } = {},
+): MenuPropsResult {
+  return {
+    role: "menu",
+    ...(opts.label ? { "aria-label": opts.label } : {}),
+    ...(opts.labelledBy ? { "aria-labelledby": opts.labelledBy } : {}),
+  };
+}

--- a/packages/react/hooks/src/lib/useNavigationTree/aria/index.ts
+++ b/packages/react/hooks/src/lib/useNavigationTree/aria/index.ts
@@ -5,6 +5,9 @@ export { default as getDisclosureToggleProps } from "./getDisclosureToggleProps.
 export { default as getMenubarItemProps } from "./getMenubarItemProps.js";
 export { default as getMenubarListItemProps } from "./getMenubarListItemProps.js";
 export { default as getMenubarMenuProps } from "./getMenubarMenuProps.js";
+export { default as getMenuGroupProps } from "./getMenuGroupProps.js";
+export { default as getMenuItemProps } from "./getMenuItemProps.js";
+export { default as getMenuProps } from "./getMenuProps.js";
 export { default as getNavigationItemProps } from "./getNavigationItemProps.js";
 export { default as getTreeItemProps } from "./getTreeItemProps.js";
 export { default as getTreeListItemProps } from "./getTreeListItemProps.js";
@@ -16,6 +19,9 @@ export type {
   MenubarItemPropsResult,
   MenubarListItemPropsResult,
   MenubarMenuPropsResult,
+  MenuGroupPropsResult,
+  MenuItemPropsResult,
+  MenuPropsResult,
   NavigationItemPropsResult,
   TreeItemPropsResult,
   TreeListItemPropsResult,

--- a/packages/react/hooks/src/lib/useNavigationTree/aria/menu.test.ts
+++ b/packages/react/hooks/src/lib/useNavigationTree/aria/menu.test.ts
@@ -1,0 +1,119 @@
+import type { _Index, _Item } from "@canonical/ds-types";
+import type { NodeStatus } from "@canonical/utils";
+import { describe, expect, it } from "vitest";
+import type { UseNavigationTreeResult } from "../types.js";
+import getMenuGroupProps from "./getMenuGroupProps.js";
+import getMenuItemProps from "./getMenuItemProps.js";
+import getMenuProps from "./getMenuProps.js";
+
+const defaultStatus: NodeStatus = {
+  selected: false,
+  inSelectedBranch: false,
+  highlighted: false,
+  inHighlightedBranch: false,
+};
+
+function createMockNav(
+  overrides: Partial<UseNavigationTreeResult> = {},
+  status: Partial<NodeStatus> = {},
+): UseNavigationTreeResult {
+  const root: _Item = { key: "menu", parentUrl: null, depth: 0 };
+  const index: _Index = { menu: root };
+
+  return {
+    selectedItems: [],
+    highlightedItems: [],
+    currentDepth: 0,
+    isOpen: true,
+    inputValue: "",
+    keysSoFar: "",
+    annotatedRoot: root,
+    index,
+    getNodeStatus: () => ({ ...defaultStatus, ...status }),
+    getToggleProps: () => ({}),
+    getMenuProps: () => ({}),
+    getItemProps: () => ({}),
+    selectItem: () => {},
+    highlightItem: () => {},
+    setHighlightedItems: () => {},
+    setInputValue: () => {},
+    openMenu: () => {},
+    closeMenu: () => {},
+    reset: () => {},
+    ...overrides,
+  } as UseNavigationTreeResult;
+}
+
+describe("contextual-menu ARIA helpers", () => {
+  it("getMenuProps returns role=menu with an accessible name", () => {
+    const nav = createMockNav();
+    expect(getMenuProps(nav, { label: "Actions" })).toEqual({
+      role: "menu",
+      "aria-label": "Actions",
+    });
+    expect(getMenuProps(nav, { labelledBy: "trigger-id" })).toEqual({
+      role: "menu",
+      "aria-labelledby": "trigger-id",
+    });
+    expect(getMenuProps(nav)).toEqual({ role: "menu" });
+  });
+
+  it("getMenuGroupProps returns role=group with an accessible name", () => {
+    const nav = createMockNav();
+    expect(getMenuGroupProps(nav, { label: "Edit" })).toEqual({
+      role: "group",
+      "aria-label": "Edit",
+    });
+    expect(getMenuGroupProps(nav)).toEqual({ role: "group" });
+  });
+
+  it("getMenuItemProps makes the highlighted item the roving tab stop", () => {
+    const item: _Item = { url: "/x", parentUrl: "menu", depth: 2 };
+
+    // The highlighted item is the roving tab stop when something is highlighted.
+    const highlighted = getMenuItemProps(
+      createMockNav({ highlightedItems: [item] }, { highlighted: true }),
+      item,
+    );
+    expect(highlighted).toEqual({ role: "menuitem", tabIndex: 0 });
+
+    const notHighlighted = getMenuItemProps(createMockNav(), item);
+    expect(notHighlighted.tabIndex).toBe(-1);
+
+    // When nothing is highlighted, the selected tail item takes the tab stop —
+    // never both, preserving the single roving tab stop.
+    const selected = getMenuItemProps(
+      createMockNav({ selectedItems: [item] }, { selected: true }),
+      item,
+    );
+    expect(selected.tabIndex).toBe(0);
+  });
+
+  it("getMenuItemProps marks a submenu trigger with haspopup/expanded", () => {
+    const parent: _Item = {
+      key: "sub",
+      parentUrl: "menu",
+      depth: 2,
+      items: [{ url: "/x/1", parentUrl: "sub", depth: 3 }],
+    };
+
+    const result = getMenuItemProps(
+      createMockNav({}, { inHighlightedBranch: true }),
+      parent,
+    );
+    expect(result["aria-haspopup"]).toBe(true);
+    expect(result["aria-expanded"]).toBe(true);
+  });
+
+  it("getMenuItemProps marks a disabled item aria-disabled", () => {
+    const disabled: _Item = {
+      url: "/d",
+      parentUrl: "menu",
+      depth: 2,
+      disabled: true,
+    };
+    expect(getMenuItemProps(createMockNav(), disabled)["aria-disabled"]).toBe(
+      true,
+    );
+  });
+});

--- a/packages/react/hooks/src/lib/useNavigationTree/aria/types.ts
+++ b/packages/react/hooks/src/lib/useNavigationTree/aria/types.ts
@@ -17,6 +17,29 @@ export interface MenubarListItemPropsResult {
   role: "none";
 }
 
+/** Props returned by the contextual-menu container helper */
+export interface MenuPropsResult {
+  role: "menu";
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+}
+
+/** Props returned by the contextual-menu group helper */
+export interface MenuGroupPropsResult {
+  role: "group";
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+}
+
+/** Props returned by the contextual-menu item helper */
+export interface MenuItemPropsResult {
+  role: "menuitem";
+  "aria-haspopup"?: true;
+  "aria-expanded"?: boolean;
+  "aria-disabled"?: true;
+  tabIndex: 0 | -1;
+}
+
 /** Props returned by tree container helpers */
 export interface TreeMenuPropsResult {
   role: "tree" | "group";

--- a/packages/utils/src/lib/navigation/createCrossGroupStateReducer.test.ts
+++ b/packages/utils/src/lib/navigation/createCrossGroupStateReducer.test.ts
@@ -1,0 +1,182 @@
+import type { Item } from "@canonical/ds-types";
+import { describe, expect, it } from "vitest";
+import { annotateTree } from "./annotateTree.js";
+import createCrossGroupStateReducer from "./createCrossGroupStateReducer.js";
+import findAncestorPath from "./findAncestorPath.js";
+import {
+  type NavigationAction,
+  NavigationActionType,
+  type NavigationState,
+} from "./navigationTypes.js";
+import { prepareIndex } from "./prepareIndex.js";
+
+// root -> group -> item. Two groups of two items each.
+const buildTree = () => {
+  const root: Item = {
+    key: "root",
+    items: [
+      {
+        key: "group-a",
+        items: [
+          { key: "a1", label: "A one", url: "/a1" },
+          { key: "a2", label: "A two", url: "/a2" },
+        ],
+      },
+      {
+        key: "group-b",
+        items: [
+          { key: "b1", label: "B one", url: "/b1" },
+          { key: "b2", label: "B two", url: "/b2" },
+        ],
+      },
+    ],
+  };
+  const index = prepareIndex(annotateTree(root));
+  return { index };
+};
+
+const stateHighlighting = (
+  index: ReturnType<typeof buildTree>["index"],
+  url: string,
+): NavigationState => {
+  const item = index[url];
+  if (!item) throw new Error(`test item ${url} not found`);
+  return {
+    selectedItems: [],
+    highlightedItems: findAncestorPath(index, item),
+    currentDepth: item.depth,
+    isOpen: true,
+    inputValue: "",
+    keysSoFar: "",
+  };
+};
+
+const arrow = (type: NavigationActionType): NavigationAction =>
+  ({ type }) as NavigationAction;
+
+describe("createCrossGroupStateReducer", () => {
+  it("moves to the first item of the next group on ArrowDown at a group's last item", () => {
+    const { index } = buildTree();
+    const reducer = createCrossGroupStateReducer();
+    const next = reducer(
+      stateHighlighting(index, "/a2"),
+      arrow(NavigationActionType.ARROW_DOWN),
+    );
+    expect(next.highlightedItems.at(-1)?.key).toBe("b1");
+  });
+
+  it("moves to the last item of the previous group on ArrowUp at a group's first item", () => {
+    const { index } = buildTree();
+    const reducer = createCrossGroupStateReducer();
+    const prev = reducer(
+      stateHighlighting(index, "/b1"),
+      arrow(NavigationActionType.ARROW_UP),
+    );
+    expect(prev.highlightedItems.at(-1)?.key).toBe("a2");
+  });
+
+  it("does not move when the item is mid-group (base reducer handles it)", () => {
+    const { index } = buildTree();
+    const reducer = createCrossGroupStateReducer();
+    const state = stateHighlighting(index, "/a1");
+    expect(reducer(state, arrow(NavigationActionType.ARROW_DOWN))).toBe(state);
+  });
+
+  it("does not move past the last group on ArrowDown", () => {
+    const { index } = buildTree();
+    const reducer = createCrossGroupStateReducer();
+    const state = stateHighlighting(index, "/b2");
+    expect(reducer(state, arrow(NavigationActionType.ARROW_DOWN))).toBe(state);
+  });
+
+  it("does not move before the first group on ArrowUp", () => {
+    const { index } = buildTree();
+    const reducer = createCrossGroupStateReducer();
+    const state = stateHighlighting(index, "/a1");
+    expect(reducer(state, arrow(NavigationActionType.ARROW_UP))).toBe(state);
+  });
+
+  it("ignores non-vertical actions", () => {
+    const { index } = buildTree();
+    const reducer = createCrossGroupStateReducer();
+    const state = stateHighlighting(index, "/a2");
+    expect(reducer(state, arrow(NavigationActionType.ARROW_RIGHT))).toBe(state);
+    expect(reducer(state, arrow(NavigationActionType.HOME))).toBe(state);
+  });
+
+  it("returns state unchanged when nothing is highlighted", () => {
+    const { index } = buildTree();
+    const reducer = createCrossGroupStateReducer();
+    const state: NavigationState = {
+      selectedItems: [],
+      highlightedItems: [],
+      currentDepth: 0,
+      isOpen: true,
+      inputValue: "",
+      keysSoFar: "",
+    };
+    expect(reducer(state, arrow(NavigationActionType.ARROW_DOWN))).toBe(state);
+  });
+
+  it("returns state unchanged when the highlighted node is the root (no parent group)", () => {
+    const root: Item = {
+      key: "root",
+      items: [{ key: "group-a", items: [{ key: "a1", url: "/a1" }] }],
+    };
+    const index = prepareIndex(annotateTree(root));
+    const reducer = createCrossGroupStateReducer();
+    const rootItem = index.root;
+    if (!rootItem) throw new Error("root not found");
+    const state: NavigationState = {
+      selectedItems: [],
+      // Highlight the root itself — getParentItem returns undefined for it.
+      highlightedItems: [rootItem],
+      currentDepth: 0,
+      isOpen: true,
+      inputValue: "",
+      keysSoFar: "",
+    };
+    expect(reducer(state, arrow(NavigationActionType.ARROW_DOWN))).toBe(state);
+  });
+
+  it("does not cross into an adjacent group that has no enabled items", () => {
+    const root: Item = {
+      key: "root",
+      items: [
+        { key: "group-a", items: [{ key: "a1", label: "A1", url: "/a1" }] },
+        // An empty group offers no landing item.
+        { key: "group-empty", items: [] },
+      ],
+    };
+    const index = prepareIndex(annotateTree(root));
+    const reducer = createCrossGroupStateReducer();
+    expect(
+      reducer(
+        stateHighlighting(index, "/a1"),
+        arrow(NavigationActionType.ARROW_DOWN),
+      ).highlightedItems.at(-1)?.key,
+    ).toBe("a1");
+  });
+
+  it("skips a disabled adjacent group", () => {
+    const root: Item = {
+      key: "root",
+      items: [
+        { key: "group-a", items: [{ key: "a1", label: "A1", url: "/a1" }] },
+        {
+          key: "group-b",
+          disabled: true,
+          items: [{ key: "b1", label: "B1", url: "/b1" }],
+        },
+        { key: "group-c", items: [{ key: "c1", label: "C1", url: "/c1" }] },
+      ],
+    };
+    const index = prepareIndex(annotateTree(root));
+    const reducer = createCrossGroupStateReducer();
+    const next = reducer(
+      stateHighlighting(index, "/a1"),
+      arrow(NavigationActionType.ARROW_DOWN),
+    );
+    expect(next.highlightedItems.at(-1)?.key).toBe("c1");
+  });
+});

--- a/packages/utils/src/lib/navigation/createCrossGroupStateReducer.ts
+++ b/packages/utils/src/lib/navigation/createCrossGroupStateReducer.ts
@@ -1,0 +1,95 @@
+import type { _Item, Item } from "@canonical/ds-types";
+import getFirstEnabledChild from "./getFirstEnabledChild.js";
+import getLastEnabledChild from "./getLastEnabledChild.js";
+import {
+  type NavigationAction,
+  NavigationActionType,
+  type NavigationState,
+} from "./navigationTypes.js";
+
+/**
+ * Scan the groups adjacent to `group` (skipping disabled or empty ones) and
+ * return the group to land in, in the given direction.
+ * @param groups The sibling groups (children of the menu root).
+ * @param group The current group being left.
+ * @param direction 1 for the next group, -1 for the previous.
+ * @returns [adjacentGroup, landingItem] or undefined at the tree's edge.
+ */
+const findAdjacentLanding = <T extends Item = Item>(
+  groups: _Item<T>[],
+  group: _Item<T>,
+  direction: 1 | -1,
+): [_Item<T>, _Item<T>] | undefined => {
+  let cursor = groups.indexOf(group) + direction;
+  while (cursor >= 0 && cursor < groups.length) {
+    const candidate = groups.at(cursor);
+    if (candidate && !candidate.disabled) {
+      // Enter a forward group at its first item, a backward group at its last.
+      const landing =
+        direction === 1
+          ? getFirstEnabledChild(candidate)
+          : getLastEnabledChild(candidate);
+      if (landing) return [candidate, landing];
+    }
+    cursor += direction;
+  }
+  return undefined;
+};
+
+/**
+ * Create a `stateReducer` for `useNavigationTree` that lets vertical arrow keys
+ * cross group boundaries. Within a group, {@link createNavigationReducer}
+ * already moves between items; at a group edge its `getSibling` finds no sibling
+ * and leaves the highlight unchanged. This reducer detects that edge structurally
+ * (the highlighted item is the first/last enabled child of its group) and moves
+ * the highlight to the adjacent group's boundary item.
+ *
+ * It operates purely on `state.highlightedItems` — the ancestor path
+ * `[root, group, item]` — so it uses the same annotated item instances the
+ * navigation tree holds internally. It needs no external index, which avoids the
+ * instance-mismatch that would arise from re-annotating the tree separately.
+ *
+ * The group boundary logic lives entirely here, so the base navigation reducer
+ * stays group-agnostic. It suits any grouped, vertically-navigated widget
+ * (contextual menus, sectioned side navigation) built on a
+ * root -> group -> item tree.
+ *
+ * @returns A `(state, action) => state` reducer to pass as `stateReducer`.
+ */
+const createCrossGroupStateReducer =
+  <T extends Item = Item>() =>
+  (
+    state: NavigationState<T>,
+    action: NavigationAction<T>,
+  ): NavigationState<T> => {
+    const isDown = action.type === NavigationActionType.ARROW_DOWN;
+    const isUp = action.type === NavigationActionType.ARROW_UP;
+    if (!isDown && !isUp) return state;
+
+    // The highlighted path is [root, group, item] for a grouped menu.
+    const path = state.highlightedItems;
+    const current = path.at(-1);
+    const group = path.at(-2);
+    const root = path.at(-3);
+    // Only items nested inside a group (root -> group -> item) can cross groups.
+    if (!current || !group || !root?.items) return state;
+
+    const boundaryChild = isDown
+      ? getLastEnabledChild(group)
+      : getFirstEnabledChild(group);
+    // Not at the group edge — the base reducer already moved within the group.
+    if (boundaryChild !== current) return state;
+
+    const landing = findAdjacentLanding(root.items, group, isDown ? 1 : -1);
+    if (!landing) return state;
+
+    const [adjacentGroup, target] = landing;
+    return {
+      ...state,
+      // Build the path from the known chain — same instances the tree holds.
+      highlightedItems: [...path.slice(0, -2), adjacentGroup, target],
+      currentDepth: target.depth,
+    };
+  };
+
+export default createCrossGroupStateReducer;

--- a/packages/utils/src/lib/navigation/index.ts
+++ b/packages/utils/src/lib/navigation/index.ts
@@ -1,4 +1,5 @@
 export { annotateTree } from "./annotateTree.js";
+export { default as createCrossGroupStateReducer } from "./createCrossGroupStateReducer.js";
 export type { NavigationReducerOptions } from "./createNavigationReducer.js";
 export { default as createNavigationReducer } from "./createNavigationReducer.js";
 export { default as findAncestorPath } from "./findAncestorPath.js";


### PR DESCRIPTION
## Done

The shared headless hooks for the overlay components — **hooks only, no component content**. The three components (Tooltip, Popover, ContextualMenu) that consume these ship in the stacked follow-up PR #731. ADR: pragma-adrs `P.01`.

- **`useDisclosure({ mode: "hover" | "click" })`** — headless, element-agnostic. `hover` reproduces the delayed tooltip behaviour; `click` adds synchronous toggle, outside-click + Escape dismissal, return-focus on every close, and `aria-expanded`. Returns `isOpen`, `open`/`close`/`toggle`, positioning refs + style, `arrowOffset`, and `getToggleProps()`/`getContentProps()`.
- **`usePopup`** → thin `@deprecated` wrapper over `useDisclosure({ mode: "hover" })`, preserving its shape so existing tooltip consumers are untouched (removed in #731).
- **`useWindowFitment`** emits an always-on `arrowOffset` (decoupled from `autoFit`) that keeps an arrow pointing at the target centre for every placement.
- **`useContextualMenu`** = `useNavigationTree` + `useDisclosure(click)`. Vertical arrow keys cross group boundaries via `createCrossGroupStateReducer`, which operates on the highlighted path (the tree's own item instances) — no external index, no instance-mismatch. Exposes menu-role ARIA getters.
- **`createCrossGroupStateReducer`** — framework-agnostic, added to `@canonical/utils` next to `createNavigationReducer`; reusable by any grouped nav (menus, and later sectioned SideNavigation).
- **`role=menu`/`menuitem`/`group` ARIA presets** added to `@canonical/react-hooks`.
- Adds `@canonical/react-hooks` as a ds-global dependency.

## QA

- `@canonical/utils`, `@canonical/react-hooks`, `@canonical/react-ds-global`: `check` + `test` + `build` all green. ds-global 233 tests, react-hooks 149, utils (100% coverage on the new reducer).
- Backwards-compat: the existing `usePopup` behaviour is preserved through the wrapper.

### PR readiness check

- [x] Label: `Feature 🎁`.
- [x] Conventional Commits title.
- [x] Code standards.
- [x] Packages define `check`/`check:fix`/`test` (+ `build`/`build:all`).
- [x] No new package.
- [x] No visual change (hooks only) — `no visual change` label to skip Chromatic.
