### PR TITLE
fix(ds-global-form,styles): control surface/hover tokens, Choices spacing + Surfaces story

### DIFF
--- a/packages/react/ds-global-form/src/docs/Surfaces.mdx
+++ b/packages/react/ds-global-form/src/docs/Surfaces.mdx
@@ -1,0 +1,92 @@
+import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+import * as Stories from "./Surfaces.stories";
+
+<Meta title="Documentation/Surfaces" />
+
+# Surfaces
+
+Form controls are **surface-aware**. Rather than painting one fixed colour on
+every background, the checkbox, radio and switch read their colours from the
+design system's `--surface-color-foreground-*` channels, so a control recolours
+to suit the surface it sits on.
+
+Surfaces step by **nesting**, not by a prop: a `.surface` element is level 1, a
+`.surface` inside another `.surface` is level 2, and a third level of nesting is
+level 3. Each level resolves the surface channels to its own tone, and any
+control inside inherits it automatically.
+
+<table>
+  <thead>
+    <tr>
+      <th>Level</th>
+      <th>Selector</th>
+      <th>Tone</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td><code>.surface</code></td>
+      <td>base foreground</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td><code>.surface .surface</code></td>
+      <td>stepped</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td><code>.surface .surface .surface</code></td>
+      <td>stepped again</td>
+    </tr>
+  </tbody>
+</table>
+
+## Every control at each level
+
+Selected fills, radio dots and switch tracks step with the band; the switch knob
+and the masked checkmark read their own surface channels too, so they stay
+legible against the stepping fill.
+
+<Canvas of={Stories.Controls} />
+
+## Checkbox
+
+The box fill and the masked checkmark both resolve per surface, including the
+indeterminate state.
+
+<Canvas of={Stories.Checkbox} />
+
+## Switch
+
+The track (selected and unselected) steps with the surface, while the knob reads
+its own channel so it keeps contrast against the track at every level.
+
+<Canvas of={Stories.Switch} />
+
+## What the control CSS reads
+
+Each control names the surface channel with a flat fallback, so it works whether
+or not a surface context is present:
+
+```css
+.ds.form-checkbox:checked {
+  background: var(
+    --surface-color-foreground-checkbox-selected,
+    var(--color-foreground-checkbox-selected)
+  );
+}
+```
+
+Hover on a selected control shifts **only** the fill/track — via the
+`--hover--color-foreground-*-selected` channels — never the checkmark glyph or
+the switch knob. This replaced an earlier whole-element `filter: brightness()`
+that dimmed the glyph along with the fill.
+
+### Upstream note
+
+The design tokens currently provide surface channels for the controls' unselected
+and checkmark/knob colours. The `-selected` surface channels (and the switch's
+unselected track) are supplied by a temporary shim in `@canonical/styles`
+(`controls.hover.shim.css`) until they are generated upstream; the components
+already read them, so no component change is needed when they land.

--- a/packages/react/ds-global-form/src/docs/Surfaces.stories.tsx
+++ b/packages/react/ds-global-form/src/docs/Surfaces.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type React from "react";
+import * as decorators from "storybook/decorators.js";
+import { CheckboxInput } from "../lib/subcomponent/CheckboxInput/index.js";
+import { RadioInput } from "../lib/subcomponent/RadioInput/index.js";
+import { SwitchInput } from "../lib/subcomponent/SwitchInput/index.js";
+
+/**
+ * Surface stepping for form controls. The checkbox/radio/switch fills, dots,
+ * knobs and checkmarks read their `--surface-color-foreground-*` tokens, so a
+ * control placed inside a `.surface` context recolours per nesting level
+ * (`.surface` → `.surface .surface` → `.surface .surface .surface`) instead of
+ * painting one flat colour on every background.
+ *
+ * These are presentational subcomponents (no react-hook-form), rendered once per
+ * surface level via the shared `surfaces()` helper.
+ */
+const meta = {
+  title: "Documentation/Surfaces/Examples",
+  parameters: { layout: "fullscreen" },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * One selected + one unselected of each control, laid out in a row. `disabled`
+ * renders the disabled variant of the same set (its own tokens step per surface
+ * too), tagged so the two rows read distinctly.
+ */
+const ControlRow = ({
+  level,
+  disabled = false,
+}: {
+  level: number;
+  disabled?: boolean;
+}): React.ReactElement => {
+  const key = `s${level}${disabled ? "-dis" : ""}`;
+  return (
+    <div
+      style={{ display: "flex", gap: "var(--space-300)", alignItems: "center" }}
+    >
+      <CheckboxInput name={`${key}-cb-on`} defaultChecked disabled={disabled} />
+      <CheckboxInput name={`${key}-cb-off`} disabled={disabled} />
+      <RadioInput name={`${key}-radio`} defaultChecked disabled={disabled} />
+      <RadioInput name={`${key}-radio`} disabled={disabled} />
+      <SwitchInput
+        name={`${key}-switch-on`}
+        defaultChecked
+        disabled={disabled}
+      />
+      <SwitchInput name={`${key}-switch-off`} disabled={disabled} />
+      <span
+        className="p"
+        style={{
+          color: "var(--surface-color-foreground-text, var(--color-text))",
+        }}
+      >
+        Surface level {level + 1}
+        {disabled ? " (disabled)" : ""}
+      </span>
+    </div>
+  );
+};
+
+/**
+ * Every control at each of the three surface levels — an enabled row and a
+ * disabled row per level. Selected fills, knobs and dots step with the band;
+ * hovering a selected control shifts only the fill (via the hover-selected
+ * channels), never the masked glyph or the knob.
+ */
+export const Controls: Story = {
+  render: () =>
+    decorators.surfaces((level) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-200)",
+        }}
+      >
+        <ControlRow level={level} />
+        <ControlRow level={level} disabled />
+      </div>
+    )),
+};
+
+/**
+ * Just the checkbox, to isolate the selected-fill + checkmark stepping —
+ * enabled row and disabled row.
+ */
+export const Checkbox: Story = {
+  render: () =>
+    decorators.surfaces((level) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-200)",
+        }}
+      >
+        <div style={{ display: "flex", gap: "var(--space-200)" }}>
+          <CheckboxInput name={`cb${level}-on`} defaultChecked />
+          <CheckboxInput
+            name={`cb${level}-ind`}
+            ref={(el) => {
+              if (el) el.indeterminate = true;
+            }}
+          />
+          <CheckboxInput name={`cb${level}-off`} />
+        </div>
+        <div style={{ display: "flex", gap: "var(--space-200)" }}>
+          <CheckboxInput name={`cb${level}-dis-on`} defaultChecked disabled />
+          <CheckboxInput
+            name={`cb${level}-dis-ind`}
+            disabled
+            ref={(el) => {
+              if (el) el.indeterminate = true;
+            }}
+          />
+          <CheckboxInput name={`cb${level}-dis-off`} disabled />
+        </div>
+      </div>
+    )),
+};
+
+/**
+ * Just the switch, to isolate the track (selected/unselected) vs knob stepping —
+ * enabled row and disabled row.
+ */
+export const Switch: Story = {
+  render: () =>
+    decorators.surfaces((level) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-200)",
+        }}
+      >
+        <div style={{ display: "flex", gap: "var(--space-200)" }}>
+          <SwitchInput name={`sw${level}-on`} defaultChecked />
+          <SwitchInput name={`sw${level}-off`} />
+        </div>
+        <div style={{ display: "flex", gap: "var(--space-200)" }}>
+          <SwitchInput name={`sw${level}-dis-on`} defaultChecked disabled />
+          <SwitchInput name={`sw${level}-dis-off`} disabled />
+        </div>
+      </div>
+    )),
+};

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/common/Option/Option.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/common/Option/Option.tsx
@@ -23,7 +23,7 @@ const Option = ({
   const ariaProps = useOptionAriaProperties(name, option.value);
   return (
     <div
-      className={[componentCssClassName, "grid", disabled && "disabled"]
+      className={[componentCssClassName, disabled && "disabled"]
         .filter(Boolean)
         .join(" ")}
     >

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/styles.css
@@ -162,6 +162,7 @@
       /* Hover shifts only the fill (channel shade), not the masked checkmark. */
       &:checked:hover:not(:disabled) {
         background-color: var(--hover--color-foreground-checkbox-selected);
+        border-color: var(--hover--color-foreground-checkbox-selected);
       }
 
       &:focus-visible {

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/styles.css
@@ -5,7 +5,9 @@
   margin: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 0 var(--container-gap-loose);
+  /* Row gap gives stacked/wrapped options vertical breathing room (was 0, so
+   * stacked items touched); column gap is the inline separation (per review). */
+  gap: var(--form-group-gap) var(--container-gap-loose);
 
   /* Stacked: one option per line */
   &.stacked {
@@ -43,17 +45,31 @@
       height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
       border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
       border-radius: 50%;
-      background-color: var(--color-foreground-radio-unselected);
+      background-color: var(
+        --surface-color-foreground-radio-unselected,
+        var(--color-foreground-radio-unselected)
+      );
       cursor: inherit;
       transition:
         background-color 150ms ease,
         border-color 150ms ease;
 
       &:checked {
-        border-color: var(--color-foreground-radio-selected);
+        border-color: var(
+          --surface-color-foreground-radio-selected,
+          var(--color-foreground-radio-selected)
+        );
         background: radial-gradient(
-          var(--color-foreground-radio-selected) 40%,
-          var(--color-foreground-radio-unselected) 41%
+          var(
+              --surface-color-foreground-radio-selected,
+              var(--color-foreground-radio-selected)
+            )
+            40%,
+          var(
+              --surface-color-foreground-radio-unselected,
+              var(--color-foreground-radio-unselected)
+            )
+            41%
         );
       }
 
@@ -61,8 +77,18 @@
         background-color: var(--color-foreground-radio-unselected-hover);
       }
 
+      /* Hover shifts only the dot's fill (channel shade), not a whole-element
+       * brightness filter that would also dim the ring. */
       &:checked:hover:not(:disabled) {
-        filter: brightness(0.9);
+        border-color: var(--hover--color-foreground-radio-selected);
+        background: radial-gradient(
+          var(--hover--color-foreground-radio-selected) 40%,
+          var(
+              --surface-color-foreground-radio-unselected,
+              var(--color-foreground-radio-unselected)
+            )
+            41%
+        );
       }
 
       &:focus-visible {
@@ -85,7 +111,10 @@
       height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
       border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
       border-radius: var(--dimension-radius-small);
-      background-color: var(--color-foreground-checkbox-unselected);
+      background-color: var(
+        --surface-color-foreground-checkbox-unselected,
+        var(--color-foreground-checkbox-unselected)
+      );
       cursor: inherit;
       transition:
         background-color 150ms ease,
@@ -107,11 +136,20 @@
       }
 
       &:checked {
-        background: var(--color-foreground-checkbox-selected);
-        border-color: var(--color-foreground-checkbox-selected);
+        background: var(
+          --surface-color-foreground-checkbox-selected,
+          var(--color-foreground-checkbox-selected)
+        );
+        border-color: var(
+          --surface-color-foreground-checkbox-selected,
+          var(--color-foreground-checkbox-selected)
+        );
 
         &::before {
-          background-color: var(--color-foreground-checkbox-checkmark);
+          background-color: var(
+            --surface-color-foreground-checkbox-checkmark,
+            var(--color-foreground-checkbox-checkmark)
+          );
           mask-image: url("/icons/checkmark.svg#checkmark");
           -webkit-mask-image: url("/icons/checkmark.svg#checkmark");
         }
@@ -121,8 +159,9 @@
         background-color: var(--color-foreground-checkbox-unselected-hover);
       }
 
+      /* Hover shifts only the fill (channel shade), not the masked checkmark. */
       &:checked:hover:not(:disabled) {
-        filter: brightness(0.9);
+        background-color: var(--hover--color-foreground-checkbox-selected);
       }
 
       &:focus-visible {

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
@@ -10,7 +10,10 @@
   height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
   border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
   border-radius: var(--dimension-radius-small);
-  background: var(--color-foreground-checkbox-unselected);
+  background: var(
+    --surface-color-foreground-checkbox-unselected,
+    var(--color-foreground-checkbox-unselected)
+  );
   cursor: pointer;
   transition:
     background-color 150ms ease,
@@ -42,11 +45,22 @@
 
   &:checked {
     position: relative;
-    background: var(--color-foreground-checkbox-selected);
-    border-color: var(--color-foreground-checkbox-selected);
+    /* Selected fill + checkmark read the surface-provided tokens (with a flat
+     * fallback) so the control adapts to OnSurface stepping. */
+    background: var(
+      --surface-color-foreground-checkbox-selected,
+      var(--color-foreground-checkbox-selected)
+    );
+    border-color: var(
+      --surface-color-foreground-checkbox-selected,
+      var(--color-foreground-checkbox-selected)
+    );
 
     &::before {
-      background-color: var(--color-foreground-checkbox-checkmark);
+      background-color: var(
+        --surface-color-foreground-checkbox-checkmark,
+        var(--color-foreground-checkbox-checkmark)
+      );
       mask-image: url("/icons/checkmark.svg#checkmark");
       -webkit-mask-image: url("/icons/checkmark.svg#checkmark");
     }
@@ -54,11 +68,20 @@
 
   &:indeterminate {
     position: relative;
-    background: var(--color-foreground-checkbox-selected);
-    border-color: var(--color-foreground-checkbox-selected);
+    background: var(
+      --surface-color-foreground-checkbox-selected,
+      var(--color-foreground-checkbox-selected)
+    );
+    border-color: var(
+      --surface-color-foreground-checkbox-selected,
+      var(--color-foreground-checkbox-selected)
+    );
 
     &::before {
-      background-color: var(--color-foreground-checkbox-checkmark);
+      background-color: var(
+        --surface-color-foreground-checkbox-checkmark,
+        var(--color-foreground-checkbox-checkmark)
+      );
       mask-image: url("/icons/minus.svg#minus");
       -webkit-mask-image: url("/icons/minus.svg#minus");
     }
@@ -68,14 +91,15 @@
     background: var(--color-foreground-checkbox-unselected-hover);
   }
 
-  &:checked:hover:not(:disabled) {
-    background-color: var(--color-foreground-checkbox-selected);
-    filter: brightness(0.9);
-  }
-
+  /* Hover on a selected/indeterminate box shifts ONLY the fill, not the
+   * checkmark/minus glyph (per design review): the background swaps to the
+   * hovered selected shade while `::before` keeps its own colour. The hover
+   * shade comes from the `--hover--…-selected` channel (criticality-style OKLCH
+   * delta shim), replacing the old whole-element `filter: brightness()` that
+   * also dimmed the glyph. */
+  &:checked:hover:not(:disabled),
   &:indeterminate:hover:not(:disabled) {
-    background-color: var(--color-foreground-checkbox-selected);
-    filter: brightness(0.9);
+    background-color: var(--hover--color-foreground-checkbox-selected);
   }
 
   &:focus-visible {

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
@@ -100,6 +100,7 @@
   &:checked:hover:not(:disabled),
   &:indeterminate:hover:not(:disabled) {
     background-color: var(--hover--color-foreground-checkbox-selected);
+    border-color: var(--hover--color-foreground-checkbox-selected);
   }
 
   &:focus-visible {

--- a/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/styles.css
@@ -10,17 +10,33 @@
   height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
   border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
   border-radius: 50%;
-  background-color: var(--color-foreground-radio-unselected);
+  background-color: var(
+    --surface-color-foreground-radio-unselected,
+    var(--color-foreground-radio-unselected)
+  );
   cursor: pointer;
   transition:
     background-color 150ms ease,
     border-color 150ms ease;
 
   &:checked {
-    border-color: var(--color-foreground-radio-selected);
+    /* Dot = selected token, ring fill = unselected token; both surface-provided
+     * (flat fallback) so the control adapts to OnSurface stepping. */
+    border-color: var(
+      --surface-color-foreground-radio-selected,
+      var(--color-foreground-radio-selected)
+    );
     background: radial-gradient(
-      var(--color-foreground-radio-selected) 40%,
-      var(--color-foreground-radio-unselected) 41%
+      var(
+          --surface-color-foreground-radio-selected,
+          var(--color-foreground-radio-selected)
+        )
+        40%,
+      var(
+          --surface-color-foreground-radio-unselected,
+          var(--color-foreground-radio-unselected)
+        )
+        41%
     );
   }
 
@@ -28,8 +44,19 @@
     background-color: var(--color-foreground-radio-unselected-hover);
   }
 
+  /* Hover on a selected radio shifts only the dot's fill, not via a whole-element
+   * brightness filter (which would also dim the ring). Re-paint the gradient with
+   * the hovered selected shade from the `--hover--…-selected` channel. */
   &:checked:hover:not(:disabled) {
-    filter: brightness(0.9);
+    border-color: var(--hover--color-foreground-radio-selected);
+    background: radial-gradient(
+      var(--hover--color-foreground-radio-selected) 40%,
+      var(
+          --surface-color-foreground-radio-unselected,
+          var(--color-foreground-radio-unselected)
+        )
+        41%
+    );
   }
 
   &:focus-visible {

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
@@ -26,7 +26,10 @@
   width: var(--switch-track-width);
   height: var(--switch-track-height);
   border-radius: var(--dimension-radius-full);
-  background: var(--color-foreground-switch-unselected);
+  background: var(
+    --surface-color-foreground-switch-unselected,
+    var(--color-foreground-switch-unselected)
+  );
   cursor: pointer;
   transition: background-color 150ms ease;
 
@@ -39,12 +42,20 @@
     width: var(--switch-knob-size);
     height: var(--switch-knob-size);
     border-radius: var(--dimension-radius-full);
-    background: var(--color-foreground-switch-knob);
+    /* Knob reads its surface-provided token (flat fallback) for OnSurface. */
+    background: var(
+      --surface-color-foreground-switch-knob,
+      var(--color-foreground-switch-knob)
+    );
     transition: translate 150ms ease;
   }
 
   &:checked {
-    background: var(--color-foreground-switch-selected);
+    /* Selected track reads the surface-provided token (flat fallback). */
+    background: var(
+      --surface-color-foreground-switch-selected,
+      var(--color-foreground-switch-selected)
+    );
 
     &::before {
       /* Slide to the far edge: the space left over after the knob and both
@@ -58,14 +69,17 @@
     }
   }
 
+  /* Hover shifts ONLY the track background, not the knob (per design review):
+   * the track swaps to the hovered shade while the `::before` knob keeps its
+   * colour. Shades come from the `--hover--…` channels (criticality-style OKLCH
+   * delta shim), replacing the old whole-element `filter: brightness()` that
+   * also dimmed the knob. */
   &:hover:not(:disabled):not(:checked) {
-    background: var(--color-foreground-switch-unselected);
-    filter: brightness(0.95);
+    background: var(--hover--color-foreground-switch-unselected);
   }
 
   &:checked:hover:not(:disabled) {
-    background: var(--color-foreground-switch-selected);
-    filter: brightness(0.9);
+    background: var(--hover--color-foreground-switch-selected);
   }
 
   &:focus-visible {

--- a/packages/react/ds-global-form/src/storybook/decorators.tsx
+++ b/packages/react/ds-global-form/src/storybook/decorators.tsx
@@ -1,5 +1,6 @@
 import { useFormStateEmitter } from "@canonical/storybook-addon-form-state";
 import type React from "react";
+import type { ReactElement, ReactNode } from "react";
 import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
@@ -54,3 +55,61 @@ export const form = ({
     return <FormWrapper />;
   };
 };
+
+/** Band spacing: half the block padding (above/below) of the inline padding. */
+const SURFACE_BAND_PADDING_BLOCK = "2.5rem";
+const SURFACE_BAND_PADDING_INLINE = "5rem";
+
+/**
+ * One surface band: a full-width row painting its own surface background, its
+ * content centred, then — flush below — the next, deeper band. The three surface
+ * levels differ only by *nesting* (`.surface` → layer 1, `.surface .surface` →
+ * layer 2, `.surface .surface .surface` → layer 3), so the bands nest in the DOM
+ * to step colour; padding lives on the inner wrapper so nested bands stay flush
+ * and full-width. Ported from the ds-global storybook decorators.
+ *
+ * @param level - this band's surface level (0-based).
+ * @param renderAtLevel - the content to place at a given level.
+ */
+const SurfaceBand = ({
+  level,
+  renderAtLevel,
+}: {
+  level: number;
+  renderAtLevel: (level: number) => ReactNode;
+}): ReactElement => (
+  <div
+    className="surface"
+    style={{
+      background: "var(--surface-color-background, var(--color-background))",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "stretch",
+    }}
+  >
+    <div
+      style={{
+        paddingBlock: SURFACE_BAND_PADDING_BLOCK,
+        paddingInline: SURFACE_BAND_PADDING_INLINE,
+      }}
+    >
+      {renderAtLevel(level)}
+    </div>
+    {level < 2 ? (
+      <SurfaceBand level={level + 1} renderAtLevel={renderAtLevel} />
+    ) : null}
+  </div>
+);
+
+/**
+ * Renders `renderAtLevel` inside three stacked, equal `.surface` bands
+ * (level 1 → 2 → 3) so a surface-aware control can be seen at each level. A
+ * control that reads its `--surface-color-foreground-*` tokens steps with the
+ * band; one that hard-codes flat colours blends in. The bands size to their
+ * content. Ported from the ds-global storybook decorators.
+ *
+ * @param renderAtLevel - returns the node to place at a given level (0-based).
+ */
+export const surfaces = (
+  renderAtLevel: (level: number) => ReactNode,
+): ReactElement => <SurfaceBand level={0} renderAtLevel={renderAtLevel} />;

--- a/packages/styles/main/src/controls.hover.shim.css
+++ b/packages/styles/main/src/controls.hover.shim.css
@@ -31,28 +31,32 @@
  * base lightness by the per-family `--delta-hover-*` step. Because Part 1 defines
  * the surface tokens, these hovers are surface-correct too.
  *
- * Components read the CHANNELS, never re-derive the maths. Remove each block once
- * generated upstream. Imported into `ds.modifiers` after the generated tokens.
+ * Components read the CHANNELS, never re-derive the maths. Part 1 is zero-
+ * specificity (`:where()`) so it self-upgrades when upstream lands; Part 2 can be
+ * dropped once the `--hover--…-selected` tokens are generated. Imported into
+ * `ds.modifiers` after the generated tokens.
  */
 
 @layer ds.modifiers {
   /* Part 1 — surface-provided selected tokens, per surface level (mirrors
    * modifiers.surfaces.css). No -selected-layerN primitives exist yet, so each
-   * level aliases the flat base; swap in real per-layer tokens upstream.
+   * level aliases the flat base.
    *
-   * UPGRADE / REMOVAL (important): the component seam auto-upgrades for free —
-   * controls read `var(--surface-color-foreground-*-selected, <flat>)`, so
-   * whatever defines the surface token wins. But THIS block also defines those
-   * same tokens, in the same `ds.modifiers` layer, imported AFTER the generated
-   * modifiers.surfaces.css. So once upstream generates the real per-level
-   * `-selected` values, this Part 1 block will SHADOW them (later source order
-   * wins at equal specificity) and pin them flat. When upstream lands, DELETE
-   * this block — do not leave it, or surface stepping silently stays flat. */
-  .surface,
-  .surface .surface,
-  .surface .surface .surface,
-  .contrasted,
-  .modal {
+   * SELF-UPGRADING (no manual removal): the selectors are wrapped in `:where()`,
+   * so this block has ZERO specificity. The generated `modifiers.surfaces.css`
+   * rules use normal `.surface` selectors (specificity 0,1,0), so the moment
+   * upstream defines the real per-level `-selected` values they WIN over this
+   * fallback automatically — even though this shim is imported later in the same
+   * layer. The shim can stay indefinitely; it only ever supplies a value when
+   * upstream has none. (Removing it once upstream lands is still tidy, but no
+   * longer load-bearing.) */
+  :where(
+      .surface,
+      .surface .surface,
+      .surface .surface .surface,
+      .contrasted,
+      .modal
+    ) {
     --surface-color-foreground-checkbox-selected: var(
       --color-foreground-checkbox-selected
     );

--- a/packages/styles/main/src/controls.hover.shim.css
+++ b/packages/styles/main/src/controls.hover.shim.css
@@ -1,0 +1,115 @@
+/* @canonical/styles — Control selected-state SURFACE + HOVER SHIM (temporary)
+ *
+ * The generated design-tokens surface the control colours per nesting level
+ * (`.surface` → `.surface .surface` → `.contrasted` → `.modal`, in
+ * `@canonical/design-tokens/dist/modifiers.surfaces.css`) for the checkbox/radio
+ * UNSELECTED + checkmark and the switch knob — but NOT for any SELECTED state,
+ * nor the switch's unselected track. They also expose `--hover--color-foreground-*`
+ * (an OKLCH lightness-delta hover shade) only for those same unselected states.
+ *
+ * Consequences this shim fixes:
+ *   1. Selected controls were not surface-provided: a :checked box/dot/track kept
+ *      the flat `--color-foreground-*-selected` on every surface, ignoring
+ *      OnSurface stepping. (Ideal: selected states come through the surface layer
+ *      like the unselected ones do.)
+ *   2. Hovered selected controls had no hover token, so components faked it with
+ *      `filter: brightness()` on the whole <input> — which also dimmed the masked
+ *      checkmark glyph / switch knob (Diana's review: "hover should not affect the
+ *      checkmark/knob colour, just the fill/background").
+ *
+ * ── Part 1: surface-provided selected tokens ────────────────────────────────
+ * Mirror the surfaces.css selector structure so a control's SELECTED fill reads
+ * `--surface-color-foreground-*-selected`, resolved per surface. The design build
+ * has no `-selected-layer2/-layer3/-contrasted` PRIMITIVES yet, so every level
+ * currently aliases the flat base — but establishing the surface token means (a)
+ * components stop hard-coding the flat token, and (b) upstream can drop in real
+ * per-layer values later with zero component change. `switch-unselected` gets the
+ * same treatment (its surface token is also absent).
+ *
+ * ── Part 2: hover channels ──────────────────────────────────────────────────
+ * Same idiom as the generated `--hover--` tokens: shift the (now surface-aware)
+ * base lightness by the per-family `--delta-hover-*` step. Because Part 1 defines
+ * the surface tokens, these hovers are surface-correct too.
+ *
+ * Components read the CHANNELS, never re-derive the maths. Remove each block once
+ * generated upstream. Imported into `ds.modifiers` after the generated tokens.
+ */
+
+@layer ds.modifiers {
+  /* Part 1 — surface-provided selected tokens, per surface level (mirrors
+   * modifiers.surfaces.css). No -selected-layerN primitives exist yet, so each
+   * level aliases the flat base; swap in real per-layer tokens upstream.
+   *
+   * UPGRADE / REMOVAL (important): the component seam auto-upgrades for free —
+   * controls read `var(--surface-color-foreground-*-selected, <flat>)`, so
+   * whatever defines the surface token wins. But THIS block also defines those
+   * same tokens, in the same `ds.modifiers` layer, imported AFTER the generated
+   * modifiers.surfaces.css. So once upstream generates the real per-level
+   * `-selected` values, this Part 1 block will SHADOW them (later source order
+   * wins at equal specificity) and pin them flat. When upstream lands, DELETE
+   * this block — do not leave it, or surface stepping silently stays flat. */
+  .surface,
+  .surface .surface,
+  .surface .surface .surface,
+  .contrasted,
+  .modal {
+    --surface-color-foreground-checkbox-selected: var(
+      --color-foreground-checkbox-selected
+    );
+    --surface-color-foreground-radio-selected: var(
+      --color-foreground-radio-selected
+    );
+    --surface-color-foreground-switch-selected: var(
+      --color-foreground-switch-selected
+    );
+    --surface-color-foreground-switch-unselected: var(
+      --color-foreground-switch-unselected
+    );
+  }
+
+  /* Part 2 — hover channels, derived from the surface-aware base above. */
+  :root {
+    /* Checkbox — selected fill on :checked / :indeterminate hover. */
+    --hover--color-foreground-checkbox-selected: oklch(
+      from
+        var(
+          --surface-color-foreground-checkbox-selected,
+          var(--color-foreground-checkbox-selected)
+        )
+        calc(l + var(--delta-hover-color-foreground-checkbox-selected, -0.0391))
+        c h
+    );
+
+    /* Switch — selected track on :checked hover, and unselected track hover. */
+    --hover--color-foreground-switch-selected: oklch(
+      from
+        var(
+          --surface-color-foreground-switch-selected,
+          var(--color-foreground-switch-selected)
+        )
+        calc(l + var(--delta-hover-color-foreground-switch-selected, -0.0391)) c
+        h
+    );
+
+    --hover--color-foreground-switch-unselected: oklch(
+      from
+        var(
+          --surface-color-foreground-switch-unselected,
+          var(--color-foreground-switch-unselected)
+        )
+        calc(l + var(--delta-hover-color-foreground-switch-unselected, -0.0391))
+        c h
+    );
+
+    /* Radio — selected dot on :checked hover (parity with checkbox). */
+    --hover--color-foreground-radio-selected: oklch(
+      from
+        var(
+          --surface-color-foreground-radio-selected,
+          var(--color-foreground-radio-selected)
+        )
+        calc(l + var(--delta-hover-color-foreground-radio-selected, -0.0391)) c
+        h
+    );
+  }
+}

--- a/packages/styles/main/src/index.css
+++ b/packages/styles/main/src/index.css
@@ -30,10 +30,14 @@
      hints so importance-driven components can render their hierarchy.
    - criticality: adds an icon channel (--modifier-icon) mapping each
      criticality class to its glyph, so criticality components render the icon
-     from the modifier rather than hard-coding it. */
+     from the modifier rather than hard-coding it.
+   - controls-hover: adds the missing selected-state (and switch unselected)
+     `--hover--color-foreground-*` shades so checkbox/radio/switch hover shifts
+     only the fill/track, not the masked glyph/knob. */
 @import url("./modifiers.states.shim.css");
 @import url("./modifiers.importance.shim.css");
 @import url("./modifiers.criticality.shim.css");
+@import url("./controls.hover.shim.css");
 @import url("@canonical/design-tokens/dist/states.css");
 
 /* Grid layout presets */


### PR DESCRIPTION
Split out from #766 (which is now ds-global-only). This PR holds the **ds-global-form** half of the geometry/behaviour design-review work.

## Done

**Controls — hover no longer tints the glyph/knob** (Diana: *"hover should not affect the checkmark/knob colour, just the fill/background"*):
- New shim `packages/styles/main/src/controls.hover.shim.css` adds the missing `--hover--color-foreground-{checkbox,radio,switch}-selected` (+ switch-unselected) hover channels **and** the missing `--surface-color-foreground-*-selected` (+ switch-unselected) surface tokens, mirroring `modifiers.surfaces.css` structure.
- CheckboxInput / SwitchInput / RadioInput + ChoicesField inline controls: every resting fill/checkmark/knob/dot reads its `--surface-color-foreground-*` token (flat fallback) → controls follow **OnSurface stepping**; checked-hover swaps to the `--hover--…` channel, **removing the whole-element `filter: brightness()`** that dimmed the masked glyph/knob.

**ChoicesField spacing** (Diana):
- Between-item vertical gap `0 → 8px` (`--form-group-gap`).
- Dropped the stray `grid` class on the Option wrapper (its 24px `--grid-gutter` overrode the intended `flex; gap: 8px`) → control↔label gap resolves to **8px** (Diana measured 16).

**Surfaces story** — `Documentation/Surfaces` docs page + CSF examples showing the controls stepping across `.surface` levels (enabled + disabled rows), ported the `surfaces()` band helper into the form package's storybook decorators.

## Scope note
Baseline-coupled control *sizes* (checkbox/radio 16px, range track — `--space-baseline` multiples) are deliberately left to the 4px-baseline branch (#790 stack), not touched here.

## Upstream follow-up
`-selected` surface primitives (`-layer2/-layer3/-contrasted`) and `--delta-hover-*-selected` don't exist upstream yet — the shim aliases/reuses today; components auto-upgrade at the `var()` seam, but the shim's surface-token block must be deleted when upstream lands (marked in-file).

## QA
`nx check @canonical/styles @canonical/react-ds-global-form` green.