### PR TITLE
feat(router-core): schema validation for URL params via Standard Schema v1

### DIFF
--- a/apps/react/boilerplate-vite/src/domains/marketing/routes.ts
+++ b/apps/react/boilerplate-vite/src/domains/marketing/routes.ts
@@ -1,6 +1,30 @@
+import type { StandardSchemaV1 } from "@canonical/router-core";
 import { route } from "@canonical/router-core";
 import GuidePage from "./GuidePage.js";
 import HomePage from "./HomePage.js";
+
+/**
+ * Standard Schema v1 params validator — the same interface Zod, Valibot, and
+ * ArkType schemas implement, so any of them can be dropped in here directly.
+ * A slug that is not lowercase kebab-case makes the URL a non-match: the
+ * router falls through to the not-found route (404) instead of rendering.
+ */
+const guideParamsSchema: StandardSchemaV1<
+  { readonly slug: string },
+  { readonly slug: string }
+> = {
+  "~standard": {
+    version: 1,
+    vendor: "boilerplate",
+    validate(value) {
+      const record = value as { slug?: string };
+
+      return record.slug && /^[a-z0-9]+(-[a-z0-9]+)*$/.test(record.slug)
+        ? { value: { slug: record.slug } }
+        : { issues: [{ message: "slug must be lowercase kebab-case" }] };
+    },
+  },
+};
 
 const routes = {
   home: route({
@@ -9,6 +33,7 @@ const routes = {
   }),
   guide: route({
     url: "/guides/:slug",
+    params: guideParamsSchema,
     content: GuidePage,
   }),
 } as const;

--- a/docs/references/ROUTER_API.md
+++ b/docs/references/ROUTER_API.md
@@ -186,19 +186,25 @@ await router.prefetch("home");
 
 ```ts
 // Redirect overload (matched first; presence of `redirect` selects it):
-function route<const TPath extends string, TTarget extends string, TWrappers extends readonly AnyWrapper[] = readonly []>(
-  definition: RedirectRouteInput<TPath, TTarget, TWrappers>,
-): RedirectRouteDefinition<TPath, TTarget, TWrappers>;
+function route<
+  const TPath extends string,
+  TTarget extends string,
+  TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
+>(
+  definition: RedirectRouteInput<TPath, TTarget, TWrappers, TParamsSchema>,
+): RedirectRouteDefinition<TPath, TTarget, TWrappers, TParamsSchema>;
 
 // Data overload:
 function route<
   const TPath extends string,
-  TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
+  TSearchSchema extends SchemaLike<unknown> | undefined = undefined,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 >(
-  definition: DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers>,
-): DataRouteDefinition<TPath, TSearchSchema, TRendered, TWrappers>;
+  definition: DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers, TParamsSchema>,
+): DataRouteDefinition<TPath, TSearchSchema, TRendered, TWrappers, TParamsSchema>;
 ```
 
 Constructs one flat route and derives its path codec. The returned definition adds `parse(url) → params | null` and `render(params) → string` over the input, and defaults `wrappers` to `[]`. Routes are **flat** — there is no nesting or `children`. Shared layout comes from [`wrapper`](#wrapper) + [`group`](#group); cross-cutting logic from [middleware](#middleware-applymiddleware).
@@ -206,13 +212,14 @@ Constructs one flat route and derives its path codec. The returned definition ad
 #### `DataRouteInput`
 
 ```ts
-interface DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers> {
+interface DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers, TParamsSchema> {
   readonly url: TPath;
-  readonly content: RouteContent<TPath, TSearchSchema, TRendered>;
+  readonly content: RouteContent<TPath, TSearchSchema, TRendered, TParamsSchema>;
   readonly prefetch?: BivariantCallback<
-    [params: RouteParams<TPath>, search: InferSearch<TSearchSchema>, context: NavigationContext],
+    [params: InferParams<TPath, TParamsSchema>, search: InferSearch<TSearchSchema>, context: NavigationContext],
     void | Promise<void>
   >;
+  readonly params?: TParamsSchema;
   readonly search?: TSearchSchema;
   readonly wrappers?: TWrappers;
   readonly meta?: Readonly<Record<string, unknown>>;
@@ -222,7 +229,8 @@ interface DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers> {
 - **`url`** — path pattern. `:param` segments become typed params; modifiers (`?`, `*`, `+`, `(regex)`) are stripped for naming. `RouteParams<TPath>` infers `{ readonly [name]: string }`, or `Record<string, never>` when the path has none.
 - **`content`** — the component, called with `RouteContentProps`. Carries an optional `preload?: () => Promise<RouteModule>` for code-splitting.
 - **`prefetch`** — see [the prefetch hook](#the-prefetch-hook).
-- **`search`** — a [Standard-Schema-like](#search-validation) validator; its `output` type flows to `content`'s `search` prop and the route's `SearchOf`.
+- **`params`** — a [Standard Schema](#params-validation) validator for the path params; its output type replaces `RouteParams<TPath>` everywhere (`content`, `prefetch`, `Link`, `navigate`, `buildPath`). A failed validation makes the URL a **non-match** (404), not an error.
+- **`search`** — a [Standard Schema](#search-validation) validator; its output type flows to `content`'s `search` prop and the route's `SearchOf`. A failed validation throws a 400 `StatusResponse`.
 - **`wrappers`** — layout wrappers (usually applied via `group`, not set by hand).
 - **`meta`** — arbitrary readonly metadata.
 
@@ -240,7 +248,7 @@ Props passed to a route's `content`:
 
 ```ts
 interface RouteContentProps<
-  TParams extends RouteParamValues | Record<string, never> = Record<string, never>,
+  TParams = Record<string, never>,
   TSearch = Record<string, never>,
 > {
   readonly params: TParams;
@@ -260,7 +268,7 @@ function AccountPage({ params, search }: RouteContentProps<{ readonly id: string
 
 ```ts
 readonly prefetch?: (
-  params: RouteParams<TPath>,
+  params: InferParams<TPath, TParamsSchema>,
   search: InferSearch<TSearchSchema>,
   context: NavigationContext,
 ) => void | Promise<void>;
@@ -291,10 +299,11 @@ prefetch: (params, search, context) => {
 ```ts
 type StaticRedirectStatus = 301 | 308;
 
-interface RedirectRouteInput<TPath, TTarget, TWrappers> {
+interface RedirectRouteInput<TPath, TTarget, TWrappers, TParamsSchema> {
   readonly url: TPath;
   readonly redirect: TTarget;       // destination path
   readonly status: StaticRedirectStatus;
+  readonly params?: TParamsSchema;  // optional params schema, gates matching like data routes
   readonly wrappers?: TWrappers;
   readonly meta?: Readonly<Record<string, unknown>>;
 }
@@ -308,14 +317,16 @@ const legacy = route({ url: "/old", redirect: "/new", status: 308 });
 
 #### Definition shapes and codec
 
-`RouteInput = DataRouteInput | RedirectRouteInput` (what `route()` accepts); `RouteDefinition = DataRouteDefinition | RedirectRouteDefinition` (what it returns). Both definitions extend `RouteCodec<TPath>`:
+`RouteInput = DataRouteInput | RedirectRouteInput` (what `route()` accepts); `RouteDefinition = DataRouteDefinition | RedirectRouteDefinition` (what it returns). Both definitions extend `RouteCodec<TPath, TParams>`:
 
 ```ts
-interface RouteCodec<TPath extends string = string> {
-  parse(url: string | URL): RouteParams<TPath> | null;
-  render(params: RouteParams<TPath>): string;
+interface RouteCodec<TPath extends string = string, TParams = RouteParams<TPath>> {
+  parse(url: string | URL): TParams | null;
+  render(params: TParams): string;
 }
 ```
+
+`TParams` is `InferParams<TPath, TParamsSchema>` — the [params schema](#params-validation)'s output when one is declared, otherwise the raw string params inferred from the path. `parse` applies the params schema: a rejected URL returns `null`, exactly like a pattern mismatch. `render` accepts the schema's output values and serializes non-string values (numbers, booleans) with `String()`.
 
 The definition is the input shape with `wrappers` made required (defaulted to `[]`) plus `parse`/`render`. `DataRouteDefinition` keeps the same three-arg `prefetch` signature as the input.
 
@@ -505,11 +516,30 @@ prefetch: async (params) => {
 },
 ```
 
-### Search validation
+### Schema validation
 
-`search` accepts any [Standard Schema](https://github.com/standard-schema/standard-schema)-compatible validator (`StandardSchemaLike`) — Zod, Valibot, ArkType, or a hand-rolled `~standard` object. Its `output` type flows to `content`'s `search` prop and to `SearchOf<TRoute>`.
+Both `params` and `search` accept a `SchemaLike` validator:
 
 ```ts
+type SchemaLike<TOutput = unknown> =
+  | StandardSchemaV1<unknown, TOutput>   // the real spec — Zod (≥3.24), Valibot, ArkType
+  | StandardSchemaLike<TOutput>;         // legacy hand-rolled shape (kept for back-compat)
+
+interface StandardSchemaV1<TInput = unknown, TOutput = TInput> {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (value: unknown) =>
+      | StandardSchemaResult<TOutput>
+      | Promise<StandardSchemaResult<TOutput>>;   // Promise results are rejected — matching is synchronous
+    readonly types?: { readonly input: TInput; readonly output: TOutput } | undefined;
+  };
+}
+
+type StandardSchemaResult<TOutput> =
+  | { readonly value: TOutput; readonly issues?: undefined }
+  | { readonly issues: ReadonlyArray<StandardSchemaIssue> };
+
 interface StandardSchemaLike<TOutput = unknown> {
   readonly "~standard": {
     readonly output?: TOutput;
@@ -517,6 +547,52 @@ interface StandardSchemaLike<TOutput = unknown> {
   };
 }
 ```
+
+Any [Standard Schema](https://standardschema.dev)-compatible library schema can be passed directly — its output type is inferred from the `types.output` phantom (`InferOutput`). The legacy shape carries its output type on the non-standard `output` phantom instead. Two constraints apply to both:
+
+- **Validation is synchronous.** `match()` is sync, so a validator that returns a `Promise` (e.g. a Zod async refinement) throws at match time with an explanatory error.
+- **Raw values are strings.** Path params and search params arrive as `Record<string, string>`; use coercion (`z.coerce.number()`, `Number(...)`) for anything else.
+
+#### Params validation
+
+`params` validates the path params extracted from the URL. The schema's output type replaces `RouteParams<TPath>` everywhere: `content`'s `params` prop, `prefetch`'s first argument, `ParamsOf<TRoute>`, and the `params` accepted by `Link`, `navigate`, and `buildPath`.
+
+**Failure semantics: a rejected URL is a non-match, not an error.** Matching falls through to the next candidate route and ultimately the `notFound` route (404) — the same behaviour as a pattern mismatch. Use it to reject syntactically invalid resource identifiers before any code runs:
+
+```ts
+const productParamsSchema: StandardSchemaV1<
+  { readonly id: string },
+  { readonly id: number }
+> = {
+  "~standard": {
+    version: 1,
+    vendor: "app",
+    validate(value) {
+      const raw = value as { id?: string };
+      const id = Number(raw.id);
+      return Number.isInteger(id) && id > 0
+        ? { value: { id } }
+        : { issues: [{ message: "id must be a positive integer" }] };
+    },
+  },
+};
+
+const product = route({
+  url: "/products/:id",
+  params: productParamsSchema,   // "/products/abc" → 404; "/products/42" → params.id === 42
+  content: ProductPage,          // ({ params }) — params.id is a number
+});
+
+router.buildPath("product", { params: { id: 42 } });   // "/products/42" — typed, serialized with String()
+```
+
+For *semantic* validation (does the record exist?), keep using `prefetch` + [`StatusResponse`](#statusresponse). For simple syntactic constraints, a `(regex)` modifier in the pattern (`/products/:id(\\d+)`) also works — `params` adds typed coercion on top.
+
+#### Search validation
+
+`search` validates the query string. Its output type flows to `content`'s `search` prop and to `SearchOf<TRoute>`.
+
+**Failure semantics: a rejected query string throws `StatusResponse(400, { issues, message })`.** During `load()`/navigation the router catches it and commits an error result (`result.status === 400`, `result.error instanceof StatusResponse`); under SSR that surfaces as a real 400, and on the client it reaches your error boundary. A shared URL with a garbage query is a *bad request*, not a crash — and for that reason, prefer **normalizing** schemas that supply defaults over rejecting ones (`z.coerce.number().catch(1)` rather than `.int()` alone), reserving hard failure for genuinely unrenderable input.
 
 ```ts
 const accountSearchSchema = {
@@ -529,6 +605,8 @@ const accountSearchSchema = {
   },
 };
 ```
+
+This hand-rolled legacy shape never fails (it normalizes), which makes it a good dependency-free default. A type-only schema (`output` phantom, no `validate`) passes the raw string record through unvalidated.
 
 ### Adapters and low-level helpers
 
@@ -578,6 +656,12 @@ interface MemoryAdapter extends PlatformAdapter {
 | `NavigationIntent` | `{ name; href; params; search; hash? }` (returned by `navigate`) |
 | `TrackedLocation<T>` | proxy over a location; reading a field subscribes to just that field |
 | `Subject<T>` | `{ next(value); subscribe(subscriber) → unsubscribe }` |
+| `SchemaLike<TOutput>` | `StandardSchemaV1<unknown, TOutput> \| StandardSchemaLike<TOutput>` — what `params`/`search` accept |
+| `InferOutput<TSchema>` | a schema's output type (`types.output` phantom, or legacy `output`) |
+| `InferParams<TPath, TParamsSchema>` | params schema output when declared, else `RouteParams<TPath>` |
+| `ParamsOf<TRoute>` | the route's params as seen by `content`/`Link`/`navigate` (schema-aware) |
+| `SearchOf<TRoute>` | the route's validated search shape (schema-aware) |
+| `StandardSchemaIssue` | `{ message; path? }` — one validation issue, per the Standard Schema spec |
 
 ---
 

--- a/docs/references/ROUTER_API.md
+++ b/docs/references/ROUTER_API.md
@@ -356,7 +356,7 @@ interface WrapperComponentProps<TRendered = unknown> {
 }
 ```
 
-Note the wrapper `prefetch` takes **two** args `(params, context)` — no `search`, unlike route `prefetch`. Wrapper prefetches are fire-and-forget and not cached.
+Note the wrapper `prefetch` takes **two** args `(params, context)` — no `search`, unlike route `prefetch`. Wrapper prefetches are fire-and-forget and not cached. Wrappers are shared across routes, so `params` is always the **raw string params** extracted from the URL (`RouteParamValues`) — a route's [params schema](#params-validation) only transforms what the route's own hooks receive.
 
 ```ts
 const publicLayout = wrapper<ReactElement>({
@@ -661,7 +661,7 @@ interface MemoryAdapter extends PlatformAdapter {
 | `InferParams<TPath, TParamsSchema>` | params schema output when declared, else `RouteParams<TPath>` |
 | `ParamsOf<TRoute>` | the route's params as seen by `content`/`Link`/`navigate` (schema-aware) |
 | `SearchOf<TRoute>` | the route's validated search shape (schema-aware) |
-| `StandardSchemaIssue` | `{ message; path? }` — one validation issue, per the Standard Schema spec |
+| `StandardSchemaIssue` | `{ message?; path? }` — one validation issue; `message` optional to tolerate legacy validators |
 
 ---
 

--- a/packages/runtime/router/README.md
+++ b/packages/runtime/router/README.md
@@ -53,6 +53,7 @@ The core package intentionally stops at route matching, state, dehydration, and 
 - **Wrappers are annotations.** Reuse layout with `wrapper()` and `group()`.
 - **Middleware is route-to-route transformation.** Use it to add auth, i18n, metrics, or shared wrapper policy. Middleware runs once, before the router is created.
 - **`prefetch()` is fire-and-forget.** It warms caches, preloads assets, or runs side effects at navigation time. It does not provide data to `content()` — components own their data via their cache library.
+- **URL params are validated by schemas.** Give a route a `params` or `search` [Standard Schema](https://standardschema.dev) validator (Zod, Valibot, ArkType, or hand-rolled) and the validated, typed output flows to `content()`, `prefetch()`, and the typed navigation helpers.
 - **SSR is built in.** `dehydrate()` preserves navigation state across the server/client boundary.
 
 ## Progressive disclosure
@@ -85,6 +86,43 @@ const userRoute = route({
   content: ({ params }) => `User: ${params.id}`,
 });
 ```
+
+### Schema validation for URL params
+
+Routes accept [Standard Schema](https://standardschema.dev) validators for both kinds of URL parameters. Any spec-compliant library schema (Zod ≥3.24, Valibot, ArkType) can be passed directly; raw values always arrive as strings, so use coercion.
+
+**Path params** — the `params` field validates and coerces `:param` segments. A rejected URL is a **non-match**: matching falls through to the next route and ultimately the not-found route (404), exactly like a pattern mismatch.
+
+```tsx
+import { route } from "@canonical/router-core";
+import { z } from "zod";
+
+const productRoute = route({
+  url: "/products/:id",
+  params: z.object({ id: z.coerce.number().int().positive() }),
+  // "/products/abc" → 404; "/products/42" → params.id === 42 (a number)
+  content: ({ params }) => `Product #${params.id}`,
+});
+
+router.buildPath("product", { params: { id: 42 } }); // "/products/42" — fully typed
+```
+
+**Search params** — the `search` field validates the query string. A rejected query throws `StatusResponse(400, { issues, message })`: `load()` commits it as a 400 error result (a real 400 under SSR, an error-boundary render on the client). Prefer normalizing schemas that supply defaults over rejecting ones — a shared URL with a stale query should not crash the page:
+
+```tsx
+const listRoute = route({
+  url: "/products",
+  search: z.object({
+    page: z.coerce.number().int().min(1).catch(1),
+    sort: z.enum(["price", "name"]).catch("name"),
+  }),
+  content: ({ search }) => `page ${search.page}, sorted by ${search.sort}`,
+});
+```
+
+No dependency? Hand-roll the schema — either the Standard Schema v1 shape (`{ "~standard": { version: 1, vendor, validate } }`, annotate with `StandardSchemaV1<In, Out>` for inference) or the legacy type-only shape (`{ "~standard": { output, validate } }`). See the [Router API reference](../../../docs/references/ROUTER_API.md#schema-validation) for both.
+
+Validation runs at match time and is **synchronous** — async validators (e.g. Zod async refinements) throw with an explanatory error. For semantic checks (does the record exist?) use `prefetch` + `StatusResponse`.
 
 ### Wrapper composition
 

--- a/packages/runtime/router/src/lib/applyMiddleware.test.ts
+++ b/packages/runtime/router/src/lib/applyMiddleware.test.ts
@@ -97,4 +97,39 @@ describe("applyMiddleware", () => {
 
     expect(unchangedRoute).toBe(baseRoute);
   });
+
+  it("preserves params schema validation in rebuilt codecs", () => {
+    const numericIdSchema = {
+      "~standard": {
+        output: {} as { readonly id: number },
+        validate(value: unknown) {
+          const raw = value as { id?: string };
+          const id = Number(raw.id);
+
+          return Number.isInteger(id)
+            ? { value: { id } }
+            : { issues: [{ message: "id must be an integer" }] };
+        },
+      },
+    };
+
+    const baseRoute = route({
+      url: "/users/:id",
+      params: numericIdSchema,
+      content: ({ params }) => String(params.id),
+    });
+
+    const prefixer = ((currentRoute: typeof baseRoute) => {
+      return {
+        ...currentRoute,
+        url: `/api${currentRoute.url}`,
+      };
+    }) as RouteMiddleware;
+
+    const [enhanced] = applyMiddleware([baseRoute] as const, [prefixer]);
+
+    expect(enhanced.parse("/api/users/42")).toEqual({ id: 42 });
+    expect(enhanced.parse("/api/users/abc")).toBeNull();
+    expect(enhanced.render({ id: 42 })).toBe("/api/users/42");
+  });
 });

--- a/packages/runtime/router/src/lib/applyMiddleware.ts
+++ b/packages/runtime/router/src/lib/applyMiddleware.ts
@@ -1,5 +1,4 @@
-import buildUrl from "./buildUrl.js";
-import { matchPath, renderPattern } from "./pathUtils.js";
+import { createRouteCodec } from "./pathUtils.js";
 import type { AnyRoute, RouteMiddleware } from "./types.js";
 
 /**
@@ -25,12 +24,7 @@ export default function applyMiddleware<TRoutes extends readonly AnyRoute[]>(
 
     return {
       ...transformed,
-      parse(input: string | URL) {
-        return matchPath(transformed.url, buildUrl(input));
-      },
-      render(params: Record<string, string> | Record<string, never>) {
-        return renderPattern(transformed.url, params as Record<string, string>);
-      },
+      ...createRouteCodec(transformed.url, transformed.params),
     };
   }) as unknown as TRoutes;
 }

--- a/packages/runtime/router/src/lib/createRouter.test.ts
+++ b/packages/runtime/router/src/lib/createRouter.test.ts
@@ -5,7 +5,7 @@ import group from "./group.js";
 import redirect from "./redirect.js";
 import route from "./route.js";
 import StatusResponse from "./StatusResponse.js";
-import type { AnyRoute, RouteMiddleware } from "./types.js";
+import type { AnyRoute, RouteMiddleware, StandardSchemaV1 } from "./types.js";
 import wrapper from "./wrapper.js";
 
 describe("createRouter", () => {
@@ -1571,7 +1571,7 @@ describe("createRouter", () => {
     expect(router.getState().location.pathname).toBe("/");
   });
 
-  it("throws when search param validation returns issues", () => {
+  it("throws a 400 StatusResponse when search param validation returns issues", () => {
     const failingSchema = {
       "~standard": {
         output: {} as { page: number },
@@ -1589,9 +1589,28 @@ describe("createRouter", () => {
       }),
     });
 
-    expect(() => router.match("/list?page=-1")).toThrow(
+    let thrownError: unknown = null;
+
+    try {
+      router.match("/list?page=-1");
+    } catch (caughtError) {
+      thrownError = caughtError;
+    }
+
+    expect(thrownError).toBeInstanceOf(StatusResponse);
+
+    const statusResponse = thrownError as StatusResponse<{
+      issues: ReadonlyArray<{ message: string }>;
+      message: string;
+    }>;
+
+    expect(statusResponse.status).toBe(400);
+    expect(statusResponse.data.message).toBe(
       "Search param validation failed: page must be positive",
     );
+    expect(statusResponse.data.issues).toEqual([
+      { message: "page must be positive" },
+    ]);
   });
 
   it("uses default message when validation issue has no message", () => {
@@ -1612,9 +1631,18 @@ describe("createRouter", () => {
       }),
     });
 
-    expect(() => router.match("/list?page=-1")).toThrow(
-      "Search param validation failed: Validation error",
-    );
+    let thrownError: unknown = null;
+
+    try {
+      router.match("/list?page=-1");
+    } catch (caughtError) {
+      thrownError = caughtError;
+    }
+
+    expect(thrownError).toBeInstanceOf(StatusResponse);
+    expect(
+      (thrownError as StatusResponse<{ message: string }>).data.message,
+    ).toBe("Search param validation failed: Validation error");
   });
 
   it("unwraps search validation result with value property", () => {
@@ -1820,6 +1848,287 @@ describe("createRouter", () => {
 
     await vi.waitFor(() => {
       expect(adapter.getLocation().pathname).toBe("/login");
+    });
+  });
+
+  describe("params schema validation", () => {
+    const numericIdSchema = {
+      "~standard": {
+        output: {} as { readonly id: number },
+        validate(value: unknown) {
+          const raw = value as { id?: string };
+          const id = Number(raw.id);
+
+          return Number.isInteger(id) && id > 0
+            ? { value: { id } }
+            : { issues: [{ message: "id must be a positive integer" }] };
+        },
+      },
+    };
+
+    it("validates and coerces path params through a params schema", () => {
+      const router = createRouter({
+        user: route({
+          url: "/users/:id",
+          params: numericIdSchema,
+          content: ({ params }) => {
+            expectTypeOf(params).toEqualTypeOf<{ readonly id: number }>();
+
+            return String(params.id);
+          },
+        }),
+      });
+
+      expect(router.match("/users/42")).toMatchObject({
+        kind: "route",
+        name: "user",
+        status: 200,
+        params: { id: 42 },
+      });
+    });
+
+    it("treats a params schema rejection as a non-match and falls through", () => {
+      const router = createRouter(
+        {
+          user: route({
+            url: "/users/:id",
+            params: numericIdSchema,
+            content: ({ params }) => String(params.id),
+          }),
+          catchAll: route({
+            url: "/users/*",
+            content: () => "catch-all",
+          }),
+        },
+        {
+          notFound: route({ url: "/*", content: () => "not-found" }),
+        },
+      );
+
+      // Invalid id falls through to the wildcard sibling.
+      expect(router.match("/users/abc")).toMatchObject({
+        kind: "route",
+        name: "catchAll",
+      });
+    });
+
+    it("resolves to not-found (404) when no other route accepts rejected params", () => {
+      const notFoundRoute = route({ url: "/*", content: () => "not-found" });
+      const router = createRouter(
+        {
+          user: route({
+            url: "/users/:id",
+            params: numericIdSchema,
+            content: ({ params }) => String(params.id),
+          }),
+        },
+        { notFound: notFoundRoute },
+      );
+
+      expect(router.match("/users/abc")).toMatchObject({
+        kind: "not-found",
+        status: 404,
+      });
+    });
+
+    it("returns null for rejected params without a not-found route", () => {
+      const router = createRouter({
+        user: route({
+          url: "/users/:id",
+          params: numericIdSchema,
+          content: ({ params }) => String(params.id),
+        }),
+      });
+
+      expect(router.match("/users/abc")).toBeNull();
+    });
+
+    it("passes validated params to prefetch and builds paths from schema output", async () => {
+      const prefetchSpy = vi.fn();
+      const router = createRouter({
+        user: route({
+          url: "/users/:id",
+          params: numericIdSchema,
+          prefetch: (params, _search, _context) => {
+            expectTypeOf(params).toEqualTypeOf<{ readonly id: number }>();
+            prefetchSpy(params);
+          },
+          content: ({ params }) => String(params.id),
+        }),
+      });
+
+      expect(router.buildPath("user", { params: { id: 42 } })).toBe(
+        "/users/42",
+      );
+
+      const intent = router.navigate("user", { params: { id: 42 } });
+
+      expectTypeOf(intent.params).toEqualTypeOf<{ readonly id: number }>();
+      expect(intent.href).toBe("/users/42");
+
+      await router.load("/users/42");
+
+      expect(prefetchSpy).toHaveBeenCalledWith({ id: 42 });
+    });
+
+    it("gates redirect routes on their params schema", () => {
+      const router = createRouter(
+        {
+          legacyUser: route({
+            url: "/old/:id",
+            redirect: "/users/:id",
+            status: 308,
+            params: numericIdSchema,
+          }),
+          user: route({
+            url: "/users/:id",
+            params: numericIdSchema,
+            content: ({ params }) => String(params.id),
+          }),
+        },
+        {
+          notFound: route({ url: "/*", content: () => "not-found" }),
+        },
+      );
+
+      expect(router.match("/old/7")).toMatchObject({
+        kind: "redirect",
+        redirectTo: "/users/7",
+        status: 308,
+      });
+      expect(router.match("/old/abc")).toMatchObject({
+        kind: "not-found",
+        status: 404,
+      });
+    });
+
+    it("throws a helpful error when a params validator is async", () => {
+      const asyncSchema = {
+        "~standard": {
+          version: 1 as const,
+          vendor: "test",
+          validate: async () => ({ value: { id: 1 } }),
+        },
+      };
+
+      const router = createRouter({
+        user: route({
+          url: "/users/:id",
+          params: asyncSchema,
+          content: () => "user",
+        }),
+      });
+
+      expect(() => router.match("/users/42")).toThrow(
+        "async schema validation is not supported",
+      );
+    });
+  });
+
+  describe("Standard Schema v1 validators", () => {
+    it("infers types and validates through a v1 search schema", () => {
+      const pageSearchSchema: StandardSchemaV1<
+        { readonly page?: string },
+        { readonly page: number }
+      > = {
+        "~standard": {
+          version: 1,
+          vendor: "pragma-test",
+          validate(value) {
+            const raw = value as { page?: string };
+            const page = Number(raw.page ?? "1");
+
+            return Number.isNaN(page)
+              ? { issues: [{ message: "page must be a number" }] }
+              : { value: { page } };
+          },
+        },
+      };
+
+      const router = createRouter({
+        list: route({
+          url: "/list",
+          search: pageSearchSchema,
+          content: ({ search }) => {
+            expectTypeOf(search).toEqualTypeOf<{ readonly page: number }>();
+
+            return String(search.page);
+          },
+        }),
+      });
+
+      expect(router.match("/list?page=2")).toMatchObject({
+        kind: "route",
+        search: { page: 2 },
+      });
+      expect(() => router.match("/list?page=abc")).toThrow();
+    });
+
+    it("infers types and validates through a v1 params schema", () => {
+      const idParamsSchema: StandardSchemaV1<
+        { readonly id: string },
+        { readonly id: number }
+      > = {
+        "~standard": {
+          version: 1,
+          vendor: "pragma-test",
+          validate(value) {
+            const raw = value as { id?: string };
+            const id = Number(raw.id);
+
+            return Number.isInteger(id)
+              ? { value: { id } }
+              : { issues: [{ message: "id must be an integer" }] };
+          },
+        },
+      };
+
+      const router = createRouter({
+        user: route({
+          url: "/users/:id",
+          params: idParamsSchema,
+          content: ({ params }) => {
+            expectTypeOf(params).toEqualTypeOf<{ readonly id: number }>();
+
+            return String(params.id);
+          },
+        }),
+      });
+
+      expect(router.match("/users/42")).toMatchObject({
+        params: { id: 42 },
+      });
+      expect(router.match("/users/abc")).toBeNull();
+    });
+  });
+
+  describe("search validation failure handling in load()", () => {
+    it("commits a 400 error result instead of rejecting the load", async () => {
+      const failingSchema = {
+        "~standard": {
+          output: {} as { page: number },
+          validate() {
+            return { issues: [{ message: "page must be positive" }] };
+          },
+        },
+      };
+
+      const router = createRouter({
+        home: route({ url: "/", content: () => "home" }),
+        list: route({
+          url: "/list",
+          search: failingSchema,
+          content: () => "list",
+        }),
+      });
+
+      const result = await router.load("/list?page=-1");
+
+      expect(result.status).toBe(400);
+      expect(result.match).toBeNull();
+      expect(result.error).toBeInstanceOf(StatusResponse);
+      expect((result.error as StatusResponse<unknown>).status).toBe(400);
+      expect(router.getState().location.status).toBe(400);
     });
   });
 });

--- a/packages/runtime/router/src/lib/createRouter.test.ts
+++ b/packages/runtime/router/src/lib/createRouter.test.ts
@@ -2002,6 +2002,39 @@ describe("createRouter", () => {
       });
     });
 
+    it("passes raw string params to wrapper prefetch, validated params to route prefetch", async () => {
+      const wrapperSpy = vi.fn();
+      const routeSpy = vi.fn();
+
+      const shell = wrapper({
+        id: "raw-params-shell",
+        component: ({ children }) => children,
+        prefetch: (params) => {
+          wrapperSpy(params);
+        },
+      });
+
+      const [userRoute] = group(shell, [
+        route({
+          url: "/users/:id",
+          params: numericIdSchema,
+          prefetch: (params) => {
+            routeSpy(params);
+          },
+          content: ({ params }) => String(params.id),
+        }),
+      ] as const);
+
+      const router = createRouter({ user: userRoute });
+
+      await router.load("/users/42");
+
+      // Wrappers are shared across routes and typed as RouteParamValues:
+      // they get the raw URL strings, untouched by the route's params schema.
+      expect(wrapperSpy).toHaveBeenCalledWith({ id: "42" });
+      expect(routeSpy).toHaveBeenCalledWith({ id: 42 });
+    });
+
     it("throws a helpful error when a params validator is async", () => {
       const asyncSchema = {
         "~standard": {

--- a/packages/runtime/router/src/lib/createRouter.ts
+++ b/packages/runtime/router/src/lib/createRouter.ts
@@ -699,12 +699,17 @@ export default function createRouter<
     // Wrapper prefetches run for all wrappers (no caching/reuse).
     // Route prefetch runs if defined. None block rendering.
     if (nextRoute) {
+      // Wrappers are shared across routes and typed as RouteParamValues, so
+      // they receive the raw string params extracted from the URL — a route's
+      // params schema only transforms what the route's own hooks receive.
+      const rawWrapperParams = (
+        currentMatch ? (matchPath(nextRoute.url, currentMatch.url) ?? {}) : {}
+      ) as RouteParamValues;
+
       for (const currentWrapper of nextRoute.wrappers) {
         if (currentWrapper.prefetch) {
-          const currentParams = currentMatch?.params as RouteParamValues;
-
           void Promise.resolve(
-            currentWrapper.prefetch(currentParams, { signal }),
+            currentWrapper.prefetch(rawWrapperParams, { signal }),
           ).catch(ignoreScheduledLoadError);
         }
       }

--- a/packages/runtime/router/src/lib/createRouter.ts
+++ b/packages/runtime/router/src/lib/createRouter.ts
@@ -4,9 +4,15 @@ import ScrollManager from "../a11y/ScrollManager.js";
 import ViewTransitionManager from "../a11y/ViewTransitionManager.js";
 import buildUrl from "./buildUrl.js";
 import createRouterStore from "./createRouterStore.js";
-import { matchPath, renderPattern, splitPathSegments } from "./pathUtils.js";
+import {
+  createRouteCodec,
+  matchPath,
+  renderPattern,
+  splitPathSegments,
+} from "./pathUtils.js";
 import RouteRedirect from "./RouteRedirect.js";
 import StatusResponse from "./StatusResponse.js";
+import { formatIssues, runSchema } from "./schemaUtils.js";
 import type {
   AnyRoute,
   BuildPathFn,
@@ -23,6 +29,7 @@ import type {
   RouteModule,
   RouteName,
   RouteOf,
+  RouteParamValues,
   Router,
   RouterAccessibilityContext,
   RouterAccessibilityDocumentLike,
@@ -32,6 +39,7 @@ import type {
   RouterMatch,
   RouterOptions,
   SearchOf,
+  StandardSchemaIssue,
 } from "./types.js";
 
 type NavigationMode = "initial" | "none" | "pop" | "push";
@@ -207,6 +215,12 @@ function readSearchParams(
   return rawSearch;
 }
 
+/** The `data` payload of the `StatusResponse` thrown on search failure. */
+export interface SearchValidationFailure {
+  readonly issues: ReadonlyArray<StandardSchemaIssue>;
+  readonly message: string;
+}
+
 function validateSearch<TRoute extends AnyRoute>(
   route: TRoute,
   url: URL,
@@ -216,33 +230,48 @@ function validateSearch<TRoute extends AnyRoute>(
   }
 
   const rawSearch = readSearchParams(url.searchParams);
-  const validator = route.search["~standard"].validate;
+  const outcome = runSchema(
+    route.search,
+    rawSearch,
+    `Route '${route.url}' search`,
+  );
 
-  if (!validator) {
-    return rawSearch as SearchOf<TRoute>;
+  if (outcome.issues) {
+    throw new StatusResponse<SearchValidationFailure>(400, {
+      issues: outcome.issues,
+      message: `Search param validation failed: ${formatIssues(outcome.issues)}`,
+    });
   }
 
-  const result = validator(rawSearch);
+  return outcome.value as SearchOf<TRoute>;
+}
 
-  if (
-    typeof result === "object" &&
-    result !== null &&
-    "issues" in result &&
-    Array.isArray((result as { issues: unknown }).issues)
-  ) {
-    const issues = (result as { issues: ReadonlyArray<{ message?: string }> })
-      .issues;
-    const messages = issues
-      .map((issue) => issue.message ?? "Validation error")
-      .join(", ");
-    throw new Error(`Search param validation failed: ${messages}`);
+/**
+ * Validate raw path params against the route's optional `params` schema.
+ *
+ * Returns `null` when the schema rejects the values: the URL does not
+ * identify this route, so matching falls through to the next candidate
+ * (and ultimately the not-found route) — a 404, not an error.
+ */
+function validateParams<TRoute extends AnyRoute>(
+  route: TRoute,
+  rawParams: Record<string, string>,
+): ParamsOf<TRoute> | null {
+  if (!route.params) {
+    return rawParams as ParamsOf<TRoute>;
   }
 
-  if (typeof result === "object" && result !== null && "value" in result) {
-    return (result as { value: unknown }).value as SearchOf<TRoute>;
+  const outcome = runSchema(
+    route.params,
+    rawParams,
+    `Route '${route.url}' params`,
+  );
+
+  if (outcome.issues) {
+    return null;
   }
 
-  return result as SearchOf<TRoute>;
+  return outcome.value as ParamsOf<TRoute>;
 }
 
 function buildHash(hash?: string): string {
@@ -371,15 +400,7 @@ function applyRouteMapMiddleware<TRoutes extends RouteMap>(
         routeName,
         {
           ...transformedRoute,
-          parse(input: string | URL) {
-            return matchPath(transformedRoute.url, buildUrl(input));
-          },
-          render(params: Record<string, string> | Record<string, never>) {
-            return renderPattern(
-              transformedRoute.url,
-              params as Record<string, string>,
-            );
-          },
+          ...createRouteCodec(transformedRoute.url, transformedRoute.params),
         },
       ];
     }),
@@ -407,7 +428,7 @@ function createRouteMatch<
       pathname: url.pathname,
       redirectTo: renderPattern(
         route.redirect as string,
-        params as Record<string, string>,
+        params as Readonly<Record<string, unknown>>,
       ),
       status: route.status,
       url,
@@ -680,7 +701,7 @@ export default function createRouter<
     if (nextRoute) {
       for (const currentWrapper of nextRoute.wrappers) {
         if (currentWrapper.prefetch) {
-          const currentParams = currentMatch?.params as ParamsOf<AnyRoute>;
+          const currentParams = currentMatch?.params as RouteParamValues;
 
           void Promise.resolve(
             currentWrapper.prefetch(currentParams, { signal }),
@@ -959,9 +980,15 @@ export default function createRouter<
     const url = buildUrl(input);
 
     for (const [name, currentRoute] of sortedRoutes) {
-      const params = matchPath(currentRoute.url, url);
+      const rawParams = matchPath(currentRoute.url, url);
 
-      if (!params) {
+      if (!rawParams) {
+        continue;
+      }
+
+      const params = validateParams(currentRoute, rawParams);
+
+      if (params === null) {
         continue;
       }
 
@@ -1009,7 +1036,32 @@ export default function createRouter<
       hydratedHref = null;
     }
 
-    const currentMatch = match(url);
+    // Matching can throw (a search schema rejecting the query string). Commit
+    // the failure as an error result — a shareable URL with a bad query is a
+    // 400 response, not an unhandled rejection.
+    let currentMatch: RouterMatch<TRoutes, TNotFound> | null;
+
+    try {
+      currentMatch = match(url);
+    } catch (thrownError) {
+      const status = getErrorStatus(thrownError);
+      let result!: RouterLoadResult<TRoutes, TNotFound>;
+
+      await runNavigationUpdate(mode, () => {
+        result = createLoadResult<TRoutes, TNotFound>({
+          error: thrownError,
+          location: store.commit(url, null, status).location,
+          match: null,
+          status,
+        });
+
+        currentLoadResult = result;
+      });
+      scheduleAccessibilityEffects(result, mode);
+
+      return result;
+    }
+
     const redirectMatch = currentMatch as unknown;
 
     if (isRedirectMatch(redirectMatch)) {
@@ -1220,7 +1272,7 @@ export default function createRouter<
         });
       },
       currentRoute.content({
-        params: result.match.params,
+        params: result.match.params as RouteParamValues,
         search: result.match.search,
       }),
     );

--- a/packages/runtime/router/src/lib/pathUtils.ts
+++ b/packages/runtime/router/src/lib/pathUtils.ts
@@ -7,6 +7,10 @@
  * handling, and path rendering.
  */
 
+import buildUrl from "./buildUrl.js";
+import { runSchema } from "./schemaUtils.js";
+import type { SchemaLike } from "./types.js";
+
 /** Strip modifier suffixes (regex groups, `?`, `*`, `+`) from a param name. */
 export function extractParamName(patternSegment: string): string {
   return patternSegment
@@ -68,12 +72,14 @@ export function matchPath(
 /**
  * Render a route pattern by substituting param values.
  *
- * Wildcard (`*`) segments are omitted from the output. Throws if a required
- * param is missing from the provided values.
+ * Wildcard (`*`) segments are omitted from the output. Non-string values
+ * (e.g. the output of a params schema that coerces to numbers) are
+ * serialized with `String()`. Throws if a required param is missing from
+ * the provided values.
  */
 export function renderPattern(
   path: string,
-  params: Record<string, string>,
+  params: Readonly<Record<string, unknown>>,
 ): string {
   const segments = splitPathSegments(path);
 
@@ -93,12 +99,54 @@ export function renderPattern(
     const paramName = extractParamName(currentSegment);
     const paramValue = params[paramName];
 
-    if (typeof paramValue !== "string") {
+    if (paramValue === undefined || paramValue === null) {
       throw new Error(`Missing route param '${paramName}' for '${path}'.`);
     }
 
-    return encodeURIComponent(paramValue);
+    return encodeURIComponent(String(paramValue));
   });
 
   return `/${renderedSegments.filter(Boolean).join("/")}`;
+}
+
+/**
+ * Build a route's `parse`/`render` codec pair from its path pattern and
+ * optional params schema.
+ *
+ * `parse` extracts raw string params from the URL and, when a params schema
+ * is present, runs it: a failed validation returns `null` — the URL does not
+ * identify this route — mirroring a plain pattern mismatch. `render` accepts
+ * the schema's output values and serializes them back into the pattern.
+ */
+export function createRouteCodec(
+  path: string,
+  paramsSchema?: SchemaLike<unknown>,
+): {
+  parse(input: string | URL): Readonly<Record<string, unknown>> | null;
+  render(params: Readonly<Record<string, unknown>>): string;
+} {
+  return {
+    parse(input: string | URL) {
+      const rawParams = matchPath(path, buildUrl(input));
+
+      if (rawParams === null || !paramsSchema) {
+        return rawParams;
+      }
+
+      const outcome = runSchema(
+        paramsSchema,
+        rawParams,
+        `Route '${path}' params`,
+      );
+
+      if (outcome.issues) {
+        return null;
+      }
+
+      return outcome.value as Readonly<Record<string, unknown>>;
+    },
+    render(params: Readonly<Record<string, unknown>>) {
+      return renderPattern(path, params);
+    },
+  };
 }

--- a/packages/runtime/router/src/lib/route.test.ts
+++ b/packages/runtime/router/src/lib/route.test.ts
@@ -90,4 +90,33 @@ describe("route", () => {
 
     expect(legacyRoute.wrappers).toEqual([]);
   });
+
+  it("applies a params schema in parse and serializes its output in render", () => {
+    const numericIdSchema = {
+      "~standard": {
+        output: {} as { readonly id: number },
+        validate(value: unknown) {
+          const raw = value as { id?: string };
+          const id = Number(raw.id);
+
+          return Number.isInteger(id)
+            ? { value: { id } }
+            : { issues: [{ message: "id must be an integer" }] };
+        },
+      },
+    };
+
+    const userRoute = route({
+      url: "/users/:id",
+      params: numericIdSchema,
+      content: ({ params }) => String(params.id),
+    });
+
+    // parse validates and coerces; rejection is a non-match, not an error.
+    expect(userRoute.parse("/users/42")).toEqual({ id: 42 });
+    expect(userRoute.parse("/users/abc")).toBeNull();
+
+    // render serializes the schema's output values back into the pattern.
+    expect(userRoute.render({ id: 42 })).toBe("/users/42");
+  });
 });

--- a/packages/runtime/router/src/lib/route.ts
+++ b/packages/runtime/router/src/lib/route.ts
@@ -1,14 +1,14 @@
-import buildUrl from "./buildUrl.js";
-import { matchPath, renderPattern } from "./pathUtils.js";
+import { createRouteCodec } from "./pathUtils.js";
 import type {
   AnyWrapper,
   DataRouteDefinition,
   DataRouteInput,
+  InferParams,
   RedirectRouteDefinition,
   RedirectRouteInput,
   RouteDefinition,
   RouteInput,
-  RouteParams,
+  SchemaLike,
 } from "./types.js";
 
 function isRedirectRouteInput<
@@ -25,29 +25,48 @@ export default function route<
   const TPath extends string,
   TTarget extends string,
   TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 >(
-  definition: RedirectRouteInput<TPath, TTarget, TWrappers>,
-): RedirectRouteDefinition<TPath, TTarget, TWrappers>;
+  definition: RedirectRouteInput<TPath, TTarget, TWrappers, TParamsSchema>,
+): RedirectRouteDefinition<TPath, TTarget, TWrappers, TParamsSchema>;
 export default function route<
   const TPath extends string,
-  TSearchSchema extends
-    | { readonly "~standard": { readonly output?: unknown } }
-    | undefined = undefined,
+  TSearchSchema extends SchemaLike<unknown> | undefined = undefined,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 >(
-  definition: DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers>,
-): DataRouteDefinition<TPath, TSearchSchema, TRendered, TWrappers>;
+  definition: DataRouteInput<
+    TPath,
+    TSearchSchema,
+    TRendered,
+    TWrappers,
+    TParamsSchema
+  >,
+): DataRouteDefinition<
+  TPath,
+  TSearchSchema,
+  TRendered,
+  TWrappers,
+  TParamsSchema
+>;
 export default function route<
   const TPath extends string,
-  TSearchSchema extends
-    | { readonly "~standard": { readonly output?: unknown } }
-    | undefined = undefined,
+  TSearchSchema extends SchemaLike<unknown> | undefined = undefined,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 >(
-  definition: RouteInput<TPath, TSearchSchema, TRendered, TWrappers>,
-): RouteDefinition<TPath, TSearchSchema, TRendered, TWrappers> {
+  definition: RouteInput<
+    TPath,
+    TSearchSchema,
+    TRendered,
+    TWrappers,
+    TParamsSchema
+  >,
+): RouteDefinition<TPath, TSearchSchema, TRendered, TWrappers, TParamsSchema> {
+  const codec = createRouteCodec(definition.url, definition.params);
+
   if (
     isRedirectRouteInput(
       definition as RouteInput<TPath, undefined, unknown, TWrappers>,
@@ -57,13 +76,10 @@ export default function route<
       ...definition,
       wrappers: (definition.wrappers ?? []) as TWrappers,
       parse(input: string | URL) {
-        return matchPath(
-          definition.url,
-          buildUrl(input),
-        ) as RouteParams<TPath> | null;
+        return codec.parse(input) as InferParams<TPath, TParamsSchema> | null;
       },
-      render(params: RouteParams<TPath>) {
-        return renderPattern(definition.url, params as Record<string, string>);
+      render(params: InferParams<TPath, TParamsSchema>) {
+        return codec.render(params as Readonly<Record<string, unknown>>);
       },
     };
   }
@@ -72,13 +88,10 @@ export default function route<
     ...definition,
     wrappers: (definition.wrappers ?? []) as TWrappers,
     parse(input: string | URL) {
-      return matchPath(
-        definition.url,
-        buildUrl(input),
-      ) as RouteParams<TPath> | null;
+      return codec.parse(input) as InferParams<TPath, TParamsSchema> | null;
     },
-    render(params: RouteParams<TPath>) {
-      return renderPattern(definition.url, params as Record<string, string>);
+    render(params: InferParams<TPath, TParamsSchema>) {
+      return codec.render(params as Readonly<Record<string, unknown>>);
     },
   };
 }

--- a/packages/runtime/router/src/lib/schemaUtils.test.ts
+++ b/packages/runtime/router/src/lib/schemaUtils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { formatIssues, runSchema } from "./schemaUtils.js";
+
+describe("runSchema", () => {
+  it("passes the input through when the schema has no validator", () => {
+    const outcome = runSchema(
+      { "~standard": { output: {} as { q?: string } } },
+      { q: "router" },
+      "test",
+    );
+
+    expect(outcome).toEqual({ issues: null, value: { q: "router" } });
+  });
+
+  it("unwraps a Standard Schema success result", () => {
+    const outcome = runSchema(
+      {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate: () => ({ value: { page: 2 } }),
+        },
+      },
+      { page: "2" },
+      "test",
+    );
+
+    expect(outcome).toEqual({ issues: null, value: { page: 2 } });
+  });
+
+  it("returns issues from a Standard Schema failure result", () => {
+    const outcome = runSchema(
+      {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate: () => ({ issues: [{ message: "invalid" }] }),
+        },
+      },
+      {},
+      "test",
+    );
+
+    expect(outcome.issues).toEqual([{ message: "invalid" }]);
+  });
+
+  it("passes through a legacy validator's plain return value", () => {
+    const outcome = runSchema(
+      {
+        "~standard": {
+          output: {} as { auth?: string },
+          validate: (value: unknown) => ({
+            auth: (value as { auth?: string }).auth,
+          }),
+        },
+      },
+      { auth: "1" },
+      "test",
+    );
+
+    expect(outcome).toEqual({ issues: null, value: { auth: "1" } });
+  });
+
+  it("throws when a validator resolves asynchronously", () => {
+    expect(() =>
+      runSchema(
+        {
+          "~standard": {
+            version: 1,
+            vendor: "test",
+            validate: async () => ({ value: {} }),
+          },
+        },
+        {},
+        "Route '/users/:id' params",
+      ),
+    ).toThrow(
+      "Route '/users/:id' params: async schema validation is not supported — the router matches synchronously.",
+    );
+  });
+});
+
+describe("formatIssues", () => {
+  it("joins issue messages and falls back to a default", () => {
+    expect(
+      formatIssues([
+        { message: "a is required" },
+        {} as { message: string },
+        { message: "b must be a number" },
+      ]),
+    ).toBe("a is required, Validation error, b must be a number");
+  });
+});

--- a/packages/runtime/router/src/lib/schemaUtils.test.ts
+++ b/packages/runtime/router/src/lib/schemaUtils.test.ts
@@ -85,7 +85,7 @@ describe("formatIssues", () => {
     expect(
       formatIssues([
         { message: "a is required" },
-        {} as { message: string },
+        {},
         { message: "b must be a number" },
       ]),
     ).toBe("a is required, Validation error, b must be a number");

--- a/packages/runtime/router/src/lib/schemaUtils.ts
+++ b/packages/runtime/router/src/lib/schemaUtils.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared Standard-Schema execution for route `params` and `search` validation.
+ *
+ * Accepts both real Standard Schema v1 validators (Zod, Valibot, ArkType — see
+ * https://standardschema.dev) and the legacy hand-rolled
+ * `{ "~standard": { output, validate } }` shape. The router matches
+ * synchronously, so validators that resolve to a `Promise` are rejected
+ * loudly instead of being silently ignored.
+ */
+
+import type { SchemaLike, StandardSchemaIssue } from "./types.js";
+
+export interface SchemaSuccess {
+  readonly issues: null;
+  readonly value: unknown;
+}
+
+export interface SchemaFailure {
+  readonly issues: ReadonlyArray<StandardSchemaIssue>;
+  readonly value?: undefined;
+}
+
+export type SchemaOutcome = SchemaSuccess | SchemaFailure;
+
+function isIssuesResult(
+  result: unknown,
+): result is { readonly issues: ReadonlyArray<StandardSchemaIssue> } {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "issues" in result &&
+    Array.isArray((result as { issues: unknown }).issues)
+  );
+}
+
+function isValueResult(result: unknown): result is { readonly value: unknown } {
+  return typeof result === "object" && result !== null && "value" in result;
+}
+
+/** Join issue messages for a human-readable validation error. */
+export function formatIssues(
+  issues: ReadonlyArray<StandardSchemaIssue>,
+): string {
+  return issues.map((issue) => issue.message ?? "Validation error").join(", ");
+}
+
+/**
+ * Run a schema's validator against a value and normalize the result.
+ *
+ * - A Standard Schema failure (`{ issues }`) becomes a `SchemaFailure`.
+ * - A Standard Schema success (`{ value }`) unwraps to its `value`.
+ * - A legacy validator returning the parsed object directly passes through.
+ * - A missing validator (legacy type-only schema) passes the input through.
+ * - A `Promise` result throws: the router matches synchronously.
+ */
+export function runSchema(
+  schema: SchemaLike<unknown>,
+  value: unknown,
+  context: string,
+): SchemaOutcome {
+  const validator = schema["~standard"].validate;
+
+  if (!validator) {
+    return { issues: null, value };
+  }
+
+  const result = validator(value);
+
+  if (result instanceof Promise) {
+    throw new Error(
+      `${context}: async schema validation is not supported — the router matches synchronously.`,
+    );
+  }
+
+  if (isIssuesResult(result)) {
+    return { issues: result.issues };
+  }
+
+  if (isValueResult(result)) {
+    return { issues: null, value: result.value };
+  }
+
+  return { issues: null, value: result };
+}

--- a/packages/runtime/router/src/lib/types.ts
+++ b/packages/runtime/router/src/lib/types.ts
@@ -12,9 +12,15 @@ export interface StandardSchemaLike<TOutput = unknown> {
   };
 }
 
-/** A single validation issue, as defined by the Standard Schema spec. */
+/**
+ * A single validation issue, as defined by the Standard Schema spec.
+ *
+ * The spec requires `message`, but it is optional here because the router
+ * also tolerates legacy hand-rolled validators that omit it (a default
+ * message is substituted when formatting).
+ */
 export interface StandardSchemaIssue {
-  readonly message: string;
+  readonly message?: string;
   readonly path?:
     | ReadonlyArray<PropertyKey | { readonly key: PropertyKey }>
     | undefined;

--- a/packages/runtime/router/src/lib/types.ts
+++ b/packages/runtime/router/src/lib/types.ts
@@ -1,9 +1,83 @@
+/**
+ * Legacy hand-rolled schema shape, kept for backwards compatibility.
+ *
+ * Prefer a real Standard Schema v1 validator ({@link StandardSchemaV1});
+ * this shape predates the router's spec alignment and carries its output
+ * type on a non-standard `output` phantom property.
+ */
 export interface StandardSchemaLike<TOutput = unknown> {
   readonly "~standard": {
     readonly output?: TOutput;
     readonly validate?: (value: unknown) => unknown;
   };
 }
+
+/** A single validation issue, as defined by the Standard Schema spec. */
+export interface StandardSchemaIssue {
+  readonly message: string;
+  readonly path?:
+    | ReadonlyArray<PropertyKey | { readonly key: PropertyKey }>
+    | undefined;
+}
+
+/** The result union a Standard Schema v1 `validate` call resolves to. */
+export type StandardSchemaResult<TOutput = unknown> =
+  | { readonly value: TOutput; readonly issues?: undefined }
+  | { readonly issues: ReadonlyArray<StandardSchemaIssue> };
+
+/**
+ * A Standard Schema v1 validator (https://standardschema.dev).
+ *
+ * Zod (≥3.24), Valibot, and ArkType all implement this interface, so their
+ * schemas can be passed directly to a route's `params`/`search` fields.
+ * The router matches synchronously: validators that resolve to a `Promise`
+ * are rejected at match time.
+ */
+export interface StandardSchemaV1<TInput = unknown, TOutput = TInput> {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (
+      value: unknown,
+    ) => StandardSchemaResult<TOutput> | Promise<StandardSchemaResult<TOutput>>;
+    readonly types?:
+      | { readonly input: TInput; readonly output: TOutput }
+      | undefined;
+  };
+}
+
+/**
+ * Any schema the router accepts: a Standard Schema v1 validator or the
+ * legacy hand-rolled shape.
+ */
+export type SchemaLike<TOutput = unknown> =
+  | StandardSchemaV1<unknown, TOutput>
+  | StandardSchemaLike<TOutput>;
+
+type InferLegacyOutput<TSchema> =
+  TSchema extends StandardSchemaLike<infer TLegacyOutput>
+    ? TLegacyOutput
+    : Record<string, never>;
+
+/**
+ * Infer a schema's output type.
+ *
+ * Standard Schema v1 carries it on the `types.output` phantom property
+ * (discriminated by the required `version`/`vendor` members); the legacy
+ * shape carries it on `output`. Falls back to an empty record when neither
+ * is present.
+ */
+export type InferOutput<TSchema> = TSchema extends {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly types?: infer TTypes;
+  };
+}
+  ? [NonNullable<TTypes>] extends [{ readonly output: infer TOutput }]
+    ? TOutput
+    : InferLegacyOutput<TSchema>
+  : InferLegacyOutput<TSchema>;
 
 export type BivariantCallback<TArgs extends readonly unknown[], TResult> = {
   bivarianceHack(...args: TArgs): TResult;
@@ -37,10 +111,24 @@ export type RouteParams<TPath extends string> = [ParamNames<TPath>] extends [
 
 export type RouteParamValues = Readonly<Record<string, string>>;
 
-export type InferSearch<TSchema> =
-  TSchema extends StandardSchemaLike<infer TOutput>
-    ? TOutput
-    : Record<string, never>;
+export type InferSearch<TSchema> = InferOutput<TSchema>;
+
+/**
+ * The params a route's `content`/`prefetch` receive: the params schema's
+ * output when one is declared, otherwise the raw string params inferred
+ * from the path pattern.
+ */
+export type InferParams<TPath extends string, TParamsSchema> = [
+  Exclude<TParamsSchema, undefined>,
+] extends [never]
+  ? RouteParams<TPath>
+  : [Exclude<TParamsSchema, undefined>] extends [SchemaLike<unknown>]
+    ? unknown extends InferOutput<Exclude<TParamsSchema, undefined>>
+      ? // The schema's output is unknowable (e.g. a widened `SchemaLike`
+        // from contextual inference) — fall back to the path-derived params.
+        RouteParams<TPath>
+      : InferOutput<Exclude<TParamsSchema, undefined>>
+    : RouteParams<TPath>;
 
 export interface NavigationContext {
   readonly signal: AbortSignal;
@@ -49,10 +137,7 @@ export interface NavigationContext {
 export type RouteModule = object;
 
 export interface RouteContentProps<
-  TParams extends RouteParamValues | Record<string, never> = Record<
-    string,
-    never
-  >,
+  TParams = Record<string, never>,
   TSearch = Record<string, never>,
 > {
   readonly params: TParams;
@@ -75,26 +160,35 @@ export interface WrapperDefinition<TRendered = unknown> {
   >;
 }
 
-export interface RouteCodec<TPath extends string = string> {
-  parse(url: string | URL): RouteParams<TPath> | null;
-  render(params: RouteParams<TPath>): string;
+export interface RouteCodec<
+  TPath extends string = string,
+  TParams = RouteParams<TPath>,
+> {
+  parse(url: string | URL): TParams | null;
+  render(params: TParams): string;
 }
 
 export type AnyWrapper = WrapperDefinition<unknown>;
 
 export type RouteContent<
   TPath extends string = string,
-  TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
+  TSearchSchema extends SchemaLike<unknown> | undefined = undefined,
   TRendered = unknown,
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 > = BivariantCallback<
-  [props: RouteContentProps<RouteParams<TPath>, InferSearch<TSearchSchema>>],
+  [
+    props: RouteContentProps<
+      InferParams<TPath, TParamsSchema>,
+      InferSearch<TSearchSchema>
+    >,
+  ],
   TRendered
 > & {
   preload?: () => Promise<RouteModule>;
 };
 
 export type AnyRouteContent = BivariantCallback<
-  [props: RouteContentProps<RouteParamValues, unknown>],
+  [props: RouteContentProps<Readonly<Record<string, unknown>>, unknown>],
   unknown
 > & {
   preload?: () => Promise<RouteModule>;
@@ -102,20 +196,27 @@ export type AnyRouteContent = BivariantCallback<
 
 export interface DataRouteInput<
   TPath extends string = string,
-  TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
+  TSearchSchema extends SchemaLike<unknown> | undefined = undefined,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 > {
   readonly url: TPath;
-  readonly content: RouteContent<TPath, TSearchSchema, TRendered>;
+  readonly content: RouteContent<
+    TPath,
+    TSearchSchema,
+    TRendered,
+    TParamsSchema
+  >;
   readonly prefetch?: BivariantCallback<
     [
-      params: RouteParams<TPath>,
+      params: InferParams<TPath, TParamsSchema>,
       search: InferSearch<TSearchSchema>,
       context: NavigationContext,
     ],
     void | Promise<void>
   >;
+  readonly params?: TParamsSchema;
   readonly search?: TSearchSchema;
   readonly wrappers?: TWrappers;
   readonly meta?: Readonly<Record<string, unknown>>;
@@ -127,39 +228,49 @@ export interface RedirectRouteInput<
   TPath extends string = string,
   TTarget extends string = string,
   TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 > {
   readonly url: TPath;
   readonly redirect: TTarget;
   readonly status: StaticRedirectStatus;
+  readonly params?: TParamsSchema;
   readonly wrappers?: TWrappers;
   readonly meta?: Readonly<Record<string, unknown>>;
 }
 
 export type RouteInput<
   TPath extends string = string,
-  TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
+  TSearchSchema extends SchemaLike<unknown> | undefined = undefined,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 > =
-  | DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers>
-  | RedirectRouteInput<TPath, string, TWrappers>;
+  | DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers, TParamsSchema>
+  | RedirectRouteInput<TPath, string, TWrappers, TParamsSchema>;
 
 export interface DataRouteDefinition<
   TPath extends string = string,
-  TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
+  TSearchSchema extends SchemaLike<unknown> | undefined = undefined,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
-> extends RouteCodec<TPath> {
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
+> extends RouteCodec<TPath, InferParams<TPath, TParamsSchema>> {
   readonly url: TPath;
-  readonly content: RouteContent<TPath, TSearchSchema, TRendered>;
+  readonly content: RouteContent<
+    TPath,
+    TSearchSchema,
+    TRendered,
+    TParamsSchema
+  >;
   readonly prefetch?: BivariantCallback<
     [
-      params: RouteParams<TPath>,
+      params: InferParams<TPath, TParamsSchema>,
       search: InferSearch<TSearchSchema>,
       context: NavigationContext,
     ],
     void | Promise<void>
   >;
+  readonly params?: TParamsSchema;
   readonly search?: TSearchSchema;
   readonly wrappers: TWrappers;
   readonly meta?: Readonly<Record<string, unknown>>;
@@ -169,22 +280,31 @@ export interface RedirectRouteDefinition<
   TPath extends string = string,
   TTarget extends string = string,
   TWrappers extends readonly AnyWrapper[] = readonly [],
-> extends RouteCodec<TPath> {
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
+> extends RouteCodec<TPath, InferParams<TPath, TParamsSchema>> {
   readonly url: TPath;
   readonly redirect: TTarget;
   readonly status: StaticRedirectStatus;
+  readonly params?: TParamsSchema;
   readonly wrappers: TWrappers;
   readonly meta?: Readonly<Record<string, unknown>>;
 }
 
 export type RouteDefinition<
   TPath extends string = string,
-  TSearchSchema extends StandardSchemaLike<unknown> | undefined = undefined,
+  TSearchSchema extends SchemaLike<unknown> | undefined = undefined,
   TRendered = unknown,
   TWrappers extends readonly AnyWrapper[] = readonly [],
+  TParamsSchema extends SchemaLike<unknown> | undefined = undefined,
 > =
-  | DataRouteDefinition<TPath, TSearchSchema, TRendered, TWrappers>
-  | RedirectRouteDefinition<TPath, string, TWrappers>;
+  | DataRouteDefinition<
+      TPath,
+      TSearchSchema,
+      TRendered,
+      TWrappers,
+      TParamsSchema
+    >
+  | RedirectRouteDefinition<TPath, string, TWrappers, TParamsSchema>;
 
 export interface AnyRoute {
   readonly url: string;
@@ -193,13 +313,14 @@ export interface AnyRoute {
     [params: unknown, search: unknown, context: NavigationContext],
     void | Promise<void>
   >;
-  readonly search?: StandardSchemaLike<unknown>;
+  readonly params?: SchemaLike<unknown>;
+  readonly search?: SchemaLike<unknown>;
   readonly redirect?: string;
   readonly status?: number;
   readonly wrappers: readonly AnyWrapper[];
   readonly meta?: Readonly<Record<string, unknown>>;
-  parse(url: string | URL): RouteParamValues | Record<string, never> | null;
-  render(params: RouteParamValues | Record<string, never>): string;
+  parse(url: string | URL): Readonly<Record<string, unknown>> | null;
+  render(params: Readonly<Record<string, unknown>>): string;
 }
 
 export type PrependWrapper<
@@ -287,19 +408,18 @@ export type PrefetchFn<TRoutes extends RouteMap> = UnionToIntersection<
 
 export type ParamsOf<TRoute extends AnyRoute> = TRoute extends {
   readonly url: infer TPath extends string;
+  readonly params?: infer TParamsSchema;
 }
-  ? RouteParams<TPath>
+  ? InferParams<TPath, TParamsSchema>
   : Record<string, never>;
 
-export type SearchOf<TRoute extends AnyRoute> =
-  TRoute extends DataRouteDefinition<
-    string,
-    infer TSearchSchema,
-    unknown,
-    readonly AnyWrapper[]
-  >
-    ? InferSearch<TSearchSchema>
-    : Record<string, never>;
+export type SearchOf<TRoute extends AnyRoute> = TRoute extends {
+  readonly search?: infer TSearchSchema;
+}
+  ? [Exclude<TSearchSchema, undefined>] extends [never]
+    ? Record<string, never>
+    : InferOutput<Exclude<TSearchSchema, undefined>>
+  : Record<string, never>;
 
 export type HasParams<TRoute extends AnyRoute> = TRoute extends {
   readonly url: infer TPath extends string;


### PR DESCRIPTION
## Done

Three additive changes to the router's URL-parameter validation, plus docs and a worked example:

- **Standard Schema v1 alignment** (`packages/runtime/router/src/lib/types.ts`): new `StandardSchemaV1`, `StandardSchemaResult`, `StandardSchemaIssue`, and `SchemaLike` types, with `InferOutput` inference keyed on the spec's `types.output` phantom — Zod (≥3.24), Valibot, and ArkType schemas now infer out of the box. The legacy hand-rolled `{ output, validate }` shape keeps working unchanged. This also fixes a latent weak-type inference bug where legacy schema output collapsed to `Record<string, never>` (surfaced by the boilerplate's `<Link search={…} to="account">`).
- **`params` schema on routes** (data and redirect): validates and coerces path params at match time via a shared `schemaUtils.runSchema` executor. A rejected URL is a **non-match** — matching falls through to the next route and ultimately `notFound` (404), mirroring a pattern mismatch. The schema's output type flows everywhere params appear: `content`, `prefetch`, `ParamsOf`, `route.parse`/`render`, `Link`, `navigate`, and `buildPath`; `renderPattern` serializes non-string outputs with `String()`. Middleware codec rebuilds (`applyMiddleware`, `createRouter`) preserve the schema.
- **Search validation failure semantics**: a rejected query string now throws `StatusResponse(400, { issues, message })` instead of a bare `Error`, and `performLoad` commits the failure as a 400 error result instead of rejecting — a real 400 under SSR, an error-boundary render on the client. Async validators throw an explanatory error since `match()` is synchronous.
- Drive-by: `route()` inline in `createRouter({…})` no longer picks up degraded schema/wrapper generics from contextual return-type inference (`InferParams` falls back to path-derived params when the schema output is unknowable).

Docs: rewritten "Schema validation" section (params + search) in `docs/references/ROUTER_API.md`, new "Schema validation for URL params" section and mental-model entry in `packages/runtime/router/README.md`. The boilerplate app's guide route gains a worked v1 params-schema example.

Tests: 18 new cases in router-core (params coercion/fall-through/redirect gating, v1 inference, async-validator rejection, 400 load results, middleware codec preservation, schemaUtils unit tests); suite is 176 passing.

## QA

- From the repo root: `bun run check` (60 projects) and `bun run test` (1065 tests) — both green.
- Runtime behaviour: in `apps/react/boilerplate-vite` (`bun run dev`), `/guides/router-core` renders while `/guides/NotKebab` now 404s; `/account?auth=1` still authenticates via the legacy search schema.
- Typed flow: `router.buildPath("user", { params: { id: 42 } })` compiles with a coercing schema and renders `/users/42`; a wrong param key is a compile error.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` and `build:all` (no new packages; existing scripts untouched).
- [x] This PR introduces no new package — first-time publish steps not applicable.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Not relevant — no visual changes (routing/type-level behaviour only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwiBfpxwWEgZLzJsnqGcTL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwiBfpxwWEgZLzJsnqGcTL)_