### PR TITLE
feat(task): content-addressable effect identity — canonicalJSON, EffectId, per-tag descriptors

### DIFF
--- a/packages/runtime/task/src/index.ts
+++ b/packages/runtime/task/src/index.ts
@@ -14,6 +14,7 @@ export type {
   ConfirmPrompt,
   DryRunResult,
   Effect,
+  EffectId,
   ExecResult,
   LogLevel,
   MultiselectPrompt,
@@ -27,6 +28,17 @@ export type {
   TraceResult,
   TraceSpan,
 } from "./lib/types.js";
+
+// =============================================================================
+// Effect Identity
+// =============================================================================
+
+export { default as canonicalJSON } from "./lib/canonicalJSON.js";
+export {
+  computeEffectId,
+  extractEffectContent,
+  formatEffectId,
+} from "./lib/effectId.js";
 
 // =============================================================================
 // Task Monad

--- a/packages/runtime/task/src/lib/canonicalJSON.test.ts
+++ b/packages/runtime/task/src/lib/canonicalJSON.test.ts
@@ -155,3 +155,41 @@ describe("canonicalJSON — injectivity edge cases", () => {
     expect(canonicalJSON(bare)).toBe('{"a":1}');
   });
 });
+
+describe("canonicalJSON — cycles and shared references", () => {
+  it("fails closed on a cyclic object", () => {
+    const a: Record<string, unknown> = {};
+    a.self = a;
+    expect(() => canonicalJSON(a)).toThrow(TypeError);
+  });
+
+  it("fails closed on a cycle through an array", () => {
+    const arr: unknown[] = [];
+    arr.push(arr);
+    expect(() => canonicalJSON(arr)).toThrow(TypeError);
+  });
+
+  it("encodes a value shared across siblings without a false cycle", () => {
+    const shared = { x: 1 };
+    expect(canonicalJSON({ a: shared, b: shared })).toBe(
+      '{"a":{"x":1},"b":{"x":1}}',
+    );
+  });
+});
+
+describe("canonicalJSON — bare-token and byte-order injectivity", () => {
+  it("keeps Infinity, -Infinity, and bigint distinct from their string forms", () => {
+    expect(canonicalJSON(Number.POSITIVE_INFINITY)).not.toBe(
+      canonicalJSON("Infinity"),
+    );
+    expect(canonicalJSON(Number.NEGATIVE_INFINITY)).not.toBe(
+      canonicalJSON("-Infinity"),
+    );
+    expect(canonicalJSON(42n)).not.toBe(canonicalJSON("42n"));
+    expect(canonicalJSON(42n)).not.toBe(canonicalJSON(42));
+  });
+
+  it("encodes a typed array by element values, independent of byte order", () => {
+    expect(canonicalJSON(new Uint16Array([1, 2]))).toBe("Uint16Array(1,2)");
+  });
+});

--- a/packages/runtime/task/src/lib/canonicalJSON.test.ts
+++ b/packages/runtime/task/src/lib/canonicalJSON.test.ts
@@ -112,3 +112,46 @@ describe("canonicalJSON", () => {
     });
   });
 });
+
+describe("canonicalJSON — injectivity edge cases", () => {
+  it("distinguishes a sparse hole from an empty array and from undefined", () => {
+    expect(canonicalJSON(new Array(1))).toBe("[hole]");
+    expect(canonicalJSON([])).toBe("[]");
+    expect(canonicalJSON(new Array(1))).not.toBe(canonicalJSON([]));
+    expect(canonicalJSON([undefined])).toBe("[undefined]");
+    expect(canonicalJSON([undefined])).not.toBe(canonicalJSON(new Array(1)));
+  });
+
+  it("encodes a DataView by its raw bytes, keeping distinct payloads distinct", () => {
+    const dv = new DataView(new Uint8Array([255, 1]).buffer);
+    expect(canonicalJSON(dv)).toBe("DataView(255,1)");
+    expect(canonicalJSON(dv)).not.toBe(
+      canonicalJSON(new DataView(new Uint8Array([0, 0]).buffer)),
+    );
+  });
+
+  it("tags Date and RegExp so distinct values stay distinct", () => {
+    expect(canonicalJSON(new Date(1_577_836_800_000))).toBe(
+      "Date(1577836800000)",
+    );
+    expect(canonicalJSON(new Date(1_577_836_800_000))).not.toBe(
+      canonicalJSON(new Date(1_609_459_200_000)),
+    );
+    expect(canonicalJSON(/abc/g)).not.toBe(canonicalJSON(/abd/g));
+  });
+
+  it("fails closed on a class instance rather than collapsing it to {}", () => {
+    const instance = new (class Widget {})();
+    expect(() => canonicalJSON(instance)).toThrow(TypeError);
+  });
+
+  it("fails closed on an object with symbol keys", () => {
+    expect(() => canonicalJSON({ [Symbol("x")]: 1 })).toThrow(TypeError);
+  });
+
+  it("encodes a null-prototype object as a plain record", () => {
+    const bare = Object.create(null) as Record<string, unknown>;
+    bare.a = 1;
+    expect(canonicalJSON(bare)).toBe('{"a":1}');
+  });
+});

--- a/packages/runtime/task/src/lib/canonicalJSON.test.ts
+++ b/packages/runtime/task/src/lib/canonicalJSON.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import canonicalJSON from "./canonicalJSON.js";
+
+describe("canonicalJSON", () => {
+  describe("primitives", () => {
+    it("encodes null", () => {
+      expect(canonicalJSON(null)).toBe("null");
+    });
+
+    it("encodes undefined with a bare token distinct from the string", () => {
+      expect(canonicalJSON(undefined)).toBe("undefined");
+      expect(canonicalJSON("undefined")).toBe('"undefined"');
+    });
+
+    it("encodes booleans", () => {
+      expect(canonicalJSON(true)).toBe("true");
+      expect(canonicalJSON(false)).toBe("false");
+    });
+
+    it("encodes bigint with an n suffix", () => {
+      expect(canonicalJSON(42n)).toBe("42n");
+    });
+
+    it("encodes strings quoted and escaped", () => {
+      expect(canonicalJSON("hi")).toBe('"hi"');
+      expect(canonicalJSON('a"b')).toBe('"a\\"b"');
+    });
+  });
+
+  describe("numbers", () => {
+    it("encodes a finite number", () => {
+      expect(canonicalJSON(42)).toBe("42");
+      expect(canonicalJSON(-3.5)).toBe("-3.5");
+    });
+
+    it("encodes NaN distinct from the string", () => {
+      expect(canonicalJSON(Number.NaN)).toBe("NaN");
+      expect(canonicalJSON("NaN")).toBe('"NaN"');
+    });
+
+    it("encodes positive and negative Infinity", () => {
+      expect(canonicalJSON(Number.POSITIVE_INFINITY)).toBe("Infinity");
+      expect(canonicalJSON(Number.NEGATIVE_INFINITY)).toBe("-Infinity");
+    });
+
+    it("distinguishes negative zero from zero", () => {
+      expect(canonicalJSON(-0)).toBe("-0");
+      expect(canonicalJSON(0)).toBe("0");
+    });
+  });
+
+  describe("collections", () => {
+    it("encodes arrays preserving order", () => {
+      expect(canonicalJSON([3, 1, 2])).toBe("[3,1,2]");
+    });
+
+    it("sorts object keys deterministically regardless of insertion order", () => {
+      expect(canonicalJSON({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+      expect(canonicalJSON({ b: 1, a: 2 })).toBe(canonicalJSON({ a: 2, b: 1 }));
+    });
+
+    it("tags and sorts Map entries by canonical key", () => {
+      const map = new Map<string, number>([
+        ["b", 1],
+        ["a", 2],
+      ]);
+      expect(canonicalJSON(map)).toBe('Map{"a":2,"b":1}');
+    });
+
+    it("tags and sorts Set elements", () => {
+      expect(canonicalJSON(new Set([3, 1, 2]))).toBe("Set{1,2,3}");
+    });
+
+    it("tags typed arrays by their constructor", () => {
+      expect(canonicalJSON(new Uint8Array([1, 2, 3]))).toBe(
+        "Uint8Array(1,2,3)",
+      );
+    });
+
+    it("recurses into nested structures", () => {
+      expect(canonicalJSON({ xs: [{ b: 2, a: 1 }], n: null })).toBe(
+        '{"n":null,"xs":[{"a":1,"b":2}]}',
+      );
+    });
+  });
+
+  describe("fail-closed behaviour", () => {
+    it("throws on a function", () => {
+      expect(() => canonicalJSON(() => undefined)).toThrow(TypeError);
+    });
+
+    it("throws on a symbol", () => {
+      expect(() => canonicalJSON(Symbol("x"))).toThrow(TypeError);
+    });
+
+    it("throws when a property getter throws an Error", () => {
+      const obj = {
+        get bad(): unknown {
+          throw new Error("boom");
+        },
+      };
+      expect(() => canonicalJSON(obj)).toThrow(/boom/);
+    });
+
+    it("throws when a property getter throws a non-Error", () => {
+      const obj = {
+        get bad(): unknown {
+          throw "raw";
+        },
+      };
+      expect(() => canonicalJSON(obj)).toThrow(/raw/);
+    });
+  });
+});

--- a/packages/runtime/task/src/lib/canonicalJSON.test.ts
+++ b/packages/runtime/task/src/lib/canonicalJSON.test.ts
@@ -99,7 +99,8 @@ describe("canonicalJSON", () => {
           throw new Error("boom");
         },
       };
-      expect(() => canonicalJSON(obj)).toThrow(/boom/);
+      expect(() => canonicalJSON(obj)).toThrow(TypeError);
+      expect(() => canonicalJSON(obj)).toThrow(/reading property "bad" threw/);
     });
 
     it("throws when a property getter throws a non-Error", () => {
@@ -108,7 +109,8 @@ describe("canonicalJSON", () => {
           throw "raw";
         },
       };
-      expect(() => canonicalJSON(obj)).toThrow(/raw/);
+      expect(() => canonicalJSON(obj)).toThrow(TypeError);
+      expect(() => canonicalJSON(obj)).toThrow(/reading property "bad" threw/);
     });
   });
 });

--- a/packages/runtime/task/src/lib/canonicalJSON.ts
+++ b/packages/runtime/task/src/lib/canonicalJSON.ts
@@ -2,17 +2,19 @@
  * Serialise a value to a canonical, deterministic, lossless string.
  *
  * Unlike `JSON.stringify`, the output is stable across runs and injective over
- * the values effect descriptors carry: object keys are sorted, `Map`/`Set` are
- * tagged and their entries sorted, typed arrays are tagged, and the values
- * `JSON.stringify` drops or mangles — `undefined`, `NaN`, `±Infinity`, `-0`,
- * and `bigint` — are each given a distinct bare token that can never collide
- * with a string (strings are always quoted). It fails closed: a value it cannot
- * represent deterministically (a function, a symbol, or a property whose getter
- * throws) raises a `TypeError` rather than emitting ambiguous output.
+ * the value domain it accepts: plain-object keys are sorted, arrays keep their
+ * length and holes, `Map`/`Set` are tagged with sorted entries, `Date` and
+ * `RegExp` are tagged, ArrayBuffer views are tagged with their raw bytes, and
+ * the values `JSON.stringify` drops or mangles — `undefined`, `NaN`,
+ * `±Infinity`, `-0`, and `bigint` — each get a distinct bare token that can
+ * never collide with a string (strings are always quoted). It fails closed
+ * with a `TypeError` on anything it cannot represent injectively: a function, a
+ * symbol, a symbol-keyed or class-instance object, or a property whose getter
+ * throws. Only own-enumerable string keys are canonicalised.
  *
  * @param value - The value to serialise.
  * @returns A canonical string representation.
- * @throws TypeError When the value contains something non-serialisable.
+ * @throws TypeError When the value is outside the canonicalisable domain.
  */
 export default function canonicalJSON(value: unknown): string {
   if (value === null) {
@@ -63,12 +65,14 @@ function encodeNumber(value: number): string {
 }
 
 /**
- * Encode a non-null object: arrays, `Map`, `Set`, typed arrays, and plain
- * records each get a distinct, deterministic form.
+ * Encode a non-null object: arrays, `Map`, `Set`, `Date`, `RegExp`, ArrayBuffer
+ * views, and plain records each get a distinct, deterministic form. A class
+ * instance with opaque state is not representable injectively, so it fails
+ * closed.
  */
 function encodeObject(value: object): string {
   if (Array.isArray(value)) {
-    return `[${value.map((item) => canonicalJSON(item)).join(",")}]`;
+    return encodeArray(value);
   }
   if (value instanceof Map) {
     return encodeMap(value);
@@ -76,11 +80,49 @@ function encodeObject(value: object): string {
   if (value instanceof Set) {
     return encodeSet(value);
   }
-  if (ArrayBuffer.isView(value)) {
-    const items = Array.from(value as unknown as ArrayLike<number>);
-    return `${value.constructor.name}(${items.map((n) => canonicalJSON(n)).join(",")})`;
+  if (value instanceof Date) {
+    return `Date(${value.getTime()})`;
   }
-  return encodeRecord(value as Record<string, unknown>);
+  if (value instanceof RegExp) {
+    return `RegExp(${JSON.stringify(value.source)},${JSON.stringify(value.flags)})`;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return encodeView(value);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype === Object.prototype || prototype === null) {
+    return encodeRecord(value as Record<string, unknown>);
+  }
+  // A class instance's identity lives in opaque internal state, not its
+  // enumerable keys — fail closed rather than conflate distinct instances.
+  throw new TypeError(
+    "canonicalJSON: cannot serialise a non-plain object (class instance)",
+  );
+}
+
+/**
+ * Encode an array element-wise, giving an absent slot (a hole) a distinct bare
+ * token so a sparse array never collapses to a shorter one.
+ */
+function encodeArray(value: unknown[]): string {
+  const parts: string[] = [];
+  for (let index = 0; index < value.length; index++) {
+    parts.push(index in value ? canonicalJSON(value.at(index)) : "hole");
+  }
+  return `[${parts.join(",")}]`;
+}
+
+/**
+ * Encode an ArrayBuffer view (typed array or `DataView`) as its constructor tag
+ * plus its raw bytes, so every view type and payload stays distinct.
+ */
+function encodeView(value: ArrayBufferView): string {
+  const bytes = new Uint8Array(
+    value.buffer,
+    value.byteOffset,
+    value.byteLength,
+  );
+  return `${value.constructor.name}(${Array.from(bytes).join(",")})`;
 }
 
 /** Encode a `Map` as a tagged, key-sorted set of canonical `key:value` pairs. */
@@ -99,8 +141,18 @@ function encodeSet(value: Set<unknown>): string {
   return `Set{${items.join(",")}}`;
 }
 
-/** Encode a plain record with keys sorted, failing closed on a throwing getter. */
+/**
+ * Encode a plain record with its own-enumerable string keys sorted, failing
+ * closed on a throwing getter. Symbol keys are rejected (a symbol-keyed object
+ * would otherwise collapse to `{}`); only own-enumerable string keys are
+ * canonicalised.
+ */
 function encodeRecord(record: Record<string, unknown>): string {
+  if (Object.getOwnPropertySymbols(record).length > 0) {
+    throw new TypeError(
+      "canonicalJSON: cannot serialise an object with symbol keys",
+    );
+  }
   const keys = Object.keys(record).sort();
   const entries = keys.map(
     (key) =>

--- a/packages/runtime/task/src/lib/canonicalJSON.ts
+++ b/packages/runtime/task/src/lib/canonicalJSON.ts
@@ -1,0 +1,126 @@
+/**
+ * Serialise a value to a canonical, deterministic, lossless string.
+ *
+ * Unlike `JSON.stringify`, the output is stable across runs and injective over
+ * the values effect descriptors carry: object keys are sorted, `Map`/`Set` are
+ * tagged and their entries sorted, typed arrays are tagged, and the values
+ * `JSON.stringify` drops or mangles — `undefined`, `NaN`, `±Infinity`, `-0`,
+ * and `bigint` — are each given a distinct bare token that can never collide
+ * with a string (strings are always quoted). It fails closed: a value it cannot
+ * represent deterministically (a function, a symbol, or a property whose getter
+ * throws) raises a `TypeError` rather than emitting ambiguous output.
+ *
+ * @param value - The value to serialise.
+ * @returns A canonical string representation.
+ * @throws TypeError When the value contains something non-serialisable.
+ */
+export default function canonicalJSON(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  const type = typeof value;
+  switch (type) {
+    case "boolean":
+      return value ? "true" : "false";
+    case "bigint":
+      return `${value as bigint}n`;
+    case "string":
+      return JSON.stringify(value);
+    case "number":
+      return encodeNumber(value as number);
+    case "object":
+      return encodeObject(value as object);
+    default:
+      // function | symbol — not representable deterministically.
+      throw new TypeError(
+        `canonicalJSON: cannot serialise a value of type ${type}`,
+      );
+  }
+}
+
+/**
+ * Encode a number, giving `NaN`, `±Infinity`, and `-0` distinct bare tokens so
+ * they survive the round trip that `JSON.stringify` would lose.
+ */
+function encodeNumber(value: number): string {
+  if (Number.isNaN(value)) {
+    return "NaN";
+  }
+  if (value === Number.POSITIVE_INFINITY) {
+    return "Infinity";
+  }
+  if (value === Number.NEGATIVE_INFINITY) {
+    return "-Infinity";
+  }
+  if (Object.is(value, -0)) {
+    return "-0";
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * Encode a non-null object: arrays, `Map`, `Set`, typed arrays, and plain
+ * records each get a distinct, deterministic form.
+ */
+function encodeObject(value: object): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJSON(item)).join(",")}]`;
+  }
+  if (value instanceof Map) {
+    return encodeMap(value);
+  }
+  if (value instanceof Set) {
+    return encodeSet(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    const items = Array.from(value as unknown as ArrayLike<number>);
+    return `${value.constructor.name}(${items.map((n) => canonicalJSON(n)).join(",")})`;
+  }
+  return encodeRecord(value as Record<string, unknown>);
+}
+
+/** Encode a `Map` as a tagged, key-sorted set of canonical `key:value` pairs. */
+function encodeMap(value: Map<unknown, unknown>): string {
+  const entries = Array.from(value.entries())
+    .map(([key, val]) => `${canonicalJSON(key)}:${canonicalJSON(val)}`)
+    .sort();
+  return `Map{${entries.join(",")}}`;
+}
+
+/** Encode a `Set` as a tagged, sorted list of canonical elements. */
+function encodeSet(value: Set<unknown>): string {
+  const items = Array.from(value)
+    .map((item) => canonicalJSON(item))
+    .sort();
+  return `Set{${items.join(",")}}`;
+}
+
+/** Encode a plain record with keys sorted, failing closed on a throwing getter. */
+function encodeRecord(record: Record<string, unknown>): string {
+  const keys = Object.keys(record).sort();
+  const entries = keys.map(
+    (key) =>
+      `${JSON.stringify(key)}:${canonicalJSON(readProperty(record, key))}`,
+  );
+  return `{${entries.join(",")}}`;
+}
+
+/**
+ * Read a property, converting a throwing getter into a fail-closed `TypeError`
+ * so a value that cannot be observed deterministically never yields output.
+ */
+function readProperty(record: Record<string, unknown>, key: string): unknown {
+  try {
+    return record[key];
+  } catch (error) {
+    throw new TypeError(
+      `canonicalJSON: reading property ${JSON.stringify(key)} threw: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/packages/runtime/task/src/lib/canonicalJSON.ts
+++ b/packages/runtime/task/src/lib/canonicalJSON.ts
@@ -4,19 +4,30 @@
  * Unlike `JSON.stringify`, the output is stable across runs and injective over
  * the value domain it accepts: plain-object keys are sorted, arrays keep their
  * length and holes, `Map`/`Set` are tagged with sorted entries, `Date` and
- * `RegExp` are tagged, ArrayBuffer views are tagged with their raw bytes, and
- * the values `JSON.stringify` drops or mangles — `undefined`, `NaN`,
- * `±Infinity`, `-0`, and `bigint` — each get a distinct bare token that can
- * never collide with a string (strings are always quoted). It fails closed
- * with a `TypeError` on anything it cannot represent injectively: a function, a
- * symbol, a symbol-keyed or class-instance object, or a property whose getter
- * throws. Only own-enumerable string keys are canonicalised.
+ * `RegExp` are tagged, a typed array is tagged with its element values and a
+ * `DataView` with its raw bytes, and the values `JSON.stringify` drops or
+ * mangles — `undefined`, `NaN`, `±Infinity`, `-0`, and `bigint` — each get a
+ * distinct bare token that can never collide with a string (strings are always
+ * quoted). It fails closed with a `TypeError` on anything it cannot represent
+ * injectively: a function, a symbol, a symbol-keyed or class-instance object, a
+ * cyclic structure, or a property whose getter throws. Only own-enumerable
+ * string keys are canonicalised; extra own properties added to a
+ * Map/Set/array/typed array/Date/RegExp beyond its intrinsic contents are not
+ * part of the canonical form.
  *
  * @param value - The value to serialise.
  * @returns A canonical string representation.
  * @throws TypeError When the value is outside the canonicalisable domain.
  */
 export default function canonicalJSON(value: unknown): string {
+  return encode(value, new WeakSet());
+}
+
+/**
+ * Recursive worker threading the set of objects on the current path, so a cycle
+ * (an object reachable from itself) fails closed instead of overflowing.
+ */
+function encode(value: unknown, seen: WeakSet<object>): string {
   if (value === null) {
     return "null";
   }
@@ -35,7 +46,7 @@ export default function canonicalJSON(value: unknown): string {
     case "number":
       return encodeNumber(value as number);
     case "object":
-      return encodeObject(value as object);
+      return encodeObject(value as object, seen);
     default:
       // function | symbol — not representable deterministically.
       throw new TypeError(
@@ -66,77 +77,95 @@ function encodeNumber(value: number): string {
 
 /**
  * Encode a non-null object: arrays, `Map`, `Set`, `Date`, `RegExp`, ArrayBuffer
- * views, and plain records each get a distinct, deterministic form. A class
- * instance with opaque state is not representable injectively, so it fails
- * closed.
+ * views, and plain records each get a distinct, deterministic form. A cyclic
+ * reference or a class instance with opaque state is not representable
+ * injectively, so it fails closed.
  */
-function encodeObject(value: object): string {
-  if (Array.isArray(value)) {
-    return encodeArray(value);
+function encodeObject(value: object, seen: WeakSet<object>): string {
+  if (seen.has(value)) {
+    throw new TypeError("canonicalJSON: cannot serialise a cyclic structure");
   }
-  if (value instanceof Map) {
-    return encodeMap(value);
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return encodeArray(value, seen);
+    }
+    if (value instanceof Map) {
+      return encodeMap(value, seen);
+    }
+    if (value instanceof Set) {
+      return encodeSet(value, seen);
+    }
+    if (value instanceof Date) {
+      return `Date(${value.getTime()})`;
+    }
+    if (value instanceof RegExp) {
+      return `RegExp(${JSON.stringify(value.source)},${JSON.stringify(value.flags)})`;
+    }
+    if (ArrayBuffer.isView(value)) {
+      return encodeView(value, seen);
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype === Object.prototype || prototype === null) {
+      return encodeRecord(value as Record<string, unknown>, seen);
+    }
+    // A class instance's identity lives in opaque internal state, not its
+    // enumerable keys — fail closed rather than conflate distinct instances.
+    throw new TypeError(
+      "canonicalJSON: cannot serialise a non-plain object (class instance)",
+    );
+  } finally {
+    // Leave the path so a value shared across siblings (a DAG, not a cycle)
+    // encodes normally on each visit.
+    seen.delete(value);
   }
-  if (value instanceof Set) {
-    return encodeSet(value);
-  }
-  if (value instanceof Date) {
-    return `Date(${value.getTime()})`;
-  }
-  if (value instanceof RegExp) {
-    return `RegExp(${JSON.stringify(value.source)},${JSON.stringify(value.flags)})`;
-  }
-  if (ArrayBuffer.isView(value)) {
-    return encodeView(value);
-  }
-  const prototype = Object.getPrototypeOf(value);
-  if (prototype === Object.prototype || prototype === null) {
-    return encodeRecord(value as Record<string, unknown>);
-  }
-  // A class instance's identity lives in opaque internal state, not its
-  // enumerable keys — fail closed rather than conflate distinct instances.
-  throw new TypeError(
-    "canonicalJSON: cannot serialise a non-plain object (class instance)",
-  );
 }
 
 /**
  * Encode an array element-wise, giving an absent slot (a hole) a distinct bare
  * token so a sparse array never collapses to a shorter one.
  */
-function encodeArray(value: unknown[]): string {
+function encodeArray(value: unknown[], seen: WeakSet<object>): string {
   const parts: string[] = [];
   for (let index = 0; index < value.length; index++) {
-    parts.push(index in value ? canonicalJSON(value.at(index)) : "hole");
+    parts.push(index in value ? encode(value.at(index), seen) : "hole");
   }
   return `[${parts.join(",")}]`;
 }
 
 /**
- * Encode an ArrayBuffer view (typed array or `DataView`) as its constructor tag
- * plus its raw bytes, so every view type and payload stays distinct.
+ * Encode an ArrayBuffer view. A typed array is encoded by its logical element
+ * values (endianness-independent); a `DataView`, which exposes no elements, by
+ * its raw bytes. The constructor tag keeps view types distinct.
  */
-function encodeView(value: ArrayBufferView): string {
-  const bytes = new Uint8Array(
-    value.buffer,
-    value.byteOffset,
-    value.byteLength,
-  );
-  return `${value.constructor.name}(${Array.from(bytes).join(",")})`;
+function encodeView(value: ArrayBufferView, seen: WeakSet<object>): string {
+  if (value instanceof DataView) {
+    const bytes = new Uint8Array(
+      value.buffer,
+      value.byteOffset,
+      value.byteLength,
+    );
+    return `DataView(${Array.from(bytes).join(",")})`;
+  }
+  const items = Array.from(value as unknown as ArrayLike<number | bigint>);
+  return `${value.constructor.name}(${items.map((item) => encode(item, seen)).join(",")})`;
 }
 
 /** Encode a `Map` as a tagged, key-sorted set of canonical `key:value` pairs. */
-function encodeMap(value: Map<unknown, unknown>): string {
+function encodeMap(
+  value: Map<unknown, unknown>,
+  seen: WeakSet<object>,
+): string {
   const entries = Array.from(value.entries())
-    .map(([key, val]) => `${canonicalJSON(key)}:${canonicalJSON(val)}`)
+    .map(([key, val]) => `${encode(key, seen)}:${encode(val, seen)}`)
     .sort();
   return `Map{${entries.join(",")}}`;
 }
 
 /** Encode a `Set` as a tagged, sorted list of canonical elements. */
-function encodeSet(value: Set<unknown>): string {
+function encodeSet(value: Set<unknown>, seen: WeakSet<object>): string {
   const items = Array.from(value)
-    .map((item) => canonicalJSON(item))
+    .map((item) => encode(item, seen))
     .sort();
   return `Set{${items.join(",")}}`;
 }
@@ -147,7 +176,10 @@ function encodeSet(value: Set<unknown>): string {
  * would otherwise collapse to `{}`); only own-enumerable string keys are
  * canonicalised.
  */
-function encodeRecord(record: Record<string, unknown>): string {
+function encodeRecord(
+  record: Record<string, unknown>,
+  seen: WeakSet<object>,
+): string {
   if (Object.getOwnPropertySymbols(record).length > 0) {
     throw new TypeError(
       "canonicalJSON: cannot serialise an object with symbol keys",
@@ -156,7 +188,7 @@ function encodeRecord(record: Record<string, unknown>): string {
   const keys = Object.keys(record).sort();
   const entries = keys.map(
     (key) =>
-      `${JSON.stringify(key)}:${canonicalJSON(readProperty(record, key))}`,
+      `${JSON.stringify(key)}:${encode(readProperty(record, key), seen)}`,
   );
   return `{${entries.join(",")}}`;
 }

--- a/packages/runtime/task/src/lib/effectId.test.ts
+++ b/packages/runtime/task/src/lib/effectId.test.ts
@@ -117,7 +117,7 @@ describe("extractEffectContent", () => {
   it.each(
     cases,
   )("extracts identity content for %s, excluding closures", (_tag, effect, expected) => {
-    expect(extractEffectContent(effect)).toEqual(expected);
+    expect(extractEffectContent(effect)).toStrictEqual(expected);
   });
 
   it.each([
@@ -144,7 +144,7 @@ describe("extractEffectContent", () => {
     ],
   ] as const)("extracts content for a %s prompt", (_type, question) => {
     const effect: Effect = { _tag: "Prompt", question };
-    expect(extractEffectContent(effect)).toEqual(question);
+    expect(extractEffectContent(effect)).toStrictEqual(question);
   });
 });
 
@@ -194,8 +194,53 @@ describe("computeEffectId", () => {
 });
 
 describe("formatEffectId", () => {
-  it("renders a stable string keyed by branch, seq, kind, and content", () => {
+  it("renders a stable JSON-tuple string of branch, seq, kind, and content", () => {
     const id = computeEffectId({ _tag: "ReadFile", path: "/a" }, "0", 2);
-    expect(formatEffectId(id)).toBe('0#2:ReadFile:{"path":"/a"}');
+    expect(formatEffectId(id)).toBe(
+      '["0",2,"ReadFile","{\\"path\\":\\"/a\\"}"]',
+    );
+  });
+
+  it("is injective across delimiter-bearing branch and content", () => {
+    const a = formatEffectId({
+      branch: "a",
+      seq: 0,
+      kind: "Log",
+      content: "a#0:Log:z",
+    });
+    const b = formatEffectId({
+      branch: "a#0:Log:a",
+      seq: 0,
+      kind: "Log",
+      content: "z",
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("computeEffectId — non-canonicalisable values", () => {
+  it("throws when a WriteContext value is not canonicalisable", () => {
+    expect(() =>
+      computeEffectId(
+        { _tag: "WriteContext", key: "logger", value: () => undefined },
+        "",
+        0,
+      ),
+    ).toThrow(TypeError);
+  });
+});
+
+describe("extractEffectContent — prompt without a default", () => {
+  it("emits an undefined default for a prompt with no default", () => {
+    const effect: Effect = {
+      _tag: "Prompt",
+      question: { type: "text", name: "n", message: "m" },
+    };
+    expect(extractEffectContent(effect)).toStrictEqual({
+      type: "text",
+      name: "n",
+      message: "m",
+      default: undefined,
+    });
   });
 });

--- a/packages/runtime/task/src/lib/effectId.test.ts
+++ b/packages/runtime/task/src/lib/effectId.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeEffectId,
+  extractEffectContent,
+  formatEffectId,
+} from "./effectId.js";
+import { pure } from "./task.js";
+import type { Effect } from "./types.js";
+
+// One representative effect per tag, several carrying closures (transform,
+// validate, undo) that must NOT appear in the extracted content.
+const cases: Array<[string, Effect, unknown]> = [
+  ["ReadFile", { _tag: "ReadFile", path: "/a" }, { path: "/a" }],
+  [
+    "WriteFile",
+    { _tag: "WriteFile", path: "/a", content: "x", undo: pure(undefined) },
+    { path: "/a", content: "x" },
+  ],
+  [
+    "AppendFile",
+    { _tag: "AppendFile", path: "/a", content: "x", createIfMissing: true },
+    { path: "/a", content: "x", createIfMissing: true },
+  ],
+  [
+    "TransformFile",
+    { _tag: "TransformFile", path: "/a", transform: (s: string) => s },
+    { path: "/a" },
+  ],
+  [
+    "CopyFile",
+    { _tag: "CopyFile", source: "/a", dest: "/b" },
+    { source: "/a", dest: "/b" },
+  ],
+  [
+    "CopyDirectory",
+    { _tag: "CopyDirectory", source: "/a", dest: "/b" },
+    { source: "/a", dest: "/b" },
+  ],
+  ["DeleteFile", { _tag: "DeleteFile", path: "/a" }, { path: "/a" }],
+  ["DeleteDirectory", { _tag: "DeleteDirectory", path: "/a" }, { path: "/a" }],
+  [
+    "MakeDir",
+    { _tag: "MakeDir", path: "/a", recursive: true },
+    { path: "/a", recursive: true },
+  ],
+  ["Exists", { _tag: "Exists", path: "/a" }, { path: "/a" }],
+  [
+    "Glob",
+    { _tag: "Glob", pattern: "*.ts", cwd: "/a" },
+    { pattern: "*.ts", cwd: "/a" },
+  ],
+  [
+    "Exec",
+    { _tag: "Exec", command: "ls", args: ["-l"], cwd: "/a" },
+    { command: "ls", args: ["-l"], cwd: "/a" },
+  ],
+  [
+    "Prompt",
+    {
+      _tag: "Prompt",
+      question: {
+        type: "text",
+        name: "n",
+        message: "m",
+        default: "d",
+        validate: () => true,
+      },
+    },
+    { type: "text", name: "n", message: "m", default: "d" },
+  ],
+  [
+    "Log",
+    { _tag: "Log", level: "info", message: "m" },
+    { level: "info", message: "m" },
+  ],
+  ["ReadContext", { _tag: "ReadContext", key: "k" }, { key: "k" }],
+  [
+    "WriteContext",
+    { _tag: "WriteContext", key: "k", value: 42 },
+    { key: "k", value: 42 },
+  ],
+  [
+    "Symlink",
+    { _tag: "Symlink", target: "/t", path: "/l" },
+    { target: "/t", path: "/l" },
+  ],
+  ["Parallel", { _tag: "Parallel", tasks: [pure(1)] }, { taskCount: 1 }],
+  ["Race", { _tag: "Race", tasks: [pure(1), pure(2)] }, { taskCount: 2 }],
+];
+
+describe("extractEffectContent", () => {
+  it.each(
+    cases,
+  )("extracts identity content for %s, excluding closures", (_tag, effect, expected) => {
+    expect(extractEffectContent(effect)).toEqual(expected);
+  });
+
+  it.each([
+    ["confirm", { type: "confirm", name: "n", message: "m", default: true }],
+    [
+      "select",
+      {
+        type: "select",
+        name: "n",
+        message: "m",
+        default: "a",
+        choices: [{ label: "A", value: "a" }],
+      },
+    ],
+    [
+      "multiselect",
+      {
+        type: "multiselect",
+        name: "n",
+        message: "m",
+        default: ["a"],
+        choices: [{ label: "A", value: "a" }],
+      },
+    ],
+  ] as const)("extracts content for a %s prompt", (_type, question) => {
+    const effect: Effect = { _tag: "Prompt", question };
+    expect(extractEffectContent(effect)).toEqual(question);
+  });
+});
+
+describe("computeEffectId", () => {
+  it("gives equal content to equal effects at the same position", () => {
+    const a = computeEffectId({ _tag: "ReadFile", path: "/a" }, "", 0);
+    const b = computeEffectId({ _tag: "ReadFile", path: "/a" }, "", 0);
+    expect(a).toEqual(b);
+    expect(a.kind).toBe("ReadFile");
+  });
+
+  it("distinguishes different content", () => {
+    const a = computeEffectId({ _tag: "ReadFile", path: "/a" }, "", 0);
+    const b = computeEffectId({ _tag: "ReadFile", path: "/b" }, "", 0);
+    expect(a.content).not.toBe(b.content);
+  });
+
+  it("distinguishes the same effect at different positions", () => {
+    const a = computeEffectId({ _tag: "ReadFile", path: "/a" }, "", 0);
+    const b = computeEffectId({ _tag: "ReadFile", path: "/a" }, "", 1);
+    expect(a.content).toBe(b.content);
+    expect(a.seq).not.toBe(b.seq);
+  });
+
+  it("ignores a transform closure so two transforms of one path match", () => {
+    const a = computeEffectId(
+      { _tag: "TransformFile", path: "/a", transform: (s) => s.toUpperCase() },
+      "",
+      0,
+    );
+    const b = computeEffectId(
+      { _tag: "TransformFile", path: "/a", transform: (s) => s.trim() },
+      "",
+      0,
+    );
+    expect(a.content).toBe(b.content);
+  });
+});
+
+describe("formatEffectId", () => {
+  it("renders a stable string keyed by branch, seq, kind, and content", () => {
+    const id = computeEffectId({ _tag: "ReadFile", path: "/a" }, "0", 2);
+    expect(formatEffectId(id)).toBe('0#2:ReadFile:{"path":"/a"}');
+  });
+});

--- a/packages/runtime/task/src/lib/effectId.test.ts
+++ b/packages/runtime/task/src/lib/effectId.test.ts
@@ -18,29 +18,48 @@ const cases: Array<[string, Effect, unknown]> = [
   ],
   [
     "AppendFile",
-    { _tag: "AppendFile", path: "/a", content: "x", createIfMissing: true },
+    {
+      _tag: "AppendFile",
+      path: "/a",
+      content: "x",
+      createIfMissing: true,
+      undo: pure(undefined),
+    },
     { path: "/a", content: "x", createIfMissing: true },
   ],
   [
     "TransformFile",
-    { _tag: "TransformFile", path: "/a", transform: (s: string) => s },
+    {
+      _tag: "TransformFile",
+      path: "/a",
+      transform: (s: string) => s,
+      undo: pure(undefined),
+    },
     { path: "/a" },
   ],
   [
     "CopyFile",
-    { _tag: "CopyFile", source: "/a", dest: "/b" },
+    { _tag: "CopyFile", source: "/a", dest: "/b", undo: pure(undefined) },
     { source: "/a", dest: "/b" },
   ],
   [
     "CopyDirectory",
-    { _tag: "CopyDirectory", source: "/a", dest: "/b" },
+    { _tag: "CopyDirectory", source: "/a", dest: "/b", undo: pure(undefined) },
     { source: "/a", dest: "/b" },
   ],
-  ["DeleteFile", { _tag: "DeleteFile", path: "/a" }, { path: "/a" }],
-  ["DeleteDirectory", { _tag: "DeleteDirectory", path: "/a" }, { path: "/a" }],
+  [
+    "DeleteFile",
+    { _tag: "DeleteFile", path: "/a", undo: pure(undefined) },
+    { path: "/a" },
+  ],
+  [
+    "DeleteDirectory",
+    { _tag: "DeleteDirectory", path: "/a", undo: pure(undefined) },
+    { path: "/a" },
+  ],
   [
     "MakeDir",
-    { _tag: "MakeDir", path: "/a", recursive: true },
+    { _tag: "MakeDir", path: "/a", recursive: true, undo: pure(undefined) },
     { path: "/a", recursive: true },
   ],
   ["Exists", { _tag: "Exists", path: "/a" }, { path: "/a" }],
@@ -51,7 +70,13 @@ const cases: Array<[string, Effect, unknown]> = [
   ],
   [
     "Exec",
-    { _tag: "Exec", command: "ls", args: ["-l"], cwd: "/a" },
+    {
+      _tag: "Exec",
+      command: "ls",
+      args: ["-l"],
+      cwd: "/a",
+      undo: pure(undefined),
+    },
     { command: "ls", args: ["-l"], cwd: "/a" },
   ],
   [
@@ -81,7 +106,7 @@ const cases: Array<[string, Effect, unknown]> = [
   ],
   [
     "Symlink",
-    { _tag: "Symlink", target: "/t", path: "/l" },
+    { _tag: "Symlink", target: "/t", path: "/l", undo: pure(undefined) },
     { target: "/t", path: "/l" },
   ],
   ["Parallel", { _tag: "Parallel", tasks: [pure(1)] }, { taskCount: 1 }],
@@ -129,6 +154,15 @@ describe("computeEffectId", () => {
     const b = computeEffectId({ _tag: "ReadFile", path: "/a" }, "", 0);
     expect(a).toEqual(b);
     expect(a.kind).toBe("ReadFile");
+  });
+
+  it("carries the effect's tag into kind for a non-ReadFile effect", () => {
+    const id = computeEffectId(
+      { _tag: "Exec", command: "ls", args: ["-l"], cwd: "/a" },
+      "",
+      0,
+    );
+    expect(id.kind).toBe("Exec");
   });
 
   it("distinguishes different content", () => {

--- a/packages/runtime/task/src/lib/effectId.ts
+++ b/packages/runtime/task/src/lib/effectId.ts
@@ -1,0 +1,126 @@
+/**
+ * Effect identity.
+ *
+ * These helpers turn an {@link Effect} into a stable {@link EffectId}: the
+ * content-addressable descriptor is derived from the effect's identity-bearing
+ * fields (excluding closures such as `transform`, a prompt's `validate`, and
+ * the `undo` task), canonicalised, and combined with a caller-supplied
+ * branch/seq position. They are the substrate a journal builds on to record and
+ * replay effect results by identity.
+ */
+
+import canonicalJSON from "./canonicalJSON.js";
+import type { Effect, EffectId, PromptQuestion } from "./types.js";
+
+/**
+ * Extract an effect's identity-bearing content — the serialisable fields that
+ * determine which effect this is, with every closure (`transform`, a prompt's
+ * `validate`, `undo`) and non-serialisable child (`Parallel`/`Race` tasks)
+ * omitted. Two effects with equal content are the same effect for the purpose
+ * of recording and replaying its result.
+ *
+ * @param effect - The effect to describe.
+ * @returns A plain, canonicalisable value identifying the effect.
+ */
+export function extractEffectContent(effect: Effect): unknown {
+  switch (effect._tag) {
+    case "ReadFile":
+    case "Exists":
+    case "DeleteFile":
+    case "DeleteDirectory":
+      return { path: effect.path };
+    case "WriteFile":
+      return { path: effect.path, content: effect.content };
+    case "AppendFile":
+      return {
+        path: effect.path,
+        content: effect.content,
+        createIfMissing: effect.createIfMissing,
+      };
+    case "TransformFile":
+      // The transform closure is not part of identity; its recorded result is.
+      return { path: effect.path };
+    case "CopyFile":
+    case "CopyDirectory":
+      return { source: effect.source, dest: effect.dest };
+    case "MakeDir":
+      return { path: effect.path, recursive: effect.recursive };
+    case "Symlink":
+      return { target: effect.target, path: effect.path };
+    case "Glob":
+      return { pattern: effect.pattern, cwd: effect.cwd };
+    case "Exec":
+      return { command: effect.command, args: effect.args, cwd: effect.cwd };
+    case "Prompt":
+      return extractPromptContent(effect.question);
+    case "Log":
+      return { level: effect.level, message: effect.message };
+    case "ReadContext":
+      return { key: effect.key };
+    case "WriteContext":
+      return { key: effect.key, value: effect.value };
+    case "Parallel":
+    case "Race":
+      // Children are closures resolved via sub-journals; identity is structural.
+      return { taskCount: effect.tasks.length };
+  }
+}
+
+/**
+ * Compute the stable identity of an effect occurrence at a given journal
+ * position.
+ *
+ * @param effect - The effect to identify.
+ * @param branch - Structural path of the enclosing parallel/race branch.
+ * @param seq - Per-branch occurrence counter.
+ * @returns The effect's {@link EffectId}.
+ */
+export function computeEffectId(
+  effect: Effect,
+  branch: string,
+  seq: number,
+): EffectId {
+  return {
+    kind: effect._tag,
+    content: canonicalJSON(extractEffectContent(effect)),
+    branch,
+    seq,
+  };
+}
+
+/**
+ * Render an {@link EffectId} to a stable string suitable for equality checks
+ * and journal keys.
+ *
+ * @param id - The effect id to format.
+ * @returns A canonical string form of the id.
+ */
+export function formatEffectId(id: EffectId): string {
+  return `${id.branch}#${id.seq}:${id.kind}:${id.content}`;
+}
+
+/**
+ * Extract a prompt's identity-bearing content, dropping the `validate` closure
+ * a text prompt may carry so the descriptor stays canonicalisable.
+ */
+function extractPromptContent(question: PromptQuestion): unknown {
+  switch (question.type) {
+    case "text":
+    case "confirm":
+      return {
+        type: question.type,
+        name: question.name,
+        message: question.message,
+        default: question.default,
+      };
+    case "select":
+    case "multiselect":
+      return {
+        type: question.type,
+        name: question.name,
+        message: question.message,
+        default: question.default,
+        choices: question.choices,
+      };
+  }
+}

--- a/packages/runtime/task/src/lib/effectId.ts
+++ b/packages/runtime/task/src/lib/effectId.ts
@@ -20,7 +20,9 @@ import type { Effect, EffectId, PromptQuestion } from "./types.js";
  * of recording and replaying its result.
  *
  * @param effect - The effect to describe.
- * @returns A plain, canonicalisable value identifying the effect.
+ * @returns The effect's identity content. This is canonicalisable for every
+ * tag except `WriteContext`, whose `value` is forwarded verbatim and may be
+ * outside {@link canonicalJSON}'s domain.
  */
 export function extractEffectContent(effect: Effect): unknown {
   switch (effect._tag) {
@@ -74,6 +76,9 @@ export function extractEffectContent(effect: Effect): unknown {
  * @param branch - Structural path of the enclosing parallel/race branch.
  * @param seq - Per-branch occurrence counter.
  * @returns The effect's {@link EffectId}.
+ * @throws TypeError When the effect's identity content is not canonicalisable —
+ * in practice only a `WriteContext` whose `value` is a function, symbol, class
+ * instance, or otherwise outside {@link canonicalJSON}'s domain.
  */
 export function computeEffectId(
   effect: Effect,
@@ -89,14 +94,15 @@ export function computeEffectId(
 }
 
 /**
- * Render an {@link EffectId} to a stable string suitable for equality checks
- * and journal keys.
+ * Render an {@link EffectId} to a stable, injective string suitable for
+ * equality checks and journal keys. The four fields are encoded as a JSON tuple
+ * so a `#` or `:` inside `branch`/`content` can never blur a field boundary.
  *
  * @param id - The effect id to format.
  * @returns A canonical string form of the id.
  */
 export function formatEffectId(id: EffectId): string {
-  return `${id.branch}#${id.seq}:${id.kind}:${id.content}`;
+  return JSON.stringify([id.branch, id.seq, id.kind, id.content]);
 }
 
 /**

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -259,6 +259,31 @@ export type Task<A, E = Effect> =
     };
 
 // =============================================================================
+// Effect Identity
+// =============================================================================
+
+/**
+ * A stable identity for a single effect occurrence.
+ *
+ * `kind` and `content` are the content-addressable part — the effect's tag plus
+ * a canonical serialisation of its identity-bearing fields (closures excluded).
+ * `branch` and `seq` are the positional part — the enclosing parallel/race path
+ * and a per-branch occurrence counter — that a journal supplies while walking a
+ * task, so that two effects with identical content at different positions stay
+ * distinct.
+ */
+export interface EffectId {
+  /** The effect's discriminant tag. */
+  kind: Effect["_tag"];
+  /** Canonical serialisation of the effect's identity-bearing content. */
+  content: string;
+  /** Structural path of the enclosing parallel/race branch. */
+  branch: string;
+  /** Per-branch occurrence counter, disambiguating same-content effects. */
+  seq: number;
+}
+
+// =============================================================================
 // Execution Result
 // =============================================================================
 


### PR DESCRIPTION
## Done

The content-addressable identity substrate for `@canonical/task`'s determinism/journal work. **Pure, additive public API — no existing behaviour changes** (the interpreter hardening this builds on landed separately in #740, now on `main`; this PR is rebased onto it).

- **`canonicalJSON`** — a total, deterministic, injective-or-fail-closed serialiser: object keys sorted; arrays keep length and holes; `Map`/`Set` tagged and sorted; `Date`/`RegExp` tagged; typed arrays encoded by element values and `DataView` by bytes; distinct bare tokens for `undefined`/`NaN`/`±Infinity`/`-0`/`bigint`; **fails closed** with a `TypeError` on functions, symbols, symbol-keyed or class-instance objects, cyclic structures, and throwing getters.
- **`extractEffectContent`** — the per-tag identity descriptor for all 19 effect tags, excluding closures (`transform`, `validate`, `undo`) and non-serialisable children.
- **`EffectId` + `computeEffectId` + `formatEffectId`** — a stable `{ kind, content, branch, seq }` identity; `formatEffectId` renders an injective JSON-tuple key. `computeEffectId` fails closed for the one tag (`WriteContext`) whose value may be uncanonicalisable — documented via `@throws`.

## QA

- `cd packages/runtime/task && bun run test` → **777 pass, 100% coverage**.
- `bun run check` → **biome + tsc + webarchitect green**.
- `bun run build` → compiles clean.
- Manual: `canonicalJSON` on a cyclic structure throws (no overflow); `new Array(1)` ≠ `[]`; a `DataView` keeps its bytes; two `EffectId`s whose `branch`/`content` contain `#`/`:` format to distinct strings.

### PR readiness check

- [x] PR should have one of the following labels: **`Feature 🎁`**.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards) (webarchitect passes).
- [x] All packages define the required scripts in `package.json`: `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] This PR does not introduce a new package.
- [x] This PR does not require visual testing — add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — library-internal change, no visual surface.