### PR TITLE
feat(storybook-addon-relay): mock Relay environments for React stories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1124,6 +1124,44 @@
         "storybook": "^10.3.1",
       },
     },
+    "packages/storybook/addon-relay": {
+      "name": "@canonical/storybook-addon-relay",
+      "version": "0.29.1",
+      "dependencies": {
+        "relay-test-utils": "^18.2.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.4.9",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config-react": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
+        "@testing-library/react": "^16.3.2",
+        "@types/node": "^24.12.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@types/react-relay": "^18.2.1",
+        "@types/relay-runtime": "^19.0.3",
+        "@types/relay-test-utils": "^18.0.0",
+        "@vitejs/plugin-react": "^6.0.0",
+        "@vitest/coverage-v8": "^4.0.18",
+        "jsdom": "^28.1.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-relay": "^18.2.0",
+        "relay-runtime": "^18.2.0",
+        "storybook": "^10.3.1",
+        "typescript": "^5.9.3",
+        "vite": "^8.0.1",
+        "vitest": "^4.0.18",
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "react-relay": ">=18.0.0 <19.0.0",
+        "relay-runtime": ">=18.0.0 <19.0.0",
+        "storybook": "^10.3.1",
+      },
+    },
     "packages/storybook/addon-utils": {
       "name": "@canonical/storybook-addon-utils",
       "version": "0.29.0",
@@ -1668,6 +1706,8 @@
     "@canonical/storybook-addon-form-state": ["@canonical/storybook-addon-form-state@workspace:packages/storybook/addon-form-state"],
 
     "@canonical/storybook-addon-msw": ["@canonical/storybook-addon-msw@workspace:packages/storybook/addon-msw"],
+
+    "@canonical/storybook-addon-relay": ["@canonical/storybook-addon-relay@workspace:packages/storybook/addon-relay"],
 
     "@canonical/storybook-addon-shell-theme": ["@canonical/storybook-addon-shell-theme@workspace:packages/storybook/addon-canonical-shell-theme"],
 
@@ -2275,6 +2315,12 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/react-relay": ["@types/react-relay@18.2.1", "", { "dependencies": { "@types/react": "*", "@types/relay-runtime": "*" } }, "sha512-KgmFapsxAylhxcFfaAv5GZZJhTHnDvV8IDZVsUm5afpJUvgZC1Y68ssfOGsFfiFY/2EhxHM/YPfpdKbfmF3Ecg=="],
+
+    "@types/relay-runtime": ["@types/relay-runtime@19.0.3", "", {}, "sha512-pvpWWQq5e9KeESF8klQaP2igLLhr2bRd3XxVCxNpGElsPQiP6Mejr59RT9/OGY3O3i8jAGGQsshVe0QCQDbxNg=="],
+
+    "@types/relay-test-utils": ["@types/relay-test-utils@18.0.0", "", { "dependencies": { "@types/react": "*", "@types/react-relay": "*", "@types/relay-runtime": "*" } }, "sha512-sg++buiunZkj0MkL1/Q6w4p19ut3USC5BQnWJ1D4Bp4pNOrck4nhVDIyklm/ilVyM0wCbvROa5wL+nsYVo4Frw=="],
+
     "@types/resolve": ["@types/resolve@1.20.6", "", {}, "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="],
 
     "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
@@ -2364,6 +2410,8 @@
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
     "arrify": ["arrify@1.0.1", "", {}, "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="],
+
+    "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
     "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
 
@@ -2559,6 +2607,8 @@
 
     "cosmiconfig": ["cosmiconfig@9.0.0", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg=="],
 
+    "cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css": ["css@2.2.4", "", { "dependencies": { "inherits": "^2.0.3", "source-map": "^0.6.1", "source-map-resolve": "^0.5.2", "urix": "^0.1.0" } }, "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw=="],
@@ -2747,6 +2797,10 @@
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
+    "fbjs": ["fbjs@3.0.5", "", { "dependencies": { "cross-fetch": "^3.1.5", "fbjs-css-vars": "^1.0.0", "loose-envify": "^1.0.0", "object-assign": "^4.1.0", "promise": "^7.1.1", "setimmediate": "^1.0.5", "ua-parser-js": "^1.0.35" } }, "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg=="],
+
+    "fbjs-css-vars": ["fbjs-css-vars@1.0.2", "", {}, "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
@@ -2928,6 +2982,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "inquirer": ["inquirer@12.9.6", "", { "dependencies": { "@inquirer/ansi": "^1.0.0", "@inquirer/core": "^10.2.2", "@inquirer/prompts": "^7.8.6", "@inquirer/type": "^3.0.8", "mute-stream": "^2.0.0", "run-async": "^4.0.5", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw=="],
+
+    "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -3319,6 +3375,8 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
+    "nullthrows": ["nullthrows@1.1.1", "", {}, "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="],
+
     "nx": ["nx@22.5.4", "", { "dependencies": { "@napi-rs/wasm-runtime": "0.2.4", "@yarnpkg/lockfile": "^1.1.0", "@yarnpkg/parsers": "3.0.2", "@zkochan/js-yaml": "0.0.7", "axios": "^1.12.0", "cli-cursor": "3.1.0", "cli-spinners": "2.6.1", "cliui": "^8.0.1", "dotenv": "~16.4.5", "dotenv-expand": "~11.0.6", "ejs": "^3.1.7", "enquirer": "~2.3.6", "figures": "3.2.0", "flat": "^5.0.2", "front-matter": "^4.0.2", "ignore": "^7.0.5", "jest-diff": "^30.0.2", "jsonc-parser": "3.2.0", "lines-and-columns": "2.0.3", "minimatch": "10.2.4", "node-machine-id": "1.1.12", "npm-run-path": "^4.0.1", "open": "^8.4.0", "ora": "5.3.0", "picocolors": "^1.1.0", "resolve.exports": "2.0.3", "semver": "^7.6.3", "string-width": "^4.2.3", "tar-stream": "~2.2.0", "tmp": "~0.2.1", "tree-kill": "^1.2.2", "tsconfig-paths": "^4.1.2", "tslib": "^2.3.0", "yaml": "^2.6.0", "yargs": "^17.6.2", "yargs-parser": "21.1.1" }, "optionalDependencies": { "@nx/nx-darwin-arm64": "22.5.4", "@nx/nx-darwin-x64": "22.5.4", "@nx/nx-freebsd-x64": "22.5.4", "@nx/nx-linux-arm-gnueabihf": "22.5.4", "@nx/nx-linux-arm64-gnu": "22.5.4", "@nx/nx-linux-arm64-musl": "22.5.4", "@nx/nx-linux-x64-gnu": "22.5.4", "@nx/nx-linux-x64-musl": "22.5.4", "@nx/nx-win32-arm64-msvc": "22.5.4", "@nx/nx-win32-x64-msvc": "22.5.4" }, "peerDependencies": { "@swc-node/register": "^1.11.1", "@swc/core": "^1.15.8" }, "optionalPeers": ["@swc-node/register", "@swc/core"], "bin": { "nx": "bin/nx.js", "nx-cloud": "bin/nx-cloud.js" } }, "sha512-L8wL7uCjnmpyvq4r2mN9s+oriUE4lY+mX9VgOpjj0ucRd5nzaEaBQppVs0zQGkbKC0BnHS8PGtnAglspd5Gh1Q=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -3453,6 +3511,8 @@
 
     "proggy": ["proggy@3.0.0", "", {}, "sha512-QE8RApCM3IaRRxVzxrjbgNMpQEX6Wu0p0KBeoSiSEw5/bsGwZHsshF4LCxH2jp/r6BU+bqA3LrMDEYNfJnpD8Q=="],
 
+    "promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
+
     "promise-all-reject-late": ["promise-all-reject-late@1.0.1", "", {}, "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw=="],
 
     "promise-call-limit": ["promise-call-limit@3.0.2", "", {}, "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw=="],
@@ -3499,6 +3559,8 @@
 
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
+    "react-relay": ["react-relay@18.2.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "relay-runtime": "18.2.0" }, "peerDependencies": { "react": "^16.9.0 || ^17 || ^18" } }, "sha512-/yHlv4pj3IQQPtDzYLfVk6P4wrOSvYPu/5ySPcRp4xV3pn9xoVOHVczSLcZkRVf72lJu8CIjoT8rn3roaGoFyQ=="],
+
     "react-shadow": ["react-shadow@20.6.0", "", { "dependencies": { "humps": "^2.0.1" }, "peerDependencies": { "prop-types": "^15.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-kY+w4OMNZ8Nj9YI9eiTgvvJ/wYO7XyX1D/LYhvwQZv5vw69iCiDtGB0BX/2U8gLUuZAMN+x/7rHJKqHh8wXFHQ=="],
 
     "react-tooltip": ["react-tooltip@5.30.0", "", { "dependencies": { "@floating-ui/dom": "^1.6.1", "classnames": "^2.3.0" }, "peerDependencies": { "react": ">=16.14.0", "react-dom": ">=16.14.0" } }, "sha512-Yn8PfbgQ/wmqnL7oBpz1QiDaLKrzZMdSUUdk7nVeGTwzbxCAJiJzR4VSYW+eIO42F1INt57sPUmpgKv0KwJKtg=="],
@@ -3520,6 +3582,10 @@
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
+
+    "relay-runtime": ["relay-runtime@18.2.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4" } }, "sha512-r4FYWlx1dPwFW+KQnuF1ugwVKR4toIFduCGheEf2paRc6nEEcCIgd2p2Jx2gRF+4niO3mCbRZvqdCoKaznUDzg=="],
+
+    "relay-test-utils": ["relay-test-utils@18.2.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4", "relay-runtime": "18.2.0" } }, "sha512-CfhZ/E9yUqdHnTLk8n9fnd0j1dz2dsLpTL6nnvvrmk8YyMJ5qKvoskVQiWyeSYFfHCfrzmWNPmNiXbxq6optqw=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
@@ -3786,6 +3852,8 @@
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
@@ -4100,6 +4168,8 @@
     "conventional-changelog-writer/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "copyfiles/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+
+    "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -4469,6 +4539,8 @@
 
     "copyfiles/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
+    "cross-fetch/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -4674,6 +4746,10 @@
     "copyfiles/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "copyfiles/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "cross-fetch/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "cross-fetch/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "get-pkg-repo/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 

--- a/packages/storybook/addon-relay/README.md
+++ b/packages/storybook/addon-relay/README.md
@@ -27,7 +27,7 @@ export default config;
 If your Storybook config is built with `@canonical/storybook-config`, pass it through `extraAddons`:
 
 ```typescript
-import createConfig from "@canonical/storybook-config";
+import { createConfig } from "@canonical/storybook-config";
 
 export default createConfig("react", {
   extraAddons: ["@canonical/storybook-addon-relay"],

--- a/packages/storybook/addon-relay/README.md
+++ b/packages/storybook/addon-relay/README.md
@@ -1,0 +1,142 @@
+# @canonical/storybook-addon-relay
+
+Mock Relay environment integration for Storybook. This addon lets React stories that use Relay hooks (`useLazyLoadQuery`, `useFragment`, `usePaginationFragment`, ...) render against a `relay-test-utils` mock environment, so components with GraphQL data requirements work in Storybook without a running GraphQL server.
+
+## Installation
+
+```bash
+bun add -D @canonical/storybook-addon-relay
+```
+
+`react-relay` and `relay-runtime` (18.x) are peer dependencies — your app already has them if it uses Relay.
+
+## Setup
+
+Register the addon in your `.storybook/main.ts`:
+
+```typescript
+const config: StorybookConfig = {
+  addons: [
+    "@canonical/storybook-addon-relay",
+  ],
+};
+
+export default config;
+```
+
+If your Storybook config is built with `@canonical/storybook-config`, pass it through `extraAddons`:
+
+```typescript
+import createConfig from "@canonical/storybook-config";
+
+export default createConfig("react", {
+  extraAddons: ["@canonical/storybook-addon-relay"],
+});
+```
+
+Registering the addon does two things:
+
+- its `preview` entry adds the `withRelayEnvironment` decorator globally;
+- its `preset` entry adds `relay-test-utils` (a CJS-only package) to Vite's `optimizeDeps.include`, so its named exports resolve in the browser ESM context.
+
+## Usage in Stories
+
+Declare a `relay` key in your story parameters. The decorator wraps the story in a `RelayEnvironmentProvider` carrying a fresh mock environment, and every GraphQL operation the story issues resolves automatically with data from `MockPayloadGenerator`:
+
+```typescript
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { RelayParameters } from "@canonical/storybook-addon-relay";
+import { UserProfile } from "./UserProfile.js";
+
+const meta: Meta<typeof UserProfile> = {
+  title: "Components/UserProfile",
+  component: UserProfile,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    relay: {
+      mockResolvers: {
+        User: () => ({
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+        }),
+      },
+    } satisfies RelayParameters,
+  },
+};
+```
+
+Stories without a `relay` parameter pass through unchanged — the decorator is a no-op for them.
+
+### Full payload control
+
+For error states or hand-crafted payloads, provide `generateFunction` — it replaces `MockPayloadGenerator.generate()` entirely:
+
+```typescript
+export const CustomPayload: Story = {
+  parameters: {
+    relay: {
+      generateFunction: (operation, mockResolvers) => ({
+        data: { user: { id: "1", name: "Custom Name" } },
+      }),
+    } satisfies RelayParameters,
+  },
+};
+```
+
+## API
+
+### `parameters.relay: RelayParameters`
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `mockResolvers` | `MockResolvers` | | Mock resolvers passed to `MockPayloadGenerator.generate()`. Keys are GraphQL type names, values are factories returning field values. Fields without a resolver receive deterministic placeholder values |
+| `generateFunction` | `(operation, mockResolvers?) => GraphQLSingularResponse` | | Full override for payload generation. When provided, `MockPayloadGenerator.generate()` is not called |
+
+### `withRelayEnvironment`
+
+The decorator itself, exported from the package root for manual composition (e.g. applying it to a single story file instead of globally). It is registered globally by the addon's `preview` entry, so most consumers never import it.
+
+## How operations resolve
+
+React components issue their Relay requests while rendering — after the decorator has returned — so the decorator queues an operation resolver on the mock environment rather than resolving up front. `relay-test-utils` consumes a queued resolver after a single operation, so the resolver re-arms itself after each one: initial queries, refetches, pagination, and mutations (including those triggered from play functions) all resolve with the same story configuration, no matter how many operations the story issues.
+
+The mock environment is created once per story mount. Re-renders (e.g. changing args via controls) keep the environment and its store; switching stories or pressing the remount toolbar button starts from a fresh environment.
+
+The environment is not exposed to the story context: operations resolve automatically, so stories and play functions do not need to drive the mock network by hand, and the `parameters.relay` contract stays minimal.
+
+## Peer Dependencies
+
+| Package | Version |
+|---------|---------|
+| `react` | ^18.0.0 \|\| ^19.0.0 |
+| `react-dom` | ^18.0.0 \|\| ^19.0.0 |
+| `react-relay` | >=18.0.0 <19.0.0 |
+| `relay-runtime` | >=18.0.0 <19.0.0 |
+| `storybook` | ^10.3.1 |
+
+## Troubleshooting
+
+### `does not provide an export named 'createMockEnvironment'`
+
+`relay-test-utils` and `relay-runtime` are CJS-only. The addon's `preset` adds `relay-test-utils` to `optimizeDeps.include` automatically — make sure the addon is registered in `.storybook/main.ts` (not only imported in `preview.ts`), otherwise the preset does not run.
+
+### A refetch or mutation never resolves
+
+Operations only resolve for stories that declare a `relay` parameter (even an empty object enables the mock environment):
+
+```typescript
+export const Default: Story = {
+  parameters: {
+    relay: {},
+  },
+};
+```
+
+### Deterministic data
+
+`MockPayloadGenerator` generates placeholder values for any field not covered by `mockResolvers`. If a story must render exact values (e.g. for visual regression tests), resolve every displayed field in `mockResolvers`, or use `generateFunction` for full control.

--- a/packages/storybook/addon-relay/biome.json
+++ b/packages/storybook/addon-relay/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["src", "*.json"]
+  }
+}

--- a/packages/storybook/addon-relay/package.json
+++ b/packages/storybook/addon-relay/package.json
@@ -1,0 +1,103 @@
+{
+  "name": "@canonical/storybook-addon-relay",
+  "version": "0.29.1",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "description": "Renders React stories that use Relay hooks against a mock Relay environment",
+  "keywords": [
+    "storybook-addons",
+    "relay",
+    "react-relay",
+    "graphql"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "license": "LGPL-3.0",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./preview": {
+      "types": "./dist/types/preview.d.ts",
+      "default": "./dist/esm/preview.js"
+    },
+    "./preset": {
+      "types": "./dist/types/preset.d.ts",
+      "default": "./dist/esm/preset.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun run build:package",
+    "build:all": "bun run build:package",
+    "build:package": "bun run build:package:tsc",
+    "build:package:tsc": "tsc -p tsconfig.build.json",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "check:webarchitect": "webarchitect library",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "relay-test-utils": "^18.2.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.9",
+    "@canonical/biome-config": "^0.29.0",
+    "@canonical/typescript-config-react": "^0.29.0",
+    "@canonical/webarchitect": "^0.29.0",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^24.12.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@types/react-relay": "^18.2.1",
+    "@types/relay-runtime": "^19.0.3",
+    "@types/relay-test-utils": "^18.0.0",
+    "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "jsdom": "^28.1.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-relay": "^18.2.0",
+    "relay-runtime": "^18.2.0",
+    "storybook": "^10.3.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.0.18"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-relay": ">=18.0.0 <19.0.0",
+    "relay-runtime": ">=18.0.0 <19.0.0",
+    "storybook": "^10.3.1"
+  },
+  "storybook": {
+    "displayName": "Relay",
+    "supportedFrameworks": [
+      "react"
+    ],
+    "icon": "https://relay.dev/img/relay.svg"
+  }
+}

--- a/packages/storybook/addon-relay/src/constants.ts
+++ b/packages/storybook/addon-relay/src/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Key under which stories declare their Relay configuration in Storybook
+ * `parameters` (i.e. `parameters.relay`).
+ */
+export const PARAM_KEY = "relay";

--- a/packages/storybook/addon-relay/src/index.ts
+++ b/packages/storybook/addon-relay/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @canonical/storybook-addon-relay — renders React stories that use Relay
+ * hooks against a `relay-test-utils` mock environment, configured per story
+ * via `parameters.relay` (`mockResolvers`, `generateFunction`).
+ *
+ * @packageDocumentation
+ */
+
+export * from "./lib/index.js";

--- a/packages/storybook/addon-relay/src/lib/index.ts
+++ b/packages/storybook/addon-relay/src/lib/index.ts
@@ -1,0 +1,2 @@
+export type { RelayParameters } from "./types.js";
+export { default as withRelayEnvironment } from "./withRelayEnvironment.js";

--- a/packages/storybook/addon-relay/src/lib/index.ts
+++ b/packages/storybook/addon-relay/src/lib/index.ts
@@ -1,2 +1,2 @@
 export type { RelayParameters } from "./types.js";
-export { default as withRelayEnvironment } from "./withRelayEnvironment.js";
+export { withRelayEnvironment } from "./withRelayEnvironment.js";

--- a/packages/storybook/addon-relay/src/lib/types.ts
+++ b/packages/storybook/addon-relay/src/lib/types.ts
@@ -1,0 +1,40 @@
+import type {
+  GraphQLSingularResponse,
+  OperationDescriptor,
+} from "relay-runtime";
+import type { MockResolvers } from "relay-test-utils";
+
+/**
+ * Shape of the `relay` key in a story's Storybook `parameters`.
+ *
+ * When present, the `withRelayEnvironment` decorator wraps the story in a
+ * mock Relay environment and resolves every GraphQL operation the story
+ * issues (initial queries, refetches, pagination, mutations) with the
+ * configuration declared here. When absent, the decorator is a no-op.
+ *
+ * The created mock environment is deliberately not exposed back to the story
+ * context: operations resolve automatically through the queued resolver, so
+ * stories and play functions have no need to drive the mock network by hand.
+ * Keeping the environment private keeps the `parameters.relay` contract to
+ * the two options below.
+ */
+export interface RelayParameters<
+  TResolvers extends MockResolvers = MockResolvers,
+> {
+  /**
+   * Mock resolvers passed to `MockPayloadGenerator.generate()`. Keys are
+   * GraphQL type names, values are factories returning field values for that
+   * type. Fields without a resolver receive deterministic placeholder values.
+   */
+  mockResolvers?: TResolvers;
+
+  /**
+   * Full override for payload generation. When provided, it is called instead
+   * of `MockPayloadGenerator.generate()` for every operation the story
+   * issues, receiving the operation and the configured `mockResolvers`.
+   */
+  generateFunction?: (
+    operation: OperationDescriptor,
+    mockResolvers?: TResolvers | null,
+  ) => GraphQLSingularResponse;
+}

--- a/packages/storybook/addon-relay/src/lib/withRelayEnvironment.test.tsx
+++ b/packages/storybook/addon-relay/src/lib/withRelayEnvironment.test.tsx
@@ -1,0 +1,280 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactElement, Suspense, useState } from "react";
+import { useLazyLoadQuery } from "react-relay";
+import type { ConcreteRequest, GraphQLSingularResponse } from "relay-runtime";
+import type { MockResolvers } from "relay-test-utils";
+import type {
+  Renderer,
+  StoryContext,
+  PartialStoryFn as StoryFunction,
+} from "storybook/internal/types";
+import { describe, expect, it, vi } from "vitest";
+import withRelayEnvironment from "./withRelayEnvironment.js";
+
+const viewerField = {
+  alias: null,
+  args: null,
+  concreteType: "User",
+  kind: "LinkedField",
+  name: "viewer",
+  plural: false,
+  selections: [
+    {
+      alias: null,
+      args: null,
+      kind: "ScalarField",
+      name: "id",
+      storageKey: null,
+    },
+    {
+      alias: null,
+      args: null,
+      kind: "ScalarField",
+      name: "name",
+      storageKey: null,
+    },
+  ],
+  storageKey: null,
+};
+
+/**
+ * Hand-written relay-compiler artifact for:
+ *
+ * ```graphql
+ * query WithRelayEnvironmentTestQuery {
+ *   viewer {
+ *     id
+ *     name
+ *   }
+ * }
+ * ```
+ *
+ * Written by hand — matching the `ConcreteRequest` structure relay-compiler
+ * emits (shared selection constant, `fragment`/`operation`/`params` shape) —
+ * instead of generated, so this test suite does not need a GraphQL schema,
+ * a relay config, and a codegen step for a single two-field query.
+ * `useLazyLoadQuery` and `MockPayloadGenerator` consume it exactly as they
+ * would a generated artifact.
+ */
+const testQuery = {
+  fragment: {
+    argumentDefinitions: [],
+    kind: "Fragment",
+    metadata: null,
+    name: "WithRelayEnvironmentTestQuery",
+    selections: [viewerField],
+    type: "Query",
+    abstractKey: null,
+  },
+  kind: "Request",
+  operation: {
+    argumentDefinitions: [],
+    kind: "Operation",
+    name: "WithRelayEnvironmentTestQuery",
+    selections: [viewerField],
+  },
+  params: {
+    cacheID: "WithRelayEnvironmentTestQuery",
+    id: null,
+    metadata: {},
+    name: "WithRelayEnvironmentTestQuery",
+    operationKind: "query",
+    text: "query WithRelayEnvironmentTestQuery {\n  viewer {\n    id\n    name\n  }\n}\n",
+  },
+} as unknown as ConcreteRequest;
+
+interface WithRelayEnvironmentTestQuery {
+  readonly variables: Record<string, never>;
+  readonly response: {
+    readonly viewer: {
+      readonly id: string;
+      readonly name: string;
+    } | null;
+  };
+}
+
+/** Story-like component fetching its own data at render time. */
+const ViewerName = (): ReactElement => {
+  const data = useLazyLoadQuery<WithRelayEnvironmentTestQuery>(testQuery, {});
+  return <output>{data.viewer?.name}</output>;
+};
+
+/** Story-like component that issues a second network operation on demand. */
+const RefetchableViewerName = (): ReactElement => {
+  const [fetchKey, setFetchKey] = useState(0);
+  const data = useLazyLoadQuery<WithRelayEnvironmentTestQuery>(
+    testQuery,
+    {},
+    { fetchKey, fetchPolicy: "network-only" },
+  );
+  return (
+    <div>
+      <output>{data.viewer?.name}</output>
+      <button type="button" onClick={() => setFetchKey((key) => key + 1)}>
+        refetch
+      </button>
+    </div>
+  );
+};
+
+/** Invokes the decorator the way Storybook would for a given story context. */
+const decorateStory = (
+  story: ReactElement,
+  context: Record<string, unknown>,
+): { storyFn: ReturnType<typeof vi.fn>; element: ReactElement } => {
+  const storyFn = vi.fn(() => story);
+  const element = withRelayEnvironment(
+    storyFn as StoryFunction<Renderer>,
+    context as unknown as StoryContext<Renderer>,
+  );
+  return { storyFn, element: element as ReactElement };
+};
+
+describe("withRelayEnvironment", () => {
+  it("passes through unchanged when the context has no parameters", () => {
+    const story = <output>plain story</output>;
+    const { storyFn, element } = decorateStory(story, {});
+
+    expect(storyFn).toHaveBeenCalledTimes(1);
+    expect(element).toBe(story);
+  });
+
+  it("passes through unchanged when parameters have no relay key", () => {
+    const story = <output>plain story</output>;
+    const { storyFn, element } = decorateStory(story, {
+      parameters: { backgrounds: { default: "light" } },
+    });
+
+    expect(storyFn).toHaveBeenCalledTimes(1);
+    expect(element).toBe(story);
+  });
+
+  it("resolves a useLazyLoadQuery story with data from mockResolvers", async () => {
+    const { element } = decorateStory(
+      <Suspense fallback={<span>loading</span>}>
+        <ViewerName />
+      </Suspense>,
+      {
+        parameters: {
+          relay: {
+            mockResolvers: {
+              User: () => ({ id: "user-1", name: "Ada Lovelace" }),
+            },
+          },
+        },
+      },
+    );
+
+    render(element);
+
+    expect(await screen.findByText("Ada Lovelace")).toBeTruthy();
+  });
+
+  it("generates placeholder data when no mockResolvers are provided", async () => {
+    const { element } = decorateStory(
+      <Suspense fallback={<span>loading</span>}>
+        <ViewerName />
+      </Suspense>,
+      { parameters: { relay: {} } },
+    );
+
+    render(element);
+
+    // MockPayloadGenerator's default scalar payload for un-resolved fields
+    expect(await screen.findByText(/mock-value-for-field/)).toBeTruthy();
+  });
+
+  it("resolves every operation a story issues, not only the first (refetch/pagination)", async () => {
+    let operationCount = 0;
+    const { element } = decorateStory(
+      <Suspense fallback={<span>loading</span>}>
+        <RefetchableViewerName />
+      </Suspense>,
+      {
+        parameters: {
+          relay: {
+            mockResolvers: {
+              User: () => {
+                operationCount += 1;
+                return {
+                  id: `user-${operationCount}`,
+                  name: `Viewer ${operationCount}`,
+                };
+              },
+            },
+          },
+        },
+      },
+    );
+
+    render(element);
+
+    expect(await screen.findByText("Viewer 1")).toBeTruthy();
+    expect(operationCount).toBe(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "refetch" }));
+
+    // The second, story-triggered operation resolves through the re-armed
+    // queued resolver — a single queued resolver would leave it pending.
+    expect(await screen.findByText("Viewer 2")).toBeTruthy();
+    expect(operationCount).toBe(2);
+  });
+
+  it("uses generateFunction instead of MockPayloadGenerator when provided", async () => {
+    const mockResolvers = {
+      User: () => ({ id: "resolver-id", name: "From Resolvers" }),
+    };
+    const generateFunction = vi.fn(
+      (): GraphQLSingularResponse => ({
+        data: { viewer: { id: "custom-id", name: "Custom Name" } },
+      }),
+    );
+
+    const { element } = decorateStory(
+      <Suspense fallback={<span>loading</span>}>
+        <ViewerName />
+      </Suspense>,
+      { parameters: { relay: { mockResolvers, generateFunction } } },
+    );
+
+    render(element);
+
+    expect(await screen.findByText("Custom Name")).toBeTruthy();
+    expect(screen.queryByText("From Resolvers")).toBeNull();
+    expect(generateFunction).toHaveBeenCalledWith(
+      expect.objectContaining({ request: expect.anything() }),
+      mockResolvers satisfies MockResolvers,
+    );
+  });
+
+  it("keeps the same environment and data across story re-renders", async () => {
+    let operationCount = 0;
+    const parameters = {
+      relay: {
+        mockResolvers: {
+          User: () => {
+            operationCount += 1;
+            return { id: "user-1", name: `Viewer ${operationCount}` };
+          },
+        },
+      },
+    };
+    const story = (
+      <Suspense fallback={<span>loading</span>}>
+        <ViewerName />
+      </Suspense>
+    );
+
+    const { element } = decorateStory(story, { parameters });
+    const view = render(element);
+    expect(await screen.findByText("Viewer 1")).toBeTruthy();
+
+    // Storybook re-invokes the decorator on re-renders (e.g. args changes);
+    // the mounted provider must keep its environment rather than refetch.
+    const { element: rerendered } = decorateStory(story, { parameters });
+    view.rerender(rerendered);
+
+    expect(await screen.findByText("Viewer 1")).toBeTruthy();
+    expect(operationCount).toBe(1);
+  });
+});

--- a/packages/storybook/addon-relay/src/lib/withRelayEnvironment.test.tsx
+++ b/packages/storybook/addon-relay/src/lib/withRelayEnvironment.test.tsx
@@ -9,7 +9,7 @@ import type {
   PartialStoryFn as StoryFunction,
 } from "storybook/internal/types";
 import { describe, expect, it, vi } from "vitest";
-import withRelayEnvironment from "./withRelayEnvironment.js";
+import { withRelayEnvironment } from "./withRelayEnvironment.js";
 
 const viewerField = {
   alias: null,

--- a/packages/storybook/addon-relay/src/lib/withRelayEnvironment.tsx
+++ b/packages/storybook/addon-relay/src/lib/withRelayEnvironment.tsx
@@ -97,7 +97,7 @@ const MockRelayEnvironmentProvider = ({
  * that automatically resolves every operation the story issues, using the
  * story's `mockResolvers` and/or `generateFunction`.
  */
-const withRelayEnvironment = (
+export const withRelayEnvironment = (
   storyFn: StoryFunction<Renderer>,
   context: StoryContext<Renderer>,
 ): ReturnType<StoryFunction<Renderer>> => {
@@ -115,5 +115,3 @@ const withRelayEnvironment = (
     </MockRelayEnvironmentProvider>
   ) as ReturnType<StoryFunction<Renderer>>;
 };
-
-export default withRelayEnvironment;

--- a/packages/storybook/addon-relay/src/lib/withRelayEnvironment.tsx
+++ b/packages/storybook/addon-relay/src/lib/withRelayEnvironment.tsx
@@ -1,0 +1,119 @@
+import { type ReactElement, type ReactNode, useState } from "react";
+// `react-relay`, `relay-runtime`, and `relay-test-utils` are CJS packages
+// with member-expression exports that Node's `cjs-module-lexer` cannot
+// detect, so these named imports fail under bare Node ESM. That is fine for
+// this package: a Storybook addon is consumed through Storybook + Vite, and
+// the `./preset` `viteFinal` pre-bundles `relay-test-utils` so the names
+// resolve in the preview iframe.
+import { RelayEnvironmentProvider } from "react-relay";
+import type {
+  GraphQLSingularResponse,
+  OperationDescriptor,
+} from "relay-runtime";
+import {
+  createMockEnvironment,
+  type MockEnvironment,
+  MockPayloadGenerator,
+} from "relay-test-utils";
+import type {
+  Renderer,
+  StoryContext,
+  PartialStoryFn as StoryFunction,
+} from "storybook/internal/types";
+import { PARAM_KEY } from "../constants.js";
+import type { RelayParameters } from "./types.js";
+
+/**
+ * Creates a mock Relay environment whose network resolves every operation
+ * with the payload described by the story's `parameters.relay`.
+ *
+ * React components issue their Relay requests while rendering (e.g.
+ * `useLazyLoadQuery` fetches when the hook runs), which happens only after
+ * the decorator has returned its element tree — so the decorator cannot call
+ * `resolveMostRecentOperation` up front; it must queue a resolver instead.
+ * `relay-test-utils` consumes a queued resolver after a single operation, so
+ * a resolver queued once would only cover the story's first query and leave
+ * refetches, pagination, and mutations (e.g. from play functions) pending
+ * forever. The queued resolver therefore re-arms itself after every
+ * operation, resolving however many operations the story issues.
+ */
+const createStoryEnvironment = (
+  parameters: RelayParameters,
+): MockEnvironment => {
+  const environment = createMockEnvironment();
+  const { mockResolvers, generateFunction } = parameters;
+
+  const resolveOperation = (
+    operation: OperationDescriptor,
+  ): GraphQLSingularResponse =>
+    generateFunction
+      ? generateFunction(operation, mockResolvers)
+      : MockPayloadGenerator.generate(operation, mockResolvers);
+
+  const armOperationResolver = (): void => {
+    environment.mock.queueOperationResolver((operation) => {
+      armOperationResolver();
+      return resolveOperation(operation);
+    });
+  };
+  armOperationResolver();
+
+  return environment;
+};
+
+/**
+ * Internal wrapper component that owns the mock environment's lifecycle.
+ *
+ * The environment is created lazily on mount and kept for the lifetime of
+ * the mounted story: re-renders (e.g. Storybook controls changing args) keep
+ * the same environment and store, while remounts (story switch, the remount
+ * toolbar button) start from a fresh one. `parameters.relay` is read when the
+ * environment is created; Storybook parameters are static per story.
+ */
+const MockRelayEnvironmentProvider = ({
+  parameters,
+  children,
+}: {
+  parameters: RelayParameters;
+  children: ReactNode;
+}): ReactElement => {
+  const [environment] = useState(() => createStoryEnvironment(parameters));
+
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      {children}
+    </RelayEnvironmentProvider>
+  );
+};
+
+/**
+ * Storybook decorator that lets React stories using Relay hooks
+ * (`useLazyLoadQuery`, `useFragment`, `usePaginationFragment`, ...) render
+ * against a mock Relay environment.
+ *
+ * Reads `parameters.relay` from the story context. If absent, the story
+ * passes through unchanged. If present, the story is wrapped in a
+ * `RelayEnvironmentProvider` carrying a `relay-test-utils` mock environment
+ * that automatically resolves every operation the story issues, using the
+ * story's `mockResolvers` and/or `generateFunction`.
+ */
+const withRelayEnvironment = (
+  storyFn: StoryFunction<Renderer>,
+  context: StoryContext<Renderer>,
+): ReturnType<StoryFunction<Renderer>> => {
+  const relayParameters = context.parameters?.[PARAM_KEY] as
+    | RelayParameters
+    | undefined;
+
+  if (!relayParameters) {
+    return storyFn();
+  }
+
+  return (
+    <MockRelayEnvironmentProvider parameters={relayParameters}>
+      {storyFn() as ReactNode}
+    </MockRelayEnvironmentProvider>
+  ) as ReturnType<StoryFunction<Renderer>>;
+};
+
+export default withRelayEnvironment;

--- a/packages/storybook/addon-relay/src/preset.test.ts
+++ b/packages/storybook/addon-relay/src/preset.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { viteFinal } from "./preset.js";
+
+describe("viteFinal", () => {
+  it("adds relay-test-utils when optimizeDeps.include is absent", () => {
+    const config: Record<string, unknown> = {};
+
+    const result = viteFinal(config);
+
+    expect(result).toBe(config);
+    expect(result.optimizeDeps).toEqual({
+      include: ["relay-test-utils"],
+    });
+  });
+
+  it("appends relay-test-utils to an existing include list", () => {
+    const config: Record<string, unknown> = {
+      optimizeDeps: {
+        include: ["other-dependency"],
+        exclude: ["excluded-dependency"],
+      },
+      plugins: ["plugin-a"],
+    };
+
+    const result = viteFinal(config);
+
+    expect(result.optimizeDeps).toEqual({
+      include: ["other-dependency", "relay-test-utils"],
+      exclude: ["excluded-dependency"],
+    });
+    expect(result.plugins).toEqual(["plugin-a"]);
+  });
+
+  it("does not duplicate relay-test-utils when already included", () => {
+    const config: Record<string, unknown> = {
+      optimizeDeps: {
+        include: ["relay-test-utils"],
+      },
+    };
+
+    const result = viteFinal(config);
+
+    expect(result.optimizeDeps).toEqual({
+      include: ["relay-test-utils"],
+    });
+  });
+});

--- a/packages/storybook/addon-relay/src/preset.ts
+++ b/packages/storybook/addon-relay/src/preset.ts
@@ -1,0 +1,24 @@
+/**
+ * Storybook addon preset — configures Vite so that `relay-test-utils`
+ * (a CJS-only package) is pre-bundled, allowing its named exports
+ * (`createMockEnvironment`, `MockPayloadGenerator`) to work in
+ * the browser ESM context.
+ *
+ * @note Named `viteFinal` per Storybook preset API convention — not a
+ * verb-first function name by design.
+ */
+export const viteFinal = (
+  config: Record<string, unknown>,
+): Record<string, unknown> => {
+  const optimizeDeps = (config.optimizeDeps ?? {}) as Record<string, unknown>;
+  const include = (optimizeDeps.include ?? []) as string[];
+
+  if (!include.includes("relay-test-utils")) {
+    include.push("relay-test-utils");
+  }
+
+  optimizeDeps.include = include;
+  config.optimizeDeps = optimizeDeps;
+
+  return config;
+};

--- a/packages/storybook/addon-relay/src/preview.test.ts
+++ b/packages/storybook/addon-relay/src/preview.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { withRelayEnvironment } from "./index.js";
+import preview from "./preview.js";
+
+describe("preview", () => {
+  it("registers the relay decorator in the Storybook preview config", () => {
+    expect(preview.decorators).toEqual([withRelayEnvironment]);
+  });
+});

--- a/packages/storybook/addon-relay/src/preview.ts
+++ b/packages/storybook/addon-relay/src/preview.ts
@@ -1,0 +1,13 @@
+import type { ProjectAnnotations, Renderer } from "storybook/internal/types";
+import withRelayEnvironment from "./lib/withRelayEnvironment.js";
+
+/**
+ * Storybook preview annotations — registers the `withRelayEnvironment`
+ * decorator globally, so adding this addon to the Storybook config is the
+ * only setup consumers need.
+ */
+const preview: ProjectAnnotations<Renderer> = {
+  decorators: [withRelayEnvironment],
+};
+
+export default preview;

--- a/packages/storybook/addon-relay/src/preview.ts
+++ b/packages/storybook/addon-relay/src/preview.ts
@@ -1,5 +1,5 @@
 import type { ProjectAnnotations, Renderer } from "storybook/internal/types";
-import withRelayEnvironment from "./lib/withRelayEnvironment.js";
+import { withRelayEnvironment } from "./lib/withRelayEnvironment.js";
 
 /**
  * Storybook preview annotations — registers the `withRelayEnvironment`

--- a/packages/storybook/addon-relay/tsconfig.build.json
+++ b/packages/storybook/addon-relay/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/storybook/addon-relay/tsconfig.json
+++ b/packages/storybook/addon-relay/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../configs/typescript-react/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "skipLibCheck": true,
+    "types": ["node", "react", "react-dom"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/storybook/addon-relay/tsconfig.json
+++ b/packages/storybook/addon-relay/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../configs/typescript-react/tsconfig.json",
+  "extends": "@canonical/typescript-config-react",
   "compilerOptions": {
     "baseUrl": "src",
     "skipLibCheck": true,

--- a/packages/storybook/addon-relay/vitest.config.ts
+++ b/packages/storybook/addon-relay/vitest.config.ts
@@ -1,0 +1,33 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+// biome-ignore lint/suspicious/noExplicitAny: Vite 8 plugin types are incompatible with vitest's Vite 7 re-exports
+const plugins: any[] = [react()];
+
+export default defineConfig({
+  plugins,
+  test: {
+    name: "client",
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "**/index.ts",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.d.ts",
+        "**/types.ts",
+      ],
+      thresholds: {
+        branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+      },
+    },
+  },
+});

--- a/packages/storybook/addon-relay/vitest.setup.ts
+++ b/packages/storybook/addon-relay/vitest.setup.ts
@@ -1,0 +1,9 @@
+import { vi } from "vitest";
+
+// relay-test-utils' `createMockEnvironment` wraps environment methods in
+// `jest.fn` mocks whenever NODE_ENV === "test", reaching for a global `jest`
+// object. Vitest sets NODE_ENV=test but exposes `vi` instead, so alias it —
+// `vi.fn` is API-compatible with the `jest.fn` surface relay-test-utils uses
+// (`.mock`, `.mockClear`). Inside Storybook itself NODE_ENV is development or
+// production, so this code path never runs at addon runtime.
+(globalThis as { jest?: typeof vi }).jest = vi;

--- a/packages/storybook/addon-relay/vitest.setup.ts
+++ b/packages/storybook/addon-relay/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { afterAll, vi } from "vitest";
 
 // relay-test-utils' `createMockEnvironment` wraps environment methods in
 // `jest.fn` mocks whenever NODE_ENV === "test", reaching for a global `jest`
@@ -6,4 +6,15 @@ import { vi } from "vitest";
 // `vi.fn` is API-compatible with the `jest.fn` surface relay-test-utils uses
 // (`.mock`, `.mockClear`). Inside Storybook itself NODE_ENV is development or
 // production, so this code path never runs at addon runtime.
-(globalThis as { jest?: typeof vi }).jest = vi;
+// Only fill the global when absent, and restore it afterwards, so a real Jest
+// global (or another suite's shim) is never masked or leaked past this suite.
+const globalWithJest = globalThis as { jest?: typeof vi };
+const previousJest = globalWithJest.jest;
+
+if (previousJest === undefined) {
+  globalWithJest.jest = vi;
+}
+
+afterAll(() => {
+  globalWithJest.jest = previousJest;
+});


### PR DESCRIPTION
## Done

New package **`@canonical/storybook-addon-relay`** (`packages/storybook/addon-relay/`) — lets React stories using Relay hooks render against a mock Relay environment, configured per story:

- **`withRelayEnvironment` decorator** — wraps the story in `react-relay`'s `RelayEnvironmentProvider` with a `relay-test-utils` `createMockEnvironment()`. `parameters.relay`:
  - `mockResolvers` → `MockPayloadGenerator.generate()` for every operation the story issues
  - `generateFunction(operation, mockResolvers)` → full override
  - no `relay` parameter → pass-through no-op
- **`./preview`** — preview annotation registering the decorator globally; **`./preset`** — `viteFinal` pushing CJS-only `relay-test-utils` into `optimizeDeps.include`. Registering the addon (e.g. via `createConfig("react", { extraAddons: [...] })`) activates both.
- The queued operation resolver **re-arms after each operation** so refetch/pagination/mutations (incl. play-function-triggered) resolve — with React-specific rationale documented in TSDoc (render-time fetch → `resolveMostRecentOperation` can't work).
- Environment is created once per story mount (lazy `useState`), stable across arg re-renders, fresh per story switch — tested.

Design lineage: structure mirrors `addon-msw`; mechanics adapted from `advl/lit-relay`'s `storybook-addon-lit-relay`; `parameters.relay` shape informed by the 2022 `storybook-addon-relay` (whose SB6-era manager panel was deliberately dropped — no manager UI here).

Pins: peers `react-relay`/`relay-runtime` `>=18.0.0 <19.0.0`, storybook `^10.3.1`; dep `relay-test-utils@^18.2.0`. tsconfig uses a relative `extends` (Vite 8 OXC cannot resolve bare-specifier extends).

## QA

```bash
bun run --filter @canonical/storybook-addon-relay check   # biome + tsc + webarchitect library
bun run --filter @canonical/storybook-addon-relay test    # 11/11, 100% coverage (v8 thresholds)
bun run --filter @canonical/storybook-addon-relay build
```

### PR readiness check

- [ ] Suggested label: `Feature 🎁`, `no visual change`
- [x] PR title follows Conventional Commits
- [x] Follows code standards — biome, tsc, webarchitect, 100% coverage
- [ ] **New package** — first-time `npm publish --access public` + trusted publisher is a manual step (needed before the generator opt-in ships, not before merge)

## Screenshots

N/A — addon infrastructure; story-visible behavior arrives with the boilerplate example stories (C8 PR, stacked on this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nYyx5PtusgA8ZBJBWK7At

---
_Generated by [Claude Code](https://claude.ai/code/session_014nYyx5PtusgA8ZBJBWK7At)_