### PR TITLE
docs(ds-global-form): realistic Form + broader Field pattern stories

### DIFF
--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
@@ -1,16 +1,15 @@
-/* @canonical/generator-ds 0.9.0-experimental.4 */
-
 import type { Meta, StoryObj } from "@storybook/react-vite";
-// Needed for function-based story, safe to remove otherwise
-// import type { FieldProps } from './types.js'
 import { useMemo } from "react";
 import * as decorators from "storybook/decorators.js";
 import Component from "./Field.js";
 import type { FieldProps } from "./types.js";
 
-// Needed for template-based story, safe to remove otherwise
-// import type { StoryFn } from '@storybook/react-vite'
-
+/**
+ * `Field` is the type-safe entry point to every form input: it dispatches on
+ * `inputType` to the matching `*Field` component, so one component drives text,
+ * select, checkbox, range, date, custom inputs and more — with per-field
+ * validation, required/optional marking and conditional display.
+ */
 const meta = {
   title: "patterns/Field",
   component: Component,
@@ -19,12 +18,6 @@ const meta = {
 } satisfies Meta<typeof Component>;
 
 export default meta;
-
-/*
-  CSF3 story
-  Uses object-based story declarations with strong TS support (`Meta` and `StoryObj`).
-  Uses the latest storybook format.
-*/
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
@@ -112,13 +105,83 @@ export const TypeCheckbox: Story = {
   },
 };
 
-const CustomComponent = () => <span>SomeExotic Input</span>;
+/**
+ * The router dispatches on `inputType`. Beyond the text/textarea/checkbox cases
+ * above it covers the richer inputs — a few shown here so the single, type-safe
+ * `Field` entry point is visible across the family.
+ */
+export const TypeSelect: Story = {
+  args: {
+    name: "fruit",
+    inputType: "select",
+    label: "Favourite fruit",
+    options: [
+      { value: "apple", label: "Apple" },
+      { value: "banana", label: "Banana" },
+      { value: "cherry", label: "Cherry" },
+    ],
+  },
+};
+
+export const TypeRange: Story = {
+  args: {
+    name: "volume",
+    inputType: "range",
+    label: "Volume",
+    min: 0,
+    max: 100,
+  },
+};
+
+export const TypeDate: Story = {
+  args: { name: "starts_on", inputType: "date", label: "Start date" },
+};
+
+export const TypeColor: Story = {
+  args: { name: "brand", inputType: "color", label: "Brand colour" },
+};
+
+/**
+ * A custom input: `inputType: "custom"` renders the supplied `CustomComponent`,
+ * which receives the field's `InputProps` (name + react-hook-form registration)
+ * so it participates in the form like any built-in input. This example is a
+ * simple star-rating control wired through `onChange`.
+ */
+const StarRating = ({
+  value,
+  onChange,
+}: {
+  value?: number;
+  onChange?: (value: number) => void;
+}) => (
+  <div role="radiogroup" aria-label="Rating">
+    {[1, 2, 3, 4, 5].map((star) => (
+      <button
+        key={star}
+        type="button"
+        aria-label={`${star} star${star > 1 ? "s" : ""}`}
+        aria-pressed={(value ?? 0) >= star}
+        onClick={() => onChange?.(star)}
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          fontSize: "1.25rem",
+          color: (value ?? 0) >= star ? "#f5a623" : "#ccc",
+        }}
+      >
+        ★
+      </button>
+    ))}
+  </div>
+);
 
 export const TypeCustom: Story = {
   args: {
-    name: "exotic",
+    name: "rating",
     inputType: "custom",
-    CustomComponent,
+    label: "Rating",
+    CustomComponent: StarRating,
   },
 };
 
@@ -161,33 +224,3 @@ export const ConditionalDisplay: Story = {
     );
   },
 };
-
-/*
-  Function-based story
-  Direct arguments passed to the component
-  Simple, but can lead to repetition if used across multiple stories with similar configurations
-
-  export const Default = (args: FieldProps) => <Component {...args} />;
-  Default.args = { children: <span>Hello world!</span> };
-*/
-
-/*
-  Template-Based story
-  Uses a template function to bind story variations, making it more reusable
-  Slightly more boilerplate but more flexible for creating multiple stories with different configurations
-
-  const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-  export const Default: StoryFn<typeof Component> = Template.bind({});
-  Default.args = {
-    children: <span>Hello world!</span>
-  };
-*/
-
-/*
-  Static story
-  Simple and straightforward, but offers the least flexibility and reusability
-
-  export const Default: StoryFn<typeof Component> = () => (
-    <Component><span>Hello world!</span></Component>
-  );
-*/

--- a/packages/react/ds-global-form/src/lib/pattern/Form/Form.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Form/Form.stories.tsx
@@ -101,7 +101,9 @@ export const SignUp: Story = {
             inputType="checkbox"
             controlLabel="I agree to the terms of service"
           />
-          <Button type="submit">Create account</Button>
+          <Button importance="primary" type="submit">
+            Create account
+          </Button>
         </Component>
         <SubmittedValues data={submitted} />
       </>
@@ -139,7 +141,9 @@ export const Validation: Story = {
         }}
       />
       <Field name="bio" inputType="textarea" label="Bio" isOptional />
-      <Button type="submit">Submit</Button>
+      <Button importance="primary" type="submit">
+        Submit
+      </Button>
     </Component>
   ),
 };
@@ -175,7 +179,9 @@ export const EditRecord: Story = {
               { value: "team", label: "Team" },
             ]}
           />
-          <Button type="submit">Save changes</Button>
+          <Button importance="primary" type="submit">
+            Save changes
+          </Button>
         </Component>
         <SubmittedValues data={submitted} />
       </>
@@ -215,7 +221,9 @@ export const MultiColumnLayout: Story = {
           { value: "de", label: "Germany" },
         ]}
       />
-      <Button type="submit">Continue</Button>
+      <Button importance="primary" type="submit">
+        Continue
+      </Button>
     </Component>
   ),
 };
@@ -231,7 +239,44 @@ export const SideLayout: Story = {
       <Field name="first_name" inputType="text" label="First name" />
       <Field name="last_name" inputType="text" label="Last name" />
       <Field name="email" inputType="text" label="Email address" />
-      <Button type="submit">Save</Button>
+      <Field name="phone" inputType="phone" label="Phone number" isOptional />
+      <Field name="company" inputType="text" label="Company" isOptional />
+      <Field name="job_title" inputType="text" label="Job title" isOptional />
+      <Field
+        name="country"
+        inputType="select"
+        label="Country"
+        options={[
+          { value: "gb", label: "United Kingdom" },
+          { value: "us", label: "United States" },
+          { value: "de", label: "Germany" },
+        ]}
+      />
+      <Field
+        name="timezone"
+        inputType="select"
+        label="Timezone"
+        options={[
+          { value: "utc", label: "UTC" },
+          { value: "cet", label: "CET" },
+          { value: "pst", label: "PST" },
+        ]}
+      />
+      <Field
+        name="bio"
+        inputType="textarea"
+        label="About you"
+        description="A short description for your profile"
+        isOptional
+      />
+      <Field
+        name="newsletter"
+        inputType="checkbox"
+        controlLabel="Subscribe to the newsletter"
+      />
+      <Button importance="primary" type="submit">
+        Save
+      </Button>
     </Component>
   ),
 };

--- a/packages/react/ds-global-form/src/lib/pattern/Form/Form.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Form/Form.stories.tsx
@@ -1,39 +1,252 @@
-import type { Meta, StoryFn } from "@storybook/react-vite";
+import { Button } from "@canonical/react-ds-global";
+import type { Meta, StoryFn, StoryObj } from "@storybook/react-vite";
+import type React from "react";
+import { useState } from "react";
 import * as decorators from "storybook/decorators.js";
 import * as fieldMaps from "storybook/fixtures.fields.js";
 import { Field } from "#lib/pattern/Field/index.js";
 import type { FieldProps } from "#lib/pattern/Field/types.js";
+import Component from "./Form.js";
 
 /**
- * ## Grid context
- *
- * Forms must be wrapped in a grid container (`.grid.responsive` or
- * `.grid.intrinsic`). The `Form` component renders as a **subgrid**
- * that inherits the parent grid's columns and passes them down to
- * individual `Field` components.
+ * A `Form` renders as a **subgrid**: it inherits the columns of the parent grid
+ * (`.grid.responsive` / `.grid.intrinsic`) and passes them down to each `Field`,
+ * so labels, inputs and multi-column spans all align to one shared grid.
  *
  * ```
- * <div class="grid responsive">       ← parent grid (consumer)
- *   <Form>                             ← form subgrid
- *     <Field ... />                    ← field subgrid
+ * <div class="grid responsive">   ← parent grid (from the story `grid` param)
+ *   <Form>                         ← form subgrid
+ *     <Field ... />                ← field subgrid
  *   </Form>
  * </div>
  * ```
+ *
+ * The first stories drive a real `useForm` through the `Form` component
+ * (`onSubmit` + optional `defaultValues`), so submit, validation and collected
+ * values are live — inspect the **Form State** addon panel, or the readout that
+ * prints submitted values. The reference stories at the end render every input
+ * type from a fixture to show the field set at a glance.
  */
 const meta = {
   title: "patterns/Form",
-  parameters: { grid: "intrinsic" },
-  decorators: [decorators.form()],
+  parameters: { layout: "padded", grid: "responsive" },
 } satisfies Meta;
 
 export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => {};
+
+/** A small readout so a story visibly shows what it submitted. */
+function SubmittedValues({ data }: { data: Record<string, unknown> | null }) {
+  if (!data) return null;
+  return (
+    <pre
+      style={{
+        marginBlockStart: "1rem",
+        padding: "0.75rem",
+        background: "var(--color-background-neutral-subtle, #f4f4f4)",
+        borderRadius: "0.25rem",
+        fontSize: "0.85em",
+        overflowX: "auto",
+      }}
+    >
+      Submitted: {JSON.stringify(data, null, 2)}
+    </pre>
+  );
+}
+
+/**
+ * A realistic sign-up form: a handful of related fields, a required rule, and a
+ * submit button whose collected values are shown below. This is what a product
+ * form actually looks like — not a dump of every input type.
+ */
+export const SignUp: Story = {
+  render: () => {
+    const [submitted, setSubmitted] = useState<Record<string, unknown> | null>(
+      null,
+    );
+    return (
+      <>
+        <Component onSubmit={setSubmitted} mode="onBlur">
+          <Field name="full_name" inputType="text" label="Full name" />
+          <Field
+            name="email"
+            inputType="text"
+            label="Email address"
+            registerProps={{ required: "Email is required" }}
+          />
+          <Field
+            name="password"
+            inputType="password"
+            label="Password"
+            description="At least 8 characters"
+            registerProps={{
+              required: "Password is required",
+              minLength: { value: 8, message: "At least 8 characters" },
+            }}
+          />
+          <Field
+            name="plan"
+            inputType="select"
+            label="Plan"
+            options={[
+              { value: "free", label: "Free" },
+              { value: "pro", label: "Pro" },
+              { value: "team", label: "Team" },
+            ]}
+          />
+          <Field
+            name="terms"
+            inputType="checkbox"
+            controlLabel="I agree to the terms of service"
+          />
+          <Button type="submit">Create account</Button>
+        </Component>
+        <SubmittedValues data={submitted} />
+      </>
+    );
+  },
+};
+
+/**
+ * Validation on a real submit: rules registered via `registerProps` surface
+ * their messages when the field is blurred or the form is submitted — no
+ * decorator trickery. Submit with empty/invalid values to see the error state.
+ */
+export const Validation: Story = {
+  render: () => (
+    <Component onSubmit={noop} mode="onBlur">
+      <Field
+        name="email"
+        inputType="text"
+        label="Email"
+        registerProps={{
+          required: "Email is required",
+          pattern: {
+            value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+            message: "Enter a valid email address",
+          },
+        }}
+      />
+      <Field
+        name="age"
+        inputType="number"
+        label="Age"
+        registerProps={{
+          required: "Age is required",
+          min: { value: 18, message: "Must be at least 18" },
+        }}
+      />
+      <Field name="bio" inputType="textarea" label="Bio" isOptional />
+      <Button type="submit">Submit</Button>
+    </Component>
+  ),
+};
+
+/**
+ * Editing an existing record: `defaultValues` pre-fills the form, so the fields
+ * mount populated and submit yields the (possibly edited) record.
+ */
+export const EditRecord: Story = {
+  render: () => {
+    const [submitted, setSubmitted] = useState<Record<string, unknown> | null>(
+      null,
+    );
+    return (
+      <>
+        <Component
+          onSubmit={setSubmitted}
+          defaultValues={{
+            full_name: "Ada Lovelace",
+            email: "ada@example.com",
+            plan: "pro",
+          }}
+        >
+          <Field name="full_name" inputType="text" label="Full name" />
+          <Field name="email" inputType="text" label="Email address" />
+          <Field
+            name="plan"
+            inputType="select"
+            label="Plan"
+            options={[
+              { value: "free", label: "Free" },
+              { value: "pro", label: "Pro" },
+              { value: "team", label: "Team" },
+            ]}
+          />
+          <Button type="submit">Save changes</Button>
+        </Component>
+        <SubmittedValues data={submitted} />
+      </>
+    );
+  },
+};
+
+/**
+ * Multi-column layout: fields default to full width, but `--form-field-columns`
+ * lets a field span part of the grid so two can share a row. Here the city and
+ * postcode sit side by side (`1 / 5` and `5 / -1`) while the other fields stay
+ * full width — the whole form still aligns to one subgrid.
+ */
+export const MultiColumnLayout: Story = {
+  render: () => (
+    <Component onSubmit={noop}>
+      <Field name="street" inputType="text" label="Street address" />
+      <Field
+        name="city"
+        inputType="text"
+        label="City"
+        style={{ "--form-field-columns": "1 / 5" } as React.CSSProperties}
+      />
+      <Field
+        name="postcode"
+        inputType="text"
+        label="Postcode"
+        style={{ "--form-field-columns": "5 / -1" } as React.CSSProperties}
+      />
+      <Field
+        name="country"
+        inputType="select"
+        label="Country"
+        options={[
+          { value: "gb", label: "United Kingdom" },
+          { value: "us", label: "United States" },
+          { value: "de", label: "Germany" },
+        ]}
+      />
+      <Button type="submit">Continue</Button>
+    </Component>
+  ),
+};
+
+/**
+ * Side layout: `.form-layout-side` places each label beside its input (label in
+ * columns 1–2, input in 3-to-end) instead of stacked above it — useful for
+ * settings-style forms.
+ */
+export const SideLayout: Story = {
+  render: () => (
+    <Component onSubmit={noop} className="form-layout-side">
+      <Field name="first_name" inputType="text" label="First name" />
+      <Field name="last_name" inputType="text" label="Last name" />
+      <Field name="email" inputType="text" label="Email address" />
+      <Button type="submit">Save</Button>
+    </Component>
+  ),
+};
+
+/* -------------------------------------------------------------------------- */
+/* Reference stories — every input type from a fixture, using the decorator's  */
+/* own useForm instance (no submit), to show the field set at a glance.        */
+/* -------------------------------------------------------------------------- */
 
 type TemplateProps = {
   fieldMap: FieldProps[];
-  otherProps: Partial<FieldProps>;
+  otherProps?: Partial<FieldProps>;
 };
 
-const Template: StoryFn<TemplateProps> = ({
+const FixtureTemplate: StoryFn<TemplateProps> = ({
   fieldMap,
   otherProps,
 }: TemplateProps) => (
@@ -44,25 +257,20 @@ const Template: StoryFn<TemplateProps> = ({
   </>
 );
 
-export const Default: StoryFn<TemplateProps> = Template.bind({});
-Default.args = {
-  fieldMap: fieldMaps.base,
-};
+/** Every supported input type, rendered from the shared fixture. */
+export const AllInputTypes: StoryFn<TemplateProps> = FixtureTemplate.bind({});
+AllInputTypes.args = { fieldMap: fieldMaps.base };
+AllInputTypes.decorators = [decorators.form()];
 
-export const AllDisabled: StoryFn<TemplateProps> = Template.bind({});
-AllDisabled.args = {
-  fieldMap: fieldMaps.base,
-  otherProps: { disabled: true },
-};
+/** The same field set, disabled throughout. */
+export const AllDisabled: StoryFn<TemplateProps> = FixtureTemplate.bind({});
+AllDisabled.args = { fieldMap: fieldMaps.base, otherProps: { disabled: true } };
+AllDisabled.decorators = [decorators.form()];
 
-export const AllOptional: StoryFn<TemplateProps> = Template.bind({});
+/** The same field set with the optional-marking house style applied. */
+export const AllOptional: StoryFn<TemplateProps> = FixtureTemplate.bind({});
 AllOptional.args = {
   fieldMap: fieldMaps.base,
   otherProps: { isOptional: true },
 };
-
-export const Side: StoryFn<TemplateProps> = Template.bind({});
-Side.args = {
-  fieldMap: fieldMaps.base,
-};
-Side.decorators = [decorators.form({ className: "form-layout-side" })];
+AllOptional.decorators = [decorators.form()];


### PR DESCRIPTION
## Done

Improve the **Form** and **Field** pattern stories with more and better examples (from the story-landscape audit), without scope creep.

**patterns/Form** — drive a real `useForm` through the `Form` component instead of dumping a fixture:
- **SignUp** — a realistic account form (name, email, password, plan, terms) with a required rule, a submit button, and a live readout of the collected values.
- **Validation** — rules that surface errors on a real submit (not the `touchedFields` decorator hack).
- **EditRecord** — `defaultValues` pre-filling an existing record.
- **MultiColumnLayout** — `--form-field-columns` spanning two fields onto one row, shown as an intentional pattern rather than buried in a fixture.
- **SideLayout** retained; the every-input-type fixture dumps kept as explicit reference stories (**AllInputTypes / AllDisabled / AllOptional**).

**patterns/Field** — show the router's breadth and a real custom input:
- Add **TypeSelect / TypeRange / TypeDate / TypeColor** so the single, type-safe `Field` entry point is visible across the family (was only text/textarea/checkbox/custom).
- Replace the throwaway `<span>` custom component with a working **star-rating** control wired through `onChange`, demonstrating the `InputProps` contract.
- Remove the generator's dead commented-out story boilerplate and stale header comments.

## QA

`cd packages/react/ds-global-form && bun run storybook` → **patterns/Form** and **patterns/Field**. On the Form stories, submit to see collected values / validation errors (or watch the Form State addon panel).

### PR readiness check

- [x] Label `Documentation 📝`.
- [x] Conventional Commits title.
- [x] Follows code standards.
- [x] Required scripts present.
- [ ] N/A — no new package.
- [ ] No runtime change — stories only; Chromatic renders the new examples.

## Screenshots

_Storybook: patterns/Form (SignUp / Validation / EditRecord / MultiColumnLayout) and patterns/Field (TypeSelect / TypeCustom star-rating). Chromatic attaches the baseline._
