### PR TITLE
fix(ds-global,ds-global-form,styles): token, colour & typography corrections from design review

### DIFF
--- a/packages/react/ds-global-form/src/index.css
+++ b/packages/react/ds-global-form/src/index.css
@@ -99,7 +99,8 @@
 
   /* ── Label ──────────────────────────────────────────────────────── */
 
-  --form-label-font-weight: var(--typography-text-primary-bold-font-weight);
+  /* Field labels use regular paragraph weight, not bold (per design review). */
+  --form-label-font-weight: var(--typography-text-primary-font-weight);
   --form-label-font-size: var(--typography-text-primary-font-size);
   --form-label-color: var(--color-text);
   /* --form-label-padding-block:  … ; */ /* block padding for label  */

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateInput/styles.css
@@ -12,4 +12,12 @@
   &::-webkit-inner-spin-button {
     display: none;
   }
+
+  /* NOTE (design review — "suggested" format text → muted): NOT implementable in
+   * pure CSS on a native <input type="date">. It has no placeholder attribute
+   * (so `:placeholder-shown` never matches), and `::-webkit-datetime-edit`
+   * colours the whole edit region — mask AND typed value — with no selector for
+   * the empty state, and Firefox ignores it entirely. A muted-only-when-empty
+   * hint needs a custom (non-native) date control or a JS empty-state hook.
+   * Parked for Diana. */
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/styles.css
@@ -12,4 +12,12 @@
   &::-webkit-inner-spin-button {
     display: none;
   }
+
+  /* NOTE (design review — "suggested" format text → muted): NOT implementable in
+   * pure CSS on a native <input type="datetime-local">. It has no placeholder
+   * attribute (so `:placeholder-shown` never matches), and
+   * `::-webkit-datetime-edit` colours the whole edit region — mask AND typed
+   * value — with no selector for the empty state, and Firefox ignores it
+   * entirely. A muted-only-when-empty hint needs a custom (non-native) control
+   * or a JS empty-state hook. Parked for Diana. */
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/styles.css
@@ -1,5 +1,5 @@
 .ds.field-label {
-  font-weight: var(--form-label-font-weight, bold);
+  font-weight: var(--form-label-font-weight, normal);
   color: var(--form-label-color);
   /* No side padding by default — the label aligns to the field edge, not the
    * input's inner padding. Overridable via the variable. */
@@ -18,9 +18,8 @@
   }
 
   /* The "(optional)" suffix is a muted hint, visually subordinate to the label
-   * (which is bold) — not the same weight/colour as the label text. */
+   * — distinguished by colour (the label now uses regular paragraph weight too). */
   & > .optional {
-    font-weight: var(--typography-text-primary-font-weight, normal);
     color: var(--color-text-muted);
   }
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/PasswordInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/PasswordInput/styles.css
@@ -29,7 +29,7 @@
     padding-inline: var(--form-field-inline-gap);
     border: none;
     background: transparent;
-    color: var(--color-text-muted);
+    color: var(--color-icon);
     cursor: pointer;
 
     & > .reveal-icon {
@@ -54,9 +54,8 @@
       }
     }
 
-    &:hover:not(:disabled) {
-      color: var(--color-text);
-    }
+    /* No hover colour change: the reveal toggle keeps `--color-icon` in all
+     * pointer states (per design review). */
 
     &:focus-visible {
       outline: none;

--- a/packages/react/ds-global/src/lib/component/Badge/styles.css
+++ b/packages/react/ds-global/src/lib/component/Badge/styles.css
@@ -1,14 +1,17 @@
-/* Component tokens (migrated from @canonical/styles-primitives-canonical tokens.css) */
-:root {
-  --badge-color-background: var(--tmp-color-text-default);
-  --badge-color-text: var(--tmp-color-background-default);
+/* Badge.css */
+.ds.badge {
+  /* Component tokens — sourced from @canonical/design-tokens */
+  --badge-color-background: var(--color-foreground-secondary);
+  --badge-color-text: var(--color-text-onForegroundSecondary);
 
-  --badge-border-radius: 1rem;
-  --badge-font-size: var(--font-size-xsmall);
-  --badge-font-weight: var(--font-weight-bold);
-  --badge-line-height: var(--line-height-xsmall);
+  --badge-border-radius: var(--dimension-radius-full);
+  --badge-font-family: var(--typography-text-tertiary-bold-font-family);
+  --badge-font-size: var(--typography-text-tertiary-bold-font-size);
+  --badge-font-weight: var(--typography-text-tertiary-bold-font-weight);
+  --badge-letter-spacing: var(--typography-text-tertiary-bold-letter-spacing);
+  --badge-line-height: var(--typography-text-tertiary-bold-line-height);
   --badge-padding-vertical: 0;
-  --badge-padding-horizontal: var(--spacing-horizontal-xsmall);
+  --badge-padding-horizontal: var(--dimension-050);
   --badge-margin-bottom: 0;
 
   --badge-max-width: 4ch;
@@ -16,12 +19,6 @@
     var(--badge-line-height) -
     (2 * var(--badge-padding-horizontal))
   );
-}
-
-/* Badge.css */
-.ds.badge {
-  /** Pull the badge closer to the edge of a chip */
-  --badge-chip-margin-tweak: 0.15rem;
 
   /* Base badge styles using tokens */
   background-color: var(
@@ -32,8 +29,10 @@
   box-sizing: content-box;
   color: var(--modifier-color-text, var(--badge-color-text));
   display: inline-block;
+  font-family: var(--badge-font-family);
   font-size: var(--badge-font-size);
   font-weight: var(--badge-font-weight);
+  letter-spacing: var(--badge-letter-spacing);
   line-height: var(--badge-line-height);
   margin-bottom: var(--badge-margin-bottom);
   max-width: var(--badge-max-width);

--- a/packages/react/ds-global/src/lib/component/Badge/styles.css
+++ b/packages/react/ds-global/src/lib/component/Badge/styles.css
@@ -27,7 +27,15 @@
   );
   border-radius: var(--badge-border-radius);
   box-sizing: content-box;
-  color: var(--modifier-color-text, var(--badge-color-text));
+  /* Label sits on the badge's own (criticality) surface, so it reads the
+   * on-surface text channel — NOT --modifier-color-text (the standalone
+   * criticality text colour), which would render same-hue-on-same-hue with
+   * failing contrast. Falls back to the neutral on-surface token for the
+   * default (no-criticality) badge. */
+  color: var(
+    --modifier-color-text-onForegroundSecondary,
+    var(--badge-color-text)
+  );
   display: inline-block;
   font-family: var(--badge-font-family);
   font-size: var(--badge-font-size);

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/styles.css
@@ -12,15 +12,15 @@
  * dimension scale (Figma specs 6px, which is not on the scale; the nearest
  * token is dimension-100 = 8px).
  */
-:root {
+.ds.breadcrumbs-item {
+  /* Component tokens — pure aliases to semantic tokens, component-scoped
+     per cs:styling.tokens.scoping */
   --breadcrumbs-item-link-color: var(--color-text-link);
   --breadcrumbs-item-current-color: var(--color-text);
   --breadcrumbs-item-separator-color: var(--color-text);
   --breadcrumbs-item-separator-margin: var(--dimension-100);
   --breadcrumbs-item-focus-color: var(--color-text-link);
-}
 
-.ds.breadcrumbs-item {
   /* layout.type: flow, layout.direction: horizontal */
   display: flex;
   flex-direction: row;

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -47,10 +47,10 @@
                          border. `.primary` overrides text/icon with the on-fill
                          contrast tokens.
 
-  Interaction states read the per-state surface/text channels supplied by the
-  states shim (`--modifier-surface-{hover,active,disabled}`,
-  `--modifier-color-text-disabled`), which resolve to the explicit state tokens
-  and recolour per anticipation.
+  Interaction states read the per-state surface/text/border channels supplied
+  by the states shim (`--modifier-surface-{hover,active,disabled}`,
+  `--modifier-color-text-disabled`, `--modifier-color-border-disabled`), which
+  resolve to the explicit state tokens and recolour per anticipation.
 */
 
 .ds.button {
@@ -120,7 +120,9 @@
   /* Disabled — explicit disabled tokens (not the computed deltas): the surface,
      text and border each resolve to their `-disabled` token. Primary supplies
      the on-fill disabled text via `--modifier-color-text-disabled`; ghost
-     importances fall back to the plain disabled text colour. */
+     importances fall back to the plain disabled text colour. The border reads
+     the disabled border channel, so it stays on the same highlighted ramp as
+     the enabled border and recolours per anticipation. */
   &:disabled {
     cursor: not-allowed;
     color: var(--modifier-color-text-disabled, var(--color-text-disabled));
@@ -128,7 +130,10 @@
       --modifier-surface-disabled,
       var(--button-color-background-disabled)
     );
-    border-color: var(--color-border-disabled);
+    border-color: var(
+      --modifier-color-border-disabled,
+      var(--color-border-highlighted-disabled)
+    );
   }
 }
 

--- a/packages/react/ds-global/src/lib/component/Chip/styles.css
+++ b/packages/react/ds-global/src/lib/component/Chip/styles.css
@@ -99,6 +99,9 @@
 
   /* Context-specific styling for badges within chips */
   & .ds.badge {
+    /** Pull the badge closer to the edge of a chip */
+    --badge-chip-margin-tweak: var(--dimension-025);
+
     align-self: center;
     margin-left: var(--spacing-horizontal-small);
     margin-right: var(--badge-chip-margin-tweak);

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/styles.css
@@ -18,6 +18,9 @@
   --contextual-menu-item-padding-inline: var(--dimension-200);
   /* 4px gap: icon<->text and text<->caret (per the spec). */
   --contextual-menu-item-gap: var(--dimension-050);
+  /* De-emphasised slot text (badge / shortcut) — muted, matching
+     KeyboardKey / Tabs. */
+  --contextual-menu-item-slot-color: var(--color-text-muted);
 }
 
 .ds.contextual-menu-item {
@@ -29,7 +32,9 @@
   padding-inline: var(--contextual-menu-item-padding-inline);
   color: var(--contextual-menu-item-color-text);
   background-color: var(--contextual-menu-item-color-background);
-  line-height: var(--line-height-text, var(--dimension-300));
+  /* The --dimension-300 (24px) fallback is load-bearing: the typography var's
+     --number-line-height-* reference is unresolved in the built tokens. */
+  line-height: var(--typography-text-primary-line-height, var(--dimension-300));
   cursor: pointer;
   user-select: none;
 
@@ -53,7 +58,7 @@
   > .slot {
     flex: 0 0 auto;
     margin-inline-start: auto;
-    opacity: 0.7;
+    color: var(--contextual-menu-item-slot-color);
   }
 
   /* The submenu caret sits on the trailing edge in a fixed icon box (Figma:
@@ -81,6 +86,11 @@
     background-color: var(--contextual-menu-item-color-background);
     cursor: not-allowed;
     pointer-events: none;
+
+    /* The slot follows the disabled text colour instead of staying muted. */
+    > .slot {
+      color: inherit;
+    }
   }
 }
 

--- a/packages/styles/main/src/modifiers.criticality.shim.css
+++ b/packages/styles/main/src/modifiers.criticality.shim.css
@@ -1,47 +1,71 @@
-/* @canonical/styles — Criticality modifier ICON SHIM (temporary)
+/* @canonical/styles — Criticality modifier SHIM (temporary)
  *
  * The generated `@canonical/design-tokens/dist/modifiers.criticality.css`
  * exposes the colour channels for each criticality (`--modifier-color-icon`,
- * `-text`, `-border`, `-foreground-secondary`) but NOT an icon channel: nothing
- * says *which glyph* signals "information" vs "warning" etc. Criticality-driven
- * components (Announcement, and future callouts) each hard-code that mapping in
- * their own markup today.
+ * `-text`, `-border`, `-foreground-secondary`) but is missing two channels this
+ * shim fills in, keyed off the criticality class. Remove each block once its
+ * channel is generated upstream in the criticality modifier tokens.
  *
- * This hand-authored shim adds a single channel, keyed off the criticality
- * class, that carries the glyph as a CSS `mask-image` reference into the
- * Canonical icon set (served at `/icons/<name>.svg`):
+ * Design contract — components listen to the CHANNEL, never to the class. A
+ * consumer must not key off `.information` / `.warning`; it reads the generic
+ * channel, so any criticality gets the right value for free.
+ *
+ * ── 1. Icon channel (--modifier-icon) ──────────────────────────────────────
+ * Nothing upstream says *which glyph* signals "information" vs "warning" etc.
+ * Criticality-driven components (Announcement, and future callouts) each
+ * hard-code that mapping in their own markup today. This adds a channel that
+ * carries the glyph as a CSS `mask-image` reference into the Canonical icon set
+ * (served at `/icons/<name>.svg`):
  *
  *   --modifier-icon   a `mask-image` value; a component masks a pseudo-element
  *                     with it and fills it with `--modifier-color-icon`, so the
  *                     glyph both matches the criticality AND takes its colour.
  *
- * Design contract — components listen to the CHANNEL, never to the class. A
- * consumer must not key off `.information` / `.warning`; it reads
- * `--modifier-icon` generically, so any criticality gets the right glyph for
- * free. This mirrors the mask technique used by Accordion's chevron and the
- * form CheckboxInput's checkmark (mask-image + background-color so the glyph is
+ * This mirrors the mask technique used by Accordion's chevron and the form
+ * CheckboxInput's checkmark (mask-image + background-color so the glyph is
  * recolourable, unlike a background-image SVG).
+ *
+ * ── 2. On-surface text channel (--modifier-color-text-onForegroundSecondary) ─
+ * The generated `--modifier-color-text` is the *standalone* criticality text
+ * colour (e.g. green text on the page background). Components that place text on
+ * the criticality's own coloured surface — Badge sits its label on
+ * `--modifier-color-foreground-secondary` — need the *on-surface* pairing
+ * instead, or they render same-hue-on-same-hue with failing contrast. The
+ * design-tokens build already defines `--color-text-onForegroundSecondary-*`
+ * per criticality; it just isn't wired into the modifier family. This exposes
+ * it as a channel so on-surface criticality components read it generically.
  *
  * Imported into the `ds.modifiers` layer after the generated criticality
  * modifiers so these class rules compose at equal specificity, later source
- * order. Remove once an icon channel is generated upstream in the criticality
- * modifier tokens.
+ * order.
  */
 
 @layer ds.modifiers {
   .information {
     --modifier-icon: url("/icons/information.svg#information");
+    --modifier-color-text-onForegroundSecondary: var(
+      --color-text-onForegroundSecondary-information
+    );
   }
 
   .success {
     --modifier-icon: url("/icons/success.svg#success");
+    --modifier-color-text-onForegroundSecondary: var(
+      --color-text-onForegroundSecondary-success
+    );
   }
 
   .warning {
     --modifier-icon: url("/icons/warning.svg#warning");
+    --modifier-color-text-onForegroundSecondary: var(
+      --color-text-onForegroundSecondary-warning
+    );
   }
 
   .error {
     --modifier-icon: url("/icons/error.svg#error");
+    --modifier-color-text-onForegroundSecondary: var(
+      --color-text-onForegroundSecondary-error
+    );
   }
 }

--- a/packages/styles/main/src/modifiers.importance.shim.css
+++ b/packages/styles/main/src/modifiers.importance.shim.css
@@ -25,8 +25,10 @@
  *   with the on-foreground contrast tokens. This shim is imported after the
  *   anticipation/emphasis modifiers in the same `ds.modifiers` layer, so on a
  *   `.primary.destructive` button the anticipation colour drives the fill while
- *   this contrast text wins (equal specificity, later source order). For ghost
- *   importances the text channel is left untouched, so the anticipation colour
+ *   this contrast text wins (equal specificity, later source order).
+ *   `.secondary` pins its text to the root text colour by the same mechanism —
+ *   per design, the secondary label never takes the anticipation colour. Only
+ *   `.tertiary` leaves the text channel untouched, so the anticipation colour
  *   lands on the text — exactly the Figma treatment.
  */
 
@@ -60,8 +62,9 @@
     );
   }
 
-  /* Secondary — outlined: a ghost background with a visible border; text/icon
-     keep the modifier colour. */
+  /* Secondary — outlined: a ghost background with a visible border; the icon
+     keeps the modifier colour, but the label is pinned to the root text colour
+     (the anticipation colour shows on the border/fill states, not the text). */
   .secondary {
     --modifier-surface: var(
       --modifier-color-foreground-ghost,
@@ -73,6 +76,10 @@
       --modifier-color-foreground-ghost-disabled
     );
     --modifier-outline: 1;
+    /* `color/text/root` compiles to the bare `--color-text` var; re-point at a
+       dedicated `button.secondary` semantic token once ratified upstream. */
+    --modifier-color-text: var(--color-text);
+    --modifier-color-text-disabled: var(--color-text-disabled);
   }
 
   /* Tertiary — text: a ghost background, no border; text/icon keep the modifier

--- a/packages/styles/main/src/modifiers.states.shim.css
+++ b/packages/styles/main/src/modifiers.states.shim.css
@@ -69,6 +69,10 @@
     );
     --modifier-color-text-disabled: var(--color-text-disabled);
     --modifier-color-icon-disabled: var(--color-icon-disabled);
+    /* The disabled border tracks the highlighted ramp the enabled border uses
+       (it matches the disabled-text tone), not the much fainter plain
+       border-disabled ramp. */
+    --modifier-color-border-disabled: var(--color-border-highlighted-disabled);
   }
 
   .constructive {
@@ -92,6 +96,7 @@
     );
     --modifier-color-text-disabled: var(--color-text-constructive-disabled);
     --modifier-color-icon-disabled: var(--color-icon-constructive-disabled);
+    --modifier-color-border-disabled: var(--color-border-constructive-disabled);
   }
 
   .destructive {
@@ -115,6 +120,7 @@
     );
     --modifier-color-text-disabled: var(--color-text-destructive-disabled);
     --modifier-color-icon-disabled: var(--color-icon-destructive-disabled);
+    --modifier-color-border-disabled: var(--color-border-destructive-disabled);
   }
 
   /* `caution` uses the `warning` colour ramp. The ghost-warning state tokens do
@@ -144,6 +150,7 @@
     );
     --modifier-color-text-disabled: var(--color-text-warning-disabled);
     --modifier-color-icon-disabled: var(--color-icon-warning-disabled);
+    --modifier-color-border-disabled: var(--color-border-warning-disabled);
   }
 
   .branded {
@@ -167,5 +174,6 @@
     );
     --modifier-color-text-disabled: var(--color-text-branded-disabled);
     --modifier-color-icon-disabled: var(--color-icon-branded-disabled);
+    --modifier-color-border-disabled: var(--color-border-branded-disabled);
   }
 }


### PR DESCRIPTION
## Done

First of a 3-PR stack addressing Diana's component-review notes (Coda `dianas_review_notes`, 26/04 pass). This PR: **token & colour corrections** — CSS-only, no geometry or behaviour changes. Stack: this → geometry (spacing/sizing) → behaviour/structure/a11y.

- **Button** — secondary label pinned to root text colour (`--modifier-color-text: var(--color-text)` in the `.secondary` shim block; anticipation colour remains on border/fill). Disabled border moves onto a new per-anticipation `--modifier-color-border-disabled` channel on the highlighted ramp (was hard-wired neutral `--color-border-disabled`). *(Diana: must fix ×2)*
- **Badge** — replaces **undefined** vars (`--tmp-color-*`, `--spacing-horizontal-xsmall`, `--font-*`) with real tokens: `--color-foreground-secondary` + `--color-text-onForegroundSecondary`, the `--typography-text-tertiary-bold-*` multi-var set (matches Figma `text/tertiary/bold` 12/16/600), `--dimension-050` padding; `1rem` radius literal → `--dimension-radius-full`; tokens scoped `:root` → `.ds.badge`; chip-margin tweak relocated into Chip and tokenised. *(Diana: "token issues visible: must fix")*
- **Breadcrumbs** — component tokens scoped `:root` → `.ds.breadcrumbs-item`; all pure aliases (link colour was already `--color-text-link` per Diana's note).
- **ContextualMenu** — slot `opacity: 0.7` literal → `--contextual-menu-item-slot-color: var(--color-text-muted)` (+ disabled slot inherits); phantom `--line-height-text` → `--typography-text-primary-line-height` (keeps the load-bearing `--dimension-300` fallback).

**Explicitly not in this PR**
- Caution ghost background *(Diana: later)* — **blocked upstream**: `color.foreground.ghost.warning*` tokens don't exist in the published design-tokens build.
- Card border 1px/border-muted — **no code change needed**: already correct; the reviewed Storybook was built with the stale token bundle fixed by #748. Please re-verify on the next deploy.
- Known upstream token-build bug: `--typography-text-tertiary-bold-*` aliases chain to never-emitted kebab-case primitives, so Badge typography falls back until design-tokens fixes the chain (issue to be filed).

## QA

- `nx run-many -t check test build --projects=@canonical/styles,@canonical/react-ds-global` — green (35 tasks).
- Chromatic runs on purpose (visual deltas are the point): expect secondary-button label colour, badge fill/typography, menu slot colour diffs.
- Sweep note: `--modifier-color-text` on `.secondary` also reaches Chip/Badge/form consumers carrying `.secondary` — intended per the design language, worth a look in the Chromatic diff.

### PR readiness check

- [x] Label: `Bug 🐛`
- [x] Conventional-commit title
- [x] Follows code standards (tokens-not-literals; component-token scoping per cs:styling)
- [x] Packages define check/test
- [ ] `no visual change` — NOT applicable: visual change is intended

## Screenshots

Chromatic will capture: Button DisabledMatrix + importance stories, Badge stories, Breadcrumbs, ContextualMenu slot stories.

---

### Update — added `ds-global-form` colour & typography (Diana form review)

Same colour/typography axis, extended to the form package (Coda `dianas_review_notes`):

- **PasswordInput** eye-toggle icon → `--color-icon` (`color/icon/root`), hover colour change removed.
- **Field label** weight → regular paragraph (`--typography-text-primary-font-weight`), global across all `*Field` labels — was bold.
- **DateInput / DateTimeInput** — "suggested" format hint → muted is **NOT implementable in pure CSS** on a native date input (no placeholder attr, `::-webkit-datetime-edit` colours the whole region, Firefox ignores it). **Parked for Diana** as an in-file NOTE; needs a custom control or JS empty-state hook.
- **NumberInput** prefix/suffix — already `--color-text-muted` in code (verified, no change); Diana likely saw the stale-token Storybook (#748).

Gate: `nx check @canonical/react-ds-global-form` green (biome + tsc + webarchitect, 39 tasks).

### Update 2 — Badge on-surface criticality text (channel via shim)

Badge sits its label on the criticality surface (`--modifier-color-foreground-secondary`) but read `--modifier-color-text` — the *standalone* criticality text colour — so coloured badges rendered same-hue-on-same-hue (failing contrast). The design-tokens build already defines `--color-text-onForegroundSecondary-{success,error,warning,information}`, but the generated criticality modifier family does not expose them.

- Extended the existing `modifiers.criticality.shim.css` (which already adds `--modifier-icon`) with a second channel **`--modifier-color-text-onForegroundSecondary`**, keyed per criticality class → the real on-surface tokens.
- **Badge** now reads that channel, falling back to the neutral on-surface token for the default (no-criticality) badge. Contract preserved: components listen to the channel, never the class.
- `onForeground` (not `onBackground`) is the correct family — a badge is a foreground chip on `foreground-secondary`; no `onBackground` family exists in the build.
- Marked to remove from the shim once generated upstream.