### PR TITLE
feat(cli): story packs — declarative read stories for any ontology (experimental)

### DIFF
--- a/packages/cli/pragma/README.md
+++ b/packages/cli/pragma/README.md
@@ -297,14 +297,58 @@ Every subject URI in the ke graph is exposed as a discoverable MCP resource via 
 
 ## Configuration
 
-Create a `pragma.config.toml` in your project root:
+Configuration is layered: built-in defaults, then the global file at
+`$XDG_CONFIG_HOME/pragma/config.json` (default `~/.config/pragma/config.json`),
+then the nearest `pragma.config.json` at or above the current directory —
+each field won by the most specific layer that sets it. Install pragma
+globally, configure once, and override per project:
 
-```toml
-tier = "apps/lxd"
-channel = "normal"    # normal | experimental | prerelease
+```json
+{
+  "tier": "apps/lxd",
+  "channel": "normal"
+}
 ```
 
-When no config file is present, pragma defaults to no tier and `normal` channel.
+`pragma config tier|channel|framework|trace` writes to the nearest existing
+project file, or to the global file when no project is configured; pass
+`--local` or `--global` to pick the layer explicitly. Every write echoes the
+file it wrote, and `pragma config show` reports which layer supplied each
+value.
+
+### Custom read stories (experimental)
+
+A config (or a semantic package, via `stories/*.json`) can declare
+declarative read stories — any ontology loaded through `packages` gets
+`pragma <noun> list` / `<noun> lookup` on both the CLI and MCP:
+
+```json
+{
+  "prefixes": { "ex": "http://example.org/recipes/" },
+  "packages": [{ "name": "my-recipes", "source": "file:///data/recipes" }],
+  "stories": [
+    {
+      "noun": "recipe",
+      "description": "List recipes",
+      "list": {
+        "query": "SELECT ?uri ?name ?category WHERE { ?uri a ex:Recipe ; ex:name ?name ; ex:category ?category } ORDER BY ?name",
+        "columns": [{ "field": "name" }, { "field": "category" }]
+      },
+      "lookup": {
+        "type": "ex:Recipe",
+        "by": "ex:name",
+        "fields": [{ "name": "category", "property": "ex:category" }],
+        "sections": [{ "name": "instructions", "property": "ex:instructions" }]
+      }
+    }
+  ]
+}
+```
+
+The lookup query is generated (user input is escaped, never interpolated by
+the pack), the store stays read-only, and config-declared stories override
+package-shipped ones on noun collisions. The format is experimental and may
+change.
 
 ## Error Handling
 

--- a/packages/cli/pragma/docs/mcp-integration.md
+++ b/packages/cli/pragma/docs/mcp-integration.md
@@ -225,6 +225,14 @@ Parameters:
 - `names` (string[], required) — skill names to look up (e.g., `["design-auditor"]`)
 - `condensed` (boolean, optional) — return token-optimized Markdown
 
+#### Story-pack tools (experimental)
+
+Declarative read stories from `pragma.config.json` (`stories`) or semantic
+packages (`stories/*.json`) register additional `<noun>_list` /
+`<noun>_lookup` tools at boot — the same envelope, condensed mode, and
+batch-error semantics as the built-in read tools. See the README's
+"Custom read stories" section for the format.
+
 ### Write Tools
 
 #### `config_tier`

--- a/packages/cli/pragma/src/config/parseConfigValues.ts
+++ b/packages/cli/pragma/src/config/parseConfigValues.ts
@@ -8,6 +8,8 @@ import {
   parsePackageEntry,
   type RawPackageEntry,
 } from "../domains/refs/operations/parseRef.js";
+import type { StoryPackDefinition } from "../domains/shared/stories/pack/types.js";
+import validateStoryPackDefinition from "../domains/shared/stories/pack/validateStoryPackDefinition.js";
 import { PragmaError } from "../error/PragmaError.js";
 import type { ConfigFileValues } from "./types.js";
 
@@ -88,6 +90,8 @@ export default function parseConfigValues(
   }
 
   const packages = parsePackagesField(parsed.packages);
+  const stories = parseStoriesField(parsed.stories, sourcePath);
+  const prefixes = parsePrefixesField(parsed.prefixes);
 
   return {
     ...(tier !== undefined ? { tier } : {}),
@@ -95,7 +99,56 @@ export default function parseConfigValues(
     ...(packages ? { packages } : {}),
     ...(trace !== undefined ? { trace } : {}),
     ...(framework !== undefined ? { framework } : {}),
+    ...(stories ? { stories } : {}),
+    ...(prefixes ? { prefixes } : {}),
   };
+}
+
+/**
+ * Validate and parse the experimental `stories` config field.
+ *
+ * @returns The validated definitions, or `undefined` when absent.
+ * @throws PragmaError if the field is present but malformed.
+ */
+function parseStoriesField(
+  raw: unknown,
+  sourcePath: string,
+): ReadonlyArray<StoryPackDefinition> | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw)) {
+    throw PragmaError.configError(
+      '"stories" must be an array of story-pack definitions.',
+    );
+  }
+  return raw.map((entry, index) =>
+    validateStoryPackDefinition(entry, `${sourcePath} (stories[${index}])`),
+  );
+}
+
+/**
+ * Validate and parse the `prefixes` config field.
+ *
+ * @returns The prefix map, or `undefined` when absent.
+ * @throws PragmaError if the field is present but malformed.
+ */
+function parsePrefixesField(
+  raw: unknown,
+): Readonly<Record<string, string>> | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw PragmaError.configError(
+      '"prefixes" must be an object mapping prefix to namespace IRI.',
+    );
+  }
+  const entries = Object.entries(raw as Record<string, unknown>);
+  for (const [prefix, namespace] of entries) {
+    if (typeof namespace !== "string" || !namespace.includes("://")) {
+      throw PragmaError.configError(
+        `Invalid namespace for prefix "${prefix}": expected an absolute IRI.`,
+      );
+    }
+  }
+  return Object.fromEntries(entries) as Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/pragma/src/config/readConfig.test.ts
+++ b/packages/cli/pragma/src/config/readConfig.test.ts
@@ -191,6 +191,64 @@ describe("readConfig", () => {
   });
 });
 
+describe("readConfig — stories and prefixes fields", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pragma-config-stories-"));
+    mkdirSync(join(dir, ".git"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("parses a valid stories array and prefixes map", () => {
+    writeFileSync(
+      join(dir, "pragma.config.json"),
+      JSON.stringify({
+        prefixes: { ex: "http://example.org/" },
+        stories: [
+          {
+            noun: "recipe",
+            list: {
+              query: "SELECT ?uri WHERE { ?uri a ex:Recipe }",
+              columns: [{ field: "uri" }],
+            },
+          },
+        ],
+      }),
+    );
+    const config = readConfig(dir);
+    expect(config.prefixes).toEqual({ ex: "http://example.org/" });
+    expect(config.stories?.at(0)?.noun).toBe("recipe");
+  });
+
+  it("throws on a non-array stories field", () => {
+    writeFileSync(
+      join(dir, "pragma.config.json"),
+      '{"stories": {"noun": "x"}}',
+    );
+    expect(() => readConfig(dir)).toThrow(/stories/);
+  });
+
+  it("throws on an invalid story definition", () => {
+    writeFileSync(
+      join(dir, "pragma.config.json"),
+      '{"stories": [{"noun": "Bad Noun"}]}',
+    );
+    expect(() => readConfig(dir)).toThrow(PragmaError);
+  });
+
+  it("throws on a prefixes value that is not an IRI", () => {
+    writeFileSync(
+      join(dir, "pragma.config.json"),
+      '{"prefixes": {"ex": "not-an-iri"}}',
+    );
+    expect(() => readConfig(dir)).toThrow(/prefix/);
+  });
+});
+
 describe("writeConfig", () => {
   let dir: string;
 

--- a/packages/cli/pragma/src/config/readConfigLayers.test.ts
+++ b/packages/cli/pragma/src/config/readConfigLayers.test.ts
@@ -42,6 +42,8 @@ describe("readConfigLayers", () => {
       packages: "default",
       trace: "default",
       framework: "default",
+      stories: "default",
+      prefixes: "default",
     });
     expect(layers.global.exists).toBe(false);
     expect(layers.project.exists).toBe(false);
@@ -73,6 +75,8 @@ describe("readConfigLayers", () => {
       packages: "default",
       trace: "global",
       framework: "default",
+      stories: "default",
+      prefixes: "default",
     });
   });
 

--- a/packages/cli/pragma/src/config/readConfigLayers.ts
+++ b/packages/cli/pragma/src/config/readConfigLayers.ts
@@ -50,6 +50,8 @@ export default function readConfigLayers(
   const packages = pick("packages");
   const trace = pick("trace");
   const framework = pick("framework");
+  const stories = pick("stories");
+  const prefixes = pick("prefixes");
 
   const config: PragmaConfig = {
     tier: tier.value,
@@ -57,6 +59,8 @@ export default function readConfigLayers(
     ...(packages.value ? { packages: packages.value } : {}),
     ...(trace.value !== undefined ? { trace: trace.value } : {}),
     ...(framework.value !== undefined ? { framework: framework.value } : {}),
+    ...(stories.value ? { stories: stories.value } : {}),
+    ...(prefixes.value ? { prefixes: prefixes.value } : {}),
   };
 
   return {
@@ -67,6 +71,8 @@ export default function readConfigLayers(
       packages: packages.origin,
       trace: trace.origin,
       framework: framework.origin,
+      stories: stories.origin,
+      prefixes: prefixes.origin,
     },
     global: { path: globalPath, exists: globalFile.exists },
     project: { path: projectPath, exists: projectFile.exists },

--- a/packages/cli/pragma/src/config/types.ts
+++ b/packages/cli/pragma/src/config/types.ts
@@ -7,6 +7,7 @@
 
 import type { Channel, Framework } from "../constants.js";
 import type { RawPackageEntry } from "../domains/refs/operations/parseRef.js";
+import type { StoryPackDefinition } from "../domains/shared/stories/pack/types.js";
 
 /** Parsed contents of pragma.config.json. */
 interface PragmaConfig {
@@ -27,6 +28,17 @@ interface PragmaConfig {
    * only — no behaviour reads it yet; reserved for future framework defaulting.
    */
   framework?: Framework | undefined;
+  /**
+   * Declarative read stories compiled into CLI commands and MCP tools at
+   * boot.
+   * @experimental Story packs (v0) are experimental — the format may change.
+   */
+  stories?: ReadonlyArray<StoryPackDefinition> | undefined;
+  /**
+   * Additional namespace prefixes merged over the built-in prefix map —
+   * registered on the store (usable in queries) and used for display.
+   */
+  prefixes?: Readonly<Record<string, string>> | undefined;
 }
 
 /** Partial update payload for writing config changes. */
@@ -53,6 +65,8 @@ interface ConfigFileValues {
   readonly packages?: ReadonlyArray<RawPackageEntry>;
   readonly trace?: boolean;
   readonly framework?: Framework;
+  readonly stories?: ReadonlyArray<StoryPackDefinition>;
+  readonly prefixes?: Readonly<Record<string, string>>;
 }
 
 /** Which config layer supplied an effective field value. */
@@ -65,6 +79,8 @@ interface ConfigOrigins {
   readonly packages: ConfigOrigin;
   readonly trace: ConfigOrigin;
   readonly framework: ConfigOrigin;
+  readonly stories: ConfigOrigin;
+  readonly prefixes: ConfigOrigin;
 }
 
 /** A resolved config file layer. */

--- a/packages/cli/pragma/src/domains/shared/bootStore.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.ts
@@ -38,6 +38,8 @@ export interface BootStoreOptions {
   refs?: ReadonlyArray<PackageRef>;
   /** Enable query tracing (from config). Env var PRAGMA_TRACE=1 overrides. */
   trace?: boolean;
+  /** Additional namespace prefixes merged over the built-in prefix map. */
+  prefixes?: Readonly<Record<string, string>>;
 }
 
 export interface BootResult {
@@ -59,12 +61,13 @@ export interface BootResult {
 export async function bootStore(
   options: BootStoreOptions = {},
 ): Promise<BootResult> {
+  const prefixes = { ...PREFIX_MAP, ...options.prefixes };
   try {
     // Testing/programmatic override — use explicit sources
     if (options.sources) {
       const store = await createStore({
         sources: options.sources,
-        prefixes: PREFIX_MAP,
+        prefixes,
         cache: options.cache,
         cwd: options.cwd,
       });
@@ -110,7 +113,7 @@ export async function bootStore(
 
     const store = await createStore({
       sources: [],
-      prefixes: PREFIX_MAP,
+      prefixes,
       cache: options.cache,
       cwd: options.cwd,
       plugins,

--- a/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
@@ -99,6 +99,7 @@ export default function createBundledLoader(): PackageLoader {
         source: "bundled",
         graphs,
         skills: [],
+        stories: [],
       };
 
       return cached;

--- a/packages/cli/pragma/src/domains/shared/loaders/gitLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/gitLoader.ts
@@ -24,8 +24,8 @@ export default function createGitLoader(): PackageLoader {
       const dir = gitCacheDir(ref.pkg, ref.ref);
       if (!existsSync(dir)) return undefined;
 
-      const { version, graphs, skills } = readPackageDir(dir);
-      return { name: ref.pkg, version, source: "git", graphs, skills };
+      const { version, graphs, skills, stories } = readPackageDir(dir);
+      return { name: ref.pkg, version, source: "git", graphs, skills, stories };
     },
   };
 }

--- a/packages/cli/pragma/src/domains/shared/loaders/localLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/localLoader.ts
@@ -28,16 +28,30 @@ export default function createLocalLoader(): PackageLoader {
       // file:// refs → direct path check first
       if (ref.kind === "file") {
         if (!existsSync(ref.path)) return undefined;
-        const { version, graphs, skills } = readPackageDir(ref.path);
-        return { name: ref.pkg, version, source: "local", graphs, skills };
+        const { version, graphs, skills, stories } = readPackageDir(ref.path);
+        return {
+          name: ref.pkg,
+          version,
+          source: "local",
+          graphs,
+          skills,
+          stories,
+        };
       }
 
       // All ref kinds → try node_modules walk
       const dir = findPackageDir(ref.pkg);
       if (!dir) return undefined;
 
-      const { version, graphs, skills } = readPackageDir(dir);
-      return { name: ref.pkg, version, source: "local", graphs, skills };
+      const { version, graphs, skills, stories } = readPackageDir(dir);
+      return {
+        name: ref.pkg,
+        version,
+        source: "local",
+        graphs,
+        skills,
+        stories,
+      };
     },
   };
 }

--- a/packages/cli/pragma/src/domains/shared/loaders/readPackageDir.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/readPackageDir.ts
@@ -16,7 +16,11 @@ import {
   statSync,
 } from "node:fs";
 import { join } from "node:path";
-import type { GraphContent, SkillEntry } from "../semanticPackage.js";
+import type {
+  GraphContent,
+  SkillEntry,
+  StoryFileEntry,
+} from "../semanticPackage.js";
 
 // ---------------------------------------------------------------------------
 // TTL discovery convention
@@ -35,6 +39,7 @@ export interface PackageDirContents {
   readonly version: string;
   readonly graphs: GraphContent[];
   readonly skills: SkillEntry[];
+  readonly stories: StoryFileEntry[];
 }
 
 /**
@@ -48,6 +53,7 @@ export default function readPackageDir(dir: string): PackageDirContents {
     version: readVersion(dir),
     graphs: readGraphs(dir),
     skills: readSkills(dir),
+    stories: readStories(dir),
   };
 }
 
@@ -85,6 +91,33 @@ function readGraphs(dir: string): GraphContent[] {
   }
 
   return graphs;
+}
+
+function readStories(dir: string): StoryFileEntry[] {
+  const storiesDir = join(dir, "stories");
+  if (!existsSync(storiesDir)) return [];
+
+  const stories: StoryFileEntry[] = [];
+  try {
+    for (const entry of readdirSync(storiesDir)) {
+      if (!entry.endsWith(".json")) continue;
+      const entryPath = join(storiesDir, entry);
+      try {
+        stories.push({
+          path: entryPath,
+          definition: JSON.parse(readFileSync(entryPath, "utf-8")),
+        });
+      } catch {
+        process.stderr.write(
+          `Warning: invalid JSON in story file ${entryPath}\n`,
+        );
+      }
+    }
+  } catch {
+    // readdir failed — no stories
+  }
+
+  return stories;
 }
 
 function readSkills(dir: string): SkillEntry[] {

--- a/packages/cli/pragma/src/domains/shared/loaders/readPackageDir.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/readPackageDir.ts
@@ -99,7 +99,9 @@ function readStories(dir: string): StoryFileEntry[] {
 
   const stories: StoryFileEntry[] = [];
   try {
-    for (const entry of readdirSync(storiesDir)) {
+    // Sorted: readdir order is filesystem-dependent, and story collision
+    // resolution must be deterministic across platforms.
+    for (const entry of [...readdirSync(storiesDir)].sort()) {
       if (!entry.endsWith(".json")) continue;
       const entryPath = join(storiesDir, entry);
       try {

--- a/packages/cli/pragma/src/domains/shared/runtime.ts
+++ b/packages/cli/pragma/src/domains/shared/runtime.ts
@@ -48,6 +48,7 @@ export async function bootPragma(options?: {
     sources: options?.sources,
     refs,
     trace: config.trace,
+    prefixes: config.prefixes,
   });
 
   return {

--- a/packages/cli/pragma/src/domains/shared/semanticPackage.ts
+++ b/packages/cli/pragma/src/domains/shared/semanticPackage.ts
@@ -25,6 +25,13 @@ export interface GraphContent {
 }
 
 /** A discovered skill directory with its filesystem path. */
+export interface StoryFileEntry {
+  /** Absolute path of the story JSON file. */
+  readonly path: string;
+  /** The file's parsed JSON — validated by the story-pack compiler. */
+  readonly definition: unknown;
+}
+
 export interface SkillEntry {
   /** Absolute path to the skill directory (must exist on disk for symlinking). */
   readonly dir: string;
@@ -44,6 +51,11 @@ export interface SemanticPackage {
   readonly graphs: GraphContent[];
   /** Skills available in this package. */
   readonly skills: SkillEntry[];
+  /**
+   * Raw story-pack files shipped by this package (`stories/*.json`).
+   * Parsed JSON, validated at compile time so one bad file cannot break boot.
+   */
+  readonly stories: StoryFileEntry[];
 }
 
 /**

--- a/packages/cli/pragma/src/domains/shared/stories/pack/buildLookupQuery.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/buildLookupQuery.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import buildLookupQuery, {
+  buildLookupNamesQuery,
+  escapeSparqlString,
+  formatTerm,
+} from "./buildLookupQuery.js";
+
+describe("escapeSparqlString", () => {
+  it("escapes quotes, backslashes, and newlines", () => {
+    expect(escapeSparqlString('a"b\\c\nd')).toBe('a\\"b\\\\c\\nd');
+  });
+});
+
+describe("formatTerm", () => {
+  it("keeps prefixed names and wraps absolute IRIs", () => {
+    expect(formatTerm("ex:Recipe")).toBe("ex:Recipe");
+    expect(formatTerm("http://example.org/x")).toBe("<http://example.org/x>");
+  });
+});
+
+describe("buildLookupQuery", () => {
+  it("generates a typed, escaped, case-insensitive match", () => {
+    const query = buildLookupQuery(
+      {
+        by: "ex:name",
+        type: "ex:Recipe",
+        fields: [{ name: "category", property: "ex:category" }],
+      },
+      'Pan"cakes',
+    );
+    expect(query).toContain("?uri ex:name ?name .");
+    expect(query).toContain("?uri a ex:Recipe .");
+    expect(query).toContain("OPTIONAL { ?uri ex:category ?category . }");
+    expect(query).toContain('LCASE("Pan\\"cakes")');
+    expect(query).toContain("LIMIT 1");
+  });
+
+  it("omits the type constraint when absent", () => {
+    const query = buildLookupQuery({ by: "ex:name" }, "x");
+    expect(query).not.toContain("?uri a ");
+  });
+});
+
+describe("buildLookupNamesQuery", () => {
+  it("selects all names for the by property", () => {
+    const query = buildLookupNamesQuery({ by: "ex:name", type: "ex:Recipe" });
+    expect(query).toContain("SELECT ?name WHERE {");
+    expect(query).toContain("?uri ex:name ?name .");
+    expect(query).toContain("?uri a ex:Recipe .");
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/buildLookupQuery.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/buildLookupQuery.ts
@@ -1,0 +1,80 @@
+import type { StoryPackLookup } from "./types.js";
+
+/**
+ * Build the generated, injection-safe lookup queries for a pack story.
+ *
+ * Pack authors declare *what* names an entity (`by`, optional `type`) and
+ * which properties to read; the query text is generated here so
+ * user-supplied names are always escaped SPARQL string literals — a pack
+ * definition never interpolates user input itself. Matching is exact and
+ * case-insensitive on the `by` property's string value.
+ */
+
+/** Escape a user-supplied value as a SPARQL string literal body. */
+export function escapeSparqlString(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\n", "\\n")
+    .replaceAll("\r", "\\r");
+}
+
+/** Render a validated term (prefixed name or absolute IRI) as a query token. */
+export function formatTerm(term: string): string {
+  return term.includes("://") ? `<${term}>` : term;
+}
+
+/**
+ * Build the SELECT retrieving one named entity with its declared fields.
+ *
+ * @param lookup - The pack's lookup declaration.
+ * @param name - User-supplied entity name (escaped here).
+ * @returns SPARQL SELECT text.
+ */
+export default function buildLookupQuery(
+  lookup: StoryPackLookup,
+  name: string,
+): string {
+  const fields = [...(lookup.fields ?? []), ...(lookup.sections ?? [])];
+  const vars = fields.map((field) => `?${field.name}`).join(" ");
+  const optionals = fields
+    .map(
+      (field) =>
+        `  OPTIONAL { ?uri ${formatTerm(field.property)} ?${field.name} . }`,
+    )
+    .join("\n");
+  const typeConstraint = lookup.type
+    ? `  ?uri a ${formatTerm(lookup.type)} .\n`
+    : "";
+
+  return [
+    `SELECT ?uri ?name${vars.length > 0 ? ` ${vars}` : ""} WHERE {`,
+    `  ?uri ${formatTerm(lookup.by)} ?name .`,
+    typeConstraint + optionals,
+    `  FILTER (LCASE(STR(?name)) = LCASE("${escapeSparqlString(name)}"))`,
+    "}",
+    "LIMIT 1",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+/**
+ * Build the SELECT listing all entity names — lookup-miss suggestions.
+ *
+ * @param lookup - The pack's lookup declaration.
+ * @returns SPARQL SELECT text yielding a `?name` per entity.
+ */
+export function buildLookupNamesQuery(lookup: StoryPackLookup): string {
+  const typeConstraint = lookup.type
+    ? `  ?uri a ${formatTerm(lookup.type)} .\n`
+    : "";
+  return [
+    "SELECT ?name WHERE {",
+    `  ?uri ${formatTerm(lookup.by)} ?name .`,
+    typeConstraint.trimEnd(),
+    "}",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
@@ -45,7 +45,7 @@ describe("collectPackStories", () => {
       "recipe",
       "other",
     ]);
-    expect(entries.at(0)?.source).toBe("pragma.config.json");
+    expect(entries.at(0)?.source).toBe("config");
     expect(entries.at(1)?.source).toBe("/pkg/stories/other.json");
   });
 
@@ -60,7 +60,7 @@ describe("collectPackStories", () => {
       new Set(),
     );
     expect(entries).toHaveLength(1);
-    expect(entries.at(0)?.source).toBe("pragma.config.json");
+    expect(entries.at(0)?.source).toBe("config");
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("already taken"));
   });
 

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PragmaError } from "#error";
+import { RECIPE_STORY } from "#testing";
+import type { SemanticPackage } from "../../semanticPackage.js";
+import collectPackStories from "./collectPackStories.js";
+
+function makePackage(stories: SemanticPackage["stories"]): SemanticPackage {
+  return {
+    name: "@canonical/example",
+    version: "1.0.0",
+    source: "local",
+    graphs: [],
+    skills: [],
+    stories,
+  };
+}
+
+const CONFIG = { tier: undefined, channel: "normal" as const };
+
+describe("collectPackStories", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("collects config stories and validated package stories", () => {
+    const entries = collectPackStories(
+      { ...CONFIG, stories: [RECIPE_STORY] },
+      [
+        makePackage([
+          {
+            path: "/pkg/stories/other.json",
+            definition: { ...RECIPE_STORY, noun: "other" },
+          },
+        ]),
+      ],
+      new Set(["block"]),
+    );
+    expect(entries.map((entry) => entry.definition.noun)).toEqual([
+      "recipe",
+      "other",
+    ]);
+    expect(entries.at(0)?.source).toBe("pragma.config.json");
+    expect(entries.at(1)?.source).toBe("/pkg/stories/other.json");
+  });
+
+  it("lets config stories win noun collisions against packages", () => {
+    const entries = collectPackStories(
+      { ...CONFIG, stories: [RECIPE_STORY] },
+      [
+        makePackage([
+          { path: "/pkg/stories/recipe.json", definition: RECIPE_STORY },
+        ]),
+      ],
+      new Set(),
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries.at(0)?.source).toBe("pragma.config.json");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("already taken"));
+  });
+
+  it("skips invalid package stories with a warning", () => {
+    const entries = collectPackStories(
+      CONFIG,
+      [
+        makePackage([
+          { path: "/pkg/stories/broken.json", definition: { nope: true } },
+        ]),
+      ],
+      new Set(),
+    );
+    expect(entries).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("skipping story"),
+    );
+  });
+
+  it("throws when a config story shadows a built-in noun", () => {
+    expect(() =>
+      collectPackStories(
+        { ...CONFIG, stories: [{ ...RECIPE_STORY, noun: "block" }] },
+        [],
+        new Set(["block"]),
+      ),
+    ).toThrow(PragmaError);
+  });
+
+  it("skips package stories that shadow built-in nouns", () => {
+    const entries = collectPackStories(
+      CONFIG,
+      [
+        makePackage([
+          {
+            path: "/pkg/stories/block.json",
+            definition: { ...RECIPE_STORY, noun: "block" },
+          },
+        ]),
+      ],
+      new Set(["block"]),
+    );
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.ts
@@ -1,0 +1,76 @@
+import type { PragmaConfig } from "#config";
+import { PragmaError } from "#error";
+import type { SemanticPackage } from "../../semanticPackage.js";
+import type { StoryPackDefinition } from "./types.js";
+import validateStoryPackDefinition from "./validateStoryPackDefinition.js";
+
+/** A validated story definition paired with where it was declared. */
+export interface PackStoryEntry {
+  readonly definition: StoryPackDefinition;
+  readonly source: string;
+}
+
+/**
+ * Gather the story-pack definitions active for a runtime.
+ *
+ * Config-declared stories come first (already validated by the config
+ * parser) and win noun collisions against package-shipped ones — the
+ * config is the user's override layer. Package story files are validated
+ * here; an invalid or colliding package story is skipped with a warning
+ * so one bad file cannot break boot. A config story colliding with a
+ * reserved (built-in) noun is a hard config error.
+ *
+ * @param config - The effective merged configuration.
+ * @param packages - Resolved semantic packages (may ship `stories/*.json`).
+ * @param reservedNouns - Built-in nouns story packs must not shadow.
+ * @returns Validated, collision-free story entries.
+ * @throws PragmaError with code `CONFIG_ERROR` when a config story shadows
+ *   a reserved noun.
+ * @note Impure — warns on stderr for skipped package stories.
+ */
+export default function collectPackStories(
+  config: PragmaConfig,
+  packages: readonly SemanticPackage[],
+  reservedNouns: ReadonlySet<string>,
+): PackStoryEntry[] {
+  const entries: PackStoryEntry[] = [];
+  const taken = new Set<string>();
+
+  for (const definition of config.stories ?? []) {
+    if (reservedNouns.has(definition.noun)) {
+      throw PragmaError.configError(
+        `Story noun "${definition.noun}" shadows a built-in command.`,
+      );
+    }
+    if (taken.has(definition.noun)) {
+      throw PragmaError.configError(
+        `Duplicate story noun "${definition.noun}" in config.`,
+      );
+    }
+    taken.add(definition.noun);
+    entries.push({ definition, source: "pragma.config.json" });
+  }
+
+  for (const pkg of packages) {
+    for (const file of pkg.stories) {
+      let definition: StoryPackDefinition;
+      try {
+        definition = validateStoryPackDefinition(file.definition, file.path);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        process.stderr.write(`Warning: skipping story — ${reason}\n`);
+        continue;
+      }
+      if (reservedNouns.has(definition.noun) || taken.has(definition.noun)) {
+        process.stderr.write(
+          `Warning: skipping story "${definition.noun}" from ${file.path} — the noun is already taken.\n`,
+        );
+        continue;
+      }
+      taken.add(definition.noun);
+      entries.push({ definition, source: file.path });
+    }
+  }
+
+  return entries;
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.ts
@@ -48,7 +48,7 @@ export default function collectPackStories(
       );
     }
     taken.add(definition.noun);
-    entries.push({ definition, source: "pragma.config.json" });
+    entries.push({ definition, source: "config" });
   }
 
   for (const pkg of packages) {

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackCommands.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackCommands.ts
@@ -1,0 +1,40 @@
+import type { CommandDefinition } from "@canonical/cli-core";
+import type { PragmaContext } from "../../context.js";
+import { PREFIX_MAP } from "../../prefixes.js";
+import compileLookupCommand from "../compileLookupCommand.js";
+import compileReadCommand from "../compileReadCommand.js";
+import collectPackStories from "./collectPackStories.js";
+import compilePackStories from "./compilePackStories.js";
+
+/**
+ * Compile every active story pack into CLI command definitions.
+ *
+ * Story packs come from the merged config (`stories`) and from resolved
+ * semantic packages (`stories/*.json`); each yields `<noun> list` and,
+ * when declared, `<noun> lookup` — projected through the same kernel as
+ * the built-in read stories, so completions and help come for free.
+ *
+ * @param ctx - Pragma context carrying config, packages, and the store.
+ * @param reservedNouns - Built-in nouns packs must not shadow.
+ * @returns Command definitions for every pack story.
+ */
+export default function compilePackCommands(
+  ctx: PragmaContext,
+  reservedNouns: ReadonlySet<string>,
+): CommandDefinition[] {
+  const prefixes = { ...PREFIX_MAP, ...ctx.config.prefixes };
+  const entries = collectPackStories(ctx.config, ctx.packages, reservedNouns);
+
+  return entries.flatMap((entry) => {
+    const compiled = compilePackStories(
+      entry.definition,
+      entry.source,
+      prefixes,
+    );
+    const commands = [compileReadCommand(ctx, compiled.list)];
+    if (compiled.lookup) {
+      commands.push(compileLookupCommand(ctx, compiled.lookup));
+    }
+    return commands;
+  });
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.test.ts
@@ -1,0 +1,111 @@
+import type { Store } from "@canonical/ke";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PragmaError } from "#error";
+import {
+  createTestStore,
+  RECIPE_PREFIXES,
+  RECIPE_STORY,
+  RECIPE_TTL,
+} from "#testing";
+import { PREFIX_MAP } from "../../prefixes.js";
+import type { PragmaRuntime } from "../../types/index.js";
+import compilePackStories from "./compilePackStories.js";
+
+const PREFIXES = { ...PREFIX_MAP, ...RECIPE_PREFIXES };
+
+let store: Store;
+let cleanup: () => void;
+let rt: PragmaRuntime;
+
+beforeAll(async () => {
+  const result = await createTestStore({
+    ttl: RECIPE_TTL,
+    prefixes: RECIPE_PREFIXES,
+  });
+  store = result.store;
+  cleanup = result.cleanup;
+  rt = { store } as PragmaRuntime;
+});
+
+afterAll(() => cleanup());
+
+describe("compilePackStories — list", () => {
+  it("resolves the pack's preferred query into rows", async () => {
+    const { list } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const rows = await list.resolve(rt, {});
+    expect(rows.map((row) => row.name)).toEqual(["Gazpacho", "Pancakes"]);
+    expect(list.toEnvelope(rows)).toEqual({
+      data: rows,
+      meta: { count: 2 },
+    });
+  });
+
+  it("renders the generic formatters with compacted prefixes", async () => {
+    const { list } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const rows = await list.resolve(rt, {});
+    const plain = list.formatters.plain(rows);
+    expect(plain).toContain("Pancakes");
+    expect(plain).toContain("breakfast");
+    const llm = list.formatters.llm(rows);
+    expect(llm).toContain("## Recipe (2)");
+    expect(llm).toContain("`ex:gazpacho`");
+    expect(JSON.parse(list.formatters.json(rows))).toHaveLength(2);
+  });
+});
+
+describe("compilePackStories — lookup", () => {
+  it("looks an entity up by name, case-insensitively", async () => {
+    const { lookup } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const result = await lookup?.resolve(rt, ["pancakes"], {});
+    expect(result?.results).toHaveLength(1);
+    const entity = result?.results.at(0);
+    expect(entity?.name).toBe("Pancakes");
+    expect(entity?.category).toBe("breakfast");
+    expect(entity?.instructions).toBe("Mix, fry, flip.");
+  });
+
+  it("renders fields and sections through the generic lookup renderer", async () => {
+    const { lookup } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const result = await lookup?.resolve(rt, ["Gazpacho"], {});
+    const entity = result?.results.at(0);
+    expect(entity).toBeDefined();
+    if (!entity || !lookup) throw new Error("expected entity");
+    const llm = lookup.formatters.llm(
+      lookup.toFmtInput(entity, {
+        surface: "cli",
+        detailed: false,
+        params: {},
+      }),
+    );
+    expect(llm).toContain("Gazpacho");
+    expect(llm).toContain("soup");
+    expect(llm).toContain("Blend everything cold.");
+  });
+
+  it("collects not-found errors with ranked suggestions", async () => {
+    const { lookup } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const result = await lookup?.resolve(rt, ["Pancake"], {});
+    expect(result?.results).toHaveLength(0);
+    const error = result?.errors.at(0);
+    expect(error?.code).toBe("ENTITY_NOT_FOUND");
+    expect(error?.suggestions).toContain("Pancakes");
+  });
+
+  it("rejects empty names with a recovery hint", () => {
+    const { lookup } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    expect(() => {
+      const error = lookup?.emptyNamesError?.();
+      if (error) throw error;
+    }).toThrow(PragmaError);
+  });
+
+  it("completes names from the store", async () => {
+    const { lookup } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const ctx = {
+      cwd: "/tmp",
+      globalFlags: { llm: false, format: "text" as const, verbose: false },
+      store,
+    };
+    await expect(lookup?.complete?.("pan", ctx)).resolves.toEqual(["Pancakes"]);
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.ts
@@ -1,0 +1,203 @@
+import type { Store } from "@canonical/ke";
+import { PragmaError } from "#error";
+import type {
+  ColumnDef,
+  LookupField,
+  RenderListOptions,
+  RenderLookupOptions,
+  SectionDef,
+} from "../../contracts.js";
+import type { Formatters } from "../../formatters.js";
+import lookupMany from "../../lookupMany.js";
+import {
+  renderListLlm,
+  renderListPlain,
+  renderLookupLlm,
+  renderLookupPlain,
+} from "../../renderers.js";
+import { suggestNames } from "../../suggestions/index.js";
+import requirePragmaContext from "../requirePragmaContext.js";
+import type { LookupStory, ReadStory } from "../types.js";
+import buildLookupQuery, { buildLookupNamesQuery } from "./buildLookupQuery.js";
+import runSelectQuery from "./runSelectQuery.js";
+import type { StoryPackDefinition, StoryPackLookup } from "./types.js";
+
+/** A pack entity/row: SELECT variable name → string value. */
+type PackRow = Record<string, string>;
+
+/** The read stories a pack definition compiles to. */
+export interface CompiledPackStories {
+  readonly list: ReadStory<PackRow[], PackRow[]>;
+  readonly lookup?: LookupStory<PackRow, PackRow>;
+}
+
+/**
+ * Compile one validated story-pack definition into kernel read stories.
+ *
+ * The list story runs the pack's preferred SELECT verbatim; the lookup
+ * story runs the generated, injection-safe per-name query. Both render
+ * through the shared generic renderers with the runtime's merged prefix
+ * map, so foreign namespaces display compacted.
+ *
+ * @param definition - A validated pack definition.
+ * @param source - Where the definition came from, for diagnostics.
+ * @param prefixes - The merged prefix map used for display.
+ * @returns The compiled list story and, when declared, the lookup story.
+ */
+export default function compilePackStories(
+  definition: StoryPackDefinition,
+  source: string,
+  prefixes: Readonly<Record<string, string>>,
+): CompiledPackStories {
+  const { noun } = definition;
+  const heading = capitalize(noun);
+  const description = definition.description ?? `List ${noun} entries`;
+
+  const listColumns: ColumnDef<PackRow>[] = definition.list.columns.map(
+    (column) => ({
+      key: column.field,
+      label: column.label ?? column.field,
+    }),
+  );
+  const listOptions: RenderListOptions<PackRow> = {
+    heading,
+    columns: listColumns,
+    prefixes,
+  };
+  const listFormatters: Formatters<PackRow[]> = {
+    plain: (rows) => renderListPlain(rows, listOptions),
+    llm: (rows) => renderListLlm(rows, listOptions),
+    json: (rows) => JSON.stringify(rows, null, 2),
+  };
+
+  const list: ReadStory<PackRow[], PackRow[]> = {
+    noun,
+    verb: "list",
+    description,
+    toolDescription:
+      definition.toolDescription ?? `${description} (story pack: ${source}).`,
+    params: [],
+    examples: [`pragma ${noun} list`, `pragma ${noun} list --llm`],
+    resolve: (rt) => runSelectQuery(rt.store, definition.list.query, source),
+    toOutput: (rows) => rows,
+    formatters: listFormatters,
+    toEnvelope: (rows) => ({ data: rows, meta: { count: rows.length } }),
+  };
+
+  const lookup = definition.lookup
+    ? compileLookup(definition.lookup, noun, source, prefixes)
+    : undefined;
+
+  return { list, ...(lookup ? { lookup } : {}) };
+}
+
+function compileLookup(
+  lookup: StoryPackLookup,
+  noun: string,
+  source: string,
+  prefixes: Readonly<Record<string, string>>,
+): LookupStory<PackRow, PackRow> {
+  const fields: LookupField<PackRow>[] = (lookup.fields ?? []).map((field) => ({
+    label: field.label ?? field.name,
+    value: (entity) => entity[field.name],
+  }));
+  const sections: SectionDef<PackRow>[] = (lookup.sections ?? []).map(
+    (section) => ({
+      key: section.name,
+      heading: section.label ?? section.name,
+      kind: section.kind ?? "field",
+    }),
+  );
+  const lookupOptions: RenderLookupOptions<PackRow> = {
+    title: (entity) => entity.name ?? entity.uri ?? "(unnamed)",
+    fields,
+    sections,
+    prefixes,
+  };
+  const lookupFormatters: Formatters<PackRow> = {
+    plain: (entity) => renderLookupPlain(entity, lookupOptions),
+    llm: (entity) => renderLookupLlm(entity, lookupOptions),
+    json: (entity) => JSON.stringify(entity, null, 2),
+  };
+
+  return {
+    noun,
+    description: `Look up ${noun} details by name`,
+    toolDescription: `Get details for one or more ${noun} entries by name (story pack: ${source}).`,
+    namesDescription: `${capitalize(noun)} names`,
+    complete: async (partial, cmdCtx) => {
+      const ctx = requirePragmaContext(cmdCtx);
+      const names = await listEntityNames(ctx.store, lookup, source);
+      return names.filter((name) =>
+        name.toLowerCase().startsWith(partial.toLowerCase()),
+      );
+    },
+    examples: [`pragma ${noun} lookup <name>`],
+    resolve: (rt, names) =>
+      lookupMany(names, (query) =>
+        lookupPackEntity(rt.store, lookup, noun, query, source),
+      ),
+    toFmtInput: (entity) => entity,
+    formatters: lookupFormatters,
+    emptyNamesError: () =>
+      PragmaError.invalidInput("names", "(empty)", {
+        recovery: {
+          message: `List available ${noun} entries.`,
+          cli: `pragma ${noun} list`,
+          mcp: { tool: `${noun}_list` },
+        },
+      }),
+  };
+}
+
+/**
+ * Look up one pack entity by name via the generated query.
+ *
+ * @throws PragmaError with code `ENTITY_NOT_FOUND` and ranked suggestions
+ *   when no entity matches.
+ * @note Impure — queries the ke store.
+ */
+async function lookupPackEntity(
+  store: Store,
+  lookup: StoryPackLookup,
+  noun: string,
+  query: string,
+  source: string,
+): Promise<PackRow> {
+  const rows = await runSelectQuery(
+    store,
+    buildLookupQuery(lookup, query),
+    source,
+  );
+  const entity = rows.at(0);
+  if (entity) {
+    return entity;
+  }
+
+  const candidates = await listEntityNames(store, lookup, source);
+  throw PragmaError.notFound(noun, query, {
+    suggestions: suggestNames(query, candidates),
+    recovery: {
+      message: `List available ${noun} entries.`,
+      cli: `pragma ${noun} list`,
+      mcp: { tool: `${noun}_list` },
+    },
+  });
+}
+
+async function listEntityNames(
+  store: Store,
+  lookup: StoryPackLookup,
+  source: string,
+): Promise<string[]> {
+  const rows = await runSelectQuery(
+    store,
+    buildLookupNamesQuery(lookup),
+    source,
+  );
+  return rows.map((row) => row.name ?? "").filter((name) => name !== "");
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackToolSpecs.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackToolSpecs.ts
@@ -1,0 +1,43 @@
+import { PREFIX_MAP } from "../../prefixes.js";
+import type { ToolSpec } from "../../ToolSpec.js";
+import type { PragmaRuntime } from "../../types/index.js";
+import compileLookupTool from "../compileLookupTool.js";
+import compileReadTool from "../compileReadTool.js";
+import collectPackStories from "./collectPackStories.js";
+import compilePackStories from "./compilePackStories.js";
+
+/**
+ * Compile every active story pack into MCP tool specs.
+ *
+ * Mirrors `compilePackCommands` on the MCP surface: each pack yields
+ * `<noun>_list` and, when declared, `<noun>_lookup`, registered alongside
+ * the built-in tools.
+ *
+ * @param runtime - Pragma runtime carrying config, packages, and the store.
+ * @param reservedNouns - Built-in nouns packs must not shadow.
+ * @returns Tool specs for every pack story.
+ */
+export default function compilePackToolSpecs(
+  runtime: PragmaRuntime,
+  reservedNouns: ReadonlySet<string>,
+): ToolSpec[] {
+  const prefixes = { ...PREFIX_MAP, ...runtime.config.prefixes };
+  const entries = collectPackStories(
+    runtime.config,
+    runtime.packages,
+    reservedNouns,
+  );
+
+  return entries.flatMap((entry) => {
+    const compiled = compilePackStories(
+      entry.definition,
+      entry.source,
+      prefixes,
+    );
+    const specs = [compileReadTool(compiled.list)];
+    if (compiled.lookup) {
+      specs.push(compileLookupTool(compiled.lookup));
+    }
+    return specs;
+  });
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/index.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Story packs — declarative read stories compiled through the kernel.
+ * @module
+ */
+
+export {
+  buildLookupNamesQuery,
+  default as buildLookupQuery,
+  escapeSparqlString,
+  formatTerm,
+} from "./buildLookupQuery.js";
+export type { PackStoryEntry } from "./collectPackStories.js";
+export { default as collectPackStories } from "./collectPackStories.js";
+export { default as compilePackCommands } from "./compilePackCommands.js";
+export type { CompiledPackStories } from "./compilePackStories.js";
+export { default as compilePackStories } from "./compilePackStories.js";
+export { default as compilePackToolSpecs } from "./compilePackToolSpecs.js";
+export { default as runSelectQuery } from "./runSelectQuery.js";
+export type {
+  StoryPackColumn,
+  StoryPackDefinition,
+  StoryPackField,
+  StoryPackList,
+  StoryPackLookup,
+  StoryPackSection,
+  StoryPackSource,
+} from "./types.js";
+export { default as validateStoryPackDefinition } from "./validateStoryPackDefinition.js";

--- a/packages/cli/pragma/src/domains/shared/stories/pack/runSelectQuery.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/runSelectQuery.ts
@@ -1,0 +1,31 @@
+import type { Store } from "@canonical/ke";
+import { PragmaError } from "#error";
+import { buildQuery } from "../../buildQuery.js";
+
+/**
+ * Run a pack story's SELECT and return its binding rows.
+ *
+ * The store rejects non-read queries at the engine level; this guards the
+ * result shape so a pack whose query is not a SELECT fails with a
+ * recoverable config error instead of a shape mismatch downstream.
+ *
+ * @param store - The ke store to query.
+ * @param query - SPARQL SELECT text (the store injects PREFIX declarations).
+ * @param source - The pack source, for error attribution.
+ * @returns One record per row, keyed by SELECT variable name.
+ * @throws PragmaError with code `CONFIG_ERROR` when the query is not a SELECT.
+ * @note Impure — queries the ke store.
+ */
+export default async function runSelectQuery(
+  store: Store,
+  query: string,
+  source: string,
+): Promise<Record<string, string>[]> {
+  const result = await store.query(buildQuery(query));
+  if (result.type !== "select") {
+    throw PragmaError.configError(
+      `Story query in ${source} must be a SELECT (got ${result.type}).`,
+    );
+  }
+  return result.bindings;
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/types.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/types.ts
@@ -1,0 +1,80 @@
+/**
+ * Declarative story-pack definitions — read stories as data.
+ *
+ * A story pack maps a noun to preferred queries: a SPARQL SELECT for the
+ * list story and a generated, injection-safe lookup. Definitions are
+ * declared in `pragma.config.json` (`stories`) or shipped by semantic
+ * packages (`stories/*.json`) and compiled through the read-story kernel
+ * into CLI commands and MCP tools at boot.
+ *
+ * @experimental The story-pack format (v0) is experimental: field names,
+ * lookup generation, and rendering semantics may change while GraphQL
+ * document queries and SHACL-derived defaults are designed.
+ */
+
+/** A list column: a SELECT variable to display. */
+export interface StoryPackColumn {
+  /** SELECT variable name (without `?`). */
+  readonly field: string;
+  /** Column heading (defaults to the field name). */
+  readonly label?: string;
+}
+
+/** A looked-up value: an output name bound to a property of the entity. */
+export interface StoryPackField {
+  /** Output field name on the looked-up entity. */
+  readonly name: string;
+  /** Property to read — a prefixed name (`ex:category`) or absolute IRI. */
+  readonly property: string;
+  /** Display label (defaults to the field name). */
+  readonly label?: string;
+}
+
+/** A long-form lookup section. */
+export interface StoryPackSection extends StoryPackField {
+  /** Rendering kind (v0 supports inline fields and code blocks). */
+  readonly kind?: "field" | "code";
+}
+
+/** The list half of a story pack. */
+export interface StoryPackList {
+  /** SPARQL SELECT producing one row per item. */
+  readonly query: string;
+  /** Columns to render, referencing SELECT variables. */
+  readonly columns: readonly StoryPackColumn[];
+}
+
+/**
+ * The lookup half of a story pack. The query is generated from `type` and
+ * `by` — user-supplied names are escaped by the generator, never
+ * interpolated by the author.
+ */
+export interface StoryPackLookup {
+  /** Property whose value names the entity — prefixed name or IRI. */
+  readonly by: string;
+  /** Optional class constraint — prefixed name or IRI. */
+  readonly type?: string;
+  /** Inline fields shown under the entity title. */
+  readonly fields?: readonly StoryPackField[];
+  /** Long-form sections shown after the fields. */
+  readonly sections?: readonly StoryPackSection[];
+}
+
+/** One declarative read story: a noun with its preferred queries. */
+export interface StoryPackDefinition {
+  /** Command noun (kebab-case), e.g. `"recipe"` → `pragma recipe list`. */
+  readonly noun: string;
+  /** CLI description for the list command. */
+  readonly description?: string;
+  /** MCP tool description (defaults to the CLI description). */
+  readonly toolDescription?: string;
+  readonly list: StoryPackList;
+  readonly lookup?: StoryPackLookup;
+}
+
+/** A story definition with the source it came from, for diagnostics. */
+export interface StoryPackSource {
+  /** Where the definition was declared (config path or package file). */
+  readonly source: string;
+  readonly definition: StoryPackDefinition;
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { PragmaError } from "#error";
+import { RECIPE_STORY } from "#testing";
+import validateStoryPackDefinition from "./validateStoryPackDefinition.js";
+
+describe("validateStoryPackDefinition", () => {
+  it("accepts a valid definition and round-trips it", () => {
+    const validated = validateStoryPackDefinition(
+      JSON.parse(JSON.stringify(RECIPE_STORY)),
+      "test",
+    );
+    expect(validated).toEqual(RECIPE_STORY);
+  });
+
+  it("rejects a non-kebab noun", () => {
+    expect(() =>
+      validateStoryPackDefinition({ ...RECIPE_STORY, noun: "Recipe" }, "test"),
+    ).toThrow(PragmaError);
+  });
+
+  it("rejects a list without a SELECT query", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        {
+          ...RECIPE_STORY,
+          list: { ...RECIPE_STORY.list, query: "DELETE WHERE { ?s ?p ?o }" },
+        },
+        "test",
+      ),
+    ).toThrow(/SELECT/);
+  });
+
+  it("rejects empty columns", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        { ...RECIPE_STORY, list: { ...RECIPE_STORY.list, columns: [] } },
+        "test",
+      ),
+    ).toThrow(/columns/);
+  });
+
+  it("rejects a lookup term that is neither prefixed nor an IRI", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        {
+          ...RECIPE_STORY,
+          lookup: { by: "just a name" },
+        },
+        "test",
+      ),
+    ).toThrow(/prefixed name/);
+  });
+
+  it("rejects an unknown section kind", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        {
+          ...RECIPE_STORY,
+          lookup: {
+            by: "ex:name",
+            sections: [{ name: "x", property: "ex:x", kind: "table" }],
+          },
+        },
+        "test",
+      ),
+    ).toThrow(/kind/);
+  });
+
+  it("names the source in errors", () => {
+    try {
+      validateStoryPackDefinition({}, "/pkg/stories/broken.json");
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PragmaError);
+      expect((error as PragmaError).message).toContain(
+        "/pkg/stories/broken.json",
+      );
+    }
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.test.ts
@@ -78,3 +78,63 @@ describe("validateStoryPackDefinition", () => {
     }
   });
 });
+
+describe("validateStoryPackDefinition — term and query hardening", () => {
+  function withLookup(lookup: Record<string, unknown>): unknown {
+    const base = JSON.parse(JSON.stringify(RECIPE_STORY)) as Record<
+      string,
+      unknown
+    >;
+    return { ...base, lookup: { ...(base.lookup as object), ...lookup } };
+  }
+
+  it("rejects a slashed prefixed name in class position", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withLookup({ type: "ex:Recipe/Sub" }),
+        "test",
+      ),
+    ).toThrow(/must be a prefixed name/);
+  });
+
+  it("accepts a property path in predicate position", () => {
+    const validated = validateStoryPackDefinition(
+      withLookup({ by: "ex:hasName/ex:value" }),
+      "test",
+    );
+    expect(validated.lookup?.by).toBe("ex:hasName/ex:value");
+  });
+
+  it("rejects a property path with a malformed segment", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withLookup({ by: "ex:hasName/not a name" }),
+        "test",
+      ),
+    ).toThrow(/property path segment/);
+  });
+
+  it("rejects an IRI that cannot embed in SPARQL", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withLookup({ type: "https://example.org/a b>c" }),
+        "test",
+      ),
+    ).toThrow(/not a valid IRI/);
+  });
+
+  it("rejects a PREFIX-led non-SELECT list query", () => {
+    const base = JSON.parse(JSON.stringify(RECIPE_STORY)) as Record<
+      string,
+      unknown
+    >;
+    const list = {
+      ...(base.list as Record<string, unknown>),
+      query:
+        "PREFIX ex: <http://example.org/> CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+    };
+    expect(() =>
+      validateStoryPackDefinition({ ...base, list }, "test"),
+    ).toThrow(/must be a SPARQL SELECT/);
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.ts
@@ -10,7 +10,10 @@ import type {
 const NOUN_PATTERN = /^[a-z][a-z0-9-]*$/;
 const FIELD_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 /** A prefixed name (`ex:Recipe`) — prefix + local part, no path slashes. */
-const PREFIXED_NAME_PATTERN = /^[A-Za-z][\w-]*:[^/<>"\s][^<>"\s]*$/;
+const PREFIXED_NAME_PATTERN = /^[A-Za-z][\w-]*:[^/<>"\s]+$/;
+
+/** An absolute IRI that can be safely embedded as `<iri>` in SPARQL. */
+const EMBEDDABLE_IRI_PATTERN = /^[A-Za-z][\w+.-]*:\/\/[^<>"\s]+$/;
 
 /**
  * Validate one raw story-pack definition.
@@ -31,7 +34,10 @@ export default function validateStoryPackDefinition(
 
   const noun = requireString(obj.noun, "noun", source);
   if (!NOUN_PATTERN.test(noun)) {
-    throw invalid(source, `"noun" must be kebab-case, got "${noun}".`);
+    throw buildStoryConfigError(
+      source,
+      `"noun" must be kebab-case, got "${noun}".`,
+    );
   }
 
   const description =
@@ -62,12 +68,24 @@ function validateList(
 ): StoryPackDefinition["list"] {
   const obj = requireObject(raw, "list", source);
   const query = requireString(obj.query, "list.query", source);
-  if (!/^\s*(PREFIX\s|SELECT\s)/i.test(query)) {
-    throw invalid(source, '"list.query" must be a SPARQL SELECT query.');
+  // Strip leading PREFIX declarations so the real query verb is checked —
+  // "PREFIX ex: <…> CONSTRUCT {…}" must fail here, not at first use.
+  const afterPrefixes = query.replace(
+    /^(\s*PREFIX\s+[A-Za-z][\w-]*:\s*<[^>]*>)+/i,
+    "",
+  );
+  if (!/^\s*SELECT\s/i.test(afterPrefixes)) {
+    throw buildStoryConfigError(
+      source,
+      '"list.query" must be a SPARQL SELECT query.',
+    );
   }
 
   if (!Array.isArray(obj.columns) || obj.columns.length === 0) {
-    throw invalid(source, '"list.columns" must be a non-empty array.');
+    throw buildStoryConfigError(
+      source,
+      '"list.columns" must be a non-empty array.',
+    );
   }
   const columns = obj.columns.map((column, index) =>
     validateColumn(column, `list.columns[${index}]`, source),
@@ -84,7 +102,10 @@ function validateColumn(
   const obj = requireObject(raw, where, source);
   const field = requireString(obj.field, `${where}.field`, source);
   if (!FIELD_PATTERN.test(field)) {
-    throw invalid(source, `"${where}.field" must name a SELECT variable.`);
+    throw buildStoryConfigError(
+      source,
+      `"${where}.field" must name a SELECT variable.`,
+    );
   }
   const label =
     obj.label === undefined
@@ -95,7 +116,7 @@ function validateColumn(
 
 function validateLookup(raw: unknown, source: string): StoryPackLookup {
   const obj = requireObject(raw, "lookup", source);
-  const by = requireTerm(obj.by, "lookup.by", source);
+  const by = requirePredicateTerm(obj.by, "lookup.by", source);
   const type =
     obj.type === undefined
       ? undefined
@@ -123,7 +144,7 @@ function validateFieldArray(
 ): readonly StoryPackField[] | undefined {
   if (raw === undefined) return undefined;
   if (!Array.isArray(raw)) {
-    throw invalid(source, `"${where}" must be an array.`);
+    throw buildStoryConfigError(source, `"${where}" must be an array.`);
   }
   return raw.map((entry, index) =>
     validateField(entry, `${where}[${index}]`, source),
@@ -137,13 +158,13 @@ function validateSectionArray(
 ): readonly StoryPackSection[] | undefined {
   if (raw === undefined) return undefined;
   if (!Array.isArray(raw)) {
-    throw invalid(source, `"${where}" must be an array.`);
+    throw buildStoryConfigError(source, `"${where}" must be an array.`);
   }
   return raw.map((entry, index) => {
     const base = validateField(entry, `${where}[${index}]`, source);
     const obj = entry as Record<string, unknown>;
     if (obj.kind !== undefined && obj.kind !== "field" && obj.kind !== "code") {
-      throw invalid(
+      throw buildStoryConfigError(
         source,
         `"${where}[${index}].kind" must be "field" or "code".`,
       );
@@ -163,9 +184,16 @@ function validateField(
   const obj = requireObject(raw, where, source);
   const name = requireString(obj.name, `${where}.name`, source);
   if (!FIELD_PATTERN.test(name)) {
-    throw invalid(source, `"${where}.name" must be a simple identifier.`);
+    throw buildStoryConfigError(
+      source,
+      `"${where}.name" must be a simple identifier.`,
+    );
   }
-  const property = requireTerm(obj.property, `${where}.property`, source);
+  const property = requirePredicateTerm(
+    obj.property,
+    `${where}.property`,
+    source,
+  );
   const label =
     obj.label === undefined
       ? undefined
@@ -179,29 +207,67 @@ function requireObject(
   source: string,
 ): Record<string, unknown> {
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    throw invalid(source, `"${where}" must be an object.`);
+    throw buildStoryConfigError(source, `"${where}" must be an object.`);
   }
   return raw as Record<string, unknown>;
 }
 
 function requireString(raw: unknown, where: string, source: string): string {
   if (typeof raw !== "string" || raw.trim() === "") {
-    throw invalid(source, `"${where}" must be a non-empty string.`);
+    throw buildStoryConfigError(
+      source,
+      `"${where}" must be a non-empty string.`,
+    );
   }
   return raw;
 }
 
-/** Require a prefixed name (`ex:Recipe`) or an absolute IRI. */
+/** Require a prefixed name (`ex:Recipe`) or an embeddable absolute IRI. */
 function requireTerm(raw: unknown, where: string, source: string): string {
   const value = requireString(raw, where, source);
-  if (value.includes("://")) return value;
+  if (value.includes("://")) {
+    if (EMBEDDABLE_IRI_PATTERN.test(value)) return value;
+    throw buildStoryConfigError(
+      source,
+      `"${where}" is not a valid IRI (no whitespace or <>" characters).`,
+    );
+  }
   if (PREFIXED_NAME_PATTERN.test(value)) return value;
-  throw invalid(
+  throw buildStoryConfigError(
     source,
     `"${where}" must be a prefixed name (ex:Recipe) or an absolute IRI.`,
   );
 }
 
-function invalid(source: string, message: string): PragmaError {
+/**
+ * Require a predicate term: a single term or a slash-separated SPARQL
+ * property path of prefixed names (`cs:hasCategory/cs:slug`).
+ *
+ * Paths are only meaningful in predicate position (`lookup.by` and
+ * `fields[].property`/`sections[].property`); class terms go through
+ * `requireTerm` and reject paths.
+ */
+function requirePredicateTerm(
+  raw: unknown,
+  where: string,
+  source: string,
+): string {
+  const value = requireString(raw, where, source);
+  if (value.includes("://") || !value.includes("/")) {
+    return requireTerm(value, where, source);
+  }
+  const segments = value.split("/");
+  for (const segment of segments) {
+    if (!PREFIXED_NAME_PATTERN.test(segment)) {
+      throw buildStoryConfigError(
+        source,
+        `"${where}" property path segment "${segment}" must be a prefixed name.`,
+      );
+    }
+  }
+  return value;
+}
+
+function buildStoryConfigError(source: string, message: string): PragmaError {
   return PragmaError.configError(`Invalid story in ${source}: ${message}`);
 }

--- a/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.ts
@@ -1,0 +1,207 @@
+import { PragmaError } from "#error";
+import type {
+  StoryPackColumn,
+  StoryPackDefinition,
+  StoryPackField,
+  StoryPackLookup,
+  StoryPackSection,
+} from "./types.js";
+
+const NOUN_PATTERN = /^[a-z][a-z0-9-]*$/;
+const FIELD_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+/** A prefixed name (`ex:Recipe`) — prefix + local part, no path slashes. */
+const PREFIXED_NAME_PATTERN = /^[A-Za-z][\w-]*:[^/<>"\s][^<>"\s]*$/;
+
+/**
+ * Validate one raw story-pack definition.
+ *
+ * Fails fast with `CONFIG_ERROR` naming the source and the offending
+ * field, mirroring how the `packages` config field is validated.
+ *
+ * @param raw - Parsed JSON value to validate.
+ * @param source - Where the definition came from, for error messages.
+ * @returns The validated definition.
+ * @throws PragmaError with code `CONFIG_ERROR` when the shape is invalid.
+ */
+export default function validateStoryPackDefinition(
+  raw: unknown,
+  source: string,
+): StoryPackDefinition {
+  const obj = requireObject(raw, "story", source);
+
+  const noun = requireString(obj.noun, "noun", source);
+  if (!NOUN_PATTERN.test(noun)) {
+    throw invalid(source, `"noun" must be kebab-case, got "${noun}".`);
+  }
+
+  const description =
+    obj.description === undefined
+      ? undefined
+      : requireString(obj.description, "description", source);
+  const toolDescription =
+    obj.toolDescription === undefined
+      ? undefined
+      : requireString(obj.toolDescription, "toolDescription", source);
+
+  const list = validateList(obj.list, source);
+  const lookup =
+    obj.lookup === undefined ? undefined : validateLookup(obj.lookup, source);
+
+  return {
+    noun,
+    ...(description !== undefined ? { description } : {}),
+    ...(toolDescription !== undefined ? { toolDescription } : {}),
+    list,
+    ...(lookup ? { lookup } : {}),
+  };
+}
+
+function validateList(
+  raw: unknown,
+  source: string,
+): StoryPackDefinition["list"] {
+  const obj = requireObject(raw, "list", source);
+  const query = requireString(obj.query, "list.query", source);
+  if (!/^\s*(PREFIX\s|SELECT\s)/i.test(query)) {
+    throw invalid(source, '"list.query" must be a SPARQL SELECT query.');
+  }
+
+  if (!Array.isArray(obj.columns) || obj.columns.length === 0) {
+    throw invalid(source, '"list.columns" must be a non-empty array.');
+  }
+  const columns = obj.columns.map((column, index) =>
+    validateColumn(column, `list.columns[${index}]`, source),
+  );
+
+  return { query, columns };
+}
+
+function validateColumn(
+  raw: unknown,
+  where: string,
+  source: string,
+): StoryPackColumn {
+  const obj = requireObject(raw, where, source);
+  const field = requireString(obj.field, `${where}.field`, source);
+  if (!FIELD_PATTERN.test(field)) {
+    throw invalid(source, `"${where}.field" must name a SELECT variable.`);
+  }
+  const label =
+    obj.label === undefined
+      ? undefined
+      : requireString(obj.label, `${where}.label`, source);
+  return { field, ...(label !== undefined ? { label } : {}) };
+}
+
+function validateLookup(raw: unknown, source: string): StoryPackLookup {
+  const obj = requireObject(raw, "lookup", source);
+  const by = requireTerm(obj.by, "lookup.by", source);
+  const type =
+    obj.type === undefined
+      ? undefined
+      : requireTerm(obj.type, "lookup.type", source);
+
+  const fields = validateFieldArray(obj.fields, "lookup.fields", source);
+  const sections = validateSectionArray(
+    obj.sections,
+    "lookup.sections",
+    source,
+  );
+
+  return {
+    by,
+    ...(type !== undefined ? { type } : {}),
+    ...(fields ? { fields } : {}),
+    ...(sections ? { sections } : {}),
+  };
+}
+
+function validateFieldArray(
+  raw: unknown,
+  where: string,
+  source: string,
+): readonly StoryPackField[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) {
+    throw invalid(source, `"${where}" must be an array.`);
+  }
+  return raw.map((entry, index) =>
+    validateField(entry, `${where}[${index}]`, source),
+  );
+}
+
+function validateSectionArray(
+  raw: unknown,
+  where: string,
+  source: string,
+): readonly StoryPackSection[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) {
+    throw invalid(source, `"${where}" must be an array.`);
+  }
+  return raw.map((entry, index) => {
+    const base = validateField(entry, `${where}[${index}]`, source);
+    const obj = entry as Record<string, unknown>;
+    if (obj.kind !== undefined && obj.kind !== "field" && obj.kind !== "code") {
+      throw invalid(
+        source,
+        `"${where}[${index}].kind" must be "field" or "code".`,
+      );
+    }
+    return {
+      ...base,
+      ...(obj.kind !== undefined ? { kind: obj.kind as "field" | "code" } : {}),
+    };
+  });
+}
+
+function validateField(
+  raw: unknown,
+  where: string,
+  source: string,
+): StoryPackField {
+  const obj = requireObject(raw, where, source);
+  const name = requireString(obj.name, `${where}.name`, source);
+  if (!FIELD_PATTERN.test(name)) {
+    throw invalid(source, `"${where}.name" must be a simple identifier.`);
+  }
+  const property = requireTerm(obj.property, `${where}.property`, source);
+  const label =
+    obj.label === undefined
+      ? undefined
+      : requireString(obj.label, `${where}.label`, source);
+  return { name, property, ...(label !== undefined ? { label } : {}) };
+}
+
+function requireObject(
+  raw: unknown,
+  where: string,
+  source: string,
+): Record<string, unknown> {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw invalid(source, `"${where}" must be an object.`);
+  }
+  return raw as Record<string, unknown>;
+}
+
+function requireString(raw: unknown, where: string, source: string): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw invalid(source, `"${where}" must be a non-empty string.`);
+  }
+  return raw;
+}
+
+/** Require a prefixed name (`ex:Recipe`) or an absolute IRI. */
+function requireTerm(raw: unknown, where: string, source: string): string {
+  const value = requireString(raw, where, source);
+  if (value.includes("://")) return value;
+  if (PREFIXED_NAME_PATTERN.test(value)) return value;
+  throw invalid(
+    source,
+    `"${where}" must be a prefixed name (ex:Recipe) or an absolute IRI.`,
+  );
+}
+
+function invalid(source: string, message: string): PragmaError {
+  return PragmaError.configError(`Invalid story in ${source}: ${message}`);
+}

--- a/packages/cli/pragma/src/mcp/tools/index.ts
+++ b/packages/cli/pragma/src/mcp/tools/index.ts
@@ -18,6 +18,7 @@ import { specs as orientationSpecs } from "../../domains/llm/mcp/index.js";
 import { specs as modifierSpecs } from "../../domains/modifier/mcp/index.js";
 import { specs as ontologySpecs } from "../../domains/ontology/mcp/index.js";
 import type { PragmaRuntime } from "../../domains/shared/runtime.js";
+import { compilePackToolSpecs } from "../../domains/shared/stories/pack/index.js";
 import type { ToolSpec } from "../../domains/shared/ToolSpec.js";
 import { specs as skillSpecs } from "../../domains/skill/mcp/index.js";
 import { specs as standardSpecs } from "../../domains/standard/mcp/index.js";
@@ -52,6 +53,14 @@ export default function registerAllTools(
   runtime: PragmaRuntime,
 ): void {
   for (const spec of allSpecs) {
+    registerFromSpec(server, runtime, spec);
+  }
+
+  // Story packs project onto the same surface; built-in nouns are reserved.
+  const reservedNouns = new Set(
+    allSpecs.map((spec) => spec.name.split("_").at(0) ?? ""),
+  );
+  for (const spec of compilePackToolSpecs(runtime, reservedNouns)) {
     registerFromSpec(server, runtime, spec);
   }
 }

--- a/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
+++ b/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
@@ -9,7 +9,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { createTestMcpClient } from "#testing";
+import {
+  createTestMcpClient,
+  RECIPE_PREFIXES,
+  RECIPE_STORY,
+  RECIPE_TTL,
+} from "#testing";
 import type { McpErrorPayload } from "../types.js";
 
 let client: Client;
@@ -973,6 +978,48 @@ describe("graph_inspect", () => {
 // =============================================================================
 // Skill tools
 // =============================================================================
+
+describe("story-pack tools", () => {
+  it("registers <noun>_list and <noun>_lookup from a stories config", async () => {
+    const scoped = await createTestMcpClient({
+      ttl: RECIPE_TTL,
+      config: {
+        tier: undefined,
+        channel: "normal",
+        stories: [RECIPE_STORY],
+        prefixes: RECIPE_PREFIXES,
+      },
+    });
+
+    try {
+      const tools = (await scoped.client.listTools()).tools.map(
+        (tool) => tool.name,
+      );
+      expect(tools).toHaveLength(32);
+      expect(tools).toContain("recipe_list");
+      expect(tools).toContain("recipe_lookup");
+
+      const listResult = await scoped.client.callTool({
+        name: "recipe_list",
+        arguments: {},
+      });
+      const rows = parseData(listResult) as { name: string }[];
+      expect(rows.map((row) => row.name)).toEqual(["Gazpacho", "Pancakes"]);
+
+      const lookupResult = await scoped.client.callTool({
+        name: "recipe_lookup",
+        arguments: { names: ["pancakes"] },
+      });
+      const data = parseData(lookupResult) as {
+        results: { name: string; instructions: string }[];
+      };
+      expect(data.results.at(0)?.name).toBe("Pancakes");
+      expect(data.results.at(0)?.instructions).toBe("Mix, fry, flip.");
+    } finally {
+      await scoped.cleanup();
+    }
+  });
+});
 
 describe("skill_list", () => {
   it("returns skills data", async () => {

--- a/packages/cli/pragma/src/pipeline/collectCommands.ts
+++ b/packages/cli/pragma/src/pipeline/collectCommands.ts
@@ -14,6 +14,7 @@ import { commands as modifierCommands } from "../domains/modifier/index.js";
 import { commands as ontologyCommands } from "../domains/ontology/index.js";
 import { commands as setupCommands } from "../domains/setup/index.js";
 import type { PragmaContext } from "../domains/shared/context.js";
+import { compilePackCommands } from "../domains/shared/stories/pack/index.js";
 import { commands as skillCommands } from "../domains/skill/index.js";
 import { commands as standardCommands } from "../domains/standard/index.js";
 import { commands as tierCommands } from "../domains/tier/index.js";
@@ -31,7 +32,7 @@ import { commands as tokenCommands } from "../domains/token/index.js";
 export default function collectCommands(
   ctx: PragmaContext,
 ): CommandDefinition[] {
-  return [
+  const builtIn: CommandDefinition[] = [
     ...configCommands(ctx),
     ...createCommands(),
     ...setupCommands(),
@@ -50,4 +51,10 @@ export default function collectCommands(
     buildLlmCommand(ctx),
     buildCapabilitiesCommand(),
   ];
+
+  // Story packs project onto the same surface; built-in nouns are reserved.
+  const reservedNouns = new Set(
+    builtIn.map((command) => command.path.at(0) ?? ""),
+  );
+  return [...builtIn, ...compilePackCommands(ctx, reservedNouns)];
 }

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -117,7 +117,9 @@ async function resolveHelpConfig(): Promise<
     const { createGitLoader, createLocalLoader } = await import(
       "../domains/shared/loaders/index.js"
     );
-    const { mergeAndParseRefs } = await import("../domains/shared/runtime.js");
+    const { mergeAndParseRefs } = await import(
+      "../domains/shared/mergeAndParseRefs.js"
+    );
     const packages = await resolveSemanticPackages(
       mergeAndParseRefs(config.packages),
       [createLocalLoader(), createGitLoader()],

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -79,9 +79,8 @@ async function handleDoctor(globalFlags: GlobalFlags): Promise<void> {
 async function handleRootHelp(globalFlags: GlobalFlags): Promise<void> {
   const stubCtx: PragmaContext = {
     store: {} as PragmaRuntime["store"],
-    config: { tier: undefined, channel: "normal" },
+    ...(await resolveHelpConfig()),
     cwd: process.cwd(),
-    packages: [],
     dispose: () => {},
     globalFlags,
     promptSession: createInteractivePromptSession,
@@ -93,6 +92,39 @@ async function handleRootHelp(globalFlags: GlobalFlags): Promise<void> {
     await program.parseAsync(["node", "pragma", "--help"]);
   } catch (err) {
     handleProgramError(err, globalFlags);
+  }
+}
+
+/**
+ * Resolve config and packages for root help without booting the store.
+ *
+ * Story-pack nouns come from config and package files, so bare
+ * `pragma --help` reads them via the filesystem loaders only. Help must
+ * never fail on a broken config — errors fall back to the empty stub and
+ * surface on the next real command instead.
+ *
+ * @note Impure — reads config and resolves packages from disk.
+ */
+async function resolveHelpConfig(): Promise<
+  Pick<PragmaRuntime, "config" | "packages">
+> {
+  try {
+    const { readConfig } = await import("#config");
+    const config = readConfig(process.cwd());
+    const { resolveSemanticPackages } = await import(
+      "../domains/shared/semanticPackage.js"
+    );
+    const { createGitLoader, createLocalLoader } = await import(
+      "../domains/shared/loaders/index.js"
+    );
+    const { mergeAndParseRefs } = await import("../domains/shared/runtime.js");
+    const packages = await resolveSemanticPackages(
+      mergeAndParseRefs(config.packages),
+      [createLocalLoader(), createGitLoader()],
+    );
+    return { config, packages };
+  } catch {
+    return { config: { tier: undefined, channel: "normal" }, packages: [] };
   }
 }
 

--- a/packages/cli/pragma/src/testing/createTestMcpClient.ts
+++ b/packages/cli/pragma/src/testing/createTestMcpClient.ts
@@ -31,7 +31,10 @@ export default async function createTestMcpClient(options?: {
   };
   const cwd = options?.cwd ?? process.cwd();
 
-  const { store, cleanup: cleanupStore } = await createTestStore({ ttl });
+  const { store, cleanup: cleanupStore } = await createTestStore({
+    ttl,
+    prefixes: config.prefixes,
+  });
 
   const runtime: PragmaRuntime = {
     store,

--- a/packages/cli/pragma/src/testing/index.ts
+++ b/packages/cli/pragma/src/testing/index.ts
@@ -12,4 +12,10 @@ export {
 } from "./graphqlFixtures.js";
 export type { PragmaTestStoreOptions } from "./store.js";
 export { createTestStore } from "./store.js";
+export {
+  RECIPE_NAMESPACE,
+  RECIPE_PREFIXES,
+  RECIPE_STORY,
+  RECIPE_TTL,
+} from "./storyFixtures.js";
 export type { TestMcpClientResult } from "./types.js";

--- a/packages/cli/pragma/src/testing/storyFixtures.ts
+++ b/packages/cli/pragma/src/testing/storyFixtures.ts
@@ -1,0 +1,56 @@
+/**
+ * Story-pack test fixtures — a foreign (non-DS) recipe ontology plus a
+ * matching pack definition.
+ *
+ * The `ex:` namespace is deliberately outside PREFIX_MAP: tests register
+ * it via config `prefixes`, proving the DS-agnostic path end to end.
+ */
+
+import type { StoryPackDefinition } from "../domains/shared/stories/pack/types.js";
+
+/** Namespace of the foreign recipe ontology. */
+export const RECIPE_NAMESPACE = "http://example.org/recipes/";
+
+/** Prefix map entry tests merge into config `prefixes`. */
+export const RECIPE_PREFIXES = { ex: RECIPE_NAMESPACE } as const;
+
+/** A tiny foreign ontology with two recipe instances. */
+export const RECIPE_TTL = `
+@prefix ex: <${RECIPE_NAMESPACE}> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:Recipe a rdfs:Class .
+
+ex:pancakes a ex:Recipe ;
+  ex:name "Pancakes" ;
+  ex:category "breakfast" ;
+  ex:instructions "Mix, fry, flip." .
+
+ex:gazpacho a ex:Recipe ;
+  ex:name "Gazpacho" ;
+  ex:category "soup" ;
+  ex:instructions "Blend everything cold." .
+`;
+
+/** A valid pack definition for the recipe ontology. */
+export const RECIPE_STORY: StoryPackDefinition = {
+  noun: "recipe",
+  description: "List recipes",
+  list: {
+    query:
+      "SELECT ?uri ?name ?category WHERE { ?uri a ex:Recipe ; ex:name ?name ; ex:category ?category } ORDER BY ?name",
+    columns: [
+      { field: "name" },
+      { field: "category" },
+      { field: "uri", label: "IRI" },
+    ],
+  },
+  lookup: {
+    type: "ex:Recipe",
+    by: "ex:name",
+    fields: [{ name: "category", property: "ex:category" }],
+    sections: [
+      { name: "instructions", property: "ex:instructions", kind: "field" },
+    ],
+  },
+};


### PR DESCRIPTION
> Split out of #774 (4 of 4). **Stacked on #777** (layered config), which stacks on #776. Merge order: #776 → #777 → this. Together with #775, the stack tip is byte-identical to #774.

## Done

- **Story packs MVP** (`@experimental`): pragma becomes design-system-agnostic for reads. JSON story definitions from config `stories` or a semantic package's `stories/*.json` compile through the read-story kernel into `pragma <noun> list|lookup` + MCP `<noun>_list`/`<noun>_lookup` over any ontology/TTL.
- List = author-declared SPARQL SELECT + column defs; lookup = **generated** injection-safe query from `type`/`by` (user input is SPARQL-escaped, never interpolated by authors), with `ENTITY_NOT_FOUND` + name suggestions on miss.
- Config `prefixes` merge into the store prefix map (foreign-namespace queries and compacted rendering work); packages ship `definitions/*.ttl` + `stories/*.json` (mirrors the `skills/` convention); invalid story files warn and skip.
- Noun collisions with built-ins or other packs fail loudly with a CONFIG_ERROR naming the source; config wins over packages.
- Registration on all surfaces: CLI commands, MCP tools, shell completions, and bare `pragma --help` (store-free `resolveHelpConfig`; help never fails on a broken config).
- Docs: README "Custom read stories (experimental)" + `docs/mcp-integration.md`.
- Known limitation (documented): `capabilities`/TOOL_CATALOG stay built-in-only this round.

ADRs: `pragma-adrs` `session/C/C.05`–`C.06`.

## QA

- `cd packages/cli/pragma && bun run check && bun run test` — green, **1,262 tests pass** (tree verified byte-identical to the #774 tip that ran the full gate).
- Live smoke: `file://` package with a foreign `ex:` recipe ontology → `pragma recipe list` table, `recipe lookup gazpacho --llm` markdown, noun in root help, MCP `tools/list` includes `recipe_list`/`recipe_lookup`, lookup returns condensed markdown, miss returns suggestions.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

No visual change — CLI + MCP behavior only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR)_