### PR TITLE
fix(cli): partial-failure-safe lookupMany, bundledLoader hardening, remove dead sem MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,8 +77,6 @@ static/js/modules
 # NX cache
 .nx/
 
-sem.toml
-sem_modules/
 .claude/
 .kg/
 node_modules

--- a/.mcp.json
+++ b/.mcp.json
@@ -22,12 +22,6 @@
       "args": [
         "mcp"
       ]
-    },
-    "sem": {
-      "args": [
-        "mcp"
-      ],
-      "command": "sem"
     }
   }
 }

--- a/packages/cli/pragma/src/domains/block/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/block/mcp/specs.ts
@@ -5,6 +5,7 @@
  * converts these into registered MCP tools via `registerFromSpec()`.
  */
 
+import { lookupToolMeta } from "../../shared/lookupMany.js";
 import type { ToolSpec } from "../../shared/ToolSpec.js";
 import {
   listFormatters as blockListFmt,
@@ -189,11 +190,14 @@ const specs: readonly ToolSpec[] = [
             results: summaries,
             errors: result.errors,
           },
-          meta: { count: summaries.length },
+          meta: lookupToolMeta(result),
         };
       }
 
-      return { data: result, meta: { count: result.results.length } };
+      return {
+        data: { results: result.results, errors: result.errors },
+        meta: lookupToolMeta(result),
+      };
     },
   },
   {

--- a/packages/cli/pragma/src/domains/block/orchestration/resolveBlockLookup.ts
+++ b/packages/cli/pragma/src/domains/block/orchestration/resolveBlockLookup.ts
@@ -19,12 +19,13 @@ export default async function resolveBlockLookup(
   const nested: LookupResult<BlockDetailed[]> =
     names.length > 0
       ? await lookupMany(names, (query) => lookupBlock(store, query, filters))
-      : { results: [], errors: [] };
+      : { results: [], errors: [], meta: { internalErrorCount: 0 } };
 
   // lookupBlock returns BlockDetailed[] (multiple matches per name) — flatten
   const result: LookupResult<BlockDetailed> = {
     results: nested.results.flat(),
     errors: [...nested.errors, ...globErrors],
+    meta: nested.meta ?? { internalErrorCount: 0 },
   };
 
   return {

--- a/packages/cli/pragma/src/domains/doctor/operations/checks.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("#config", async (importOriginal) => ({
   ...(await importOriginal<typeof import("#config")>()),
@@ -25,6 +28,7 @@ import { bootStore } from "../../shared/bootStore.js";
 import {
   checkConfigFile,
   checkKeStore,
+  checkMcpCommands,
   checkMcpConfigured,
   checkNodeVersion,
   checkPragmaVersion,
@@ -142,6 +146,111 @@ describe("checkMcpConfigured", () => {
     const result = await checkMcpConfigured(ctx);
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("Claude Code");
+  });
+});
+
+describe("checkMcpCommands", () => {
+  const harness = {
+    id: "claude-code",
+    name: "Claude Code",
+    configPath: () => "/test/.mcp.json",
+    skillsPath: () => "/test/.claude/skills",
+    detect: [],
+    version: "*",
+    configFormat: "json" as const,
+    mcpKey: "mcpServers",
+  };
+  const detected = {
+    harness,
+    confidence: "high" as const,
+    configExists: true,
+    configPath: "/test/.mcp.json",
+  };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("skips when no harnesses detected", async () => {
+    vi.mocked(detectHarnesses).mockReturnValue(Promise.resolve([]) as never);
+    const result = await checkMcpCommands(ctx);
+    expect(result.status).toBe("skip");
+  });
+
+  it("skips when only URL-based servers are configured", async () => {
+    vi.mocked(detectHarnesses).mockReturnValue(
+      Promise.resolve([detected]) as never,
+    );
+    vi.mocked(readMcpConfig).mockReturnValue(
+      Promise.resolve({
+        figma: { type: "http", url: "https://mcp.figma.com/mcp" },
+      }) as never,
+    );
+
+    const result = await checkMcpCommands(ctx);
+    expect(result.status).toBe("skip");
+    expect(result.detail).toContain("no command-based");
+  });
+
+  it("passes when every configured command resolves on PATH", async () => {
+    const binDir = mkdtempSync(join(tmpdir(), "pragma-doctor-"));
+    writeFileSync(join(binDir, "pragma"), "#!/bin/sh\n", { mode: 0o755 });
+    vi.stubEnv("PATH", binDir);
+
+    vi.mocked(detectHarnesses).mockReturnValue(
+      Promise.resolve([detected]) as never,
+    );
+    vi.mocked(readMcpConfig).mockReturnValue(
+      Promise.resolve({
+        pragma: { command: "pragma", args: ["mcp"] },
+      }) as never,
+    );
+
+    const result = await checkMcpCommands(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("1 command");
+  });
+
+  it("fails and names the entry whose command does not resolve", async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "pragma-doctor-empty-"));
+    vi.stubEnv("PATH", emptyDir);
+
+    vi.mocked(detectHarnesses).mockReturnValue(
+      Promise.resolve([detected]) as never,
+    );
+    vi.mocked(readMcpConfig).mockReturnValue(
+      Promise.resolve({
+        sem: { command: "sem", args: ["mcp"] },
+      }) as never,
+    );
+
+    const result = await checkMcpCommands(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain('"sem"');
+    expect(result.detail).toContain("/test/.mcp.json");
+    expect(result.remedy).toBeDefined();
+  });
+
+  it("flags only the broken entry among several", async () => {
+    const binDir = mkdtempSync(join(tmpdir(), "pragma-doctor-mixed-"));
+    writeFileSync(join(binDir, "pragma"), "#!/bin/sh\n", { mode: 0o755 });
+    vi.stubEnv("PATH", binDir);
+
+    vi.mocked(detectHarnesses).mockReturnValue(
+      Promise.resolve([detected]) as never,
+    );
+    vi.mocked(readMcpConfig).mockReturnValue(
+      Promise.resolve({
+        pragma: { command: "pragma", args: ["mcp"] },
+        sem: { command: "sem", args: ["mcp"] },
+        figma: { type: "http", url: "https://mcp.figma.com/mcp" },
+      }) as never,
+    );
+
+    const result = await checkMcpCommands(ctx);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain('"sem"');
+    expect(result.detail).not.toContain('"pragma"');
   });
 });
 

--- a/packages/cli/pragma/src/domains/doctor/operations/checks/checkMcpCommands.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks/checkMcpCommands.ts
@@ -1,0 +1,130 @@
+import { existsSync } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
+import type { DetectedHarness } from "@canonical/harnesses";
+import { detectHarnesses, readMcpConfig } from "@canonical/harnesses";
+import { runTask } from "@canonical/task";
+import type { CheckContext, CheckResult } from "../types.js";
+
+const NAME = "MCP commands";
+
+/**
+ * Extract the stdio command from an MCP server config entry, if any.
+ * HTTP/SSE entries (e.g. `{ "type": "http", "url": ... }`) have no command
+ * and are not checked.
+ *
+ * @param entry - Raw server entry from a harness MCP config.
+ * @returns The command string, or `undefined` when the entry is not
+ *   command-based.
+ */
+function commandOf(entry: unknown): string | undefined {
+  if (typeof entry !== "object" || entry === null) return undefined;
+  const command = (entry as { command?: unknown }).command;
+  return typeof command === "string" && command.length > 0
+    ? command
+    : undefined;
+}
+
+/**
+ * Resolve a command the way a shell would: entries containing a path
+ * separator are checked as file paths (relative to the project root),
+ * bare names are searched across `PATH`.
+ *
+ * @param command - Command string from an MCP server entry.
+ * @param cwd - Project root for resolving relative paths.
+ * @returns Whether the command resolves to an existing file.
+ * @note Impure — reads `process.env.PATH` and the filesystem.
+ */
+function commandResolves(command: string, cwd: string): boolean {
+  if (command.includes("/") || command.includes("\\")) {
+    return existsSync(isAbsolute(command) ? command : join(cwd, command));
+  }
+
+  return (process.env.PATH ?? "")
+    .split(delimiter)
+    .filter((dir) => dir.length > 0)
+    .some((dir) => existsSync(join(dir, command)));
+}
+
+/**
+ * Check that every command-based MCP server entry in detected harness
+ * configs resolves to an executable. A dead entry (e.g. a leftover server
+ * whose binary was never installed) makes every agent session try and fail
+ * to boot it, so it is flagged with the offending config path.
+ *
+ * @param ctx - Check context with the working directory.
+ * @returns A CheckResult: pass when all commands resolve, fail listing the
+ *   broken entries, or skip when there is nothing to check.
+ * @note Impure
+ */
+export default async function checkMcpCommands(
+  ctx: CheckContext,
+): Promise<CheckResult> {
+  let detected: DetectedHarness[];
+  try {
+    detected = await runTask(detectHarnesses(ctx.cwd));
+  } catch {
+    return {
+      name: NAME,
+      status: "skip",
+      detail: "harness detection failed",
+    };
+  }
+
+  const withConfig = detected.filter((d) => d.configExists);
+  if (withConfig.length === 0) {
+    return {
+      name: NAME,
+      status: "skip",
+      detail: "no MCP configs found",
+    };
+  }
+
+  const broken: string[] = [];
+  let checked = 0;
+
+  for (const d of withConfig) {
+    let servers: Record<string, unknown>;
+    try {
+      servers = await runTask(readMcpConfig(d.harness, ctx.cwd));
+    } catch {
+      // Config unreadable — the "MCP configured" check reports on this.
+      continue;
+    }
+
+    for (const [serverName, entry] of Object.entries(servers)) {
+      const command = commandOf(entry);
+      if (!command) continue;
+
+      checked += 1;
+      if (!commandResolves(command, ctx.cwd)) {
+        broken.push(
+          `"${serverName}" ("${command}" not found, ${d.configPath})`,
+        );
+      }
+    }
+  }
+
+  if (checked === 0) {
+    return {
+      name: NAME,
+      status: "skip",
+      detail: "no command-based MCP servers configured",
+    };
+  }
+
+  if (broken.length === 0) {
+    return {
+      name: NAME,
+      status: "pass",
+      detail: `${checked} command${checked === 1 ? "" : "s"} resolve on PATH`,
+    };
+  }
+
+  return {
+    name: NAME,
+    status: "fail",
+    detail: `unresolvable: ${broken.join("; ")}`,
+    remedy:
+      "Install the missing command or remove the entry from the MCP config — every agent session tries and fails to boot it.",
+  };
+}

--- a/packages/cli/pragma/src/domains/doctor/operations/checks/index.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks/index.ts
@@ -1,6 +1,7 @@
 /** @module Individual environment health checks invoked by runChecks. */
 export { default as checkConfigFile } from "./checkConfigFile.js";
 export { default as checkKeStore } from "./checkKeStore.js";
+export { default as checkMcpCommands } from "./checkMcpCommands.js";
 export { default as checkMcpConfigured } from "./checkMcpConfigured.js";
 export { default as checkNodeVersion } from "./checkNodeVersion.js";
 export { default as checkPackageRefs } from "./checkPackageRefs.js";

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.test.ts
@@ -8,12 +8,14 @@ vi.mock("./checks/index.js", () => ({
   checkKeStore: vi.fn(),
   checkShellCompletions: vi.fn(),
   checkMcpConfigured: vi.fn(),
+  checkMcpCommands: vi.fn(),
   checkSkillsSymlinked: vi.fn(),
 }));
 
 import {
   checkConfigFile,
   checkKeStore,
+  checkMcpCommands,
   checkMcpConfigured,
   checkNodeVersion,
   checkPackageRefs,
@@ -50,13 +52,14 @@ describe("runChecks", () => {
     vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
     vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkMcpCommands).mockResolvedValue(pass("mcp commands"));
     vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
 
     const data = await runChecks({ cwd: "/test" });
-    expect(data.passed).toBe(8);
+    expect(data.passed).toBe(9);
     expect(data.failed).toBe(0);
     expect(data.skipped).toBe(0);
-    expect(data.checks).toHaveLength(8);
+    expect(data.checks).toHaveLength(9);
   });
 
   it("counts failures and skips correctly", async () => {
@@ -67,10 +70,11 @@ describe("runChecks", () => {
     vi.mocked(checkKeStore).mockResolvedValue(fail("store"));
     vi.mocked(checkShellCompletions).mockResolvedValue(fail("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkMcpCommands).mockResolvedValue(pass("mcp commands"));
     vi.mocked(checkSkillsSymlinked).mockResolvedValue(skip("skills"));
 
     const data = await runChecks({ cwd: "/test" });
-    expect(data.passed).toBe(4);
+    expect(data.passed).toBe(5);
     expect(data.failed).toBe(3);
     expect(data.skipped).toBe(1);
   });
@@ -83,6 +87,7 @@ describe("runChecks", () => {
     vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
     vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkMcpCommands).mockResolvedValue(pass("mcp commands"));
     vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
 
     const data = await runChecks({ cwd: "/test" });
@@ -91,7 +96,7 @@ describe("runChecks", () => {
     expect(data.checks[2].name).toBe("config");
     expect(data.checks[3].name).toBe("refs");
     expect(data.checks[4].name).toBe("store");
-    expect(data.checks[7].name).toBe("skills");
+    expect(data.checks[8].name).toBe("skills");
   });
 
   it("preserves order even when checks resolve out of order", async () => {
@@ -109,6 +114,7 @@ describe("runChecks", () => {
     vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
     vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkMcpCommands).mockResolvedValue(pass("mcp commands"));
     vi.mocked(checkSkillsSymlinked).mockReturnValue(delayed(pass("skills"), 0));
 
     const data = await runChecks({ cwd: "/test" });
@@ -120,6 +126,7 @@ describe("runChecks", () => {
       "store",
       "completions",
       "mcp",
+      "mcp commands",
       "skills",
     ]);
   });
@@ -132,13 +139,14 @@ describe("runChecks", () => {
     vi.mocked(checkKeStore).mockResolvedValue(pass("store"));
     vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkMcpCommands).mockResolvedValue(pass("mcp commands"));
     vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
 
     const data = await runChecks({ cwd: "/test" });
 
     // The whole run still completes; the thrown check becomes a fail in place.
-    expect(data.checks).toHaveLength(8);
-    expect(data.passed).toBe(7);
+    expect(data.checks).toHaveLength(9);
+    expect(data.passed).toBe(8);
     expect(data.failed).toBe(1);
     const failed = data.checks[2];
     expect(failed.status).toBe("fail");
@@ -157,6 +165,7 @@ describe("runChecks", () => {
     vi.mocked(checkKeStore).mockRejectedValue("string failure");
     vi.mocked(checkShellCompletions).mockResolvedValue(pass("completions"));
     vi.mocked(checkMcpConfigured).mockResolvedValue(pass("mcp"));
+    vi.mocked(checkMcpCommands).mockResolvedValue(pass("mcp commands"));
     vi.mocked(checkSkillsSymlinked).mockResolvedValue(pass("skills"));
 
     const data = await runChecks({ cwd: "/test" });

--- a/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/runChecks.ts
@@ -1,6 +1,7 @@
 import {
   checkConfigFile,
   checkKeStore,
+  checkMcpCommands,
   checkMcpConfigured,
   checkNodeVersion,
   checkPackageRefs,
@@ -28,6 +29,7 @@ function buildChecks(
     ["ke store", checkKeStore(ctx)],
     ["Shell completions", checkShellCompletions()],
     ["MCP configured", checkMcpConfigured(ctx)],
+    ["MCP commands", checkMcpCommands(ctx)],
     ["Skills symlinked", checkSkillsSymlinked(ctx)],
   ];
 }

--- a/packages/cli/pragma/src/domains/modifier/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/modifier/mcp/specs.ts
@@ -5,6 +5,7 @@
  * converts these into registered MCP tools via `registerFromSpec()`.
  */
 
+import { lookupToolMeta } from "../../shared/lookupMany.js";
 import type { ToolSpec } from "../../shared/ToolSpec.js";
 import {
   listFormatters as modifierListFmt,
@@ -91,7 +92,10 @@ const specs: readonly ToolSpec[] = [
         };
       }
 
-      return { data: result, meta: { count: result.results.length } };
+      return {
+        data: { results: result.results, errors: result.errors },
+        meta: lookupToolMeta(result),
+      };
     },
   },
   {

--- a/packages/cli/pragma/src/domains/modifier/orchestration/resolveModifierLookup.ts
+++ b/packages/cli/pragma/src/domains/modifier/orchestration/resolveModifierLookup.ts
@@ -18,11 +18,12 @@ export default async function resolveModifierLookup(
   const lookupResult: LookupResult<ModifierFamily> =
     names.length > 0
       ? await lookupMany(names, (query) => lookupModifier(store, query))
-      : { results: [], errors: [] };
+      : { results: [], errors: [], meta: { internalErrorCount: 0 } };
 
   const result: LookupResult<ModifierFamily> = {
     results: lookupResult.results,
     errors: [...lookupResult.errors, ...globErrors],
+    meta: lookupResult.meta ?? { internalErrorCount: 0 },
   };
 
   return {

--- a/packages/cli/pragma/src/domains/shared/contracts.ts
+++ b/packages/cli/pragma/src/domains/shared/contracts.ts
@@ -50,6 +50,15 @@ export interface ListResult<T> {
     | { readonly level: "detailed" };
 }
 
+/** Aggregate metadata about a multi-query lookup. */
+export interface LookupResultMeta {
+  /**
+   * Number of queries that failed with an unexpected (non-Pragma) error.
+   * Each such failure is also present in `errors` with code `INTERNAL_ERROR`.
+   */
+  readonly internalErrorCount: number;
+}
+
 export interface LookupResult<T> {
   readonly results: readonly T[];
   readonly errors: readonly {
@@ -58,6 +67,8 @@ export interface LookupResult<T> {
     message: string;
     suggestions?: readonly string[];
   }[];
+  /** Populated by `lookupMany`; may be absent on hand-built results. */
+  readonly meta?: LookupResultMeta;
 }
 
 export interface ShowContract<T> {

--- a/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.test.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PackageRef } from "../../refs/operations/parseRef.js";
+import createBundledLoader, {
+  resetBundledLoaderCache,
+} from "./bundledLoader.js";
+
+const ref: PackageRef = { kind: "npm", pkg: "@canonical/design-system" };
+
+/** Minimal stand-in for a Bun embedded-file blob. */
+interface FakeBlob {
+  readonly name: string;
+  text(): Promise<string>;
+}
+
+const blob = (name: string, content: string): FakeBlob => ({
+  name,
+  text: async () => content,
+});
+
+const corruptBlob = (name: string): FakeBlob => ({
+  name,
+  text: async () => {
+    throw new Error("embedded blob unreadable");
+  },
+});
+
+const TTL = "@prefix ds: <https://example.test/ds#> .";
+
+function stubEmbeddedFiles(blobs: readonly FakeBlob[]): void {
+  (globalThis as { Bun?: unknown }).Bun = { embeddedFiles: blobs };
+}
+
+const hadBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+const originalBun = (globalThis as { Bun?: unknown }).Bun;
+
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetBundledLoaderCache();
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  resetBundledLoaderCache();
+  if (hadBun) {
+    (globalThis as { Bun?: unknown }).Bun = originalBun;
+  } else {
+    delete (globalThis as { Bun?: unknown }).Bun;
+  }
+  stderrSpy.mockRestore();
+});
+
+const stderrText = (): string =>
+  stderrSpy.mock.calls.map((call) => String(call[0])).join("");
+
+describe("createBundledLoader", () => {
+  it("returns undefined outside a compiled Bun binary", async () => {
+    if (!hadBun) {
+      delete (globalThis as { Bun?: unknown }).Bun;
+      const resolved = await createBundledLoader().resolve(ref);
+      expect(resolved).toBeUndefined();
+    }
+  });
+
+  it("bundles all embedded TTL and reads the manifest version", async () => {
+    stubEmbeddedFiles([
+      blob("button-a1b2c3d4.ttl", TTL),
+      blob("package-a1b2c3d4.json", JSON.stringify({ version: "1.2.3" })),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved).toBeDefined();
+    expect(resolved?.source).toBe("bundled");
+    expect(resolved?.version).toBe("1.2.3");
+    expect(resolved?.graphs).toEqual([
+      {
+        path: "(bundled)/button-a1b2c3d4.ttl",
+        content: TTL,
+        format: "turtle",
+      },
+    ]);
+  });
+
+  it("accepts a plain package.json basename", async () => {
+    stubEmbeddedFiles([
+      blob("button.ttl", TTL),
+      blob("package.json", JSON.stringify({ version: "2.0.0" })),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+    expect(resolved?.version).toBe("2.0.0");
+  });
+
+  it("warns and skips a corrupt TTL blob instead of silently dropping it", async () => {
+    stubEmbeddedFiles([
+      blob("good-a1b2c3d4.ttl", TTL),
+      corruptBlob("bad-a1b2c3d4.ttl"),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved?.graphs).toHaveLength(1);
+    expect(stderrText()).toContain("bad-a1b2c3d4.ttl");
+    expect(stderrText()).toContain("embedded blob unreadable");
+  });
+
+  it("warns on a corrupt package manifest and falls back to 0.0.0", async () => {
+    stubEmbeddedFiles([
+      blob("button.ttl", TTL),
+      blob("package-deadbeef.json", "{ not json"),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved?.version).toBe("0.0.0");
+    expect(stderrText()).toContain("package-deadbeef.json");
+  });
+
+  it("rejects JSON blobs whose basename is not a package manifest", async () => {
+    stubEmbeddedFiles([
+      blob("button.ttl", TTL),
+      blob("mypackage.json", JSON.stringify({ version: "9.9.9" })),
+      blob("package-lock.json", JSON.stringify({ version: "8.8.8" })),
+      blob("packages.json", JSON.stringify({ version: "7.7.7" })),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+    expect(resolved?.version).toBe("0.0.0");
+  });
+
+  it("warns on an invalid semver version and keeps looking", async () => {
+    stubEmbeddedFiles([
+      blob("button.ttl", TTL),
+      blob("package-aaaaaaaa.json", JSON.stringify({ version: "not-semver" })),
+      blob("package-bbbbbbbb.json", JSON.stringify({ version: "3.4.5" })),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved?.version).toBe("3.4.5");
+    expect(stderrText()).toContain('invalid semver "not-semver"');
+  });
+
+  it("caches the resolved package until the cache is reset", async () => {
+    stubEmbeddedFiles([
+      blob("button.ttl", TTL),
+      blob("package.json", JSON.stringify({ version: "1.0.0" })),
+    ]);
+
+    const first = await createBundledLoader().resolve(ref);
+    expect(first?.version).toBe("1.0.0");
+
+    // New fixture without reset — cached result still returned.
+    stubEmbeddedFiles([
+      blob("other.ttl", TTL),
+      blob("package.json", JSON.stringify({ version: "5.0.0" })),
+    ]);
+    const second = await createBundledLoader().resolve(ref);
+    expect(second).toBe(first);
+
+    // After reset the loader re-reads the embedded files.
+    resetBundledLoaderCache();
+    const third = await createBundledLoader().resolve(ref);
+    expect(third?.version).toBe("5.0.0");
+    expect(third).not.toBe(first);
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
@@ -6,13 +6,19 @@
  *
  * Blob names are hashed by bun (e.g. `button-a1b2c3d4.ttl`), losing
  * directory and package association. The loader therefore returns a
- * single SemanticPackage containing ALL embedded TTL content. RDF
- * stores deduplicate triples, so this is safe when combined with
- * higher-precedence loaders that resolve individual packages.
+ * single SemanticPackage containing ALL embedded TTL content, and the
+ * same cached package is returned for every ref this loader resolves.
+ * Note that repeated loads are NOT fully deduplicated by the store:
+ * Oxigraph applies set semantics to ground triples, but blank nodes are
+ * re-minted on every parse, so content loaded both here and by a
+ * higher-precedence loader can produce duplicated blank-node subgraphs.
+ * The orchestrator's first-loader-wins precedence (local > git >
+ * bundled) is what keeps individual packages from double-loading.
  *
  * @note Impure — reads embedded blobs.
  */
 
+import { basename } from "node:path";
 import type { PackageRef } from "../../refs/operations/parseRef.js";
 import type {
   GraphContent,
@@ -26,6 +32,45 @@ import type {
 
 /** Cached result — embedded content is immutable, no need to re-read. */
 let cached: SemanticPackage | undefined;
+
+/**
+ * Reset the module-level cache. Test-only: lets suites exercise the loader
+ * against different `Bun.embeddedFiles` fixtures without module isolation.
+ */
+export function resetBundledLoaderCache(): void {
+  cached = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Embedded package manifest basename: exactly `package.json`, or
+ * `package-<hash>.json` where `<hash>` is bun's content hash suffix.
+ */
+const PACKAGE_MANIFEST_PATTERN = /^package(?:-[0-9a-f]{6,64})?\.json$/i;
+
+/**
+ * Semver 2.0.0 validation (semver.org's suggested pattern).
+ */
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+/**
+ * Whether a blob name is an embedded package manifest — strict basename
+ * match, so unrelated JSON blobs (e.g. `mypackage.json`) are not misread.
+ */
+function isPackageManifest(name: string): boolean {
+  return PACKAGE_MANIFEST_PATTERN.test(basename(name));
+}
+
+/**
+ * Emit a loader warning on stderr (safe for both CLI and MCP stdio use).
+ */
+function warn(message: string): void {
+  process.stderr.write(`Warning: bundled loader: ${message}\n`);
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -80,7 +125,10 @@ async function readEmbeddedGraphs(
         content,
         format: "turtle",
       });
-    } catch {}
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      warn(`skipping unreadable embedded graph "${blob.name}": ${reason}`);
+    }
   }
 
   return graphs;
@@ -94,14 +142,23 @@ async function readEmbeddedVersion(
   blobs: ReadonlyArray<Blob & { name: string }>,
 ): Promise<string> {
   for (const blob of blobs) {
-    if (!blob.name.includes("package") || !blob.name.endsWith(".json"))
-      continue;
+    if (!isPackageManifest(blob.name)) continue;
 
     try {
       const text = await blob.text();
-      const parsed = JSON.parse(text) as { version?: string };
-      if (parsed.version) return parsed.version;
-    } catch {}
+      const parsed = JSON.parse(text) as { version?: unknown };
+      if (typeof parsed.version !== "string") continue;
+      if (!SEMVER_PATTERN.test(parsed.version)) {
+        warn(
+          `ignoring invalid semver "${parsed.version}" in embedded manifest "${blob.name}"`,
+        );
+        continue;
+      }
+      return parsed.version;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      warn(`skipping corrupt embedded manifest "${blob.name}": ${reason}`);
+    }
   }
 
   return "0.0.0";

--- a/packages/cli/pragma/src/domains/shared/loaders/index.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/index.ts
@@ -1,6 +1,9 @@
 /** @module Semantic package loaders — local, git, and bundled resolution. */
 
-export { default as createBundledLoader } from "./bundledLoader.js";
+export {
+  default as createBundledLoader,
+  resetBundledLoaderCache,
+} from "./bundledLoader.js";
 export { default as createGitLoader } from "./gitLoader.js";
 export { default as createLocalLoader } from "./localLoader.js";
 export { default as readPackageDir } from "./readPackageDir.js";

--- a/packages/cli/pragma/src/domains/shared/lookupMany.test.ts
+++ b/packages/cli/pragma/src/domains/shared/lookupMany.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { PragmaError } from "#error";
+import lookupMany, { lookupToolMeta } from "./lookupMany.js";
+
+describe("lookupMany", () => {
+  it("returns all results when every query resolves", async () => {
+    const result = await lookupMany(["a", "b"], async (q) => q.toUpperCase());
+
+    expect(result.results).toEqual(["A", "B"]);
+    expect(result.errors).toEqual([]);
+    expect(result.meta).toEqual({ internalErrorCount: 0 });
+  });
+
+  it("collects PragmaError failures as structured error entries", async () => {
+    const result = await lookupMany(["Button", "Buton"], async (q) => {
+      if (q === "Buton") {
+        throw PragmaError.notFound("block", q, { suggestions: ["Button"] });
+      }
+      return q;
+    });
+
+    expect(result.results).toEqual(["Button"]);
+    expect(result.errors).toEqual([
+      {
+        query: "Buton",
+        code: "ENTITY_NOT_FOUND",
+        message: 'block "Buton" not found.',
+        suggestions: ["Button"],
+      },
+    ]);
+    expect(result.meta).toEqual({ internalErrorCount: 0 });
+  });
+
+  it("keeps N-1 results when one query throws a non-PragmaError", async () => {
+    const result = await lookupMany(
+      ["a", "poisoned", "c"],
+      async (q): Promise<string> => {
+        if (q === "poisoned") {
+          throw new TypeError("cannot read properties of undefined");
+        }
+        return q.toUpperCase();
+      },
+    );
+
+    expect(result.results).toEqual(["A", "C"]);
+    expect(result.errors).toEqual([
+      {
+        query: "poisoned",
+        code: "INTERNAL_ERROR",
+        message: "Internal error: cannot read properties of undefined",
+      },
+    ]);
+    expect(result.meta).toEqual({ internalErrorCount: 1 });
+  });
+
+  it("stringifies non-Error rejection values", async () => {
+    const result = await lookupMany(["a"], async () => {
+      throw "string failure";
+    });
+
+    expect(result.results).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        query: "a",
+        code: "INTERNAL_ERROR",
+        message: "Internal error: string failure",
+      },
+    ]);
+    expect(result.meta).toEqual({ internalErrorCount: 1 });
+  });
+
+  it("counts each internal error and mixes with PragmaError entries", async () => {
+    const result = await lookupMany(
+      ["ok", "missing", "boom-1", "boom-2"],
+      async (q): Promise<string> => {
+        if (q === "missing") throw PragmaError.notFound("token", q);
+        if (q.startsWith("boom")) throw new Error(q);
+        return q;
+      },
+    );
+
+    expect(result.results).toEqual(["ok"]);
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors.map((e) => e.code)).toEqual([
+      "ENTITY_NOT_FOUND",
+      "INTERNAL_ERROR",
+      "INTERNAL_ERROR",
+    ]);
+    expect(result.meta).toEqual({ internalErrorCount: 2 });
+  });
+});
+
+describe("lookupToolMeta", () => {
+  it("reports count and omits internalErrorCount when zero", async () => {
+    const result = await lookupMany(["a", "b"], async (q) => q);
+
+    expect(lookupToolMeta(result)).toEqual({ count: 2 });
+  });
+
+  it("includes internalErrorCount when at least one query failed unexpectedly", async () => {
+    const result = await lookupMany(
+      ["a", "boom"],
+      async (q): Promise<string> => {
+        if (q === "boom") throw new Error("boom");
+        return q;
+      },
+    );
+
+    expect(lookupToolMeta(result)).toEqual({
+      count: 1,
+      internalErrorCount: 1,
+    });
+  });
+
+  it("tolerates hand-built results without meta", () => {
+    expect(lookupToolMeta({ results: ["x"], errors: [] })).toEqual({
+      count: 1,
+    });
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/lookupMany.ts
+++ b/packages/cli/pragma/src/domains/shared/lookupMany.ts
@@ -6,6 +6,11 @@ import type { LookupResult } from "./contracts.js";
  *
  * Used by MCP lookup tools so a single call can return multiple results
  * without failing the entire request when one query is missing.
+ *
+ * The collection loop never rejects: a `PragmaError` becomes an error entry
+ * with its own code, and any other thrown value becomes an `INTERNAL_ERROR`
+ * entry — so one poisoned query cannot discard the other queries' results.
+ * `meta.internalErrorCount` reports how many entries are internal errors.
  */
 export default async function lookupMany<TResult>(
   queries: readonly string[],
@@ -21,6 +26,7 @@ export default async function lookupMany<TResult>(
     queries.map((query) => lookup(query)),
   );
   const results: TResult[] = [];
+  let internalErrorCount = 0;
 
   for (const [index, outcome] of settled.entries()) {
     const query = queries[index];
@@ -45,9 +51,35 @@ export default async function lookupMany<TResult>(
         }),
       });
     } else {
-      throw error;
+      internalErrorCount += 1;
+      const reason = error instanceof Error ? error.message : String(error);
+      errors.push({
+        query,
+        code: "INTERNAL_ERROR",
+        message: `Internal error: ${reason}`,
+      });
     }
   }
 
-  return { results, errors };
+  return { results, errors, meta: { internalErrorCount } };
+}
+
+/**
+ * Build MCP envelope metadata for a lookup result.
+ *
+ * Always reports `count`; includes `internalErrorCount` only when at least
+ * one query failed unexpectedly, so healthy responses stay unchanged.
+ *
+ * @param result - A lookup result, typically produced via {@link lookupMany}.
+ * @returns Meta object for the `{ ok, data, meta }` tool envelope.
+ */
+export function lookupToolMeta<TResult>(result: LookupResult<TResult>): {
+  count: number;
+  internalErrorCount?: number;
+} {
+  const internalErrorCount = result.meta?.internalErrorCount ?? 0;
+  return {
+    count: result.results.length,
+    ...(internalErrorCount > 0 && { internalErrorCount }),
+  };
 }

--- a/packages/cli/pragma/src/domains/standard/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/standard/mcp/specs.ts
@@ -5,6 +5,7 @@
  * converts these into registered MCP tools via `registerFromSpec()`.
  */
 
+import { lookupToolMeta } from "../../shared/lookupMany.js";
 import type { ToolSpec } from "../../shared/ToolSpec.js";
 import {
   type StandardListOutput,
@@ -159,11 +160,14 @@ const specs: readonly ToolSpec[] = [
             ),
             errors: result.errors,
           },
-          meta: { count: result.results.length },
+          meta: lookupToolMeta(result),
         };
       }
 
-      return { data: result, meta: { count: result.results.length } };
+      return {
+        data: { results: result.results, errors: result.errors },
+        meta: lookupToolMeta(result),
+      };
     },
   },
 

--- a/packages/cli/pragma/src/domains/standard/orchestration/resolveStandardLookup.ts
+++ b/packages/cli/pragma/src/domains/standard/orchestration/resolveStandardLookup.ts
@@ -18,11 +18,12 @@ export default async function resolveStandardLookup(
   const lookupResult: LookupResult<StandardDetailed> =
     names.length > 0
       ? await lookupMany(names, (query) => lookupStandard(store, query))
-      : { results: [], errors: [] };
+      : { results: [], errors: [], meta: { internalErrorCount: 0 } };
 
   const result: LookupResult<StandardDetailed> = {
     results: lookupResult.results,
     errors: [...lookupResult.errors, ...globErrors],
+    meta: lookupResult.meta ?? { internalErrorCount: 0 },
   };
 
   return {

--- a/packages/cli/pragma/src/domains/token/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/token/mcp/specs.ts
@@ -7,6 +7,7 @@
 
 import { writeFileSync } from "node:fs";
 import { PragmaError } from "#error";
+import { lookupToolMeta } from "../../shared/lookupMany.js";
 import type { ToolSpec } from "../../shared/ToolSpec.js";
 import {
   createLookupFormatters as createTokenLookupFmt,
@@ -101,7 +102,10 @@ const specs: readonly ToolSpec[] = [
         };
       }
 
-      return { data: result, meta: { count: result.results.length } };
+      return {
+        data: { results: result.results, errors: result.errors },
+        meta: lookupToolMeta(result),
+      };
     },
   },
 

--- a/packages/cli/pragma/src/domains/token/orchestration/resolveTokenLookup.ts
+++ b/packages/cli/pragma/src/domains/token/orchestration/resolveTokenLookup.ts
@@ -18,11 +18,12 @@ export default async function resolveTokenLookup(
   const lookupResult: LookupResult<TokenDetailed> =
     names.length > 0
       ? await lookupMany(names, (query) => lookupToken(store, query))
-      : { results: [], errors: [] };
+      : { results: [], errors: [], meta: { internalErrorCount: 0 } };
 
   const result: LookupResult<TokenDetailed> = {
     results: lookupResult.results,
     errors: [...lookupResult.errors, ...globErrors],
+    meta: lookupResult.meta ?? { internalErrorCount: 0 },
   };
 
   return {

--- a/packages/cli/pragma/src/mcp/types.ts
+++ b/packages/cli/pragma/src/mcp/types.ts
@@ -25,6 +25,8 @@ export type ToolPayload =
       readonly meta?: {
         readonly count?: number;
         readonly filters?: Record<string, string>;
+        /** Queries that failed unexpectedly (surfaced only when > 0). */
+        readonly internalErrorCount?: number;
       };
     }
   | {
@@ -47,6 +49,8 @@ export interface ToolResponse<T = unknown> {
   readonly meta: {
     readonly count?: number;
     readonly filters?: Record<string, string>;
+    /** Queries that failed unexpectedly (surfaced only when > 0). */
+    readonly internalErrorCount?: number;
   };
 }
 

--- a/packages/summon/monorepo/src/templates/gitignore.ejs
+++ b/packages/summon/monorepo/src/templates/gitignore.ejs
@@ -61,5 +61,3 @@ session/
 GEMINI.md
 .kg/
 .mcp.json
-sem.toml
-sem_modules/


### PR DESCRIPTION
## Done

- **`lookupMany` partial-failure safety** (`packages/cli/pragma/src/domains/shared/lookupMany.ts`): a non-`PragmaError` thrown for one item used to rethrow and abort the whole batch, discarding all good results. Unexpected failures now become `INTERNAL_ERROR` error entries (same shape as the existing not-found entries) and the result carries `meta.internalErrorCount`. The four MCP lookup tools (`block_lookup`, `modifier_lookup`, `standard_lookup`, `token_lookup`) surface `internalErrorCount` in the `{ ok, data, meta }` envelope meta only when it is non-zero, so healthy responses stay byte-identical (verified by the existing parity tests). New unit suite `lookupMany.test.ts` covers the N−1-results + 1-`INTERNAL_ERROR` batch, non-Error rejections, and meta counts.
- **Remove the dead `sem` MCP server**: dropped the `"sem": { "command": "sem" }` entry from `.mcp.json` (the command does not exist, so every agent session tried and failed to boot it). Repo-wide grep found two leftovers of the same tool, both removed: `sem.toml` / `sem_modules/` ignore entries in `.gitignore` and in `packages/summon/monorepo/src/templates/gitignore.ejs`. No other references exist (remaining `sem` hits are unrelated `semver`/`semantic` strings).
- **New doctor check `MCP commands`** (`packages/cli/pragma/src/domains/doctor/operations/checks/checkMcpCommands.ts`): flags MCP config entries in detected harnesses whose `command` does not resolve on `PATH` (URL-based servers are ignored), naming the broken entry and config file with a remedy. Wired into `runChecks.ts`; unit tests added in `checks.test.ts` and `runChecks.test.ts`.
- **`bundledLoader` hardening** (`packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts`): the two silent `catch {}` blocks now emit stderr warnings (stdio-safe for MCP) so skipped/corrupt embedded blobs are visible; the loose `blob.name.includes("package")` manifest match is replaced with strict basename validation (`package.json` / `package-<hash>.json`) plus semver validation of the `version` field; exported `resetBundledLoaderCache()` gives tests a way to reset the module-level cache; the false "RDF stores deduplicate triples" header comment now describes the actual behavior (Oxigraph set semantics on ground triples, blank nodes re-minted per parse, first-loader-wins precedence). New suite `bundledLoader.test.ts` covers corrupt-blob warning + skip, basename rejection, invalid semver, and cache reset.

Out of scope per owner: anything in the `pragma token` domain (token add-config's phantom package reference is deferred).

## QA

- `cd packages/cli/pragma && bun run check`:
  ```
  ✓ biome ✓ package-structure ✓ package-license — Summary: All 3 validations passed
  ```
  (`check:biome`, `check:ts`, and `check:webarchitect` all green)
- `cd packages/cli/pragma && bun run test`:
  ```
  Test Files  150 passed | 1 skipped (151)
       Tests  1086 passed | 2 skipped (1088)
  ```
- `python3 -c "import json; json.load(open('.mcp.json'))"` → valid JSON after the `sem` removal.
- `git grep -n '\bsem\b'` (excluding `semver`/`semantic`) → no remaining references to the dead server.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. (No changes to package scripts in this PR.)
- [x] This PR introduces no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic. (CLI-only change, no visual surface.)

## Screenshots

Not relevant — CLI/MCP behavior only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Be8jVERCqAqCPLHZXH4uJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012Be8jVERCqAqCPLHZXH4uJ)_