### PR TITLE
feat(react-boilerplate-vite): Relay data layer (CSR) with local mock schema and storybook mocking

### DIFF
--- a/apps/react/boilerplate-vite/.storybook/main.ts
+++ b/apps/react/boilerplate-vite/.storybook/main.ts
@@ -2,4 +2,7 @@ import { createConfig } from "@canonical/storybook-config";
 
 export default createConfig("react", {
   staticDirs: ["../src/assets", "../public"],
+  // Wraps stories that declare `parameters.relay` in a relay-test-utils mock
+  // environment, so components using Relay hooks render without a server.
+  extraAddons: ["@canonical/storybook-addon-relay"],
 });

--- a/apps/react/boilerplate-vite/README.md
+++ b/apps/react/boilerplate-vite/README.md
@@ -62,6 +62,12 @@ production behaviour.
 - `bun run build:server` — `vite build --ssr src/server/renderer.tsx` →
   `dist/server`. Needed only for `preview:*`; the `preview:*` scripts run it.
 - `bun run build:all` — the client bundle plus the static Storybook.
+- `bun run relay` — `relay-compiler`, regenerating the artifacts in
+  `src/relay/__generated__`. The artifacts are committed (the Vite plugin runs
+  with `codegen: false`), so run this after editing any `graphql` tag or the
+  schema — the build does not regenerate them for you.
+- `bun run relay:watch` — the same, re-running on change; pair it with `dev:*`
+  while working on queries.
 
 ## Testing
 
@@ -91,8 +97,11 @@ src/
 ├── domains/              Feature domains, each owning its routes and pages
 │   ├── marketing/        Home, guides
 │   ├── account/          Account, login
+│   ├── catalog/          Product catalog — the Relay data-layer example
 │   └── contact/          Contact form (present when scaffolded with forms)
 ├── lib/                  Shared components (Navigation, ThemeSelector, …)
+├── relay/                Relay environment factory, executable mock schema,
+│                         and generated artifacts (__generated__/)
 ├── styles/               Application CSS
 ├── assets/               Assets imported in code (bundled and hashed by Vite)
 ├── Application.tsx       Application shell
@@ -107,11 +116,31 @@ files. `src/assets/` and `public/` both ship by default — the former for asset
 referenced in code, the latter for fixed-URL files — and either may be removed if
 an application uses only one.
 
+## Data layer (Relay)
+
+The `catalog` domain demonstrates the app's [Relay](https://relay.dev) data
+layer: `ProductList` fetches a page of products with `useLazyLoadQuery`, and
+each `ProductCard` reads its own colocated `useFragment` — the component owns
+its field selection, the parent query just spreads it.
+
+**By default the app needs no backend.** `createEnvironment`
+(`src/relay/environment.ts`) resolves every GraphQL operation in-process
+against an executable mock schema (`src/relay/schema.ts`, built from the SDL
+in `src/relay/schema.graphql`) backed by a small deterministic catalog. Set
+`VITE_GRAPHQL_URL` (or pass `graphqlUrl` to `createEnvironment`) to switch the
+environment to posting operations to a real GraphQL endpoint instead — no code
+changes needed.
+
+**Generated artifacts are committed.** The Vite plugin runs with
+`codegen: false`, so `src/relay/__generated__/` is not rebuilt on the fly:
+after editing a `graphql` tag or the schema, run `bun run relay` (or keep
+`bun run relay:watch` running) to regenerate the artifacts, and commit them.
+
 ## Conventions
 
-Path aliases (`#lib`, `#domains`, `#styles`) are Node subpath imports declared in
-`package.json`, resolved natively by Vite and TypeScript without a resolver
-plugin. Linting and formatting run through Biome (`bun run check`). The
+Path aliases (`#lib`, `#domains`, `#relay`, `#styles`) are Node subpath
+imports declared in `package.json`, resolved natively by Vite and TypeScript
+without a resolver plugin. Linting and formatting run through Biome (`bun run check`). The
 application is built on `@canonical/react-ds-global`, `@canonical/react-ssr`,
 `@canonical/router-react`, and the shared design tokens — the same packages every
 Canonical application uses, so conventions carry across projects.

--- a/apps/react/boilerplate-vite/biome.json
+++ b/apps/react/boilerplate-vite/biome.json
@@ -1,6 +1,6 @@
 {
   "extends": ["@canonical/biome-config"],
   "files": {
-    "includes": ["src", "*.json", "vite.config.ts"]
+    "includes": ["src", "*.json", "vite.config.ts", "!src/relay/__generated__"]
   }
 }

--- a/apps/react/boilerplate-vite/package.json
+++ b/apps/react/boilerplate-vite/package.json
@@ -68,6 +68,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/react-relay": "^18.2.1",
     "@types/relay-runtime": "^19.0.3",
+    "@types/relay-test-utils": "^18.0.0",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "^4.0.18",
     "bun-types": "^1.3.9",

--- a/apps/react/boilerplate-vite/package.json
+++ b/apps/react/boilerplate-vite/package.json
@@ -7,6 +7,7 @@
   "imports": {
     "#lib/*": "./src/lib/*",
     "#domains/*": "./src/domains/*",
+    "#relay/*": "./src/relay/*",
     "#styles/*": "./src/styles/*"
   },
   "scripts": {
@@ -26,6 +27,8 @@
     "check:biome": "biome check",
     "check:biome:fix": "biome check --write",
     "check:ts": "tsc --noEmit",
+    "relay": "relay-compiler",
+    "relay:watch": "relay-compiler --watch",
     "storybook": "storybook dev -p 6010 --no-open --host 0.0.0.0",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -40,11 +43,16 @@
     "@canonical/react-ssr": "^0.29.0",
     "@canonical/router-core": "^0.29.0",
     "@canonical/router-react": "^0.29.0",
+    "@canonical/storybook-addon-relay": "^0.29.1",
     "@canonical/storybook-config": "^0.29.1",
     "@canonical/styles": "^0.29.0",
     "express": "^5.2.1",
+    "graphql": "^16.11.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-relay": "^18.2.0",
+    "relay-runtime": "^18.2.0",
+    "relay-runtime-network": "^0.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.9",
@@ -58,14 +66,19 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/react-relay": "^18.2.1",
+    "@types/relay-runtime": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "^4.0.18",
     "bun-types": "^1.3.9",
     "jsdom": "^28.1.0",
+    "relay-compiler": "^18.2.0",
+    "relay-test-utils": "^18.2.0",
     "storybook": "^10.3.1",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.1",
+    "vite-plugin-relay-lite": "^0.12.0",
     "vitest": "^4.0.18"
   }
 }

--- a/apps/react/boilerplate-vite/relay.config.json
+++ b/apps/react/boilerplate-vite/relay.config.json
@@ -1,0 +1,8 @@
+{
+  "src": "./src",
+  "schema": "./src/relay/schema.graphql",
+  "language": "typescript",
+  "eagerEsModules": true,
+  "artifactDirectory": "./src/relay/__generated__",
+  "excludes": ["**/node_modules/**", "**/__generated__/**", "**/dist/**"]
+}

--- a/apps/react/boilerplate-vite/src/client/entry.tsx
+++ b/apps/react/boilerplate-vite/src/client/entry.tsx
@@ -2,6 +2,8 @@ import { HeadProvider } from "@canonical/react-head";
 import { createBrowserRouter } from "@canonical/router-core";
 import { Outlet, RouterProvider } from "@canonical/router-react";
 import { hydrateRoot } from "react-dom/client";
+import { RelayEnvironmentProvider } from "react-relay";
+import { createEnvironment } from "#relay/environment.js";
 import { appRoutes, middleware, notFoundRoute } from "../routes.js";
 import "#styles/index.css";
 
@@ -9,6 +11,10 @@ const router = createBrowserRouter(appRoutes, {
   middleware: [...middleware],
   notFound: notFoundRoute,
 });
+
+// One Relay environment (network + normalized store) for the whole browser
+// session — module scope, so client-side navigations share the cache.
+const relayEnvironment = createEnvironment();
 
 const root = document.getElementById("root");
 if (!root) {
@@ -18,8 +24,10 @@ if (!root) {
 hydrateRoot(
   root,
   <HeadProvider>
-    <RouterProvider router={router}>
-      <Outlet fallback={<p>Loading…</p>} />
-    </RouterProvider>
+    <RelayEnvironmentProvider environment={relayEnvironment}>
+      <RouterProvider router={router}>
+        <Outlet fallback={<p>Loading…</p>} />
+      </RouterProvider>
+    </RelayEnvironmentProvider>
   </HeadProvider>,
 );

--- a/apps/react/boilerplate-vite/src/domains/catalog/CatalogPage.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/CatalogPage.tsx
@@ -1,6 +1,7 @@
 import { useHead } from "@canonical/react-head";
 import { type ReactElement, Suspense } from "react";
 import { ClientOnly } from "#lib/index.js";
+import ErrorBoundary from "./ErrorBoundary.js";
 import ProductList from "./ProductList.js";
 
 export default function CatalogPage(): ReactElement {
@@ -24,10 +25,25 @@ export default function CatalogPage(): ReactElement {
         then `ClientOnly` keeps the query off the server render path: the
         server streams the fallback and the browser fetches after hydration.
       */}
+      {/*
+        The canonical Relay pairing: Suspense renders the pending state while
+        `useLazyLoadQuery` is in flight, and the ErrorBoundary renders the
+        failure state when the query errors (e.g. an unreachable endpoint in
+        `VITE_GRAPHQL_URL` mode) — without it a thrown query error would
+        unmount the whole tree to a blank page.
+      */}
       <ClientOnly fallback={<p>Loading catalog…</p>}>
-        <Suspense fallback={<p>Loading catalog…</p>}>
-          <ProductList />
-        </Suspense>
+        <ErrorBoundary
+          fallback={
+            <p role="alert">
+              The catalog failed to load. Reload the page to try again.
+            </p>
+          }
+        >
+          <Suspense fallback={<p>Loading catalog…</p>}>
+            <ProductList />
+          </Suspense>
+        </ErrorBoundary>
       </ClientOnly>
     </section>
   );

--- a/apps/react/boilerplate-vite/src/domains/catalog/CatalogPage.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/CatalogPage.tsx
@@ -1,0 +1,34 @@
+import { useHead } from "@canonical/react-head";
+import { type ReactElement, Suspense } from "react";
+import { ClientOnly } from "#lib/index.js";
+import ProductList from "./ProductList.js";
+
+export default function CatalogPage(): ReactElement {
+  useHead({ title: "Catalog — Boilerplate" });
+
+  return (
+    <section aria-labelledby="catalog-title">
+      <h1 id="catalog-title">Catalog</h1>
+      <p>
+        This page demonstrates the Relay data layer. <code>ProductList</code>{" "}
+        issues a <code>useLazyLoadQuery</code>, each <code>ProductCard</code>{" "}
+        reads its own <code>useFragment</code>, and the environment resolves
+        operations against the local mock schema in{" "}
+        <code>src/relay/schema.ts</code> — set <code>VITE_GRAPHQL_URL</code> to
+        point it at a real endpoint instead.
+      </p>
+      {/*
+        SSR guard: `useLazyLoadQuery` fetches (and suspends) while rendering,
+        and the server has no way to serialize the fetched store for the
+        client yet — that lands in the follow-up SSR data-hydration PR. Until
+        then `ClientOnly` keeps the query off the server render path: the
+        server streams the fallback and the browser fetches after hydration.
+      */}
+      <ClientOnly fallback={<p>Loading catalog…</p>}>
+        <Suspense fallback={<p>Loading catalog…</p>}>
+          <ProductList />
+        </Suspense>
+      </ClientOnly>
+    </section>
+  );
+}

--- a/apps/react/boilerplate-vite/src/domains/catalog/ErrorBoundary.tests.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ErrorBoundary.tests.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { RelayEnvironmentProvider } from "react-relay";
+import { createMockEnvironment } from "relay-test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ErrorBoundary from "./ErrorBoundary.js";
+import ProductList from "./ProductList.js";
+
+describe("ErrorBoundary component", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders its children while nothing throws", () => {
+    render(
+      <ErrorBoundary fallback={<p role="alert">Failed.</p>}>
+        <p>Catalog content</p>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Catalog content")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders the fallback when the catalog query errors", async () => {
+    // React logs errors caught by boundaries; keep the test output clean.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const environment = createMockEnvironment();
+    // Resolving an operation with an Error rejects it, which makes
+    // `useLazyLoadQuery` re-throw during render — exactly what happens when
+    // a real endpoint is unreachable. Queue it before rendering, as the
+    // query is issued during the initial render.
+    environment.mock.queueOperationResolver(
+      () => new Error("backend unreachable"),
+    );
+
+    render(
+      <RelayEnvironmentProvider environment={environment}>
+        <ErrorBoundary
+          fallback={<p role="alert">The catalog failed to load.</p>}
+        >
+          <Suspense fallback={<p>Loading catalog…</p>}>
+            <ProductList />
+          </Suspense>
+        </ErrorBoundary>
+      </RelayEnvironmentProvider>,
+    );
+
+    // The fallback replaces the subtree instead of white-screening.
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "The catalog failed to load.",
+    );
+    expect(screen.queryByText(/products/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/react/boilerplate-vite/src/domains/catalog/ErrorBoundary.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import { Component, type ReactNode } from "react";
+
+export interface ErrorBoundaryProps {
+  /** Subtree whose render errors this boundary catches. */
+  readonly children: ReactNode;
+  /** Rendered in place of `children` after an error. */
+  readonly fallback: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  readonly hasError: boolean;
+}
+
+/**
+ * Catches render errors below it and renders `fallback` instead of letting
+ * the error unmount the whole tree to a blank page.
+ *
+ * Relay's `useLazyLoadQuery` re-throws query errors during render — Suspense
+ * only handles the pending state — so a data-driven subtree needs both
+ * boundaries: Suspense for loading, this for failure (the canonical Relay
+ * pairing; see `CatalogPage`). A class component because error boundaries
+ * have no hook equivalent.
+ */
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render(): ReactNode {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}

--- a/apps/react/boilerplate-vite/src/domains/catalog/ProductCard.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ProductCard.tsx
@@ -1,0 +1,49 @@
+import type { ReactElement } from "react";
+import { graphql, useFragment } from "react-relay";
+import type { ProductCard_product$key } from "#relay/__generated__/ProductCard_product.graphql.js";
+
+// Data this card needs, colocated with the component. The parent query
+// spreads the fragment, so the card can evolve its field selection without
+// touching `ProductList`.
+const productCardFragment = graphql`
+  fragment ProductCard_product on Product {
+    name
+    tagline
+    priceCents
+    currency
+    rating
+    inStock
+  }
+`;
+
+/** Formats a minor-unit price deterministically (fixed locale, real currency). */
+const formatPrice = (priceCents: number, currency: string): string =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+    priceCents / 100,
+  );
+
+export interface ProductCardProps {
+  /** Fragment reference to the product this card renders. */
+  readonly product: ProductCard_product$key;
+}
+
+/**
+ * Renders one catalog product from a Relay fragment reference.
+ */
+export default function ProductCard({
+  product,
+}: ProductCardProps): ReactElement {
+  const data = useFragment(productCardFragment, product);
+
+  return (
+    <article aria-label={data.name}>
+      <h3>{data.name}</h3>
+      <p>{data.tagline}</p>
+      <p>
+        <strong>{formatPrice(data.priceCents, data.currency)}</strong> · rated{" "}
+        {data.rating.toFixed(1)} / 5 ·{" "}
+        {data.inStock ? "in stock" : "out of stock"}
+      </p>
+    </article>
+  );
+}

--- a/apps/react/boilerplate-vite/src/domains/catalog/ProductList.stories.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ProductList.stories.tsx
@@ -73,6 +73,8 @@ export const Default: Story = {
     await expect(
       canvas.getByText(/showing 2 of 5 products/),
     ).toBeInTheDocument();
+    // The Polar Sensor Kit is the story's out-of-stock product.
+    await expect(canvas.getByText(/out of stock/)).toBeInTheDocument();
     await expect(
       canvas.getByText("More products are available."),
     ).toBeInTheDocument();

--- a/apps/react/boilerplate-vite/src/domains/catalog/ProductList.stories.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ProductList.stories.tsx
@@ -1,0 +1,101 @@
+import type { RelayParameters } from "@canonical/storybook-addon-relay";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Suspense } from "react";
+import { expect } from "storybook/test";
+import Component from "./ProductList.js";
+
+const meta = {
+  title: "Catalog/ProductList",
+  component: Component,
+  // `useLazyLoadQuery` suspends while the (mocked) query is in flight, so
+  // every story renders inside a Suspense boundary — the same shape the
+  // catalog page uses.
+  decorators: [
+    (Story) => (
+      <Suspense fallback={<p>Loading catalog…</p>}>
+        <Story />
+      </Suspense>
+    ),
+  ],
+} satisfies Meta<typeof Component>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * `@canonical/storybook-addon-relay` reads `parameters.relay` and resolves
+ * the story's operations with `MockPayloadGenerator` + these resolvers.
+ * Every displayed field is resolved explicitly so the story is deterministic
+ * for visual regression testing.
+ */
+export const Default: Story = {
+  parameters: {
+    relay: {
+      mockResolvers: {
+        Viewer: () => ({ name: "Ada Lovelace" }),
+        ProductConnection: () => ({
+          totalCount: 5,
+          pageInfo: { hasNextPage: true },
+          edges: [
+            {
+              node: {
+                id: "Product:story-1",
+                name: "Aurora Dev Board",
+                tagline: "A hackable single-board computer for prototyping",
+                priceCents: 14_900,
+                currency: "USD",
+                rating: 4.6,
+                inStock: true,
+              },
+            },
+            {
+              node: {
+                id: "Product:story-2",
+                name: "Polar Sensor Kit",
+                tagline: "Twelve calibrated sensors in a rugged case",
+                priceCents: 8_900,
+                currency: "USD",
+                rating: 4.2,
+                inStock: false,
+              },
+            },
+          ],
+        }),
+      },
+    } satisfies RelayParameters,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByText("Aurora Dev Board"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Ada Lovelace")).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/showing 2 of 5 products/),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText("More products are available."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const EmptyCatalog: Story = {
+  parameters: {
+    relay: {
+      mockResolvers: {
+        Viewer: () => ({ name: "Ada Lovelace" }),
+        ProductConnection: () => ({
+          totalCount: 0,
+          pageInfo: { hasNextPage: false },
+          edges: [],
+        }),
+      },
+    } satisfies RelayParameters,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByText(/showing 0 of 0 products/),
+    ).toBeInTheDocument();
+    await expect(canvas.queryByRole("article")).not.toBeInTheDocument();
+  },
+};

--- a/apps/react/boilerplate-vite/src/domains/catalog/ProductList.tests.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ProductList.tests.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { RelayEnvironmentProvider } from "react-relay";
+import type { IEnvironment } from "relay-runtime";
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils";
+import { describe, expect, it } from "vitest";
+import { createEnvironment } from "#relay/environment.js";
+import { CATALOG_PRODUCTS } from "#relay/schema.js";
+import ProductList from "./ProductList.js";
+
+const renderProductList = (environment: IEnvironment) =>
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback={<p>Loading catalog…</p>}>
+        <ProductList />
+      </Suspense>
+    </RelayEnvironmentProvider>,
+  );
+
+describe("ProductList component", () => {
+  it("renders the first page from the app's local mock schema", async () => {
+    // Integration path: the real factory, whose local executor resolves the
+    // query against src/relay/schema.ts — no relay-test-utils involved.
+    renderProductList(createEnvironment());
+
+    const firstProduct = CATALOG_PRODUCTS[0];
+    expect(
+      await screen.findByRole("article", { name: firstProduct?.name }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`of ${CATALOG_PRODUCTS.length} products`)),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("More products are available."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders payloads resolved by a relay-test-utils mock environment", async () => {
+    const environment = createMockEnvironment();
+    // Queue the resolver before rendering: useLazyLoadQuery issues the
+    // request during render, and the queued resolver answers it immediately.
+    environment.mock.queueOperationResolver((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Viewer: () => ({ name: "Grace Hopper" }),
+        ProductConnection: () => ({
+          totalCount: 1,
+          pageInfo: { hasNextPage: false },
+          edges: [
+            {
+              node: {
+                id: "Product:mocked",
+                name: "Mocked Product",
+                tagline: "Straight from MockPayloadGenerator",
+                priceCents: 12_500,
+                currency: "USD",
+                rating: 4.5,
+                inStock: true,
+              },
+            },
+          ],
+        }),
+      }),
+    );
+
+    renderProductList(environment);
+
+    expect(await screen.findByText("Mocked Product")).toBeInTheDocument();
+    expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
+    expect(screen.getByText("$125.00", { exact: false })).toBeInTheDocument();
+    expect(
+      screen.queryByText("More products are available."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/react/boilerplate-vite/src/domains/catalog/ProductList.tests.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ProductList.tests.tsx
@@ -31,6 +31,10 @@ describe("ProductList component", () => {
     expect(
       screen.getByText(new RegExp(`of ${CATALOG_PRODUCTS.length} products`)),
     ).toBeInTheDocument();
+    // Product:3 (Beacon Micro Server) is the first page's out-of-stock,
+    // 4.2-rated product — pins the stock label and the rating formatting.
+    expect(screen.getByText(/out of stock/)).toBeInTheDocument();
+    expect(screen.getByText(/rated 4\.2 \/ 5/)).toBeInTheDocument();
     expect(
       screen.getByText("More products are available."),
     ).toBeInTheDocument();
@@ -68,6 +72,7 @@ describe("ProductList component", () => {
     expect(await screen.findByText("Mocked Product")).toBeInTheDocument();
     expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
     expect(screen.getByText("$125.00", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(/in stock/)).toBeInTheDocument();
     expect(
       screen.queryByText("More products are available."),
     ).not.toBeInTheDocument();

--- a/apps/react/boilerplate-vite/src/domains/catalog/ProductList.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ProductList.tsx
@@ -1,0 +1,59 @@
+import type { ReactElement } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import type { ProductListQuery } from "#relay/__generated__/ProductListQuery.graphql.js";
+import ProductCard from "./ProductCard.js";
+
+/** How many products the list requests from the connection. */
+const PAGE_SIZE = 4;
+
+const productListQuery = graphql`
+  query ProductListQuery($count: Int!, $cursor: String) {
+    viewer {
+      name
+      products(first: $count, after: $cursor) {
+        totalCount
+        pageInfo {
+          hasNextPage
+        }
+        edges {
+          node {
+            id
+            ...ProductCard_product
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetches the first page of the product catalog with `useLazyLoadQuery` and
+ * renders a `ProductCard` (a `useFragment` child) per edge.
+ *
+ * The hook suspends while the query is in flight, so render this component
+ * inside a `Suspense` boundary — and, until the SSR data-serialization PR
+ * lands, only on the client (see `CatalogPage`).
+ */
+export default function ProductList(): ReactElement {
+  const data = useLazyLoadQuery<ProductListQuery>(productListQuery, {
+    count: PAGE_SIZE,
+  });
+  const { products } = data.viewer;
+
+  return (
+    <section aria-label="Product catalog">
+      <p>
+        Signed in as <strong>{data.viewer.name}</strong> — showing{" "}
+        {products.edges.length} of {products.totalCount} products.
+      </p>
+      <ul>
+        {products.edges.map(({ node }) => (
+          <li key={node.id}>
+            <ProductCard product={node} />
+          </li>
+        ))}
+      </ul>
+      {products.pageInfo.hasNextPage && <p>More products are available.</p>}
+    </section>
+  );
+}

--- a/apps/react/boilerplate-vite/src/domains/catalog/routes.ts
+++ b/apps/react/boilerplate-vite/src/domains/catalog/routes.ts
@@ -1,0 +1,11 @@
+import { route } from "@canonical/router-core";
+import CatalogPage from "./CatalogPage.js";
+
+const routes = {
+  catalog: route({
+    url: "/catalog",
+    content: CatalogPage,
+  }),
+} as const;
+
+export default routes;

--- a/apps/react/boilerplate-vite/src/lib/ClientOnly/ClientOnly.tests.tsx
+++ b/apps/react/boilerplate-vite/src/lib/ClientOnly/ClientOnly.tests.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import ClientOnly from "./ClientOnly.js";
+
+describe("ClientOnly component", () => {
+  it("renders children after mounting in the browser", () => {
+    render(
+      <ClientOnly fallback={<p>Loading…</p>}>
+        <p>Client content</p>
+      </ClientOnly>,
+    );
+    expect(screen.getByText("Client content")).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  });
+
+  it("renders the fallback when server-rendered", () => {
+    const html = renderToString(
+      <ClientOnly fallback={<p>Loading…</p>}>
+        <p>Client content</p>
+      </ClientOnly>,
+    );
+    expect(html).toContain("Loading…");
+    expect(html).not.toContain("Client content");
+  });
+
+  it("renders nothing on the server without a fallback", () => {
+    const html = renderToString(
+      <ClientOnly>
+        <p>Client content</p>
+      </ClientOnly>,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/apps/react/boilerplate-vite/src/lib/ClientOnly/ClientOnly.tsx
+++ b/apps/react/boilerplate-vite/src/lib/ClientOnly/ClientOnly.tsx
@@ -1,0 +1,31 @@
+import { type ReactElement, type ReactNode, useEffect, useState } from "react";
+
+export interface ClientOnlyProps {
+  /** Content rendered only after the component mounts in the browser. */
+  readonly children: ReactNode;
+  /** Rendered during SSR and the initial hydration pass. Defaults to nothing. */
+  readonly fallback?: ReactNode;
+}
+
+/**
+ * Defers `children` until after hydration, so they render only in the browser.
+ *
+ * The server (and React's first client pass, so hydration stays
+ * mismatch-free) renders `fallback`; the mount effect then flips to
+ * `children`. Use this for content that must not run during server
+ * rendering — e.g. components that fetch on render, like the Relay example
+ * on the catalog page, until server-side data serialization/hydration lands
+ * in a follow-up PR.
+ */
+export default function ClientOnly({
+  children,
+  fallback = null,
+}: ClientOnlyProps): ReactElement {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return <>{isMounted ? children : fallback}</>;
+}

--- a/apps/react/boilerplate-vite/src/lib/ClientOnly/index.ts
+++ b/apps/react/boilerplate-vite/src/lib/ClientOnly/index.ts
@@ -1,0 +1,1 @@
+export { type ClientOnlyProps, default } from "./ClientOnly.js";

--- a/apps/react/boilerplate-vite/src/lib/Navigation/Navigation.tsx
+++ b/apps/react/boilerplate-vite/src/lib/Navigation/Navigation.tsx
@@ -10,6 +10,7 @@ export default function Navigation(): ReactElement {
       <Link params={{ slug: "router-core" }} to="guide">
         Guide
       </Link>
+      <Link to="catalog">Catalog</Link>
       <Link to="contact">Contact</Link>
       <Link search={{ auth: "1" }} to="account">
         Demo sign-in

--- a/apps/react/boilerplate-vite/src/lib/index.ts
+++ b/apps/react/boilerplate-vite/src/lib/index.ts
@@ -1,3 +1,4 @@
+export { default as ClientOnly } from "./ClientOnly/index.js";
 export { ExampleComponent } from "./ExampleComponent/index.js";
 export { default as LazyComponent } from "./LazyComponent/index.js";
 export { default as LocaleSelector } from "./LocaleSelector/index.js";

--- a/apps/react/boilerplate-vite/src/relay/__generated__/ProductCard_product.graphql.ts
+++ b/apps/react/boilerplate-vite/src/relay/__generated__/ProductCard_product.graphql.ts
@@ -1,0 +1,82 @@
+/**
+ * @generated SignedSource<<a6fcbf029d2f62fcf6f378581e4985a3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ProductCard_product$data = {
+  readonly currency: string;
+  readonly inStock: boolean;
+  readonly name: string;
+  readonly priceCents: number;
+  readonly rating: number;
+  readonly tagline: string;
+  readonly " $fragmentType": "ProductCard_product";
+};
+export type ProductCard_product$key = {
+  readonly " $data"?: ProductCard_product$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ProductCard_product">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ProductCard_product",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tagline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "priceCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currency",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "rating",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "inStock",
+      "storageKey": null
+    }
+  ],
+  "type": "Product",
+  "abstractKey": null
+};
+
+(node as any).hash = "542f84e3fd8c5cc8222c4d637a9ee99d";
+
+export default node;

--- a/apps/react/boilerplate-vite/src/relay/__generated__/ProductListQuery.graphql.ts
+++ b/apps/react/boilerplate-vite/src/relay/__generated__/ProductListQuery.graphql.ts
@@ -1,0 +1,272 @@
+/**
+ * @generated SignedSource<<dce8cdbb66e817eb63b1c8d044cdd730>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ProductListQuery$variables = {
+  count: number;
+  cursor?: string | null | undefined;
+};
+export type ProductListQuery$data = {
+  readonly viewer: {
+    readonly name: string;
+    readonly products: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"ProductCard_product">;
+        };
+      }>;
+      readonly pageInfo: {
+        readonly hasNextPage: boolean;
+      };
+      readonly totalCount: number;
+    };
+  };
+};
+export type ProductListQuery = {
+  response: ProductListQuery$data;
+  variables: ProductListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "count"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "cursor"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "count"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "totalCount",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProductListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "ProductConnection",
+            "kind": "LinkedField",
+            "name": "products",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProductEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Product",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "ProductCard_product"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProductListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "ProductConnection",
+            "kind": "LinkedField",
+            "name": "products",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProductEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Product",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "tagline",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "priceCents",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "currency",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "rating",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "inStock",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "57efd1ef4c828e58566c12be84d1987b",
+    "id": null,
+    "metadata": {},
+    "name": "ProductListQuery",
+    "operationKind": "query",
+    "text": "query ProductListQuery(\n  $count: Int!\n  $cursor: String\n) {\n  viewer {\n    name\n    products(first: $count, after: $cursor) {\n      totalCount\n      pageInfo {\n        hasNextPage\n      }\n      edges {\n        node {\n          id\n          ...ProductCard_product\n        }\n      }\n    }\n  }\n}\n\nfragment ProductCard_product on Product {\n  name\n  tagline\n  priceCents\n  currency\n  rating\n  inStock\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c95b3cfceaf197d5391b4d63a8c1ed36";
+
+export default node;

--- a/apps/react/boilerplate-vite/src/relay/environment.tests.ts
+++ b/apps/react/boilerplate-vite/src/relay/environment.tests.ts
@@ -1,0 +1,87 @@
+import { fetchQuery } from "relay-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import productListQueryNode, {
+  type ProductListQuery,
+} from "./__generated__/ProductListQuery.graphql.js";
+import { createEnvironment } from "./environment.js";
+import { CATALOG_PRODUCTS } from "./schema.js";
+
+/** Minimal valid GraphQL payload for {@link ProductListQuery}. */
+const ENDPOINT_PAYLOAD = {
+  data: {
+    viewer: {
+      name: "Endpoint Viewer",
+      products: {
+        totalCount: 0,
+        pageInfo: { hasNextPage: false },
+        edges: [],
+      },
+    },
+  },
+};
+
+const fetchProductList = (environment: ReturnType<typeof createEnvironment>) =>
+  fetchQuery<ProductListQuery>(environment, productListQueryNode, {
+    count: 2,
+  }).toPromise();
+
+describe("createEnvironment", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("executes operations against the local mock schema by default", async () => {
+    const data = await fetchProductList(createEnvironment());
+
+    expect(data?.viewer.name).toBe("Ada Lovelace");
+    expect(data?.viewer.products.totalCount).toBe(CATALOG_PRODUCTS.length);
+    expect(data?.viewer.products.edges).toHaveLength(2);
+    expect(data?.viewer.products.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it("posts operations to the endpoint when a URL is passed", async () => {
+    const fetchSpy = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(async () => Response.json(ENDPOINT_PAYLOAD, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const data = await fetchProductList(
+      createEnvironment({ graphqlUrl: "https://api.example.test/graphql" }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://api.example.test/graphql",
+    );
+    expect(data?.viewer.name).toBe("Endpoint Viewer");
+  });
+
+  it("reads the endpoint URL from VITE_GRAPHQL_URL", async () => {
+    const fetchSpy = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(async () => Response.json(ENDPOINT_PAYLOAD, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubEnv("VITE_GRAPHQL_URL", "https://env.example.test/graphql");
+
+    await fetchProductList(createEnvironment());
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://env.example.test/graphql",
+    );
+  });
+
+  it("keeps stores independent across environments", async () => {
+    const first = createEnvironment();
+    const second = createEnvironment();
+    await fetchProductList(first);
+
+    expect(first.getStore().getSource().getRecordIDs().length).toBeGreaterThan(
+      1,
+    );
+    // An untouched store holds only Relay's client root record.
+    expect(second.getStore().getSource().getRecordIDs()).toEqual([
+      "client:root",
+    ]);
+  });
+});

--- a/apps/react/boilerplate-vite/src/relay/environment.ts
+++ b/apps/react/boilerplate-vite/src/relay/environment.ts
@@ -1,5 +1,5 @@
 /**
- * @module Relay environment factory.
+ * Relay environment factory.
  *
  * Builds the app's Relay `Environment` on top of `relay-runtime-network`'s
  * middleware-driven fetch pipeline, in one of two modes:
@@ -28,7 +28,6 @@ import {
   type RelayRuntimeFetch,
   urlMiddleware,
 } from "relay-runtime-network";
-import { executeLocalOperation } from "./schema.js";
 
 /** Options for {@link createEnvironment}. */
 export interface CreateEnvironmentOptions {
@@ -47,18 +46,26 @@ const readConfiguredGraphqlUrl = (): string | undefined => {
     : undefined;
 };
 
-/** Builds the in-process network that executes against the mock schema. */
+/**
+ * Builds the in-process network that executes against the mock schema.
+ *
+ * The schema module (and its `graphql` dependency) is loaded lazily inside
+ * the executor — `execute` already returns a promise, so the dynamic import
+ * adds no async boundary — keeping graphql-js and the mock catalog out of
+ * the main bundle, and unparsed, whenever the endpoint path is taken.
+ */
 const createLocalNetwork = () =>
   createRelayRuntimeNetwork({
     fetch: {
       executor: localGraphExecutor({
-        execute: (context: RelayFetchContext) => {
+        execute: async (context: RelayFetchContext) => {
           const { text } = context.operation;
           if (!text) {
             throw new Error(
               "The local mock schema requires full operation text; persisted queries are not supported.",
             );
           }
+          const { executeLocalOperation } = await import("./schema.js");
           return executeLocalOperation({
             text,
             variables: context.variables,

--- a/apps/react/boilerplate-vite/src/relay/environment.ts
+++ b/apps/react/boilerplate-vite/src/relay/environment.ts
@@ -1,0 +1,112 @@
+/**
+ * @module Relay environment factory.
+ *
+ * Builds the app's Relay `Environment` on top of `relay-runtime-network`'s
+ * middleware-driven fetch pipeline, in one of two modes:
+ *
+ * - **local (default)** — a `localGraphExecutor` resolves every operation
+ *   in-process against the mock catalog schema (`./schema.ts`), so the
+ *   boilerplate runs with zero backend.
+ * - **endpoint** — when `VITE_GRAPHQL_URL` is set (or a URL is passed
+ *   explicitly), an `httpExecutor` + `urlMiddleware` posts operations to a
+ *   real GraphQL server.
+ */
+
+import {
+  Environment,
+  type FetchFunction,
+  type GraphQLResponse,
+  Network,
+  RecordSource,
+  Store,
+} from "relay-runtime";
+import {
+  createRelayRuntimeNetwork,
+  httpExecutor,
+  localGraphExecutor,
+  type RelayFetchContext,
+  type RelayRuntimeFetch,
+  urlMiddleware,
+} from "relay-runtime-network";
+import { executeLocalOperation } from "./schema.js";
+
+/** Options for {@link createEnvironment}. */
+export interface CreateEnvironmentOptions {
+  /**
+   * GraphQL endpoint URL. Overrides the `VITE_GRAPHQL_URL` env var; when
+   * neither is set the environment executes against the local mock schema.
+   */
+  readonly graphqlUrl?: string;
+}
+
+/** Reads the endpoint URL from Vite's env, treating the empty string as unset. */
+const readConfiguredGraphqlUrl = (): string | undefined => {
+  const configured: unknown = import.meta.env.VITE_GRAPHQL_URL;
+  return typeof configured === "string" && configured.length > 0
+    ? configured
+    : undefined;
+};
+
+/** Builds the in-process network that executes against the mock schema. */
+const createLocalNetwork = () =>
+  createRelayRuntimeNetwork({
+    fetch: {
+      executor: localGraphExecutor({
+        execute: (context: RelayFetchContext) => {
+          const { text } = context.operation;
+          if (!text) {
+            throw new Error(
+              "The local mock schema requires full operation text; persisted queries are not supported.",
+            );
+          }
+          return executeLocalOperation({
+            text,
+            variables: context.variables,
+          });
+        },
+      }),
+    },
+  });
+
+/** Builds the HTTP network that posts operations to `graphqlUrl`. */
+const createHttpNetwork = (graphqlUrl: string) =>
+  createRelayRuntimeNetwork({
+    fetch: {
+      executor: httpExecutor(),
+      middlewares: [urlMiddleware({ url: graphqlUrl })],
+    },
+  });
+
+/**
+ * Adapts the pipeline's fetch to relay-runtime's `FetchFunction`. Both
+ * describe the same GraphQL response wire shape, but relay-runtime types the
+ * payload as `PayloadData` where the pipeline says `unknown`, and takes its
+ * cache config as an interface where the pipeline wants a plain record —
+ * hence the spread and the single response cast at this library boundary.
+ */
+const toFetchFunction =
+  (fetchGraphQL: RelayRuntimeFetch): FetchFunction =>
+  (params, variables, cacheConfig) =>
+    fetchGraphQL(params, variables, {
+      ...cacheConfig,
+    }) as Promise<GraphQLResponse>;
+
+/**
+ * Creates a Relay `Environment` for the app.
+ *
+ * Call once per browser session (module scope in the client entry) and once
+ * per request on the server, so no store state leaks across requests.
+ */
+export const createEnvironment = (
+  options: CreateEnvironmentOptions = {},
+): Environment => {
+  const graphqlUrl = options.graphqlUrl ?? readConfiguredGraphqlUrl();
+  const network = graphqlUrl
+    ? createHttpNetwork(graphqlUrl)
+    : createLocalNetwork();
+
+  return new Environment({
+    network: Network.create(toFetchFunction(network.fetch)),
+    store: new Store(new RecordSource()),
+  });
+};

--- a/apps/react/boilerplate-vite/src/relay/schema.graphql
+++ b/apps/react/boilerplate-vite/src/relay/schema.graphql
@@ -1,0 +1,111 @@
+# Mock GraphQL schema for the Relay data-layer example.
+#
+# A compact catalog domain, shaped the Relay way: an object identification
+# `Node` interface with globally unique IDs, a `viewer` root field as the
+# entry point, and one paginated connection (`Viewer.products`) following the
+# Relay Cursor Connections specification. `relay-compiler` validates queries
+# against this file (see relay.config.json); `schema.ts` makes it executable
+# against an in-memory dataset so the app runs without a GraphQL backend.
+
+"""
+An object with a globally unique ID, per the Relay object identification spec.
+"""
+interface Node {
+  """
+  The globally unique ID of the object.
+  """
+  id: ID!
+}
+
+"""
+The authenticated entry point into the graph.
+"""
+type Viewer {
+  """
+  Display name of the current user.
+  """
+  name: String!
+
+  """
+  Products in the catalog, paginated forwards through a connection.
+  """
+  products(first: Int, after: String): ProductConnection!
+}
+
+"""
+A product in the catalog.
+"""
+type Product implements Node {
+  id: ID!
+
+  """
+  Human-readable product name.
+  """
+  name: String!
+
+  """
+  One-line marketing description.
+  """
+  tagline: String!
+
+  """
+  Price in the minor unit of `currency` (e.g. cents).
+  """
+  priceCents: Int!
+
+  """
+  ISO 4217 currency code for `priceCents`.
+  """
+  currency: String!
+
+  """
+  Average review rating, from 0.0 to 5.0.
+  """
+  rating: Float!
+
+  """
+  Whether the product can currently be ordered.
+  """
+  inStock: Boolean!
+}
+
+"""
+A page of products and the cursors to continue paginating.
+"""
+type ProductConnection {
+  edges: [ProductEdge!]!
+  pageInfo: PageInfo!
+
+  """
+  Total number of products in the catalog, across all pages.
+  """
+  totalCount: Int!
+}
+
+"""
+A product plus the opaque cursor identifying its position.
+"""
+type ProductEdge {
+  cursor: String!
+  node: Product!
+}
+
+"""
+Forward-pagination info per the Relay connection specification.
+"""
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+}
+
+type Query {
+  """
+  Fetches an object by its globally unique ID.
+  """
+  node(id: ID!): Node
+
+  """
+  The entry point for the current user's view of the graph.
+  """
+  viewer: Viewer!
+}

--- a/apps/react/boilerplate-vite/src/relay/schema.tests.ts
+++ b/apps/react/boilerplate-vite/src/relay/schema.tests.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { CATALOG_PRODUCTS, executeLocalOperation } from "./schema.js";
+
+interface ProductsPage {
+  readonly viewer: {
+    readonly products: {
+      readonly edges: readonly {
+        readonly cursor: string;
+        readonly node: { readonly id: string; readonly name: string };
+      }[];
+      readonly pageInfo: {
+        readonly endCursor: string | null;
+        readonly hasNextPage: boolean;
+      };
+      readonly totalCount: number;
+    };
+  };
+}
+
+const PRODUCTS_QUERY = `
+  query SchemaTestsProductsQuery($first: Int, $after: String) {
+    viewer {
+      products(first: $first, after: $after) {
+        edges {
+          cursor
+          node {
+            id
+            name
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        totalCount
+      }
+    }
+  }
+`;
+
+const fetchProductsPage = async (variables: {
+  first?: number;
+  after?: string;
+}): Promise<ProductsPage> => {
+  const result = await executeLocalOperation({
+    text: PRODUCTS_QUERY,
+    variables,
+  });
+  expect(result.errors).toBeUndefined();
+  return result.data as ProductsPage;
+};
+
+describe("executeLocalOperation", () => {
+  it("resolves the viewer with the first page of products", async () => {
+    const data = await fetchProductsPage({ first: 2 });
+    const { products } = data.viewer;
+
+    expect(products.totalCount).toBe(CATALOG_PRODUCTS.length);
+    expect(products.edges.map((edge) => edge.node.name)).toEqual([
+      CATALOG_PRODUCTS[0]?.name,
+      CATALOG_PRODUCTS[1]?.name,
+    ]);
+    expect(products.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it("paginates forward from an end cursor without gaps or overlap", async () => {
+    const firstPage = await fetchProductsPage({ first: 2 });
+    const { endCursor } = firstPage.viewer.products.pageInfo;
+    expect(endCursor).not.toBeNull();
+
+    const secondPage = await fetchProductsPage({
+      first: 2,
+      after: endCursor as string,
+    });
+    expect(
+      secondPage.viewer.products.edges.map((edge) => edge.node.id),
+    ).toEqual([CATALOG_PRODUCTS[2]?.id, CATALOG_PRODUCTS[3]?.id]);
+  });
+
+  it("reports the end of the catalog", async () => {
+    const page = await fetchProductsPage({ first: CATALOG_PRODUCTS.length });
+    expect(page.viewer.products.pageInfo.hasNextPage).toBe(false);
+    expect(page.viewer.products.edges).toHaveLength(CATALOG_PRODUCTS.length);
+  });
+
+  it("rejects malformed cursors as a GraphQL error", async () => {
+    const result = await executeLocalOperation({
+      text: PRODUCTS_QUERY,
+      variables: { first: 1, after: "not-a-cursor" },
+    });
+    expect(result.errors?.[0]?.message).toContain("Invalid cursor");
+  });
+
+  it("looks up nodes by global ID and misses unknown IDs", async () => {
+    const nodeQuery = `
+      query SchemaTestsNodeQuery($id: ID!) {
+        node(id: $id) {
+          id
+          ... on Product {
+            name
+          }
+        }
+      }
+    `;
+    const target = CATALOG_PRODUCTS[3];
+
+    const hit = await executeLocalOperation({
+      text: nodeQuery,
+      variables: { id: target?.id },
+    });
+    expect(hit.data).toEqual({
+      node: { id: target?.id, name: target?.name },
+    });
+
+    const miss = await executeLocalOperation({
+      text: nodeQuery,
+      variables: { id: "Product:does-not-exist" },
+    });
+    expect(miss.data).toEqual({ node: null });
+  });
+
+  it("returns validation problems as GraphQL errors, not exceptions", async () => {
+    const result = await executeLocalOperation({
+      text: "query SchemaTestsInvalidQuery { nope }",
+    });
+    expect(result.data).toBeNull();
+    expect(result.errors?.[0]?.message).toContain("nope");
+  });
+});

--- a/apps/react/boilerplate-vite/src/relay/schema.tests.ts
+++ b/apps/react/boilerplate-vite/src/relay/schema.tests.ts
@@ -91,6 +91,14 @@ describe("executeLocalOperation", () => {
     expect(result.errors?.[0]?.message).toContain("Invalid cursor");
   });
 
+  it("rejects negative cursor indices that encodeCursor can never produce", async () => {
+    const result = await executeLocalOperation({
+      text: PRODUCTS_QUERY,
+      variables: { first: 1, after: "cursor:-1" },
+    });
+    expect(result.errors?.[0]?.message).toContain("Invalid cursor");
+  });
+
   it("looks up nodes by global ID and misses unknown IDs", async () => {
     const nodeQuery = `
       query SchemaTestsNodeQuery($id: ID!) {

--- a/apps/react/boilerplate-vite/src/relay/schema.ts
+++ b/apps/react/boilerplate-vite/src/relay/schema.ts
@@ -108,7 +108,11 @@ const encodeCursor = (index: number): string => `${CURSOR_PREFIX}${index}`;
 /** Decodes a connection cursor back to a catalog index; rejects foreign cursors. */
 const decodeCursor = (cursor: string): number => {
   const index = Number(cursor.slice(CURSOR_PREFIX.length));
-  if (!cursor.startsWith(CURSOR_PREFIX) || !Number.isInteger(index)) {
+  if (
+    !cursor.startsWith(CURSOR_PREFIX) ||
+    !Number.isInteger(index) ||
+    index < 0
+  ) {
     throw new GraphQLError(`Invalid cursor: ${cursor}`);
   }
   return index;

--- a/apps/react/boilerplate-vite/src/relay/schema.ts
+++ b/apps/react/boilerplate-vite/src/relay/schema.ts
@@ -1,5 +1,5 @@
 /**
- * @module Executable mock schema for the Relay data layer.
+ * Executable mock schema for the Relay data layer.
  *
  * Builds the SDL in ./schema.graphql into a graphql-js schema backed by a
  * small, deterministic in-memory catalog, so the app (and its tests and

--- a/apps/react/boilerplate-vite/src/relay/schema.ts
+++ b/apps/react/boilerplate-vite/src/relay/schema.ts
@@ -1,0 +1,201 @@
+/**
+ * @module Executable mock schema for the Relay data layer.
+ *
+ * Builds the SDL in ./schema.graphql into a graphql-js schema backed by a
+ * small, deterministic in-memory catalog, so the app (and its tests and
+ * Storybook) can execute real GraphQL operations without a backend. The
+ * dataset is static — no randomness, no clocks — which keeps unit tests and
+ * visual tests reproducible.
+ *
+ * (The file name above is deliberately not backtick-quoted:
+ * vite-plugin-relay-lite's tag scanner matches the word "graphql" followed
+ * by a backtick even inside comments, and would try to parse what follows
+ * as a GraphQL document.)
+ */
+
+import { buildSchema, GraphQLError, graphql } from "graphql";
+import schemaSource from "./schema.graphql?raw";
+
+/** A product row in the in-memory catalog. */
+export interface ProductRecord {
+  /** Discriminant used by graphql-js to resolve the `Node` interface. */
+  readonly __typename: "Product";
+  readonly id: string;
+  readonly name: string;
+  readonly tagline: string;
+  readonly priceCents: number;
+  readonly currency: string;
+  readonly rating: number;
+  readonly inStock: boolean;
+}
+
+/**
+ * The full catalog, in stable order. IDs follow the `Product:{n}` global-ID
+ * convention consumed by `Query.node`; they are opaque to clients.
+ */
+export const CATALOG_PRODUCTS: readonly ProductRecord[] = [
+  {
+    __typename: "Product",
+    id: "Product:1",
+    name: "Vanguard Workstation",
+    tagline: "A certified Ubuntu desktop for heavy compilation workloads",
+    priceCents: 189_900,
+    currency: "USD",
+    rating: 4.7,
+    inStock: true,
+  },
+  {
+    __typename: "Product",
+    id: "Product:2",
+    name: "Meridian Laptop 14",
+    tagline: "Thin, quiet, and pre-loaded with your team's golden image",
+    priceCents: 129_900,
+    currency: "USD",
+    rating: 4.5,
+    inStock: true,
+  },
+  {
+    __typename: "Product",
+    id: "Product:3",
+    name: "Beacon Micro Server",
+    tagline: "A fanless edge node that fits in a network cabinet",
+    priceCents: 64_900,
+    currency: "USD",
+    rating: 4.2,
+    inStock: false,
+  },
+  {
+    __typename: "Product",
+    id: "Product:4",
+    name: "Atlas Rack Server",
+    tagline: "Dense compute for private-cloud deployments",
+    priceCents: 449_900,
+    currency: "USD",
+    rating: 4.8,
+    inStock: true,
+  },
+  {
+    __typename: "Product",
+    id: "Product:5",
+    name: "Harbor NAS Enclosure",
+    tagline: "Four bays of quiet, snapshot-friendly storage",
+    priceCents: 89_900,
+    currency: "USD",
+    rating: 4.1,
+    inStock: true,
+  },
+  {
+    __typename: "Product",
+    id: "Product:6",
+    name: "Relay IoT Gateway",
+    tagline: "Bridges field sensors onto your message bus securely",
+    priceCents: 29_900,
+    currency: "USD",
+    rating: 3.9,
+    inStock: false,
+  },
+];
+
+const productsById = new Map(
+  CATALOG_PRODUCTS.map((product) => [product.id, product]),
+);
+
+const CURSOR_PREFIX = "cursor:";
+
+/** Encodes a catalog index as an opaque connection cursor. */
+const encodeCursor = (index: number): string => `${CURSOR_PREFIX}${index}`;
+
+/** Decodes a connection cursor back to a catalog index; rejects foreign cursors. */
+const decodeCursor = (cursor: string): number => {
+  const index = Number(cursor.slice(CURSOR_PREFIX.length));
+  if (!cursor.startsWith(CURSOR_PREFIX) || !Number.isInteger(index)) {
+    throw new GraphQLError(`Invalid cursor: ${cursor}`);
+  }
+  return index;
+};
+
+interface ProductsArguments {
+  readonly first?: number | null;
+  readonly after?: string | null;
+}
+
+/**
+ * Resolves `Viewer.products` with honest forward cursor pagination: `after`
+ * positions the window just past the given cursor, `first` bounds its size,
+ * and `pageInfo` reflects whether more of the catalog remains.
+ */
+const resolveProducts = ({ first, after }: ProductsArguments) => {
+  if (typeof first === "number" && first < 0) {
+    throw new GraphQLError(
+      `Argument "first" must be non-negative, got ${first}`,
+    );
+  }
+  const startIndex = after == null ? 0 : decodeCursor(after) + 1;
+  const endIndex = first == null ? CATALOG_PRODUCTS.length : startIndex + first;
+  const edges = CATALOG_PRODUCTS.slice(startIndex, endIndex).map(
+    (node, offset) => ({
+      cursor: encodeCursor(startIndex + offset),
+      node,
+    }),
+  );
+
+  return {
+    edges,
+    pageInfo: {
+      endCursor: edges.at(-1)?.cursor ?? null,
+      hasNextPage: startIndex + edges.length < CATALOG_PRODUCTS.length,
+    },
+    totalCount: CATALOG_PRODUCTS.length,
+  };
+};
+
+const schema = buildSchema(schemaSource);
+
+// Root value for graphql-js's default field resolver: root fields are
+// functions receiving the field arguments, and `Viewer.products` is a method
+// on the viewer object for the same reason. `Node` resolution relies on the
+// `__typename` discriminant each record carries.
+const rootValue = {
+  node: ({ id }: { id: string }) => productsById.get(id) ?? null,
+  viewer: () => ({
+    name: "Ada Lovelace",
+    products: (args: ProductsArguments) => resolveProducts(args),
+  }),
+};
+
+/** Input for {@link executeLocalOperation}. */
+export interface ExecuteLocalOperationOptions {
+  /** Full GraphQL source text of the operation. */
+  readonly text: string;
+  /** Variable values for the operation. */
+  readonly variables?: Record<string, unknown>;
+}
+
+/** Result shape of {@link executeLocalOperation} — a standard GraphQL response. */
+export interface LocalOperationResult {
+  readonly data?: unknown;
+  readonly errors?: readonly { readonly message: string }[];
+}
+
+/**
+ * Executes a GraphQL operation against the in-memory catalog schema.
+ *
+ * This is the execution half of the mock backend: `relay.config.json` points
+ * the compiler at ./schema.graphql for validation and codegen, and the Relay
+ * environment's local executor calls this function at runtime.
+ */
+export const executeLocalOperation = async (
+  options: ExecuteLocalOperationOptions,
+): Promise<LocalOperationResult> => {
+  const result = await graphql({
+    schema,
+    source: options.text,
+    variableValues: options.variables,
+    rootValue,
+  });
+
+  return {
+    data: result.data ?? null,
+    errors: result.errors?.map((error) => error.toJSON()),
+  };
+};

--- a/apps/react/boilerplate-vite/src/routes.tsx
+++ b/apps/react/boilerplate-vite/src/routes.tsx
@@ -10,6 +10,7 @@ import {
 } from "@canonical/router-core";
 import type { ReactElement, ReactNode } from "react";
 import accountRoutes from "#domains/account/routes.js";
+import catalogRoutes from "#domains/catalog/routes.js";
 import contactRoutes from "#domains/contact/routes.js";
 import marketingRoutes from "#domains/marketing/routes.js";
 import Navigation from "#lib/Navigation/index.js";
@@ -106,12 +107,15 @@ const [account, login] = group(publicLayout, [
 
 const [contact] = group(publicLayout, [contactRoutes.contact] as const);
 
+const [catalog] = group(publicLayout, [catalogRoutes.catalog] as const);
+
 const appRoutes = {
   guide,
   home,
   account,
   login,
   contact,
+  catalog,
 } as const;
 
 export type AppRoutes = typeof appRoutes;

--- a/apps/react/boilerplate-vite/src/server/entry.tsx
+++ b/apps/react/boilerplate-vite/src/server/entry.tsx
@@ -2,7 +2,9 @@ import { HeadProvider } from "@canonical/react-head";
 import type { ServerEntrypointProps } from "@canonical/react-ssr/renderer";
 import { createStaticRouter } from "@canonical/router-core";
 import { Outlet, RouterProvider } from "@canonical/router-react";
+import { RelayEnvironmentProvider } from "react-relay";
 import { dirForLocale } from "#lib/i18n/index.js";
+import { createEnvironment } from "#relay/environment.js";
 import { appRoutes, middleware, notFoundRoute } from "../routes.js";
 import "#styles/app.css";
 
@@ -22,6 +24,13 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
     notFound: notFoundRoute,
   });
 
+  // A fresh Relay environment per server render, so no store state leaks
+  // between requests. Nothing fetches through it yet: components that issue
+  // queries are wrapped in `ClientOnly` (see CatalogPage) until the follow-up
+  // SSR PR adds data serialization/hydration; the provider is here so any
+  // component touching Relay context renders without branching on runtime.
+  const relayEnvironment = createEnvironment();
+
   // Paint the cookie-resolved theme on <html> for a flash-free first render —
   // the same element `usePreferredTheme` toggles on the client, and one React
   // does not hydrate (only `#root` is), so there is no mismatch to reconcile.
@@ -39,9 +48,11 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
       <body>
         <div id="root">
           <HeadProvider>
-            <RouterProvider router={router}>
-              <Outlet fallback={<p>Loading…</p>} />
-            </RouterProvider>
+            <RelayEnvironmentProvider environment={relayEnvironment}>
+              <RouterProvider router={router}>
+                <Outlet fallback={<p>Loading…</p>} />
+              </RouterProvider>
+            </RelayEnvironmentProvider>
           </HeadProvider>
         </div>
       </body>

--- a/apps/react/boilerplate-vite/src/sitemap/getSitemapItems.ts
+++ b/apps/react/boilerplate-vite/src/sitemap/getSitemapItems.ts
@@ -22,6 +22,7 @@ export default async function getSitemapItems(): Promise<SitemapItem[]> {
   return [
     { loc: "/", changefreq: "weekly", priority: 1.0 },
     { loc: "/guides/router-core", changefreq: "monthly", priority: 0.8 },
+    { loc: "/catalog", changefreq: "weekly", priority: 0.7 },
     { loc: "/contact", changefreq: "monthly", priority: 0.7 },
     { loc: "/account", changefreq: "monthly", priority: 0.5 },
     { loc: "/login", changefreq: "yearly", priority: 0.3 },

--- a/apps/react/boilerplate-vite/tsconfig.json
+++ b/apps/react/boilerplate-vite/tsconfig.json
@@ -15,6 +15,7 @@
     "paths": {
       "#lib/*": ["./lib/*"],
       "#domains/*": ["./domains/*"],
+      "#relay/*": ["./relay/*"],
       "#styles/*": ["./styles/*"]
     }
   },

--- a/apps/react/boilerplate-vite/vite.config.ts
+++ b/apps/react/boilerplate-vite/vite.config.ts
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import relay from "vite-plugin-relay-lite";
 
 // Path aliases (#lib, #domains, #styles) are declared as Node subpath imports
 // in package.json "imports" and resolved natively by Vite — no resolver plugin.
@@ -13,7 +14,15 @@ const PORT = Number(process.env.PORT) || undefined;
 // (`dev`, `build:client`, `preview`) uses the default mode and the SPA client
 // build (`--ssrManifest --outDir dist/client`).
 export default defineConfig(({ mode }) => ({
-  plugins: [react()],
+  // Relay's `graphql\`...\`` tags must be rewritten into imports of the
+  // compiler-generated artifacts. `@vitejs/plugin-react` v6 is OXC-based (no
+  // Babel), so the classic `babel-plugin-relay` route would need the
+  // `@rolldown/plugin-babel` escape hatch; `vite-plugin-relay-lite` does the
+  // same rewrite with its own parser and no Babel, and works on Vite 8 /
+  // rolldown despite its peer range stopping at Vite 7 (bun installs it with
+  // only a peer-version warning). `codegen: false` because artifacts are
+  // committed and regenerated explicitly via `bun run relay` / `relay:watch`.
+  plugins: [relay({ codegen: false }), react()],
   // Honour the PORT env var for `dev` (SPA) and `preview` so all server scripts
   // — including the SSR ones, which already read PORT — respond to it uniformly.
   server: { port: PORT },
@@ -40,6 +49,15 @@ export default defineConfig(({ mode }) => ({
     // which Node cannot load (ERR_UNKNOWN_FILE_EXTENSION) but Vite's SSR
     // transform no-ops. The regex covers the whole scope so any current or
     // future @canonical dependency is handled.
+    //
+    // The Relay packages (react-relay, relay-runtime, relay-runtime-network,
+    // graphql) stay externalised like react itself. Two packaging defects
+    // made that possible and are fixed via `patchedDependencies` (see
+    // patches/ at the repo root): react-relay's CJS exports are member
+    // expressions cjs-module-lexer cannot detect (breaking named imports
+    // under Node SSR and Vite's dev module runner), and
+    // relay-runtime-network@0.1.0 ships an `imports` map pointing at its
+    // unpublished src/ directory.
     noExternal: [/^@canonical\//],
   },
 }));

--- a/apps/react/boilerplate-vite/vitest.setup.ts
+++ b/apps/react/boilerplate-vite/vitest.setup.ts
@@ -1,8 +1,15 @@
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { cleanup } from "@testing-library/react";
-import { afterEach, expect } from "vitest";
+import { afterEach, expect, vi } from "vitest";
 
 expect.extend(matchers as unknown as Parameters<typeof expect.extend>[0]);
+
+// relay-test-utils' `createMockEnvironment` wraps environment methods in
+// `jest.fn` mocks whenever NODE_ENV === "test", reaching for a global `jest`
+// object. Vitest sets NODE_ENV=test but exposes `vi` instead, so alias it —
+// `vi.fn` is API-compatible with the `jest.fn` surface relay-test-utils uses
+// (`.mock`, `.mockClear`).
+(globalThis as { jest?: typeof vi }).jest = vi;
 
 afterEach(() => {
   cleanup();

--- a/bun.lock
+++ b/bun.lock
@@ -14,16 +14,16 @@
       "name": "@canonical/lit-demo",
       "version": "0.29.1",
       "dependencies": {
-        "@canonical/lit-ds-prototype": "^0.27.1-experimental.0",
-        "@canonical/styles": "^0.27.1-experimental.0",
+        "@canonical/lit-ds-prototype": "^0.29.1",
+        "@canonical/styles": "^0.29.0",
         "@lit-labs/ssr": "^3.3.0",
         "@lit-labs/ssr-client": "^1.1.7",
         "lit": "^3.3.2",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-lit": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config-lit": "^0.29.0",
         "@types/express": "^5.0.6",
         "@types/node": "^24.12.0",
         "express": "^5.2.1",
@@ -35,23 +35,28 @@
       "name": "@canonical/react-boilerplate-vite",
       "version": "0.29.1",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.27.1-experimental.0",
-        "@canonical/react-ds-global-form": "^0.27.1-experimental.0",
-        "@canonical/react-head": "^0.27.1-experimental.0",
-        "@canonical/react-hooks": "^0.27.1-experimental.0",
-        "@canonical/react-ssr": "^0.27.1-experimental.0",
-        "@canonical/router-core": "^0.27.1-experimental.0",
-        "@canonical/router-react": "^0.27.1-experimental.0",
-        "@canonical/storybook-config": "^0.27.1-experimental.0",
-        "@canonical/styles": "^0.27.1-experimental.0",
+        "@canonical/react-ds-global": "^0.29.1",
+        "@canonical/react-ds-global-form": "^0.29.1",
+        "@canonical/react-head": "^0.29.0",
+        "@canonical/react-hooks": "^0.29.0",
+        "@canonical/react-ssr": "^0.29.0",
+        "@canonical/router-core": "^0.29.0",
+        "@canonical/router-react": "^0.29.0",
+        "@canonical/storybook-addon-relay": "^0.29.1",
+        "@canonical/storybook-config": "^0.29.1",
+        "@canonical/styles": "^0.29.0",
         "express": "^5.2.1",
+        "graphql": "^16.11.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-relay": "^18.2.0",
+        "relay-runtime": "^18.2.0",
+        "relay-runtime-network": "^0.1.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config-react": "^0.29.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/react-vite": "^10.3.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -60,14 +65,19 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/react-relay": "^18.2.1",
+        "@types/relay-runtime": "^19.0.3",
         "@vitejs/plugin-react": "^6.0.0",
         "@vitest/coverage-v8": "^4.0.18",
         "bun-types": "^1.3.9",
         "jsdom": "^28.1.0",
+        "relay-compiler": "^18.2.0",
+        "relay-test-utils": "^18.2.0",
         "storybook": "^10.3.1",
         "tsx": "^4.19.0",
         "typescript": "^5.9.3",
         "vite": "^8.0.1",
+        "vite-plugin-relay-lite": "^0.12.0",
         "vitest": "^4.0.18",
       },
     },
@@ -75,12 +85,12 @@
       "name": "@canonical/ds-demo-site",
       "version": "0.29.1",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.27.1-experimental.0",
-        "@canonical/react-ds-global-form": "^0.27.1-experimental.0",
-        "@canonical/react-ssr": "^0.27.1-experimental.0",
-        "@canonical/storybook-config": "^0.27.1-experimental.0",
-        "@canonical/styles": "^0.27.1-experimental.0",
-        "@canonical/styles-debug": "^0.27.1-experimental.0",
+        "@canonical/react-ds-global": "^0.29.1",
+        "@canonical/react-ds-global-form": "^0.29.1",
+        "@canonical/react-ssr": "^0.29.0",
+        "@canonical/storybook-config": "^0.29.1",
+        "@canonical/styles": "^0.29.0",
+        "@canonical/styles-debug": "^0.29.0",
         "@canonical/styles-primitives-canonical": "^0.26.0",
         "express": "^5.2.1",
         "react": "^19.2.4",
@@ -90,8 +100,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config-react": "^0.29.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/react-vite": "^10.3.1",
         "@types/express": "^5.0.6",
@@ -109,25 +119,25 @@
       "name": "@canonical/storybook-hub",
       "version": "0.29.1",
       "dependencies": {
-        "@canonical/ds-types": "^0.27.1-experimental.0",
-        "@canonical/react-ds-app": "^0.27.1-experimental.0",
-        "@canonical/react-ds-app-anbox": "^0.27.1-experimental.0",
-        "@canonical/react-ds-app-landscape": "^0.27.1-experimental.0",
-        "@canonical/react-ds-app-launchpad": "^0.27.1-experimental.0",
-        "@canonical/react-ds-app-lxd": "^0.27.1-experimental.0",
-        "@canonical/react-ds-app-portal": "^0.27.1-experimental.0",
-        "@canonical/react-ds-global": "^0.27.1-experimental.0",
-        "@canonical/react-ds-global-form": "^0.27.1-experimental.0",
-        "@canonical/storybook-addon-form-state": "^0.27.1-experimental.0",
-        "@canonical/storybook-addon-msw": "^0.27.1-experimental.0",
-        "@canonical/storybook-config": "^0.27.1-experimental.0",
-        "@canonical/styles": "^0.27.1-experimental.0",
-        "@canonical/styles-debug": "^0.27.1-experimental.0",
+        "@canonical/ds-types": "^0.29.0",
+        "@canonical/react-ds-app": "^0.29.1",
+        "@canonical/react-ds-app-anbox": "^0.29.1",
+        "@canonical/react-ds-app-landscape": "^0.29.1",
+        "@canonical/react-ds-app-launchpad": "^0.29.1",
+        "@canonical/react-ds-app-lxd": "^0.29.1",
+        "@canonical/react-ds-app-portal": "^0.29.1",
+        "@canonical/react-ds-global": "^0.29.1",
+        "@canonical/react-ds-global-form": "^0.29.1",
+        "@canonical/storybook-addon-form-state": "^0.29.0",
+        "@canonical/storybook-addon-msw": "^0.29.0",
+        "@canonical/storybook-config": "^0.29.1",
+        "@canonical/styles": "^0.29.0",
+        "@canonical/styles-debug": "^0.29.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config-react": "^0.29.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
         "@types/node": "^24.12.0",
@@ -201,11 +211,11 @@
       "name": "@canonical/typescript-config-lit",
       "version": "0.29.0",
       "dependencies": {
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
+        "@canonical/typescript-config": "^0.29.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
@@ -288,16 +298,16 @@
       },
       "dependencies": {
         "@canonical/anatomy-dsl": "^0.2.2",
-        "@canonical/cli-core": "^0.27.1-experimental.0",
+        "@canonical/cli-core": "^0.29.0",
         "@canonical/code-standards": "^0.1.2",
         "@canonical/design-system": "^0.1.2",
-        "@canonical/harnesses": "^0.27.1-experimental.0",
-        "@canonical/ke": "^0.27.1-experimental.0",
-        "@canonical/ke-graphql": "^0.27.1-experimental.0",
-        "@canonical/summon-component": "^0.27.1-experimental.0",
-        "@canonical/summon-core": "^0.27.1-experimental.0",
-        "@canonical/summon-package": "^0.27.1-experimental.0",
-        "@canonical/task": "^0.27.1-experimental.0",
+        "@canonical/harnesses": "^0.29.0",
+        "@canonical/ke": "^0.29.0",
+        "@canonical/ke-graphql": "^0.29.0",
+        "@canonical/summon-component": "^0.29.0",
+        "@canonical/summon-core": "^0.29.0",
+        "@canonical/summon-package": "^0.29.0",
+        "@canonical/task": "^0.29.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.3",
@@ -308,9 +318,9 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -383,16 +393,16 @@
       "name": "@canonical/lit-ds-prototype",
       "version": "0.29.1",
       "dependencies": {
-        "@canonical/storybook-config": "^0.27.1-experimental.0",
+        "@canonical/storybook-config": "^0.29.1",
         "lit": "^3.3.2",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/ds-types": "^0.27.1-experimental.0",
-        "@canonical/styles": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-lit": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/ds-types": "^0.29.0",
+        "@canonical/styles": "^0.29.0",
+        "@canonical/typescript-config-lit": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/web-components-vite": "^10.3.1",
         "@types/node": "^24.12.0",
@@ -962,13 +972,13 @@
       "name": "@canonical/harnesses",
       "version": "0.29.0",
       "dependencies": {
-        "@canonical/task": "^0.27.1-experimental.0",
+        "@canonical/task": "^0.29.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -995,9 +1005,9 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "expect-type": "^1.3.0",
@@ -1014,10 +1024,10 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/ke": "^0.27.1-experimental.0",
-        "@canonical/typescript-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/ke": "^0.29.0",
+        "@canonical/typescript-config": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1290,15 +1300,15 @@
       "name": "@canonical/summon-application",
       "version": "0.29.0",
       "dependencies": {
-        "@canonical/summon-core": "^0.27.1-experimental.0",
-        "@canonical/task": "^0.27.1-experimental.0",
-        "@canonical/utils": "^0.27.1-experimental.0",
+        "@canonical/summon-core": "^0.29.0",
+        "@canonical/task": "^0.29.0",
+        "@canonical/utils": "^0.29.0",
         "typescript": "^5.9.3",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
         "@types/node": "^24.12.0",
         "vitest": "^4.0.18",
       },
@@ -1320,8 +1330,8 @@
         "vitest": "^4.0.18",
       },
       "peerDependencies": {
-        "@canonical/summon-core": "^0.18.0 || ^0.20.0",
-        "@canonical/task": "^0.18.0 || ^0.20.0",
+        "@canonical/summon-core": "^0.29.0",
+        "@canonical/task": "^0.29.0",
       },
     },
     "packages/summon/core": {
@@ -1349,14 +1359,14 @@
       "name": "@canonical/summon-monorepo",
       "version": "0.29.0",
       "dependencies": {
-        "@canonical/summon-core": "^0.29.0-experimental.0",
-        "@canonical/task": "^0.29.0-experimental.0",
+        "@canonical/summon-core": "^0.29.0",
+        "@canonical/task": "^0.29.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.28.0",
-        "@canonical/typescript-config": "^0.28.0",
-        "@canonical/webarchitect": "^0.29.0-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/typescript-config": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1425,14 +1435,14 @@
       "version": "0.29.1",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/ds-types": "^0.27.1-experimental.0",
-        "@canonical/storybook-config": "^0.27.1-experimental.0",
-        "@canonical/storybook-helpers": "^0.27.1-experimental.0",
-        "@canonical/styles": "^0.27.1-experimental.0",
-        "@canonical/svelte-ssr-test": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-svelte": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.29.0",
+        "@canonical/ds-types": "^0.29.0",
+        "@canonical/storybook-config": "^0.29.1",
+        "@canonical/storybook-helpers": "^0.29.0",
+        "@canonical/styles": "^0.29.0",
+        "@canonical/svelte-ssr-test": "^0.29.0",
+        "@canonical/typescript-config-svelte": "^0.29.0",
+        "@canonical/webarchitect": "^0.29.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/addon-svelte-csf": "^5.0.11",
         "@sveltejs/package": "^2.5.7",
@@ -1550,6 +1560,8 @@
     },
   },
   "patchedDependencies": {
+    "react-relay@18.2.0": "patches/react-relay@18.2.0.patch",
+    "relay-runtime-network@0.1.0": "patches/relay-runtime-network@0.1.0.patch",
     "ejs@5.0.1": "patches/ejs@5.0.1.patch",
   },
   "packages": {
@@ -3583,7 +3595,11 @@
 
     "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
+    "relay-compiler": ["relay-compiler@18.2.0", "", { "bin": { "relay-compiler": "cli.js" } }, "sha512-P3o5/Gv/oLC9hckUaz/a+KvDgbFERpjtz5lgsJSIQILg9paaF3k1yaX9qSxErGuU4icZvjoK5G82a/bfPgGZpA=="],
+
     "relay-runtime": ["relay-runtime@18.2.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4" } }, "sha512-r4FYWlx1dPwFW+KQnuF1ugwVKR4toIFduCGheEf2paRc6nEEcCIgd2p2Jx2gRF+4niO3mCbRZvqdCoKaznUDzg=="],
+
+    "relay-runtime-network": ["relay-runtime-network@0.1.0", "", { "peerDependencies": { "relay-runtime": ">=16.0.0" } }, "sha512-TN7/X24Io1Ln7vl+ENAqVZoLLyLKgk9kQEi15I12Hi7P6xVTYV7g0cF8Pr1fRHK7UTs1qzAo0CYkvAYxl2FZ3w=="],
 
     "relay-test-utils": ["relay-test-utils@18.2.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4", "relay-runtime": "18.2.0" } }, "sha512-CfhZ/E9yUqdHnTLk8n9fnd0j1dz2dsLpTL6nnvvrmk8YyMJ5qKvoskVQiWyeSYFfHCfrzmWNPmNiXbxq6optqw=="],
 
@@ -3915,6 +3931,8 @@
 
     "vite": ["vite@8.0.1", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.10", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw=="],
 
+    "vite-plugin-relay-lite": ["vite-plugin-relay-lite@0.12.0", "", { "dependencies": { "cosmiconfig": "^9.0.0", "kleur": "^4.1.5", "magic-string": "^0.30.1" }, "peerDependencies": { "graphql": "^15.0.0 || ^16.0.0", "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-oEQTf5VSHhOW8+jpnnA2uxSwVHYucH4LDa5sLdFNvVKcnHBE0A2QNsQjedmInd05sNla9PDjZs/rejhk6l6Heg=="],
+
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 
     "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
@@ -4011,6 +4029,8 @@
 
     "@canonical/i18n-react/@canonical/webarchitect": ["@canonical/webarchitect@0.27.1-experimental.0", "", { "dependencies": { "ajv": "^8.18.0", "chalk": "^5.6.2", "commander": "^14.0.3" }, "bin": { "webarchitect": "src/cli.ts" } }, "sha512-WLJZMrGzfURGRvTbUGkGf/sBlQL9W23EAuIMxuYe4AkH5oJ8yonmFEeC9UwrAELwAcdFsdq1PFHdt8ocSsXw5Q=="],
 
+    "@canonical/react-boilerplate-vite/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
+
     "@canonical/react-hooks/@canonical/biome-config": ["@canonical/biome-config@0.22.0", "", { "peerDependencies": { "@biomejs/biome": "2.4.9" } }, "sha512-0DRY1gh+FM2CPysbmW6tNWHoctCMDWALcKwivDSIPYVCdz5C+5uZmK26Od2KNQ0jd2HWTVad/EwPebK4IfyOLA=="],
 
     "@canonical/react-hooks/@canonical/typescript-config": ["@canonical/typescript-config@0.22.0", "", { "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-2EaALHQcHELmiuzY4N/BimYDPfLJjmd8LcOOjr+cb8WM0F9MqCGD+huQHtAkw2eM7fRJ2V4Hl0EhTx6oSmVRgg=="],
@@ -4018,8 +4038,6 @@
     "@canonical/react-hooks/@canonical/typescript-config-react": ["@canonical/typescript-config-react@0.22.0", "", { "dependencies": { "@canonical/typescript-config": "^0.22.0" }, "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-K065hSK6nzAPH3iK9MNCxMmzrl/111SdLXOYyeXvquSEDFQqoOtSZAN7yE2fw4vKGBf+5RJvRbkOUXHva0uj/g=="],
 
     "@canonical/react-hooks/@canonical/webarchitect": ["@canonical/webarchitect@0.22.0", "", { "dependencies": { "ajv": "^8.18.0", "chalk": "^5.6.2", "commander": "^14.0.3" }, "bin": { "webarchitect": "src/cli.ts" } }, "sha512-HoiqlMgF9PsVyQCPEvV4gREQEa/SpJeeJxKHglpfEez+pKAkmAlah1i37a55hHUYDAREHguxlktAJ0UYGAiqzQ=="],
-
-    "@canonical/svelte-ds-app-wpe/playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "@canonical/svelte-ds-global/@canonical/biome-config": ["@canonical/biome-config@0.28.0", "", { "peerDependencies": { "@biomejs/biome": "2.4.9" } }, "sha512-e3D/ujt7dkGnSJ5zkTOJjEuPkFIQmDRDSB31D310t4gcMn11q1bj1L214O5HoEYzkbNPA6sf4GrAIzaMHVBp/Q=="],
 
@@ -4417,6 +4435,10 @@
 
     "vite/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
+    "vite-plugin-relay-lite/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
+
+    "vite-plugin-relay-lite/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
     "vitest/@vitest/utils": ["@vitest/utils@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ=="],
 
     "vitest/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
@@ -4442,10 +4464,6 @@
     "@bundled-es-modules/glob/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "@canonical/i18n-react/@canonical/typescript-config-react/@canonical/typescript-config": ["@canonical/typescript-config@0.27.1-experimental.0", "", { "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-TrFbfERGQT6XMYngtYdKuK+CyQI9iPyQaTz0jrw7a38WTHMuBiPzRbx9mm4I2SI0u0suCoPCLdNBPAInveUSZQ=="],
-
-    "@canonical/svelte-ds-app-wpe/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
-    "@canonical/svelte-ds-app-wpe/playwright/playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "@canonical/svelte-ds-global/@canonical/styles/@canonical/design-tokens": ["@canonical/design-tokens@0.6.1", "", { "dependencies": { "@canonical/terrazzo-lsp": "^0.6.0" }, "bin": { "terrazzo-lsp": "bin/terrazzo-lsp.mjs" } }, "sha512-YH7S5iTZ1L4fmI+LcKirC9zj5BKU592u/nFPI/CfVgKYyusStx/d+m6phi9YXsnVn7/k7V0Re/keixVnf6WUMw=="],
 
@@ -4704,6 +4722,8 @@
     "tuf-js/make-fetch-happen/proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
     "tuf-js/make-fetch-happen/ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
+
+    "vite-plugin-relay-lite/vite/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/react-relay": "^18.2.1",
         "@types/relay-runtime": "^19.0.3",
+        "@types/relay-test-utils": "^18.0.0",
         "@vitejs/plugin-react": "^6.0.0",
         "@vitest/coverage-v8": "^4.0.18",
         "bun-types": "^1.3.9",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     ]
   },
   "patchedDependencies": {
-    "ejs@5.0.1": "patches/ejs@5.0.1.patch"
+    "ejs@5.0.1": "patches/ejs@5.0.1.patch",
+    "relay-runtime-network@0.1.0": "patches/relay-runtime-network@0.1.0.patch",
+    "react-relay@18.2.0": "patches/react-relay@18.2.0.patch"
   }
 }

--- a/patches/react-relay@18.2.0.patch
+++ b/patches/react-relay@18.2.0.patch
@@ -1,0 +1,52 @@
+diff --git a/index.js b/index.js
+index 5fe5bc4a2adf6210e2dc5f84cc33382f47953384..407b9665ffa3b703f8fb2bfffa843a869b5c0957 100644
+--- a/index.js
++++ b/index.js
+@@ -8,3 +8,47 @@
+  */
+ 
+ module.exports = require('./lib/index.js');
++
++// Patch (pragma): cjs-module-lexer cannot statically detect the exports of
++// ./lib/index.js because they are member expressions inside an object
++// literal, so `import { useFragment } from "react-relay"` fails under Node
++// ESM (and under Vite's dev SSR module runner, which mirrors Node semantics).
++// The dead branch below is the esbuild-style lexer hint: never executed, but
++// statically registers the named exports.
++0 && (module.exports = {
++  ConnectionHandler: null,
++  QueryRenderer: null,
++  LocalQueryRenderer: null,
++  MutationTypes: null,
++  RangeOperations: null,
++  ReactRelayContext: null,
++  applyOptimisticMutation: null,
++  commitLocalUpdate: null,
++  commitMutation: null,
++  createFragmentContainer: null,
++  createPaginationContainer: null,
++  createRefetchContainer: null,
++  fetchQuery_DEPRECATED: null,
++  graphql: null,
++  readInlineData: null,
++  requestSubscription: null,
++  EntryPointContainer: null,
++  RelayEnvironmentProvider: null,
++  ProfilerContext: null,
++  fetchQuery: null,
++  loadQuery: null,
++  loadEntryPoint: null,
++  useClientQuery: null,
++  useFragment: null,
++  useLazyLoadQuery: null,
++  useEntryPointLoader: null,
++  useQueryLoader: null,
++  useMutation: null,
++  usePaginationFragment: null,
++  usePreloadedQuery: null,
++  useRefetchableFragment: null,
++  usePrefetchableForwardPaginationFragment_EXPERIMENTAL: null,
++  useRelayEnvironment: null,
++  useSubscribeToInvalidationState: null,
++  useSubscription: null,
++});

--- a/patches/relay-runtime-network@0.1.0.patch
+++ b/patches/relay-runtime-network@0.1.0.patch
@@ -1,0 +1,46 @@
+diff --git a/package.json b/package.json
+index e07d3e3d0a22b44df7eb9e0234b3d4e834ed02f2..361aaa655faf54fa13252696ffb248cc4f2694f7 100644
+--- a/package.json
++++ b/package.json
+@@ -24,13 +24,34 @@
+     "test:watch": "vitest"
+   },
+   "imports": {
+-    "#auth/*": "./src/lib/auth/*",
+-    "#errors/*": "./src/lib/errors/*",
+-    "#executors/*": "./src/lib/executors/*",
+-    "#middlewares/*": "./src/lib/middlewares/*",
+-    "#ssr/*": "./src/lib/ssr/*",
+-    "#testing/*": "./src/lib/testing/*",
+-    "#types/*": "./src/lib/types/*"
++    "#auth/*": {
++      "types": "./dist/types/lib/auth/*",
++      "default": "./dist/esm/lib/auth/*"
++    },
++    "#errors/*": {
++      "types": "./dist/types/lib/errors/*",
++      "default": "./dist/esm/lib/errors/*"
++    },
++    "#executors/*": {
++      "types": "./dist/types/lib/executors/*",
++      "default": "./dist/esm/lib/executors/*"
++    },
++    "#middlewares/*": {
++      "types": "./dist/types/lib/middlewares/*",
++      "default": "./dist/esm/lib/middlewares/*"
++    },
++    "#ssr/*": {
++      "types": "./dist/types/lib/ssr/*",
++      "default": "./dist/esm/lib/ssr/*"
++    },
++    "#testing/*": {
++      "types": "./dist/types/lib/testing/*",
++      "default": "./dist/esm/lib/testing/*"
++    },
++    "#types/*": {
++      "types": "./dist/types/lib/types/*",
++      "default": "./dist/esm/lib/types/*"
++    }
+   },
+   "peerDependencies": {
+     "relay-runtime": ">=16.0.0"


### PR DESCRIPTION
## Done

Client-side Relay data layer for the reference boilerplate app. **Stacked on #750** (consumes `@canonical/storybook-addon-relay` from the workspace); retarget to main after #750 merges. SSR data serialization/hydration is deliberately out of scope (next PR).

- **Transform**: `vite-plugin-relay-lite@0.12.0` — verified working end-to-end on Vite 8/rolldown with `@vitejs/plugin-react` v6 (dev, client+server builds, vitest). Wired `relay({ codegen: false })`; artifacts committed, regenerate via `bun run relay`/`relay:watch`. The Babel fallback was never needed. Known footgun documented in-code: its tag scanner matches `graphql`+backtick inside comments too.
- **Mock schema**: compact catalog domain in `src/relay/schema.graphql` — `Node` interface with global IDs, `products` connection with honest cursor pagination, deterministic in-memory dataset (`src/relay/schema.ts`).
- **Environment** (`src/relay/environment.ts`): `createEnvironment()` on `relay-runtime-network@0.1.0` — default mode executes in-process via `localGraphExecutor` over the mock schema (no backend needed); `VITE_GRAPHQL_URL` switches to `httpExecutor` + `urlMiddleware`.
- **App wiring**: `RelayEnvironmentProvider` in client + server entries (fresh env per server render); example `src/domains/catalog/` (`CatalogPage` → `ProductList` `useLazyLoadQuery` → `ProductCard` `useFragment`) wired into routes/navigation/sitemap; new shared `ClientOnly` component keeps SSR green until the SSR-data PR (comment points there).
- **Storybook**: addon registered via `createConfig("react", { extraAddons: ["@canonical/storybook-addon-relay"] })`; `ProductList.stories.tsx` uses `parameters.relay.mockResolvers` (`satisfies RelayParameters`).
- **Upstream defects found & patched** (`bun patch`, repo `patches/` precedent):
  - `relay-runtime-network@0.1.0` — published `imports` map targets `./src/lib/*` which is not in the tarball (`files: ["dist"]`); root import fails. Patched to `dist` targets. **Needs an upstream fix + 0.1.1 in advl/lit-relay** (its pack-smoke doesn't exercise the `#` imports map).
  - `react-relay@18.2.0` — CJS named exports invisible to cjs-module-lexer; added the standard lexer hint so the relay stack stays externalized in SSR (server bundle 204 kB vs 1.27 MB bundled).

## QA

```bash
bun install --linker=hoisted && bun run relay        # idempotent, artifacts committed
bun run --filter @canonical/react-boilerplate-vite check   # biome + tsc clean
bun run --filter @canonical/react-boilerplate-vite test    # 7 files / 32 tests green
bun run --filter @canonical/react-boilerplate-vite test:e2e # 6/6 server-matrix cells
bun run build:client && bun run build:server && bun run build:storybook
# live smoke: dev:bun + dev:express serve /catalog (guard fallback, no errors)
```

### PR readiness check

- [ ] Suggested label: `Feature 🎁`
- [x] PR title follows Conventional Commits
- [x] Follows code standards — biome, tsc, colocated tests, `#` subpath imports

## Screenshots

Catalog page + ProductList stories appear in the Storybook build / Chromatic run of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nYyx5PtusgA8ZBJBWK7At

---
_Generated by [Claude Code](https://claude.ai/code/session_014nYyx5PtusgA8ZBJBWK7At)_