### PR TITLE
refactor(cli): per-(noun,verb) story-pack guard — leaf-cutover keystone

### DIFF
--- a/packages/cli/pragma/src/domains/info/operations/collectEntityCounts.test.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectEntityCounts.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createTestStore, DS_ALL_TTL } from "#testing";
 import listBlocks from "../../block/operations/list.js";
 import listModifiers from "../../modifier/operations/list.js";
+import { TTL_PREFIXES } from "../../shared/prefixes.js";
 import type { FilterConfig } from "../../shared/types/index.js";
 import listStandards from "../../standard/operations/list.js";
 import listTokens from "../../token/operations/list.js";
@@ -50,5 +51,94 @@ describe("collectEntityCounts", () => {
     expect(counts.standards).toBeGreaterThan(0);
     expect(counts.modifierFamilies).toBeGreaterThan(0);
     expect(counts.tokens).toBeGreaterThan(0);
+  });
+});
+
+// A dedicated fan-out store (kept separate from the shared dsFixtures so its
+// enriched cardinality does not ripple into other suites). Every entity fans
+// its list op to MORE rows than there are distinct subjects, which is exactly
+// where a single-variable `COUNT(DISTINCT ?subject)` would undercount — so
+// these fixtures pin the grain-faithful subquery counts (FIX 4).
+const FAN_OUT_TTL = `
+${TTL_PREFIXES}
+
+# One block asserted as TWO types -> two GROUP BY (?component ?type ?name ?tier)
+# groups, so listBlocks emits two rows for a single subject.
+ds:fanout.multitype a ds:Component, ds:Pattern ;
+  ds:name "MultiType" ;
+  ds:tier ds:global ;
+  ds:release ds:stable .
+
+# A beta-only single-type block -> present under prerelease, filtered under
+# normal, so the block count also tracks channel scoping.
+ds:fanout.solo a ds:Component ;
+  ds:name "Solo" ;
+  ds:tier ds:global ;
+  ds:release ds:beta .
+
+# One modifier family with TWO names -> two GROUP BY (?family ?name) groups.
+ds:fanout.family a ds:ModifierFamily ;
+  ds:name "Alpha", "Beta" .
+
+# One standard in TWO categories -> the OPTIONAL hasCategory fans two rows.
+cs:fanout_cat_a a cs:Category ; cs:slug "cat-a" .
+cs:fanout_cat_b a cs:Category ; cs:slug "cat-b" .
+cs:fanout_std a cs:CodeStandard ;
+  cs:name "fanout/standard" ;
+  cs:description "A standard in two categories." ;
+  cs:hasCategory cs:fanout_cat_a, cs:fanout_cat_b .
+
+# One token with TWO token types -> the OPTIONAL tokenType fans two rows.
+ds:fanout_tt_a a ds:TokenType ; rdfs:label "TypeA" .
+ds:fanout_tt_b a ds:TokenType ; rdfs:label "TypeB" .
+ds:fanout.token a ds:Token ;
+  ds:tokenId "fanout.token" ;
+  ds:tokenType ds:fanout_tt_a, ds:fanout_tt_b .
+`;
+
+describe("collectEntityCounts fan-out parity", () => {
+  let fanStore: Store;
+  let fanCleanup: () => void;
+
+  beforeAll(async () => {
+    const result = await createTestStore({ ttl: FAN_OUT_TTL });
+    fanStore = result.store;
+    fanCleanup = result.cleanup;
+  });
+
+  afterAll(() => fanCleanup());
+
+  const fanConfigs: Record<string, FilterConfig> = {
+    prerelease: { tier: undefined, channel: "prerelease" },
+    normal: { tier: undefined, channel: "normal" },
+  };
+
+  it.each(
+    Object.entries(fanConfigs),
+  )("each count equals its legacy list-op length under %s channel", async (_label, config) => {
+    const counts = await collectEntityCounts(fanStore, config);
+
+    expect(counts.blocks).toBe((await listBlocks(fanStore, config)).length);
+    expect(counts.standards).toBe((await listStandards(fanStore)).length);
+    expect(counts.modifierFamilies).toBe(
+      (await listModifiers(fanStore)).length,
+    );
+    expect(counts.tokens).toBe((await listTokens(fanStore)).length);
+  });
+
+  it("actually fans each entity beyond its distinct-subject count", async () => {
+    // These are the cardinalities a naive `COUNT(DISTINCT ?subject)` would
+    // undercount (blocks 3 vs 2 subjects, families 2 vs 1, etc.).
+    const config: FilterConfig = { tier: undefined, channel: "prerelease" };
+    expect((await listBlocks(fanStore, config)).length).toBe(3);
+    expect((await listModifiers(fanStore)).length).toBe(2);
+    expect((await listStandards(fanStore)).length).toBe(2);
+    expect((await listTokens(fanStore)).length).toBe(2);
+
+    // And under normal channel the beta block drops out (2 block rows).
+    expect(
+      (await listBlocks(fanStore, { tier: undefined, channel: "normal" }))
+        .length,
+    ).toBe(2);
   });
 });

--- a/packages/cli/pragma/src/domains/info/operations/collectEntityCounts.test.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectEntityCounts.test.ts
@@ -1,0 +1,54 @@
+import type { Store } from "@canonical/ke";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestStore, DS_ALL_TTL } from "#testing";
+import listBlocks from "../../block/operations/list.js";
+import listModifiers from "../../modifier/operations/list.js";
+import type { FilterConfig } from "../../shared/types/index.js";
+import listStandards from "../../standard/operations/list.js";
+import listTokens from "../../token/operations/list.js";
+import { collectEntityCounts } from "./collectEntityCounts.js";
+
+let store: Store;
+let cleanup: () => void;
+
+beforeAll(async () => {
+  const result = await createTestStore({ ttl: DS_ALL_TTL });
+  store = result.store;
+  cleanup = result.cleanup;
+});
+
+afterAll(() => cleanup());
+
+// The block count is the only filtered count, so its parity must hold under
+// every tier/channel combination the list op supports.
+const configs: Record<string, FilterConfig> = {
+  "no tier, prerelease": { tier: undefined, channel: "prerelease" },
+  "no tier, normal": { tier: undefined, channel: "normal" },
+  "global tier": { tier: "global", channel: "prerelease" },
+  "apps/lxd tier": { tier: "apps/lxd", channel: "normal" },
+};
+
+describe("collectEntityCounts", () => {
+  it.each(
+    Object.entries(configs),
+  )("matches legacy list-op lengths for %s", async (_label, config) => {
+    const counts = await collectEntityCounts(store, config);
+
+    expect(counts.blocks).toBe((await listBlocks(store, config)).length);
+    expect(counts.standards).toBe((await listStandards(store)).length);
+    expect(counts.modifierFamilies).toBe((await listModifiers(store)).length);
+    expect(counts.tokens).toBe((await listTokens(store)).length);
+  });
+
+  it("returns positive counts on the full fixture", async () => {
+    const counts = await collectEntityCounts(store, {
+      tier: undefined,
+      channel: "prerelease",
+    });
+
+    expect(counts.blocks).toBeGreaterThan(0);
+    expect(counts.standards).toBeGreaterThan(0);
+    expect(counts.modifierFamilies).toBeGreaterThan(0);
+    expect(counts.tokens).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/pragma/src/domains/info/operations/collectEntityCounts.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectEntityCounts.ts
@@ -31,13 +31,18 @@ async function countRows(store: Store, query: string): Promise<number> {
  * Each `COUNT` reproduces the row cardinality of the matching leaf list
  * operation, so the results equal `(await listX(...)).length` exactly:
  *
- * - **blocks** group by `?component` (like `listBlocks`), so
- *   `COUNT(DISTINCT ?component)`; the `?name`/`?tier` patterns and
- *   `buildFilters` mirror `listBlocks` for identical tier/channel scoping.
+ * - **blocks** count the distinct `(?component, ?type, ?name, ?tier)` groups
+ *   `listBlocks` emits via `GROUP BY ?component ?type ?name ?tier`, so a
+ *   `COUNT(*)` over a `SELECT DISTINCT` of that exact grain (incl.
+ *   `buildFilters` for identical tier/channel scoping). This stays exact even
+ *   for a block asserted as several types or tiers, which would fan a
+ *   single-variable `COUNT(DISTINCT ?component)` short of the grouped rows.
+ * - **modifier families** count the distinct `(?family, ?name)` groups
+ *   `listModifiers` emits via `GROUP BY ?family ?name`, so a `COUNT(*)` over a
+ *   `SELECT DISTINCT` of that grain — exact even for a family with two names.
  * - **standards** and **tokens** have no `GROUP BY` and an `OPTIONAL` that
- *   fans rows out, so `COUNT(*)` over the identical `WHERE`.
- * - **modifier families** group by `?family` (like `listModifiers`), so
- *   `COUNT(DISTINCT ?family)`.
+ *   fans rows out, so `COUNT(*)` over the identical `WHERE` matches row for
+ *   row (including the fan-out).
  *
  * @note Queries ke store
  *
@@ -55,13 +60,16 @@ async function collectEntityCounts(
     countRows(
       store,
       `
-      SELECT (COUNT(DISTINCT ?component) AS ?count)
+      SELECT (COUNT(*) AS ?count)
       WHERE {
-        VALUES ?type { ${P.ds}Component ${P.ds}Pattern ${P.ds}Layout ${P.ds}Subcomponent }
-        ?component a ?type ;
-                   ${P.ds}name ?name ;
-                   ${P.ds}tier ?tier .
-        ${filterClauses}
+        SELECT DISTINCT ?component ?type ?name ?tier
+        WHERE {
+          VALUES ?type { ${P.ds}Component ${P.ds}Pattern ${P.ds}Layout ${P.ds}Subcomponent }
+          ?component a ?type ;
+                     ${P.ds}name ?name ;
+                     ${P.ds}tier ?tier .
+          ${filterClauses}
+        }
       }
     `,
     ),
@@ -83,10 +91,13 @@ async function collectEntityCounts(
     countRows(
       store,
       `
-      SELECT (COUNT(DISTINCT ?family) AS ?count)
+      SELECT (COUNT(*) AS ?count)
       WHERE {
-        ?family a ${P.ds}ModifierFamily ;
-                ${P.ds}name ?name .
+        SELECT DISTINCT ?family ?name
+        WHERE {
+          ?family a ${P.ds}ModifierFamily ;
+                  ${P.ds}name ?name .
+        }
       }
     `,
     ),

--- a/packages/cli/pragma/src/domains/info/operations/collectEntityCounts.ts
+++ b/packages/cli/pragma/src/domains/info/operations/collectEntityCounts.ts
@@ -1,0 +1,112 @@
+import type { Store } from "@canonical/ke";
+import { buildQuery } from "../../shared/buildQuery.js";
+import { buildFilters } from "../../shared/filters/buildFilters.js";
+import { P } from "../../shared/prefixes.js";
+import type { FilterConfig } from "../../shared/types/index.js";
+import type { EntityCounts } from "../types.js";
+
+/**
+ * Run a `COUNT` query and parse its single `?count` binding.
+ *
+ * SPARQL `COUNT` yields a typed literal serialized as a string, so the
+ * value is parsed defensively and falls back to `0` when the query does
+ * not resolve to a select result.
+ *
+ * @param store - The ke store to query.
+ * @param query - A `SELECT (COUNT(...) AS ?count)` query string.
+ * @returns The parsed count, or `0` when unavailable.
+ * @note Queries ke store
+ */
+async function countRows(store: Store, query: string): Promise<number> {
+  const result = await store.query(buildQuery(query));
+  if (result.type !== "select") return 0;
+  const first = result.bindings[0];
+  return first ? Number.parseInt(first.count ?? "0", 10) || 0 : 0;
+}
+
+/**
+ * Count blocks, standards, modifier families, and tokens for the
+ * `pragma llm` orientation summary.
+ *
+ * Each `COUNT` reproduces the row cardinality of the matching leaf list
+ * operation, so the results equal `(await listX(...)).length` exactly:
+ *
+ * - **blocks** group by `?component` (like `listBlocks`), so
+ *   `COUNT(DISTINCT ?component)`; the `?name`/`?tier` patterns and
+ *   `buildFilters` mirror `listBlocks` for identical tier/channel scoping.
+ * - **standards** and **tokens** have no `GROUP BY` and an `OPTIONAL` that
+ *   fans rows out, so `COUNT(*)` over the identical `WHERE`.
+ * - **modifier families** group by `?family` (like `listModifiers`), so
+ *   `COUNT(DISTINCT ?family)`.
+ *
+ * @note Queries ke store
+ *
+ * @param store - The ke store to query.
+ * @param config - Filter config providing tier and channel settings.
+ * @returns Entity counts matching the four leaf list operations' lengths.
+ */
+async function collectEntityCounts(
+  store: Store,
+  config: FilterConfig,
+): Promise<EntityCounts> {
+  const filterClauses = buildFilters(config);
+
+  const [blocks, standards, modifierFamilies, tokens] = await Promise.all([
+    countRows(
+      store,
+      `
+      SELECT (COUNT(DISTINCT ?component) AS ?count)
+      WHERE {
+        VALUES ?type { ${P.ds}Component ${P.ds}Pattern ${P.ds}Layout ${P.ds}Subcomponent }
+        ?component a ?type ;
+                   ${P.ds}name ?name ;
+                   ${P.ds}tier ?tier .
+        ${filterClauses}
+      }
+    `,
+    ),
+    countRows(
+      store,
+      `
+      SELECT (COUNT(*) AS ?count)
+      WHERE {
+        ?standard a ${P.cs}CodeStandard ;
+                  ${P.cs}name ?name ;
+                  ${P.cs}description ?description .
+        OPTIONAL {
+          ?standard ${P.cs}hasCategory ?cat .
+          ?cat ${P.cs}slug ?categoryName .
+        }
+      }
+    `,
+    ),
+    countRows(
+      store,
+      `
+      SELECT (COUNT(DISTINCT ?family) AS ?count)
+      WHERE {
+        ?family a ${P.ds}ModifierFamily ;
+                ${P.ds}name ?name .
+      }
+    `,
+    ),
+    countRows(
+      store,
+      `
+      SELECT (COUNT(*) AS ?count)
+      WHERE {
+        ?token a ${P.ds}Token ;
+               ${P.ds}tokenId ?tokenId .
+        OPTIONAL {
+          ?token ${P.ds}tokenType ?type .
+          ?type ${P.rdfs}label ?typeName .
+        }
+      }
+    `,
+    ),
+  ]);
+
+  return { blocks, standards, modifierFamilies, tokens };
+}
+
+export { collectEntityCounts };

--- a/packages/cli/pragma/src/domains/info/operations/index.ts
+++ b/packages/cli/pragma/src/domains/info/operations/index.ts
@@ -1,5 +1,6 @@
 /** @module Barrel for info operations. */
 
 export { default as checkRegistryVersion } from "./checkRegistryVersion.js";
+export { collectEntityCounts } from "./collectEntityCounts.js";
 export { default as collectInfo } from "./collectInfo.js";
 export { collectStoreSummary } from "./collectStoreSummary.js";

--- a/packages/cli/pragma/src/domains/info/types.ts
+++ b/packages/cli/pragma/src/domains/info/types.ts
@@ -52,3 +52,16 @@ export interface StoreSummary {
   readonly tripleCount: number;
   readonly graphNames: readonly string[];
 }
+
+/**
+ * Entity counts for the `pragma llm` orientation summary.
+ *
+ * Mirrors the row cardinality of the four leaf list operations
+ * (`listBlocks`, `listStandards`, `listModifiers`, `listTokens`).
+ */
+export interface EntityCounts {
+  readonly blocks: number;
+  readonly standards: number;
+  readonly modifierFamilies: number;
+  readonly tokens: number;
+}

--- a/packages/cli/pragma/src/domains/llm/operations/collectContext.test.ts
+++ b/packages/cli/pragma/src/domains/llm/operations/collectContext.test.ts
@@ -1,0 +1,59 @@
+import type { Store } from "@canonical/ke";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestStore, DS_ALL_TTL } from "#testing";
+import type { FilterConfig } from "../../shared/types/index.js";
+import { renderLlmOrientation } from "../formatters/index.js";
+import type { LlmData } from "../types.js";
+import collectContext from "./collectContext.js";
+
+let store: Store;
+let cleanup: () => void;
+
+beforeAll(async () => {
+  const result = await createTestStore({ ttl: DS_ALL_TTL });
+  store = result.store;
+  cleanup = result.cleanup;
+});
+
+afterAll(() => cleanup());
+
+const config: FilterConfig = { tier: undefined, channel: "prerelease" };
+
+/** Extract the `## Context` data lines from a rendered orientation doc. */
+function contextBlock(rendered: string): string {
+  const lines = rendered.split("\n");
+  const start = lines.indexOf("## Context");
+  const block: string[] = [];
+  for (let i = start + 1; i < lines.length && lines[i] !== ""; i++) {
+    block.push(lines[i] ?? "");
+  }
+  return block.join("\n");
+}
+
+describe("collectContext", () => {
+  it("assembles counts and namespaces from the store", async () => {
+    const ctx = await collectContext(store, config);
+
+    expect(ctx.tier).toBeUndefined();
+    expect(ctx.channel).toBe("prerelease");
+    expect(ctx.counts.blocks).toBeGreaterThan(0);
+    expect(ctx.counts.standards).toBeGreaterThan(0);
+    expect(ctx.counts.modifierFamilies).toBeGreaterThan(0);
+    expect(ctx.counts.tokens).toBeGreaterThan(0);
+    expect(ctx.namespaces.length).toBeGreaterThan(0);
+  });
+
+  it("renders a stable `## Context` block", async () => {
+    const data: LlmData = {
+      context: await collectContext(store, config),
+      decisionTrees: [],
+      commandReference: [],
+    };
+
+    expect(contextBlock(renderLlmOrientation(data))).toMatchInlineSnapshot(`
+      "tier: (none) | channel: prerelease
+      data: 5 blocks, 3 standards, 2 modifier families, 2 tokens
+      namespaces: cs, ds"
+    `);
+  });
+});

--- a/packages/cli/pragma/src/domains/llm/operations/collectContext.ts
+++ b/packages/cli/pragma/src/domains/llm/operations/collectContext.ts
@@ -1,18 +1,16 @@
 import type { Store } from "@canonical/ke";
-import { listBlocks } from "../../block/operations/index.js";
-import { listModifiers } from "../../modifier/operations/index.js";
+import { collectEntityCounts } from "../../info/operations/index.js";
 import { listOntologies } from "../../ontology/operations/index.js";
 import { resolveTierChain } from "../../shared/filters/buildTierFilter.js";
 import type { FilterConfig } from "../../shared/types/index.js";
-import { listStandards } from "../../standard/operations/index.js";
-import { listTokens } from "../../token/operations/index.js";
 import type { LlmContext } from "../types.js";
 
 /**
  * Collects dynamic context for the `pragma llm` orientation output.
  *
- * Queries the store in parallel for block, standard, modifier, token, and
- * ontology counts, and combines them with tier/channel config state.
+ * Queries the store in parallel for entity counts (via
+ * {@link collectEntityCounts}) and ontology namespaces, and combines them
+ * with tier/channel config state.
  *
  * @note Queries ke store
  *
@@ -24,11 +22,8 @@ export default async function collectContext(
   store: Store,
   config: FilterConfig,
 ): Promise<LlmContext> {
-  const [blocks, standards, modifiers, tokens, ontologies] = await Promise.all([
-    listBlocks(store, config),
-    listStandards(store),
-    listModifiers(store),
-    listTokens(store),
+  const [counts, ontologies] = await Promise.all([
+    collectEntityCounts(store, config),
     listOntologies(store),
   ]);
 
@@ -36,12 +31,7 @@ export default async function collectContext(
     tier: config.tier,
     tierChain: resolveTierChain(config.tier),
     channel: config.channel,
-    counts: {
-      blocks: blocks.length,
-      standards: standards.length,
-      modifierFamilies: modifiers.length,
-      tokens: tokens.length,
-    },
+    counts,
     namespaces: ontologies.map((o) => o.prefix),
   };
 }

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
@@ -3,6 +3,7 @@ import { PragmaError } from "#error";
 import { RECIPE_STORY } from "#testing";
 import type { SemanticPackage } from "../../semanticPackage.js";
 import collectPackStories from "./collectPackStories.js";
+import { buildReservedVerbs } from "./reservedVerbs.js";
 
 function makePackage(stories: SemanticPackage["stories"]): SemanticPackage {
   return {
@@ -39,7 +40,7 @@ describe("collectPackStories", () => {
           },
         ]),
       ],
-      new Set(["block"]),
+      buildReservedVerbs([["block", undefined]]),
     );
     expect(entries.map((entry) => entry.definition.noun)).toEqual([
       "recipe",
@@ -57,7 +58,7 @@ describe("collectPackStories", () => {
           { path: "/pkg/stories/recipe.json", definition: RECIPE_STORY },
         ]),
       ],
-      new Set(),
+      buildReservedVerbs([]),
     );
     expect(entries).toHaveLength(1);
     expect(entries.at(0)?.source).toBe("config");
@@ -72,7 +73,7 @@ describe("collectPackStories", () => {
           { path: "/pkg/stories/broken.json", definition: { nope: true } },
         ]),
       ],
-      new Set(),
+      buildReservedVerbs([]),
     );
     expect(entries).toHaveLength(0);
     expect(warn).toHaveBeenCalledWith(
@@ -85,7 +86,7 @@ describe("collectPackStories", () => {
       collectPackStories(
         { ...CONFIG, stories: [{ ...RECIPE_STORY, noun: "block" }] },
         [],
-        new Set(["block"]),
+        buildReservedVerbs([["block", undefined]]),
       ),
     ).toThrow(PragmaError);
   });
@@ -101,8 +102,41 @@ describe("collectPackStories", () => {
           },
         ]),
       ],
-      new Set(["block"]),
+      buildReservedVerbs([["block", undefined]]),
     );
     expect(entries).toHaveLength(0);
+  });
+
+  it("admits a pack once its noun's verbs leave the reserved map", () => {
+    // Post-migration simulation: `standard`'s list/lookup wrappers are gone,
+    // so only categories/sample remain reserved — a `standard` pack (which
+    // emits list + lookup) is now admissible. `info` is a bare (whole-noun)
+    // built-in, so an `info` pack stays blocked. This is the keystone: the
+    // per-verb guard makes the leaf cutover incremental.
+    const reserved = buildReservedVerbs([
+      ["standard", "categories"],
+      ["standard", "sample"],
+      ["info", undefined],
+    ]);
+
+    const entries = collectPackStories(
+      CONFIG,
+      [
+        makePackage([
+          {
+            path: "/pkg/stories/standard.json",
+            definition: { ...RECIPE_STORY, noun: "standard" },
+          },
+          {
+            path: "/pkg/stories/info.json",
+            definition: { ...RECIPE_STORY, noun: "info" },
+          },
+        ]),
+      ],
+      reserved,
+    );
+
+    expect(entries.map((entry) => entry.definition.noun)).toEqual(["standard"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("already taken"));
   });
 });

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
@@ -105,7 +105,9 @@ describe("collectPackStories", () => {
     );
     expect(entries).toHaveLength(1);
     expect(entries.at(0)?.source).toBe("config");
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("already taken"));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("already provided"),
+    );
   });
 
   it("skips invalid package stories with a warning", () => {
@@ -180,7 +182,9 @@ describe("collectPackStories", () => {
     );
 
     expect(entries.map((entry) => entry.definition.noun)).toEqual(["standard"]);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("already taken"));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("shadows built-in command"),
+    );
   });
 
   // Regression restoration (FIX 1): operational nouns own no list/lookup, so
@@ -226,7 +230,7 @@ describe("collectPackStories", () => {
       );
       expect(entries).toHaveLength(0);
       expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining("already taken"),
+        expect.stringContaining("shadows built-in command"),
       );
     });
   });
@@ -291,7 +295,7 @@ describe("collectPackStories", () => {
       );
       expect(entries).toHaveLength(0);
       expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining("already taken"),
+        expect.stringContaining("shadows built-in command"),
       );
     });
   });

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.test.ts
@@ -3,7 +3,11 @@ import { PragmaError } from "#error";
 import { RECIPE_STORY } from "#testing";
 import type { SemanticPackage } from "../../semanticPackage.js";
 import collectPackStories from "./collectPackStories.js";
-import { buildReservedVerbs } from "./reservedVerbs.js";
+import {
+  buildReservedVerbs,
+  deriveReservedVerbs,
+  isReserved,
+} from "./reservedVerbs.js";
 
 function makePackage(stories: SemanticPackage["stories"]): SemanticPackage {
   return {
@@ -17,6 +21,45 @@ function makePackage(stories: SemanticPackage["stories"]): SemanticPackage {
 }
 
 const CONFIG = { tier: undefined, channel: "normal" as const };
+
+// A representative slice of the real built-in surface: leaf read nouns that
+// own `list`/`lookup`, plus operational nouns (graph, config, create, graphql,
+// setup, tokens) that own neither and so must be reserved wholesale.
+const BUILTIN_PAIRS: readonly (readonly [string, string | undefined])[] = [
+  ["standard", "list"],
+  ["standard", "lookup"],
+  ["standard", "categories"],
+  ["standard", "sample"],
+  ["block", "list"],
+  ["block", "lookup"],
+  ["token", "list"],
+  ["token", "lookup"],
+  ["tier", "list"],
+  ["config", "show"],
+  ["config", "tier"],
+  ["config", "channel"],
+  ["graph", "query"],
+  ["graph", "inspect"],
+  ["create", "component"],
+  ["create", "package"],
+  ["graphql", "build"],
+  ["graphql", "check"],
+  ["graphql", "serve"],
+  ["setup", "all"],
+  ["setup", "lsp"],
+  ["tokens", "add-config"],
+  ["info", undefined],
+];
+
+/** Run a thunk and return the error it throws (or `undefined`). */
+function caught(run: () => unknown): unknown {
+  try {
+    run();
+  } catch (error) {
+    return error;
+  }
+  return undefined;
+}
 
 describe("collectPackStories", () => {
   let warn: ReturnType<typeof vi.spyOn>;
@@ -138,5 +181,118 @@ describe("collectPackStories", () => {
 
     expect(entries.map((entry) => entry.definition.noun)).toEqual(["standard"]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("already taken"));
+  });
+
+  // Regression restoration (FIX 1): operational nouns own no list/lookup, so
+  // deriveReservedVerbs promotes them to a whole-noun reservation. Since a
+  // pack always emits `list`, a pack targeting an operational namespace must
+  // stay BLOCKED — this is the load-bearing proof that the per-verb flip did
+  // not silently open pragma's core operational namespaces to packs.
+  describe("operational nouns stay reserved wholesale", () => {
+    const reserved = deriveReservedVerbs(BUILTIN_PAIRS);
+
+    it("promotes every operational noun to a whole-noun reservation", () => {
+      for (const noun of ["config", "graph", "create", "graphql", "setup"]) {
+        expect(isReserved(reserved, noun, "list")).toBe(true);
+      }
+      // `tokens` (the plural add-config noun) owns only `add-config`.
+      expect(isReserved(reserved, "tokens", "list")).toBe(true);
+    });
+
+    it("throws a config error when a config story shadows an operational noun", () => {
+      const error = caught(() =>
+        collectPackStories(
+          { ...CONFIG, stories: [{ ...RECIPE_STORY, noun: "graph" }] },
+          [],
+          reserved,
+        ),
+      );
+      expect(error).toBeInstanceOf(PragmaError);
+      expect((error as PragmaError).code).toBe("CONFIG_ERROR");
+    });
+
+    it("skips a package story that shadows an operational noun", () => {
+      const entries = collectPackStories(
+        CONFIG,
+        [
+          makePackage([
+            {
+              path: "/pkg/stories/graph.json",
+              definition: { ...RECIPE_STORY, noun: "graph" },
+            },
+          ]),
+        ],
+        reserved,
+      );
+      expect(entries).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("already taken"),
+      );
+    });
+  });
+
+  // Keystone incremental window (FIX 3): `standard`'s `list` wrapper is
+  // deleted but `lookup` is still built-in (alongside categories/sample).
+  describe("incremental leaf cutover window", () => {
+    const reserved = deriveReservedVerbs([
+      ["standard", "lookup"],
+      ["standard", "categories"],
+      ["standard", "sample"],
+      ["info", undefined],
+    ]);
+
+    it("keeps `standard` per-verb because it still owns lookup (not promoted)", () => {
+      // Disjointness check: the noun retains a read verb, so it must NOT be
+      // wholesale-promoted — otherwise `list` could never be freed.
+      expect(isReserved(reserved, "standard", "list")).toBe(false);
+      expect(isReserved(reserved, "standard", "lookup")).toBe(true);
+    });
+
+    it("admits a standard pack that declares only list", () => {
+      const listOnly = { ...RECIPE_STORY, noun: "standard", lookup: undefined };
+      const entries = collectPackStories(
+        CONFIG,
+        [
+          makePackage([
+            { path: "/pkg/stories/standard.json", definition: listOnly },
+          ]),
+        ],
+        reserved,
+      );
+      expect(entries.map((entry) => entry.definition.noun)).toEqual([
+        "standard",
+      ]);
+    });
+
+    it("rejects a standard pack that also declares lookup (config throws)", () => {
+      const error = caught(() =>
+        collectPackStories(
+          { ...CONFIG, stories: [{ ...RECIPE_STORY, noun: "standard" }] },
+          [],
+          reserved,
+        ),
+      );
+      expect(error).toBeInstanceOf(PragmaError);
+      expect((error as PragmaError).code).toBe("CONFIG_ERROR");
+    });
+
+    it("rejects a standard pack that also declares lookup (package skips)", () => {
+      const entries = collectPackStories(
+        CONFIG,
+        [
+          makePackage([
+            {
+              path: "/pkg/stories/standard.json",
+              definition: { ...RECIPE_STORY, noun: "standard" },
+            },
+          ]),
+        ],
+        reserved,
+      );
+      expect(entries).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("already taken"),
+      );
+    });
   });
 });

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.ts
@@ -20,6 +20,16 @@ function emittedVerbs(definition: StoryPackDefinition): string[] {
 }
 
 /**
+ * Name the built-in `(noun, verb)` command(s) a pack collides with, for
+ * actionable diagnostics — e.g. `built-in command "standard lookup"`.
+ * Since the guard is per-verb, reporting the noun alone is misleading.
+ */
+function describeShadow(noun: string, verbs: readonly string[]): string {
+  const pairs = verbs.map((verb) => `"${noun} ${verb}"`).join(", ");
+  return `built-in command${verbs.length > 1 ? "s" : ""} ${pairs}`;
+}
+
+/**
  * Gather the story-pack definitions active for a runtime.
  *
  * Config-declared stories come first (already validated by the config
@@ -47,13 +57,15 @@ export default function collectPackStories(
   const taken = new Set<string>();
 
   for (const definition of config.stories ?? []) {
-    if (
-      emittedVerbs(definition).some((verb) =>
-        isReserved(reserved, definition.noun, verb),
-      )
-    ) {
+    const shadowed = emittedVerbs(definition).filter((verb) =>
+      isReserved(reserved, definition.noun, verb),
+    );
+    if (shadowed.length > 0) {
       throw PragmaError.configError(
-        `Story noun "${definition.noun}" shadows a built-in command.`,
+        `Story noun "${definition.noun}" shadows ${describeShadow(
+          definition.noun,
+          shadowed,
+        )}.`,
       );
     }
     if (taken.has(definition.noun)) {
@@ -75,14 +87,21 @@ export default function collectPackStories(
         process.stderr.write(`Warning: skipping story — ${reason}\n`);
         continue;
       }
-      if (
-        emittedVerbs(definition).some((verb) =>
-          isReserved(reserved, definition.noun, verb),
-        ) ||
-        taken.has(definition.noun)
-      ) {
+      const shadowed = emittedVerbs(definition).filter((verb) =>
+        isReserved(reserved, definition.noun, verb),
+      );
+      if (shadowed.length > 0) {
         process.stderr.write(
-          `Warning: skipping story "${definition.noun}" from ${file.path} — the noun is already taken.\n`,
+          `Warning: skipping story "${definition.noun}" from ${file.path} — it shadows ${describeShadow(
+            definition.noun,
+            shadowed,
+          )}.\n`,
+        );
+        continue;
+      }
+      if (taken.has(definition.noun)) {
+        process.stderr.write(
+          `Warning: skipping story "${definition.noun}" from ${file.path} — the noun is already provided by a higher-precedence source.\n`,
         );
         continue;
       }

--- a/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/collectPackStories.ts
@@ -1,6 +1,7 @@
 import type { PragmaConfig } from "#config";
 import { PragmaError } from "#error";
 import type { SemanticPackage } from "../../semanticPackage.js";
+import { isReserved, type ReservedVerbs } from "./reservedVerbs.js";
 import type { StoryPackDefinition } from "./types.js";
 import validateStoryPackDefinition from "./validateStoryPackDefinition.js";
 
@@ -8,6 +9,14 @@ import validateStoryPackDefinition from "./validateStoryPackDefinition.js";
 export interface PackStoryEntry {
   readonly definition: StoryPackDefinition;
   readonly source: string;
+}
+
+/**
+ * The verbs a pack definition compiles to — mirrors `compilePackStories`,
+ * which always emits `list` and adds `lookup` only when declared.
+ */
+function emittedVerbs(definition: StoryPackDefinition): string[] {
+  return ["list", ...(definition.lookup ? ["lookup"] : [])];
 }
 
 /**
@@ -22,22 +31,27 @@ export interface PackStoryEntry {
  *
  * @param config - The effective merged configuration.
  * @param packages - Resolved semantic packages (may ship `stories/*.json`).
- * @param reservedNouns - Built-in nouns story packs must not shadow.
+ * @param reserved - Built-in `(noun, verb)` reservations packs must not
+ *   shadow; a pack collides only when it emits a reserved verb.
  * @returns Validated, collision-free story entries.
  * @throws PragmaError with code `CONFIG_ERROR` when a config story shadows
- *   a reserved noun.
+ *   a reserved built-in verb.
  * @note Impure — warns on stderr for skipped package stories.
  */
 export default function collectPackStories(
   config: PragmaConfig,
   packages: readonly SemanticPackage[],
-  reservedNouns: ReadonlySet<string>,
+  reserved: ReservedVerbs,
 ): PackStoryEntry[] {
   const entries: PackStoryEntry[] = [];
   const taken = new Set<string>();
 
   for (const definition of config.stories ?? []) {
-    if (reservedNouns.has(definition.noun)) {
+    if (
+      emittedVerbs(definition).some((verb) =>
+        isReserved(reserved, definition.noun, verb),
+      )
+    ) {
       throw PragmaError.configError(
         `Story noun "${definition.noun}" shadows a built-in command.`,
       );
@@ -61,7 +75,12 @@ export default function collectPackStories(
         process.stderr.write(`Warning: skipping story — ${reason}\n`);
         continue;
       }
-      if (reservedNouns.has(definition.noun) || taken.has(definition.noun)) {
+      if (
+        emittedVerbs(definition).some((verb) =>
+          isReserved(reserved, definition.noun, verb),
+        ) ||
+        taken.has(definition.noun)
+      ) {
         process.stderr.write(
           `Warning: skipping story "${definition.noun}" from ${file.path} — the noun is already taken.\n`,
         );

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackCommands.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackCommands.ts
@@ -5,6 +5,7 @@ import compileLookupCommand from "../compileLookupCommand.js";
 import compileReadCommand from "../compileReadCommand.js";
 import collectPackStories from "./collectPackStories.js";
 import compilePackStories from "./compilePackStories.js";
+import type { ReservedVerbs } from "./reservedVerbs.js";
 
 /**
  * Compile every active story pack into CLI command definitions.
@@ -15,15 +16,15 @@ import compilePackStories from "./compilePackStories.js";
  * the built-in read stories, so completions and help come for free.
  *
  * @param ctx - Pragma context carrying config, packages, and the store.
- * @param reservedNouns - Built-in nouns packs must not shadow.
+ * @param reserved - Built-in `(noun, verb)` reservations packs must not shadow.
  * @returns Command definitions for every pack story.
  */
 export default function compilePackCommands(
   ctx: PragmaContext,
-  reservedNouns: ReadonlySet<string>,
+  reserved: ReservedVerbs,
 ): CommandDefinition[] {
   const prefixes = { ...PREFIX_MAP, ...ctx.config.prefixes };
-  const entries = collectPackStories(ctx.config, ctx.packages, reservedNouns);
+  const entries = collectPackStories(ctx.config, ctx.packages, reserved);
 
   return entries.flatMap((entry) => {
     const compiled = compilePackStories(

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackToolSpecs.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackToolSpecs.ts
@@ -5,6 +5,7 @@ import compileLookupTool from "../compileLookupTool.js";
 import compileReadTool from "../compileReadTool.js";
 import collectPackStories from "./collectPackStories.js";
 import compilePackStories from "./compilePackStories.js";
+import type { ReservedVerbs } from "./reservedVerbs.js";
 
 /**
  * Compile every active story pack into MCP tool specs.
@@ -14,18 +15,18 @@ import compilePackStories from "./compilePackStories.js";
  * the built-in tools.
  *
  * @param runtime - Pragma runtime carrying config, packages, and the store.
- * @param reservedNouns - Built-in nouns packs must not shadow.
+ * @param reserved - Built-in `(noun, verb)` reservations packs must not shadow.
  * @returns Tool specs for every pack story.
  */
 export default function compilePackToolSpecs(
   runtime: PragmaRuntime,
-  reservedNouns: ReadonlySet<string>,
+  reserved: ReservedVerbs,
 ): ToolSpec[] {
   const prefixes = { ...PREFIX_MAP, ...runtime.config.prefixes };
   const entries = collectPackStories(
     runtime.config,
     runtime.packages,
-    reservedNouns,
+    reserved,
   );
 
   return entries.flatMap((entry) => {

--- a/packages/cli/pragma/src/domains/shared/stories/pack/index.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/index.ts
@@ -18,6 +18,7 @@ export { default as compilePackToolSpecs } from "./compilePackToolSpecs.js";
 export type { ReservedVerbs } from "./reservedVerbs.js";
 export {
   buildReservedVerbs,
+  deriveReservedVerbs,
   isReserved,
   nounVerbFromPath,
   nounVerbFromToolName,

--- a/packages/cli/pragma/src/domains/shared/stories/pack/index.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/index.ts
@@ -15,6 +15,13 @@ export { default as compilePackCommands } from "./compilePackCommands.js";
 export type { CompiledPackStories } from "./compilePackStories.js";
 export { default as compilePackStories } from "./compilePackStories.js";
 export { default as compilePackToolSpecs } from "./compilePackToolSpecs.js";
+export type { ReservedVerbs } from "./reservedVerbs.js";
+export {
+  buildReservedVerbs,
+  isReserved,
+  nounVerbFromPath,
+  nounVerbFromToolName,
+} from "./reservedVerbs.js";
 export { default as runSelectQuery } from "./runSelectQuery.js";
 export type {
   StoryPackColumn,

--- a/packages/cli/pragma/src/domains/shared/stories/pack/reservedVerbs.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/reservedVerbs.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReservedVerbs,
+  isReserved,
+  nounVerbFromPath,
+  nounVerbFromToolName,
+} from "./reservedVerbs.js";
+
+describe("nounVerbFromPath", () => {
+  it("splits a [noun, verb] path", () => {
+    expect(nounVerbFromPath(["standard", "list"])).toEqual([
+      "standard",
+      "list",
+    ]);
+  });
+
+  it("treats a single-segment path as a whole-noun reservation", () => {
+    expect(nounVerbFromPath(["info"])).toEqual(["info", undefined]);
+  });
+
+  it("preserves the hyphenated multi-word built-in verb", () => {
+    expect(nounVerbFromPath(["tokens", "add-config"])).toEqual([
+      "tokens",
+      "add-config",
+    ]);
+  });
+});
+
+describe("nounVerbFromToolName", () => {
+  it("splits a single-underscore tool name", () => {
+    expect(nounVerbFromToolName("standard_list")).toEqual(["standard", "list"]);
+  });
+
+  it("keeps every segment after the first for multi-underscore names", () => {
+    expect(nounVerbFromToolName("tokens_add_config")).toEqual([
+      "tokens",
+      "add_config",
+    ]);
+  });
+
+  it("treats a single-token name as a whole-noun reservation", () => {
+    expect(nounVerbFromToolName("info")).toEqual(["info", undefined]);
+  });
+});
+
+describe("buildReservedVerbs", () => {
+  // Mirrors the real built-in CLI command paths (pinned by
+  // collectCommands.test.ts's golden snapshot).
+  const CLI_PATHS: readonly (readonly string[])[] = [
+    ["standard", "list"],
+    ["standard", "lookup"],
+    ["standard", "categories"],
+    ["standard", "sample"],
+    ["token", "list"],
+    ["token", "lookup"],
+    ["token", "sample"],
+    ["tokens", "add-config"],
+    ["config", "show"],
+    ["config", "tier"],
+    ["config", "channel"],
+    ["info"],
+    ["llm"],
+    ["doctor"],
+    ["capabilities"],
+  ];
+
+  // Mirrors the real built-in MCP tool names (pinned by registerTools.test.ts).
+  const MCP_NAMES: readonly string[] = [
+    "standard_list",
+    "standard_lookup",
+    "standard_categories",
+    "standard_sample",
+    "token_list",
+    "token_lookup",
+    "token_sample",
+    "tokens_add_config",
+    "info",
+    "llm",
+  ];
+
+  it("assembles verb sets per noun from real CLI command paths", () => {
+    const reserved = buildReservedVerbs(
+      CLI_PATHS.map((path) => nounVerbFromPath(path)),
+    );
+
+    expect(reserved.get("standard")).toEqual(
+      new Set(["list", "lookup", "categories", "sample"]),
+    );
+    expect(reserved.get("token")).toEqual(
+      new Set(["list", "lookup", "sample"]),
+    );
+    expect(reserved.get("tokens")).toEqual(new Set(["add-config"]));
+    expect(reserved.get("info")).toEqual(new Set(["*"]));
+  });
+
+  it("assembles verb sets per noun from real MCP tool names", () => {
+    const reserved = buildReservedVerbs(
+      MCP_NAMES.map((name) => nounVerbFromToolName(name)),
+    );
+
+    expect(reserved.get("standard")).toEqual(
+      new Set(["list", "lookup", "categories", "sample"]),
+    );
+    // The token/tokens split plus underscore verb is harmless surface skew.
+    expect(reserved.get("tokens")).toEqual(new Set(["add_config"]));
+    expect(reserved.get("info")).toEqual(new Set(["*"]));
+  });
+
+  it("keeps both entries when a noun has a concrete verb and a bare form", () => {
+    const reserved = buildReservedVerbs([
+      ["config", "show"],
+      ["config", undefined],
+    ]);
+
+    expect(reserved.get("config")).toEqual(new Set(["show", "*"]));
+  });
+});
+
+describe("isReserved", () => {
+  const reserved = buildReservedVerbs(
+    (
+      [
+        ["standard", "list"],
+        ["standard", "lookup"],
+        ["standard", "categories"],
+        ["standard", "sample"],
+        ["config", "show"],
+        ["info"],
+      ] as const
+    ).map((path) => nounVerbFromPath(path)),
+  );
+
+  it("reserves a verb the built-in noun owns", () => {
+    expect(isReserved(reserved, "standard", "list")).toBe(true);
+  });
+
+  it("admits a new verb on an existing noun (per-verb relaxation)", () => {
+    expect(isReserved(reserved, "standard", "foo")).toBe(false);
+  });
+
+  it("reserves every verb of a whole-noun (`*`) reservation", () => {
+    expect(isReserved(reserved, "info", "list")).toBe(true);
+  });
+
+  it("does not reserve an unowned verb of a partially reserved noun", () => {
+    expect(isReserved(reserved, "config", "list")).toBe(false);
+  });
+
+  it("does not reserve a noun with no built-in", () => {
+    expect(isReserved(reserved, "recipe", "list")).toBe(false);
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/stories/pack/reservedVerbs.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/reservedVerbs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildReservedVerbs,
+  deriveReservedVerbs,
   isReserved,
   nounVerbFromPath,
   nounVerbFromToolName,
@@ -117,6 +118,9 @@ describe("buildReservedVerbs", () => {
 });
 
 describe("isReserved", () => {
+  // Raw grouping (buildReservedVerbs, no promotion): a partially reserved
+  // noun like `config` keeps only its concrete verbs. The policy-applied
+  // promotion of operational nouns is exercised under `deriveReservedVerbs`.
   const reserved = buildReservedVerbs(
     (
       [
@@ -142,11 +146,68 @@ describe("isReserved", () => {
     expect(isReserved(reserved, "info", "list")).toBe(true);
   });
 
-  it("does not reserve an unowned verb of a partially reserved noun", () => {
+  it("does not reserve an unowned verb of a partially reserved noun (raw map)", () => {
+    // buildReservedVerbs alone does NOT promote `config`; deriveReservedVerbs
+    // does (asserted below). This pins the pure-grouping behavior.
     expect(isReserved(reserved, "config", "list")).toBe(false);
   });
 
   it("does not reserve a noun with no built-in", () => {
     expect(isReserved(reserved, "recipe", "list")).toBe(false);
+  });
+});
+
+describe("deriveReservedVerbs", () => {
+  // Mirrors the real built-in surface: leaf read nouns that own list/lookup
+  // plus operational nouns that own neither.
+  const PAIRS: readonly (readonly [string, string | undefined])[] = [
+    ["standard", "list"],
+    ["standard", "lookup"],
+    ["standard", "categories"],
+    ["standard", "sample"],
+    ["config", "show"],
+    ["config", "tier"],
+    ["config", "channel"],
+    ["graph", "query"],
+    ["graph", "inspect"],
+    ["create", "component"],
+    ["create", "package"],
+    ["graphql", "build"],
+    ["setup", "all"],
+    ["tokens", "add-config"],
+    ["info", undefined],
+  ];
+  const derived = deriveReservedVerbs(PAIRS);
+
+  it("promotes operational nouns (no list/lookup) to a whole-noun reservation", () => {
+    for (const noun of ["config", "graph", "create", "graphql", "setup"]) {
+      expect(isReserved(derived, noun, "list")).toBe(true);
+      // Whole-noun means every verb is reserved, not just list.
+      expect(isReserved(derived, noun, "anything")).toBe(true);
+    }
+    // The plural add-config noun owns only a non-read verb, so it too promotes.
+    expect(isReserved(derived, "tokens", "list")).toBe(true);
+    // The promoted set is exactly the whole-noun sentinel.
+    expect(derived.get("config")).toEqual(new Set(["*"]));
+  });
+
+  it("keeps leaf read nouns per-verb (does not promote `standard`)", () => {
+    expect(isReserved(derived, "standard", "list")).toBe(true);
+    expect(isReserved(derived, "standard", "lookup")).toBe(true);
+    // A verb the built-in noun does not own stays admissible.
+    expect(isReserved(derived, "standard", "foo")).toBe(false);
+    // Untouched: the per-verb set is preserved verbatim.
+    expect(derived.get("standard")).toEqual(
+      new Set(["list", "lookup", "categories", "sample"]),
+    );
+  });
+
+  it("leaves a bare whole-noun reservation idempotent", () => {
+    expect(derived.get("info")).toEqual(new Set(["*"]));
+    expect(isReserved(derived, "info", "list")).toBe(true);
+  });
+
+  it("does not reserve a noun with no built-in", () => {
+    expect(isReserved(derived, "recipe", "list")).toBe(false);
   });
 });

--- a/packages/cli/pragma/src/domains/shared/stories/pack/reservedVerbs.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/reservedVerbs.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-(noun, verb) reservation for story packs.
+ *
+ * A story pack must not shadow a built-in command. The built-in surface is
+ * derived at assembly time into a {@link ReservedVerbs} map: each built-in
+ * noun maps to the set of verbs it already occupies. A pack is only blocked
+ * when it would emit a verb the built-in noun actually owns — so a new verb
+ * on an existing noun is admissible, and once a noun's `list`/`lookup`
+ * wrapper is deleted (leaf cutover, ADR C.07) that verb automatically
+ * leaves the map, making the migration incremental.
+ *
+ * The sentinel `"*"` reserves a whole noun: single-word built-ins (e.g.
+ * `info`, `llm`, `doctor`) have no verb, so they reserve every verb.
+ * @module
+ */
+
+/**
+ * Built-in reservations: noun → the verbs it occupies.
+ *
+ * The `"*"` sentinel in a noun's verb set reserves the entire noun.
+ */
+export type ReservedVerbs = ReadonlyMap<string, ReadonlySet<string>>;
+
+/**
+ * Whether a `(noun, verb)` pair is reserved by a built-in command.
+ *
+ * @param reserved - The assembled reservation map.
+ * @param noun - The story pack noun.
+ * @param verb - A verb the pack would emit (e.g. `"list"`).
+ * @returns `true` when the noun reserves this verb or the whole noun (`"*"`).
+ */
+export function isReserved(
+  reserved: ReservedVerbs,
+  noun: string,
+  verb: string,
+): boolean {
+  const verbs = reserved.get(noun);
+  return verbs !== undefined && (verbs.has(verb) || verbs.has("*"));
+}
+
+/**
+ * Split a CLI command path into a `(noun, verb)` pair.
+ *
+ * `["standard", "list"]` → `["standard", "list"]`; a single-segment path
+ * like `["info"]` → `["info", undefined]` (whole-noun reservation).
+ *
+ * @param path - A command's path segments.
+ * @returns The `[noun, verb]` pair; `verb` is `undefined` for a bare noun.
+ */
+export function nounVerbFromPath(
+  path: readonly string[],
+): [string, string | undefined] {
+  return [path.at(0) ?? "", path.at(1)];
+}
+
+/**
+ * Split an MCP tool name into a `(noun, verb)` pair on `"_"`.
+ *
+ * The verb keeps every segment after the first, so the one multi-underscore
+ * built-in parses as `"tokens_add_config"` → `["tokens", "add_config"]`;
+ * `"standard_list"` → `["standard", "list"]`; a bare `"info"` →
+ * `["info", undefined]`.
+ *
+ * Note the surface asymmetry this tolerates: the CLI reserves `tokens
+ * add-config` (hyphen) while MCP reserves `tokens_add_config` (underscore),
+ * and CLI/MCP reserve different noun sets overall. That is harmless — each
+ * surface derives and consumes its own map, and packs only ever emit the
+ * `list`/`lookup` verbs.
+ *
+ * @param name - An MCP tool name (e.g. `"token_lookup"`).
+ * @returns The `[noun, verb]` pair; `verb` is `undefined` for a bare noun.
+ */
+export function nounVerbFromToolName(
+  name: string,
+): [string, string | undefined] {
+  const parts = name.split("_");
+  const noun = parts.at(0) ?? "";
+  const verb = parts.length > 1 ? parts.slice(1).join("_") : undefined;
+  return [noun, verb];
+}
+
+/**
+ * Assemble a {@link ReservedVerbs} map from `(noun, verb)` pairs.
+ *
+ * A pair with an `undefined` verb reserves the whole noun (stored as the
+ * `"*"` sentinel). A noun appearing with both a concrete verb and
+ * `undefined` keeps both entries in its set, which is harmless because
+ * `"*"` already matches every verb.
+ *
+ * @param pairs - `(noun, verb)` pairs, e.g. from {@link nounVerbFromPath}.
+ * @returns The assembled reservation map.
+ */
+export function buildReservedVerbs(
+  pairs: Iterable<readonly [string, string | undefined]>,
+): ReservedVerbs {
+  const reserved = new Map<string, Set<string>>();
+  for (const [noun, verb] of pairs) {
+    const verbs = reserved.get(noun) ?? new Set<string>();
+    verbs.add(verb ?? "*");
+    reserved.set(noun, verbs);
+  }
+  return reserved;
+}

--- a/packages/cli/pragma/src/domains/shared/stories/pack/reservedVerbs.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/reservedVerbs.ts
@@ -2,22 +2,43 @@
  * Per-(noun, verb) reservation for story packs.
  *
  * A story pack must not shadow a built-in command. The built-in surface is
- * derived at assembly time into a {@link ReservedVerbs} map: each built-in
- * noun maps to the set of verbs it already occupies. A pack is only blocked
- * when it would emit a verb the built-in noun actually owns — so a new verb
- * on an existing noun is admissible, and once a noun's `list`/`lookup`
- * wrapper is deleted (leaf cutover, ADR C.07) that verb automatically
- * leaves the map, making the migration incremental.
+ * derived at assembly time into a {@link ReservedVerbs} map via
+ * {@link deriveReservedVerbs}: each built-in noun maps to the set of verbs it
+ * already occupies. A pack is only blocked when it would emit a verb the
+ * built-in noun actually owns — so a new verb on an existing noun is
+ * admissible, and once a noun's `list`/`lookup` wrapper is deleted (leaf
+ * cutover, ADR C.07) that verb automatically leaves the map, making the
+ * migration incremental.
  *
- * The sentinel `"*"` reserves a whole noun: single-word built-ins (e.g.
- * `info`, `llm`, `doctor`) have no verb, so they reserve every verb.
+ * Per-verb relaxation applies ONLY to nouns that own a `list`/`lookup` read
+ * verb (the real leaf-migration targets: block/standard/modifier/token/tier).
+ * A built-in noun that owns neither — an operational command like `config`,
+ * `graph`, `setup` — is reserved wholesale by {@link deriveReservedVerbs}, so
+ * a pack can never colonize its namespace.
+ *
+ * The {@link WHOLE_NOUN} sentinel (`"*"`) reserves a whole noun: single-word
+ * built-ins (e.g. `info`, `llm`, `doctor`) have no verb, so they reserve every
+ * verb, as do promoted operational nouns.
  * @module
  */
+
+/** Sentinel verb reserving an entire noun (matches every verb). */
+const WHOLE_NOUN = "*";
+
+/**
+ * The read-story verbs a pack can emit — the only verbs a leaf cutover frees.
+ *
+ * A built-in noun that owns one of these is a declarative-read migration
+ * target and keeps per-verb reservation; a noun disjoint from this set is
+ * operational and is reserved wholesale.
+ */
+const READ_STORY_VERBS: ReadonlySet<string> = new Set(["list", "lookup"]);
 
 /**
  * Built-in reservations: noun → the verbs it occupies.
  *
- * The `"*"` sentinel in a noun's verb set reserves the entire noun.
+ * The {@link WHOLE_NOUN} (`"*"`) sentinel in a noun's verb set reserves the
+ * entire noun.
  */
 export type ReservedVerbs = ReadonlyMap<string, ReadonlySet<string>>;
 
@@ -35,7 +56,7 @@ export function isReserved(
   verb: string,
 ): boolean {
   const verbs = reserved.get(noun);
-  return verbs !== undefined && (verbs.has(verb) || verbs.has("*"));
+  return verbs !== undefined && (verbs.has(verb) || verbs.has(WHOLE_NOUN));
 }
 
 /**
@@ -82,13 +103,15 @@ export function nounVerbFromToolName(
 /**
  * Assemble a {@link ReservedVerbs} map from `(noun, verb)` pairs.
  *
- * A pair with an `undefined` verb reserves the whole noun (stored as the
- * `"*"` sentinel). A noun appearing with both a concrete verb and
- * `undefined` keeps both entries in its set, which is harmless because
- * `"*"` already matches every verb.
+ * Pure grouping only — no reservation policy. A pair with an `undefined`
+ * verb reserves the whole noun (stored as the {@link WHOLE_NOUN} sentinel).
+ * A noun appearing with both a concrete verb and `undefined` keeps both
+ * entries in its set, which is harmless because `"*"` already matches every
+ * verb. Callers wanting the policy-applied surface use
+ * {@link deriveReservedVerbs}, not this function.
  *
  * @param pairs - `(noun, verb)` pairs, e.g. from {@link nounVerbFromPath}.
- * @returns The assembled reservation map.
+ * @returns The assembled reservation map (raw grouping).
  */
 export function buildReservedVerbs(
   pairs: Iterable<readonly [string, string | undefined]>,
@@ -96,8 +119,52 @@ export function buildReservedVerbs(
   const reserved = new Map<string, Set<string>>();
   for (const [noun, verb] of pairs) {
     const verbs = reserved.get(noun) ?? new Set<string>();
-    verbs.add(verb ?? "*");
+    verbs.add(verb ?? WHOLE_NOUN);
     reserved.set(noun, verbs);
   }
   return reserved;
+}
+
+/**
+ * Derive the policy-applied {@link ReservedVerbs} the guard consumes.
+ *
+ * A built-in noun that exposes neither `list` nor `lookup` is an operational
+ * command (config, graph, setup, …), never a declarative-read migration
+ * target, so it is reserved wholesale — a pack may not colonize its
+ * namespace. Nouns that own `list`/`lookup` keep per-verb reservation so a
+ * later cutover phase can free an individual read verb by deleting its
+ * wrapper.
+ *
+ * Both the CLI and MCP surfaces route through this single derivation, so the
+ * two surfaces reserve the same `list`/`lookup` verbs for every leaf noun.
+ *
+ * Limitation: a fully-migrated leaf noun whose only *remaining* built-in
+ * verbs are non-read (e.g. `sample`/`categories` after both `list` and
+ * `lookup` are deleted) would be wholesale-promoted here; that Phase-3 case
+ * is served by the built-in pack's own precedence (C.07) and must be
+ * revisited when it lands.
+ *
+ * @param pairs - `(noun, verb)` pairs, e.g. from {@link nounVerbFromPath}.
+ * @returns The reservation map with operational nouns promoted to whole-noun.
+ */
+export function deriveReservedVerbs(
+  pairs: Iterable<readonly [string, string | undefined]>,
+): ReservedVerbs {
+  // Mutable working copy of the pure grouping.
+  const map = new Map<string, Set<string>>();
+  for (const [noun, verbs] of buildReservedVerbs(pairs)) {
+    map.set(noun, new Set(verbs));
+  }
+
+  // Promote every operational noun (verb-set disjoint from the read verbs)
+  // to a wholesale reservation. Bare nouns already hold `{"*"}`, so this is
+  // idempotent for them; leaf read nouns keep their per-verb sets untouched.
+  for (const [noun, verbs] of map) {
+    const ownsReadVerb = [...verbs].some((verb) => READ_STORY_VERBS.has(verb));
+    if (!ownsReadVerb) {
+      map.set(noun, new Set([WHOLE_NOUN]));
+    }
+  }
+
+  return map;
 }

--- a/packages/cli/pragma/src/mcp/tools/index.ts
+++ b/packages/cli/pragma/src/mcp/tools/index.ts
@@ -19,8 +19,8 @@ import { specs as modifierSpecs } from "../../domains/modifier/mcp/index.js";
 import { specs as ontologySpecs } from "../../domains/ontology/mcp/index.js";
 import type { PragmaRuntime } from "../../domains/shared/runtime.js";
 import {
-  buildReservedVerbs,
   compilePackToolSpecs,
+  deriveReservedVerbs,
   nounVerbFromToolName,
 } from "../../domains/shared/stories/pack/index.js";
 import type { ToolSpec } from "../../domains/shared/ToolSpec.js";
@@ -30,7 +30,13 @@ import { specs as tierSpecs } from "../../domains/tier/mcp/index.js";
 import { specs as tokenSpecs } from "../../domains/token/mcp/index.js";
 import registerFromSpec from "./registerFromSpec.js";
 
-const allSpecs: readonly ToolSpec[] = [
+/**
+ * The full built-in MCP tool surface, in registration order.
+ *
+ * Exported so tests can derive the reserved-verb map from the identical
+ * array production consumes (see the cross-surface reservation invariant).
+ */
+export const allSpecs: readonly ToolSpec[] = [
   ...blockSpecs,
   ...standardSpecs,
   ...modifierSpecs,
@@ -60,9 +66,10 @@ export default function registerAllTools(
     registerFromSpec(server, runtime, spec);
   }
 
-  // Story packs project onto the same surface; each built-in (noun, verb)
-  // is reserved, so a pack can only add a verb no built-in noun owns.
-  const reserved = buildReservedVerbs(
+  // Story packs project onto the same surface. Leaf read nouns reserve only
+  // the (noun, verb) pairs they own, so a pack can add a verb no built-in
+  // owns; operational nouns (config, graph, …) stay reserved wholesale.
+  const reserved = deriveReservedVerbs(
     allSpecs.map((spec) => nounVerbFromToolName(spec.name)),
   );
   for (const spec of compilePackToolSpecs(runtime, reserved)) {

--- a/packages/cli/pragma/src/mcp/tools/index.ts
+++ b/packages/cli/pragma/src/mcp/tools/index.ts
@@ -18,7 +18,11 @@ import { specs as orientationSpecs } from "../../domains/llm/mcp/index.js";
 import { specs as modifierSpecs } from "../../domains/modifier/mcp/index.js";
 import { specs as ontologySpecs } from "../../domains/ontology/mcp/index.js";
 import type { PragmaRuntime } from "../../domains/shared/runtime.js";
-import { compilePackToolSpecs } from "../../domains/shared/stories/pack/index.js";
+import {
+  buildReservedVerbs,
+  compilePackToolSpecs,
+  nounVerbFromToolName,
+} from "../../domains/shared/stories/pack/index.js";
 import type { ToolSpec } from "../../domains/shared/ToolSpec.js";
 import { specs as skillSpecs } from "../../domains/skill/mcp/index.js";
 import { specs as standardSpecs } from "../../domains/standard/mcp/index.js";
@@ -56,11 +60,12 @@ export default function registerAllTools(
     registerFromSpec(server, runtime, spec);
   }
 
-  // Story packs project onto the same surface; built-in nouns are reserved.
-  const reservedNouns = new Set(
-    allSpecs.map((spec) => spec.name.split("_").at(0) ?? ""),
+  // Story packs project onto the same surface; each built-in (noun, verb)
+  // is reserved, so a pack can only add a verb no built-in noun owns.
+  const reserved = buildReservedVerbs(
+    allSpecs.map((spec) => nounVerbFromToolName(spec.name)),
   );
-  for (const spec of compilePackToolSpecs(runtime, reservedNouns)) {
+  for (const spec of compilePackToolSpecs(runtime, reserved)) {
     registerFromSpec(server, runtime, spec);
   }
 }

--- a/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
+++ b/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
@@ -112,6 +112,47 @@ describe("tool listing", () => {
       expect(tool.name).not.toMatch(/^pragma_/);
     }
   });
+
+  // Golden surface: the full built-in tool set with no story packs. The
+  // per-(noun, verb) reserved-guard flip must leave this byte-identical.
+  it("has a stable built-in tool surface", async () => {
+    const names = (await client.listTools()).tools
+      .map((tool) => tool.name)
+      .sort();
+
+    expect(names).toEqual([
+      "block_list",
+      "block_lookup",
+      "block_sample",
+      "capabilities",
+      "config_channel",
+      "config_show",
+      "config_tier",
+      "create_component",
+      "create_package",
+      "doctor",
+      "graph_inspect",
+      "graph_query",
+      "info",
+      "llm",
+      "modifier_list",
+      "modifier_lookup",
+      "modifier_sample",
+      "ontology_list",
+      "ontology_show",
+      "skill_list",
+      "skill_lookup",
+      "standard_categories",
+      "standard_list",
+      "standard_lookup",
+      "standard_sample",
+      "tier_list",
+      "token_list",
+      "token_lookup",
+      "token_sample",
+      "tokens_add_config",
+    ]);
+  });
 });
 
 // =============================================================================

--- a/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
+++ b/packages/cli/pragma/src/mcp/tools/registerTools.test.ts
@@ -113,44 +113,44 @@ describe("tool listing", () => {
     }
   });
 
-  // Golden surface: the full built-in tool set with no story packs. The
-  // per-(noun, verb) reserved-guard flip must leave this byte-identical.
+  // Golden surface: the full built-in tool set with no story packs, in
+  // registration order. The per-(noun, verb) reserved-guard flip must leave
+  // this byte-identical AND order-identical — registration order is the tool
+  // surface a client sees.
   it("has a stable built-in tool surface", async () => {
-    const names = (await client.listTools()).tools
-      .map((tool) => tool.name)
-      .sort();
+    const names = (await client.listTools()).tools.map((tool) => tool.name);
 
     expect(names).toEqual([
       "block_list",
       "block_lookup",
       "block_sample",
-      "capabilities",
-      "config_channel",
-      "config_show",
-      "config_tier",
-      "create_component",
-      "create_package",
-      "doctor",
-      "graph_inspect",
-      "graph_query",
-      "info",
-      "llm",
+      "standard_list",
+      "standard_lookup",
+      "standard_categories",
+      "standard_sample",
       "modifier_list",
       "modifier_lookup",
       "modifier_sample",
-      "ontology_list",
-      "ontology_show",
-      "skill_list",
-      "skill_lookup",
-      "standard_categories",
-      "standard_list",
-      "standard_lookup",
-      "standard_sample",
-      "tier_list",
       "token_list",
       "token_lookup",
-      "token_sample",
       "tokens_add_config",
+      "token_sample",
+      "tier_list",
+      "config_show",
+      "config_tier",
+      "config_channel",
+      "ontology_list",
+      "ontology_show",
+      "graph_query",
+      "graph_inspect",
+      "skill_list",
+      "skill_lookup",
+      "doctor",
+      "info",
+      "capabilities",
+      "llm",
+      "create_component",
+      "create_package",
     ]);
   });
 });

--- a/packages/cli/pragma/src/pipeline/collectCommands.test.ts
+++ b/packages/cli/pragma/src/pipeline/collectCommands.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { PragmaContext } from "../domains/shared/context.js";
 import type { PragmaRuntime } from "../domains/shared/runtime.js";
+import {
+  deriveReservedVerbs,
+  isReserved,
+  nounVerbFromPath,
+  nounVerbFromToolName,
+} from "../domains/shared/stories/pack/index.js";
+import { allSpecs } from "../mcp/tools/index.js";
 import createTestRuntime from "../testing/helpers/createTestRuntime.js";
 import collectCommands from "./collectCommands.js";
 
@@ -36,56 +43,106 @@ describe("collectCommands", () => {
   });
 
   // Golden surface: the full built-in command set under default config (no
-  // packs). The per-(noun, verb) reserved-guard flip must not add, drop, or
-  // rename a single built-in command, so this list is byte-identical to the
-  // pre-flip surface.
+  // packs), in emission order. The per-(noun, verb) reserved-guard flip must
+  // not add, drop, rename, or REORDER a single built-in command — order drives
+  // help output and registration — so this list is byte-identical (and
+  // order-identical) to the pre-flip surface.
   it("has a stable built-in command surface", () => {
-    const paths = collectCommands(makeCtx())
-      .map((command) => command.path.join(" "))
-      .sort();
+    const paths = collectCommands(makeCtx()).map((command) =>
+      command.path.join(" "),
+    );
 
     expect(paths).toEqual([
-      "block list",
-      "block lookup",
-      "block sample",
-      "capabilities",
+      "config tier",
       "config channel",
+      "config trace",
       "config framework",
       "config show",
-      "config tier",
-      "config trace",
       "create component",
       "create package",
-      "doctor",
-      "graph inspect",
-      "graph query",
-      "graphql build",
-      "graphql check",
-      "graphql serve",
-      "info",
-      "llm",
+      "setup all",
+      "setup lsp",
+      "setup mcp",
+      "setup completions",
+      "setup skills",
+      "standard list",
+      "standard lookup",
+      "standard categories",
+      "standard sample",
       "modifier list",
       "modifier lookup",
       "modifier sample",
-      "ontology list",
-      "ontology show",
-      "setup all",
-      "setup completions",
-      "setup lsp",
-      "setup mcp",
-      "setup skills",
-      "skill list",
-      "skill lookup",
-      "standard categories",
-      "standard list",
-      "standard lookup",
-      "standard sample",
       "tier list",
       "token list",
       "token lookup",
-      "token sample",
       "tokens add-config",
+      "token sample",
+      "block list",
+      "block lookup",
+      "block sample",
+      "ontology list",
+      "ontology show",
+      "graph query",
+      "graph inspect",
+      "graphql build",
+      "graphql check",
+      "graphql serve",
+      "skill list",
+      "skill lookup",
+      "doctor",
+      "info",
       "upgrade",
+      "llm",
+      "capabilities",
     ]);
+  });
+});
+
+// Cross-surface skew invariant (FIX 2 / R4-F1): the CLI and MCP surfaces both
+// derive their reserved map through the single shared deriveReservedVerbs, so
+// they MUST agree on every leaf read (noun, verb) reservation. If they drifted,
+// a pack migrating a `list`/`lookup` verb could be admitted on one surface and
+// blocked on the other. Operational nouns legitimately differ (graphql/setup/
+// upgrade are CLI-only), so the invariant is scoped to the read verbs that
+// packs actually emit.
+describe("cross-surface reserved-verb parity", () => {
+  const READ_VERBS = ["list", "lookup"] as const;
+
+  it("CLI and MCP reserve the same list/lookup verbs for every leaf read noun", () => {
+    const cliPairs = collectCommands(makeCtx()).map((command) =>
+      nounVerbFromPath(command.path),
+    );
+    const mcpPairs = allSpecs.map((spec) => nounVerbFromToolName(spec.name));
+
+    const cliReserved = deriveReservedVerbs(cliPairs);
+    const mcpReserved = deriveReservedVerbs(mcpPairs);
+
+    // FIX 1 on the real CLI surface: operational nouns own no list/lookup, so
+    // they are reserved wholesale — a pack emitting `list` stays blocked.
+    for (const noun of ["config", "graph", "graphql", "setup", "create"]) {
+      expect(isReserved(cliReserved, noun, "list")).toBe(true);
+    }
+
+    // Leaf read nouns: those that own a `list`/`lookup` verb on either surface.
+    const readNouns = new Set(
+      [...cliPairs, ...mcpPairs]
+        .filter(([, verb]) => verb === "list" || verb === "lookup")
+        .map(([noun]) => noun),
+    );
+
+    // Sanity: the real leaf-migration targets are present, so this asserts
+    // something (a silently empty set would make the test vacuous).
+    for (const noun of ["standard", "block", "modifier", "token", "tier"]) {
+      expect(readNouns.has(noun)).toBe(true);
+    }
+
+    for (const noun of readNouns) {
+      for (const verb of READ_VERBS) {
+        expect(
+          isReserved(cliReserved, noun, verb),
+          `CLI/MCP disagree on ${noun} ${verb}`,
+        ).toBe(isReserved(mcpReserved, noun, verb));
+      }
+    }
   });
 });

--- a/packages/cli/pragma/src/pipeline/collectCommands.test.ts
+++ b/packages/cli/pragma/src/pipeline/collectCommands.test.ts
@@ -34,4 +34,58 @@ describe("collectCommands", () => {
     expect(paths).toContain("graph query");
     expect(paths).toContain("graph inspect");
   });
+
+  // Golden surface: the full built-in command set under default config (no
+  // packs). The per-(noun, verb) reserved-guard flip must not add, drop, or
+  // rename a single built-in command, so this list is byte-identical to the
+  // pre-flip surface.
+  it("has a stable built-in command surface", () => {
+    const paths = collectCommands(makeCtx())
+      .map((command) => command.path.join(" "))
+      .sort();
+
+    expect(paths).toEqual([
+      "block list",
+      "block lookup",
+      "block sample",
+      "capabilities",
+      "config channel",
+      "config framework",
+      "config show",
+      "config tier",
+      "config trace",
+      "create component",
+      "create package",
+      "doctor",
+      "graph inspect",
+      "graph query",
+      "graphql build",
+      "graphql check",
+      "graphql serve",
+      "info",
+      "llm",
+      "modifier list",
+      "modifier lookup",
+      "modifier sample",
+      "ontology list",
+      "ontology show",
+      "setup all",
+      "setup completions",
+      "setup lsp",
+      "setup mcp",
+      "setup skills",
+      "skill list",
+      "skill lookup",
+      "standard categories",
+      "standard list",
+      "standard lookup",
+      "standard sample",
+      "tier list",
+      "token list",
+      "token lookup",
+      "token sample",
+      "tokens add-config",
+      "upgrade",
+    ]);
+  });
 });

--- a/packages/cli/pragma/src/pipeline/collectCommands.ts
+++ b/packages/cli/pragma/src/pipeline/collectCommands.ts
@@ -14,7 +14,11 @@ import { commands as modifierCommands } from "../domains/modifier/index.js";
 import { commands as ontologyCommands } from "../domains/ontology/index.js";
 import { commands as setupCommands } from "../domains/setup/index.js";
 import type { PragmaContext } from "../domains/shared/context.js";
-import { compilePackCommands } from "../domains/shared/stories/pack/index.js";
+import {
+  buildReservedVerbs,
+  compilePackCommands,
+  nounVerbFromPath,
+} from "../domains/shared/stories/pack/index.js";
 import { commands as skillCommands } from "../domains/skill/index.js";
 import { commands as standardCommands } from "../domains/standard/index.js";
 import { commands as tierCommands } from "../domains/tier/index.js";
@@ -52,9 +56,10 @@ export default function collectCommands(
     buildCapabilitiesCommand(),
   ];
 
-  // Story packs project onto the same surface; built-in nouns are reserved.
-  const reservedNouns = new Set(
-    builtIn.map((command) => command.path.at(0) ?? ""),
+  // Story packs project onto the same surface; each built-in (noun, verb)
+  // is reserved, so a pack can only add a verb no built-in noun owns.
+  const reserved = buildReservedVerbs(
+    builtIn.map((command) => nounVerbFromPath(command.path)),
   );
-  return [...builtIn, ...compilePackCommands(ctx, reservedNouns)];
+  return [...builtIn, ...compilePackCommands(ctx, reserved)];
 }

--- a/packages/cli/pragma/src/pipeline/collectCommands.ts
+++ b/packages/cli/pragma/src/pipeline/collectCommands.ts
@@ -15,8 +15,8 @@ import { commands as ontologyCommands } from "../domains/ontology/index.js";
 import { commands as setupCommands } from "../domains/setup/index.js";
 import type { PragmaContext } from "../domains/shared/context.js";
 import {
-  buildReservedVerbs,
   compilePackCommands,
+  deriveReservedVerbs,
   nounVerbFromPath,
 } from "../domains/shared/stories/pack/index.js";
 import { commands as skillCommands } from "../domains/skill/index.js";
@@ -56,9 +56,10 @@ export default function collectCommands(
     buildCapabilitiesCommand(),
   ];
 
-  // Story packs project onto the same surface; each built-in (noun, verb)
-  // is reserved, so a pack can only add a verb no built-in noun owns.
-  const reserved = buildReservedVerbs(
+  // Story packs project onto the same surface. Leaf read nouns reserve only
+  // the (noun, verb) pairs they own, so a pack can add a verb no built-in
+  // owns; operational nouns (config, graph, setup, …) stay reserved wholesale.
+  const reserved = deriveReservedVerbs(
     builtIn.map((command) => nounVerbFromPath(command.path)),
   );
   return [...builtIn, ...compilePackCommands(ctx, reserved)];

--- a/packages/cli/pragma/src/testing/standardParityFixtures.ts
+++ b/packages/cli/pragma/src/testing/standardParityFixtures.ts
@@ -88,5 +88,5 @@ export const PARITY_GAPS: readonly string[] = [
   "lookup descriptions and examples: the pack lookup CLI description, tool description, names description, and examples are generated from the noun; the built-in curates all of them (e.g. `Look up detailed information for a standard by name or IRI`)",
   "ink renderers: the built-in stories declare renderInk TUI views; the pack format has none",
   "extra verbs: the standard noun also ships `categories` and `sample` commands; v0 packs compile only list and lookup",
-  "noun cutover: a pack story cannot register the noun `standard` while the built-in exists (reserved-noun guard in collectPackStories), so cutover must remove the built-in stories in the same release",
+  "noun cutover: cutover is per-verb, not same-release-atomic — the reserved guard in collectPackStories reserves `standard` per (noun, verb), so a pack may claim a built-in read verb (`list`/`lookup`) as soon as that specific built-in wrapper is deleted, independently of the noun's other verbs (`categories`/`sample` may stay); a pack is blocked only while it would emit a verb the built-in still owns",
 ];


### PR DESCRIPTION
> Phase 0, PR #2 of the leaf-cutover ([C.07](https://github.com/advl/pragma-adrs/blob/claude/mcp-cli-graphql-status-ac1y6j/session/C/C.07.LEAF_CUTOVER_TIERED_QUERY.md)) — the **keystone** that converts the cutover from atomic-per-noun to **incremental per-(noun, verb)**. Refactor + tests only: **zero production behavior change** — every built-in command and MCP tool is byte-identical today, nothing is deleted. Builds on the parity harness (#794).

## Done

Two Phase-0 refactors that unblock deleting leaf TypeScript one *verb* at a time.

**1. Per-(noun, verb) reserved guard** (`d8623145`, hardened in `7598cfad`)
- The story-pack guard was a flat `Set<noun>` — a pack whose noun matched any built-in was rejected wholesale. It is now a `ReservedVerbs` map (`noun → {verbs}`, `"*"` = whole-noun) derived from the **live** command/tool surface through one shared `deriveReservedVerbs`. So when a later phase deletes a noun's `list.ts` wrapper, that verb leaves the reserved set automatically and a pack can claim `<noun> list` while `lookup` stays bespoke. That per-verb freeing is the mechanism the whole cutover rides on.
- **Operational namespace stays protected.** Nouns that expose neither `list` nor `lookup` (`config`, `graph`, `setup`, `graphql`, `create`, `tokens`) are reserved wholesale (`"*"`) — a third-party pack can never colonize pragma's own commands. Only the leaf read nouns (`block`/`standard`/`modifier`/`token`/`tier`) get per-verb relaxation.
- Both CLI (`collectCommands`, from `path`) and MCP (`registerAllTools`, from `name.split("_")`) route through the **one** shared helper; a cross-surface test pins that they agree on every `list`/`lookup` reservation, so a future phase can't free a verb on one surface and forget the other.

**2. Decouple `pragma llm` orientation from the leaf list ops** (`35e00984`)
- `collectContext` no longer imports the four leaf `list*` operations. A new `collectEntityCounts` issues grain-faithful `COUNT` queries — `COUNT(*)` over a `SELECT DISTINCT` that mirrors each list op's exact `GROUP BY`, so a multi-tier block / multi-category standard counts identically to `listX().length`. `namespaces` still flows through `listOntologies` (ontology stays bespoke — C.07). This removes the last `domains/<leaf>/operations` coupling that would otherwise break orientation when the leaf code is deleted.

Reviewed by a 5-lens opus swarm (zero-behavior-change · twin-derivation drift · count parity · keystone readiness · test honesty), adversarially verified. The one HIGH finding — operational nouns briefly over-freed — plus every MED/LOW finding are addressed in `7598cfad`.

## QA

- `cd packages/cli/pragma && bun run check && bun run test` — biome + tsc + webarchitect green; **1,412 pass, 2 skipped, 0 failed** (200 files; +15 new tests).
- **Golden surfaces** (now order-pinned): the 42-command CLI surface and 30-tool MCP surface are byte-identical to `main`.
- **Keystone proof:** `collectPackStories` with `standard`'s `list` freed but `lookup` still reserved admits a list-only `standard` pack and rejects a list+lookup one — the precise incremental window.
- **Regression pin:** a `graph`/`config` pack story is rejected (config → `CONFIG_ERROR`, package → skipped) exactly as on `main`.
- **Count parity:** on a dedicated fan-out fixture (multi-type block, multi-name family, multi-category standard, multi-type token) each count equals `listX(store, config).length`; the shared `## Context` orientation snapshot (`5 blocks, 3 standards, 2 modifier families, 2 tokens`) is unchanged.

### PR readiness check

- [x] Label: `Maintenance 🔨`.
- [x] Conventional Commits title.
- [x] [Code standards](https://github.com/canonical/web-code-standards): named exports, `.at()`, `it()`, colocated tests, TSDoc states the reservation contract precisely.
- [x] `check` / `check:fix` / `test` present.
- [x] No new package.
- [x] `no visual change`.

## Screenshots

No visual change — CLI/MCP refactor + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAQt61LLfNso4v8jbYUZR)_