### PR TITLE
fix(ds-global): sizing, spacing & alignment from design review

### DIFF
--- a/packages/react/ds-global-form/src/docs/Surfaces.mdx
+++ b/packages/react/ds-global-form/src/docs/Surfaces.mdx
@@ -1,0 +1,92 @@
+import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+import * as Stories from "./Surfaces.stories";
+
+<Meta title="Documentation/Surfaces" />
+
+# Surfaces
+
+Form controls are **surface-aware**. Rather than painting one fixed colour on
+every background, the checkbox, radio and switch read their colours from the
+design system's `--surface-color-foreground-*` channels, so a control recolours
+to suit the surface it sits on.
+
+Surfaces step by **nesting**, not by a prop: a `.surface` element is level 1, a
+`.surface` inside another `.surface` is level 2, and a third level of nesting is
+level 3. Each level resolves the surface channels to its own tone, and any
+control inside inherits it automatically.
+
+<table>
+  <thead>
+    <tr>
+      <th>Level</th>
+      <th>Selector</th>
+      <th>Tone</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td><code>.surface</code></td>
+      <td>base foreground</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td><code>.surface .surface</code></td>
+      <td>stepped</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td><code>.surface .surface .surface</code></td>
+      <td>stepped again</td>
+    </tr>
+  </tbody>
+</table>
+
+## Every control at each level
+
+Selected fills, radio dots and switch tracks step with the band; the switch knob
+and the masked checkmark read their own surface channels too, so they stay
+legible against the stepping fill.
+
+<Canvas of={Stories.Controls} />
+
+## Checkbox
+
+The box fill and the masked checkmark both resolve per surface, including the
+indeterminate state.
+
+<Canvas of={Stories.Checkbox} />
+
+## Switch
+
+The track (selected and unselected) steps with the surface, while the knob reads
+its own channel so it keeps contrast against the track at every level.
+
+<Canvas of={Stories.Switch} />
+
+## What the control CSS reads
+
+Each control names the surface channel with a flat fallback, so it works whether
+or not a surface context is present:
+
+```css
+.ds.form-checkbox:checked {
+  background: var(
+    --surface-color-foreground-checkbox-selected,
+    var(--color-foreground-checkbox-selected)
+  );
+}
+```
+
+Hover on a selected control shifts **only** the fill/track — via the
+`--hover--color-foreground-*-selected` channels — never the checkmark glyph or
+the switch knob. This replaced an earlier whole-element `filter: brightness()`
+that dimmed the glyph along with the fill.
+
+### Upstream note
+
+The design tokens currently provide surface channels for the controls' unselected
+and checkmark/knob colours. The `-selected` surface channels (and the switch's
+unselected track) are supplied by a temporary shim in `@canonical/styles`
+(`controls.hover.shim.css`) until they are generated upstream; the components
+already read them, so no component change is needed when they land.

--- a/packages/react/ds-global-form/src/docs/Surfaces.stories.tsx
+++ b/packages/react/ds-global-form/src/docs/Surfaces.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type React from "react";
+import * as decorators from "storybook/decorators.js";
+import { CheckboxInput } from "../lib/subcomponent/CheckboxInput/index.js";
+import { RadioInput } from "../lib/subcomponent/RadioInput/index.js";
+import { SwitchInput } from "../lib/subcomponent/SwitchInput/index.js";
+
+/**
+ * Surface stepping for form controls. The checkbox/radio/switch fills, dots,
+ * knobs and checkmarks read their `--surface-color-foreground-*` tokens, so a
+ * control placed inside a `.surface` context recolours per nesting level
+ * (`.surface` → `.surface .surface` → `.surface .surface .surface`) instead of
+ * painting one flat colour on every background.
+ *
+ * These are presentational subcomponents (no react-hook-form), rendered once per
+ * surface level via the shared `surfaces()` helper.
+ */
+const meta = {
+  title: "Documentation/Surfaces/Examples",
+  parameters: { layout: "fullscreen" },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * One selected + one unselected of each control, laid out in a row. `disabled`
+ * renders the disabled variant of the same set (its own tokens step per surface
+ * too), tagged so the two rows read distinctly.
+ */
+const ControlRow = ({
+  level,
+  disabled = false,
+}: {
+  level: number;
+  disabled?: boolean;
+}): React.ReactElement => {
+  const key = `s${level}${disabled ? "-dis" : ""}`;
+  return (
+    <div
+      style={{ display: "flex", gap: "var(--space-300)", alignItems: "center" }}
+    >
+      <CheckboxInput name={`${key}-cb-on`} defaultChecked disabled={disabled} />
+      <CheckboxInput name={`${key}-cb-off`} disabled={disabled} />
+      <RadioInput name={`${key}-radio`} defaultChecked disabled={disabled} />
+      <RadioInput name={`${key}-radio`} disabled={disabled} />
+      <SwitchInput
+        name={`${key}-switch-on`}
+        defaultChecked
+        disabled={disabled}
+      />
+      <SwitchInput name={`${key}-switch-off`} disabled={disabled} />
+      <span
+        className="p"
+        style={{
+          color: "var(--surface-color-foreground-text, var(--color-text))",
+        }}
+      >
+        Surface level {level + 1}
+        {disabled ? " (disabled)" : ""}
+      </span>
+    </div>
+  );
+};
+
+/**
+ * Every control at each of the three surface levels — an enabled row and a
+ * disabled row per level. Selected fills, knobs and dots step with the band;
+ * hovering a selected control shifts only the fill (via the hover-selected
+ * channels), never the masked glyph or the knob.
+ */
+export const Controls: Story = {
+  render: () =>
+    decorators.surfaces((level) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-200)",
+        }}
+      >
+        <ControlRow level={level} />
+        <ControlRow level={level} disabled />
+      </div>
+    )),
+};
+
+/**
+ * Just the checkbox, to isolate the selected-fill + checkmark stepping —
+ * enabled row and disabled row.
+ */
+export const Checkbox: Story = {
+  render: () =>
+    decorators.surfaces((level) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-200)",
+        }}
+      >
+        <div style={{ display: "flex", gap: "var(--space-200)" }}>
+          <CheckboxInput name={`cb${level}-on`} defaultChecked />
+          <CheckboxInput
+            name={`cb${level}-ind`}
+            ref={(el) => {
+              if (el) el.indeterminate = true;
+            }}
+          />
+          <CheckboxInput name={`cb${level}-off`} />
+        </div>
+        <div style={{ display: "flex", gap: "var(--space-200)" }}>
+          <CheckboxInput name={`cb${level}-dis-on`} defaultChecked disabled />
+          <CheckboxInput
+            name={`cb${level}-dis-ind`}
+            disabled
+            ref={(el) => {
+              if (el) el.indeterminate = true;
+            }}
+          />
+          <CheckboxInput name={`cb${level}-dis-off`} disabled />
+        </div>
+      </div>
+    )),
+};
+
+/**
+ * Just the switch, to isolate the track (selected/unselected) vs knob stepping —
+ * enabled row and disabled row.
+ */
+export const Switch: Story = {
+  render: () =>
+    decorators.surfaces((level) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-200)",
+        }}
+      >
+        <div style={{ display: "flex", gap: "var(--space-200)" }}>
+          <SwitchInput name={`sw${level}-on`} defaultChecked />
+          <SwitchInput name={`sw${level}-off`} />
+        </div>
+        <div style={{ display: "flex", gap: "var(--space-200)" }}>
+          <SwitchInput name={`sw${level}-dis-on`} defaultChecked disabled />
+          <SwitchInput name={`sw${level}-dis-off`} disabled />
+        </div>
+      </div>
+    )),
+};

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/common/Option/Option.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/common/Option/Option.tsx
@@ -23,7 +23,7 @@ const Option = ({
   const ariaProps = useOptionAriaProperties(name, option.value);
   return (
     <div
-      className={[componentCssClassName, "grid", disabled && "disabled"]
+      className={[componentCssClassName, disabled && "disabled"]
         .filter(Boolean)
         .join(" ")}
     >

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/styles.css
@@ -5,7 +5,9 @@
   margin: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 0 var(--container-gap-loose);
+  /* Row gap gives stacked/wrapped options vertical breathing room (was 0, so
+   * stacked items touched); column gap is the inline separation (per review). */
+  gap: var(--form-group-gap) var(--container-gap-loose);
 
   /* Stacked: one option per line */
   &.stacked {
@@ -43,17 +45,31 @@
       height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
       border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
       border-radius: 50%;
-      background-color: var(--color-foreground-radio-unselected);
+      background-color: var(
+        --surface-color-foreground-radio-unselected,
+        var(--color-foreground-radio-unselected)
+      );
       cursor: inherit;
       transition:
         background-color 150ms ease,
         border-color 150ms ease;
 
       &:checked {
-        border-color: var(--color-foreground-radio-selected);
+        border-color: var(
+          --surface-color-foreground-radio-selected,
+          var(--color-foreground-radio-selected)
+        );
         background: radial-gradient(
-          var(--color-foreground-radio-selected) 40%,
-          var(--color-foreground-radio-unselected) 41%
+          var(
+              --surface-color-foreground-radio-selected,
+              var(--color-foreground-radio-selected)
+            )
+            40%,
+          var(
+              --surface-color-foreground-radio-unselected,
+              var(--color-foreground-radio-unselected)
+            )
+            41%
         );
       }
 
@@ -61,8 +77,18 @@
         background-color: var(--color-foreground-radio-unselected-hover);
       }
 
+      /* Hover shifts only the dot's fill (channel shade), not a whole-element
+       * brightness filter that would also dim the ring. */
       &:checked:hover:not(:disabled) {
-        filter: brightness(0.9);
+        border-color: var(--hover--color-foreground-radio-selected);
+        background: radial-gradient(
+          var(--hover--color-foreground-radio-selected) 40%,
+          var(
+              --surface-color-foreground-radio-unselected,
+              var(--color-foreground-radio-unselected)
+            )
+            41%
+        );
       }
 
       &:focus-visible {
@@ -85,7 +111,10 @@
       height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
       border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
       border-radius: var(--dimension-radius-small);
-      background-color: var(--color-foreground-checkbox-unselected);
+      background-color: var(
+        --surface-color-foreground-checkbox-unselected,
+        var(--color-foreground-checkbox-unselected)
+      );
       cursor: inherit;
       transition:
         background-color 150ms ease,
@@ -107,11 +136,20 @@
       }
 
       &:checked {
-        background: var(--color-foreground-checkbox-selected);
-        border-color: var(--color-foreground-checkbox-selected);
+        background: var(
+          --surface-color-foreground-checkbox-selected,
+          var(--color-foreground-checkbox-selected)
+        );
+        border-color: var(
+          --surface-color-foreground-checkbox-selected,
+          var(--color-foreground-checkbox-selected)
+        );
 
         &::before {
-          background-color: var(--color-foreground-checkbox-checkmark);
+          background-color: var(
+            --surface-color-foreground-checkbox-checkmark,
+            var(--color-foreground-checkbox-checkmark)
+          );
           mask-image: url("/icons/checkmark.svg#checkmark");
           -webkit-mask-image: url("/icons/checkmark.svg#checkmark");
         }
@@ -121,8 +159,10 @@
         background-color: var(--color-foreground-checkbox-unselected-hover);
       }
 
+      /* Hover shifts only the fill (channel shade), not the masked checkmark. */
       &:checked:hover:not(:disabled) {
-        filter: brightness(0.9);
+        background-color: var(--hover--color-foreground-checkbox-selected);
+        border-color: var(--hover--color-foreground-checkbox-selected);
       }
 
       &:focus-visible {

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
@@ -10,7 +10,10 @@
   height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
   border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
   border-radius: var(--dimension-radius-small);
-  background: var(--color-foreground-checkbox-unselected);
+  background: var(
+    --surface-color-foreground-checkbox-unselected,
+    var(--color-foreground-checkbox-unselected)
+  );
   cursor: pointer;
   transition:
     background-color 150ms ease,
@@ -42,11 +45,22 @@
 
   &:checked {
     position: relative;
-    background: var(--color-foreground-checkbox-selected);
-    border-color: var(--color-foreground-checkbox-selected);
+    /* Selected fill + checkmark read the surface-provided tokens (with a flat
+     * fallback) so the control adapts to OnSurface stepping. */
+    background: var(
+      --surface-color-foreground-checkbox-selected,
+      var(--color-foreground-checkbox-selected)
+    );
+    border-color: var(
+      --surface-color-foreground-checkbox-selected,
+      var(--color-foreground-checkbox-selected)
+    );
 
     &::before {
-      background-color: var(--color-foreground-checkbox-checkmark);
+      background-color: var(
+        --surface-color-foreground-checkbox-checkmark,
+        var(--color-foreground-checkbox-checkmark)
+      );
       mask-image: url("/icons/checkmark.svg#checkmark");
       -webkit-mask-image: url("/icons/checkmark.svg#checkmark");
     }
@@ -54,11 +68,20 @@
 
   &:indeterminate {
     position: relative;
-    background: var(--color-foreground-checkbox-selected);
-    border-color: var(--color-foreground-checkbox-selected);
+    background: var(
+      --surface-color-foreground-checkbox-selected,
+      var(--color-foreground-checkbox-selected)
+    );
+    border-color: var(
+      --surface-color-foreground-checkbox-selected,
+      var(--color-foreground-checkbox-selected)
+    );
 
     &::before {
-      background-color: var(--color-foreground-checkbox-checkmark);
+      background-color: var(
+        --surface-color-foreground-checkbox-checkmark,
+        var(--color-foreground-checkbox-checkmark)
+      );
       mask-image: url("/icons/minus.svg#minus");
       -webkit-mask-image: url("/icons/minus.svg#minus");
     }
@@ -68,14 +91,16 @@
     background: var(--color-foreground-checkbox-unselected-hover);
   }
 
-  &:checked:hover:not(:disabled) {
-    background-color: var(--color-foreground-checkbox-selected);
-    filter: brightness(0.9);
-  }
-
+  /* Hover on a selected/indeterminate box shifts ONLY the fill, not the
+   * checkmark/minus glyph (per design review): the background swaps to the
+   * hovered selected shade while `::before` keeps its own colour. The hover
+   * shade comes from the `--hover--…-selected` channel (criticality-style OKLCH
+   * delta shim), replacing the old whole-element `filter: brightness()` that
+   * also dimmed the glyph. */
+  &:checked:hover:not(:disabled),
   &:indeterminate:hover:not(:disabled) {
-    background-color: var(--color-foreground-checkbox-selected);
-    filter: brightness(0.9);
+    background-color: var(--hover--color-foreground-checkbox-selected);
+    border-color: var(--hover--color-foreground-checkbox-selected);
   }
 
   &:focus-visible {

--- a/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/styles.css
@@ -10,17 +10,33 @@
   height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
   border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
   border-radius: 50%;
-  background-color: var(--color-foreground-radio-unselected);
+  background-color: var(
+    --surface-color-foreground-radio-unselected,
+    var(--color-foreground-radio-unselected)
+  );
   cursor: pointer;
   transition:
     background-color 150ms ease,
     border-color 150ms ease;
 
   &:checked {
-    border-color: var(--color-foreground-radio-selected);
+    /* Dot = selected token, ring fill = unselected token; both surface-provided
+     * (flat fallback) so the control adapts to OnSurface stepping. */
+    border-color: var(
+      --surface-color-foreground-radio-selected,
+      var(--color-foreground-radio-selected)
+    );
     background: radial-gradient(
-      var(--color-foreground-radio-selected) 40%,
-      var(--color-foreground-radio-unselected) 41%
+      var(
+          --surface-color-foreground-radio-selected,
+          var(--color-foreground-radio-selected)
+        )
+        40%,
+      var(
+          --surface-color-foreground-radio-unselected,
+          var(--color-foreground-radio-unselected)
+        )
+        41%
     );
   }
 
@@ -28,8 +44,19 @@
     background-color: var(--color-foreground-radio-unselected-hover);
   }
 
+  /* Hover on a selected radio shifts only the dot's fill, not via a whole-element
+   * brightness filter (which would also dim the ring). Re-paint the gradient with
+   * the hovered selected shade from the `--hover--…-selected` channel. */
   &:checked:hover:not(:disabled) {
-    filter: brightness(0.9);
+    border-color: var(--hover--color-foreground-radio-selected);
+    background: radial-gradient(
+      var(--hover--color-foreground-radio-selected) 40%,
+      var(
+          --surface-color-foreground-radio-unselected,
+          var(--color-foreground-radio-unselected)
+        )
+        41%
+    );
   }
 
   &:focus-visible {

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
@@ -26,7 +26,10 @@
   width: var(--switch-track-width);
   height: var(--switch-track-height);
   border-radius: var(--dimension-radius-full);
-  background: var(--color-foreground-switch-unselected);
+  background: var(
+    --surface-color-foreground-switch-unselected,
+    var(--color-foreground-switch-unselected)
+  );
   cursor: pointer;
   transition: background-color 150ms ease;
 
@@ -39,12 +42,20 @@
     width: var(--switch-knob-size);
     height: var(--switch-knob-size);
     border-radius: var(--dimension-radius-full);
-    background: var(--color-foreground-switch-knob);
+    /* Knob reads its surface-provided token (flat fallback) for OnSurface. */
+    background: var(
+      --surface-color-foreground-switch-knob,
+      var(--color-foreground-switch-knob)
+    );
     transition: translate 150ms ease;
   }
 
   &:checked {
-    background: var(--color-foreground-switch-selected);
+    /* Selected track reads the surface-provided token (flat fallback). */
+    background: var(
+      --surface-color-foreground-switch-selected,
+      var(--color-foreground-switch-selected)
+    );
 
     &::before {
       /* Slide to the far edge: the space left over after the knob and both
@@ -58,14 +69,17 @@
     }
   }
 
+  /* Hover shifts ONLY the track background, not the knob (per design review):
+   * the track swaps to the hovered shade while the `::before` knob keeps its
+   * colour. Shades come from the `--hover--…` channels (criticality-style OKLCH
+   * delta shim), replacing the old whole-element `filter: brightness()` that
+   * also dimmed the knob. */
   &:hover:not(:disabled):not(:checked) {
-    background: var(--color-foreground-switch-unselected);
-    filter: brightness(0.95);
+    background: var(--hover--color-foreground-switch-unselected);
   }
 
   &:checked:hover:not(:disabled) {
-    background: var(--color-foreground-switch-selected);
-    filter: brightness(0.9);
+    background: var(--hover--color-foreground-switch-selected);
   }
 
   &:focus-visible {

--- a/packages/react/ds-global-form/src/storybook/decorators.tsx
+++ b/packages/react/ds-global-form/src/storybook/decorators.tsx
@@ -1,5 +1,6 @@
 import { useFormStateEmitter } from "@canonical/storybook-addon-form-state";
 import type React from "react";
+import type { ReactElement, ReactNode } from "react";
 import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
@@ -54,3 +55,61 @@ export const form = ({
     return <FormWrapper />;
   };
 };
+
+/** Band spacing: half the block padding (above/below) of the inline padding. */
+const SURFACE_BAND_PADDING_BLOCK = "2.5rem";
+const SURFACE_BAND_PADDING_INLINE = "5rem";
+
+/**
+ * One surface band: a full-width row painting its own surface background, its
+ * content centred, then — flush below — the next, deeper band. The three surface
+ * levels differ only by *nesting* (`.surface` → layer 1, `.surface .surface` →
+ * layer 2, `.surface .surface .surface` → layer 3), so the bands nest in the DOM
+ * to step colour; padding lives on the inner wrapper so nested bands stay flush
+ * and full-width. Ported from the ds-global storybook decorators.
+ *
+ * @param level - this band's surface level (0-based).
+ * @param renderAtLevel - the content to place at a given level.
+ */
+const SurfaceBand = ({
+  level,
+  renderAtLevel,
+}: {
+  level: number;
+  renderAtLevel: (level: number) => ReactNode;
+}): ReactElement => (
+  <div
+    className="surface"
+    style={{
+      background: "var(--surface-color-background, var(--color-background))",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "stretch",
+    }}
+  >
+    <div
+      style={{
+        paddingBlock: SURFACE_BAND_PADDING_BLOCK,
+        paddingInline: SURFACE_BAND_PADDING_INLINE,
+      }}
+    >
+      {renderAtLevel(level)}
+    </div>
+    {level < 2 ? (
+      <SurfaceBand level={level + 1} renderAtLevel={renderAtLevel} />
+    ) : null}
+  </div>
+);
+
+/**
+ * Renders `renderAtLevel` inside three stacked, equal `.surface` bands
+ * (level 1 → 2 → 3) so a surface-aware control can be seen at each level. A
+ * control that reads its `--surface-color-foreground-*` tokens steps with the
+ * band; one that hard-codes flat colours blends in. The bands size to their
+ * content. Ported from the ds-global storybook decorators.
+ *
+ * @param renderAtLevel - returns the node to place at a given level (0-based).
+ */
+export const surfaces = (
+  renderAtLevel: (level: number) => ReactNode,
+): ReactElement => <SurfaceBand level={0} renderAtLevel={renderAtLevel} />;

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
@@ -7,7 +7,9 @@
  * spec: header interactive background uses the ghost surface channel (which
  * auto-steps on nested .surface contexts to layer2/layer3), text uses
  * color-text, the chevron uses color-icon, and dividers use color-border-muted.
- * Vertical padding is expressed in baseline multiples.
+ * Content vertical padding is expressed in baseline multiples; header block
+ * padding is 6px so the collapsed item meets the Figma element size (36px in
+ * sites, 32px in apps).
  */
 :root {
   --accordion-item-color-text: var(--color-text);
@@ -34,8 +36,12 @@
     --color-foreground-ghost-active
   );
 
-  --accordion-item-header-gap: var(--dimension-100);
-  --accordion-item-header-padding-block: var(--dimension-100);
+  --accordion-item-header-gap: var(--dimension-200);
+  /* 6px block padding: padding + line box + the item's 1px block-end divider
+     lands the collapsed item border-box at the Figma element size — 36px in
+     sites, 32px in apps. No 6px token exists in the built scale (there is no
+     --dimension-075), so halve --dimension-150 (12px). */
+  --accordion-item-header-padding-block: calc(var(--dimension-150) / 2);
   --accordion-item-header-padding-inline: var(--dimension-200);
 
   --accordion-item-content-padding-inline: var(--dimension-200);
@@ -119,10 +125,19 @@
   line-height: var(--typography-text-primary-line-height);
   letter-spacing: var(--typography-text-primary-letter-spacing);
 
+  /* The header owns vertical rhythm: zero the baseline engine's padding-block
+     nudges on every heading element so the header height stays padding-driven
+     and the flex centring keeps the chevron aligned with the heading text. */
+  & :is(h1, h2, h3, h4, h5, h6) {
+    padding-block: 0;
+  }
+
   /* Normalise every heading element except <h6> down to the inherited body
-     tier. <h6> is left untouched so the base h6 tier from
-     @canonical/styles-typography applies (correct heading-6 tokens, including
-     the baseline-snapped line-height) — no heading-6 tokens are restated here. */
+     tier. <h6> keeps the base h6 tier from @canonical/styles-typography
+     (correct heading-6 tokens), but its engine --line-height is unsnapped to
+     the raw font-size x ratio product so the h6 line box matches the
+     plain-text header line box per context (24px sites / 20px apps) instead
+     of the baseline-rounded 24px everywhere. */
   & :is(h1, h2, h3, h4, h5) {
     margin: 0;
     font: inherit;
@@ -130,6 +145,11 @@
   }
 
   & h6 {
+    --line-height: calc(
+      var(--typography-heading-6-font-size) *
+      var(--typography-heading-6-line-height)
+    );
+
     margin: 0;
   }
 }
@@ -187,10 +207,11 @@
   padding-inline-end: var(--accordion-item-content-padding-inline);
 }
 
-/* 1px divider baseline compensation: subtract the divider thickness from the
-   block-end padding of whichever element sits directly above the item's
-   block-end border, so the item's border-box height stays a baseline multiple
-   (no drift down the list) without pulling the content up in the process.
+/* 1px divider compensation: subtract the divider thickness from the block-end
+   padding of whichever element sits directly above the item's block-end
+   border, so the divider fits inside the item's target border-box height
+   (collapsed: the 36/32 element size; expanded: a baseline multiple, so no
+   drift down the list) without pulling the content up in the process.
    - collapsed: only the header is shown -> compensate the header
    - expanded:  the content is at the bottom -> compensate the content */
 .ds.accordion-item:not([open]) > .header {

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
@@ -7,9 +7,12 @@
  * spec: header interactive background uses the ghost surface channel (which
  * auto-steps on nested .surface contexts to layer2/layer3), text uses
  * color-text, the chevron uses color-icon, and dividers use color-border-muted.
- * Content vertical padding is expressed in baseline multiples; header block
- * padding is 6px so the collapsed item meets the Figma element size (36px in
- * sites, 32px in apps).
+ * Vertical padding is expressed in baseline multiples.
+ *
+ * NOTE: the apps/sites element-size sizing (collapsed item at 36px sites / 32px
+ * apps, and the matching h6 line box) is intentionally NOT set here — control
+ * heights across apps vs sites are owned by the density/height bucket, not this
+ * design-review geometry pass.
  */
 :root {
   --accordion-item-color-text: var(--color-text);
@@ -37,11 +40,9 @@
   );
 
   --accordion-item-header-gap: var(--dimension-200);
-  /* 6px block padding: padding + line box + the item's 1px block-end divider
-     lands the collapsed item border-box at the Figma element size — 36px in
-     sites, 32px in apps. No 6px token exists in the built scale (there is no
-     --dimension-075), so halve --dimension-150 (12px). */
-  --accordion-item-header-padding-block: calc(var(--dimension-150) / 2);
+  /* Header block padding in baseline multiples (dimension-100 = 1 bU). The
+     apps/sites element-size sizing (6px → 36/32) is owned by the height bucket. */
+  --accordion-item-header-padding-block: var(--dimension-100);
   --accordion-item-header-padding-inline: var(--dimension-200);
 
   --accordion-item-content-padding-inline: var(--dimension-200);
@@ -125,19 +126,13 @@
   line-height: var(--typography-text-primary-line-height);
   letter-spacing: var(--typography-text-primary-letter-spacing);
 
-  /* The header owns vertical rhythm: zero the baseline engine's padding-block
-     nudges on every heading element so the header height stays padding-driven
-     and the flex centring keeps the chevron aligned with the heading text. */
-  & :is(h1, h2, h3, h4, h5, h6) {
-    padding-block: 0;
-  }
-
   /* Normalise every heading element except <h6> down to the inherited body
      tier. <h6> keeps the base h6 tier from @canonical/styles-typography
-     (correct heading-6 tokens), but its engine --line-height is unsnapped to
-     the raw font-size x ratio product so the h6 line box matches the
-     plain-text header line box per context (24px sites / 20px apps) instead
-     of the baseline-rounded 24px everywhere. */
+     (correct heading-6 tokens, including the baseline-snapped line-height) — no
+     heading-6 tokens are restated here.
+     NOTE: the per-context h6 line box (24px sites / 20px apps) and zeroing the
+     heading padding-block nudges to make the header height padding-driven are
+     part of the apps/sites height bucket, not this pass. */
   & :is(h1, h2, h3, h4, h5) {
     margin: 0;
     font: inherit;
@@ -145,11 +140,6 @@
   }
 
   & h6 {
-    --line-height: calc(
-      var(--typography-heading-6-font-size) *
-      var(--typography-heading-6-line-height)
-    );
-
     margin: 0;
   }
 }
@@ -207,11 +197,10 @@
   padding-inline-end: var(--accordion-item-content-padding-inline);
 }
 
-/* 1px divider compensation: subtract the divider thickness from the block-end
-   padding of whichever element sits directly above the item's block-end
-   border, so the divider fits inside the item's target border-box height
-   (collapsed: the 36/32 element size; expanded: a baseline multiple, so no
-   drift down the list) without pulling the content up in the process.
+/* 1px divider baseline compensation: subtract the divider thickness from the
+   block-end padding of whichever element sits directly above the item's
+   block-end border, so the item's border-box height stays a baseline multiple
+   (no drift down the list) without pulling the content up in the process.
    - collapsed: only the header is shown -> compensate the header
    - expanded:  the content is at the bottom -> compensate the content */
 .ds.accordion-item:not([open]) > .header {

--- a/packages/react/ds-global/src/lib/component/Badge/styles.css
+++ b/packages/react/ds-global/src/lib/component/Badge/styles.css
@@ -14,11 +14,7 @@
   --badge-padding-horizontal: var(--dimension-050);
   --badge-margin-bottom: 0;
 
-  --badge-max-width: 4ch;
-  --badge-min-width: calc(
-    var(--badge-line-height) -
-    (2 * var(--badge-padding-horizontal))
-  );
+  --badge-min-width: calc(var(--badge-line-height) * 1em);
 
   /* Base badge styles using tokens */
   background-color: var(
@@ -26,7 +22,7 @@
     var(--badge-color-background)
   );
   border-radius: var(--badge-border-radius);
-  box-sizing: content-box;
+  box-sizing: border-box;
   /* Label sits on the badge's own (criticality) surface, so it reads the
    * on-surface text channel — NOT --modifier-color-text (the standalone
    * criticality text colour), which would render same-hue-on-same-hue with
@@ -43,9 +39,7 @@
   letter-spacing: var(--badge-letter-spacing);
   line-height: var(--badge-line-height);
   margin-bottom: var(--badge-margin-bottom);
-  max-width: var(--badge-max-width);
   min-width: var(--badge-min-width);
-  overflow: hidden;
   padding: var(--badge-padding-vertical) var(--badge-padding-horizontal);
   text-align: center;
 }

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -29,7 +29,20 @@
   --button-gap: var(--dimension-100);
   --button-border-width: var(--dimension-stroke-thickness-medium);
   /* Label weight — the button label is medium, not the `.p` body weight. */
-  --button-font-weight: var(--font-weight-medium, var(--font-weight-default));
+  --button-font-weight: var(--typography-weight-medium);
+  /* Label size — the button label is the text-secondary tier (14px), not the
+     `.p` text-primary tier (16px). The line-height snaps up to the baseline
+     grid exactly as the typography mapper does, so the box stays 32px tall
+     (24px line + 8px of baseline nudges) around 14px text. */
+  --button-font-size: var(--typography-text-secondary-font-size);
+  --button-line-height: round(
+    up,
+    calc(
+      var(--button-font-size) *
+      var(--typography-text-secondary-line-height)
+    ),
+    var(--baseline-height)
+  );
 }
 
 /* ==========================================================================
@@ -70,10 +83,14 @@
   border-width: calc(var(--modifier-outline, 0) * var(--button-border-width));
 
   /* Typography and block padding come from the `.p` baseline utility on the
-     element (font-size, snapped line-height, and the padding-block nudges that
-     align the box to the baseline grid). The button only overrides the label
-     weight and its own inline padding — declaring font-size/line-height/
-     padding-block here would bypass the baseline-grid maths. */
+     element (font-family and the padding-block nudges that align the box to
+     the baseline grid). The button re-points the engine's --font-size/
+     --line-height variables at its text-secondary component tokens —
+     `.ds.button` (0,2,0) outranks `.p` (0,1,0) on the same element — so the
+     label is 14px while the baseline-grid maths stay intact. Declaring
+     font-size/line-height/padding-block directly would bypass the engine. */
+  --font-size: var(--button-font-size);
+  --line-height: var(--button-line-height);
   font-weight: var(--button-font-weight);
   padding-inline: var(--button-padding-inline-start)
     var(--button-padding-inline-end);

--- a/packages/react/ds-global/src/lib/component/Card/common/Content/styles.css
+++ b/packages/react/ds-global/src/lib/component/Card/common/Content/styles.css
@@ -4,11 +4,14 @@
  *
  * DSL anatomy: layout.type stack, direction vertical.
  * A content-bearing section: it pads itself (the card frame applies no general
- * padding). Vertical padding is in baseline multiples.
+ * padding). Vertical padding is in baseline multiples, asymmetric per the
+ * Figma styling frame: one baseline on top, two below (top 100 / bottom 200 /
+ * sides 200).
  */
 :root {
   --card-content-gap: var(--dimension-100);
-  --card-content-padding-block: var(--dimension-200);
+  --card-content-padding-block-start: var(--dimension-100);
+  --card-content-padding-block-end: var(--dimension-200);
   --card-content-padding-inline: var(--dimension-200);
 }
 
@@ -17,6 +20,7 @@
   flex-direction: column;
   gap: var(--card-content-gap);
 
-  padding-block: var(--card-content-padding-block);
+  padding-block-start: var(--card-content-padding-block-start);
+  padding-block-end: var(--card-content-padding-block-end);
   padding-inline: var(--card-content-padding-inline);
 }

--- a/packages/react/ds-global/src/lib/component/Card/styles.css
+++ b/packages/react/ds-global/src/lib/component/Card/styles.css
@@ -28,6 +28,13 @@
   /* Clip section corners (e.g. full-bleed images) to the card radius. */
   overflow: hidden;
 
+  /* When a layout (e.g. a grid row) stretches cards to equal frame heights,
+     the single content section absorbs the surplus, pinning the footer to the
+     block end so footers align across the row. */
+  & > .card-content {
+    flex-grow: 1;
+  }
+
   /* Section separators: a divider between adjacent sections. The card frame
      already provides the outer border, so the last section has none. The card
      itself applies NO general padding — only the content-bearing sections

--- a/packages/react/ds-global/src/storybook/decorators.tsx
+++ b/packages/react/ds-global/src/storybook/decorators.tsx
@@ -1,5 +1,10 @@
 import type { Decorator } from "@storybook/react-vite";
-import type { ElementType, ReactElement, ReactNode } from "react";
+import type {
+  CSSProperties,
+  ElementType,
+  ReactElement,
+  ReactNode,
+} from "react";
 
 export const rtl = () => (Story: ElementType) => (
   <div dir="rtl">
@@ -107,13 +112,20 @@ export const surfaces = (
   </div>
 );
 
+/**
+ * Wraps a story in the design system's bare `.grid` preset ("bring your own
+ * columns"): the template is supplied via the preset's `--modifier-grid-template`
+ * knob, while both row and column gaps resolve from the grid gutter token chain
+ * (`--grid-gutter`) instead of ad-hoc literals.
+ */
 export const grid = () => (Story: ElementType) => (
   <div
-    style={{
-      display: "grid",
-      gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
-      gap: "1em",
-    }}
+    className="grid"
+    style={
+      {
+        "--modifier-grid-template": "repeat(auto-fit, minmax(300px, 1fr))",
+      } as CSSProperties
+    }
   >
     <Story />
   </div>

--- a/packages/styles/main/src/controls.hover.shim.css
+++ b/packages/styles/main/src/controls.hover.shim.css
@@ -1,0 +1,119 @@
+/* @canonical/styles — Control selected-state SURFACE + HOVER SHIM (temporary)
+ *
+ * The generated design-tokens surface the control colours per nesting level
+ * (`.surface` → `.surface .surface` → `.contrasted` → `.modal`, in
+ * `@canonical/design-tokens/dist/modifiers.surfaces.css`) for the checkbox/radio
+ * UNSELECTED + checkmark and the switch knob — but NOT for any SELECTED state,
+ * nor the switch's unselected track. They also expose `--hover--color-foreground-*`
+ * (an OKLCH lightness-delta hover shade) only for those same unselected states.
+ *
+ * Consequences this shim fixes:
+ *   1. Selected controls were not surface-provided: a :checked box/dot/track kept
+ *      the flat `--color-foreground-*-selected` on every surface, ignoring
+ *      OnSurface stepping. (Ideal: selected states come through the surface layer
+ *      like the unselected ones do.)
+ *   2. Hovered selected controls had no hover token, so components faked it with
+ *      `filter: brightness()` on the whole <input> — which also dimmed the masked
+ *      checkmark glyph / switch knob (Diana's review: "hover should not affect the
+ *      checkmark/knob colour, just the fill/background").
+ *
+ * ── Part 1: surface-provided selected tokens ────────────────────────────────
+ * Mirror the surfaces.css selector structure so a control's SELECTED fill reads
+ * `--surface-color-foreground-*-selected`, resolved per surface. The design build
+ * has no `-selected-layer2/-layer3/-contrasted` PRIMITIVES yet, so every level
+ * currently aliases the flat base — but establishing the surface token means (a)
+ * components stop hard-coding the flat token, and (b) upstream can drop in real
+ * per-layer values later with zero component change. `switch-unselected` gets the
+ * same treatment (its surface token is also absent).
+ *
+ * ── Part 2: hover channels ──────────────────────────────────────────────────
+ * Same idiom as the generated `--hover--` tokens: shift the (now surface-aware)
+ * base lightness by the per-family `--delta-hover-*` step. Because Part 1 defines
+ * the surface tokens, these hovers are surface-correct too.
+ *
+ * Components read the CHANNELS, never re-derive the maths. Part 1 is zero-
+ * specificity (`:where()`) so it self-upgrades when upstream lands; Part 2 can be
+ * dropped once the `--hover--…-selected` tokens are generated. Imported into
+ * `ds.modifiers` after the generated tokens.
+ */
+
+@layer ds.modifiers {
+  /* Part 1 — surface-provided selected tokens, per surface level (mirrors
+   * modifiers.surfaces.css). No -selected-layerN primitives exist yet, so each
+   * level aliases the flat base.
+   *
+   * SELF-UPGRADING (no manual removal): the selectors are wrapped in `:where()`,
+   * so this block has ZERO specificity. The generated `modifiers.surfaces.css`
+   * rules use normal `.surface` selectors (specificity 0,1,0), so the moment
+   * upstream defines the real per-level `-selected` values they WIN over this
+   * fallback automatically — even though this shim is imported later in the same
+   * layer. The shim can stay indefinitely; it only ever supplies a value when
+   * upstream has none. (Removing it once upstream lands is still tidy, but no
+   * longer load-bearing.) */
+  :where(
+      .surface,
+      .surface .surface,
+      .surface .surface .surface,
+      .contrasted,
+      .modal
+    ) {
+    --surface-color-foreground-checkbox-selected: var(
+      --color-foreground-checkbox-selected
+    );
+    --surface-color-foreground-radio-selected: var(
+      --color-foreground-radio-selected
+    );
+    --surface-color-foreground-switch-selected: var(
+      --color-foreground-switch-selected
+    );
+    --surface-color-foreground-switch-unselected: var(
+      --color-foreground-switch-unselected
+    );
+  }
+
+  /* Part 2 — hover channels, derived from the surface-aware base above. */
+  :root {
+    /* Checkbox — selected fill on :checked / :indeterminate hover. */
+    --hover--color-foreground-checkbox-selected: oklch(
+      from
+        var(
+          --surface-color-foreground-checkbox-selected,
+          var(--color-foreground-checkbox-selected)
+        )
+        calc(l + var(--delta-hover-color-foreground-checkbox-selected, -0.0391))
+        c h
+    );
+
+    /* Switch — selected track on :checked hover, and unselected track hover. */
+    --hover--color-foreground-switch-selected: oklch(
+      from
+        var(
+          --surface-color-foreground-switch-selected,
+          var(--color-foreground-switch-selected)
+        )
+        calc(l + var(--delta-hover-color-foreground-switch-selected, -0.0391)) c
+        h
+    );
+
+    --hover--color-foreground-switch-unselected: oklch(
+      from
+        var(
+          --surface-color-foreground-switch-unselected,
+          var(--color-foreground-switch-unselected)
+        )
+        calc(l + var(--delta-hover-color-foreground-switch-unselected, -0.0391))
+        c h
+    );
+
+    /* Radio — selected dot on :checked hover (parity with checkbox). */
+    --hover--color-foreground-radio-selected: oklch(
+      from
+        var(
+          --surface-color-foreground-radio-selected,
+          var(--color-foreground-radio-selected)
+        )
+        calc(l + var(--delta-hover-color-foreground-radio-selected, -0.0391)) c
+        h
+    );
+  }
+}

--- a/packages/styles/main/src/index.css
+++ b/packages/styles/main/src/index.css
@@ -30,10 +30,14 @@
      hints so importance-driven components can render their hierarchy.
    - criticality: adds an icon channel (--modifier-icon) mapping each
      criticality class to its glyph, so criticality components render the icon
-     from the modifier rather than hard-coding it. */
+     from the modifier rather than hard-coding it.
+   - controls-hover: adds the missing selected-state (and switch unselected)
+     `--hover--color-foreground-*` shades so checkbox/radio/switch hover shifts
+     only the fill/track, not the masked glyph/knob. */
 @import url("./modifiers.states.shim.css");
 @import url("./modifiers.importance.shim.css");
 @import url("./modifiers.criticality.shim.css");
+@import url("./controls.hover.shim.css");
 @import url("@canonical/design-tokens/dist/states.css");
 
 /* Grid layout presets */


### PR DESCRIPTION
## Done

Second of the 3-PR stack for Diana's component review — **geometry: sizing, spacing, alignment**. Stacked on #764 (tokens & colours); review this diff against `fix/diana-tokens-colours`.

- **Accordion** *(must fix ×2 + nice)* — collapsed header hits the Figma element size **36px sites / 32px apps** (item border-box incl. its 1px divider): 6px block padding as `calc(--dimension-150 / 2)` (no 075 token exists — flagged for upstream). H6 headers were 47px: the baseline engine's padding nudges are zeroed inside the header and h6's line-height unsnaps to the raw product, so h6 stays 36/32 and the chevron re-centres. Header spacing is now 16-icon-16-text (`--dimension-200` gap) and the content indent auto-derives to **48px** (matches Figma `accordion-content-left: 48`).
- **Button** *(must fix)* — 32px button now carries **14px text** (text-secondary tier) instead of 16px: `--button-font-size`/`--button-line-height` feed the baseline engine through the existing `.p` machinery (no bypass); weight drive-by: nonexistent `--font-weight-medium` → `--typography-weight-medium` (500).
- **Badge** *(must fix ×3)* — `overflow: hidden` removed (restores inline baseline alignment); the `4ch` max-width clipping hack removed (badge sizes to its formatted value); min-width formula was an invalid `calc(<number> − <length>)` → `calc(var(--badge-line-height) * 1em)` + `border-box`, so single-digit badges render as circles.
- **Card** *(later)* — content top inset 16 → **8px** per the Figma spacing indicators (top 8 / bottom 16 / sides 16), via split `--card-content-padding-block-start/-end`.
- **Cards grid** *(must fix ×3)* — the `grid()` Storybook decorator now composes the DS `.grid` preset (both gaps from the grid gutter tokens) instead of an ad-hoc inline grid; `.card-content` gets `flex-grow: 1` so footers pin to the bottom and heights align across a row.

**Open design questions (not blocking):** header-first cards keep a 16px top inset (Card.Header's symmetric padding — needs a ruling whether the 8px applies regardless of first section); 36px collapsed accordions are off the 8px baseline grid by design of the 36px ruling; the 300px grid column minimum stays an untokenised literal (the bare-mode template must carry its own minmax).

## QA

- `nx run-many -t check test build --projects=@canonical/react-ds-global` — green (35 tasks); Accordion 7/7, Button 41/41 behavioural tests pass.
- jsdom can't assert computed geometry — please eyeball in Storybook: Accordion `Heading` story (36/32 + chevron/h6 alignment), Button `Default`/matrix (optical centring of the 14px label), Badge in Chip, Card `GridLayout` (gutters + pinned footers).
- Expected Chromatic deltas: accordion header heights/indent, button label 14px + weight 500 (em icon scales with it), badge pill proportions, card top inset, grid gutters.

### PR readiness check

- [x] Label: `Bug 🐛`
- [x] Conventional-commit title
- [x] Follows code standards (tokens/calc-of-tokens only; scoped selectors)
- [ ] `no visual change` — NOT applicable: visual change is the point

## Screenshots

Chromatic captures the stories listed above.

---

---

### ⚠️ Review note — apps/sites control heights moved out to the height bucket

This PR intentionally does **not** set the apps-vs-sites control **heights** (Diana's recurring *"32px for apps, 36px for sites"*). Those are a density/height concern owned by a separate bucket (the 4px-baseline / density work), not this geometry & spacing review.

Specifically reverted to baseline behaviour on **Accordion** (`common/Item/styles.css`), with in-file NOTEs pointing at the height bucket:
- header block padding `6px (calc(--dimension-150 / 2))` → `--dimension-100` (1 baseline unit)
- dropped the `:is(h1..h6) { padding-block: 0 }` that made header height padding-driven (to hit 36/32)
- dropped the h6 `--line-height` unsnap (per-context 24px sites / 20px apps line box)
- divider compensation targets a baseline multiple again, not the 36/32 element size

**Kept** (spacing/alignment/colour, not height): Accordion header gap, Card content top-inset (16→8) + footer pinning, Badge width/clip, Button baseline-derived line-height. The 36/32 element sizing is tracked for the height bucket to implement consistently across components.