### PR TITLE
test(cli): standard-noun parity pilot — pack definition vs built-in story

### DIFF
--- a/packages/cli/pragma/src/domains/shared/stories/pack/standardParity.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/standardParity.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Standard-noun parity pilot — the built-in `standard` read stories vs
+ * the declarative pack definition in `standardParityFixtures.ts`.
+ *
+ * Both paths run against the real @canonical/code-standards graphs,
+ * resolved from node_modules through the production loader chain — no
+ * fixture TTL. Assertions demand byte parity wherever the v0 pack
+ * format reaches; every remaining divergence is pinned exactly and
+ * must be named in PARITY_GAPS. Nothing is cut over: the built-in
+ * stories stay untouched and the pack is compiled directly.
+ */
+
+import type { Store } from "@canonical/ke";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PARITY_GAPS, STANDARD_PACK_STORY } from "#testing";
+import { parsePackageEntry } from "../../../refs/operations/parseRef.js";
+import type { StandardListOutput } from "../../../standard/formatters/index.js";
+import {
+  standardListStory,
+  standardLookupStory,
+} from "../../../standard/stories.js";
+import { bootStore } from "../../bootStore.js";
+import compactUri from "../../compactUri.js";
+import { PREFIX_MAP } from "../../prefixes.js";
+import type { PragmaRuntime, StandardDetailed } from "../../types/index.js";
+import type { LookupStoryView } from "../types.js";
+import compilePackStories, {
+  type CompiledPackStories,
+} from "./compilePackStories.js";
+import validateStoryPackDefinition from "./validateStoryPackDefinition.js";
+
+const PACK_SOURCE = "standardParityFixtures";
+
+/** The built-in CLI default view: summary lookup, no extra params. */
+const SUMMARY_VIEW: LookupStoryView = {
+  surface: "cli",
+  detailed: false,
+  params: {},
+};
+
+/** Real standard names without cs:extends — full byte parity expected. */
+const PARITY_LOOKUP_NAMES = [
+  "code/function/purity",
+  "react/component/props",
+] as const;
+
+/** A real standard with cs:extends — pins the JSON compaction gap. */
+const EXTENDS_LOOKUP_NAME = "react/component/structure/context";
+
+/** A near-miss query — both paths must produce identical suggestions. */
+const NEAR_MISS_NAME = "code/function/puriti";
+
+let store: Store;
+let rt: PragmaRuntime;
+let packList: CompiledPackStories["list"];
+let packLookup: NonNullable<CompiledPackStories["lookup"]>;
+
+beforeAll(async () => {
+  const boot = await bootStore({
+    refs: [parsePackageEntry("@canonical/code-standards")],
+  });
+  store = boot.store;
+  rt = { store } as PragmaRuntime;
+
+  const compiled = compilePackStories(STANDARD_PACK_STORY, PACK_SOURCE, {
+    ...PREFIX_MAP,
+  });
+  packList = compiled.list;
+  const lookup = compiled.lookup;
+  if (!lookup) {
+    throw new Error("STANDARD_PACK_STORY must declare a lookup story");
+  }
+  packLookup = lookup;
+});
+
+afterAll(() => store.dispose());
+
+/** Resolve one name through the built-in lookup story. */
+async function lookupBuiltin(name: string): Promise<StandardDetailed> {
+  const result = await standardLookupStory.resolve(rt, [name], {});
+  expect(result.errors).toEqual([]);
+  const entity = result.results.at(0);
+  if (entity === undefined) {
+    throw new Error(`built-in lookup found no result for "${name}"`);
+  }
+  return entity;
+}
+
+/** Resolve one name through the compiled pack lookup story. */
+async function lookupPack(name: string): Promise<Record<string, string>> {
+  const result = await packLookup.resolve(rt, [name], {});
+  expect(result.errors).toEqual([]);
+  const entity = result.results.at(0);
+  if (entity === undefined) {
+    throw new Error(`pack lookup found no result for "${name}"`);
+  }
+  return entity;
+}
+
+/**
+ * Remove the built-in's URI field line — the one v0 lookup rendering
+ * gap (see PARITY_GAPS: "lookup uri field"). Asserts the line occurs
+ * exactly once so the transformation cannot mask other divergence.
+ */
+function dropUriField(text: string, marker: "  URI: " | "- URI: "): string {
+  const lines = text.split("\n");
+  const remaining = lines.filter((line) => !line.startsWith(marker));
+  expect(lines.length - remaining.length).toBe(1);
+  return remaining.join("\n");
+}
+
+/** Assert every name appears in the text, in order. */
+function expectNamesInOrder(text: string, names: readonly string[]): void {
+  let cursor = 0;
+  for (const name of names) {
+    const index = text.indexOf(name, cursor);
+    expect(
+      index,
+      `expected "${name}" after position ${cursor}`,
+    ).toBeGreaterThanOrEqual(0);
+    cursor = index + name.length;
+  }
+}
+
+describe("standard pack definition", () => {
+  it("round-trips as declarative JSON and validates as a v0 pack", () => {
+    const raw: unknown = JSON.parse(JSON.stringify(STANDARD_PACK_STORY));
+    expect(validateStoryPackDefinition(raw, PACK_SOURCE)).toEqual(
+      STANDARD_PACK_STORY,
+    );
+  });
+
+  it("records every known gap as a distinct capability entry", () => {
+    expect(PARITY_GAPS.length).toBeGreaterThan(0);
+    expect(new Set(PARITY_GAPS).size).toBe(PARITY_GAPS.length);
+    for (const gap of PARITY_GAPS) {
+      expect(gap.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("standard list parity", () => {
+  let builtinOutput: StandardListOutput;
+  let packRows: Record<string, string>[];
+
+  beforeAll(async () => {
+    const resolution = await standardListStory.resolve(rt, {});
+    builtinOutput = standardListStory.toOutput(resolution, {});
+    packRows = await packList.resolve(rt, {});
+  });
+
+  it("resolves the same rows as the built-in resolver", () => {
+    expect(packRows.length).toBeGreaterThan(0);
+    expect(packRows).toEqual(builtinOutput.items);
+  });
+
+  it("json output is byte-identical", () => {
+    const builtinJson = standardListStory.formatters.json(builtinOutput);
+    const packJson = packList.formatters.json(packList.toOutput(packRows, {}));
+    expect(packJson).toBe(builtinJson);
+  });
+
+  it("MCP envelope matches the built-in summary envelope", async () => {
+    const resolution = await standardListStory.resolve(rt, {});
+    expect(packList.toEnvelope(packRows)).toEqual(
+      standardListStory.toEnvelope(resolution),
+    );
+  });
+
+  it("plain output carries every standard in order — layout is a recorded gap", () => {
+    const names = builtinOutput.items.map((item) => item.name);
+    const builtinPlain = standardListStory.formatters.plain(builtinOutput);
+    const packPlain = packList.formatters.plain(
+      packList.toOutput(packRows, {}),
+    );
+    expectNamesInOrder(builtinPlain, names);
+    expectNamesInOrder(packPlain, names);
+    // Layout divergence pinned — see PARITY_GAPS "list plain template".
+    expect(packPlain).not.toBe(builtinPlain);
+  });
+
+  it("llm output carries every standard in order — templates are a recorded gap", () => {
+    const names = builtinOutput.items.map((item) => item.name);
+    const builtinLlm = standardListStory.formatters.llm(builtinOutput);
+    const packLlm = packList.formatters.llm(packList.toOutput(packRows, {}));
+    expectNamesInOrder(builtinLlm, names);
+    expectNamesInOrder(packLlm, names);
+    // Heading divergence pinned — see PARITY_GAPS "list llm template".
+    expect(builtinLlm.startsWith("## Standards\n")).toBe(true);
+    expect(packLlm.startsWith(`## Standard (${packRows.length})\n`)).toBe(true);
+    expect(packLlm).not.toBe(builtinLlm);
+  });
+});
+
+describe("standard lookup parity (summary view)", () => {
+  for (const name of PARITY_LOOKUP_NAMES) {
+    it(`plain output for "${name}" matches modulo the URI field gap`, async () => {
+      const builtinPlain = standardLookupStory.formatters.plain(
+        standardLookupStory.toFmtInput(await lookupBuiltin(name), SUMMARY_VIEW),
+      );
+      const packPlain = packLookup.formatters.plain(
+        packLookup.toFmtInput(await lookupPack(name), SUMMARY_VIEW),
+      );
+      expect(packPlain).toBe(dropUriField(builtinPlain, "  URI: "));
+    });
+
+    it(`llm output for "${name}" matches modulo the URI field gap`, async () => {
+      const builtinLlm = standardLookupStory.formatters.llm(
+        standardLookupStory.toFmtInput(await lookupBuiltin(name), SUMMARY_VIEW),
+      );
+      const packLlm = packLookup.formatters.llm(
+        packLookup.toFmtInput(await lookupPack(name), SUMMARY_VIEW),
+      );
+      expect(packLlm).toBe(dropUriField(builtinLlm, "- URI: "));
+    });
+
+    it(`json output for "${name}" is byte-identical`, async () => {
+      const builtinJson = standardLookupStory.formatters.json(
+        standardLookupStory.toFmtInput(await lookupBuiltin(name), SUMMARY_VIEW),
+      );
+      const packJson = packLookup.formatters.json(
+        packLookup.toFmtInput(await lookupPack(name), SUMMARY_VIEW),
+      );
+      expect(packJson).toBe(builtinJson);
+    });
+  }
+});
+
+describe("standard lookup parity — cs:extends divergence", () => {
+  it("plain and llm stay byte-identical modulo the URI field", async () => {
+    const builtinInput = standardLookupStory.toFmtInput(
+      await lookupBuiltin(EXTENDS_LOOKUP_NAME),
+      SUMMARY_VIEW,
+    );
+    const packInput = packLookup.toFmtInput(
+      await lookupPack(EXTENDS_LOOKUP_NAME),
+      SUMMARY_VIEW,
+    );
+    expect(packLookup.formatters.plain(packInput)).toBe(
+      dropUriField(
+        standardLookupStory.formatters.plain(builtinInput),
+        "  URI: ",
+      ),
+    );
+    expect(packLookup.formatters.llm(packInput)).toBe(
+      dropUriField(standardLookupStory.formatters.llm(builtinInput), "- URI: "),
+    );
+  });
+
+  it("json diverges only on extends compaction — a recorded gap", async () => {
+    const builtinJson = standardLookupStory.formatters.json(
+      standardLookupStory.toFmtInput(
+        await lookupBuiltin(EXTENDS_LOOKUP_NAME),
+        SUMMARY_VIEW,
+      ),
+    );
+    const packJson = packLookup.formatters.json(
+      packLookup.toFmtInput(
+        await lookupPack(EXTENDS_LOOKUP_NAME),
+        SUMMARY_VIEW,
+      ),
+    );
+    // Divergence pinned — see PARITY_GAPS "lookup data compaction".
+    expect(packJson).not.toBe(builtinJson);
+
+    const builtinParsed = JSON.parse(builtinJson) as Record<string, string>;
+    const packParsed = JSON.parse(packJson) as Record<string, string>;
+    const packExtends = packParsed.extends;
+    if (packExtends === undefined) {
+      throw new Error(`expected cs:extends on "${EXTENDS_LOOKUP_NAME}"`);
+    }
+    // The built-in compacts extends in resolved data; the pack keeps the
+    // raw IRI. Compacting the pack value restores byte-level agreement.
+    expect({
+      ...packParsed,
+      extends: compactUri(packExtends, PREFIX_MAP),
+    }).toEqual(builtinParsed);
+    expect(
+      JSON.stringify(
+        { ...packParsed, extends: compactUri(packExtends, PREFIX_MAP) },
+        null,
+        2,
+      ),
+    ).toBe(builtinJson);
+  });
+});
+
+describe("standard lookup miss parity", () => {
+  it("collects identical not-found entries with ranked suggestions", async () => {
+    const builtinResult = await standardLookupStory.resolve(
+      rt,
+      [NEAR_MISS_NAME],
+      {},
+    );
+    const packResult = await packLookup.resolve(rt, [NEAR_MISS_NAME], {});
+    expect(builtinResult.results).toEqual([]);
+    expect(packResult.results).toEqual([]);
+
+    const builtinError = builtinResult.errors.at(0);
+    const packError = packResult.errors.at(0);
+    if (builtinError === undefined || packError === undefined) {
+      throw new Error("both paths must report a not-found error");
+    }
+    expect(packError).toEqual(builtinError);
+    expect(builtinError.code).toBe("ENTITY_NOT_FOUND");
+    expect(builtinError.suggestions).toContain("code/function/purity");
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/standardParity.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/standardParity.test.ts
@@ -73,7 +73,7 @@ beforeAll(async () => {
   packLookup = lookup;
 });
 
-afterAll(() => store.dispose());
+afterAll(() => store?.dispose());
 
 /** Resolve one name through the built-in lookup story. */
 async function lookupBuiltin(name: string): Promise<StandardDetailed> {
@@ -140,12 +140,13 @@ describe("standard pack definition", () => {
 });
 
 describe("standard list parity", () => {
+  let builtinResolution: Awaited<ReturnType<typeof standardListStory.resolve>>;
   let builtinOutput: StandardListOutput;
   let packRows: Record<string, string>[];
 
   beforeAll(async () => {
-    const resolution = await standardListStory.resolve(rt, {});
-    builtinOutput = standardListStory.toOutput(resolution, {});
+    builtinResolution = await standardListStory.resolve(rt, {});
+    builtinOutput = standardListStory.toOutput(builtinResolution, {});
     packRows = await packList.resolve(rt, {});
   });
 
@@ -160,10 +161,9 @@ describe("standard list parity", () => {
     expect(packJson).toBe(builtinJson);
   });
 
-  it("MCP envelope matches the built-in summary envelope", async () => {
-    const resolution = await standardListStory.resolve(rt, {});
+  it("MCP envelope matches the built-in summary envelope", () => {
     expect(packList.toEnvelope(packRows)).toEqual(
-      standardListStory.toEnvelope(resolution),
+      standardListStory.toEnvelope(builtinResolution),
     );
   });
 

--- a/packages/cli/pragma/src/testing/index.ts
+++ b/packages/cli/pragma/src/testing/index.ts
@@ -10,6 +10,10 @@ export {
   GRAPHQL_ERROR_TTL,
   GRAPHQL_FATAL_TTL,
 } from "./graphqlFixtures.js";
+export {
+  PARITY_GAPS,
+  STANDARD_PACK_STORY,
+} from "./standardParityFixtures.js";
 export type { PragmaTestStoreOptions } from "./store.js";
 export { createTestStore } from "./store.js";
 export {

--- a/packages/cli/pragma/src/testing/standardParityFixtures.ts
+++ b/packages/cli/pragma/src/testing/standardParityFixtures.ts
@@ -1,0 +1,92 @@
+/**
+ * Standard-noun parity pilot fixtures.
+ *
+ * The built-in `standard` list/lookup read stories re-expressed as a v0
+ * story-pack definition, plus the honest record of what v0 cannot yet
+ * reproduce. Together they form the pilot's contract: the definition is
+ * asserted byte-compatible with the built-in output where the format
+ * reaches (`standardParity.test.ts`), and every remaining divergence
+ * must appear in {@link PARITY_GAPS} rather than being papered over.
+ */
+
+import type { StoryPackDefinition } from "../domains/shared/stories/pack/types.js";
+
+/**
+ * The built-in `standard` stories as a declarative pack definition.
+ *
+ * The list SELECT mirrors the query `listStandards` sends the store,
+ * with variables renamed to the built-in's output fields (`?standard` →
+ * `?uri`, `?categoryName` → `?category`) so pack rows carry the same
+ * keys as the built-in summary items. The lookup mirrors the built-in
+ * title and inline fields as far as v0 reaches — {@link PARITY_GAPS}
+ * lists what it cannot express.
+ */
+export const STANDARD_PACK_STORY: StoryPackDefinition = {
+  noun: "standard",
+  description: "List all code standards",
+  list: {
+    query: [
+      "SELECT ?uri ?name ?category ?description",
+      "WHERE {",
+      "  ?uri a cs:CodeStandard ;",
+      "       cs:name ?name ;",
+      "       cs:description ?description .",
+      "  OPTIONAL {",
+      "    ?uri cs:hasCategory ?cat .",
+      "    ?cat cs:slug ?category .",
+      "  }",
+      "}",
+      "ORDER BY ?name",
+    ].join("\n"),
+    columns: [
+      { field: "uri", label: "IRI" },
+      { field: "name", label: "Name" },
+      { field: "category", label: "Category" },
+      { field: "description", label: "Description" },
+    ],
+  },
+  lookup: {
+    type: "cs:CodeStandard",
+    by: "cs:name",
+    fields: [
+      {
+        name: "category",
+        property: "cs:hasCategory/cs:slug",
+        label: "Category",
+      },
+      {
+        name: "description",
+        property: "cs:description",
+        label: "Description",
+      },
+      { name: "extends", property: "cs:extends", label: "Extends" },
+    ],
+  },
+};
+
+/**
+ * Every place the v0 pack format cannot reproduce the built-in standard
+ * stories — the pilot's primary output. Each entry names the concrete
+ * missing pack-format capability; remove an entry only when the format
+ * gains the capability and the parity test asserts it.
+ */
+export const PARITY_GAPS: readonly string[] = [
+  "list params: packs declare no story parameters, so the built-in --category and --search filters (and their MCP tool arguments) cannot be expressed",
+  "list disclosure: no digest/detailed progressive-disclosure levels — the built-in --digest/--detailed flags enrich rows with extends/example/dos/donts and add disclosure meta to the MCP envelope; pack lists always render summary rows",
+  "list empty guard: the built-in raises EMPTY_RESULTS with an install-hint recovery when no standards load; the pack format has no emptyError hook, so a pack list renders nothing",
+  "list plain template: packs render the shared aligned-column table; the built-in renders stacked `name [category]` blocks with an indented description — v0 columns carry no layout or template control",
+  "list llm template: pack headings are `## <Noun> (<count>)` with `` `iri` — **name** value | value `` items; the built-in emits `## Standards` with `- **name** [category]` plus an indented description line — heading text and item template are not authorable",
+  "lookup uri field: the entity IRI cannot be declared as an inline field — v0 fields are property-derived, and a field named `uri` generates a duplicate ?uri SELECT variable the store rejects; the built-in renders `URI: cs:...` as its first lookup field",
+  "lookup property paths: `category` needs the two-hop path cs:hasCategory/cs:slug; the documented v0 `property` contract is a single predicate, and the path only passes validation because the prefixed-name pattern rejects `/` in the first character alone — multi-hop fields need first-class support",
+  "lookup data compaction: the built-in compacts `extends` in resolved data (JSON shows `cs:ComponentFolderStructure`); pack rows keep the raw IRI, so lookup JSON diverges for standards with cs:extends (plain/llm still match because renderers compact at display time)",
+  "lookup sections: dos/donts (cs:do/cs:dont → Example nodes with description/language/code) cannot be declared — v0 sections are single-valued field/code kinds, and the generated single-row lookup query cannot collect arrays of structured code blocks",
+  "lookup detailed toggle: no detailedParam — the built-in CLI adds Do/Don't sections under --detailed and MCP defaults to detailed with a summary projection (project); a pack lookup has one fixed output shape",
+  "lookup empty placeholders: the built-in renders `Category: —` for a standard without a category; pack renderers skip empty fields — no fallback/placeholder declaration (every current standard has a category, so outputs match today)",
+  "lookup glob expansion: the built-in expands glob queries (e.g. `react/*`) via expandLookupQueries before resolving; pack lookups pass names through verbatim",
+  "lookup by IRI: the built-in resolves an IRI or prefixed name (e.g. `cs:ComponentProps`) as the query; a pack lookup only matches the `by` property's string value, and only case-insensitively — exact-match semantics are not selectable",
+  "lookup recovery copy: built-in not-found errors carry cross-domain hints and the recovery message `List available standards.`; pack errors generate `List available standard entries.` — recovery copy is not authorable",
+  "lookup descriptions and examples: the pack lookup CLI description, tool description, names description, and examples are generated from the noun; the built-in curates all of them (e.g. `Look up detailed information for a standard by name or IRI`)",
+  "ink renderers: the built-in stories declare renderInk TUI views; the pack format has none",
+  "extra verbs: the standard noun also ships `categories` and `sample` commands; v0 packs compile only list and lookup",
+  "noun cutover: a pack story cannot register the noun `standard` while the built-in exists (reserved-noun guard in collectPackStories), so cutover must remove the built-in stories in the same release",
+];


### PR DESCRIPTION
> Round 2, item 4 (the pilot phase). **Stacked on #778**, sibling of #779/#780/#781. Test-only — zero production code. This de-risks the eventual cutover of built-in DS stories to declarative pack definitions by measuring exactly how close the pack format already gets, and naming every gap.

## Done

- `STANDARD_PACK_STORY`: the built-in `standard` noun expressed as a v0 pack definition (list SELECT derived from the real `listStandards` query; columns mirroring the built-in's; lookup by `cs:name` with Category/Description/Extends fields).
- `standardParity.test.ts`: boots the **real store from the actual `@canonical/code-standards` graphs (76 standards)** through the production loader chain and asserts both paths against each other, surface by surface.

**Byte parity reached** (asserted with `toBe`):
- list **json** — byte-identical (32,573 bytes, all 76 standards; MCP summary envelope identical)
- lookup **json** — byte-identical for standards without `cs:extends`
- lookup **plain & llm** — byte-identical minus exactly one line (the built-in's `URI:` field, inexpressible in v0)
- lookup **not-found errors** — deep-equal including ranked suggestions

**Divergences pinned by assertions** (not fudged): list plain/llm templates differ (aligned table vs stacked blocks; heading style) — same standards in the same order asserted on both sides.

- **`PARITY_GAPS`** — the pilot's main output: 18 concrete, named pack-format capabilities the cutover needs, exported from the fixture. Highlights: list filter params (`--category`/`--search` — #780 supplies the mechanism), list disclosure levels + empty-results guard, an author-controlled `uri` field, property paths for two-hop lookups, multi-valued code-block sections (dos/donts), detailed toggle, list template control, extra verbs (`categories`, `sample`), and the reserved-noun guard implication (cutover must remove the built-in in the same release).

## QA

- `cd packages/cli/pragma && bun run check && bun run test` — green, **1,278 tests** (16 = the new parity suite).

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

No visual change — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR)_