### PR TITLE
feat(task): journal record/replay for deterministic effect execution

### DIFF
--- a/packages/runtime/task/src/index.ts
+++ b/packages/runtime/task/src/index.ts
@@ -16,6 +16,10 @@ export type {
   Effect,
   EffectId,
   ExecResult,
+  Journal,
+  JournalEntry,
+  JournalOutcome,
+  JournalRun,
   LogLevel,
   MultiselectPrompt,
   PromptQuestion,
@@ -173,10 +177,20 @@ export {
 export type { RunTaskOptions } from "./lib/interpreter.js";
 export {
   executeEffect,
+  JournalDivergenceError,
   run,
   runTask,
   TaskExecutionError,
 } from "./lib/interpreter.js";
+
+// =============================================================================
+// Journal — record / replay
+// =============================================================================
+
+export { default as deserializeJournal } from "./lib/deserializeJournal.js";
+export { default as recordTask } from "./lib/recordTask.js";
+export { default as replayTask } from "./lib/replayTask.js";
+export { default as serializeJournal } from "./lib/serializeJournal.js";
 
 // =============================================================================
 // Dry-Run

--- a/packages/runtime/task/src/index.ts
+++ b/packages/runtime/task/src/index.ts
@@ -178,6 +178,9 @@ export type { RunTaskOptions } from "./lib/interpreter.js";
 export {
   executeEffect,
   JournalDivergenceError,
+  JournalError,
+  JournalIncompleteError,
+  JournalUnsupportedEffectError,
   run,
   runTask,
   TaskExecutionError,

--- a/packages/runtime/task/src/lib/deserializeJournal.test.ts
+++ b/packages/runtime/task/src/lib/deserializeJournal.test.ts
@@ -1,18 +1,28 @@
 import { describe, expect, it } from "vitest";
 import deserializeJournal from "./deserializeJournal.js";
 
+const validId = { kind: "ReadFile", content: "{}", branch: "", seq: 0 };
+const wrap = (entry: unknown): string => JSON.stringify({ entries: [entry] });
+
 describe("deserializeJournal", () => {
-  it("parses a well-formed journal", () => {
-    const text =
-      '{"entries":[{"id":{"kind":"ReadFile","content":"{}","branch":"","seq":0},"outcome":{"ok":true,"value":"x"}}]}';
+  it("parses a well-formed success entry", () => {
+    const text = wrap({ id: validId, outcome: { ok: true, value: "x" } });
     expect(deserializeJournal(text)).toEqual({
-      entries: [
-        {
-          id: { kind: "ReadFile", content: "{}", branch: "", seq: 0 },
-          outcome: { ok: true, value: "x" },
-        },
-      ],
+      entries: [{ id: validId, outcome: { ok: true, value: "x" } }],
     });
+  });
+
+  it("parses a success entry whose value is absent", () => {
+    const text = wrap({ id: validId, outcome: { ok: true } });
+    expect(deserializeJournal(text).entries).toHaveLength(1);
+  });
+
+  it("parses a failure entry with a TaskError-shaped error", () => {
+    const text = wrap({
+      id: validId,
+      outcome: { ok: false, error: { code: "FILE_NOT_FOUND", message: "no" } },
+    });
+    expect(deserializeJournal(text).entries).toHaveLength(1);
   });
 
   it("parses an empty journal", () => {
@@ -41,20 +51,54 @@ describe("deserializeJournal", () => {
   });
 
   it("fails closed when an entry is not an object", () => {
-    expect(() => deserializeJournal('{"entries":[1]}')).toThrow(
+    expect(() => deserializeJournal(wrap(1))).toThrow(
       /not a well-formed journal/,
     );
   });
 
   it("fails closed when an entry id is not an object", () => {
     expect(() =>
-      deserializeJournal('{"entries":[{"id":1,"outcome":{}}]}'),
+      deserializeJournal(wrap({ id: 1, outcome: { ok: true } })),
     ).toThrow(/not a well-formed journal/);
   });
 
-  it("fails closed when an entry outcome is not an object", () => {
+  it.each([
+    ["kind", { ...validId, kind: 1 }],
+    ["content", { ...validId, content: 1 }],
+    ["branch", { ...validId, branch: 1 }],
+    ["seq", { ...validId, seq: "0" }],
+  ])("fails closed when the effect id %s is the wrong type", (_field, id) => {
     expect(() =>
-      deserializeJournal('{"entries":[{"id":{},"outcome":1}]}'),
+      deserializeJournal(wrap({ id, outcome: { ok: true } })),
+    ).toThrow(/not a well-formed journal/);
+  });
+
+  it("fails closed when the outcome is not an object", () => {
+    expect(() => deserializeJournal(wrap({ id: validId, outcome: 1 }))).toThrow(
+      /not a well-formed journal/,
+    );
+  });
+
+  it("fails closed when the outcome has no ok discriminant", () => {
+    expect(() =>
+      deserializeJournal(wrap({ id: validId, outcome: {} })),
+    ).toThrow(/not a well-formed journal/);
+  });
+
+  it("fails closed when a failure outcome has no TaskError-shaped error", () => {
+    expect(() =>
+      deserializeJournal(
+        wrap({ id: validId, outcome: { ok: false, error: 1 } }),
+      ),
+    ).toThrow(/not a well-formed journal/);
+  });
+
+  it.each([
+    ["code", { code: 1, message: "m" }],
+    ["message", { code: "X", message: 1 }],
+  ])("fails closed when a failure error %s is the wrong type", (_field, error) => {
+    expect(() =>
+      deserializeJournal(wrap({ id: validId, outcome: { ok: false, error } })),
     ).toThrow(/not a well-formed journal/);
   });
 });

--- a/packages/runtime/task/src/lib/deserializeJournal.test.ts
+++ b/packages/runtime/task/src/lib/deserializeJournal.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import deserializeJournal from "./deserializeJournal.js";
+
+describe("deserializeJournal", () => {
+  it("parses a well-formed journal", () => {
+    const text =
+      '{"entries":[{"id":{"kind":"ReadFile","content":"{}","branch":"","seq":0},"outcome":{"ok":true,"value":"x"}}]}';
+    expect(deserializeJournal(text)).toEqual({
+      entries: [
+        {
+          id: { kind: "ReadFile", content: "{}", branch: "", seq: 0 },
+          outcome: { ok: true, value: "x" },
+        },
+      ],
+    });
+  });
+
+  it("parses an empty journal", () => {
+    expect(deserializeJournal('{"entries":[]}')).toEqual({ entries: [] });
+  });
+
+  it("fails closed with a TypeError on invalid JSON", () => {
+    expect(() => deserializeJournal("not json")).toThrow(TypeError);
+    expect(() => deserializeJournal("not json")).toThrow(/not valid JSON/);
+  });
+
+  it("fails closed on JSON null", () => {
+    expect(() => deserializeJournal("null")).toThrow(
+      /not a well-formed journal/,
+    );
+  });
+
+  it("fails closed on a non-object", () => {
+    expect(() => deserializeJournal("42")).toThrow(/not a well-formed journal/);
+  });
+
+  it("fails closed when entries is not an array", () => {
+    expect(() => deserializeJournal('{"entries":5}')).toThrow(
+      /not a well-formed journal/,
+    );
+  });
+
+  it("fails closed when an entry is not an object", () => {
+    expect(() => deserializeJournal('{"entries":[1]}')).toThrow(
+      /not a well-formed journal/,
+    );
+  });
+
+  it("fails closed when an entry id is not an object", () => {
+    expect(() =>
+      deserializeJournal('{"entries":[{"id":1,"outcome":{}}]}'),
+    ).toThrow(/not a well-formed journal/);
+  });
+
+  it("fails closed when an entry outcome is not an object", () => {
+    expect(() =>
+      deserializeJournal('{"entries":[{"id":{},"outcome":1}]}'),
+    ).toThrow(/not a well-formed journal/);
+  });
+});

--- a/packages/runtime/task/src/lib/deserializeJournal.test.ts
+++ b/packages/runtime/task/src/lib/deserializeJournal.test.ts
@@ -12,9 +12,19 @@ describe("deserializeJournal", () => {
     });
   });
 
-  it("parses a success entry whose value is absent", () => {
-    const text = wrap({ id: validId, outcome: { ok: true } });
+  it("parses a void-effect success entry whose value is absent", () => {
+    const text = wrap({
+      id: { ...validId, kind: "WriteFile" },
+      outcome: { ok: true },
+    });
     expect(deserializeJournal(text).entries).toHaveLength(1);
+  });
+
+  it("fails closed when an always-valued effect success has no recorded value", () => {
+    // A ReadFile that "succeeded" with no value is corrupt — it would replay as
+    // undefined instead of the file's contents.
+    const text = wrap({ id: validId, outcome: { ok: true } });
+    expect(() => deserializeJournal(text)).toThrow(/not a well-formed journal/);
   });
 
   it("parses a failure entry with a TaskError-shaped error", () => {

--- a/packages/runtime/task/src/lib/deserializeJournal.ts
+++ b/packages/runtime/task/src/lib/deserializeJournal.ts
@@ -1,0 +1,43 @@
+import type { Journal } from "./types.js";
+
+/**
+ * Parse a {@link Journal} from the JSON string produced by
+ * {@link serializeJournal}, failing closed with a `TypeError` when the text is
+ * not a well-formed journal — so a corrupt or foreign file can never drive
+ * replay with garbage entries.
+ *
+ * @param text - The serialised journal.
+ * @returns The parsed journal.
+ * @throws TypeError When the text is not valid JSON or not a journal shape.
+ */
+export default function deserializeJournal(text: string): Journal {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new TypeError("deserializeJournal: input is not valid JSON");
+  }
+  if (!isJournal(parsed)) {
+    throw new TypeError(
+      "deserializeJournal: input is not a well-formed journal",
+    );
+  }
+  return parsed;
+}
+
+/** Narrow an unknown parse result to the {@link Journal} shape replay relies on. */
+function isJournal(value: unknown): value is Journal {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.entries) &&
+    value.entries.every(
+      (entry) =>
+        isRecord(entry) && isRecord(entry.id) && isRecord(entry.outcome),
+    )
+  );
+}
+
+/** Test whether a value is a non-null object usable as a property bag. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/runtime/task/src/lib/deserializeJournal.ts
+++ b/packages/runtime/task/src/lib/deserializeJournal.ts
@@ -6,6 +6,12 @@ import type { Journal } from "./types.js";
  * not a well-formed journal — so a corrupt or foreign file can never drive
  * replay with garbage entries.
  *
+ * Validation is structural and deep: every entry must carry a well-typed
+ * {@link EffectId} and an outcome that is either `{ ok: true }` (a success,
+ * whose value may be absent when it was `undefined`) or `{ ok: false }` with a
+ * `TaskError`-shaped `error`. A shape-valid but semantically malformed entry is
+ * rejected here rather than detonating mid-replay.
+ *
  * @param text - The serialised journal.
  * @returns The parsed journal.
  * @throws TypeError When the text is not valid JSON or not a journal shape.
@@ -30,10 +36,44 @@ function isJournal(value: unknown): value is Journal {
   return (
     isRecord(value) &&
     Array.isArray(value.entries) &&
-    value.entries.every(
-      (entry) =>
-        isRecord(entry) && isRecord(entry.id) && isRecord(entry.outcome),
-    )
+    value.entries.every(isJournalEntry)
+  );
+}
+
+/** Validate one entry: a well-typed effect id plus a discriminated outcome. */
+function isJournalEntry(value: unknown): boolean {
+  return isRecord(value) && isEffectId(value.id) && isOutcome(value.outcome);
+}
+
+/** Validate an {@link EffectId}: the four primitive identity fields. */
+function isEffectId(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.kind === "string" &&
+    typeof value.content === "string" &&
+    typeof value.branch === "string" &&
+    typeof value.seq === "number"
+  );
+}
+
+/**
+ * Validate a {@link JournalOutcome} discriminant: `ok` must be a boolean, and a
+ * failure must carry a `TaskError`-shaped error. A success value may be absent
+ * (an `undefined` result serialises to no `value` key), so it is not required.
+ */
+function isOutcome(value: unknown): boolean {
+  if (!isRecord(value) || typeof value.ok !== "boolean") {
+    return false;
+  }
+  return value.ok || isTaskError(value.error);
+}
+
+/** Validate the minimal `TaskError` shape replay reconstructs a failure from. */
+function isTaskError(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.code === "string" &&
+    typeof value.message === "string"
   );
 }
 

--- a/packages/runtime/task/src/lib/deserializeJournal.ts
+++ b/packages/runtime/task/src/lib/deserializeJournal.ts
@@ -1,4 +1,4 @@
-import type { Journal } from "./types.js";
+import type { Effect, EffectId, Journal, JournalOutcome } from "./types.js";
 
 /**
  * Parse a {@link Journal} from the JSON string produced by
@@ -7,10 +7,11 @@ import type { Journal } from "./types.js";
  * replay with garbage entries.
  *
  * Validation is structural and deep: every entry must carry a well-typed
- * {@link EffectId} and an outcome that is either `{ ok: true }` (a success,
- * whose value may be absent when it was `undefined`) or `{ ok: false }` with a
- * `TaskError`-shaped `error`. A shape-valid but semantically malformed entry is
- * rejected here rather than detonating mid-replay.
+ * {@link EffectId} and an outcome that is either `{ ok: true }` (a success) or
+ * `{ ok: false }` with a `TaskError`-shaped `error`. A success `value` may be
+ * absent only for a kind whose result can be `undefined`; a `ReadFile`/`Exec`/
+ * `Exists`/`Glob` success with no recorded value is corrupt and rejected here
+ * rather than replaying silently as `undefined`.
  *
  * @param text - The serialised journal.
  * @returns The parsed journal.
@@ -31,6 +32,19 @@ export default function deserializeJournal(text: string): Journal {
   return parsed;
 }
 
+/**
+ * Effect kinds whose successful result is never `undefined`, so a success entry
+ * for one of them must carry a `value`. Void effects (their result is
+ * `undefined`) and `ReadContext`/`Prompt` (which can legitimately yield
+ * `undefined`) are deliberately absent, so a missing value stays valid for them.
+ */
+const ALWAYS_VALUED: ReadonlySet<Effect["_tag"]> = new Set([
+  "ReadFile",
+  "Exists",
+  "Glob",
+  "Exec",
+]);
+
 /** Narrow an unknown parse result to the {@link Journal} shape replay relies on. */
 function isJournal(value: unknown): value is Journal {
   return (
@@ -42,11 +56,21 @@ function isJournal(value: unknown): value is Journal {
 
 /** Validate one entry: a well-typed effect id plus a discriminated outcome. */
 function isJournalEntry(value: unknown): boolean {
-  return isRecord(value) && isEffectId(value.id) && isOutcome(value.outcome);
+  if (!isRecord(value) || !isEffectId(value.id) || !isOutcome(value.outcome)) {
+    return false;
+  }
+  // A success value that was `undefined` serialises to no `value` key; that is
+  // only legitimate for a kind whose result can be undefined, so an always-valued
+  // kind with no recorded value is corrupt.
+  return !(
+    value.outcome.ok &&
+    !("value" in value.outcome) &&
+    ALWAYS_VALUED.has(value.id.kind)
+  );
 }
 
 /** Validate an {@link EffectId}: the four primitive identity fields. */
-function isEffectId(value: unknown): boolean {
+function isEffectId(value: unknown): value is EffectId {
   return (
     isRecord(value) &&
     typeof value.kind === "string" &&
@@ -59,9 +83,9 @@ function isEffectId(value: unknown): boolean {
 /**
  * Validate a {@link JournalOutcome} discriminant: `ok` must be a boolean, and a
  * failure must carry a `TaskError`-shaped error. A success value may be absent
- * (an `undefined` result serialises to no `value` key), so it is not required.
+ * here; {@link isJournalEntry} enforces its presence for always-valued kinds.
  */
-function isOutcome(value: unknown): boolean {
+function isOutcome(value: unknown): value is JournalOutcome {
   if (!isRecord(value) || typeof value.ok !== "boolean") {
     return false;
   }

--- a/packages/runtime/task/src/lib/effectId.ts
+++ b/packages/runtime/task/src/lib/effectId.ts
@@ -63,7 +63,9 @@ export function extractEffectContent(effect: Effect): unknown {
       return { key: effect.key, value: effect.value };
     case "Parallel":
     case "Race":
-      // Children are closures resolved via sub-journals; identity is structural.
+      // Children are nested tasks, not identity-bearing leaf fields; identity is
+      // structural (a journal does not record composites — see the interpreter's
+      // journaling seam — so this coarse descriptor is not used for replay).
       return { taskCount: effect.tasks.length };
   }
 }

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -10,15 +10,23 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { orElse, parallel, sequence_ } from "./combinators.js";
+import { orElse, parallel, race, sequence_ } from "./combinators.js";
 import {
   executeEffect,
   JournalDivergenceError,
+  JournalUnsupportedEffectError,
   run,
   runTask,
   TaskExecutionError,
 } from "./interpreter.js";
-import { info, readFile, succeed, warn } from "./primitives.js";
+import {
+  info,
+  promptText,
+  readFile,
+  setContext,
+  succeed,
+  warn,
+} from "./primitives.js";
 import recordTask from "./recordTask.js";
 import replayTask from "./replayTask.js";
 import {
@@ -1829,25 +1837,38 @@ describe("Interpreter - journal seam", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("records a Parallel as one opaque entry and replays its composite result without running children", async () => {
-    const a = join(dir, "par-a.txt");
-    const b = join(dir, "par-b.txt");
-    writeFileSync(a, "A");
-    writeFileSync(b, "B");
+  it("rejects a Parallel effect under a journal (composites have no positional identity)", async () => {
+    await expect(
+      recordTask(parallel([succeed("a"), succeed("b")])),
+    ).rejects.toBeInstanceOf(JournalUnsupportedEffectError);
+  });
 
-    const par = parallel([readFile(a), readFile(b)]);
-    const recorded = await recordTask(par);
+  it("rejects a Race effect under a journal", async () => {
+    await expect(recordTask(race([succeed("a")]))).rejects.toBeInstanceOf(
+      JournalUnsupportedEffectError,
+    );
+  });
 
-    expect(recorded.value).toEqual(["A", "B"]);
-    expect(recorded.journal.entries).toHaveLength(1);
-    expect(recorded.journal.entries.at(0)?.id.kind).toBe("Parallel");
+  it("lets a JournalUnsupportedEffectError escape an enclosing recover", async () => {
+    const guarded = orElse(parallel([succeed("a")]), pure("swallowed"));
+    await expect(recordTask(guarded)).rejects.toBeInstanceOf(
+      JournalUnsupportedEffectError,
+    );
+  });
 
-    // Children must not re-run on replay: mutate the files, expect the recorded
-    // composite regardless.
-    writeFileSync(a, "A2");
-    writeFileSync(b, "B2");
-    const replayed = await replayTask(par, recorded.journal);
-    expect(replayed.value).toEqual(["A", "B"]);
+  it("rejects a WriteContext whose value is not canonicalisable, and does not let recover swallow it", async () => {
+    const nonSerialisable = setContext("logger", () => undefined);
+    await expect(recordTask(nonSerialisable)).rejects.toBeInstanceOf(
+      JournalUnsupportedEffectError,
+    );
+
+    const guarded = orElse(
+      setContext("logger", () => undefined),
+      pure("swallowed"),
+    );
+    await expect(recordTask(guarded)).rejects.toBeInstanceOf(
+      JournalUnsupportedEffectError,
+    );
   });
 
   it("lets a JournalDivergenceError escape an enclosing recover instead of being caught", async () => {
@@ -1866,24 +1887,17 @@ describe("Interpreter - journal seam", () => {
     );
   });
 
-  it("does not record an effect interrupted mid-flight during a journaled run", async () => {
-    const controller = new AbortController();
-
-    // A parallel child logs (aborting the run as a side effect) and then reaches
-    // a second effect whose pre-step interrupt check fires. The interruption
-    // surfaces through the Parallel's perform but must leave the journal empty.
-    const child = gen(function* () {
-      yield* $(info("go"));
-      yield* $(info("after"));
-    });
+  it("does not record an effect the prompt handler interrupts during a journaled run", async () => {
     const journal = { entries: [] };
+    const promptHandler = () => {
+      throw new TaskExecutionError({
+        code: "TASK_INTERRUPTED",
+        message: "cancelled",
+      });
+    };
 
     await expect(
-      runTask(parallel([child]), {
-        journal,
-        signal: controller.signal,
-        onLog: () => controller.abort("stop"),
-      }),
+      runTask(promptText("name", "Your name?"), { journal, promptHandler }),
     ).rejects.toMatchObject({ code: "TASK_INTERRUPTED" });
 
     expect(journal.entries).toHaveLength(0);

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -9,15 +9,18 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
-import { parallel, sequence_ } from "./combinators.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { orElse, parallel, sequence_ } from "./combinators.js";
 import {
   executeEffect,
+  JournalDivergenceError,
   run,
   runTask,
   TaskExecutionError,
 } from "./interpreter.js";
-import { info, succeed, warn } from "./primitives.js";
+import { info, readFile, succeed, warn } from "./primitives.js";
+import recordTask from "./recordTask.js";
+import replayTask from "./replayTask.js";
 import {
   $,
   effect,
@@ -1808,5 +1811,81 @@ describe("Interpreter - interruption bypasses recovery", () => {
 
     // The interrupt bypassed the recover handler entirely.
     expect(handlerCalls).toBe(0);
+  });
+});
+
+// =============================================================================
+// Journal seam (record / replay in runTask)
+// =============================================================================
+
+describe("Interpreter - journal seam", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "task-journal-seam-"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("records a Parallel as one opaque entry and replays its composite result without running children", async () => {
+    const a = join(dir, "par-a.txt");
+    const b = join(dir, "par-b.txt");
+    writeFileSync(a, "A");
+    writeFileSync(b, "B");
+
+    const par = parallel([readFile(a), readFile(b)]);
+    const recorded = await recordTask(par);
+
+    expect(recorded.value).toEqual(["A", "B"]);
+    expect(recorded.journal.entries).toHaveLength(1);
+    expect(recorded.journal.entries.at(0)?.id.kind).toBe("Parallel");
+
+    // Children must not re-run on replay: mutate the files, expect the recorded
+    // composite regardless.
+    writeFileSync(a, "A2");
+    writeFileSync(b, "B2");
+    const replayed = await replayTask(par, recorded.journal);
+    expect(replayed.value).toEqual(["A", "B"]);
+  });
+
+  it("lets a JournalDivergenceError escape an enclosing recover instead of being caught", async () => {
+    const a = join(dir, "esc-a.txt");
+    const b = join(dir, "esc-b.txt");
+    writeFileSync(a, "A");
+    writeFileSync(b, "B");
+
+    const recorded = await recordTask(readFile(a));
+    // The replayed task reads a *different* path under a recover; the divergence
+    // must not be swallowed by the handler.
+    const diverged = orElse(readFile(b), pure("swallowed"));
+
+    await expect(replayTask(diverged, recorded.journal)).rejects.toBeInstanceOf(
+      JournalDivergenceError,
+    );
+  });
+
+  it("does not record an effect interrupted mid-flight during a journaled run", async () => {
+    const controller = new AbortController();
+
+    // A parallel child logs (aborting the run as a side effect) and then reaches
+    // a second effect whose pre-step interrupt check fires. The interruption
+    // surfaces through the Parallel's perform but must leave the journal empty.
+    const child = gen(function* () {
+      yield* $(info("go"));
+      yield* $(info("after"));
+    });
+    const journal = { entries: [] };
+
+    await expect(
+      runTask(parallel([child]), {
+        journal,
+        signal: controller.signal,
+        onLog: () => controller.abort("stop"),
+      }),
+    ).rejects.toMatchObject({ code: "TASK_INTERRUPTED" });
+
+    expect(journal.entries).toHaveLength(0);
   });
 });

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -7,7 +7,15 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { Effect, ExecResult, Task, TaskError } from "./types.js";
+import { computeEffectId, formatEffectId } from "./effectId.js";
+import type {
+  Effect,
+  EffectId,
+  ExecResult,
+  Journal,
+  Task,
+  TaskError,
+} from "./types.js";
 
 // =============================================================================
 // Task Execution Error
@@ -58,6 +66,31 @@ const normalizeThrownError = (thrown: unknown): TaskError => {
     stack: thrown instanceof Error ? thrown.stack : undefined,
   };
 };
+
+/**
+ * Raised when a task, replayed against a {@link Journal}, performs an effect
+ * whose identity does not match the entry recorded at that position — the
+ * task's shape diverged from the recording (a different prompt answer took a
+ * different branch, an input changed). Replay fails closed here rather than
+ * returning a stale recorded result for a different effect.
+ */
+export class JournalDivergenceError extends Error {
+  public readonly position: number;
+  public readonly expected: EffectId;
+  public readonly actual: EffectId;
+
+  constructor(position: number, expected: EffectId, actual: EffectId) {
+    super(
+      `Journal divergence at position ${position}: expected ${formatEffectId(
+        expected,
+      )} but the task performed ${formatEffectId(actual)}`,
+    );
+    this.name = "JournalDivergenceError";
+    this.position = position;
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
 
 // =============================================================================
 // Effect Executor
@@ -316,6 +349,13 @@ export interface RunTaskOptions {
   onLog?: (level: "debug" | "info" | "warn" | "error", message: string) => void;
   /** AbortSignal for interrupting task execution */
   signal?: AbortSignal;
+  /**
+   * Journal to record into and/or replay from. An empty journal records every
+   * effect outcome; a populated one replays matching outcomes without I/O and
+   * appends anything performed past its recorded end. Mutated in place as the
+   * run proceeds.
+   */
+  journal?: Journal;
 }
 
 // =============================================================================
@@ -349,6 +389,7 @@ export const runTask = async <A>(
     onEffectComplete,
     onLog,
     signal,
+    journal,
   } = options;
 
   const checkInterrupted = (): void => {
@@ -362,16 +403,18 @@ export const runTask = async <A>(
     }
   };
 
-  // Perform a single effect and return its result. Structural Parallel/Race
-  // effects run their children through a fresh interpreter pass; every other
-  // effect is routed to executeEffect.
-  const perform = async (effect: Effect): Promise<unknown> => {
+  // Perform a single effect for real and return its result. Structural
+  // Parallel/Race effects drive their children through a fresh, non-journaled
+  // pass — so a journal records the whole composite as one opaque entry rather
+  // than interleaving child effects — and every other effect is routed to
+  // executeEffect.
+  const performRaw = async (effect: Effect): Promise<unknown> => {
     if (effect._tag === "Parallel") {
       onEffectStart?.(effect);
       const startTime = performance.now();
 
       const settled = await Promise.allSettled(
-        effect.tasks.map((child) => interpret(child)),
+        effect.tasks.map((child) => drive(child, performRaw)),
       );
 
       const errors: TaskError[] = [];
@@ -407,7 +450,7 @@ export const runTask = async <A>(
       const startTime = performance.now();
 
       const result = await Promise.race(
-        effect.tasks.map((child) => interpret(child)),
+        effect.tasks.map((child) => drive(child, performRaw)),
       );
 
       onEffectComplete?.(effect, performance.now() - startTime);
@@ -421,9 +464,62 @@ export const runTask = async <A>(
     return result;
   };
 
+  // The journaling seam. With a journal present, each top-level effect either
+  // replays the outcome recorded at the current position (no I/O) or, once past
+  // the recorded prefix, runs for real via performRaw and appends its outcome —
+  // so an empty journal records, a full journal replays, and a partial one
+  // resumes. An effect whose identity disagrees with the recorded entry fails
+  // closed with a JournalDivergenceError.
+  let cursor = 0;
+  const perform: (effect: Effect) => Promise<unknown> =
+    journal === undefined
+      ? performRaw
+      : async (effect: Effect): Promise<unknown> => {
+          const id = computeEffectId(effect, "", cursor);
+          const recorded = journal.entries.at(cursor);
+          const position = cursor;
+          cursor += 1;
+
+          if (recorded) {
+            if (formatEffectId(recorded.id) !== formatEffectId(id)) {
+              throw new JournalDivergenceError(position, recorded.id, id);
+            }
+            if (recorded.outcome.ok) {
+              return recorded.outcome.value;
+            }
+            throw new TaskExecutionError(recorded.outcome.error);
+          }
+
+          try {
+            const value = await performRaw(effect);
+            journal.entries.push({ id, outcome: { ok: true, value } });
+            return value;
+          } catch (thrown) {
+            const error = normalizeThrownError(thrown);
+            // Interruption is not a reproducible effect outcome — leave it
+            // unrecorded so a resumed run re-attempts the interrupted effect.
+            if (error.code === "TASK_INTERRUPTED") {
+              throw thrown;
+            }
+            journal.entries.push({
+              id,
+              outcome: {
+                ok: false,
+                error: { code: error.code, message: error.message },
+              },
+            });
+            throw new TaskExecutionError(error);
+          }
+        };
+
   // The trampoline: drive a task to its final value on an explicit stack of
   // bind/recover frames, so no node type recurses through the host call stack.
-  const interpret = async (root: Task<unknown>): Promise<unknown> => {
+  // `performEffect` supplies each leaf effect's result — the raw performer, or
+  // the journaling seam wrapping it.
+  const drive = async (
+    root: Task<unknown>,
+    performEffect: (effect: Effect) => Promise<unknown>,
+  ): Promise<unknown> => {
     const stack: Frame[] = [];
     let cur: Task<unknown> = root;
 
@@ -460,8 +556,14 @@ export const runTask = async <A>(
           // failures — not just explicit Fail nodes.
           let result: unknown;
           try {
-            result = await perform(cur.effect);
+            result = await performEffect(cur.effect);
           } catch (thrown) {
+            // A journal divergence is a structural mismatch, not a recoverable
+            // effect failure — it escapes rather than being caught by an
+            // enclosing recover/orElse/retry.
+            if (thrown instanceof JournalDivergenceError) {
+              throw thrown;
+            }
             const taskError = normalizeThrownError(thrown);
             // Interruption is not recoverable: an abort surfaced from a
             // Parallel/Race child (whose own guard fired mid-flight) bypasses
@@ -503,7 +605,7 @@ export const runTask = async <A>(
     }
   };
 
-  return interpret(task as Task<unknown>) as Promise<A>;
+  return drive(task as Task<unknown>, perform) as Promise<A>;
 };
 
 /**

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -75,7 +75,9 @@ const normalizeThrownError = (thrown: unknown): TaskError => {
  * `-0`, or a nested `undefined`; {@link canonicalJSON} is injective over exactly
  * those, so a canonical form that differs after the round trip means the value
  * would not replay faithfully. A top-level `undefined` (a void effect's result)
- * round-trips to `undefined` and is always journalable.
+ * round-trips to `undefined` and is always journalable. Like `canonicalJSON`'s
+ * injectivity, this excludes non-intrinsic own properties (e.g. an extra keyed
+ * property on an array), which both it and JSON drop.
  */
 const isJournalableValue = (value: unknown): boolean => {
   if (value === undefined) {

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -71,9 +71,10 @@ const normalizeThrownError = (thrown: unknown): TaskError => {
  * Base class for the failures a {@link Journal} raises. They signal a broken
  * record/replay contract rather than a task-level effect failure, so the
  * interpreter lets them escape recovery instead of routing them to a
- * `recover`/`orElse` handler.
+ * `recover`/`orElse` handler. Never thrown directly — catch it to handle any
+ * journal failure, or a subclass for a specific one.
  */
-export class JournalError extends Error {}
+export abstract class JournalError extends Error {}
 
 /**
  * Raised when a task, replayed against a {@link Journal}, performs an effect
@@ -569,14 +570,18 @@ export const runTask = async <A>(
             journal.entries.push({ id, outcome: { ok: true, value } });
             return value;
           } catch (thrown) {
-            const error = normalizeThrownError(thrown);
+            const raw = normalizeThrownError(thrown);
             // Interruption is not a reproducible effect outcome — leave it
             // unrecorded so a resumed run re-attempts the interrupted effect.
-            if (error.code === "TASK_INTERRUPTED") {
+            if (raw.code === "TASK_INTERRUPTED") {
               throw thrown;
             }
-            // Record the whole structured error so a replayed recovery handler
-            // sees the same cause/context/suppressed the recording run did.
+            // Journal only the deterministic, serialisable error fields — the
+            // raw cause is non-serialisable (a cyclic cause would break
+            // serializeJournal) and the stack is non-deterministic. Re-throw the
+            // same projection so the recording run's recovery handler observes
+            // exactly what a replay will.
+            const error: TaskError = { code: raw.code, message: raw.message };
             journal.entries.push({ id, outcome: { ok: false, error } });
             throw new TaskExecutionError(error);
           }

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -68,13 +68,21 @@ const normalizeThrownError = (thrown: unknown): TaskError => {
 };
 
 /**
+ * Base class for the failures a {@link Journal} raises. They signal a broken
+ * record/replay contract rather than a task-level effect failure, so the
+ * interpreter lets them escape recovery instead of routing them to a
+ * `recover`/`orElse` handler.
+ */
+export class JournalError extends Error {}
+
+/**
  * Raised when a task, replayed against a {@link Journal}, performs an effect
  * whose identity does not match the entry recorded at that position — the
  * task's shape diverged from the recording (a different prompt answer took a
  * different branch, an input changed). Replay fails closed here rather than
  * returning a stale recorded result for a different effect.
  */
-export class JournalDivergenceError extends Error {
+export class JournalDivergenceError extends JournalError {
   public readonly position: number;
   public readonly expected: EffectId;
   public readonly actual: EffectId;
@@ -89,6 +97,44 @@ export class JournalDivergenceError extends Error {
     this.position = position;
     this.expected = expected;
     this.actual = actual;
+  }
+}
+
+/**
+ * Raised when an effect cannot be journaled: a structural `Parallel`/`Race`
+ * (whose concurrent children have no sound positional identity), or an effect
+ * whose identity content is not canonicalisable (a `WriteContext` carrying a
+ * function, symbol, class instance, or cyclic value). A journal spans sequential
+ * tasks; this fails closed rather than record an effect it cannot replay.
+ */
+export class JournalUnsupportedEffectError extends JournalError {
+  public readonly effectTag: Effect["_tag"];
+
+  constructor(effectTag: Effect["_tag"], reason: string) {
+    super(`Cannot journal a ${effectTag} effect: ${reason}`);
+    this.name = "JournalUnsupportedEffectError";
+    this.effectTag = effectTag;
+  }
+}
+
+/**
+ * Raised when a replayed task completes having consumed fewer effects than the
+ * journal recorded — the task grew shorter than its recording (a diverged
+ * branch, or a single-use `gen` task replayed without being rebuilt). The
+ * unconsumed tail signals a divergence, so replay fails closed rather than
+ * returning a truncated value.
+ */
+export class JournalIncompleteError extends JournalError {
+  public readonly consumed: number;
+  public readonly recorded: number;
+
+  constructor(consumed: number, recorded: number) {
+    super(
+      `Journal replay consumed ${consumed} of ${recorded} recorded effects: the task is shorter than its recording`,
+    );
+    this.name = "JournalIncompleteError";
+    this.consumed = consumed;
+    this.recorded = recorded;
   }
 }
 
@@ -464,18 +510,39 @@ export const runTask = async <A>(
     return result;
   };
 
-  // The journaling seam. With a journal present, each top-level effect either
-  // replays the outcome recorded at the current position (no I/O) or, once past
-  // the recorded prefix, runs for real via performRaw and appends its outcome —
-  // so an empty journal records, a full journal replays, and a partial one
-  // resumes. An effect whose identity disagrees with the recorded entry fails
-  // closed with a JournalDivergenceError.
+  // The journaling seam. With a journal present, each effect either replays the
+  // outcome recorded at the current position (no I/O) or, once past the recorded
+  // prefix, runs for real via performRaw and appends its outcome — so an empty
+  // journal records, a full journal replays, and a partial one resumes. A
+  // journal spans sequential tasks only: a Parallel/Race, or an effect whose
+  // identity is not canonicalisable, fails closed with a
+  // JournalUnsupportedEffectError; an effect whose identity disagrees with the
+  // recorded entry, with a JournalDivergenceError.
   let cursor = 0;
   const perform: (effect: Effect) => Promise<unknown> =
     journal === undefined
       ? performRaw
       : async (effect: Effect): Promise<unknown> => {
-          const id = computeEffectId(effect, "", cursor);
+          if (effect._tag === "Parallel" || effect._tag === "Race") {
+            throw new JournalUnsupportedEffectError(
+              effect._tag,
+              "a journal records a linear sequence and cannot key concurrent children by position",
+            );
+          }
+
+          let id: EffectId;
+          try {
+            id = computeEffectId(effect, "", cursor);
+          } catch {
+            // A non-canonicalisable identity (e.g. a WriteContext value that is a
+            // function or cyclic) can never be matched on replay — fail closed
+            // rather than let it masquerade as a recoverable effect error.
+            throw new JournalUnsupportedEffectError(
+              effect._tag,
+              "its identity content is not canonicalisable",
+            );
+          }
+
           const recorded = journal.entries.at(cursor);
           const position = cursor;
           cursor += 1;
@@ -485,6 +552,13 @@ export const runTask = async <A>(
               throw new JournalDivergenceError(position, recorded.id, id);
             }
             if (recorded.outcome.ok) {
+              // Re-apply an in-memory context write so a later live effect past
+              // the recorded prefix (a resume) observes the reconstructed
+              // context; the durable side effects of I/O effects already
+              // happened on the recorded run.
+              if (effect._tag === "WriteContext") {
+                context.set(effect.key, effect.value);
+              }
               return recorded.outcome.value;
             }
             throw new TaskExecutionError(recorded.outcome.error);
@@ -501,13 +575,9 @@ export const runTask = async <A>(
             if (error.code === "TASK_INTERRUPTED") {
               throw thrown;
             }
-            journal.entries.push({
-              id,
-              outcome: {
-                ok: false,
-                error: { code: error.code, message: error.message },
-              },
-            });
+            // Record the whole structured error so a replayed recovery handler
+            // sees the same cause/context/suppressed the recording run did.
+            journal.entries.push({ id, outcome: { ok: false, error } });
             throw new TaskExecutionError(error);
           }
         };
@@ -558,10 +628,11 @@ export const runTask = async <A>(
           try {
             result = await performEffect(cur.effect);
           } catch (thrown) {
-            // A journal divergence is a structural mismatch, not a recoverable
-            // effect failure — it escapes rather than being caught by an
-            // enclosing recover/orElse/retry.
-            if (thrown instanceof JournalDivergenceError) {
+            // A journal control failure (divergence, an unsupported effect) is a
+            // broken record/replay contract, not a recoverable effect failure —
+            // it escapes rather than being caught by an enclosing
+            // recover/orElse/retry.
+            if (thrown instanceof JournalError) {
               throw thrown;
             }
             const taskError = normalizeThrownError(thrown);
@@ -605,7 +676,17 @@ export const runTask = async <A>(
     }
   };
 
-  return drive(task as Task<unknown>, perform) as Promise<A>;
+  const result = await drive(task as Task<unknown>, perform);
+
+  // A completed replay must have consumed the whole recorded prefix. Fewer
+  // consumed entries means the task grew shorter than its recording (a diverged
+  // branch, or a single-use gen task replayed without being rebuilt) — fail
+  // closed rather than return a truncated value.
+  if (journal !== undefined && cursor < journal.entries.length) {
+    throw new JournalIncompleteError(cursor, journal.entries.length);
+  }
+
+  return result as A;
 };
 
 /**

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -7,6 +7,7 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import canonicalJSON from "./canonicalJSON.js";
 import { computeEffectId, formatEffectId } from "./effectId.js";
 import type {
   Effect,
@@ -65,6 +66,28 @@ const normalizeThrownError = (thrown: unknown): TaskError => {
     cause: thrown,
     stack: thrown instanceof Error ? thrown.stack : undefined,
   };
+};
+
+/**
+ * Test whether an effect result can be journaled — i.e. it survives the JSON
+ * round trip a journal is persisted through. `JSON.stringify` throws on a bigint
+ * or cyclic value and silently mangles a `Date`, `Map`/`Set`, `NaN`/`±Infinity`,
+ * `-0`, or a nested `undefined`; {@link canonicalJSON} is injective over exactly
+ * those, so a canonical form that differs after the round trip means the value
+ * would not replay faithfully. A top-level `undefined` (a void effect's result)
+ * round-trips to `undefined` and is always journalable.
+ */
+const isJournalableValue = (value: unknown): boolean => {
+  if (value === undefined) {
+    return true;
+  }
+  try {
+    return (
+      canonicalJSON(value) === canonicalJSON(JSON.parse(JSON.stringify(value)))
+    );
+  } catch {
+    return false;
+  }
 };
 
 /**
@@ -565,10 +588,9 @@ export const runTask = async <A>(
             throw new TaskExecutionError(recorded.outcome.error);
           }
 
+          let value: unknown;
           try {
-            const value = await performRaw(effect);
-            journal.entries.push({ id, outcome: { ok: true, value } });
-            return value;
+            value = await performRaw(effect);
           } catch (thrown) {
             const raw = normalizeThrownError(thrown);
             // Interruption is not a reproducible effect outcome — leave it
@@ -585,6 +607,19 @@ export const runTask = async <A>(
             journal.entries.push({ id, outcome: { ok: false, error } });
             throw new TaskExecutionError(error);
           }
+
+          // A result that would not survive JSON persistence (a bigint, cyclic
+          // value, Date, Map/Set, …) cannot be replayed faithfully — fail closed
+          // rather than record a value serializeJournal would throw on or
+          // silently corrupt. Thrown outside the try so it escapes recovery.
+          if (!isJournalableValue(value)) {
+            throw new JournalUnsupportedEffectError(
+              effect._tag,
+              "its result is not JSON-serialisable",
+            );
+          }
+          journal.entries.push({ id, outcome: { ok: true, value } });
+          return value;
         };
 
   // The trampoline: drive a task to its final value on an explicit stack of

--- a/packages/runtime/task/src/lib/recordTask.test.ts
+++ b/packages/runtime/task/src/lib/recordTask.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { getContext, setContext } from "./primitives.js";
+import recordTask from "./recordTask.js";
+import { $, gen } from "./task.js";
+import type { Journal } from "./types.js";
+
+// A factory, not a shared instance: a gen-built task holds a single-use
+// iterator, so each run needs a freshly-built task.
+const greet = () =>
+  gen(function* () {
+    yield* $(setContext("name", "pragma"));
+    const name = yield* $(getContext<string>("name"));
+    return `hello ${name}`;
+  });
+
+describe("recordTask", () => {
+  it("returns the task value and a journal of its effect outcomes", async () => {
+    const { value, journal } = await recordTask(greet());
+
+    expect(value).toBe("hello pragma");
+    expect(journal.entries.map((entry) => entry.id.kind)).toEqual([
+      "WriteContext",
+      "ReadContext",
+    ]);
+    expect(journal.entries.at(1)?.outcome).toEqual({
+      ok: true,
+      value: "pragma",
+    });
+  });
+
+  it("numbers entries by position in a fresh branch", async () => {
+    const { journal } = await recordTask(greet());
+    expect(journal.entries.map((entry) => entry.id.seq)).toEqual([0, 1]);
+    expect(journal.entries.every((entry) => entry.id.branch === "")).toBe(true);
+  });
+
+  it("ignores any journal supplied in options, recording into a fresh one", async () => {
+    const seeded: Journal = {
+      entries: [
+        {
+          id: { kind: "Log", content: "{}", branch: "", seq: 0 },
+          outcome: { ok: true, value: undefined },
+        },
+      ],
+    };
+
+    const { journal } = await recordTask(greet(), { journal: seeded });
+
+    expect(journal).not.toBe(seeded);
+    expect(journal.entries).toHaveLength(2);
+    expect(seeded.entries).toHaveLength(1);
+  });
+});

--- a/packages/runtime/task/src/lib/recordTask.test.ts
+++ b/packages/runtime/task/src/lib/recordTask.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { JournalUnsupportedEffectError } from "./interpreter.js";
 import { getContext, setContext } from "./primitives.js";
 import recordTask from "./recordTask.js";
 import { $, gen } from "./task.js";
@@ -49,5 +50,16 @@ describe("recordTask", () => {
     expect(journal).not.toBe(seeded);
     expect(journal.entries).toHaveLength(2);
     expect(seeded.entries).toHaveLength(1);
+  });
+
+  it("fails closed on a result that would not survive JSON persistence", async () => {
+    // A bigint makes JSON.stringify throw; a Date silently mangles to a string —
+    // both would break a replay, so recording fails closed instead.
+    await expect(
+      recordTask(getContext("k"), { context: new Map([["k", 10n]]) }),
+    ).rejects.toBeInstanceOf(JournalUnsupportedEffectError);
+    await expect(
+      recordTask(getContext("k"), { context: new Map([["k", new Date(0)]]) }),
+    ).rejects.toBeInstanceOf(JournalUnsupportedEffectError);
   });
 });

--- a/packages/runtime/task/src/lib/recordTask.ts
+++ b/packages/runtime/task/src/lib/recordTask.ts
@@ -14,7 +14,12 @@ import type { Journal, JournalRun, Task } from "./types.js";
  * to keep a partial recording.
  *
  * Pass a freshly-built task: a `gen`-based task holds a single-use iterator, so
- * the same instance must not be reused for a later record or replay.
+ * the same instance must not be reused for a later record or replay. A recorded
+ * result must survive JSON persistence; a non-serialisable one (a bigint,
+ * `Date`, `Map`, cyclic value, …) fails closed. Under a journal a recovery
+ * handler observes only a failure's `code` and `message` (its `cause` and
+ * `stack` are not journaled, so a recording and its replay agree), unlike plain
+ * `runTask` — a handler that branches on `error.cause` must not be journaled.
  *
  * @typeParam A - The task's result type.
  * @param task - The task to run and record.

--- a/packages/runtime/task/src/lib/recordTask.ts
+++ b/packages/runtime/task/src/lib/recordTask.ts
@@ -1,0 +1,26 @@
+import { type RunTaskOptions, runTask } from "./interpreter.js";
+import type { Journal, JournalRun, Task } from "./types.js";
+
+/**
+ * Run a task to completion while recording every effect outcome into a fresh
+ * {@link Journal}, returning both the value and the journal.
+ *
+ * The journal can be serialised with {@link serializeJournal} for persistence,
+ * or handed to {@link replayTask} to reproduce the run — replaying recorded
+ * outcomes without performing any I/O.
+ *
+ * @typeParam A - The task's result type.
+ * @param task - The task to run and record.
+ * @param options - Interpreter options (context, prompt handler, signal, …); any
+ * `journal` in it is ignored in favour of the fresh recording journal.
+ * @returns The task's value and the journal captured during the run.
+ * @note Impure — performs the task's effects while recording their outcomes.
+ */
+export default async function recordTask<A>(
+  task: Task<A>,
+  options: RunTaskOptions = {},
+): Promise<JournalRun<A>> {
+  const journal: Journal = { entries: [] };
+  const value = await runTask(task, { ...options, journal });
+  return { value, journal };
+}

--- a/packages/runtime/task/src/lib/recordTask.ts
+++ b/packages/runtime/task/src/lib/recordTask.ts
@@ -7,7 +7,14 @@ import type { Journal, JournalRun, Task } from "./types.js";
  *
  * The journal can be serialised with {@link serializeJournal} for persistence,
  * or handed to {@link replayTask} to reproduce the run — replaying recorded
- * outcomes without performing any I/O.
+ * outcomes without performing any I/O. A journal spans a sequential task; a
+ * `Parallel`/`Race` effect, or a `WriteContext` with a non-canonicalisable
+ * value, fails closed with a `JournalUnsupportedEffectError`. If the task
+ * throws, no journal is returned — drive `runTask` with a caller-owned journal
+ * to keep a partial recording.
+ *
+ * Pass a freshly-built task: a `gen`-based task holds a single-use iterator, so
+ * the same instance must not be reused for a later record or replay.
  *
  * @typeParam A - The task's result type.
  * @param task - The task to run and record.

--- a/packages/runtime/task/src/lib/replayTask.test.ts
+++ b/packages/runtime/task/src/lib/replayTask.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { orElse } from "./combinators.js";
+import { JournalDivergenceError } from "./interpreter.js";
+import { readFile } from "./primitives.js";
+import recordTask from "./recordTask.js";
+import replayTask from "./replayTask.js";
+import { $, gen, pure } from "./task.js";
+
+describe("replayTask", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "task-replay-"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("replays a recorded read without touching the filesystem", async () => {
+    const file = join(dir, "read.txt");
+    writeFileSync(file, "v1");
+
+    const readIt = readFile(file);
+    const recorded = await recordTask(readIt);
+    expect(recorded.value).toBe("v1");
+
+    // Change the world; a replay must ignore it and return the recorded value.
+    writeFileSync(file, "v2");
+    const replayed = await replayTask(readIt, recorded.journal);
+    expect(replayed.value).toBe("v1");
+  });
+
+  it("resumes past the recorded prefix without mutating the input journal", async () => {
+    const a = join(dir, "a.txt");
+    const b = join(dir, "b.txt");
+    writeFileSync(a, "A");
+    writeFileSync(b, "B");
+
+    const prefix = await recordTask(readFile(a));
+
+    const both = gen(function* () {
+      const x = yield* $(readFile(a));
+      const y = yield* $(readFile(b));
+      return `${x}${y}`;
+    });
+
+    const { value, journal } = await replayTask(both, prefix.journal);
+
+    expect(value).toBe("AB");
+    expect(prefix.journal.entries).toHaveLength(1);
+    expect(journal.entries).toHaveLength(2);
+  });
+
+  it("throws JournalDivergenceError when the task shape diverges", async () => {
+    const a = join(dir, "diverge-a.txt");
+    const b = join(dir, "diverge-b.txt");
+    writeFileSync(a, "A");
+    writeFileSync(b, "B");
+
+    const recorded = await recordTask(readFile(a));
+
+    await expect(
+      replayTask(readFile(b), recorded.journal),
+    ).rejects.toBeInstanceOf(JournalDivergenceError);
+  });
+
+  it("reproduces a recovered failure on replay without re-attempting the I/O", async () => {
+    const missing = join(dir, "absent.txt");
+    const task = orElse(readFile(missing), pure("fallback"));
+
+    const recorded = await recordTask(task);
+    expect(recorded.value).toBe("fallback");
+    expect(recorded.journal.entries).toHaveLength(1);
+    expect(recorded.journal.entries.at(0)?.outcome).toMatchObject({
+      ok: false,
+      error: { code: "FILE_NOT_FOUND" },
+    });
+
+    // The file now exists — replay must still reproduce the recorded failure.
+    writeFileSync(missing, "now here");
+    const replayed = await replayTask(task, recorded.journal);
+    expect(replayed.value).toBe("fallback");
+  });
+});

--- a/packages/runtime/task/src/lib/replayTask.test.ts
+++ b/packages/runtime/task/src/lib/replayTask.test.ts
@@ -10,6 +10,7 @@ import {
 import { getContext, readFile, setContext } from "./primitives.js";
 import recordTask from "./recordTask.js";
 import replayTask from "./replayTask.js";
+import serializeJournal from "./serializeJournal.js";
 import { $, gen, pure, recover } from "./task.js";
 
 describe("replayTask", () => {
@@ -89,21 +90,31 @@ describe("replayTask", () => {
     expect(replayed.value).toBe("fallback");
   });
 
-  it("replays a recovered failure with its full error so a cause-inspecting handler agrees", async () => {
+  it("replays a recovered failure consistently, keying on the preserved error code", async () => {
     const missing = join(dir, "cause.txt");
-    // The handler branches on err.cause, which is dropped by a lossy {code,message}
-    // recording — record and replay must still take the same branch.
-    const build = () =>
-      recover(readFile(missing), (err) =>
-        pure(err.cause !== undefined ? "had-cause" : "no-cause"),
-      );
+    // A journaled failure carries its code and message; a handler keying on the
+    // code takes the same branch on record and replay.
+    const build = () => recover(readFile(missing), (err) => pure(err.code));
 
     const recorded = await recordTask(build());
-    expect(recorded.value).toBe("had-cause");
+    expect(recorded.value).toBe("FILE_NOT_FOUND");
 
     writeFileSync(missing, "exists");
     const replayed = await replayTask(build(), recorded.journal);
-    expect(replayed.value).toBe("had-cause");
+    expect(replayed.value).toBe("FILE_NOT_FOUND");
+  });
+
+  it("records a failure as a serialisable {code,message} projection with no cause or stack", async () => {
+    const missing = join(dir, "serialise-fail.txt");
+    const recorded = await recordTask(orElse(readFile(missing), pure("ok")));
+
+    // Exactly code + message — no raw cause or non-deterministic stack — so a
+    // recorded failure can never break serializeJournal.
+    expect(recorded.journal.entries.at(0)?.outcome).toEqual({
+      ok: false,
+      error: { code: "FILE_NOT_FOUND", message: expect.any(String) },
+    });
+    expect(() => serializeJournal(recorded.journal)).not.toThrow();
   });
 
   it("reconstructs in-memory context across a resume so a live read sees a replayed write", async () => {

--- a/packages/runtime/task/src/lib/replayTask.test.ts
+++ b/packages/runtime/task/src/lib/replayTask.test.ts
@@ -3,11 +3,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { orElse } from "./combinators.js";
-import { JournalDivergenceError } from "./interpreter.js";
-import { readFile } from "./primitives.js";
+import {
+  JournalDivergenceError,
+  JournalIncompleteError,
+} from "./interpreter.js";
+import { getContext, readFile, setContext } from "./primitives.js";
 import recordTask from "./recordTask.js";
 import replayTask from "./replayTask.js";
-import { $, gen, pure } from "./task.js";
+import { $, gen, pure, recover } from "./task.js";
 
 describe("replayTask", () => {
   let dir: string;
@@ -84,5 +87,61 @@ describe("replayTask", () => {
     writeFileSync(missing, "now here");
     const replayed = await replayTask(task, recorded.journal);
     expect(replayed.value).toBe("fallback");
+  });
+
+  it("replays a recovered failure with its full error so a cause-inspecting handler agrees", async () => {
+    const missing = join(dir, "cause.txt");
+    // The handler branches on err.cause, which is dropped by a lossy {code,message}
+    // recording — record and replay must still take the same branch.
+    const build = () =>
+      recover(readFile(missing), (err) =>
+        pure(err.cause !== undefined ? "had-cause" : "no-cause"),
+      );
+
+    const recorded = await recordTask(build());
+    expect(recorded.value).toBe("had-cause");
+
+    writeFileSync(missing, "exists");
+    const replayed = await replayTask(build(), recorded.journal);
+    expect(replayed.value).toBe("had-cause");
+  });
+
+  it("reconstructs in-memory context across a resume so a live read sees a replayed write", async () => {
+    const build = () =>
+      gen(function* () {
+        yield* $(setContext("k", "v"));
+        const value = yield* $(getContext<string>("k"));
+        return value;
+      });
+
+    const recorded = await recordTask(build());
+    expect(recorded.value).toBe("v");
+
+    // Truncate to just the WriteContext entry — a crash before the read was
+    // recorded. Resuming replays the write, then reads context live.
+    const partial = { entries: recorded.journal.entries.slice(0, 1) };
+    const resumed = await replayTask(build(), partial);
+    expect(resumed.value).toBe("v");
+  });
+
+  it("fails closed when a single-use gen task is replayed without being rebuilt", async () => {
+    const first = join(dir, "reuse-a.txt");
+    const second = join(dir, "reuse-b.txt");
+    writeFileSync(first, "A");
+    writeFileSync(second, "B");
+
+    const single = gen(function* () {
+      const a = yield* $(readFile(first));
+      const b = yield* $(readFile(second));
+      return `${a}${b}`;
+    });
+
+    const recorded = await recordTask(single);
+    expect(recorded.value).toBe("AB");
+
+    // Reusing the exhausted instance ends after one effect — caught, not silent.
+    await expect(replayTask(single, recorded.journal)).rejects.toBeInstanceOf(
+      JournalIncompleteError,
+    );
   });
 });

--- a/packages/runtime/task/src/lib/replayTask.ts
+++ b/packages/runtime/task/src/lib/replayTask.ts
@@ -8,7 +8,12 @@ import type { Journal, JournalRun, Task } from "./types.js";
  * I/O; if the task runs past the recorded prefix — a resumed run — the remaining
  * effects execute for real and are appended. The input journal is never mutated:
  * the returned journal is a fresh copy carrying any resumed entries. A structural
- * mismatch against the recording throws `JournalDivergenceError`.
+ * mismatch against the recording throws `JournalDivergenceError`, and a task that
+ * ends before consuming the whole recording throws `JournalIncompleteError`.
+ *
+ * Pass a freshly-built task, not the instance that was recorded: a `gen`-based
+ * task holds a single-use iterator, so replaying an already-run instance would
+ * end early (caught as `JournalIncompleteError`).
  *
  * @typeParam A - The task's result type.
  * @param task - The task to replay.

--- a/packages/runtime/task/src/lib/replayTask.ts
+++ b/packages/runtime/task/src/lib/replayTask.ts
@@ -1,0 +1,30 @@
+import { type RunTaskOptions, runTask } from "./interpreter.js";
+import type { Journal, JournalRun, Task } from "./types.js";
+
+/**
+ * Re-run a task against a recorded {@link Journal}.
+ *
+ * Every effect whose identity matches the recording replays its outcome with no
+ * I/O; if the task runs past the recorded prefix — a resumed run — the remaining
+ * effects execute for real and are appended. The input journal is never mutated:
+ * the returned journal is a fresh copy carrying any resumed entries. A structural
+ * mismatch against the recording throws `JournalDivergenceError`.
+ *
+ * @typeParam A - The task's result type.
+ * @param task - The task to replay.
+ * @param journal - The journal recorded by a prior {@link recordTask} run.
+ * @param options - Interpreter options (context, prompt handler, signal, …); any
+ * `journal` in it is ignored in favour of the supplied one.
+ * @returns The task's value and the replayed (possibly extended) journal.
+ * @note Impure — replays recorded outcomes and executes any effects performed
+ * past the recorded prefix.
+ */
+export default async function replayTask<A>(
+  task: Task<A>,
+  journal: Journal,
+  options: RunTaskOptions = {},
+): Promise<JournalRun<A>> {
+  const working: Journal = { entries: journal.entries.slice() };
+  const value = await runTask(task, { ...options, journal: working });
+  return { value, journal: working };
+}

--- a/packages/runtime/task/src/lib/replayTask.ts
+++ b/packages/runtime/task/src/lib/replayTask.ts
@@ -13,7 +13,9 @@ import type { Journal, JournalRun, Task } from "./types.js";
  *
  * Pass a freshly-built task, not the instance that was recorded: a `gen`-based
  * task holds a single-use iterator, so replaying an already-run instance would
- * end early (caught as `JournalIncompleteError`).
+ * end early (caught as `JournalIncompleteError`). A replayed failure carries only
+ * its `code` and `message`, so a recovery handler branching on `error.cause`
+ * must not be journaled.
  *
  * @typeParam A - The task's result type.
  * @param task - The task to replay.

--- a/packages/runtime/task/src/lib/serializeJournal.test.ts
+++ b/packages/runtime/task/src/lib/serializeJournal.test.ts
@@ -26,9 +26,18 @@ describe("serializeJournal", () => {
     expect(deserializeJournal(serializeJournal(journal))).toEqual(journal);
   });
 
-  it("is deterministic for structurally-equal journals", () => {
-    const copy: Journal = { entries: journal.entries.slice() };
-    expect(serializeJournal(copy)).toBe(serializeJournal(journal));
+  it("serialises to a compact JSON encoding of the entries", () => {
+    const one: Journal = {
+      entries: [
+        {
+          id: { kind: "ReadFile", content: "{}", branch: "", seq: 0 },
+          outcome: { ok: true, value: "x" },
+        },
+      ],
+    };
+    expect(serializeJournal(one)).toBe(
+      '{"entries":[{"id":{"kind":"ReadFile","content":"{}","branch":"","seq":0},"outcome":{"ok":true,"value":"x"}}]}',
+    );
   });
 
   it("serialises an empty journal", () => {

--- a/packages/runtime/task/src/lib/serializeJournal.test.ts
+++ b/packages/runtime/task/src/lib/serializeJournal.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import deserializeJournal from "./deserializeJournal.js";
+import serializeJournal from "./serializeJournal.js";
+import type { Journal } from "./types.js";
+
+const journal: Journal = {
+  entries: [
+    {
+      id: { kind: "ReadFile", content: '{"path":"/a"}', branch: "", seq: 0 },
+      outcome: { ok: true, value: "hello" },
+    },
+    {
+      id: {
+        kind: "Exec",
+        content: '{"args":[],"command":"nope","cwd":undefined}',
+        branch: "",
+        seq: 1,
+      },
+      outcome: { ok: false, error: { code: "INTERNAL", message: "boom" } },
+    },
+  ],
+};
+
+describe("serializeJournal", () => {
+  it("round-trips through deserializeJournal", () => {
+    expect(deserializeJournal(serializeJournal(journal))).toEqual(journal);
+  });
+
+  it("is deterministic for structurally-equal journals", () => {
+    const copy: Journal = { entries: journal.entries.slice() };
+    expect(serializeJournal(copy)).toBe(serializeJournal(journal));
+  });
+
+  it("serialises an empty journal", () => {
+    expect(serializeJournal({ entries: [] })).toBe('{"entries":[]}');
+  });
+
+  it("round-trips an undefined effect result as undefined", () => {
+    const withVoid: Journal = {
+      entries: [
+        {
+          id: { kind: "WriteFile", content: "{}", branch: "", seq: 0 },
+          outcome: { ok: true, value: undefined },
+        },
+      ],
+    };
+    const restored = deserializeJournal(serializeJournal(withVoid));
+    const [entry] = restored.entries;
+    expect(entry?.outcome).toEqual({ ok: true });
+  });
+});

--- a/packages/runtime/task/src/lib/serializeJournal.ts
+++ b/packages/runtime/task/src/lib/serializeJournal.ts
@@ -5,8 +5,9 @@ import type { Journal } from "./types.js";
  *
  * The output is a plain JSON encoding of the ordered entries — each carrying an
  * {@link EffectId} and its recorded outcome — and round-trips through
- * {@link deserializeJournal}. Effect outcomes must be JSON-representable (as the
- * built-in effects' results are); a recorded failure keeps only its `code` and
+ * {@link deserializeJournal}. A journal from {@link recordTask}/{@link replayTask}
+ * is always JSON-representable: a success value that would not survive the round
+ * trip fails closed at record time, and a failure keeps only its `code` and
  * `message`.
  *
  * @param journal - The journal to serialise.

--- a/packages/runtime/task/src/lib/serializeJournal.ts
+++ b/packages/runtime/task/src/lib/serializeJournal.ts
@@ -1,0 +1,17 @@
+import type { Journal } from "./types.js";
+
+/**
+ * Serialise a {@link Journal} to a JSON string for persistence between runs.
+ *
+ * The output is a plain JSON encoding of the ordered entries — each carrying an
+ * {@link EffectId} and its recorded outcome — and round-trips through
+ * {@link deserializeJournal}. Effect outcomes must be JSON-representable (as the
+ * built-in effects' results are); a recorded failure keeps only its `code` and
+ * `message`.
+ *
+ * @param journal - The journal to serialise.
+ * @returns A JSON string that {@link deserializeJournal} can parse back.
+ */
+export default function serializeJournal(journal: Journal): string {
+  return JSON.stringify(journal);
+}

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -294,9 +294,12 @@ export interface EffectId {
  * recovery handler exactly that projection, so a recorded run and its replay
  * take the same branch. The raw `cause` and `stack` are not journaled (they are
  * non-serialisable and non-deterministic); a handler keys on `code`.
+ *
+ * A success `value` is optional: a void effect's `undefined` result serialises
+ * to no `value` key, so a round-tripped success outcome is `{ ok: true }`.
  */
 export type JournalOutcome =
-  | { ok: true; value: unknown }
+  | { ok: true; value?: unknown }
   | { ok: false; error: TaskError };
 
 /**

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -289,8 +289,11 @@ export interface EffectId {
 
 /**
  * The recorded outcome of a single journaled effect: either the value it
- * produced, or the structured error it raised. Both are replayed verbatim so a
- * recovered failure reproduces the same recovery path on replay.
+ * produced, or the full structured error it raised. Both are replayed verbatim
+ * so a recovered failure reproduces the same recovery path — including the
+ * error's `cause`, `context`, and `suppressed` — on replay. (A non-serialisable
+ * `cause` survives an in-memory replay but degrades through
+ * {@link serializeJournal}.)
  */
 export type JournalOutcome =
   | { ok: true; value: unknown }

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -284,6 +284,53 @@ export interface EffectId {
 }
 
 // =============================================================================
+// Journal
+// =============================================================================
+
+/**
+ * The recorded outcome of a single journaled effect: either the value it
+ * produced, or the structured error it raised. Both are replayed verbatim so a
+ * recovered failure reproduces the same recovery path on replay.
+ */
+export type JournalOutcome =
+  | { ok: true; value: unknown }
+  | { ok: false; error: TaskError };
+
+/**
+ * One recorded effect occurrence: its stable {@link EffectId} and the
+ * {@link JournalOutcome} to replay at that position.
+ */
+export interface JournalEntry {
+  /** Identity of the effect this entry records. */
+  id: EffectId;
+  /** The outcome to replay when the same effect recurs at this position. */
+  outcome: JournalOutcome;
+}
+
+/**
+ * An ordered log of effect outcomes captured while running a task. An empty
+ * journal records a run; a full journal replays one without any I/O; a partial
+ * journal replays its prefix and resumes live execution past the recorded end.
+ */
+export interface Journal {
+  /** Effect outcomes in the order they were performed. */
+  entries: JournalEntry[];
+}
+
+/**
+ * The value a task produced together with the {@link Journal} a run captured or
+ * extended — the result of {@link recordTask} and {@link replayTask}.
+ *
+ * @typeParam A - The task's result type.
+ */
+export interface JournalRun<A> {
+  /** The task's final value. */
+  value: A;
+  /** The journal captured (record) or extended (resume) by the run. */
+  journal: Journal;
+}
+
+// =============================================================================
 // Execution Result
 // =============================================================================
 

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -289,11 +289,11 @@ export interface EffectId {
 
 /**
  * The recorded outcome of a single journaled effect: either the value it
- * produced, or the full structured error it raised. Both are replayed verbatim
- * so a recovered failure reproduces the same recovery path — including the
- * error's `cause`, `context`, and `suppressed` — on replay. (A non-serialisable
- * `cause` survives an in-memory replay but degrades through
- * {@link serializeJournal}.)
+ * produced, or the failure it raised. A failure is journaled by its `code` and
+ * `message` — the deterministic, serialisable error fields — and replay hands a
+ * recovery handler exactly that projection, so a recorded run and its replay
+ * take the same branch. The raw `cause` and `stack` are not journaled (they are
+ * non-serialisable and non-deterministic); a handler keys on `code`.
  */
 export type JournalOutcome =
   | { ok: true; value: unknown }

--- a/packages/runtime/task/src/testing/regression/0003-journal-replay-performs-no-io.test.ts
+++ b/packages/runtime/task/src/testing/regression/0003-journal-replay-performs-no-io.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression: replaying a task against a recorded journal must reproduce the
+ * run purely from the journal, performing no I/O — even if the files it read
+ * during recording have since changed or been deleted.
+ *
+ * This is the determinism guarantee the journal exists to provide: a recorded
+ * run is a self-contained, replayable artifact. If replay silently fell back to
+ * live execution, a deleted input would surface as an `ENOENT` here instead of
+ * the recorded value.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readFile } from "../../lib/primitives.js";
+import recordTask from "../../lib/recordTask.js";
+import replayTask from "../../lib/replayTask.js";
+import { $, gen } from "../../lib/task.js";
+
+describe("regression 0003 — journal replay performs no I/O", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "task-regression-0003-"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reproduces a multi-read run after its inputs are deleted", async () => {
+    const first = join(dir, "first.txt");
+    const second = join(dir, "second.txt");
+    writeFileSync(first, "one");
+    writeFileSync(second, "two");
+
+    // A gen task holds a single-use iterator, so record and replay each get a
+    // freshly-built task — exactly as a resumed run would rebuild it.
+    const readBoth = () =>
+      gen(function* () {
+        const a = yield* $(readFile(first));
+        const b = yield* $(readFile(second));
+        return `${a}:${b}`;
+      });
+
+    const recorded = await recordTask(readBoth());
+    expect(recorded.value).toBe("one:two");
+
+    // Delete the inputs entirely — a live read would now throw ENOENT.
+    rmSync(first);
+    rmSync(second);
+
+    const replayed = await replayTask(readBoth(), recorded.journal);
+    expect(replayed.value).toBe("one:two");
+  });
+});


### PR DESCRIPTION
## Done

The record/replay layer for `@canonical/task`'s determinism work, built on the content-addressable effect identity landed in #741. **Additive — no existing behaviour changes.** A run's effect outcomes can now be recorded and later replayed by identity, performing no I/O.

- **Journaling seam in `runTask`** — a new `journal` option. An empty journal **records** every effect outcome; a full journal **replays** matching outcomes with zero I/O; a partial journal **resumes** — replays its prefix, then executes live past the recorded end and appends. `cursor`-positioned entries key off `computeEffectId`.
- **Opaque Parallel/Race** — structural composites are journaled as a single entry (their children run through a fresh, non-journaled pass), keeping the top-level log linear and guaranteeing replay performs no child I/O.
- **Faithful failures** — a recovered effect failure is recorded as an outcome too, so replay reproduces the same recovery path; an interruption is left unrecorded so a resumed run re-attempts it.
- **Fails closed on divergence** — a task whose shape diverges from its recording throws `JournalDivergenceError`, which escapes recovery rather than being swallowed by an enclosing `recover`/`orElse`.
- **Ergonomic + persistable API** — `recordTask` / `replayTask` wrap the seam; `serializeJournal` / `deserializeJournal` round-trip a journal to JSON and fail closed with a `TypeError` on a malformed file.

New public exports: `Journal`, `JournalEntry`, `JournalOutcome`, `JournalRun` (types), `JournalDivergenceError`, `recordTask`, `replayTask`, `serializeJournal`, `deserializeJournal`.

## QA

- `cd packages/runtime/task && bun run test` → **801 pass, 100% coverage** (statements/branches/functions/lines).
- `bun run check` → **biome + tsc + webarchitect green**.
- New regression `0003-journal-replay-performs-no-io` records a two-read run, **deletes both inputs**, and replays to the same value — proving replay is filesystem-independent.
- Manual: replaying a task that read a since-changed file returns the recorded value; a diverged replay under `orElse` throws `JournalDivergenceError` instead of being caught; a recorded `orElse(readFile(missing), …)` failure replays as the fallback even after the file is created.

### PR readiness check

- [x] PR should have one of the following labels: **`Feature 🎁`**.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards) (webarchitect passes).
- [x] All packages define the required scripts in `package.json`: `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] This PR does not introduce a new package.
- [x] This PR does not require visual testing — add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — library-internal change, no visual surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF9ExVCukzqpe1Fus9V1no)_