### PR TITLE
fix(ds-types): remove React-styled className from shared Item type

### DIFF
--- a/packages/ds-types/src/navigation/types.ts
+++ b/packages/ds-types/src/navigation/types.ts
@@ -39,12 +39,6 @@ export interface Item<C = DefaultComponent> {
   disabled?: boolean;
 
   /**
-   * CSS class name for custom styling of the item.
-   * e.g. 'nav-item-active' to highlight the current page.
-   */
-  className?: string;
-
-  /**
    * Array of child items for nested navigation structures.
    * e.g. Submenu items under a parent like 'Settings'.
    */

--- a/packages/ds-types/src/navigation/types.ts
+++ b/packages/ds-types/src/navigation/types.ts
@@ -1,19 +1,15 @@
 /**
- * Default component type for navigation items.
- * Framework-agnostic — consumers supply a concrete type
- * (e.g. React.ComponentType) via the generic parameter.
- */
-export type DefaultComponent = unknown;
-
-/**
  * Navigation item - Public API (WD405)
  *
  * A unified type for navigation items across the design system.
  * Used by Breadcrumbs, SiteNavigation, FileTree, MegaMenu, etc.
  *
- * @template C - Custom component type for rendering the item
+ * Only fields consumed by the shared navigation utilities belong here.
+ * Styling and rendering customization (CSS classes, custom renderers)
+ * belong on the item types that components declare by extending this
+ * one (e.g. BreadcrumbItem, MenuItem), using each framework's own idioms.
  */
-export interface Item<C = DefaultComponent> {
+export interface Item {
   /**
    * Unique identifier for the item when a URL is not provided.
    * e.g. 'section-header' for a non-navigable grouping item.
@@ -42,19 +38,13 @@ export interface Item<C = DefaultComponent> {
    * Array of child items for nested navigation structures.
    * e.g. Submenu items under a parent like 'Settings'.
    */
-  items?: Item<C>[];
+  items?: Item[];
 
   /**
    * Enum value determining the type of display for items.
    * e.g. 'list' for rendering as a simple list.
    */
   displayItemsType?: "default" | "custom";
-
-  /**
-   * Custom component for rendering the item itself.
-   * e.g. A specialized renderer for complex items.
-   */
-  Component?: C;
 }
 
 /**
@@ -65,8 +55,7 @@ export interface Item<C = DefaultComponent> {
  *
  * Generic over the **whole item type** `T` it annotates, so an enhanced item
  * (extra fields beyond the base WD405 `Item`, e.g. `icon`/`slot`) survives
- * annotation with its fields intact and fully typed. `T` may itself carry a
- * custom component type (`Item<C>`).
+ * annotation with its fields intact and fully typed.
  *
  * @template T - The item type being annotated (defaults to the base `Item`)
  */

--- a/packages/ds-types/src/navigation/types.ts
+++ b/packages/ds-types/src/navigation/types.ts
@@ -39,12 +39,6 @@ export interface Item {
    * e.g. Submenu items under a parent like 'Settings'.
    */
   items?: Item[];
-
-  /**
-   * Enum value determining the type of display for items.
-   * e.g. 'list' for rendering as a simple list.
-   */
-  displayItemsType?: "default" | "custom";
 }
 
 /**

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
@@ -31,7 +31,6 @@ const Item = ({
   // NavItem fields not spread to the DOM.
   key: _key,
   items,
-  displayItemsType: _displayItemsType,
   className,
   ...props
 }: ItemProps): React.ReactElement => {

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
@@ -32,7 +32,6 @@ const Item = ({
   key: _key,
   items,
   displayItemsType: _displayItemsType,
-  Component: _Component,
   className,
   ...props
 }: ItemProps): React.ReactElement => {

--- a/packages/react/ds-app/src/lib/SideNavigation/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/types.ts
@@ -28,6 +28,8 @@ export interface NavItem extends Omit<Item, "items"> {
   slot?: ReactNode;
   /** Subitems. Presence drives the disclosure caret (vs the leaf `slot`). */
   items?: NavItem[];
+  /** CSS class name applied to this item's row, in addition to the base classes. */
+  className?: string;
 }
 
 export interface SideNavigationProps extends HTMLAttributes<HTMLDivElement> {

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.tsx
@@ -24,7 +24,6 @@ const Item = ({
   // Destructure Item props we don't spread to DOM
   key: _key,
   items: _items,
-  displayItemsType: _displayItemsType,
   Component: _Component,
   ...props
 }: ItemProps): React.ReactElement => {

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/types.ts
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/types.ts
@@ -14,10 +14,7 @@ export type { LinkComponentProps };
  *
  * @implements dso:global.subcomponent.breadcrumbs-item
  */
-export interface ItemProps
-  extends HTMLAttributes<HTMLLIElement>,
-    // biome-ignore lint/suspicious/noExplicitAny: Component accepts any props
-    Item<ComponentType<any>> {
+export interface ItemProps extends HTMLAttributes<HTMLLIElement>, Item {
   /**
    * The link content (text or element)
    * Falls back to `label` from Item if not provided
@@ -39,4 +36,10 @@ export interface ItemProps
    * @default "a"
    */
   LinkComponent?: ComponentType<LinkComponentProps> | "a";
+  /**
+   * Custom component for rendering this item itself.
+   * e.g. A specialized renderer for complex items.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: Component accepts any props
+  Component?: ComponentType<any>;
 }

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/types.ts
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/types.ts
@@ -13,8 +13,7 @@ import type { ItemProps, LinkComponentProps } from "./common/Item/types.js";
  * Adds breadcrumb-specific properties while maintaining
  * compatibility with the unified navigation type.
  */
-// biome-ignore lint/suspicious/noExplicitAny: Component accepts any props
-export interface BreadcrumbItem extends Item<ComponentType<any>> {
+export interface BreadcrumbItem extends Item {
   /**
    * Whether this is the current page.
    * When true, renders as text instead of link.
@@ -22,6 +21,12 @@ export interface BreadcrumbItem extends Item<ComponentType<any>> {
   current?: boolean;
   /** CSS class name applied to this item's `<li>`, in addition to the base classes. */
   className?: string;
+  /**
+   * Custom component for rendering this item itself.
+   * e.g. A specialized renderer for complex items.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: Component accepts any props
+  Component?: ComponentType<any>;
 }
 
 /**

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/types.ts
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/types.ts
@@ -20,6 +20,8 @@ export interface BreadcrumbItem extends Item<ComponentType<any>> {
    * When true, renders as text instead of link.
    */
   current?: boolean;
+  /** CSS class name applied to this item's `<li>`, in addition to the base classes. */
+  className?: string;
 }
 
 /**

--- a/packages/react/ds-global/src/lib/component/Tabs/types.ts
+++ b/packages/react/ds-global/src/lib/component/Tabs/types.ts
@@ -8,7 +8,10 @@ import type { LinkComponent } from "../../types/link.js";
  * `label` (visible text), `key` (identity when there is no url), and
  * `disabled`. Nested `items` are ignored (tabs cannot nest).
  */
-export type TabItem = Item;
+export interface TabItem extends Item {
+  /** CSS class name applied to this tab's `<li>`, in addition to the base classes. */
+  className?: string;
+}
 
 /**
  * Props for the Tabs component

--- a/packages/react/ds-global/src/lib/component/Tabs/types.ts
+++ b/packages/react/ds-global/src/lib/component/Tabs/types.ts
@@ -11,12 +11,6 @@ import type { LinkComponent } from "../../types/link.js";
 export interface TabItem extends Item {
   /** CSS class name applied to this tab's `<li>`, in addition to the base classes. */
   className?: string;
-  /**
-   * Child items — narrowed from the base `Item.items` (`Item[]`) so tab
-   * literals under `navigationRoot.items` can set `className` without
-   * failing excess-property checks. Tabs cannot nest, so this is unused.
-   */
-  items?: TabItem[];
 }
 
 /**

--- a/packages/react/ds-global/src/lib/component/Tabs/types.ts
+++ b/packages/react/ds-global/src/lib/component/Tabs/types.ts
@@ -11,6 +11,12 @@ import type { LinkComponent } from "../../types/link.js";
 export interface TabItem extends Item {
   /** CSS class name applied to this tab's `<li>`, in addition to the base classes. */
   className?: string;
+  /**
+   * Child items — narrowed from the base `Item.items` (`Item[]`) so tab
+   * literals under `navigationRoot.items` can set `className` without
+   * failing excess-property checks. Tabs cannot nest, so this is unused.
+   */
+  items?: TabItem[];
 }
 
 /**

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
@@ -17,8 +17,7 @@ import type {
  * shortcut) in addition to the base navigation fields. The slot is an optional
  * extension that survives tree annotation.
  */
-export interface MenuItem
-  extends Item<React.ComponentType<{ item: MenuItem }>> {
+export interface MenuItem extends Item {
   /** Content rendered right-aligned within the item, such as a badge or shortcut. */
   slot?: React.ReactNode;
   /** Icon rendered left of the label. */
@@ -27,6 +26,8 @@ export interface MenuItem
   items?: MenuItem[];
   /** CSS class name applied to this item, in addition to the base classes. */
   className?: string;
+  /** Custom component for rendering this item itself, when `displayItemsType` is `"custom"`. */
+  Component?: React.ComponentType<{ item: MenuItem }>;
 }
 
 export interface UseContextualMenuProps

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
@@ -25,6 +25,8 @@ export interface MenuItem
   icon?: React.ReactNode;
   /** Child items — a group's items, or a future submenu's entries. */
   items?: MenuItem[];
+  /** CSS class name applied to this item, in addition to the base classes. */
+  className?: string;
 }
 
 export interface UseContextualMenuProps

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
@@ -26,6 +26,11 @@ export interface MenuItem extends Item {
   items?: MenuItem[];
   /** CSS class name applied to this item, in addition to the base classes. */
   className?: string;
+  /**
+   * Opts this item into rendering via `Component` instead of the default
+   * layout. `"custom"` without a `Component` falls back to the default.
+   */
+  displayItemsType?: "default" | "custom";
   /** Custom component for rendering this item itself, when `displayItemsType` is `"custom"`. */
   Component?: React.ComponentType<{ item: MenuItem }>;
 }

--- a/packages/utils/src/lib/navigation/annotateTree.test.ts
+++ b/packages/utils/src/lib/navigation/annotateTree.test.ts
@@ -74,15 +74,18 @@ describe("annotateTree", () => {
   });
 
   it("preserves extra properties on items", () => {
-    const root: Item = {
+    interface EnhancedItem extends Item {
+      icon?: string;
+    }
+    const root: EnhancedItem = {
       url: "/home",
       label: "Home",
-      className: "active",
+      icon: "home",
       disabled: true,
     };
     const result = annotateTree(root);
 
-    expect(result.className).toBe("active");
+    expect(result.icon).toBe("home");
     expect(result.disabled).toBe(true);
   });
 

--- a/packages/utils/src/lib/navigation/annotateTree.ts
+++ b/packages/utils/src/lib/navigation/annotateTree.ts
@@ -26,7 +26,7 @@ export function annotateTree<T extends Item = Item>(
   } as _Item<T>;
   if (items) {
     // The tree is homogeneous: every node is the same item type `T`. The base
-    // `Item<C>.items` is typed `Item<C>[]`, so narrow children back to `T`
+    // `Item.items` is typed `Item[]`, so narrow children back to `T`
     // (enhanced item types like `NavItem` already declare `items?: NavItem[]`).
     annotated.items = (items as T[]).map((child) =>
       annotateTree<T>(child, getItemId(root), depth + 1),


### PR DESCRIPTION
Refactors the `Item` interface to focus more strongly on its role as a Navigation utility adapter. Properties with no relation to navigation have been removed. This has the added benefit of removing framework-specific properties like `className`, which is a React idiom.

Other updates:
- Updates `utils` package tests and documentation to no longer reference `Item` as a generic.
- Updates `react-ds-core` components that extend `Item` to separately declare `className` and `Component` on their props to apply framework customization at a more appropriate level of abstraction.

#### Sample usage patterns

##### React
```ts
// types.ts
import type { Item } from "@canonical/ds-types";
import type { ComponentType } from "react";

export interface BreadcrumbItem extends Item {
  current?: boolean;
  className?: string;
  Component?: ComponentType<ItemProps>;
}
```
```tsx
// Breadcrumbs.tsx
{items.map((item) => {
  const ItemComponent = item.Component ?? Item;
  return <ItemComponent key={getItemId(item)} {...item} />;
})}
```

##### Svelte
Optionally apply `class` (rather than `className`), a snippet renderer (in place of a React component type), and Breadctumb-specific behavior like `current`. 

```ts
// types.ts
import type { Item } from "@canonical/ds-types";
import type { Snippet } from "svelte";

export interface BreadcrumbItem extends Item {
  current?: boolean;
  class?: string;
  render?: Snippet<[BreadcrumbItem]>; // Svelte's override idiom: swap the markup
}
```

```svelte
<!-- Breadcrumbs.svelte -->
{#each items as item (getItemId(item))}
  {#if item.render}{@render item.render(item)}{:else}<Item {...item} />{/if}
{/each}
```