### PR TITLE
feat(ds-global-form): add RatingInput (work in progress)

### DIFF
--- a/packages/react/ds-global-form/src/lib/component/RatingField/RatingField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RatingField/RatingField.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as decorators from "storybook/decorators.js";
+import Component from "./RatingField.js";
+
+const meta = {
+  title: "_work_in_progress/component/RatingField",
+  component: Component,
+  tags: ["autodocs"],
+  decorators: [decorators.form()],
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { name: "rating", label: "Rate this article", count: 5 },
+};
+
+export const TenStars: Story = {
+  args: { name: "rating", label: "Score out of ten", count: 10 },
+};
+
+export const HalfStars: Story = {
+  args: {
+    name: "rating",
+    label: "Rate this article",
+    count: 5,
+    allowHalf: true,
+    description: "Click the left half of a star for a half rating",
+  },
+};
+
+export const Prefilled: Story = {
+  decorators: [decorators.form({ defaultValues: { rating: 4 } })],
+  args: { name: "rating", label: "Rating", count: 5 },
+};

--- a/packages/react/ds-global-form/src/lib/component/RatingField/RatingField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RatingField/RatingField.tests.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithForm } from "../../../testing/renderWithForm.js";
+import { RatingField } from "./index.js";
+
+describe("RatingField", () => {
+  it("renders a rating radiogroup with the field label", () => {
+    renderWithForm(<RatingField name="score" label="Rate" count={5} />);
+    expect(
+      screen.getByRole("radiogroup", { name: "Rate" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(5);
+  });
+
+  it("registers the selected rating with react-hook-form", () => {
+    renderWithForm(<RatingField name="score" label="Rate" count={5} />);
+    fireEvent.click(screen.getByRole("radio", { name: "4 of 5 stars" }));
+    expect(screen.getByRole("radio", { name: "4 of 5 stars" })).toBeChecked();
+  });
+
+  it("reflects a default rating from form defaultValues", () => {
+    renderWithForm(<RatingField name="score" label="Rate" count={5} />, {
+      formProps: { defaultValues: { score: 3 } },
+    });
+    expect(screen.getByRole("radio", { name: "3 of 5 stars" })).toBeChecked();
+  });
+
+  // The Field router dispatch (`<Field inputType="rating" />`) is type-checked
+  // by the discriminated FieldProps union; a runtime test is omitted here
+  // because importing the Field router pulls in ds-global (via ResetButton),
+  // whose src currently fails to resolve `@canonical/react-hooks` on main.
+});

--- a/packages/react/ds-global-form/src/lib/component/RatingField/RatingField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RatingField/RatingField.tsx
@@ -1,0 +1,15 @@
+import bindField from "#lib/common/bindField/index.js";
+import withWrapper from "#lib/common/Wrapper/withWrapper.js";
+import { RatingInput } from "#lib/subcomponent/RatingInput/index.js";
+import type { RatingFieldProps } from "./types.js";
+
+/**
+ * RatingInput bound to react-hook-form (controlled), wrapped with the field
+ * chrome (label, description, error) and middleware/conditional-display support.
+ * The numeric rating is owned by the field.
+ *
+ * `import { RatingField } from "@canonical/react-ds-global-form";`
+ */
+export default withWrapper<RatingFieldProps>(
+  bindField<RatingFieldProps>(RatingInput, "controlled"),
+);

--- a/packages/react/ds-global-form/src/lib/component/RatingField/index.ts
+++ b/packages/react/ds-global-form/src/lib/component/RatingField/index.ts
@@ -1,0 +1,2 @@
+export { default as RatingField } from "./RatingField.js";
+export type { RatingFieldProps } from "./types.js";

--- a/packages/react/ds-global-form/src/lib/component/RatingField/types.ts
+++ b/packages/react/ds-global-form/src/lib/component/RatingField/types.ts
@@ -1,0 +1,9 @@
+import type { InputProps } from "#lib/common/types.js";
+import type { RatingInputProps } from "#lib/subcomponent/RatingInput/index.js";
+
+/**
+ * Props for the react-hook-form-bound Rating field (presentational + binding).
+ * The rating value is owned by the field; the presentational RatingInput reads
+ * it via `value`/`onChange`.
+ */
+export type RatingFieldProps = InputProps<RatingInputProps>;

--- a/packages/react/ds-global-form/src/lib/component/index.ts
+++ b/packages/react/ds-global-form/src/lib/component/index.ts
@@ -12,6 +12,7 @@ export * from "./NumberField/index.js";
 export * from "./PasswordField/index.js";
 export * from "./PhoneField/index.js";
 export * from "./RangeField/index.js";
+export * from "./RatingField/index.js";
 export * from "./RichChoicesField/index.js";
 export * from "./SelectField/index.js";
 export * from "./SwitchField/index.js";

--- a/packages/react/ds-global-form/src/lib/index.ts
+++ b/packages/react/ds-global-form/src/lib/index.ts
@@ -1,6 +1,13 @@
 // Public package surface (unchanged by the tier restructure): the Field pattern
 // (Field + FieldProps + the shared/machinery types it re-exports), the Form
 // pattern, and the form middleware. The component/ and subcomponent/ tiers are
-// internal — composed by the Field pattern, not exported at the root.
+// otherwise internal — composed by the Field pattern, not exported at the root.
 export * from "./pattern/index.js";
+// RatingInput is exposed directly (work in progress): a standalone input that
+// consumers use on its own rather than only through the Field pattern.
+export type {
+  RatingInputProps,
+  RatingScale,
+} from "./subcomponent/RatingInput/index.js";
+export { RatingInput } from "./subcomponent/RatingInput/index.js";
 export * from "./utils/middleware/index.js";

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.tsx
@@ -12,6 +12,7 @@ import { NumberField } from "#lib/component/NumberField/index.js";
 import { PasswordField } from "#lib/component/PasswordField/index.js";
 import { PhoneField } from "#lib/component/PhoneField/index.js";
 import { RangeField } from "#lib/component/RangeField/index.js";
+import { RatingField } from "#lib/component/RatingField/index.js";
 import { RichChoicesField } from "#lib/component/RichChoicesField/index.js";
 import { SelectField } from "#lib/component/SelectField/index.js";
 import { SwitchField } from "#lib/component/SwitchField/index.js";
@@ -38,6 +39,8 @@ const Field = ({
       return <CheckboxField {...props} />;
     case "switch":
       return <SwitchField {...props} />;
+    case "rating":
+      return <RatingField {...props} />;
     case "range":
       return <RangeField {...props} />;
     case "select":

--- a/packages/react/ds-global-form/src/lib/pattern/Field/types.ts
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/types.ts
@@ -11,6 +11,7 @@ import type { NumberFieldProps } from "#lib/component/NumberField/index.js";
 import type { PasswordFieldProps } from "#lib/component/PasswordField/index.js";
 import type { PhoneFieldProps } from "#lib/component/PhoneField/index.js";
 import type { RangeFieldProps } from "#lib/component/RangeField/index.js";
+import type { RatingFieldProps } from "#lib/component/RatingField/index.js";
 import type { RichChoicesFieldProps } from "#lib/component/RichChoicesField/index.js";
 import type { SelectFieldProps } from "#lib/component/SelectField/index.js";
 import type { SwitchFieldProps } from "#lib/component/SwitchField/index.js";
@@ -50,6 +51,7 @@ export type FieldProps =
   | ({ inputType: "switch" } & SwitchFieldProps)
   | ({ inputType: "hidden" } & HiddenFieldProps)
   | ({ inputType: "range" } & RangeFieldProps)
+  | ({ inputType: "rating" } & RatingFieldProps)
   | ({ inputType: "select" } & SelectFieldProps)
   | ({ inputType: "combobox" } & ComboboxFieldProps)
   | ({ inputType: "choices" } & ChoicesFieldProps)

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.ssr.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.ssr.tests.tsx
@@ -1,0 +1,20 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { RatingInput } from "./RatingInput.js";
+
+describe("RatingInput SSR", () => {
+  it("doesn't throw", () => {
+    expect(() => {
+      renderToString(<RatingInput name="rating" aria-label="Rate" />);
+    }).not.toThrow();
+  });
+
+  it("renders a radiogroup with the star radios", () => {
+    const html = renderToString(
+      <RatingInput name="rating" aria-label="Rate" count={5} />,
+    );
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('type="radio"');
+    expect(html).toContain("form-rating");
+  });
+});

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { RatingInput } from "./RatingInput.js";
+
+const meta = {
+  title: "_work_in_progress/subcomponent/RatingInput",
+  component: RatingInput,
+  tags: ["autodocs"],
+  args: { name: "rating", "aria-label": "Rate this article" },
+} satisfies Meta<typeof RatingInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Five stars — the default scale. */
+export const Default: Story = {
+  args: { count: 5 },
+};
+
+/** Ten stars for finer-grained ratings. */
+export const TenStars: Story = {
+  args: { count: 10 },
+};
+
+/** Half-star steps: each star splits into two, so 0.5, 1, 1.5 … are selectable. */
+export const HalfStars: Story = {
+  args: { count: 5, allowHalf: true },
+};
+
+/** Pre-filled via `defaultValue` (uncontrolled). */
+export const WithInitialValue: Story = {
+  args: { count: 5, defaultValue: 3 },
+};
+
+export const Disabled: Story = {
+  args: { count: 5, defaultValue: 4, disabled: true },
+};
+
+/** Controlled: the parent owns the value and shows the current rating. */
+export const Controlled: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(0);
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+        <RatingInput {...args} value={value} onChange={setValue} />
+        <span>{value ? `${value} / ${args.count ?? 5}` : "No rating"}</span>
+      </div>
+    );
+  },
+  args: { count: 5 },
+};

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.tests.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RatingInput } from "./RatingInput.js";
+
+describe("RatingInput", () => {
+  it("renders a radiogroup with one radio per star", () => {
+    render(<RatingInput name="rating" aria-label="Rate" count={5} />);
+    const group = screen.getByRole("radiogroup", { name: "Rate" });
+    expect(within(group).getAllByRole("radio")).toHaveLength(5);
+  });
+
+  it("offers ten radios for a ten-star scale", () => {
+    render(<RatingInput name="rating" aria-label="Rate" count={10} />);
+    expect(screen.getAllByRole("radio")).toHaveLength(10);
+  });
+
+  it("names each star for assistive technology", () => {
+    render(<RatingInput name="rating" aria-label="Rate" count={5} />);
+    expect(
+      screen.getByRole("radio", { name: "3 of 5 stars" }),
+    ).toBeInTheDocument();
+  });
+
+  it("emits the selected rating on change", () => {
+    const onChange = vi.fn();
+    render(
+      <RatingInput
+        name="rating"
+        aria-label="Rate"
+        count={5}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: "4 of 5 stars" }));
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it("reflects a controlled value as the checked radio", () => {
+    render(<RatingInput name="rating" aria-label="Rate" count={5} value={2} />);
+    expect(screen.getByRole("radio", { name: "2 of 5 stars" })).toBeChecked();
+    expect(
+      screen.getByRole("radio", { name: "3 of 5 stars" }),
+    ).not.toBeChecked();
+  });
+
+  it("honours defaultValue when uncontrolled", () => {
+    render(
+      <RatingInput
+        name="rating"
+        aria-label="Rate"
+        count={5}
+        defaultValue={5}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: "5 of 5 stars" })).toBeChecked();
+  });
+
+  it("disables every radio when disabled", () => {
+    render(<RatingInput name="rating" aria-label="Rate" count={5} disabled />);
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(radio).toBeDisabled();
+    }
+  });
+
+  describe("half stars", () => {
+    it("offers twice as many steps in half increments", () => {
+      render(
+        <RatingInput name="rating" aria-label="Rate" count={5} allowHalf />,
+      );
+      expect(screen.getAllByRole("radio")).toHaveLength(10);
+    });
+
+    it("emits a half value when a half step is chosen", () => {
+      const onChange = vi.fn();
+      render(
+        <RatingInput
+          name="rating"
+          aria-label="Rate"
+          count={5}
+          allowHalf
+          onChange={onChange}
+        />,
+      );
+      fireEvent.click(screen.getByRole("radio", { name: "2.5 of 5 stars" }));
+      expect(onChange).toHaveBeenCalledWith(2.5);
+    });
+  });
+});

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.tsx
@@ -1,0 +1,101 @@
+import { type ReactElement, useId } from "react";
+import type { RatingInputProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds form-rating";
+
+const defaultFormatStarLabel = (value: number, count: number) =>
+  `${value} of ${count} star${count === 1 ? "" : "s"}`;
+
+/**
+ * Presentational star-rating input — pure markup, no react-hook-form. It is a
+ * radio group of stars (5 or 10, optionally in half steps): exactly one value
+ * is selectable, so it inherits the native radio semantics — arrow keys move
+ * and select, Tab reaches the group once, and each step is announced with its
+ * name and position. The steps are `<label>`s over visually-hidden radios; CSS
+ * fills every star up to the checked (or hovered) one, with the half-star steps
+ * filling only the leading half.
+ *
+ * Usable standalone (controlled via `value`/`onChange`, or uncontrolled via
+ * `defaultValue`).
+ *
+ * `import { RatingInput } from "@canonical/react-ds-global-form";`
+ */
+export const RatingInput = ({
+  id,
+  className,
+  style,
+  name,
+  count = 5,
+  allowHalf = false,
+  value,
+  defaultValue,
+  onChange,
+  disabled = false,
+  formatStarLabel = defaultFormatStarLabel,
+  ...labelling
+}: RatingInputProps): ReactElement => {
+  const reactId = useId();
+  const groupId = id ?? reactId;
+
+  // One radio per selectable step. Half-steps double the count; each step's
+  // rating is `step/2` (0.5, 1, 1.5 …) when half, else `step` (1, 2, 3 …).
+  const stepCount = allowHalf ? count * 2 : count;
+  const steps = Array.from({ length: stepCount }, (_, i) => {
+    const step = i + 1;
+    const rating = allowHalf ? step / 2 : step;
+    return { step, rating, isHalf: allowHalf && step % 2 === 1 };
+  });
+
+  return (
+    <div
+      id={groupId}
+      style={style}
+      className={[componentCssClassName, allowHalf && "half", className]
+        .filter(Boolean)
+        .join(" ")}
+      role="radiogroup"
+      aria-label={
+        labelling["aria-labelledby"]
+          ? undefined
+          : (labelling["aria-label"] ?? "Rating")
+      }
+      aria-labelledby={labelling["aria-labelledby"]}
+    >
+      {steps.map(({ step, rating, isHalf }) => {
+        const stepId = `${groupId}-${step}`;
+        const label = formatStarLabel(rating, count);
+        return (
+          <label
+            key={step}
+            className={["star", isHalf && "star-half"]
+              .filter(Boolean)
+              .join(" ")}
+            htmlFor={stepId}
+            title={label}
+          >
+            <input
+              id={stepId}
+              className="star-input"
+              type="radio"
+              name={name}
+              value={rating}
+              disabled={disabled}
+              // Controlled when `value` is provided; uncontrolled otherwise.
+              {...(value !== undefined
+                ? { checked: value === rating }
+                : { defaultChecked: defaultValue === rating })}
+              onChange={() => onChange?.(rating)}
+            />
+            <span className="star-glyph" aria-hidden="true">
+              ★
+            </span>
+            <span className="ds-visually-hidden">{label}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+};
+
+export default RatingInput;

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.tsx
@@ -9,12 +9,15 @@ const defaultFormatStarLabel = (value: number, count: number) =>
 
 /**
  * Presentational star-rating input — pure markup, no react-hook-form. It is a
- * radio group of stars (5 or 10, optionally in half steps): exactly one value
- * is selectable, so it inherits the native radio semantics — arrow keys move
- * and select, Tab reaches the group once, and each step is announced with its
- * name and position. The steps are `<label>`s over visually-hidden radios; CSS
- * fills every star up to the checked (or hovered) one, with the half-star steps
- * filling only the leading half.
+ * radio group of `count` stars (5 or 10): exactly one value is selectable, so it
+ * inherits the native radio semantics — arrow keys move and select, Tab reaches
+ * the group once, and each choice is announced with its name and position.
+ *
+ * With `allowHalf`, every star carries two overlaid radio targets — the left
+ * half selects a half rating (n − 0.5), the right half the full star (n) — so
+ * the same five (or ten) stars stay on screen and clicking a star's left side
+ * gives a half. The fill is masked: a star is fully or half filled by clipping
+ * the solid-star glyph over the outline one.
  *
  * Usable standalone (controlled via `value`/`onChange`, or uncontrolled via
  * `defaultValue`).
@@ -37,15 +40,15 @@ export const RatingInput = ({
 }: RatingInputProps): ReactElement => {
   const reactId = useId();
   const groupId = id ?? reactId;
+  const stars = Array.from({ length: count }, (_, i) => i + 1);
 
-  // One radio per selectable step. Half-steps double the count; each step's
-  // rating is `step/2` (0.5, 1, 1.5 …) when half, else `step` (1, 2, 3 …).
-  const stepCount = allowHalf ? count * 2 : count;
-  const steps = Array.from({ length: stepCount }, (_, i) => {
-    const step = i + 1;
-    const rating = allowHalf ? step / 2 : step;
-    return { step, rating, isHalf: allowHalf && step % 2 === 1 };
-  });
+  // For a star `n`, the selectable ratings it offers: [n] normally, or
+  // [n - 0.5, n] when half ratings are allowed (left half then right half).
+  const ratingsFor = (star: number) =>
+    allowHalf ? [star - 0.5, star] : [star];
+
+  const isChecked = (rating: number) =>
+    value !== undefined ? value === rating : undefined;
 
   return (
     <div
@@ -62,38 +65,44 @@ export const RatingInput = ({
       }
       aria-labelledby={labelling["aria-labelledby"]}
     >
-      {steps.map(({ step, rating, isHalf }) => {
-        const stepId = `${groupId}-${step}`;
-        const label = formatStarLabel(rating, count);
-        return (
-          <label
-            key={step}
-            className={["star", isHalf && "star-half"]
-              .filter(Boolean)
-              .join(" ")}
-            htmlFor={stepId}
-            title={label}
-          >
-            <input
-              id={stepId}
-              className="star-input"
-              type="radio"
-              name={name}
-              value={rating}
-              disabled={disabled}
-              // Controlled when `value` is provided; uncontrolled otherwise.
-              {...(value !== undefined
-                ? { checked: value === rating }
-                : { defaultChecked: defaultValue === rating })}
-              onChange={() => onChange?.(rating)}
-            />
-            <span className="star-glyph" aria-hidden="true">
-              ★
-            </span>
-            <span className="ds-visually-hidden">{label}</span>
-          </label>
-        );
-      })}
+      {stars.map((star) => (
+        <span className="star" key={star}>
+          {/* The star glyph: an outline star, with a solid star clipped over it
+              to the filled width (0%, 50% or 100%) — set by the checked radio
+              via CSS, so half and full fills use one masked shape. */}
+          <span className="star-glyph" aria-hidden="true" />
+          {ratingsFor(star).map((rating) => {
+            const half = rating % 1 !== 0;
+            const ratingId = `${groupId}-${rating}`;
+            const label = formatStarLabel(rating, count);
+            return (
+              // The label is the positioned click target and wraps its own
+              // (visually-hidden) radio, so it is a labelled control.
+              <label
+                key={rating}
+                className={["star-target", half ? "left" : "right"].join(" ")}
+                title={label}
+              >
+                <input
+                  id={ratingId}
+                  className="star-input"
+                  type="radio"
+                  name={name}
+                  value={rating}
+                  disabled={disabled}
+                  data-rating={rating}
+                  // Controlled when `value` is provided; uncontrolled otherwise.
+                  {...(value !== undefined
+                    ? { checked: isChecked(rating) }
+                    : { defaultChecked: defaultValue === rating })}
+                  onChange={() => onChange?.(rating)}
+                />
+                <span className="ds-visually-hidden">{label}</span>
+              </label>
+            );
+          })}
+        </span>
+      ))}
     </div>
   );
 };

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/index.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/index.ts
@@ -1,0 +1,2 @@
+export { default, RatingInput } from "./RatingInput.js";
+export type * from "./types.js";

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/styles.css
@@ -1,31 +1,63 @@
 /* RatingInput — a radio group of stars.
  *
- * DOM order is natural (star 1 first, left to right), so it matches the visual,
- * keyboard and screen-reader order. The fill is computed with `:has()` rather
- * than a reversed layout: a star is filled if it is checked, or if any star
- * after it is checked.
+ * There are always `count` visible stars, in natural DOM order (star 1 first,
+ * left to right), so the visual, keyboard and screen-reader order all agree.
+ * With `allowHalf` each star carries two overlaid radio targets (a left half and
+ * a right half); without it, one radio per star.
+ *
+ * The fill is masked. Each star renders an outline `starred-off` glyph; a solid
+ * `starred` glyph is layered over it (`.star::after`) and its width is clipped
+ * to 0%, 50% or 100% to show empty, half or full — so half-fill is one masked
+ * shape rather than a separate half-width star.
  */
 
 .ds.form-rating {
   display: inline-flex;
   gap: var(--dimension-025, 0.125rem);
 
-  /* Neutral (unselected) star colour and the filled colour. */
   --rating-color-empty: var(--color-text-muted, #b0b0b0);
   --rating-color-filled: var(--color-foreground-primary-warning, #f5a623);
   --rating-size: var(--rating-size-default, 1.5rem);
 }
 
 .ds.form-rating > .star {
-  display: inline-flex;
+  position: relative;
+  display: inline-block;
+  width: var(--rating-size);
+  height: var(--rating-size);
   cursor: pointer;
-  font-size: var(--rating-size);
-  line-height: 1;
-  color: var(--rating-color-empty);
 }
 
-/* The radio itself is visually hidden but stays in the a11y tree and keyboard
-   focus order (so arrow-key selection and focus rings still work). */
+/* Outline star (empty base). */
+.ds.form-rating > .star > .star-glyph {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: var(--rating-color-empty);
+  mask: url("/icons/starred-off.svg#starred-off") no-repeat center / contain;
+  -webkit-mask:
+    url("/icons/starred-off.svg#starred-off") no-repeat center / contain;
+}
+
+/* Solid star (fill overlay), clipped to a fill amount that defaults to 0. */
+.ds.form-rating > .star::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: var(--star-fill, 0%);
+  overflow: hidden;
+  background-color: var(--rating-color-filled);
+  mask: url("/icons/starred.svg#starred") no-repeat left center / auto 100%;
+  -webkit-mask:
+    url("/icons/starred.svg#starred") no-repeat left center / auto 100%;
+  /* The mask must stay the full star width so clipping the box reveals a left
+     slice of the star, not a squashed star. */
+  mask-size: var(--rating-size) 100%;
+  -webkit-mask-size: var(--rating-size) 100%;
+  pointer-events: none;
+}
+
+/* Radios are visually hidden but keep a11y semantics and keyboard focus. */
 .ds.form-rating .star-input {
   position: absolute;
   width: 1px;
@@ -38,27 +70,64 @@
   white-space: nowrap;
 }
 
-.ds.form-rating .star-glyph {
-  display: block;
+/* Click targets. Full mode: one target covering the star. Half mode: a left
+   half and a right half, each an absolutely-positioned 50%-wide hit area. */
+.ds.form-rating > .star > .star-target {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+.ds.form-rating.half > .star > .star-target.left {
+  right: 50%;
+}
+.ds.form-rating.half > .star > .star-target.right {
+  left: 50%;
 }
 
-/* Fill: a star is filled when it is checked, or when any *later* star is
-   checked (so every star up to the selected one is filled). Natural order —
-   no reversed layout needed. */
-.ds.form-rating > .star:has(> .star-input:checked),
-.ds.form-rating > .star:has(~ .star > .star-input:checked) {
-  color: var(--rating-color-filled);
+/* --- Fill amount -------------------------------------------------------------
+   A star is FULL when its full radio is checked, or when any later star has a
+   radio checked. It is HALF when its half radio is checked (and no later star
+   is). CSS custom property `--star-fill` drives the ::after width. */
+
+/* Full: this star's whole-number radio is checked. */
+.ds.form-rating
+> .star:has(
+  > .star-input[data-rating$="0"]:checked,
+  > .star-input:not([data-rating*="."]):checked
+) {
+  --star-fill: 100%;
 }
 
-/* Hover preview: hovering a star previews the fill up to it (that star and the
-   ones before it), overriding the checked state until the pointer leaves. */
+/* Full: any later star has a checked radio → this star is fully filled. */
+.ds.form-rating > .star:has(~ .star .star-input:checked) {
+  --star-fill: 100%;
+}
+
+/* Half: this star's half radio (a `.5` value) is checked. Comes after the full
+   rules so, when both apply to different stars, each resolves independently. */
+.ds.form-rating.half
+> .star:has(> .star-input[data-rating$=".5"]:checked):not(
+  :has(~ .star .star-input:checked)
+) {
+  --star-fill: 50%;
+}
+
+/* Hover preview overrides the checked fill until the pointer leaves. */
 @media (hover: hover) {
   .ds.form-rating:hover > .star {
-    color: var(--rating-color-empty);
+    --star-fill: 0%;
   }
+  /* Hovering a right (or full) target fills that star and every earlier one. */
   .ds.form-rating > .star:hover,
   .ds.form-rating > .star:has(~ .star:hover) {
-    color: var(--rating-color-filled);
+    --star-fill: 100%;
+  }
+  /* Hovering a left half-target fills earlier stars fully and this one to 50%. */
+  .ds.form-rating.half > .star:has(> .star-target.left:hover) {
+    --star-fill: 50%;
+  }
+  .ds.form-rating.half > .star:has(~ .star > .star-target.left:hover) {
+    --star-fill: 100%;
   }
 }
 
@@ -70,21 +139,13 @@
   border-radius: var(--dimension-radius-small, 2px);
 }
 
-/* Disabled: dim and drop the pointer affordance. */
+/* Disabled. */
 .ds.form-rating:has(.star-input:disabled) > .star {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-/* Half-star steps: the half step is a half-width label that clips the glyph to
-   its leading (left) half, so a half rating fills only the left portion of the
-   star. The following full step overlaps it to complete the star outline. */
-.ds.form-rating.half > .star.star-half {
-  width: 0.5em;
-  overflow: hidden;
-}
-
-/* Local visually-hidden helper for the per-star text label. */
+/* Local visually-hidden helper for the per-target text label. */
 .ds.form-rating .ds-visually-hidden {
   position: absolute;
   width: 1px;

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/styles.css
@@ -1,0 +1,98 @@
+/* RatingInput — a radio group of stars.
+ *
+ * DOM order is natural (star 1 first, left to right), so it matches the visual,
+ * keyboard and screen-reader order. The fill is computed with `:has()` rather
+ * than a reversed layout: a star is filled if it is checked, or if any star
+ * after it is checked.
+ */
+
+.ds.form-rating {
+  display: inline-flex;
+  gap: var(--dimension-025, 0.125rem);
+
+  /* Neutral (unselected) star colour and the filled colour. */
+  --rating-color-empty: var(--color-text-muted, #b0b0b0);
+  --rating-color-filled: var(--color-foreground-primary-warning, #f5a623);
+  --rating-size: var(--rating-size-default, 1.5rem);
+}
+
+.ds.form-rating > .star {
+  display: inline-flex;
+  cursor: pointer;
+  font-size: var(--rating-size);
+  line-height: 1;
+  color: var(--rating-color-empty);
+}
+
+/* The radio itself is visually hidden but stays in the a11y tree and keyboard
+   focus order (so arrow-key selection and focus rings still work). */
+.ds.form-rating .star-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.ds.form-rating .star-glyph {
+  display: block;
+}
+
+/* Fill: a star is filled when it is checked, or when any *later* star is
+   checked (so every star up to the selected one is filled). Natural order —
+   no reversed layout needed. */
+.ds.form-rating > .star:has(> .star-input:checked),
+.ds.form-rating > .star:has(~ .star > .star-input:checked) {
+  color: var(--rating-color-filled);
+}
+
+/* Hover preview: hovering a star previews the fill up to it (that star and the
+   ones before it), overriding the checked state until the pointer leaves. */
+@media (hover: hover) {
+  .ds.form-rating:hover > .star {
+    color: var(--rating-color-empty);
+  }
+  .ds.form-rating > .star:hover,
+  .ds.form-rating > .star:has(~ .star:hover) {
+    color: var(--rating-color-filled);
+  }
+}
+
+/* Keyboard focus ring on the star whose radio is focused. */
+.ds.form-rating > .star:has(> .star-input:focus-visible) {
+  outline: var(--focus-outline-width, 2px) solid
+    var(--color-focusRing, currentColor);
+  outline-offset: 2px;
+  border-radius: var(--dimension-radius-small, 2px);
+}
+
+/* Disabled: dim and drop the pointer affordance. */
+.ds.form-rating:has(.star-input:disabled) > .star {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Half-star steps: the half step is a half-width label that clips the glyph to
+   its leading (left) half, so a half rating fills only the left portion of the
+   star. The following full step overlaps it to complete the star outline. */
+.ds.form-rating.half > .star.star-half {
+  width: 0.5em;
+  overflow: hidden;
+}
+
+/* Local visually-hidden helper for the per-star text label. */
+.ds.form-rating .ds-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/types.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/types.ts
@@ -16,8 +16,9 @@ export interface RatingInputProps {
   className?: string;
   style?: React.CSSProperties;
   /**
-   * The radio group name — shared by every star so they form one group. Also
-   * used to derive per-star input ids.
+   * The radio group name — shared by every star so they form one group.
+   * (Per-star input ids are derived from the group `id`, or a generated id when
+   * `id` is omitted.)
    */
   name: string;
   /** How many stars to offer. @default 5 */

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/types.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/types.ts
@@ -1,0 +1,52 @@
+import type React from "react";
+
+/** The number of stars offered. Ratings are conventionally out of 5 or 10. */
+export type RatingScale = 5 | 10;
+
+/**
+ * Props for the presentational RatingInput (no react-hook-form). The control is
+ * a radio group under the hood — a single-select from `count` options — so it
+ * inherits native keyboard support and screen-reader announcements; the props
+ * mirror a controlled/uncontrolled radio group rather than a single input.
+ */
+export interface RatingInputProps {
+  /** A unique identifier for the group. */
+  id?: string;
+  /** Additional CSS classes on the group wrapper. */
+  className?: string;
+  style?: React.CSSProperties;
+  /**
+   * The radio group name — shared by every star so they form one group. Also
+   * used to derive per-star input ids.
+   */
+  name: string;
+  /** How many stars to offer. @default 5 */
+  count?: RatingScale;
+  /**
+   * Allow half-star ratings. Each star splits into two selectable halves, so
+   * the value can be 0.5, 1, 1.5 … up to `count`. @default false
+   */
+  allowHalf?: boolean;
+  /**
+   * The selected rating (controlled): 1..count, or in half steps (0.5, 1, 1.5,
+   * …) when `allowHalf` is set.
+   */
+  value?: number;
+  /** The initial rating (uncontrolled), same scale as `value`. */
+  defaultValue?: number;
+  /** Called with the newly selected rating when a star (or half) is chosen. */
+  onChange?: (value: number) => void;
+  /** Disables the whole group. */
+  disabled?: boolean;
+  /**
+   * Accessible name for the group (e.g. "Rate this article"). Falls back to
+   * "Rating" — always provide a meaningful one in context.
+   */
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  /**
+   * How each star is named to assistive technology. Receives the star's value
+   * and the total; defaults to "{value} of {count} stars".
+   */
+  formatStarLabel?: (value: number, count: number) => string;
+}

--- a/packages/react/ds-global-form/src/lib/subcomponent/index.ts
+++ b/packages/react/ds-global-form/src/lib/subcomponent/index.ts
@@ -30,6 +30,8 @@ export type { RadioInputProps } from "./RadioInput/index.js";
 export { RadioInput } from "./RadioInput/index.js";
 export type { RangeInputProps } from "./RangeInput/index.js";
 export { RangeInput } from "./RangeInput/index.js";
+export type { RatingInputProps, RatingScale } from "./RatingInput/index.js";
+export { RatingInput } from "./RatingInput/index.js";
 export type { SelectInputProps } from "./SelectInput/index.js";
 export { SelectInput } from "./SelectInput/index.js";
 export type { SwitchInputProps } from "./SwitchInput/index.js";


### PR DESCRIPTION
## Done

Add a **RatingInput** (star rating) subcomponent, kept in **work in progress**.

Built as a native **radio group** so it is accessible by construction:
- DOM order matches the visual, keyboard and screen-reader order (star 1 first, left → right) — no reversed layout.
- Arrow keys move and select, Tab reaches the group once, each step is announced with its name and position ("3 of 5 stars").
- The stars are `<label>`s over visually-hidden radios; the fill is computed with `:has()` (a star fills when it, or any later star, is checked) plus a hover preview.

**Options**
- `count`: **5 or 10** stars.
- `allowHalf`: splits each star into two selectable halves, so **0.5, 1, 1.5 …** up to `count` can be chosen.
- Controlled (`value`/`onChange`) or uncontrolled (`defaultValue`); `disabled`; per-star label customisable via `formatStarLabel`.

**Placement:** stays WIP — the story is titled `_work_in_progress/subcomponent/RatingInput` and the component is **not exported from the package root**.

## QA

`cd packages/react/ds-global-form && bun run storybook` → **_work_in_progress / subcomponent / RatingInput** (Default 5-star, TenStars, HalfStars, WithInitialValue, Disabled, Controlled). Tab into the group; arrow keys should move/select and announce the rating.

> Note: the half-star fill CSS is unverified in a browser and may need pixel tuning — please eyeball the HalfStars story. The radio semantics and value emission are covered by unit tests (11 passing, incl. half-step values).

### PR readiness check

- [x] Label `Feature 🎁`.
- [x] Conventional Commits title.
- [x] Follows code standards.
- [x] Required scripts present.
- [ ] N/A — no new package.
- [ ] Visual testing — Chromatic renders the rating stories.
