### PR TITLE
fix(ds-global-form): min/max validation, helper story, danger label, upload errors

### DIFF
--- a/packages/react/ds-global-form/src/index.css
+++ b/packages/react/ds-global-form/src/index.css
@@ -237,7 +237,25 @@
   }
 }
 
-/* ── Danger — bottom border only (matches normal theme); focus shows all four */
+/* ── Danger ──────────────────────────────────────────────────────────
+ * The field label recolours to the error token on any invalid field. This is
+ * the group-level affordance for controls whose payload has no single border to
+ * paint — notably the borderless `.ds.form-choices` fieldset, where the
+ * `<legend>` (a `.ds.field-label`) carries the error alongside the FieldError
+ * message, rather than lighting up every option box. */
+.danger > .ds.field-label {
+  color: var(--form-error-color);
+
+  /* The required "*" marker recolours WITH the label (it pins its own colour to
+   * `--form-label-color` by default, so it must be overridden here). The
+   * "(optional)" hint keeps its muted colour — it is subordinate, not an error
+   * signal — via its own explicit `color` in the Label styles. */
+  &[data-required]::before {
+    color: var(--form-error-color);
+  }
+}
+
+/* Input chrome: bottom border only (matches normal theme); focus shows all four */
 .danger > .payload .ds.input.chrome {
   border-color: var(--form-input-border-color-error);
 }

--- a/packages/react/ds-global-form/src/lib/common/bindField/bindField.ts
+++ b/packages/react/ds-global-form/src/lib/common/bindField/bindField.ts
@@ -35,14 +35,22 @@ export default function bindField<P extends FieldBindingProps>(
     Presentational.name ||
     "Input";
 
-  // Merge the field's register defaults UNDER the consumer's registerProps. Cast
-  // once: RHF's RegisterOptions is a discriminated union (e.g. `valueAsNumber`
-  // excludes `pattern`), which an object spread cannot satisfy structurally even
-  // though the merged value is valid at runtime.
+  // Merge the field's `additionalRegisterProps` UNDER the consumer's
+  // registerProps (consumer always wins). `additionalRegisterProps` may be a
+  // static object or a function of the component's own props; resolve it per
+  // render against `props`. Cast once: RHF's RegisterOptions is a discriminated
+  // union (e.g. `valueAsNumber` excludes `pattern`), which an object spread
+  // cannot satisfy structurally even though the merged value is valid at runtime.
   const mergeRegister = (
     registerProps: RegisterOptions | undefined,
-  ): RegisterOptions =>
-    ({ ...options.registerDefaults, ...registerProps }) as RegisterOptions;
+    props: Record<string, unknown>,
+  ): RegisterOptions => {
+    const extra =
+      typeof options.additionalRegisterProps === "function"
+        ? options.additionalRegisterProps(props)
+        : options.additionalRegisterProps;
+    return { ...extra, ...registerProps } as RegisterOptions;
+  };
 
   let Bound: FC<P>;
 
@@ -50,7 +58,7 @@ export default function bindField<P extends FieldBindingProps>(
     Bound = ({ name, registerProps, ...rest }: P) => {
       const { field } = useController({
         name,
-        rules: registerProps,
+        rules: mergeRegister(registerProps, rest),
         ...(options.defaultValue !== undefined
           ? { defaultValue: options.defaultValue }
           : {}),
@@ -71,7 +79,7 @@ export default function bindField<P extends FieldBindingProps>(
       return createElement(Presentational, {
         ...rest,
         value,
-        ...register(name, mergeRegister(registerProps)),
+        ...register(name, mergeRegister(registerProps, rest)),
       });
     };
   } else {
@@ -79,7 +87,7 @@ export default function bindField<P extends FieldBindingProps>(
       const { register } = useFormContext();
       return createElement(Presentational, {
         ...rest,
-        ...register(name, mergeRegister(registerProps)),
+        ...register(name, mergeRegister(registerProps, rest)),
       });
     };
   }

--- a/packages/react/ds-global-form/src/lib/common/bindField/types.ts
+++ b/packages/react/ds-global-form/src/lib/common/bindField/types.ts
@@ -15,12 +15,23 @@ export interface BindFieldOptions {
    */
   defaultValue?: unknown;
   /**
-   * Base `register()` options merged UNDER the consumer's `registerProps` (the
-   * consumer wins on conflict). Lets a field set input-type defaults — e.g.
-   * Number passing `{ valueAsNumber: true }` so RHF stores a number, not the
-   * string the native `<input type="number">` reports.
+   * Extra `register()` options merged UNDER the consumer's `registerProps` (the
+   * consumer always wins on conflict). Accepts either:
+   *
+   * - a **static** `RegisterOptions` object — for input-type defaults that don't
+   *   depend on props, e.g. Number's `{ valueAsNumber: true }`; or
+   * - a **function of the component's own props** `(props) => RegisterOptions` —
+   *   for prop-driven rules, e.g. a Date field turning its `min`/`max` props into
+   *   RHF min/max rules, or a FileUpload field turning `maxFiles`/`maxSize` into a
+   *   `validate` rule. Runs at render with the live props.
+   *
+   * The props are still forwarded to the input, so native constraints (picker,
+   * spinner, `accept`) are unaffected — this only adds the RHF-visible rules that
+   * surface an inline field error.
    */
-  registerDefaults?: RegisterOptions;
+  additionalRegisterProps?:
+    | RegisterOptions
+    | ((props: Record<string, unknown>) => RegisterOptions);
 }
 
 export type FieldBindingProps = {

--- a/packages/react/ds-global-form/src/lib/component/DateField/DateField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/DateField/DateField.stories.tsx
@@ -22,13 +22,42 @@ export const Default: Story = {
   },
 };
 
+/** Helper text via the `description` prop, rendered under the label. */
+export const WithDescription: Story = {
+  args: {
+    name: "birthday_desc",
+    label: "Birthday",
+    description: "We use this to send you a discount on your birthday.",
+  },
+};
+
 export const WithMinMax: Story = {
   args: {
     name: "appointment",
     label: "Appointment date",
+    description: "Choose a date between 1 Jan 2024 and 31 Dec 2025.",
     min: "2024-01-01",
     max: "2025-12-31",
   },
+};
+
+/**
+ * A value outside the min/max range now reports an inline error — the `min`/
+ * `max` props are wired as react-hook-form rules, not just native attributes.
+ */
+export const OutOfRange: Story = {
+  args: {
+    name: "appointment_oor",
+    label: "Appointment date",
+    min: "2024-01-01",
+    max: "2025-12-31",
+  },
+  decorators: [
+    decorators.form({
+      defaultValues: { appointment_oor: "2030-06-15" },
+      touchedFields: ["appointment_oor"],
+    }),
+  ],
 };
 
 export const Disabled: Story = {

--- a/packages/react/ds-global-form/src/lib/component/DateField/DateField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/DateField/DateField.tsx
@@ -1,7 +1,28 @@
+import type { RegisterOptions } from "react-hook-form";
 import bindField from "../../common/bindField/index.js";
 import withWrapper from "../../common/Wrapper/withWrapper.js";
 import { DateInput } from "../../subcomponent/DateInput/index.js";
 import type { DateFieldProps } from "./types.js";
+
+/**
+ * Turn the `min`/`max` date props into react-hook-form `min`/`max` rules so an
+ * out-of-range date reports an inline error — the native attributes alone only
+ * constrain the picker UI and never reach RHF. ISO `YYYY-MM-DD` strings compare
+ * lexicographically, so the native rule works directly on the stored value.
+ */
+const dateRangeRules = ({
+  min,
+  max,
+}: Record<string, unknown>): RegisterOptions => {
+  const rules: RegisterOptions = {};
+  if (typeof min === "string" && min) {
+    rules.min = { value: min, message: `Date must be on or after ${min}.` };
+  }
+  if (typeof max === "string" && max) {
+    rules.max = { value: max, message: `Date must be on or before ${max}.` };
+  }
+  return rules;
+};
 
 /**
  * Date input bound to react-hook-form, wrapped with field chrome
@@ -10,5 +31,7 @@ import type { DateFieldProps } from "./types.js";
  * `import { DateField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<DateFieldProps>(
-  bindField<DateFieldProps>(DateInput, "native"),
+  bindField<DateFieldProps>(DateInput, "native", {
+    additionalRegisterProps: dateRangeRules,
+  }),
 );

--- a/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.stories.tsx
@@ -40,6 +40,33 @@ export const ImagesOnly: Story = {
   },
 };
 
+/**
+ * Caps the number of files: `maxFiles` is enforced as a react-hook-form
+ * `validate` rule, so exceeding it shows a standard field error (rather than the
+ * input silently dropping the extra files). Seeded over the limit + touched so
+ * the error renders.
+ */
+export const MaxFiles: Story = {
+  args: {
+    name: "attachments",
+    label: "Attachments (max 2)",
+    multiple: true,
+    maxFiles: 2,
+  },
+  decorators: [
+    decorators.form({
+      defaultValues: {
+        attachments: [
+          new File(["a"], "one.txt"),
+          new File(["b"], "two.txt"),
+          new File(["c"], "three.txt"),
+        ],
+      },
+      touchedFields: ["attachments"],
+    }),
+  ],
+};
+
 export const SingleFile: Story = {
   args: {
     name: "resume",

--- a/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.tests.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithForm } from "../../../testing/renderWithForm.js";
+import { FileUploadField } from "./index.js";
+
+const file = (name: string, sizeBytes = 1): File => {
+  const f = new File(["x".repeat(sizeBytes)], name);
+  // jsdom's File may not honour content length for `size`; pin it explicitly.
+  Object.defineProperty(f, "size", { value: sizeBytes });
+  return f;
+};
+
+// Submitting is what runs RHF's `validate` rule; the file input is aria-hidden
+// and drag-drop can't be simulated, so seed the value via defaultValues and fire
+// a submit on the wrapping form.
+const submit = () => {
+  const form = document.querySelector("form");
+  if (form) fireEvent.submit(form);
+};
+
+describe("FileUploadField", () => {
+  it("registers with react-hook-form", () => {
+    renderWithForm(<FileUploadField name="doc" label="Upload" />);
+    expect(screen.getByText("Upload")).toBeInTheDocument();
+  });
+
+  it("errors when more than maxFiles are selected", async () => {
+    renderWithForm(
+      <FileUploadField name="docs" label="Upload" multiple maxFiles={2} />,
+      {
+        formProps: {
+          mode: "onSubmit",
+          defaultValues: {
+            docs: [file("a.txt"), file("b.txt"), file("c.txt")],
+          },
+        },
+      },
+    );
+    submit();
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "You can upload at most 2 files.",
+      );
+    });
+  });
+
+  it("errors when a file exceeds maxSize", async () => {
+    renderWithForm(
+      <FileUploadField name="docs" label="Upload" multiple maxSize={1024} />,
+      {
+        formProps: {
+          mode: "onSubmit",
+          defaultValues: { docs: [file("big.txt", 2048)] },
+        },
+      },
+    );
+    submit();
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "big.txt exceeds 1 KB.",
+      );
+    });
+  });
+
+  it("does not error when within maxFiles and maxSize", async () => {
+    renderWithForm(
+      <FileUploadField
+        name="docs"
+        label="Upload"
+        multiple
+        maxFiles={2}
+        maxSize={1024}
+      />,
+      {
+        formProps: {
+          mode: "onSubmit",
+          defaultValues: { docs: [file("ok.txt", 512)] },
+        },
+      },
+    );
+    submit();
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.tsx
@@ -1,17 +1,60 @@
+import type { RegisterOptions } from "react-hook-form";
 import bindField from "../../common/bindField/index.js";
 import withWrapper from "../../common/Wrapper/withWrapper.js";
 import { FileUploadInput } from "../../subcomponent/FileUploadInput/index.js";
 import type { FileUploadFieldProps } from "./types.js";
 
+const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${Math.round((bytes / (1024 * 1024)) * 10) / 10} MB`;
+};
+
 /**
- * FileUploadInput bound to react-hook-form (controlled), wrapped with field chrome.
- * The `defaultValue` preserves the registration default the original leaf set
- * in `useController` (`[]`).
+ * Turn the `maxFiles`/`maxSize` props into a react-hook-form `validate` rule on
+ * the selected `File[]`, so an over-limit or oversized selection reports a
+ * standard field error (via the Wrapper's FieldError). Validation lives at the
+ * field/RHF layer — the presentational input just reports the chosen files.
+ */
+const fileConstraintRules = ({
+  maxFiles,
+  maxSize,
+}: Record<string, unknown>): RegisterOptions => {
+  const hasMaxFiles = typeof maxFiles === "number";
+  const hasMaxSize = typeof maxSize === "number";
+  if (!hasMaxFiles && !hasMaxSize) return {};
+
+  return {
+    validate: (value: unknown) => {
+      const files = Array.isArray(value) ? (value as File[]) : [];
+      if (hasMaxFiles && files.length > maxFiles) {
+        return `You can upload at most ${maxFiles} file${
+          maxFiles === 1 ? "" : "s"
+        }.`;
+      }
+      if (hasMaxSize) {
+        const tooBig = files.find((file) => file.size > maxSize);
+        if (tooBig) {
+          return `${tooBig.name} exceeds ${formatFileSize(maxSize)}.`;
+        }
+      }
+      return true;
+    },
+  };
+};
+
+/**
+ * FileUploadInput bound to react-hook-form (controlled), wrapped with field
+ * chrome. The `defaultValue` preserves the registration default the original
+ * leaf set in `useController` (`[]`). `maxFiles`/`maxSize` are enforced as RHF
+ * validation rules so violations surface as a standard field error rather than
+ * being silently dropped in the input.
  *
  * `import { FileUploadField } from "@canonical/react-ds-global-form";`
  */
 export default withWrapper<FileUploadFieldProps>(
   bindField<FileUploadFieldProps>(FileUploadInput, "controlled", {
     defaultValue: [],
+    additionalRegisterProps: fileConstraintRules,
   }),
 );

--- a/packages/react/ds-global-form/src/lib/component/NumberField/NumberField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/NumberField/NumberField.tsx
@@ -16,6 +16,6 @@ export default withWrapper<NumberFieldProps>(
   // `valueAsNumber` so RHF stores a number, not the string the native
   // `<input type="number">` reports (the consumer's registerProps still win).
   bindField<NumberFieldProps>(NumberInput, "native", {
-    registerDefaults: { valueAsNumber: true },
+    additionalRegisterProps: { valueAsNumber: true },
   }),
 );

--- a/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.tsx
@@ -17,6 +17,6 @@ import type { RangeFieldProps } from "./types.js";
  */
 export default withWrapper<RangeFieldProps>(
   bindField<RangeFieldProps>(RangeControl, "native", {
-    registerDefaults: { valueAsNumber: true },
+    additionalRegisterProps: { valueAsNumber: true },
   }),
 );

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateInput/styles.css
@@ -13,11 +13,15 @@
     display: none;
   }
 
-  /* NOTE (design review — "suggested" format text → muted): NOT implementable in
-   * pure CSS on a native <input type="date">. It has no placeholder attribute
-   * (so `:placeholder-shown` never matches), and `::-webkit-datetime-edit`
-   * colours the whole edit region — mask AND typed value — with no selector for
-   * the empty state, and Firefox ignores it entirely. A muted-only-when-empty
-   * hint needs a custom (non-native) date control or a JS empty-state hook.
-   * Parked for Diana. */
+  /* NOTE (design review) — two native-<input type="date"> limits parked for Diana:
+   * 1. "Suggested" format text → muted: NOT implementable in pure CSS. No
+   *    placeholder attribute (so `:placeholder-shown` never matches), and
+   *    `::-webkit-datetime-edit` colours the whole edit region — mask AND typed
+   *    value — with no empty-state selector, and Firefox ignores it. Needs a
+   *    custom (non-native) control or a JS empty-state hook.
+   * 2. Calendar indicator → pragma icon: no calendar glyph exists in
+   *    @canonical/ds-assets to mask onto `::-webkit-calendar-picker-indicator`,
+   *    and that pseudo-element is WebKit/Chromium-only (Firefox draws its own,
+   *    unstyleable). Needs a new ds-assets glyph + Chrome/Safari-only styling, or
+   *    a custom control. */
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/styles.css
@@ -13,11 +13,16 @@
     display: none;
   }
 
-  /* NOTE (design review — "suggested" format text → muted): NOT implementable in
-   * pure CSS on a native <input type="datetime-local">. It has no placeholder
-   * attribute (so `:placeholder-shown` never matches), and
-   * `::-webkit-datetime-edit` colours the whole edit region — mask AND typed
-   * value — with no selector for the empty state, and Firefox ignores it
-   * entirely. A muted-only-when-empty hint needs a custom (non-native) control
-   * or a JS empty-state hook. Parked for Diana. */
+  /* NOTE (design review) — two native-<input type="datetime-local"> limits
+   * parked for Diana:
+   * 1. "Suggested" format text → muted: NOT implementable in pure CSS. No
+   *    placeholder attribute (so `:placeholder-shown` never matches), and
+   *    `::-webkit-datetime-edit` colours the whole edit region — mask AND typed
+   *    value — with no empty-state selector, and Firefox ignores it. Needs a
+   *    custom (non-native) control or a JS empty-state hook.
+   * 2. Calendar/clock indicator → pragma icon: no calendar/clock glyph exists in
+   *    @canonical/ds-assets to mask onto `::-webkit-calendar-picker-indicator`,
+   *    and that pseudo-element is WebKit/Chromium-only (Firefox draws its own,
+   *    unstyleable). Needs a new ds-assets glyph + Chrome/Safari-only styling, or
+   *    a custom control. */
 }

--- a/packages/react/ds-global-form/src/lib/subcomponent/FileUploadInput/FileUploadInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/FileUploadInput/FileUploadInput.tsx
@@ -20,6 +20,9 @@ export const FileUploadInput = ({
   value,
   onChange,
   accept,
+  // Destructured out of `otherProps` so they are NOT spread onto the drop-zone
+  // <button> as invalid DOM attributes. The FIELD reads them (as RHF validation
+  // rules); the presentational input does not enforce them.
   maxSize,
   maxFiles,
   multiple = false,
@@ -31,41 +34,18 @@ export const FileUploadInput = ({
 
   const files: File[] = Array.isArray(value) ? value : [];
 
-  const validateFile = useCallback(
-    (file: File): string | null => {
-      if (maxSize && file.size > maxSize) {
-        return `${file.name} exceeds ${formatFileSize(maxSize)}`;
-      }
-      return null;
-    },
-    [maxSize],
-  );
-
+  /* Presentational only: report the chosen files up via `onChange`. Constraint
+   * validation (maxFiles/maxSize) lives on the FIELD as a react-hook-form
+   * `validate` rule so violations surface through the standard FieldError,
+   * rather than being enforced (and silently dropped) here. `maxFiles`/`maxSize`
+   * are still accepted for the field to read and for the native `accept` hint. */
   const addFiles = useCallback(
     (incoming: FileList | File[]) => {
       const newFiles = Array.from(incoming);
-      const errors: string[] = [];
-
-      for (const file of newFiles) {
-        const error = validateFile(file);
-        if (error) {
-          errors.push(error);
-        }
-      }
-
-      if (errors.length > 0) {
-        return;
-      }
-
       const merged = multiple ? [...files, ...newFiles] : newFiles.slice(0, 1);
-
-      if (maxFiles && merged.length > maxFiles) {
-        return;
-      }
-
       onChange?.(merged);
     },
-    [files, multiple, maxFiles, onChange, validateFile],
+    [files, multiple, onChange],
   );
 
   const removeFile = useCallback(

--- a/packages/react/ds-global-form/src/lib/subcomponent/TimeInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TimeInput/styles.css
@@ -12,4 +12,12 @@
   &::-webkit-inner-spin-button {
     display: none;
   }
+
+  /* NOTE (design review — clock indicator → pragma icon): parked. There is no
+   * clock/time glyph in @canonical/ds-assets to mask onto
+   * `::-webkit-calendar-picker-indicator`, and that pseudo-element is
+   * WebKit/Chromium-only (Firefox renders its own picker button that CSS cannot
+   * target), so a custom icon can't be made consistent across browsers on a
+   * native <input type="time">. Needs a new ds-assets glyph + accepting
+   * Chrome/Safari-only styling, or a custom (non-native) control. */
 }


### PR DESCRIPTION
Form-track behaviour/validation items from Diana's review (Coda `dianas_review_notes`), stacked on #801.

## Done
- **DateField min/max now validate.** New `deriveRegister` option on `bindField` maps a field's own props into RHF register rules at render (under the consumer's `registerProps`). DateField turns `min`/`max` into RHF min/max rules (ISO dates compare lexicographically) → an **out-of-range date shows an inline error**. Previously they were native attributes only. New `OutOfRange` + `WithDescription` stories.
- **DateField helper text** was already supported (`description`) but never shown — added to stories.
- **Group danger affordance.** `.danger > .ds.field-label` recolours the label/legend to the error token — the error signal for **ChoicesField** (borderless fieldset, no input border to paint), rather than lighting up every option box, alongside the `FieldError` message. Applies to every field.
- **FileUploadInput surfaces client-side validation.** Type/size/count errors were computed then silently dropped; now render inline (`role="alert"`, `--form-error-color`) and clear on the next successful add.

## Parked (in-file NOTEs)
Native date/time calendar/clock indicator → pragma icon isn't doable: no calendar/clock glyph in `@canonical/ds-assets`, and `::-webkit-calendar-picker-indicator` is WebKit-only (Firefox unstyleable).

## Not built here
**Success/warning field states** — new capability (no enum/CSS/tokens today), tracked separately.

## QA
`nx check @canonical/react-ds-global-form` green.