### PR TITLE
docs: correct pragma create component examples; document the shared execution interpreter

### DIFF
--- a/packages/cli/pragma/src/domains/create/commands/component.ts
+++ b/packages/cli/pragma/src/domains/create/commands/component.ts
@@ -90,7 +90,7 @@ export default function buildComponentCommand(): CommandDefinition {
           validOptions: ["react", "svelte", "lit"],
           recovery: {
             message: "Provide a framework for component generation.",
-            cli: "pragma create component react --component-path src/components/Button",
+            cli: "pragma create component react src/components/Button",
           },
         });
       }
@@ -109,10 +109,10 @@ export default function buildComponentCommand(): CommandDefinition {
     },
     meta: {
       examples: [
-        "pragma create component react --component-path src/components/Button",
-        "pragma create component svelte --component-path src/lib/components/Toggle",
-        "pragma create component lit --component-path src/lib/Accordion",
-        "pragma create component react --component-path src/components/Button --dry-run",
+        "pragma create component react src/components/Button",
+        "pragma create component svelte src/lib/components/Toggle",
+        "pragma create component lit src/lib/Accordion",
+        "pragma create component react src/components/Button --dry-run",
       ],
     },
     parameterGroups: {

--- a/packages/summon/core/docs/explanation.md
+++ b/packages/summon/core/docs/explanation.md
@@ -244,6 +244,46 @@ These are just function calls that return Tasks. No async/await ceremony. No cal
 
 ---
 
+## One Interpreter, Every Binary
+
+Effects-as-data pays off most when more than one program interprets the same
+Task. Summon generators are consumed by two front-ends — the `summon` CLI and
+pragma's `create`/`setup` commands — and both run generators through a **single
+shared production interpreter** (`runGeneratorTask`, in `@canonical/cli-core`)
+rather than each re-implementing execution.
+
+Because the interpreter owns execution and the binaries only decorate it, the
+same generator invoked with the same answers writes **byte-identical output**
+through either front-end — generated-file stamps included. That equivalence is
+not a convention anyone has to maintain by hand; a cross-binary differential
+test generates with both paths and asserts the trees match, so a drift between
+them fails CI.
+
+The interpreter exposes a small set of **seams** the front-ends plug into
+without forking execution:
+
+- a **prompt handler** that answers `Prompt` effects — an interactive session
+  (readline for pragma, Ink for summon) or a defaults resolver for
+  non-interactive runs;
+- **effect lifecycle hooks** (`onEffectStart` / `onEffectComplete`) that drive
+  progress display and apply the generated-file stamp as a content transform, so
+  stamping is identical everywhere rather than bolted onto one binary;
+- a **log sink** and an abort **signal**.
+
+This is the payoff of the interpreter pattern taken one step further: not just
+"same generator, different interpreters," but *one* interpreter shared across
+every binary, with the UI held at the edges.
+
+A note on prompting today: form-first generators (a static `prompts` list plus
+`generate(answers)`) have their answers gathered up front — summon's Ink wizard,
+pragma's readline session — and any `Prompt` effect raised *during* execution
+resolves to its default. The Task alphabet already carries `Prompt` as a
+first-class effect, so a generator that asks a question mid-run is expressible;
+wiring the execution-phase handler to an interactive UI is the remaining step to
+make mid-run questions fully interactive.
+
+---
+
 ## The Functional Programming Heritage
 
 Summon's approach comes from a long tradition in functional programming:


### PR DESCRIPTION
## Done

Follow-up docs pass after the P.05 prompting-unification train.

- **Fix stale `pragma create component` examples.** `componentPath` is a positional argument in the pragma command (`[componentPath]`), not a `--component-path` flag — the flag form errors with `unknown option`. The `--help` examples and the missing-framework recovery hint were copied from summon (where `--component-path` is a real flag) and never adjusted. They now point at the working positional form (`pragma create component react src/components/Button`).
- **Document the shared execution interpreter (summon).** New "One Interpreter, Every Binary" section in `summon/core/docs/explanation.md`: the single production interpreter both the `summon` CLI and pragma's `create`/`setup` commands run generators through, the byte-identical output it guarantees (generated-file stamps included, enforced by the cross-binary differential test), the execution seams the front-ends plug into, and an honest note on the current form-first prompting reality.

CHANGELOGs are intentionally untouched — they are lerna-autogenerated from conventional commits at release time.

## QA

- `pragma create component --help` shows the positional examples; `pragma create component react src/components/Button --dry-run` runs; the previously-documented `--component-path` flag form correctly errors.
- `cd packages/cli/pragma && bun run check` and the component + golden suites pass (examples live only in `--help`, so no golden drift).
- Docs change is prose only — no links/anchors added.

### PR readiness check

- [x] PR should have one of the following labels: `Documentation 📝`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts in `package.json`.
- [x] No new package introduced.
- [x] No visual testing required — `no visual change` label added to skip Chromatic.

## Screenshots

N/A — documentation and help-text only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF9ExVCukzqpe1Fus9V1no

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF9ExVCukzqpe1Fus9V1no)_