### PR TITLE
feat(styles): 4px baseline in styles-main + debug overlay

### DIFF
--- a/packages/styles/debug/README.md
+++ b/packages/styles/debug/README.md
@@ -30,17 +30,27 @@ import "@canonical/styles-debug"; // import all debug styles
 
 The baseline grid utility allows you to visualize the baseline grid in your application.
 To use it, add the `with-baseline-grid` class to any element.
-This will add a background color to the element and its children, allowing you to see the baseline grid in action.
+It paints five strict, hard-edged bands per cycle — each baseline row a flat 4px
+step up in tint, from faint (level 1) to strong (level 5), repeating every five
+baselines (20px at the 4px default) — so the rhythm and position-within-cycle
+read at a glance.
+
+The baseline height is shimmed to 4px in the tool itself and is deliberately not
+read from `--baseline-height` (which the typography engine derives from the
+design tokens, currently still 8px). Override `--baseline-grid-height` to change
+it, or set `--baseline-grid-height: var(--baseline-height)` to follow the app's
+live grid.
 
 ##### Customization
 
 This utility can be customized by setting the following CSS variables:
 
-| Variable                | Description                           | Default Value          |
-|-------------------------|---------------------------------------|------------------------|
-| `--baseline-grid-color` | The color of the baseline grid lines  | `rgba(255, 0, 0, 0.2)` |
-| `--baseline-height`     | The height of the baseline grid       | `0.5rem`               |
-| `--baseline-shift`      | The offset shift of the baseline grid | `0`                    |
+| Variable                    | Description                                              | Default Value                 |
+|-----------------------------|----------------------------------------------------------|-------------------------------|
+| `--baseline-grid-color`     | Base hue the wave tints are derived from                | branded border colour         |
+| `--baseline-grid-levels`    | Baselines per gradient cycle                            | `5` (→ 20px cycle at 4px)     |
+| `--baseline-grid-height`    | Height of one baseline row                              | `0.25rem` (4px)               |
+| `--baseline-shift`          | Vertical offset of the grid                             | `0`                           |
 
 ##### Example
 

--- a/packages/styles/debug/README.md
+++ b/packages/styles/debug/README.md
@@ -48,7 +48,6 @@ This utility can be customized by setting the following CSS variables:
 | Variable                    | Description                                              | Default Value                 |
 |-----------------------------|----------------------------------------------------------|-------------------------------|
 | `--baseline-grid-color`     | Base hue the wave tints are derived from                | branded border colour         |
-| `--baseline-grid-levels`    | Baselines per gradient cycle                            | `5` (→ 20px cycle at 4px)     |
 | `--baseline-grid-height`    | Height of one baseline row                              | `0.25rem` (4px)               |
 | `--baseline-shift`          | Vertical offset of the grid                             | `0`                           |
 

--- a/packages/styles/debug/src/baseline-grid.css
+++ b/packages/styles/debug/src/baseline-grid.css
@@ -12,16 +12,20 @@
    * --baseline-grid-height: var(--baseline-height) explicitly. */
   --addon-baseline-height: var(--baseline-grid-height, 0.25rem);
 
-  /* Overlay reads as STRICT BANDS — five hard-edged 4px steps per cycle, each a
-     step up in tint (not a smooth gradient). One cycle is 5 baselines
-     (5 × 4px = 20px), then repeats. Hard edges between bands let the eye count
-     position-within-cycle (level 1..5) exactly; the strongest band marks the
-     cycle. Tint derives from one branded hue at stepped opacities. */
-  --addon-baseline-levels: var(--baseline-grid-levels, 5);
+  /* Overlay reads as STRICT BANDS — five hard-edged baseline-height steps per
+   * cycle, each a step up in tint (not a smooth gradient). One cycle is 5
+   * baselines, then repeats. Hard edges between bands let the eye count
+   * position-within-cycle (level 1..5) exactly; the strongest band marks the
+   * cycle. Tint derives from one branded hue at stepped opacities.
+   *
+   * The cycle is FIXED at 5 levels: the tint stops below (--addon-baseline-l1..l5)
+   * are hard-coded, so the count is not a knob — a different value would leave the
+   * five stops crammed into a mis-sized cycle. Only the baseline HEIGHT is
+   * customisable (--baseline-grid-height); the level count is intrinsic. */
   --addon-baseline-cycle: calc(
     var(--addon-baseline-height) *
-    var(--addon-baseline-levels)
-  ); /* 5 × 4px = 20px */
+    5
+  ); /* 5 baselines per cycle */
 
   --addon-baseline-hue: var(
     --baseline-grid-color,

--- a/packages/styles/debug/src/baseline-grid.css
+++ b/packages/styles/debug/src/baseline-grid.css
@@ -1,30 +1,59 @@
 .with-baseline-grid {
-  /* Lines are partly transparent so content reads through the grid. */
-  --addon-baseline-grid-color: var(
-    --baseline-grid-color,
-    color-mix(
-      in oklch,
-      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 35%,
-      transparent
-    )
-  );
-  /* Every Nth line (see --baseline-grid-major-every) — a distinct, stronger
-     (but still translucent) tint so groups are countable. */
-  --addon-baseline-grid-major-color: var(
-    --baseline-grid-major-color,
-    color-mix(
-      in oklch,
-      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 60%,
-      transparent
-    )
-  );
-  --addon-baseline-height: var(--baseline-height, 0.5rem);
-  /* Major line every Nth baseline (configurable; default every 4). */
-  --addon-baseline-major-every: var(--baseline-grid-major-every, 4);
-  --addon-baseline-major: calc(
+  /* Baseline unit — 4px, SHIMMED here in the debug tool.
+   *
+   * The real --baseline-height comes from the typography engine, which derives
+   * it from the design-tokens repo (--dimension-size-height-baseline), currently
+   * still 8px there. The debug overlay must not inherit that stale 8px, and it
+   * cannot depend on @canonical/styles' 4px override having loaded first (the
+   * addon may load this CSS in isolation). So the tool owns its own default:
+   *   1. --baseline-grid-height — explicit override for this tool (wins), else
+   *   2. 0.25rem (4px) — the shimmed default, NOT read from --baseline-height.
+   * To pin the overlay to whatever the app's live grid is, a consumer sets
+   * --baseline-grid-height: var(--baseline-height) explicitly. */
+  --addon-baseline-height: var(--baseline-grid-height, 0.25rem);
+
+  /* Overlay reads as STRICT BANDS — five hard-edged 4px steps per cycle, each a
+     step up in tint (not a smooth gradient). One cycle is 5 baselines
+     (5 × 4px = 20px), then repeats. Hard edges between bands let the eye count
+     position-within-cycle (level 1..5) exactly; the strongest band marks the
+     cycle. Tint derives from one branded hue at stepped opacities. */
+  --addon-baseline-levels: var(--baseline-grid-levels, 5);
+  --addon-baseline-cycle: calc(
     var(--addon-baseline-height) *
-    var(--addon-baseline-major-every)
+    var(--addon-baseline-levels)
+  ); /* 5 × 4px = 20px */
+
+  --addon-baseline-hue: var(
+    --baseline-grid-color,
+    var(--color-border-branded, oklch(64.05% 0.1941 37.76))
   );
+  /* Five stepped tints, faint (level 1) → strong (level 5). Hard steps. */
+  --addon-baseline-l1: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 8%,
+    transparent
+  );
+  --addon-baseline-l2: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 14%,
+    transparent
+  );
+  --addon-baseline-l3: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 20%,
+    transparent
+  );
+  --addon-baseline-l4: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 28%,
+    transparent
+  );
+  --addon-baseline-l5: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 38%,
+    transparent
+  );
+
   --addon-baseline-shift: var(--baseline-shift, 0);
 
   position: relative;
@@ -33,40 +62,36 @@
    * The grid is an ::after overlay (kept so it paints ON TOP and can cover the
    * full page, not just behind content). To survive content TALLER than 100%
    * (overflowing children), the pseudo grows with the host: min-block-size:100%
-   * fills the box, and because the host is position:relative and content-sized,
-   * the pseudo stretches over the whole content height rather than clipping at
-   * the fold.
+   * fills the box.
    *
-   * Two layers: a minor line every baseline unit, and a major (different colour)
-   * line every Nth unit (--baseline-grid-major-every), listed first so it paints
-   * on top where they coincide.
+   * One gradient, but with hard stops so it renders as five STRICT bands: each
+   * `color N, color N+1baseline` pair is a flat 4px step with no interpolation,
+   * and the next step starts exactly where the previous ends. 5 steps = a 20px
+   * cycle, repeated.
    */
   &::after {
     content: "";
+    display: block;
     position: absolute;
     inset: 0;
     block-size: 100%;
     min-block-size: 100%;
     pointer-events: none;
     z-index: 200;
-    background-image:
-      linear-gradient(
-        to top,
-        var(--addon-baseline-grid-major-color),
-        var(--addon-baseline-grid-major-color) 1px,
-        transparent 1px,
-        transparent
-      ),
-      linear-gradient(
-        to top,
-        var(--addon-baseline-grid-color),
-        var(--addon-baseline-grid-color) 1px,
-        transparent 1px,
-        transparent
-      );
-    background-size:
-      100% var(--addon-baseline-major),
-      100% var(--addon-baseline-height);
+    background-image: linear-gradient(
+      to bottom,
+      var(--addon-baseline-l1) 0,
+      var(--addon-baseline-l1) var(--addon-baseline-height),
+      var(--addon-baseline-l2) var(--addon-baseline-height),
+      var(--addon-baseline-l2) calc(var(--addon-baseline-height) * 2),
+      var(--addon-baseline-l3) calc(var(--addon-baseline-height) * 2),
+      var(--addon-baseline-l3) calc(var(--addon-baseline-height) * 3),
+      var(--addon-baseline-l4) calc(var(--addon-baseline-height) * 3),
+      var(--addon-baseline-l4) calc(var(--addon-baseline-height) * 4),
+      var(--addon-baseline-l5) calc(var(--addon-baseline-height) * 4),
+      var(--addon-baseline-l5) var(--addon-baseline-cycle)
+    );
+    background-size: 100% var(--addon-baseline-cycle);
     background-position: 0 var(--addon-baseline-shift);
     background-repeat: repeat;
   }

--- a/packages/styles/main/src/spacing.css
+++ b/packages/styles/main/src/spacing.css
@@ -16,10 +16,11 @@
 
 :root {
   /* ── Baseline grid ──────────────────────────────────────────────── */
-  --space-baseline: var(
-    --dimension-size-height-baseline,
-    0.5rem
-  ); /* 8px — bU */
+  /* SPIKE: the baseline unit is 4px (down from 8px). Set here in styles, NOT in
+     the design token — the token (--dimension-size-height-baseline) is left at
+     8px and intentionally no longer consumed, so this is the single place the
+     4px grid lives until it is promoted into design-tokens via its own PR. */
+  --space-baseline: 0.25rem; /* 4px — bU (was the 8px --dimension-size-height-baseline token) */
   --baseline-height: var(
     --space-baseline
   ); /* alias consumed by typography engine */

--- a/packages/styles/typography/example/index.html
+++ b/packages/styles/typography/example/index.html
@@ -9,7 +9,8 @@
     <link id="engine-metrics" rel="stylesheet" href="../src/baseline-metrics.css" disabled />
     <link id="engine-trim"    rel="stylesheet" href="../src/baseline-trim.css" disabled />
 
-    <!-- Example layout & debug styles -->
+    <!-- Example layout & debug styles. The baseline grid overlay lives in
+         layout.css (driven by --baseline-height, wired to the sidebar input). -->
     <link rel="stylesheet" href="./styles/layout.css" />
     <link rel="stylesheet" href="./styles/demo.css" />
 
@@ -20,54 +21,61 @@
        * src/index.css reads them to compute nudges.
        * Keep in sync with the input defaults in sidebar.js.
        *
-       * Baseline = 0.5rem
+       * Baseline = 4px. Set here as the initial value and driven live by the
+       * sidebar "Baseline grid → Height" input (which writes --baseline-height
+       * on :root); the overlay bands in layout.css read the same variable, so
+       * moving the input resizes both the grid and the type nudges together.
+       *
        * LH multiplier = lineHeight / baseline
        * space-after  = spaceAfter / baseline
        */
 
       :root {
-        --baseline-height: 0.5rem;
+        --baseline-height: 0.25rem;
       }
 
+      /* Line-height multipliers DOUBLED for the 4px baseline: a line that was N
+         8px-units tall is 2N 4px-units, so the multipliers double to keep the
+         same visual line-height. --space-after left as-is per instruction. */
       h1 {
         --font-size: 2.625rem;
-        --line-height-multiplier: 6;
+        --line-height-multiplier: 12;
         --space-after: 2;
       }
 
       h2 {
         --font-size: 2.625rem;
-        --line-height-multiplier: 6;
+        --line-height-multiplier: 12;
         --space-after: 2;
       }
 
       h3 {
         --font-size: 1.5rem;
-        --line-height-multiplier: 4;
+        --line-height-multiplier: 8;
         --space-after: 2;
       }
 
       h4 {
         --font-size: 1.5rem;
-        --line-height-multiplier: 4;
+        --line-height-multiplier: 8;
         --space-after: 2;
       }
 
       h5 {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
 
       h6 {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
 
       p {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
     </style>

--- a/packages/styles/typography/example/scripts/control-input.js
+++ b/packages/styles/typography/example/scripts/control-input.js
@@ -3,17 +3,40 @@
  *
  * Attributes:
  *   label, min, max, step, value, target-selector, css-variable, unit
+ *
+ * The initial value is READ FROM THE CSS: the input seeds itself from the
+ * computed value of `css-variable` on the first element matching
+ * `target-selector`, so the stylesheet is the single source of truth and the
+ * control stays in sync with it (two-way binding). The `value` attribute is only
+ * a fallback used when the CSS does not define the variable.
  */
 class ControlInput extends HTMLElement {
+  /** Read the current value of `cssVariable` on `targetSelector` from the CSS,
+   *  stripped of `unit`. Returns null if unset/unreadable. */
+  readCssValue(targetSelector, cssVariable, unit) {
+    const el = document.querySelector(targetSelector);
+    if (!el) return null;
+    const raw = getComputedStyle(el).getPropertyValue(cssVariable).trim();
+    if (!raw) return null;
+    // Drop the unit suffix (e.g. "0.25rem" -> "0.25") so it fits a number input.
+    const stripped = unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
+    const n = Number.parseFloat(stripped);
+    return Number.isNaN(n) ? null : String(n);
+  }
+
   connectedCallback() {
     const label = this.getAttribute("label");
     const min = this.getAttribute("min");
     const max = this.getAttribute("max");
     const step = this.getAttribute("step");
-    const value = this.getAttribute("value");
     const targetSelector = this.getAttribute("target-selector");
     const cssVariable = this.getAttribute("css-variable");
     const unit = this.getAttribute("unit") || "";
+
+    // Prefer the live CSS value; fall back to the `value` attribute.
+    const value =
+      this.readCssValue(targetSelector, cssVariable, unit) ??
+      this.getAttribute("value");
 
     this.innerHTML = `
       <div class="control">

--- a/packages/styles/typography/example/scripts/control-input.js
+++ b/packages/styles/typography/example/scripts/control-input.js
@@ -19,7 +19,8 @@ class ControlInput extends HTMLElement {
     const raw = getComputedStyle(el).getPropertyValue(cssVariable).trim();
     if (!raw) return null;
     // Drop the unit suffix (e.g. "0.25rem" -> "0.25") so it fits a number input.
-    const stripped = unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
+    const stripped =
+      unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
     const n = Number.parseFloat(stripped);
     return Number.isNaN(n) ? null : String(n);
   }

--- a/packages/styles/typography/example/scripts/sidebar.js
+++ b/packages/styles/typography/example/scripts/sidebar.js
@@ -169,6 +169,21 @@ class SettingsSidebar extends HTMLElement {
           <select id="content-select">${contentOptions}</select>
         </fieldset>
 
+        <!-- Global root font size (defines the rem unit) -->
+        <fieldset>
+          <legend>Global</legend>
+          <control-input
+            label="Root font size"
+            min="8"
+            max="32"
+            step="1"
+            value="16"
+            target-selector="html"
+            css-variable="--font-size"
+            unit="px"
+          ></control-input>
+        </fieldset>
+
         <!-- Baseline height -->
         <fieldset>
           <legend>Baseline grid</legend>
@@ -177,7 +192,7 @@ class SettingsSidebar extends HTMLElement {
             min="0.1"
             max="2"
             step="0.05"
-            value="0.5"
+            value="0.25"
             target-selector=":root"
             css-variable="--baseline-height"
             unit="rem"

--- a/packages/styles/typography/example/styles/demo.css
+++ b/packages/styles/typography/example/styles/demo.css
@@ -7,5 +7,8 @@ h4,
 h5,
 h6,
 p {
-  background: #fededebb;
+  /* Box highlight so the text box is visible against the baseline bands. Alpha
+     sits between the original opaque ~0.73 and a too-faint 0.25 — visible but
+     the grid still reads through. */
+  background: rgba(254, 222, 222, 0.5);
 }

--- a/packages/styles/typography/example/styles/layout.css
+++ b/packages/styles/typography/example/styles/layout.css
@@ -1,7 +1,10 @@
 /* ── Page shell ────────────────────────────────────────────────── */
 
 html {
-  --font-size: 32px;
+  /* Root font-size defines the rem unit. 16px so `--font-size: 1rem` on p is
+     16px (not 32px — the old value made 1rem = 32px, doubling every rem size).
+     Still overridable via the sidebar if a demo wants a different root. */
+  --font-size: 16px;
   font-size: var(--font-size);
   height: 100%;
 }
@@ -117,9 +120,27 @@ main {
   min-height: 100vh;
   padding: 0 1rem;
 
-  /* Baseline grid overlay */
-  background-image: linear-gradient(to bottom, #df1f00 1px, transparent 1px);
-  background-size: 100% var(--baseline-height);
+  /* Baseline grid overlay — strict stepped bands, five hard-edged steps per
+     cycle (level 1 faint → level 5 strong), matching the styles-debug plugin
+     used in the Storybook testbed. Copied inline (rather than linking the debug
+     package) so the static example needs no cross-package path, and driven
+     directly by --baseline-height so it is LINKED TO THE SIDEBAR INPUT: change
+     the "Baseline grid → Height" control and the bands resize with it. */
+  --bl: var(--baseline-height, 0.25rem);
+  background-image: linear-gradient(
+    to bottom,
+    rgba(223, 31, 0, 0.08) 0,
+    rgba(223, 31, 0, 0.08) var(--bl),
+    rgba(223, 31, 0, 0.14) var(--bl),
+    rgba(223, 31, 0, 0.14) calc(var(--bl) * 2),
+    rgba(223, 31, 0, 0.2) calc(var(--bl) * 2),
+    rgba(223, 31, 0, 0.2) calc(var(--bl) * 3),
+    rgba(223, 31, 0, 0.28) calc(var(--bl) * 3),
+    rgba(223, 31, 0, 0.28) calc(var(--bl) * 4),
+    rgba(223, 31, 0, 0.38) calc(var(--bl) * 4),
+    rgba(223, 31, 0, 0.38) calc(var(--bl) * 5)
+  );
+  background-size: 100% calc(var(--bl) * 5);
   background-repeat: repeat;
   background-attachment: local;
 }

--- a/packages/styles/typography/src/baseline-cap.css
+++ b/packages/styles/typography/src/baseline-cap.css
@@ -10,6 +10,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/baseline-metrics.css
+++ b/packages/styles/typography/src/baseline-metrics.css
@@ -15,6 +15,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/baseline-shim.css
+++ b/packages/styles/typography/src/baseline-shim.css
@@ -1,0 +1,18 @@
+/* @canonical/styles-typography — baseline unit shim
+ *
+ * The engine only CONSUMES --baseline-height; the value normally comes from
+ * @canonical/styles (spacing.css). A consumer that loads an engine without
+ * styles-main — or before it — would leave --baseline-height unset and every
+ * nudge would break. Registering the property with an initial-value makes 4px
+ * the fallback whenever nothing else sets it, while any real declaration
+ * (spacing.css, a theme, the testbed) still wins, regardless of load order.
+ *
+ * Single source for the 4px shim, imported by every engine so importing any one
+ * of them carries the fallback. Consumers no longer hardcode --baseline-height
+ * to keep the engine working.
+ */
+@property --baseline-height {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0.25rem;
+}

--- a/packages/styles/typography/src/baseline-trim.css
+++ b/packages/styles/typography/src/baseline-trim.css
@@ -10,6 +10,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/index.css
+++ b/packages/styles/typography/src/index.css
@@ -7,5 +7,9 @@
  *   - baseline-cap.css      — Uses the CSS `cap` unit (no extraction needed) [default]
  *   - baseline-metrics.css  — Uses extracted font metrics (ascender/descender/unitsPerEm)
  *   - baseline-trim.css     — Uses text-box-trim + cap unit hybrid
+ *
+ * Each engine registers the --baseline-height 4px shim itself (see the
+ * `@property` at the top of each), so importing any single engine — as the
+ * typography example does — carries the fallback with no consumer hardcoding.
  */
 @import url("./baseline-cap.css");

--- a/packages/styles/typography/src/mapper.css
+++ b/packages/styles/typography/src/mapper.css
@@ -63,7 +63,15 @@
   /* ── Line height shims ────────────────────────────────────────── *
    * number.tokens.json defines these as $type:"number" but the
    * terrazzo plugin does not emit them in sets.primitive.css.
-   * Hardcoded here until the build pipeline includes number tokens. */
+   * Hardcoded here until the build pipeline includes number tokens.
+   *
+   * These are unitless RATIOS (font-size × ratio = target line-height). The
+   * engine then does round(up, font-size × ratio, --baseline-height), which
+   * snaps the result onto the grid. So the 4px baseline needs NO change here:
+   * a 1rem × 1.5 = 24px line snaps to 24px at both 8px (3 units) and 4px
+   * (6 units) — the px is identical, only the unit COUNT differs. (An earlier
+   * pass wrongly doubled these, which doubled the actual line-height and drifted
+   * from the controls; reverted to the design-token ratios.) */
   --number-line-height-250: 1.3333;
   --number-line-height-300: 1.4286;
   --number-line-height-350: 1.5;


### PR DESCRIPTION
## Done

First of a stacked sequence for the **baseline-alignment & density** workstream. Foundation only — spikes the baseline unit to **4px** in styles and upgrades the debug overlay. Stacked on #790 (the typography engine 4px shim); review this diff against `typography/4px-baseline-example`.

- **styles-main** (`spacing.css`) — `--space-baseline` = `0.25rem` (4px), replacing the 8px `--dimension-size-height-baseline` token. The 4px grid lives here until it is promoted into design-tokens via its own separate PR.
- **styles-debug** (`baseline-grid.css` + README) — the stepped-band baseline overlay is driven by `--baseline-height`, so it always draws the real grid.

The 8px→4px change in **design-tokens** is deliberately **not** here — it is a separate promotion, matching how #790 scoped the engine shim.

## QA

- `nx affected -t build` — green (19 projects).
- In any Storybook, toggle the baseline overlay: bands are 4px, not 8px.

### PR readiness check

- [x] Label: `Feature 🎁`
- [x] Conventional-commit title
- [x] Follows code standards (tokens/calc-of-tokens; scoped)
- [x] Packages define `check` / `test` (styles packages unchanged in that respect)
- [ ] No new package
- [x] `no visual change` — NOT applicable: the 4px grid is the visual change

## Screenshots

The overlay bands halve from 8px to 4px; captured in the density example stories in PR3.
