### PR TITLE
fix(ke-graphql): peer @canonical/ke range follows the stable release line

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1042,7 +1042,7 @@
         "vitest": "^4.0.18",
       },
       "peerDependencies": {
-        "@canonical/ke": "^0.27.1-experimental.0",
+        "@canonical/ke": "^0.29.0",
       },
     },
     "packages/runtime/router": {

--- a/packages/runtime/ke-graphql/package.json
+++ b/packages/runtime/ke-graphql/package.json
@@ -63,7 +63,7 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
-    "@canonical/ke": "^0.27.1-experimental.0"
+    "@canonical/ke": "^0.29.0"
   },
   "dependencies": {
     "dataloader": "^2.2.3",


### PR DESCRIPTION
> Split out of #774 (1 of 4). Fully independent — mergeable in any order.

## Done

- `@canonical/ke-graphql` peers on `@canonical/ke ^0.29.0` (was `^0.27.1-experimental.0`), so it co-installs with `ke@latest` instead of pinning consumers to a stale experimental line.

## QA

- `cd packages/runtime/ke-graphql && bun run check` — green.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

No visual change — dependency metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR)_