### PR TITLE
docs: truth pass on README and CLI docs; add lychee link checking

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,44 @@
+name: Links
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "lychee.toml"
+      - ".github/workflows/links.yml"
+  schedule:
+    # Weekly full check including external URLs (Monday 06:00 UTC).
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  internal-links:
+    name: Internal links and anchors (offline)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Check internal Markdown links
+        # lycheeverse/lychee-action v2.9.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
+        with:
+          args: --config ./lychee.toml --offline --include-fragments --no-progress './**/*.md'
+          fail: true
+
+  external-links:
+    name: All links including external (weekly)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Check all Markdown links
+        # lycheeverse/lychee-action v2.9.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
+        with:
+          args: --config ./lychee.toml --include-fragments --no-progress './**/*.md'
+          fail: true

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The server starts at http://localhost:6006. Each component package has its own S
 
 ## Repository Structure
 
-The monorepo uses Lerna for versioning and publishing, with Nx providing task caching and dependency-aware execution. All packages share a single version number (currently 0.11.0) to eliminate compatibility matrices between internal dependencies.
+The monorepo uses Lerna for versioning and publishing, with Nx providing task caching and dependency-aware execution. Lerna keeps package versions in lockstep (currently the 0.29.x line, tracked in [`lerna.json`](lerna.json)) to eliminate compatibility matrices between internal dependencies.
 
 A guiding principle throughout the codebase is that structure should be discoverable by both humans and machines. This means explicit conventions rather than hidden magic, schema-validated configurations, and specifications expressed as queryable data where possible.
 
@@ -90,10 +90,10 @@ React components are organised into tiers based on their scope of applicability.
 
 | Tier | Package | Scope |
 |------|---------|-------|
-| Global | `@canonical/react-ds-global` | Universal components like Button, Badge, Card, and Chip that apply across all contexts. Components are grouped by maturity: **Stable** (production-ready), **Beta** (API may change), and **Experimental** (early-stage). |
+| Global | `@canonical/react-ds-global` | Universal components like Button, Badge, Card, and Chip that apply across all contexts. Production-ready components live under `src/lib/component`, `src/lib/group`, and `src/lib/pattern`; early-stage work sits in `src/lib/_work_in_progress`. |
 | Global Form | `@canonical/react-ds-global-form` | Form controls including Input, Select, and Checkbox, along with validation patterns. See the [package README](packages/react/ds-global-form/README.md) for usage and guides. |
-| Apps | `@canonical/react-ds-app` | Application-level UI such as Navigation and Toolbar, suited for internal tools. |
-| Apps/WPE | `@canonical/react-ds-app-launchpad` | Components specific to Launchpad and Workplace Engineering applications. |
+| Apps | `@canonical/react-ds-app` | Application-level UI such as ApplicationLayout, SideNavigation, and ContentLayout, suited for internal tools. |
+| Apps (product-specific) | `@canonical/react-ds-app-*` | Components specific to a single product: Launchpad (`-launchpad`), LXD (`-lxd`), Anbox (`-anbox`), Landscape (`-landscape`), and Portal (`-portal`). |
 
 The tiers correspond to the [Design System Ontology](https://github.com/canonical/design-system), which models the design system as structured, queryable data. Each component has a formal specification including usage guidelines, modifier families, and anatomy definitions. This semantic approach enables tooling to understand design intent, not just implementation details.
 
@@ -103,7 +103,7 @@ Three packages provide the foundation that component packages build upon.
 
 **@canonical/ds-types** defines TypeScript types for modifier families. A modifier family is a set of related visual variants that components can support. For example, the `severity` modifier family includes `neutral`, `positive`, `negative`, `caution`, and `information`. The `ModifierFamily<'severity'>` type resolves to a union of these string literals, ensuring type safety when applying modifiers to components.
 
-**@canonical/ds-assets** contains icons and shared visual assets. Icons use a consistent 16x16 viewBox with `currentColor` for fill, allowing them to inherit text colour from their context.
+**@canonical/ds-assets** contains icons and shared visual assets. Icons use `currentColor` for fill, allowing them to inherit text colour from their context, and a 16x16 viewBox as the standard size.
 
 **@canonical/utils** provides battle-tested utility functions like `debounce` and `throttle`. Functions only enter this package after proving useful across multiple packages; premature abstraction is actively avoided.
 
@@ -111,19 +111,19 @@ Three packages provide the foundation that component packages build upon.
 
 Pragma uses pure CSS with no preprocessors, no CSS-in-JS, and no build-time transformations beyond standard bundling. The stylesheets you write are the stylesheets that ship. This decision keeps the styling system understandable to anyone who knows CSS, eliminates runtime overhead from style injection, and ensures styles work correctly during server-side rendering without hydration concerns.
 
-The CSS architecture uses layered packages rather than a monolithic stylesheet. **@canonical/styles** is the aggregator package that imports all style layers in the correct order. Applications typically import only this package.
+The CSS architecture uses layered imports rather than a monolithic stylesheet. **@canonical/styles** (at `packages/styles/main`) is the aggregator package that imports all style layers in the correct order. Applications typically import only this package.
 
-The layers build upon each other: **styles-primitives-canonical** defines raw design tokens as CSS custom properties, **styles-elements** provides base HTML element styling (built on normalize.css), and the **styles-modes-*** packages handle theming concerns like colour modes, density variants, and motion preferences.
+The layers build upon each other: normalize.css provides the reset, **@canonical/styles-typography** supplies the baseline-grid alignment engine and typography scale tokens, and generated tokens from `@canonical/design-tokens` define colour, spacing, surface, and state custom properties, followed by grid, spacing, overflow, and motion tokens. **@canonical/styles-debug** offers opt-in development aids such as a baseline grid overlay.
 
 Component styles live with their components rather than in the styles packages. Each component imports its own `styles.css` file, which uses CSS custom properties that reference the design tokens. This co-location keeps styles maintainable and allows tree-shaking of unused component styles. The Button component, for example, defines its colours through custom properties like `--button-color-background` that can be overridden by consumers or themed through modifier classes.
 
 ### Developer Tooling
 
-**@canonical/webarchitect** validates that packages conform to architectural standards. Rather than enforcing conventions through runtime magic, it uses JSON Schema-based rulesets to verify package.json structure, TypeScript configuration, Biome setup, and license compliance. Every package runs `bun run check:webarchitect` as part of its check script. The schemas serve as executable documentation: they describe what valid structure looks like while simultaneously enforcing it.
+**@canonical/webarchitect** validates that packages conform to architectural standards. Rather than enforcing conventions through runtime magic, it uses JSON Schema-based rulesets to verify package.json structure, TypeScript configuration, Biome setup, and license compliance. Most packages run `bun run check:webarchitect` as part of their check script. The schemas serve as executable documentation: they describe what valid structure looks like while simultaneously enforcing it.
 
-Three rulesets cover the common cases. The `library` ruleset enforces LGPL-3.0 licensing for reusable packages. The `tool` ruleset enforces GPL-3.0 for CLI tools and applications. The `tool-ts` ruleset handles TypeScript-only tools that run directly with Bun without a build step.
+Three rulesets cover the common cases. The `library` ruleset targets reusable packages (LGPL-3.0 licensing by default). The `tool` ruleset targets CLI tools and applications (GPL-3.0). The `tool-ts` ruleset handles TypeScript-only tools that run directly with Bun without a build step. Further rulesets (`base`, `package`, `package-react`, `package-svelte`, `assets`) cover specialised cases; see [`packages/webarchitect/rulesets`](packages/webarchitect/rulesets).
 
-**@canonical/generator-ds** scaffolds new components using Yeoman. Install it globally with `npm install -g yo @canonical/generator-ds`, then run `yo @canonical/ds:component src/MyComponent` from within a package directory. The generator creates the component file, types, styles, stories, unit tests, and SSR tests following the [standard structure](docs/explanations/COMPONENT_FOLDER_STRUCTURE.md).
+**Summon** scaffolds new code. The `@canonical/summon` CLI (at `packages/cli/summon`) is a small framework that discovers generator packages installed alongside it: `@canonical/summon-component` scaffolds React, Svelte, and Lit components (`summon component react src/lib/MyComponent`), `@canonical/summon-package` scaffolds monorepo packages, `@canonical/summon-application` scaffolds applications, domains, routes, and wrappers, and `@canonical/summon-monorepo` scaffolds entire monorepos — all built on the `@canonical/summon-core` framework (`packages/summon/*`). The component generator creates the component file, types, styles, stories, unit tests, and SSR tests following the [standard structure](docs/explanations/COMPONENT_FOLDER_STRUCTURE.md). The `pragma` CLI wraps the component and package generators as `pragma create component` and `pragma create package`, adding `--undo` support to reverse a scaffold. See the [Prerequisites](#prerequisites) section for installation.
 
 ## Component Structure
 
@@ -142,7 +142,7 @@ Button/
 
 The component file imports its types and styles, then exports a function component. Props interfaces extend the appropriate HTML attributes interface (e.g., `ButtonHTMLAttributes<HTMLButtonElement>`) to ensure all native attributes pass through correctly.
 
-Styles use a `ds` namespace class combined with the component name: `className={["ds", "button", appearance, className].filter(Boolean).join(" ")}`. This pattern allows modifier classes to apply directly while preserving any custom classes passed by consumers.
+Styles use a `ds` namespace class combined with the component name and modifier props: `className={["ds button", importance, className].filter(Boolean).join(" ")}`. This pattern allows modifier classes to apply directly while preserving any custom classes passed by consumers.
 
 The barrel export in `index.ts` explicitly names every export rather than using `export *`. This makes the public API visible at a glance and enables precise tree-shaking.
 
@@ -193,30 +193,68 @@ The `docs/` folder contains guides for working with the monorepo:
 
 ## Package Reference
 
-The following table lists all packages in the monorepo with their location and purpose.
+The following tables list all workspace packages with their location and purpose. Packages marked **internal** have `"private": true` in their package.json and are not published to npm.
 
 ### React Components
 
 | Package | Path | Description |
 |---------|------|-------------|
-| `@canonical/react-ds-global` | `packages/react/ds-global` | Global tier components grouped by maturity: **Stable** (Accordion, Breadcrumbs, Card, Icon, Timeline), **Beta** (Button, Label, Tile), **Experimental** (Badge, Chip, Link, Rule, Section, SkipLink, Tooltip) |
+| `@canonical/react-ds-global` | `packages/react/ds-global` | Global tier components: Accordion, Announcement, Badge, Breadcrumbs, Button, Card, Chip, ContextualMenu, Heading, Icon, InlineCode, KeyboardKey(s), Popover, Tabs, Tile, Timeline, Tooltip |
 | `@canonical/react-ds-global-form` | `packages/react/ds-global-form` | Form components with react-hook-form integration. See [README](packages/react/ds-global-form/README.md) for guides |
-| `@canonical/react-ds-app` | `packages/react/ds-app` | Application tier components: Navigation, Toolbar |
-| `@canonical/react-ds-app-launchpad` | `packages/react/ds-app-launchpad` | Launchpad-specific: Markdown renderer, Tooltip variants |
+| `@canonical/react-ds-app` | `packages/react/ds-app` | Application tier components: ApplicationLayout, ContentLayout, SideNavigation, ViewLayout |
+| `@canonical/react-ds-app-anbox` | `packages/react/ds-app-anbox` | Anbox-specific components |
+| `@canonical/react-ds-app-landscape` | `packages/react/ds-app-landscape` | Landscape-specific components |
+| `@canonical/react-ds-app-launchpad` | `packages/react/ds-app-launchpad` | Launchpad-specific components: GitDiffViewer, MarkdownEditor, FileTree, EditableBlock, RelativeTime, DiffChangeMarker |
+| `@canonical/react-ds-app-lxd` | `packages/react/ds-app-lxd` | LXD-specific components |
+| `@canonical/react-ds-app-portal` | `packages/react/ds-app-portal` | Portal-specific components |
+
+### React Utilities
+
+| Package | Path | Description |
+|---------|------|-------------|
 | `@canonical/react-ssr` | `packages/react/ssr` | Server-side rendering utilities |
+| `@canonical/ssr-adapter-cloudflare` | `packages/react/ssr-adapter-cloudflare` | Cloudflare Workers adapter for `@canonical/react-ssr` (**internal**) |
+| `@canonical/ssr-adapter-deno` | `packages/react/ssr-adapter-deno` | Deno Deploy adapter for `@canonical/react-ssr` (**internal**) |
+| `@canonical/ssr-adapter-vercel` | `packages/react/ssr-adapter-vercel` | Vercel deployment adapter for `@canonical/react-ssr` (**internal**) |
+| `@canonical/react-head` | `packages/react/head` | Declarative head management for React with SSR collection |
+| `@canonical/react-hooks` | `packages/react/hooks` | Shared React hooks: preferences, navigation tree |
+| `@canonical/i18n-react` | `packages/react/i18n` | React bindings for `@canonical/i18n-core`: I18nProvider plus useTranslation, useLocale, and useFormatters hooks |
+| `@canonical/router-react` | `packages/react/router` | React bindings for `@canonical/router-core` |
+| `@canonical/react-tokens` | `packages/react/tokens` | Token explorer components (TokenTable, TokenSwatch) for browsing design tokens in Storybook |
+
+### Svelte Components
+
+| Package | Path | Description |
+|---------|------|-------------|
+| `@canonical/svelte-ds-global` | `packages/svelte/ds-global` | Global components for Svelte 5 |
+| `@canonical/svelte-ds-app-launchpad` | `packages/svelte/ds-app-launchpad` | Launchpad-specific Svelte components |
+| `@canonical/svelte-ds-app-wpe` | `packages/svelte/ds-app-wpe` | WPE-specific Svelte components |
+| `@canonical/svelte-ssr-test` | `packages/svelte/ssr-test` | Test package for Svelte SSR testing |
+
+### Web Components
+
+| Package | Path | Description |
+|---------|------|-------------|
+| `@canonical/lit-ds-prototype` | `packages/lit/ds-prototype` | Prototype Web Components built with Lit |
 
 ### Styles
 
 | Package | Path | Description |
 |---------|------|-------------|
-| `@canonical/styles` | `packages/styles/main/canonical` | Aggregator importing all style layers |
-| `@canonical/styles-primitives-canonical` | `packages/styles/primitives/canonical` | Design tokens as CSS custom properties |
-| `@canonical/styles-elements` | `packages/styles/elements` | Base HTML element styling (extends normalize.css) |
-| `@canonical/styles-modes-canonical` | `packages/styles/modes/canonical` | Canonical colour theme |
-| `@canonical/styles-modes-density` | `packages/styles/modes/density` | Density variants (compact, comfortable) |
-| `@canonical/styles-modes-intents` | `packages/styles/modes/intents` | Intent modifiers (positive, negative, caution) |
-| `@canonical/styles-modes-motion` | `packages/styles/modes/motion` | Motion and animation preferences |
+| `@canonical/styles` | `packages/styles/main` | Global stylesheet aggregating normalize.css, typography, and design tokens |
+| `@canonical/styles-typography` | `packages/styles/typography` | Typography baseline alignment engines and scale tokens |
 | `@canonical/styles-debug` | `packages/styles/debug` | Development aids including baseline grid overlay |
+
+### Runtime
+
+| Package | Path | Description |
+|---------|------|-------------|
+| `@canonical/ke` | `packages/runtime/ke` | Headless triple store runtime built on Oxigraph WASM |
+| `@canonical/ke-graphql` | `packages/runtime/ke-graphql` | OWL to GraphQL compiler for the ke triple store |
+| `@canonical/router-core` | `packages/runtime/router` | Framework-agnostic router core built on flat route triplets |
+| `@canonical/i18n-core` | `packages/runtime/i18n` | Framework-agnostic internationalization core built on native Intl |
+| `@canonical/task` | `packages/runtime/task` | Monadic effect framework for composable, testable, dry-runnable CLI operations |
+| `@canonical/harnesses` | `packages/runtime/harnesses` | AI harness detection and MCP config read/write (Claude Code, Cursor, Windsurf, Cline, Roo Code) |
 
 ### Core Infrastructure
 
@@ -224,26 +262,56 @@ The following table lists all packages in the monorepo with their location and p
 |---------|------|-------------|
 | `@canonical/ds-types` | `packages/ds-types` | TypeScript types for modifier families and component props |
 | `@canonical/ds-assets` | `packages/ds-assets` | Icons and shared visual assets |
-| `@canonical/utils` | `packages/utils` | Utility functions: debounce, throttle |
-| `@canonical/styles-typography` | `packages/styles/typography` | Baseline grid alignment engines, typography scale tokens, and font metric extraction |
+| `@canonical/utils` | `packages/utils` | Utility functions: debounce, throttle, casing, pluralize, and more |
 
 ### Developer Tooling
 
 | Package | Path | Description |
 |---------|------|-------------|
 | `@canonical/webarchitect` | `packages/webarchitect` | Architecture validation CLI with JSON Schema rulesets |
-| `@canonical/generator-ds` | `packages/generator-ds` | Yeoman generator for scaffolding components |
+| `@canonical/pragma-cli` | `packages/cli/pragma` | CLI and MCP server for querying the design system |
+| `@canonical/cli-core` | `packages/cli/core` | Shared CLI machinery: command definitions, registration, completions, output adapters |
+| `@canonical/summon` | `packages/cli/summon` | Interactive code generator CLI with Ink UI and shell completion |
+| `@canonical/summon-core` | `packages/summon/core` | Code generation framework: generator definitions, templates, discovery |
+| `@canonical/summon-component` | `packages/summon/component` | React, Svelte, and Lit component generators |
+| `@canonical/summon-package` | `packages/summon/package` | Package generator for scaffolding npm packages |
+| `@canonical/summon-application` | `packages/summon/application` | Application scaffolding generators: application, domain, route, wrapper |
+| `@canonical/summon-monorepo` | `packages/summon/monorepo` | Monorepo generator: Bun + Lerna monorepos with CI and shared config |
+
+### Storybook
+
+| Package | Path | Description |
+|---------|------|-------------|
 | `@canonical/storybook-addon-msw` | `packages/storybook/addon-msw` | Mock Service Worker integration for Storybook |
 | `@canonical/storybook-addon-utils` | `packages/storybook/addon-utils` | Debug and layout utilities: grid mode, color scheme, baseline grid, outlines |
+| `@canonical/storybook-addon-form-state` | `packages/storybook/addon-form-state` | Panel displaying live react-hook-form state |
+| `@canonical/storybook-addon-relay` | `packages/storybook/addon-relay` | Renders stories that use Relay hooks against a mock Relay environment |
+| `@canonical/storybook-addon-shell-theme` | `packages/storybook/addon-canonical-shell-theme` | Applies the Canonical shell theme with light and dark modes |
+| `@canonical/storybook-helpers` | `packages/storybook/helpers` | Shared Storybook utilities and helper components |
 
 ### Configuration
 
 | Package | Path | Description |
 |---------|------|-------------|
-| `@canonical/biome-config` | `configs/biome-config` | Shared Biome configuration for linting and formatting |
-| `@canonical/typescript-config` | `configs/typescript-config` | Base TypeScript configuration |
-| `@canonical/typescript-config-react` | `configs/typescript-config-react` | TypeScript configuration extending base with React settings |
-| `@canonical/storybook-config` | `configs/storybook-config` | Shared Storybook configuration factory |
+| `@canonical/biome-config` | `configs/biome` | Shared Biome configuration for linting and formatting |
+| `@canonical/renovate-config` | `configs/renovate` | Shared Renovate configuration for Canonical monorepos |
+| `@canonical/typescript-config` | `configs/typescript` | Base TypeScript configuration |
+| `@canonical/typescript-config-react` | `configs/typescript-react` | TypeScript configuration extending base with React settings |
+| `@canonical/typescript-config-lit` | `configs/typescript-lit` | TypeScript configuration for Lit Web Components projects |
+| `@canonical/typescript-config-svelte` | `configs/typescript-svelte` | TypeScript configuration for Svelte projects |
+| `@canonical/storybook-config` | `configs/storybook` | Shared Storybook configuration factory |
+| `@canonical/vitest-config-react` | `configs/vitest-config-react` | Shared Vitest configuration factory for React packages |
+
+### Apps (internal)
+
+These workspace apps are development and demo surfaces; none are published.
+
+| Package | Path | Description |
+|---------|------|-------------|
+| `@canonical/ds-demo-site` | `apps/react/demo` | Design system demo site |
+| `@canonical/react-boilerplate-vite` | `apps/react/boilerplate-vite` | React application scaffold with SSR on Canonical's shared packages |
+| `@canonical/storybook-hub` | `apps/react/storybook-hub` | Aggregated Storybook hub |
+| `@canonical/lit-demo` | `apps/lit/demo` | Minimal SSR demo for the Lit prototype |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Button/
 
 The component file imports its types and styles, then exports a function component. Props interfaces extend the appropriate HTML attributes interface (e.g., `ButtonHTMLAttributes<HTMLButtonElement>`) to ensure all native attributes pass through correctly.
 
-Styles use a `ds` namespace class combined with the component name and modifier props: `className={["ds button", importance, className].filter(Boolean).join(" ")}`. This pattern allows modifier classes to apply directly while preserving any custom classes passed by consumers.
+Styles use a `ds` namespace class combined with the component name, baseline utilities, modifier props, and state classes. Button, for example, composes `className={["ds button", "p", importance, anticipation, variant, loading && "loading", className].filter(Boolean).join(" ")}` — the `p` baseline utility, the `importance`/`anticipation`/`variant` modifiers, and a `loading` state class. This pattern allows modifier classes to apply directly while preserving any custom classes passed by consumers.
 
 The barrel export in `index.ts` explicitly names every export rather than using `export *`. This makes the public API visible at a glance and enables precise tree-shaking.
 
@@ -199,7 +199,7 @@ The following tables list all workspace packages with their location and purpose
 
 | Package | Path | Description |
 |---------|------|-------------|
-| `@canonical/react-ds-global` | `packages/react/ds-global` | Global tier components: Accordion, Announcement, Badge, Breadcrumbs, Button, Card, Chip, ContextualMenu, Heading, Icon, InlineCode, KeyboardKey(s), Popover, Tabs, Tile, Timeline, Tooltip |
+| `@canonical/react-ds-global` | `packages/react/ds-global` | Global tier components: Accordion, Announcement, Badge, Breadcrumbs, Button, Card, Chip, ContextualMenu, Heading, Icon, InlineCode, KeyboardKey, KeyboardKeys, Popover, Tabs, Tile, Timeline, Tooltip |
 | `@canonical/react-ds-global-form` | `packages/react/ds-global-form` | Form components with react-hook-form integration. See [README](packages/react/ds-global-form/README.md) for guides |
 | `@canonical/react-ds-app` | `packages/react/ds-app` | Application tier components: ApplicationLayout, ContentLayout, SideNavigation, ViewLayout |
 | `@canonical/react-ds-app-anbox` | `packages/react/ds-app-anbox` | Anbox-specific components |

--- a/docs/explanations/COMPONENT_FOLDER_STRUCTURE.md
+++ b/docs/explanations/COMPONENT_FOLDER_STRUCTURE.md
@@ -78,6 +78,8 @@ const Button = ({
   children,
   style,
   appearance,
+  icon,
+  loading = false,
   ...props
 }: Props): React.ReactElement => {
   // Booleans and nullish children render nothing; everything else (including
@@ -85,15 +87,18 @@ const Button = ({
   const hasVisibleChildren =
     children != null && typeof children !== "boolean" && children !== "";
 
+  // Icon-only states (an icon, or a loading spinner in its place) render no
+  // visible text, so the accessible name must be supplied explicitly.
   if (
     typeof process !== "undefined" &&
     process.env.NODE_ENV !== "production" &&
+    (icon || loading) &&
     !hasVisibleChildren &&
     !props["aria-label"] &&
     !props["aria-labelledby"]
   ) {
     console.warn(
-      "Button: buttons without visible text need an explicit `aria-label` or `aria-labelledby` to be accessible.",
+      "Button: icon-only buttons need an explicit `aria-label` or `aria-labelledby` to be accessible.",
     );
   }
 
@@ -106,6 +111,7 @@ const Button = ({
       style={style}
       {...props}
     >
+      {icon && <span className="icon">{icon}</span>}
       {children}
     </button>
   );
@@ -116,7 +122,7 @@ export default Button;
 
 Several patterns appear consistently across all components. The type import uses `.js` extension because TypeScript compilation produces JavaScript files with those extensions. The CSS import has no specifier because it triggers a side effect (loading styles) rather than providing a value. The component uses default export because the barrel file will re-export it with a named export.
 
-The component never fabricates an accessible name from its children. Stringifying an arbitrary React node produces garbage like `[object Object]`, and visible text is already read by screen readers, so a synthesized `aria-label` would at best be redundant and at worst wrong. Instead, the component guards accessibility with a development-only warning: when the button renders no visible text and the consumer supplied neither `aria-label` nor `aria-labelledby`, it warns so the missing name is caught during development rather than shipped.
+The component never fabricates an accessible name from its children. Stringifying an arbitrary React node produces garbage like `[object Object]`, and visible text is already read by screen readers, so a synthesized `aria-label` would at best be redundant and at worst wrong. Instead, the component guards accessibility with a development-only warning scoped to icon-only states: when the button has an `icon` (or is `loading`, which puts a spinner in the icon's place), renders no visible text children, and the consumer supplied neither `aria-label` nor `aria-labelledby`, it warns so the missing name is caught during development rather than shipped.
 
 The className construction follows a standard pattern. The array `["ds", "button", appearance, className]` contains the namespace (`ds`), the component class (`button`), any modifier props (`appearance`), and any consumer-provided classes (`className`). The `filter(Boolean)` removes falsy values like `undefined` when no appearance is specified. The `join(" ")` produces the final class string.
 
@@ -135,6 +141,8 @@ export interface BaseProps {
   className?: string;
   children: ReactNode;
   appearance?: ModifierFamily<"severity"> | "base" | "link";
+  icon?: ReactNode;
+  loading?: boolean;
 }
 
 type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;

--- a/docs/explanations/COMPONENT_FOLDER_STRUCTURE.md
+++ b/docs/explanations/COMPONENT_FOLDER_STRUCTURE.md
@@ -80,6 +80,23 @@ const Button = ({
   appearance,
   ...props
 }: Props): React.ReactElement => {
+  // Booleans and nullish children render nothing; everything else (including
+  // the number 0) produces visible text that names the button.
+  const hasVisibleChildren =
+    children != null && typeof children !== "boolean" && children !== "";
+
+  if (
+    typeof process !== "undefined" &&
+    process.env.NODE_ENV !== "production" &&
+    !hasVisibleChildren &&
+    !props["aria-label"] &&
+    !props["aria-labelledby"]
+  ) {
+    console.warn(
+      "Button: buttons without visible text need an explicit `aria-label` or `aria-labelledby` to be accessible.",
+    );
+  }
+
   return (
     <button
       id={id}
@@ -87,7 +104,6 @@ const Button = ({
         .filter(Boolean)
         .join(" ")}
       style={style}
-      aria-label={props["aria-label"] || children?.toString()}
       {...props}
     >
       {children}
@@ -99,6 +115,8 @@ export default Button;
 ```
 
 Several patterns appear consistently across all components. The type import uses `.js` extension because TypeScript compilation produces JavaScript files with those extensions. The CSS import has no specifier because it triggers a side effect (loading styles) rather than providing a value. The component uses default export because the barrel file will re-export it with a named export.
+
+The component never fabricates an accessible name from its children. Stringifying an arbitrary React node produces garbage like `[object Object]`, and visible text is already read by screen readers, so a synthesized `aria-label` would at best be redundant and at worst wrong. Instead, the component guards accessibility with a development-only warning: when the button renders no visible text and the consumer supplied neither `aria-label` nor `aria-labelledby`, it warns so the missing name is caught during development rather than shipped.
 
 The className construction follows a standard pattern. The array `["ds", "button", appearance, className]` contains the namespace (`ds`), the component class (`button`), any modifier props (`appearance`), and any consumer-provided classes (`className`). The `filter(Boolean)` removes falsy values like `undefined` when no appearance is specified. The `join(" ")` produces the final class string.
 

--- a/docs/how-to-guides/CREATE_A_REACT_COMPONENT.md
+++ b/docs/how-to-guides/CREATE_A_REACT_COMPONENT.md
@@ -37,7 +37,7 @@ To create a subcomponent, follow the following steps:
 
 1. Create a folder `common` inside a component's directory. 
 2. Set your active directory to `common`. 
-3. Use the generator as in step #3 of the [getting started section](#getting-started) to generate a subcomponent. Per the [React standards](https://github.com/canonical/code-standards), subcomponent names should not be prefixed with their parent component name. For example, if your parent component is called `Button`, you might name a subcomponent `Icon` instead of `ButtonIcon`.
+3. Use the generator as in step #3 of the [getting started section](#3-getting-started) to generate a subcomponent. Per the [React standards](https://github.com/canonical/code-standards), subcomponent names should not be prefixed with their parent component name. For example, if your parent component is called `Button`, you might name a subcomponent `Icon` instead of `ButtonIcon`.
 4. The generator should create `common/index.ts` which re-exports each subcomponent. This will the top-level component (or other subcomponents) to import subcomponents from `common/index.js`. If you would also like to expose the subcomponents outside of the component, you can either re-export `common/index.js` from `index.ts`, or re-export only the subcomponents that you'd like to expose.
 
 ### 5 State
@@ -51,7 +51,7 @@ The decisions and steps to create hooks and context providers are explored below
 
 #### 5.1 Hooks
 Hooks are a great way to encapsulate state management and logic that is reusable across multiple components.
-If your component provides context that should be accessible by child components (such as a toast component which provides a notification context), you should consider creating a [context provider](#context-providers).
+If your component provides context that should be accessible by child components (such as a toast component which provides a notification context), you should consider creating a [context provider](#52-context-providers).
 
 _Note: hook creation is not yet supported by the generator, but this is planned functionality._
 
@@ -71,6 +71,6 @@ _Note: context provider creation is not yet supported by the generator, but this
 
 1. Create a `types.ts` file inside the component directory. Create a `ContextOptions` type that describes the state that will be provided to context consumers. See [example](../../apps/react/demo/src/ui/Showcase/common/Example/types.ts).
 2. Create a `Context.tsx` file inside the component directory. This file should create an empty context using `createContext`, and bind the context to the type from `types.ts`. See [example](../../apps/react/demo/src/ui/Showcase/common/Example/Context.tsx).
-3. Use [custom hooks](#hooks) to encapsulate the context state. Create a `common/hooks/<hookName>.ts` file inside the component directory. This file should create a custom hook that uses `useContext` to access the context and return the context value. See [example](../../apps/react/demo/src/ui/Showcase/common/Example/hooks/useProviderState.ts).
+3. Use [custom hooks](#51-hooks) to encapsulate the context state. Create a `common/hooks/<hookName>.ts` file inside the component directory. This file should create a custom hook that uses `useContext` to access the context and return the context value. See [example](../../apps/react/demo/src/ui/Showcase/common/Example/hooks/useProviderState.ts).
 4. Create a `Provider.tsx` file inside the component directory. This file should create a simple component that accepts the props of your custom hooks, invokes the custom hooks to get the current state, and wraps a child component with the current context. See [example](../../apps/react/demo/src/ui/Showcase/common/Example/Provider.tsx).
 5. Create an `index.ts` file inside the component directory. This file serves as the publicly consumed API for the component. It should export the Provider component, but also export any subcomponents that consume the context within the index component scope. See [example](../../apps/react/demo/src/ui/Showcase/common/Example/index.ts).

--- a/docs/references/ROUTER_API.md
+++ b/docs/references/ROUTER_API.md
@@ -201,7 +201,7 @@ function route<
 ): DataRouteDefinition<TPath, TSearchSchema, TRendered, TWrappers>;
 ```
 
-Constructs one flat route and derives its path codec. The returned definition adds `parse(url) → params | null` and `render(params) → string` over the input, and defaults `wrappers` to `[]`. Routes are **flat** — there is no nesting or `children`. Shared layout comes from [`wrapper`](#wrapper) + [`group`](#group); cross-cutting logic from [middleware](#middleware-applymiddleware).
+Constructs one flat route and derives its path codec. The returned definition adds `parse(url) → params | null` and `render(params) → string` over the input, and defaults `wrappers` to `[]`. Routes are **flat** — there is no nesting or `children`. Shared layout comes from [`wrapper`](#wrapper) + [`group`](#group); cross-cutting logic from [middleware](#middleware--applymiddleware).
 
 #### `DataRouteInput`
 
@@ -274,7 +274,7 @@ interface NavigationContext {
 }
 ```
 
-Throwing inside `prefetch` is meaningful: throw a [`StatusResponse`](#statusresponse) for an HTTP-like error, or call [`redirect()`](#redirect-redirect-routeredirect) to short-circuit navigation. Both propagate to standard React error boundaries on the client and to the server handler under SSR.
+Throwing inside `prefetch` is meaningful: throw a [`StatusResponse`](#statusresponse) for an HTTP-like error, or call [`redirect()`](#runtime-redirects--redirect-redirect-routeredirect) to short-circuit navigation. Both propagate to standard React error boundaries on the client and to the server handler under SSR.
 
 ```ts
 prefetch: (params, search, context) => {
@@ -300,7 +300,7 @@ interface RedirectRouteInput<TPath, TTarget, TWrappers> {
 }
 ```
 
-A route with no `content`. The `status` is restricted to permanent redirects (`301 | 308`) — distinct from the runtime [`redirect()`](#redirect-redirect-routeredirect) helper's wider union. Matched ahead of data routes by the presence of `redirect`.
+A route with no `content`. The `status` is restricted to permanent redirects (`301 | 308`) — distinct from the runtime [`redirect()`](#runtime-redirects--redirect-redirect-routeredirect) helper's wider union. Matched ahead of data routes by the presence of `redirect`.
 
 ```ts
 const legacy = route({ url: "/old", redirect: "/new", status: 308 });
@@ -659,7 +659,7 @@ Renders the matched route subtree (route content wrapped by its wrappers). Reren
 
 ### Hooks
 
-All default their generics to `RegisteredRouteMap` / `RegisteredNotFound` (see [`register`](#register)), so once you register your routes no generics are needed. Each subscribes to the narrowest channel it needs.
+All default their generics to `RegisteredRouteMap` / `RegisteredNotFound` (see [`register`](#register--typed-routing-without-generics)), so once you register your routes no generics are needed. Each subscribes to the narrowest channel it needs.
 
 #### `useRouter`
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,32 @@
+# Configuration for the lychee link checker (https://lychee.cli.rs/),
+# shared by both jobs in .github/workflows/links.yml:
+#   - the PR job runs with `--offline` (internal/relative links and anchors only)
+#   - the weekly job runs a full check that also includes external URLs
+
+# Fragment (anchor) checking is enabled via the --include-fragments CLI flag in
+# the workflow, so it applies uniformly to both jobs.
+
+# Archived pre-monorepo code; its docs are intentionally frozen.
+# Values are regular expressions matched against file paths.
+exclude_path = ["(^|/)old/"]
+
+# Applies to the weekly external check only (remote URLs are skipped in offline mode).
+max_retries = 3
+timeout = 30
+
+# Treat rate-limiting (429) as alive rather than broken.
+accept = ["200..=204", "429"]
+
+exclude = [
+    # Local development servers referenced in setup instructions.
+    "^https?://localhost",
+    "^https?://127\\.0\\.0\\.1",
+    # Documentation placeholders.
+    "^https?://(www\\.)?example\\.(com|org)",
+    "^https?://router\\.local",
+    # Auth-walled workspace; always fails for anonymous CI.
+    "^https://coda\\.io",
+    # npm registry pages aggressively rate-limit and bot-block CI requests.
+    "^https?://(www\\.)?npmjs\\.(com|org)",
+    "^https://docs\\.npmjs\\.com",
+]

--- a/packages/cli/pragma/README.md
+++ b/packages/cli/pragma/README.md
@@ -22,7 +22,7 @@ See [docs/getting-started.md](docs/getting-started.md) for a full walkthrough.
 
 ## CLI Commands
 
-pragma organizes commands into 14 domains. Every command supports three output modes: plain text (default), `--llm` (condensed Markdown), and `--format json` (structured JSON).
+pragma organizes commands into 17 domains — counting every directory under `src/domains/` except `shared/`, which holds cross-domain infrastructure rather than commands. The 14 day-to-day domains are documented below; the remaining three are specialised: `graphql` (compile TTL ontologies into GraphQL schema artifacts), `refs` (`pragma update-refs`, package reference data), and `trace` (query access tracing). Every command supports three output modes: plain text (default), `--llm` (condensed Markdown), and `--format json` (structured JSON).
 
 ### Block
 
@@ -336,7 +336,7 @@ With `--format json`, errors are returned as structured JSON with error code, su
 
 pragma is structured as a domain-driven application using the federation pattern from `@canonical/cli-core`:
 
-1. **Domains** — 14 domain modules (block, standard, modifier, token, tier, ontology, graph, config, skill, llm, setup, create, doctor, info), each exporting `CommandDefinition[]`
+1. **Domains** — 17 domain modules (block, config, create, doctor, graph, graphql, info, llm, modifier, ontology, refs, setup, skill, standard, tier, token, trace — every directory under `src/domains/` except the `shared/` infrastructure folder), each contributing `CommandDefinition`s
 2. **Operations** — data retrieval functions that query the ke triple store via SPARQL
 3. **Formatters** — three-mode output adapters (plain/llm/json) for each operation
 4. **Commands** — thin wiring layer connecting Commander.js parameters to operations + formatters
@@ -364,13 +364,13 @@ bun build --compile --minify src/bin.ts --outfile dist/pragma
 
 ## Dependencies
 
-- [`@canonical/ke`](../runtime/ke/) — triple store runtime (Oxigraph WASM)
+- [`@canonical/ke`](../../runtime/ke/) — triple store runtime (Oxigraph WASM)
 - [`@canonical/cli-core`](../core/) — shared CLI machinery (Commander.js registration, help formatting)
-- [`@canonical/task`](../../lib/task/) — reversible task trees for setup/create with undo support
-- [`@canonical/harnesses`](../../lib/harnesses/) — AI harness detection (Claude Code, Cursor, Windsurf)
-- [`@canonical/summon-core`](../../lib/summon-core/) — code generation runtime
-- [`@canonical/summon-component`](../../lib/summon-component/) — component generator
-- [`@canonical/summon-package`](../../lib/summon-package/) — package generator
+- [`@canonical/task`](../../runtime/task/) — reversible task trees for setup/create with undo support
+- [`@canonical/harnesses`](../../runtime/harnesses/) — AI harness detection (Claude Code, Cursor, Windsurf)
+- [`@canonical/summon-core`](../../summon/core/) — code generation runtime
+- [`@canonical/summon-component`](../../summon/component/) — component generator
+- [`@canonical/summon-package`](../../summon/package/) — package generator
 
 ## License
 

--- a/packages/cli/pragma/docs/DOMAIN_STRUCTURE.md
+++ b/packages/cli/pragma/docs/DOMAIN_STRUCTURE.md
@@ -6,9 +6,9 @@ Canonical structure for all command and operation domains in `@canonical/pragma-
 
 ## Two domain tiers
 
-**CLI domains** have commands, operations, formatters, and optionally helpers. Six exist today: `component`, `config`, `modifier`, `standard`, `tier`, `token`.
+**CLI domains** have commands, operations, formatters, and optionally helpers. Seventeen exist today — every directory under `src/domains/` except `shared/`, which holds cross-domain infrastructure: `block`, `config`, `create`, `doctor`, `graph`, `graphql`, `info`, `llm`, `modifier`, `ontology`, `refs`, `setup`, `skill`, `standard`, `tier`, `token`, `trace`.
 
-**Operations-only domains** expose operations consumed by the MCP adapter but have no CLI commands. Two exist today: `graph`, `ontology`.
+**Operations-only domains** expose operations consumed by the MCP adapter but have no CLI commands. None exist today (`graph` and `ontology` have since gained CLI commands), but the tier remains available for future domains.
 
 ---
 
@@ -124,16 +124,16 @@ The domain barrel is the domain's public API. It exports:
 2. Re-exports of operations for the package barrel and MCP adapter
 
 ```typescript
-// domains/component/index.ts
+// domains/block/index.ts
 import type { CommandDefinition } from "@canonical/cli-core";
 import type { PragmaContext } from "../shared/context.js";
-import { getCommand, listCommand } from "./commands/index.js";
+import { listCommand, lookupCommand } from "./commands/index.js";
 
 export function commands(ctx: PragmaContext): CommandDefinition[] {
-  return [listCommand(ctx), getCommand(ctx)];
+  return [listCommand(ctx), lookupCommand(ctx)];
 }
 
-export { getComponent, listComponents } from "./operations/index.js";
+export { listBlocks, lookupBlock } from "./operations/index.js";
 ```
 
 ---
@@ -224,20 +224,20 @@ interface ComponentGetInput {
 
 ---
 
-## Command collection in runCli.ts
+## Command collection in collectCommands.ts
 
-Each CLI domain exports `commands(ctx)`. `runCli.ts` spreads them:
+Each CLI domain exports `commands(ctx)`. `pipeline/collectCommands.ts` spreads them:
 
 ```typescript
-import { commands as componentCommands } from "../domains/component/index.js";
+import { commands as blockCommands } from "../domains/block/index.js";
 import { commands as configCommands } from "../domains/config/index.js";
 import { commands as standardCommands } from "../domains/standard/index.js";
 
-function collectCommands(ctx: PragmaContext): CommandDefinition[] {
+export default function collectCommands(ctx: PragmaContext): CommandDefinition[] {
   return [
     ...configCommands(ctx),
     ...standardCommands(ctx),
-    ...componentCommands(ctx),
+    ...blockCommands(ctx),
   ];
 }
 ```
@@ -252,7 +252,7 @@ function collectCommands(ctx: PragmaContext): CommandDefinition[] {
 4. Write commands in `commands/` using `PragmaContext` + `selectFormatter`
 5. Create barrels in each subfolder
 6. Create domain `index.ts` with `commands(ctx)` + operation re-exports
-7. Add `...{name}Commands(ctx)` to `collectCommands()` in `runCli.ts`
+7. Add `...{name}Commands(ctx)` to `collectCommands()` in `pipeline/collectCommands.ts`
 8. Add operation re-exports to `src/index.ts` package barrel
 
 ## Adding a new operations-only domain

--- a/packages/react/ds-app-anbox/ARCHITECTURE.md
+++ b/packages/react/ds-app-anbox/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Our architecture is driven by several core goals and design principles:
 
 ### 1.2 Tooling Choices
 
-On top of the [root-level architecture](../../../guides/ARCHITECTURE.md), this package leverages a modern React
+On top of the [root-level architecture](../../../docs/explanations/ARCHITECTURE.md), this package leverages a modern React
 toolchain to achieve its goals:
 
 | Tool(s)                                | Enables                                                                     | Benefits                                                                              |

--- a/packages/react/ds-app-anbox/CONTRIBUTING.md
+++ b/packages/react/ds-app-anbox/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This package provides an overview of the contribution process for the React Core
 
 ## 1. Getting Started
 
-Follow the [repository setup](../../../guides/CONTRIBUTING.md) guide to set up your development environment.
+Follow the [repository setup](../../../README.md#quick-start) guide to set up your development environment.
 
 Once the repository is set up, navigate to the `packages/react/ds-core` package directory and run `bun run storybook` to
 start
@@ -17,12 +17,10 @@ Storybook will automatically reload when you make changes to the components, usi
 
 ### 1.1 Building a component
 
-The [react component generator](../../generator-ds/src/component/README.md) provides a CLI to generate new components.
-To create a new component, [install Yeoman](../../generator-ds/README.md), then navigate to the component root directory
-`src/ui`.
-Run `yo @canonical/ds:component MyNewComponent` to generate a new component.
-You can also run `yo @canonical/ds:component --help` to see more available options, such as generating a component with
-a story and/or CSS file included.
+The [component generator](../../summon/component/README.md) scaffolds new components.
+Install the Summon CLI and generator (`npm install -g @canonical/summon @canonical/summon-component`), then run
+`summon component react src/lib/MyNewComponent` from the package root to generate a new component.
+You can also run `summon component react --help` to see more available options.
 
 Components should follow this basic structure:
 

--- a/packages/react/ds-app-landscape/ARCHITECTURE.md
+++ b/packages/react/ds-app-landscape/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Our architecture is driven by several core goals and design principles:
 
 ### 1.2 Tooling Choices
 
-On top of the [root-level architecture](../../../guides/ARCHITECTURE.md), this package leverages a modern React
+On top of the [root-level architecture](../../../docs/explanations/ARCHITECTURE.md), this package leverages a modern React
 toolchain to achieve its goals:
 
 | Tool(s)                                | Enables                                                                     | Benefits                                                                              |

--- a/packages/react/ds-app-landscape/CONTRIBUTING.md
+++ b/packages/react/ds-app-landscape/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This package provides an overview of the contribution process for the React Core
 
 ## 1. Getting Started
 
-Follow the [repository setup](../../../guides/CONTRIBUTING.md) guide to set up your development environment.
+Follow the [repository setup](../../../README.md#quick-start) guide to set up your development environment.
 
 Once the repository is set up, navigate to the `packages/react/ds-core` package directory and run `bun run storybook` to
 start
@@ -17,12 +17,10 @@ Storybook will automatically reload when you make changes to the components, usi
 
 ### 1.1 Building a component
 
-The [react component generator](../../generator-ds/src/component/README.md) provides a CLI to generate new components.
-To create a new component, [install Yeoman](../../generator-ds/README.md), then navigate to the component root directory
-`src/ui`.
-Run `yo @canonical/ds:component MyNewComponent` to generate a new component.
-You can also run `yo @canonical/ds:component --help` to see more available options, such as generating a component with
-a story and/or CSS file included.
+The [component generator](../../summon/component/README.md) scaffolds new components.
+Install the Summon CLI and generator (`npm install -g @canonical/summon @canonical/summon-component`), then run
+`summon component react src/lib/MyNewComponent` from the package root to generate a new component.
+You can also run `summon component react --help` to see more available options.
 
 Components should follow this basic structure:
 

--- a/packages/react/ds-app-lxd/ARCHITECTURE.md
+++ b/packages/react/ds-app-lxd/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Our architecture is driven by several core goals and design principles:
 
 ### 1.2 Tooling Choices
 
-On top of the [root-level architecture](../../../guides/ARCHITECTURE.md), this package leverages a modern React
+On top of the [root-level architecture](../../../docs/explanations/ARCHITECTURE.md), this package leverages a modern React
 toolchain to achieve its goals:
 
 | Tool(s)                                | Enables                                                                     | Benefits                                                                              |

--- a/packages/react/ds-app-lxd/CONTRIBUTING.md
+++ b/packages/react/ds-app-lxd/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This package provides an overview of the contribution process for the React Core
 
 ## 1. Getting Started
 
-Follow the [repository setup](../../../guides/CONTRIBUTING.md) guide to set up your development environment.
+Follow the [repository setup](../../../README.md#quick-start) guide to set up your development environment.
 
 Once the repository is set up, navigate to the `packages/react/ds-core` package directory and run `bun run storybook` to
 start
@@ -17,12 +17,10 @@ Storybook will automatically reload when you make changes to the components, usi
 
 ### 1.1 Building a component
 
-The [react component generator](../../generator-ds/src/component/README.md) provides a CLI to generate new components.
-To create a new component, [install Yeoman](../../generator-ds/README.md), then navigate to the component root directory
-`src/ui`.
-Run `yo @canonical/ds:component MyNewComponent` to generate a new component.
-You can also run `yo @canonical/ds:component --help` to see more available options, such as generating a component with
-a story and/or CSS file included.
+The [component generator](../../summon/component/README.md) scaffolds new components.
+Install the Summon CLI and generator (`npm install -g @canonical/summon @canonical/summon-component`), then run
+`summon component react src/lib/MyNewComponent` from the package root to generate a new component.
+You can also run `summon component react --help` to see more available options.
 
 Components should follow this basic structure:
 

--- a/packages/react/ds-app-portal/ARCHITECTURE.md
+++ b/packages/react/ds-app-portal/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Our architecture is driven by several core goals and design principles:
 
 ### 1.2 Tooling Choices
 
-On top of the [root-level architecture](../../../guides/ARCHITECTURE.md), this package leverages a modern React
+On top of the [root-level architecture](../../../docs/explanations/ARCHITECTURE.md), this package leverages a modern React
 toolchain to achieve its goals:
 
 | Tool(s)                                | Enables                                                                     | Benefits                                                                              |

--- a/packages/react/ds-app-portal/CONTRIBUTING.md
+++ b/packages/react/ds-app-portal/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This package provides an overview of the contribution process for the React Core
 
 ## 1. Getting Started
 
-Follow the [repository setup](../../../guides/CONTRIBUTING.md) guide to set up your development environment.
+Follow the [repository setup](../../../README.md#quick-start) guide to set up your development environment.
 
 Once the repository is set up, navigate to the `packages/react/ds-core` package directory and run `bun run storybook` to
 start
@@ -17,12 +17,10 @@ Storybook will automatically reload when you make changes to the components, usi
 
 ### 1.1 Building a component
 
-The [react component generator](../../generator-ds/src/component/README.md) provides a CLI to generate new components.
-To create a new component, [install Yeoman](../../generator-ds/README.md), then navigate to the component root directory
-`src/ui`.
-Run `yo @canonical/ds:component MyNewComponent` to generate a new component.
-You can also run `yo @canonical/ds:component --help` to see more available options, such as generating a component with
-a story and/or CSS file included.
+The [component generator](../../summon/component/README.md) scaffolds new components.
+Install the Summon CLI and generator (`npm install -g @canonical/summon @canonical/summon-component`), then run
+`summon component react src/lib/MyNewComponent` from the package root to generate a new component.
+You can also run `summon component react --help` to see more available options.
 
 Components should follow this basic structure:
 

--- a/packages/react/ds-app/ARCHITECTURE.md
+++ b/packages/react/ds-app/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Our architecture is driven by several core goals and design principles:
 
 ### 1.2 Tooling Choices
 
-On top of the [root-level architecture](../../../guides/ARCHITECTURE.md), this package leverages a modern React
+On top of the [root-level architecture](../../../docs/explanations/ARCHITECTURE.md), this package leverages a modern React
 toolchain to achieve its goals:
 
 | Tool(s)                                | Enables                                                                     | Benefits                                                                              |

--- a/packages/react/ds-app/CONTRIBUTING.md
+++ b/packages/react/ds-app/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This package provides an overview of the contribution process for the React Core
 
 ## 1. Getting Started
 
-Follow the [repository setup](../../../guides/CONTRIBUTING.md) guide to set up your development environment.
+Follow the [repository setup](../../../README.md#quick-start) guide to set up your development environment.
 
 Once the repository is set up, navigate to the `packages/react/ds-core` package directory and run `bun run storybook` to
 start
@@ -17,12 +17,10 @@ Storybook will automatically reload when you make changes to the components, usi
 
 ### 1.1 Building a component
 
-The [react component generator](../../generator-ds/src/component/README.md) provides a CLI to generate new components.
-To create a new component, [install Yeoman](../../generator-ds/README.md), then navigate to the component root directory
-`src/ui`.
-Run `yo @canonical/ds:component MyNewComponent` to generate a new component.
-You can also run `yo @canonical/ds:component --help` to see more available options, such as generating a component with
-a story and/or CSS file included.
+The [component generator](../../summon/component/README.md) scaffolds new components.
+Install the Summon CLI and generator (`npm install -g @canonical/summon @canonical/summon-component`), then run
+`summon component react src/lib/MyNewComponent` from the package root to generate a new component.
+You can also run `summon component react --help` to see more available options.
 
 Components should follow this basic structure:
 

--- a/packages/react/ds-global/ARCHITECTURE.md
+++ b/packages/react/ds-global/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Our architecture is driven by several core goals and design principles:
 
 ### 1.2 Tooling Choices
 
-On top of the [root-level architecture](../../../guides/ARCHITECTURE.md), this package leverages a modern React
+On top of the [root-level architecture](../../../docs/explanations/ARCHITECTURE.md), this package leverages a modern React
 toolchain to achieve its goals:
 
 | Tool(s)                                | Enables                                                                     | Benefits                                                                              |

--- a/packages/react/ds-global/CONTRIBUTING.md
+++ b/packages/react/ds-global/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This package provides an overview of the contribution process for the React Core
 
 ## 1. Getting Started
 
-Follow the [repository setup](../../../guides/CONTRIBUTING.md) guide to set up your development environment.
+Follow the [repository setup](../../../README.md#quick-start) guide to set up your development environment.
 
 Once the repository is set up, navigate to the `packages/react/ds-core` package directory and run `bun run storybook` to
 start
@@ -17,12 +17,10 @@ Storybook will automatically reload when you make changes to the components, usi
 
 ### 1.1 Building a component
 
-The [react component generator](../../generator-ds/src/component/README.md) provides a CLI to generate new components.
-To create a new component, [install Yeoman](../../generator-ds/README.md), then navigate to the component root directory
-`src/ui`.
-Run `yo @canonical/ds:component MyNewComponent` to generate a new component.
-You can also run `yo @canonical/ds:component --help` to see more available options, such as generating a component with
-a story and/or CSS file included.
+The [component generator](../../summon/component/README.md) scaffolds new components.
+Install the Summon CLI and generator (`npm install -g @canonical/summon @canonical/summon-component`), then run
+`summon component react src/lib/MyNewComponent` from the package root to generate a new component.
+You can also run `summon component react --help` to see more available options.
 
 Components should follow this basic structure:
 

--- a/packages/react/i18n/README.md
+++ b/packages/react/i18n/README.md
@@ -92,7 +92,7 @@ locales — all via the shared `@canonical/i18n-core` source.
 
 For a correct first paint, set `<html lang dir>` on the server from the
 negotiated locale with `documentAttrs` (see the
-[`@canonical/i18n-core` README](../../runtime/i18n#server-side-rendering)).
+[`@canonical/i18n-core` README](../../runtime/i18n/README.md#server-side-rendering)).
 
 ## License
 

--- a/packages/storybook/addon-msw/ADDON_KIT_README.md
+++ b/packages/storybook/addon-msw/ADDON_KIT_README.md
@@ -42,7 +42,7 @@ Addons can interact with a Storybook project in multiple ways. It is recommended
 - Preview entries are used to add UI or behavior to the preview iframe where stories are rendered.
 - Presets are used to modify the Storybook configuration, similar to how [users can configure their `main.ts` configurations](https://storybook.js.org/docs/react/api/main-config).
 
-Since each of these places represents a different environment with different features and modules, it is also recommended to split and build your modules accordingly. This addon-kit comes with a preconfigured [bundling configuration](./tsup.config.ts) that supports this split, and you are free to modify and extend it as needed.
+Since each of these places represents a different environment with different features and modules, it is also recommended to split and build your modules accordingly. This addon-kit comes with a preconfigured bundling configuration that supports this split, and you are free to modify and extend it as needed.
 
 You can define which modules match which environments in the [`package.json#bundler`](./package.json) property:
 

--- a/packages/storybook/addon-utils/ADDON_KIT_README.md
+++ b/packages/storybook/addon-utils/ADDON_KIT_README.md
@@ -42,7 +42,7 @@ Addons can interact with a Storybook project in multiple ways. It is recommended
 - Preview entries are used to add UI or behavior to the preview iframe where stories are rendered.
 - Presets are used to modify the Storybook configuration, similar to how [users can configure their `main.ts` configurations](https://storybook.js.org/docs/react/api/main-config).
 
-Since each of these places represents a different environment with different features and modules, it is also recommended to split and build your modules accordingly. This addon-kit comes with a preconfigured [bundling configuration](./tsup.config.ts) that supports this split, and you are free to modify and extend it as needed.
+Since each of these places represents a different environment with different features and modules, it is also recommended to split and build your modules accordingly. This addon-kit comes with a preconfigured bundling configuration that supports this split, and you are free to modify and extend it as needed.
 
 You can define which modules match which environments in the [`package.json#bundler`](./package.json) property:
 

--- a/packages/summon/component/README.md
+++ b/packages/summon/component/README.md
@@ -592,8 +592,8 @@ The generator appends to `{parentDir}/index.ts`. If your project uses a differen
 
 ## Related
 
-- **[@canonical/summon](../summon/)** — The generator framework (required peer dependency)
-- **[@canonical/summon-package](../summon-package/)** — Package scaffolding for the monorepo
+- **[@canonical/summon-core](../core/)** — The generator framework (required peer dependency)
+- **[@canonical/summon-package](../package/)** — Package scaffolding for the monorepo
 
 ---
 
@@ -633,7 +633,7 @@ Generated templates use generic patterns. For project-specific standards (CSS na
 
 ### Non-Interactive Environments
 
-See [Summon How-To: Non-Interactive Usage](/packages/summon/docs/how-to.md#non-interactive--llm-usage) for CI/LLM usage patterns.
+See [Summon How-To: Non-Interactive Usage](../core/docs/how-to.md#non-interactive--llm-usage) for CI/LLM usage patterns.
 
 ## License
 

--- a/packages/summon/package/README.md
+++ b/packages/summon/package/README.md
@@ -488,8 +488,8 @@ After generating a package:
 
 ## Related
 
-- **[@canonical/summon](../summon/)** — The generator framework (required peer dependency)
-- **[@canonical/summon-component](../summon-component/)** — Component scaffolding
+- **[@canonical/summon-core](../core/)** — The generator framework (required peer dependency)
+- **[@canonical/summon-component](../component/)** — Component scaffolding
 
 ## License
 


### PR DESCRIPTION
## Done

Docs-only PR: makes the public-facing docs match the actual workspace, and adds CI link checking so internal links can't silently rot again. No component/CLI source code is touched.

- Root `README.md` truth pass — every corrected falsehood (before → after):
  - `@canonical/generator-ds` at `packages/generator-ds` with Yeoman install instructions (`npm i -g yo @canonical/generator-ds`) → package no longer exists; section replaced with the actual scaffolding tooling: the `@canonical/summon` CLI + generator packages under `packages/summon/*` and their `pragma create component` / `pragma create package` wrappers.
  - "All packages share a single version number (currently 0.11.0)" → Lerna-lockstep 0.29.x line, tracked in `lerna.json`.
  - Component tiers: "grouped by maturity: Stable/Beta/Experimental" → actual grouping is `src/lib/component|group|pattern` plus `_work_in_progress` (no maturity folders exist).
  - `@canonical/react-ds-app` "Navigation, Toolbar" → actual components are ApplicationLayout, ContentLayout, SideNavigation, ViewLayout.
  - "Apps/WPE" tier row (launchpad only) → product-specific tier now covers `-launchpad`, `-lxd`, `-anbox`, `-landscape`, `-portal`.
  - `@canonical/react-ds-app-launchpad` "Markdown renderer, Tooltip variants" → GitDiffViewer, MarkdownEditor, FileTree, EditableBlock, RelativeTime, DiffChangeMarker.
  - Styles table listed phantom packages (`styles/main/canonical`, `styles-primitives-canonical`, `styles-elements`, four `styles-modes-*`) → only `styles/main`, `styles/typography`, `styles/debug` exist; layering description rewritten to match `packages/styles/main/src/index.css` (normalize.css + styles-typography + `@canonical/design-tokens`).
  - Configuration table paths `configs/biome-config`, `configs/typescript-config`, `configs/typescript-config-react`, `configs/storybook-config` → actual dirs `configs/biome`, `configs/typescript`, `configs/typescript-react`, `configs/storybook`; missing `renovate`, `typescript-lit`, `typescript-svelte`, `vitest-config-react` rows added.
  - Package Reference tables reconciled against **every** `package.json` in the workspace: 61 rows, one per real package (React utilities, Svelte, Lit, runtime, summon, CLI, storybook addons, apps all added). `private: true` packages (the three `ssr-adapter-*` and the four apps) are explicitly marked **internal** instead of being presented as installable. Note: `react-ds-app` is *not* private on main today, so it is listed as a normal published package.
  - Drive-bys: "Every package runs `check:webarchitect`" → "Most packages" (38 of 57); "Three rulesets" claim now names the other five rulesets (`base`, `package`, `package-react`, `package-svelte`, `assets`); ds-assets icon claim softened (156/164 SVGs are 16x16, all use `currentColor`); className pattern updated to the real Button construction (`["ds button", importance, …]`).
- `docs/explanations/COMPONENT_FOLDER_STRUCTURE.md`: the example still showed the `aria-label={props["aria-label"] || children?.toString()}` pattern removed by #661 → rewritten to the current guarded approach from the real `Button.tsx` (visible-children check + dev-only `console.warn` when no accessible name; never synthesize `aria-label` from children), with a paragraph explaining why.
- CLI docs counts (`packages/cli/pragma`): README claimed "14 domains" in two places and `docs/DOMAIN_STRUCTURE.md` claimed six CLI domains + two operations-only domains → all corrected to **17**, with the counting rule stated in the text: every directory under `src/domains/` except `shared/` (cross-domain infrastructure). All 17 contribute commands (`refs`/`trace`/`graphql` via the store-skip path); the operations-only tier is now empty since `graph` and `ontology` gained commands. Also fixed: "Command collection in runCli.ts" → `pipeline/collectCommands.ts`, the nonexistent `component` domain in examples → `block`, and six broken relative dependency links (`../../lib/task/` → `../../runtime/task/`, etc.).
- Repo-wide broken internal links fixed so the new offline check passes (42 lychee errors → 0): stale `guides/` + `generator-ds` boilerplate links in six `packages/react/ds-*` ARCHITECTURE/CONTRIBUTING files, wrong sibling links and a root-relative link in `packages/summon/{component,package}/README.md`, dead in-file anchors in `docs/references/ROUTER_API.md` and `docs/how-to-guides/CREATE_A_REACT_COMPONENT.md`, a dead `tsup.config.ts` link in two ADDON_KIT_README files, and a directory-plus-fragment link in `packages/react/i18n/README.md`.
- New `.github/workflows/links.yml` (new file only — no existing workflows touched) + `lychee.toml`:
  - PR-triggered job: `lychee --offline --include-fragments` over `**/*.md` — broken internal/relative links and anchors fail PRs, zero external requests.
  - Weekly scheduled job (Mon 06:00 UTC, plus `workflow_dispatch`): full check including external URLs, failing visibly (no issue automation). Excludes flaky/auth domains (coda.io, npmjs.com/org, localhost, placeholder hosts) and the archived `old/` tree via `lychee.toml`.
  - `lycheeverse/lychee-action` pinned to the full v2.9.0 commit SHA `e7477775783ea5526144ba13e8db5eec57747ce8` (SHA verified against the upstream commit page); checkout uses `actions/checkout@v6` to match the repo's existing workflows.

## QA

Every package name/path in the README tables verified against the workspace (61/61 rows OK, no failures):

```console
$ awk -F'\\| *`' '/^\| `@canonical\// {split($2,n,"`"); split($3,p,"`"); if (p[1] ~ /^(packages|configs|apps)\//) print n[1]"\t"p[1]}' README.md \
  | while IFS=$'\t' read -r name path; do actual=$(node -pe "require('./$path/package.json').name" 2>/dev/null); \
    [ "$actual" = "$name" ] && echo "OK  $name" || echo "FAIL $name -> $path (found: ${actual:-missing})"; done | grep -c '^OK'
61
$ # reverse direction: every workspace package appears in the README
$ for f in $(find packages configs apps -maxdepth 3 -name package.json -not -path '*/node_modules/*'); do \
    n=$(node -pe "require('./$f').name"); grep -q "\`$n\`" README.md || echo "MISSING: $n"; done; echo done
done
```

Domain count verified against the source tree (rule: directories under `src/domains/` minus `shared/`):

```console
$ ls -d packages/cli/pragma/src/domains/*/ | wc -l
18
$ ls -d packages/cli/pragma/src/domains/*/ | grep -vc shared
17
```

All 17 export commands: 15 are wired in `src/pipeline/collectCommands.ts`; `refs` and `trace` are registered on the store-skip path in `src/pipeline/runCli.ts`.

Lychee executed locally with the exact PR-job invocation, using lychee v0.24.2 compiled from crates.io — the same version `lychee-action` v2.9.0 pins by default (`lycheeVersion: v0.24.2`):

```console
$ lychee --config ./lychee.toml --offline --include-fragments --no-progress './**/*.md'
🔍 4455 Total (in 43ms) 🔗 1180 Unique ✅ 174 OK 🚫 0 Errors 👻 4281 Excluded
```

(Before the fixes the same command reported 42 errors.) The weekly job's external check was not executed locally (sandboxed network); its config parses with the same binary and differs only by dropping `--offline`. Workflow YAML validated with a YAML parser; `actionlint` was not available in this environment.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`: (n/a — docs and CI config only)
- [x] If this PR introduces a **new package**: (n/a — no new packages)
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

n/a — documentation and CI configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Be8jVERCqAqCPLHZXH4uJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012Be8jVERCqAqCPLHZXH4uJ)_