### PR TITLE
feat(cli): bundled loader serves embedded story definitions

### DIFF
--- a/packages/cli/pragma/scripts/build.ts
+++ b/packages/cli/pragma/scripts/build.ts
@@ -5,6 +5,9 @@
  * embedding all non-JS assets that the binary needs at runtime:
  * - TTL graph files from semantic packages (definitions + data)
  * - Skill markdown files from semantic packages
+ * - Story-pack JSON files from semantic packages (`stories/*.json`,
+ *   forced to file assets by the story-assets plugin so they surface
+ *   in `Bun.embeddedFiles` instead of compiling into JSON modules)
  * - Package.json files for version detection
  * - EJS templates from summon packages (component/package generators)
  *
@@ -12,6 +15,7 @@
  */
 
 import { Glob } from "bun";
+import createStoryAssetsPlugin from "../src/domains/shared/loaders/storyAssetsPlugin.js";
 
 // ---------------------------------------------------------------------------
 // Asset discovery
@@ -19,16 +23,20 @@ import { Glob } from "bun";
 
 /** Glob patterns for files to embed from node_modules. */
 const EMBED_PATTERNS = [
-  // Semantic graph packages — TTL definitions, data, skills, and package.json
+  // Semantic graph packages — TTL definitions, data, skills, stories,
+  // and package.json
   "node_modules/@canonical/design-system/definitions/**/*.ttl",
   "node_modules/@canonical/design-system/data/**/*.ttl",
   "node_modules/@canonical/design-system/skills/**/*.md",
+  "node_modules/@canonical/design-system/stories/*.json",
   "node_modules/@canonical/design-system/package.json",
   "node_modules/@canonical/code-standards/definitions/**/*.ttl",
   "node_modules/@canonical/code-standards/data/**/*.ttl",
   "node_modules/@canonical/code-standards/skills/**/*.md",
+  "node_modules/@canonical/code-standards/stories/*.json",
   "node_modules/@canonical/code-standards/package.json",
   "node_modules/@canonical/anatomy-dsl/definitions/**/*.ttl",
+  "node_modules/@canonical/anatomy-dsl/stories/*.json",
   "node_modules/@canonical/anatomy-dsl/package.json",
   // Summon templates — EJS files for component/package generators
   "node_modules/@canonical/summon-component/src/templates/**/*.ejs",
@@ -56,6 +64,7 @@ console.log(`Embedding ${assets.length} assets`);
 const result = await Bun.build({
   entrypoints: ["src/bin.ts", ...assets],
   minify: true,
+  plugins: [createStoryAssetsPlugin()],
   compile: {
     target: "bun-linux-x64",
     outfile: "dist/pragma",

--- a/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.test.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.test.ts
@@ -105,6 +105,86 @@ describe("createBundledLoader", () => {
     expect(stderrText()).toContain("embedded blob unreadable");
   });
 
+  it("serves embedded story JSON as story-file entries", async () => {
+    stubEmbeddedFiles([
+      blob("button-a1b2c3d4.ttl", TTL),
+      blob("package-a1b2c3d4.json", JSON.stringify({ version: "1.2.3" })),
+      blob("colors-fyskc7pf.json", JSON.stringify({ noun: "color" })),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved?.stories).toEqual([
+      {
+        path: "(bundled)/colors-fyskc7pf.json",
+        definition: { noun: "color" },
+      },
+    ]);
+    expect(resolved?.version).toBe("1.2.3");
+  });
+
+  it("does not serve package manifests as stories", async () => {
+    stubEmbeddedFiles([
+      blob("button.ttl", TTL),
+      blob("package.json", JSON.stringify({ version: "2.0.0" })),
+      blob("package-deadbeef.json", JSON.stringify({ version: "3.0.0" })),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved?.stories).toEqual([]);
+  });
+
+  it("warns and skips a story blob with invalid JSON instead of crashing", async () => {
+    stubEmbeddedFiles([
+      blob("button.ttl", TTL),
+      blob("good-a1b2c3d4.json", JSON.stringify({ noun: "color" })),
+      blob("broken-a1b2c3d4.json", "{ not json"),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved?.stories).toHaveLength(1);
+    expect(resolved?.stories.at(0)?.definition).toEqual({ noun: "color" });
+    expect(stderrText()).toContain("broken-a1b2c3d4.json");
+  });
+
+  it("warns and skips an unreadable story blob", async () => {
+    stubEmbeddedFiles([
+      blob("button.ttl", TTL),
+      corruptBlob("story-a1b2c3d4.json"),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved?.stories).toEqual([]);
+    expect(stderrText()).toContain("story-a1b2c3d4.json");
+    expect(stderrText()).toContain("embedded blob unreadable");
+  });
+
+  it("resolves a stories-only bundle with no TTL graphs", async () => {
+    stubEmbeddedFiles([
+      blob("colors-fyskc7pf.json", JSON.stringify({ noun: "color" })),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved).toBeDefined();
+    expect(resolved?.graphs).toEqual([]);
+    expect(resolved?.stories).toHaveLength(1);
+  });
+
+  it("returns undefined when no TTL or story content is embedded", async () => {
+    stubEmbeddedFiles([
+      blob("template-a1b2c3d4.ejs", "<%= name %>"),
+      blob("skill-a1b2c3d4.md", "# Skill"),
+    ]);
+
+    const resolved = await createBundledLoader().resolve(ref);
+
+    expect(resolved).toBeUndefined();
+  });
+
   it("warns on a corrupt package manifest and falls back to 0.0.0", async () => {
     stubEmbeddedFiles([
       blob("button.ttl", TTL),

--- a/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
@@ -1,13 +1,15 @@
 /**
  * Bundled package loader for compiled binaries.
  *
- * Resolves semantic content from `Bun.embeddedFiles` — TTL and skill
- * files embedded into the compiled binary via the build command.
+ * Resolves semantic content from `Bun.embeddedFiles` — TTL, story-pack
+ * JSON, and skill files embedded into the compiled binary via the build
+ * command.
  *
  * Blob names are hashed by bun (e.g. `button-a1b2c3d4.ttl`), losing
  * directory and package association. The loader therefore returns a
- * single SemanticPackage containing ALL embedded TTL content, and the
- * same cached package is returned for every ref this loader resolves.
+ * single SemanticPackage containing ALL embedded TTL and story content,
+ * and the same cached package is returned for every ref this loader
+ * resolves.
  * Note that repeated loads are NOT fully deduplicated by the store:
  * Oxigraph applies set semantics to ground triples, but blank nodes are
  * re-minted on every parse, so content loaded both here and by a
@@ -24,6 +26,7 @@ import type {
   GraphContent,
   PackageLoader,
   SemanticPackage,
+  StoryFileEntry,
 } from "../semanticPackage.js";
 
 // ---------------------------------------------------------------------------
@@ -89,7 +92,8 @@ export default function createBundledLoader(): PackageLoader {
       if (!blobs?.length) return undefined;
 
       const graphs = await readEmbeddedGraphs(blobs);
-      if (graphs.length === 0) return undefined;
+      const stories = await readEmbeddedStories(blobs);
+      if (graphs.length === 0 && stories.length === 0) return undefined;
 
       const version = await readEmbeddedVersion(blobs);
 
@@ -99,7 +103,7 @@ export default function createBundledLoader(): PackageLoader {
         source: "bundled",
         graphs,
         skills: [],
-        stories: [],
+        stories,
       };
 
       return cached;
@@ -133,6 +137,42 @@ async function readEmbeddedGraphs(
   }
 
   return graphs;
+}
+
+// ---------------------------------------------------------------------------
+// Story reading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read story-pack definitions from embedded `.json` blobs.
+ *
+ * The build's story-assets plugin makes `stories/*.json` the only JSON
+ * embedded as file assets (see storyAssetsPlugin.ts), so every `.json`
+ * blob not named like a package manifest is a story file. Mirrors the
+ * local loader: a blob that cannot be read or parsed warns on stderr
+ * and is skipped — one bad file cannot break boot. Definitions are
+ * shape-validated later by the story-pack compiler.
+ */
+async function readEmbeddedStories(
+  blobs: ReadonlyArray<Blob & { name: string }>,
+): Promise<StoryFileEntry[]> {
+  const stories: StoryFileEntry[] = [];
+
+  for (const blob of blobs) {
+    if (!blob.name.endsWith(".json") || isPackageManifest(blob.name)) continue;
+
+    try {
+      stories.push({
+        path: `(bundled)/${blob.name}`,
+        definition: JSON.parse(await blob.text()),
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      warn(`skipping invalid embedded story "${blob.name}": ${reason}`);
+    }
+  }
+
+  return stories;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
@@ -1,9 +1,9 @@
 /**
  * Bundled package loader for compiled binaries.
  *
- * Resolves semantic content from `Bun.embeddedFiles` — TTL, story-pack
- * JSON, and skill files embedded into the compiled binary via the build
- * command.
+ * Resolves semantic content from `Bun.embeddedFiles` — the TTL graphs
+ * and story-pack JSON embedded into the compiled binary via the build
+ * command. Skills are not embedded; this loader reports `skills: []`.
  *
  * Blob names are hashed by bun (e.g. `button-a1b2c3d4.ttl`), losing
  * directory and package association. The loader therefore returns a

--- a/packages/cli/pragma/src/domains/shared/loaders/storyAssetsPlugin.test.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/storyAssetsPlugin.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BunPlugin } from "bun";
+import { afterEach, describe, expect, it } from "vitest";
+import createStoryAssetsPlugin, {
+  STORY_ASSET_PATH_PATTERN,
+} from "./storyAssetsPlugin.js";
+
+interface OnLoadRegistration {
+  readonly filter: RegExp;
+  readonly callback: (args: { path: string }) => unknown;
+}
+
+/** Run the plugin's setup against a stub builder and capture its onLoad. */
+function captureOnLoadRegistration(): OnLoadRegistration {
+  let captured: OnLoadRegistration | undefined;
+  const builder = {
+    onLoad(
+      constraints: { filter: RegExp },
+      callback: OnLoadRegistration["callback"],
+    ): void {
+      captured = { filter: constraints.filter, callback };
+    },
+  };
+
+  createStoryAssetsPlugin().setup(
+    builder as unknown as Parameters<BunPlugin["setup"]>[0],
+  );
+
+  if (!captured) throw new Error("plugin did not register an onLoad handler");
+  return captured;
+}
+
+describe("STORY_ASSET_PATH_PATTERN", () => {
+  it("matches JSON directly inside a stories directory", () => {
+    expect(
+      STORY_ASSET_PATH_PATTERN.test(
+        "/repo/node_modules/@canonical/design-system/stories/color.json",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects manifests, nested files, near-miss directories, and non-JSON", () => {
+    const nonStories = [
+      "/repo/node_modules/@canonical/design-system/package.json",
+      "/repo/node_modules/@canonical/design-system/stories/nested/color.json",
+      "/repo/node_modules/@canonical/design-system/histories/color.json",
+      "/repo/node_modules/@canonical/design-system/stories/color.jsonc",
+      "/repo/node_modules/@canonical/design-system/stories/color.ttl",
+    ];
+    for (const path of nonStories) {
+      expect(STORY_ASSET_PATH_PATTERN.test(path), path).toBe(false);
+    }
+  });
+});
+
+describe("createStoryAssetsPlugin", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  it("registers its load hook under the story path filter", () => {
+    const { filter } = captureOnLoadRegistration();
+    expect(filter).toBe(STORY_ASSET_PATH_PATTERN);
+  });
+
+  it("loads story JSON contents under the file loader", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pragma-story-assets-"));
+    const storyPath = join(tmpDir, "color.json");
+    const content = JSON.stringify({ noun: "color" });
+    writeFileSync(storyPath, content);
+
+    const { callback } = captureOnLoadRegistration();
+
+    expect(callback({ path: storyPath })).toEqual({
+      contents: content,
+      loader: "file",
+    });
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/loaders/storyAssetsPlugin.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/storyAssetsPlugin.ts
@@ -1,0 +1,46 @@
+/**
+ * Build-time bundler plugin: embed story-pack JSON as file assets.
+ *
+ * Bun compiles `.json` build inputs into JSON modules, which never
+ * surface in `Bun.embeddedFiles`. Story-pack files must instead be
+ * embedded as file assets — like TTL graphs — so the bundled loader can
+ * serve them inside the compiled binary. This plugin scopes the `file`
+ * loader to story paths only, leaving every other JSON input (e.g.
+ * `package.json` imported for the CLI version) compiled as a module.
+ *
+ * Contract with the bundled loader: story files are the only `.json`
+ * content embedded as file assets, so every `.json` blob in
+ * `Bun.embeddedFiles` that is not named like a package manifest is a
+ * story definition. Consequence: no module in the bundle may import a
+ * `stories/*.json` file as a JSON module — the plugin would rewrite
+ * such an import into a file-path string.
+ *
+ * Consumed by `scripts/build.ts` only; never bundled into the binary.
+ */
+
+import { readFileSync } from "node:fs";
+import type { BunPlugin } from "bun";
+
+/**
+ * Matches story-pack files: a `.json` directly inside a `stories/`
+ * directory — the same non-recursive scope the local loader scans.
+ */
+export const STORY_ASSET_PATH_PATTERN = /[\\/]stories[\\/][^\\/]+\.json$/;
+
+/**
+ * Create the bundler plugin that embeds `stories/*.json` as file assets.
+ *
+ * @returns A `Bun.build` plugin for the compiled-binary build.
+ * @note Impure — the registered load callback reads the filesystem.
+ */
+export default function createStoryAssetsPlugin(): BunPlugin {
+  return {
+    name: "story-assets",
+    setup(build) {
+      build.onLoad({ filter: STORY_ASSET_PATH_PATTERN }, (args) => ({
+        contents: readFileSync(args.path, "utf-8"),
+        loader: "file",
+      }));
+    },
+  };
+}

--- a/packages/cli/pragma/src/domains/shared/semanticPackage.ts
+++ b/packages/cli/pragma/src/domains/shared/semanticPackage.ts
@@ -24,9 +24,13 @@ export interface GraphContent {
   readonly format: "turtle";
 }
 
-/** A discovered skill directory with its filesystem path. */
+/** A discovered story-pack JSON file with its content. */
 export interface StoryFileEntry {
-  /** Absolute path of the story JSON file. */
+  /**
+   * Original file path, or a virtual identifier for embedded sources
+   * (e.g. `(bundled)/…`) — for provenance/debugging, not guaranteed to
+   * exist on disk.
+   */
   readonly path: string;
   /** The file's parsed JSON — validated by the story-pack compiler. */
   readonly definition: unknown;


### PR DESCRIPTION
> Round 2, item 3 of the DS-agnostic sequencing. **Stacked on #778**, sibling of #779/#780. Hard prerequisite for moving built-in DS stories into packages: without it, a fresh compiled binary would lose its story nouns.

## Done

- **Embed pipeline**: `scripts/build.ts` now globs `stories/*.json` from the semantic packages into the existing `Bun.build --compile` asset mechanism, via a new scoped `storyAssetsPlugin` — an `onLoad` filter that forces the `file` loader for story paths **only**. (A global `.json → file` override was tested and rejected: it silently breaks `import … with { type: "json" }` elsewhere; the plugin keeps one embed mechanism without collateral.)
- **Bundled loader**: `readEmbeddedStories()` exposes every non-manifest embedded `.json` as `SemanticPackage.stories` with the local loader's validate-warn-skip contract (invalid JSON = stderr warning + skip, never a crash). The resolve gate and cache carry stories; a stories-only bundle now resolves.
- **End-to-end proof**: a scratch binary compiled with the real plugin + loader against a fixture package served the valid story (parsed definition, `(bundled)/…` path) and warn-skipped a broken one; the real `dist/pragma` still builds (273 assets, unchanged — canonical packages ship no stories yet) and `--version` still works.
- **Pre-existing issues surfaced** (not changed here, worth follow-ups): embedded `package.json` manifests compile as JSON *modules* and never reach `Bun.embeddedFiles`, so bundled version reporting has always fallen back to `0.0.0`; the manifest filename pattern also expects hex hashes while Bun emits base-32-ish names.

## QA

- Package gates green (`bun run check`, 1,272 tests) **and** root gates green (61-project check, 46-project test). 10 new tests across the plugin and the bundled-stories path (serving, manifest exclusion, invalid-JSON skip, unreadable-blob skip, stories-only bundle, nothing-embedded).

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

No visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR)_