### PR TITLE
refactor(cli): built-in defaults become a declarative config document

### DIFF
--- a/packages/cli/pragma/src/config/defaultConfig.test.ts
+++ b/packages/cli/pragma/src/config/defaultConfig.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { VALID_CHANNELS } from "../constants.js";
+import { parsePackageEntry } from "../domains/refs/operations/parseRef.js";
+import { DEFAULT_CONFIG } from "./defaultConfig.js";
+
+describe("DEFAULT_CONFIG", () => {
+  it("declares a valid channel", () => {
+    expect(VALID_CHANNELS).toContain(DEFAULT_CONFIG.channel);
+  });
+
+  it("declares at least one package, all parseable", () => {
+    expect(DEFAULT_CONFIG.packages.length).toBeGreaterThan(0);
+    for (const entry of DEFAULT_CONFIG.packages) {
+      const ref = parsePackageEntry(entry);
+      expect(ref.pkg.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("carries the canonical design-system package by default", () => {
+    const names = DEFAULT_CONFIG.packages.map((entry) =>
+      typeof entry === "string" ? entry : entry.name,
+    );
+    expect(names).toContain("@canonical/design-system");
+  });
+
+  it("does not declare fields the document must not layer", () => {
+    // tier/trace/framework defaults are semantic absences, and packages
+    // must reach the merge via DEFAULT_PACKAGES (see defaultConfig.ts).
+    expect(DEFAULT_CONFIG.tier).toBeUndefined();
+    expect(DEFAULT_CONFIG.trace).toBeUndefined();
+    expect(DEFAULT_CONFIG.framework).toBeUndefined();
+  });
+});

--- a/packages/cli/pragma/src/config/defaultConfig.ts
+++ b/packages/cli/pragma/src/config/defaultConfig.ts
@@ -1,0 +1,59 @@
+import type { Channel } from "../constants.js";
+import type { RawPackageEntry } from "../domains/refs/operations/parseRef.js";
+import { PragmaError } from "../error/PragmaError.js";
+import defaultsDocument from "./defaults.json" with { type: "json" };
+import parseConfigValues from "./parseConfigValues.js";
+import type { ConfigFileValues } from "./types.js";
+
+/** The built-in defaults with the fields every install relies on present. */
+interface DefaultConfig extends ConfigFileValues {
+  /** Release channel active when no config file sets one. */
+  readonly channel: Channel;
+  /** Semantic packages loaded when no config or global refs declare any. */
+  readonly packages: ReadonlyArray<RawPackageEntry>;
+}
+
+/**
+ * Validate the embedded defaults document into the built-in config layer.
+ *
+ * The document goes through the same parser as user config files, so an
+ * invalid edit to `defaults.json` fails loudly at first import (and in
+ * tests) instead of silently changing behavior.
+ *
+ * @throws PragmaError with code `CONFIG_ERROR` when the document is
+ *         invalid or misses a required default.
+ */
+function parseDefaultsDocument(): DefaultConfig {
+  const values = parseConfigValues(
+    JSON.stringify(defaultsDocument),
+    "built-in defaults (src/config/defaults.json)",
+  );
+  if (values.channel === undefined) {
+    throw PragmaError.configError("Built-in defaults must declare a channel.", {
+      recovery: { message: "Restore `channel` in src/config/defaults.json." },
+    });
+  }
+  if (values.packages === undefined || values.packages.length === 0) {
+    throw PragmaError.configError(
+      "Built-in defaults must declare at least one semantic package.",
+      {
+        recovery: {
+          message: "Restore `packages` in src/config/defaults.json.",
+        },
+      },
+    );
+  }
+  return { ...values, channel: values.channel, packages: values.packages };
+}
+
+/**
+ * The built-in configuration layer, sourced from the embedded declarative
+ * `defaults.json` document rather than hardcoded values.
+ *
+ * `packages` is deliberately NOT surfaced through the layered `pick()` in
+ * `readConfigLayers` — it feeds `DEFAULT_PACKAGES` (and from there the
+ * ref merge), where global `refs.json` entries still merge over it by
+ * package name. Sourcing it as an ordinary config layer would make it
+ * look user-declared and shut global refs out.
+ */
+export const DEFAULT_CONFIG: DefaultConfig = parseDefaultsDocument();

--- a/packages/cli/pragma/src/config/defaults.json
+++ b/packages/cli/pragma/src/config/defaults.json
@@ -1,0 +1,17 @@
+{
+  "channel": "normal",
+  "packages": [
+    {
+      "name": "@canonical/design-system",
+      "source": "git+https://github.com/canonical/design-system.git#main"
+    },
+    {
+      "name": "@canonical/anatomy-dsl",
+      "source": "git+https://github.com/canonical/anatomy-dsl.git#main"
+    },
+    {
+      "name": "@canonical/code-standards",
+      "source": "git+https://github.com/canonical/web-code-standards.git#main"
+    }
+  ]
+}

--- a/packages/cli/pragma/src/config/readConfigLayers.ts
+++ b/packages/cli/pragma/src/config/readConfigLayers.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { DEFAULT_CONFIG } from "./defaultConfig.js";
 import findProjectConfigPath from "./findProjectConfigPath.js";
 import parseConfigValues from "./parseConfigValues.js";
 import resolveConfigPath from "./resolveConfigPath.js";
@@ -9,6 +10,18 @@ import type {
   ConfigOrigin,
   PragmaConfig,
 } from "./types.js";
+
+/**
+ * Fields the built-in defaults document contributes to the layer merge.
+ *
+ * `packages` is deliberately absent: it reaches the ref merge through
+ * `DEFAULT_PACKAGES` instead, so global `refs.json` entries keep merging
+ * over the default packages by name. Surfacing it here would make the
+ * defaults look user-declared and replace the merged set wholesale.
+ */
+const DEFAULT_LAYER: ConfigFileValues = {
+  channel: DEFAULT_CONFIG.channel,
+};
 
 /**
  * Resolve the layered configuration with per-field provenance.
@@ -42,6 +55,9 @@ export default function readConfigLayers(
     if (field in globalFile.values) {
       return { value: globalFile.values[field], origin: "global" };
     }
+    if (field in DEFAULT_LAYER) {
+      return { value: DEFAULT_LAYER[field], origin: "default" };
+    }
     return { value: undefined, origin: "default" };
   };
 
@@ -55,7 +71,7 @@ export default function readConfigLayers(
 
   const config: PragmaConfig = {
     tier: tier.value,
-    channel: channel.value ?? "normal",
+    channel: channel.value ?? DEFAULT_CONFIG.channel,
     ...(packages.value ? { packages: packages.value } : {}),
     ...(trace.value !== undefined ? { trace: trace.value } : {}),
     ...(framework.value !== undefined ? { framework: framework.value } : {}),

--- a/packages/cli/pragma/src/domains/shared/packages.ts
+++ b/packages/cli/pragma/src/domains/shared/packages.ts
@@ -3,9 +3,11 @@
  *
  * Sourced from the declarative built-in defaults document
  * (`src/config/defaults.json`) — pragma core carries no hardcoded
- * knowledge of specific design-system packages. Loaded when no config
- * layer or global refs declare packages; global `refs.json` entries
- * merge over these by package name (see `mergeAndParseRefs`).
+ * knowledge of specific design-system packages. These form the base
+ * package set whenever a config layer does not declare a non-empty
+ * `packages` list; global `refs.json` entries then merge over them by
+ * package name, and a non-empty config list replaces them entirely
+ * (see `mergeAndParseRefs`).
  *
  * Resolution is handled by the loader chain in `loaders/`.
  */

--- a/packages/cli/pragma/src/domains/shared/packages.ts
+++ b/packages/cli/pragma/src/domains/shared/packages.ts
@@ -1,27 +1,18 @@
 /**
  * Default semantic graph package registry.
  *
- * Defines the default graph packages loaded when no config overrides
- * are present. Each entry is a git ref pointing to the canonical
- * repository so `pragma update-refs` fetches data out of the box.
+ * Sourced from the declarative built-in defaults document
+ * (`src/config/defaults.json`) — pragma core carries no hardcoded
+ * knowledge of specific design-system packages. Loaded when no config
+ * layer or global refs declare packages; global `refs.json` entries
+ * merge over these by package name (see `mergeAndParseRefs`).
  *
  * Resolution is handled by the loader chain in `loaders/`.
  */
 
+import { DEFAULT_CONFIG } from "../../config/defaultConfig.js";
 import type { RawPackageEntry } from "../refs/operations/parseRef.js";
 
 /** Default semantic graph packages loaded when no config overrides are present. */
-export const DEFAULT_PACKAGES: readonly RawPackageEntry[] = [
-  {
-    name: "@canonical/design-system",
-    source: "git+https://github.com/canonical/design-system.git#main",
-  },
-  {
-    name: "@canonical/anatomy-dsl",
-    source: "git+https://github.com/canonical/anatomy-dsl.git#main",
-  },
-  {
-    name: "@canonical/code-standards",
-    source: "git+https://github.com/canonical/web-code-standards.git#main",
-  },
-];
+export const DEFAULT_PACKAGES: readonly RawPackageEntry[] =
+  DEFAULT_CONFIG.packages;


### PR DESCRIPTION
> Round 2, item 1 of the DS-agnostic sequencing. **Stacked on #778** (story packs); retargets as the stack merges. First step of "remove the hardcoded design-system configs": the default *data* moves out of code.

## Done

- The default channel and semantic package list move out of hardcoded TypeScript into an embedded, declarative `src/config/defaults.json`, validated at first import through the **same parser as user config files** (`parseConfigValues`) — an invalid edit to the document fails loudly in tests, with required-field assertions (channel present, packages non-empty).
- `readConfigLayers` sources the default channel from the document (single source of truth; the scattered `?? "normal"` literal is gone). `DEFAULT_PACKAGES` re-exports the document's packages, so every existing importer is untouched.
- Deliberate subtlety, documented in both files: `packages` is **excluded from the layer pick** — it reaches the ref merge via `DEFAULT_PACKAGES`, so global `refs.json` entries keep name-merging over the defaults. Surfacing it as an ordinary layer value would make defaults look user-declared and shut refs.json out (behavior regression).
- No behavior change: config output, origins, and package resolution are byte-identical; this is a data-relocation refactor.

## QA

- `cd packages/cli/pragma && bun run check && bun run test` — green, **1,266 tests** (4 new: document validity, package parseability, canonical package presence, non-layered-fields guard).
- `bun run build` + compiled-binary smoke: `dist/pragma config show` in a fresh HOME renders `channel: normal (stable)` from the embedded document.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

No visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR)_