### PR TITLE
feat(react): add ds-experiments — graph-representation component playground

### DIFF
--- a/packages/react/ds-experiments/.storybook/main.ts
+++ b/packages/react/ds-experiments/.storybook/main.ts
@@ -1,0 +1,10 @@
+import { createConfig } from "@canonical/storybook-config";
+
+export default createConfig("react", {
+  // Wraps stories that declare `parameters.relay` in a relay-test-utils mock
+  // environment, so the graph projection components (which use Relay hooks)
+  // render without a server. The `graphql\`...\`` tags they contain are rewritten
+  // by `vite-plugin-relay-lite`, configured in the package's `vite.config.ts`,
+  // which Storybook's react-vite framework merges automatically.
+  extraAddons: ["@canonical/storybook-addon-relay"],
+});

--- a/packages/react/ds-experiments/.storybook/preview.ts
+++ b/packages/react/ds-experiments/.storybook/preview.ts
@@ -1,0 +1,11 @@
+import previewConfig from "@canonical/storybook-config/preview";
+
+import "./styles.css";
+
+const preview = {
+  ...previewConfig,
+  // https://github.com/storybookjs/storybook/issues/31842
+  tags: ["autodocs"],
+};
+
+export default preview;

--- a/packages/react/ds-experiments/.storybook/styles.css
+++ b/packages/react/ds-experiments/.storybook/styles.css
@@ -1,0 +1,1 @@
+@import url("@canonical/styles");

--- a/packages/react/ds-experiments/README.md
+++ b/packages/react/ds-experiments/README.md
@@ -1,0 +1,111 @@
+# @canonical/react-ds-experiments
+
+A **playground** for advanced, graph-shaped design-system components, developed
+in isolation from the shipped tiers (`ds-global`, `ds-global-form`, …). Nothing
+here is published; it exists so we can prototype the harder ideas — starting with
+a **graph representation of the knowledge graph** — against the real toolchain
+(Storybook, Relay, the code standards) before promoting anything.
+
+> Status: **experimental**. `private: true`, not part of the published DS.
+
+## What's in the box
+
+A small kit for drawing a slice of the Pragma ontology as an interactive graph,
+built on [React Flow](https://reactflow.dev) (`@xyflow/react`):
+
+| Export | Kind | What it is |
+| --- | --- | --- |
+| `GraphCanvas` | pure | The composition root. Give it plain `entities` + `relations`; it draws the graph, a legend, controls, and background. |
+| `EntityNode` | pure | The node renderer — a card showing an entity's category, label, tier, and summary. Registered as the `entity` node type. |
+| `RelationEdge` | pure | The edge renderer for **associative** relations (`uses`, `governs`, `refines`) — a curved, tinted, labelled edge. |
+| `SubclassEdge` | pure | The edge renderer for the **taxonomic** `SUBCLASS_OF` ("is a") — an orthogonal edge with a hollow generalisation arrowhead. |
+| `GraphLegend` | pure | The key: every entity kind and relation kind with the colour used to draw it. |
+| helpers | pure | `buildGraphElements`, `computeGraphLayout`, `resolveEntityAppearance`, `resolveRelationAppearance`. |
+| `OntologyGraph` | **projection** | Binds a Relay query and hands the result to `GraphCanvas`. Demonstrated in Storybook (see below), not exported from the build. |
+
+### How edges are modelled
+
+Two archetypes, because the ontology has two:
+
+- **Taxonomy** — `SUBCLASS_OF`, the "is a" backbone. Drawn by `SubclassEdge`
+  with the UML generalisation arrow (a hollow triangle) so `Button is a
+  Component` reads as a classification.
+- **Association** — `uses` / `governs` / `refines`, drawn by `RelationEdge`,
+  each tinted by kind and carrying its verb as a label.
+
+`buildGraphElements` routes each relation to the right renderer via
+`resolveRelationAppearance`, so adding a relation kind is a one-line change in
+one resolver — the canvas and the legend both follow.
+
+## Architecture: pure components vs the projection
+
+This mirrors the split from the A-workstream ADRs (`advl/pragma-adrs`,
+`A.06.COMPOSITION`):
+
+- **Pure components** are presentational. They take a plain graph slice as props
+  and render it. They fetch nothing, so they build, typecheck, and test on their
+  own, and they are the package's public API.
+- The **projection** (`OntologyGraph`) binds a GraphQL query and maps its result
+  to the pure `GraphCanvas`. That binding — the same query a human sees rendered
+  and an agent would issue — is the bi-modal invariant. It is demonstrated in
+  Storybook rather than shipped in `dist`, because a Relay `graphql` tag has to
+  be rewritten by the compiler and would not survive a plain `tsc` build.
+
+```
+query (OntologyGraphQuery)  ──useLazyLoadQuery──▶  OntologyGraph  ──▶  GraphCanvas
+                                                    (projection)        (pure)
+```
+
+## Relay setup
+
+Wired exactly like `apps/react/boilerplate-vite`:
+
+- **`relay.config.json`** points the compiler at `src/relay/schema.graphql` and
+  emits TypeScript artifacts into `src/relay/__generated__` (committed, and
+  excluded from Biome).
+- **`vite-plugin-relay-lite`** (`codegen: false`) rewrites `graphql` tags into
+  imports of those artifacts; Storybook's react-vite framework merges the config.
+- **`@canonical/storybook-addon-relay`** supplies a `relay-test-utils` mock
+  environment per story via `parameters.relay` — see
+  `OntologyGraph.stories.tsx`.
+- **`src/relay/schema.ts`** builds an executable mock schema over the same
+  `ontologySample` fixture, so `OntologyGraph` can also run against
+  `createExperimentsEnvironment` with no backend (the graph-shaped analogue of
+  the boilerplate's catalog mock).
+
+Regenerate artifacts after changing a query:
+
+```sh
+bun run relay        # one-shot
+bun run relay:watch  # on change
+```
+
+### A note on the Relay version
+
+This package was requested with "compiler v21", but the whole workspace is
+pinned to **Relay `18.2.0`** (patched in `patches/` for React 19 + packaging
+fixes), and `@canonical/storybook-addon-relay` declares a peer range of
+`react-relay >=18 <19`. Pinning v21 here would fork Relay in the monorepo,
+bypass those patches, and break the addon's peer requirement. So this package
+tracks the workspace at 18.2.0; bumping the whole repo to Relay 21 is a separate,
+repo-wide change.
+
+## Develop
+
+```sh
+bun run storybook   # play with the components (port 6011)
+bun run test        # unit tests (helpers + GraphLegend)
+bun run check       # biome + tsc
+bun run relay       # regenerate Relay artifacts
+```
+
+## Conventions
+
+Components follow the `summon component react` generator layout —
+`Component.tsx` · `types.ts` (named `…Props`) · `index.ts` (`export type *`) ·
+`Component.stories.tsx` · `Component.tests.tsx` — and the repo code standards
+(folder named for the component, `ds`-prefixed class-name construction, per-file
+default exports, verb-named helper functions). The graph canvas and its
+nodes/edges are gated visually through Storybook/Chromatic rather than jsdom
+unit tests, since React Flow measures a real layout; the deterministic logic is
+unit-tested.

--- a/packages/react/ds-experiments/biome.json
+++ b/packages/react/ds-experiments/biome.json
@@ -1,0 +1,14 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": [
+      "src",
+      ".storybook",
+      "*.json",
+      "vite.config.ts",
+      "vitest.config.ts",
+      "vitest.setup.ts",
+      "!src/relay/__generated__"
+    ]
+  }
+}

--- a/packages/react/ds-experiments/package.json
+++ b/packages/react/ds-experiments/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@canonical/react-ds-experiments",
+  "version": "0.29.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/esm/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "scripts": {
+    "build": "bun run build:package",
+    "build:all": "bun run build:package && bun run build:storybook",
+    "build:storybook": "storybook build",
+    "build:package": "bun run build:package:tsc && bun run build:package:copycss",
+    "build:package:copycss": "copyfiles -u 1 'src/lib/{,**/}*.css' dist/esm",
+    "build:package:tsc": "tsc -p tsconfig.build.json",
+    "check": "bun run check:biome && bun run check:ts",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "relay": "relay-compiler",
+    "relay:watch": "relay-compiler --watch",
+    "storybook": "storybook dev -p 6011 --no-open --host 0.0.0.0",
+    "test": "bun run test:vitest",
+    "test:vitest": "vitest run",
+    "test:vitest:watch": "vitest"
+  },
+  "dependencies": {
+    "@canonical/react-ds-global": "^0.29.1",
+    "@canonical/styles": "^0.29.0",
+    "@xyflow/react": "^12.11.2",
+    "graphql": "^16.11.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-relay": "^18.2.0",
+    "relay-runtime": "^18.2.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.9",
+    "@canonical/biome-config": "^0.29.0",
+    "@canonical/storybook-addon-relay": "^0.29.1",
+    "@canonical/storybook-config": "^0.29.1",
+    "@canonical/typescript-config-react": "^0.29.0",
+    "@chromatic-com/storybook": "^5.0.1",
+    "@storybook/addon-docs": "^10.3.1",
+    "@storybook/react-vite": "^10.3.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^24.12.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@types/react-relay": "^18.2.1",
+    "@types/relay-runtime": "^19.0.3",
+    "@types/relay-test-utils": "^18.0.0",
+    "@vitejs/plugin-react": "^6.0.0",
+    "copyfiles": "^2.4.1",
+    "jsdom": "^28.1.0",
+    "relay-compiler": "^18.2.0",
+    "relay-test-utils": "^18.2.0",
+    "storybook": "^10.3.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vite-plugin-relay-lite": "^0.12.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/react/ds-experiments/relay.config.json
+++ b/packages/react/ds-experiments/relay.config.json
@@ -1,0 +1,8 @@
+{
+  "src": "./src",
+  "schema": "./src/relay/schema.graphql",
+  "language": "typescript",
+  "eagerEsModules": true,
+  "artifactDirectory": "./src/relay/__generated__",
+  "excludes": ["**/node_modules/**", "**/__generated__/**", "**/dist/**"]
+}

--- a/packages/react/ds-experiments/src/fixtures/ontologySample.ts
+++ b/packages/react/ds-experiments/src/fixtures/ontologySample.ts
@@ -1,0 +1,138 @@
+import type { SchemaGraph } from "../graph/types.js";
+
+/**
+ * A small, curated slice of the design-system knowledge graph used by the pure
+ * component stories and tests. It deliberately exercises every entity kind
+ * (standard · concept · component · token) and every relation kind (subclass ·
+ * uses · governs · refines), so a single fixture drives the whole visual legend.
+ *
+ * The data is static and hand-written — no clocks, no randomness — so stories
+ * and visual snapshots are reproducible.
+ */
+const ontologySample: SchemaGraph = {
+  entities: [
+    {
+      id: "ds:standard.component-folder-structure",
+      label: "component-folder-structure",
+      kind: "STANDARD",
+      summary: "How a component's files are named and laid out.",
+    },
+    {
+      id: "ds:standard.class-name-construction",
+      label: "class-name-construction",
+      kind: "STANDARD",
+      summary: "How a component assembles its class names.",
+    },
+    {
+      id: "ds:concept.component",
+      label: "Component",
+      kind: "CONCEPT",
+      summary: "A reusable unit of interface.",
+    },
+    {
+      id: "ds:concept.token",
+      label: "Token",
+      kind: "CONCEPT",
+      summary: "A named design decision.",
+    },
+    {
+      id: "ds:global.component.button",
+      label: "Button",
+      kind: "COMPONENT",
+      tier: "GLOBAL",
+      summary: "Triggers an action within an interface.",
+    },
+    {
+      id: "ds:global.component.card",
+      label: "Card",
+      kind: "COMPONENT",
+      tier: "GLOBAL",
+      summary: "A surface that groups related content.",
+    },
+    {
+      id: "ds:global.component.icon",
+      label: "Icon",
+      kind: "COMPONENT",
+      tier: "GLOBAL",
+      summary: "A small pictographic glyph.",
+    },
+    {
+      id: "ds:global.token.color-accent",
+      label: "color-accent",
+      kind: "TOKEN",
+      tier: "GLOBAL",
+      summary: "The accent colour used for emphasis.",
+    },
+    {
+      id: "ds:global.token.spacing-small",
+      label: "spacing-small",
+      kind: "TOKEN",
+      tier: "GLOBAL",
+      summary: "The small step on the spacing scale.",
+    },
+  ],
+  relations: [
+    {
+      id: "r:button-isa-component",
+      source: "ds:global.component.button",
+      target: "ds:concept.component",
+      kind: "SUBCLASS_OF",
+    },
+    {
+      id: "r:card-isa-component",
+      source: "ds:global.component.card",
+      target: "ds:concept.component",
+      kind: "SUBCLASS_OF",
+    },
+    {
+      id: "r:icon-isa-component",
+      source: "ds:global.component.icon",
+      target: "ds:concept.component",
+      kind: "SUBCLASS_OF",
+    },
+    {
+      id: "r:accent-isa-token",
+      source: "ds:global.token.color-accent",
+      target: "ds:concept.token",
+      kind: "SUBCLASS_OF",
+    },
+    {
+      id: "r:spacing-isa-token",
+      source: "ds:global.token.spacing-small",
+      target: "ds:concept.token",
+      kind: "SUBCLASS_OF",
+    },
+    {
+      id: "r:button-uses-accent",
+      source: "ds:global.component.button",
+      target: "ds:global.token.color-accent",
+      kind: "USES",
+    },
+    {
+      id: "r:button-uses-icon",
+      source: "ds:global.component.button",
+      target: "ds:global.component.icon",
+      kind: "USES",
+    },
+    {
+      id: "r:card-uses-spacing",
+      source: "ds:global.component.card",
+      target: "ds:global.token.spacing-small",
+      kind: "USES",
+    },
+    {
+      id: "r:folder-governs-component",
+      source: "ds:standard.component-folder-structure",
+      target: "ds:concept.component",
+      kind: "GOVERNS",
+    },
+    {
+      id: "r:classname-refines-folder",
+      source: "ds:standard.class-name-construction",
+      target: "ds:standard.component-folder-structure",
+      kind: "REFINES",
+    },
+  ],
+};
+
+export default ontologySample;

--- a/packages/react/ds-experiments/src/graph/types.ts
+++ b/packages/react/ds-experiments/src/graph/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Domain vocabulary for the ontology-graph components.
+ *
+ * These are the *pure* data shapes the graph components render — a plain,
+ * framework-agnostic projection of a slice of the Pragma knowledge graph. They
+ * intentionally mirror the GraphQL schema in `../relay/schema.graphql`, so the
+ * Relay projection (`OntologyGraph`) can hand its query result straight to the
+ * pure `GraphCanvas` with only a narrowing cast. Nothing here imports React,
+ * Relay, or React Flow — the presentational layer depends on this file, never
+ * the other way round.
+ */
+
+/** The ontology category an entity belongs to. */
+export type EntityKind = "COMPONENT" | "TOKEN" | "STANDARD" | "CONCEPT";
+
+/** The design-system tier an entity is sourced from. */
+export type EntityTier = "GLOBAL" | "DOCS" | "APPLICATION" | "SCDN";
+
+/** The kind of a typed relation between two entities. */
+export type RelationKind = "SUBCLASS_OF" | "USES" | "GOVERNS" | "REFINES";
+
+/** A single entity — a node in the knowledge graph. */
+export interface GraphEntity {
+  /** Opaque, stable global identifier. */
+  id: string;
+  /** Human-readable label, e.g. `"Button"`. */
+  label: string;
+  /** The ontology category this entity belongs to. */
+  kind: EntityKind;
+  /** The design-system tier this entity is sourced from, when known. */
+  tier?: EntityTier | null;
+  /** A one-line description of the entity. */
+  summary?: string | null;
+}
+
+/** A directed, typed relation — an edge in the knowledge graph. */
+export interface GraphRelation {
+  /** Opaque, stable identifier for the relation itself. */
+  id: string;
+  /** `id` of the entity the relation starts from. */
+  source: string;
+  /** `id` of the entity the relation points to. */
+  target: string;
+  /** The kind of relation. */
+  kind: RelationKind;
+  /** An optional label rendered on the edge; falls back to the kind's verb. */
+  label?: string | null;
+}
+
+/** A 2-D position on the canvas, in the coordinate space React Flow uses. */
+export interface GraphPosition {
+  x: number;
+  y: number;
+}
+
+/** A slice of the knowledge graph: its entities and the relations among them. */
+export interface SchemaGraph {
+  entities: GraphEntity[];
+  relations: GraphRelation[];
+}

--- a/packages/react/ds-experiments/src/helpers/buildGraphElements.tests.ts
+++ b/packages/react/ds-experiments/src/helpers/buildGraphElements.tests.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { GraphEntity, GraphRelation } from "../graph/types.js";
+import buildGraphElements from "./buildGraphElements.js";
+
+const entities: GraphEntity[] = [
+  { id: "x", label: "X", kind: "COMPONENT" },
+  { id: "y", label: "Y", kind: "CONCEPT" },
+];
+
+const relations: GraphRelation[] = [
+  { id: "e1", source: "x", target: "y", kind: "SUBCLASS_OF" },
+  { id: "e2", source: "x", target: "y", kind: "USES", label: "depends on" },
+];
+
+describe("buildGraphElements", () => {
+  it("turns each entity into an entity node carrying its data", () => {
+    const { nodes } = buildGraphElements(entities, relations);
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]).toMatchObject({ id: "x", type: "entity" });
+    expect(nodes[0].data.entity.label).toBe("X");
+  });
+
+  it("routes edges to the right renderer by relation kind", () => {
+    const { edges } = buildGraphElements(entities, relations);
+
+    expect(edges[0].type).toBe("subclass");
+    expect(edges[1].type).toBe("relation");
+  });
+
+  it("prefers an explicit relation label over the kind verb", () => {
+    const { edges } = buildGraphElements(entities, relations);
+
+    // SUBCLASS_OF has no explicit label -> falls back to the verb.
+    expect(edges[0].label).toBe("is a");
+    // USES carries one -> it wins.
+    expect(edges[1].label).toBe("depends on");
+  });
+
+  it("honours curated positions over the computed layout", () => {
+    const positions = new Map([["x", { x: 42, y: 7 }]]);
+    const { nodes } = buildGraphElements(entities, relations, { positions });
+
+    expect(nodes.find((node) => node.id === "x")?.position).toEqual({
+      x: 42,
+      y: 7,
+    });
+  });
+});

--- a/packages/react/ds-experiments/src/helpers/buildGraphElements.ts
+++ b/packages/react/ds-experiments/src/helpers/buildGraphElements.ts
@@ -1,0 +1,74 @@
+import type {
+  GraphEntity,
+  GraphPosition,
+  GraphRelation,
+} from "../graph/types.js";
+import type { EntityFlowNode } from "../lib/EntityNode/types.js";
+import type { RelationFlowEdge } from "../lib/RelationEdge/types.js";
+import computeGraphLayout, {
+  type GraphLayoutOptions,
+} from "./computeGraphLayout.js";
+import resolveRelationAppearance from "./resolveRelationAppearance.js";
+
+/** Options for {@link buildGraphElements}. */
+export interface BuildGraphElementsOptions {
+  /**
+   * Curated positions keyed by entity id. Any entity absent from the map is
+   * placed by {@link computeGraphLayout}, so partial curation is fine.
+   */
+  readonly positions?: Map<string, GraphPosition>;
+  /** Forwarded to {@link computeGraphLayout} for entities without a position. */
+  readonly layout?: GraphLayoutOptions;
+}
+
+/** The React Flow `nodes` and `edges` a `GraphCanvas` renders. */
+export interface GraphElements {
+  readonly nodes: EntityFlowNode[];
+  readonly edges: RelationFlowEdge[];
+}
+
+/**
+ * Converts a pure graph slice — plain entities and relations — into the typed
+ * node and edge arrays React Flow consumes. This is the single adapter between
+ * the domain vocabulary and the rendering library: entities become `entity`
+ * nodes carrying their data, and each relation becomes an edge whose renderer
+ * (`subclass` vs `relation`) and default label come from
+ * {@link resolveRelationAppearance}.
+ *
+ * Positioning is resolved here so both the node array and any caller share one
+ * coordinate system: curated `positions` win, and everything else falls back to
+ * the deterministic layered layout.
+ */
+const buildGraphElements = (
+  entities: readonly GraphEntity[],
+  relations: readonly GraphRelation[],
+  options: BuildGraphElementsOptions = {},
+): GraphElements => {
+  const computed = computeGraphLayout(entities, options.layout);
+  const positionOf = (id: string): GraphPosition =>
+    options.positions?.get(id) ?? computed.get(id) ?? { x: 0, y: 0 };
+
+  const nodes: EntityFlowNode[] = entities.map((entity) => ({
+    id: entity.id,
+    type: "entity",
+    position: positionOf(entity.id),
+    data: { entity },
+  }));
+
+  const edges: RelationFlowEdge[] = relations.map((relation) => {
+    const appearance = resolveRelationAppearance(relation.kind);
+    return {
+      id: relation.id,
+      source: relation.source,
+      target: relation.target,
+      type: appearance.edgeRenderer,
+      // The verb is shown on the edge; an explicit relation label overrides it.
+      label: relation.label ?? appearance.label,
+      data: { relation, modifier: appearance.modifier },
+    };
+  });
+
+  return { nodes, edges };
+};
+
+export default buildGraphElements;

--- a/packages/react/ds-experiments/src/helpers/computeGraphLayout.tests.ts
+++ b/packages/react/ds-experiments/src/helpers/computeGraphLayout.tests.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { GraphEntity } from "../graph/types.js";
+import computeGraphLayout from "./computeGraphLayout.js";
+
+const entity = (id: string, kind: GraphEntity["kind"]): GraphEntity => ({
+  id,
+  label: id,
+  kind,
+});
+
+describe("computeGraphLayout", () => {
+  it("stacks entities of the same kind in one column", () => {
+    const positions = computeGraphLayout(
+      [entity("a", "COMPONENT"), entity("b", "COMPONENT")],
+      { columnGap: 200, rowGap: 100 },
+    );
+
+    expect(positions.get("a")).toEqual({ x: 400, y: 0 });
+    // COMPONENT is column index 2 -> x = 2 * 200; second entity drops one row.
+    expect(positions.get("b")).toEqual({ x: 400, y: 100 });
+  });
+
+  it("separates different kinds into different columns", () => {
+    const positions = computeGraphLayout(
+      [entity("s", "STANDARD"), entity("t", "TOKEN")],
+      { columnGap: 200, rowGap: 100 },
+    );
+
+    expect(positions.get("s")?.x).toBe(0);
+    expect(positions.get("t")?.x).toBe(600);
+  });
+
+  it("is deterministic for the same input", () => {
+    const input = [entity("a", "COMPONENT"), entity("b", "TOKEN")];
+
+    expect([...computeGraphLayout(input)]).toEqual([
+      ...computeGraphLayout(input),
+    ]);
+  });
+});

--- a/packages/react/ds-experiments/src/helpers/computeGraphLayout.ts
+++ b/packages/react/ds-experiments/src/helpers/computeGraphLayout.ts
@@ -1,0 +1,73 @@
+import type { EntityKind, GraphEntity, GraphPosition } from "../graph/types.js";
+
+/** Tuning for {@link computeGraphLayout}; every value is in canvas pixels. */
+export interface GraphLayoutOptions {
+  /** Horizontal distance between category columns. */
+  readonly columnGap?: number;
+  /** Vertical distance between entities stacked in a column. */
+  readonly rowGap?: number;
+  /** Inset of the whole layout from the top-left origin. */
+  readonly origin?: GraphPosition;
+}
+
+const DEFAULT_COLUMN_GAP = 260;
+const DEFAULT_ROW_GAP = 120;
+const DEFAULT_ORIGIN: GraphPosition = { x: 0, y: 0 };
+
+/**
+ * Column order, left to right. Standards sit upstream of the concepts they
+ * define, which sit upstream of the components and tokens that realise them —
+ * so reading the canvas left to right roughly follows governance flowing into
+ * implementation.
+ */
+const COLUMN_ORDER: readonly EntityKind[] = [
+  "STANDARD",
+  "CONCEPT",
+  "COMPONENT",
+  "TOKEN",
+];
+
+const columnIndexOf = (kind: string): number => {
+  const index = COLUMN_ORDER.indexOf(kind as EntityKind);
+  // Unknown kinds fall into a trailing column of their own rather than
+  // collapsing onto STANDARD at index 0.
+  return index === -1 ? COLUMN_ORDER.length : index;
+};
+
+/**
+ * Computes a deterministic position for every entity: category chooses the
+ * column, arrival order chooses the row within it. Deterministic in, deterministic
+ * out — no clocks, no randomness — so stories and visual snapshots are stable.
+ *
+ * This is intentionally a simple layered placement, not a force-directed or
+ * hierarchical solver; it is the honest default for a first playground, and the
+ * seam where a real layout engine (e.g. elkjs) would later slot in. Callers that
+ * have curated coordinates should pass them to `GraphCanvas` directly and skip
+ * this entirely.
+ */
+const computeGraphLayout = (
+  entities: readonly GraphEntity[],
+  options: GraphLayoutOptions = {},
+): Map<string, GraphPosition> => {
+  const columnGap = options.columnGap ?? DEFAULT_COLUMN_GAP;
+  const rowGap = options.rowGap ?? DEFAULT_ROW_GAP;
+  const origin = options.origin ?? DEFAULT_ORIGIN;
+
+  const rowByColumn = new Map<number, number>();
+  const positions = new Map<string, GraphPosition>();
+
+  for (const entity of entities) {
+    const column = columnIndexOf(entity.kind);
+    const row = rowByColumn.get(column) ?? 0;
+    rowByColumn.set(column, row + 1);
+
+    positions.set(entity.id, {
+      x: origin.x + column * columnGap,
+      y: origin.y + row * rowGap,
+    });
+  }
+
+  return positions;
+};
+
+export default computeGraphLayout;

--- a/packages/react/ds-experiments/src/helpers/index.ts
+++ b/packages/react/ds-experiments/src/helpers/index.ts
@@ -1,0 +1,14 @@
+export type {
+  BuildGraphElementsOptions,
+  GraphElements,
+} from "./buildGraphElements.js";
+export { default as buildGraphElements } from "./buildGraphElements.js";
+export type { GraphLayoutOptions } from "./computeGraphLayout.js";
+export { default as computeGraphLayout } from "./computeGraphLayout.js";
+export type { EntityAppearance } from "./resolveEntityAppearance.js";
+export { default as resolveEntityAppearance } from "./resolveEntityAppearance.js";
+export type {
+  EdgeRenderer,
+  RelationAppearance,
+} from "./resolveRelationAppearance.js";
+export { default as resolveRelationAppearance } from "./resolveRelationAppearance.js";

--- a/packages/react/ds-experiments/src/helpers/resolveEntityAppearance.tests.ts
+++ b/packages/react/ds-experiments/src/helpers/resolveEntityAppearance.tests.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import resolveEntityAppearance from "./resolveEntityAppearance.js";
+
+describe("resolveEntityAppearance", () => {
+  it("maps each known kind to its own modifier, label, and accent token", () => {
+    expect(resolveEntityAppearance("COMPONENT")).toEqual({
+      modifier: "component",
+      label: "Component",
+      accentVar: "--entity-accent-component",
+    });
+    expect(resolveEntityAppearance("TOKEN").accentVar).toBe(
+      "--entity-accent-token",
+    );
+    expect(resolveEntityAppearance("STANDARD").label).toBe("Standard");
+    expect(resolveEntityAppearance("CONCEPT").modifier).toBe("concept");
+  });
+
+  it("degrades an unknown kind to a neutral appearance instead of throwing", () => {
+    const appearance = resolveEntityAppearance("%future added value");
+
+    expect(appearance.modifier).toBe("unknown");
+    expect(appearance.label).toBe("Entity");
+    expect(appearance.accentVar).toBe("--entity-accent-unknown");
+  });
+});

--- a/packages/react/ds-experiments/src/helpers/resolveEntityAppearance.ts
+++ b/packages/react/ds-experiments/src/helpers/resolveEntityAppearance.ts
@@ -1,0 +1,60 @@
+import type { EntityKind } from "../graph/types.js";
+
+/**
+ * The visual encoding of one ontology category — the single source of truth
+ * shared by `EntityNode` (how a node is drawn) and `GraphLegend` (how the
+ * encoding is explained). Keeping both consumers on the same resolver is what
+ * guarantees the legend never drifts from the canvas.
+ */
+export interface EntityAppearance {
+  /** Modifier class appended to the node, e.g. `"component"`. */
+  readonly modifier: string;
+  /** Human-readable name of the category, e.g. `"Component"`. */
+  readonly label: string;
+  /**
+   * CSS custom property (design token) that colours this category. Defined in
+   * `EntityNode`'s stylesheet and referenced by both the node and the legend
+   * swatch, so a palette change is a one-line edit.
+   */
+  readonly accentVar: string;
+}
+
+const APPEARANCE_BY_KIND: Record<EntityKind, EntityAppearance> = {
+  COMPONENT: {
+    modifier: "component",
+    label: "Component",
+    accentVar: "--entity-accent-component",
+  },
+  TOKEN: {
+    modifier: "token",
+    label: "Token",
+    accentVar: "--entity-accent-token",
+  },
+  STANDARD: {
+    modifier: "standard",
+    label: "Standard",
+    accentVar: "--entity-accent-standard",
+  },
+  CONCEPT: {
+    modifier: "concept",
+    label: "Concept",
+    accentVar: "--entity-accent-concept",
+  },
+};
+
+const FALLBACK_APPEARANCE: EntityAppearance = {
+  modifier: "unknown",
+  label: "Entity",
+  accentVar: "--entity-accent-unknown",
+};
+
+/**
+ * Resolves the visual encoding for an entity category. Accepts a plain string
+ * (not just the `EntityKind` union) so a value the graph has grown but this
+ * package has not yet learned — GraphQL's `"%future added value"` — degrades to
+ * a neutral appearance instead of crashing the render.
+ */
+const resolveEntityAppearance = (kind: string): EntityAppearance =>
+  APPEARANCE_BY_KIND[kind as EntityKind] ?? FALLBACK_APPEARANCE;
+
+export default resolveEntityAppearance;

--- a/packages/react/ds-experiments/src/helpers/resolveRelationAppearance.tests.ts
+++ b/packages/react/ds-experiments/src/helpers/resolveRelationAppearance.tests.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import resolveRelationAppearance from "./resolveRelationAppearance.js";
+
+describe("resolveRelationAppearance", () => {
+  it("routes the taxonomic SUBCLASS_OF to the subclass renderer", () => {
+    const appearance = resolveRelationAppearance("SUBCLASS_OF");
+
+    expect(appearance.edgeRenderer).toBe("subclass");
+    expect(appearance.label).toBe("is a");
+  });
+
+  it("routes associative kinds to the relation renderer", () => {
+    for (const kind of ["USES", "GOVERNS", "REFINES"]) {
+      expect(resolveRelationAppearance(kind).edgeRenderer).toBe("relation");
+    }
+    expect(resolveRelationAppearance("USES").label).toBe("uses");
+  });
+
+  it("degrades an unknown kind to a neutral associative edge", () => {
+    const appearance = resolveRelationAppearance("%future added value");
+
+    expect(appearance.edgeRenderer).toBe("relation");
+    expect(appearance.modifier).toBe("unknown");
+  });
+});

--- a/packages/react/ds-experiments/src/helpers/resolveRelationAppearance.ts
+++ b/packages/react/ds-experiments/src/helpers/resolveRelationAppearance.ts
@@ -1,0 +1,66 @@
+import type { RelationKind } from "../graph/types.js";
+
+/** Which registered React Flow edge renderer draws a relation. */
+export type EdgeRenderer = "subclass" | "relation";
+
+/**
+ * The visual encoding of one relation kind — shared by `buildGraphElements`
+ * (which picks the edge renderer and label) and `GraphLegend` (which explains
+ * it). `edgeRenderer` splits the ontology's two edge archetypes: the taxonomic
+ * `SUBCLASS_OF` ("is a") is drawn by `SubclassEdge` with a hollow arrowhead,
+ * while associative relations are drawn by `RelationEdge`.
+ */
+export interface RelationAppearance {
+  /** Modifier class appended to the edge, e.g. `"uses"`. */
+  readonly modifier: string;
+  /** The verb rendered on the edge when it carries no explicit label. */
+  readonly label: string;
+  /** The registered edge component that draws this relation. */
+  readonly edgeRenderer: EdgeRenderer;
+  /** CSS custom property (design token) that colours this relation. */
+  readonly accentVar: string;
+}
+
+const APPEARANCE_BY_KIND: Record<RelationKind, RelationAppearance> = {
+  SUBCLASS_OF: {
+    modifier: "subclass",
+    label: "is a",
+    edgeRenderer: "subclass",
+    accentVar: "--relation-accent-subclass",
+  },
+  USES: {
+    modifier: "uses",
+    label: "uses",
+    edgeRenderer: "relation",
+    accentVar: "--relation-accent-uses",
+  },
+  GOVERNS: {
+    modifier: "governs",
+    label: "governs",
+    edgeRenderer: "relation",
+    accentVar: "--relation-accent-governs",
+  },
+  REFINES: {
+    modifier: "refines",
+    label: "refines",
+    edgeRenderer: "relation",
+    accentVar: "--relation-accent-refines",
+  },
+};
+
+const FALLBACK_APPEARANCE: RelationAppearance = {
+  modifier: "unknown",
+  label: "relates to",
+  edgeRenderer: "relation",
+  accentVar: "--relation-accent-unknown",
+};
+
+/**
+ * Resolves the visual encoding for a relation kind, degrading unknown kinds
+ * (e.g. GraphQL's `"%future added value"`) to a neutral associative edge rather
+ * than failing the render.
+ */
+const resolveRelationAppearance = (kind: string): RelationAppearance =>
+  APPEARANCE_BY_KIND[kind as RelationKind] ?? FALLBACK_APPEARANCE;
+
+export default resolveRelationAppearance;

--- a/packages/react/ds-experiments/src/index.ts
+++ b/packages/react/ds-experiments/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @canonical/react-ds-experiments — a playground for advanced, graph-shaped
+ * design-system components, developed in isolation from the shipped tiers.
+ *
+ * The public surface is the *pure* graph layer: presentational components that
+ * render a plain slice of the knowledge graph, plus the helpers that lay it out
+ * and colour it. The Relay *projection* (`OntologyGraph`) and its mock schema
+ * are demonstrated in Storybook rather than exported, because they depend on a
+ * compiler pass — see the package README.
+ *
+ * @packageDocumentation
+ */
+
+// Domain vocabulary
+export type * from "./graph/types.js";
+// Helpers
+export * from "./helpers/index.js";
+export type {
+  EntityFlowNode,
+  EntityNodeData,
+  EntityNodeProps,
+} from "./lib/EntityNode/index.js";
+export { EntityNode } from "./lib/EntityNode/index.js";
+export type { GraphCanvasProps } from "./lib/GraphCanvas/index.js";
+// Components
+export { GraphCanvas } from "./lib/GraphCanvas/index.js";
+export type { GraphLegendProps } from "./lib/GraphLegend/index.js";
+export { GraphLegend } from "./lib/GraphLegend/index.js";
+export type {
+  RelationEdgeData,
+  RelationEdgeProps,
+  RelationFlowEdge,
+} from "./lib/RelationEdge/index.js";
+export { RelationEdge } from "./lib/RelationEdge/index.js";
+export type { SubclassEdgeProps } from "./lib/SubclassEdge/index.js";
+export { SubclassEdge } from "./lib/SubclassEdge/index.js";

--- a/packages/react/ds-experiments/src/lib/EntityNode/EntityNode.stories.tsx
+++ b/packages/react/ds-experiments/src/lib/EntityNode/EntityNode.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type NodeTypes, ReactFlow } from "@xyflow/react";
+import type { ReactElement } from "react";
+import type { GraphEntity } from "../../graph/types.js";
+import EntityNode from "./EntityNode.js";
+import type { EntityFlowNode } from "./types.js";
+import "@xyflow/react/dist/style.css";
+
+// A custom node only receives its handle context inside a React Flow canvas, so
+// the gallery renders each entity on a small, static one-node canvas.
+const nodeTypes: NodeTypes = { entity: EntityNode };
+
+interface EntityNodePreviewProps {
+  /** The entity to draw. */
+  entity: GraphEntity;
+  /** Render the node in its selected state. */
+  selected?: boolean;
+}
+
+const EntityNodePreview = ({
+  entity,
+  selected,
+}: EntityNodePreviewProps): ReactElement => {
+  const nodes: EntityFlowNode[] = [
+    {
+      id: entity.id,
+      type: "entity",
+      position: { x: 0, y: 0 },
+      data: { entity },
+      selected,
+    },
+  ];
+
+  return (
+    <div style={{ inlineSize: 340, blockSize: 200 }}>
+      <ReactFlow
+        nodes={nodes}
+        nodeTypes={nodeTypes}
+        fitView
+        fitViewOptions={{ maxZoom: 1 }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        panOnDrag={false}
+        zoomOnScroll={false}
+      />
+    </div>
+  );
+};
+
+const meta: Meta<typeof EntityNodePreview> = {
+  title: "Components/EntityNode",
+  component: EntityNodePreview,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof EntityNodePreview>;
+
+export const Component: Story = {
+  args: {
+    entity: {
+      id: "ds:global.component.button",
+      label: "Button",
+      kind: "COMPONENT",
+      tier: "GLOBAL",
+      summary: "Triggers an action within an interface.",
+    },
+  },
+};
+
+export const Token: Story = {
+  args: {
+    entity: {
+      id: "ds:global.token.color-accent",
+      label: "color-accent",
+      kind: "TOKEN",
+      tier: "GLOBAL",
+      summary: "The accent colour used for emphasis and focus.",
+    },
+  },
+};
+
+export const Standard: Story = {
+  args: {
+    entity: {
+      id: "ds:standard.class-name-construction",
+      label: "class-name-construction",
+      kind: "STANDARD",
+      summary: "How component class names are assembled.",
+    },
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    entity: {
+      id: "ds:global.component.card",
+      label: "Card",
+      kind: "COMPONENT",
+      tier: "GLOBAL",
+      summary: "A surface that groups related content.",
+    },
+    selected: true,
+  },
+};

--- a/packages/react/ds-experiments/src/lib/EntityNode/EntityNode.tsx
+++ b/packages/react/ds-experiments/src/lib/EntityNode/EntityNode.tsx
@@ -1,0 +1,59 @@
+import { Handle, Position } from "@xyflow/react";
+import type React from "react";
+import resolveEntityAppearance from "../../helpers/resolveEntityAppearance.js";
+import type { EntityNodeProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds entity-node";
+
+/**
+ * The renderer React Flow uses to draw an ontology entity — a card showing the
+ * entity's category, label, tier, and summary. It is a *pure* presentational
+ * node: everything it needs arrives in `data.entity`, and its accent colour
+ * comes from `resolveEntityAppearance` — the same resolver `GraphLegend` reads,
+ * so canvas and legend can never disagree.
+ *
+ * Register it with `GraphCanvas`'s `nodeTypes` under the key `"entity"`; the
+ * left and right handles are the anchor points relations attach to.
+ *
+ * @implements ds:experiments.component.entity-node
+ */
+const EntityNode = ({
+  data,
+  selected,
+}: EntityNodeProps): React.ReactElement => {
+  const { entity } = data;
+  const appearance = resolveEntityAppearance(entity.kind);
+
+  return (
+    <div
+      className={[
+        componentCssClassName,
+        appearance.modifier,
+        selected ? "is-selected" : null,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={
+        {
+          "--entity-accent": `var(${appearance.accentVar})`,
+        } as React.CSSProperties
+      }
+    >
+      <Handle type="target" position={Position.Left} />
+      <header className="entity-node-header">
+        <span className="entity-node-kind">{appearance.label}</span>
+        {entity.tier ? (
+          <span className="entity-node-tier">{entity.tier.toLowerCase()}</span>
+        ) : null}
+      </header>
+      <p className="entity-node-label">{entity.label}</p>
+      {entity.summary ? (
+        <p className="entity-node-summary">{entity.summary}</p>
+      ) : null}
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+};
+
+export default EntityNode;

--- a/packages/react/ds-experiments/src/lib/EntityNode/index.ts
+++ b/packages/react/ds-experiments/src/lib/EntityNode/index.ts
@@ -1,0 +1,2 @@
+export { default as EntityNode } from "./EntityNode.js";
+export type * from "./types.js";

--- a/packages/react/ds-experiments/src/lib/EntityNode/styles.css
+++ b/packages/react/ds-experiments/src/lib/EntityNode/styles.css
@@ -1,0 +1,75 @@
+/* ==========================================================================
+   Graph palette — entity accents
+   Mirrored in GraphLegend's stylesheet so a standalone legend renders the same
+   colours; `resolveEntityAppearance` is the single source of truth for which
+   token a category maps to. Keep the two in sync.
+   ========================================================================== */
+:root {
+  --entity-accent-component: var(--color-feedback-information, #0066cc);
+  --entity-accent-token: var(--color-feedback-positive, #0e8420);
+  --entity-accent-standard: var(--color-feedback-caution, #f99b11);
+  --entity-accent-concept: var(--color-accent, #7764d8);
+  --entity-accent-unknown: var(--color-border-high-contrast, #666);
+
+  --entity-node-width: 12rem;
+  --entity-node-radius: var(--spacing-border-radius, 0.25rem);
+  --entity-node-padding: var(--spacing-horizontal-small, 0.5rem);
+}
+
+/* ==========================================================================
+   Entity node card
+   ========================================================================== */
+.ds.entity-node {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  inline-size: var(--entity-node-width);
+  padding: var(--entity-node-padding);
+  border: var(--spacing-border-width, 1px) solid
+    var(--color-border-high-contrast, #cdcdcd);
+  border-inline-start: 3px solid var(--entity-accent, currentColor);
+  border-radius: var(--entity-node-radius);
+  background-color: var(--color-background-default, #fff);
+  color: var(--color-text, #111);
+  font-size: var(--font-size-default, 0.875rem);
+  line-height: var(--line-height-default, 1.5);
+}
+
+.ds.entity-node.is-selected {
+  outline: 2px solid var(--entity-accent, currentColor);
+  outline-offset: 1px;
+}
+
+.ds.entity-node .entity-node-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.ds.entity-node .entity-node-kind {
+  font-size: var(--font-size-caption, 0.75rem);
+  font-weight: var(--font-weight-bold, 550);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--entity-accent, currentColor);
+}
+
+.ds.entity-node .entity-node-tier {
+  font-size: var(--font-size-caption, 0.75rem);
+  padding-inline: 0.375rem;
+  border-radius: 999px;
+  background-color: var(--color-background-hover, #f2f2f2);
+  color: var(--color-text-muted, #666);
+}
+
+.ds.entity-node .entity-node-label {
+  margin: 0;
+  font-weight: var(--font-weight-bold, 550);
+}
+
+.ds.entity-node .entity-node-summary {
+  margin: 0;
+  font-size: var(--font-size-caption, 0.75rem);
+  color: var(--color-text-muted, #666);
+}

--- a/packages/react/ds-experiments/src/lib/EntityNode/types.ts
+++ b/packages/react/ds-experiments/src/lib/EntityNode/types.ts
@@ -1,0 +1,16 @@
+import type { Node, NodeProps } from "@xyflow/react";
+import type { GraphEntity } from "../../graph/types.js";
+
+/**
+ * Data an entity node carries on the canvas. Declared as a `type` (not an
+ * `interface`) so it satisfies React Flow's `Record<string, unknown>` data
+ * constraint through TypeScript's implicit index signature for object-literal
+ * type aliases.
+ */
+export type EntityNodeData = { entity: GraphEntity };
+
+/** The typed React Flow node the `EntityNode` renderer draws. */
+export type EntityFlowNode = Node<EntityNodeData, "entity">;
+
+/** Props React Flow passes to the `EntityNode` renderer. */
+export type EntityNodeProps = NodeProps<EntityFlowNode>;

--- a/packages/react/ds-experiments/src/lib/GraphCanvas/GraphCanvas.stories.tsx
+++ b/packages/react/ds-experiments/src/lib/GraphCanvas/GraphCanvas.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import ontologySample from "../../fixtures/ontologySample.js";
+import GraphCanvas from "./GraphCanvas.js";
+
+const meta: Meta<typeof GraphCanvas> = {
+  title: "Components/GraphCanvas",
+  component: GraphCanvas,
+  tags: ["autodocs"],
+  args: {
+    entities: ontologySample.entities,
+    relations: ontologySample.relations,
+    height: 520,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GraphCanvas>;
+
+/** The full sample ontology: every entity kind and every relation kind. */
+export const Default: Story = {};
+
+/** The canvas without its legend panel — e.g. when embedded beside one. */
+export const WithoutLegend: Story = {
+  args: {
+    showLegend: false,
+  },
+};
+
+/** Just the graph: no legend, controls, or background chrome. */
+export const Minimal: Story = {
+  args: {
+    showLegend: false,
+    showControls: false,
+    showBackground: false,
+  },
+};
+
+/** Only the taxonomy — the `SUBCLASS_OF` backbone of the ontology. */
+export const TaxonomyOnly: Story = {
+  args: {
+    relations: ontologySample.relations.filter(
+      (relation) => relation.kind === "SUBCLASS_OF",
+    ),
+  },
+};

--- a/packages/react/ds-experiments/src/lib/GraphCanvas/GraphCanvas.tsx
+++ b/packages/react/ds-experiments/src/lib/GraphCanvas/GraphCanvas.tsx
@@ -1,0 +1,112 @@
+import { Background, Controls, Panel, ReactFlow } from "@xyflow/react";
+import { type ReactElement, useMemo } from "react";
+import buildGraphElements from "../../helpers/buildGraphElements.js";
+import EntityNode from "../EntityNode/EntityNode.js";
+import GraphLegend from "../GraphLegend/GraphLegend.js";
+import RelationEdge from "../RelationEdge/RelationEdge.js";
+import SubclassEdge from "../SubclassEdge/SubclassEdge.js";
+import type { GraphCanvasProps } from "./types.js";
+import "@xyflow/react/dist/style.css";
+import "./styles.css";
+
+const componentCssClassName = "ds graph-canvas";
+
+// Registered outside the component so React Flow sees stable identities and
+// does not warn about (or re-mount from) new type maps on every render.
+const nodeTypes = { entity: EntityNode };
+const edgeTypes = { relation: RelationEdge, subclass: SubclassEdge };
+
+/**
+ * The composition root for the ontology graph — a pure, presentational canvas.
+ * Give it a slice of the knowledge graph (plain `entities` and `relations`) and
+ * it draws it: entities become `EntityNode`s, relations become `RelationEdge`s
+ * or `SubclassEdge`s, and it layers a legend, controls, and background on top.
+ *
+ * It fetches nothing. The Relay projection `OntologyGraph` binds a query and
+ * hands its result straight here — the seam that keeps the human canvas and the
+ * agent-facing query one and the same.
+ *
+ * The two arrowhead markers the edges reference (`#ds-relation-arrow`, the
+ * filled associative arrow, and `#ds-subclass-arrow`, the hollow taxonomic one)
+ * are defined once here so every edge shares them.
+ *
+ * @implements ds:experiments.component.graph-canvas
+ */
+const GraphCanvas = ({
+  entities,
+  relations,
+  positions,
+  height = 480,
+  showLegend = true,
+  showControls = true,
+  showBackground = true,
+  fitView = true,
+  className,
+  ...props
+}: GraphCanvasProps): ReactElement => {
+  const { nodes, edges } = useMemo(
+    () =>
+      buildGraphElements(entities, relations, {
+        positions: positions ? new Map(Object.entries(positions)) : undefined,
+      }),
+    [entities, relations, positions],
+  );
+
+  return (
+    <div
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      style={{ blockSize: height }}
+      {...props}
+    >
+      {/* Document-scoped arrowhead markers the edges resolve by id. */}
+      <svg className="ds graph-markers" aria-hidden="true">
+        <title>Graph edge markers</title>
+        <defs>
+          <marker
+            id="ds-relation-arrow"
+            markerWidth={12}
+            markerHeight={12}
+            refX={9}
+            refY={5}
+            orient="auto"
+            markerUnits="userSpaceOnUse"
+          >
+            <path className="ds relation-arrow" d="M0,0 L9,5 L0,10 z" />
+          </marker>
+          <marker
+            id="ds-subclass-arrow"
+            markerWidth={18}
+            markerHeight={18}
+            refX={14}
+            refY={7}
+            orient="auto"
+            markerUnits="userSpaceOnUse"
+          >
+            <path className="ds subclass-arrow" d="M0,0 L14,7 L0,14 z" />
+          </marker>
+        </defs>
+      </svg>
+
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView={fitView}
+        nodesDraggable
+        elementsSelectable
+        minZoom={0.2}
+      >
+        {showBackground ? <Background /> : null}
+        {showControls ? <Controls /> : null}
+        {showLegend ? (
+          <Panel position="top-right">
+            <GraphLegend />
+          </Panel>
+        ) : null}
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default GraphCanvas;

--- a/packages/react/ds-experiments/src/lib/GraphCanvas/index.ts
+++ b/packages/react/ds-experiments/src/lib/GraphCanvas/index.ts
@@ -1,0 +1,2 @@
+export { default as GraphCanvas } from "./GraphCanvas.js";
+export type * from "./types.js";

--- a/packages/react/ds-experiments/src/lib/GraphCanvas/styles.css
+++ b/packages/react/ds-experiments/src/lib/GraphCanvas/styles.css
@@ -1,0 +1,32 @@
+/* ==========================================================================
+   Graph canvas — the container React Flow renders into
+   ========================================================================== */
+.ds.graph-canvas {
+  position: relative;
+  inline-size: 100%;
+  border: var(--spacing-border-width, 1px) solid
+    var(--color-border-low-contrast, #e5e5e5);
+  border-radius: var(--spacing-border-radius, 0.25rem);
+  background-color: var(--color-background-alt, #f7f7f7);
+  overflow: hidden;
+}
+
+/* The marker host carries only <defs>; it must occupy no layout space. */
+.ds.graph-markers {
+  position: absolute;
+  inline-size: 0;
+  block-size: 0;
+  overflow: hidden;
+}
+
+/* Filled associative arrowhead (uses / governs / refines). */
+.ds.relation-arrow {
+  fill: var(--color-border-high-contrast, #666);
+}
+
+/* Hollow taxonomic arrowhead — the UML generalisation triangle (is a). */
+.ds.subclass-arrow {
+  fill: var(--color-background-default, #fff);
+  stroke: var(--relation-accent-subclass, var(--color-text, #111));
+  stroke-width: 1.5;
+}

--- a/packages/react/ds-experiments/src/lib/GraphCanvas/types.ts
+++ b/packages/react/ds-experiments/src/lib/GraphCanvas/types.ts
@@ -1,0 +1,29 @@
+import type { HTMLAttributes } from "react";
+import type {
+  GraphEntity,
+  GraphPosition,
+  GraphRelation,
+} from "../../graph/types.js";
+
+export interface GraphCanvasProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  /** The entities to draw as nodes. */
+  entities: GraphEntity[];
+  /** The relations to draw as edges between those entities. */
+  relations: GraphRelation[];
+  /**
+   * Curated positions keyed by entity id. Entities without one are placed by
+   * the deterministic layered layout, so partial curation is fine.
+   */
+  positions?: Record<string, GraphPosition>;
+  /** Height of the canvas; a number is treated as pixels. Defaults to `480`. */
+  height?: number | string;
+  /** Show the legend panel. Defaults to `true`. */
+  showLegend?: boolean;
+  /** Show the zoom/fit controls. Defaults to `true`. */
+  showControls?: boolean;
+  /** Show the dotted background. Defaults to `true`. */
+  showBackground?: boolean;
+  /** Fit the graph to the viewport on mount. Defaults to `true`. */
+  fitView?: boolean;
+}

--- a/packages/react/ds-experiments/src/lib/GraphLegend/GraphLegend.ssr.tests.tsx
+++ b/packages/react/ds-experiments/src/lib/GraphLegend/GraphLegend.ssr.tests.tsx
@@ -1,0 +1,13 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import GraphLegend from "./GraphLegend.js";
+
+describe("GraphLegend SSR", () => {
+  it("renders to static markup without a browser", () => {
+    const html = renderToString(<GraphLegend />);
+
+    expect(html).toContain("ds graph-legend");
+    expect(html).toContain("Component");
+    expect(html).toContain("is a");
+  });
+});

--- a/packages/react/ds-experiments/src/lib/GraphLegend/GraphLegend.stories.tsx
+++ b/packages/react/ds-experiments/src/lib/GraphLegend/GraphLegend.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import GraphLegend from "./GraphLegend.js";
+
+const meta: Meta<typeof GraphLegend> = {
+  title: "Components/GraphLegend",
+  component: GraphLegend,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof GraphLegend>;
+
+export const Default: Story = {};
+
+/** Explain only a subset of kinds — e.g. a tokens-focused view. */
+export const EntitiesOnly: Story = {
+  args: {
+    relationKinds: [],
+  },
+};
+
+/** Drop the heading when the legend sits inside a titled panel. */
+export const WithoutHeading: Story = {
+  args: {
+    heading: null,
+  },
+};

--- a/packages/react/ds-experiments/src/lib/GraphLegend/GraphLegend.tests.tsx
+++ b/packages/react/ds-experiments/src/lib/GraphLegend/GraphLegend.tests.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import GraphLegend from "./GraphLegend.js";
+
+describe("GraphLegend", () => {
+  it("names every entity and relation kind by default", () => {
+    render(<GraphLegend />);
+
+    for (const label of ["Component", "Token", "Standard", "Concept"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    for (const verb of ["is a", "uses", "governs", "refines"]) {
+      expect(screen.getByText(verb)).toBeInTheDocument();
+    }
+  });
+
+  it("renders only the kinds it is given", () => {
+    render(<GraphLegend entityKinds={["TOKEN"]} relationKinds={[]} />);
+
+    expect(screen.getByText("Token")).toBeInTheDocument();
+    expect(screen.queryByText("Component")).not.toBeInTheDocument();
+    expect(screen.queryByText("uses")).not.toBeInTheDocument();
+  });
+
+  it("applies a custom className and forwards props", () => {
+    render(<GraphLegend className="custom-class" data-testid="legend" />);
+
+    const element = screen.getByTestId("legend");
+    expect(element.className).toContain("ds graph-legend");
+    expect(element.className).toContain("custom-class");
+  });
+
+  it("omits the heading when passed null", () => {
+    render(<GraphLegend heading={null} />);
+
+    expect(screen.queryByText("Legend")).not.toBeInTheDocument();
+  });
+});

--- a/packages/react/ds-experiments/src/lib/GraphLegend/GraphLegend.tsx
+++ b/packages/react/ds-experiments/src/lib/GraphLegend/GraphLegend.tsx
@@ -1,0 +1,90 @@
+import type React from "react";
+import type { EntityKind, RelationKind } from "../../graph/types.js";
+import resolveEntityAppearance from "../../helpers/resolveEntityAppearance.js";
+import resolveRelationAppearance from "../../helpers/resolveRelationAppearance.js";
+import type { GraphLegendProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds graph-legend";
+
+const DEFAULT_ENTITY_KINDS: EntityKind[] = [
+  "COMPONENT",
+  "TOKEN",
+  "STANDARD",
+  "CONCEPT",
+];
+
+const DEFAULT_RELATION_KINDS: RelationKind[] = [
+  "SUBCLASS_OF",
+  "USES",
+  "GOVERNS",
+  "REFINES",
+];
+
+/**
+ * The key to the canvas: it names each entity category and relation kind and
+ * shows the colour used to draw it. Both columns read from the same
+ * `resolveEntityAppearance` / `resolveRelationAppearance` resolvers the nodes
+ * and edges use, so the legend is guaranteed to match what is on the canvas.
+ *
+ * It is a pure presentational component — no React Flow, no data fetching — so
+ * it renders anywhere, including as a `Panel` inside `GraphCanvas`.
+ *
+ * @implements ds:experiments.component.graph-legend
+ */
+const GraphLegend = ({
+  entityKinds = DEFAULT_ENTITY_KINDS,
+  relationKinds = DEFAULT_RELATION_KINDS,
+  heading = "Legend",
+  className,
+  ...props
+}: GraphLegendProps): React.ReactElement => {
+  return (
+    <div
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      {heading != null ? (
+        <p className="graph-legend-heading">{heading}</p>
+      ) : null}
+
+      <div className="graph-legend-group">
+        <p className="graph-legend-group-title">Entities</p>
+        <ul className="graph-legend-items">
+          {entityKinds.map((kind) => {
+            const appearance = resolveEntityAppearance(kind);
+            return (
+              <li key={kind} className="graph-legend-item">
+                <span
+                  className="graph-legend-swatch graph-legend-swatch-entity"
+                  style={{ backgroundColor: `var(${appearance.accentVar})` }}
+                />
+                <span className="graph-legend-label">{appearance.label}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <div className="graph-legend-group">
+        <p className="graph-legend-group-title">Relations</p>
+        <ul className="graph-legend-items">
+          {relationKinds.map((kind) => {
+            const appearance = resolveRelationAppearance(kind);
+            return (
+              <li key={kind} className="graph-legend-item">
+                <span
+                  className="graph-legend-swatch graph-legend-swatch-relation"
+                  style={{ backgroundColor: `var(${appearance.accentVar})` }}
+                />
+                <span className="graph-legend-label">{appearance.label}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default GraphLegend;

--- a/packages/react/ds-experiments/src/lib/GraphLegend/index.ts
+++ b/packages/react/ds-experiments/src/lib/GraphLegend/index.ts
@@ -1,0 +1,2 @@
+export { default as GraphLegend } from "./GraphLegend.js";
+export type * from "./types.js";

--- a/packages/react/ds-experiments/src/lib/GraphLegend/styles.css
+++ b/packages/react/ds-experiments/src/lib/GraphLegend/styles.css
@@ -1,0 +1,88 @@
+/* ==========================================================================
+   Graph palette — canonical mirror
+   The legend is the key to the whole palette, so it declares every accent token
+   (entities and relations) here. EntityNode and the edge components declare
+   their own subsets for standalone rendering; keep all three in sync — the
+   `resolve*Appearance` helpers choose which token applies.
+   ========================================================================== */
+:root {
+  --entity-accent-component: var(--color-feedback-information, #0066cc);
+  --entity-accent-token: var(--color-feedback-positive, #0e8420);
+  --entity-accent-standard: var(--color-feedback-caution, #f99b11);
+  --entity-accent-concept: var(--color-accent, #7764d8);
+  --entity-accent-unknown: var(--color-border-high-contrast, #666);
+
+  --relation-accent-subclass: var(--color-text, #111);
+  --relation-accent-uses: var(--color-feedback-information, #0066cc);
+  --relation-accent-governs: var(--color-feedback-caution, #f99b11);
+  --relation-accent-refines: var(--color-accent, #7764d8);
+  --relation-accent-unknown: var(--color-border-high-contrast, #888);
+}
+
+/* ==========================================================================
+   Legend
+   ========================================================================== */
+.ds.graph-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: var(--spacing-horizontal-small, 0.5rem)
+    var(--spacing-horizontal-medium, 0.75rem);
+  border: var(--spacing-border-width, 1px) solid
+    var(--color-border-low-contrast, #e5e5e5);
+  border-radius: var(--spacing-border-radius, 0.25rem);
+  background-color: var(--color-background-default, #fff);
+  color: var(--color-text, #111);
+  font-size: var(--font-size-caption, 0.75rem);
+  line-height: var(--line-height-default, 1.5);
+}
+
+.ds.graph-legend .graph-legend-heading {
+  margin: 0;
+  font-weight: var(--font-weight-bold, 550);
+}
+
+.ds.graph-legend .graph-legend-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.ds.graph-legend .graph-legend-group-title {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #666);
+}
+
+.ds.graph-legend .graph-legend-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ds.graph-legend .graph-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ds.graph-legend .graph-legend-swatch {
+  flex-shrink: 0;
+  background-color: var(--color-border-high-contrast, #666);
+}
+
+.ds.graph-legend .graph-legend-swatch-entity {
+  inline-size: 0.75rem;
+  block-size: 0.75rem;
+  border-radius: 2px;
+}
+
+.ds.graph-legend .graph-legend-swatch-relation {
+  inline-size: 1.25rem;
+  block-size: 3px;
+  border-radius: 2px;
+}

--- a/packages/react/ds-experiments/src/lib/GraphLegend/types.ts
+++ b/packages/react/ds-experiments/src/lib/GraphLegend/types.ts
@@ -1,0 +1,11 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import type { EntityKind, RelationKind } from "../../graph/types.js";
+
+export interface GraphLegendProps extends HTMLAttributes<HTMLDivElement> {
+  /** Entity kinds to explain, in order. Defaults to all four. */
+  entityKinds?: EntityKind[];
+  /** Relation kinds to explain, in order. Defaults to all four. */
+  relationKinds?: RelationKind[];
+  /** Heading rendered above the key; pass `null` to omit it. */
+  heading?: ReactNode;
+}

--- a/packages/react/ds-experiments/src/lib/OntologyGraph/OntologyGraph.stories.tsx
+++ b/packages/react/ds-experiments/src/lib/OntologyGraph/OntologyGraph.stories.tsx
@@ -1,0 +1,71 @@
+import type { RelayParameters } from "@canonical/storybook-addon-relay";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Suspense } from "react";
+import ontologySample from "../../fixtures/ontologySample.js";
+import OntologyGraph from "./OntologyGraph.js";
+
+const meta: Meta<typeof OntologyGraph> = {
+  title: "Projections/OntologyGraph",
+  component: OntologyGraph,
+  tags: ["autodocs"],
+  // `useLazyLoadQuery` suspends while the (mocked) query is in flight, so every
+  // story renders inside a Suspense boundary.
+  decorators: [
+    (Story) => (
+      <Suspense fallback={<p>Loading ontology…</p>}>
+        <Story />
+      </Suspense>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof OntologyGraph>;
+
+// `@canonical/storybook-addon-relay` reads `parameters.relay` and resolves the
+// story's operation with `MockPayloadGenerator` + these resolvers. Resolving
+// `SchemaGraph` explicitly makes the story deterministic for visual regression.
+const fullGraphResolvers = {
+  SchemaGraph: () => ({
+    entities: ontologySample.entities.map((entity) => ({
+      id: entity.id,
+      label: entity.label,
+      kind: entity.kind,
+      tier: entity.tier ?? null,
+      summary: entity.summary ?? null,
+    })),
+    relations: ontologySample.relations.map((relation) => ({
+      id: relation.id,
+      source: relation.source,
+      target: relation.target,
+      kind: relation.kind,
+      label: relation.label ?? null,
+    })),
+  }),
+};
+
+/** The projection resolving against a mock environment: the full sample graph. */
+export const Default: Story = {
+  args: {
+    height: 520,
+  },
+  parameters: {
+    relay: {
+      mockResolvers: fullGraphResolvers,
+    } satisfies RelayParameters,
+  },
+};
+
+/** The empty state: a valid response with no entities or relations. */
+export const Empty: Story = {
+  args: {
+    height: 320,
+  },
+  parameters: {
+    relay: {
+      mockResolvers: {
+        SchemaGraph: () => ({ entities: [], relations: [] }),
+      },
+    } satisfies RelayParameters,
+  },
+};

--- a/packages/react/ds-experiments/src/lib/OntologyGraph/OntologyGraph.tsx
+++ b/packages/react/ds-experiments/src/lib/OntologyGraph/OntologyGraph.tsx
@@ -1,0 +1,99 @@
+import { type ReactElement, useMemo } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import type {
+  EntityKind,
+  EntityTier,
+  GraphEntity,
+  GraphRelation,
+  RelationKind,
+} from "../../graph/types.js";
+import type { OntologyGraphQuery } from "../../relay/__generated__/OntologyGraphQuery.graphql.js";
+import GraphCanvas from "../GraphCanvas/GraphCanvas.js";
+import type { OntologyGraphProps } from "./types.js";
+
+// The projection contract: the exact slice of the graph the canvas renders.
+// `vite-plugin-relay-lite` rewrites this tag into an import of the committed
+// artifact in `../../relay/__generated__`; regenerate with `bun run relay`.
+const ontologyGraphQuery = graphql`
+  query OntologyGraphQuery($focus: ID) {
+    ontology(focus: $focus) {
+      entities {
+        id
+        label
+        kind
+        tier
+        summary
+      }
+      relations {
+        id
+        source
+        target
+        kind
+        label
+      }
+    }
+  }
+`;
+
+/**
+ * The Relay *projection* of the ontology graph: it binds a GraphQL query and
+ * hands the result to the pure `GraphCanvas`. This binding is the bi-modal
+ * invariant from the A-workstream ADRs — the same query a human sees rendered
+ * here is the one an agent would issue — so the projection, not the pixels, is
+ * the contract.
+ *
+ * It suspends while the query is in flight, so render it inside a `Suspense`
+ * boundary (and, in Storybook, under the `@canonical/storybook-addon-relay`
+ * mock environment via `parameters.relay`).
+ *
+ * @implements ds:experiments.projection.ontology-graph
+ */
+const OntologyGraph = ({
+  focus = null,
+  height,
+  showLegend,
+  className,
+}: OntologyGraphProps): ReactElement => {
+  const data = useLazyLoadQuery<OntologyGraphQuery>(ontologyGraphQuery, {
+    focus,
+  });
+
+  // Narrow the query result (readonly, with GraphQL's open enums) to the pure
+  // domain shapes the canvas consumes. `resolve*Appearance` tolerates unknown
+  // kinds, so the casts are safe even if the graph grows a value we predate.
+  const entities: GraphEntity[] = useMemo(
+    () =>
+      data.ontology.entities.map((entity) => ({
+        id: entity.id,
+        label: entity.label,
+        kind: entity.kind as EntityKind,
+        tier: (entity.tier ?? null) as EntityTier | null,
+        summary: entity.summary ?? null,
+      })),
+    [data],
+  );
+
+  const relations: GraphRelation[] = useMemo(
+    () =>
+      data.ontology.relations.map((relation) => ({
+        id: relation.id,
+        source: relation.source,
+        target: relation.target,
+        kind: relation.kind as RelationKind,
+        label: relation.label ?? null,
+      })),
+    [data],
+  );
+
+  return (
+    <GraphCanvas
+      entities={entities}
+      relations={relations}
+      height={height}
+      showLegend={showLegend}
+      className={className}
+    />
+  );
+};
+
+export default OntologyGraph;

--- a/packages/react/ds-experiments/src/lib/OntologyGraph/index.ts
+++ b/packages/react/ds-experiments/src/lib/OntologyGraph/index.ts
@@ -1,0 +1,2 @@
+export { default as OntologyGraph } from "./OntologyGraph.js";
+export type * from "./types.js";

--- a/packages/react/ds-experiments/src/lib/OntologyGraph/types.ts
+++ b/packages/react/ds-experiments/src/lib/OntologyGraph/types.ts
@@ -1,0 +1,13 @@
+export interface OntologyGraphProps {
+  /**
+   * Optional focus entity id. When set, only that entity's neighbourhood is
+   * loaded; when omitted, the whole graph is returned.
+   */
+  focus?: string | null;
+  /** Height of the canvas; forwarded to `GraphCanvas`. Defaults to `480`. */
+  height?: number | string;
+  /** Show the legend panel. Defaults to `true`. */
+  showLegend?: boolean;
+  /** Additional CSS classes for the canvas wrapper. */
+  className?: string;
+}

--- a/packages/react/ds-experiments/src/lib/RelationEdge/RelationEdge.stories.tsx
+++ b/packages/react/ds-experiments/src/lib/RelationEdge/RelationEdge.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { SchemaGraph } from "../../graph/types.js";
+import GraphCanvas from "../GraphCanvas/GraphCanvas.js";
+import RelationEdge from "./RelationEdge.js";
+
+// An edge renderer only has geometry inside a canvas, so the story shows it in
+// context. This slice carries the three associative relation kinds.
+const slice: SchemaGraph = {
+  entities: [
+    { id: "button", label: "Button", kind: "COMPONENT", tier: "GLOBAL" },
+    { id: "accent", label: "color-accent", kind: "TOKEN", tier: "GLOBAL" },
+    { id: "concept", label: "Component", kind: "CONCEPT" },
+    { id: "folder", label: "component-folder-structure", kind: "STANDARD" },
+    { id: "classname", label: "class-name-construction", kind: "STANDARD" },
+  ],
+  relations: [
+    { id: "uses", source: "button", target: "accent", kind: "USES" },
+    { id: "governs", source: "folder", target: "concept", kind: "GOVERNS" },
+    { id: "refines", source: "classname", target: "folder", kind: "REFINES" },
+  ],
+};
+
+const meta: Meta<typeof RelationEdge> = {
+  title: "Components/RelationEdge",
+  component: RelationEdge,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof RelationEdge>;
+
+/** The `uses`, `governs`, and `refines` relations, each in its own colour. */
+export const InContext: Story = {
+  render: () => (
+    <GraphCanvas
+      entities={slice.entities}
+      relations={slice.relations}
+      height={360}
+      showLegend={false}
+    />
+  ),
+};

--- a/packages/react/ds-experiments/src/lib/RelationEdge/RelationEdge.tsx
+++ b/packages/react/ds-experiments/src/lib/RelationEdge/RelationEdge.tsx
@@ -1,0 +1,65 @@
+import { BaseEdge, EdgeLabelRenderer, getBezierPath } from "@xyflow/react";
+import type React from "react";
+import type { RelationEdgeProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds relation-edge";
+
+/**
+ * The renderer React Flow uses for an *associative* relation — `uses`,
+ * `governs`, `refines`. It draws a curved edge tinted by the relation kind (the
+ * `modifier` in its data), ends it with the shared filled arrowhead marker that
+ * `GraphCanvas` defines, and floats the relation's verb at the midpoint.
+ *
+ * Register it with `GraphCanvas`'s `edgeTypes` under the key `"relation"`; the
+ * taxonomic `SUBCLASS_OF` relation is drawn by `SubclassEdge` instead.
+ *
+ * @implements ds:experiments.component.relation-edge
+ */
+const RelationEdge = ({
+  sourceX,
+  sourceY,
+  sourcePosition,
+  targetX,
+  targetY,
+  targetPosition,
+  data,
+  label,
+}: RelationEdgeProps): React.ReactElement => {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const className = [componentCssClassName, data?.modifier]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <>
+      <BaseEdge
+        path={edgePath}
+        markerEnd="url(#ds-relation-arrow)"
+        className={className}
+      />
+      {label ? (
+        <EdgeLabelRenderer>
+          <span
+            className="ds relation-edge-label"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            {label}
+          </span>
+        </EdgeLabelRenderer>
+      ) : null}
+    </>
+  );
+};
+
+export default RelationEdge;

--- a/packages/react/ds-experiments/src/lib/RelationEdge/index.ts
+++ b/packages/react/ds-experiments/src/lib/RelationEdge/index.ts
@@ -1,0 +1,2 @@
+export { default as RelationEdge } from "./RelationEdge.js";
+export type * from "./types.js";

--- a/packages/react/ds-experiments/src/lib/RelationEdge/styles.css
+++ b/packages/react/ds-experiments/src/lib/RelationEdge/styles.css
@@ -1,0 +1,48 @@
+/* ==========================================================================
+   Graph palette — relation accents
+   Mirrored in GraphLegend's stylesheet; `resolveRelationAppearance` is the
+   single source of truth for which token a relation kind maps to.
+   ========================================================================== */
+:root {
+  --relation-accent-subclass: var(--color-text, #111);
+  --relation-accent-uses: var(--color-feedback-information, #0066cc);
+  --relation-accent-governs: var(--color-feedback-caution, #f99b11);
+  --relation-accent-refines: var(--color-accent, #7764d8);
+  --relation-accent-unknown: var(--color-border-high-contrast, #888);
+}
+
+/* ==========================================================================
+   Associative relation edge
+   ========================================================================== */
+.ds.relation-edge {
+  fill: none;
+  stroke: var(--relation-accent-unknown);
+  stroke-width: 1.5;
+}
+
+.ds.relation-edge.uses {
+  stroke: var(--relation-accent-uses);
+}
+
+.ds.relation-edge.governs {
+  stroke: var(--relation-accent-governs);
+}
+
+.ds.relation-edge.refines {
+  stroke: var(--relation-accent-refines);
+}
+
+/* Edge label — a small pill floated at the edge midpoint. */
+.ds.relation-edge-label {
+  position: absolute;
+  padding-inline: 0.375rem;
+  border-radius: 999px;
+  background-color: var(--color-background-default, #fff);
+  border: var(--spacing-border-width, 1px) solid
+    var(--color-border-low-contrast, #e5e5e5);
+  color: var(--color-text-muted, #555);
+  font-size: var(--font-size-caption, 0.75rem);
+  line-height: 1.4;
+  pointer-events: all;
+  white-space: nowrap;
+}

--- a/packages/react/ds-experiments/src/lib/RelationEdge/types.ts
+++ b/packages/react/ds-experiments/src/lib/RelationEdge/types.ts
@@ -1,0 +1,20 @@
+import type { Edge, EdgeProps } from "@xyflow/react";
+import type { GraphRelation } from "../../graph/types.js";
+
+/**
+ * Data every graph edge carries. Shared by both edge renderers — `RelationEdge`
+ * (associative relations) and `SubclassEdge` (the taxonomic "is a") — since they
+ * differ only in how they are drawn, not in what they represent. Declared as a
+ * `type` so it satisfies React Flow's `Record<string, unknown>` data constraint.
+ */
+export type RelationEdgeData = {
+  relation: GraphRelation;
+  /** Appearance modifier class, e.g. `"uses"`, from `resolveRelationAppearance`. */
+  modifier: string;
+};
+
+/** The typed React Flow edge produced by `buildGraphElements`. */
+export type RelationFlowEdge = Edge<RelationEdgeData, "relation" | "subclass">;
+
+/** Props React Flow passes to the `RelationEdge` renderer. */
+export type RelationEdgeProps = EdgeProps<RelationFlowEdge>;

--- a/packages/react/ds-experiments/src/lib/SubclassEdge/SubclassEdge.stories.tsx
+++ b/packages/react/ds-experiments/src/lib/SubclassEdge/SubclassEdge.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { SchemaGraph } from "../../graph/types.js";
+import GraphCanvas from "../GraphCanvas/GraphCanvas.js";
+import SubclassEdge from "./SubclassEdge.js";
+
+// The taxonomic "is a": two components generalising to one concept, drawn with
+// the hollow generalisation arrowhead.
+const slice: SchemaGraph = {
+  entities: [
+    { id: "button", label: "Button", kind: "COMPONENT", tier: "GLOBAL" },
+    { id: "card", label: "Card", kind: "COMPONENT", tier: "GLOBAL" },
+    { id: "concept", label: "Component", kind: "CONCEPT" },
+  ],
+  relations: [
+    {
+      id: "button-isa",
+      source: "button",
+      target: "concept",
+      kind: "SUBCLASS_OF",
+    },
+    { id: "card-isa", source: "card", target: "concept", kind: "SUBCLASS_OF" },
+  ],
+};
+
+const meta: Meta<typeof SubclassEdge> = {
+  title: "Components/SubclassEdge",
+  component: SubclassEdge,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof SubclassEdge>;
+
+/** `Button is a Component`, `Card is a Component` — the taxonomy backbone. */
+export const InContext: Story = {
+  render: () => (
+    <GraphCanvas
+      entities={slice.entities}
+      relations={slice.relations}
+      height={320}
+      showLegend={false}
+    />
+  ),
+};

--- a/packages/react/ds-experiments/src/lib/SubclassEdge/SubclassEdge.tsx
+++ b/packages/react/ds-experiments/src/lib/SubclassEdge/SubclassEdge.tsx
@@ -1,0 +1,61 @@
+import { BaseEdge, EdgeLabelRenderer, getSmoothStepPath } from "@xyflow/react";
+import type React from "react";
+import type { SubclassEdgeProps } from "./types.js";
+import "./styles.css";
+
+const componentCssClassName = "ds subclass-edge";
+
+/**
+ * The renderer React Flow uses for the *taxonomic* `SUBCLASS_OF` relation — the
+ * ontological "is a". It is deliberately distinct from the associative
+ * `RelationEdge`: an orthogonal smooth-step path and the hollow-triangle marker
+ * `GraphCanvas` defines, borrowing the UML generalisation arrow so a reader can
+ * tell "Button is a Component" apart from "Button uses color-accent" at a glance.
+ *
+ * Register it with `GraphCanvas`'s `edgeTypes` under the key `"subclass"`.
+ *
+ * @implements ds:experiments.component.subclass-edge
+ */
+const SubclassEdge = ({
+  sourceX,
+  sourceY,
+  sourcePosition,
+  targetX,
+  targetY,
+  targetPosition,
+  label,
+}: SubclassEdgeProps): React.ReactElement => {
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    borderRadius: 8,
+  });
+
+  return (
+    <>
+      <BaseEdge
+        path={edgePath}
+        markerEnd="url(#ds-subclass-arrow)"
+        className={componentCssClassName}
+      />
+      {label ? (
+        <EdgeLabelRenderer>
+          <span
+            className="ds subclass-edge-label"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            {label}
+          </span>
+        </EdgeLabelRenderer>
+      ) : null}
+    </>
+  );
+};
+
+export default SubclassEdge;

--- a/packages/react/ds-experiments/src/lib/SubclassEdge/index.ts
+++ b/packages/react/ds-experiments/src/lib/SubclassEdge/index.ts
@@ -1,0 +1,2 @@
+export { default as SubclassEdge } from "./SubclassEdge.js";
+export type * from "./types.js";

--- a/packages/react/ds-experiments/src/lib/SubclassEdge/styles.css
+++ b/packages/react/ds-experiments/src/lib/SubclassEdge/styles.css
@@ -1,0 +1,23 @@
+/* ==========================================================================
+   Taxonomic subclass edge — the ontological "is a"
+   ========================================================================== */
+.ds.subclass-edge {
+  fill: none;
+  stroke: var(--relation-accent-subclass, var(--color-text, #111));
+  stroke-width: 1.5;
+}
+
+.ds.subclass-edge-label {
+  position: absolute;
+  padding-inline: 0.375rem;
+  border-radius: 999px;
+  background-color: var(--color-background-default, #fff);
+  border: var(--spacing-border-width, 1px) solid
+    var(--color-border-low-contrast, #e5e5e5);
+  color: var(--color-text-muted, #555);
+  font-size: var(--font-size-caption, 0.75rem);
+  font-style: italic;
+  line-height: 1.4;
+  pointer-events: all;
+  white-space: nowrap;
+}

--- a/packages/react/ds-experiments/src/lib/SubclassEdge/types.ts
+++ b/packages/react/ds-experiments/src/lib/SubclassEdge/types.ts
@@ -1,0 +1,9 @@
+import type { EdgeProps } from "@xyflow/react";
+import type { RelationFlowEdge } from "../RelationEdge/types.js";
+
+/**
+ * Props React Flow passes to the `SubclassEdge` renderer. It draws the same
+ * `RelationFlowEdge` data as `RelationEdge`; only the visual treatment differs,
+ * so the edge data type is shared rather than duplicated.
+ */
+export type SubclassEdgeProps = EdgeProps<RelationFlowEdge>;

--- a/packages/react/ds-experiments/src/relay/__generated__/OntologyGraphQuery.graphql.ts
+++ b/packages/react/ds-experiments/src/relay/__generated__/OntologyGraphQuery.graphql.ts
@@ -1,0 +1,175 @@
+/**
+ * @generated SignedSource<<73fc9b59b5a466e555f00c302e25a06f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type EntityKind = "COMPONENT" | "CONCEPT" | "STANDARD" | "TOKEN" | "%future added value";
+export type EntityTier = "APPLICATION" | "DOCS" | "GLOBAL" | "SCDN" | "%future added value";
+export type RelationKind = "GOVERNS" | "REFINES" | "SUBCLASS_OF" | "USES" | "%future added value";
+export type OntologyGraphQuery$variables = {
+  focus?: string | null | undefined;
+};
+export type OntologyGraphQuery$data = {
+  readonly ontology: {
+    readonly entities: ReadonlyArray<{
+      readonly id: string;
+      readonly kind: EntityKind;
+      readonly label: string;
+      readonly summary: string | null | undefined;
+      readonly tier: EntityTier | null | undefined;
+    }>;
+    readonly relations: ReadonlyArray<{
+      readonly id: string;
+      readonly kind: RelationKind;
+      readonly label: string | null | undefined;
+      readonly source: string;
+      readonly target: string;
+    }>;
+  };
+};
+export type OntologyGraphQuery = {
+  response: OntologyGraphQuery$data;
+  variables: OntologyGraphQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "focus"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "kind",
+  "storageKey": null
+},
+v4 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "focus",
+        "variableName": "focus"
+      }
+    ],
+    "concreteType": "SchemaGraph",
+    "kind": "LinkedField",
+    "name": "ontology",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "GraphEntity",
+        "kind": "LinkedField",
+        "name": "entities",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "tier",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "summary",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "GraphRelation",
+        "kind": "LinkedField",
+        "name": "relations",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "source",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "target",
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "OntologyGraphQuery",
+    "selections": (v4/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "OntologyGraphQuery",
+    "selections": (v4/*: any*/)
+  },
+  "params": {
+    "cacheID": "2f05e137642019fb3e8b76bea7e89baf",
+    "id": null,
+    "metadata": {},
+    "name": "OntologyGraphQuery",
+    "operationKind": "query",
+    "text": "query OntologyGraphQuery(\n  $focus: ID\n) {\n  ontology(focus: $focus) {\n    entities {\n      id\n      label\n      kind\n      tier\n      summary\n    }\n    relations {\n      id\n      source\n      target\n      kind\n      label\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d6dcb1c84779dfbaf688abafca1a3611";
+
+export default node;

--- a/packages/react/ds-experiments/src/relay/environment.ts
+++ b/packages/react/ds-experiments/src/relay/environment.ts
@@ -1,0 +1,83 @@
+/**
+ * Relay environment factory for the ontology projection.
+ *
+ * Builds a Relay `Environment` in one of two modes:
+ *
+ * - **local (default)** — every operation is resolved in-process against the
+ *   mock ontology schema (`./schema.ts`), so the projection runs with no
+ *   backend. This is the runtime counterpart to the compiler pointing at
+ *   `schema.graphql`.
+ * - **endpoint** — when `VITE_GRAPHQL_URL` is set (or a URL is passed), the
+ *   fetch posts operations to a real GraphQL server instead.
+ *
+ * Storybook does not use this factory: the `@canonical/storybook-addon-relay`
+ * decorator supplies a `relay-test-utils` mock environment per story. This
+ * exists so `OntologyGraph` can also run in a real application.
+ */
+
+import {
+  Environment,
+  type FetchFunction,
+  type GraphQLResponse,
+  Network,
+  RecordSource,
+  Store,
+} from "relay-runtime";
+import { executeLocalOperation } from "./schema.js";
+
+/** Options for {@link createExperimentsEnvironment}. */
+export interface CreateExperimentsEnvironmentOptions {
+  /**
+   * GraphQL endpoint URL. Overrides `VITE_GRAPHQL_URL`; when neither is set the
+   * environment executes against the local mock schema.
+   */
+  readonly graphqlUrl?: string;
+}
+
+/** Reads the endpoint URL from Vite's env, treating the empty string as unset. */
+const readConfiguredGraphqlUrl = (): string | undefined => {
+  const configured: unknown = import.meta.env.VITE_GRAPHQL_URL;
+  return typeof configured === "string" && configured.length > 0
+    ? configured
+    : undefined;
+};
+
+/** Fetch that resolves operations in-process against the mock ontology schema. */
+const createLocalFetch = (): FetchFunction => async (params, variables) => {
+  if (!params.text) {
+    throw new Error(
+      "The local mock schema requires full operation text; persisted queries are not supported.",
+    );
+  }
+  const result = await executeLocalOperation({ text: params.text, variables });
+  return result as unknown as GraphQLResponse;
+};
+
+/** Fetch that posts operations to a real GraphQL endpoint. */
+const createHttpFetch =
+  (graphqlUrl: string): FetchFunction =>
+  async (params, variables) => {
+    const response = await fetch(graphqlUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: params.text, variables }),
+    });
+    return (await response.json()) as GraphQLResponse;
+  };
+
+/**
+ * Creates a Relay `Environment`. Call once per browser session (module scope in
+ * a client entry) and once per request on a server, so no store state leaks
+ * across requests.
+ */
+export const createExperimentsEnvironment = (
+  options: CreateExperimentsEnvironmentOptions = {},
+): Environment => {
+  const graphqlUrl = options.graphqlUrl ?? readConfiguredGraphqlUrl();
+  const fetchFn = graphqlUrl ? createHttpFetch(graphqlUrl) : createLocalFetch();
+
+  return new Environment({
+    network: Network.create(fetchFn),
+    store: new Store(new RecordSource()),
+  });
+};

--- a/packages/react/ds-experiments/src/relay/schema.graphql
+++ b/packages/react/ds-experiments/src/relay/schema.graphql
@@ -1,0 +1,101 @@
+"""
+An ontology-graph slice of the Pragma knowledge graph: the entities (nodes)
+that make up a neighbourhood and the typed relations (edges) between them.
+This is the projection contract the graph components render.
+"""
+interface Node {
+  id: ID!
+}
+
+"""
+The ontology category an entity belongs to.
+"""
+enum EntityKind {
+  COMPONENT
+  TOKEN
+  STANDARD
+  CONCEPT
+}
+
+"""
+The design-system tier an entity is sourced from.
+"""
+enum EntityTier {
+  GLOBAL
+  DOCS
+  APPLICATION
+  SCDN
+}
+
+"""
+The kind of a typed relation between two entities.
+"""
+enum RelationKind {
+  SUBCLASS_OF
+  USES
+  GOVERNS
+  REFINES
+}
+
+"""
+A single entity — a node in the knowledge graph.
+"""
+type GraphEntity implements Node {
+  id: ID!
+  """
+  Human-readable label, e.g. "Button".
+  """
+  label: String!
+  """
+  The ontology category this entity belongs to.
+  """
+  kind: EntityKind!
+  """
+  The design-system tier this entity is sourced from, when known.
+  """
+  tier: EntityTier
+  """
+  A one-line description of the entity.
+  """
+  summary: String
+}
+
+"""
+A directed, typed relation — an edge in the knowledge graph.
+"""
+type GraphRelation implements Node {
+  id: ID!
+  """
+  Global id of the entity the relation starts from.
+  """
+  source: ID!
+  """
+  Global id of the entity the relation points to.
+  """
+  target: ID!
+  """
+  The kind of relation.
+  """
+  kind: RelationKind!
+  """
+  An optional label rendered on the edge.
+  """
+  label: String
+}
+
+"""
+A slice of the knowledge graph: its entities and their relations.
+"""
+type SchemaGraph {
+  entities: [GraphEntity!]!
+  relations: [GraphRelation!]!
+}
+
+type Query {
+  node(id: ID!): Node
+  """
+  The ontology neighbourhood rooted at an optional focus entity; with no
+  focus, the whole sample graph is returned.
+  """
+  ontology(focus: ID): SchemaGraph!
+}

--- a/packages/react/ds-experiments/src/relay/schema.ts
+++ b/packages/react/ds-experiments/src/relay/schema.ts
@@ -1,0 +1,102 @@
+/**
+ * Executable mock schema for the Relay data layer.
+ *
+ * Builds the SDL in ./schema.graphql into a graphql-js schema backed by the
+ * same static ontology slice the pure stories use (../fixtures/ontologySample),
+ * so the projection component can execute real GraphQL operations without a
+ * backend. The dataset is static — no randomness, no clocks — which keeps unit
+ * tests and visual tests reproducible.
+ *
+ * (The file name above is written without a backtick after the word "graphql"
+ * on purpose: vite-plugin-relay-lite's tag scanner matches that word followed
+ * by a backtick, even inside comments, and would try to parse what follows.)
+ */
+
+import { buildSchema, GraphQLError, graphql } from "graphql";
+import ontologySample from "../fixtures/ontologySample.js";
+import schemaSource from "./schema.graphql?raw";
+
+const schema = buildSchema(schemaSource);
+
+const entitiesById = new Map(
+  ontologySample.entities.map((entity) => [entity.id, entity]),
+);
+
+interface OntologyArguments {
+  readonly focus?: string | null;
+}
+
+/**
+ * Resolves `Query.ontology`. With no focus it returns the whole sample graph;
+ * with a focus it returns that entity's immediate neighbourhood — the relations
+ * incident to it and the entities those relations touch.
+ */
+const resolveOntology = ({ focus }: OntologyArguments) => {
+  if (focus == null) {
+    return ontologySample;
+  }
+  if (!entitiesById.has(focus)) {
+    throw new GraphQLError(`Unknown focus entity: ${focus}`);
+  }
+
+  const relations = ontologySample.relations.filter(
+    (relation) => relation.source === focus || relation.target === focus,
+  );
+
+  const neighbourIds = new Set<string>([focus]);
+  for (const relation of relations) {
+    neighbourIds.add(relation.source);
+    neighbourIds.add(relation.target);
+  }
+
+  return {
+    entities: ontologySample.entities.filter((entity) =>
+      neighbourIds.has(entity.id),
+    ),
+    relations,
+  };
+};
+
+// Root value for graphql-js's default field resolver: root fields are functions
+// receiving the field arguments. `node` is present for schema completeness even
+// though the projection query does not use it.
+const rootValue = {
+  node: ({ id }: { id: string }) => entitiesById.get(id) ?? null,
+  ontology: (args: OntologyArguments) => resolveOntology(args),
+};
+
+/** Input for {@link executeLocalOperation}. */
+export interface ExecuteLocalOperationOptions {
+  /** Full GraphQL source text of the operation. */
+  readonly text: string;
+  /** Variable values for the operation. */
+  readonly variables?: Record<string, unknown>;
+}
+
+/** Result shape of {@link executeLocalOperation} — a standard GraphQL response. */
+export interface LocalOperationResult {
+  readonly data?: unknown;
+  readonly errors?: readonly { readonly message: string }[];
+}
+
+/**
+ * Executes a GraphQL operation against the in-memory ontology schema. This is
+ * the execution half of the mock backend: `relay.config.json` points the
+ * compiler at ./schema.graphql for validation and codegen, and the Relay
+ * environment's local executor calls this function at runtime.
+ */
+export const executeLocalOperation = async (
+  options: ExecuteLocalOperationOptions,
+): Promise<LocalOperationResult> => {
+  const result = await graphql({
+    schema,
+    source: options.text,
+    variableValues: options.variables,
+    rootValue,
+  });
+
+  return {
+    data: result.data ?? null,
+    errors: result.errors?.map((error) => error.toJSON()),
+  };
+};

--- a/packages/react/ds-experiments/src/vite-env.d.ts
+++ b/packages/react/ds-experiments/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/react/ds-experiments/tsconfig.build.json
+++ b/packages/react/ds-experiments/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": false,
+    "types": ["node", "react", "react-dom"]
+  },
+  "exclude": [
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.tests.ts",
+    "src/**/*.tests.tsx",
+    "src/fixtures/**",
+    "src/lib/OntologyGraph/**",
+    "src/relay/**",
+    "vite.config.ts",
+    "vitest.setup.ts",
+    "vitest.config.ts",
+    ".storybook"
+  ]
+}

--- a/packages/react/ds-experiments/tsconfig.json
+++ b/packages/react/ds-experiments/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "@canonical/typescript-config-react",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "skipLibCheck": true,
+    "types": [
+      "node",
+      "react",
+      "react-dom",
+      "vitest/globals",
+      "@testing-library/jest-dom"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".storybook/*.ts",
+    ".storybook/*.tsx",
+    "vite.config.ts",
+    "vitest.setup.ts",
+    "vitest.config.ts"
+  ]
+}

--- a/packages/react/ds-experiments/vite.config.ts
+++ b/packages/react/ds-experiments/vite.config.ts
@@ -1,0 +1,24 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import relay from "vite-plugin-relay-lite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  // Relay's `graphql\`...\`` tags must be rewritten into imports of the
+  // compiler-generated artifacts before React can run them. `@vitejs/plugin-react`
+  // v6 is OXC-based (no Babel), so the classic `babel-plugin-relay` route would
+  // need the `@rolldown/plugin-babel` escape hatch; `vite-plugin-relay-lite` does
+  // the same rewrite with its own parser and no Babel, and works on Vite 8 /
+  // rolldown despite its peer range stopping at Vite 7 (bun installs it with only
+  // a peer-version warning). `codegen: false` because artifacts are committed and
+  // regenerated explicitly via `bun run relay` / `relay:watch`. Storybook's
+  // react-vite framework merges this config, so the same rewrite applies there.
+  plugins: [relay({ codegen: false }), react()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  build: {
+    // include sourcemaps for easier debugging
+    sourcemap: true,
+  },
+});

--- a/packages/react/ds-experiments/vitest.config.ts
+++ b/packages/react/ds-experiments/vitest.config.ts
@@ -1,0 +1,38 @@
+// Testing posture: Measured — Chromatic is the primary visual gate for the
+// graph canvas and its nodes/edges (they measure the DOM through React Flow,
+// which jsdom cannot fully reproduce), so unit tests here cover the
+// deterministic logic — the appearance resolvers, the element builder, the
+// layout — and the pure presentational component (GraphLegend).
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config.js";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      projects: [
+        {
+          test: {
+            name: "client",
+            // browser-like environment for component tests
+            environment: "jsdom",
+            // vite globals for terser test code
+            globals: true,
+            // extend matchers and clean up the DOM after each test
+            setupFiles: ["./vitest.setup.ts"],
+            include: ["src/**/*.tests.ts", "src/**/*.tests.tsx"],
+            exclude: ["src/**/*.ssr.tests.tsx"],
+          },
+        },
+        {
+          test: {
+            name: "ssr",
+            // Node environment for server-side rendering tests
+            environment: "node",
+            include: ["src/**/*.ssr.tests.tsx"],
+          },
+        },
+      ],
+    },
+  }),
+);

--- a/packages/react/ds-experiments/vitest.setup.ts
+++ b/packages/react/ds-experiments/vitest.setup.ts
@@ -1,0 +1,21 @@
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { cleanup } from "@testing-library/react";
+import { afterEach, expect, vi } from "vitest";
+
+expect.extend(matchers as unknown as Parameters<typeof expect.extend>[0]);
+
+// Clean up the DOM after each test
+afterEach(() => {
+  cleanup();
+});
+
+// React Flow observes the size of its container via ResizeObserver, which jsdom
+// does not implement. A no-op mock lets components that mount a canvas render in
+// unit tests without measuring a real layout.
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;


### PR DESCRIPTION
## Done

Introduces **`@canonical/react-ds-experiments`** — an experimental (`private: true`) package that hosts a playground for advanced, graph-shaped components in isolation from the shipped tiers. First subject: a **React Flow representation of a slice of the knowledge graph**.

**Pure components** (presentational, the package's public API):
- `GraphCanvas` — composition root; takes plain `entities` + `relations`, draws the graph, legend, controls, background, and defines the shared arrowhead markers.
- `EntityNode` — node renderer (category · label · tier · summary), registered as the `entity` node type.
- `RelationEdge` — **associative** relations (`uses`/`governs`/`refines`): curved, tinted, labelled.
- `SubclassEdge` — **taxonomic** `SUBCLASS_OF` ("is a"): orthogonal edge with a hollow UML generalisation arrowhead.
- `GraphLegend` — the key; reads the same appearance resolvers as the canvas so it can't drift.
- Helpers (verb-named, deterministic): `buildGraphElements`, `computeGraphLayout`, `resolveEntityAppearance`, `resolveRelationAppearance`.

**Relay projection** (demonstrated in Storybook, not shipped in `dist`):
- `OntologyGraph` binds `OntologyGraphQuery` via `useLazyLoadQuery` and maps the result to the pure `GraphCanvas` — the **bi-modal invariant** from the A-workstream ADRs (the query a human sees rendered is the one an agent would issue).
- Wired exactly like `apps/react/boilerplate-vite`: `relay.config.json`, `vite-plugin-relay-lite` (`codegen:false`), committed artifacts under `src/relay/__generated__`, and the `@canonical/storybook-addon-relay` mock environment via `parameters.relay`.
- Graph-shaped mock schema (`src/relay/schema.graphql` + executable `schema.ts`) over the ontology fixture — the graph analogue of the boilerplate's catalog mock.

Follows the **`summon component react`** generator layout (`Component.tsx` · `types.ts` with named `…Props` · `index.ts` with `export type *` · `.stories.tsx` · `.tests.tsx`) and the repo code standards (component-named folders, `ds`-prefixed class-name construction, per-file default exports, verb-named functions).

> **Relay version note:** requested as "compiler v21", but the whole workspace is pinned to patched **Relay 18.2.0** and `@canonical/storybook-addon-relay` peers on `react-relay >=18 <19`. Pinning v21 here would fork Relay in the monorepo and break the addon's peer range, so this package tracks 18.2.0. A repo-wide bump to Relay 21 is a separate change. Details in the package README.

## QA

```sh
bun install
cd packages/react/ds-experiments
bun run relay      # regenerate artifacts — should produce no diff (already committed)
bun run check      # biome + tsc
bun run test       # unit tests (helpers + GraphLegend, incl. SSR)
bun run storybook  # port 6011 — Components/* and Projections/OntologyGraph
```

Validated offline while authoring: Biome (2.4.9, canonical config) clean; `relay-compiler` reproduces the committed artifact byte-for-byte; `tsc --noEmit` (NodeNext/strict) clean across core source, tests, **and** stories against real `@xyflow/react` 12 + Relay 18 + Storybook 10 types.

### PR readiness check

- [ ] PR should have one of the following labels — suggested: **`Feature 🎁`** (and `no visual change` is **not** applicable; this adds visual stories).
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts in `package.json`:
  - [x] `check`, `check:fix`, and `test`.
  - [x] Build steps: `build` and `build:all` (ships the pure components; the Relay projection + mock are excluded from the `tsc` build by design).
- [ ] New package publish: **N/A** — `private: true`, intentionally not published.
- [ ] `no visual change` label: **not** added — this PR adds Storybook stories that should go through Chromatic.

## Screenshots

Rendered in Storybook rather than attached here: `Components/GraphCanvas` (full ontology, taxonomy-only, minimal), `Components/EntityNode`, `Components/RelationEdge`, `Components/SubclassEdge`, `Components/GraphLegend`, and `Projections/OntologyGraph` (Relay mock env: full + empty states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01332o2bu9djBa16FBwKN4us)_