### PR TITLE
fix(harnesses): stop setup mcp from destroying valid JSONC configs (SEC-1)

### DIFF
--- a/packages/cli/pragma/src/domains/setup/operations/setupMcp.test.ts
+++ b/packages/cli/pragma/src/domains/setup/operations/setupMcp.test.ts
@@ -10,7 +10,12 @@ const mockExists =
 function mocks(
   existsPredicate: (path: string) => boolean,
 ): Map<string, (effect: Effect) => unknown> {
-  return new Map([["Exists", mockExists(existsPredicate)]]);
+  return new Map<string, (effect: Effect) => unknown>([
+    ["Exists", mockExists(existsPredicate)],
+    // An existing config reads back as an empty-but-valid JSON object, so a
+    // write merges into it rather than failing closed on the dry-run placeholder.
+    ["ReadFile", () => "{}"],
+  ]);
 }
 
 describe("setupMcp", () => {

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -400,3 +400,88 @@ describe("TOML config (Codex)", () => {
     expect(writeEffects[0].content).not.toContain("[mcp_servers.pragma]");
   });
 });
+
+// SEC-1: a JSONC config (comments, trailing commas — valid in Cursor/VS Code/
+// Windsurf) must be read and merged, never silently overwritten; a config that
+// is not valid JSON/JSONC must fail closed rather than be destroyed.
+describe("SEC-1 — non-destructive JSONC handling", () => {
+  const jsoncConfig = [
+    "{",
+    "  // editor-managed servers",
+    '  "mcpServers": {',
+    '    "figma": { "command": "figma-mcp" },',
+    "  },",
+    "}",
+  ].join("\n");
+
+  it("reads mcpServers from a JSONC config with comments and a trailing comma", () => {
+    const result = dryRunWith(
+      readMcpConfig(claude, "/project"),
+      buildMocks({
+        Exists: existsMock(() => true),
+        ReadFile: readFileMock(jsoncConfig),
+      }),
+    );
+
+    expect(result.value).toEqual({ figma: { command: "figma-mcp" } });
+  });
+
+  it("merges into a JSONC config, preserving the existing server", () => {
+    const result = dryRunWith(
+      writeMcpConfig(claude, "/project", "pragma", { command: "pragma" }),
+      buildMocks({
+        Exists: existsMock(() => true),
+        ReadFile: readFileMock(jsoncConfig),
+        WriteFile: writeMock,
+      }),
+    );
+
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    expect(writeEffects.length).toBe(1);
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.mcpServers.figma).toEqual({ command: "figma-mcp" });
+    expect(written.mcpServers.pragma).toEqual({ command: "pragma" });
+  });
+
+  it("adds mcpServers to a valid config that lacks the key, keeping other fields", () => {
+    const result = dryRunWith(
+      writeMcpConfig(claude, "/project", "pragma", { command: "pragma" }),
+      buildMocks({
+        Exists: existsMock(() => true),
+        ReadFile: readFileMock(JSON.stringify({ otherField: true })),
+        WriteFile: writeMock,
+      }),
+    );
+
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.mcpServers.pragma).toEqual({ command: "pragma" });
+    expect(written.otherField).toBe(true);
+  });
+
+  it("refuses to write over an unparseable config (fails closed, no WriteFile)", () => {
+    expect(() =>
+      dryRunWith(
+        writeMcpConfig(claude, "/project", "pragma", { command: "pragma" }),
+        buildMocks({
+          Exists: existsMock(() => true),
+          ReadFile: readFileMock("{ this is not valid json"),
+          WriteFile: writeMock,
+        }),
+      ),
+    ).toThrow(/Refusing to modify/);
+  });
+
+  it("refuses to remove from an unparseable config", () => {
+    expect(() =>
+      dryRunWith(
+        removeMcpConfig(claude, "/project", "pragma"),
+        buildMocks({
+          Exists: existsMock(() => true),
+          ReadFile: readFileMock("}}} broken"),
+          WriteFile: writeMock,
+        }),
+      ),
+    ).toThrow(/Refusing to modify/);
+  });
+});

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -484,4 +484,35 @@ describe("SEC-1 — non-destructive JSONC handling", () => {
       ),
     ).toThrow(/Refusing to modify/);
   });
+
+  it.each([
+    ["a string", '{"mcpServers":"oops"}'],
+    ["null", '{"mcpServers":null}'],
+    ["an array", '{"mcpServers":[1,2]}'],
+  ])("treats a %s mcpServers as empty on read", (_label, content) => {
+    const result = dryRunWith(
+      readMcpConfig(claude, "/project"),
+      buildMocks({
+        Exists: existsMock(() => true),
+        ReadFile: readFileMock(content),
+      }),
+    );
+    expect(result.value).toEqual({});
+  });
+
+  it("re-initialises a non-object mcpServers on write, keeping other fields", () => {
+    const result = dryRunWith(
+      writeMcpConfig(claude, "/project", "pragma", { command: "pragma" }),
+      buildMocks({
+        Exists: existsMock(() => true),
+        ReadFile: readFileMock('{"mcpServers":"corrupt","otherField":true}'),
+        WriteFile: writeMock,
+      }),
+    );
+
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.mcpServers.pragma).toEqual({ command: "pragma" });
+    expect(written.otherField).toBe(true);
+  });
 });

--- a/packages/runtime/harnesses/src/lib/config.ts
+++ b/packages/runtime/harnesses/src/lib/config.ts
@@ -33,6 +33,17 @@ const formatJson = (value: Record<string, unknown>): string =>
   `${JSON.stringify(value, null, 2)}\n`;
 
 /**
+ * Coerce a config's server map to a plain record, defaulting a missing or
+ * non-object `mcpServers` (a corrupt config where it is a string/number/array)
+ * to an empty map — so a read honours its `Record` contract and a merge never
+ * mutates a primitive or array.
+ */
+const asServerRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+/**
  * Fail-closed message for a config a write refuses to overwrite because it is
  * not valid JSON/JSONC — see {@link parseJsonc}.
  */
@@ -68,7 +79,10 @@ export const readMcpConfig = (
     exists(configPath),
     map(readFile(configPath), (content) => {
       const parsed = parseJsonc(content) ?? {};
-      return (parsed[harness.mcpKey] ?? {}) as Record<string, McpServerConfig>;
+      return asServerRecord(parsed[harness.mcpKey]) as Record<
+        string,
+        McpServerConfig
+      >;
     }),
     pure({} as Record<string, McpServerConfig>),
   );
@@ -128,7 +142,7 @@ export const writeMcpConfig = (
       if (parsed === undefined) {
         return unparseableConfig(configPath);
       }
-      const servers = (parsed[harness.mcpKey] ?? {}) as Record<string, unknown>;
+      const servers = asServerRecord(parsed[harness.mcpKey]);
       servers[serverName] = config;
       parsed[harness.mcpKey] = servers;
       return writeFile(configPath, formatJson(parsed), { undo: undoTask });
@@ -178,7 +192,7 @@ export const removeMcpConfig = (
       if (parsed === undefined) {
         return unparseableConfig(configPath);
       }
-      const servers = (parsed[harness.mcpKey] ?? {}) as Record<string, unknown>;
+      const servers = asServerRecord(parsed[harness.mcpKey]);
       delete servers[serverName];
       parsed[harness.mcpKey] = servers;
       return writeFile(configPath, formatJson(parsed));

--- a/packages/runtime/harnesses/src/lib/config.ts
+++ b/packages/runtime/harnesses/src/lib/config.ts
@@ -76,11 +76,15 @@ export const readMcpConfig = (
 
 /**
  * Write or merge an MCP server entry into a harness config file.
- * If the file exists, the new entry is merged into existing servers.
- * If the file does not exist, it is created with the entry.
+ * If the file exists, the new entry is merged into existing servers, preserving
+ * every other server. If the file does not exist, it is created with the entry.
+ * A file that is not valid JSON/JSONC fails closed rather than being overwritten.
  *
  * @note This function is impure — it reads and writes the filesystem
  * via Task effects.
+ * @note A JSON merge is written back as formatted JSON, so a JSONC config's
+ * comments and custom formatting are not preserved across the write — only its
+ * server entries are.
  */
 export const writeMcpConfig = (
   harness: HarnessDefinition,
@@ -141,10 +145,13 @@ export const writeMcpConfig = (
 
 /**
  * Remove an MCP server entry from a harness config file.
- * If the file does not exist, this is a no-op.
+ * If the file does not exist, this is a no-op. A file that is not valid
+ * JSON/JSONC fails closed rather than being overwritten.
  *
  * @note This function is impure — it reads and writes the filesystem
  * via Task effects.
+ * @note As with {@link writeMcpConfig}, a JSON rewrite does not preserve a
+ * JSONC config's comments or formatting — only its server entries.
  */
 export const removeMcpConfig = (
   harness: HarnessDefinition,

--- a/packages/runtime/harnesses/src/lib/config.ts
+++ b/packages/runtime/harnesses/src/lib/config.ts
@@ -7,6 +7,7 @@
 import { dirname } from "node:path";
 import {
   exists,
+  failWith,
   flatMap,
   ifElseM,
   map,
@@ -16,6 +17,7 @@ import {
   type Task,
   writeFile,
 } from "@canonical/task";
+import parseJsonc from "./parseJsonc.js";
 import {
   mergeTomlSection,
   parseTomlSection,
@@ -25,29 +27,20 @@ import {
 import type { HarnessDefinition, McpServerConfig } from "./types.js";
 
 /**
- * Parse a JSON string into a record, returning an empty object on failure.
- */
-const parseJsonSafe = (content: string): Record<string, unknown> => {
-  try {
-    const parsed: unknown = JSON.parse(content);
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      !Array.isArray(parsed)
-    ) {
-      return parsed as Record<string, unknown>;
-    }
-    return {};
-  } catch {
-    return {};
-  }
-};
-
-/**
  * Serialize a record to formatted JSON with a trailing newline.
  */
 const formatJson = (value: Record<string, unknown>): string =>
   `${JSON.stringify(value, null, 2)}\n`;
+
+/**
+ * Fail-closed message for a config a write refuses to overwrite because it is
+ * not valid JSON/JSONC — see {@link parseJsonc}.
+ */
+const unparseableConfig = (configPath: string): Task<void> =>
+  failWith(
+    "MCP_CONFIG_UNPARSEABLE",
+    `Refusing to modify ${configPath}: it is not valid JSON/JSONC, so writing would overwrite it. Back it up or fix it, then retry.`,
+  );
 
 /**
  * Read existing MCP server entries from a harness config file.
@@ -74,7 +67,7 @@ export const readMcpConfig = (
   return ifElseM(
     exists(configPath),
     map(readFile(configPath), (content) => {
-      const parsed = parseJsonSafe(content);
+      const parsed = parseJsonc(content) ?? {};
       return (parsed[harness.mcpKey] ?? {}) as Record<string, McpServerConfig>;
     }),
     pure({} as Record<string, McpServerConfig>),
@@ -127,7 +120,10 @@ export const writeMcpConfig = (
   return ifElseM(
     exists(configPath),
     flatMap(readFile(configPath), (content) => {
-      const parsed = parseJsonSafe(content);
+      const parsed = parseJsonc(content);
+      if (parsed === undefined) {
+        return unparseableConfig(configPath);
+      }
       const servers = (parsed[harness.mcpKey] ?? {}) as Record<string, unknown>;
       servers[serverName] = config;
       parsed[harness.mcpKey] = servers;
@@ -171,7 +167,10 @@ export const removeMcpConfig = (
   return ifElseM(
     exists(configPath),
     flatMap(readFile(configPath), (content) => {
-      const parsed = parseJsonSafe(content);
+      const parsed = parseJsonc(content);
+      if (parsed === undefined) {
+        return unparseableConfig(configPath);
+      }
       const servers = (parsed[harness.mcpKey] ?? {}) as Record<string, unknown>;
       delete servers[serverName];
       parsed[harness.mcpKey] = servers;

--- a/packages/runtime/harnesses/src/lib/parseJsonc.test.ts
+++ b/packages/runtime/harnesses/src/lib/parseJsonc.test.ts
@@ -82,5 +82,10 @@ describe("parseJsonc", () => {
     it("rejects an unterminated comment before a would-be closer", () => {
       expect(parseJsonc('{"a":1,/*')).toBeUndefined();
     });
+
+    it("fails closed on an unterminated block comment after otherwise-valid JSON", () => {
+      // Must not silently strip the dangling `/*` and accept `{ "a": 1 }`.
+      expect(parseJsonc('{ "a": 1 }/*')).toBeUndefined();
+    });
   });
 });

--- a/packages/runtime/harnesses/src/lib/parseJsonc.test.ts
+++ b/packages/runtime/harnesses/src/lib/parseJsonc.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import parseJsonc from "./parseJsonc.js";
+
+describe("parseJsonc", () => {
+  describe("plain JSON", () => {
+    it("parses a JSON object", () => {
+      expect(parseJsonc('{"a":1,"b":"two"}')).toEqual({ a: 1, b: "two" });
+    });
+
+    it("returns an empty object for empty or whitespace-only text", () => {
+      expect(parseJsonc("")).toEqual({});
+      expect(parseJsonc("   \n\t  ")).toEqual({});
+    });
+  });
+
+  describe("JSONC tolerance", () => {
+    it("strips a line comment", () => {
+      expect(parseJsonc('// header\n{"a":1}')).toEqual({ a: 1 });
+    });
+
+    it("strips a block comment", () => {
+      expect(parseJsonc('/* note */ {"a":1}')).toEqual({ a: 1 });
+    });
+
+    it("treats a comment-only file as an empty object", () => {
+      expect(parseJsonc("// just a comment")).toEqual({});
+    });
+
+    it("drops a trailing comma before a closing brace or bracket", () => {
+      expect(parseJsonc('{"a":1,}')).toEqual({ a: 1 });
+      expect(parseJsonc('{"a":[1,2,]}')).toEqual({ a: [1, 2] });
+    });
+
+    it("keeps a comma that separates members", () => {
+      expect(parseJsonc('{"a":1,"b":2}')).toEqual({ a: 1, b: 2 });
+    });
+
+    it("drops a trailing comma even when a comment sits before the closer", () => {
+      expect(parseJsonc('{"a":1, // last\n}')).toEqual({ a: 1 });
+      expect(parseJsonc('{"a":1, /* last */ }')).toEqual({ a: 1 });
+    });
+  });
+
+  describe("string contents are preserved", () => {
+    it("does not strip // inside a string (a URL)", () => {
+      expect(parseJsonc('{"url":"http://x//y"}')).toEqual({
+        url: "http://x//y",
+      });
+    });
+
+    it("does not treat a comma inside a string as trailing", () => {
+      expect(parseJsonc('{"a":"x,}"}')).toEqual({ a: "x,}" });
+    });
+
+    it("preserves an escaped quote inside a string", () => {
+      expect(parseJsonc('{"a":"x\\"y"}')).toEqual({ a: 'x"y' });
+    });
+  });
+
+  describe("fails closed (returns undefined) on non-objects", () => {
+    it("rejects genuinely malformed text", () => {
+      expect(parseJsonc("not json")).toBeUndefined();
+    });
+
+    it("rejects a JSON array at the top level", () => {
+      expect(parseJsonc("[1,2,3]")).toBeUndefined();
+    });
+
+    it("rejects a top-level primitive", () => {
+      expect(parseJsonc("42")).toBeUndefined();
+      expect(parseJsonc("null")).toBeUndefined();
+    });
+
+    it("rejects a string that ends mid-escape", () => {
+      expect(parseJsonc('{"a":"x\\')).toBeUndefined();
+    });
+
+    it("rejects a comma whose lookahead runs off the end", () => {
+      expect(parseJsonc("[1,2,")).toBeUndefined();
+    });
+
+    it("rejects an unterminated comment before a would-be closer", () => {
+      expect(parseJsonc('{"a":1,/*')).toBeUndefined();
+    });
+  });
+});

--- a/packages/runtime/harnesses/src/lib/parseJsonc.ts
+++ b/packages/runtime/harnesses/src/lib/parseJsonc.ts
@@ -1,0 +1,124 @@
+/**
+ * Parse JSON-with-comments (JSONC) text into a plain object.
+ *
+ * Editor MCP configs (Cursor, VS Code, Windsurf) are routinely JSONC — they
+ * carry `//` and block comments and trailing commas — so a strict `JSON.parse`
+ * would reject a perfectly valid config. This tolerates both, then parses the
+ * normalised JSON. It returns `undefined` when the text is not a JSON object
+ * (genuinely malformed, or a non-object top level) so a caller can fail closed
+ * rather than overwrite a config it cannot safely read; whitespace- or
+ * comment-only text parses as an empty object (a config to be initialised).
+ *
+ * @param content - The raw config text.
+ * @returns The parsed object, or `undefined` when the text is not a JSON object.
+ */
+export default function parseJsonc(
+  content: string,
+): Record<string, unknown> | undefined {
+  const normalized = stripJsonc(content).trim();
+  if (normalized === "") {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(normalized);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+/**
+ * Strip comments and trailing commas from JSONC, leaving string contents (a URL
+ * with `//`, an escaped quote) untouched, so the result is plain JSON.
+ */
+function stripJsonc(input: string): string {
+  let out = "";
+  let index = 0;
+  let inString = false;
+  while (index < input.length) {
+    const char = input[index];
+    if (inString) {
+      out += char;
+      if (char === "\\") {
+        index++;
+        if (index < input.length) {
+          out += input[index];
+        }
+      } else if (char === '"') {
+        inString = false;
+      }
+      index++;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      out += char;
+      index++;
+      continue;
+    }
+    if (char === "/" && input[index + 1] === "/") {
+      index += 2;
+      while (index < input.length && input[index] !== "\n") {
+        index++;
+      }
+      continue;
+    }
+    if (char === "/" && input[index + 1] === "*") {
+      index += 2;
+      while (
+        index < input.length &&
+        !(input[index] === "*" && input[index + 1] === "/")
+      ) {
+        index++;
+      }
+      index += 2;
+      continue;
+    }
+    if (char === "," && isTrailingComma(input, index + 1)) {
+      index++;
+      continue;
+    }
+    out += char;
+    index++;
+  }
+  return out;
+}
+
+/**
+ * Whether the next significant token after a comma — skipping whitespace and
+ * comments — is a closing `}` or `]`, marking the comma as trailing.
+ */
+function isTrailingComma(input: string, from: number): boolean {
+  let index = from;
+  while (index < input.length) {
+    const char = input[index];
+    if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+      index++;
+      continue;
+    }
+    if (char === "/" && input[index + 1] === "/") {
+      index += 2;
+      while (index < input.length && input[index] !== "\n") {
+        index++;
+      }
+      continue;
+    }
+    if (char === "/" && input[index + 1] === "*") {
+      index += 2;
+      while (
+        index < input.length &&
+        !(input[index] === "*" && input[index + 1] === "/")
+      ) {
+        index++;
+      }
+      index += 2;
+      continue;
+    }
+    return char === "}" || char === "]";
+  }
+  return false;
+}

--- a/packages/runtime/harnesses/src/lib/parseJsonc.ts
+++ b/packages/runtime/harnesses/src/lib/parseJsonc.ts
@@ -68,14 +68,14 @@ function stripJsonc(input: string): string {
       continue;
     }
     if (char === "/" && input[index + 1] === "*") {
-      index += 2;
-      while (
-        index < input.length &&
-        !(input[index] === "*" && input[index + 1] === "/")
-      ) {
-        index++;
+      const close = input.indexOf("*/", index + 2);
+      if (close === -1) {
+        // Unterminated block comment — malformed. Keep the rest verbatim so
+        // JSON.parse rejects it (fail closed) rather than silently accepting.
+        out += input.slice(index);
+        break;
       }
-      index += 2;
+      index = close + 2;
       continue;
     }
     if (char === "," && isTrailingComma(input, index + 1)) {


### PR DESCRIPTION
## Done

Fixes **SEC-1** — `pragma setup mcp` silently **destroyed** user MCP configs. `parseJsonSafe` swallowed a JSON parse error into `{}`, and the write path then rewrote the file with only the pragma entry — wiping every other server (and comments) in a JSONC config. JSONC (comments, trailing commas) is valid and common in Cursor / VS Code / Windsurf, so a real user config would be destroyed by a single `setup mcp`.

- **Add `parseJsonc`** — a JSONC-aware parser (string-safe stripping of `//` and `/* */` comments and trailing commas) that returns `undefined` when the text is not a JSON object, instead of a silent `{}`.
- **Read JSONC-aware** — a valid editor config is now parsed and merged, preserving every existing server, rather than treated as empty.
- **Fail closed on write/remove** — `writeMcpConfig` / `removeMcpConfig` refuse to overwrite a config that is not valid JSON/JSONC (clear `MCP_CONFIG_UNPARSEABLE` error) instead of destroying it.

Documented tradeoff: a JSON merge is written back as formatted JSON, so a JSONC config's comments/formatting are not preserved across the write — only its server entries are (noted on both functions).

Fixes [SEC-1].

## QA

- `cd packages/runtime/harnesses && bun run test` → **97 pass, 100% coverage** (statements/branches/functions/lines). New `parseJsonc.test.ts` covers comments/trailing-commas, string-content preservation (URLs with `//`, commas and escaped quotes inside strings), and fail-closed on non-objects/malformed input; new `config.test.ts` cases cover JSONC read+merge and fail-closed write/remove.
- `bun run check` → **biome + tsc + webarchitect green**.
- An adversarial review swarm found no correctness bypass in the parser (one low doc-note, applied).

### PR readiness check

- [x] PR should have one of the following labels: **`Bug 🐛`**.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards) (webarchitect passes).
- [x] All packages define the required scripts in `package.json`: `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] This PR does not introduce a new package.
- [x] This PR does not require visual testing — add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — library-internal change, no visual surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF9ExVCukzqpe1Fus9V1no)_

[SEC-1]: https://warthogs.atlassian.net/browse/SEC-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ