### PR TITLE
fix(task): route effect exceptions through recovery and trampoline preview/undo interpreters

### DIFF
--- a/packages/runtime/task/src/lib/driveSync.test.ts
+++ b/packages/runtime/task/src/lib/driveSync.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import driveSync from "./driveSync.js";
+import { TaskExecutionError } from "./interpreter.js";
+import { effect, fail, flatMap, pure, recover } from "./task.js";
+import type { Effect, Task } from "./types.js";
+
+const failIfCalled = (): unknown => {
+  throw new Error("resolveEffect should not be called for effect-free tasks");
+};
+
+describe("driveSync", () => {
+  it("returns the value of a pure task", () => {
+    const task: Task<unknown> = pure(42);
+
+    expect(driveSync(task, failIfCalled)).toBe(42);
+  });
+
+  it("drives a flatMap chain to its final value", () => {
+    const task: Task<unknown> = flatMap(pure(1), (x) =>
+      flatMap(pure(2), (y) => pure(x + y)),
+    );
+
+    expect(driveSync(task, failIfCalled)).toBe(3);
+  });
+
+  it("resolves each leaf effect through resolveEffect and threads the result", () => {
+    const seen: Effect[] = [];
+    const task: Task<unknown> = effect<string>({
+      _tag: "ReadFile",
+      path: "/x",
+    });
+
+    const value = driveSync(task, (leaf) => {
+      seen.push(leaf);
+      return "content";
+    });
+
+    expect(value).toBe("content");
+    expect(seen).toHaveLength(1);
+    expect(seen.at(0)?._tag).toBe("ReadFile");
+  });
+
+  it("routes a Fail to the nearest recover handler", () => {
+    const task: Task<unknown> = recover(
+      fail<number>({ code: "BOOM", message: "boom" }),
+      (err) => pure(`recovered:${err.code}`),
+    );
+
+    expect(driveSync(task, failIfCalled)).toBe("recovered:BOOM");
+  });
+
+  it("throws TaskExecutionError when a Fail has no recover frame", () => {
+    const task: Task<unknown> = fail<number>({ code: "BOOM", message: "boom" });
+
+    expect(() => driveSync(task, failIfCalled)).toThrow(TaskExecutionError);
+  });
+
+  it("routes a TaskExecutionError thrown by resolveEffect to recover", () => {
+    const task: Task<unknown> = recover(
+      effect<string>({ _tag: "ReadFile", path: "/x" }),
+      (err) => pure(`recovered:${err.code}`),
+    );
+
+    const value = driveSync(task, () => {
+      throw new TaskExecutionError({ code: "IO", message: "io" });
+    });
+
+    expect(value).toBe("recovered:IO");
+  });
+
+  it("propagates a non-TaskExecutionError thrown by resolveEffect", () => {
+    const task: Task<unknown> = effect<string>({
+      _tag: "ReadFile",
+      path: "/x",
+    });
+
+    expect(() =>
+      driveSync(task, () => {
+        throw new Error("raw");
+      }),
+    ).toThrow("raw");
+  });
+
+  it("discards recover frames on the success path", () => {
+    const task: Task<unknown> = flatMap(
+      recover(pure(1), () => pure(-1)),
+      (x) => pure(x + 1),
+    );
+
+    expect(driveSync(task, failIfCalled)).toBe(2);
+  });
+
+  it("is stack-safe on a deep flatMap chain", () => {
+    let task: Task<number> = pure(0);
+    for (let i = 0; i < 100_000; i++) {
+      task = flatMap(task, (x) => pure(x + 1));
+    }
+
+    expect(driveSync(task as Task<unknown>, failIfCalled)).toBe(100_000);
+  });
+});

--- a/packages/runtime/task/src/lib/driveSync.test.ts
+++ b/packages/runtime/task/src/lib/driveSync.test.ts
@@ -96,6 +96,6 @@ describe("driveSync", () => {
       task = flatMap(task, (x) => pure(x + 1));
     }
 
-    expect(driveSync(task as Task<unknown>, failIfCalled)).toBe(100_000);
+    expect(driveSync(task, failIfCalled)).toBe(100_000);
   });
 });

--- a/packages/runtime/task/src/lib/driveSync.ts
+++ b/packages/runtime/task/src/lib/driveSync.ts
@@ -7,8 +7,6 @@
  * explicit continuation/handler-frame stack rather than by recursing through
  * the task structure, so arbitrarily long `flatMap`/`gen` chains run in
  * constant call-stack depth.
- *
- * @packageDocumentation
  */
 
 import { TaskExecutionError } from "./interpreter.js";

--- a/packages/runtime/task/src/lib/driveSync.ts
+++ b/packages/runtime/task/src/lib/driveSync.ts
@@ -40,10 +40,10 @@ type SyncFrame =
  * @note Impure — `resolveEffect` typically records effects or mutates caller
  * state.
  */
-export const driveSync = (
+export default function driveSync(
   root: Task<unknown>,
   resolveEffect: (effect: Effect) => unknown,
-): unknown => {
+): unknown {
   const stack: SyncFrame[] = [];
   let cur: Task<unknown> = root;
 
@@ -109,4 +109,4 @@ export const driveSync = (
         break;
     }
   }
-};
+}

--- a/packages/runtime/task/src/lib/driveSync.ts
+++ b/packages/runtime/task/src/lib/driveSync.ts
@@ -1,0 +1,114 @@
+/**
+ * Synchronous Task trampoline.
+ *
+ * The shared engine behind the preview interpreters (`dryRun`, `dryRunWith`,
+ * `collectEffects`) and the undo collector (`collectUndos`). Like the
+ * production `runTask` interpreter, it realises bind and error-recovery on an
+ * explicit continuation/handler-frame stack rather than by recursing through
+ * the task structure, so arbitrarily long `flatMap`/`gen` chains run in
+ * constant call-stack depth.
+ *
+ * @packageDocumentation
+ */
+
+import { TaskExecutionError } from "./interpreter.js";
+import type { Effect, Task, TaskError } from "./types.js";
+
+/**
+ * A frame on the synchronous interpreter's continuation stack: either a pending
+ * bind (the `f` of a `FlatMap`) or an installed error-recovery handler (the
+ * `handler` of a `Recover`).
+ */
+type SyncFrame =
+  | { kind: "bind"; f: (x: unknown) => Task<unknown> }
+  | { kind: "recover"; handler: (error: TaskError) => Task<unknown> };
+
+/**
+ * Drive a task to its final value synchronously, resolving each leaf effect
+ * through `resolveEffect`.
+ *
+ * `resolveEffect` returns the value a leaf effect would produce (a mock, a
+ * collected placeholder, and so on) and may record effects or mutate caller
+ * state as a side effect. Structural `Parallel`/`Race` effects are resolved by
+ * the caller inside `resolveEffect`, typically by driving their children. A
+ * `Fail` node — or a {@link TaskExecutionError} thrown by `resolveEffect` —
+ * unwinds to the nearest recovery frame; with none installed it throws
+ * `TaskExecutionError`, matching the production interpreter. Any other thrown
+ * value propagates unchanged.
+ *
+ * @param root - The task to drive.
+ * @param resolveEffect - Produces the result for each leaf effect.
+ * @returns The task's final value.
+ * @note Impure — `resolveEffect` typically records effects or mutates caller
+ * state.
+ */
+export const driveSync = (
+  root: Task<unknown>,
+  resolveEffect: (effect: Effect) => unknown,
+): unknown => {
+  const stack: SyncFrame[] = [];
+  let cur: Task<unknown> = root;
+
+  // Unwind to the nearest recovery frame, discarding pending binds. With no
+  // recovery frame installed the error escapes as a TaskExecutionError.
+  const recoverFrom = (error: TaskError): Task<unknown> => {
+    while (stack.length > 0) {
+      const frame = stack.pop();
+      if (frame?.kind === "recover") {
+        return frame.handler(error);
+      }
+    }
+    throw new TaskExecutionError(error);
+  };
+
+  for (;;) {
+    switch (cur._tag) {
+      case "FlatMap":
+        stack.push({ kind: "bind", f: cur.f });
+        cur = cur.inner;
+        break;
+
+      case "Recover":
+        stack.push({ kind: "recover", handler: cur.handler });
+        cur = cur.inner;
+        break;
+
+      case "Effect": {
+        let result: unknown;
+        try {
+          result = resolveEffect(cur.effect);
+        } catch (thrown) {
+          if (thrown instanceof TaskExecutionError) {
+            cur = recoverFrom(thrown.taskError);
+            break;
+          }
+          throw thrown;
+        }
+        cur = cur.cont(result);
+        break;
+      }
+
+      case "Pure": {
+        // Success: unwind to the next bind frame, discarding recovery frames.
+        const value = cur.value;
+        let resumed = false;
+        while (stack.length > 0) {
+          const frame = stack.pop() as SyncFrame;
+          if (frame.kind === "bind") {
+            cur = frame.f(value);
+            resumed = true;
+            break;
+          }
+        }
+        if (!resumed) {
+          return value;
+        }
+        break;
+      }
+
+      case "Fail":
+        cur = recoverFrom(cur.error);
+        break;
+    }
+  }
+};

--- a/packages/runtime/task/src/lib/driveSync.ts
+++ b/packages/runtime/task/src/lib/driveSync.ts
@@ -1,14 +1,3 @@
-/**
- * Synchronous Task trampoline.
- *
- * The shared engine behind the preview interpreters (`dryRun`, `dryRunWith`,
- * `collectEffects`) and the undo collector (`collectUndos`). Like the
- * production `runTask` interpreter, it realises bind and error-recovery on an
- * explicit continuation/handler-frame stack rather than by recursing through
- * the task structure, so arbitrarily long `flatMap`/`gen` chains run in
- * constant call-stack depth.
- */
-
 import { TaskExecutionError } from "./interpreter.js";
 import type { Effect, Task, TaskError } from "./types.js";
 
@@ -23,7 +12,12 @@ type SyncFrame =
 
 /**
  * Drive a task to its final value synchronously, resolving each leaf effect
- * through `resolveEffect`.
+ * through `resolveEffect`. This is the shared engine behind the preview
+ * interpreters (`dryRun`, `dryRunWith`, `collectEffects`) and the undo
+ * collector (`collectUndos`): like the production `runTask` interpreter it
+ * realises bind and error-recovery on an explicit continuation/handler-frame
+ * stack rather than by recursing through the task structure, so arbitrarily
+ * long `flatMap`/`gen` chains run in constant call-stack depth.
  *
  * `resolveEffect` returns the value a leaf effect would produce (a mock, a
  * collected placeholder, and so on) and may record effects or mutate caller

--- a/packages/runtime/task/src/lib/driveSync.ts
+++ b/packages/runtime/task/src/lib/driveSync.ts
@@ -28,18 +28,19 @@ type SyncFrame =
  * `TaskExecutionError`, matching the production interpreter. Any other thrown
  * value propagates unchanged.
  *
+ * @typeParam A - The task's result type.
  * @param root - The task to drive.
  * @param resolveEffect - Produces the result for each leaf effect.
  * @returns The task's final value.
  * @note Impure — `resolveEffect` typically records effects or mutates caller
  * state.
  */
-export default function driveSync(
-  root: Task<unknown>,
+export default function driveSync<A>(
+  root: Task<A>,
   resolveEffect: (effect: Effect) => unknown,
-): unknown {
+): A {
   const stack: SyncFrame[] = [];
-  let cur: Task<unknown> = root;
+  let cur: Task<unknown> = root as Task<unknown>;
 
   // Unwind to the nearest recovery frame, discarding pending binds. With no
   // recovery frame installed the error escapes as a TaskExecutionError.
@@ -93,7 +94,7 @@ export default function driveSync(
           }
         }
         if (!resumed) {
-          return value;
+          return value as A;
         }
         break;
       }

--- a/packages/runtime/task/src/lib/dry-run.test.ts
+++ b/packages/runtime/task/src/lib/dry-run.test.ts
@@ -1439,3 +1439,20 @@ describe("Dry-Run - mock values for multiselect Prompt in task", () => {
     expect(value).toEqual([]);
   });
 });
+
+// =============================================================================
+// Dry-Run - virtual filesystem across concurrency combinators
+// =============================================================================
+
+describe("Dry-Run - Symlink tracking inside a parallel child", () => {
+  it("tracks a Symlink created in a parallel child for a later Exists", () => {
+    // The Symlink runs inside a Parallel child, and the shared virtual
+    // filesystem carries the created path forward so a subsequent Exists at the
+    // top level reports true.
+    const task = flatMap(parallel([symlink("/target", "/link")]), () =>
+      exists("/link"),
+    );
+
+    expect(dryRun(task).value).toBe(true);
+  });
+});

--- a/packages/runtime/task/src/lib/dry-run.ts
+++ b/packages/runtime/task/src/lib/dry-run.ts
@@ -5,6 +5,7 @@
  * without actually executing their effects.
  */
 
+import { driveSync } from "./driveSync.js";
 import { TaskExecutionError } from "./interpreter.js";
 import type { DryRunResult, Effect, Task } from "./types.js";
 
@@ -77,98 +78,45 @@ export const mockEffect = (effect: Effect): unknown => {
   }
 };
 
+/**
+ * Mock an effect result while tracking virtual filesystem state, so an
+ * `Exists` check reflects files a preceding effect would have created within
+ * the same dry-run.
+ *
+ * @param effect - The effect to mock.
+ * @param virtualFs - The set of paths created so far during the dry-run.
+ * @returns The mocked result for the effect.
+ * @note Impure — mutates the shared `virtualFs` set.
+ */
+export const mockEffectWithFs = (
+  effect: Effect,
+  virtualFs: Set<string>,
+): unknown => {
+  switch (effect._tag) {
+    case "WriteFile":
+    case "AppendFile":
+    case "TransformFile":
+    case "MakeDir":
+    case "Symlink":
+      virtualFs.add(effect.path);
+      return undefined;
+    case "Exists":
+      return virtualFs.has(effect.path);
+    default:
+      return mockEffect(effect);
+  }
+};
+
 // =============================================================================
 // Dry-Run Interpreter
 // =============================================================================
 
 /**
- * Run a task in dry-run mode, collecting effects without executing them.
- * Tracks virtual filesystem state to properly handle exists() checks.
- */
-export const dryRun = <A>(task: Task<A>): DryRunResult<A> => {
-  const effects: Effect[] = [];
-  // Track files/dirs that would be created during dry-run
-  const virtualFs = new Set<string>();
-
-  const mockEffectWithFs = (effect: Effect): unknown => {
-    switch (effect._tag) {
-      case "WriteFile":
-      case "AppendFile":
-      case "TransformFile":
-        virtualFs.add(effect.path);
-        return undefined;
-      case "MakeDir":
-        virtualFs.add(effect.path);
-        return undefined;
-      case "Symlink":
-        virtualFs.add(effect.path);
-        return undefined;
-      case "Exists":
-        // Check if file was "created" during this dry-run
-        return virtualFs.has(effect.path);
-      default:
-        return mockEffect(effect);
-    }
-  };
-
-  const run = <T>(t: Task<T>): T => {
-    switch (t._tag) {
-      case "Pure":
-        return t.value;
-
-      case "Fail":
-        throw new TaskExecutionError(t.error);
-
-      case "Effect": {
-        const effect = t.effect;
-
-        // Handle Parallel specially - collect effects from all child tasks
-        if (effect._tag === "Parallel") {
-          const results = effect.tasks.map((childTask) => {
-            const childResult = dryRunWithVirtualFs(childTask, virtualFs);
-            effects.push(...childResult.effects);
-            return childResult.value;
-          });
-          return run(t.cont(results) as Task<T>);
-        }
-
-        // Handle Race specially - collect effects from first child task
-        if (effect._tag === "Race") {
-          if (effect.tasks.length > 0) {
-            const childResult = dryRunWithVirtualFs(effect.tasks[0], virtualFs);
-            effects.push(...childResult.effects);
-            return run(t.cont(childResult.value) as Task<T>);
-          }
-          return run(t.cont(undefined) as Task<T>);
-        }
-
-        // Regular effects - add to list and mock
-        effects.push(effect);
-        const mockResult = mockEffectWithFs(effect);
-        return run(t.cont(mockResult) as Task<T>);
-      }
-
-      case "FlatMap":
-        return run(t.f(run(t.inner)) as Task<T>);
-
-      case "Recover":
-        try {
-          return run(t.inner);
-        } catch (error) {
-          if (error instanceof TaskExecutionError) {
-            return run(t.handler(error.taskError));
-          }
-          throw error;
-        }
-    }
-  };
-
-  const value = run(task);
-  return { value, effects };
-};
-
-/**
- * Internal helper: Run dry-run with shared virtual filesystem state.
+ * Run a task in dry-run mode over a shared virtual filesystem, collecting
+ * effects without executing them. `Parallel`/`Race` children are dry-run
+ * against the same `virtualFs` so `Exists` checks stay consistent.
+ *
+ * @note Impure — records effects and mutates the shared `virtualFs` set.
  */
 const dryRunWithVirtualFs = <A>(
   task: Task<A>,
@@ -176,75 +124,39 @@ const dryRunWithVirtualFs = <A>(
 ): DryRunResult<A> => {
   const effects: Effect[] = [];
 
-  const mockEffectWithFs = (effect: Effect): unknown => {
-    switch (effect._tag) {
-      case "WriteFile":
-      case "AppendFile":
-      case "TransformFile":
-        virtualFs.add(effect.path);
-        return undefined;
-      case "MakeDir":
-        virtualFs.add(effect.path);
-        return undefined;
-      case "Exists":
-        return virtualFs.has(effect.path);
-      default:
-        return mockEffect(effect);
+  const resolveEffect = (effect: Effect): unknown => {
+    if (effect._tag === "Parallel") {
+      return effect.tasks.map((child) => {
+        const childResult = dryRunWithVirtualFs(child, virtualFs);
+        effects.push(...childResult.effects);
+        return childResult.value;
+      });
     }
-  };
 
-  const run = <T>(t: Task<T>): T => {
-    switch (t._tag) {
-      case "Pure":
-        return t.value;
-
-      case "Fail":
-        throw new TaskExecutionError(t.error);
-
-      case "Effect": {
-        const effect = t.effect;
-
-        if (effect._tag === "Parallel") {
-          const results = effect.tasks.map((childTask) => {
-            const childResult = dryRunWithVirtualFs(childTask, virtualFs);
-            effects.push(...childResult.effects);
-            return childResult.value;
-          });
-          return run(t.cont(results) as Task<T>);
-        }
-
-        if (effect._tag === "Race") {
-          if (effect.tasks.length > 0) {
-            const childResult = dryRunWithVirtualFs(effect.tasks[0], virtualFs);
-            effects.push(...childResult.effects);
-            return run(t.cont(childResult.value) as Task<T>);
-          }
-          return run(t.cont(undefined) as Task<T>);
-        }
-
-        effects.push(effect);
-        const mockResult = mockEffectWithFs(effect);
-        return run(t.cont(mockResult) as Task<T>);
+    if (effect._tag === "Race") {
+      const first = effect.tasks.at(0);
+      if (first !== undefined) {
+        const childResult = dryRunWithVirtualFs(first, virtualFs);
+        effects.push(...childResult.effects);
+        return childResult.value;
       }
-
-      case "FlatMap":
-        return run(t.f(run(t.inner)) as Task<T>);
-
-      case "Recover":
-        try {
-          return run(t.inner);
-        } catch (error) {
-          if (error instanceof TaskExecutionError) {
-            return run(t.handler(error.taskError));
-          }
-          throw error;
-        }
+      return undefined;
     }
+
+    effects.push(effect);
+    return mockEffectWithFs(effect, virtualFs);
   };
 
-  const value = run(task);
+  const value = driveSync(task as Task<unknown>, resolveEffect) as A;
   return { value, effects };
 };
+
+/**
+ * Run a task in dry-run mode, collecting effects without executing them.
+ * Tracks virtual filesystem state to properly handle exists() checks.
+ */
+export const dryRun = <A>(task: Task<A>): DryRunResult<A> =>
+  dryRunWithVirtualFs(task, new Set());
 
 /**
  * Run a task in dry-run mode with custom mock values.
@@ -255,44 +167,13 @@ export const dryRunWith = <A>(
 ): DryRunResult<A> => {
   const effects: Effect[] = [];
 
-  const getMock = (effect: Effect): unknown => {
+  const resolveEffect = (effect: Effect): unknown => {
+    effects.push(effect);
     const customMock = mocks.get(effect._tag);
-    if (customMock) {
-      return customMock(effect);
-    }
-    return mockEffect(effect);
+    return customMock ? customMock(effect) : mockEffect(effect);
   };
 
-  const run = <T>(t: Task<T>): T => {
-    switch (t._tag) {
-      case "Pure":
-        return t.value;
-
-      case "Fail":
-        throw new TaskExecutionError(t.error);
-
-      case "Effect": {
-        effects.push(t.effect);
-        const mockResult = getMock(t.effect);
-        return run(t.cont(mockResult));
-      }
-
-      case "FlatMap":
-        return run(t.f(run(t.inner)));
-
-      case "Recover":
-        try {
-          return run(t.inner);
-        } catch (error) {
-          if (error instanceof TaskExecutionError) {
-            return run(t.handler(error.taskError));
-          }
-          throw error;
-        }
-    }
-  };
-
-  const value = run(task);
+  const value = driveSync(task as Task<unknown>, resolveEffect) as A;
   return { value, effects };
 };
 
@@ -307,37 +188,15 @@ export const dryRunWith = <A>(
 export const collectEffects = <A>(task: Task<A>): Effect[] => {
   const effects: Effect[] = [];
 
-  const drive = (t: Task<unknown>): unknown => {
-    switch (t._tag) {
-      case "Pure":
-        return t.value;
-
-      case "Fail":
-        throw new TaskExecutionError(t.error);
-
-      case "Effect":
-        effects.push(t.effect);
-        return drive(t.cont(mockEffect(t.effect)));
-
-      case "FlatMap":
-        return drive(t.f(drive(t.inner)));
-
-      case "Recover":
-        try {
-          return drive(t.inner);
-        } catch (error) {
-          if (error instanceof TaskExecutionError) {
-            return drive(t.handler(error.taskError));
-          }
-          throw error;
-        }
-    }
+  const resolveEffect = (effect: Effect): unknown => {
+    effects.push(effect);
+    return mockEffect(effect);
   };
 
   // Walk the task collecting each leaf effect, tolerating an unrecovered
-  // failure (the original short-circuits on a Fail rather than throwing).
+  // failure (a Fail short-circuits the walk rather than propagating).
   try {
-    drive(task as Task<unknown>);
+    driveSync(task as Task<unknown>, resolveEffect);
   } catch (error) {
     if (!(error instanceof TaskExecutionError)) {
       throw error;

--- a/packages/runtime/task/src/lib/dry-run.ts
+++ b/packages/runtime/task/src/lib/dry-run.ts
@@ -80,8 +80,11 @@ export const mockEffect = (effect: Effect): unknown => {
 
 /**
  * Mock an effect result while tracking virtual filesystem state, so an
- * `Exists` check reflects files a preceding effect would have created within
- * the same dry-run.
+ * `Exists` check reflects paths a preceding write-like effect (`WriteFile`,
+ * `AppendFile`, `TransformFile`, `MakeDir`, `Symlink`) would have created
+ * within the same dry-run. Copy destinations and deletions are not modelled —
+ * dry-run tracking is a best-effort preview of created paths, not a full
+ * virtual filesystem.
  *
  * @param effect - The effect to mock.
  * @param virtualFs - The set of paths created so far during the dry-run.
@@ -147,7 +150,7 @@ const dryRunWithVirtualFs = <A>(
     return mockEffectWithFs(effect, virtualFs);
   };
 
-  const value = driveSync(task as Task<unknown>, resolveEffect) as A;
+  const value = driveSync(task, resolveEffect);
   return { value, effects };
 };
 
@@ -173,7 +176,7 @@ export const dryRunWith = <A>(
     return customMock ? customMock(effect) : mockEffect(effect);
   };
 
-  const value = driveSync(task as Task<unknown>, resolveEffect) as A;
+  const value = driveSync(task, resolveEffect);
   return { value, effects };
 };
 
@@ -196,7 +199,7 @@ export const collectEffects = <A>(task: Task<A>): Effect[] => {
   // Walk the task collecting each leaf effect, tolerating an unrecovered
   // failure (a Fail short-circuits the walk rather than propagating).
   try {
-    driveSync(task as Task<unknown>, resolveEffect);
+    driveSync(task, resolveEffect);
   } catch (error) {
     if (!(error instanceof TaskExecutionError)) {
       throw error;

--- a/packages/runtime/task/src/lib/dry-run.ts
+++ b/packages/runtime/task/src/lib/dry-run.ts
@@ -5,7 +5,7 @@
  * without actually executing their effects.
  */
 
-import { driveSync } from "./driveSync.js";
+import driveSync from "./driveSync.js";
 import { TaskExecutionError } from "./interpreter.js";
 import type { DryRunResult, Effect, Task } from "./types.js";
 

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -1375,7 +1375,11 @@ describe("Interpreter - executeEffect Log fallback for all levels", () => {
 // =============================================================================
 
 describe("Interpreter - runTask Parallel with raw errors", () => {
-  it("wraps non-TaskExecutionError as INTERNAL code", async () => {
+  it("surfaces a parallel child's ENOENT read as FILE_NOT_FOUND", async () => {
+    // A raw ENOENT from a child effect is now normalised inside the child (like
+    // any effect exception), so the Parallel aggregator sees a structured
+    // FILE_NOT_FOUND rather than an opaque INTERNAL — consistent with a
+    // top-level read of a missing file.
     const throwingTask: Task<number> = {
       _tag: "Effect",
       effect: {
@@ -1395,6 +1399,7 @@ describe("Interpreter - runTask Parallel with raw errors", () => {
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(TaskExecutionError);
+      expect((err as TaskExecutionError).code).toBe("FILE_NOT_FOUND");
     }
   });
 });
@@ -1584,24 +1589,35 @@ describe("Interpreter - effect exceptions route through recovery", () => {
     expect(await runTask(task)).toBe("FILE_NOT_FOUND");
   });
 
-  it("routes a throwing Error transform into recover as INTERNAL", async () => {
+  it("routes a throwing Error transform into recover as INTERNAL, preserving cause and stack", async () => {
     const dir = mkdtempSync(join(tmpdir(), "task-transform-err-"));
 
     try {
       const path = join(dir, "f.txt");
       writeFileSync(path, "original");
+      const thrown = new Error("boom");
+      let captured: TaskError | undefined;
       const task = recover(
         effect<void>({
           _tag: "TransformFile",
           path,
           transform: () => {
-            throw new Error("boom");
+            throw thrown;
           },
         }),
-        (err) => pure(`${err.code}:${err.message}`),
+        (err) => {
+          captured = err;
+          return pure("recovered");
+        },
       );
 
-      expect(await runTask(task)).toBe("INTERNAL:boom");
+      expect(await runTask(task)).toBe("recovered");
+      expect(captured?.code).toBe("INTERNAL");
+      expect(captured?.message).toBe("boom");
+      // The original throw is preserved as cause, and the Error stack carried
+      // through, so a handler can inspect the underlying failure.
+      expect(captured?.cause).toBe(thrown);
+      expect(captured?.stack).toBe(thrown.stack);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -1707,6 +1723,48 @@ describe("Interpreter - effect exceptions route through recovery", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(TaskExecutionError);
       expect((err as TaskExecutionError).code).toBe("INTERNAL");
+    }
+  });
+});
+
+// =============================================================================
+// runTask - un-recovered effect exceptions reject with a normalised code
+// =============================================================================
+
+describe("Interpreter - un-recovered effect exceptions reject with a normalised code", () => {
+  it("rejects a missing-file read as TaskExecutionError FILE_NOT_FOUND", async () => {
+    const missing = join(tmpdir(), "task-unrecovered-enoent-xyz");
+
+    try {
+      await runTask(effect<string>({ _tag: "ReadFile", path: missing }));
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TaskExecutionError);
+      expect((err as TaskExecutionError).code).toBe("FILE_NOT_FOUND");
+    }
+  });
+
+  it("rejects a throwing transform as TaskExecutionError INTERNAL", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "task-unrecovered-internal-"));
+
+    try {
+      const path = join(dir, "f.txt");
+      writeFileSync(path, "original");
+      await runTask(
+        effect<void>({
+          _tag: "TransformFile",
+          path,
+          transform: () => {
+            throw new Error("nope");
+          },
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TaskExecutionError);
+      expect((err as TaskExecutionError).code).toBe("INTERNAL");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -1568,3 +1568,145 @@ describe("Interpreter - runTask stack safety", () => {
     expect(await runTask(task)).toBe(N);
   });
 });
+
+// =============================================================================
+// runTask - effect exceptions route through the recovery channel (TASK-1)
+// =============================================================================
+
+describe("Interpreter - effect exceptions route through recovery", () => {
+  it("routes a real ENOENT read into recover as FILE_NOT_FOUND", async () => {
+    const missing = join(tmpdir(), "task-enoent-does-not-exist-xyz");
+    const task = recover(
+      effect<string>({ _tag: "ReadFile", path: missing }),
+      (err) => pure(err.code),
+    );
+
+    expect(await runTask(task)).toBe("FILE_NOT_FOUND");
+  });
+
+  it("routes a throwing Error transform into recover as INTERNAL", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "task-transform-err-"));
+
+    try {
+      const path = join(dir, "f.txt");
+      writeFileSync(path, "original");
+      const task = recover(
+        effect<void>({
+          _tag: "TransformFile",
+          path,
+          transform: () => {
+            throw new Error("boom");
+          },
+        }),
+        (err) => pure(`${err.code}:${err.message}`),
+      );
+
+      expect(await runTask(task)).toBe("INTERNAL:boom");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalises a non-Error throw, using String() and no stack", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "task-transform-str-"));
+
+    try {
+      const path = join(dir, "f.txt");
+      writeFileSync(path, "original");
+      const task = recover(
+        effect<void>({
+          _tag: "TransformFile",
+          path,
+          transform: () => {
+            throw "raw-string";
+          },
+        }),
+        (err) => pure(`${err.code}:${err.message}:${err.stack}`),
+      );
+
+      expect(await runTask(task)).toBe("INTERNAL:raw-string:undefined");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalises a thrown null as INTERNAL", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "task-transform-null-"));
+
+    try {
+      const path = join(dir, "f.txt");
+      writeFileSync(path, "original");
+      const task = recover(
+        effect<void>({
+          _tag: "TransformFile",
+          path,
+          transform: () => {
+            throw null;
+          },
+        }),
+        (err) => pure(err.code),
+      );
+
+      expect(await runTask(task)).toBe("INTERNAL");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("maps a non-ENOENT coded throw to INTERNAL, not FILE_NOT_FOUND", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "task-transform-eperm-"));
+
+    try {
+      const path = join(dir, "f.txt");
+      writeFileSync(path, "original");
+      const task = recover(
+        effect<void>({
+          _tag: "TransformFile",
+          path,
+          transform: () => {
+            throw { code: "EPERM", message: "denied" };
+          },
+        }),
+        (err) => pure(err.code),
+      );
+
+      expect(await runTask(task)).toBe("INTERNAL");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes a TaskExecutionError through recover unchanged", async () => {
+    const task = recover(
+      effect<unknown>({
+        _tag: "Prompt",
+        question: { type: "confirm", name: "ok", message: "Proceed?" },
+      }),
+      (err) => pure(err.code),
+    );
+
+    expect(await runTask(task)).toBe("NO_PROMPT_HANDLER");
+  });
+
+  it("wraps a raw continuation failure in a parallel child as INTERNAL", async () => {
+    const rawChild: Task<number> = {
+      _tag: "Effect",
+      effect: { _tag: "ReadContext", key: "unused" },
+      cont: () => {
+        throw new Error("raw continuation");
+      },
+    };
+    const task = effect<unknown[]>({
+      _tag: "Parallel",
+      tasks: [rawChild, pure(2)],
+    });
+
+    try {
+      await runTask(task);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TaskExecutionError);
+      expect((err as TaskExecutionError).code).toBe("INTERNAL");
+    }
+  });
+});

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -1768,3 +1768,45 @@ describe("Interpreter - un-recovered effect exceptions reject with a normalised 
     }
   });
 });
+
+// =============================================================================
+// runTask - interruption bypasses recovery
+// =============================================================================
+
+describe("Interpreter - interruption bypasses recovery", () => {
+  it("does not invoke a surrounding recover when a Parallel child is aborted mid-flight", async () => {
+    const controller = new AbortController();
+    let handlerCalls = 0;
+
+    // The child performs a prompt whose handler aborts the signal; the child's
+    // next loop-top guard then raises TASK_INTERRUPTED, which surfaces through
+    // the Parallel aggregator into the recover frame's effect catch.
+    const child = effect<boolean>({
+      _tag: "Prompt",
+      question: { type: "confirm", name: "go", message: "Proceed?" },
+    });
+    const task = recover(
+      effect<unknown[]>({ _tag: "Parallel", tasks: [child] }),
+      () => {
+        handlerCalls += 1;
+        return pure("recovered");
+      },
+    );
+
+    const promptHandler = async () => {
+      controller.abort("stop");
+      return true;
+    };
+
+    try {
+      await runTask(task, { signal: controller.signal, promptHandler });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TaskExecutionError);
+      expect((err as TaskExecutionError).code).toBe("TASK_INTERRUPTED");
+    }
+
+    // The interrupt bypassed the recover handler entirely.
+    expect(handlerCalls).toBe(0);
+  });
+});

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -29,6 +29,36 @@ export class TaskExecutionError extends Error {
   }
 }
 
+/**
+ * Normalise a value thrown while performing an effect into a structured
+ * {@link TaskError}, so a real I/O exception can be routed through the
+ * interpreter's recovery channel rather than escaping it. A
+ * {@link TaskExecutionError} carries its `taskError` through unchanged; a
+ * filesystem `ENOENT` maps to `FILE_NOT_FOUND`; anything else becomes
+ * `INTERNAL`, preserving the original throw as `cause`.
+ *
+ * @param thrown - The value thrown while performing an effect.
+ * @returns The equivalent structured task error.
+ */
+const normalizeThrownError = (thrown: unknown): TaskError => {
+  if (thrown instanceof TaskExecutionError) {
+    return thrown.taskError;
+  }
+
+  const isFileNotFound =
+    typeof thrown === "object" &&
+    thrown !== null &&
+    "code" in thrown &&
+    (thrown as { code: unknown }).code === "ENOENT";
+
+  return {
+    code: isFileNotFound ? "FILE_NOT_FOUND" : "INTERNAL",
+    message: thrown instanceof Error ? thrown.message : String(thrown),
+    cause: thrown,
+    stack: thrown instanceof Error ? thrown.stack : undefined,
+  };
+};
+
 // =============================================================================
 // Effect Executor
 // =============================================================================
@@ -397,6 +427,18 @@ export const runTask = async <A>(
     const stack: Frame[] = [];
     let cur: Task<unknown> = root;
 
+    // Unwind to the nearest recovery frame, discarding pending binds. With no
+    // recovery frame installed the error escapes as a TaskExecutionError.
+    const recoverFrom = (error: TaskError): Task<unknown> => {
+      while (stack.length > 0) {
+        const frame = stack.pop();
+        if (frame?.kind === "recover") {
+          return frame.handler(error);
+        }
+      }
+      throw new TaskExecutionError(error);
+    };
+
     for (;;) {
       checkInterrupted();
 
@@ -412,7 +454,17 @@ export const runTask = async <A>(
           break;
 
         case "Effect": {
-          const result = await perform(cur.effect);
+          // A raw exception from the effect (e.g. ENOENT from a real read, or a
+          // throwing TransformFile transform) is normalised and routed through
+          // the recovery channel, so recover/retry/orElse can see real I/O
+          // failures — not just explicit Fail nodes.
+          let result: unknown;
+          try {
+            result = await perform(cur.effect);
+          } catch (thrown) {
+            cur = recoverFrom(normalizeThrownError(thrown));
+            break;
+          }
           cur = cur.cont(result);
           break;
         }
@@ -435,23 +487,10 @@ export const runTask = async <A>(
           break;
         }
 
-        case "Fail": {
+        case "Fail":
           // Failure: unwind to the nearest recovery frame, discarding binds.
-          const error = cur.error;
-          let resumed = false;
-          while (stack.length > 0) {
-            const frame = stack.pop();
-            if (frame?.kind === "recover") {
-              cur = frame.handler(error);
-              resumed = true;
-              break;
-            }
-          }
-          if (!resumed) {
-            throw new TaskExecutionError(error);
-          }
+          cur = recoverFrom(cur.error);
           break;
-        }
       }
     }
   };

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -462,7 +462,15 @@ export const runTask = async <A>(
           try {
             result = await perform(cur.effect);
           } catch (thrown) {
-            cur = recoverFrom(normalizeThrownError(thrown));
+            const taskError = normalizeThrownError(thrown);
+            // Interruption is not recoverable: an abort surfaced from a
+            // Parallel/Race child (whose own guard fired mid-flight) bypasses
+            // recovery, preserving the invariant that a cancelled task cannot
+            // be resurrected by an enclosing recover/orElse/retry.
+            if (taskError.code === "TASK_INTERRUPTED") {
+              throw thrown;
+            }
+            cur = recoverFrom(taskError);
             break;
           }
           cur = cur.cont(result);

--- a/packages/runtime/task/src/lib/undo-interpreter.test.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.test.ts
@@ -574,23 +574,25 @@ describe("collectUndos - lazy node handling", () => {
 // =============================================================================
 
 describe("collectUndos - Parallel result threaded to continuation", () => {
-  it("exposes the array of child values to a continuation without crashing", () => {
-    // A continuation that reads the Parallel result (e.g. its length) must see
-    // the array of child forward values, mirroring dryRun — not undefined.
-    let seenLength = -1;
+  it("threads each child's real mocked forward value to a continuation", () => {
+    // The continuation must receive each child's real mocked forward value,
+    // mirroring dryRun: a ReadFile mocks to its content string, a WriteFile to
+    // undefined. Distinct, non-empty values are used deliberately so the
+    // assertion fails against any placeholder shape (e.g. an array of []).
+    let seenResults: unknown[] = [];
     const task = flatMap(
-      parallel([writeFile("/a.txt", "a"), writeFile("/b.txt", "b")]),
+      parallel([readFile("/a.txt"), writeFile("/b.txt", "b")]),
       (results) => {
-        seenLength = (results as unknown[]).length;
+        seenResults = results as unknown[];
         return writeFile("/c.txt", "c");
       },
     );
 
     const undos = collectUndos(task);
 
-    // Two parallel writes + the continuation write, all undoable.
-    expect(undos).toHaveLength(3);
-    // The continuation read the Parallel result as a real 2-element array.
-    expect(seenLength).toBe(2);
+    expect(seenResults).toEqual(["[mock content of /a.txt]", undefined]);
+    // WriteFile /b and the continuation WriteFile /c are undoable; readFile is
+    // not, so exactly two undos are collected.
+    expect(undos).toHaveLength(2);
   });
 });

--- a/packages/runtime/task/src/lib/undo-interpreter.test.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.test.ts
@@ -568,3 +568,29 @@ describe("collectUndos - lazy node handling", () => {
     ).toThrow("raw");
   });
 });
+
+// =============================================================================
+// collectUndos - Parallel result value is readable by a continuation
+// =============================================================================
+
+describe("collectUndos - Parallel result threaded to continuation", () => {
+  it("exposes the array of child values to a continuation without crashing", () => {
+    // A continuation that reads the Parallel result (e.g. its length) must see
+    // the array of child forward values, mirroring dryRun — not undefined.
+    let seenLength = -1;
+    const task = flatMap(
+      parallel([writeFile("/a.txt", "a"), writeFile("/b.txt", "b")]),
+      (results) => {
+        seenLength = (results as unknown[]).length;
+        return writeFile("/c.txt", "c");
+      },
+    );
+
+    const undos = collectUndos(task);
+
+    // Two parallel writes + the continuation write, all undoable.
+    expect(undos).toHaveLength(3);
+    // The continuation read the Parallel result as a real 2-element array.
+    expect(seenLength).toBe(2);
+  });
+});

--- a/packages/runtime/task/src/lib/undo-interpreter.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.ts
@@ -12,7 +12,7 @@
  * the same task definition + same answers = deterministic undo.
  */
 
-import { driveSync } from "./driveSync.js";
+import driveSync from "./driveSync.js";
 import { mockEffectWithFs } from "./dry-run.js";
 import { type RunTaskOptions, runTask } from "./interpreter.js";
 import type { Effect, Task } from "./types.js";

--- a/packages/runtime/task/src/lib/undo-interpreter.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.ts
@@ -90,42 +90,46 @@ export const collectUndos = <A>(task: Task<A>): Task<void>[] => {
 /**
  * Walk a task tree with mocked forward effects over a shared virtual
  * filesystem, appending each effect's `undo` task (in forward order) to
- * `undos`. `Parallel`/`Race` children are walked against the same `virtualFs`.
- * The forward walk is trampolined via {@link driveSync}, so deep chains stay
+ * `undos`, and returning the task's mocked forward value. Forward mocking
+ * mirrors `dryRun` exactly — `Parallel` resolves to the array of its children's
+ * mocked values and `Race` to its first child's — so a continuation that reads
+ * a concurrency result sees the same shape it would under `dryRun`.
+ * `Parallel`/`Race` children are walked against the same `virtualFs`, and the
+ * forward walk is trampolined via {@link driveSync}, so deep chains stay
  * stack-safe.
  *
  * @param task - The task to collect undos from.
  * @param virtualFs - Shared set of paths created so far during the walk.
  * @param undos - Accumulator appended in forward execution order.
+ * @returns The task's mocked forward value.
  * @note Impure — mutates the shared `virtualFs` set and `undos` accumulator.
  */
 const collectUndosInto = (
   task: Task<unknown>,
   virtualFs: Set<string>,
   undos: Task<void>[],
-): void => {
+): unknown => {
   const resolveEffect = (effect: Effect): unknown => {
     if ("undo" in effect && effect.undo) {
       undos.push(effect.undo);
     }
 
     if (effect._tag === "Parallel") {
-      return effect.tasks.map((child) => {
-        collectUndosInto(child, virtualFs, undos);
-        return undefined;
-      });
+      return effect.tasks.map((child) =>
+        collectUndosInto(child, virtualFs, undos),
+      );
     }
 
     if (effect._tag === "Race") {
       const first = effect.tasks.at(0);
       if (first !== undefined) {
-        collectUndosInto(first, virtualFs, undos);
+        return collectUndosInto(first, virtualFs, undos);
       }
-      return mockEffectWithFs(effect, virtualFs);
+      return undefined;
     }
 
     return mockEffectWithFs(effect, virtualFs);
   };
 
-  driveSync(task, resolveEffect);
+  return driveSync(task, resolveEffect);
 };

--- a/packages/runtime/task/src/lib/undo-interpreter.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.ts
@@ -12,13 +12,10 @@
  * the same task definition + same answers = deterministic undo.
  */
 
-import { mockEffect } from "./dry-run.js";
-import {
-  type RunTaskOptions,
-  runTask,
-  TaskExecutionError,
-} from "./interpreter.js";
-import type { Task } from "./types.js";
+import { driveSync } from "./driveSync.js";
+import { mockEffectWithFs } from "./dry-run.js";
+import { type RunTaskOptions, runTask } from "./interpreter.js";
+import type { Effect, Task } from "./types.js";
 
 // =============================================================================
 // Undo Result
@@ -81,74 +78,8 @@ export const runUndo = async <A>(
  */
 export const collectUndos = <A>(task: Task<A>): Task<void>[] => {
   const undos: Task<void>[] = [];
-  // Track virtual filesystem state for exists() checks (same as dryRun)
-  const virtualFs = new Set<string>();
-
-  const walk = <T>(t: Task<T>): T => {
-    switch (t._tag) {
-      case "Pure":
-        return t.value;
-
-      case "Fail":
-        throw new TaskExecutionError(t.error);
-
-      case "Effect": {
-        const eff = t.effect;
-
-        // Collect undo if present
-        if ("undo" in eff && eff.undo) {
-          undos.push(eff.undo);
-        }
-
-        // Handle Parallel — walk all children
-        if (eff._tag === "Parallel") {
-          const results = eff.tasks.map((childTask) => {
-            const childUndos = collectUndosWithVirtualFs(childTask, virtualFs);
-            undos.push(...childUndos);
-            // Mock the child result
-            const childResult = mockEffectWithFs(
-              { _tag: "Parallel", tasks: [] },
-              virtualFs,
-            );
-            return childResult;
-          });
-          return walk(t.cont(results) as Task<T>);
-        }
-
-        // Handle Race — walk first child only (same as dryRun)
-        if (eff._tag === "Race") {
-          if (eff.tasks.length > 0) {
-            const childUndos = collectUndosWithVirtualFs(
-              eff.tasks[0],
-              virtualFs,
-            );
-            undos.push(...childUndos);
-          }
-          const mockResult = mockEffectWithFs(eff, virtualFs);
-          return walk(t.cont(mockResult) as Task<T>);
-        }
-
-        // Track virtual filesystem state for conditional branching
-        const mockResult = mockEffectWithFs(eff, virtualFs);
-        return walk(t.cont(mockResult) as Task<T>);
-      }
-
-      case "FlatMap":
-        return walk(t.f(walk(t.inner)) as Task<T>);
-
-      case "Recover":
-        try {
-          return walk(t.inner);
-        } catch (error) {
-          if (error instanceof TaskExecutionError) {
-            return walk(t.handler(error.taskError));
-          }
-          throw error;
-        }
-    }
-  };
-
-  walk(task);
+  // Track virtual filesystem state for exists() checks (same as dryRun).
+  collectUndosInto(task as Task<unknown>, new Set(), undos);
   return undos;
 };
 
@@ -157,97 +88,44 @@ export const collectUndos = <A>(task: Task<A>): Task<void>[] => {
 // =============================================================================
 
 /**
- * Mock an effect result, tracking virtual filesystem state.
- * Mirrors the logic in dry-run.ts.
+ * Walk a task tree with mocked forward effects over a shared virtual
+ * filesystem, appending each effect's `undo` task (in forward order) to
+ * `undos`. `Parallel`/`Race` children are walked against the same `virtualFs`.
+ * The forward walk is trampolined via {@link driveSync}, so deep chains stay
+ * stack-safe.
+ *
+ * @param task - The task to collect undos from.
+ * @param virtualFs - Shared set of paths created so far during the walk.
+ * @param undos - Accumulator appended in forward execution order.
+ * @note Impure — mutates the shared `virtualFs` set and `undos` accumulator.
  */
-const mockEffectWithFs = (
-  eff: import("./types.js").Effect,
+const collectUndosInto = (
+  task: Task<unknown>,
   virtualFs: Set<string>,
-): unknown => {
-  switch (eff._tag) {
-    case "WriteFile":
-    case "AppendFile":
-    case "TransformFile":
-      virtualFs.add(eff.path);
-      return undefined;
-    case "MakeDir":
-      virtualFs.add(eff.path);
-      return undefined;
-    case "Symlink":
-      virtualFs.add(eff.path);
-      return undefined;
-    case "Exists":
-      return virtualFs.has(eff.path);
-    default:
-      return mockEffect(eff);
-  }
-};
-
-/**
- * Collect undos from a child task, sharing virtual filesystem state.
- * Used for Parallel/Race child tasks.
- */
-const collectUndosWithVirtualFs = <A>(
-  task: Task<A>,
-  virtualFs: Set<string>,
-): Task<void>[] => {
-  const undos: Task<void>[] = [];
-
-  const walk = <T>(t: Task<T>): T => {
-    switch (t._tag) {
-      case "Pure":
-        return t.value;
-
-      case "Fail":
-        throw new TaskExecutionError(t.error);
-
-      case "Effect": {
-        const eff = t.effect;
-
-        if ("undo" in eff && eff.undo) {
-          undos.push(eff.undo);
-        }
-
-        if (eff._tag === "Parallel") {
-          const results = eff.tasks.map((childTask) => {
-            const childUndos = collectUndosWithVirtualFs(childTask, virtualFs);
-            undos.push(...childUndos);
-            return undefined;
-          });
-          return walk(t.cont(results) as Task<T>);
-        }
-
-        if (eff._tag === "Race") {
-          if (eff.tasks.length > 0) {
-            const childUndos = collectUndosWithVirtualFs(
-              eff.tasks[0],
-              virtualFs,
-            );
-            undos.push(...childUndos);
-          }
-          const mockResult = mockEffectWithFs(eff, virtualFs);
-          return walk(t.cont(mockResult) as Task<T>);
-        }
-
-        const mockResult = mockEffectWithFs(eff, virtualFs);
-        return walk(t.cont(mockResult) as Task<T>);
-      }
-
-      case "FlatMap":
-        return walk(t.f(walk(t.inner)) as Task<T>);
-
-      case "Recover":
-        try {
-          return walk(t.inner);
-        } catch (error) {
-          if (error instanceof TaskExecutionError) {
-            return walk(t.handler(error.taskError));
-          }
-          throw error;
-        }
+  undos: Task<void>[],
+): void => {
+  const resolveEffect = (effect: Effect): unknown => {
+    if ("undo" in effect && effect.undo) {
+      undos.push(effect.undo);
     }
+
+    if (effect._tag === "Parallel") {
+      return effect.tasks.map((child) => {
+        collectUndosInto(child, virtualFs, undos);
+        return undefined;
+      });
+    }
+
+    if (effect._tag === "Race") {
+      const first = effect.tasks.at(0);
+      if (first !== undefined) {
+        collectUndosInto(first, virtualFs, undos);
+      }
+      return mockEffectWithFs(effect, virtualFs);
+    }
+
+    return mockEffectWithFs(effect, virtualFs);
   };
 
-  walk(task);
-  return undos;
+  driveSync(task, resolveEffect);
 };

--- a/packages/runtime/task/src/testing/regression/0001-recover-catches-effect-exceptions.test.ts
+++ b/packages/runtime/task/src/testing/regression/0001-recover-catches-effect-exceptions.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression: a real I/O exception thrown while performing an effect must be
+ * routable through the recovery channel, not escape the interpreter.
+ *
+ * Before the fix, only explicit `Fail` nodes reached `recover`/`orElse`; a raw
+ * exception (e.g. `ENOENT` from reading a missing file) propagated straight out
+ * of `runTask`, so `orElse`/`recover`/`optional` could never see real failures.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { orElse } from "../../lib/combinators.js";
+import { runTask } from "../../lib/interpreter.js";
+import { readFile } from "../../lib/primitives.js";
+import { pure, recover } from "../../lib/task.js";
+
+describe("regression 0001 — recover catches effect exceptions", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "task-regression-0001-"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("recovers from a missing-file read instead of rejecting", async () => {
+    const missing = join(dir, "definitely-absent.txt");
+
+    const task = recover(readFile(missing), (err) =>
+      pure(`recovered:${err.code}`),
+    );
+
+    expect(await runTask(task)).toBe("recovered:FILE_NOT_FOUND");
+  });
+
+  it("falls back via orElse when a read fails", async () => {
+    const missing = join(dir, "also-absent.txt");
+
+    const task = orElse(readFile(missing), pure("fallback"));
+
+    expect(await runTask(task)).toBe("fallback");
+  });
+});

--- a/packages/runtime/task/src/testing/regression/0002-preview-interpreters-are-stack-safe.test.ts
+++ b/packages/runtime/task/src/testing/regression/0002-preview-interpreters-are-stack-safe.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression: the preview interpreters must be stack-safe.
+ *
+ * Before the fix, only `runTask` was trampolined; `dryRun`, `collectEffects`,
+ * and `collectUndos` walked the task tree recursively, so a deep `flatMap`/`gen`
+ * chain overflowed the call stack (`RangeError`) under preview and undo even
+ * though the same chain ran fine in production.
+ */
+
+import { describe, expect, it } from "vitest";
+import { collectEffects, dryRun } from "../../lib/dry-run.js";
+import { writeFile } from "../../lib/primitives.js";
+import { flatMap, pure } from "../../lib/task.js";
+import type { Task } from "../../lib/types.js";
+import { collectUndos } from "../../lib/undo-interpreter.js";
+
+// A depth well beyond the native call-stack limit (~10k frames), so a recursive
+// walk would overflow while a trampolined one completes.
+const DEPTH = 100_000;
+
+describe("regression 0002 — preview interpreters are stack-safe", () => {
+  it("dryRun completes on a deep flatMap chain", () => {
+    let task: Task<number> = pure(0);
+    for (let i = 0; i < DEPTH; i++) {
+      task = flatMap(task, (x) => pure(x + 1));
+    }
+
+    expect(dryRun(task).value).toBe(DEPTH);
+  });
+
+  it("collectEffects completes on a deep flatMap chain", () => {
+    let task: Task<number> = pure(0);
+    for (let i = 0; i < DEPTH; i++) {
+      task = flatMap(task, (x) => pure(x + 1));
+    }
+
+    expect(collectEffects(task)).toEqual([]);
+  });
+
+  it("collectUndos completes on a deep chain of undoable effects", () => {
+    let task: Task<unknown> = pure(undefined);
+    for (let i = 0; i < DEPTH; i++) {
+      task = flatMap(task, () => writeFile(`/virtual/file-${i}.txt`, "x"));
+    }
+
+    expect(collectUndos(task)).toHaveLength(DEPTH);
+  });
+});


### PR DESCRIPTION
## Done

Interpreter hardening for `@canonical/task` — the first of a five-step train that prepares the interpreter for record/replay determinism. Both changes are self-contained and ship value on their own.

- **Error channel routing.** A raw exception thrown while performing an effect (e.g. `ENOENT` from a real read, or a throwing `TransformFile` transform) is now normalised into a structured `TaskError` and routed through the recovery channel, so `recover` / `retry` / `orElse` / `optional` can see real I/O failures instead of only explicit `Fail` nodes. `ENOENT` maps to the previously-dead `FILE_NOT_FOUND` code; anything else becomes `INTERNAL` with the original throw preserved as `cause`. Interruption stays non-recoverable.
- **Stack-safe preview/undo.** `dryRun`, `dryRunWith`, `collectEffects`, and `collectUndos` are now driven by a shared explicit-stack trampoline (`driveSync`), matching the production `runTask`. Deep `flatMap`/`gen` chains that overflowed the call stack under preview/undo now complete.
- **De-duplication (drive-by).** The five near-identical recursive walkers across `dry-run.ts` and `undo-interpreter.ts` collapse into the one `driveSync` engine; the virtual-filesystem mock (`mockEffectWithFs`) is unified into a single implementation, and `collectUndos` now threads each child's real mocked forward value into a `Parallel`/`Race` continuation (mirroring `dryRun`).
- **Tests.** Full branch coverage for the new error-normalisation and `INTERNAL`-wrapping paths, plus numbered regression tests: `0001` (recover catches effect exceptions) and `0002` (preview interpreters are stack-safe at 100k depth). Every observable value that shifted versus prior behavior is pinned by an assertion.

Public API is unchanged (`src/index.ts` untouched).

Fixes: internal findings TASK-1 (raw exceptions bypass the recovery channel) and TASK-3 (preview/undo interpreters not stack-safe).

## Behavior changes (`@canonical/task` consumers)

These are intentional consistency changes — every in-repo consumer was audited and none breaks (all catch sites read `error.message`, which is preserved). Flagged here for any **external** consumer:

- An **un-handled effect exception** now rejects `runTask` as a `TaskExecutionError` (code `FILE_NOT_FOUND` for `ENOENT`, else `INTERNAL`) rather than escaping as the raw Node error. Inside a `Parallel`, a raw child `ENOENT` now aggregates as `FILE_NOT_FOUND` (previously `INTERNAL`). Code branching on the raw error type — or on the old `INTERNAL` code for a missing-file case — must update.
- `recover` / `orElse` / `retry` / `optional` / `attempt` now catch **real I/O exceptions**, not only explicit `Fail` nodes. Code that relied on an effect exception bypassing recovery will now be caught.
- `collectUndos` now threads the **real array of child forward values** into a `Parallel`/`Race` continuation (matching `dryRun`), where it previously passed placeholder values.

## QA

- `cd packages/runtime/task && bun run test` → **706 pass, 100% coverage** (statements/branches/functions/lines).
- `bun run check` → **biome + tsc + webarchitect all green**.
- `bun run build` → compiles clean.
- Manual: a task that reads a missing file wrapped in `recover(...)` / `orElse(...)` now resolves to the fallback instead of rejecting; a 100k-deep `flatMap` chain runs through `dryRun`/`collectEffects`/`collectUndos` without a `RangeError`.

### PR readiness check

- [x] PR should have one of the following labels: **`Bug 🐛`**.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards) (webarchitect passes).
- [x] All packages define the required scripts in `package.json`: `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] This PR does not introduce a new package.
- [x] This PR does not require visual testing — add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — interpreter-internal change, no visual surface.