### PR TITLE
feat(cli)!: layered config — defaults < global XDG file < nearest project file

### DIFF
--- a/packages/cli/pragma/src/config/findProjectConfigPath.test.ts
+++ b/packages/cli/pragma/src/config/findProjectConfigPath.test.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import findProjectConfigPath from "./findProjectConfigPath.js";
+
+describe("findProjectConfigPath", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "pragma-find-config-"));
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, "packages/app/src"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("finds the config in the starting directory", () => {
+    writeFileSync(join(root, "packages/app/pragma.config.json"), "{}");
+    expect(findProjectConfigPath(join(root, "packages/app"))).toBe(
+      join(root, "packages/app/pragma.config.json"),
+    );
+  });
+
+  it("walks up to the nearest config", () => {
+    writeFileSync(join(root, "pragma.config.json"), "{}");
+    expect(findProjectConfigPath(join(root, "packages/app/src"))).toBe(
+      join(root, "pragma.config.json"),
+    );
+  });
+
+  it("prefers the nearest config over a higher one", () => {
+    writeFileSync(join(root, "pragma.config.json"), "{}");
+    writeFileSync(join(root, "packages/app/pragma.config.json"), "{}");
+    expect(findProjectConfigPath(join(root, "packages/app/src"))).toBe(
+      join(root, "packages/app/pragma.config.json"),
+    );
+  });
+
+  it("stops at the repository root (.git) without escaping", () => {
+    // The fixture root has .git and no config; nothing above it may leak in.
+    expect(findProjectConfigPath(join(root, "packages/app/src"))).toBe(
+      undefined,
+    );
+  });
+
+  it("checks the .git directory's own level before stopping", () => {
+    writeFileSync(join(root, "pragma.config.json"), "{}");
+    expect(findProjectConfigPath(root)).toBe(join(root, "pragma.config.json"));
+  });
+});

--- a/packages/cli/pragma/src/config/findProjectConfigPath.ts
+++ b/packages/cli/pragma/src/config/findProjectConfigPath.ts
@@ -1,0 +1,36 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+/**
+ * Find the nearest `pragma.config.json` at or above `cwd`.
+ *
+ * Walks up the directory tree so pragma works from anywhere inside a
+ * project. The walk is bounded: it stops after checking the first
+ * directory that contains `.git` (the repository root), after checking
+ * the home directory, and at the filesystem root — a config outside the
+ * repository or home never leaks in.
+ *
+ * @param cwd - Directory to start from.
+ * @returns Absolute path of the nearest config file, or `undefined`.
+ * @note Impure — probes the filesystem while walking up.
+ */
+export default function findProjectConfigPath(cwd: string): string | undefined {
+  const home = homedir();
+  let dir = resolve(cwd);
+
+  while (true) {
+    const candidate = join(dir, "pragma.config.json");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    if (existsSync(join(dir, ".git")) || dir === home) {
+      return undefined;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
+  }
+}

--- a/packages/cli/pragma/src/config/index.ts
+++ b/packages/cli/pragma/src/config/index.ts
@@ -1,6 +1,21 @@
-/** @module Configuration file reading, writing, and path resolution. */
+/** @module Configuration reading, writing, layered resolution, and paths. */
 export { default as configExists } from "./configExists.js";
+export { default as findProjectConfigPath } from "./findProjectConfigPath.js";
+export { default as mergeConfigFileUpdate } from "./mergeConfigFileUpdate.js";
+export { default as parseConfigValues } from "./parseConfigValues.js";
 export { default as readConfig } from "./readConfig.js";
+export { default as readConfigLayers } from "./readConfigLayers.js";
 export { default as resolveConfigPath } from "./resolveConfigPath.js";
-export type { ConfigUpdate, PragmaConfig } from "./types.js";
+export { default as resolveGlobalConfigPath } from "./resolveGlobalConfigPath.js";
+export { default as resolveWriteConfigPath } from "./resolveWriteConfigPath.js";
+export type {
+  ConfigFileValues,
+  ConfigLayer,
+  ConfigLayers,
+  ConfigOrigin,
+  ConfigOrigins,
+  ConfigScope,
+  ConfigUpdate,
+  PragmaConfig,
+} from "./types.js";
 export { default as writeConfig } from "./writeConfig.js";

--- a/packages/cli/pragma/src/config/mergeConfigFileUpdate.ts
+++ b/packages/cli/pragma/src/config/mergeConfigFileUpdate.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import type { ConfigUpdate } from "./types.js";
+
+/**
+ * Compute a config file's new contents after applying an update.
+ *
+ * Reads the target file itself (not the merged layers — a write must
+ * never copy values from another layer into this file), applies the
+ * update per field (`undefined` with the key present removes the field),
+ * and returns the serialized JSON. Unknown keys already in the file are
+ * preserved verbatim.
+ *
+ * @param configPath - Absolute path of the config file to update.
+ * @param update - Fields to set or remove.
+ * @returns The file's new contents, newline-terminated.
+ * @throws The raw filesystem/parse error when the existing file is
+ *   present but unreadable or not valid JSON — never silently clobbers.
+ * @note Impure — reads the current file contents.
+ */
+export default function mergeConfigFileUpdate(
+  configPath: string,
+  update: ConfigUpdate,
+): string {
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    existing = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err: unknown) {
+    // Only swallow "file not found" — surface parse or permission errors.
+    const isNotFound =
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isNotFound) {
+      throw err;
+    }
+  }
+
+  applyField(existing, update, "tier");
+  applyField(existing, update, "channel");
+  applyField(existing, update, "packages");
+  applyField(existing, update, "trace");
+  applyField(existing, update, "framework");
+
+  return `${JSON.stringify(existing, null, 2)}\n`;
+}
+
+function applyField(
+  existing: Record<string, unknown>,
+  update: ConfigUpdate,
+  field: keyof ConfigUpdate,
+): void {
+  if (update[field] !== undefined) {
+    existing[field] = update[field];
+  } else if (field in update) {
+    delete existing[field];
+  }
+}

--- a/packages/cli/pragma/src/config/parseConfigValues.ts
+++ b/packages/cli/pragma/src/config/parseConfigValues.ts
@@ -1,0 +1,155 @@
+import {
+  type Channel,
+  type Framework,
+  VALID_CHANNELS,
+  VALID_FRAMEWORKS,
+} from "../constants.js";
+import {
+  parsePackageEntry,
+  type RawPackageEntry,
+} from "../domains/refs/operations/parseRef.js";
+import { PragmaError } from "../error/PragmaError.js";
+import type { ConfigFileValues } from "./types.js";
+
+/**
+ * Type guard: check whether a value is a recognized channel string.
+ *
+ * @param value - Candidate value.
+ * @returns `true` if value is a valid Channel.
+ */
+function isValidChannel(value: unknown): value is Channel {
+  return typeof value === "string" && VALID_CHANNELS.includes(value as Channel);
+}
+
+/**
+ * Type guard: check whether a value is a recognized framework string.
+ *
+ * @param value - Candidate value.
+ * @returns `true` if value is a valid Framework.
+ */
+function isValidFramework(value: unknown): value is Framework {
+  return (
+    typeof value === "string" && VALID_FRAMEWORKS.includes(value as Framework)
+  );
+}
+
+/**
+ * Parse and validate one config file's raw contents.
+ *
+ * Returns only the fields the file actually sets — presence drives layer
+ * merging in `readConfigLayers`. An empty or whitespace-only file sets
+ * nothing.
+ *
+ * @param raw - The file's raw text.
+ * @param sourcePath - Absolute path, used in error messages.
+ * @returns The values this file declares.
+ * @throws PragmaError with code `CONFIG_ERROR` on invalid JSON or values.
+ */
+export default function parseConfigValues(
+  raw: string,
+  sourcePath: string,
+): ConfigFileValues {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return {};
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    throw PragmaError.configError(`Invalid JSON in ${sourcePath}.`);
+  }
+
+  const tier = typeof parsed.tier === "string" ? parsed.tier : undefined;
+
+  let channel: Channel | undefined;
+  if (parsed.channel !== undefined) {
+    if (!isValidChannel(parsed.channel)) {
+      throw PragmaError.configError(
+        `Invalid channel "${String(parsed.channel)}".`,
+        { validOptions: [...VALID_CHANNELS] },
+      );
+    }
+    channel = parsed.channel;
+  }
+
+  const trace = typeof parsed.trace === "boolean" ? parsed.trace : undefined;
+
+  let framework: Framework | undefined;
+  if (parsed.framework !== undefined) {
+    if (!isValidFramework(parsed.framework)) {
+      throw PragmaError.configError(
+        `Invalid framework "${String(parsed.framework)}".`,
+        { validOptions: [...VALID_FRAMEWORKS] },
+      );
+    }
+    framework = parsed.framework;
+  }
+
+  const packages = parsePackagesField(parsed.packages);
+
+  return {
+    ...(tier !== undefined ? { tier } : {}),
+    ...(channel !== undefined ? { channel } : {}),
+    ...(packages ? { packages } : {}),
+    ...(trace !== undefined ? { trace } : {}),
+    ...(framework !== undefined ? { framework } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Packages field parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate and parse the `packages` config field.
+ *
+ * @returns The validated array, or `undefined` when the field is absent.
+ * @throws PragmaError if the field is present but malformed.
+ */
+function parsePackagesField(
+  raw: unknown,
+): ReadonlyArray<RawPackageEntry> | undefined {
+  if (raw === undefined || raw === null) return undefined;
+
+  if (!Array.isArray(raw)) {
+    throw PragmaError.configError(
+      '"packages" must be an array of strings or { name, source? } objects.',
+    );
+  }
+
+  const entries: RawPackageEntry[] = [];
+  for (const item of raw) {
+    if (typeof item === "string") {
+      entries.push(item);
+      continue;
+    }
+    if (typeof item === "object" && item !== null && !Array.isArray(item)) {
+      const obj = item as Record<string, unknown>;
+      if (typeof obj.name !== "string" || obj.name.length === 0) {
+        throw PragmaError.configError(
+          'Each object in "packages" must have a non-empty "name" string.',
+        );
+      }
+      const entry: { name: string; source?: string } = { name: obj.name };
+      if (obj.source !== undefined) {
+        if (typeof obj.source !== "string") {
+          throw PragmaError.configError(
+            `Invalid source for "${obj.name}": expected a string.`,
+          );
+        }
+        entry.source = obj.source;
+      }
+      // Validate format eagerly — fail fast on bad config
+      parsePackageEntry(entry);
+      entries.push(entry);
+      continue;
+    }
+    throw PragmaError.configError(
+      'Each entry in "packages" must be a string or { name, source? } object.',
+    );
+  }
+
+  return entries;
+}

--- a/packages/cli/pragma/src/config/parseConfigValues.ts
+++ b/packages/cli/pragma/src/config/parseConfigValues.ts
@@ -119,6 +119,13 @@ function parsePackagesField(
     );
   }
 
+  // An explicitly empty list means "not configured": ref resolution falls
+  // back to global refs/defaults for an empty list (see mergeAndParseRefs),
+  // so dropping the field here keeps provenance in config show/doctor/info
+  // consistent with the behavior instead of reporting a project/global
+  // origin that resolution then ignores.
+  if (raw.length === 0) return undefined;
+
   const entries: RawPackageEntry[] = [];
   for (const item of raw) {
     if (typeof item === "string") {

--- a/packages/cli/pragma/src/config/readConfig.test.ts
+++ b/packages/cli/pragma/src/config/readConfig.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -6,11 +12,22 @@ import { PragmaError } from "../error/PragmaError.js";
 import readConfig from "./readConfig.js";
 import writeConfig from "./writeConfig.js";
 
+/** Write to `<dir>/pragma.config.json` — these tests pin file mechanics. */
+function writeConfigLocal(
+  dir: string,
+  update: Parameters<typeof writeConfig>[1],
+): string {
+  return writeConfig(dir, update, "local");
+}
+
 describe("readConfig", () => {
   let dir: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "pragma-config-"));
+    // Bound the project-config walk at this fixture root so a stray
+    // pragma.config.json in an ancestor directory can never leak in.
+    mkdirSync(join(dir, ".git"));
   });
 
   afterEach(() => {
@@ -186,14 +203,14 @@ describe("writeConfig", () => {
   });
 
   it("creates a new config file with tier", () => {
-    writeConfig(dir, { tier: "apps/lxd" });
+    writeConfigLocal(dir, { tier: "apps/lxd" });
     const config = readConfig(dir);
     expect(config.tier).toBe("apps/lxd");
     expect(config.channel).toBe("normal");
   });
 
   it("creates a new config file with channel", () => {
-    writeConfig(dir, { channel: "experimental" });
+    writeConfigLocal(dir, { channel: "experimental" });
     const config = readConfig(dir);
     expect(config.channel).toBe("experimental");
     expect(config.tier).toBeUndefined();
@@ -201,7 +218,7 @@ describe("writeConfig", () => {
 
   it("merges tier into existing config", () => {
     writeFileSync(join(dir, "pragma.config.json"), '{"channel":"prerelease"}');
-    writeConfig(dir, { tier: "global" });
+    writeConfigLocal(dir, { tier: "global" });
     const config = readConfig(dir);
     expect(config.tier).toBe("global");
     expect(config.channel).toBe("prerelease");
@@ -212,7 +229,7 @@ describe("writeConfig", () => {
       join(dir, "pragma.config.json"),
       '{"tier":"apps","channel":"normal"}',
     );
-    writeConfig(dir, { tier: undefined });
+    writeConfigLocal(dir, { tier: undefined });
     const config = readConfig(dir);
     expect(config.tier).toBeUndefined();
     expect(config.channel).toBe("normal");
@@ -223,7 +240,7 @@ describe("writeConfig", () => {
       join(dir, "pragma.config.json"),
       '{"tier":"apps","channel":"experimental"}',
     );
-    writeConfig(dir, { channel: undefined });
+    writeConfigLocal(dir, { channel: undefined });
     const config = readConfig(dir);
     expect(config.tier).toBe("apps");
     // Channel defaults to "normal" when absent from file
@@ -231,7 +248,7 @@ describe("writeConfig", () => {
   });
 
   it("round-trips tier and channel through write then read", () => {
-    writeConfig(dir, { tier: "apps/lxd", channel: "prerelease" });
+    writeConfigLocal(dir, { tier: "apps/lxd", channel: "prerelease" });
     const config = readConfig(dir);
     expect(config.tier).toBe("apps/lxd");
     expect(config.channel).toBe("prerelease");
@@ -239,19 +256,19 @@ describe("writeConfig", () => {
 
   it("writes valid empty JSON when all fields removed", () => {
     writeFileSync(join(dir, "pragma.config.json"), '{"tier":"apps"}');
-    writeConfig(dir, { tier: undefined });
+    writeConfigLocal(dir, { tier: undefined });
     const raw = readFileSync(join(dir, "pragma.config.json"), "utf-8");
     expect(raw).toBe("{}\n");
   });
 
   it("throws on unparseable existing config instead of silently overwriting", () => {
     writeFileSync(join(dir, "pragma.config.json"), "{invalid json");
-    expect(() => writeConfig(dir, { tier: "apps" })).toThrow();
+    expect(() => writeConfigLocal(dir, { tier: "apps" })).toThrow();
   });
 
   describe("packages field", () => {
     it("writes packages array", () => {
-      writeConfig(dir, {
+      writeConfigLocal(dir, {
         packages: [
           "@canonical/design-system",
           {
@@ -272,7 +289,7 @@ describe("writeConfig", () => {
 
     it("merges packages into existing config without touching tier", () => {
       writeFileSync(join(dir, "pragma.config.json"), '{"tier":"global"}');
-      writeConfig(dir, { packages: ["@canonical/design-system"] });
+      writeConfigLocal(dir, { packages: ["@canonical/design-system"] });
       const config = readConfig(dir);
       expect(config.tier).toBe("global");
       expect(config.packages).toEqual(["@canonical/design-system"]);
@@ -283,7 +300,7 @@ describe("writeConfig", () => {
         join(dir, "pragma.config.json"),
         JSON.stringify({ packages: ["@canonical/design-system"] }),
       );
-      writeConfig(dir, { packages: undefined });
+      writeConfigLocal(dir, { packages: undefined });
       const config = readConfig(dir);
       expect(config.packages).toBeUndefined();
     });
@@ -296,7 +313,7 @@ describe("writeConfig", () => {
           source: "git+https://github.com/canonical/anatomy-dsl.git#main",
         },
       ];
-      writeConfig(dir, { packages });
+      writeConfigLocal(dir, { packages });
       const config = readConfig(dir);
       expect(config.packages).toEqual(packages);
     });

--- a/packages/cli/pragma/src/config/readConfig.test.ts
+++ b/packages/cli/pragma/src/config/readConfig.test.ts
@@ -319,3 +319,19 @@ describe("writeConfig", () => {
     });
   });
 });
+
+describe("readConfig — empty packages normalization", () => {
+  it("treats an explicitly empty packages list as not configured", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pragma-empty-pkgs-"));
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    writeFileSync(
+      join(dir, "pragma.config.json"),
+      JSON.stringify({ channel: "normal", packages: [] }),
+    );
+    const config = readConfig(dir);
+    // The field is dropped at parse time so provenance matches the ref
+    // resolution behavior (empty list falls back to defaults/global refs).
+    expect(config.packages).toBeUndefined();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/cli/pragma/src/config/readConfig.ts
+++ b/packages/cli/pragma/src/config/readConfig.ts
@@ -1,162 +1,21 @@
-import { readFileSync } from "node:fs";
-import {
-  type Channel,
-  type Framework,
-  VALID_CHANNELS,
-  VALID_FRAMEWORKS,
-} from "../constants.js";
-import {
-  parsePackageEntry,
-  type RawPackageEntry,
-} from "../domains/refs/operations/parseRef.js";
-import { PragmaError } from "../error/PragmaError.js";
-import resolveConfigPath from "./resolveConfigPath.js";
+import readConfigLayers from "./readConfigLayers.js";
 import type { PragmaConfig } from "./types.js";
 
 /**
- * Type guard: check whether a value is a recognized channel string.
+ * Read the effective pragma configuration for a directory.
  *
- * @param value - Candidate value.
- * @returns `true` if value is a valid Channel.
- */
-function isValidChannel(value: unknown): value is Channel {
-  return typeof value === "string" && VALID_CHANNELS.includes(value as Channel);
-}
-
-/**
- * Type guard: check whether a value is a recognized framework string.
+ * Layered resolution: built-in defaults, then the global XDG file
+ * (`~/.config/pragma/config.json`), then the nearest project
+ * `pragma.config.json` at or above `cwd` — each field won by the most
+ * specific layer that sets it. Returns defaults (no tier, `"normal"`
+ * channel) when no layer configures anything.
  *
- * @param value - Candidate value.
- * @returns `true` if value is a valid Framework.
- */
-function isValidFramework(value: unknown): value is Framework {
-  return (
-    typeof value === "string" && VALID_FRAMEWORKS.includes(value as Framework)
-  );
-}
-
-/**
- * Read pragma config from `pragma.config.json` in the given directory.
+ * @param cwd - Directory the project layer is resolved from (defaults to `process.cwd()`).
+ * @returns The effective merged configuration.
+ * @throws PragmaError with code `CONFIG_ERROR` if a layer file has invalid JSON or values.
  *
- * Returns defaults (no tier, `"normal"` channel) when the file is missing or empty.
- *
- * @param cwd - Directory containing pragma.config.json (defaults to `process.cwd()`).
- * @returns Parsed configuration.
- * @throws PragmaError with code `CONFIG_ERROR` if JSON is invalid or channel is unrecognized.
- *
- * @note Impure — reads config from filesystem.
+ * @note Impure — reads config files from the filesystem.
  */
 export default function readConfig(cwd: string = process.cwd()): PragmaConfig {
-  const configPath = resolveConfigPath(cwd);
-
-  let raw: string;
-  try {
-    raw = readFileSync(configPath, "utf-8");
-  } catch {
-    return { tier: undefined, channel: "normal" };
-  }
-
-  const trimmed = raw.trim();
-  if (trimmed === "") {
-    return { tier: undefined, channel: "normal" };
-  }
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(trimmed) as Record<string, unknown>;
-  } catch {
-    throw PragmaError.configError(`Invalid JSON in ${configPath}.`);
-  }
-
-  const tier = typeof parsed.tier === "string" ? parsed.tier : undefined;
-
-  let channel: Channel = "normal";
-  if (parsed.channel !== undefined) {
-    if (!isValidChannel(parsed.channel)) {
-      throw PragmaError.configError(
-        `Invalid channel "${String(parsed.channel)}".`,
-        { validOptions: [...VALID_CHANNELS] },
-      );
-    }
-    channel = parsed.channel;
-  }
-
-  const trace = typeof parsed.trace === "boolean" ? parsed.trace : undefined;
-
-  let framework: Framework | undefined;
-  if (parsed.framework !== undefined) {
-    if (!isValidFramework(parsed.framework)) {
-      throw PragmaError.configError(
-        `Invalid framework "${String(parsed.framework)}".`,
-        { validOptions: [...VALID_FRAMEWORKS] },
-      );
-    }
-    framework = parsed.framework;
-  }
-
-  const packages = parsePackagesField(parsed.packages);
-
-  return {
-    tier,
-    channel,
-    ...(packages ? { packages } : {}),
-    ...(trace !== undefined ? { trace } : {}),
-    ...(framework !== undefined ? { framework } : {}),
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Packages field parsing
-// ---------------------------------------------------------------------------
-
-/**
- * Validate and parse the `packages` config field.
- *
- * @returns The validated array, or `undefined` when the field is absent.
- * @throws PragmaError if the field is present but malformed.
- */
-function parsePackagesField(
-  raw: unknown,
-): ReadonlyArray<RawPackageEntry> | undefined {
-  if (raw === undefined || raw === null) return undefined;
-
-  if (!Array.isArray(raw)) {
-    throw PragmaError.configError(
-      '"packages" must be an array of strings or { name, source? } objects.',
-    );
-  }
-
-  const entries: RawPackageEntry[] = [];
-  for (const item of raw) {
-    if (typeof item === "string") {
-      entries.push(item);
-      continue;
-    }
-    if (typeof item === "object" && item !== null && !Array.isArray(item)) {
-      const obj = item as Record<string, unknown>;
-      if (typeof obj.name !== "string" || obj.name.length === 0) {
-        throw PragmaError.configError(
-          'Each object in "packages" must have a non-empty "name" string.',
-        );
-      }
-      const entry: { name: string; source?: string } = { name: obj.name };
-      if (obj.source !== undefined) {
-        if (typeof obj.source !== "string") {
-          throw PragmaError.configError(
-            `Invalid source for "${obj.name}": expected a string.`,
-          );
-        }
-        entry.source = obj.source;
-      }
-      // Validate format eagerly — fail fast on bad config
-      parsePackageEntry(entry);
-      entries.push(entry);
-      continue;
-    }
-    throw PragmaError.configError(
-      'Each entry in "packages" must be a string or { name, source? } object.',
-    );
-  }
-
-  return entries;
+  return readConfigLayers(cwd).config;
 }

--- a/packages/cli/pragma/src/config/readConfigLayers.test.ts
+++ b/packages/cli/pragma/src/config/readConfigLayers.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PragmaError } from "../error/PragmaError.js";
+import readConfigLayers from "./readConfigLayers.js";
+
+describe("readConfigLayers", () => {
+  let xdgDir: string;
+  let projectDir: string;
+  let originalXdg: string | undefined;
+
+  beforeEach(() => {
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    xdgDir = mkdtempSync(join(tmpdir(), "pragma-layers-xdg-"));
+    process.env.XDG_CONFIG_HOME = xdgDir;
+    projectDir = mkdtempSync(join(tmpdir(), "pragma-layers-project-"));
+    mkdirSync(join(projectDir, ".git"));
+  });
+
+  afterEach(() => {
+    process.env.XDG_CONFIG_HOME = originalXdg;
+    rmSync(xdgDir, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeGlobal(content: string): void {
+    mkdirSync(join(xdgDir, "pragma"), { recursive: true });
+    writeFileSync(join(xdgDir, "pragma/config.json"), content);
+  }
+
+  function writeProject(content: string): void {
+    writeFileSync(join(projectDir, "pragma.config.json"), content);
+  }
+
+  it("returns defaults with default origins when no layer exists", () => {
+    const layers = readConfigLayers(projectDir);
+    expect(layers.config).toEqual({ tier: undefined, channel: "normal" });
+    expect(layers.origins).toEqual({
+      tier: "default",
+      channel: "default",
+      packages: "default",
+      trace: "default",
+      framework: "default",
+    });
+    expect(layers.global.exists).toBe(false);
+    expect(layers.project.exists).toBe(false);
+    expect(layers.project.path).toBe(join(projectDir, "pragma.config.json"));
+  });
+
+  it("reads the global layer when no project file exists", () => {
+    writeGlobal('{"channel":"experimental","tier":"global"}');
+    const layers = readConfigLayers(projectDir);
+    expect(layers.config.channel).toBe("experimental");
+    expect(layers.config.tier).toBe("global");
+    expect(layers.origins.channel).toBe("global");
+    expect(layers.origins.tier).toBe("global");
+    expect(layers.global.exists).toBe(true);
+  });
+
+  it("merges per field — project wins only the fields it sets", () => {
+    writeGlobal('{"channel":"experimental","trace":true}');
+    writeProject('{"tier":"apps/lxd"}');
+    const layers = readConfigLayers(projectDir);
+    expect(layers.config).toEqual({
+      tier: "apps/lxd",
+      channel: "experimental",
+      trace: true,
+    });
+    expect(layers.origins).toEqual({
+      tier: "project",
+      channel: "global",
+      packages: "default",
+      trace: "global",
+      framework: "default",
+    });
+  });
+
+  it("lets the project override a global field wholesale", () => {
+    writeGlobal('{"packages":["@canonical/a"],"channel":"experimental"}');
+    writeProject('{"packages":["@canonical/b"],"channel":"normal"}');
+    const layers = readConfigLayers(projectDir);
+    expect(layers.config.packages).toEqual(["@canonical/b"]);
+    expect(layers.config.channel).toBe("normal");
+    expect(layers.origins.packages).toBe("project");
+    expect(layers.origins.channel).toBe("project");
+  });
+
+  it("finds the project layer from a subdirectory", () => {
+    writeProject('{"tier":"apps/lxd"}');
+    const sub = join(projectDir, "packages/app");
+    mkdirSync(sub, { recursive: true });
+    const layers = readConfigLayers(sub);
+    expect(layers.config.tier).toBe("apps/lxd");
+    expect(layers.project.path).toBe(join(projectDir, "pragma.config.json"));
+    expect(layers.project.exists).toBe(true);
+  });
+
+  it("throws on invalid JSON in the global layer", () => {
+    writeGlobal("{not json");
+    expect(() => readConfigLayers(projectDir)).toThrow(PragmaError);
+  });
+});

--- a/packages/cli/pragma/src/config/readConfigLayers.ts
+++ b/packages/cli/pragma/src/config/readConfigLayers.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import findProjectConfigPath from "./findProjectConfigPath.js";
+import parseConfigValues from "./parseConfigValues.js";
+import resolveConfigPath from "./resolveConfigPath.js";
+import resolveGlobalConfigPath from "./resolveGlobalConfigPath.js";
+import type {
+  ConfigFileValues,
+  ConfigLayers,
+  ConfigOrigin,
+  PragmaConfig,
+} from "./types.js";
+
+/**
+ * Resolve the layered configuration with per-field provenance.
+ *
+ * Layer order, least to most specific: built-in defaults, the global XDG
+ * file (`~/.config/pragma/config.json`), and the nearest project
+ * `pragma.config.json` up the tree. Merging is per field — a field set by
+ * a more specific layer wins wholesale (`packages` replaces as a whole,
+ * preserving the established project-pins-exactly semantics).
+ *
+ * @param cwd - Directory the project layer is resolved from.
+ * @returns The effective config, per-field origins, and both layers.
+ * @throws PragmaError with code `CONFIG_ERROR` when either file is invalid.
+ * @note Impure — reads config files from the filesystem.
+ */
+export default function readConfigLayers(
+  cwd: string = process.cwd(),
+): ConfigLayers {
+  const globalPath = resolveGlobalConfigPath();
+  const projectPath = findProjectConfigPath(cwd) ?? resolveConfigPath(cwd);
+
+  const globalFile = readConfigFile(globalPath);
+  const projectFile = readConfigFile(projectPath);
+
+  const pick = <K extends keyof ConfigFileValues>(
+    field: K,
+  ): { value: ConfigFileValues[K] | undefined; origin: ConfigOrigin } => {
+    if (field in projectFile.values) {
+      return { value: projectFile.values[field], origin: "project" };
+    }
+    if (field in globalFile.values) {
+      return { value: globalFile.values[field], origin: "global" };
+    }
+    return { value: undefined, origin: "default" };
+  };
+
+  const tier = pick("tier");
+  const channel = pick("channel");
+  const packages = pick("packages");
+  const trace = pick("trace");
+  const framework = pick("framework");
+
+  const config: PragmaConfig = {
+    tier: tier.value,
+    channel: channel.value ?? "normal",
+    ...(packages.value ? { packages: packages.value } : {}),
+    ...(trace.value !== undefined ? { trace: trace.value } : {}),
+    ...(framework.value !== undefined ? { framework: framework.value } : {}),
+  };
+
+  return {
+    config,
+    origins: {
+      tier: tier.origin,
+      channel: channel.origin,
+      packages: packages.origin,
+      trace: trace.origin,
+      framework: framework.origin,
+    },
+    global: { path: globalPath, exists: globalFile.exists },
+    project: { path: projectPath, exists: projectFile.exists },
+  };
+}
+
+/**
+ * Read and parse one config file layer.
+ *
+ * A missing or unreadable file contributes no values — the layer simply
+ * does not participate in the merge.
+ */
+function readConfigFile(path: string): {
+  values: ConfigFileValues;
+  exists: boolean;
+} {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return { values: {}, exists: false };
+  }
+  return { values: parseConfigValues(raw, path), exists: true };
+}

--- a/packages/cli/pragma/src/config/resolveGlobalConfigPath.ts
+++ b/packages/cli/pragma/src/config/resolveGlobalConfigPath.ts
@@ -1,0 +1,13 @@
+import { join } from "node:path";
+import { globalConfigDir } from "../domains/refs/operations/paths.js";
+
+/**
+ * Resolve the absolute path of the global config file.
+ *
+ * Lives next to `refs.json` in the pragma XDG config directory:
+ * `$XDG_CONFIG_HOME/pragma/config.json`, defaulting to
+ * `~/.config/pragma/config.json`.
+ */
+export default function resolveGlobalConfigPath(): string {
+  return join(globalConfigDir(), "config.json");
+}

--- a/packages/cli/pragma/src/config/resolveWriteConfigPath.test.ts
+++ b/packages/cli/pragma/src/config/resolveWriteConfigPath.test.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import resolveWriteConfigPath from "./resolveWriteConfigPath.js";
+
+describe("resolveWriteConfigPath", () => {
+  let xdgDir: string;
+  let projectDir: string;
+  let originalXdg: string | undefined;
+
+  beforeEach(() => {
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    xdgDir = mkdtempSync(join(tmpdir(), "pragma-write-xdg-"));
+    process.env.XDG_CONFIG_HOME = xdgDir;
+    projectDir = mkdtempSync(join(tmpdir(), "pragma-write-project-"));
+    mkdirSync(join(projectDir, ".git"));
+  });
+
+  afterEach(() => {
+    process.env.XDG_CONFIG_HOME = originalXdg;
+    rmSync(xdgDir, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("targets the nearest existing project file", () => {
+    writeFileSync(join(projectDir, "pragma.config.json"), "{}");
+    const sub = join(projectDir, "packages/app");
+    mkdirSync(sub, { recursive: true });
+    expect(resolveWriteConfigPath(sub)).toBe(
+      join(projectDir, "pragma.config.json"),
+    );
+  });
+
+  it("falls back to the global file when no project file exists", () => {
+    expect(resolveWriteConfigPath(projectDir)).toBe(
+      join(xdgDir, "pragma/config.json"),
+    );
+  });
+
+  it("honors an explicit local scope even without an existing file", () => {
+    expect(resolveWriteConfigPath(projectDir, "local")).toBe(
+      join(projectDir, "pragma.config.json"),
+    );
+  });
+
+  it("honors an explicit global scope over an existing project file", () => {
+    writeFileSync(join(projectDir, "pragma.config.json"), "{}");
+    expect(resolveWriteConfigPath(projectDir, "global")).toBe(
+      join(xdgDir, "pragma/config.json"),
+    );
+  });
+});

--- a/packages/cli/pragma/src/config/resolveWriteConfigPath.ts
+++ b/packages/cli/pragma/src/config/resolveWriteConfigPath.ts
@@ -1,0 +1,31 @@
+import findProjectConfigPath from "./findProjectConfigPath.js";
+import resolveConfigPath from "./resolveConfigPath.js";
+import resolveGlobalConfigPath from "./resolveGlobalConfigPath.js";
+import type { ConfigScope } from "./types.js";
+
+/**
+ * Resolve which config file a write should target.
+ *
+ * An explicit scope wins: `"local"` targets `<cwd>/pragma.config.json`,
+ * `"global"` targets the XDG file. Otherwise the nearest existing project
+ * file up the tree is updated in place, and when none exists the write
+ * goes to the global file — pragma is global-first: an unconfigured
+ * directory should not sprout a project file as a side effect.
+ *
+ * @param cwd - Directory the project layer is resolved from.
+ * @param scope - Optional explicit target layer.
+ * @returns Absolute path of the config file to write.
+ * @note Impure — probes the filesystem for the nearest project file.
+ */
+export default function resolveWriteConfigPath(
+  cwd: string,
+  scope?: ConfigScope,
+): string {
+  if (scope === "local") {
+    return resolveConfigPath(cwd);
+  }
+  if (scope === "global") {
+    return resolveGlobalConfigPath();
+  }
+  return findProjectConfigPath(cwd) ?? resolveGlobalConfigPath();
+}

--- a/packages/cli/pragma/src/config/types.ts
+++ b/packages/cli/pragma/src/config/types.ts
@@ -43,4 +43,63 @@ interface ConfigUpdate {
   framework?: Framework | undefined;
 }
 
-export type { ConfigUpdate, PragmaConfig };
+/**
+ * Values a single config file declares. A key is present only when the
+ * file sets it — presence drives which layer wins during merging.
+ */
+interface ConfigFileValues {
+  readonly tier?: string;
+  readonly channel?: Channel;
+  readonly packages?: ReadonlyArray<RawPackageEntry>;
+  readonly trace?: boolean;
+  readonly framework?: Framework;
+}
+
+/** Which config layer supplied an effective field value. */
+type ConfigOrigin = "default" | "global" | "project";
+
+/** Per-field provenance for the effective merged config. */
+interface ConfigOrigins {
+  readonly tier: ConfigOrigin;
+  readonly channel: ConfigOrigin;
+  readonly packages: ConfigOrigin;
+  readonly trace: ConfigOrigin;
+  readonly framework: ConfigOrigin;
+}
+
+/** A resolved config file layer. */
+interface ConfigLayer {
+  /** Absolute path of the layer's config file (existing or would-be). */
+  readonly path: string;
+  /** Whether the file exists and was readable. */
+  readonly exists: boolean;
+}
+
+/** Layered config resolution result with per-field provenance. */
+interface ConfigLayers {
+  /** The effective merged configuration (defaults < global < project). */
+  readonly config: PragmaConfig;
+  /** Which layer supplied each effective field. */
+  readonly origins: ConfigOrigins;
+  /** The global XDG layer (`$XDG_CONFIG_HOME/pragma/config.json`). */
+  readonly global: ConfigLayer;
+  /**
+   * The project layer: the nearest `pragma.config.json` up the tree, or
+   * the would-be path at `cwd` when none exists.
+   */
+  readonly project: ConfigLayer;
+}
+
+/** Target layer selector for config writes. */
+type ConfigScope = "global" | "local";
+
+export type {
+  ConfigFileValues,
+  ConfigLayer,
+  ConfigLayers,
+  ConfigOrigin,
+  ConfigOrigins,
+  ConfigScope,
+  ConfigUpdate,
+  PragmaConfig,
+};

--- a/packages/cli/pragma/src/config/writeConfig.ts
+++ b/packages/cli/pragma/src/config/writeConfig.ts
@@ -1,67 +1,37 @@
-import { readFileSync, renameSync, writeFileSync } from "node:fs";
-import resolveConfigPath from "./resolveConfigPath.js";
-import type { ConfigUpdate } from "./types.js";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import mergeConfigFileUpdate from "./mergeConfigFileUpdate.js";
+import resolveWriteConfigPath from "./resolveWriteConfigPath.js";
+import type { ConfigScope, ConfigUpdate } from "./types.js";
 
 /**
- * Write config updates to pragma.config.json.
+ * Write config updates to the resolved target layer.
  *
- * Merges updates into existing JSON. A field set to `undefined` removes it.
- * Creates the file if it doesn't exist.
+ * The target follows the global-first write rule (see
+ * `resolveWriteConfigPath`): an explicit scope wins, else the nearest
+ * existing project file, else the global XDG file. Merges updates into
+ * that file's own contents — a field set to `undefined` removes it —
+ * creating the file (and its directory) if needed, atomically via a
+ * temp file rename.
  *
- * @param cwd - Directory containing (or to contain) pragma.config.json.
+ * @param cwd - Directory the project layer is resolved from.
  * @param update - Fields to set or remove.
+ * @param scope - Optional explicit target layer (`"global"` | `"local"`).
+ * @returns Absolute path of the file that was written.
  *
  * @note Impure — writes to the filesystem.
  */
-export default function writeConfig(cwd: string, update: ConfigUpdate): void {
-  const configPath = resolveConfigPath(cwd);
+export default function writeConfig(
+  cwd: string,
+  update: ConfigUpdate,
+  scope?: ConfigScope,
+): string {
+  const configPath = resolveWriteConfigPath(cwd, scope);
   const tempPath = `${configPath}.tmp`;
+  const content = mergeConfigFileUpdate(configPath, update);
 
-  let existing: Record<string, unknown> = {};
-  try {
-    const raw = readFileSync(configPath, "utf-8");
-    existing = JSON.parse(raw) as Record<string, unknown>;
-  } catch (err: unknown) {
-    // Only swallow "file not found" — surface parse or permission errors.
-    const isNotFound =
-      err instanceof Error &&
-      "code" in err &&
-      (err as NodeJS.ErrnoException).code === "ENOENT";
-    if (!isNotFound) {
-      throw err;
-    }
-  }
-
-  if (update.tier !== undefined) {
-    existing.tier = update.tier;
-  } else if ("tier" in update) {
-    delete existing.tier;
-  }
-
-  if (update.channel !== undefined) {
-    existing.channel = update.channel;
-  } else if ("channel" in update) {
-    delete existing.channel;
-  }
-
-  if (update.packages !== undefined) {
-    existing.packages = update.packages;
-  } else if ("packages" in update) {
-    delete existing.packages;
-  }
-
-  if (update.trace !== undefined) {
-    existing.trace = update.trace;
-  } else if ("trace" in update) {
-    delete existing.trace;
-  }
-
-  if (update.framework !== undefined) {
-    existing.framework = update.framework;
-  } else if ("framework" in update) {
-    delete existing.framework;
-  }
-
-  writeFileSync(tempPath, `${JSON.stringify(existing, null, 2)}\n`);
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(tempPath, content);
   renameSync(tempPath, configPath);
+  return configPath;
 }

--- a/packages/cli/pragma/src/domains/config/commands/channel.test.ts
+++ b/packages/cli/pragma/src/domains/config/commands/channel.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Store } from "@canonical/ke";
@@ -18,13 +18,24 @@ function makeCtx(cwd: string): PragmaContext {
 
 describe("config channel command", () => {
   let dir: string;
+  let xdgDir: string;
+  let originalXdg: string | undefined;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "pragma-cmd-channel-"));
+    // Bound the config walk at the fixture root, seed an empty project
+    // file so writes stay local, and isolate the global XDG layer.
+    mkdirSync(join(dir, ".git"));
+    writeFileSync(join(dir, "pragma.config.json"), "{}");
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    xdgDir = mkdtempSync(join(tmpdir(), "pragma-cmd-channel-xdg-"));
+    process.env.XDG_CONFIG_HOME = xdgDir;
   });
 
   afterEach(() => {
+    process.env.XDG_CONFIG_HOME = originalXdg;
     rmSync(dir, { recursive: true, force: true });
+    rmSync(xdgDir, { recursive: true, force: true });
   });
 
   it("sets channel to experimental", async () => {
@@ -45,7 +56,7 @@ describe("config channel command", () => {
     expect(result.tag).toBe("output");
     if (result.tag === "output") {
       const text = result.render.plain(result.value);
-      expect(text).toBe('Set channel to "prerelease".');
+      expect(text).toContain('Set channel to "prerelease".');
     }
   });
 
@@ -72,7 +83,7 @@ describe("config channel command", () => {
     expect(result.tag).toBe("output");
     if (result.tag === "output") {
       const text = result.render.plain(result.value);
-      expect(text).toBe("Reset channel to default.");
+      expect(text).toContain("Reset channel to default.");
     }
   });
 

--- a/packages/cli/pragma/src/domains/config/commands/channel.ts
+++ b/packages/cli/pragma/src/domains/config/commands/channel.ts
@@ -10,6 +10,7 @@ import { selectFormatter } from "../../shared/formatters.js";
 import { channelFormatters } from "../formatters/index.js";
 import { validateChannel } from "../operations/index.js";
 import { setChannelTask } from "../tasks/index.js";
+import { resolveConfigScope, SCOPE_PARAMETERS } from "./configScope.js";
 
 /**
  * Build the `pragma config channel` command definition.
@@ -40,6 +41,7 @@ export default function buildChannelCommand(
         type: "boolean",
         default: false,
       },
+      ...SCOPE_PARAMETERS,
     ],
     meta: {
       examples: [
@@ -50,15 +52,17 @@ export default function buildChannelCommand(
     execute: async (
       params: Record<string, unknown>,
     ): Promise<CommandResult> => {
+      const scope = resolveConfigScope(params);
       const reset = params.reset === true;
       const value = params.value as string | undefined;
 
       if (reset) {
-        await runTask(setChannelTask(ctx.cwd, undefined));
+        const result = await runTask(setChannelTask(ctx.cwd, undefined, scope));
         const format = selectFormatter(ctx, channelFormatters.reset);
-        return createOutputResult("Reset channel to default.", {
-          plain: format,
-        });
+        return createOutputResult(
+          { field: "channel", path: result.path },
+          { plain: format },
+        );
       }
 
       if (!value) {
@@ -71,10 +75,10 @@ export default function buildChannelCommand(
 
       const channel = validateChannel(value);
 
-      await runTask(setChannelTask(ctx.cwd, channel));
+      const result = await runTask(setChannelTask(ctx.cwd, channel, scope));
       const format = selectFormatter(ctx, channelFormatters.set);
       return createOutputResult(
-        { field: "channel", value: channel },
+        { field: "channel", value: channel, path: result.path },
         { plain: format },
       );
     },

--- a/packages/cli/pragma/src/domains/config/commands/configScope.ts
+++ b/packages/cli/pragma/src/domains/config/commands/configScope.ts
@@ -1,0 +1,45 @@
+import type { ParameterDefinition } from "@canonical/cli-core";
+import { PragmaError } from "#error";
+import type { ConfigScope } from "../../../config/index.js";
+
+/**
+ * The `--global` / `--local` target-layer flags shared by every config
+ * write command. Without either flag the write follows the global-first
+ * rule: nearest existing project file, else the global XDG file.
+ */
+export const SCOPE_PARAMETERS: readonly ParameterDefinition[] = [
+  {
+    name: "global",
+    description: "Write to the global config (~/.config/pragma/config.json)",
+    type: "boolean",
+    default: false,
+  },
+  {
+    name: "local",
+    description: "Write to ./pragma.config.json in the current directory",
+    type: "boolean",
+    default: false,
+  },
+];
+
+/**
+ * Resolve the explicit write scope from parsed command parameters.
+ *
+ * @param params - Parsed command parameters.
+ * @returns The explicit scope, or `undefined` for the default rule.
+ * @throws PragmaError with code `INVALID_INPUT` when both flags are set.
+ */
+export function resolveConfigScope(
+  params: Record<string, unknown>,
+): ConfigScope | undefined {
+  const global = params.global === true;
+  const local = params.local === true;
+  if (global && local) {
+    throw PragmaError.invalidInput("scope", "--global --local", {
+      recovery: { message: "Pass at most one of --global or --local." },
+    });
+  }
+  if (global) return "global";
+  if (local) return "local";
+  return undefined;
+}

--- a/packages/cli/pragma/src/domains/config/commands/configScope.ts
+++ b/packages/cli/pragma/src/domains/config/commands/configScope.ts
@@ -10,7 +10,8 @@ import type { ConfigScope } from "../../../config/index.js";
 export const SCOPE_PARAMETERS: readonly ParameterDefinition[] = [
   {
     name: "global",
-    description: "Write to the global config (~/.config/pragma/config.json)",
+    description:
+      "Write to the global config ($XDG_CONFIG_HOME/pragma/config.json, default ~/.config/pragma/config.json)",
     type: "boolean",
     default: false,
   },

--- a/packages/cli/pragma/src/domains/config/commands/framework.test.ts
+++ b/packages/cli/pragma/src/domains/config/commands/framework.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Store } from "@canonical/ke";
@@ -18,13 +24,24 @@ function makeCtx(cwd: string): PragmaContext {
 
 describe("config framework command", () => {
   let dir: string;
+  let xdgDir: string;
+  let originalXdg: string | undefined;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "pragma-cmd-framework-"));
+    // Bound the config walk at the fixture root, seed an empty project
+    // file so writes stay local, and isolate the global XDG layer.
+    mkdirSync(join(dir, ".git"));
+    writeFileSync(join(dir, "pragma.config.json"), "{}");
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    xdgDir = mkdtempSync(join(tmpdir(), "pragma-cmd-framework-xdg-"));
+    process.env.XDG_CONFIG_HOME = xdgDir;
   });
 
   afterEach(() => {
+    process.env.XDG_CONFIG_HOME = originalXdg;
     rmSync(dir, { recursive: true, force: true });
+    rmSync(xdgDir, { recursive: true, force: true });
   });
 
   it("sets framework to react", async () => {

--- a/packages/cli/pragma/src/domains/config/commands/framework.ts
+++ b/packages/cli/pragma/src/domains/config/commands/framework.ts
@@ -10,6 +10,7 @@ import { selectFormatter } from "../../shared/formatters.js";
 import { frameworkFormatters } from "../formatters/index.js";
 import { validateFramework } from "../operations/index.js";
 import { setFrameworkTask } from "../tasks/index.js";
+import { resolveConfigScope, SCOPE_PARAMETERS } from "./configScope.js";
 
 /**
  * Build the `pragma config framework` command definition.
@@ -41,6 +42,7 @@ export default function buildFrameworkCommand(
         type: "boolean",
         default: false,
       },
+      ...SCOPE_PARAMETERS,
     ],
     meta: {
       examples: [
@@ -53,15 +55,19 @@ export default function buildFrameworkCommand(
     execute: async (
       params: Record<string, unknown>,
     ): Promise<CommandResult> => {
+      const scope = resolveConfigScope(params);
       const reset = params.reset === true;
       const value = params.value as string | undefined;
 
       if (reset) {
-        await runTask(setFrameworkTask(ctx.cwd, undefined));
+        const result = await runTask(
+          setFrameworkTask(ctx.cwd, undefined, scope),
+        );
         const format = selectFormatter(ctx, frameworkFormatters.reset);
-        return createOutputResult("Reset framework to default.", {
-          plain: format,
-        });
+        return createOutputResult(
+          { field: "framework", path: result.path },
+          { plain: format },
+        );
       }
 
       if (!value) {
@@ -74,10 +80,10 @@ export default function buildFrameworkCommand(
 
       const framework = validateFramework(value);
 
-      await runTask(setFrameworkTask(ctx.cwd, framework));
+      const result = await runTask(setFrameworkTask(ctx.cwd, framework, scope));
       const format = selectFormatter(ctx, frameworkFormatters.set);
       return createOutputResult(
-        { field: "framework", value: framework },
+        { field: "framework", value: framework, path: result.path },
         { plain: format },
       );
     },

--- a/packages/cli/pragma/src/domains/config/commands/tier.test.ts
+++ b/packages/cli/pragma/src/domains/config/commands/tier.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Store } from "@canonical/ke";
@@ -18,13 +18,24 @@ function makeCtx(cwd: string): PragmaContext {
 
 describe("config tier command", () => {
   let dir: string;
+  let xdgDir: string;
+  let originalXdg: string | undefined;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "pragma-cmd-tier-"));
+    // Bound the config walk at the fixture root, seed an empty project
+    // file so writes stay local, and isolate the global XDG layer.
+    mkdirSync(join(dir, ".git"));
+    writeFileSync(join(dir, "pragma.config.json"), "{}");
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    xdgDir = mkdtempSync(join(tmpdir(), "pragma-cmd-tier-xdg-"));
+    process.env.XDG_CONFIG_HOME = xdgDir;
   });
 
   afterEach(() => {
+    process.env.XDG_CONFIG_HOME = originalXdg;
     rmSync(dir, { recursive: true, force: true });
+    rmSync(xdgDir, { recursive: true, force: true });
   });
 
   it("resets tier via --reset flag", async () => {
@@ -51,7 +62,7 @@ describe("config tier command", () => {
     expect(result.tag).toBe("output");
     if (result.tag === "output") {
       const text = result.render.plain(result.value);
-      expect(text).toBe("Reset tier to default.");
+      expect(text).toContain("Reset tier to default.");
     }
   });
 

--- a/packages/cli/pragma/src/domains/config/commands/tier.ts
+++ b/packages/cli/pragma/src/domains/config/commands/tier.ts
@@ -10,6 +10,7 @@ import { selectFormatter } from "../../shared/formatters.js";
 import { tierFormatters } from "../formatters/index.js";
 import { validateTier } from "../operations/index.js";
 import { setTierTask } from "../tasks/index.js";
+import { resolveConfigScope, SCOPE_PARAMETERS } from "./configScope.js";
 
 /**
  * Build the `pragma config tier` command definition.
@@ -40,6 +41,7 @@ export default function buildTierCommand(
         type: "boolean",
         default: false,
       },
+      ...SCOPE_PARAMETERS,
     ],
     meta: {
       examples: ["pragma config tier apps/lxd", "pragma config tier --reset"],
@@ -47,15 +49,17 @@ export default function buildTierCommand(
     execute: async (
       params: Record<string, unknown>,
     ): Promise<CommandResult> => {
+      const scope = resolveConfigScope(params);
       const reset = params.reset === true;
       const tierPath = params.path as string | undefined;
 
       if (reset) {
-        await runTask(setTierTask(ctx.cwd, undefined));
+        const result = await runTask(setTierTask(ctx.cwd, undefined, scope));
         const format = selectFormatter(ctx, tierFormatters.reset);
-        return createOutputResult("Reset tier to default.", {
-          plain: format,
-        });
+        return createOutputResult(
+          { field: "tier", path: result.path },
+          { plain: format },
+        );
       }
 
       if (!tierPath) {
@@ -69,10 +73,10 @@ export default function buildTierCommand(
       // Validate tier against ontology
       await validateTier(ctx.store, tierPath);
 
-      await runTask(setTierTask(ctx.cwd, tierPath));
+      const result = await runTask(setTierTask(ctx.cwd, tierPath, scope));
       const format = selectFormatter(ctx, tierFormatters.set);
       return createOutputResult(
-        { field: "tier", value: tierPath },
+        { field: "tier", value: tierPath, path: result.path },
         { plain: format },
       );
     },

--- a/packages/cli/pragma/src/domains/config/commands/trace.test.ts
+++ b/packages/cli/pragma/src/domains/config/commands/trace.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Store } from "@canonical/ke";
@@ -18,13 +24,24 @@ function makeCtx(cwd: string): PragmaContext {
 
 describe("config trace command", () => {
   let dir: string;
+  let xdgDir: string;
+  let originalXdg: string | undefined;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "pragma-cmd-trace-"));
+    // Bound the config walk at the fixture root, seed an empty project
+    // file so writes stay local, and isolate the global XDG layer.
+    mkdirSync(join(dir, ".git"));
+    writeFileSync(join(dir, "pragma.config.json"), "{}");
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    xdgDir = mkdtempSync(join(tmpdir(), "pragma-cmd-trace-xdg-"));
+    process.env.XDG_CONFIG_HOME = xdgDir;
   });
 
   afterEach(() => {
+    process.env.XDG_CONFIG_HOME = originalXdg;
     rmSync(dir, { recursive: true, force: true });
+    rmSync(xdgDir, { recursive: true, force: true });
   });
 
   it("enables tracing", async () => {
@@ -54,7 +71,7 @@ describe("config trace command", () => {
 
     expect(result.tag).toBe("output");
     if (result.tag === "output") {
-      expect(result.render.plain(result.value)).toBe("Tracing enabled.");
+      expect(result.render.plain(result.value)).toContain("Tracing enabled.");
     }
   });
 

--- a/packages/cli/pragma/src/domains/config/commands/trace.ts
+++ b/packages/cli/pragma/src/domains/config/commands/trace.ts
@@ -10,6 +10,7 @@ import type { PragmaContext } from "../../shared/context.js";
 import { selectFormatter } from "../../shared/formatters.js";
 import { traceFormatters } from "../formatters/index.js";
 import { setTraceTask } from "../tasks/index.js";
+import { resolveConfigScope, SCOPE_PARAMETERS } from "./configScope.js";
 
 /**
  * Build the `pragma config trace` command definition.
@@ -30,6 +31,7 @@ export default function buildTraceCommand(
         type: "string",
         positional: true,
       },
+      ...SCOPE_PARAMETERS,
     ],
     meta: {
       examples: [
@@ -43,6 +45,7 @@ export default function buildTraceCommand(
     execute: async (
       params: Record<string, unknown>,
     ): Promise<CommandResult> => {
+      const scope = resolveConfigScope(params);
       const value = params.value as string | undefined;
 
       // Query mode — no argument
@@ -68,11 +71,11 @@ export default function buildTraceCommand(
 
       // Set mode
       const enabled = value === "on";
-      await runTask(setTraceTask(ctx.cwd, enabled));
+      const result = await runTask(setTraceTask(ctx.cwd, enabled, scope));
 
       const format = selectFormatter(ctx, traceFormatters.set);
       return createOutputResult(
-        { field: "trace", value: enabled },
+        { field: "trace", value: enabled, path: result.path },
         { plain: format },
       );
     },

--- a/packages/cli/pragma/src/domains/config/formatters/channel.test.ts
+++ b/packages/cli/pragma/src/domains/config/formatters/channel.test.ts
@@ -2,14 +2,22 @@ import { describe, expect, it } from "vitest";
 import formatters from "./channel.js";
 
 describe("channelFormatters.set", () => {
-  const data = { field: "channel", value: "experimental" };
+  const data = {
+    field: "channel",
+    value: "experimental",
+    path: "/repo/pragma.config.json",
+  };
 
   it("plain renders set message", () => {
-    expect(formatters.set.plain(data)).toBe('Set channel to "experimental".');
+    expect(formatters.set.plain(data)).toBe(
+      'Set channel to "experimental".\nWrote /repo/pragma.config.json',
+    );
   });
 
   it("llm renders set message", () => {
-    expect(formatters.set.llm(data)).toBe('Set channel to "experimental".');
+    expect(formatters.set.llm(data)).toBe(
+      'Set channel to "experimental".\nWrote /repo/pragma.config.json',
+    );
   });
 
   it("json returns valid JSON", () => {
@@ -21,15 +29,21 @@ describe("channelFormatters.set", () => {
 
 describe("channelFormatters.reset", () => {
   it("plain renders reset message", () => {
-    expect(formatters.reset.plain("")).toBe("Reset channel to default.");
+    expect(
+      formatters.reset.plain({ field: "channel", path: "/repo/p.json" }),
+    ).toBe("Reset channel to default.\nWrote /repo/p.json");
   });
 
   it("llm renders reset message", () => {
-    expect(formatters.reset.llm("")).toBe("Reset channel to default.");
+    expect(
+      formatters.reset.llm({ field: "channel", path: "/repo/p.json" }),
+    ).toBe("Reset channel to default.\nWrote /repo/p.json");
   });
 
   it("json returns valid JSON", () => {
-    const parsed = JSON.parse(formatters.reset.json(""));
+    const parsed = JSON.parse(
+      formatters.reset.json({ field: "channel", path: "/repo/p.json" }),
+    );
     expect(parsed.field).toBe("channel");
     expect(parsed.reset).toBe(true);
   });

--- a/packages/cli/pragma/src/domains/config/formatters/channel.ts
+++ b/packages/cli/pragma/src/domains/config/formatters/channel.ts
@@ -9,19 +9,22 @@ import type { Formatters } from "../../shared/formatters.js";
  */
 const channelFormatters = {
   set: {
-    plain: (d: { field: string; value: string }) =>
-      `Set ${d.field} to "${d.value}".`,
-    llm: (d: { field: string; value: string }) =>
-      `Set ${d.field} to "${d.value}".`,
-    json: (d: { field: string; value: string }) =>
-      JSON.stringify({ field: d.field, value: d.value }),
-  } satisfies Formatters<{ field: string; value: string }>,
+    plain: (d: { field: string; value: string; path: string }) =>
+      `Set ${d.field} to "${d.value}".\nWrote ${d.path}`,
+    llm: (d: { field: string; value: string; path: string }) =>
+      `Set ${d.field} to "${d.value}".\nWrote ${d.path}`,
+    json: (d: { field: string; value: string; path: string }) =>
+      JSON.stringify({ field: d.field, value: d.value, path: d.path }),
+  } satisfies Formatters<{ field: string; value: string; path: string }>,
 
   reset: {
-    plain: () => "Reset channel to default.",
-    llm: () => "Reset channel to default.",
-    json: () => JSON.stringify({ field: "channel", reset: true }),
-  } satisfies Formatters<string>,
+    plain: (d: { field: string; path: string }) =>
+      `Reset channel to default.\nWrote ${d.path}`,
+    llm: (d: { field: string; path: string }) =>
+      `Reset channel to default.\nWrote ${d.path}`,
+    json: (d: { field: string; path: string }) =>
+      JSON.stringify({ field: "channel", reset: true, path: d.path }),
+  } satisfies Formatters<{ field: string; path: string }>,
 
   query: {
     plain: (channel: string) => `Current channel: ${channel}`,

--- a/packages/cli/pragma/src/domains/config/formatters/framework.ts
+++ b/packages/cli/pragma/src/domains/config/formatters/framework.ts
@@ -9,19 +9,22 @@ import type { Formatters } from "../../shared/formatters.js";
  */
 const frameworkFormatters = {
   set: {
-    plain: (d: { field: string; value: string }) =>
-      `Set ${d.field} to "${d.value}".`,
-    llm: (d: { field: string; value: string }) =>
-      `Set ${d.field} to "${d.value}".`,
-    json: (d: { field: string; value: string }) =>
-      JSON.stringify({ field: d.field, value: d.value }),
-  } satisfies Formatters<{ field: string; value: string }>,
+    plain: (d: { field: string; value: string; path: string }) =>
+      `Set ${d.field} to "${d.value}".\nWrote ${d.path}`,
+    llm: (d: { field: string; value: string; path: string }) =>
+      `Set ${d.field} to "${d.value}".\nWrote ${d.path}`,
+    json: (d: { field: string; value: string; path: string }) =>
+      JSON.stringify({ field: d.field, value: d.value, path: d.path }),
+  } satisfies Formatters<{ field: string; value: string; path: string }>,
 
   reset: {
-    plain: () => "Reset framework to default.",
-    llm: () => "Reset framework to default.",
-    json: () => JSON.stringify({ field: "framework", reset: true }),
-  } satisfies Formatters<string>,
+    plain: (d: { field: string; path: string }) =>
+      `Reset framework to default.\nWrote ${d.path}`,
+    llm: (d: { field: string; path: string }) =>
+      `Reset framework to default.\nWrote ${d.path}`,
+    json: (d: { field: string; path: string }) =>
+      JSON.stringify({ field: "framework", reset: true, path: d.path }),
+  } satisfies Formatters<{ field: string; path: string }>,
 
   query: {
     plain: (framework: string) => `Current framework: ${framework}`,

--- a/packages/cli/pragma/src/domains/config/formatters/show.test.ts
+++ b/packages/cli/pragma/src/domains/config/formatters/show.test.ts
@@ -11,6 +11,15 @@ const WITH_TIER: ConfigShowData = {
   installSource: "bun (global)",
   configFilePath: "/project/pragma.config.json",
   configFileExists: true,
+  globalConfigPath: "/home/u/.config/pragma/config.json",
+  globalConfigExists: false,
+  origins: {
+    tier: "project",
+    channel: "project",
+    packages: "default",
+    trace: "default",
+    framework: "default",
+  },
 };
 
 const WITHOUT_TIER: ConfigShowData = {
@@ -22,6 +31,15 @@ const WITHOUT_TIER: ConfigShowData = {
   installSource: "bun (local)",
   configFilePath: "/project/pragma.config.json",
   configFileExists: false,
+  globalConfigPath: "/home/u/.config/pragma/config.json",
+  globalConfigExists: false,
+  origins: {
+    tier: "project",
+    channel: "project",
+    packages: "default",
+    trace: "default",
+    framework: "default",
+  },
 };
 
 const PRERELEASE: ConfigShowData = {
@@ -33,6 +51,15 @@ const PRERELEASE: ConfigShowData = {
   installSource: "pnpm (global)",
   configFilePath: "/project/pragma.config.json",
   configFileExists: true,
+  globalConfigPath: "/home/u/.config/pragma/config.json",
+  globalConfigExists: false,
+  origins: {
+    tier: "project",
+    channel: "project",
+    packages: "default",
+    trace: "default",
+    framework: "default",
+  },
 };
 
 describe("formatters.plain", () => {

--- a/packages/cli/pragma/src/domains/config/formatters/show.ts
+++ b/packages/cli/pragma/src/domains/config/formatters/show.ts
@@ -8,25 +8,39 @@ import type { ConfigShowData } from "../operations/types.js";
  * - **llm** renders a markdown section with bullet points.
  * - **json** serializes the raw ConfigShowData.
  */
+/** Render a `[layer]` marker for values a config file supplied. */
+function originMarker(origin: "default" | "global" | "project"): string {
+  return origin === "default" ? "" : ` [${origin}]`;
+}
+
 const formatters: Formatters<ConfigShowData> = {
   plain(data) {
     const lines: string[] = [];
 
     if (data.tier !== undefined) {
       const chain = data.tierChain.join(" → ");
-      lines.push(`tier: ${data.tier} (${chain})`);
+      lines.push(
+        `tier: ${data.tier} (${chain})${originMarker(data.origins.tier)}`,
+      );
     } else {
       lines.push("tier: (none — all tiers visible)");
     }
 
     const releases = data.includedReleases.join(" + ");
-    lines.push(`channel: ${data.channel} (${releases})`);
+    lines.push(
+      `channel: ${data.channel} (${releases})${originMarker(data.origins.channel)}`,
+    );
     lines.push(`installed via: ${data.installSource}`);
 
     if (data.configFileExists) {
       lines.push(`config file: ${data.configFilePath}`);
     } else {
       lines.push("config file: (not found)");
+    }
+    if (data.globalConfigExists) {
+      lines.push(`global config: ${data.globalConfigPath}`);
+    } else {
+      lines.push("global config: (not found)");
     }
 
     return lines.join("\n");
@@ -40,19 +54,28 @@ const formatters: Formatters<ConfigShowData> = {
 
     if (data.tier !== undefined) {
       const chain = data.tierChain.join(" > ");
-      lines.push(`- **Tier:** ${data.tier} (${chain})`);
+      lines.push(
+        `- **Tier:** ${data.tier} (${chain})${originMarker(data.origins.tier)}`,
+      );
     } else {
       lines.push("- **Tier:** none (all tiers visible)");
     }
 
     const releases = data.includedReleases.join(", ");
-    lines.push(`- **Channel:** ${data.channel} (${releases})`);
+    lines.push(
+      `- **Channel:** ${data.channel} (${releases})${originMarker(data.origins.channel)}`,
+    );
     lines.push(`- **Installed via:** ${data.installSource}`);
 
     if (data.configFileExists) {
       lines.push(`- **Config file:** \`${data.configFilePath}\``);
     } else {
       lines.push("- **Config file:** not found");
+    }
+    if (data.globalConfigExists) {
+      lines.push(`- **Global config:** \`${data.globalConfigPath}\``);
+    } else {
+      lines.push("- **Global config:** not found");
     }
 
     return lines.join("\n");

--- a/packages/cli/pragma/src/domains/config/formatters/tier.test.ts
+++ b/packages/cli/pragma/src/domains/config/formatters/tier.test.ts
@@ -2,36 +2,52 @@ import { describe, expect, it } from "vitest";
 import formatters from "./tier.js";
 
 describe("tierFormatters.set", () => {
-  const data = { field: "tier", value: "apps/lxd" };
+  const data = {
+    field: "tier",
+    value: "apps/lxd",
+    path: "/repo/pragma.config.json",
+  };
 
-  it("plain renders set message", () => {
-    expect(formatters.set.plain(data)).toBe('Set tier to "apps/lxd".');
+  it("plain renders set message with the written path", () => {
+    expect(formatters.set.plain(data)).toBe(
+      'Set tier to "apps/lxd".\nWrote /repo/pragma.config.json',
+    );
   });
 
-  it("llm renders set message", () => {
-    expect(formatters.set.llm(data)).toBe('Set tier to "apps/lxd".');
+  it("llm renders set message with the written path", () => {
+    expect(formatters.set.llm(data)).toBe(
+      'Set tier to "apps/lxd".\nWrote /repo/pragma.config.json',
+    );
   });
 
   it("json returns valid JSON", () => {
     const parsed = JSON.parse(formatters.set.json(data));
     expect(parsed.field).toBe("tier");
     expect(parsed.value).toBe("apps/lxd");
+    expect(parsed.path).toBe("/repo/pragma.config.json");
   });
 });
 
 describe("tierFormatters.reset", () => {
-  it("plain renders reset message", () => {
-    expect(formatters.reset.plain("")).toBe("Reset tier to default.");
+  const data = { field: "tier", path: "/repo/pragma.config.json" };
+
+  it("plain renders reset message with the written path", () => {
+    expect(formatters.reset.plain(data)).toBe(
+      "Reset tier to default.\nWrote /repo/pragma.config.json",
+    );
   });
 
-  it("llm renders reset message", () => {
-    expect(formatters.reset.llm("")).toBe("Reset tier to default.");
+  it("llm renders reset message with the written path", () => {
+    expect(formatters.reset.llm(data)).toBe(
+      "Reset tier to default.\nWrote /repo/pragma.config.json",
+    );
   });
 
   it("json returns valid JSON", () => {
-    const parsed = JSON.parse(formatters.reset.json(""));
+    const parsed = JSON.parse(formatters.reset.json(data));
     expect(parsed.field).toBe("tier");
     expect(parsed.reset).toBe(true);
+    expect(parsed.path).toBe("/repo/pragma.config.json");
   });
 });
 

--- a/packages/cli/pragma/src/domains/config/formatters/tier.ts
+++ b/packages/cli/pragma/src/domains/config/formatters/tier.ts
@@ -1,5 +1,12 @@
 import type { Formatters } from "../../shared/formatters.js";
 
+/** Payload for a persisted config write, including the file written. */
+interface TierWrite {
+  readonly field: string;
+  readonly value: string;
+  readonly path: string;
+}
+
 /**
  * Formatter sets for `pragma config tier` output, grouped by branch:
  *
@@ -9,19 +16,20 @@ import type { Formatters } from "../../shared/formatters.js";
  */
 const tierFormatters = {
   set: {
-    plain: (d: { field: string; value: string }) =>
-      `Set ${d.field} to "${d.value}".`,
-    llm: (d: { field: string; value: string }) =>
-      `Set ${d.field} to "${d.value}".`,
-    json: (d: { field: string; value: string }) =>
-      JSON.stringify({ field: d.field, value: d.value }),
-  } satisfies Formatters<{ field: string; value: string }>,
+    plain: (d: TierWrite) => `Set ${d.field} to "${d.value}".\nWrote ${d.path}`,
+    llm: (d: TierWrite) => `Set ${d.field} to "${d.value}".\nWrote ${d.path}`,
+    json: (d: TierWrite) =>
+      JSON.stringify({ field: d.field, value: d.value, path: d.path }),
+  } satisfies Formatters<TierWrite>,
 
   reset: {
-    plain: () => "Reset tier to default.",
-    llm: () => "Reset tier to default.",
-    json: () => JSON.stringify({ field: "tier", reset: true }),
-  } satisfies Formatters<string>,
+    plain: (d: { field: string; path: string }) =>
+      `Reset tier to default.\nWrote ${d.path}`,
+    llm: (d: { field: string; path: string }) =>
+      `Reset tier to default.\nWrote ${d.path}`,
+    json: (d: { field: string; path: string }) =>
+      JSON.stringify({ field: "tier", reset: true, path: d.path }),
+  } satisfies Formatters<{ field: string; path: string }>,
 
   query: {
     plain: (tier: string | undefined) =>

--- a/packages/cli/pragma/src/domains/config/formatters/trace.ts
+++ b/packages/cli/pragma/src/domains/config/formatters/trace.ts
@@ -8,13 +8,13 @@ import type { Formatters } from "../../shared/formatters.js";
  */
 const traceFormatters = {
   set: {
-    plain: (d: { field: string; value: boolean }) =>
-      d.value ? "Tracing enabled." : "Tracing disabled.",
-    llm: (d: { field: string; value: boolean }) =>
-      d.value ? "Tracing enabled." : "Tracing disabled.",
-    json: (d: { field: string; value: boolean }) =>
-      JSON.stringify({ field: d.field, value: d.value }),
-  } satisfies Formatters<{ field: string; value: boolean }>,
+    plain: (d: { field: string; value: boolean; path: string }) =>
+      `${d.value ? "Tracing enabled." : "Tracing disabled."}\nWrote ${d.path}`,
+    llm: (d: { field: string; value: boolean; path: string }) =>
+      `${d.value ? "Tracing enabled." : "Tracing disabled."}\nWrote ${d.path}`,
+    json: (d: { field: string; value: boolean; path: string }) =>
+      JSON.stringify({ field: d.field, value: d.value, path: d.path }),
+  } satisfies Formatters<{ field: string; value: boolean; path: string }>,
 
   query: {
     plain: (status: string) => status,

--- a/packages/cli/pragma/src/domains/config/mcp/specs.ts
+++ b/packages/cli/pragma/src/domains/config/mcp/specs.ts
@@ -30,18 +30,25 @@ const specs: readonly ToolSpec[] = [
         description: "Reset tier to default",
         optional: true,
       },
+      global: {
+        type: "boolean",
+        description: "Write to the global config instead of the project file",
+        optional: true,
+      },
     },
     readOnly: false,
-    async execute(rt, { path, reset }) {
+    async execute(rt, { path, reset, global: globalScope }) {
+      const scope = globalScope === true ? "global" : undefined;
+
       if (reset) {
-        writeConfig(rt.cwd, { tier: undefined });
-        return { data: { tier: null, action: "reset" } };
+        const written = writeConfig(rt.cwd, { tier: undefined }, scope);
+        return { data: { tier: null, action: "reset", path: written } };
       }
 
       if (path) {
         await validateTier(rt.store, path as string);
-        writeConfig(rt.cwd, { tier: path as string });
-        return { data: { tier: path, action: "set" } };
+        const written = writeConfig(rt.cwd, { tier: path as string }, scope);
+        return { data: { tier: path, action: "set", path: written } };
       }
 
       const config = readConfig(rt.cwd);
@@ -63,18 +70,25 @@ const specs: readonly ToolSpec[] = [
         description: "Reset channel to normal",
         optional: true,
       },
+      global: {
+        type: "boolean",
+        description: "Write to the global config instead of the project file",
+        optional: true,
+      },
     },
     readOnly: false,
-    async execute(rt, { value, reset }) {
+    async execute(rt, { value, reset, global: globalScope }) {
+      const scope = globalScope === true ? "global" : undefined;
+
       if (reset) {
-        writeConfig(rt.cwd, { channel: undefined });
-        return { data: { channel: "normal", action: "reset" } };
+        const written = writeConfig(rt.cwd, { channel: undefined }, scope);
+        return { data: { channel: "normal", action: "reset", path: written } };
       }
 
       if (value) {
         const channel = validateChannel(value as string);
-        writeConfig(rt.cwd, { channel });
-        return { data: { channel, action: "set" } };
+        const written = writeConfig(rt.cwd, { channel }, scope);
+        return { data: { channel, action: "set", path: written } };
       }
 
       const config = readConfig(rt.cwd);

--- a/packages/cli/pragma/src/domains/config/operations/show.test.ts
+++ b/packages/cli/pragma/src/domains/config/operations/show.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
+import type { ConfigOrigins } from "#config";
 import resolveConfigShow from "./show.js";
+
+const PROJECT_ORIGINS: ConfigOrigins = {
+  tier: "project",
+  channel: "project",
+  packages: "default",
+  trace: "default",
+  framework: "default",
+};
+
+const PROVENANCE = {
+  globalConfigPath: "/home/u/.config/pragma/config.json",
+  globalConfigExists: false,
+  origins: PROJECT_ORIGINS,
+};
 
 describe("resolveConfigShow", () => {
   it("resolves tier chain and included releases", () => {
@@ -10,6 +25,7 @@ describe("resolveConfigShow", () => {
         installSource: "bun (global)",
         configFilePath: "/tmp/pragma.config.json",
         configFileExists: true,
+        ...PROVENANCE,
       },
     );
 
@@ -30,6 +46,7 @@ describe("resolveConfigShow", () => {
         installSource: "bun (local)",
         configFilePath: "/tmp/pragma.config.json",
         configFileExists: false,
+        ...PROVENANCE,
       },
     );
 
@@ -47,6 +64,7 @@ describe("resolveConfigShow", () => {
         installSource: "pnpm (global)",
         configFilePath: "/tmp/pragma.config.json",
         configFileExists: true,
+        ...PROVENANCE,
       },
     );
 

--- a/packages/cli/pragma/src/domains/config/operations/show.ts
+++ b/packages/cli/pragma/src/domains/config/operations/show.ts
@@ -1,4 +1,4 @@
-import type { PragmaConfig } from "#config";
+import type { ConfigOrigins, PragmaConfig } from "#config";
 import { CHANNEL_RELEASES } from "../../shared/filters/buildChannelFilter.js";
 import { resolveTierChain } from "../../shared/filters/buildTierFilter.js";
 import type { ConfigShowData } from "./types.js";
@@ -20,6 +20,9 @@ export default function resolveConfigShow(
     installSource: string;
     configFilePath: string;
     configFileExists: boolean;
+    globalConfigPath: string;
+    globalConfigExists: boolean;
+    origins: ConfigOrigins;
   },
 ): ConfigShowData {
   // Don't throw for stale config — show always displays what's configured.
@@ -38,5 +41,8 @@ export default function resolveConfigShow(
     installSource: opts.installSource,
     configFilePath: opts.configFilePath,
     configFileExists: opts.configFileExists,
+    globalConfigPath: opts.globalConfigPath,
+    globalConfigExists: opts.globalConfigExists,
+    origins: opts.origins,
   };
 }

--- a/packages/cli/pragma/src/domains/config/operations/types.ts
+++ b/packages/cli/pragma/src/domains/config/operations/types.ts
@@ -1,3 +1,4 @@
+import type { ConfigOrigins } from "#config";
 import type { Channel } from "#constants";
 
 /** Data returned by `pragma config show`, including resolved tier chain and channel releases. */
@@ -8,6 +9,12 @@ export interface ConfigShowData {
   readonly includedReleases: readonly string[];
   readonly packageManager: string;
   readonly installSource: string;
+  /** Nearest project config file (or the would-be path at cwd). */
   readonly configFilePath: string;
   readonly configFileExists: boolean;
+  /** The global XDG config file. */
+  readonly globalConfigPath: string;
+  readonly globalConfigExists: boolean;
+  /** Which layer supplied each effective field. */
+  readonly origins: ConfigOrigins;
 }

--- a/packages/cli/pragma/src/domains/config/stories.ts
+++ b/packages/cli/pragma/src/domains/config/stories.ts
@@ -7,7 +7,7 @@
  * `pragma.config.json` / `true` regardless of the working directory).
  */
 
-import { configExists, readConfig, resolveConfigPath } from "#config";
+import { readConfigLayers } from "#config";
 import { detectInstallSource } from "#package-manager";
 import type { ReadStory } from "../shared/stories/index.js";
 import { showFormatters } from "./formatters/index.js";
@@ -24,13 +24,16 @@ export const configShowStory: ReadStory<ConfigShowData, ConfigShowData> = {
   params: [],
   examples: ["pragma config show"],
   resolve: async (rt) => {
-    const config = readConfig(rt.cwd);
+    const layers = readConfigLayers(rt.cwd);
     const install = detectInstallSource();
-    return resolveConfigShow(config, {
+    return resolveConfigShow(layers.config, {
       packageManager: install.packageManager,
       installSource: install.label,
-      configFilePath: resolveConfigPath(rt.cwd),
-      configFileExists: configExists(rt.cwd),
+      configFilePath: layers.project.path,
+      configFileExists: layers.project.exists,
+      globalConfigPath: layers.global.path,
+      globalConfigExists: layers.global.exists,
+      origins: layers.origins,
     });
   },
   toOutput: (data) => data,

--- a/packages/cli/pragma/src/domains/config/tasks/index.ts
+++ b/packages/cli/pragma/src/domains/config/tasks/index.ts
@@ -3,3 +3,4 @@ export { default as setChannelTask } from "./setChannel.js";
 export { default as setFrameworkTask } from "./setFramework.js";
 export { default as setTierTask } from "./setTier.js";
 export { default as setTraceTask } from "./setTrace.js";
+export { default as writeConfigFieldTask } from "./writeConfigField.js";

--- a/packages/cli/pragma/src/domains/config/tasks/setChannel.ts
+++ b/packages/cli/pragma/src/domains/config/tasks/setChannel.ts
@@ -1,36 +1,21 @@
-import { $, gen, type Task, writeFile } from "@canonical/task";
-import { readConfig } from "../../../config/index.js";
-import resolveConfigPath from "../../../config/resolveConfigPath.js";
+import type { Task } from "@canonical/task";
+import type { ConfigScope } from "../../../config/index.js";
+import type { Channel } from "../../../constants.js";
+import writeConfigField from "./writeConfigField.js";
 
 /**
  * Build a config-write task for setting or resetting the release channel.
  *
- * @param cwd - Working directory containing pragma.config.json.
- * @param channel - Channel value to persist, or `undefined` to reset.
- * @returns Task yielding the persisted field/value payload.
- * @note - Impure — reads config and writes to the file system.
+ * @param cwd - Working directory the target config layer is resolved from.
+ * @param channel - Channel to persist, or `undefined` to reset.
+ * @param scope - Optional explicit target layer (`"global"` | `"local"`).
+ * @returns Task yielding the persisted field/value payload and target path.
+ * @note - Impure — reads and writes the target config file.
  */
 export default function setChannel(
   cwd: string,
-  channel: string | undefined,
-): Task<{ field: "channel"; value: string | undefined }> {
-  return gen(function* () {
-    // Merge onto the full existing config so other fields (e.g. `packages`,
-    // `trace`) survive. `readConfig` normalises defaults (tier: undefined,
-    // channel: "normal"); strip those to keep the file minimal, then apply
-    // the channel change (`undefined` resets it).
-    const current = readConfig(cwd);
-    const { tier, channel: _current, ...rest } = current;
-    const next = {
-      ...rest,
-      ...(tier !== undefined ? { tier } : {}),
-      ...(channel !== undefined ? { channel } : {}),
-    };
-
-    yield* $(
-      writeFile(resolveConfigPath(cwd), `${JSON.stringify(next, null, 2)}\n`),
-    );
-
-    return { field: "channel", value: channel };
-  });
+  channel: Channel | undefined,
+  scope?: ConfigScope,
+): Task<{ field: "channel"; value: Channel | undefined; path: string }> {
+  return writeConfigField(cwd, "channel", channel, scope);
 }

--- a/packages/cli/pragma/src/domains/config/tasks/setFramework.ts
+++ b/packages/cli/pragma/src/domains/config/tasks/setFramework.ts
@@ -1,40 +1,21 @@
-import { $, gen, type Task, writeFile } from "@canonical/task";
-import type { Framework } from "#constants";
-import { readConfig } from "../../../config/index.js";
-import resolveConfigPath from "../../../config/resolveConfigPath.js";
+import type { Task } from "@canonical/task";
+import type { ConfigScope } from "../../../config/index.js";
+import type { Framework } from "../../../constants.js";
+import writeConfigField from "./writeConfigField.js";
 
 /**
  * Build a config-write task for setting or resetting the preferred framework.
  *
- * @param cwd - Working directory containing pragma.config.json.
+ * @param cwd - Working directory the target config layer is resolved from.
  * @param framework - Framework to persist, or `undefined` to reset.
- * @returns Task yielding the persisted field/value payload.
- * @note - Impure — reads config and writes to the file system.
+ * @param scope - Optional explicit target layer (`"global"` | `"local"`).
+ * @returns Task yielding the persisted field/value payload and target path.
+ * @note - Impure — reads and writes the target config file.
  */
 export default function setFramework(
   cwd: string,
   framework: Framework | undefined,
-): Task<{ field: "framework"; value: Framework | undefined }> {
-  return gen(function* () {
-    // Merge onto the full existing config so other fields (e.g. `packages`,
-    // `trace`) survive. `readConfig` normalises defaults (tier: undefined,
-    // channel: "normal"); strip those to keep the file minimal, then apply
-    // the framework change (`undefined` resets it).
-    const current = readConfig(cwd);
-    // Destructure out `framework` too, so a reset (framework === undefined)
-    // actually removes it rather than letting the old value survive in `rest`.
-    const { tier, channel, framework: _current, ...rest } = current;
-    const next = {
-      ...rest,
-      ...(tier !== undefined ? { tier } : {}),
-      ...(channel !== "normal" ? { channel } : {}),
-      ...(framework !== undefined ? { framework } : {}),
-    };
-
-    yield* $(
-      writeFile(resolveConfigPath(cwd), `${JSON.stringify(next, null, 2)}\n`),
-    );
-
-    return { field: "framework", value: framework };
-  });
+  scope?: ConfigScope,
+): Task<{ field: "framework"; value: Framework | undefined; path: string }> {
+  return writeConfigField(cwd, "framework", framework, scope);
 }

--- a/packages/cli/pragma/src/domains/config/tasks/setTier.ts
+++ b/packages/cli/pragma/src/domains/config/tasks/setTier.ts
@@ -1,39 +1,20 @@
-import { $, gen, type Task, writeFile } from "@canonical/task";
-import { readConfig } from "../../../config/index.js";
-import resolveConfigPath from "../../../config/resolveConfigPath.js";
+import type { Task } from "@canonical/task";
+import type { ConfigScope } from "../../../config/index.js";
+import writeConfigField from "./writeConfigField.js";
 
 /**
  * Build a config-write task for setting or resetting the active tier.
  *
- * @param cwd - Working directory containing pragma.config.json.
+ * @param cwd - Working directory the target config layer is resolved from.
  * @param tier - Tier path to persist, or `undefined` to reset.
- * @returns Task yielding the persisted field/value payload.
- * @note - Impure — reads config and writes to the file system.
+ * @param scope - Optional explicit target layer (`"global"` | `"local"`).
+ * @returns Task yielding the persisted field/value payload and target path.
+ * @note - Impure — reads and writes the target config file.
  */
 export default function setTier(
   cwd: string,
   tier: string | undefined,
-): Task<{
-  field: "tier";
-  value: string | undefined;
-}> {
-  return gen(function* () {
-    // Merge onto the full existing config so other fields (e.g. `packages`,
-    // `trace`) survive. `readConfig` normalises defaults (tier: undefined,
-    // channel: "normal"); strip those to keep the file minimal, then apply
-    // the tier change (`undefined` resets it).
-    const current = readConfig(cwd);
-    const { tier: _current, channel, ...rest } = current;
-    const next = {
-      ...rest,
-      ...(tier !== undefined ? { tier } : {}),
-      ...(channel !== "normal" ? { channel } : {}),
-    };
-
-    yield* $(
-      writeFile(resolveConfigPath(cwd), `${JSON.stringify(next, null, 2)}\n`),
-    );
-
-    return { field: "tier", value: tier };
-  });
+  scope?: ConfigScope,
+): Task<{ field: "tier"; value: string | undefined; path: string }> {
+  return writeConfigField(cwd, "tier", tier, scope);
 }

--- a/packages/cli/pragma/src/domains/config/tasks/setTrace.ts
+++ b/packages/cli/pragma/src/domains/config/tasks/setTrace.ts
@@ -1,38 +1,20 @@
-import { $, gen, type Task, writeFile } from "@canonical/task";
-import { readConfig } from "../../../config/index.js";
-import resolveConfigPath from "../../../config/resolveConfigPath.js";
+import type { Task } from "@canonical/task";
+import type { ConfigScope } from "../../../config/index.js";
+import writeConfigField from "./writeConfigField.js";
 
 /**
  * Build a config-write task for enabling or disabling query tracing.
  *
- * @param cwd - Working directory containing pragma.config.json.
+ * @param cwd - Working directory the target config layer is resolved from.
  * @param trace - `true` to enable, `false` to disable.
- * @returns Task yielding the persisted field/value payload.
+ * @param scope - Optional explicit target layer (`"global"` | `"local"`).
+ * @returns Task yielding the persisted field/value payload and target path.
+ * @note - Impure — reads and writes the target config file.
  */
 export default function setTrace(
   cwd: string,
   trace: boolean,
-): Task<{ field: "trace"; value: boolean }> {
-  return gen(function* () {
-    // Merge onto the full existing config so other fields (e.g. `packages`)
-    // survive — rebuilding from a fixed field list silently drops everything
-    // not listed, and `packages` is runtime-consumed, so dropping it is data
-    // loss. `readConfig` normalises defaults (tier: undefined, channel:
-    // "normal"); strip those so we keep the file minimal, matching the
-    // existing convention of not persisting unset defaults.
-    const current = readConfig(cwd);
-    const { tier, channel, ...rest } = current;
-    const next = {
-      ...rest,
-      ...(tier !== undefined ? { tier } : {}),
-      ...(channel !== "normal" ? { channel } : {}),
-      trace,
-    };
-
-    yield* $(
-      writeFile(resolveConfigPath(cwd), `${JSON.stringify(next, null, 2)}\n`),
-    );
-
-    return { field: "trace", value: trace };
-  });
+  scope?: ConfigScope,
+): Task<{ field: "trace"; value: boolean | undefined; path: string }> {
+  return writeConfigField(cwd, "trace", trace, scope);
 }

--- a/packages/cli/pragma/src/domains/config/tasks/writeConfigField.ts
+++ b/packages/cli/pragma/src/domains/config/tasks/writeConfigField.ts
@@ -1,0 +1,41 @@
+import { $, gen, type Task, writeFile } from "@canonical/task";
+import {
+  type ConfigScope,
+  type ConfigUpdate,
+  mergeConfigFileUpdate,
+  resolveWriteConfigPath,
+} from "../../../config/index.js";
+
+/**
+ * Build a config-write task for one field.
+ *
+ * Resolves the target layer with the global-first write rule (explicit
+ * scope wins, else the nearest existing project file, else the global XDG
+ * file), merges the update into that file's own contents — never copying
+ * values from another layer — and writes through the tracked `writeFile`
+ * effect so the change participates in dry-run and undo. `undefined`
+ * removes the field from the target file.
+ *
+ * @param cwd - Working directory the project layer is resolved from.
+ * @param field - Config field to set or remove.
+ * @param value - New value, or `undefined` to remove the field.
+ * @param scope - Optional explicit target layer.
+ * @returns Task yielding the persisted field/value payload and the path written.
+ * @note Impure — resolves and reads the target file, writes via effect.
+ */
+export default function writeConfigField<F extends keyof ConfigUpdate>(
+  cwd: string,
+  field: F,
+  value: ConfigUpdate[F],
+  scope?: ConfigScope,
+): Task<{ field: F; value: ConfigUpdate[F]; path: string }> {
+  return gen(function* () {
+    const path = resolveWriteConfigPath(cwd, scope);
+    const update = { [field]: value } as ConfigUpdate;
+    const content = mergeConfigFileUpdate(path, update);
+
+    yield* $(writeFile(path, content));
+
+    return { field, value, path };
+  });
+}

--- a/packages/cli/pragma/src/domains/doctor/operations/checks.test.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("#config", async (importOriginal) => ({
   ...(await importOriginal<typeof import("#config")>()),
   configExists: vi.fn(),
+  readConfigLayers: vi.fn(),
 }));
 vi.mock("../../shared/bootStore.js", () => ({
   bootStore: vi.fn(),
@@ -22,7 +23,7 @@ vi.mock("@canonical/task", () => ({
 }));
 
 import { detectHarnesses, readMcpConfig } from "@canonical/harnesses";
-import { configExists } from "#config";
+import { configExists, readConfigLayers } from "#config";
 import { collectStoreSummary } from "../../info/operations/index.js";
 import { bootStore } from "../../shared/bootStore.js";
 import {
@@ -59,14 +60,55 @@ describe("checkPragmaVersion", () => {
 });
 
 describe("checkConfigFile", () => {
-  it("passes when config exists", async () => {
-    vi.mocked(configExists).mockReturnValue(true);
+  it("passes when a project config exists", async () => {
+    vi.mocked(readConfigLayers).mockReturnValue({
+      config: { tier: undefined, channel: "normal" },
+      origins: {
+        tier: "default",
+        channel: "default",
+        packages: "default",
+        trace: "default",
+        framework: "default",
+      },
+      global: { path: "/home/u/.config/pragma/config.json", exists: false },
+      project: { path: "/repo/pragma.config.json", exists: true },
+    });
     const result = await checkConfigFile(ctx);
     expect(result.status).toBe("pass");
+    expect(result.detail).toContain("/repo/pragma.config.json");
   });
 
-  it("fails with remedy when config missing", async () => {
-    vi.mocked(configExists).mockReturnValue(false);
+  it("passes when only the global config exists", async () => {
+    vi.mocked(readConfigLayers).mockReturnValue({
+      config: { tier: undefined, channel: "normal" },
+      origins: {
+        tier: "default",
+        channel: "default",
+        packages: "default",
+        trace: "default",
+        framework: "default",
+      },
+      global: { path: "/home/u/.config/pragma/config.json", exists: true },
+      project: { path: "/repo/pragma.config.json", exists: false },
+    });
+    const result = await checkConfigFile(ctx);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("global config active");
+  });
+
+  it("fails with remedy when neither layer exists", async () => {
+    vi.mocked(readConfigLayers).mockReturnValue({
+      config: { tier: undefined, channel: "normal" },
+      origins: {
+        tier: "default",
+        channel: "default",
+        packages: "default",
+        trace: "default",
+        framework: "default",
+      },
+      global: { path: "/home/u/.config/pragma/config.json", exists: false },
+      project: { path: "/repo/pragma.config.json", exists: false },
+    });
     const result = await checkConfigFile(ctx);
     expect(result.status).toBe("fail");
     expect(result.remedy).toBeDefined();

--- a/packages/cli/pragma/src/domains/doctor/operations/checks/checkConfigFile.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks/checkConfigFile.ts
@@ -1,21 +1,35 @@
-import { configExists } from "#config";
+import { readConfigLayers } from "#config";
 import type { CheckContext, CheckResult } from "../types.js";
 
 /**
- * Check that `pragma.config.json` exists in the working directory.
+ * Check which config layer is active for the working directory.
+ *
+ * Passes when a project `pragma.config.json` is found up the tree, or —
+ * pragma is global-first — when only the global XDG config exists. Fails
+ * only when neither layer is configured.
  *
  * @param ctx - Check context with the working directory.
- * @returns A CheckResult indicating pass or fail.
+ * @returns A CheckResult indicating pass or fail with the active layer.
  * @note Impure
  */
 export default async function checkConfigFile(
   ctx: CheckContext,
 ): Promise<CheckResult> {
-  if (configExists(ctx.cwd)) {
+  const layers = readConfigLayers(ctx.cwd);
+
+  if (layers.project.exists) {
     return {
       name: "pragma.config.json",
       status: "pass",
-      detail: "found",
+      detail: `found (${layers.project.path})`,
+    };
+  }
+
+  if (layers.global.exists) {
+    return {
+      name: "pragma.config.json",
+      status: "pass",
+      detail: `no project config — global config active (${layers.global.path})`,
     };
   }
 

--- a/packages/cli/pragma/src/domains/doctor/operations/checks/checkPackageRefs.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks/checkPackageRefs.ts
@@ -6,14 +6,12 @@
  */
 
 import { readConfig } from "#config";
-import { parsePackageEntry } from "../../../refs/operations/parseRef.js";
-import readGlobalRefs from "../../../refs/operations/readGlobalRefs.js";
 import {
   createBundledLoader,
   createGitLoader,
   createLocalLoader,
 } from "../../../shared/loaders/index.js";
-import { DEFAULT_PACKAGES } from "../../../shared/packages.js";
+import { mergeAndParseRefs } from "../../../shared/runtime.js";
 import { resolveSemanticPackages } from "../../../shared/semanticPackage.js";
 import type { CheckContext, CheckResult } from "../types.js";
 
@@ -21,17 +19,7 @@ export default async function checkPackageRefs(
   ctx: CheckContext,
 ): Promise<CheckResult> {
   const config = readConfig(ctx.cwd);
-  const globalEntries = readGlobalRefs();
-
-  const projectRefs = config.packages;
-  const rawEntries =
-    projectRefs && projectRefs.length > 0
-      ? projectRefs
-      : globalEntries.length > 0
-        ? globalEntries
-        : DEFAULT_PACKAGES;
-
-  const refs = [...rawEntries].map(parsePackageEntry);
+  const refs = mergeAndParseRefs(config.packages);
   const loaders = [
     createLocalLoader(),
     createGitLoader(),

--- a/packages/cli/pragma/src/domains/doctor/operations/checks/checkPackageRefs.ts
+++ b/packages/cli/pragma/src/domains/doctor/operations/checks/checkPackageRefs.ts
@@ -11,7 +11,7 @@ import {
   createGitLoader,
   createLocalLoader,
 } from "../../../shared/loaders/index.js";
-import { mergeAndParseRefs } from "../../../shared/runtime.js";
+import { mergeAndParseRefs } from "../../../shared/mergeAndParseRefs.js";
 import { resolveSemanticPackages } from "../../../shared/semanticPackage.js";
 import type { CheckContext, CheckResult } from "../types.js";
 

--- a/packages/cli/pragma/src/domains/info/operations/collectInfo.test.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectInfo.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const readConfigMock = vi.fn();
+const readConfigLayersMock = vi.fn();
 const detectInstallSourceMock = vi.fn();
 const bootStoreMock = vi.fn();
 const checkRegistryVersionMock = vi.fn();
@@ -8,7 +8,7 @@ const collectStoreSummaryMock = vi.fn();
 
 vi.mock("#config", async (importOriginal) => ({
   ...(await importOriginal<typeof import("#config")>()),
-  readConfig: readConfigMock,
+  readConfigLayers: readConfigLayersMock,
 }));
 
 vi.mock("#package-manager", async (importOriginal) => {
@@ -46,7 +46,18 @@ describe("collectInfo", () => {
       scope: "global",
       label: "bun (global)",
     });
-    readConfigMock.mockReturnValue({ tier: "apps/lxd", channel: "normal" });
+    readConfigLayersMock.mockReturnValue({
+      config: { tier: "apps/lxd", channel: "normal" },
+      origins: {
+        tier: "project",
+        channel: "default",
+        packages: "default",
+        trace: "default",
+        framework: "default",
+      },
+      global: { path: "/home/u/.config/pragma/config.json", exists: false },
+      project: { path: "/repo/pragma.config.json", exists: true },
+    });
   });
 
   it("includes update information and store summary when available", async () => {

--- a/packages/cli/pragma/src/domains/info/operations/collectInfo.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectInfo.ts
@@ -1,4 +1,4 @@
-import { readConfig } from "#config";
+import { readConfigLayers } from "#config";
 import { VERSION } from "#constants";
 import { detectInstallSource, PM_COMMANDS } from "#package-manager";
 import {
@@ -28,7 +28,8 @@ import { collectStoreSummary } from "./collectStoreSummary.js";
 export default async function collectInfo(cwd: string): Promise<InfoData> {
   const install = detectInstallSource();
   const pm = install.packageManager;
-  const config = readConfig(cwd);
+  const layers = readConfigLayers(cwd);
+  const config = layers.config;
   const tierChain = resolveTierChain(config.tier);
   const channelReleases = CHANNEL_RELEASES[config.channel];
 
@@ -65,7 +66,9 @@ export default async function collectInfo(cwd: string): Promise<InfoData> {
     version: VERSION,
     pm,
     installSource: install.label,
-    configPath: "pragma.config.json",
+    configPath: layers.project.exists
+      ? layers.project.path
+      : layers.global.path,
     tier: config.tier,
     tierChain,
     channel: config.channel,

--- a/packages/cli/pragma/src/domains/info/operations/collectInfo.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectInfo.ts
@@ -1,15 +1,14 @@
 import { readConfigLayers } from "#config";
 import { VERSION } from "#constants";
 import { detectInstallSource, PM_COMMANDS } from "#package-manager";
-import {
-  type PackageRef,
-  parsePackageEntry,
+import type {
+  PackageRef,
+  RawPackageEntry,
 } from "../../refs/operations/parseRef.js";
-import readGlobalRefs from "../../refs/operations/readGlobalRefs.js";
 import { bootStore } from "../../shared/bootStore.js";
 import { CHANNEL_RELEASES } from "../../shared/filters/buildChannelFilter.js";
 import { resolveTierChain } from "../../shared/filters/buildTierFilter.js";
-import { DEFAULT_PACKAGES } from "../../shared/packages.js";
+import { mergeAndParseRefs } from "../../shared/mergeAndParseRefs.js";
 import type { InfoData, PackageRefSummary } from "../types.js";
 import checkRegistryVersion from "./checkRegistryVersion.js";
 import { collectStoreSummary } from "./collectStoreSummary.js";
@@ -81,14 +80,9 @@ export default async function collectInfo(cwd: string): Promise<InfoData> {
 }
 
 function collectPackageRefSummaries(
-  projectPackages?: ReadonlyArray<
-    string | { readonly name: string; readonly source?: string }
-  >,
+  configPackages?: ReadonlyArray<RawPackageEntry>,
 ): PackageRefSummary[] {
-  const entries = projectPackages ?? readGlobalRefs();
-  const raw = entries.length > 0 ? entries : DEFAULT_PACKAGES.map((pkg) => pkg);
-
-  return raw.map((entry) => refToSummary(parsePackageEntry(entry)));
+  return mergeAndParseRefs(configPackages).map(refToSummary);
 }
 
 function refToSummary(ref: PackageRef): PackageRefSummary {

--- a/packages/cli/pragma/src/domains/refs/operations/updateRefs.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/updateRefs.ts
@@ -8,12 +8,11 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { readConfig } from "#config";
-import { DEFAULT_PACKAGES } from "../../shared/packages.js";
+import { mergeAndParseRefs } from "../../shared/runtime.js";
 import { cloneRef, fetchRef, pruneCache } from "./gitOps.js";
 import type { PackageRef, RawPackageEntry } from "./parseRef.js";
 import { parsePackageEntry } from "./parseRef.js";
 import { cacheRoot, gitCacheDir } from "./paths.js";
-import readGlobalRefs from "./readGlobalRefs.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -56,7 +55,7 @@ export default async function updateRefs(
   options: UpdateRefsOptions,
 ): Promise<UpdateResult[]> {
   const config = readConfig(options.cwd);
-  const refs = mergeEntries(config.packages);
+  const refs = mergeAndParseRefs(config.packages);
   const results: UpdateResult[] = [];
 
   for (const ref of refs) {
@@ -136,40 +135,6 @@ export default async function updateRefs(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Merge global + project entries, parse into PackageRef[]. */
-function mergeEntries(
-  projectPackages?: ReadonlyArray<RawPackageEntry>,
-): PackageRef[] {
-  const globalEntries = readGlobalRefs();
-
-  if (
-    (!projectPackages || projectPackages.length === 0) &&
-    globalEntries.length === 0
-  ) {
-    return DEFAULT_PACKAGES.map((pkg) => parsePackageEntry(pkg));
-  }
-
-  const merged = new Map<string, RawPackageEntry>();
-
-  for (const entry of DEFAULT_PACKAGES) {
-    const name = typeof entry === "string" ? entry : entry.name;
-    merged.set(name, entry);
-  }
-  for (const entry of globalEntries) {
-    const name = typeof entry === "string" ? entry : entry.name;
-    merged.set(name, entry);
-  }
-  if (projectPackages) {
-    merged.clear();
-    for (const entry of projectPackages) {
-      const name = typeof entry === "string" ? entry : entry.name;
-      merged.set(name, entry);
-    }
-  }
-
-  return [...merged.values()].map(parsePackageEntry);
-}
 
 /**
  * Remove cache directories that don't match any configured git ref.

--- a/packages/cli/pragma/src/domains/refs/operations/updateRefs.ts
+++ b/packages/cli/pragma/src/domains/refs/operations/updateRefs.ts
@@ -8,7 +8,7 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { readConfig } from "#config";
-import { mergeAndParseRefs } from "../../shared/runtime.js";
+import { mergeAndParseRefs } from "../../shared/mergeAndParseRefs.js";
 import { cloneRef, fetchRef, pruneCache } from "./gitOps.js";
 import type { PackageRef, RawPackageEntry } from "./parseRef.js";
 import { parsePackageEntry } from "./parseRef.js";

--- a/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
+++ b/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
@@ -508,6 +508,8 @@ describe("config_show", () => {
 describe("config_tier", () => {
   it("sets, queries, and resets tier in workspace config", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pragma-mcp-tier-"));
+    // Seed a project file so global-first writes stay in this workspace.
+    writeFileSync(join(dir, "pragma.config.json"), "{}");
 
     try {
       const scoped = await createTestMcpClient({ cwd: dir });
@@ -517,7 +519,10 @@ describe("config_tier", () => {
           name: "config_tier",
           arguments: { path: "global" },
         });
-        expect(parseData(setResult)).toEqual({ tier: "global", action: "set" });
+        expect(parseData(setResult)).toMatchObject({
+          tier: "global",
+          action: "set",
+        });
 
         const queryResult = await scoped.client.callTool({
           name: "config_tier",
@@ -532,7 +537,10 @@ describe("config_tier", () => {
           name: "config_tier",
           arguments: { reset: true },
         });
-        expect(parseData(resetResult)).toEqual({ tier: null, action: "reset" });
+        expect(parseData(resetResult)).toMatchObject({
+          tier: null,
+          action: "reset",
+        });
 
         const queriedAfterReset = await scoped.client.callTool({
           name: "config_tier",
@@ -554,6 +562,8 @@ describe("config_tier", () => {
 describe("config_channel", () => {
   it("sets, queries, and resets channel in workspace config", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pragma-mcp-channel-"));
+    // Seed a project file so global-first writes stay in this workspace.
+    writeFileSync(join(dir, "pragma.config.json"), "{}");
 
     try {
       const scoped = await createTestMcpClient({ cwd: dir });
@@ -563,7 +573,7 @@ describe("config_channel", () => {
           name: "config_channel",
           arguments: { value: "experimental" },
         });
-        expect(parseData(setResult)).toEqual({
+        expect(parseData(setResult)).toMatchObject({
           channel: "experimental",
           action: "set",
         });
@@ -581,7 +591,7 @@ describe("config_channel", () => {
           name: "config_channel",
           arguments: { reset: true },
         });
-        expect(parseData(resetResult)).toEqual({
+        expect(parseData(resetResult)).toMatchObject({
           channel: "normal",
           action: "reset",
         });

--- a/packages/cli/pragma/src/testing/integration/parity.test.ts
+++ b/packages/cli/pragma/src/testing/integration/parity.test.ts
@@ -10,7 +10,7 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // ---- Shared utilities ----
-import { configExists, readConfig, resolveConfigPath } from "#config";
+import { readConfigLayers } from "#config";
 import { VERSION } from "#constants";
 import { detectInstallSource } from "#package-manager";
 // ---- Formatters ----
@@ -445,12 +445,16 @@ describe("config parity", () => {
   // story, so parity is asserted against the real config path/existence
   // (the MCP tool previously hardcoded "pragma.config.json" / true).
   function resolveExpectedConfigShow() {
+    const layers = readConfigLayers(rt.cwd);
     const install = detectInstallSource();
-    return resolveConfigShow(readConfig(rt.cwd), {
+    return resolveConfigShow(layers.config, {
       packageManager: install.packageManager,
       installSource: install.label,
-      configFilePath: resolveConfigPath(rt.cwd),
-      configFileExists: configExists(rt.cwd),
+      configFilePath: layers.project.path,
+      configFileExists: layers.project.exists,
+      globalConfigPath: layers.global.path,
+      globalConfigExists: layers.global.exists,
+      origins: layers.origins,
     });
   }
 

--- a/packages/cli/pragma/src/testing/setupXdgIsolation.ts
+++ b/packages/cli/pragma/src/testing/setupXdgIsolation.ts
@@ -1,0 +1,15 @@
+/**
+ * Global test setup: isolate the XDG config layer.
+ *
+ * The layered config reader consults `$XDG_CONFIG_HOME/pragma/config.json`
+ * on every read, and global-first writes create it. Point XDG at a
+ * per-run temp directory so tests neither observe nor pollute the
+ * developer's real global configuration. Individual tests that exercise
+ * XDG behavior override this value themselves.
+ */
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "pragma-test-xdg-"));

--- a/packages/cli/pragma/vitest.config.ts
+++ b/packages/cli/pragma/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["src/**/*.test.ts"],
+    setupFiles: ["./src/testing/setupXdgIsolation.ts"],
     environment: "node",
     coverage: {
       provider: "v8",


### PR DESCRIPTION
> Split out of #774 (3 of 4). **Stacked on #776** (read-story kernel) — the diff shows only this layer; base retargets to `main` when #776 merges (rebase ping welcome, I can re-kick it).

## Done

- **Layered resolution**: config merges per field as defaults < global `$XDG_CONFIG_HOME/pragma/config.json` < nearest `pragma.config.json` walking up from cwd (bounded by the first `.git` dir, `$HOME`, or the fs root). `readConfig(cwd)` keeps its signature — all call sites work unchanged; `readConfigLayers` exposes per-field origins for provenance consumers.
- **Breaking — global-by-default writes**: `pragma config <field> <value>` writes the nearest existing project file, else the **global** file (previously always created `./pragma.config.json`). `--global`/`--local` override; every write echoes the path it wrote. MCP `config_tier`/`config_channel` accept a `global` param and return the path.
- **Provenance surfaces**: `config show` renders per-field origin (`tier: apps/lxd (project)`) + both layer paths; `doctor` reports the active layer and only fails when neither file exists; `info` shows the real resolved config path.
- **Ref-merge unification**: `updateRefs`, the doctor package check, and `pragma info` all use the store-free `mergeAndParseRefs` module (#682) — killing three divergent merge variants (`info` could previously report a different package list than the store boots).
- Test infra: per-run XDG isolation (`setupXdgIsolation.ts`), `.git` walk markers in fixtures.

ADR: `pragma-adrs` `session/C/C.04`.

## QA

- `cd packages/cli/pragma && bun run check && bun run test` on this branch — green, **1,233 tests pass**.
- Compiled-binary smoke (`bun run build`, 273 embedded assets): `dist/pragma config channel experimental` in an empty dir writes the XDG file and echoes the path; `config show` renders `channel: experimental … [global]` with both layer paths.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

No visual change — CLI + MCP behavior only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR)_