### PR TITLE
fix(cli): don't boot the ke store for `create` scaffolding

### DIFF
--- a/packages/cli/pragma/src/pipeline/resolveCommandKind.test.ts
+++ b/packages/cli/pragma/src/pipeline/resolveCommandKind.test.ts
@@ -40,6 +40,18 @@ describe("resolveCommandKind", () => {
     expect(result).toEqual({ kind: "store-skip", command: "mcp" });
   });
 
+  it("detects store-skip for create (pure scaffolding, no store)", () => {
+    const result = resolveCommandKind([
+      "node",
+      "pragma",
+      "create",
+      "component",
+      "react",
+      "Accordion2",
+    ]);
+    expect(result).toEqual({ kind: "store-skip", command: "create" });
+  });
+
   it("defaults to store-required for regular commands", () => {
     const result = resolveCommandKind(["node", "pragma", "component", "list"]);
     expect(result).toEqual({ kind: "store-required" });

--- a/packages/cli/pragma/src/pipeline/resolveCommandKind.ts
+++ b/packages/cli/pragma/src/pipeline/resolveCommandKind.ts
@@ -15,6 +15,10 @@ const STORE_SKIP_COMMANDS = new Set([
   "capabilities",
   "trace",
   "graphql",
+  // `create` is pure scaffolding (summon generators) — it never queries the
+  // design-system graph, so booting the shared store just couples it to the
+  // installed packages and makes it fail when they are missing or malformed.
+  "create",
 ]);
 
 function findCommandArg(argv: readonly string[]): string | undefined {

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -1,5 +1,6 @@
 import type { GlobalFlags } from "@canonical/cli-core";
 import { CommanderError } from "commander";
+import { commands as createCommands } from "../domains/create/index.js";
 import { commands as graphqlCommands } from "../domains/graphql/index.js";
 import { buildCapabilitiesCommand } from "../domains/llm/index.js";
 import { commands as refsCommands } from "../domains/refs/index.js";
@@ -185,6 +186,7 @@ async function runStoreSkip(
     ...refsCommands(),
     ...traceCommands(),
     ...graphqlCommands(),
+    ...createCommands(),
     buildCapabilitiesCommand(),
   ];
   const program = createProgram(commands, stubCtx);


### PR DESCRIPTION
## Done

`pragma create component|package` is pure summon-generator scaffolding — it never queries the design-system graph. But `create` was missing from `STORE_SKIP_COMMANDS`, so it routed to the store-required path and booted the shared ke store before generating anything. That coupled a self-contained scaffolding command to the installed semantic packages: with packages absent or containing malformed TTL, `pragma create component react Accordion2` failed with `Failed to initialize store. Parser error ...` despite needing no store.

- Add `create` to `STORE_SKIP_COMMANDS` in `resolveCommandKind`.
- Register the create commands on the store-skip path in `runStoreSkip` (it builds its own command list, so the skip path needs them explicitly).
- Cover the new routing in `resolveCommandKind` tests.

Fixes the reported `pragma create component react Accordion2` store-boot failure.

## QA

```
# From packages/cli/pragma
bun run src/bin.ts create component react Accordion2 --dry-run --yes
# → scaffolds the component with NO "Failed to initialize store" error,
#   even when design-system packages are missing/broken.
npx vitest run src/pipeline/resolveCommandKind.test.ts   # create → store-skip
```

Note: the ke-store-resilience PR independently prevents this same failure by not dying on bad TTL; this PR removes the coupling entirely. Both are worth landing.

### PR readiness check

- [ ] PR should have one of the following labels: `Bug 🐛` (suggested).
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate code standards (biome clean).
- [x] All packages define the required scripts in `package.json`.
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — CLI routing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WrkZXTopfNP1ogcpSJRKi)_