### PR TITLE
fix(ds-global)!: behaviour, structure & a11y from design review

### DIFF
--- a/packages/react/ds-global/src/lib/component/Accordion/Accordion.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Accordion/Accordion.tests.tsx
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Accordion from "./Accordion.js";
@@ -95,5 +98,47 @@ describe("Accordion.Item", () => {
     expect(
       screen.getByRole("heading", { level: 3, name: "Section" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("Accordion.Item styles contract: header surface stepping", () => {
+  // The header hover/active surface stepping is pure CSS (Chromatic owns the
+  // visual gate), so this asserts the stylesheet's contract directly: the
+  // built surfaces modifier exposes no ghost hover/active channel, so the
+  // component itself must re-point its hover/active tokens at the layered
+  // state tokens per surface nesting depth (the OnSurfaces story regression).
+  const stylesheet = readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "common",
+      "Item",
+      "styles.css",
+    ),
+    "utf-8",
+  )
+    // Normalise formatting so assertions survive line wrapping.
+    .replace(/\s+/g, " ")
+    .replace(/\( /g, "(")
+    .replace(/ \)/g, ")");
+
+  it("prefers the surface hover/active channels with token fallbacks", () => {
+    expect(stylesheet).toContain(
+      "background-color: var(--surface-color-foreground-ghost-hover, var(--accordion-item-header-background-hover));",
+    );
+    expect(stylesheet).toContain(
+      "background-color: var(--surface-color-foreground-ghost-active, var(--accordion-item-header-background-active));",
+    );
+  });
+
+  it("steps hover/active to the layer2 tokens on doubly nested surfaces", () => {
+    expect(stylesheet).toContain(
+      ".surface .surface .ds.accordion-item { --accordion-item-header-background-hover: var(--color-foreground-ghost-layer2-hover); --accordion-item-header-background-active: var(--color-foreground-ghost-layer2-active); }",
+    );
+  });
+
+  it("steps hover/active to the layer3 tokens on triply nested surfaces", () => {
+    expect(stylesheet).toContain(
+      ".surface .surface .surface .ds.accordion-item { --accordion-item-header-background-hover: var(--color-foreground-ghost-layer3-hover); --accordion-item-header-background-active: var(--color-foreground-ghost-layer3-active); }",
+    );
   });
 });

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
@@ -30,9 +30,11 @@
   /* Default header background (surface 1). The surface channel is applied on
      the element below — NOT here — because a var() referencing
      --surface-color-foreground-ghost resolved in :root would capture the :root
-     value (where no .surface is active) and never step. The surface layer only
-     re-channels the base ghost (no hover/active channel), so hover/active pair
-     to the non-layered ghost vars directly. */
+     value (where no .surface is active) and never step. The built surface
+     layer re-channels only the base ghost (no hover/active channel), so
+     hover/active default to the non-layered ghost state vars here and are
+     re-pointed per surface nesting depth by the stopgap rules below the
+     header. */
   --accordion-item-header-background: var(--color-foreground-ghost);
   --accordion-item-header-background-hover: var(--color-foreground-ghost-hover);
   --accordion-item-header-background-active: var(
@@ -102,13 +104,49 @@
     display: none;
   }
 
+  /* Prefer the surface hover/active channels so a future token build that
+     ships them steps automatically; today they are unset everywhere, so these
+     resolve to the fallback tokens, re-pointed per nesting depth below. */
   &:hover {
-    background-color: var(--accordion-item-header-background-hover);
+    background-color: var(
+      --surface-color-foreground-ghost-hover,
+      var(--accordion-item-header-background-hover)
+    );
   }
 
   &:active {
-    background-color: var(--accordion-item-header-background-active);
+    background-color: var(
+      --surface-color-foreground-ghost-active,
+      var(--accordion-item-header-background-active)
+    );
   }
+}
+
+/* STOPGAP — step the header hover/active backgrounds with surface nesting.
+   The built surfaces modifier re-channels only the base ghost (it exposes no
+   --surface-color-foreground-ghost-hover/-active), so without this, hovering
+   a header on a layer-2/3 surface painted the base-layer colour. These rules
+   mirror the modifier's own nesting selectors to re-point the hover/active
+   tokens at the layered state tokens. Hard-coding surface depth in component
+   CSS is exactly what the token block above avoids — delete both rules once
+   the surfaces modifier ships the hover/active channels (the :hover/:active
+   rules above already prefer them). */
+.surface .surface .ds.accordion-item {
+  --accordion-item-header-background-hover: var(
+    --color-foreground-ghost-layer2-hover
+  );
+  --accordion-item-header-background-active: var(
+    --color-foreground-ghost-layer2-active
+  );
+}
+
+.surface .surface .surface .ds.accordion-item {
+  --accordion-item-header-background-hover: var(
+    --color-foreground-ghost-layer3-hover
+  );
+  --accordion-item-header-background-active: var(
+    --color-foreground-ghost-layer3-active
+  );
 }
 
 /* The consumer supplies the heading content — plain text by default (rendered

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -52,9 +52,35 @@ export const ManyLevels: Story = {
 };
 
 /**
+ * Breadcrumbs wrapping in a constrained container. On overflow each separator
+ * wraps together with its following link, so the slash starts the second line
+ * (and does not trail the first), with a 4px vertical distance between rows.
+ */
+export const Overflow: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: "18rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    items: [
+      { url: "/", label: "Ubuntu" },
+      { url: "/server", label: "Server" },
+      { url: "/server/docs", label: "Documentation" },
+      { url: "/server/docs/installation", label: "Installation" },
+      { url: "/server/docs/installation/advanced", label: "Advanced" },
+      { key: "autoinstall", label: "Autoinstall", current: true },
+    ],
+  },
+};
+
+/**
  * Breadcrumbs using a custom separator character.
  *
- * Note: the `separator` prop is not part of the core api.
+ * For external (non-Canonical) products only. Not designed or approved for
+ * Canonical products; Canonical products must use the default "/" separator.
  */
 export const CustomSeparator: Story = {
   args: {
@@ -84,8 +110,13 @@ export const WithCustomAriaLabel: Story = {
  * Breadcrumbs with a custom item component.
  * Demonstrates the switch pattern for custom rendering.
  *
- * Note: this story is not part of the core api — it illustrates a userland
- * pattern (rendering items through a custom component), not a supported prop.
+ * For external (non-Canonical) products only. Not designed or approved for
+ * Canonical products; Canonical products must use the default
+ * Breadcrumbs.Item.
+ *
+ * Custom components must render the separator BEFORE the link so that on
+ * wrap the separator starts the new line (it is hidden on the first item
+ * via CSS).
  */
 const CustomItem = ({
   label,
@@ -94,6 +125,9 @@ const CustomItem = ({
   separator,
 }: BreadcrumbItem & { separator?: React.ReactNode }) => (
   <li className="ds breadcrumbs-item custom">
+    <span className="separator" aria-hidden="true">
+      {separator}
+    </span>
     {current ? (
       <strong className="link" aria-current="page">
         {label}
@@ -103,12 +137,16 @@ const CustomItem = ({
         {label}
       </a>
     )}
-    <span className="separator" aria-hidden="true">
-      {separator}
-    </span>
   </li>
 );
 
+/**
+ * Breadcrumbs rendering items through a custom per-item Component.
+ *
+ * For external (non-Canonical) products only. Not designed or approved for
+ * Canonical products; Canonical products must use the default
+ * Breadcrumbs.Item.
+ */
 export const WithCustomComponent: Story = {
   args: {
     items: [

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.tests.tsx
@@ -74,7 +74,7 @@ describe("Breadcrumbs", () => {
       />,
     );
     const separators = screen.getAllByText("/");
-    // Both items have separators, last one hidden via CSS
+    // Both items have separators, first one hidden via CSS
     expect(separators[0]).toHaveAttribute("aria-hidden", "true");
   });
 
@@ -91,7 +91,7 @@ describe("Breadcrumbs", () => {
     expect(screen.getAllByText("›")).toHaveLength(2);
   });
 
-  it("maintains DOM order: link before separator", () => {
+  it("maintains DOM order: separator before link, so wrapped rows start with the separator", () => {
     render(
       <Breadcrumbs
         items={[{ url: "/", label: "Home", className: "test-item" }]}
@@ -99,8 +99,8 @@ describe("Breadcrumbs", () => {
     );
     const item = document.querySelector(".test-item");
     const children = item?.children;
-    expect(children?.[0]).toHaveClass("link");
-    expect(children?.[1]).toHaveClass("separator");
+    expect(children?.[0]).toHaveClass("separator");
+    expect(children?.[1]).toHaveClass("link");
   });
 
   it("uses custom LinkComponent", () => {

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.stories.tsx
@@ -34,7 +34,8 @@ const meta = {
     },
     separator: {
       control: { type: "text" },
-      description: "Custom separator character or element.",
+      description:
+        'Custom separator character or element. For external (non-Canonical) products only. Not designed or approved for Canonical products; Canonical products must use the default "/" separator.',
     },
   },
   decorators: [
@@ -93,6 +94,9 @@ export const Disabled: Story = {
 
 /**
  * Breadcrumb item with custom separator.
+ *
+ * For external (non-Canonical) products only. Not designed or approved for
+ * Canonical products; Canonical products must use the default "/" separator.
  */
 export const CustomSeparator: Story = {
   args: {

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.tsx
@@ -37,6 +37,13 @@ const Item = ({
         .join(" ")}
       {...props}
     >
+      {/* edges[1]: separator - rendered before the link (inverting the
+          anatomy-DSL edge order) so that on wrap the slash starts the new
+          line rather than trailing the previous one; hidden on the first
+          item via CSS */}
+      <span className="separator" aria-hidden="true">
+        {separator}
+      </span>
       {/* edges[0]: link (cardinality: 1, slotName: default) */}
       {current || disabled ? (
         <span className="link" aria-current={current ? "page" : undefined}>
@@ -47,10 +54,6 @@ const Item = ({
           {content}
         </Link>
       )}
-      {/* edges[1]: separator - hidden on last item via CSS */}
-      <span className="separator" aria-hidden="true">
-        {separator}
-      </span>
     </li>
   );
 };

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/styles.css
@@ -48,13 +48,14 @@
     }
   }
 
-  /* Separator element — DSL role: separator. Hidden on the last item. */
+  /* Separator element — DSL role: separator. Rendered before the link so a
+     wrapped row starts with the slash; hidden on the first item. */
   & > .separator {
     margin-inline: var(--breadcrumbs-item-separator-margin);
     color: var(--breadcrumbs-item-separator-color);
   }
 
-  &:last-of-type > .separator {
+  &:first-of-type > .separator {
     display: none;
   }
 

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/types.ts
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/types.ts
@@ -27,6 +27,11 @@ export interface ItemProps extends HTMLAttributes<HTMLLIElement>, Item {
   current?: boolean;
   /**
    * Custom separator character or element
+   *
+   * @remarks
+   * For external (non-Canonical) products only. Not designed/approved for
+   * Canonical products; Canonical products must use the default "/"
+   * separator.
    * @default "/"
    */
   separator?: ReactNode;

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/styles.css
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/styles.css
@@ -17,6 +17,9 @@
     flex-direction: row;
     flex-wrap: wrap;
 
+    /* Guidelines: 4px vertical distance between wrapped rows */
+    row-gap: var(--dimension-050);
+
     /* layout.align: center */
     align-items: center;
 

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/types.ts
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/types.ts
@@ -12,6 +12,11 @@ import type { ItemProps, LinkComponentProps } from "./common/Item/types.js";
  *
  * Adds breadcrumb-specific properties while maintaining
  * compatibility with the unified navigation type.
+ *
+ * @remarks
+ * The per-item `Component` substitution is for external (non-Canonical)
+ * products only. Not designed/approved for Canonical products; Canonical
+ * products must use the default Breadcrumbs.Item.
  */
 export interface BreadcrumbItem extends Item {
   /**
@@ -38,10 +43,20 @@ export interface BreadcrumbsProps extends HTMLAttributes<HTMLElement> {
   /**
    * Navigation items to display (WD405 Item type)
    * Each item is spread onto Breadcrumbs.Item or custom Component
+   *
+   * @remarks
+   * Per-item `Component` substitution is for external (non-Canonical)
+   * products only. Not designed/approved for Canonical products; Canonical
+   * products must use the default Breadcrumbs.Item.
    */
   items: BreadcrumbItem[];
   /**
    * Custom separator between items
+   *
+   * @remarks
+   * For external (non-Canonical) products only. Not designed/approved for
+   * Canonical products; Canonical products must use the default "/"
+   * separator.
    * @default "/"
    */
   separator?: ReactNode;

--- a/packages/react/ds-global/src/lib/component/Button/Button.ssr.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.ssr.tests.tsx
@@ -59,11 +59,10 @@ describe("Button SSR", () => {
     expect(html).toContain("link");
   });
 
-  it("renders icon with icon class", () => {
-    const html = renderToString(
-      <Component icon={<span>+</span>}>Add</Component>,
-    );
+  it("renders the named design-system icon inside the icon slot", () => {
+    const html = renderToString(<Component icon="edit">Add</Component>);
     expect(html).toContain('class="icon"');
-    expect(html).toContain(">+<");
+    expect(html).toContain("ds icon");
+    expect(html).toContain("/icons/edit.svg#edit");
   });
 });

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -135,26 +135,16 @@ export const LinkVariant: Story = {
   },
 };
 
-const EditIcon = () => (
-  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
-    <path
-      d="M11.5 2.5l2 2L5 13l-3 1 1-3 8.5-8.5z"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
-
 /**
  * The full matrix with a leading icon in every cell — so the icon colour can be
  * checked against each importance × anticipation combination (the icon should
  * follow the label colour: contrast on a filled primary, the modifier colour on
- * ghost secondary/tertiary).
+ * ghost secondary/tertiary). The `icon` prop takes a design-system icon name;
+ * the sprite is served from the `@canonical/ds-assets` staticDir at `/icons`.
  */
 export const IconMatrix: Story = {
   render: (args) => <MatrixGrid {...args} />,
-  args: { children: "Button", icon: <EditIcon /> },
+  args: { children: "Button", icon: "edit" },
 };
 
 /**
@@ -163,7 +153,7 @@ export const IconMatrix: Story = {
  */
 export const DisabledIconMatrix: Story = {
   render: (args) => <MatrixGrid {...args} />,
-  args: { children: "Button", icon: <EditIcon />, disabled: true },
+  args: { children: "Button", icon: "edit", disabled: true },
 };
 
 /**

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -1,3 +1,4 @@
+import { ICON_NAMES } from "@canonical/ds-assets";
 import { MODIFIER_FAMILIES } from "@canonical/ds-types";
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import type React from "react";
@@ -43,6 +44,12 @@ const meta = {
     variant: {
       control: "select",
       options: [undefined, "link"],
+    },
+    // Icon is a design-system icon NAME (not arbitrary markup): a select over the
+    // ds-assets icon set, with `undefined` = no icon (the default).
+    icon: {
+      control: "select",
+      options: [undefined, ...ICON_NAMES],
     },
   },
   args: { onClick: fn(), importance: "primary" },

--- a/packages/react/ds-global/src/lib/component/Button/Button.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tests.tsx
@@ -88,12 +88,11 @@ describe("Button component", () => {
   });
 
   describe("icon prop", () => {
-    it("renders icon at start position by default", () => {
-      const icon = <span data-testid="icon">+</span>;
-      render(<Component icon={icon}>Add</Component>);
+    it("renders the design-system Icon at the start position by default", () => {
+      const { container } = render(<Component icon="edit">Add</Component>);
 
       const button = screen.getByRole("button");
-      const iconElement = screen.getByTestId("icon");
+      const iconElement = container.querySelector<SVGSVGElement>("svg.ds.icon");
       const labelElement = screen.getByText("Add");
 
       // Icon should come before label in DOM order
@@ -101,19 +100,33 @@ describe("Button component", () => {
       expect(labelElement).toBeInTheDocument();
     });
 
-    it("renders icon-only button", () => {
-      const icon = <span data-testid="icon">×</span>;
-      render(<Component icon={icon} aria-label="Close" />);
+    it("maps the icon name to the ds-assets sprite", () => {
+      const { container } = render(<Component icon="edit">Edit</Component>);
 
-      expect(screen.getByTestId("icon")).toBeInTheDocument();
+      const use = container.querySelector("svg.ds.icon use");
+      expect(use).toHaveAttribute("href", "/icons/edit.svg#edit");
+    });
+
+    it("renders the icon decoratively (hidden from assistive technology)", () => {
+      const { container } = render(<Component icon="edit">Edit</Component>);
+
+      const iconElement = container.querySelector("svg.ds.icon");
+      expect(iconElement).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("renders icon-only button", () => {
+      const { container } = render(
+        <Component icon="close" aria-label="Close" />,
+      );
+
+      expect(container.querySelector("svg.ds.icon")).toBeInTheDocument();
       expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Close");
     });
 
-    it("wraps icon in icon class", () => {
-      const icon = <span data-testid="icon">+</span>;
-      render(<Component icon={icon}>Add</Component>);
+    it("wraps the Icon in the icon slot class", () => {
+      const { container } = render(<Component icon="edit">Add</Component>);
 
-      const iconWrapper = screen.getByTestId("icon").parentElement;
+      const iconWrapper = container.querySelector("svg.ds.icon")?.parentElement;
       expect(iconWrapper).toHaveClass("icon");
     });
   });
@@ -149,7 +162,7 @@ describe("Button component", () => {
 
     it("warns in development for icon-only buttons without an accessible name", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-      render(<Component icon={<span>+</span>} />);
+      render(<Component icon="plus" />);
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining("icon-only buttons"),
       );
@@ -157,19 +170,19 @@ describe("Button component", () => {
 
     it("does not warn when an icon-only button has an aria-label", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-      render(<Component icon={<span>+</span>} aria-label="Add" />);
+      render(<Component icon="plus" aria-label="Add" />);
       expect(warn).not.toHaveBeenCalled();
     });
 
     it("does not warn when an icon button has visible text", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-      render(<Component icon={<span>+</span>}>Add</Component>);
+      render(<Component icon="plus">Add</Component>);
       expect(warn).not.toHaveBeenCalled();
     });
 
     it("does not warn when children is the number 0", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-      render(<Component icon={<span>#</span>}>{0}</Component>);
+      render(<Component icon="plus">{0}</Component>);
       expect(warn).not.toHaveBeenCalled();
     });
   });
@@ -204,12 +217,12 @@ describe("Button component", () => {
 
     it("keeps the consumer icon in the DOM but adds the Spinner overlay", () => {
       const { container } = render(
-        <Component loading icon={<span data-testid="icon">+</span>}>
+        <Component loading icon="edit">
           Saving
         </Component>,
       );
       // The icon remains (hidden via CSS), and the Spinner is overlaid on top.
-      expect(screen.getByTestId("icon")).toBeInTheDocument();
+      expect(container.querySelector(".icon svg.ds.icon")).toBeInTheDocument();
       expect(
         container.querySelector(".loading-spinner .ds.spinner"),
       ).toBeInTheDocument();

--- a/packages/react/ds-global/src/lib/component/Button/Button.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { Spinner } from "../../subcomponent/Spinner/index.js";
+import { Icon } from "../Icon/index.js";
 import type Props from "./types.js";
 import "./styles.css";
 
@@ -45,7 +46,13 @@ const Button = ({
     );
   }
 
-  const iconElement = icon && <span className="icon">{icon}</span>;
+  // The icon slot only accepts a design-system icon name; the Icon component
+  // maps it to the @canonical/ds-assets sprite (decorative by default).
+  const iconElement = icon && (
+    <span className="icon">
+      <Icon icon={icon} />
+    </span>
+  );
 
   return (
     <button

--- a/packages/react/ds-global/src/lib/component/Button/types.ts
+++ b/packages/react/ds-global/src/lib/component/Button/types.ts
@@ -1,3 +1,4 @@
+import type { IconName } from "@canonical/ds-assets";
 import type { ModifierFamily } from "@canonical/ds-types";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
@@ -34,11 +35,12 @@ export interface BaseProps {
    */
   variant?: "link";
   /**
-   * Icon element to display before the label. The button has a single,
-   * leading icon slot — the right-side icon was removed when the select and
-   * dropdown affordances became their own components.
+   * Name of the design-system icon to display before the label, rendered via
+   * the `Icon` component (an `@canonical/ds-assets` sprite). The button has a
+   * single, leading icon slot — the right-side icon was removed when the
+   * select and dropdown affordances became their own components.
    */
-  icon?: ReactNode;
+  icon?: IconName;
   /**
    * Whether the button is in a loading (busy) state. Replaces the leading icon
    * with a Spinner, marks the button `aria-busy`, and disables interaction so

--- a/packages/react/ds-global/src/lib/component/Card/Card.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/Card.stories.tsx
@@ -1,7 +1,15 @@
 import type { Meta, StoryFn } from "@storybook/react-vite";
 import * as decorators from "../../../storybook/decorators.js";
+import { Chip } from "../Chip/index.js";
 import Component from "./Card.js";
 import type { CardProps } from "./types.js";
+
+/**
+ * Neutral placeholder (grey 16:9 SVG data URI) for card media in stories,
+ * pending on-brand assets nominated by design.
+ */
+const placeholderImageSrc =
+  "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='800'%20height='450'%3E%3Crect%20width='100%25'%20height='100%25'%20fill='%23d9d9d9'/%3E%3C/svg%3E";
 
 const meta = {
   title: "components/Card",
@@ -50,27 +58,33 @@ export const WithImage: StoryFn<CardProps> = (props) => (
 /**
  * A card with a header, content and footer. Only the content-bearing sections
  * pad themselves; the card frame applies no general padding and the image
- * bleeds edge to edge. Dividers separate adjacent sections.
+ * bleeds edge to edge. The header is not a separate visual section: no divider
+ * is drawn under it and it merges with the content below, so title and body
+ * read as one region. The footer holds tags and labels, not actions — CTAs
+ * belong in `Card.Content`.
  *
  * `Card.Header`, `Card.Image` and `Card.Footer` are **not core API** — the base
  * card is just `Card.Content`; these are optional sections layered on top.
  */
 export const HeaderContentFooter: StoryFn<CardProps> = (props) => (
   <Component {...props} style={{ maxWidth: "24rem" }}>
+    <Component.Image src="https://assets.ubuntu.com/v1/5ce214a4-rpi.png" />
     <Component.Header>
       <h4>Ubuntu 24.04 LTS</h4>
       <span className="p">Noble Numbat</span>
     </Component.Header>
-    <Component.Image src="https://assets.ubuntu.com/v1/08478b35-ubuntu-core-cybersecurity.png" />
     <Component.Content>
       <p className="p">
         The latest long-term support release, with ten years of security
-        maintenance and a refreshed toolchain for developers and operators.
+        maintenance and a refreshed toolchain for developers and operators.{" "}
+        <a href="https://ubuntu.com/download">Download</a> or read the{" "}
+        <a href="https://ubuntu.com/blog">release notes</a>.
       </p>
     </Component.Content>
     <Component.Footer>
-      <a href="https://ubuntu.com/download">Download</a>
-      <a href="https://ubuntu.com/blog">Release notes</a>
+      <Chip value="LTS" />
+      <Chip value="Desktop" />
+      <Chip value="Server" />
     </Component.Footer>
   </Component>
 );
@@ -78,47 +92,56 @@ export const HeaderContentFooter: StoryFn<CardProps> = (props) => (
 /**
  * A grid of cards sharing the same structure, so attributes line up and can be
  * scanned across the set — the primary use case for cards over the flexible
- * Tile.
+ * Tile. Footers carry tags and labels; links live in the content.
  */
 export const GridLayout: StoryFn<CardProps> = () => (
   <>
     <Component>
-      <Component.Image src="https://assets.ubuntu.com/v1/0aa26309-maas_banners_leaderboard.png" />
+      <Component.Image src={placeholderImageSrc} />
       <Component.Content>
-        <h4>MAAS</h4>
+        <h4>
+          <a href="https://maas.io">MAAS</a>
+        </h4>
         <p className="p">
           Self-service, remote installation of Windows, CentOS, ESXi and Ubuntu
           on real servers, turning your data centre into a bare-metal cloud.
         </p>
       </Component.Content>
       <Component.Footer>
-        <a href="https://maas.io">maas.io</a>
+        <Chip value="bare metal" />
+        <Chip value="provisioning" />
       </Component.Footer>
     </Component>
     <Component>
-      <Component.Image src="https://assets.ubuntu.com/v1/2c7e3fab-juju-header-illustration.svg" />
+      <Component.Image src={placeholderImageSrc} />
       <Component.Content>
-        <h4>Juju</h4>
+        <h4>
+          <a href="https://juju.is">Juju</a>
+        </h4>
         <p className="p">
           An open-source orchestration engine for software operators that
           simplifies deployment, configuration and scaling of applications.
         </p>
       </Component.Content>
       <Component.Footer>
-        <a href="https://juju.is">juju.is</a>
+        <Chip value="orchestration" />
+        <Chip value="operations" />
       </Component.Footer>
     </Component>
     <Component>
-      <Component.Image src="https://assets.ubuntu.com/v1/20ace314-managed_services.png" />
+      <Component.Image src={placeholderImageSrc} />
       <Component.Content>
-        <h4>Landscape</h4>
+        <h4>
+          <a href="https://ubuntu.com/landscape">Landscape</a>
+        </h4>
         <p className="p">
           Systems-management for Ubuntu estates: patching, compliance and
           monitoring across physical, virtual and cloud instances at scale.
         </p>
       </Component.Content>
       <Component.Footer>
-        <a href="https://ubuntu.com/landscape">ubuntu.com/landscape</a>
+        <Chip value="management" />
+        <Chip value="compliance" />
       </Component.Footer>
     </Component>
   </>

--- a/packages/react/ds-global/src/lib/component/Card/Card.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/Card.tests.tsx
@@ -1,10 +1,34 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { Chip } from "../Chip/index.js";
 import Component from "./Card.js";
 
 describe("Card component", () => {
   it("renders", () => {
     render(<Component>Card</Component>);
     expect(screen.getByText("Card")).toBeInTheDocument();
+  });
+
+  it("renders a full composition with the header adjacent to the content", () => {
+    const { container } = render(
+      <Component>
+        <Component.Image src="test.png" />
+        <Component.Header>Title</Component.Header>
+        <Component.Content>Body</Component.Content>
+        <Component.Footer>
+          <Chip value="tag" />
+        </Component.Footer>
+      </Component>,
+    );
+
+    const header = screen.getByText("Title");
+    expect(header).toHaveClass("card-header");
+    // The header is not a separate visual section: it merges with the content
+    // that follows (the seam-collapse selector targets this adjacency).
+    expect(header.nextElementSibling).toHaveClass("card-content");
+    expect(screen.getByText("Body")).toHaveClass("card-content");
+    // Footer carries tags and labels (e.g. Chip), not CTAs or links.
+    expect(screen.getByText("tag")).toBeInTheDocument();
+    expect(container.querySelector(".card-footer a")).toBeNull();
   });
 });

--- a/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Chip } from "../../../Chip/index.js";
 import Component from "./Footer.js";
 
 const meta = {
@@ -8,7 +9,8 @@ const meta = {
   argTypes: {
     children: {
       control: { type: "text" },
-      description: "Footer content (required).",
+      description:
+        "Footer content (required): tags and labels (e.g. `Chip`), not CTAs or links.",
     },
   },
   decorators: [
@@ -26,5 +28,20 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     children: "Card footer",
+  },
+};
+
+/**
+ * The intended footer content: tags and labels flowing in a wrapping row.
+ */
+export const Tags: Story = {
+  args: {
+    children: (
+      <>
+        <Chip value="LTS" />
+        <Chip value="Desktop" />
+        <Chip value="Server" />
+      </>
+    ),
   },
 };

--- a/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.stories.tsx.disabled
+++ b/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.stories.tsx.disabled
@@ -1,3 +1,7 @@
+// TEMPORARILY DISABLED (Card footer design under review).
+// Renamed out of the `*.stories.tsx` glob so Storybook does not index it.
+// Re-enable by renaming this file back to `Footer.stories.tsx`.
+
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Chip } from "../../../Chip/index.js";
 import Component from "./Footer.js";

--- a/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.tsx
@@ -6,7 +6,7 @@ const componentCssClassName = "ds card-footer";
 
 /**
  * Footer component for Card. A padded content-bearing section pinned to the
- * bottom of the card, for actions or supplementary information.
+ * bottom of the card, for tags and labels.
  *
  * @implements ds:global.subcomponent.card-footer
  */

--- a/packages/react/ds-global/src/lib/component/Card/common/Footer/styles.css
+++ b/packages/react/ds-global/src/lib/component/Card/common/Footer/styles.css
@@ -3,7 +3,8 @@
  * @implements ds:global.subcomponent.card-footer
  *
  * A content-bearing section: it pads itself (the card frame applies no general
- * padding). Vertical padding is in baseline multiples.
+ * padding). Vertical padding is in baseline multiples. Holds tags and labels,
+ * which flow in a wrapping row.
  */
 :root {
   --card-footer-gap: var(--dimension-100);
@@ -13,7 +14,8 @@
 
 .ds.card-footer {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   gap: var(--card-footer-gap);
 
   padding-block: var(--card-footer-padding-block);

--- a/packages/react/ds-global/src/lib/component/Card/common/Footer/types.ts
+++ b/packages/react/ds-global/src/lib/component/Card/common/Footer/types.ts
@@ -6,6 +6,6 @@ import type { HTMLAttributes, ReactNode } from "react";
  * @implements ds:global.subcomponent.card-footer
  */
 export interface FooterProps extends HTMLAttributes<HTMLDivElement> {
-  /** Required child contents */
+  /** Required child contents: tags and labels (e.g. `Chip`), not CTAs or links */
   children: ReactNode;
 }

--- a/packages/react/ds-global/src/lib/component/Card/styles.css
+++ b/packages/react/ds-global/src/lib/component/Card/styles.css
@@ -38,11 +38,16 @@
   /* Section separators: a divider between adjacent sections. The card frame
      already provides the outer border, so the last section has none. The card
      itself applies NO general padding — only the content-bearing sections
-     (Content, Header, Footer) pad themselves; media (Image) stays full-bleed. */
-  &
-    > :is(.card-header, .card-content, .card-footer, .card-image):not(
-      :last-child
-    ) {
+     (Content, Header, Footer) pad themselves; media (Image) stays full-bleed.
+     The header is NOT a separate visual section: no divider is drawn under it
+     and it merges with the content that follows. */
+  & > :is(.card-content, .card-footer, .card-image):not(:last-child) {
     border-block-end: var(--card-border-width) solid var(--card-color-border);
+  }
+
+  /* Collapse the header/content seam so title and content read as one region
+     (raw 0: unthemable by design). */
+  & > .card-header:has(+ .card-content) {
+    padding-block-end: 0;
   }
 }

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tests.tsx
@@ -109,4 +109,92 @@ describe("ContextualMenu", () => {
       "true",
     );
   });
+
+  it("returns focus to the trigger on Escape", () => {
+    // Regression: the disclosure's focus-return ref sat on the non-focusable
+    // wrapper div, so `focus()` was a no-op and focus fell to <body>.
+    renderMenu();
+    const trigger = screen.getByRole("button", { name: "Actions" });
+    fireEvent.click(trigger);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(trigger).toHaveFocus();
+  });
+
+  it("returns focus to the trigger when an item is selected", () => {
+    renderMenu();
+    const trigger = screen.getByRole("button", { name: "Actions" });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByText("Copy"));
+    expect(trigger).toHaveFocus();
+  });
+
+  describe("submenu ARIA state", () => {
+    const submenuGroups: MenuItem[] = [
+      {
+        key: "group",
+        items: [
+          { key: "first", label: "First", url: "#first" },
+          {
+            key: "parent",
+            label: "Parent",
+            items: [
+              { key: "sub1", label: "Sub one", url: "#sub1" },
+              { key: "sub2", label: "Sub two", url: "#sub2" },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const openSubmenuMenu = () => {
+      render(<ContextualMenu trigger="Actions" groups={submenuGroups} />);
+      fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+      return {
+        menu: screen.getByRole("menu"),
+        parent: screen.getByRole("menuitem", { name: "Parent" }),
+      };
+    };
+
+    it("reflects the real popup state on aria-expanded (keyboard path)", () => {
+      // Regression: aria-expanded was computed from the highlight branch alone,
+      // reporting true for a merely-highlighted parent whose popup is not even
+      // mounted (WCAG 4.1.2 name/role/value).
+      const { menu, parent } = openSubmenuMenu();
+      expect(parent).toHaveAttribute("aria-haspopup", "true");
+      expect(parent).toHaveAttribute("aria-expanded", "false");
+
+      // ArrowDown highlights the parent itself — the popup stays unmounted, so
+      // it must still report closed.
+      fireEvent.keyDown(menu, { key: "ArrowDown" });
+      expect(screen.queryByText("Sub one")).not.toBeInTheDocument();
+      expect(parent).toHaveAttribute("aria-expanded", "false");
+
+      // ArrowRight descends into the submenu — now it is genuinely open, and
+      // the parent points at the popup it controls.
+      fireEvent.keyDown(menu, { key: "ArrowRight" });
+      const submenu = screen.getByText("Sub one").closest('[role="menu"]');
+      expect(submenu).not.toBeNull();
+      expect(parent).toHaveAttribute("aria-expanded", "true");
+      expect(parent).toHaveAttribute("aria-controls", submenu?.id);
+    });
+
+    it("reflects a hover-opened popup on aria-expanded", () => {
+      // Regression: hover-open is local state invisible to the navigation
+      // tree, so a hover-opened submenu reported aria-expanded="false".
+      const { parent } = openSubmenuMenu();
+      const anchor = parent.closest(".submenu-anchor");
+      expect(anchor).not.toBeNull();
+      expect(parent).toHaveAttribute("aria-expanded", "false");
+
+      fireEvent.pointerEnter(anchor as HTMLElement);
+      expect(screen.getByText("Sub one")).toBeInTheDocument();
+      expect(parent).toHaveAttribute("aria-expanded", "true");
+
+      fireEvent.pointerLeave(anchor as HTMLElement);
+      expect(screen.queryByText("Sub one")).not.toBeInTheDocument();
+      expect(parent).toHaveAttribute("aria-expanded", "false");
+      // Closed popup: no dangling aria-controls IDREF.
+      expect(parent).not.toHaveAttribute("aria-controls");
+    });
+  });
 });

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
@@ -158,15 +158,20 @@ const ContextualMenu = ({
     <MenuContext.Provider value={menuContextValue}>
       <div
         className={[componentCssClassName, className].filter(Boolean).join(" ")}
-        ref={targetRef}
         {...props}
       >
         {/* getTriggerProps drives the disclosure (the source of truth for open)
-            and carries the menu ARIA wiring. */}
+            and carries the menu ARIA wiring. The disclosure's target ref sits on
+            the BUTTON, not the wrapper: closing returns focus via
+            `targetRef.current?.focus()`, and `focus()` on a non-focusable div is
+            a no-op — focus would silently fall to <body> (WCAG 2.4.3). The
+            fitment hook types its anchor as a div; the button anchors the same
+            rect, so cast (Popover precedent). */}
         <button
           type="button"
           id={triggerId}
           className="trigger"
+          ref={targetRef as React.Ref<HTMLButtonElement>}
           {...triggerProps}
         >
           {trigger}

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/Item/styles.css
@@ -21,6 +21,12 @@
   /* De-emphasised slot text (badge / shortcut) — muted, matching
      KeyboardKey / Tabs. */
   --contextual-menu-item-slot-color: var(--color-text-muted);
+  /* Keyboard focus ring (Button precedent) — the semantic focus-ring colour,
+     with a currentColor backstop should the theme layer not be loaded. */
+  --contextual-menu-item-focus-ring-color: var(--color-focusRing, currentColor);
+  --contextual-menu-item-focus-ring-width: var(
+    --dimension-stroke-thickness-large
+  );
 }
 
 .ds.contextual-menu-item {
@@ -43,11 +49,23 @@
   }
 
   /* The highlighted (roving) item shows the active fill — matching the Figma
-     "Active" state — so keyboard focus is visible without a separate outline. */
+     "Active" state. */
   &:focus-visible,
   &[tabindex="0"] {
     background-color: var(--contextual-menu-item-color-background-active);
     outline: none;
+  }
+
+  /* The active fill alone is ~1.2:1 against the resting item — below the 3:1
+     non-text minimum — so keyboard focus additionally draws a ring (WCAG
+     1.4.11 / 2.4.13). Inset (negative offset) so the popup surface's
+     `overflow-y: auto` never clips it; :focus-visible only, so pointer users
+     keep the quiet Figma look. Deliberately diverges from the Figma "Active"
+     state, which fails WCAG. */
+  &:focus-visible {
+    outline: var(--contextual-menu-item-focus-ring-width) solid
+      var(--contextual-menu-item-focus-ring-color);
+    outline-offset: calc(-1 * var(--contextual-menu-item-focus-ring-width));
   }
 
   > .label {

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/SubMenu/SubMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/SubMenu/SubMenu.tsx
@@ -1,7 +1,7 @@
 import type { _Item } from "@canonical/ds-types";
 import { getItemId } from "@canonical/utils";
 import type React from "react";
-import { type ReactElement, useEffect, useRef, useState } from "react";
+import { type ReactElement, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { MENU_PLACEMENT, useWindowFitment } from "../../../../hooks/index.js";
 import type { MenuItem } from "../../types.js";
@@ -60,6 +60,11 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
   const { targetRef, popupRef, popupPositionStyle, bestPosition } =
     useWindowFitment({ preferredDirections: MENU_PLACEMENT, autoFit: true });
 
+  // A stable, instance-unique id for the submenu surface so the parent item
+  // can reference the popup it controls (item keys are only unique within one
+  // menu, so useId rather than the item id).
+  const submenuId = useId();
+
   // The item carries both the roving props and the fitment target ref. The
   // tree's getItemProps already returns a `ref` (it registers the node for
   // roving focus); COMPOSE ours with it rather than replacing it, or the
@@ -68,6 +73,14 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
   const navRef = (baseItemProps as { ref?: React.Ref<HTMLElement> }).ref;
   const itemProps = {
     ...baseItemProps,
+    // The composed `aria-expanded` (from getMenuItemProps) tracks only the
+    // keyboard highlight branch: it reports false for a HOVER-opened submenu
+    // and true for a merely-highlighted parent whose popup is not even
+    // mounted. Override with the REAL open state (WCAG 4.1.2 name/role/value).
+    "aria-expanded": open,
+    // Point at the popup only while it exists — the surface is unmounted when
+    // closed, and a dangling IDREF is invalid ARIA.
+    "aria-controls": open ? submenuId : undefined,
     ref: (node: HTMLDivElement | null) => {
       targetRef.current = node;
       if (typeof navRef === "function") navRef(node);
@@ -116,19 +129,23 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
       ]
         .filter(Boolean)
         .join(" ")}
+      id={submenuId}
       aria-hidden={false}
       // Reveal visually only once positioned. The submenu mounts on open but
       // `bestPosition` resolves a frame later; without this gate it paints for a
       // frame at the fallback top:0/left:0 before snapping to the anchor.
       data-positioned={bestPosition ? "true" : undefined}
       style={popupPositionStyle}
+      {...menuProps}
+      // After the spread so this composing callback wins over menuProps.ref
+      // (later JSX props override earlier ones): it captures the surface for
+      // the keyboard-open focus effect AND forwards to the tree's ref.
       ref={(el) => {
         surfaceRef.current = el;
         if (typeof menuProps.ref === "function") menuProps.ref(el);
         else if (menuProps.ref)
           (menuProps.ref as React.RefObject<HTMLElement | null>).current = el;
       }}
-      {...menuProps}
     >
       {children.map((child) => (
         // Recurse: a submenu child may itself be a submenu parent.

--- a/packages/react/ds-global/src/lib/component/Icon/Icon.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Icon/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import { ICON_NAMES } from "@canonical/ds-assets/src/index.js";
+import { ICON_NAMES } from "@canonical/ds-assets";
 import type { Meta, StoryFn, StoryObj } from "@storybook/react-vite";
 import Component from "./Icon.js";
 

--- a/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
@@ -292,7 +292,7 @@ export const AutoFitPlayground: StoryFn<{ x: number; y: number }> = ({
               inlineSize: "9rem",
               justifyContent: "center",
             }}
-            icon={<Icon icon="drag" />}
+            icon="drag"
             onPointerDown={(e) => {
               setDragging(true);
               e.currentTarget.setPointerCapture?.(e.pointerId);

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.tests.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.tests.tsx
@@ -123,6 +123,37 @@ describe("useContextualMenu", () => {
     expect(result.current.highlightedItems.at(-1)?.key).toBe("b1");
   });
 
+  it("keeps the keyboard highlight when the pointer leaves the menu", () => {
+    // Regression: the tree's default menu props dispatch CLOSE on mouse-leave,
+    // wiping highlightedItems while the disclosure keeps the popup open — a
+    // pointer grazing off the surface destroyed a keyboard user's position.
+    // The composed getMenuProps must neutralise that handler.
+    const { result } = renderHook(() => useContextualMenu({ root: menu }));
+
+    act(() => result.current.open());
+    const key = (k: string) =>
+      ({ key: k, preventDefault: () => {} }) as unknown as React.KeyboardEvent;
+
+    // Open highlights "a1"; ArrowDown crosses into group B ("b1").
+    act(() => result.current.getMenuProps().onKeyDown?.(key("ArrowDown")));
+    expect(result.current.highlightedItems.at(-1)?.key).toBe("b1");
+
+    // The surface carries no tree mouse-leave handler; simulate the leave
+    // anyway (optional call) — the highlight must survive it.
+    const menuProps = result.current.getMenuProps();
+    expect(menuProps.onMouseLeave).toBeUndefined();
+    act(() => {
+      menuProps.onMouseLeave?.({} as React.SyntheticEvent);
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.highlightedItems.at(-1)?.key).toBe("b1");
+
+    // Arrow keys continue from where they were (back up into group A's last
+    // item), not from a reset state.
+    act(() => result.current.getMenuProps().onKeyDown?.(key("ArrowUp")));
+    expect(result.current.highlightedItems.at(-1)?.key).toBe("a2");
+  });
+
   it("opens a submenu on ArrowRight and closes it on ArrowLeft", () => {
     // A menu with a submenu parent ("parent" → "sub1"/"sub2").
     const withSubmenu: MenuItem = {

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
@@ -194,6 +194,12 @@ const useContextualMenu = ({
       return {
         ...baseProps,
         ...getMenuAriaProps(nav, opts),
+        // The tree's default menu props dispatch CLOSE on mouse-leave, wiping
+        // the keyboard highlight (and collapsing keyboard-opened submenus)
+        // while the popup stays visually open — a pointer grazing off the
+        // surface would destroy a keyboard user's position. The DISCLOSURE
+        // owns open/close for a contextual menu, so neutralise it.
+        onMouseLeave: undefined,
         onKeyDown: (event: React.KeyboardEvent) =>
           handleMenuKeyDown(event, treeKeyDown),
       };


### PR DESCRIPTION
## Done

Third of the 3-PR stack for Diana's component review — **behaviour, structure, stories & a11y**. Stacked on #766; review against `fix/diana-geometry`.

- **Breadcrumbs** *(must fix)* — separator renders **before** its link (hidden on the first item), so a wrapped row *starts* with the slash; `row-gap: 4px` between wrapped rows; new `Overflow` story for design review. Custom separator/custom component marked **external use only** across types, stories, autodocs. ⚠ Ontology follow-up: `breadcrumbs-item.ttl` anatomy edge order is now inverted vs DOM — needs a TTL update or a ruling that edge order is non-normative.
- **Card** *(must fix ×4)* — header no longer reads as a separate section (divider dropped + seam collapse); footer is a wrapping row for **tags/labels, not CTAs** (docs/stories/prop docs updated, "for actions" removed); `HeaderContentFooter` story reordered; off-brand image replaced.
- **Button** *(must fix — ⚠ BREAKING)* — `icon?: ReactNode` → `icon?: IconName`, rendering the pragma `Icon` sprite. Stories/tests migrated (43 pass); TooltipArea story drive-by (caught by tsc). Sprite serving verified: `@canonical/storybook-config` already static-serves `ds-assets` at `/icons`.
- **ContextualMenu a11y** *(from the "check accessibility" audit)* — focus returns to the trigger on every close path; visible `:focus-visible` ring (Button mechanism) layered over the roving fill; submenu parents carry real `aria-expanded` + `aria-controls` (`useId` — item keys aren't globally unique); pointer-leave no longer wipes the keyboard highlight. **+7 behavioural tests.** Also fixed a pre-existing bug the adversarial review caught: `{...menuProps}` overrode the composing `surfaceRef` callback, so keyboard-open focus into submenus never ran.
- **Accordion** — `OnSurfaces` preview fixed: header hover/active colours step with surface nesting (component-CSS stopgap; the proper `--surface-color-foreground-ghost-*` tokens belong upstream — follow-up noted).

**Adversarial review:** an independent verify agent tried to break the Breadcrumbs DOM-order and a11y changes — verdict clean; its one finding (the surfaceRef bug above) is fixed in this PR.

**Open design questions:** wrapped-row slash is indented 8px by the separator's symmetric margin — should row 2 start flush? WCAG bar (AA vs AAA) still gates the 44px target-size question (parked).

## QA

- `nx run-many -t check test build --projects=@canonical/react-ds-global` — green; Breadcrumbs 16/16, Button 43/43, ContextualMenu+hook 22/22 (7 new), Accordion 10/10.
- Storybook eyeball recommended: Breadcrumbs `Overflow`, Card `HeaderContentFooter` + Footer `Tags`, Button icon matrices, ContextualMenu keyboard walk (focus ring, submenu focus, Escape return), Accordion `OnSurfaces`.

### PR readiness check

- [x] Label: `Bug 🐛` (+ `Breaking change` if the repo uses one — Button icon prop)
- [x] Conventional-commit title (`!`)
- [x] Standards: tokens-not-literals, verb-first, tests alongside behaviour
- [ ] `no visual change` — NOT applicable

## Screenshots

Chromatic captures the stories above.
