### PR TITLE
feat(cli): declarative list filters for story packs

### DIFF
--- a/packages/cli/pragma/README.md
+++ b/packages/cli/pragma/README.md
@@ -332,7 +332,10 @@ declarative read stories — any ontology loaded through `packages` gets
       "description": "List recipes",
       "list": {
         "query": "SELECT ?uri ?name ?category WHERE { ?uri a ex:Recipe ; ex:name ?name ; ex:category ?category } ORDER BY ?name",
-        "columns": [{ "field": "name" }, { "field": "category" }]
+        "columns": [{ "field": "name" }, { "field": "category" }],
+        "filters": [
+          { "param": "category", "variable": "category", "values": ["breakfast", "soup"] }
+        ]
       },
       "lookup": {
         "type": "ex:Recipe",
@@ -347,8 +350,11 @@ declarative read stories — any ontology loaded through `packages` gets
 
 The lookup query is generated (user input is escaped, never interpolated by
 the pack), the store stays read-only, and config-declared stories override
-package-shipped ones on noun collisions. The format is experimental and may
-change.
+package-shipped ones on noun collisions. Declared `filters` become
+`pragma recipe list --category soup` on the CLI and an enum parameter on the
+MCP tool; they are row predicates applied after the query runs, so filter
+input can never inject SPARQL and the query's ordering is preserved. The
+format is experimental and may change.
 
 ## Error Handling
 

--- a/packages/cli/pragma/src/domains/shared/stories/pack/applyPackFilters.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/applyPackFilters.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { PragmaError } from "#error";
+import applyPackFilters from "./applyPackFilters.js";
+import type { StoryPackFilter } from "./types.js";
+
+const ROWS = [
+  { name: "Gazpacho", category: "soup" },
+  { name: "Pancakes", category: "breakfast" },
+];
+const FILTERS: StoryPackFilter[] = [
+  { param: "category", variable: "category", values: ["breakfast", "soup"] },
+];
+
+describe("applyPackFilters", () => {
+  it("returns rows unchanged when no filter value is provided", () => {
+    expect(applyPackFilters(ROWS, FILTERS, {})).toEqual(ROWS);
+  });
+
+  it("returns rows unchanged when no filters are declared", () => {
+    expect(applyPackFilters(ROWS, undefined, { category: "soup" })).toEqual(
+      ROWS,
+    );
+  });
+
+  it("keeps only rows matching the provided value", () => {
+    const rows = applyPackFilters(ROWS, FILTERS, { category: "soup" });
+    expect(rows.map((row) => row.name)).toEqual(["Gazpacho"]);
+  });
+
+  it("rejects values outside the declared set", () => {
+    expect(() =>
+      applyPackFilters(ROWS, FILTERS, { category: "dinner" }),
+    ).toThrowError(PragmaError);
+    try {
+      applyPackFilters(ROWS, FILTERS, { category: "dinner" });
+    } catch (error) {
+      expect((error as PragmaError).code).toBe("INVALID_INPUT");
+      expect((error as PragmaError).recovery?.message).toContain("breakfast");
+    }
+  });
+
+  it("rejects non-string values and suggests the declared set", () => {
+    expect(() => applyPackFilters(ROWS, FILTERS, { category: 3 })).toThrowError(
+      PragmaError,
+    );
+    try {
+      applyPackFilters(ROWS, FILTERS, { category: ["soup"] });
+    } catch (error) {
+      expect((error as PragmaError).validOptions).toEqual([
+        "breakfast",
+        "soup",
+      ]);
+    }
+  });
+
+  it("canonicalizes case-insensitive input to the declared value", () => {
+    const rows = applyPackFilters(ROWS, FILTERS, { category: "SOUP" });
+    expect(rows.map((row) => row.name)).toEqual(["Gazpacho"]);
+  });
+
+  it("trims surrounding whitespace from the provided value", () => {
+    const rows = applyPackFilters(ROWS, FILTERS, { category: "  soup " });
+    expect(rows.map((row) => row.name)).toEqual(["Gazpacho"]);
+  });
+
+  it("matches unicode values across NFC/NFD normalization forms", () => {
+    const filters: StoryPackFilter[] = [
+      { param: "kind", variable: "kind", values: ["entr\u00e9e"] },
+    ];
+    const rows = [{ name: "Salad", kind: "entre\u0301e" }];
+    expect(
+      applyPackFilters(rows, filters, { kind: "entre\u0301e" }),
+    ).toHaveLength(1);
+  });
+
+  it("never matches rows without a binding for the variable", () => {
+    const rows = [{ name: "Mystery" }, ...ROWS];
+    const filtered = applyPackFilters(rows, FILTERS, { category: "soup" });
+    expect(filtered.map((row) => row.name)).toEqual(["Gazpacho"]);
+  });
+
+  it("carries the declared values as valid options on rejection", () => {
+    try {
+      applyPackFilters(ROWS, FILTERS, { category: "sopu" });
+    } catch (error) {
+      expect((error as PragmaError).code).toBe("INVALID_INPUT");
+      expect((error as PragmaError).validOptions).toContain("soup");
+    }
+  });
+
+  it("applies several filters conjunctively", () => {
+    const filters: StoryPackFilter[] = [
+      ...FILTERS,
+      { param: "name", variable: "name", values: ["Gazpacho", "Pancakes"] },
+    ];
+    const rows = applyPackFilters(ROWS, filters, {
+      category: "soup",
+      name: "Pancakes",
+    });
+    expect(rows).toEqual([]);
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/applyPackFilters.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/applyPackFilters.ts
@@ -1,0 +1,76 @@
+import { PragmaError } from "#error";
+import type { StoryPackFilter } from "./types.js";
+
+/**
+ * Apply declared pack filters to resolved list rows.
+ *
+ * Filters are row predicates on projected SELECT variables — the author
+ * query is never modified, so user input cannot inject SPARQL and the
+ * query's ordering is preserved.
+ *
+ * Matching semantics:
+ * - Input is trimmed, unicode-normalized (NFC), and matched against the
+ *   declared values case-insensitively; the DECLARED value is canonical
+ *   and is what rows are compared against.
+ * - Row comparison is exact on the canonical value (NFC on both sides).
+ *   ke bindings carry lexical forms — language tags and datatypes are
+ *   already stripped — so plain equality is sound.
+ * - A row without a binding for the variable (e.g. from OPTIONAL) never
+ *   matches an active filter.
+ * - Several provided filters combine conjunctively.
+ *
+ * @param rows - Rows produced by the pack's list query.
+ * @param filters - Declared filters (absent means no filtering).
+ * @param params - Story parameters as provided by the surface.
+ * @returns Rows matching every provided filter.
+ * @throws PragmaError with code `INVALID_INPUT` (carrying the declared
+ *         values as valid options) when a provided value is not in the
+ *         filter's declared set.
+ */
+export default function applyPackFilters(
+  rows: Record<string, string>[],
+  filters: readonly StoryPackFilter[] | undefined,
+  params: Record<string, unknown>,
+): Record<string, string>[] {
+  // Start from the caller's array; each active filter's `.filter()` yields a
+  // fresh array, so with no active filter the rows pass through unmodified —
+  // no defensive clone (the caller owns the query result).
+  let result = rows;
+  for (const filter of filters ?? []) {
+    const provided = params[filter.param];
+    if (provided === undefined) continue;
+    const canonical = canonicalizeFilterValue(provided, filter);
+    result = result.filter(
+      (row) => row[filter.variable]?.normalize("NFC") === canonical,
+    );
+  }
+  return result;
+}
+
+/**
+ * Resolve a provided filter value to its declared canonical form.
+ *
+ * @throws PragmaError with code `INVALID_INPUT` when the value is not a
+ *         string or not in the declared set.
+ */
+function canonicalizeFilterValue(
+  provided: unknown,
+  filter: StoryPackFilter,
+): string {
+  if (typeof provided === "string") {
+    const normalized = provided.trim().normalize("NFC");
+    const match = filter.values.find(
+      (value) =>
+        value.normalize("NFC").toLowerCase() === normalized.toLowerCase(),
+    );
+    if (match !== undefined) {
+      return match.normalize("NFC");
+    }
+  }
+  throw PragmaError.invalidInput(filter.param, String(provided), {
+    validOptions: [...filter.values],
+    recovery: {
+      message: `Allowed values for --${filter.param}: ${filter.values.join(", ")}.`,
+    },
+  });
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.test.ts
@@ -53,6 +53,41 @@ describe("compilePackStories — list", () => {
   });
 });
 
+describe("compilePackStories — list filters", () => {
+  it("projects declared filters as enum story parameters", () => {
+    const { list } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const param = list.params.at(0);
+    expect(param?.name).toBe("category");
+    expect(param?.type).toBe("string");
+    expect(param?.enum).toEqual(["breakfast", "soup"]);
+  });
+
+  it("filters resolved rows by the provided value", async () => {
+    const { list } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const rows = await list.resolve(rt, { category: "soup" });
+    expect(rows.map((row) => row.name)).toEqual(["Gazpacho"]);
+    expect(list.toEnvelope(rows).meta).toEqual({ count: 1 });
+  });
+
+  it("canonicalizes case-insensitive input through resolve", async () => {
+    const { list } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    const rows = await list.resolve(rt, { category: "SOUP" });
+    expect(rows.map((row) => row.name)).toEqual(["Gazpacho"]);
+  });
+
+  it("rejects a value outside the declared set with INVALID_INPUT", async () => {
+    const { list } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    await expect(
+      list.resolve(rt, { category: "dinner" }),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+  });
+
+  it("mentions the first filter in the examples", () => {
+    const { list } = compilePackStories(RECIPE_STORY, "test", PREFIXES);
+    expect(list.examples).toContain("pragma recipe list --category breakfast");
+  });
+});
+
 describe("compilePackStories — lookup", () => {
   it("looks an entity up by name, case-insensitively", async () => {
     const { lookup } = compilePackStories(RECIPE_STORY, "test", PREFIXES);

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.ts
@@ -17,10 +17,15 @@ import {
 } from "../../renderers.js";
 import { suggestNames } from "../../suggestions/index.js";
 import requirePragmaContext from "../requirePragmaContext.js";
-import type { LookupStory, ReadStory } from "../types.js";
+import type { LookupStory, ReadStory, StoryParam } from "../types.js";
+import applyPackFilters from "./applyPackFilters.js";
 import buildLookupQuery, { buildLookupNamesQuery } from "./buildLookupQuery.js";
 import runSelectQuery from "./runSelectQuery.js";
-import type { StoryPackDefinition, StoryPackLookup } from "./types.js";
+import type {
+  StoryPackDefinition,
+  StoryPackFilter,
+  StoryPackLookup,
+} from "./types.js";
 
 /** A pack entity/row: SELECT variable name → string value. */
 type PackRow = Record<string, string>;
@@ -70,15 +75,30 @@ export default function compilePackStories(
     json: (rows) => JSON.stringify(rows, null, 2),
   };
 
+  const filters = definition.list.filters;
+  const filterExample = filters?.at(0);
   const list: ReadStory<PackRow[], PackRow[]> = {
     noun,
     verb: "list",
     description,
     toolDescription:
       definition.toolDescription ?? `${description} (story pack: ${source}).`,
-    params: [],
-    examples: [`pragma ${noun} list`, `pragma ${noun} list --llm`],
-    resolve: (rt) => runSelectQuery(rt.store, definition.list.query, source),
+    params: projectFilterParams(filters),
+    examples: [
+      `pragma ${noun} list`,
+      ...(filterExample
+        ? [
+            `pragma ${noun} list --${filterExample.param} ${quoteExampleValue(filterExample.values.at(0) ?? "")}`,
+          ]
+        : []),
+      `pragma ${noun} list --llm`,
+    ],
+    resolve: async (rt, params) =>
+      applyPackFilters(
+        await runSelectQuery(rt.store, definition.list.query, source),
+        filters,
+        params,
+      ),
     toOutput: (rows) => rows,
     formatters: listFormatters,
     toEnvelope: (rows) => ({ data: rows, meta: { count: rows.length } }),
@@ -196,6 +216,36 @@ async function listEntityNames(
     source,
   );
   return rows.map((row) => row.name ?? "").filter((name) => name !== "");
+}
+
+/**
+ * Quote a filter value for a shell help example when it is not a bare word.
+ *
+ * Values with whitespace or shell-sensitive characters are double-quoted
+ * so the generated `pragma … list --flag value` example stays valid to
+ * copy-paste; simple tokens render unquoted.
+ */
+function quoteExampleValue(value: string): string {
+  return /^[\w.-]+$/.test(value) ? value : JSON.stringify(value);
+}
+
+/**
+ * Project declared pack filters onto kernel story parameters.
+ *
+ * The declared value set becomes the parameter's enum, which the kernel
+ * projects to CLI select choices and an MCP enum schema.
+ */
+function projectFilterParams(
+  filters: readonly StoryPackFilter[] | undefined,
+): StoryParam[] {
+  return (filters ?? []).map((filter) => ({
+    name: filter.param,
+    type: "string",
+    description:
+      filter.description ??
+      `Filter by ${filter.variable} (${filter.values.join(", ")})`,
+    enum: filter.values,
+  }));
 }
 
 function capitalize(value: string): string {

--- a/packages/cli/pragma/src/domains/shared/stories/pack/types.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/types.ts
@@ -36,12 +36,36 @@ export interface StoryPackSection extends StoryPackField {
   readonly kind?: "field" | "code";
 }
 
+/**
+ * A declarative list filter: a CLI/MCP parameter constraining one SELECT
+ * variable to a declared value set.
+ *
+ * Filters are row predicates applied AFTER the author query runs — the
+ * query text is never modified, so filter input cannot inject SPARQL,
+ * and the author's ORDER BY is preserved.
+ */
+export interface StoryPackFilter {
+  /**
+   * Parameter name — a single lowercase word, exposed as `--param` on the
+   * CLI and as the parameter key on the MCP tool.
+   */
+  readonly param: string;
+  /** SELECT variable the filter constrains (without `?`). */
+  readonly variable: string;
+  /** Allowed values; anything else is rejected with INVALID_INPUT. */
+  readonly values: readonly string[];
+  /** Help text (defaults to a generated description). */
+  readonly description?: string;
+}
+
 /** The list half of a story pack. */
 export interface StoryPackList {
   /** SPARQL SELECT producing one row per item. */
   readonly query: string;
   /** Columns to render, referencing SELECT variables. */
   readonly columns: readonly StoryPackColumn[];
+  /** Declarative filters projected to CLI flags and MCP parameters. */
+  readonly filters?: readonly StoryPackFilter[];
 }
 
 /**

--- a/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.test.ts
@@ -138,3 +138,103 @@ describe("validateStoryPackDefinition — term and query hardening", () => {
     ).toThrow(/must be a SPARQL SELECT/);
   });
 });
+
+describe("validateStoryPackDefinition — list filters", () => {
+  const base = JSON.parse(JSON.stringify(RECIPE_STORY)) as Record<
+    string,
+    unknown
+  >;
+
+  function withFilters(filters: unknown): unknown {
+    const list = { ...(base.list as Record<string, unknown>), filters };
+    return { ...base, list };
+  }
+
+  it("accepts declared filters", () => {
+    const validated = validateStoryPackDefinition(
+      withFilters([
+        { param: "category", variable: "category", values: ["soup"] },
+      ]),
+      "test",
+    );
+    expect(validated.list.filters?.at(0)?.param).toBe("category");
+  });
+
+  it("rejects an empty filters array", () => {
+    expect(() => validateStoryPackDefinition(withFilters([]), "test")).toThrow(
+      /list.filters/,
+    );
+  });
+
+  it("rejects reserved parameter names", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withFilters([{ param: "format", variable: "category", values: ["x"] }]),
+        "test",
+      ),
+    ).toThrow(/reserved/);
+  });
+
+  it("rejects the MCP-appended condensed parameter name", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withFilters([
+          { param: "condensed", variable: "category", values: ["x"] },
+        ]),
+        "test",
+      ),
+    ).toThrow(/reserved/);
+  });
+
+  it("rejects a hyphenated parameter name that breaks CLI readback", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withFilters([
+          { param: "meal-type", variable: "category", values: ["x"] },
+        ]),
+        "test",
+      ),
+    ).toThrow(/single lowercase word/);
+  });
+
+  it("rejects duplicate parameter names", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withFilters([
+          { param: "category", variable: "category", values: ["x"] },
+          { param: "category", variable: "name", values: ["y"] },
+        ]),
+        "test",
+      ),
+    ).toThrow(/duplicate filter param/);
+  });
+
+  it("rejects a filter variable the query never mentions", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withFilters([{ param: "season", variable: "season", values: ["x"] }]),
+        "test",
+      ),
+    ).toThrow(/does not appear in "list.query"/);
+  });
+
+  it("rejects case-insensitive duplicate values", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withFilters([
+          { param: "category", variable: "category", values: ["Soup", "soup"] },
+        ]),
+        "test",
+      ),
+    ).toThrow(/duplicate value/);
+  });
+
+  it("rejects empty values arrays", () => {
+    expect(() =>
+      validateStoryPackDefinition(
+        withFilters([{ param: "category", variable: "category", values: [] }]),
+        "test",
+      ),
+    ).toThrow(/values/);
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/validateStoryPackDefinition.ts
@@ -3,6 +3,7 @@ import type {
   StoryPackColumn,
   StoryPackDefinition,
   StoryPackField,
+  StoryPackFilter,
   StoryPackLookup,
   StoryPackSection,
 } from "./types.js";
@@ -14,6 +15,33 @@ const PREFIXED_NAME_PATTERN = /^[A-Za-z][\w-]*:[^/<>"\s]+$/;
 
 /** An absolute IRI that can be safely embedded as `<iri>` in SPARQL. */
 const EMBEDDABLE_IRI_PATTERN = /^[A-Za-z][\w+.-]*:\/\/[^<>"\s]+$/;
+
+/**
+ * A filter parameter name: a single lowercase word.
+ *
+ * Deliberately stricter than a noun (no hyphens): the name is used
+ * verbatim as the CLI flag, the Commander result key, and the MCP
+ * parameter key. A hyphenated name would register as `--meal-type` but
+ * be read back by Commander under the camelCased `mealType`, so the
+ * filter would silently never apply on the CLI while working on MCP.
+ * Restricting to one lowercase word keeps all three identical.
+ */
+const FILTER_PARAM_PATTERN = /^[a-z][a-z0-9]*$/;
+
+/**
+ * Parameter names taken by global flags or parameters the kernel appends
+ * to every read story — `condensed` is added to every MCP list tool, and
+ * `detailed` to every lookup — so a filter may not reuse them.
+ */
+const RESERVED_FILTER_PARAMS = new Set([
+  "llm",
+  "format",
+  "verbose",
+  "detailed",
+  "condensed",
+  "names",
+  "help",
+]);
 
 /**
  * Validate one raw story-pack definition.
@@ -91,7 +119,114 @@ function validateList(
     validateColumn(column, `list.columns[${index}]`, source),
   );
 
-  return { query, columns };
+  const filters = validateFilterArray(obj.filters, source);
+  for (const filter of filters ?? []) {
+    if (!referencesVariable(query, filter.variable)) {
+      throw buildStoryConfigError(
+        source,
+        `filter variable "?${filter.variable}" does not appear in "list.query".`,
+      );
+    }
+  }
+
+  return { query, columns, ...(filters ? { filters } : {}) };
+}
+
+/**
+ * Check that the query mentions the variable (`?name` or `$name`).
+ *
+ * A textual check, not a SPARQL parse — it exists to fail typos at boot
+ * instead of silently filtering every row out at first use.
+ */
+function referencesVariable(query: string, variable: string): boolean {
+  const pattern = new RegExp(`[?$]${variable}\\b`);
+  return pattern.test(query);
+}
+
+function validateFilterArray(
+  raw: unknown,
+  source: string,
+): readonly StoryPackFilter[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw buildStoryConfigError(
+      source,
+      '"list.filters" must be a non-empty array.',
+    );
+  }
+  const filters = raw.map((entry, index) =>
+    validateFilter(entry, `list.filters[${index}]`, source),
+  );
+  const seen = new Set<string>();
+  for (const filter of filters) {
+    if (seen.has(filter.param)) {
+      throw buildStoryConfigError(
+        source,
+        `duplicate filter param "${filter.param}".`,
+      );
+    }
+    seen.add(filter.param);
+  }
+  return filters;
+}
+
+function validateFilter(
+  raw: unknown,
+  where: string,
+  source: string,
+): StoryPackFilter {
+  const obj = requireObject(raw, where, source);
+  const param = requireString(obj.param, `${where}.param`, source);
+  if (!FILTER_PARAM_PATTERN.test(param)) {
+    throw buildStoryConfigError(
+      source,
+      `"${where}.param" must be a single lowercase word (letters and digits, no hyphens), got "${param}".`,
+    );
+  }
+  if (RESERVED_FILTER_PARAMS.has(param)) {
+    throw buildStoryConfigError(
+      source,
+      `"${where}.param" "${param}" is a reserved name.`,
+    );
+  }
+  const variable = requireString(obj.variable, `${where}.variable`, source);
+  if (!FIELD_PATTERN.test(variable)) {
+    throw buildStoryConfigError(
+      source,
+      `"${where}.variable" must name a SELECT variable.`,
+    );
+  }
+  if (!Array.isArray(obj.values) || obj.values.length === 0) {
+    throw buildStoryConfigError(
+      source,
+      `"${where}.values" must be a non-empty array.`,
+    );
+  }
+  const values = obj.values.map((value, index) =>
+    requireString(value, `${where}.values[${index}]`, source),
+  );
+  const lowered = new Set<string>();
+  for (const value of values) {
+    const key = value.toLowerCase();
+    if (lowered.has(key)) {
+      throw buildStoryConfigError(
+        source,
+        `"${where}.values" contains duplicate value "${value}" ` +
+          "(values must be unique, case-insensitively).",
+      );
+    }
+    lowered.add(key);
+  }
+  const description =
+    obj.description === undefined
+      ? undefined
+      : requireString(obj.description, `${where}.description`, source);
+  return {
+    param,
+    variable,
+    values,
+    ...(description !== undefined ? { description } : {}),
+  };
 }
 
 function validateColumn(

--- a/packages/cli/pragma/src/testing/storyFixtures.ts
+++ b/packages/cli/pragma/src/testing/storyFixtures.ts
@@ -44,6 +44,13 @@ export const RECIPE_STORY: StoryPackDefinition = {
       { field: "category" },
       { field: "uri", label: "IRI" },
     ],
+    filters: [
+      {
+        param: "category",
+        variable: "category",
+        values: ["breakfast", "soup"],
+      },
+    ],
   },
   lookup: {
     type: "ex:Recipe",


### PR DESCRIPTION
> Round 2, item 2 of the DS-agnostic sequencing (pack format v1, first capability). **Stacked on #778** (story packs), sibling of #779. This is the first of the two capabilities the standard/block cutover pilots need.

## Done

- **Declarative list filters**: a pack list can declare `filters` — `{ param, variable, values[] }`. Each filter projects through the read-story kernel to a **CLI select flag** (`pragma recipe list --category soup`, with choices) and an **MCP enum parameter** on `<noun>_list`, plus a generated example in help.
- **Injection-free by construction**: filters are row predicates applied *after* the author query runs — the query text is never modified, so filter input cannot inject SPARQL, and the author's `ORDER BY` is preserved. A provided value must be in the declared set; anything else fails with `INVALID_INPUT` naming the allowed values.
- Validation joins the existing fail-fast pass: kebab-case params, reserved-name guard (`llm`, `format`, `verbose`, `detailed`, `names`, `help`), duplicate-param guard, non-empty value sets — all `CONFIG_ERROR`s naming the source.
- Recipe fixture gains a `category` filter so the whole chain (validate → params → CLI/MCP projection → filtered resolve → envelope count) is exercised end to end; README documents the field.
- Design note for reviewers: SPARQL pushdown of filters is a deliberate non-goal at this scale (list tables); it can become an optimization later without changing the declared format. Tier-chain/channel filter kinds (needed for the `block` cutover) come next and compose through this same row-predicate mechanism with computed value sets.

## QA

- `cd packages/cli/pragma && bun run check && bun run test` — green, **1,277 tests** (15 new across validator, predicate unit, and compiled-story integration).

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

No visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR)_