### PR TITLE
feat(summon-application): opt-in Relay data layer for generated apps (--relay)

### DIFF
--- a/packages/summon/application/CONVENTIONS.md
+++ b/packages/summon/application/CONVENTIONS.md
@@ -1,7 +1,7 @@
 # Application Conventions
 
-> From `@canonical/summon-application` v0.25.0
-> Last updated: 2026-04-24
+> From `@canonical/summon-application` v0.29.0
+> Last updated: 2026-07-10
 
 ## Taxonomy Key
 
@@ -17,6 +17,7 @@
 | `A8` | Head | Document head management |
 | `A9` | Navigation | Client-side navigation |
 | `A10` | Types | Type registration and safety |
+| `A11` | Data | Relay (GraphQL) data layer (when `--relay` is enabled) |
 
 ---
 
@@ -252,6 +253,42 @@ const [invoices, payments] = group(sidebarWrapper, [
 | A10.2 | `AppRoutes` type exported from `routes.tsx` | type export present |
 | A10.3 | No `as` casts in route or page code | zero cast count |
 | A10.4 | No `@ts-ignore` or `@ts-expect-error` in generated code | zero suppression count |
+
+---
+
+## A11 — Data (Relay)
+
+Present only when the application is scaffolded with `--relay`.
+
+| ID | Rule | Gate |
+|----|------|------|
+| A11.1 | The Relay layer lives in `src/relay/` (environment factory, mock schema, artifacts) | `src/relay/environment.ts` exists |
+| A11.2 | The environment factory defaults to the local in-process mock schema; `VITE_GRAPHQL_URL` (or an explicit URL) switches to an HTTP executor | `createEnvironment` branches on the URL |
+| A11.3 | Compiler artifacts in `src/relay/__generated__/` are committed, never rebuilt by the app build (`codegen: false`); regenerate explicitly with the `relay` script after any schema or `graphql` tag edit | committed artifacts match schema |
+| A11.4 | Data requirements are colocated: containers use `useLazyLoadQuery`, leaf components own their `useFragment`, parents just spread it | fragment per component |
+| A11.5 | Query subtrees pair `Suspense` (pending state) with an `ErrorBoundary` (failure state) | both boundaries wrap the subtree |
+| A11.6 | Query subtrees render inside `ClientOnly` until SSR data serialization/hydration is supported | `ClientOnly` wraps query subtrees |
+| A11.7 | One Relay environment per browser session (module scope in the client entry); a fresh environment per request in the server entry | environment creation sites |
+
+### ClientOnly (pending SSR data support)
+
+`src/lib/ClientOnly/` is emitted (and exported from the lib barrel) only when
+`--relay` is enabled: the catalog page is its only consumer today. It defers
+`children` until after hydration, so `useLazyLoadQuery` — which fetches and
+suspends during render — never runs on the server, where there is no way yet
+to serialize the fetched store for the client. The server streams the
+fallback; the browser fetches after hydration. The server entry still
+provides a fresh per-request `RelayEnvironmentProvider`, so any component
+touching Relay context renders without branching on runtime. Once SSR data
+serialization/hydration lands, the guard is removed rather than generalised.
+
+### Committed artifacts
+
+`src/relay/__generated__/` ships with the scaffold as the deterministic
+relay-compiler output of the committed `schema.graphql` and the catalog
+queries. The Vite plugin runs with `codegen: false`, so the artifacts are a
+source-of-truth input to the build, not a build product — edit a query or the
+schema, run the `relay` script, and commit the regenerated artifacts.
 
 ---
 

--- a/packages/summon/application/README.md
+++ b/packages/summon/application/README.md
@@ -11,6 +11,7 @@ Scaffolds a complete React application with SSR, routing, Storybook, and two sta
 ```bash
 summon application/react my-app
 summon application/react --forms my-app
+summon application/react --relay my-app
 ```
 
 Produces:
@@ -23,6 +24,7 @@ my-app/
 │   └── decorators/
 │       ├── withRouter.tsx    # Hash-based router decorator
 │       └── index.ts
+├── patches/                  # bun dependency patches (--relay only)
 ├── src/
 │   ├── client/entry.tsx      # Client hydration
 │   ├── server/
@@ -33,23 +35,72 @@ my-app/
 │   ├── domains/
 │   │   ├── marketing/        # HomePage, GuidePage, routes
 │   │   ├── account/          # AccountPage, LoginPage, routes
-│   │   └── contact/          # ContactPage, routes (--forms only)
+│   │   ├── contact/          # ContactPage, routes (--forms only)
+│   │   └── catalog/          # CatalogPage, ProductList, ProductCard (--relay only)
 │   ├── lib/
 │   │   ├── Navigation/
 │   │   ├── ThemeSelector/
 │   │   ├── ExampleComponent/
-│   │   └── LazyComponent/
+│   │   ├── LazyComponent/
+│   │   └── ClientOnly/       # SSR query guard (--relay only)
+│   ├── relay/                # Environment factory, mock schema, __generated__ (--relay only)
 │   ├── styles/
 │   ├── routes.tsx
 │   └── vite-env.d.ts
 ├── biome.json
 ├── index.html
 ├── package.json
+├── relay.config.json         # (--relay only)
 ├── tsconfig.json
 └── vite.config.ts
 ```
 
 The `--forms` flag adds the contact domain with form components and wires `contactRoutes` into `routes.tsx`.
+
+#### `--relay`: Relay (GraphQL) data layer
+
+The `--relay` flag (off by default) mirrors the boilerplate's Relay data layer:
+
+- **`src/relay/`** — a `createEnvironment` factory built on
+  `relay-runtime-network`'s middleware pipeline: by default a local executor
+  resolves every operation in-process against the executable mock catalog
+  schema (`schema.graphql` + `schema.ts`), so the app runs with zero backend;
+  setting `VITE_GRAPHQL_URL` (or passing `graphqlUrl`) switches to posting
+  operations to a real endpoint. The relay-compiler artifacts in
+  `src/relay/__generated__/` are committed — deterministic outputs of the
+  committed schema — and regenerated with `bun run relay` (or `relay:watch`)
+  after any schema or `graphql` tag edit.
+- **`src/domains/catalog/`** — an example domain wiring `useLazyLoadQuery`
+  (`ProductList`) and a colocated `useFragment` (`ProductCard`) behind the
+  canonical Suspense + `ErrorBoundary` pairing, with Storybook stories mocked
+  via `@canonical/storybook-addon-relay` (`parameters.relay` mock resolvers +
+  play tests) and component tests against both the local schema and
+  `relay-test-utils`.
+- **`src/lib/ClientOnly/`** — keeps queries off the server render path until
+  SSR data serialization/hydration is supported: the server streams the
+  fallback and the browser fetches after hydration. It is emitted only with
+  `--relay` because the catalog page is its only consumer today.
+- **`patches/` + `"patchedDependencies"`** — a generated app is standalone and
+  cannot inherit the monorepo's `patches/`, so the two bun patches ship with
+  the scaffold: `react-relay@18.2.0` (cjs-module-lexer export hints so named
+  imports survive Node SSR externalisation) and `relay-runtime-network@0.1.0`
+  (fixes its broken package `imports` map — temporary until the fixed
+  upstream release lands, advl/lit-relay#32, after which the patch and its
+  `patchedDependencies` entry can be dropped).
+- **Wiring** — `RelayEnvironmentProvider` in both entries (one environment
+  per browser session on the client, a fresh one per request on the server),
+  `vite-plugin-relay-lite` in `vite.config.ts` (`codegen: false`; artifacts
+  are committed), the `relay` / `relay:watch` scripts, catalog route, nav
+  link, and sitemap entries, and the relay addon via `extraAddons` in
+  `.storybook/main.ts`.
+
+**Known caveats — not yet on npm.** `@canonical/storybook-addon-relay` and
+the fixed `relay-runtime-network` release have not been published yet. A
+scaffolded app's install currently fails to resolve
+`@canonical/storybook-addon-relay` (404 from the registry), and the
+`relay-runtime-network` patch remains necessary until the fixed upstream
+release lands. The scaffold encodes the intended end state; a `--relay` app's
+install will only fully resolve once those packages publish.
 
 ### `summon domain <name>`
 
@@ -145,12 +196,23 @@ src/
 │   │   ├── AccountPage.tsx
 │   │   ├── LoginPage.tsx
 │   │   └── routes.ts
-│   └── contact/            # When --forms is enabled
-│       ├── ContactPage.tsx
+│   ├── contact/            # When --forms is enabled
+│   │   ├── ContactPage.tsx
+│   │   └── routes.ts
+│   └── catalog/            # When --relay is enabled
+│       ├── CatalogPage.tsx
+│       ├── ProductList.tsx
+│       ├── ProductCard.tsx
+│       ├── ErrorBoundary.tsx
 │       └── routes.ts
 ├── lib/                    # Shared components
 │   ├── Navigation/
 │   └── SidebarLayout/
+├── relay/                  # When --relay is enabled
+│   ├── environment.ts      # Environment factory (local executor / HTTP)
+│   ├── schema.graphql      # Mock SDL (relay-compiler validates against it)
+│   ├── schema.ts           # Executable mock schema (graphql-js)
+│   └── __generated__/      # Committed relay-compiler artifacts
 ├── styles/                 # CSS
 └── routes.tsx              # Root route map, middleware, type registration
 ```

--- a/packages/summon/application/biome.json
+++ b/packages/summon/application/biome.json
@@ -1,6 +1,10 @@
 {
   "extends": ["@canonical/biome-config"],
   "files": {
-    "includes": ["src", "*.json"]
+    "includes": [
+      "src",
+      "*.json",
+      "!src/application/react/templates/src/relay/__generated__"
+    ]
   }
 }

--- a/packages/summon/application/src/application/react/index.ts
+++ b/packages/summon/application/src/application/react/index.ts
@@ -24,6 +24,7 @@ export interface ApplicationReactAnswers {
   readonly ssr: boolean;
   readonly router: boolean;
   readonly forms: boolean;
+  readonly relay: boolean;
   readonly runInstall: boolean;
 }
 
@@ -58,6 +59,13 @@ const prompts: PromptDefinition[] = [
     group: "Application",
   },
   {
+    name: "relay",
+    type: "confirm",
+    message: "Include a Relay (GraphQL) data layer with a local mock schema?",
+    default: false,
+    group: "Application",
+  },
+  {
     name: "runInstall",
     type: "confirm",
     message: "Install dependencies now?",
@@ -85,6 +93,8 @@ export const generator: GeneratorDefinition<ApplicationReactAnswers> = {
   - Head management with @canonical/react-head
   - Two domains (marketing + account) with pages
   - Contact domain with form components (when --forms is enabled)
+  - Relay (GraphQL) data layer with a local mock schema, catalog example
+    domain, and Storybook mocking (when --relay is enabled)
   - Navigation, ThemeSelector, ExampleComponent
   - Storybook with router decorator
   - Biome + TypeScript configuration
@@ -93,7 +103,8 @@ Requires both --ssr and --router flags.`,
     examples: [
       "summon application/react my-app",
       "summon application/react --forms my-app",
-      "summon application/react --ssr --router --forms my-app",
+      "summon application/react --relay my-app",
+      "summon application/react --ssr --router --forms --relay my-app",
     ],
   },
 
@@ -140,6 +151,7 @@ Requires both --ssr and --router flags.`,
       const vars = withHelpers({
         name,
         forms: answers.forms,
+        relay: answers.relay,
         pragmaVersion,
       });
 
@@ -198,11 +210,28 @@ Requires both --ssr and --router flags.`,
         }),
 
         // Root config
-        copy("tsconfig.json"),
-        copy("vite.config.ts"),
+        // tsconfig (EJS — #relay path alias only when --relay)
+        template({
+          source: src("tsconfig.json.ejs"),
+          dest: dest("tsconfig.json"),
+          vars,
+        }),
+        // vite config (EJS — vite-plugin-relay-lite only when --relay)
+        template({
+          source: src("vite.config.ts.ejs"),
+          dest: dest("vite.config.ts"),
+          vars,
+        }),
         copy("vitest.config.ts"),
-        copy("vitest.setup.ts"),
+        // vitest setup (EJS — relay-test-utils' jest→vi alias only when --relay)
+        template({
+          source: src("vitest.setup.ts.ejs"),
+          dest: dest("vitest.setup.ts"),
+          vars,
+        }),
         copy("vitest.e2e.config.ts"),
+        // Relay compiler config (validates queries against the mock SDL)
+        when(answers.relay, copy("relay.config.json")),
         // index.html (EJS — <title> uses the app name)
         template({
           source: src("index.html.ejs"),
@@ -227,12 +256,21 @@ Requires both --ssr and --router flags.`,
         }),
         copy("src/styles/app.css"),
 
-        // Client
-        copy("src/client/entry.tsx"),
+        // Client (EJS — RelayEnvironmentProvider only when --relay)
+        template({
+          source: src("src/client/entry.tsx.ejs"),
+          dest: dest("src/client/entry.tsx"),
+          vars,
+        }),
 
         // Server — dev (Vite + HMR) and preview (compiled) servers each route
         // between the app + sitemap renderers; the renderers stay routing-agnostic.
-        copy("src/server/entry.tsx"),
+        // Server entry (EJS — a per-request RelayEnvironmentProvider only when --relay)
+        template({
+          source: src("src/server/entry.tsx.ejs"),
+          dest: dest("src/server/entry.tsx"),
+          vars,
+        }),
         copy("src/server/renderer.tsx"),
         copy("src/server/server.express.ts"),
         copy("src/server/server.bun.ts"),
@@ -241,7 +279,8 @@ Requires both --ssr and --router flags.`,
 
         // Sitemap (rendered route at /sitemap.xml)
         copy("src/sitemap/renderer.ts"),
-        // sitemap getters (EJS — /contact entry only when --forms)
+        // sitemap getters (EJS — /contact entry only when --forms, /catalog
+        // entry only when --relay)
         template({
           source: src("src/sitemap/getSitemapItems.ts.ejs"),
           dest: dest("src/sitemap/getSitemapItems.ts"),
@@ -262,14 +301,62 @@ Requires both --ssr and --router flags.`,
         when(answers.forms, copy("src/domains/contact/ContactPage.tsx")),
         when(answers.forms, copy("src/domains/contact/routes.ts")),
 
-        // Routes (EJS — conditionally includes contact domain)
+        // Relay data layer (when --relay is enabled): environment factory +
+        // executable mock schema, the catalog example domain, and the
+        // ClientOnly SSR guard (whose only consumer today is the catalog page).
+        when(answers.relay, copy("src/relay/schema.graphql")),
+        when(answers.relay, copy("src/relay/schema.ts")),
+        when(answers.relay, copy("src/relay/schema.tests.ts")),
+        when(answers.relay, copy("src/relay/environment.ts")),
+        when(answers.relay, copy("src/relay/environment.tests.ts")),
+        // Committed relay-compiler artifacts — deterministic outputs of the
+        // committed schema + the catalog queries; `bun run relay` regenerates
+        // them in the scaffolded app after any schema or graphql-tag edit.
+        when(
+          answers.relay,
+          copy("src/relay/__generated__/ProductCard_product.graphql.ts"),
+        ),
+        when(
+          answers.relay,
+          copy("src/relay/__generated__/ProductListQuery.graphql.ts"),
+        ),
+
+        // Domain: catalog (when --relay is enabled)
+        when(answers.relay, copy("src/domains/catalog/CatalogPage.tsx")),
+        when(answers.relay, copy("src/domains/catalog/ProductList.tsx")),
+        when(
+          answers.relay,
+          copy("src/domains/catalog/ProductList.stories.tsx"),
+        ),
+        when(answers.relay, copy("src/domains/catalog/ProductList.tests.tsx")),
+        when(answers.relay, copy("src/domains/catalog/ProductCard.tsx")),
+        when(answers.relay, copy("src/domains/catalog/ErrorBoundary.tsx")),
+        when(
+          answers.relay,
+          copy("src/domains/catalog/ErrorBoundary.tests.tsx"),
+        ),
+        when(answers.relay, copy("src/domains/catalog/routes.ts")),
+
+        // Standalone dependency patches (when --relay is enabled): a generated
+        // app cannot inherit the monorepo's patches/, so they ship with the
+        // scaffold and are applied via "patchedDependencies" in package.json.
+        // react-relay: cjs-module-lexer export hints so named imports survive
+        // Node SSR externalisation.
+        when(answers.relay, copy("patches/react-relay@18.2.0.patch")),
+        // relay-runtime-network: fixes the broken package `imports` map.
+        // Temporary until the fixed upstream release lands (advl/lit-relay#32);
+        // then this patch and its patchedDependencies entry can be dropped.
+        when(answers.relay, copy("patches/relay-runtime-network@0.1.0.patch")),
+
+        // Routes (EJS — conditionally includes contact + catalog domains)
         template({
           source: src("src/routes.tsx.ejs"),
           dest: dest("src/routes.tsx"),
           vars,
         }),
 
-        // Lib: Navigation (EJS — contact link only when --forms)
+        // Lib: Navigation (EJS — contact link only when --forms, catalog
+        // link only when --relay)
         template({
           source: src("src/lib/Navigation/Navigation.tsx.ejs"),
           dest: dest("src/lib/Navigation/Navigation.tsx"),
@@ -294,14 +381,30 @@ Requires both --ssr and --router flags.`,
         copy("src/lib/LazyComponent/LazyComponent.stories.tsx"),
         copy("src/lib/LazyComponent/index.ts"),
 
-        // Lib barrel
-        copy("src/lib/index.ts"),
+        // Lib: ClientOnly (when --relay is enabled — the catalog page is its
+        // only consumer, keeping Relay queries off the server render until
+        // SSR data serialization/hydration is supported)
+        when(answers.relay, copy("src/lib/ClientOnly/ClientOnly.tsx")),
+        when(answers.relay, copy("src/lib/ClientOnly/ClientOnly.tests.tsx")),
+        when(answers.relay, copy("src/lib/ClientOnly/index.ts")),
+
+        // Lib barrel (EJS — ClientOnly export only when --relay)
+        template({
+          source: src("src/lib/index.ts.ejs"),
+          dest: dest("src/lib/index.ts"),
+          vars,
+        }),
 
         // Vite types
         copy("src/vite-env.d.ts"),
 
         // Storybook
-        copy(".storybook/main.ts"),
+        // main config (EJS — the relay mocking addon only when --relay)
+        template({
+          source: src(".storybook/main.ts.ejs"),
+          dest: dest(".storybook/main.ts"),
+          vars,
+        }),
         copy(".storybook/preview.ts"),
         copy(".storybook/decorators/withRouter.tsx"),
         copy(".storybook/decorators/index.ts"),

--- a/packages/summon/application/src/application/react/templates/.storybook/main.ts
+++ b/packages/summon/application/src/application/react/templates/.storybook/main.ts
@@ -1,5 +1,0 @@
-import { createConfig } from "@canonical/storybook-config";
-
-export default createConfig("react", {
-  staticDirs: ["../src/assets", "../public"],
-});

--- a/packages/summon/application/src/application/react/templates/.storybook/main.ts.ejs
+++ b/packages/summon/application/src/application/react/templates/.storybook/main.ts.ejs
@@ -1,0 +1,10 @@
+import { createConfig } from "@canonical/storybook-config";
+
+export default createConfig("react", {
+  staticDirs: ["../src/assets", "../public"],
+<% if (relay) { -%>
+  // Wraps stories that declare `parameters.relay` in a relay-test-utils mock
+  // environment, so components using Relay hooks render without a server.
+  extraAddons: ["@canonical/storybook-addon-relay"],
+<% } -%>
+});

--- a/packages/summon/application/src/application/react/templates/README.md.ejs
+++ b/packages/summon/application/src/application/react/templates/README.md.ejs
@@ -36,6 +36,15 @@ renderer over the built assets, the same artifact that deploys.
 ```bash
 bun run storybook    # component workshop
 ```
+<% if (relay) { -%>
+
+Relay's compiler artifacts are committed, not rebuilt on the fly:
+
+```bash
+bun run relay          # regenerate src/relay/__generated__ after schema/query edits
+bun run relay:watch    # the same, re-running on change — pair with dev:*
+```
+<% } -%>
 
 ## Adding routes
 
@@ -69,6 +78,10 @@ src/
 ├── server/         Server entry, compiled renderer, dev servers, sitemap
 ├── domains/        Feature domains (each owns its routes and pages)
 ├── lib/            Shared components
+<% if (relay) { -%>
+├── relay/          Relay environment factory, executable mock schema,
+│                   and generated artifacts (__generated__/)
+<% } -%>
 ├── styles/         Application CSS
 ├── assets/         Assets imported in code (bundled and hashed by Vite)
 └── routes.tsx      Root route map
@@ -80,3 +93,44 @@ Domains are the unit of feature organisation: each owns its routes and pages, so
 adding a feature is adding a domain rather than threading changes through shared
 files. This app ships both `src/assets/` (assets imported in code) and `public/`
 (files served by fixed URL); either may be removed if the app uses only one.
+<% if (relay) { -%>
+
+## Data layer (Relay)
+
+The `catalog` domain demonstrates the app's [Relay](https://relay.dev) data
+layer: `ProductList` fetches a page of products with `useLazyLoadQuery`, and
+each `ProductCard` reads its own colocated `useFragment` — the component owns
+its field selection, the parent query just spreads it.
+
+**By default the app needs no backend.** `createEnvironment`
+(`src/relay/environment.ts`) resolves every GraphQL operation in-process
+against an executable mock schema (`src/relay/schema.ts`, built from the SDL
+in `src/relay/schema.graphql`) backed by a small deterministic catalog. Set
+`VITE_GRAPHQL_URL` (or pass `graphqlUrl` to `createEnvironment`) to switch the
+environment to posting operations to a real GraphQL endpoint instead — no code
+changes needed.
+
+**Generated artifacts are committed.** The Vite plugin runs with
+`codegen: false`, so `src/relay/__generated__/` is not rebuilt on the fly:
+after editing a `graphql` tag or the schema, run `bun run relay` (or keep
+`bun run relay:watch` running) to regenerate the artifacts, and commit them.
+
+**SSR ships no data yet.** `useLazyLoadQuery` fetches (and suspends) while
+rendering, and the server cannot serialize the fetched store for the client
+yet, so the catalog page wraps its query subtree in `ClientOnly`
+(`src/lib/ClientOnly/`): the server streams the fallback and the browser
+fetches after hydration.
+
+**Patched dependencies.** `patches/` carries two package patches applied via
+`patchedDependencies` in `package.json` (a bun feature — with another package
+manager, apply the equivalent mechanism): `react-relay@18.2.0` needs a
+cjs-module-lexer export hint so named imports survive Node SSR, and
+`relay-runtime-network@0.1.0` ships a broken `imports` map. The latter patch
+is temporary until the fixed upstream release lands
+([advl/lit-relay#32](https://github.com/advl/lit-relay/pull/32)); drop it and
+its `patchedDependencies` entry once a fixed version is published.
+
+**Not yet on npm.** `@canonical/storybook-addon-relay` and the fixed
+`relay-runtime-network` release have not been published yet, so a fresh
+install of this app will not fully resolve until they land on npm.
+<% } -%>

--- a/packages/summon/application/src/application/react/templates/biome.json.ejs
+++ b/packages/summon/application/src/application/react/templates/biome.json.ejs
@@ -1,6 +1,6 @@
 {
   "extends": ["@canonical/biome-config"],
   "files": {
-    "includes": ["src", "*.json", "vite.config.ts"]
+    "includes": ["src", "*.json", "vite.config.ts"<% if (relay) { %>, "!src/relay/__generated__"<% } %>]
   }
 }

--- a/packages/summon/application/src/application/react/templates/package.json.ejs
+++ b/packages/summon/application/src/application/react/templates/package.json.ejs
@@ -7,6 +7,9 @@
   "imports": {
     "#lib/*": "./src/lib/*",
     "#domains/*": "./src/domains/*",
+<% if (relay) { -%>
+    "#relay/*": "./src/relay/*",
+<% } -%>
     "#styles/*": "./src/styles/*"
   },
   "scripts": {
@@ -26,6 +29,10 @@
     "check:biome": "biome check",
     "check:biome:fix": "biome check --write",
     "check:ts": "tsc --noEmit",
+<% if (relay) { -%>
+    "relay": "relay-compiler",
+    "relay:watch": "relay-compiler --watch",
+<% } -%>
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -42,11 +49,20 @@
     "@canonical/react-ssr": "<%= pragmaVersion %>",
     "@canonical/router-core": "<%= pragmaVersion %>",
     "@canonical/router-react": "<%= pragmaVersion %>",
+<% if (relay) { -%>
+    "@canonical/storybook-addon-relay": "<%= pragmaVersion %>",
+<% } -%>
     "@canonical/storybook-config": "<%= pragmaVersion %>",
     "@canonical/styles": "<%= pragmaVersion %>",
     "express": "^5.2.1",
+<% if (relay) { -%>
+    "graphql": "^16.11.0",
+<% } -%>
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4"<% if (relay) { %>,
+    "react-relay": "^18.2.0",
+    "relay-runtime": "^18.2.0",
+    "relay-runtime-network": "^0.1.0"<% } %>
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.9",
@@ -59,14 +75,30 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+<% if (relay) { -%>
+    "@types/react-relay": "^18.2.1",
+    "@types/relay-runtime": "^19.0.3",
+    "@types/relay-test-utils": "^18.0.0",
+<% } -%>
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "^4.0.18",
     "bun-types": "^1.3.9",
     "jsdom": "^28.1.0",
+<% if (relay) { -%>
+    "relay-compiler": "^18.2.0",
+    "relay-test-utils": "^18.2.0",
+<% } -%>
     "storybook": "^10.3.1",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.1",
+<% if (relay) { -%>
+    "vite-plugin-relay-lite": "^0.12.0",
+<% } -%>
     "vitest": "^4.0.18"
-  }
+  }<% if (relay) { %>,
+  "patchedDependencies": {
+    "react-relay@18.2.0": "patches/react-relay@18.2.0.patch",
+    "relay-runtime-network@0.1.0": "patches/relay-runtime-network@0.1.0.patch"
+  }<% } %>
 }

--- a/packages/summon/application/src/application/react/templates/patches/react-relay@18.2.0.patch
+++ b/packages/summon/application/src/application/react/templates/patches/react-relay@18.2.0.patch
@@ -1,0 +1,52 @@
+diff --git a/index.js b/index.js
+index 5fe5bc4a2adf6210e2dc5f84cc33382f47953384..407b9665ffa3b703f8fb2bfffa843a869b5c0957 100644
+--- a/index.js
++++ b/index.js
+@@ -8,3 +8,47 @@
+  */
+ 
+ module.exports = require('./lib/index.js');
++
++// Patch (pragma): cjs-module-lexer cannot statically detect the exports of
++// ./lib/index.js because they are member expressions inside an object
++// literal, so `import { useFragment } from "react-relay"` fails under Node
++// ESM (and under Vite's dev SSR module runner, which mirrors Node semantics).
++// The dead branch below is the esbuild-style lexer hint: never executed, but
++// statically registers the named exports.
++0 && (module.exports = {
++  ConnectionHandler: null,
++  QueryRenderer: null,
++  LocalQueryRenderer: null,
++  MutationTypes: null,
++  RangeOperations: null,
++  ReactRelayContext: null,
++  applyOptimisticMutation: null,
++  commitLocalUpdate: null,
++  commitMutation: null,
++  createFragmentContainer: null,
++  createPaginationContainer: null,
++  createRefetchContainer: null,
++  fetchQuery_DEPRECATED: null,
++  graphql: null,
++  readInlineData: null,
++  requestSubscription: null,
++  EntryPointContainer: null,
++  RelayEnvironmentProvider: null,
++  ProfilerContext: null,
++  fetchQuery: null,
++  loadQuery: null,
++  loadEntryPoint: null,
++  useClientQuery: null,
++  useFragment: null,
++  useLazyLoadQuery: null,
++  useEntryPointLoader: null,
++  useQueryLoader: null,
++  useMutation: null,
++  usePaginationFragment: null,
++  usePreloadedQuery: null,
++  useRefetchableFragment: null,
++  usePrefetchableForwardPaginationFragment_EXPERIMENTAL: null,
++  useRelayEnvironment: null,
++  useSubscribeToInvalidationState: null,
++  useSubscription: null,
++});

--- a/packages/summon/application/src/application/react/templates/patches/relay-runtime-network@0.1.0.patch
+++ b/packages/summon/application/src/application/react/templates/patches/relay-runtime-network@0.1.0.patch
@@ -1,0 +1,46 @@
+diff --git a/package.json b/package.json
+index e07d3e3d0a22b44df7eb9e0234b3d4e834ed02f2..361aaa655faf54fa13252696ffb248cc4f2694f7 100644
+--- a/package.json
++++ b/package.json
+@@ -24,13 +24,34 @@
+     "test:watch": "vitest"
+   },
+   "imports": {
+-    "#auth/*": "./src/lib/auth/*",
+-    "#errors/*": "./src/lib/errors/*",
+-    "#executors/*": "./src/lib/executors/*",
+-    "#middlewares/*": "./src/lib/middlewares/*",
+-    "#ssr/*": "./src/lib/ssr/*",
+-    "#testing/*": "./src/lib/testing/*",
+-    "#types/*": "./src/lib/types/*"
++    "#auth/*": {
++      "types": "./dist/types/lib/auth/*",
++      "default": "./dist/esm/lib/auth/*"
++    },
++    "#errors/*": {
++      "types": "./dist/types/lib/errors/*",
++      "default": "./dist/esm/lib/errors/*"
++    },
++    "#executors/*": {
++      "types": "./dist/types/lib/executors/*",
++      "default": "./dist/esm/lib/executors/*"
++    },
++    "#middlewares/*": {
++      "types": "./dist/types/lib/middlewares/*",
++      "default": "./dist/esm/lib/middlewares/*"
++    },
++    "#ssr/*": {
++      "types": "./dist/types/lib/ssr/*",
++      "default": "./dist/esm/lib/ssr/*"
++    },
++    "#testing/*": {
++      "types": "./dist/types/lib/testing/*",
++      "default": "./dist/esm/lib/testing/*"
++    },
++    "#types/*": {
++      "types": "./dist/types/lib/types/*",
++      "default": "./dist/esm/lib/types/*"
++    }
+   },
+   "peerDependencies": {
+     "relay-runtime": ">=16.0.0"

--- a/packages/summon/application/src/application/react/templates/relay.config.json
+++ b/packages/summon/application/src/application/react/templates/relay.config.json
@@ -1,0 +1,8 @@
+{
+  "src": "./src",
+  "schema": "./src/relay/schema.graphql",
+  "language": "typescript",
+  "eagerEsModules": true,
+  "artifactDirectory": "./src/relay/__generated__",
+  "excludes": ["**/node_modules/**", "**/__generated__/**", "**/dist/**"]
+}

--- a/packages/summon/application/src/application/react/templates/src/client/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/client/entry.tsx.ejs
@@ -2,6 +2,10 @@ import { HeadProvider } from "@canonical/react-head";
 import { createBrowserRouter } from "@canonical/router-core";
 import { Outlet, RouterProvider } from "@canonical/router-react";
 import { hydrateRoot } from "react-dom/client";
+<% if (relay) { -%>
+import { RelayEnvironmentProvider } from "react-relay";
+import { createEnvironment } from "#relay/environment.js";
+<% } -%>
 import { appRoutes, middleware, notFoundRoute } from "../routes.js";
 import "#styles/index.css";
 
@@ -9,12 +13,30 @@ const router = createBrowserRouter(appRoutes, {
   middleware: [...middleware],
   notFound: notFoundRoute,
 });
+<% if (relay) { -%>
+
+// One Relay environment (network + normalized store) for the whole browser
+// session — module scope, so client-side navigations share the cache.
+const relayEnvironment = createEnvironment();
+<% } -%>
 
 const root = document.getElementById("root");
 if (!root) {
   throw new Error('Root element "#root" not found');
 }
 
+<% if (relay) { -%>
+hydrateRoot(
+  root,
+  <HeadProvider>
+    <RelayEnvironmentProvider environment={relayEnvironment}>
+      <RouterProvider router={router}>
+        <Outlet fallback={<p>Loading…</p>} />
+      </RouterProvider>
+    </RelayEnvironmentProvider>
+  </HeadProvider>,
+);
+<% } else { -%>
 hydrateRoot(
   root,
   <HeadProvider>
@@ -23,3 +45,4 @@ hydrateRoot(
     </RouterProvider>
   </HeadProvider>,
 );
+<% } -%>

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/CatalogPage.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/CatalogPage.tsx
@@ -1,0 +1,50 @@
+import { useHead } from "@canonical/react-head";
+import { type ReactElement, Suspense } from "react";
+import { ClientOnly } from "#lib/index.js";
+import ErrorBoundary from "./ErrorBoundary.js";
+import ProductList from "./ProductList.js";
+
+export default function CatalogPage(): ReactElement {
+  useHead({ title: "Catalog — Boilerplate" });
+
+  return (
+    <section aria-labelledby="catalog-title">
+      <h1 id="catalog-title">Catalog</h1>
+      <p>
+        This page demonstrates the Relay data layer. <code>ProductList</code>{" "}
+        issues a <code>useLazyLoadQuery</code>, each <code>ProductCard</code>{" "}
+        reads its own <code>useFragment</code>, and the environment resolves
+        operations against the local mock schema in{" "}
+        <code>src/relay/schema.ts</code> — set <code>VITE_GRAPHQL_URL</code> to
+        point it at a real endpoint instead.
+      </p>
+      {/*
+        SSR guard: `useLazyLoadQuery` fetches (and suspends) while rendering,
+        and the server has no way to serialize the fetched store for the
+        client yet — that lands in the follow-up SSR data-hydration PR. Until
+        then `ClientOnly` keeps the query off the server render path: the
+        server streams the fallback and the browser fetches after hydration.
+      */}
+      {/*
+        The canonical Relay pairing: Suspense renders the pending state while
+        `useLazyLoadQuery` is in flight, and the ErrorBoundary renders the
+        failure state when the query errors (e.g. an unreachable endpoint in
+        `VITE_GRAPHQL_URL` mode) — without it a thrown query error would
+        unmount the whole tree to a blank page.
+      */}
+      <ClientOnly fallback={<p>Loading catalog…</p>}>
+        <ErrorBoundary
+          fallback={
+            <p role="alert">
+              The catalog failed to load. Reload the page to try again.
+            </p>
+          }
+        >
+          <Suspense fallback={<p>Loading catalog…</p>}>
+            <ProductList />
+          </Suspense>
+        </ErrorBoundary>
+      </ClientOnly>
+    </section>
+  );
+}

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/ErrorBoundary.tests.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/ErrorBoundary.tests.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { RelayEnvironmentProvider } from "react-relay";
+import { createMockEnvironment } from "relay-test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ErrorBoundary from "./ErrorBoundary.js";
+import ProductList from "./ProductList.js";
+
+describe("ErrorBoundary component", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders its children while nothing throws", () => {
+    render(
+      <ErrorBoundary fallback={<p role="alert">Failed.</p>}>
+        <p>Catalog content</p>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Catalog content")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders the fallback when the catalog query errors", async () => {
+    // React logs errors caught by boundaries; keep the test output clean.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const environment = createMockEnvironment();
+    // Resolving an operation with an Error rejects it, which makes
+    // `useLazyLoadQuery` re-throw during render — exactly what happens when
+    // a real endpoint is unreachable. Queue it before rendering, as the
+    // query is issued during the initial render.
+    environment.mock.queueOperationResolver(
+      () => new Error("backend unreachable"),
+    );
+
+    render(
+      <RelayEnvironmentProvider environment={environment}>
+        <ErrorBoundary
+          fallback={<p role="alert">The catalog failed to load.</p>}
+        >
+          <Suspense fallback={<p>Loading catalog…</p>}>
+            <ProductList />
+          </Suspense>
+        </ErrorBoundary>
+      </RelayEnvironmentProvider>,
+    );
+
+    // The fallback replaces the subtree instead of white-screening.
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "The catalog failed to load.",
+    );
+    expect(screen.queryByText(/products/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/ErrorBoundary.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import { Component, type ReactNode } from "react";
+
+export interface ErrorBoundaryProps {
+  /** Subtree whose render errors this boundary catches. */
+  readonly children: ReactNode;
+  /** Rendered in place of `children` after an error. */
+  readonly fallback: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  readonly hasError: boolean;
+}
+
+/**
+ * Catches render errors below it and renders `fallback` instead of letting
+ * the error unmount the whole tree to a blank page.
+ *
+ * Relay's `useLazyLoadQuery` re-throws query errors during render — Suspense
+ * only handles the pending state — so a data-driven subtree needs both
+ * boundaries: Suspense for loading, this for failure (the canonical Relay
+ * pairing; see `CatalogPage`). A class component because error boundaries
+ * have no hook equivalent.
+ */
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render(): ReactNode {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductCard.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductCard.tsx
@@ -1,0 +1,49 @@
+import type { ReactElement } from "react";
+import { graphql, useFragment } from "react-relay";
+import type { ProductCard_product$key } from "#relay/__generated__/ProductCard_product.graphql.js";
+
+// Data this card needs, colocated with the component. The parent query
+// spreads the fragment, so the card can evolve its field selection without
+// touching `ProductList`.
+const productCardFragment = graphql`
+  fragment ProductCard_product on Product {
+    name
+    tagline
+    priceCents
+    currency
+    rating
+    inStock
+  }
+`;
+
+/** Formats a minor-unit price deterministically (fixed locale, real currency). */
+const formatPrice = (priceCents: number, currency: string): string =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+    priceCents / 100,
+  );
+
+export interface ProductCardProps {
+  /** Fragment reference to the product this card renders. */
+  readonly product: ProductCard_product$key;
+}
+
+/**
+ * Renders one catalog product from a Relay fragment reference.
+ */
+export default function ProductCard({
+  product,
+}: ProductCardProps): ReactElement {
+  const data = useFragment(productCardFragment, product);
+
+  return (
+    <article aria-label={data.name}>
+      <h3>{data.name}</h3>
+      <p>{data.tagline}</p>
+      <p>
+        <strong>{formatPrice(data.priceCents, data.currency)}</strong> · rated{" "}
+        {data.rating.toFixed(1)} / 5 ·{" "}
+        {data.inStock ? "in stock" : "out of stock"}
+      </p>
+    </article>
+  );
+}

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductList.stories.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductList.stories.tsx
@@ -1,0 +1,103 @@
+import type { RelayParameters } from "@canonical/storybook-addon-relay";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Suspense } from "react";
+import { expect } from "storybook/test";
+import Component from "./ProductList.js";
+
+const meta = {
+  title: "Catalog/ProductList",
+  component: Component,
+  // `useLazyLoadQuery` suspends while the (mocked) query is in flight, so
+  // every story renders inside a Suspense boundary — the same shape the
+  // catalog page uses.
+  decorators: [
+    (Story) => (
+      <Suspense fallback={<p>Loading catalog…</p>}>
+        <Story />
+      </Suspense>
+    ),
+  ],
+} satisfies Meta<typeof Component>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * `@canonical/storybook-addon-relay` reads `parameters.relay` and resolves
+ * the story's operations with `MockPayloadGenerator` + these resolvers.
+ * Every displayed field is resolved explicitly so the story is deterministic
+ * for visual regression testing.
+ */
+export const Default: Story = {
+  parameters: {
+    relay: {
+      mockResolvers: {
+        Viewer: () => ({ name: "Ada Lovelace" }),
+        ProductConnection: () => ({
+          totalCount: 5,
+          pageInfo: { hasNextPage: true },
+          edges: [
+            {
+              node: {
+                id: "Product:story-1",
+                name: "Aurora Dev Board",
+                tagline: "A hackable single-board computer for prototyping",
+                priceCents: 14_900,
+                currency: "USD",
+                rating: 4.6,
+                inStock: true,
+              },
+            },
+            {
+              node: {
+                id: "Product:story-2",
+                name: "Polar Sensor Kit",
+                tagline: "Twelve calibrated sensors in a rugged case",
+                priceCents: 8_900,
+                currency: "USD",
+                rating: 4.2,
+                inStock: false,
+              },
+            },
+          ],
+        }),
+      },
+    } satisfies RelayParameters,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByText("Aurora Dev Board"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Ada Lovelace")).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/showing 2 of 5 products/),
+    ).toBeInTheDocument();
+    // The Polar Sensor Kit is the story's out-of-stock product.
+    await expect(canvas.getByText(/out of stock/)).toBeInTheDocument();
+    await expect(
+      canvas.getByText("More products are available."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const EmptyCatalog: Story = {
+  parameters: {
+    relay: {
+      mockResolvers: {
+        Viewer: () => ({ name: "Ada Lovelace" }),
+        ProductConnection: () => ({
+          totalCount: 0,
+          pageInfo: { hasNextPage: false },
+          edges: [],
+        }),
+      },
+    } satisfies RelayParameters,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByText(/showing 0 of 0 products/),
+    ).toBeInTheDocument();
+    await expect(canvas.queryByRole("article")).not.toBeInTheDocument();
+  },
+};

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductList.tests.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductList.tests.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { RelayEnvironmentProvider } from "react-relay";
+import type { IEnvironment } from "relay-runtime";
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils";
+import { describe, expect, it } from "vitest";
+import { createEnvironment } from "#relay/environment.js";
+import { CATALOG_PRODUCTS } from "#relay/schema.js";
+import ProductList from "./ProductList.js";
+
+const renderProductList = (environment: IEnvironment) =>
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback={<p>Loading catalog…</p>}>
+        <ProductList />
+      </Suspense>
+    </RelayEnvironmentProvider>,
+  );
+
+describe("ProductList component", () => {
+  it("renders the first page from the app's local mock schema", async () => {
+    // Integration path: the real factory, whose local executor resolves the
+    // query against src/relay/schema.ts — no relay-test-utils involved.
+    renderProductList(createEnvironment());
+
+    const firstProduct = CATALOG_PRODUCTS[0];
+    expect(
+      await screen.findByRole("article", { name: firstProduct?.name }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`of ${CATALOG_PRODUCTS.length} products`)),
+    ).toBeInTheDocument();
+    // Product:3 (Beacon Micro Server) is the first page's out-of-stock,
+    // 4.2-rated product — pins the stock label and the rating formatting.
+    expect(screen.getByText(/out of stock/)).toBeInTheDocument();
+    expect(screen.getByText(/rated 4\.2 \/ 5/)).toBeInTheDocument();
+    expect(
+      screen.getByText("More products are available."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders payloads resolved by a relay-test-utils mock environment", async () => {
+    const environment = createMockEnvironment();
+    // Queue the resolver before rendering: useLazyLoadQuery issues the
+    // request during render, and the queued resolver answers it immediately.
+    environment.mock.queueOperationResolver((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Viewer: () => ({ name: "Grace Hopper" }),
+        ProductConnection: () => ({
+          totalCount: 1,
+          pageInfo: { hasNextPage: false },
+          edges: [
+            {
+              node: {
+                id: "Product:mocked",
+                name: "Mocked Product",
+                tagline: "Straight from MockPayloadGenerator",
+                priceCents: 12_500,
+                currency: "USD",
+                rating: 4.5,
+                inStock: true,
+              },
+            },
+          ],
+        }),
+      }),
+    );
+
+    renderProductList(environment);
+
+    expect(await screen.findByText("Mocked Product")).toBeInTheDocument();
+    expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
+    expect(screen.getByText("$125.00", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(/in stock/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("More products are available."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductList.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductList.tsx
@@ -1,0 +1,59 @@
+import type { ReactElement } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import type { ProductListQuery } from "#relay/__generated__/ProductListQuery.graphql.js";
+import ProductCard from "./ProductCard.js";
+
+/** How many products the list requests from the connection. */
+const PAGE_SIZE = 4;
+
+const productListQuery = graphql`
+  query ProductListQuery($count: Int!, $cursor: String) {
+    viewer {
+      name
+      products(first: $count, after: $cursor) {
+        totalCount
+        pageInfo {
+          hasNextPage
+        }
+        edges {
+          node {
+            id
+            ...ProductCard_product
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetches the first page of the product catalog with `useLazyLoadQuery` and
+ * renders a `ProductCard` (a `useFragment` child) per edge.
+ *
+ * The hook suspends while the query is in flight, so render this component
+ * inside a `Suspense` boundary — and, until the SSR data-serialization PR
+ * lands, only on the client (see `CatalogPage`).
+ */
+export default function ProductList(): ReactElement {
+  const data = useLazyLoadQuery<ProductListQuery>(productListQuery, {
+    count: PAGE_SIZE,
+  });
+  const { products } = data.viewer;
+
+  return (
+    <section aria-label="Product catalog">
+      <p>
+        Signed in as <strong>{data.viewer.name}</strong> — showing{" "}
+        {products.edges.length} of {products.totalCount} products.
+      </p>
+      <ul>
+        {products.edges.map(({ node }) => (
+          <li key={node.id}>
+            <ProductCard product={node} />
+          </li>
+        ))}
+      </ul>
+      {products.pageInfo.hasNextPage && <p>More products are available.</p>}
+    </section>
+  );
+}

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/routes.ts
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/routes.ts
@@ -1,0 +1,11 @@
+import { route } from "@canonical/router-core";
+import CatalogPage from "./CatalogPage.js";
+
+const routes = {
+  catalog: route({
+    url: "/catalog",
+    content: CatalogPage,
+  }),
+} as const;
+
+export default routes;

--- a/packages/summon/application/src/application/react/templates/src/lib/ClientOnly/ClientOnly.tests.tsx
+++ b/packages/summon/application/src/application/react/templates/src/lib/ClientOnly/ClientOnly.tests.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import ClientOnly from "./ClientOnly.js";
+
+describe("ClientOnly component", () => {
+  it("renders children after mounting in the browser", () => {
+    render(
+      <ClientOnly fallback={<p>Loading…</p>}>
+        <p>Client content</p>
+      </ClientOnly>,
+    );
+    expect(screen.getByText("Client content")).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  });
+
+  it("renders the fallback when server-rendered", () => {
+    const html = renderToString(
+      <ClientOnly fallback={<p>Loading…</p>}>
+        <p>Client content</p>
+      </ClientOnly>,
+    );
+    expect(html).toContain("Loading…");
+    expect(html).not.toContain("Client content");
+  });
+
+  it("renders nothing on the server without a fallback", () => {
+    const html = renderToString(
+      <ClientOnly>
+        <p>Client content</p>
+      </ClientOnly>,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/packages/summon/application/src/application/react/templates/src/lib/ClientOnly/ClientOnly.tsx
+++ b/packages/summon/application/src/application/react/templates/src/lib/ClientOnly/ClientOnly.tsx
@@ -1,0 +1,31 @@
+import { type ReactElement, type ReactNode, useEffect, useState } from "react";
+
+export interface ClientOnlyProps {
+  /** Content rendered only after the component mounts in the browser. */
+  readonly children: ReactNode;
+  /** Rendered during SSR and the initial hydration pass. Defaults to nothing. */
+  readonly fallback?: ReactNode;
+}
+
+/**
+ * Defers `children` until after hydration, so they render only in the browser.
+ *
+ * The server (and React's first client pass, so hydration stays
+ * mismatch-free) renders `fallback`; the mount effect then flips to
+ * `children`. Use this for content that must not run during server
+ * rendering — e.g. components that fetch on render, like the Relay example
+ * on the catalog page, until server-side data serialization/hydration lands
+ * in a follow-up PR.
+ */
+export default function ClientOnly({
+  children,
+  fallback = null,
+}: ClientOnlyProps): ReactElement {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return <>{isMounted ? children : fallback}</>;
+}

--- a/packages/summon/application/src/application/react/templates/src/lib/ClientOnly/index.ts
+++ b/packages/summon/application/src/application/react/templates/src/lib/ClientOnly/index.ts
@@ -1,0 +1,1 @@
+export { type ClientOnlyProps, default } from "./ClientOnly.js";

--- a/packages/summon/application/src/application/react/templates/src/lib/Navigation/Navigation.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/lib/Navigation/Navigation.tsx.ejs
@@ -9,6 +9,9 @@ export default function Navigation(): ReactElement {
       <Link params={{ slug: "router-core" }} to="guide">
         Guide
       </Link>
+<% if (relay) { -%>
+      <Link to="catalog">Catalog</Link>
+<% } -%>
 <% if (forms) { -%>
       <Link to="contact">Contact</Link>
 <% } -%>

--- a/packages/summon/application/src/application/react/templates/src/lib/index.ts.ejs
+++ b/packages/summon/application/src/application/react/templates/src/lib/index.ts.ejs
@@ -1,3 +1,6 @@
+<% if (relay) { -%>
+export { default as ClientOnly } from "./ClientOnly/index.js";
+<% } -%>
 export { ExampleComponent } from "./ExampleComponent/index.js";
 export { default as LazyComponent } from "./LazyComponent/index.js";
 export { default as Navigation } from "./Navigation/index.js";

--- a/packages/summon/application/src/application/react/templates/src/relay/__generated__/ProductCard_product.graphql.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/__generated__/ProductCard_product.graphql.ts
@@ -1,0 +1,82 @@
+/**
+ * @generated SignedSource<<a6fcbf029d2f62fcf6f378581e4985a3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ProductCard_product$data = {
+  readonly currency: string;
+  readonly inStock: boolean;
+  readonly name: string;
+  readonly priceCents: number;
+  readonly rating: number;
+  readonly tagline: string;
+  readonly " $fragmentType": "ProductCard_product";
+};
+export type ProductCard_product$key = {
+  readonly " $data"?: ProductCard_product$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ProductCard_product">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ProductCard_product",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tagline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "priceCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currency",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "rating",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "inStock",
+      "storageKey": null
+    }
+  ],
+  "type": "Product",
+  "abstractKey": null
+};
+
+(node as any).hash = "542f84e3fd8c5cc8222c4d637a9ee99d";
+
+export default node;

--- a/packages/summon/application/src/application/react/templates/src/relay/__generated__/ProductListQuery.graphql.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/__generated__/ProductListQuery.graphql.ts
@@ -1,0 +1,272 @@
+/**
+ * @generated SignedSource<<dce8cdbb66e817eb63b1c8d044cdd730>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ProductListQuery$variables = {
+  count: number;
+  cursor?: string | null | undefined;
+};
+export type ProductListQuery$data = {
+  readonly viewer: {
+    readonly name: string;
+    readonly products: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"ProductCard_product">;
+        };
+      }>;
+      readonly pageInfo: {
+        readonly hasNextPage: boolean;
+      };
+      readonly totalCount: number;
+    };
+  };
+};
+export type ProductListQuery = {
+  response: ProductListQuery$data;
+  variables: ProductListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "count"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "cursor"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "count"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "totalCount",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProductListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "ProductConnection",
+            "kind": "LinkedField",
+            "name": "products",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProductEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Product",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "ProductCard_product"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProductListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "ProductConnection",
+            "kind": "LinkedField",
+            "name": "products",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProductEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Product",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "tagline",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "priceCents",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "currency",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "rating",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "inStock",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "57efd1ef4c828e58566c12be84d1987b",
+    "id": null,
+    "metadata": {},
+    "name": "ProductListQuery",
+    "operationKind": "query",
+    "text": "query ProductListQuery(\n  $count: Int!\n  $cursor: String\n) {\n  viewer {\n    name\n    products(first: $count, after: $cursor) {\n      totalCount\n      pageInfo {\n        hasNextPage\n      }\n      edges {\n        node {\n          id\n          ...ProductCard_product\n        }\n      }\n    }\n  }\n}\n\nfragment ProductCard_product on Product {\n  name\n  tagline\n  priceCents\n  currency\n  rating\n  inStock\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c95b3cfceaf197d5391b4d63a8c1ed36";
+
+export default node;

--- a/packages/summon/application/src/application/react/templates/src/relay/environment.tests.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/environment.tests.ts
@@ -1,0 +1,87 @@
+import { fetchQuery } from "relay-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import productListQueryNode, {
+  type ProductListQuery,
+} from "./__generated__/ProductListQuery.graphql.js";
+import { createEnvironment } from "./environment.js";
+import { CATALOG_PRODUCTS } from "./schema.js";
+
+/** Minimal valid GraphQL payload for {@link ProductListQuery}. */
+const ENDPOINT_PAYLOAD = {
+  data: {
+    viewer: {
+      name: "Endpoint Viewer",
+      products: {
+        totalCount: 0,
+        pageInfo: { hasNextPage: false },
+        edges: [],
+      },
+    },
+  },
+};
+
+const fetchProductList = (environment: ReturnType<typeof createEnvironment>) =>
+  fetchQuery<ProductListQuery>(environment, productListQueryNode, {
+    count: 2,
+  }).toPromise();
+
+describe("createEnvironment", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("executes operations against the local mock schema by default", async () => {
+    const data = await fetchProductList(createEnvironment());
+
+    expect(data?.viewer.name).toBe("Ada Lovelace");
+    expect(data?.viewer.products.totalCount).toBe(CATALOG_PRODUCTS.length);
+    expect(data?.viewer.products.edges).toHaveLength(2);
+    expect(data?.viewer.products.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it("posts operations to the endpoint when a URL is passed", async () => {
+    const fetchSpy = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(async () => Response.json(ENDPOINT_PAYLOAD, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const data = await fetchProductList(
+      createEnvironment({ graphqlUrl: "https://api.example.test/graphql" }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://api.example.test/graphql",
+    );
+    expect(data?.viewer.name).toBe("Endpoint Viewer");
+  });
+
+  it("reads the endpoint URL from VITE_GRAPHQL_URL", async () => {
+    const fetchSpy = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(async () => Response.json(ENDPOINT_PAYLOAD, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubEnv("VITE_GRAPHQL_URL", "https://env.example.test/graphql");
+
+    await fetchProductList(createEnvironment());
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://env.example.test/graphql",
+    );
+  });
+
+  it("keeps stores independent across environments", async () => {
+    const first = createEnvironment();
+    const second = createEnvironment();
+    await fetchProductList(first);
+
+    expect(first.getStore().getSource().getRecordIDs().length).toBeGreaterThan(
+      1,
+    );
+    // An untouched store holds only Relay's client root record.
+    expect(second.getStore().getSource().getRecordIDs()).toEqual([
+      "client:root",
+    ]);
+  });
+});

--- a/packages/summon/application/src/application/react/templates/src/relay/environment.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/environment.ts
@@ -1,0 +1,119 @@
+/**
+ * Relay environment factory.
+ *
+ * Builds the app's Relay `Environment` on top of `relay-runtime-network`'s
+ * middleware-driven fetch pipeline, in one of two modes:
+ *
+ * - **local (default)** — a `localGraphExecutor` resolves every operation
+ *   in-process against the mock catalog schema (`./schema.ts`), so the
+ *   boilerplate runs with zero backend.
+ * - **endpoint** — when `VITE_GRAPHQL_URL` is set (or a URL is passed
+ *   explicitly), an `httpExecutor` + `urlMiddleware` posts operations to a
+ *   real GraphQL server.
+ */
+
+import {
+  Environment,
+  type FetchFunction,
+  type GraphQLResponse,
+  Network,
+  RecordSource,
+  Store,
+} from "relay-runtime";
+import {
+  createRelayRuntimeNetwork,
+  httpExecutor,
+  localGraphExecutor,
+  type RelayFetchContext,
+  type RelayRuntimeFetch,
+  urlMiddleware,
+} from "relay-runtime-network";
+
+/** Options for {@link createEnvironment}. */
+export interface CreateEnvironmentOptions {
+  /**
+   * GraphQL endpoint URL. Overrides the `VITE_GRAPHQL_URL` env var; when
+   * neither is set the environment executes against the local mock schema.
+   */
+  readonly graphqlUrl?: string;
+}
+
+/** Reads the endpoint URL from Vite's env, treating the empty string as unset. */
+const readConfiguredGraphqlUrl = (): string | undefined => {
+  const configured: unknown = import.meta.env.VITE_GRAPHQL_URL;
+  return typeof configured === "string" && configured.length > 0
+    ? configured
+    : undefined;
+};
+
+/**
+ * Builds the in-process network that executes against the mock schema.
+ *
+ * The schema module (and its `graphql` dependency) is loaded lazily inside
+ * the executor — `execute` already returns a promise, so the dynamic import
+ * adds no async boundary — keeping graphql-js and the mock catalog out of
+ * the main bundle, and unparsed, whenever the endpoint path is taken.
+ */
+const createLocalNetwork = () =>
+  createRelayRuntimeNetwork({
+    fetch: {
+      executor: localGraphExecutor({
+        execute: async (context: RelayFetchContext) => {
+          const { text } = context.operation;
+          if (!text) {
+            throw new Error(
+              "The local mock schema requires full operation text; persisted queries are not supported.",
+            );
+          }
+          const { executeLocalOperation } = await import("./schema.js");
+          return executeLocalOperation({
+            text,
+            variables: context.variables,
+          });
+        },
+      }),
+    },
+  });
+
+/** Builds the HTTP network that posts operations to `graphqlUrl`. */
+const createHttpNetwork = (graphqlUrl: string) =>
+  createRelayRuntimeNetwork({
+    fetch: {
+      executor: httpExecutor(),
+      middlewares: [urlMiddleware({ url: graphqlUrl })],
+    },
+  });
+
+/**
+ * Adapts the pipeline's fetch to relay-runtime's `FetchFunction`. Both
+ * describe the same GraphQL response wire shape, but relay-runtime types the
+ * payload as `PayloadData` where the pipeline says `unknown`, and takes its
+ * cache config as an interface where the pipeline wants a plain record —
+ * hence the spread and the single response cast at this library boundary.
+ */
+const toFetchFunction =
+  (fetchGraphQL: RelayRuntimeFetch): FetchFunction =>
+  (params, variables, cacheConfig) =>
+    fetchGraphQL(params, variables, {
+      ...cacheConfig,
+    }) as Promise<GraphQLResponse>;
+
+/**
+ * Creates a Relay `Environment` for the app.
+ *
+ * Call once per browser session (module scope in the client entry) and once
+ * per request on the server, so no store state leaks across requests.
+ */
+export const createEnvironment = (
+  options: CreateEnvironmentOptions = {},
+): Environment => {
+  const graphqlUrl = options.graphqlUrl ?? readConfiguredGraphqlUrl();
+  const network = graphqlUrl
+    ? createHttpNetwork(graphqlUrl)
+    : createLocalNetwork();
+
+  return new Environment({
+    network: Network.create(toFetchFunction(network.fetch)),
+    store: new Store(new RecordSource()),
+  });
+};

--- a/packages/summon/application/src/application/react/templates/src/relay/schema.graphql
+++ b/packages/summon/application/src/application/react/templates/src/relay/schema.graphql
@@ -1,0 +1,111 @@
+# Mock GraphQL schema for the Relay data-layer example.
+#
+# A compact catalog domain, shaped the Relay way: an object identification
+# `Node` interface with globally unique IDs, a `viewer` root field as the
+# entry point, and one paginated connection (`Viewer.products`) following the
+# Relay Cursor Connections specification. `relay-compiler` validates queries
+# against this file (see relay.config.json); `schema.ts` makes it executable
+# against an in-memory dataset so the app runs without a GraphQL backend.
+
+"""
+An object with a globally unique ID, per the Relay object identification spec.
+"""
+interface Node {
+  """
+  The globally unique ID of the object.
+  """
+  id: ID!
+}
+
+"""
+The authenticated entry point into the graph.
+"""
+type Viewer {
+  """
+  Display name of the current user.
+  """
+  name: String!
+
+  """
+  Products in the catalog, paginated forwards through a connection.
+  """
+  products(first: Int, after: String): ProductConnection!
+}
+
+"""
+A product in the catalog.
+"""
+type Product implements Node {
+  id: ID!
+
+  """
+  Human-readable product name.
+  """
+  name: String!
+
+  """
+  One-line marketing description.
+  """
+  tagline: String!
+
+  """
+  Price in the minor unit of `currency` (e.g. cents).
+  """
+  priceCents: Int!
+
+  """
+  ISO 4217 currency code for `priceCents`.
+  """
+  currency: String!
+
+  """
+  Average review rating, from 0.0 to 5.0.
+  """
+  rating: Float!
+
+  """
+  Whether the product can currently be ordered.
+  """
+  inStock: Boolean!
+}
+
+"""
+A page of products and the cursors to continue paginating.
+"""
+type ProductConnection {
+  edges: [ProductEdge!]!
+  pageInfo: PageInfo!
+
+  """
+  Total number of products in the catalog, across all pages.
+  """
+  totalCount: Int!
+}
+
+"""
+A product plus the opaque cursor identifying its position.
+"""
+type ProductEdge {
+  cursor: String!
+  node: Product!
+}
+
+"""
+Forward-pagination info per the Relay connection specification.
+"""
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+}
+
+type Query {
+  """
+  Fetches an object by its globally unique ID.
+  """
+  node(id: ID!): Node
+
+  """
+  The entry point for the current user's view of the graph.
+  """
+  viewer: Viewer!
+}

--- a/packages/summon/application/src/application/react/templates/src/relay/schema.tests.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/schema.tests.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { CATALOG_PRODUCTS, executeLocalOperation } from "./schema.js";
+
+interface ProductsPage {
+  readonly viewer: {
+    readonly products: {
+      readonly edges: readonly {
+        readonly cursor: string;
+        readonly node: { readonly id: string; readonly name: string };
+      }[];
+      readonly pageInfo: {
+        readonly endCursor: string | null;
+        readonly hasNextPage: boolean;
+      };
+      readonly totalCount: number;
+    };
+  };
+}
+
+const PRODUCTS_QUERY = `
+  query SchemaTestsProductsQuery($first: Int, $after: String) {
+    viewer {
+      products(first: $first, after: $after) {
+        edges {
+          cursor
+          node {
+            id
+            name
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        totalCount
+      }
+    }
+  }
+`;
+
+const fetchProductsPage = async (variables: {
+  first?: number;
+  after?: string;
+}): Promise<ProductsPage> => {
+  const result = await executeLocalOperation({
+    text: PRODUCTS_QUERY,
+    variables,
+  });
+  expect(result.errors).toBeUndefined();
+  return result.data as ProductsPage;
+};
+
+describe("executeLocalOperation", () => {
+  it("resolves the viewer with the first page of products", async () => {
+    const data = await fetchProductsPage({ first: 2 });
+    const { products } = data.viewer;
+
+    expect(products.totalCount).toBe(CATALOG_PRODUCTS.length);
+    expect(products.edges.map((edge) => edge.node.name)).toEqual([
+      CATALOG_PRODUCTS[0]?.name,
+      CATALOG_PRODUCTS[1]?.name,
+    ]);
+    expect(products.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it("paginates forward from an end cursor without gaps or overlap", async () => {
+    const firstPage = await fetchProductsPage({ first: 2 });
+    const { endCursor } = firstPage.viewer.products.pageInfo;
+    expect(endCursor).not.toBeNull();
+
+    const secondPage = await fetchProductsPage({
+      first: 2,
+      after: endCursor as string,
+    });
+    expect(
+      secondPage.viewer.products.edges.map((edge) => edge.node.id),
+    ).toEqual([CATALOG_PRODUCTS[2]?.id, CATALOG_PRODUCTS[3]?.id]);
+  });
+
+  it("reports the end of the catalog", async () => {
+    const page = await fetchProductsPage({ first: CATALOG_PRODUCTS.length });
+    expect(page.viewer.products.pageInfo.hasNextPage).toBe(false);
+    expect(page.viewer.products.edges).toHaveLength(CATALOG_PRODUCTS.length);
+  });
+
+  it("rejects malformed cursors as a GraphQL error", async () => {
+    const result = await executeLocalOperation({
+      text: PRODUCTS_QUERY,
+      variables: { first: 1, after: "not-a-cursor" },
+    });
+    expect(result.errors?.[0]?.message).toContain("Invalid cursor");
+  });
+
+  it("rejects negative cursor indices that encodeCursor can never produce", async () => {
+    const result = await executeLocalOperation({
+      text: PRODUCTS_QUERY,
+      variables: { first: 1, after: "cursor:-1" },
+    });
+    expect(result.errors?.[0]?.message).toContain("Invalid cursor");
+  });
+
+  it("looks up nodes by global ID and misses unknown IDs", async () => {
+    const nodeQuery = `
+      query SchemaTestsNodeQuery($id: ID!) {
+        node(id: $id) {
+          id
+          ... on Product {
+            name
+          }
+        }
+      }
+    `;
+    const target = CATALOG_PRODUCTS[3];
+
+    const hit = await executeLocalOperation({
+      text: nodeQuery,
+      variables: { id: target?.id },
+    });
+    expect(hit.data).toEqual({
+      node: { id: target?.id, name: target?.name },
+    });
+
+    const miss = await executeLocalOperation({
+      text: nodeQuery,
+      variables: { id: "Product:does-not-exist" },
+    });
+    expect(miss.data).toEqual({ node: null });
+  });
+
+  it("returns validation problems as GraphQL errors, not exceptions", async () => {
+    const result = await executeLocalOperation({
+      text: "query SchemaTestsInvalidQuery { nope }",
+    });
+    expect(result.data).toBeNull();
+    expect(result.errors?.[0]?.message).toContain("nope");
+  });
+});

--- a/packages/summon/application/src/application/react/templates/src/relay/schema.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/schema.ts
@@ -1,0 +1,205 @@
+/**
+ * Executable mock schema for the Relay data layer.
+ *
+ * Builds the SDL in ./schema.graphql into a graphql-js schema backed by a
+ * small, deterministic in-memory catalog, so the app (and its tests and
+ * Storybook) can execute real GraphQL operations without a backend. The
+ * dataset is static — no randomness, no clocks — which keeps unit tests and
+ * visual tests reproducible.
+ *
+ * (The file name above is deliberately not backtick-quoted:
+ * vite-plugin-relay-lite's tag scanner matches the word "graphql" followed
+ * by a backtick even inside comments, and would try to parse what follows
+ * as a GraphQL document.)
+ */
+
+import { buildSchema, GraphQLError, graphql } from "graphql";
+import schemaSource from "./schema.graphql?raw";
+
+/** A product row in the in-memory catalog. */
+export interface ProductRecord {
+  /** Discriminant used by graphql-js to resolve the `Node` interface. */
+  readonly __typename: "Product";
+  readonly id: string;
+  readonly name: string;
+  readonly tagline: string;
+  readonly priceCents: number;
+  readonly currency: string;
+  readonly rating: number;
+  readonly inStock: boolean;
+}
+
+/**
+ * The full catalog, in stable order. IDs follow the `Product:{n}` global-ID
+ * convention consumed by `Query.node`; they are opaque to clients.
+ */
+export const CATALOG_PRODUCTS: readonly ProductRecord[] = [
+  {
+    __typename: "Product",
+    id: "Product:1",
+    name: "Vanguard Workstation",
+    tagline: "A certified Ubuntu desktop for heavy compilation workloads",
+    priceCents: 189_900,
+    currency: "USD",
+    rating: 4.7,
+    inStock: true,
+  },
+  {
+    __typename: "Product",
+    id: "Product:2",
+    name: "Meridian Laptop 14",
+    tagline: "Thin, quiet, and pre-loaded with your team's golden image",
+    priceCents: 129_900,
+    currency: "USD",
+    rating: 4.5,
+    inStock: true,
+  },
+  {
+    __typename: "Product",
+    id: "Product:3",
+    name: "Beacon Micro Server",
+    tagline: "A fanless edge node that fits in a network cabinet",
+    priceCents: 64_900,
+    currency: "USD",
+    rating: 4.2,
+    inStock: false,
+  },
+  {
+    __typename: "Product",
+    id: "Product:4",
+    name: "Atlas Rack Server",
+    tagline: "Dense compute for private-cloud deployments",
+    priceCents: 449_900,
+    currency: "USD",
+    rating: 4.8,
+    inStock: true,
+  },
+  {
+    __typename: "Product",
+    id: "Product:5",
+    name: "Harbor NAS Enclosure",
+    tagline: "Four bays of quiet, snapshot-friendly storage",
+    priceCents: 89_900,
+    currency: "USD",
+    rating: 4.1,
+    inStock: true,
+  },
+  {
+    __typename: "Product",
+    id: "Product:6",
+    name: "Relay IoT Gateway",
+    tagline: "Bridges field sensors onto your message bus securely",
+    priceCents: 29_900,
+    currency: "USD",
+    rating: 3.9,
+    inStock: false,
+  },
+];
+
+const productsById = new Map(
+  CATALOG_PRODUCTS.map((product) => [product.id, product]),
+);
+
+const CURSOR_PREFIX = "cursor:";
+
+/** Encodes a catalog index as an opaque connection cursor. */
+const encodeCursor = (index: number): string => `${CURSOR_PREFIX}${index}`;
+
+/** Decodes a connection cursor back to a catalog index; rejects foreign cursors. */
+const decodeCursor = (cursor: string): number => {
+  const index = Number(cursor.slice(CURSOR_PREFIX.length));
+  if (
+    !cursor.startsWith(CURSOR_PREFIX) ||
+    !Number.isInteger(index) ||
+    index < 0
+  ) {
+    throw new GraphQLError(`Invalid cursor: ${cursor}`);
+  }
+  return index;
+};
+
+interface ProductsArguments {
+  readonly first?: number | null;
+  readonly after?: string | null;
+}
+
+/**
+ * Resolves `Viewer.products` with honest forward cursor pagination: `after`
+ * positions the window just past the given cursor, `first` bounds its size,
+ * and `pageInfo` reflects whether more of the catalog remains.
+ */
+const resolveProducts = ({ first, after }: ProductsArguments) => {
+  if (typeof first === "number" && first < 0) {
+    throw new GraphQLError(
+      `Argument "first" must be non-negative, got ${first}`,
+    );
+  }
+  const startIndex = after == null ? 0 : decodeCursor(after) + 1;
+  const endIndex = first == null ? CATALOG_PRODUCTS.length : startIndex + first;
+  const edges = CATALOG_PRODUCTS.slice(startIndex, endIndex).map(
+    (node, offset) => ({
+      cursor: encodeCursor(startIndex + offset),
+      node,
+    }),
+  );
+
+  return {
+    edges,
+    pageInfo: {
+      endCursor: edges.at(-1)?.cursor ?? null,
+      hasNextPage: startIndex + edges.length < CATALOG_PRODUCTS.length,
+    },
+    totalCount: CATALOG_PRODUCTS.length,
+  };
+};
+
+const schema = buildSchema(schemaSource);
+
+// Root value for graphql-js's default field resolver: root fields are
+// functions receiving the field arguments, and `Viewer.products` is a method
+// on the viewer object for the same reason. `Node` resolution relies on the
+// `__typename` discriminant each record carries.
+const rootValue = {
+  node: ({ id }: { id: string }) => productsById.get(id) ?? null,
+  viewer: () => ({
+    name: "Ada Lovelace",
+    products: (args: ProductsArguments) => resolveProducts(args),
+  }),
+};
+
+/** Input for {@link executeLocalOperation}. */
+export interface ExecuteLocalOperationOptions {
+  /** Full GraphQL source text of the operation. */
+  readonly text: string;
+  /** Variable values for the operation. */
+  readonly variables?: Record<string, unknown>;
+}
+
+/** Result shape of {@link executeLocalOperation} — a standard GraphQL response. */
+export interface LocalOperationResult {
+  readonly data?: unknown;
+  readonly errors?: readonly { readonly message: string }[];
+}
+
+/**
+ * Executes a GraphQL operation against the in-memory catalog schema.
+ *
+ * This is the execution half of the mock backend: `relay.config.json` points
+ * the compiler at ./schema.graphql for validation and codegen, and the Relay
+ * environment's local executor calls this function at runtime.
+ */
+export const executeLocalOperation = async (
+  options: ExecuteLocalOperationOptions,
+): Promise<LocalOperationResult> => {
+  const result = await graphql({
+    schema,
+    source: options.text,
+    variableValues: options.variables,
+    rootValue,
+  });
+
+  return {
+    data: result.data ?? null,
+    errors: result.errors?.map((error) => error.toJSON()),
+  };
+};

--- a/packages/summon/application/src/application/react/templates/src/routes.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/routes.tsx.ejs
@@ -10,6 +10,9 @@ import {
 } from "@canonical/router-core";
 import type { ReactElement, ReactNode } from "react";
 import accountRoutes from "#domains/account/routes.js";
+<% if (relay) { -%>
+import catalogRoutes from "#domains/catalog/routes.js";
+<% } -%>
 <% if (forms) { -%>
 import contactRoutes from "#domains/contact/routes.js";
 <% } -%>
@@ -106,6 +109,10 @@ const [account, login] = group(publicLayout, [
 const [contact] = group(publicLayout, [contactRoutes.contact] as const);
 
 <% } -%>
+<% if (relay) { -%>
+const [catalog] = group(publicLayout, [catalogRoutes.catalog] as const);
+
+<% } -%>
 const appRoutes = {
   guide,
   home,
@@ -113,6 +120,9 @@ const appRoutes = {
   login,
 <% if (forms) { -%>
   contact,
+<% } -%>
+<% if (relay) { -%>
+  catalog,
 <% } -%>
 } as const;
 

--- a/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
@@ -2,6 +2,10 @@ import { HeadProvider } from "@canonical/react-head";
 import type { ServerEntrypointProps } from "@canonical/react-ssr/renderer";
 import { createStaticRouter } from "@canonical/router-core";
 import { Outlet, RouterProvider } from "@canonical/router-react";
+<% if (relay) { -%>
+import { RelayEnvironmentProvider } from "react-relay";
+import { createEnvironment } from "#relay/environment.js";
+<% } -%>
 import { appRoutes, middleware, notFoundRoute } from "../routes.js";
 import "#styles/app.css";
 
@@ -18,10 +22,41 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
     middleware: [...middleware],
     notFound: notFoundRoute,
   });
+<% if (relay) { -%>
+
+  // A fresh Relay environment per server render, so no store state leaks
+  // between requests. Nothing fetches through it yet: components that issue
+  // queries are wrapped in `ClientOnly` (see CatalogPage) until data
+  // serialization/hydration is supported; the provider is here so any
+  // component touching Relay context renders without branching on runtime.
+  const relayEnvironment = createEnvironment();
+<% } -%>
 
   // Paint the cookie-resolved theme on <html> for a flash-free first render —
   // the same element `usePreferredTheme` toggles on the client, and one React
   // does not hydrate (only `#root` is), so there is no mismatch to reconcile.
+<% if (relay) { -%>
+  return (
+    <html lang={props.lang} className={initialData.theme}>
+      <head>
+        {props.otherHeadElements}
+        {props.scriptElements}
+        {props.linkElements}
+      </head>
+      <body>
+        <div id="root">
+          <HeadProvider>
+            <RelayEnvironmentProvider environment={relayEnvironment}>
+              <RouterProvider router={router}>
+                <Outlet fallback={<p>Loading…</p>} />
+              </RouterProvider>
+            </RelayEnvironmentProvider>
+          </HeadProvider>
+        </div>
+      </body>
+    </html>
+  );
+<% } else { -%>
   return (
     <html lang={props.lang} className={initialData.theme}>
       <head>
@@ -40,6 +75,7 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
       </body>
     </html>
   );
+<% } -%>
 }
 
 export type { InitialData };

--- a/packages/summon/application/src/application/react/templates/src/sitemap/getSitemapItems.ts.ejs
+++ b/packages/summon/application/src/application/react/templates/src/sitemap/getSitemapItems.ts.ejs
@@ -22,6 +22,9 @@ export default async function getSitemapItems(): Promise<SitemapItem[]> {
   return [
     { loc: "/", changefreq: "weekly", priority: 1.0 },
     { loc: "/guides/router-core", changefreq: "monthly", priority: 0.8 },
+<% if (relay) { -%>
+    { loc: "/catalog", changefreq: "weekly", priority: 0.7 },
+<% } -%>
 <% if (forms) { -%>
     { loc: "/contact", changefreq: "monthly", priority: 0.7 },
 <% } -%>

--- a/packages/summon/application/src/application/react/templates/tsconfig.json.ejs
+++ b/packages/summon/application/src/application/react/templates/tsconfig.json.ejs
@@ -15,6 +15,9 @@
     "paths": {
       "#lib/*": ["./lib/*"],
       "#domains/*": ["./domains/*"],
+<% if (relay) { -%>
+      "#relay/*": ["./relay/*"],
+<% } -%>
       "#styles/*": ["./styles/*"]
     }
   },

--- a/packages/summon/application/src/application/react/templates/vite.config.ts.ejs
+++ b/packages/summon/application/src/application/react/templates/vite.config.ts.ejs
@@ -1,5 +1,8 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+<% if (relay) { -%>
+import relay from "vite-plugin-relay-lite";
+<% } -%>
 
 // Path aliases (#lib, #domains, #styles) are declared as Node subpath imports
 // in package.json "imports" and resolved natively by Vite — no resolver plugin.
@@ -13,7 +16,22 @@ const PORT = Number(process.env.PORT) || undefined;
 // (`dev`, `build:client`, `preview`) uses the default mode and the SPA client
 // build (`--ssrManifest --outDir dist/client`).
 export default defineConfig(({ mode }) => ({
+<% if (relay) { -%>
+  // Relay's `graphql\`...\`` tags must be rewritten into imports of the
+  // compiler-generated artifacts. `@vitejs/plugin-react` v6 is OXC-based (no
+  // Babel), so the classic `babel-plugin-relay` route would need the
+  // `@rolldown/plugin-babel` escape hatch; `vite-plugin-relay-lite` does the
+  // same rewrite with its own parser and no Babel, and works on Vite 8 /
+  // rolldown despite its peer range stopping at Vite 7 (bun installs it with
+  // only a peer-version warning). Footgun: its tag scanner matches the word
+  // "graphql" followed by a backtick even inside comments, so never
+  // backtick-quote a graphql file name in a comment. `codegen: false` because
+  // artifacts are committed and regenerated explicitly via the `relay` /
+  // `relay:watch` scripts.
+  plugins: [relay({ codegen: false }), react()],
+<% } else { -%>
   plugins: [react()],
+<% } -%>
   // Honour the PORT env var for `dev` (SPA) and `preview` so all server scripts
   // — including the SSR ones, which already read PORT — respond to it uniformly.
   server: { port: PORT },
@@ -40,6 +58,16 @@ export default defineConfig(({ mode }) => ({
     // which Node cannot load (ERR_UNKNOWN_FILE_EXTENSION) but Vite's SSR
     // transform no-ops. The regex covers the whole scope so any current or
     // future @canonical dependency is handled.
+<% if (relay) { -%>
+    //
+    // The Relay packages (react-relay, relay-runtime, relay-runtime-network,
+    // graphql) stay externalised like react itself. Two packaging defects
+    // made that possible and are fixed via `patchedDependencies` (see
+    // patches/): react-relay's CJS exports are member expressions
+    // cjs-module-lexer cannot detect (breaking named imports under Node SSR
+    // and Vite's dev module runner), and relay-runtime-network@0.1.0 ships an
+    // `imports` map pointing at its unpublished src/ directory.
+<% } -%>
     noExternal: [/^@canonical\//],
   },
 }));

--- a/packages/summon/application/src/application/react/templates/vitest.setup.ts
+++ b/packages/summon/application/src/application/react/templates/vitest.setup.ts
@@ -1,9 +1,0 @@
-import * as matchers from "@testing-library/jest-dom/matchers";
-import { cleanup } from "@testing-library/react";
-import { afterEach, expect } from "vitest";
-
-expect.extend(matchers as unknown as Parameters<typeof expect.extend>[0]);
-
-afterEach(() => {
-  cleanup();
-});

--- a/packages/summon/application/src/application/react/templates/vitest.setup.ts.ejs
+++ b/packages/summon/application/src/application/react/templates/vitest.setup.ts.ejs
@@ -1,0 +1,22 @@
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { cleanup } from "@testing-library/react";
+<% if (relay) { -%>
+import { afterEach, expect, vi } from "vitest";
+<% } else { -%>
+import { afterEach, expect } from "vitest";
+<% } -%>
+
+expect.extend(matchers as unknown as Parameters<typeof expect.extend>[0]);
+<% if (relay) { -%>
+
+// relay-test-utils' `createMockEnvironment` wraps environment methods in
+// `jest.fn` mocks whenever NODE_ENV === "test", reaching for a global `jest`
+// object. Vitest sets NODE_ENV=test but exposes `vi` instead, so alias it —
+// `vi.fn` is API-compatible with the `jest.fn` surface relay-test-utils uses
+// (`.mock`, `.mockClear`).
+(globalThis as { jest?: typeof vi }).jest = vi;
+<% } -%>
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/summon/application/src/index.test.ts
+++ b/packages/summon/application/src/index.test.ts
@@ -28,6 +28,7 @@ describe("application/react generator", () => {
         ssr: true,
         router: true,
         forms: false,
+        relay: false,
         runInstall: false,
       }),
     );
@@ -116,6 +117,7 @@ describe("application/react generator", () => {
         ssr: true,
         router: true,
         forms: true,
+        relay: true,
         runInstall: false,
       }),
     );
@@ -143,6 +145,7 @@ describe("application/react generator", () => {
         ssr: true,
         router: true,
         forms: true,
+        relay: false,
         runInstall: false,
       }),
     );
@@ -176,6 +179,7 @@ describe("application/react generator", () => {
         ssr: true,
         router: true,
         forms: false,
+        relay: false,
         runInstall: false,
       }),
     );
@@ -194,6 +198,107 @@ describe("application/react generator", () => {
     expect(filePaths).not.toContain("my-app/src/domains/contact/routes.ts");
   });
 
+  it("includes the relay layer, catalog domain, and patches when relay=true", () => {
+    const result = dryRun(
+      generators["application/react"].generate({
+        appPath: "my-app",
+        ssr: true,
+        router: true,
+        forms: false,
+        relay: true,
+        runInstall: false,
+      }),
+    );
+
+    const filePaths = result.effects
+      .filter((e) => e._tag === "WriteFile" || e._tag === "CopyFile")
+      .map(
+        (e) =>
+          (e as { path?: string; dest?: string }).path ??
+          (e as { dest?: string }).dest,
+      );
+
+    // Relay layer: compiler config, environment factory, executable mock
+    // schema, and the committed compiler artifacts.
+    expect(filePaths).toContain("my-app/relay.config.json");
+    expect(filePaths).toContain("my-app/src/relay/schema.graphql");
+    expect(filePaths).toContain("my-app/src/relay/schema.ts");
+    expect(filePaths).toContain("my-app/src/relay/schema.tests.ts");
+    expect(filePaths).toContain("my-app/src/relay/environment.ts");
+    expect(filePaths).toContain("my-app/src/relay/environment.tests.ts");
+    expect(filePaths).toContain(
+      "my-app/src/relay/__generated__/ProductCard_product.graphql.ts",
+    );
+    expect(filePaths).toContain(
+      "my-app/src/relay/__generated__/ProductListQuery.graphql.ts",
+    );
+
+    // Catalog example domain
+    expect(filePaths).toContain("my-app/src/domains/catalog/CatalogPage.tsx");
+    expect(filePaths).toContain("my-app/src/domains/catalog/ProductList.tsx");
+    expect(filePaths).toContain(
+      "my-app/src/domains/catalog/ProductList.stories.tsx",
+    );
+    expect(filePaths).toContain(
+      "my-app/src/domains/catalog/ProductList.tests.tsx",
+    );
+    expect(filePaths).toContain("my-app/src/domains/catalog/ProductCard.tsx");
+    expect(filePaths).toContain("my-app/src/domains/catalog/ErrorBoundary.tsx");
+    expect(filePaths).toContain(
+      "my-app/src/domains/catalog/ErrorBoundary.tests.tsx",
+    );
+    expect(filePaths).toContain("my-app/src/domains/catalog/routes.ts");
+
+    // ClientOnly SSR guard (relay is its only consumer today)
+    expect(filePaths).toContain("my-app/src/lib/ClientOnly/ClientOnly.tsx");
+    expect(filePaths).toContain(
+      "my-app/src/lib/ClientOnly/ClientOnly.tests.tsx",
+    );
+    expect(filePaths).toContain("my-app/src/lib/ClientOnly/index.ts");
+
+    // Standalone dependency patches applied via patchedDependencies
+    expect(filePaths).toContain("my-app/patches/react-relay@18.2.0.patch");
+    expect(filePaths).toContain(
+      "my-app/patches/relay-runtime-network@0.1.0.patch",
+    );
+  });
+
+  it("excludes the relay layer, catalog domain, and patches when relay=false", () => {
+    const result = dryRun(
+      generators["application/react"].generate({
+        appPath: "my-app",
+        ssr: true,
+        router: true,
+        forms: true,
+        relay: false,
+        runInstall: false,
+      }),
+    );
+
+    const filePaths = result.effects
+      .filter((e) => e._tag === "WriteFile" || e._tag === "CopyFile")
+      .map(
+        (e) =>
+          (e as { path?: string; dest?: string }).path ??
+          (e as { dest?: string }).dest,
+      );
+
+    // No src/relay/, no catalog domain, no ClientOnly, no patches.
+    expect(filePaths.filter((p) => p?.startsWith("my-app/src/relay/"))).toEqual(
+      [],
+    );
+    expect(
+      filePaths.filter((p) => p?.startsWith("my-app/src/domains/catalog/")),
+    ).toEqual([]);
+    expect(
+      filePaths.filter((p) => p?.startsWith("my-app/src/lib/ClientOnly/")),
+    ).toEqual([]);
+    expect(filePaths.filter((p) => p?.startsWith("my-app/patches/"))).toEqual(
+      [],
+    );
+    expect(filePaths).not.toContain("my-app/relay.config.json");
+  });
+
   it("uses the appPath in file paths", () => {
     const result = dryRun(
       generators["application/react"].generate({
@@ -201,6 +306,7 @@ describe("application/react generator", () => {
         ssr: true,
         router: true,
         forms: false,
+        relay: false,
         runInstall: false,
       }),
     );
@@ -225,6 +331,7 @@ describe("application/react generator", () => {
           ssr: false,
           router: true,
           forms: false,
+          relay: false,
           runInstall: false,
         }),
       ),
@@ -239,6 +346,7 @@ describe("application/react generator", () => {
           ssr: true,
           router: false,
           forms: false,
+          relay: false,
           runInstall: false,
         }),
       ),


### PR DESCRIPTION
## Done

Mirrors the reference app's Relay data layer (#751) into the `application/react` generator as an **opt-in `relay` confirm prompt / `--relay` flag, default `false`** — threaded exactly like `forms` (answers field → prompt → `withHelpers` → EJS conditionals → `when(answers.relay, …)` file gating).

- **New gated templates**: `src/relay/` (SDL + executable mock schema + environment factory + tests + committed `__generated__` artifacts), the `catalog` example domain (query/fragment components, ErrorBoundary, stories, tests), `src/lib/ClientOnly/`, `relay.config.json`, and — because scaffolded apps are standalone and can't inherit monorepo patches — `patches/react-relay@18.2.0.patch` + `patches/relay-runtime-network@0.1.0.patch` with `patchedDependencies` entries (the latter marked temporary pending advl/lit-relay#32's release).
- **`.ejs`-ified** (static → conditional): `vite.config.ts`, `tsconfig.json`, `vitest.setup.ts`, both entries (`RelayEnvironmentProvider`), `src/lib/index.ts`, `.storybook/main.ts` (`extraAddons`). Existing EJS updated: `package.json.ejs` (deps/scripts/`patchedDependencies`; addon pinned via `pragmaVersion` like other `@canonical` deps), `routes.tsx`, Navigation, sitemap, biome, README.
- **Docs**: generator README `--relay` section (with the honest caveat below) and `CONVENTIONS.md` **A11 — Data (Relay)** (A11.1–A11.7: layout, local-vs-endpoint environment, committed artifacts + explicit regeneration, colocated fragments, Suspense+ErrorBoundary pairing, ClientOnly pending SSR data, environment lifetimes).

**Known caveat, stated in both READMEs and empirically confirmed**: a scaffolded relay app's `bun install` fails today at `@canonical/storybook-addon-relay` (npm 404) — the flag becomes fully usable once the addon's first publish and the fixed `relay-runtime-network` release land.

## QA

```bash
bun run --filter @canonical/summon-application check   # biome + tsc + webarchitect
bun run --filter @canonical/summon-application test    # 29/29 — incl. relay gating tests + manifest completeness with relay:true
```

Plus real (non-dry-run) scaffolds: `--no-relay` output **byte-identical** to the pre-change generator; `--relay` scaffold inside the monorepo — `tsc --noEmit` clean, `vitest run` 20/20, biome clean.

### PR readiness check

- [ ] Suggested label: `Feature 🎁`, `no visual change`
- [x] PR title follows Conventional Commits
- [x] Follows code standards — biome, tsc, webarchitect

## Screenshots

N/A — generator templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nYyx5PtusgA8ZBJBWK7At

---
_Generated by [Claude Code](https://claude.ai/code/session_014nYyx5PtusgA8ZBJBWK7At)_