### PR TITLE
feat(ds-global): reconcile + fully style Button (re-target to main)

### DIFF
--- a/packages/react/ds-global/src/lib/component/Button/Button.ssr.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.ssr.tests.tsx
@@ -16,7 +16,8 @@ describe("Button SSR", () => {
 
   it("applies base classes", () => {
     const html = renderToString(<Component>Test</Component>);
-    expect(html).toContain('class="ds button"');
+    // `ds button` plus the `.p` baseline utility that aligns the box to the grid.
+    expect(html).toContain("ds button p");
   });
 
   it("applies custom className", () => {

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -115,26 +115,35 @@ export const LinkVariant: Story = {
   },
 };
 
-const TrashIcon = () => (
-  <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+const EditIcon = () => (
+  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
     <path
-      d="M2 4h12M5 4V2h6v2M6 7v5M10 7v5M4 4l1 10h6l1-10"
+      d="M11.5 2.5l2 2L5 13l-3 1 1-3 8.5-8.5z"
       stroke="currentColor"
       strokeWidth="1.5"
-      fill="none"
+      strokeLinejoin="round"
     />
   </svg>
 );
 
 /**
- * Button with icon and label.
+ * The full matrix with a leading icon in every cell — so the icon colour can be
+ * checked against each importance × anticipation combination (the icon should
+ * follow the label colour: contrast on a filled primary, the modifier colour on
+ * ghost secondary/tertiary).
  */
-export const WithIcon: Story = {
-  args: {
-    children: "Delete",
-    icon: <TrashIcon />,
-    anticipation: "destructive",
-  },
+export const IconMatrix: Story = {
+  render: (args) => <MatrixGrid {...args} />,
+  args: { children: "Button", icon: <EditIcon /> },
+};
+
+/**
+ * The icon matrix in the disabled state — the icon should dim with the label
+ * across every combination.
+ */
+export const DisabledIconMatrix: Story = {
+  render: (args) => <MatrixGrid {...args} />,
+  args: { children: "Button", icon: <EditIcon />, disabled: true },
 };
 
 /**

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -7,7 +7,7 @@ import { fn } from "storybook/test";
 import Component from "./Button.js";
 
 const meta = {
-  title: "_work_in_progress/component/Button",
+  title: "components/Button",
   component: Component,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -157,13 +157,3 @@ export const Loading: Story = {
     loading: true,
   },
 };
-
-/**
- * Disabled button using design-tokens disabled state variables.
- */
-export const Disabled: Story = {
-  args: {
-    children: "Disabled",
-    disabled: true,
-  },
-};

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -1,5 +1,6 @@
 import { MODIFIER_FAMILIES } from "@canonical/ds-types";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type React from "react";
 import { Fragment } from "react";
 import { fn } from "storybook/test";
 
@@ -36,6 +37,52 @@ export const Default: Story = {
   },
 };
 
+/** The importance × anticipation grid: importance as rows, the neutral base
+ *  plus every anticipation as columns. Shared by the Matrix and DisabledMatrix
+ *  stories. */
+const MatrixGrid = (args: React.ComponentProps<typeof Component>) => (
+  <div
+    style={{
+      display: "grid",
+      gridTemplateColumns: `auto repeat(${
+        MODIFIER_FAMILIES.anticipation.length + 1
+      }, auto)`,
+      gap: "0.75rem 1rem",
+      alignItems: "center",
+      justifyItems: "start",
+    }}
+  >
+    {/* Header row: blank corner + column labels. */}
+    <span />
+    <span style={{ fontSize: "0.75rem", opacity: 0.6 }}>neutral</span>
+    {MODIFIER_FAMILIES.anticipation.map((a) => (
+      <span key={a} style={{ fontSize: "0.75rem", opacity: 0.6 }}>
+        {a}
+      </span>
+    ))}
+
+    {/* One row per importance. */}
+    {MODIFIER_FAMILIES.importance.map((importance) => (
+      <Fragment key={importance}>
+        <span style={{ fontSize: "0.75rem", opacity: 0.6 }}>{importance}</span>
+        <Component {...args} importance={importance}>
+          Button
+        </Component>
+        {MODIFIER_FAMILIES.anticipation.map((anticipation) => (
+          <Component
+            key={anticipation}
+            {...args}
+            importance={importance}
+            anticipation={anticipation}
+          >
+            Button
+          </Component>
+        ))}
+      </Fragment>
+    ))}
+  </div>
+);
+
 /**
  * The full variant matrix: each importance (rows) combined with the neutral
  * base and every anticipation (columns). Importance decides how the colour is
@@ -44,51 +91,18 @@ export const Default: Story = {
  * orthogonally.
  */
 export const Matrix: Story = {
-  render: (args) => (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: `auto repeat(${
-          MODIFIER_FAMILIES.anticipation.length + 1
-        }, auto)`,
-        gap: "0.75rem 1rem",
-        alignItems: "center",
-        justifyItems: "start",
-      }}
-    >
-      {/* Header row: blank corner + column labels. */}
-      <span />
-      <span style={{ fontSize: "0.75rem", opacity: 0.6 }}>neutral</span>
-      {MODIFIER_FAMILIES.anticipation.map((a) => (
-        <span key={a} style={{ fontSize: "0.75rem", opacity: 0.6 }}>
-          {a}
-        </span>
-      ))}
-
-      {/* One row per importance. */}
-      {MODIFIER_FAMILIES.importance.map((importance) => (
-        <Fragment key={importance}>
-          <span style={{ fontSize: "0.75rem", opacity: 0.6 }}>
-            {importance}
-          </span>
-          <Component {...args} importance={importance}>
-            Button
-          </Component>
-          {MODIFIER_FAMILIES.anticipation.map((anticipation) => (
-            <Component
-              key={anticipation}
-              {...args}
-              importance={importance}
-              anticipation={anticipation}
-            >
-              Button
-            </Component>
-          ))}
-        </Fragment>
-      ))}
-    </div>
-  ),
+  render: (args) => <MatrixGrid {...args} />,
   args: { children: "Button" },
+};
+
+/**
+ * The same matrix in the disabled state — every importance × anticipation
+ * combination rendered `disabled`, so the disabled treatment is visible across
+ * the whole grid.
+ */
+export const DisabledMatrix: Story = {
+  render: (args) => <MatrixGrid {...args} />,
+  args: { children: "Button", disabled: true },
 };
 
 /**

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -1,5 +1,6 @@
 import { MODIFIER_FAMILIES } from "@canonical/ds-types";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Fragment } from "react";
 import { fn } from "storybook/test";
 
 import Component from "./Button.js";
@@ -35,20 +36,58 @@ export const Default: Story = {
 };
 
 /**
- * Anticipation modifiers express the expected consequence of an action.
+ * The full variant matrix: each importance (rows) combined with the neutral
+ * base and every anticipation (columns). Importance decides how the colour is
+ * applied — primary fills, secondary outlines, tertiary is text — while
+ * anticipation (and the neutral base) decides which colour. The two compose
+ * orthogonally.
  */
-export const Anticipation: Story = {
+export const Matrix: Story = {
   render: (args) => (
-    <div style={{ display: "flex", gap: "0.5rem" }}>
-      <Component {...args}>Default</Component>
-      {MODIFIER_FAMILIES.anticipation.map((value) => (
-        <Component key={value} {...args} anticipation={value}>
-          {value}
-        </Component>
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `auto repeat(${
+          MODIFIER_FAMILIES.anticipation.length + 1
+        }, auto)`,
+        gap: "0.75rem 1rem",
+        alignItems: "center",
+        justifyItems: "start",
+      }}
+    >
+      {/* Header row: blank corner + column labels. */}
+      <span />
+      <span style={{ fontSize: "0.75rem", opacity: 0.6 }}>neutral</span>
+      {MODIFIER_FAMILIES.anticipation.map((a) => (
+        <span key={a} style={{ fontSize: "0.75rem", opacity: 0.6 }}>
+          {a}
+        </span>
+      ))}
+
+      {/* One row per importance. */}
+      {MODIFIER_FAMILIES.importance.map((importance) => (
+        <Fragment key={importance}>
+          <span style={{ fontSize: "0.75rem", opacity: 0.6 }}>
+            {importance}
+          </span>
+          <Component {...args} importance={importance}>
+            Button
+          </Component>
+          {MODIFIER_FAMILIES.anticipation.map((anticipation) => (
+            <Component
+              key={anticipation}
+              {...args}
+              importance={importance}
+              anticipation={anticipation}
+            >
+              Button
+            </Component>
+          ))}
+        </Fragment>
       ))}
     </div>
   ),
-  args: { children: "Not rendered" },
+  args: { children: "Button" },
 };
 
 /**

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -10,9 +10,10 @@ const meta = {
   component: Component,
   tags: ["autodocs"],
   argTypes: {
+    // Importance is never blank — primary is the default hierarchy.
     importance: {
       control: "select",
-      options: [undefined, ...MODIFIER_FAMILIES.importance],
+      options: [...MODIFIER_FAMILIES.importance],
     },
     anticipation: {
       control: "select",
@@ -23,7 +24,7 @@ const meta = {
       options: [undefined, "link"],
     },
   },
-  args: { onClick: fn() },
+  args: { onClick: fn(), importance: "primary" },
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -9,6 +9,10 @@ const meta = {
   component: Component,
   tags: ["autodocs"],
   argTypes: {
+    importance: {
+      control: "select",
+      options: [undefined, ...MODIFIER_FAMILIES.importance],
+    },
     anticipation: {
       control: "select",
       options: [undefined, ...MODIFIER_FAMILIES.anticipation],
@@ -16,10 +20,6 @@ const meta = {
     variant: {
       control: "select",
       options: [undefined, "link"],
-    },
-    iconPosition: {
-      control: "select",
-      options: ["start", "end"],
     },
   },
   args: { onClick: fn() },
@@ -80,6 +80,18 @@ export const WithIcon: Story = {
     children: "Delete",
     icon: <TrashIcon />,
     anticipation: "destructive",
+  },
+};
+
+/**
+ * A loading button shows a Spinner in the leading icon slot, is marked
+ * `aria-busy`, and is disabled so the action cannot be triggered again while
+ * it is in flight.
+ */
+export const Loading: Story = {
+  args: {
+    children: "Saving",
+    loading: true,
   },
 };
 

--- a/packages/react/ds-global/src/lib/component/Button/Button.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tests.tsx
@@ -101,22 +101,6 @@ describe("Button component", () => {
       expect(labelElement).toBeInTheDocument();
     });
 
-    it("renders icon at end position", () => {
-      const icon = <span data-testid="icon">→</span>;
-      render(
-        <Component icon={icon} iconPosition="end">
-          Continue
-        </Component>,
-      );
-
-      const button = screen.getByRole("button");
-      const iconElement = screen.getByTestId("icon");
-
-      // Text should come before icon in DOM order
-      expect(button.textContent).toBe("Continue→");
-      expect(iconElement).toBeInTheDocument();
-    });
-
     it("renders icon-only button", () => {
       const icon = <span data-testid="icon">×</span>;
       render(<Component icon={icon} aria-label="Close" />);
@@ -194,6 +178,38 @@ describe("Button component", () => {
     it("can be disabled", () => {
       render(<Component disabled>Disabled</Component>);
       expect(screen.getByRole("button")).toBeDisabled();
+    });
+  });
+
+  describe("loading state", () => {
+    it("renders a Spinner in the icon slot", () => {
+      const { container } = render(<Component loading>Saving</Component>);
+      const spinner = container.querySelector(".icon .ds.spinner");
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it("marks the button aria-busy and disabled", () => {
+      render(<Component loading>Saving</Component>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-busy", "true");
+      expect(button).toBeDisabled();
+    });
+
+    it("replaces the consumer icon with the Spinner while loading", () => {
+      const { container } = render(
+        <Component loading icon={<span data-testid="icon">+</span>}>
+          Saving
+        </Component>,
+      );
+      expect(screen.queryByTestId("icon")).not.toBeInTheDocument();
+      expect(container.querySelector(".ds.spinner")).toBeInTheDocument();
+    });
+
+    it("is neither busy nor disabled when not loading", () => {
+      render(<Component>Idle</Component>);
+      const button = screen.getByRole("button");
+      expect(button).not.toHaveAttribute("aria-busy");
+      expect(button).not.toBeDisabled();
     });
   });
 

--- a/packages/react/ds-global/src/lib/component/Button/Button.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tests.tsx
@@ -182,9 +182,9 @@ describe("Button component", () => {
   });
 
   describe("loading state", () => {
-    it("renders a Spinner in the icon slot", () => {
+    it("overlays a Spinner while loading", () => {
       const { container } = render(<Component loading>Saving</Component>);
-      const spinner = container.querySelector(".icon .ds.spinner");
+      const spinner = container.querySelector(".loading-spinner .ds.spinner");
       expect(spinner).toBeInTheDocument();
     });
 
@@ -195,14 +195,24 @@ describe("Button component", () => {
       expect(button).toBeDisabled();
     });
 
-    it("replaces the consumer icon with the Spinner while loading", () => {
+    it("keeps the label in the DOM while loading (preserves width, no collapse)", () => {
+      const { container } = render(<Component loading>Saving</Component>);
+      // The label stays rendered (hidden via CSS) so the button keeps its width.
+      const label = container.querySelector(".label");
+      expect(label).toHaveTextContent("Saving");
+    });
+
+    it("keeps the consumer icon in the DOM but adds the Spinner overlay", () => {
       const { container } = render(
         <Component loading icon={<span data-testid="icon">+</span>}>
           Saving
         </Component>,
       );
-      expect(screen.queryByTestId("icon")).not.toBeInTheDocument();
-      expect(container.querySelector(".ds.spinner")).toBeInTheDocument();
+      // The icon remains (hidden via CSS), and the Spinner is overlaid on top.
+      expect(screen.getByTestId("icon")).toBeInTheDocument();
+      expect(
+        container.querySelector(".loading-spinner .ds.spinner"),
+      ).toBeInTheDocument();
     });
 
     it("is neither busy nor disabled when not loading", () => {

--- a/packages/react/ds-global/src/lib/component/Button/Button.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tsx
@@ -45,24 +45,21 @@ const Button = ({
     );
   }
 
-  // While loading, the Spinner takes the single leading icon slot; otherwise
-  // the consumer's icon (if any) does.
-  const leading = loading ? (
-    <span className="icon">
-      <Spinner />
-    </span>
-  ) : (
-    icon && <span className="icon">{icon}</span>
-  );
+  const iconElement = icon && <span className="icon">{icon}</span>;
 
   return (
     <button
       id={id}
       className={[
         componentCssClassName,
+        // The `.p` baseline utility supplies the body-text tier (font, snapped
+        // line-height) and the padding-block nudges that align the button box
+        // to the baseline grid — so the box height tracks the text inside.
+        "p",
         importance,
         anticipation,
         variant,
+        loading && "loading",
         className,
       ]
         .filter(Boolean)
@@ -73,8 +70,17 @@ const Button = ({
       disabled={disabled || loading}
       {...props}
     >
-      {leading}
-      {children}
+      {/* The icon and label stay in the DOM while loading so the button keeps
+          its width; CSS hides them (visibility:hidden) and the Spinner is
+          overlaid centered on top. The label is wrapped so it can be hidden
+          (a bare text child is not an element and cannot be). */}
+      {iconElement}
+      {hasVisibleChildren && <span className="label">{children}</span>}
+      {loading && (
+        <span className="loading-spinner" aria-hidden="true">
+          <Spinner />
+        </span>
+      )}
     </button>
   );
 };

--- a/packages/react/ds-global/src/lib/component/Button/Button.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tsx
@@ -19,7 +19,7 @@ const Button = ({
   className,
   children,
   style,
-  importance,
+  importance = "primary",
   anticipation,
   variant,
   icon,

--- a/packages/react/ds-global/src/lib/component/Button/Button.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { Spinner } from "#lib/subcomponent/Spinner/index.js";
 import type Props from "./types.js";
 import "./styles.css";
 
@@ -8,6 +9,8 @@ const componentCssClassName = "ds button";
  * Buttons trigger actions within an interface, typically involving
  * data transformation or manipulation. They provide clear visual
  * indicators of the primary actions users can perform.
+ *
+ * `import { Button } from "@canonical/react-ds-global";`
  *
  * @implements ds:global.component.button
  */
@@ -20,7 +23,8 @@ const Button = ({
   anticipation,
   variant,
   icon,
-  iconPosition = "start",
+  loading = false,
+  disabled,
   ...props
 }: Props): React.ReactElement => {
   // Booleans and nullish children render nothing; everything else (including
@@ -31,7 +35,7 @@ const Button = ({
   if (
     typeof process !== "undefined" &&
     process.env.NODE_ENV !== "production" &&
-    icon &&
+    (icon || loading) &&
     !hasVisibleChildren &&
     !props["aria-label"] &&
     !props["aria-labelledby"]
@@ -41,7 +45,15 @@ const Button = ({
     );
   }
 
-  const iconElement = icon && <span className="icon">{icon}</span>;
+  // While loading, the Spinner takes the single leading icon slot; otherwise
+  // the consumer's icon (if any) does.
+  const leading = loading ? (
+    <span className="icon">
+      <Spinner />
+    </span>
+  ) : (
+    icon && <span className="icon">{icon}</span>
+  );
 
   return (
     <button
@@ -56,19 +68,13 @@ const Button = ({
         .filter(Boolean)
         .join(" ")}
       style={style}
+      // A loading button is busy and must not be re-triggered mid-action.
+      aria-busy={loading || undefined}
+      disabled={disabled || loading}
       {...props}
     >
-      {iconPosition === "start" ? (
-        <>
-          {iconElement}
-          {children}
-        </>
-      ) : (
-        <>
-          {children}
-          {iconElement}
-        </>
-      )}
+      {leading}
+      {children}
     </button>
   );
 };

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -1,17 +1,18 @@
 /* Component tokens — sourced from @canonical/design-tokens */
 :root {
-  --button-color-background: var(--color-foreground-secondary);
-  --button-color-background-hover: var(--color-foreground-secondary-hover);
-  --button-color-background-active: var(--color-foreground-secondary-active);
+  /* Fallbacks for the modifier channel, used when no importance modifier is
+     applied (a bare button reads as the ghost/neutral secondary look). */
+  --button-color-background: var(
+    --surface-color-foreground-ghost,
+    var(--color-foreground-ghost)
+  );
   --button-color-text: var(--color-text);
-  --button-color-border: var(--color-border-high-contrast);
-  --button-color-border-hover: var(--button-color-border);
-  --button-color-border-active: var(--button-color-border);
+  --button-color-border: var(--color-border);
 
-  /* Inline padding only — the block padding is owned by the `.p` baseline
-     utility, which snaps the box height to the baseline grid (see below).
-     Figma: dimension/100 (8px) inline. */
+  /* Inline padding + gap. Figma: dimension/100 (8px) inline, dimension/200
+     (16px) between the icon and the label. */
   --button-padding-horizontal: var(--dimension-100);
+  --button-gap: var(--dimension-200);
   --button-border-width: var(--dimension-stroke-thickness-medium);
   /* Label weight — the button label is medium, not the `.p` body weight. */
   --button-font-weight: var(--font-weight-medium, var(--font-weight-default));
@@ -22,12 +23,19 @@
    ========================================================================== */
 
 /*
-  Modifier channel variables (from @canonical/design-tokens):
-    --modifier-color-foreground-primary  filled background (constructive, destructive, caution)
-    --modifier-color-text                text colour
-    --modifier-color-border              border colour
-    --modifier-color-icon                icon colour
-    --modifier-color-focusRing           focus ring colour
+  The button reads the modifier CHANNEL generically — it is not aware of any
+  particular importance/anticipation class or combination:
+
+    --modifier-surface   which foreground fills the background (importance:
+                         filled for primary, ghost for secondary/tertiary).
+    --modifier-outline   1 when a border shows, 0 when it does not (importance).
+    --modifier-color-*   the colour itself (anticipation/emphasis): text, icon,
+                         border. `.primary` overrides text/icon with the on-fill
+                         contrast tokens.
+
+  Interaction states come free from `@canonical/design-tokens/dist/states.css`,
+  which derives `--hover--*` / `--active--*` / `--disabled--*` from whatever the
+  channel resolved to.
 */
 
 .ds.button {
@@ -35,17 +43,16 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--spacing-horizontal-small, 0.5rem);
+  gap: var(--button-gap);
   cursor: pointer;
 
   color: var(--modifier-color-text, var(--button-color-text));
-  background-color: var(
-    --modifier-color-foreground-primary,
-    var(--button-color-background)
-  );
+  background-color: var(--modifier-surface, var(--button-color-background));
   border-color: var(--modifier-color-border, var(--button-color-border));
   border-style: solid;
-  border-width: var(--button-border-width);
+  /* The outline flag (0/1) toggles the border on: multiplying the width means
+     a borderless importance simply resolves to 0 with no separate rule. */
+  border-width: calc(var(--modifier-outline, 0) * var(--button-border-width));
 
   /* Typography and block padding come from the `.p` baseline utility on the
      element (font-size, snapped line-height, and the padding-block nudges that
@@ -59,19 +66,32 @@
   text-decoration: none;
 
   &:hover:not(:disabled) {
-    background-color: var(--button-color-background-hover);
-    border-color: var(--button-color-border-hover);
+    background-color: var(--modifier-surface-hover, var(--modifier-surface));
   }
 
   &:active:not(:disabled) {
-    background-color: var(--button-color-background-active);
-    border-color: var(--button-color-border-active);
+    background-color: var(--modifier-surface-active, var(--modifier-surface));
   }
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 0.5;
+    color: var(--disabled--color-text);
+    background-color: var(--modifier-surface-disabled, transparent);
+    border-color: var(--disabled--color-border);
   }
+}
+
+/* ==========================================================================
+   Icon Slot
+   ========================================================================== */
+
+.ds.button > .icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: var(--icon-size, 1em);
+  height: var(--icon-size, 1em);
 }
 
 /* ==========================================================================
@@ -94,19 +114,6 @@
     align-items: center;
     justify-content: center;
   }
-}
-
-/* ==========================================================================
-   Icon Slot
-   ========================================================================== */
-
-.ds.button > .icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: var(--icon-size, 1em);
-  height: var(--icon-size, 1em);
 }
 
 /* ==========================================================================

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -8,9 +8,9 @@
     --modifier-color-foreground-primary,
     var(--color-foreground-primary)
   );
-  --button-color-background-hover: var(--hover--color-foreground-primary);
-  --button-color-background-active: var(--active--color-foreground-primary);
-  --button-color-background-disabled: var(--disabled--color-foreground-primary);
+  --button-color-background-hover: var(--color-foreground-primary-hover);
+  --button-color-background-active: var(--color-foreground-primary-active);
+  --button-color-background-disabled: var(--color-foreground-primary-disabled);
   /* Neutral text is the normal text colour. The filled default reads as
      contrast on the fill because `.primary` (the default importance, applied by
      the component) overrides text/icon to the on-fill contrast tokens; ghost
@@ -110,14 +110,18 @@
     outline-offset: var(--focus-outline-offset, 2px);
   }
 
+  /* Disabled — explicit disabled tokens (not the computed deltas): the surface,
+     text and border each resolve to their `-disabled` token. Primary supplies
+     the on-fill disabled text via `--modifier-color-text-disabled`; ghost
+     importances fall back to the plain disabled text colour. */
   &:disabled {
     cursor: not-allowed;
-    color: var(--disabled--color-text, var(--button-color-text));
+    color: var(--modifier-color-text-disabled, var(--color-text-disabled));
     background-color: var(
       --modifier-surface-disabled,
       var(--button-color-background-disabled)
     );
-    border-color: var(--disabled--color-border);
+    border-color: var(--color-border-disabled);
   }
 }
 

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -1,12 +1,17 @@
 /* Component tokens — sourced from @canonical/design-tokens */
 :root {
-  /* Fallbacks for the modifier channel, used when no importance modifier is
-     applied (a bare button reads as the ghost/neutral secondary look). */
+  /* Channel fallbacks used when no importance modifier is applied. Primary is
+     the default hierarchy, so a bare `<button class="ds button">` reads as the
+     filled primary look: the primary foreground fills the background and the
+     label takes the on-fill contrast colour. */
   --button-color-background: var(
-    --surface-color-foreground-ghost,
-    var(--color-foreground-ghost)
+    --modifier-color-foreground-primary,
+    var(--color-foreground-primary)
   );
-  --button-color-text: var(--color-text);
+  --button-color-background-hover: var(--hover--color-foreground-primary);
+  --button-color-background-active: var(--active--color-foreground-primary);
+  --button-color-background-disabled: var(--disabled--color-foreground-primary);
+  --button-color-text: var(--color-text-onForegroundPrimary);
   --button-color-border: var(--color-border);
 
   /* Inline padding + gap. Figma: dimension/100 (8px) inline, dimension/200
@@ -65,18 +70,29 @@
   text-align: center;
   text-decoration: none;
 
+  /* State fallbacks resolve to the default (primary) surface states when no
+     importance modifier supplies `--modifier-surface-*`. */
   &:hover:not(:disabled) {
-    background-color: var(--modifier-surface-hover, var(--modifier-surface));
+    background-color: var(
+      --modifier-surface-hover,
+      var(--button-color-background-hover)
+    );
   }
 
   &:active:not(:disabled) {
-    background-color: var(--modifier-surface-active, var(--modifier-surface));
+    background-color: var(
+      --modifier-surface-active,
+      var(--button-color-background-active)
+    );
   }
 
   &:disabled {
     cursor: not-allowed;
-    color: var(--disabled--color-text);
-    background-color: var(--modifier-surface-disabled, transparent);
+    color: var(--disabled--color-text, var(--button-color-text));
+    background-color: var(
+      --modifier-surface-disabled,
+      var(--button-color-background-disabled)
+    );
     border-color: var(--disabled--color-border);
   }
 }

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -160,8 +160,15 @@
 
 /* Loading replaces the label with a Spinner but keeps the button's width: the
    icon and label stay in the DOM (hidden, so their box still reserves space)
-   and the Spinner is overlaid centred on top. */
+   and the Spinner is overlaid centred on top. A loading button is disabled (so
+   it can't be re-triggered), but it must not *read* as disabled — it is
+   working, not unavailable — so it keeps the enabled surface, text and border
+   colours, overriding the :disabled greying above. */
 .ds.button.loading {
+  color: var(--modifier-color-text, var(--button-color-text));
+  background-color: var(--modifier-surface, var(--button-color-background));
+  border-color: var(--modifier-color-border, var(--button-color-border));
+
   & > .icon,
   & > .label {
     visibility: hidden;

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -143,6 +143,15 @@
   flex-shrink: 0;
   width: var(--icon-size, 1em);
   height: var(--icon-size, 1em);
+
+  /* The icon has its own colour channel (distinct from the label text): on a
+     filled primary it is the on-fill contrast icon, on ghost importances the
+     modifier icon colour. Icons drawn with `currentColor` follow this. */
+  color: var(--modifier-color-icon, var(--modifier-color-text, currentColor));
+}
+
+.ds.button:disabled > .icon {
+  color: var(--modifier-color-icon-disabled, var(--color-icon-disabled));
 }
 
 /* ==========================================================================

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -8,14 +8,13 @@
   --button-color-border-hover: var(--button-color-border);
   --button-color-border-active: var(--button-color-border);
 
-  --button-margin-left: var(--spacing-horizontal-large);
-  --button-margin-bottom: var(--spacing-input-margin-bottom);
-  --button-padding-vertical: var(--spacing-input-padding-vertical);
-  --button-padding-horizontal: var(--spacing-horizontal-large);
-  --button-border-width: var(--spacing-border-width);
-  --button-font-size: var(--font-size-default);
-  --button-font-weight: var(--font-weight-default);
-  --button-line-height: var(--line-height-default);
+  /* Inline padding only — the block padding is owned by the `.p` baseline
+     utility, which snaps the box height to the baseline grid (see below).
+     Figma: dimension/100 (8px) inline. */
+  --button-padding-horizontal: var(--dimension-100);
+  --button-border-width: var(--dimension-stroke-thickness-medium);
+  /* Label weight — the button label is medium, not the `.p` body weight. */
+  --button-font-weight: var(--font-weight-medium, var(--font-weight-default));
 }
 
 /* ==========================================================================
@@ -32,6 +31,7 @@
 */
 
 .ds.button {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -47,12 +47,12 @@
   border-style: solid;
   border-width: var(--button-border-width);
 
-  font-size: var(--button-font-size);
+  /* Typography and block padding come from the `.p` baseline utility on the
+     element (font-size, snapped line-height, and the padding-block nudges that
+     align the box to the baseline grid). The button only overrides the label
+     weight and its own inline padding — declaring font-size/line-height/
+     padding-block here would bypass the baseline-grid maths. */
   font-weight: var(--button-font-weight);
-  line-height: var(--button-line-height);
-  margin-block-end: var(--button-margin-bottom);
-  margin-inline-end: var(--button-margin-left);
-  padding-block: var(--button-padding-vertical);
   padding-inline: var(--button-padding-horizontal);
 
   text-align: center;
@@ -71,6 +71,28 @@
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
+  }
+}
+
+/* ==========================================================================
+   Loading State
+   ========================================================================== */
+
+/* Loading replaces the label with a Spinner but keeps the button's width: the
+   icon and label stay in the DOM (hidden, so their box still reserves space)
+   and the Spinner is overlaid centred on top. */
+.ds.button.loading {
+  & > .icon,
+  & > .label {
+    visibility: hidden;
+  }
+
+  & > .loading-spinner {
+    position: absolute;
+    inset: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 }
 

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -11,8 +11,12 @@
   --button-color-background-hover: var(--hover--color-foreground-primary);
   --button-color-background-active: var(--active--color-foreground-primary);
   --button-color-background-disabled: var(--disabled--color-foreground-primary);
-  --button-color-text: var(--color-text-onForegroundPrimary);
-  --button-color-border: var(--color-border);
+  /* Neutral text is the normal text colour. The filled default reads as
+     contrast on the fill because `.primary` (the default importance, applied by
+     the component) overrides text/icon to the on-fill contrast tokens; ghost
+     importances keep this normal colour, so they stay visible. */
+  --button-color-text: var(--color-text);
+  --button-color-border: var(--color-border-highlighted, var(--color-border));
 
   /* Inline padding (Figma):
      - end (right): always dimension-200 (16px) — the label always sits 16px
@@ -96,6 +100,14 @@
       --modifier-surface-active,
       var(--button-color-background-active)
     );
+  }
+
+  /* Keyboard focus ring — driven by the modifier focusRing channel so it
+     recolours per anticipation; falls back to the base focus ring token. */
+  &:focus-visible {
+    outline: var(--focus-outline-width, 2px) solid
+      var(--modifier-color-focusRing, var(--color-focusRing, currentColor));
+    outline-offset: var(--focus-outline-offset, 2px);
   }
 
   &:disabled {

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -47,9 +47,10 @@
                          border. `.primary` overrides text/icon with the on-fill
                          contrast tokens.
 
-  Interaction states come free from `@canonical/design-tokens/dist/states.css`,
-  which derives `--hover--*` / `--active--*` / `--disabled--*` from whatever the
-  channel resolved to.
+  Interaction states read the per-state surface/text channels supplied by the
+  states shim (`--modifier-surface-{hover,active,disabled}`,
+  `--modifier-color-text-disabled`), which resolve to the explicit state tokens
+  and recolour per anticipation.
 */
 
 .ds.button {
@@ -79,6 +80,12 @@
 
   text-align: center;
   text-decoration: none;
+
+  /* Fast colour transition on state change (hover/active/disabled). */
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-easing-standard),
+    color var(--motion-duration-fast) var(--motion-easing-standard),
+    border-color var(--motion-duration-fast) var(--motion-easing-standard);
 
   /* A leading icon tightens the start padding to dimension-100; the gap between
      the icon and label is already dimension-100. */

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -14,10 +14,15 @@
   --button-color-text: var(--color-text-onForegroundPrimary);
   --button-color-border: var(--color-border);
 
-  /* Inline padding + gap. Figma: dimension/100 (8px) inline, dimension/200
-     (16px) between the icon and the label. */
-  --button-padding-horizontal: var(--dimension-100);
-  --button-gap: var(--dimension-200);
+  /* Inline padding (Figma):
+     - end (right): always dimension-200 (16px) — the label always sits 16px
+       from the trailing edge.
+     - start (left): dimension-200 (16px) with no icon; dimension-100 (8px) when
+       an icon leads (the icon then sits closer to the edge), with a
+       dimension-100 (8px) gap between the icon and the label. */
+  --button-padding-inline-end: var(--dimension-200);
+  --button-padding-inline-start: var(--dimension-200);
+  --button-gap: var(--dimension-100);
   --button-border-width: var(--dimension-stroke-thickness-medium);
   /* Label weight — the button label is medium, not the `.p` body weight. */
   --button-font-weight: var(--font-weight-medium, var(--font-weight-default));
@@ -65,10 +70,17 @@
      weight and its own inline padding — declaring font-size/line-height/
      padding-block here would bypass the baseline-grid maths. */
   font-weight: var(--button-font-weight);
-  padding-inline: var(--button-padding-horizontal);
+  padding-inline: var(--button-padding-inline-start)
+    var(--button-padding-inline-end);
 
   text-align: center;
   text-decoration: none;
+
+  /* A leading icon tightens the start padding to dimension-100; the gap between
+     the icon and label is already dimension-100. */
+  &:has(> .icon) {
+    --button-padding-inline-start: var(--dimension-100);
+  }
 
   /* State fallbacks resolve to the default (primary) surface states when no
      importance modifier supplies `--modifier-surface-*`. */

--- a/packages/react/ds-global/src/lib/component/Button/types.ts
+++ b/packages/react/ds-global/src/lib/component/Button/types.ts
@@ -34,14 +34,18 @@ export interface BaseProps {
    */
   variant?: "link";
   /**
-   * Icon element to display alongside the label.
+   * Icon element to display before the label. The button has a single,
+   * leading icon slot — the right-side icon was removed when the select and
+   * dropdown affordances became their own components.
    */
   icon?: ReactNode;
   /**
-   * Position of the icon relative to the label.
-   * @default "start"
+   * Whether the button is in a loading (busy) state. Replaces the leading icon
+   * with a Spinner, marks the button `aria-busy`, and disables interaction so
+   * the action cannot be triggered again while it is in flight.
+   * @default false
    */
-  iconPosition?: "start" | "end";
+  loading?: boolean;
 }
 
 type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;

--- a/packages/styles/main/src/index.css
+++ b/packages/styles/main/src/index.css
@@ -21,9 +21,14 @@
 @import url("@canonical/design-tokens/dist/modifiers.criticality.css");
 @import url("@canonical/design-tokens/dist/modifiers.emphasis.css");
 @import url("@canonical/design-tokens/dist/modifiers.importance.css");
-/* TEMP shim: maps the (currently empty) importance modifiers to channel hints
-   so importance-driven components can render their hierarchy. Loaded after the
-   generated file; remove once importance tokens are generated upstream. */
+/* TEMP shims (remove once generated upstream):
+   - states: writes the explicit per-state colour tokens into the modifier
+     channel (the generated modifiers only expose root), so hover/active/
+     disabled compose with anticipation. Imported after the anticipation/
+     emphasis modifiers so the anticipation-class overrides win.
+   - importance: maps the (currently empty) importance modifiers to channel
+     hints so importance-driven components can render their hierarchy. */
+@import url("./modifiers.states.shim.css");
 @import url("./modifiers.importance.shim.css");
 @import url("@canonical/design-tokens/dist/states.css");
 

--- a/packages/styles/main/src/index.css
+++ b/packages/styles/main/src/index.css
@@ -21,6 +21,10 @@
 @import url("@canonical/design-tokens/dist/modifiers.criticality.css");
 @import url("@canonical/design-tokens/dist/modifiers.emphasis.css");
 @import url("@canonical/design-tokens/dist/modifiers.importance.css");
+/* TEMP shim: maps the (currently empty) importance modifiers to channel hints
+   so importance-driven components can render their hierarchy. Loaded after the
+   generated file; remove once importance tokens are generated upstream. */
+@import url("./modifiers.importance.shim.css");
 @import url("@canonical/design-tokens/dist/states.css");
 
 /* Grid layout presets */

--- a/packages/styles/main/src/modifiers.importance.shim.css
+++ b/packages/styles/main/src/modifiers.importance.shim.css
@@ -50,6 +50,9 @@
       --color-text-onForegroundPrimary-disabled
     );
     --modifier-color-icon: var(--color-icon-onForegroundPrimary);
+    --modifier-color-icon-disabled: var(
+      --color-icon-onForegroundPrimary-disabled
+    );
   }
 
   /* Secondary — outlined: a ghost background with a visible border; text/icon

--- a/packages/styles/main/src/modifiers.importance.shim.css
+++ b/packages/styles/main/src/modifiers.importance.shim.css
@@ -49,9 +49,14 @@
     --modifier-color-text-disabled: var(
       --color-text-onForegroundPrimary-disabled
     );
-    --modifier-color-icon: var(--color-icon-onForegroundPrimary);
+    /* The `--color-icon-onForegroundPrimary[-disabled]` tokens are broken
+       upstream (they reference a non-existent `on-foreground-primary` token);
+       use the working camelCase on-fill text tokens — the on-fill icon and
+       text share the same contrast colour. Remove once the icon tokens are
+       fixed upstream. */
+    --modifier-color-icon: var(--color-text-onForegroundPrimary);
     --modifier-color-icon-disabled: var(
-      --color-icon-onForegroundPrimary-disabled
+      --color-text-onForegroundPrimary-disabled
     );
   }
 

--- a/packages/styles/main/src/modifiers.importance.shim.css
+++ b/packages/styles/main/src/modifiers.importance.shim.css
@@ -39,9 +39,11 @@
       --modifier-color-foreground-primary,
       var(--color-foreground-primary)
     );
-    --modifier-surface-hover: var(--color-foreground-primary-hover);
-    --modifier-surface-active: var(--color-foreground-primary-active);
-    --modifier-surface-disabled: var(--color-foreground-primary-disabled);
+    --modifier-surface-hover: var(--modifier-color-foreground-primary-hover);
+    --modifier-surface-active: var(--modifier-color-foreground-primary-active);
+    --modifier-surface-disabled: var(
+      --modifier-color-foreground-primary-disabled
+    );
     --modifier-outline: 0;
     --modifier-color-text: var(--color-text-onForegroundPrimary);
     --modifier-color-text-disabled: var(
@@ -57,9 +59,11 @@
       --modifier-color-foreground-ghost,
       var(--surface-color-foreground-ghost, var(--color-foreground-ghost))
     );
-    --modifier-surface-hover: var(--color-foreground-ghost-hover);
-    --modifier-surface-active: var(--color-foreground-ghost-active);
-    --modifier-surface-disabled: var(--color-foreground-ghost-disabled);
+    --modifier-surface-hover: var(--modifier-color-foreground-ghost-hover);
+    --modifier-surface-active: var(--modifier-color-foreground-ghost-active);
+    --modifier-surface-disabled: var(
+      --modifier-color-foreground-ghost-disabled
+    );
     --modifier-outline: 1;
   }
 
@@ -70,9 +74,11 @@
       --modifier-color-foreground-ghost,
       var(--surface-color-foreground-ghost, var(--color-foreground-ghost))
     );
-    --modifier-surface-hover: var(--color-foreground-ghost-hover);
-    --modifier-surface-active: var(--color-foreground-ghost-active);
-    --modifier-surface-disabled: var(--color-foreground-ghost-disabled);
+    --modifier-surface-hover: var(--modifier-color-foreground-ghost-hover);
+    --modifier-surface-active: var(--modifier-color-foreground-ghost-active);
+    --modifier-surface-disabled: var(
+      --modifier-color-foreground-ghost-disabled
+    );
     --modifier-outline: 0;
   }
 }

--- a/packages/styles/main/src/modifiers.importance.shim.css
+++ b/packages/styles/main/src/modifiers.importance.shim.css
@@ -1,0 +1,75 @@
+/* @canonical/styles — Importance modifier SHIM (temporary)
+ *
+ * The generated `@canonical/design-tokens/dist/modifiers.importance.css` is
+ * currently EMPTY: the `primary` / `secondary` / `tertiary` importance
+ * modifiers have no token mapping yet. This hand-authored shim provides a
+ * plausible mapping so importance-driven components (notably Button) can render
+ * their hierarchy today. It is expected to be superseded by the generated file
+ * once the importance tokens are ratified upstream — keep it minimal and remove
+ * it when that lands.
+ *
+ * Design contract — components listen to the CHANNEL, never to the class:
+ *   Importance decides HOW colour is applied, not which colour. It exposes two
+ *   channel hints that a consuming component reads generically (it must not key
+ *   off `.primary` / `.secondary` / `.tertiary` directly):
+ *
+ *     --modifier-surface  the foreground channel that fills the background
+ *                         (a filled importance points it at the primary
+ *                         foreground; a ghost importance at the ghost
+ *                         foreground).
+ *     --modifier-outline  1 when the importance shows a border, 0 when it does
+ *                         not. A component multiplies its border width by this.
+ *
+ *   For a FILLED importance the text/icon must read as contrast ON the fill, so
+ *   `.primary` also overrides `--modifier-color-text` / `--modifier-color-icon`
+ *   with the on-foreground contrast tokens. This shim is imported after the
+ *   anticipation/emphasis modifiers in the same `ds.modifiers` layer, so on a
+ *   `.primary.destructive` button the anticipation colour drives the fill while
+ *   this contrast text wins (equal specificity, later source order). For ghost
+ *   importances the text channel is left untouched, so the anticipation colour
+ *   lands on the text — exactly the Figma treatment.
+ */
+
+@layer ds.modifiers {
+  /* Primary — filled: the primary foreground fills the background, no border,
+     and the label reads as contrast on the fill. The surface state variants
+     point at the primary-foreground state deltas from states.css. */
+  .primary {
+    --modifier-surface: var(
+      --modifier-color-foreground-primary,
+      var(--color-foreground-primary)
+    );
+    --modifier-surface-hover: var(--hover--color-foreground-primary);
+    --modifier-surface-active: var(--active--color-foreground-primary);
+    --modifier-surface-disabled: var(--disabled--color-foreground-primary);
+    --modifier-outline: 0;
+    --modifier-color-text: var(--color-text-onForegroundPrimary);
+    --modifier-color-icon: var(--color-icon-onForegroundPrimary);
+  }
+
+  /* Secondary — outlined: a ghost background with a visible border; text/icon
+     keep the modifier colour. */
+  .secondary {
+    --modifier-surface: var(
+      --modifier-color-foreground-ghost,
+      var(--surface-color-foreground-ghost, var(--color-foreground-ghost))
+    );
+    --modifier-surface-hover: var(--hover--color-foreground-ghost);
+    --modifier-surface-active: var(--active--color-foreground-ghost);
+    --modifier-surface-disabled: var(--disabled--color-foreground-ghost);
+    --modifier-outline: 1;
+  }
+
+  /* Tertiary — text: a ghost background, no border; text/icon keep the modifier
+     colour (this is where the anticipation colour shows). */
+  .tertiary {
+    --modifier-surface: var(
+      --modifier-color-foreground-ghost,
+      var(--surface-color-foreground-ghost, var(--color-foreground-ghost))
+    );
+    --modifier-surface-hover: var(--hover--color-foreground-ghost);
+    --modifier-surface-active: var(--active--color-foreground-ghost);
+    --modifier-surface-disabled: var(--disabled--color-foreground-ghost);
+    --modifier-outline: 0;
+  }
+}

--- a/packages/styles/main/src/modifiers.importance.shim.css
+++ b/packages/styles/main/src/modifiers.importance.shim.css
@@ -39,11 +39,14 @@
       --modifier-color-foreground-primary,
       var(--color-foreground-primary)
     );
-    --modifier-surface-hover: var(--hover--color-foreground-primary);
-    --modifier-surface-active: var(--active--color-foreground-primary);
-    --modifier-surface-disabled: var(--disabled--color-foreground-primary);
+    --modifier-surface-hover: var(--color-foreground-primary-hover);
+    --modifier-surface-active: var(--color-foreground-primary-active);
+    --modifier-surface-disabled: var(--color-foreground-primary-disabled);
     --modifier-outline: 0;
     --modifier-color-text: var(--color-text-onForegroundPrimary);
+    --modifier-color-text-disabled: var(
+      --color-text-onForegroundPrimary-disabled
+    );
     --modifier-color-icon: var(--color-icon-onForegroundPrimary);
   }
 
@@ -54,9 +57,9 @@
       --modifier-color-foreground-ghost,
       var(--surface-color-foreground-ghost, var(--color-foreground-ghost))
     );
-    --modifier-surface-hover: var(--hover--color-foreground-ghost);
-    --modifier-surface-active: var(--active--color-foreground-ghost);
-    --modifier-surface-disabled: var(--disabled--color-foreground-ghost);
+    --modifier-surface-hover: var(--color-foreground-ghost-hover);
+    --modifier-surface-active: var(--color-foreground-ghost-active);
+    --modifier-surface-disabled: var(--color-foreground-ghost-disabled);
     --modifier-outline: 1;
   }
 
@@ -67,9 +70,9 @@
       --modifier-color-foreground-ghost,
       var(--surface-color-foreground-ghost, var(--color-foreground-ghost))
     );
-    --modifier-surface-hover: var(--hover--color-foreground-ghost);
-    --modifier-surface-active: var(--active--color-foreground-ghost);
-    --modifier-surface-disabled: var(--disabled--color-foreground-ghost);
+    --modifier-surface-hover: var(--color-foreground-ghost-hover);
+    --modifier-surface-active: var(--color-foreground-ghost-active);
+    --modifier-surface-disabled: var(--color-foreground-ghost-disabled);
     --modifier-outline: 0;
   }
 }

--- a/packages/styles/main/src/modifiers.states.shim.css
+++ b/packages/styles/main/src/modifiers.states.shim.css
@@ -1,0 +1,136 @@
+/* @canonical/styles — Modifier state-channel SHIM (temporary)
+ *
+ * The generated modifier files expose only the ROOT colour channel
+ * (`--modifier-color-foreground-primary`, `--modifier-color-foreground-ghost`);
+ * they do not expose per-STATE channels. The explicit state tokens exist
+ * (`--color-foreground-primary-hover`, `-active`, `-disabled`, and their
+ * anticipation-suffixed variants), but nothing wires them into the channel, so
+ * a component that wants a hover/active/disabled colour has nothing to read —
+ * hover and focus appear to do nothing.
+ *
+ * This shim writes those explicit state tokens into new channel vars:
+ *
+ *   --modifier-color-foreground-primary-hover  / -active / -disabled
+ *   --modifier-color-foreground-ghost-hover    / -active / -disabled
+ *
+ * so a consumer reads the channel uniformly and the states compose with the
+ * anticipation modifier (each anticipation class re-points the channel at its
+ * own `-{anticipation}-{state}` tokens). Neutral defaults live on `:root`; the
+ * anticipation classes override in the `ds.modifiers` layer, imported after the
+ * generated modifiers so they win.
+ *
+ * Remove once the generated modifiers expose state channels upstream.
+ */
+
+@layer ds.modifiers {
+  /* Neutral defaults — the plain (non-anticipation) state tokens. */
+  :root {
+    --modifier-color-foreground-primary-hover: var(
+      --color-foreground-primary-hover
+    );
+    --modifier-color-foreground-primary-active: var(
+      --color-foreground-primary-active
+    );
+    --modifier-color-foreground-primary-disabled: var(
+      --color-foreground-primary-disabled
+    );
+    --modifier-color-foreground-ghost-hover: var(
+      --color-foreground-ghost-hover
+    );
+    --modifier-color-foreground-ghost-active: var(
+      --color-foreground-ghost-active
+    );
+    --modifier-color-foreground-ghost-disabled: var(
+      --color-foreground-ghost-disabled
+    );
+  }
+
+  .constructive {
+    --modifier-color-foreground-primary-hover: var(
+      --color-foreground-primary-constructive-hover
+    );
+    --modifier-color-foreground-primary-active: var(
+      --color-foreground-primary-constructive-active
+    );
+    --modifier-color-foreground-primary-disabled: var(
+      --color-foreground-primary-constructive-disabled
+    );
+    --modifier-color-foreground-ghost-hover: var(
+      --color-foreground-ghost-constructive-hover
+    );
+    --modifier-color-foreground-ghost-active: var(
+      --color-foreground-ghost-constructive-active
+    );
+    --modifier-color-foreground-ghost-disabled: var(
+      --color-foreground-ghost-constructive-disabled
+    );
+  }
+
+  .destructive {
+    --modifier-color-foreground-primary-hover: var(
+      --color-foreground-primary-destructive-hover
+    );
+    --modifier-color-foreground-primary-active: var(
+      --color-foreground-primary-destructive-active
+    );
+    --modifier-color-foreground-primary-disabled: var(
+      --color-foreground-primary-destructive-disabled
+    );
+    --modifier-color-foreground-ghost-hover: var(
+      --color-foreground-ghost-destructive-hover
+    );
+    --modifier-color-foreground-ghost-active: var(
+      --color-foreground-ghost-destructive-active
+    );
+    --modifier-color-foreground-ghost-disabled: var(
+      --color-foreground-ghost-destructive-disabled
+    );
+  }
+
+  /* `caution` uses the `warning` colour ramp. The ghost-warning state tokens do
+     not exist upstream, so those fall back to the root ghost-warning colour. */
+  .caution {
+    --modifier-color-foreground-primary-hover: var(
+      --color-foreground-primary-warning-hover
+    );
+    --modifier-color-foreground-primary-active: var(
+      --color-foreground-primary-warning-active
+    );
+    --modifier-color-foreground-primary-disabled: var(
+      --color-foreground-primary-warning-disabled
+    );
+    --modifier-color-foreground-ghost-hover: var(
+      --color-foreground-ghost-warning-hover,
+      var(--color-foreground-ghost-warning)
+    );
+    --modifier-color-foreground-ghost-active: var(
+      --color-foreground-ghost-warning-active,
+      var(--color-foreground-ghost-warning)
+    );
+    --modifier-color-foreground-ghost-disabled: var(
+      --color-foreground-ghost-warning-disabled,
+      var(--color-foreground-ghost-warning)
+    );
+  }
+
+  .branded {
+    --modifier-color-foreground-primary-hover: var(
+      --color-foreground-primary-branded-hover
+    );
+    --modifier-color-foreground-primary-active: var(
+      --color-foreground-primary-branded-active
+    );
+    --modifier-color-foreground-primary-disabled: var(
+      --color-foreground-primary-branded-disabled
+    );
+    --modifier-color-foreground-ghost-hover: var(
+      --color-foreground-ghost-branded-hover
+    );
+    --modifier-color-foreground-ghost-active: var(
+      --color-foreground-ghost-branded-active
+    );
+    --modifier-color-foreground-ghost-disabled: var(
+      --color-foreground-ghost-branded-disabled
+    );
+  }
+}

--- a/packages/styles/main/src/modifiers.states.shim.css
+++ b/packages/styles/main/src/modifiers.states.shim.css
@@ -68,6 +68,7 @@
       --color-foreground-ghost-disabled
     );
     --modifier-color-text-disabled: var(--color-text-disabled);
+    --modifier-color-icon-disabled: var(--color-icon-disabled);
   }
 
   .constructive {
@@ -90,6 +91,7 @@
       --color-foreground-ghost-constructive-disabled
     );
     --modifier-color-text-disabled: var(--color-text-constructive-disabled);
+    --modifier-color-icon-disabled: var(--color-icon-constructive-disabled);
   }
 
   .destructive {
@@ -112,6 +114,7 @@
       --color-foreground-ghost-destructive-disabled
     );
     --modifier-color-text-disabled: var(--color-text-destructive-disabled);
+    --modifier-color-icon-disabled: var(--color-icon-destructive-disabled);
   }
 
   /* `caution` uses the `warning` colour ramp. The ghost-warning state tokens do
@@ -140,6 +143,7 @@
       --color-foreground-ghost-warning-disabled
     );
     --modifier-color-text-disabled: var(--color-text-warning-disabled);
+    --modifier-color-icon-disabled: var(--color-icon-warning-disabled);
   }
 
   .branded {
@@ -162,5 +166,6 @@
       --color-foreground-ghost-branded-disabled
     );
     --modifier-color-text-disabled: var(--color-text-branded-disabled);
+    --modifier-color-icon-disabled: var(--color-icon-branded-disabled);
   }
 }

--- a/packages/styles/main/src/modifiers.states.shim.css
+++ b/packages/styles/main/src/modifiers.states.shim.css
@@ -67,6 +67,7 @@
     --modifier-color-foreground-ghost-disabled: var(
       --color-foreground-ghost-disabled
     );
+    --modifier-color-text-disabled: var(--color-text-disabled);
   }
 
   .constructive {
@@ -88,6 +89,7 @@
     --modifier-color-foreground-ghost-disabled: var(
       --color-foreground-ghost-constructive-disabled
     );
+    --modifier-color-text-disabled: var(--color-text-constructive-disabled);
   }
 
   .destructive {
@@ -109,6 +111,7 @@
     --modifier-color-foreground-ghost-disabled: var(
       --color-foreground-ghost-destructive-disabled
     );
+    --modifier-color-text-disabled: var(--color-text-destructive-disabled);
   }
 
   /* `caution` uses the `warning` colour ramp. The ghost-warning state tokens do
@@ -136,6 +139,7 @@
     --modifier-color-foreground-ghost-disabled: var(
       --color-foreground-ghost-warning-disabled
     );
+    --modifier-color-text-disabled: var(--color-text-warning-disabled);
   }
 
   .branded {
@@ -157,5 +161,6 @@
     --modifier-color-foreground-ghost-disabled: var(
       --color-foreground-ghost-branded-disabled
     );
+    --modifier-color-text-disabled: var(--color-text-branded-disabled);
   }
 }

--- a/packages/styles/main/src/modifiers.states.shim.css
+++ b/packages/styles/main/src/modifiers.states.shim.css
@@ -23,6 +23,30 @@
  */
 
 @layer ds.modifiers {
+  /* Missing upstream tokens: `caution` uses the `warning` ramp, but the
+     warning ghost tokens (root + states) are not generated. Define plausible
+     values here, mirroring the destructive/constructive ghost pattern (a very
+     light / very dark tint at the ramp's hue — warning hue ≈ 66.86). Remove
+     once the warning ghost tokens are generated upstream. */
+  :root {
+    --color-foreground-ghost-warning: light-dark(
+      var(--color-palette-white),
+      var(--color-palette-gray-990)
+    );
+    --color-foreground-ghost-warning-hover: light-dark(
+      oklch(96% 0.06 66.86),
+      oklch(20% 0.045 66.86)
+    );
+    --color-foreground-ghost-warning-active: light-dark(
+      oklch(93% 0.08 66.86),
+      oklch(24% 0.05 66.86)
+    );
+    --color-foreground-ghost-warning-disabled: light-dark(
+      var(--color-palette-white),
+      oklch(12% 0 0)
+    );
+  }
+
   /* Neutral defaults — the plain (non-anticipation) state tokens. */
   :root {
     --modifier-color-foreground-primary-hover: var(
@@ -90,6 +114,10 @@
   /* `caution` uses the `warning` colour ramp. The ghost-warning state tokens do
      not exist upstream, so those fall back to the root ghost-warning colour. */
   .caution {
+    /* The generated `.caution` modifier omits the ghost root channel that
+       destructive/constructive set — add it so caution ghost importances have a
+       base fill to state from. */
+    --modifier-color-foreground-ghost: var(--color-foreground-ghost-warning);
     --modifier-color-foreground-primary-hover: var(
       --color-foreground-primary-warning-hover
     );
@@ -100,16 +128,13 @@
       --color-foreground-primary-warning-disabled
     );
     --modifier-color-foreground-ghost-hover: var(
-      --color-foreground-ghost-warning-hover,
-      var(--color-foreground-ghost-warning)
+      --color-foreground-ghost-warning-hover
     );
     --modifier-color-foreground-ghost-active: var(
-      --color-foreground-ghost-warning-active,
-      var(--color-foreground-ghost-warning)
+      --color-foreground-ghost-warning-active
     );
     --modifier-color-foreground-ghost-disabled: var(
-      --color-foreground-ghost-warning-disabled,
-      var(--color-foreground-ghost-warning)
+      --color-foreground-ghost-warning-disabled
     );
   }
 


### PR DESCRIPTION
> **Re-targets the Button reconcile to `main`.** PR #728 was stacked on the Spinner branch (#726) and got merged into that branch instead of `main` when #726 landed first, so the Button work never reached `main`. This is the same 17 commits rebased directly onto `main` (spinner commits dropped, no conflicts). Supersedes #728.

Reconciles and fully styles the Button against the Coda spec + documentation-visuals Figma, spanning `@canonical/react-ds-global` + `@canonical/styles`.

## Done

**Behaviour** — single leading icon (right-side icon removed per the spec changelog + Figma); `loading` state (Spinner overlay, keeps width, keeps its enabled look); `importance` defaults to `primary`.

**Box** — baseline-aligned via the `.p` utility; asymmetric icon-aware inline padding (right always `dimension-200`; left `dimension-200`, or `dimension-100` with a leading icon); `--dimension-*` tokens throughout.

**Colour — channel-driven 3×3 matrix (importance × anticipation)** — the Button reads the modifier channel generically (never keys off a class/combination). Two temporary shims in `@canonical/styles` fill gaps in the generated tokens:
- `modifiers.importance.shim.css` — the empty importance modifiers → channel hints (surface/outline; primary → on-fill contrast text/icon).
- `modifiers.states.shim.css` — writes the explicit per-state colour tokens into the channel so hover/active/disabled compose with anticipation (generated modifiers only expose root); plus the missing caution/warning ghost tokens and a workaround for the broken on-fill icon token reference.
- Fast colour transition on state change; `:focus-visible` ring from the focusRing channel.

**Stories / tier** — Matrix, DisabledMatrix, IconMatrix, DisabledIconMatrix; promoted out of `_work_in_progress` → `components/Button`.

## Spec / token deltas (for the Coda / design-tokens layer)

The shims are temporary; upstream needs: importance modifier tokens generated; per-state modifier channels; `.caution` ghost channel + warning-ghost tokens; the `--color-icon-onForegroundPrimary[-disabled]` broken reference fixed; plus the spec edits (drop `variantSpecial`, radius token, `size` set, `branded` anticipation, "primary is default").

## QA

`cd packages/react/ds-global && bun run storybook` → **components/Button**. Check the four matrices: importance (fill/outline/text) × anticipation recolouring, hover/active/focus/disabled states, icon colour, and the loading button keeping its enabled background.

### PR readiness check
- [x] Label `Feature 🎁`.
- [x] Conventional Commits title.
- [x] Follows code standards.
- [x] Required scripts present.
- [ ] N/A — no new package.
- [ ] Visual testing — Chromatic renders the matrices/states.
