### PR TITLE
fix(cli): boot the ke store resiliently and name the offending file

### DIFF
--- a/packages/cli/pragma/src/domains/shared/bootStore.test.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.test.ts
@@ -20,19 +20,23 @@ const badGraph = (path: string) => ({
 
 async function countTriples(
   graphs: readonly ReturnType<typeof goodGraph>[],
-): Promise<{ count: number; store: Awaited<ReturnType<typeof createStore>> }> {
+): Promise<number> {
   const store = await createStore({
     sources: [],
     prefixes: PREFIXES,
     plugins: [createGraphLoaderPlugin(graphs)],
   });
-  const result = await store.query(
-    "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }",
-  );
-  const count = Number(
-    result.type === "select" ? (result.bindings[0]?.n ?? "0") : "0",
-  );
-  return { count, store };
+  // Always dispose the WASM-backed store so it can't leak across tests.
+  try {
+    const result = await store.query(
+      "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }",
+    );
+    return Number(
+      result.type === "select" ? (result.bindings[0]?.n ?? "0") : "0",
+    );
+  } finally {
+    store.dispose();
+  }
 }
 
 let stderrSpy: ReturnType<typeof vi.spyOn>;
@@ -50,7 +54,7 @@ const stderrText = (): string =>
 
 describe("createGraphLoaderPlugin", () => {
   it("loads every graph when all are well-formed", async () => {
-    const { count } = await countTriples([
+    const count = await countTriples([
       goodGraph("a.ttl", "global.component.a"),
       goodGraph("b.ttl", "global.component.b"),
     ]);
@@ -59,7 +63,7 @@ describe("createGraphLoaderPlugin", () => {
   });
 
   it("skips a malformed graph but still boots and loads the good ones", async () => {
-    const { count } = await countTriples([
+    const count = await countTriples([
       goodGraph("a.ttl", "global.component.a"),
       badGraph("data/global/component/broken.ttl"),
       goodGraph("b.ttl", "global.component.b"),

--- a/packages/cli/pragma/src/domains/shared/bootStore.test.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.test.ts
@@ -1,0 +1,78 @@
+import { createStore } from "@canonical/ke";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGraphLoaderPlugin } from "./bootStore.js";
+
+const PREFIXES = { ds: "https://ds.canonical.com/" };
+
+const goodGraph = (path: string, subject: string) => ({
+  path,
+  content: `@prefix ds: <https://ds.canonical.com/>.\nds:${subject} a ds:Component.\n`,
+  format: "turtle" as const,
+});
+
+/** Mirrors the malformed `ds:hasSubcomponent ds:global..` shipped by upstream. */
+const badGraph = (path: string) => ({
+  path,
+  content:
+    "@prefix ds: <https://ds.canonical.com/>.\nds:global.component.broken a ds:Component;\n    ds:hasSubcomponent ds:global...\n",
+  format: "turtle" as const,
+});
+
+async function countTriples(
+  graphs: readonly ReturnType<typeof goodGraph>[],
+): Promise<{ count: number; store: Awaited<ReturnType<typeof createStore>> }> {
+  const store = await createStore({
+    sources: [],
+    prefixes: PREFIXES,
+    plugins: [createGraphLoaderPlugin(graphs)],
+  });
+  const result = await store.query(
+    "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }",
+  );
+  const count = Number(
+    result.type === "select" ? (result.bindings[0]?.n ?? "0") : "0",
+  );
+  return { count, store };
+}
+
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+});
+
+const stderrText = (): string =>
+  stderrSpy.mock.calls.map((call) => String(call[0])).join("");
+
+describe("createGraphLoaderPlugin", () => {
+  it("loads every graph when all are well-formed", async () => {
+    const { count } = await countTriples([
+      goodGraph("a.ttl", "global.component.a"),
+      goodGraph("b.ttl", "global.component.b"),
+    ]);
+    expect(count).toBe(2);
+    expect(stderrText()).toBe("");
+  });
+
+  it("skips a malformed graph but still boots and loads the good ones", async () => {
+    const { count } = await countTriples([
+      goodGraph("a.ttl", "global.component.a"),
+      badGraph("data/global/component/broken.ttl"),
+      goodGraph("b.ttl", "global.component.b"),
+    ]);
+    // The two good graphs load; the malformed one is skipped, not fatal.
+    expect(count).toBe(2);
+  });
+
+  it("warns with the offending file path and parse error", async () => {
+    await countTriples([badGraph("data/global/component/broken.ttl")]);
+    const text = stderrText();
+    expect(text).toContain("skipping malformed graph");
+    expect(text).toContain("data/global/component/broken.ttl");
+    expect(text).toContain("Check the TTL syntax");
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/bootStore.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.ts
@@ -90,19 +90,8 @@ export async function bootStore(
     // Collect all graph content from resolved packages
     const allGraphs = packages.flatMap((pkg) => pkg.graphs);
 
-    // Use a ke plugin to load graph content during store creation.
-    // The onReady hook has access to ctx.load() which loads raw content.
-    const graphLoaderPlugin = definePlugin({
-      name: "pragma-graph-loader",
-      onReady(ctx) {
-        for (const graph of allGraphs) {
-          ctx.load(graph.content, { format: graph.format });
-        }
-      },
-    });
-
     // biome-ignore lint: Plugin generic variance requires explicit unknown
-    const plugins: Plugin<any>[] = [graphLoaderPlugin];
+    const plugins: Plugin<any>[] = [createGraphLoaderPlugin(allGraphs)];
     const traceEnabled =
       process.env.PRAGMA_TRACE === "1" || options.trace === true;
     if (traceEnabled) {
@@ -127,9 +116,49 @@ export async function bootStore(
       {
         recovery: {
           message:
-            "Ensure design system packages are installed: bun add -D @canonical/design-system @canonical/code-standards @canonical/anatomy-dsl",
+            "If this is a parser error, check the TTL syntax of the source graphs " +
+            "(the message above names the line and column). Otherwise ensure design " +
+            "system packages are installed: bun add -D @canonical/design-system " +
+            "@canonical/code-standards @canonical/anatomy-dsl",
         },
       },
     );
   }
+}
+
+/**
+ * Build the ke plugin that loads resolved graph content into the store.
+ *
+ * Each graph is loaded independently inside its own try/catch: a single
+ * malformed TTL file (e.g. invalid Turtle emitted by an upstream authoring
+ * tool) must not abort the entire boot and take the whole CLI down with it.
+ * Failed graphs are skipped and surfaced as warnings, mirroring the
+ * resilience the story loader already provides ("one bad file cannot break
+ * boot"). A store built from N-1 good graphs is far more useful than a store
+ * that refuses to boot because of one bad graph.
+ *
+ * @note Impure — writes warnings to stderr on parse failure.
+ */
+export function createGraphLoaderPlugin(
+  graphs: readonly { path: string; content: string; format: "turtle" }[],
+): Plugin {
+  return definePlugin({
+    name: "pragma-graph-loader",
+    onReady(ctx) {
+      for (const graph of graphs) {
+        try {
+          ctx.load(graph.content, { format: graph.format });
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          // Name the offending file and the parse error, and point at the fix.
+          // The store still boots from the remaining graphs, so this is a
+          // warning, not a fatal error.
+          process.stderr.write(
+            `Warning: skipping malformed graph "${graph.path}" — ${reason}. ` +
+              "Check the TTL syntax of this source file; the remaining graphs still load.\n",
+          );
+        }
+      }
+    },
+  });
 }

--- a/packages/cli/pragma/src/domains/shared/bootStore.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.ts
@@ -90,7 +90,10 @@ export async function bootStore(
     // Collect all graph content from resolved packages
     const allGraphs = packages.flatMap((pkg) => pkg.graphs);
 
-    // biome-ignore lint: Plugin generic variance requires explicit unknown
+    // `Plugin<T>` is invariant in its API type and createStore expects
+    // `Plugin<void>[]`, so heterogeneous plugins (graph loader + trace) can only
+    // share an array via `any`. `unknown` does not satisfy `Plugin<void>`.
+    // biome-ignore lint/suspicious/noExplicitAny: intentional — see above
     const plugins: Plugin<any>[] = [createGraphLoaderPlugin(allGraphs)];
     const traceEnabled =
       process.env.PRAGMA_TRACE === "1" || options.trace === true;


### PR DESCRIPTION
## Done

The ke store aborted its entire boot when any single graph file failed to parse. One malformed TTL file among the ~380 design-system graphs took the whole CLI down — `pragma ontology`, `block list`, and `doctor` all failed with `Failed to initialize store. Parser error at line 16 column 146: . is not a valid subject or graph name`, with no indication of which file.

- Load each graph independently in its own try/catch (extracted as `createGraphLoaderPlugin`); skip unparseable graphs with a warning that names the file, the parse error, and points at the TTL syntax as the fix. Mirrors the resilience the story loader already provides ("one bad file cannot break boot"). A store built from N-1 good graphs beats one that refuses to boot.
- Improve the fatal store-error recovery hint to mention checking TTL syntax.
- Add bootStore resilience tests.

Fixes the `ke store failed to boot` failure on malformed design-system data.

## QA

```
# From packages/cli/pragma
npx vitest run src/domains/shared/bootStore.test.ts
# With malformed graphs present, pragma doctor / ontology now boot and warn
# per bad file (naming it) instead of aborting.
```

### PR readiness check

- [ ] PR should have one of the following labels: `Bug 🐛` (suggested).
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate code standards (biome clean).
- [x] All packages define the required scripts in `package.json`.
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — store boot robustness + error messaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WrkZXTopfNP1ogcpSJRKi)_