### PR TITLE
fix(cli): jail agent-supplied paths in create MCP tools (SEC-2)

### DIFF
--- a/packages/cli/pragma/src/domains/create/mcp/assertSafeRelativePath.test.ts
+++ b/packages/cli/pragma/src/domains/create/mcp/assertSafeRelativePath.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import assertSafeRelativePath from "./assertSafeRelativePath.js";
+
+describe("assertSafeRelativePath", () => {
+  it("accepts a normal relative component path", () => {
+    expect(() =>
+      assertSafeRelativePath("componentPath", "src/components/Button"),
+    ).not.toThrow();
+  });
+
+  it("accepts a scoped package name", () => {
+    expect(() =>
+      assertSafeRelativePath("name", "@canonical/my-package"),
+    ).not.toThrow();
+  });
+
+  it("rejects a parent-traversal path", () => {
+    expect(() =>
+      assertSafeRelativePath("componentPath", "../../etc/Button"),
+    ).toThrow(/Invalid componentPath/);
+  });
+
+  it("rejects a scoped name that traverses through the scope", () => {
+    expect(() => assertSafeRelativePath("name", "@scope/../../etc")).toThrow(
+      /Invalid name/,
+    );
+  });
+
+  it("rejects an interior .. segment", () => {
+    expect(() =>
+      assertSafeRelativePath("componentPath", "src/../../secret/Button"),
+    ).toThrow();
+  });
+
+  it("rejects an absolute path", () => {
+    expect(() =>
+      assertSafeRelativePath("componentPath", "/etc/passwd"),
+    ).toThrow();
+  });
+
+  it("rejects a backslash traversal", () => {
+    expect(() =>
+      assertSafeRelativePath("componentPath", "..\\..\\etc"),
+    ).toThrow();
+  });
+
+  it("rejects a bare .. value", () => {
+    expect(() => assertSafeRelativePath("name", "..")).toThrow();
+  });
+});

--- a/packages/cli/pragma/src/domains/create/mcp/assertSafeRelativePath.ts
+++ b/packages/cli/pragma/src/domains/create/mcp/assertSafeRelativePath.ts
@@ -1,0 +1,25 @@
+import { isAbsolute } from "node:path";
+import { PragmaError } from "#error";
+
+/**
+ * Reject an agent-supplied path or name that could write outside the project.
+ *
+ * The MCP `create_*` tools run on untrusted agent input and hand it to a
+ * generator that builds file paths from it. A value that is an absolute path,
+ * or that contains a `..` segment, would resolve to a location outside the
+ * working directory — so it is refused before it can reach any file write. No
+ * legitimate component path or package name needs either.
+ *
+ * @param field - The parameter name, used in the error message.
+ * @param value - The agent-supplied path or name.
+ * @throws PragmaError When the value is absolute or contains a `..` segment.
+ */
+export default function assertSafeRelativePath(
+  field: string,
+  value: string,
+): void {
+  const segments = value.split(/[/\\]/);
+  if (isAbsolute(value) || segments.includes("..")) {
+    throw PragmaError.invalidInput(field, value);
+  }
+}

--- a/packages/cli/pragma/src/domains/create/mcp/specs.test.ts
+++ b/packages/cli/pragma/src/domains/create/mcp/specs.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { PragmaError } from "#error";
+import type { PragmaRuntime } from "../../shared/types/runtime.js";
+import specs from "./specs.js";
+
+// Only `cwd` is read before the path jail throws.
+const rt = { cwd: "/project" } as unknown as PragmaRuntime;
+
+const bySpec = (name: string) => {
+  const spec = specs.find((s) => s.name === name);
+  if (!spec) throw new Error(`missing spec: ${name}`);
+  return spec;
+};
+
+describe("create MCP specs — path jail (SEC-2)", () => {
+  it("create_component refuses a traversal componentPath before generating", async () => {
+    await expect(
+      bySpec("create_component").execute(rt, {
+        framework: "react",
+        componentPath: "../../etc/Button",
+      }),
+    ).rejects.toBeInstanceOf(PragmaError);
+  });
+
+  it("create_component refuses an absolute componentPath", async () => {
+    await expect(
+      bySpec("create_component").execute(rt, {
+        framework: "react",
+        componentPath: "/etc/evil/Button",
+      }),
+    ).rejects.toBeInstanceOf(PragmaError);
+  });
+
+  it("create_package refuses a name that traverses through its scope", async () => {
+    await expect(
+      bySpec("create_package").execute(rt, {
+        name: "@scope/../../etc",
+        type: "library",
+      }),
+    ).rejects.toBeInstanceOf(PragmaError);
+  });
+});

--- a/packages/cli/pragma/src/domains/create/mcp/specs.test.ts
+++ b/packages/cli/pragma/src/domains/create/mcp/specs.test.ts
@@ -39,4 +39,13 @@ describe("create MCP specs — path jail (SEC-2)", () => {
       }),
     ).rejects.toBeInstanceOf(PragmaError);
   });
+
+  it("create_package refuses a double-slash scope that derives an absolute directory", async () => {
+    await expect(
+      bySpec("create_package").execute(rt, {
+        name: "@scope//etc/passwd",
+        type: "library",
+      }),
+    ).rejects.toBeInstanceOf(PragmaError);
+  });
 });

--- a/packages/cli/pragma/src/domains/create/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/create/mcp/specs.ts
@@ -141,9 +141,14 @@ const specs: readonly ToolSpec[] = [
         },
       };
 
-      // Untrusted agent input: the package name derives the target directory
-      // (getPackageShortName), so refuse a name that would escape cwd.
-      assertSafeRelativePath("name", String(params.name));
+      // Untrusted agent input: the package name derives the target directory,
+      // so jail both the raw name and the unscoped short name the generator
+      // actually builds the path from — `getPackageShortName` strips only the
+      // first scope slash, so "@scope//etc" would otherwise yield an absolute
+      // "/etc" directory the raw check never sees.
+      const rawName = String(params.name);
+      assertSafeRelativePath("name", rawName);
+      assertSafeRelativePath("name", rawName.replace(/^@[^/]+\//, ""));
 
       const gen = packageGenerators.package as AnyGenerator | undefined;
       if (!gen) throw PragmaError.internalError("Package generator not found");

--- a/packages/cli/pragma/src/domains/create/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/create/mcp/specs.ts
@@ -8,6 +8,7 @@ import { generators as packageGenerators } from "@canonical/summon-package";
 import { PragmaError } from "#error";
 import type { ToolSpec } from "../../shared/ToolSpec.js";
 import { COMPONENT_GENERATORS } from "../generators.js";
+import assertSafeRelativePath from "./assertSafeRelativePath.js";
 
 const specs: readonly ToolSpec[] = [
   {
@@ -54,6 +55,9 @@ const specs: readonly ToolSpec[] = [
           verbose: false,
         },
       };
+
+      // Untrusted agent input: refuse a component path that would escape cwd.
+      assertSafeRelativePath("componentPath", String(params.componentPath));
 
       const framework = params.framework as string;
       const gen = COMPONENT_GENERATORS[framework];
@@ -136,6 +140,10 @@ const specs: readonly ToolSpec[] = [
           verbose: false,
         },
       };
+
+      // Untrusted agent input: the package name derives the target directory
+      // (getPackageShortName), so refuse a name that would escape cwd.
+      assertSafeRelativePath("name", String(params.name));
 
       const gen = packageGenerators.package as AnyGenerator | undefined;
       if (!gen) throw PragmaError.internalError("Package generator not found");

--- a/packages/cli/pragma/src/domains/create/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/create/mcp/specs.ts
@@ -143,12 +143,14 @@ const specs: readonly ToolSpec[] = [
 
       // Untrusted agent input: the package name derives the target directory,
       // so jail both the raw name and the unscoped short name the generator
-      // actually builds the path from — `getPackageShortName` strips only the
-      // first scope slash, so "@scope//etc" would otherwise yield an absolute
-      // "/etc" directory the raw check never sees.
+      // actually builds the path from — "@scope//etc" derives an absolute "/etc"
+      // directory the raw check never sees. The short name mirrors
+      // @canonical/summon-package's getPackageShortName exactly (scope stripped
+      // only when a segment follows the slash) so the jail matches its output.
       const rawName = String(params.name);
       assertSafeRelativePath("name", rawName);
-      assertSafeRelativePath("name", rawName.replace(/^@[^/]+\//, ""));
+      const shortNameMatch = rawName.match(/^@[^/]+\/(.+)$/);
+      assertSafeRelativePath("name", shortNameMatch?.[1] ?? rawName);
 
       const gen = packageGenerators.package as AnyGenerator | undefined;
       if (!gen) throw PragmaError.internalError("Package generator not found");


### PR DESCRIPTION
## Done

Fixes **SEC-2** — the `create_component` and `create_package` MCP tools (`readOnly: false`) passed agent-supplied strings straight to a generator that builds file paths from them, with **no traversal check**. `validateComponentPath` only checks the *basename* is PascalCase, and the prompt validators are bypassed on the MCP/batch path. So `componentPath: "../../etc/Button"`, or `name: "@scope/../../etc"` (which `getPackageShortName` turns into the directory `../../etc`), would build paths outside the working directory.

- **Add `assertSafeRelativePath`** — refuse an absolute path, or one containing a `..` segment, before it reaches a generator.
- **Enforce it at both MCP tool boundaries.** For `create_component`, jail `componentPath` (used verbatim as the target dir). For `create_package`, jail **both** the raw `name` and the unscoped short name the generator actually derives (`getPackageShortName` strips only the first scope slash, so `@scope//etc` would otherwise yield an absolute `/etc` directory the raw check never sees).

Fixes [SEC-2].

## QA

- `cd packages/cli/pragma && bun run test` → **1076 pass**; `bun run check` → **biome + tsc + webarchitect green**.
- New `assertSafeRelativePath.test.ts` (unit: traversal, absolute, backslash, bare `..`, scope-absorption) and `specs.test.ts` (boundary: both tools reject a traversal/absolute/double-slash input before generating).
- An adversarial review swarm found a bypass (`@scope//etc/passwd` → derived absolute `/etc/passwd`); it is fixed here, and a follow-up verification fuzzed 37,448 inputs with **zero escapes** (the derived directory is always one of the two jailed strings).

### PR readiness check

- [x] PR should have one of the following labels: **`Bug 🐛`**.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards) (webarchitect passes).
- [x] All packages define the required scripts in `package.json`: `check`, `check:fix`, `test`, `build`, `build:all`.
- [x] This PR does not introduce a new package.
- [x] This PR does not require visual testing — add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — MCP/CLI security change, no visual surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF9ExVCukzqpe1Fus9V1no)_

[SEC-2]: https://warthogs.atlassian.net/browse/SEC-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ