### PR TITLE
feat(styles): 4px baseline shim + typography example upgrade

### DIFF
--- a/packages/styles/typography/example/index.html
+++ b/packages/styles/typography/example/index.html
@@ -9,7 +9,8 @@
     <link id="engine-metrics" rel="stylesheet" href="../src/baseline-metrics.css" disabled />
     <link id="engine-trim"    rel="stylesheet" href="../src/baseline-trim.css" disabled />
 
-    <!-- Example layout & debug styles -->
+    <!-- Example layout & debug styles. The baseline grid overlay lives in
+         layout.css (driven by --baseline-height, wired to the sidebar input). -->
     <link rel="stylesheet" href="./styles/layout.css" />
     <link rel="stylesheet" href="./styles/demo.css" />
 
@@ -20,54 +21,61 @@
        * src/index.css reads them to compute nudges.
        * Keep in sync with the input defaults in sidebar.js.
        *
-       * Baseline = 0.5rem
+       * Baseline = 4px. Set here as the initial value and driven live by the
+       * sidebar "Baseline grid → Height" input (which writes --baseline-height
+       * on :root); the overlay bands in layout.css read the same variable, so
+       * moving the input resizes both the grid and the type nudges together.
+       *
        * LH multiplier = lineHeight / baseline
        * space-after  = spaceAfter / baseline
        */
 
       :root {
-        --baseline-height: 0.5rem;
+        --baseline-height: 0.25rem;
       }
 
+      /* Line-height multipliers DOUBLED for the 4px baseline: a line that was N
+         8px-units tall is 2N 4px-units, so the multipliers double to keep the
+         same visual line-height. --space-after left as-is per instruction. */
       h1 {
         --font-size: 2.625rem;
-        --line-height-multiplier: 6;
+        --line-height-multiplier: 12;
         --space-after: 2;
       }
 
       h2 {
         --font-size: 2.625rem;
-        --line-height-multiplier: 6;
+        --line-height-multiplier: 12;
         --space-after: 2;
       }
 
       h3 {
         --font-size: 1.5rem;
-        --line-height-multiplier: 4;
+        --line-height-multiplier: 8;
         --space-after: 2;
       }
 
       h4 {
         --font-size: 1.5rem;
-        --line-height-multiplier: 4;
+        --line-height-multiplier: 8;
         --space-after: 2;
       }
 
       h5 {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
 
       h6 {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
 
       p {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
     </style>

--- a/packages/styles/typography/example/scripts/control-input.js
+++ b/packages/styles/typography/example/scripts/control-input.js
@@ -3,17 +3,40 @@
  *
  * Attributes:
  *   label, min, max, step, value, target-selector, css-variable, unit
+ *
+ * The initial value is READ FROM THE CSS: the input seeds itself from the
+ * computed value of `css-variable` on the first element matching
+ * `target-selector`, so the stylesheet is the single source of truth and the
+ * control stays in sync with it (two-way binding). The `value` attribute is only
+ * a fallback used when the CSS does not define the variable.
  */
 class ControlInput extends HTMLElement {
+  /** Read the current value of `cssVariable` on `targetSelector` from the CSS,
+   *  stripped of `unit`. Returns null if unset/unreadable. */
+  readCssValue(targetSelector, cssVariable, unit) {
+    const el = document.querySelector(targetSelector);
+    if (!el) return null;
+    const raw = getComputedStyle(el).getPropertyValue(cssVariable).trim();
+    if (!raw) return null;
+    // Drop the unit suffix (e.g. "0.25rem" -> "0.25") so it fits a number input.
+    const stripped = unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
+    const n = Number.parseFloat(stripped);
+    return Number.isNaN(n) ? null : String(n);
+  }
+
   connectedCallback() {
     const label = this.getAttribute("label");
     const min = this.getAttribute("min");
     const max = this.getAttribute("max");
     const step = this.getAttribute("step");
-    const value = this.getAttribute("value");
     const targetSelector = this.getAttribute("target-selector");
     const cssVariable = this.getAttribute("css-variable");
     const unit = this.getAttribute("unit") || "";
+
+    // Prefer the live CSS value; fall back to the `value` attribute.
+    const value =
+      this.readCssValue(targetSelector, cssVariable, unit) ??
+      this.getAttribute("value");
 
     this.innerHTML = `
       <div class="control">

--- a/packages/styles/typography/example/scripts/control-input.js
+++ b/packages/styles/typography/example/scripts/control-input.js
@@ -19,7 +19,8 @@ class ControlInput extends HTMLElement {
     const raw = getComputedStyle(el).getPropertyValue(cssVariable).trim();
     if (!raw) return null;
     // Drop the unit suffix (e.g. "0.25rem" -> "0.25") so it fits a number input.
-    const stripped = unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
+    const stripped =
+      unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
     const n = Number.parseFloat(stripped);
     return Number.isNaN(n) ? null : String(n);
   }

--- a/packages/styles/typography/example/scripts/sidebar.js
+++ b/packages/styles/typography/example/scripts/sidebar.js
@@ -169,6 +169,21 @@ class SettingsSidebar extends HTMLElement {
           <select id="content-select">${contentOptions}</select>
         </fieldset>
 
+        <!-- Global root font size (defines the rem unit) -->
+        <fieldset>
+          <legend>Global</legend>
+          <control-input
+            label="Root font size"
+            min="8"
+            max="32"
+            step="1"
+            value="16"
+            target-selector="html"
+            css-variable="--font-size"
+            unit="px"
+          ></control-input>
+        </fieldset>
+
         <!-- Baseline height -->
         <fieldset>
           <legend>Baseline grid</legend>
@@ -177,7 +192,7 @@ class SettingsSidebar extends HTMLElement {
             min="0.1"
             max="2"
             step="0.05"
-            value="0.5"
+            value="0.25"
             target-selector=":root"
             css-variable="--baseline-height"
             unit="rem"

--- a/packages/styles/typography/example/styles/demo.css
+++ b/packages/styles/typography/example/styles/demo.css
@@ -7,5 +7,8 @@ h4,
 h5,
 h6,
 p {
-  background: #fededebb;
+  /* Box highlight so the text box is visible against the baseline bands. Alpha
+     sits between the original opaque ~0.73 and a too-faint 0.25 — visible but
+     the grid still reads through. */
+  background: rgba(254, 222, 222, 0.5);
 }

--- a/packages/styles/typography/example/styles/layout.css
+++ b/packages/styles/typography/example/styles/layout.css
@@ -1,7 +1,10 @@
 /* ── Page shell ────────────────────────────────────────────────── */
 
 html {
-  --font-size: 32px;
+  /* Root font-size defines the rem unit. 16px so `--font-size: 1rem` on p is
+     16px (not 32px — the old value made 1rem = 32px, doubling every rem size).
+     Still overridable via the sidebar if a demo wants a different root. */
+  --font-size: 16px;
   font-size: var(--font-size);
   height: 100%;
 }
@@ -117,9 +120,27 @@ main {
   min-height: 100vh;
   padding: 0 1rem;
 
-  /* Baseline grid overlay */
-  background-image: linear-gradient(to bottom, #df1f00 1px, transparent 1px);
-  background-size: 100% var(--baseline-height);
+  /* Baseline grid overlay — strict stepped bands, five hard-edged steps per
+     cycle (level 1 faint → level 5 strong), matching the styles-debug plugin
+     used in the Storybook testbed. Copied inline (rather than linking the debug
+     package) so the static example needs no cross-package path, and driven
+     directly by --baseline-height so it is LINKED TO THE SIDEBAR INPUT: change
+     the "Baseline grid → Height" control and the bands resize with it. */
+  --bl: var(--baseline-height, 0.25rem);
+  background-image: linear-gradient(
+    to bottom,
+    rgba(223, 31, 0, 0.08) 0,
+    rgba(223, 31, 0, 0.08) var(--bl),
+    rgba(223, 31, 0, 0.14) var(--bl),
+    rgba(223, 31, 0, 0.14) calc(var(--bl) * 2),
+    rgba(223, 31, 0, 0.2) calc(var(--bl) * 2),
+    rgba(223, 31, 0, 0.2) calc(var(--bl) * 3),
+    rgba(223, 31, 0, 0.28) calc(var(--bl) * 3),
+    rgba(223, 31, 0, 0.28) calc(var(--bl) * 4),
+    rgba(223, 31, 0, 0.38) calc(var(--bl) * 4),
+    rgba(223, 31, 0, 0.38) calc(var(--bl) * 5)
+  );
+  background-size: 100% calc(var(--bl) * 5);
   background-repeat: repeat;
   background-attachment: local;
 }

--- a/packages/styles/typography/src/baseline-cap.css
+++ b/packages/styles/typography/src/baseline-cap.css
@@ -10,6 +10,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/baseline-metrics.css
+++ b/packages/styles/typography/src/baseline-metrics.css
@@ -15,6 +15,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/baseline-shim.css
+++ b/packages/styles/typography/src/baseline-shim.css
@@ -1,0 +1,18 @@
+/* @canonical/styles-typography — baseline unit shim
+ *
+ * The engine only CONSUMES --baseline-height; the value normally comes from
+ * @canonical/styles (spacing.css). A consumer that loads an engine without
+ * styles-main — or before it — would leave --baseline-height unset and every
+ * nudge would break. Registering the property with an initial-value makes 4px
+ * the fallback whenever nothing else sets it, while any real declaration
+ * (spacing.css, a theme, the testbed) still wins, regardless of load order.
+ *
+ * Single source for the 4px shim, imported by every engine so importing any one
+ * of them carries the fallback. Consumers no longer hardcode --baseline-height
+ * to keep the engine working.
+ */
+@property --baseline-height {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0.25rem;
+}

--- a/packages/styles/typography/src/baseline-trim.css
+++ b/packages/styles/typography/src/baseline-trim.css
@@ -10,6 +10,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/index.css
+++ b/packages/styles/typography/src/index.css
@@ -7,5 +7,9 @@
  *   - baseline-cap.css      — Uses the CSS `cap` unit (no extraction needed) [default]
  *   - baseline-metrics.css  — Uses extracted font metrics (ascender/descender/unitsPerEm)
  *   - baseline-trim.css     — Uses text-box-trim + cap unit hybrid
+ *
+ * Each engine registers the --baseline-height 4px shim itself (see the
+ * `@property` at the top of each), so importing any single engine — as the
+ * typography example does — carries the fallback with no consumer hardcoding.
  */
 @import url("./baseline-cap.css");

--- a/packages/styles/typography/src/mapper.css
+++ b/packages/styles/typography/src/mapper.css
@@ -63,7 +63,15 @@
   /* ── Line height shims ────────────────────────────────────────── *
    * number.tokens.json defines these as $type:"number" but the
    * terrazzo plugin does not emit them in sets.primitive.css.
-   * Hardcoded here until the build pipeline includes number tokens. */
+   * Hardcoded here until the build pipeline includes number tokens.
+   *
+   * These are unitless RATIOS (font-size × ratio = target line-height). The
+   * engine then does round(up, font-size × ratio, --baseline-height), which
+   * snaps the result onto the grid. So the 4px baseline needs NO change here:
+   * a 1rem × 1.5 = 24px line snaps to 24px at both 8px (3 units) and 4px
+   * (6 units) — the px is identical, only the unit COUNT differs. (An earlier
+   * pass wrongly doubled these, which doubled the actual line-height and drifted
+   * from the controls; reverted to the design-token ratios.) */
   --number-line-height-250: 1.3333;
   --number-line-height-300: 1.4286;
   --number-line-height-350: 1.5;


### PR DESCRIPTION
## What

Adds a 4px baseline shim to `@canonical/styles-typography` and upgrades the interactive example.

### Engine
- **`baseline-shim.css`** — registers `--baseline-height` via `@property` with a **4px** `initial-value`, imported by every engine (cap / metrics / trim). This makes 4px the **order-independent** fallback: a consumer that loads an engine without `@canonical/styles` (which normally supplies `--baseline-height`) no longer leaves it unset and breaks every nudge.
- **`mapper.css`** — comment-only: clarifies that `--number-line-height-*` are unitless ratios wrapped in `round(up, …, --baseline-height)`, so the baseline unit can change with **no ratio edit**. Values unchanged.

### Example (`packages/styles/typography/example`)
- 4px baseline; strict stepped-band grid overlay driven by `--baseline-height` (tracks the sidebar Height control).
- `control-input` now reads each control's initial value **from the live CSS**, so the stylesheet is the single source of truth and the sidebar stays in sync (two-way binding). Fixes controls showing stale hardcoded defaults.
- Root `font-size` 32px → **16px** (the old value made `1rem = 32px`, doubling every rem size).
- New **"Root font size"** control (bound to `html --font-size`, default 16px).
- Text-box highlight alpha eased so the grid reads through.

## Why

Part of the vertical-sizing / density exploration. The engine shim removes a load-order fragility (4px only worked if styles-main loaded first); the example changes make it a faithful witness of type on the 4px grid.

## Notes
- The 8px→4px default in the design tokens themselves is intentionally **not** in this PR — that's a separate design-tokens change. This only adds the engine-level fallback + example.