### PR TITLE
feat(density): density model + 2×3 form-channel matrix, prose partition, guides

### DIFF
--- a/packages/react/ds-global-form/src/density.css
+++ b/packages/react/ds-global-form/src/density.css
@@ -1,0 +1,349 @@
+/* @canonical/react-ds-global-form — density & baseline alignment
+ *
+ * Two composed modifier families that size controls and seat their text on the
+ * 4px baseline grid. Applied as classes on an ancestor (e.g. the app root, or the
+ * Storybook root via the DS-utils toolbar):
+ *
+ *   CONTEXT  .app / .site / .docs  — the surface. Sets the comfortable/dense
+ *            control height PAIR. Default (no class) = apps.
+ *   DENSITY  .comfortable / .dense — picks within the context pair. Default
+ *            (no class) = comfortable.
+ *
+ * Control height (a whole 4px multiple), context × density:
+ *                comfortable   dense
+ *     apps          32px        24px
+ *     sites/docs    36px        28px
+ *
+ * The text baseline sits round(up, height × 2/3) baselines down the box, so every
+ * control — button, input, and inline text — shares one baseline. Zero-JS
+ * (cap-unit approximation); alignment holds to the cap tolerance (~±1px).
+ */
+
+/* ── Context family: the comfortable/dense PAIR per surface ──────────────────
+ * The density model is a 2×3 matrix — density (comfortable/dense) × context (app /
+ * site / docs), where DOCS = SITE (they share a pair). Context sets the pair for
+ * every DENSITY primitive (control height, inline padding, and three neutral
+ * vertical spacing rungs sm/md/lg); density (below) picks within it. Sites/docs
+ * run one baseline looser than apps on the height (+4px) and each rung, so the
+ * looser surface breathes. Every value is a WHOLE baseline multiple, so vertical
+ * rhythm holds in all four cells.
+ *
+ * LAYERING: this file is the LOWER layer. It exposes only GENERIC, domain-neutral
+ * primitives (--density-*) — a line-height, an inline padding, and a three-rung
+ * vertical spacing scale (--density-space-sm/-md/-lg). It knows NOTHING about the
+ * form or its fields. The FORM layer (index.css) maps its own --form-field-*
+ * tokens onto these rungs. Never name a field concept here.
+ *
+ *                    app                 site / docs
+ *                    comfy   dense       comfy   dense
+ *   line-height      32 (8)  24 (6)      36 (9)  28 (7)
+ *   padding-inline   16 (4)   8 (2)      16 (4)  12 (3)
+ *   space-lg         24 (6)  16 (4)      28 (7)  20 (5)
+ *   space-md         16 (4)   8 (2)      20 (5)  12 (3)
+ *   space-sm          8 (2)   4 (1)       8 (2)   8 (2)
+ *   (parenthesised = baseline units; 1 bU = --baseline-height = 4px)
+ */
+.app {
+  --lh-comfy: calc(var(--baseline-height) * 8); /* 32px */
+  --lh-dense: calc(var(--baseline-height) * 6); /* 24px */
+  --pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --pad-inline-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --space-lg-comfy: calc(var(--baseline-height) * 6); /* 24px */
+  --space-lg-dense: calc(var(--baseline-height) * 4); /* 16px */
+  --space-md-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --space-sm-dense: calc(var(--baseline-height) * 1); /*  4px */
+}
+.site,
+.docs {
+  --lh-comfy: calc(var(--baseline-height) * 9); /* 36px */
+  --lh-dense: calc(var(--baseline-height) * 7); /* 28px */
+  --pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --pad-inline-dense: calc(var(--baseline-height) * 3); /* 12px */
+  --space-lg-comfy: calc(var(--baseline-height) * 7); /* 28px */
+  --space-lg-dense: calc(var(--baseline-height) * 5); /* 20px */
+  --space-md-comfy: calc(var(--baseline-height) * 5); /* 20px */
+  --space-md-dense: calc(var(--baseline-height) * 3); /* 12px */
+  --space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --space-sm-dense: calc(var(--baseline-height) * 2); /*  8px */
+}
+
+/* ── Density family: pick within the context pair ────────────────────────────
+ * Each density tier resolves every GENERIC primitive from the context's
+ * *-comfy / *-dense pair. Fallbacks cover the app-comfortable defaults when no
+ * context class is present (a plain `.comfortable` still works). Output is the
+ * neutral --density-* surface the form layer consumes — no field names here. */
+.comfortable {
+  --density-line-height: var(--lh-comfy, calc(var(--baseline-height) * 8));
+  --density-padding-inline: var(
+    --pad-inline-comfy,
+    calc(var(--baseline-height) * 4)
+  );
+  --density-space-lg: var(--space-lg-comfy, calc(var(--baseline-height) * 6));
+  --density-space-md: var(--space-md-comfy, calc(var(--baseline-height) * 4));
+  --density-space-sm: var(--space-sm-comfy, calc(var(--baseline-height) * 2));
+}
+.dense {
+  --density-line-height: var(--lh-dense, calc(var(--baseline-height) * 6));
+  --density-padding-inline: var(
+    --pad-inline-dense,
+    calc(var(--baseline-height) * 2)
+  );
+  --density-space-lg: var(--space-lg-dense, calc(var(--baseline-height) * 4));
+  --density-space-md: var(--space-md-dense, calc(var(--baseline-height) * 2));
+  --density-space-sm: var(--space-sm-dense, calc(var(--baseline-height) * 1));
+}
+
+/* ── Target baseline = round(up, height × 2/3) ──────────────────────────────
+ * Snapped UP so fractional cases lift (apps-comfy 5.33→6) while exact multiples
+ * stay (apps-dense 4.0, sites-comfy 6.0). Matches: apps 32→6th/24→4th,
+ * sites 36→6th/28→5th. */
+:where(.comfortable, .dense, .app, .site, .docs) {
+  /* Effective line-height with the SAME fallback chain the control box uses
+     (--density-line-height → context --lh-comfy → apps-comfy literal). Without
+     this fallback, a bare context class (.app/.site/.docs applied with no density
+     class — the documented "no class = comfortable" case) leaves
+     --density-line-height unset, the round(calc(var(--density-line-height)…))
+     becomes invalid, the target resolves to 0, and controls lose their seating. */
+  --density-line-height-effective: var(
+    --density-line-height,
+    var(--lh-comfy, calc(var(--baseline-height) * 8))
+  );
+  --density-target-baseline-px: round(
+    up,
+    calc(var(--density-line-height-effective) * 2 / 3),
+    var(--baseline-height)
+  );
+}
+
+/* The FORM layer's mapping of these generic --density-* primitives onto its own
+ * --form-field-* tokens lives in index.css (the form owns that knowledge, not the
+ * density layer). This file stops at exposing the primitives. */
+
+/* ── Controls consume the density box ───────────────────────────────────────
+ * A control is a FIXED grid-multiple height with border-box so its border is
+ * absorbed into that height (not added past it) — so a bordered and a borderless
+ * control of the same density are the same height. Top-referenced so the
+ * space-before below (not flex centre/stretch) governs the text.
+ *
+ * Controls no longer carry `.p` — the density system supplies the body font tier
+ * (font-size / weight / family) here, and the baseline placement below. */
+/* `:is()` on the density scope (0,1,0) so `:is(...) .ds.button` (0,2,0) beats the
+ * Button's own `.ds.button { align-items: center }` (0,1,0) — otherwise the label
+ * stays flex-CENTRED and the padding-based baseline placement can't govern. */
+/* NB `.ds.input.textarea` is EXCLUDED: a textarea is a multi-line control whose
+ * height is intrinsic (its `min-height: 5lh`), not a single density line — the
+ * single-line crush below would flatten it. It gets its own placement further
+ * down (grid-multiple line-height so every row sits on the grid). */
+:is(.comfortable, .dense, .app, .site, .docs)
+  :is(.ds.button, .ds.input:not(.textarea)) {
+  box-sizing: border-box;
+  /* Same effective line-height the target-baseline uses (single source of the
+     fallback chain), so a bare context class keeps a valid box height too. */
+  --density-box-height: var(--density-line-height-effective);
+  block-size: var(--density-box-height);
+  min-block-size: var(--density-box-height);
+  align-items: flex-start;
+  justify-content: flex-start;
+  /* Kill the UA BOTTOM padding only. Do NOT zero padding-block-start here: this
+     selector is more specific (0,4,0) than the placement rule below (0,2,0), so a
+     `padding-block: 0` shorthand would out-specify and WIPE the placement's
+     `padding-block-start: var(--space-before)` — leaving the label pinned to the
+     box top (off the baseline). The placement rule owns the start. */
+  padding-block-end: 0;
+
+  /* Body font tier — what `.p` used to supply. */
+  font-size: var(--typography-text-primary-font-size);
+  font-family: var(--typography-text-primary-font-family);
+}
+
+/* The input WRAPPER is the box (like the button element): don't stretch its
+ * child, top-reference it so the input's own space-before governs. Needs to beat
+ * the TextInput's `.ds.input.text { align-items: stretch }` (0,3,0). */
+:is(.comfortable, .dense, .app, .site, .docs) .ds.input.text,
+:is(.comfortable, .dense, .app, .site, .docs) .ds.input {
+  align-items: flex-start;
+}
+
+/* The <input> is the text carrier — treat it exactly like the button label:
+ * same body font tier, and normalised so only the space-before (below) positions
+ * its text. (It's content-box with an intrinsic height, so reset that.) */
+:is(.comfortable, .dense, .app, .site, .docs) .ds.input > input {
+  box-sizing: border-box;
+  min-block-size: 0;
+  block-size: auto;
+  margin-block: 0;
+  font-size: var(--typography-text-primary-font-size);
+  font-family: var(--typography-text-primary-font-family);
+}
+
+/* ── Baseline placement: `.baseline` nudge + `--space-before` ───────────────
+ * Two parts, the combination that put controls ON the grid:
+ *
+ *  1. NUDGE (the DS.01 `.baseline` mechanism): --bl-start-nudge snaps the text's
+ *     first baseline onto the NEAREST grid line, computed from the element's own
+ *     font (1cap + line-height) — font-relative, so it's exact at any size and
+ *     needs no per-element fudge. This is what lands text exactly on a line.
+ *
+ *  2. --space-before: whole baselines added to move that snapped baseline DOWN to
+ *     the density TARGET line (round-up of the remaining distance), less the box's
+ *     own top border.
+ *
+ *     padding-block-start = bl-start-nudge + space-before − border-top
+ *     space-before = round(up, target − bl-start-nudge − border-top, baseline)
+ *
+ * Applies to the button, the input, and the field label/description/error — i.e.
+ * CONTROL-like text only. Bare prose (p / .p / h1–h6) is DELIBERATELY NOT here:
+ * running text belongs to the typography engine, which already seats it on the
+ * grid (snapped --computed-line-height + --start/--end-nudge) and lets `.editorial`
+ * add its inter-block margins. Density crushing prose to line-height:1 fought that
+ * engine (and only ever put the FIRST line on-grid — wrapped lines drifted). By
+ * partitioning prose OUT, density and the engine write to disjoint element sets,
+ * so `.editorial` composes with density with no specificity war. `:is()` (not
+ * `:where()`) still gives the control seat the specificity to beat a control's own
+ * centring (e.g. the Button's `align-items: center`). */
+/* Body font tier for the field label/description/error, which lost `.p`. Scoped
+   to just these (NOT the headings, which keep their own tier). */
+:is(.comfortable, .dense, .app, .site, .docs)
+  :is(.ds.field-label, .ds.field-description, .ds.field-error) {
+  font-size: var(--typography-text-primary-font-size);
+  font-family: var(--typography-text-primary-font-family);
+}
+
+:is(.comfortable, .dense, .app, .site, .docs) .ds.button,
+:is(.comfortable, .dense, .app, .site, .docs) .ds.input > input,
+:is(.comfortable, .dense, .app, .site, .docs)
+  :is(.ds.field-label, .ds.field-description, .ds.field-error) {
+  line-height: 1;
+  /* Baseline within a line-height:1 box (font-relative cap approximation). */
+  --natural-baseline: calc((1em + 1cap) / 2);
+  /* Pad the top so the baseline lands at the density target, less the box's own
+     top border. */
+  --space-before: max(
+    0px,
+    calc(
+      var(--density-target-baseline-px, 0px) -
+      var(--natural-baseline) -
+      var(--border-top-width, 0px)
+    )
+  );
+  padding-block-start: var(--space-before);
+  padding-block-end: 0;
+}
+
+/* ── Textarea: a multi-line control on the grid ──────────────────────────────
+ * Unlike the single-line input, a textarea has MANY text rows, so it needs a
+ * line-height that is itself a whole baseline multiple — then EVERY row sits on
+ * a grid line, not just the first. It's excluded from the single-line box crush
+ * (keeps its intrinsic `5lh` height) and from the `line-height: 1` placement
+ * above; here it gets its own placement:
+ *   · line-height = the density line-height (a whole baseline multiple), so rows
+ *     advance one grid interval each.
+ *   · the FIRST row is seated on the density target the same way as everything
+ *     else: nudge onto the nearest grid line, then space-before to the target,
+ *     less the border (0 — border is on the chrome box) and the drift knob.
+ * The chrome supplies the box's own block padding; we ADD the seating on top. */
+:is(.comfortable, .dense, .app, .site, .docs) .ds.input.textarea {
+  --td-line-height: var(
+    --density-line-height,
+    var(--lh-comfy, calc(var(--baseline-height) * 8))
+  );
+  line-height: var(--td-line-height);
+  font-size: var(--typography-text-primary-font-size);
+  font-family: var(--typography-text-primary-font-family);
+
+  /* Same form-control drift as the single-line input (see the knob's KLAXON note
+     below). Set locally so this stays self-contained — the button path is never
+     touched. */
+  --control-text-drift-AVOID-USAGE: 2px;
+  /* First row's baseline within its own line-box, then lift to the target. */
+  --natural-baseline: calc((var(--td-line-height) + 1cap) / 2);
+  /* Unlike the single-line input (a borderless inner <input> inside a bordered
+     wrapper), the textarea IS the chrome: it carries `.ds.input.chrome`, whose
+     top border-width occupies layout space above the text even when the top
+     border colour is transparent. So subtract that top border — exactly as the
+     button subtracts its own — or the first row seats ~1px low versus the
+     button/input target. */
+  --td-border-top: var(
+    --form-input-border-width-top,
+    var(--form-input-border-width, 0px)
+  );
+  --td-space-before: max(
+    0px,
+    calc(
+      var(--density-target-baseline-px, 0px) -
+      var(--natural-baseline) -
+      var(--td-border-top) -
+      var(--control-text-drift-AVOID-USAGE, 0px)
+    )
+  );
+  /* Seat the first row ON TOP OF the chrome's block padding (don't replace it —
+     that padding is the box inset; this is the grid seating). */
+  padding-block-start: calc(
+    var(--form-input-padding-block, 0px) +
+    var(--td-space-before)
+  );
+}
+
+/* ── Bottom rhythm: density-seated flow text only (NOT prose) ─────────────────
+ * A BORDERED control (button, input wrapper) has a fixed `block-size` that is
+ * already a whole baseline multiple, so its bottom rhythm is the box height —
+ * no bottom padding needed (and it would be inert against the fixed height).
+ *
+ * The field label/description/error are density-seated with line-height:1, so
+ * their box ends at the text descender; with `padding-block-end: 0` a following
+ * grid/flow sibling (e.g. the textarea below a field label) resumes off-grid.
+ * Fill the box out to a whole density line-height so its bottom lands on a grid
+ * line. The `- 1em` term is correct precisely because these are line-height:1.
+ *
+ * Bare prose (p / .p / h1–h6) is NOT here: it is no longer density-seated (see the
+ * partition above), so its box is its OWN snapped line-height and the engine's
+ * --end-nudge already lands its bottom on the grid. Adding a density fill on top
+ * would double-pad. Prose bottom rhythm belongs to the engine / `.editorial`. */
+:is(.comfortable, .dense, .app, .site, .docs)
+  :is(.ds.field-label, .ds.field-description, .ds.field-error) {
+  padding-block-end: max(
+    0px,
+    calc(
+      var(
+        --density-line-height,
+        var(--lh-comfy, calc(var(--baseline-height) * 8))
+      ) -
+      var(--space-before) -
+      1em
+    )
+  );
+}
+
+/* The box's top border sits above the content and counts toward the target, so
+ * subtract it once. The NOMINAL --button-border-width (1px) is what put the button
+ * ON the baseline — subtract it for BOTH importances. The primary's 0-outline
+ * (borderless) is handled by the grid maths, NOT by zeroing this term: switching
+ * to `calc(--modifier-outline × width)` lifts the primary a pixel and breaks the
+ * alignment (regression found & reverted). Leave the nominal term alone. */
+:where(.comfortable, .dense, .app, .site, .docs) .ds.button {
+  --border-top-width: var(--button-border-width, 0px);
+}
+
+/* ── --control-text-drift-AVOID-USAGE — the one honest patch ──────────────────
+ * A native form control (<input>, <textarea>) renders its text a couple of px
+ * LOWER than a <span>/<button> label at byte-identical CSS — a UA metrics quirk
+ * of editable controls, NOT a border and NOT captured by the cap-unit maths. The
+ * cap approximation is exact for real text runs but optimistic for a form
+ * control's internal text box, so the leaf needs a small lift to share the grid
+ * line with the button/label.
+ *
+ * The name is a deliberate KLAXON: this is empirical (calibrated by eye, may vary
+ * by browser/font), never a knob to reach for in app code. 🔴 TODO(#15): find the
+ * structural cause (line-box rounding? UA control metrics?) and delete it.
+ *
+ * It feeds the SAME `--border-top-width` term the shared placement formula reads
+ * (a larger subtraction ⇒ less space-before ⇒ text lifts UP). Doing it this way —
+ * rather than adding a separate term to the shared formula — keeps the BUTTON's
+ * placement byte-identical to its known-good state: the button never sets this
+ * knob, so its `--border-top-width` stays the pure border calc above. */
+:where(.comfortable, .dense, .app, .site, .docs) .ds.input > input {
+  --control-text-drift-AVOID-USAGE: 2px;
+  --border-top-width: var(--control-text-drift-AVOID-USAGE);
+}

--- a/packages/react/ds-global-form/src/docs/BaselineGrid.mdx
+++ b/packages/react/ds-global-form/src/docs/BaselineGrid.mdx
@@ -1,0 +1,202 @@
+import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+import * as Examples from "./examples/DensityExamples.stories";
+
+<Meta title="Documentation/Guides/The Baseline Grid" />
+
+# The Baseline Grid
+
+Every piece of text in the form system seats itself on a shared 4px baseline
+grid. A control's label, an input's value, and a paragraph of running prose all
+land their baselines on the same set of horizontal lines, so a form reads as one
+continuous rhythm rather than a stack of independently-spaced boxes. This guide
+explains what the grid is, how text is placed on it, and why the placement holds
+at any font size without per-element tuning.
+
+For how to _apply_ densities and drive the form's spacing from them, see
+[Density & the Form Channel](?path=/docs/documentation-guides-density--docs).
+
+## The grid unit
+
+The grid is defined by a single custom property, `--baseline-height`, which the
+typography engine sets to **4px** (`0.25rem`). Everything vertical is expressed
+as a whole multiple of this unit — a control height, a gap between fields, the
+padding that seats a line of text. Because the unit is a variable, the whole
+system re-flows if it changes; nothing hard-codes `4px`.
+
+Throughout this documentation, spacing is quoted in **baseline units** (bU): 1 bU
+= `--baseline-height` = 4px. A 32px control is "8 bU"; a 24px gap is "6 bU".
+
+## How a line of text seats on the grid
+
+A font does not place its baseline at the top or bottom of its line box — it sits
+some fraction of the way down, determined by the font's metrics. To land that
+baseline on a grid line, the system adds a calculated top padding.
+
+The distance from the top of a `line-height: 1` box to the text baseline is
+approximated, font-relatively, as:
+
+```css
+--natural-baseline: calc((1em + 1cap) / 2);
+```
+
+`1cap` is the cap height of the current font, `1em` its size. The average of the
+two is a close, size-independent stand-in for where the alphabetic baseline sits
+— no magic pixel constant, and correct at any font size because both terms scale
+with the font. That size-independence is the entire reason for the cap-unit form:
+a naive implementation would hard-code a pixel offset per font size and break the
+moment the size changed; this expression tracks the font automatically.
+
+The text is then seated on a chosen grid line — the **target baseline** — by
+padding the top with the remaining distance:
+
+```css
+--space-before: max(0px, calc(target − --natural-baseline − border-top));
+padding-block-start: var(--space-before);
+```
+
+The result: the first baseline lands exactly on `target`, which is always a whole
+baseline multiple, so the text is on the grid.
+
+## A worked example
+
+Take **apps-comfortable**, the default cell. Its control height is a whole
+baseline multiple:
+
+```
+control-height = --baseline-height × 8 = 32px   (8 bU)
+```
+
+The density model seats a control's single baseline on its **target line**, which
+is two-thirds of the box height, rounded _up_ to the next baseline:
+
+```
+target = round(up, control-height × 2/3, --baseline-height)
+       = round(up, 32 × 2/3, 4)
+       = round(up, 21.33px, 4)
+       = 24px                                    (6 bU)
+```
+
+Rounding up is deliberate — a fractional case such as this one (21.33) lifts to
+the next whole line (24), while an already-exact case stays put (apps-dense's
+`24 × 2/3 = 16` is exact, so it stays on the 4th baseline).
+
+Now seat a 14px label into that box. With a cap height of roughly 10px for the
+body face:
+
+```
+natural-baseline = (1em + 1cap) / 2 = (14 + 10) / 2 = 12px
+space-before     = max(0px, 24 − 12 − border-top)
+```
+
+For a borderless label (`border-top = 0`) that is `24 − 12 = 12px` of top
+padding, and the baseline lands exactly on the 6th grid line. Change the font
+size and both terms move together, so the arithmetic still lands on `24px` — the
+target never has to be re-tuned per size.
+
+The stories below force the baseline overlay on, so this seating can be read
+directly: the label's baseline and the input's baseline both rest on the same
+pink band boundary.
+
+<Canvas of={Examples.ButtonAndInput} />
+
+## The whole-multiple invariant
+
+The single rule that keeps _multi-line_ content on the grid:
+
+> A line-height that must stay on the grid has to be a whole multiple of
+> `--baseline-height`.
+
+The first line seats on the grid via `--space-before` (above). Each subsequent
+line advances by exactly one `line-height`. So every wrapped line lands on a grid
+line **if and only if** the line-height is itself a whole baseline multiple. A
+single-line control can use any line-height (only its first baseline matters); a
+paragraph or a textarea cannot — its line-height must be snapped to the grid.
+
+The typography engine already guarantees this for prose: it computes each tier's
+line-height as `round(up, font-size × ratio, --baseline-height)`, a snapped
+value. A `1rem × 1.5` body line snaps to `24px` — exactly 6 bU — so running text
+stays on the grid line after line. This is also why the textarea, alone among the
+form controls, takes the density line-height (a whole multiple) rather than the
+`line-height: 1` crush: it has many rows, and every row must land on a grid line,
+not just the first.
+
+## Two ways text reaches the grid
+
+The system seats text through two distinct mechanisms, applied to two disjoint
+sets of elements. Knowing which owns a given element is the key to the whole
+model.
+
+- **Controls** — a button label, an input's text, a field label / description /
+  error. These are seated by the **density model**: crushed to `line-height: 1`,
+  then padded so their single baseline lands on the density _target_ line
+  (`round(up, height × 2/3, baseline)`, as worked above). This is what makes a
+  32px button's label and a 32px input's value share one line.
+
+- **Running prose** — bare `p`, `h1`–`h6`, and anything in an `.editorial`
+  context. These are seated by the **typography engine**: each keeps its tier's
+  snapped natural line-height and is nudged onto the _nearest_ grid line (via the
+  engine's `--start-nudge` / `--end-nudge`), so multi-line reading rhythm is
+  preserved and every wrapped line stays on-grid.
+
+The two never fight over the same element. Density seats controls; the engine
+seats prose. Because they write to **disjoint** element sets, there is no
+specificity war between them — a point returned to below. A paragraph placed next
+to a control will sit on _a_ grid line, but not necessarily the control's target
+line — controls and prose answer to different seating rules by design.
+
+## The seat is computed against the box, not the border
+
+The target baseline is measured from the top of the **control box**, and the box
+is `border-box` sized: a control's border is absorbed into its fixed height, not
+added past it. So a bordered and a borderless control of the same density are the
+same height, and their text seats on the same line.
+
+The border only enters the placement as the `border-top` term subtracted in
+`--space-before` — it accounts for the border occupying part of the space above
+the text, nothing more. A borderless primary button (`border-top = 0`) and a
+bordered secondary (a 1px top border) therefore share one baseline: the secondary
+simply contributes 1px of border where the primary contributes 1px more padding.
+The example below places the two side by side against the overlay.
+
+<Canvas of={Examples.BorderlessAndBordered} />
+
+## Why not just set `line-height: 1` everywhere?
+
+Crushing everything to `line-height: 1` seats the _first_ line of any element on
+the grid, which is why an earlier iteration did exactly that. But it breaks
+running prose two ways: it removes the leading that makes multi-line text
+readable, and — because a crushed line-height is not a whole baseline multiple —
+it lets every _wrapped_ line drift off the grid.
+
+The fix (call it "Stage A") was to **partition** the two mechanisms: density
+seats controls only, and the typography engine owns prose. Because the two now
+write to disjoint element sets, `.editorial` composes with density without a
+specificity war, and — since the engine snaps prose line-height to a whole
+baseline multiple — wrapped-prose drift is gone as well. The current model keeps
+`line-height: 1` only where it is safe (single-line controls) and hands prose to
+the engine.
+
+## An honest rough edge: control text drift
+
+The cap-unit maths is exact for a real text run such as a `<span>` or a button
+label, but native form controls are less obliging: an `<input>` or `<textarea>`
+renders its text roughly **2px lower** than a `<span>` at byte-identical CSS — a
+user-agent metrics quirk of editable controls, not a border and not something the
+cap approximation captures.
+
+To keep the input's value on the same grid line as the button's label, a small
+lift is applied through a knob deliberately named
+`--control-text-drift-AVOID-USAGE`. The name is a klaxon: the value is empirical
+(calibrated by eye, may vary by browser and font), it is set only on the input
+and textarea paths — never in app code, and never on the button — and it is
+tracked for a structural fix rather than treated as a permanent design lever. It
+is documented here honestly because the alignment depends on it.
+
+## The debug overlay
+
+The Storybook baseline overlay (the stepped pink bands) is driven by the same
+`--baseline-height`, so it always draws the real grid. Turn it on to read any
+element against the grid: a correctly-seated baseline sits on a band boundary.
+The overlay is a measuring tool only — it is never part of a shipped component.
+The example stories above enable it automatically, which is why their controls
+appear striped.

--- a/packages/react/ds-global-form/src/docs/Density.mdx
+++ b/packages/react/ds-global-form/src/docs/Density.mdx
@@ -1,0 +1,220 @@
+import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+import * as Examples from "./examples/DensityExamples.stories";
+
+<Meta title="Documentation/Guides/Density & the Form Channel" />
+
+# Density & the Form Channel
+
+Density controls how tightly a form is packed: the height of its controls, the
+padding inside them, and the gaps between fields. It is a small, composable
+model — two class families on an ancestor — that resolves to a set of generic
+spacing primitives, which the form then maps onto its own tokens. Everything it
+produces is a whole baseline multiple, so a denser form is still on the grid.
+
+For the underlying grid and how text seats on it, read
+[The Baseline Grid](?path=/docs/documentation-guides-the-baseline-grid--docs)
+first.
+
+## The 2×3 matrix
+
+Density is a matrix of two axes:
+
+- **Context** — `.app` / `.site` / `.docs` — the _surface_. `docs` shares its
+  values with `site`. A site or docs surface runs one baseline looser than an
+  app surface.
+- **Density** — `.comfortable` / `.dense` — the _tightness_ within a context.
+
+Apply one class from each axis on an ancestor (the app root, or the Storybook
+toolbar in this workspace). With no class, a form keeps its plain defaults.
+
+The matrix, in baseline units (1 bU = `--baseline-height` = 4px):
+
+```
+                   app                 site / docs
+                   comfy   dense       comfy   dense
+  line-height      32 (8)  24 (6)      36 (9)  28 (7)
+  padding-inline   16 (4)   8 (2)      16 (4)  12 (3)
+  space-lg         24 (6)  16 (4)      28 (7)  20 (5)   ← between fields
+  space-md         16 (4)   8 (2)      20 (5)  12 (3)   ← label → control
+  space-sm          8 (2)   4 (1)       8 (2)   8 (2)   ← desc/error → input
+```
+
+Context sets the `*-comfy` / `*-dense` pair for every value; density picks within
+it. Every cell is a whole baseline multiple, so vertical rhythm holds in all four
+combinations.
+
+### Reading one cell
+
+Take **site / dense**. The context is `.site`, so it runs one baseline looser
+than an app; the density is `.dense`, so it picks the `*-dense` half of each of
+the site's pairs. Read straight down that column:
+
+- **line-height** — 28px, so a control is a 7 bU box (`--baseline-height * 7`).
+- **padding-inline** — 12px = 3 bU of inline padding inside the control and on
+  the horizontal label↔input gap.
+- **space-lg** — 20px = 5 bU between one field and the next.
+- **space-md** — 12px = 3 bU from a field's label down to its control.
+- **space-sm** — 8px = 2 bU from a description or error across to the input.
+
+Compare that to **app / dense** one baseline tighter: the box is 24px (6 bU) and
+the inline padding drops to 8px (2 bU). The site column never goes below its 8px
+`space-sm` — a site stays a touch airier than an app even when dense.
+
+## How to apply density
+
+Density is two classes on an **ancestor**, not on each control. Put one context
+class and one density class on a wrapper and every control beneath it sizes and
+seats to that cell:
+
+```jsx
+// site / dense — a moderately loose surface, packed tight.
+<div className="site dense">
+  <Form>
+    <Field name="email" label="Email">
+      <TextInput name="email" />
+    </Field>
+    <Field name="role" label="Role">
+      <Select name="role" options={roles} />
+    </Field>
+    <Button importance="primary">Save</Button>
+  </Form>
+</div>
+```
+
+The wrapper carries `.site .dense`; the `Form`, `Field`s and `Button` inside it
+inherit the cell through the cascade. Swap the two classes on the wrapper and the
+whole form retunes — nothing on the controls changes. In this workspace the
+Storybook toolbar sets the two classes globally so an unwrapped story still has a
+cell; the examples below instead wrap each row in an explicit `.app .comfortable`
+(etc.) so they pin one named cell regardless of the toolbar.
+
+<Canvas of={Examples.AppsComfortableVsDense} />
+
+Comfortable is the 32px (8 bU) box; dense drops it to 24px (6 bU). The label text
+still lands on a grid line in both rows — the seat is computed against the box, so
+it holds as the height changes.
+
+## Context: one baseline looser
+
+The **context** axis is the surface, and its whole job is to run a site or docs
+surface one baseline looser than an app. At the same `.comfortable` density an app
+control is 32px (8 bU) and a site control is 36px (9 bU): the extra 4px is the one
+baseline of headroom that makes a marketing or docs surface breathe. Every rung
+below the height lifts to match, so the looser surface is looser everywhere, not
+just taller.
+
+<Canvas of={Examples.AppsVsSites} />
+
+## How density flows to the form
+
+The model is layered so each layer knows only about the one below it:
+
+1. **Context classes** set raw pairs — `--lh-comfy` / `--lh-dense`,
+   `--pad-inline-comfy` / `--pad-inline-dense`, and the three vertical rungs
+   `--space-{sm,md,lg}-comfy` / `-dense`.
+2. **Density classes** pick within each pair and expose _generic, domain-neutral_
+   primitives: `--density-line-height`, `--density-padding-inline`, and
+   `--density-space-{sm,md,lg}`. This layer knows nothing about "form" or
+   "field".
+3. **The form** maps its own tokens onto those primitives — this is the only
+   place a field concept meets a density value:
+
+```css
+--form-input-padding-inline: var(--density-padding-inline);   /* inline */
+--form-field-inline-gap:     var(--density-padding-inline);   /* inline */
+--form-field-block-gap:      var(--density-space-lg);         /* between fields   */
+--form-field-label-gap:      var(--density-space-md);         /* label → control  */
+--form-group-gap:            var(--density-space-sm);         /* desc/error → input */
+```
+
+### Why the layering direction matters
+
+Density is the lower layer and must **never** reference a `--form-*` token; the
+form reaches _down_ to density, never the reverse. This is not a style
+preference — it is what keeps density reusable and keeps the two layers from
+deadlocking.
+
+Concretely, imagine the arrow reversed: the density layer setting
+`--density-space-lg: var(--form-field-block-gap)`. Now density is defined in terms
+of a form concept, so density can no longer size anything that is not a form —
+and the form maps `--form-field-block-gap` back onto `--density-space-lg`, so the
+two tokens each resolve to the other and the value collapses to nothing. Keeping
+density domain-neutral (it only ever emits `--density-*` primitives) means the
+same layer can one day seat a toolbar, a list row or an Accordion header with no
+form in sight. If a new density-driven spacing is needed, add a primitive to the
+density layer and map it in the form — do not reach upward from density.
+
+## Gaps are split by axis
+
+The form's gap tokens are separated by direction so a density tier can tune each
+axis independently, and so a token's name never lies about its axis:
+
+- **Block (vertical):** `--form-field-block-gap`, `--form-field-label-gap`,
+  `--form-group-gap`.
+- **Inline (horizontal):** `--form-field-inline-gap`.
+
+`--form-field-inline-gap` is horizontal only. The vertical label-to-control gap
+is `--form-field-label-gap` — a dedicated block token, not the inline one.
+
+This split fixes a concrete trap. An earlier version had a single inline token
+doing double duty: it set the horizontal label↔input gap _and_ was borrowed as a
+vertical `row-gap` for the stacked label-over-control layout. So the moment that
+token was retuned to fix horizontal spacing, the vertical gap moved with it —
+one edit dragged both axes at once, and there was no way to nudge one without
+disturbing the other. Giving the vertical gap its own block token
+(`--form-field-label-gap`) means each axis is now tuned in isolation.
+
+## Control height
+
+A density control is a fixed grid-multiple box: `block-size` is the density
+line-height, with `box-sizing: border-box` so a bordered and a borderless control
+of the same density are the same height. The control is top-referenced, and its
+label is seated to the density _target_ baseline —
+`round(up, height × 2/3, --baseline-height)` — so text at any font size lands on
+the grid.
+
+<Canvas of={Examples.ButtonAndInput} />
+
+A borderless importance (e.g. a primary button) and a bordered one (a secondary)
+seat **identically**, because the seat is computed against the box, not the
+border. This was a subtle earlier bug: the placement formula subtracted the
+border only for bordered controls, so the borderless primary — with nothing to
+subtract — sat a pixel high against its bordered neighbour. The fix was to
+subtract a _nominal_ border width (`--button-border-width`, 1px) for **both**
+importances and let the grid maths absorb it; switching the borderless case to
+its real 0-width outline lifted it a pixel again (regression found and reverted).
+The nominal term stays.
+
+## Composition: density and running prose
+
+Density seats **controls**. It does not touch **running prose** — bare `p`,
+`h1`–`h6`, or anything in an `.editorial` context. Those keep their engine-owned
+snapped line-height and inter-block margins.
+
+This is the rule that lets a density scope and `.editorial` prose _nest_ without
+conflict — for example a density-sized header above an `.editorial` content
+panel (the future Accordion case). Because density and the typography engine
+write to disjoint element sets, there is no specificity war and no override: each
+system owns its own elements. An earlier attempt to have density crush prose to
+`line-height: 1` fought the engine and only ever landed the _first_ line on the
+grid — wrapped lines drifted. Partitioning prose out removed that fight entirely.
+
+Practically:
+
+- Put controls (buttons, inputs, field labels) inside a density scope — they size
+  and seat to the density.
+- Let running prose be plain `p` / `h*` or wrap it in `.editorial` — it keeps its
+  reading rhythm and stays on the grid, whether or not it sits inside a density
+  scope.
+- Do **not** try to make density seat a paragraph. If a text reference must line
+  up with controls (as the spike testbed does for its measuring lead), seat that
+  one element explicitly; do not change how prose ships.
+
+## Known rough edge
+
+Native form controls (`input`, `textarea`) render their text a couple of pixels
+lower than a `span` at identical CSS — a browser metrics quirk of editable
+controls, not captured by the cap approximation. The model lifts them with a
+single, deliberately-named knob, `--control-text-drift-AVOID-USAGE` (currently
+2px). The name is a warning: it is an empirical constant, may vary by browser and
+font, and is tracked for a structural fix. Never reach for it in application code.

--- a/packages/react/ds-global-form/src/docs/SeatingByElement.mdx
+++ b/packages/react/ds-global-form/src/docs/SeatingByElement.mdx
@@ -1,0 +1,200 @@
+import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+import * as Examples from "./examples/DensityExamples.stories";
+
+<Meta title="Documentation/Guides/Seating by Element Type" />
+
+# Seating by Element Type
+
+The baseline grid is one idea, but three kinds of element reach it by three
+different routes: **default text** (prose), **buttons**, and **inputs**. Each has a
+different box, different metrics, and a different set of things that had to be
+tried and discarded before it sat cleanly on the grid. This guide is the technical
+record of how each is seated, what was considered, and what was dropped — so the
+next person to touch the model knows which choices are load-bearing and which were
+dead ends.
+
+Read [The Baseline Grid](?path=/docs/documentation-guides-the-baseline-grid--docs)
+and [Density & the Form Channel](?path=/docs/documentation-guides-density--docs)
+first; this guide assumes the seating formula and the density matrix.
+
+## The one rule that governs all three
+
+Every element is seated by the same two-part expression:
+
+```css
+--natural-baseline: calc((1em + 1cap) / 2);   /* baseline offset in a lh:1 box */
+--space-before: max(0px, calc(target − --natural-baseline − border-top));
+padding-block-start: var(--space-before);
+```
+
+The three element types differ only in **what plays the part of `target`,
+`border-top`, and the box** — and in one case, whether this expression governs at
+all. Everything below is a variation on this.
+
+---
+
+## Default text and prose
+
+**Route: the typography engine, not the density model.**
+
+Bare `p`, `.p`, and `h1`–`h6` — and anything inside an `.editorial` context — are
+**not** seated by the density system at all. They are left to the typography
+engine, which gives each tier a line-height snapped to the grid
+(`round(up, font-size × ratio, --baseline-height)`) and nudges the first line onto
+the nearest grid line. Because the snapped line-height is a whole baseline
+multiple, every wrapped line stays on the grid too.
+
+### What was considered and dropped
+
+An earlier iteration seated **everything** — prose included — by crushing it to
+`line-height: 1` and running the density formula on it. It was dropped for two
+reasons, both instructive:
+
+- **Readability.** Crushing prose to `line-height: 1` removes the leading that
+  makes multi-line text readable. Body copy became a dense slab.
+- **Wrapped-line drift.** A crushed line-height is **not** a whole baseline
+  multiple, so only the *first* line of a paragraph landed on the grid; every
+  wrapped line drifted. The crush that was meant to align text actually
+  mis-aligned all but the first line.
+
+The fix — internally called the *prose partition* — was to make the density
+selectors and the engine selectors **disjoint**: density seats controls, the
+engine seats prose. Two systems, two element sets, no overlap. The payoff beyond
+readability: because they never touch the same element, `.editorial` prose can
+nest inside a density scope (a density-sized header above an editorial content
+panel) with **no specificity war** — there is nothing to out-specify.
+
+The lesson worth carrying: _do not try to make the density model seat a
+paragraph._ If a single text reference needs to line up with controls (as the
+spike testbed's measuring lead does), seat that one element explicitly; do not
+reach for the global prose tags.
+
+---
+
+## Buttons
+
+**Route: the density box, seated against the box.**
+
+A button is a fixed grid-multiple box: its `block-size` is the density
+line-height, `box-sizing: border-box`, top-referenced (`align-items: flex-start`),
+and its label is the text run seated by the formula. `target` is the density
+target line, `round(up, height × 2/3, --baseline-height)`.
+
+<Canvas of={Examples.BorderlessAndBordered} />
+
+### The border term, and the bug that taught us how it works
+
+The subtle part of a button is the `border-top` term. A button's border and its
+label live on the **same element**, so a top border pushes the label down and must
+be subtracted from `--space-before`. The instinct was to subtract the button's
+*actual* rendered border:
+
+```css
+/* The tempting version — and the bug. */
+--border-top-width: calc(var(--modifier-outline, 0) * var(--button-border-width));
+```
+
+This looks correct — a borderless importance (`--modifier-outline: 0`) subtracts 0,
+a bordered one subtracts its 1px. But it made the **borderless primary button sit
+one pixel higher** than the bordered secondary beside it. The two no longer shared
+a baseline.
+
+The reason: the density `target` is measured from the top of the *box*, and the
+box is `border-box`, so the border is already absorbed into the fixed height. The
+label's seat should be computed **against the box, not against whether a border
+happens to render**. The version that works subtracts a **nominal** border for
+both importances and lets the grid maths place them identically:
+
+```css
+/* The version that ships. */
+--border-top-width: var(--button-border-width, 0px);   /* nominal, both importances */
+```
+
+So a borderless primary and a bordered secondary contribute the same amount to the
+seat: the secondary as 1px of real border, the primary as 1px more padding. They
+share the line. The `modifier-outline` version was reverted; the nominal term is
+load-bearing and should be left alone.
+
+### A related trap: the box padding shorthand
+
+The box rule sets the control height; the placement rule sets
+`padding-block-start`. When the box rule used the `padding-block: 0` **shorthand**,
+a specificity quirk let it out-specify the placement rule's `padding-block-start`
+and wipe the seat, pinning the label to the box top. The box rule now clears only
+`padding-block-end`; the placement rule owns the start. If a control's label ever
+jumps to the top of its box, this shorthand-vs-longhand interaction is the first
+thing to check.
+
+---
+
+## Inputs
+
+**Route: the chrome box is the density box; the text leaf is seated inside it.**
+
+An input is not one element but two: the **chrome** (the bordered box —
+`.ds.input.text` wrapper for a text input, or the `<textarea>`/`<select>` element
+itself) and the **text leaf** (the inner `<input>`, or the textarea's own text).
+The chrome is the density box (fixed height, border-box, border absorbed); the
+leaf is the text run seated inside it. So unlike the button, the input's
+`border-top` term is a **true 0** — the border lives on the chrome, not on the leaf
+that carries the text.
+
+<Canvas of={Examples.ButtonAndInput} />
+
+### The single-line input and the drift knob
+
+With the border accounted for by the chrome, a text input's inner `<input>` should
+seat exactly like a button label. It nearly does — but a native `<input>` renders
+its text roughly **2px lower** than a `<span>` at byte-identical CSS. This is a
+user-agent metrics quirk of editable controls, not a border and not something the
+cap approximation predicts.
+
+The considered options, and what was chosen:
+
+- **Rejected — fold it into the border term.** The first attempt expressed the 2px
+  as a fake `border-top-width` on the input. It worked but lied: the input has no
+  such border, and the number would not generalise to the textarea.
+- **Rejected — a metrics engine / text-box-trim.** A precise fix would measure the
+  control's actual text box. This was explicitly out of scope: the whole model is a
+  zero-JS cap approximation, and swapping the seating method for form controls
+  alone would fork it.
+- **Chosen — one honest, self-shaming knob.** The lift is applied through
+  `--control-text-drift-AVOID-USAGE` (currently 2px), set only on the input and
+  textarea paths. The name is the documentation: it is empirical, may vary by
+  browser and font, is never for app code, and is tracked for a structural fix. It
+  is a calibrated constant, deliberately quarantined, not a design lever.
+
+### The textarea: many rows, so the invariant bites
+
+A single-line input only has to seat its first baseline. A `<textarea>` has many
+rows, so the whole-multiple invariant applies: **every** row must land on a grid
+line, not just the first. That forces two departures from the single-line path:
+
+- It is **excluded from the single-line box crush** — it keeps its intrinsic
+  `min-height: 5lh` rather than being flattened to one density line.
+- It is seated with a **grid-multiple line-height** (the density line-height)
+  rather than `line-height: 1`, so each successive row advances by exactly one grid
+  interval. Its first row is placed on the density target on top of the chrome's
+  own block padding; the rest follow the grid for free.
+
+The textarea is where the generalised form of the seating formula first appeared —
+`(--seat-line-height + 1cap) / 2` instead of `(1em + 1cap) / 2` — because its
+line-height is not 1. That generalisation is the seed of a possible future unifying
+of all three routes under one formula, but it is deliberately not taken further
+yet: the single-line controls stay on the exact `1em` form so their pixel-tuned
+seating is not disturbed.
+
+---
+
+## Summary
+
+| Element | Box | `target` | `border-top` | Notable |
+| --- | --- | --- | --- | --- |
+| Prose / `.editorial` | — (engine-owned) | nearest grid line | — | Not density-seated; snapped line-height keeps every wrapped line on-grid |
+| Button | the button element | `round(up, h × 2/3)` | nominal `--button-border-width` (both importances) | Seat is against the box, not the rendered border |
+| Input (single-line) | chrome wrapper | `round(up, h × 2/3)` | 0 (border on the chrome) | `--control-text-drift-AVOID-USAGE` lifts the ~2px UA quirk |
+| Textarea | the element (chrome + leaf) | first row on target | 0 | Grid-multiple line-height so every row seats; generalised formula |
+
+The through-line: **seat against the box, keep the line-height a whole baseline
+multiple wherever more than one line matters, and give each element type only the
+compensation its own metrics genuinely need — no more.**

--- a/packages/react/ds-global-form/src/docs/examples/DensityExamples.stories.tsx
+++ b/packages/react/ds-global-form/src/docs/examples/DensityExamples.stories.tsx
@@ -1,0 +1,114 @@
+import { Button } from "@canonical/react-ds-global";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Label } from "../../lib/subcomponent/Field/Label/index.js";
+import { TextInput } from "../../lib/subcomponent/TextInput/index.js";
+import "./density-examples.css";
+
+/**
+ * Doc examples for the baseline / density guides. Every story turns the 4px
+ * baseline overlay ON by default (`parameters.baseline`), so a reader sees text
+ * seating on the grid without touching the toolbar. Each example wraps its
+ * controls in an explicit density scope (a `.<context> .<density>` class) so the
+ * story shows ONE named cell of the matrix, independent of the toolbar globals.
+ */
+const meta = {
+  title: "Documentation/Examples/Density",
+  tags: ["!autodocs"],
+  parameters: {
+    layout: "padded",
+    // Baseline overlay ON by default — the point of these examples.
+    baseline: true,
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A named density cell: applies `.<context>` + `.<density>` on a wrapper so the
+ *  controls inside size and seat to that exact cell of the matrix. */
+const Cell = ({
+  context = "app",
+  density = "comfortable",
+  children,
+}: {
+  context?: "app" | "site" | "docs";
+  density?: "comfortable" | "dense";
+  children: ReactNode;
+}) => (
+  <div className={`${context} ${density}`}>
+    <div className="density-example__row">{children}</div>
+  </div>
+);
+
+/**
+ * A button and an input side by side. Their text — the button label and the
+ * input value/placeholder — seat on the SAME baseline (a grid line of the
+ * overlay), because both are density-seated to the cell's target baseline.
+ */
+export const ButtonAndInput: Story = {
+  render: () => (
+    <Cell context="app" density="comfortable">
+      <Button importance="primary">Save</Button>
+      <Button importance="secondary">Cancel</Button>
+      <Label name="email">Email</Label>
+      <TextInput name="email" placeholder="you@example.com" />
+    </Cell>
+  ),
+};
+
+/**
+ * The same controls at both densities of the apps context. Comfortable is 32px
+ * (8 baseline units) tall, dense is 24px (6 bU). In both, the label text still
+ * lands on a grid line — the seat is computed against the box, so it holds as the
+ * height changes.
+ */
+export const AppsComfortableVsDense: Story = {
+  render: () => (
+    <div className="density-example__stack">
+      <Cell context="app" density="comfortable">
+        <Button importance="primary">Comfortable</Button>
+        <TextInput name="a" placeholder="32px tall" />
+      </Cell>
+      <Cell context="app" density="dense">
+        <Button importance="primary">Dense</Button>
+        <TextInput name="b" placeholder="24px tall" />
+      </Cell>
+    </div>
+  ),
+};
+
+/**
+ * Apps (32px) vs sites (36px) at the same comfortable density. A site surface
+ * runs one baseline looser, so its controls are taller — yet the text still seats
+ * on a grid line in each. Toggle the two rows against the overlay to see the
+ * shared rhythm at different heights.
+ */
+export const AppsVsSites: Story = {
+  render: () => (
+    <div className="density-example__stack">
+      <Cell context="app" density="comfortable">
+        <Button importance="primary">Apps</Button>
+        <TextInput name="c" placeholder="32px" />
+      </Cell>
+      <Cell context="site" density="comfortable">
+        <Button importance="primary">Sites</Button>
+        <TextInput name="d" placeholder="36px" />
+      </Cell>
+    </div>
+  ),
+};
+
+/**
+ * A borderless primary and a bordered secondary button. Their labels seat on the
+ * SAME baseline: the density seat is computed against the control box, not the
+ * border, so a borderless and a bordered control of the same density align.
+ */
+export const BorderlessAndBordered: Story = {
+  render: () => (
+    <Cell context="site" density="comfortable">
+      <Button importance="primary">Primary (no border)</Button>
+      <Button importance="secondary">Secondary (1px border)</Button>
+    </Cell>
+  ),
+};

--- a/packages/react/ds-global-form/src/docs/examples/density-examples.css
+++ b/packages/react/ds-global-form/src/docs/examples/density-examples.css
@@ -1,0 +1,20 @@
+/* Layout for the density/baseline doc examples. Minimal: an inline row of
+ * controls (so their baselines can be read against the overlay together) and a
+ * vertical stack for comparing two cells. No overrides that would shift text off
+ * the grid — the examples must show the real seating. */
+
+.density-example__row {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: flex-start; /* controls are top-referenced; the seat is internal */
+  gap: calc(var(--baseline-height, 0.25rem) * 3); /* 12px */
+  overflow-x: auto;
+}
+
+.density-example__stack {
+  display: flex;
+  flex-direction: column;
+  /* One field-block gap between the compared cells, so the stack itself stays on
+     the grid. */
+  gap: calc(var(--baseline-height, 0.25rem) * 6); /* 24px */
+}

--- a/packages/react/ds-global-form/src/index.css
+++ b/packages/react/ds-global-form/src/index.css
@@ -9,6 +9,9 @@
  *   inline = horizontal axis (inline-start = left in LTR, right in RTL)
  */
 
+/* Density & baseline alignment (context × density → control height + baseline). */
+@import url("./density.css");
+
 :root {
   /* ── Form grid layout ───────────────────────────────────────────── */
   /* Forms are subgrids: they inherit columns from a parent .grid      */
@@ -32,15 +35,22 @@
   /* ── Field layout spacing ───────────────────────────────────────── */
   /* Container-owned: the form/field wrapper controls all spacing.     */
 
+  /* Gaps are split by AXIS so no token spans both directions (a density tier can
+     then tune each axis independently, and the names stay honest):
+       BLOCK (vertical):  field-block-gap · field-label-gap · group-gap
+       INLINE (horizontal): field-inline-gap                                    */
   --form-field-block-gap: var(
     --container-gap-loose
-  ); /* 24px — block-direction (vertical) gap between fields */
-  --form-field-inline-gap: var(
+  ); /* 24px — block: gap BETWEEN fields */
+  --form-field-label-gap: var(
     --container-gap-default
-  ); /* 16px — inline-direction (horizontal) gap: label ↔ input */
+  ); /* 16px — block: gap from a field's LABEL down to its control */
   --form-group-gap: var(
     --space-100
-  ); /* 8px — block-direction gap: desc/error ↔ input */
+  ); /* 8px — block: gap from desc/error to the input */
+  --form-field-inline-gap: var(
+    --container-gap-default
+  ); /* 16px — inline: label↔input, prefix/suffix (HORIZONTAL only) */
 
   /* ── Input chrome ───────────────────────────────────────────────── */
   /* Component-owned: internal padding regardless of context.           */
@@ -134,6 +144,37 @@
   --form-focus-ring-color-error: var(--color-focusRing-error);
   /* --form-focus-ring-width:  … ; */ /* focus ring thickness (default: 1px via box-shadow) */
   /* --form-focus-ring-offset: … ; */ /* focus ring offset from border */
+}
+
+/* ── Density → form channel mapping ──────────────────────────────────────────
+ * The FORM layer decides which generic density primitive (density.css exposes
+ * --density-line-height, --density-padding-inline, and the neutral vertical rungs
+ * --density-space-sm/-md/-lg) each of its own tokens follows. Density knows
+ * nothing about "field"; this is where the form makes that choice.
+ *
+ * Scoped to the density classes so a plain form (no density class) keeps the
+ * :root defaults above. The var() fallbacks keep values sane if only a CONTEXT
+ * class (.app/.site/.docs) is present without a density class.
+ *
+ *   INLINE (horizontal): control padding + label↔input / prefix-suffix gap
+ *     → --density-padding-inline
+ *   BLOCK (vertical), by magnitude:
+ *     between-fields   → --density-space-lg   (widest structural gap)
+ *     label → control  → --density-space-md   (label to its own control)
+ *     desc/error → input → --density-space-sm (tight annotation gap)
+ *   All rungs are whole baseline multiples, so vertical rhythm holds. */
+:where(.comfortable, .dense, .app, .site, .docs) {
+  --form-input-padding-inline: var(--density-padding-inline, var(--space-200));
+  --form-field-inline-gap: var(--density-padding-inline, var(--space-200));
+  --form-field-block-gap: var(
+    --density-space-lg,
+    calc(var(--baseline-height) * 6)
+  );
+  --form-field-label-gap: var(
+    --density-space-md,
+    calc(var(--baseline-height) * 4)
+  );
+  --form-group-gap: var(--density-space-sm, calc(var(--baseline-height) * 2));
 }
 
 /* ── .ds.input.chrome — shared input chrome ─────────────────────────

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/DensityTestbed.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/DensityTestbed.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  BaselineProofLine,
+  BoxedProofLine,
+  ControlsLine,
+  EditorialLine,
+  ListsLine,
+  NavigationLine,
+  TypographyLine,
+} from "./Testbed.js";
+
+/**
+ * # Baseline-alignment spike (work in progress)
+ *
+ * Line-based spike surface. Each story is ONE bucket rendered on a single
+ * horizontal line: a few letters of paragraph text at the start (baseline
+ * reference), then the components inline. No cards, no labels — just alignment.
+ *
+ * The 4px baseline grid (strict stepped bands) is drawn by the styles-debug
+ * plugin, applied automatically via `parameters: { baseline: true }`. Every
+ * bucket renders the shipped engine model (no current ↔ proposed toggle — the
+ * alternative model was dropped); Typography is pure engine output at several
+ * sizes, and Editorial shows prose composing inside a density scope.
+ */
+const meta = {
+  title: "_work_in_progress/BaselineAlignmentSpike",
+  tags: ["!autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    baseline: true,
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Controls — buttons + inputs on one line. */
+export const Controls: Story = { render: () => <ControlsLine /> };
+
+/** Navigation — tab / side-nav items on one line. */
+export const Navigation: Story = { render: () => <NavigationLine /> };
+
+/** Lists — list/table rows (shared border) on one line. */
+export const Lists: Story = { render: () => <ListsLine /> };
+
+/** Typography — real paragraph text at several sizes; witness the 4px baseline. */
+export const Typography: Story = { render: () => <TypographyLine /> };
+
+/**
+ * Editorial — `.editorial` prose inside the density scope. Witnesses DS.04: prose
+ * keeps its engine-owned natural leading + inter-block margins and stays on-grid,
+ * while density seats controls. Toggle context/density — prose rhythm must not
+ * change, proving they compose instead of collide.
+ */
+export const Editorial: Story = { render: () => <EditorialLine /> };
+
+/**
+ * DS.01 — the size-agnostic `.baseline` class. Arbitrary off-scale font sizes,
+ * each snapped to the grid by `.baseline` alone (no tier). Proves the alignment
+ * machinery is decoupled from any particular font size.
+ */
+export const BaselineClass: Story = { render: () => <BaselineProofLine /> };
+
+/**
+ * DS.02 — `.spike-baseline-boxed` (prototype) fixed box. Dense (24px) and
+ * comfortable (32px) rows; within each, mixed sizes share a box height snapped to
+ * the grid (a fixed `block-size` plus `.baseline` line-height snapping), so the
+ * seated baselines line up regardless of font size.
+ */
+export const BoxedBaseline: Story = { render: () => <BoxedProofLine /> };

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/SPIKE.md
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/SPIKE.md
@@ -1,0 +1,198 @@
+# Baseline-alignment spike — findings
+
+Exploratory spike, not a production refactor. It covers two linked changes:
+
+1. Moving the baseline unit from **8px to 4px**.
+2. An alternative baseline-alignment model for **boxed controls** (buttons,
+   inputs, nav items, list/table rows) that stops forcing the bottom border onto
+   the grid.
+
+Everything is scoped to `_work_in_progress`; the only shared-package edits are
+the 4px default (in `styles`, not tokens) and the grid overlay (in
+`styles-debug`), both called out below.
+
+---
+
+## 1. What the shipped engine does today
+
+The typography engine (`@canonical/styles-typography`, default
+`baseline-cap.css`) snaps each text element's box to the grid with two padding
+nudges computed live in CSS:
+
+```
+--start-nudge = baseline − mod(baseline-position, baseline)   /* seat the text baseline */
+--end-nudge   = baseline − start-nudge                        /* fill to a whole grid multiple */
+
+padding-block-start: var(--start-nudge);
+padding-block-end:   var(--end-nudge);
+```
+
+Because `start-nudge + end-nudge = baseline`, the box height is always a whole
+number of baseline units **and both the top and bottom borders sit on the grid**.
+
+The cost: whenever `start-nudge ≠ end-nudge`, the interior is asymmetric — the
+text is nudged down from the top by one amount and up from the bottom by a
+different amount. On a control with a visible border and a fixed look (a 24px or
+32px button), that reads as the label sitting slightly high or low in its box.
+
+## 2. The proposed model
+
+Keep the top alignment; make the interior symmetric; move the leftover outside
+the box:
+
+```
+padding-block-start: var(--start-nudge);   /* unchanged — seat the baseline */
+padding-block-end:   var(--start-nudge);   /* MIRROR the top nudge, not end-nudge */
+
+/* the box is now NOT a whole grid multiple, so compensate outside it */
+--visible: calc(2*border + 2*start-nudge + line-height);
+margin-block-end: calc(round(up, var(--visible), var(--baseline-height)) − var(--visible));
+```
+
+- Top border stays on the grid.
+- Interior spacing above and below the text is equal → visually balanced.
+- Bottom border floats where it naturally lands.
+- External `margin-block-end` (0…<1 baseline) pads the *occupied* height back to
+  a 4px multiple, so downstream layout rhythm is preserved.
+
+Worked example (the brief's numbers): borders + top nudge + line-height + bottom
+nudge come to a 21px visible box → `margin-block-end: 3px` → 24px occupied.
+
+The alternative (top-align + external-margin) model was prototyped and then
+dropped: the testbed now renders the **shipped engine model only** (the asymmetric
+start/end nudges), with no `.model-current` / `.model-proposed` toggle. This
+section is kept as the record of what was considered and why the external-margin
+approach was not adopted (see §4).
+
+---
+
+## 3. Architectural & token changes required
+
+**Baseline unit (4px).** Set in `packages/styles/main/src/spacing.css`:
+`--space-baseline: 0.25rem`, no longer reading `--dimension-size-height-baseline`
+(which stays 8px). Promoting 4px into `@canonical/design-tokens` is a **separate
+tokens PR** — not done here on purpose. The engine reads `--baseline-height`
+live, so nothing else changed to move the grid.
+
+**Grid overlay (debug).** `packages/styles/debug/src/baseline-grid.css` now
+defaults to 4px and paints **alternating bands** (tinted 4px / clear 4px) plus a
+major line every 4th baseline, so the denser grid stays readable. Applied only
+via the plugin — the story opts in with `parameters: { baseline: true }` and
+`storybook-addon-utils` toggles `.with-baseline-grid`. (The addon was extended to
+honor that parameter, not just the toolbar global; its `dist` must be rebuilt for
+the change to take effect.)
+
+**The alignment model itself** would live in the engine
+(`baseline-cap.css` / `-metrics` / `-trim`), because that is where `start-nudge`
+/ `end-nudge` are defined. Concretely:
+
+- Add an opt-in mode (class or custom property, e.g. `.baseline-boxed` /
+  `--baseline-mode: boxed`) that swaps `padding-block-end` from `--end-nudge` to
+  `--start-nudge` and emits the compensating `margin-block-end`.
+- The engine currently reserves `margin-block-end` for `--space-after`
+  (editorial). The boxed mode has to **add to** that margin, not overwrite it:
+  `margin-block-end: calc(space-after-margin + compensation)`. This is the one
+  real coupling to untangle.
+- `round()` is already relied on elsewhere in the engine, so no new browser
+  floor.
+
+**Per-component.** Boxed controls (`Button`, form inputs, future Tabs/SideNav
+items, list/table rows) opt into the boxed mode on their outer element. Their
+own `padding-block` (where they set it) must be reconciled with the nudges so the
+two don't stack.
+
+---
+
+## 4. Risks introduced by external margin compensation
+
+- **Margin collapsing.** `margin-block-end` collapses with adjacent block
+  margins and through empty parents. In flex/grid containers margins don't
+  collapse (safe — that is where most controls live), but in plain block flow a
+  control's compensation can merge with a following sibling's top margin and the
+  rhythm silently shifts. The engine deliberately used *padding* to avoid exactly
+  this; the proposed model reintroduces the hazard by design.
+- **Last-child / container edges.** Trailing compensation adds phantom space at
+  the bottom of a container (extra gap under the last row of a table, below the
+  last field in a form). Needs a `:last-child` reset in boxed contexts —
+  analogous to the existing `.content-flow > :last-child { margin-bottom: 0 }`.
+- **`gap` double-counts.** In a flex/grid layout that already sets `gap`, each
+  item's external margin **adds to** the gap, so spacing between controls grows
+  by the compensation amount. Either the layout drops `gap` in favour of the
+  margins, or boxed controls suppress their margin when a gap owns the spacing.
+  (The testbed sets `gap: 0` on the control column precisely so the compensation
+  stays visible instead of being masked.)
+- **Backgrounds / borders / dividers.** The compensation is outside the box, so
+  a full-bleed row background or a shared list divider stops at the border, not
+  at the occupied edge — a 3px unpainted strip appears between rows. The
+  shared-border list case in the testbed is there to show this.
+- **Vertical centering.** Anything relying on the control's *box* being a grid
+  multiple to center it (icon next to label, absolutely-positioned affordances)
+  now centers against a non-grid box; the external margin doesn't participate.
+- **Sticky / scroll math.** Occupied height ≠ border-box height means
+  `scroll-margin`, sticky offsets and `IntersectionObserver` thresholds computed
+  from `getBoundingClientRect()` are off by the compensation.
+
+## 5. Where this model should NOT be used
+
+- **Inline text / prose.** Paragraphs and inline runs already balance naturally;
+  the whole point of the symmetric-interior model is boxed controls with a
+  visible border. Prose keeps the current engine (`.p`, headings unchanged).
+- **Controls whose height is externally fixed** (`height: 32px`, icon-only
+  square buttons). If the height is pinned, interior symmetry is governed by
+  `align-items`, not the nudges, and the external margin just adds stray space.
+- **Grid/flex items that must fill a track** (`align-items: stretch`, table cells
+  with row-spanning). Stretch overrides the box height and the compensation
+  margin is ignored or fights the track.
+- **Anything inside `gap`-based layouts** unless the gap-vs-margin
+  double-count is resolved for that container.
+- **Overlapping / absolutely positioned** elements — margin does nothing there.
+
+## 6. Recommended implementation strategy
+
+Ship it as an **opt-in engine mode**, defaulted off, so nothing changes until a
+component asks for it.
+
+1. **Engine flag.** Add `--baseline-mode: grid | boxed` (default `grid`). In
+   `boxed`, `padding-block-end` mirrors `--start-nudge` and the engine emits
+   `margin-block-end: calc(var(--space-after-margin) + var(--baseline-compensation))`.
+   Keep `grid` byte-for-byte as today.
+2. **Container reset.** Provide a `.baseline-boxed-flow` (or reuse
+   `content-flow`) that zeroes the trailing compensation on the last child and
+   documents the gap-vs-margin rule.
+3. **Adopt on one control first** (Button), verify against prose in the testbed
+   at several sizes, then inputs, then nav items, then list/table rows (the
+   shared-border case last, since it exposes the divider gap).
+4. **Only then** consider promoting 4px + a `density: boxed` token set into
+   `@canonical/design-tokens`.
+
+### Before / after
+
+```css
+/* BEFORE — grid mode (ships today): both borders on grid, interior can be asymmetric */
+.ds.button > .p {
+  padding-block-start: var(--start-nudge);   /* e.g. 3px */
+  padding-block-end:   var(--end-nudge);     /* e.g. 1px  → text sits high */
+}
+
+/* AFTER — boxed mode: symmetric interior, bottom border free, rhythm via margin */
+.ds.button {
+  --visible: calc(2px + calc(2 * var(--start-nudge)) + var(--computed-line-height));
+  margin-block-end: calc(
+    var(--space-after-margin, 0px) +
+    (round(up, var(--visible), var(--baseline-height)) - var(--visible))
+  );
+}
+.ds.button > .p {
+  padding-block-start: var(--start-nudge);   /* 3px */
+  padding-block-end:   var(--start-nudge);   /* 3px  → text balanced */
+}
+```
+
+### Caveat surfaced by the testbed
+
+At the default body size on a 4px grid, `start-nudge ≈ end-nudge`, so the two
+models render nearly identically — the asymmetry the model fixes only becomes
+visible at particular font-size / line-height / border combinations. Any adoption
+decision should be made against a size where the current asymmetry is actually
+visible, not the default paragraph tier. The testbed should grow a row at such a
+size before this is taken forward.

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/Testbed.tsx
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/Testbed.tsx
@@ -1,0 +1,176 @@
+import { Button } from "@canonical/react-ds-global";
+import type { ReactNode } from "react";
+import { Label } from "../../subcomponent/Field/Label/index.js";
+import { TextInput } from "../../subcomponent/TextInput/index.js";
+import { SpikeBox, SpikeRows } from "./mocks.js";
+import "./density.testbed.css";
+import "./baseline-system.css";
+
+/**
+ * Baseline-alignment spike harness (WORK IN PROGRESS)
+ *
+ * Line-based: each bucket renders as ONE horizontal line (its own story), with
+ * a few letters of paragraph-style text at the start (the baseline reference)
+ * followed by the components inline. No cards, no labels. The 4px baseline grid
+ * is supplied by the styles-debug plugin (story parameter).
+ */
+
+/**
+ * A bucket = a short prose prefix + the components, laid out inline with the
+ * NORMAL component structure (no flattening, no overrides) so what we see is what
+ * ships. `align-items: baseline` lines them up; nothing else is customised.
+ */
+const Line = ({ lead, children }: { lead: string; children: ReactNode }) => (
+  <div className="density-testbed">
+    <div className="density-testbed__row">
+      {/* The lead is a REFERENCE marker meant to sit on the controls' baseline.
+          Prose is no longer density-seated (Stage A: the engine owns running
+          text, seated to the NEAREST grid line — a different line from the
+          controls' density TARGET). So this testbed-only class re-seats the lead
+          to the density target, purely so the reference agrees with the controls
+          it is measuring against. Not a change to the shipping model. */}
+      <p className="p density-testbed__lead">{lead}</p>
+      {children}
+    </div>
+  </div>
+);
+
+/** Controls bucket — real Button + a standalone Label and TextInput (used
+ *  separately, so there's no stacked Field grid to flatten). */
+export const ControlsLine = () => (
+  <Line lead="Sample">
+    <Button importance="primary">Re</Button>
+    <Button importance="secondary">Se</Button>
+    <Label name="n">Label</Label>
+    <TextInput name="n" placeholder="In" />
+  </Line>
+);
+
+/** Navigation bucket — tab / side-nav item stand-ins on one line. */
+export const NavigationLine = () => (
+  <Line lead="Ov">
+    <SpikeBox>Ov</SpikeBox>
+    <SpikeBox>In</SpikeBox>
+    <SpikeBox>St</SpikeBox>
+    <SpikeBox>Ne</SpikeBox>
+  </Line>
+);
+
+/** Lists bucket — list/table rows (shared border) on one line. */
+export const ListsLine = () => (
+  <Line lead="Ro">
+    <SpikeRows rows={["n1", "n2", "n3"]} />
+  </Line>
+);
+
+const PROSE =
+  "The quick brown fox jumps over the lazy dog. Pack my box with five dozen " +
+  "liquor jugs, and watch how each line of real prose seats itself on the 4px " +
+  "baseline grid as the size changes.";
+
+/** The real typography tiers the engine styles — h1..h6 + p (mapper.css). No
+ *  custom size classes: each tag IS its tier. */
+const TIERS = ["h1", "h2", "h3", "h4", "h5", "h6", "p"] as const;
+
+/**
+ * Typography bucket — pure engine output, using the package's own tags (h1..h6,
+ * p). First an inline row of each tier side by side (to compare their baselines),
+ * then full stacked paragraphs of each tier (to witness how a real prose block
+ * of each tier sits on the 4px grid).
+ */
+export const TypographyLine = () => (
+  <div className="density-testbed">
+    <div className="density-testbed__type">
+      {TIERS.map((Tag) => (
+        <Tag key={Tag}>The quick brown fox</Tag>
+      ))}
+    </div>
+
+    <div className="density-testbed__prose">
+      {TIERS.map((Tag) => (
+        <Tag key={Tag}>{PROSE}</Tag>
+      ))}
+    </div>
+  </div>
+);
+
+const EDITORIAL_BODY =
+  "Running prose belongs to the typography engine, not the density system. Each " +
+  "line keeps its tier's snapped line-height, so every baseline lands on the 4px " +
+  "grid — and, unlike a line-height:1 crush, WRAPPED lines stay on the grid too.";
+
+/**
+ * Editorial bucket — a real `.editorial` prose document (mixed headings + body)
+ * rendered INSIDE the density scope the story toolbar applies. This witnesses the
+ * DS.04 composition: density seats controls, but leaves prose to the engine, so
+ * `.editorial` here keeps its natural multi-line leading, seats every line on the
+ * grid, AND gets its whole-baseline inter-block margins (--space-after) — with no
+ * density override fighting it. Flip context/density in the toolbar: the prose
+ * rhythm must NOT change (it is engine-owned), proving density and editorial
+ * compose rather than collide.
+ */
+export const EditorialLine = () => (
+  <div className="density-testbed">
+    <article className="editorial density-testbed__prose">
+      <h2>Editorial composes with density</h2>
+      <p>{EDITORIAL_BODY}</p>
+      <h3>Inter-block rhythm</h3>
+      <p>{PROSE}</p>
+      <p>
+        A second paragraph, so the `--space-after` margin between blocks is
+        visible: each block still opens and closes on a grid line.
+      </p>
+    </article>
+  </div>
+);
+
+/** Deliberately off-scale sizes — none is a tier. Each is only a `.baseline`
+ *  element with an inline font-size; if they all seat on the grid, `.baseline`
+ *  is genuinely size-agnostic (DS.01). */
+const OFF_SCALE = [19, 27, 35, 43, 53, 61];
+
+/**
+ * DS.01 proof — the size-agnostic `.baseline` class. A row of arbitrary,
+ * off-scale font sizes, each snapped to the 4px grid by `.baseline` alone (no
+ * tier, no engine size class). The tags h1..h6/p are untouched and still nudge
+ * by default — this is additive.
+ */
+export const BaselineProofLine = () => (
+  <div className="density-testbed">
+    <div className="baseline-proof">
+      {OFF_SCALE.map((px) => (
+        <span key={px} className="baseline" style={{ fontSize: `${px}px` }}>
+          {px}px
+        </span>
+      ))}
+    </div>
+  </div>
+);
+
+/** Mixed sizes in the density box, at both densities. Kept within what a dense
+ *  (24px) / comfortable (32px) line-height can hold without clipping. */
+const BOXED_SIZES = [16, 18, 20, 22];
+
+/**
+ * DS.02 proof — `.spike-baseline-boxed` (PROTOTYPE, not core API). Two density
+ * line-heights: dense (24px) and comfortable (32px). Each box snaps to the grid
+ * via the existing start/end nudge; top-referenced, so the boxes share the top
+ * rhythm (a fixed baseline-from-bottom is NOT what the existing calc produces).
+ */
+export const BoxedProofLine = () => (
+  <div className="density-testbed">
+    {(["is-dense", "is-comfortable"] as const).map((density) => (
+      <div key={density} className={`boxed-proof ${density}`}>
+        {BOXED_SIZES.map((px) => (
+          <span
+            key={px}
+            className="baseline spike-baseline-boxed"
+            style={{ fontSize: `${px}px` }}
+          >
+            {px}
+          </span>
+        ))}
+      </div>
+    ))}
+  </div>
+);

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/baseline-system.css
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/baseline-system.css
@@ -1,0 +1,81 @@
+/**
+ * Testbed chrome for the baseline/density spike (WORK IN PROGRESS).
+ *
+ * The density + baseline MODEL now lives in the package: src/density.css
+ * (imported by src/index.css), so real components consume it by default. This
+ * file keeps only the TESTBED-ONLY helpers: the size-agnostic `.baseline` proof
+ * class and the `.spike-baseline-boxed` prototype + their proof surfaces.
+ */
+
+/* ── DS.01 — .baseline: snap any element to the grid, whatever its size ──────
+ * Reads whatever --font-size / --line-height is present and computes the same
+ * cap-unit nudges the engine uses on h1..h6/p, without assigning a tier. The
+ * maths is font-relative, so it holds at any size. */
+.baseline {
+  --bl-line-height-ratio: var(--line-height-ratio, 1.4);
+  --bl-computed-line-height: var(
+    --line-height,
+    round(up, calc(1em * var(--bl-line-height-ratio)), var(--baseline-height))
+  );
+  line-height: var(--bl-computed-line-height);
+
+  --bl-baseline-position: calc((var(--bl-computed-line-height) + 1cap) / 2);
+  --bl-start-nudge: calc(
+    var(--baseline-height) -
+    mod(var(--bl-baseline-position), var(--baseline-height))
+  );
+  --bl-end-nudge: calc(var(--baseline-height) - var(--bl-start-nudge));
+
+  padding-block-start: var(--bl-start-nudge);
+  padding-block-end: var(--bl-end-nudge);
+  margin-block: 0;
+}
+
+/* ── DS.02 — .spike-baseline-boxed: PROTOTYPE ONLY, NOT CORE API ─────────────
+ * `.baseline` with a density-chosen line-height; the box height is snapped to the
+ * grid (intrinsic snap via calc-size where supported, fixed grid-multiple
+ * fallback). Testbed only; never export. */
+.spike-baseline-boxed {
+  --line-height: var(--density-line-height, calc(var(--baseline-height) * 6));
+  box-sizing: border-box;
+  block-size: var(--density-line-height, calc(var(--baseline-height) * 6));
+}
+@supports (block-size: calc-size(min-content, size)) {
+  .spike-baseline-boxed {
+    block-size: calc-size(min-content, round(up, size, var(--baseline-height)));
+  }
+}
+
+/* ── Proof surface for .baseline (DS.01) — off-scale sizes on one line ─────── */
+.baseline-proof {
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--baseline-height) * 4);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.baseline-proof > .baseline {
+  font-family: inherit;
+}
+
+/* ── Proof surface for .spike-baseline-boxed (DS.02) — mixed sizes, 2 densities ── */
+.boxed-proof {
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--baseline-height) * 3);
+  overflow-x: auto;
+  white-space: nowrap;
+  margin-block: calc(var(--baseline-height) * 2);
+}
+.boxed-proof > .spike-baseline-boxed {
+  border: 1px solid var(--color-border, #b3b3b3);
+  border-radius: var(--dimension-radius-100, 0.25rem);
+  padding-inline: calc(var(--baseline-height) * 2);
+  background: transparent; /* let the grid overlay show through */
+}
+.boxed-proof.is-dense {
+  --density-line-height: calc(var(--baseline-height) * 6); /* 24px */
+}
+.boxed-proof.is-comfortable {
+  --density-line-height: calc(var(--baseline-height) * 8); /* 32px */
+}

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/density.testbed.css
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/density.testbed.css
@@ -1,0 +1,153 @@
+/**
+ * Baseline-alignment spike — testbed stylesheet (WORK IN PROGRESS)
+ *
+ * SPIKE surface, not shipping CSS. Scoped under `.density-testbed`.
+ *
+ * Layout philosophy (per session S TODOs 2–4, 7):
+ *   · No cards, no field labels — zero chrome noise.
+ *   · LINE-BASED: each bucket is ONE horizontal line of inline-block elements.
+ *     Overflow-x scroll is fine; we are reading vertical alignment, not layout.
+ *   · One bucket per story.
+ *   · Every line starts with a few letters of paragraph-style text (the `.p`
+ *     reference), so controls can be read against prose on the same baseline.
+ *
+ * The baseline grid overlay comes from the styles-debug plugin (story
+ * `parameters.baseline`); the box seat uses the shipped engine model (the
+ * alternative top-align + external-margin model lives in SPIKE.md).
+ */
+
+/* ── The testbed root ── */
+.density-testbed {
+  /* --baseline-height is 4px. Source of truth, in order:
+     1. @canonical/styles-typography's baseline-shim.css registers it via
+        `@property … initial-value: 0.25rem`, so the engine ALWAYS has 4px even
+        if styles-main did not load (order-independent — learned from the
+        typography example, which loads an engine standalone). Then
+     2. @canonical/styles' spacing.css sets it explicitly to 0.25rem when present.
+     The literal fallback below is belt-and-suspenders; the @property makes it
+     redundant. Nothing to override here. */
+  padding: 0 var(--baseline-height, 0.25rem);
+  color: var(--color-text, #1a1a1a);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Bucket row — REGULAR component layout, no flattening or overrides
+ *
+ * A simple inline row: a short prose lead, then the components in their NORMAL
+ * structure laid inline. Controls are top-referenced density boxes (the density
+ * system seats each one's text on the grid INTERNALLY), so the row aligns the
+ * boxes by their TOPS. No block padding — the row must sit at the canvas origin
+ * so what we read is the density system's own grid registration, not a nudge. */
+.density-testbed__row {
+  display: flex;
+  flex-wrap: nowrap; /* one horizontal line — overflow scrolls, never wraps */
+  align-items: flex-start;
+  gap: calc(var(--baseline-height) * 3); /* 12px */
+  overflow-x: auto;
+}
+.density-testbed__row > * {
+  flex: 0 0 auto; /* natural width, don't grow/shrink; the row scrolls instead */
+}
+.density-testbed__row > .p {
+  margin: 0;
+}
+
+/* Re-seat the reference LEAD to the density target (TESTBED ONLY) ──────────────
+ * Prose is engine-seated now (Stage A), which lands it on the NEAREST grid line —
+ * one baseline off from the controls' density TARGET line. The lead only exists to
+ * be read against the controls, so here (and only here) we opt it back into the
+ * exact density seat the controls use: crush to line-height 1, then pad the top by
+ * the same `target − (1em+1cap)/2` the shipping controls use. This is calibration
+ * of a measuring stick, NOT a change to how prose ships. */
+.density-testbed__row > .density-testbed__lead.p {
+  line-height: 1;
+  padding-block-start: max(
+    0px,
+    calc(var(--density-target-baseline-px, 0px) - calc((1em + 1cap) / 2))
+  );
+  padding-block-end: 0;
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Boxed controls — the two alignment models
+ *
+ * `.spike-box` is a bordered box whose interior is a single line of `.p` text
+ * (button label, input value, nav item, table cell). Inline-block so it sits on
+ * the line. The text seat reads the engine's --start-nudge / --end-nudge.
+ * ─────────────────────────────────────────────────────────────────────────── */
+.density-testbed .spike-box {
+  --box-border-width: 1px;
+  --box-padding-inline: var(--density-padding-inline, 0.75rem);
+
+  display: inline-flex;
+  align-items: stretch;
+  box-sizing: border-box;
+  vertical-align: baseline;
+  border: var(--box-border-width) solid var(--color-border, #b3b3b3);
+  border-radius: var(--dimension-radius-100, 0.25rem);
+  padding-inline: var(--box-padding-inline);
+  background: var(--color-background, #fff);
+}
+
+.density-testbed .spike-box > .seat {
+  display: block;
+  white-space: nowrap;
+}
+
+/* Shared-border stack (list/table rows) — laid horizontally on the line here,
+   each cell a box; the shared-border collapse is between inline siblings. */
+.density-testbed .spike-rows {
+  display: inline-flex;
+  vertical-align: baseline;
+}
+.density-testbed .spike-rows > .spike-box {
+  border-radius: 0;
+}
+.density-testbed .spike-rows > .spike-box + .spike-box {
+  border-inline-start: none;
+}
+
+/* Box seat — the shipped engine model: engine's asymmetric nudges, both borders
+ * on the grid. (The current/proposed model toggle was removed; the alternative
+ * top-align + external-margin model is documented in SPIKE.md.) */
+.density-testbed .spike-box > .seat {
+  padding-block-start: var(--start-nudge);
+  padding-block-end: var(--end-nudge);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Typography bucket (TODO 5) — real paragraph text at several sizes on one line,
+ * to witness how the 4px baseline affects cap-based nudges (TODO 6). Inline so
+ * the sizes sit next to each other and can be read against the grid together.
+ * ─────────────────────────────────────────────────────────────────────────── */
+.density-testbed__type {
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--baseline-height) * 4);
+  overflow-x: auto;
+  white-space: nowrap;
+  padding-block: calc(var(--baseline-height) * 2);
+}
+
+/* Stacked full paragraphs of each tier, one after another, below the inline
+   row — so a real prose BLOCK of each tier can be read against the grid. */
+.density-testbed__prose {
+  max-width: 40rem;
+  margin-top: calc(var(--baseline-height) * 4);
+}
+
+/* Both sections use the package's own tags (h1..h6, p). The engine sizes each
+   tier; we only reset the demo margins so the grid reading is clean. No custom
+   size classes — each tag IS its tier. */
+.density-testbed__type > :where(h1, h2, h3, h4, h5, h6, p),
+.density-testbed__prose > :where(h1, h2, h3, h4, h5, h6, p) {
+  margin: 0;
+}
+
+/* ── Density inline lever (retained) ── */
+.density-comfortable {
+  --density-padding-inline: 0.75rem;
+}
+.density-dense {
+  --density-padding-inline: 0.5rem;
+}

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/mocks.tsx
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/mocks.tsx
@@ -1,0 +1,47 @@
+import type React from "react";
+
+/**
+ * Baseline-alignment spike — boxed-control primitive + mocks (WORK IN PROGRESS)
+ *
+ * `SpikeBox` is the unit under test: a bordered box whose interior is a single
+ * line of `.p`-tier text (a stand-in for a button label, input value, nav-item
+ * text or table-cell text). Its seat uses the shipped engine model (the
+ * asymmetric start/end nudges from `density.testbed.css`); the alternative
+ * external-margin model was dropped, so there is no model toggle. Using one
+ * primitive keeps buckets comparing like-for-like; the real Button/inputs are
+ * shown alongside in the story for reference.
+ */
+
+/** A boxed control: border + a `.p` text seat, seated on the grid by the engine's
+ *  start/end nudges (see density.testbed.css). */
+export const SpikeBox = ({
+  children,
+  as = "div",
+  role,
+}: {
+  children: React.ReactNode;
+  as?: "div" | "button";
+  role?: string;
+}): React.ReactElement => {
+  const Tag = as;
+  return (
+    <Tag
+      className="spike-box"
+      role={role}
+      type={as === "button" ? "button" : undefined}
+    >
+      <span className="seat p">{children}</span>
+    </Tag>
+  );
+};
+
+/** A run of boxed cells sharing one border — the list/table-row case, laid out
+ *  inline on the bucket line (the CSS collapses the between-borders). Exercises
+ *  how per-cell external margin interacts with a shared border. */
+export const SpikeRows = ({ rows }: { rows: string[] }): React.ReactElement => (
+  <div className="spike-rows">
+    {rows.map((r) => (
+      <SpikeBox key={r}>{r}</SpikeBox>
+    ))}
+  </div>
+);

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/styles.css
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/styles.css
@@ -2,7 +2,9 @@
   display: grid;
   grid-template-columns: subgrid;
   grid-column: var(--form-field-columns, 1 / -1);
-  row-gap: var(--form-field-inline-gap);
+  /* Vertical gap from the label row down to the payload row. Uses the block-axis
+     label-gap token — NOT --form-field-inline-gap (that is horizontal-only now). */
+  row-gap: var(--form-field-label-gap);
   align-items: baseline;
 
   & > .ds.field-label {

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.tsx
@@ -44,9 +44,7 @@ const Label = ({
       style={style}
       htmlFor={Element === "label" ? htmlFor : undefined}
       data-required={markRequired || undefined}
-      className={[componentCssClassName, "p", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
     >
       {children || name}
       {showOptionalSuffix && (

--- a/packages/react/ds-global-form/src/lib/subcomponent/TextInput/TextInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TextInput/TextInput.tsx
@@ -33,7 +33,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
         className={[componentCssClassName, className].filter(Boolean).join(" ")}
       >
         {prefix && <span className="prefix">{prefix}</span>}
-        <input className="p" type={inputType} ref={ref} {...nativeProps} />
+        <input type={inputType} ref={ref} {...nativeProps} />
         {suffix && <span className="suffix">{suffix}</span>}
       </div>
     );

--- a/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/TextareaInput.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/TextareaInput.tsx
@@ -24,9 +24,7 @@ export const TextareaInput = forwardRef<
     <textarea
       id={id}
       style={style}
-      className={[componentCssClassName, "p", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
       ref={ref}
       {...nativeProps}
     />

--- a/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/styles.css
@@ -3,15 +3,10 @@
    * (`.ds.input.chrome` provides only the block padding). */
   padding-inline: var(--form-input-padding-inline);
 
-  /* Combine chrome padding with baseline engine nudges */
-  padding-block-start: calc(
-    var(--form-input-padding-block) +
-    var(--start-nudge, 0px)
-  );
-  padding-block-end: calc(
-    var(--form-input-padding-block) +
-    var(--end-nudge, 0px)
-  );
+  /* Block placement is supplied by density.css (baseline-grid seating of the
+     first line + grid-multiple line-height). The chrome contributes only its
+     block padding as the box's own inset; the baseline nudge lives in density. */
+  padding-block: var(--form-input-padding-block);
   min-height: calc(5lh + var(--form-input-padding-block) * 2);
   resize: vertical;
 }

--- a/packages/react/ds-global/src/lib/component/Button/Button.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.tsx
@@ -52,10 +52,6 @@ const Button = ({
       id={id}
       className={[
         componentCssClassName,
-        // The `.p` baseline utility supplies the body-text tier (font, snapped
-        // line-height) and the padding-block nudges that align the button box
-        // to the baseline grid — so the box height tracks the text inside.
-        "p",
         importance,
         anticipation,
         variant,

--- a/packages/storybook/addon-utils/src/constants.ts
+++ b/packages/storybook/addon-utils/src/constants.ts
@@ -6,9 +6,53 @@ export const KEY_GRID = "grid";
 export const KEY_SCHEME = "scheme";
 export const KEY_BASELINE = "baseline";
 export const KEY_OUTLINES = "outlines";
+export const KEY_DENSITY = "density";
+export const KEY_CONTEXT = "context";
 
 export type GridMode = "none" | "intrinsic" | "responsive";
 export const GRID_MODES: GridMode[] = ["none", "intrinsic", "responsive"];
 
 export type SchemeMode = "none" | "light" | "dark";
 export const SCHEME_MODES: SchemeMode[] = ["none", "light", "dark"];
+
+// Density modifier. Defaults to "comfortable" — a control always has a density;
+// there is no "none".
+export type DensityMode = "comfortable" | "dense";
+export const DENSITY_MODES: DensityMode[] = ["comfortable", "dense"];
+export const DEFAULT_DENSITY: DensityMode = "comfortable";
+
+// Context (surface) modifier. Defaults to "app" (the base surface); there is no
+// "none" — a surface is always one of app/site/docs.
+export type ContextMode = "app" | "site" | "docs";
+export const CONTEXT_MODES: ContextMode[] = ["app", "site", "docs"];
+export const DEFAULT_CONTEXT: ContextMode = "app";
+
+/**
+ * Class-name maps for each modifier: mode value → the class it applies (null =
+ * apply no class, e.g. the "none"/default option). `withUtilStyles` reads these
+ * instead of hard-coding `.light`/`.dense`/… inline, so adding a modifier value
+ * only touches this file. Keyed by mode; every value in the *_MODES array must
+ * have an entry.
+ */
+export const SCHEME_CLASSES: Record<SchemeMode, string | null> = {
+  none: null,
+  light: "light",
+  dark: "dark",
+};
+
+export const DENSITY_CLASSES: Record<DensityMode, string | null> = {
+  comfortable: "comfortable",
+  dense: "dense",
+};
+
+export const GRID_CLASSES: Record<GridMode, string | null> = {
+  none: null,
+  intrinsic: "intrinsic",
+  responsive: "responsive",
+};
+
+export const CONTEXT_CLASSES: Record<ContextMode, string | null> = {
+  app: "app",
+  site: "site",
+  docs: "docs",
+};

--- a/packages/storybook/addon-utils/src/lib/Tool.ts
+++ b/packages/storybook/addon-utils/src/lib/Tool.ts
@@ -43,7 +43,7 @@ const schemeOptions = SCHEME_MODES.map((mode) => ({
 
 const densityOptions = DENSITY_MODES.map((mode) => ({
   value: mode,
-  title: { none: "Default", comfortable: "Comfortable", dense: "Dense" }[mode],
+  title: { comfortable: "Comfortable", dense: "Dense" }[mode],
 }));
 
 const contextOptions = CONTEXT_MODES.map((mode) => ({
@@ -59,6 +59,8 @@ export const Tool: FC<{ api: API }> = memo(function UtilsToolbar({ api }) {
   const paramScheme = useParameter<SchemeMode>(KEY_SCHEME);
   const paramDensity = useParameter<DensityMode>(KEY_DENSITY);
   const paramContext = useParameter<ContextMode>(KEY_CONTEXT);
+  const paramBaseline = useParameter<boolean>(KEY_BASELINE);
+  const paramOutlines = useParameter<boolean>(KEY_OUTLINES);
 
   // undefined = user hasn't touched → fall back to story parameter
   // any string (including "none") = user explicitly chose
@@ -75,8 +77,16 @@ export const Tool: FC<{ api: API }> = memo(function UtilsToolbar({ api }) {
   const surface: ContextMode =
     rawContext !== undefined ? rawContext : (paramContext ?? DEFAULT_CONTEXT);
 
-  const baseline: boolean = globals[KEY_BASELINE] ?? false;
-  const outlines: boolean = globals[KEY_OUTLINES] ?? false;
+  // Resolve like grid/scheme: an explicit global wins; otherwise fall back to the
+  // story parameter (so `parameters: { baseline: true }` keeps the toggle in sync),
+  // then to off. Reading globals alone left the UI out of step with a
+  // parameter-enabled overlay and needed two clicks to turn off.
+  const rawBaseline = globals[KEY_BASELINE] as boolean | undefined;
+  const rawOutlines = globals[KEY_OUTLINES] as boolean | undefined;
+  const baseline: boolean =
+    rawBaseline !== undefined ? rawBaseline : (paramBaseline ?? false);
+  const outlines: boolean =
+    rawOutlines !== undefined ? rawOutlines : (paramOutlines ?? false);
 
   const setGrid = useCallback(
     (mode: GridMode) => updateGlobals({ [KEY_GRID]: mode }),
@@ -197,7 +207,8 @@ export const Tool: FC<{ api: API }> = memo(function UtilsToolbar({ api }) {
         : null,
     ),
 
-    // Context (surface) select — sets the density pair; composes with Density.
+    // Context (surface) select — picks the surface (apps / sites / docs);
+    // composes with Density, which picks the tightness within that surface.
     createElement(
       Select,
       {

--- a/packages/storybook/addon-utils/src/lib/Tool.ts
+++ b/packages/storybook/addon-utils/src/lib/Tool.ts
@@ -1,4 +1,6 @@
 import {
+  BookIcon,
+  ComponentIcon,
   ContrastIcon,
   GridIcon,
   OutlineIcon,
@@ -9,9 +11,17 @@ import { Select, ToggleButton } from "storybook/internal/components";
 import { type API, useGlobals, useParameter } from "storybook/manager-api";
 import {
   ADDON_ID,
+  CONTEXT_MODES,
+  type ContextMode,
+  DEFAULT_CONTEXT,
+  DEFAULT_DENSITY,
+  DENSITY_MODES,
+  type DensityMode,
   GRID_MODES,
   type GridMode,
   KEY_BASELINE,
+  KEY_CONTEXT,
+  KEY_DENSITY,
   KEY_GRID,
   KEY_OUTLINES,
   KEY_SCHEME,
@@ -31,21 +41,39 @@ const schemeOptions = SCHEME_MODES.map((mode) => ({
   title: { none: "System", light: "Light", dark: "Dark" }[mode],
 }));
 
+const densityOptions = DENSITY_MODES.map((mode) => ({
+  value: mode,
+  title: { none: "Default", comfortable: "Comfortable", dense: "Dense" }[mode],
+}));
+
+const contextOptions = CONTEXT_MODES.map((mode) => ({
+  value: mode,
+  title: { app: "Apps", site: "Sites", docs: "Docs" }[mode],
+}));
+
 export const Tool: FC<{ api: API }> = memo(function UtilsToolbar({ api }) {
   const [globals, updateGlobals] = useGlobals();
 
   // Read story-level parameter defaults
   const paramGrid = useParameter<GridMode>(KEY_GRID);
   const paramScheme = useParameter<SchemeMode>(KEY_SCHEME);
+  const paramDensity = useParameter<DensityMode>(KEY_DENSITY);
+  const paramContext = useParameter<ContextMode>(KEY_CONTEXT);
 
   // undefined = user hasn't touched → fall back to story parameter
   // any string (including "none") = user explicitly chose
   const rawGrid = globals[KEY_GRID] as GridMode | undefined;
   const rawScheme = globals[KEY_SCHEME] as SchemeMode | undefined;
+  const rawDensity = globals[KEY_DENSITY] as DensityMode | undefined;
+  const rawContext = globals[KEY_CONTEXT] as ContextMode | undefined;
   const gridMode: GridMode =
     rawGrid !== undefined ? rawGrid : (paramGrid ?? "none");
   const scheme: SchemeMode =
     rawScheme !== undefined ? rawScheme : (paramScheme ?? "none");
+  const density: DensityMode =
+    rawDensity !== undefined ? rawDensity : (paramDensity ?? DEFAULT_DENSITY);
+  const surface: ContextMode =
+    rawContext !== undefined ? rawContext : (paramContext ?? DEFAULT_CONTEXT);
 
   const baseline: boolean = globals[KEY_BASELINE] ?? false;
   const outlines: boolean = globals[KEY_OUTLINES] ?? false;
@@ -57,6 +85,16 @@ export const Tool: FC<{ api: API }> = memo(function UtilsToolbar({ api }) {
 
   const setScheme = useCallback(
     (mode: SchemeMode) => updateGlobals({ [KEY_SCHEME]: mode }),
+    [updateGlobals],
+  );
+
+  const setDensity = useCallback(
+    (mode: DensityMode) => updateGlobals({ [KEY_DENSITY]: mode }),
+    [updateGlobals],
+  );
+
+  const setContext = useCallback(
+    (mode: ContextMode) => updateGlobals({ [KEY_CONTEXT]: mode }),
     [updateGlobals],
   );
 
@@ -157,6 +195,34 @@ export const Tool: FC<{ api: API }> = memo(function UtilsToolbar({ api }) {
       scheme !== "none"
         ? schemeOptions.find((o) => o.value === scheme)?.title
         : null,
+    ),
+
+    // Context (surface) select — sets the density pair; composes with Density.
+    createElement(
+      Select,
+      {
+        ariaLabel: "Context",
+        tooltip: "Context (surface)",
+        icon: createElement(BookIcon),
+        defaultOptions: surface,
+        options: contextOptions,
+        onSelect: (value) => setContext(value as ContextMode),
+      },
+      contextOptions.find((o) => o.value === surface)?.title,
+    ),
+
+    // Density select
+    createElement(
+      Select,
+      {
+        ariaLabel: "Density",
+        tooltip: "Density",
+        icon: createElement(ComponentIcon),
+        defaultOptions: density,
+        options: densityOptions,
+        onSelect: (value) => setDensity(value as DensityMode),
+      },
+      densityOptions.find((o) => o.value === density)?.title,
     ),
 
     // Baseline toggle

--- a/packages/storybook/addon-utils/src/preview.ts
+++ b/packages/storybook/addon-utils/src/preview.ts
@@ -6,8 +6,6 @@ import "@canonical/styles-debug";
 import "./forceLightDocs.js";
 
 import {
-  DEFAULT_CONTEXT,
-  DEFAULT_DENSITY,
   KEY_BASELINE,
   KEY_CONTEXT,
   KEY_DENSITY,
@@ -21,14 +19,17 @@ const preview: ProjectAnnotations<Renderer> = {
   decorators: [withUtilStyles],
   initialGlobals: {
     // All undefined so `withUtilStyles` falls back to each story's parameters
-    // (e.g. `parameters: { baseline: true }`) until the user picks in the toolbar.
+    // (e.g. `parameters: { baseline: true }`), then to the resolver's own default,
+    // until the user picks in the toolbar. Density/context are undefined here too
+    // (like grid/scheme): a control ALWAYS has a density, but that default lives in
+    // withUtilStyles (fallback to DEFAULT_DENSITY / DEFAULT_CONTEXT), so a story can
+    // still set `parameters: { density, context }` and have it take effect.
     [KEY_GRID]: undefined,
     [KEY_SCHEME]: undefined,
     [KEY_BASELINE]: undefined,
     [KEY_OUTLINES]: undefined,
-    [KEY_DENSITY]: DEFAULT_DENSITY,
-    // Context defaults to "apps" (the base surface), not undefined.
-    [KEY_CONTEXT]: DEFAULT_CONTEXT,
+    [KEY_DENSITY]: undefined,
+    [KEY_CONTEXT]: undefined,
   },
 };
 

--- a/packages/storybook/addon-utils/src/preview.ts
+++ b/packages/storybook/addon-utils/src/preview.ts
@@ -6,7 +6,11 @@ import "@canonical/styles-debug";
 import "./forceLightDocs.js";
 
 import {
+  DEFAULT_CONTEXT,
+  DEFAULT_DENSITY,
   KEY_BASELINE,
+  KEY_CONTEXT,
+  KEY_DENSITY,
   KEY_GRID,
   KEY_OUTLINES,
   KEY_SCHEME,
@@ -16,10 +20,15 @@ import { withUtilStyles } from "./withUtilStyles.js";
 const preview: ProjectAnnotations<Renderer> = {
   decorators: [withUtilStyles],
   initialGlobals: {
+    // All undefined so `withUtilStyles` falls back to each story's parameters
+    // (e.g. `parameters: { baseline: true }`) until the user picks in the toolbar.
     [KEY_GRID]: undefined,
     [KEY_SCHEME]: undefined,
-    [KEY_BASELINE]: false,
-    [KEY_OUTLINES]: false,
+    [KEY_BASELINE]: undefined,
+    [KEY_OUTLINES]: undefined,
+    [KEY_DENSITY]: DEFAULT_DENSITY,
+    // Context defaults to "apps" (the base surface), not undefined.
+    [KEY_CONTEXT]: DEFAULT_CONTEXT,
   },
 };
 

--- a/packages/storybook/addon-utils/src/withUtilStyles.tsx
+++ b/packages/storybook/addon-utils/src/withUtilStyles.tsx
@@ -5,13 +5,40 @@ import type {
   PartialStoryFn as StoryFunction,
 } from "storybook/internal/types";
 import {
+  CONTEXT_CLASSES,
+  type ContextMode,
+  DEFAULT_CONTEXT,
+  DEFAULT_DENSITY,
+  DENSITY_CLASSES,
+  type DensityMode,
+  GRID_CLASSES,
   type GridMode,
   KEY_BASELINE,
+  KEY_CONTEXT,
+  KEY_DENSITY,
   KEY_GRID,
   KEY_OUTLINES,
   KEY_SCHEME,
+  SCHEME_CLASSES,
   type SchemeMode,
 } from "./constants.js";
+
+/**
+ * Apply a modifier's class from its class-name map: remove every class the map
+ * can produce, then add the one for the active mode (null = add nothing). Keeps
+ * the mode→class mapping in constants.ts, not scattered inline.
+ */
+function applyModifierClass(
+  el: HTMLElement,
+  classMap: Record<string, string | null>,
+  activeMode: string,
+): void {
+  for (const cls of Object.values(classMap)) {
+    if (cls) el.classList.remove(cls);
+  }
+  const active = classMap[activeMode];
+  if (active) el.classList.add(active);
+}
 
 export const withUtilStyles = (
   StoryFn: StoryFunction<Renderer>,
@@ -33,8 +60,33 @@ export const withUtilStyles = (
       ? rawScheme
       : ((context.parameters?.scheme as SchemeMode) ?? "none");
 
-  const baseline: boolean = globals[KEY_BASELINE] ?? false;
-  const outlines: boolean = globals[KEY_OUTLINES] ?? false;
+  // undefined = user hasn't touched the toolbar toggle → fall back to the story's
+  // parameters so a story can opt into the baseline grid / outlines declaratively
+  // (`parameters: { baseline: true }`) without anyone flipping the toolbar. An
+  // explicit toolbar choice (true/false) always wins over the parameter.
+  const rawBaseline = globals[KEY_BASELINE] as boolean | undefined;
+  const baseline: boolean =
+    rawBaseline !== undefined
+      ? rawBaseline
+      : ((context.parameters?.baseline as boolean) ?? false);
+
+  const rawOutlines = globals[KEY_OUTLINES] as boolean | undefined;
+  const outlines: boolean =
+    rawOutlines !== undefined
+      ? rawOutlines
+      : ((context.parameters?.outlines as boolean) ?? false);
+
+  const rawDensity = globals[KEY_DENSITY] as DensityMode | undefined;
+  const density: DensityMode =
+    rawDensity !== undefined
+      ? rawDensity
+      : ((context.parameters?.density as DensityMode) ?? DEFAULT_DENSITY);
+
+  const rawContext = globals[KEY_CONTEXT] as ContextMode | undefined;
+  const surface: ContextMode =
+    rawContext !== undefined
+      ? rawContext
+      : ((context.parameters?.context as ContextMode) ?? DEFAULT_CONTEXT);
 
   useEffect(() => {
     const root = document.getElementById("storybook-root");
@@ -46,24 +98,38 @@ export const withUtilStyles = (
   useEffect(() => {
     const root = document.getElementById("storybook-root");
     if (!root) return;
-    // Remove previous grid mode classes
-    root.classList.remove("grid", "responsive", "intrinsic");
+    // The grid classes come from GRID_CLASSES; the "grid" marker + align-content
+    // are grid-specific extras layered on top.
+    applyModifierClass(root, GRID_CLASSES, gridMode);
     if (gridMode !== "none") {
-      root.classList.add("grid", gridMode);
+      root.classList.add("grid");
       // The story root fills the preview height, so a grid there would stretch
       // its (single) row and the story looks vertically centred. Top-align so
       // rows take their natural height instead.
       root.style.alignContent = "start";
     } else {
+      root.classList.remove("grid");
       root.style.removeProperty("align-content");
     }
   }, [gridMode]);
 
   useEffect(() => {
-    const { classList } = document.documentElement;
-    classList.toggle("light", scheme === "light");
-    classList.toggle("dark", scheme === "dark");
+    applyModifierClass(document.documentElement, SCHEME_CLASSES, scheme);
   }, [scheme]);
+
+  useEffect(() => {
+    // Density on the story root (same node as the grid/baseline overlays).
+    const root = document.getElementById("storybook-root");
+    if (!root) return;
+    applyModifierClass(root, DENSITY_CLASSES, density);
+  }, [density]);
+
+  useEffect(() => {
+    // Context (surface) on the story root, composes with density.
+    const root = document.getElementById("storybook-root");
+    if (!root) return;
+    applyModifierClass(root, CONTEXT_CLASSES, surface);
+  }, [surface]);
 
   return StoryFn();
 };

--- a/packages/styles/debug/README.md
+++ b/packages/styles/debug/README.md
@@ -30,17 +30,27 @@ import "@canonical/styles-debug"; // import all debug styles
 
 The baseline grid utility allows you to visualize the baseline grid in your application.
 To use it, add the `with-baseline-grid` class to any element.
-This will add a background color to the element and its children, allowing you to see the baseline grid in action.
+It paints five strict, hard-edged bands per cycle — each baseline row a flat 4px
+step up in tint, from faint (level 1) to strong (level 5), repeating every five
+baselines (20px at the 4px default) — so the rhythm and position-within-cycle
+read at a glance.
+
+The baseline height is shimmed to 4px in the tool itself and is deliberately not
+read from `--baseline-height` (which the typography engine derives from the
+design tokens, currently still 8px). Override `--baseline-grid-height` to change
+it, or set `--baseline-grid-height: var(--baseline-height)` to follow the app's
+live grid.
 
 ##### Customization
 
 This utility can be customized by setting the following CSS variables:
 
-| Variable                | Description                           | Default Value          |
-|-------------------------|---------------------------------------|------------------------|
-| `--baseline-grid-color` | The color of the baseline grid lines  | `rgba(255, 0, 0, 0.2)` |
-| `--baseline-height`     | The height of the baseline grid       | `0.5rem`               |
-| `--baseline-shift`      | The offset shift of the baseline grid | `0`                    |
+| Variable                    | Description                                              | Default Value                 |
+|-----------------------------|----------------------------------------------------------|-------------------------------|
+| `--baseline-grid-color`     | Base hue the wave tints are derived from                | branded border colour         |
+| `--baseline-grid-levels`    | Baselines per gradient cycle                            | `5` (→ 20px cycle at 4px)     |
+| `--baseline-grid-height`    | Height of one baseline row                              | `0.25rem` (4px)               |
+| `--baseline-shift`          | Vertical offset of the grid                             | `0`                           |
 
 ##### Example
 

--- a/packages/styles/debug/README.md
+++ b/packages/styles/debug/README.md
@@ -48,7 +48,6 @@ This utility can be customized by setting the following CSS variables:
 | Variable                    | Description                                              | Default Value                 |
 |-----------------------------|----------------------------------------------------------|-------------------------------|
 | `--baseline-grid-color`     | Base hue the wave tints are derived from                | branded border colour         |
-| `--baseline-grid-levels`    | Baselines per gradient cycle                            | `5` (→ 20px cycle at 4px)     |
 | `--baseline-grid-height`    | Height of one baseline row                              | `0.25rem` (4px)               |
 | `--baseline-shift`          | Vertical offset of the grid                             | `0`                           |
 

--- a/packages/styles/debug/src/baseline-grid.css
+++ b/packages/styles/debug/src/baseline-grid.css
@@ -12,16 +12,20 @@
    * --baseline-grid-height: var(--baseline-height) explicitly. */
   --addon-baseline-height: var(--baseline-grid-height, 0.25rem);
 
-  /* Overlay reads as STRICT BANDS — five hard-edged 4px steps per cycle, each a
-     step up in tint (not a smooth gradient). One cycle is 5 baselines
-     (5 × 4px = 20px), then repeats. Hard edges between bands let the eye count
-     position-within-cycle (level 1..5) exactly; the strongest band marks the
-     cycle. Tint derives from one branded hue at stepped opacities. */
-  --addon-baseline-levels: var(--baseline-grid-levels, 5);
+  /* Overlay reads as STRICT BANDS — five hard-edged baseline-height steps per
+   * cycle, each a step up in tint (not a smooth gradient). One cycle is 5
+   * baselines, then repeats. Hard edges between bands let the eye count
+   * position-within-cycle (level 1..5) exactly; the strongest band marks the
+   * cycle. Tint derives from one branded hue at stepped opacities.
+   *
+   * The cycle is FIXED at 5 levels: the tint stops below (--addon-baseline-l1..l5)
+   * are hard-coded, so the count is not a knob — a different value would leave the
+   * five stops crammed into a mis-sized cycle. Only the baseline HEIGHT is
+   * customisable (--baseline-grid-height); the level count is intrinsic. */
   --addon-baseline-cycle: calc(
     var(--addon-baseline-height) *
-    var(--addon-baseline-levels)
-  ); /* 5 × 4px = 20px */
+    5
+  ); /* 5 baselines per cycle */
 
   --addon-baseline-hue: var(
     --baseline-grid-color,

--- a/packages/styles/debug/src/baseline-grid.css
+++ b/packages/styles/debug/src/baseline-grid.css
@@ -1,30 +1,59 @@
 .with-baseline-grid {
-  /* Lines are partly transparent so content reads through the grid. */
-  --addon-baseline-grid-color: var(
-    --baseline-grid-color,
-    color-mix(
-      in oklch,
-      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 35%,
-      transparent
-    )
-  );
-  /* Every Nth line (see --baseline-grid-major-every) — a distinct, stronger
-     (but still translucent) tint so groups are countable. */
-  --addon-baseline-grid-major-color: var(
-    --baseline-grid-major-color,
-    color-mix(
-      in oklch,
-      var(--color-border-branded, oklch(64.05% 0.1941 37.76)) 60%,
-      transparent
-    )
-  );
-  --addon-baseline-height: var(--baseline-height, 0.5rem);
-  /* Major line every Nth baseline (configurable; default every 4). */
-  --addon-baseline-major-every: var(--baseline-grid-major-every, 4);
-  --addon-baseline-major: calc(
+  /* Baseline unit — 4px, SHIMMED here in the debug tool.
+   *
+   * The real --baseline-height comes from the typography engine, which derives
+   * it from the design-tokens repo (--dimension-size-height-baseline), currently
+   * still 8px there. The debug overlay must not inherit that stale 8px, and it
+   * cannot depend on @canonical/styles' 4px override having loaded first (the
+   * addon may load this CSS in isolation). So the tool owns its own default:
+   *   1. --baseline-grid-height — explicit override for this tool (wins), else
+   *   2. 0.25rem (4px) — the shimmed default, NOT read from --baseline-height.
+   * To pin the overlay to whatever the app's live grid is, a consumer sets
+   * --baseline-grid-height: var(--baseline-height) explicitly. */
+  --addon-baseline-height: var(--baseline-grid-height, 0.25rem);
+
+  /* Overlay reads as STRICT BANDS — five hard-edged 4px steps per cycle, each a
+     step up in tint (not a smooth gradient). One cycle is 5 baselines
+     (5 × 4px = 20px), then repeats. Hard edges between bands let the eye count
+     position-within-cycle (level 1..5) exactly; the strongest band marks the
+     cycle. Tint derives from one branded hue at stepped opacities. */
+  --addon-baseline-levels: var(--baseline-grid-levels, 5);
+  --addon-baseline-cycle: calc(
     var(--addon-baseline-height) *
-    var(--addon-baseline-major-every)
+    var(--addon-baseline-levels)
+  ); /* 5 × 4px = 20px */
+
+  --addon-baseline-hue: var(
+    --baseline-grid-color,
+    var(--color-border-branded, oklch(64.05% 0.1941 37.76))
   );
+  /* Five stepped tints, faint (level 1) → strong (level 5). Hard steps. */
+  --addon-baseline-l1: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 8%,
+    transparent
+  );
+  --addon-baseline-l2: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 14%,
+    transparent
+  );
+  --addon-baseline-l3: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 20%,
+    transparent
+  );
+  --addon-baseline-l4: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 28%,
+    transparent
+  );
+  --addon-baseline-l5: color-mix(
+    in oklch,
+    var(--addon-baseline-hue) 38%,
+    transparent
+  );
+
   --addon-baseline-shift: var(--baseline-shift, 0);
 
   position: relative;
@@ -33,40 +62,36 @@
    * The grid is an ::after overlay (kept so it paints ON TOP and can cover the
    * full page, not just behind content). To survive content TALLER than 100%
    * (overflowing children), the pseudo grows with the host: min-block-size:100%
-   * fills the box, and because the host is position:relative and content-sized,
-   * the pseudo stretches over the whole content height rather than clipping at
-   * the fold.
+   * fills the box.
    *
-   * Two layers: a minor line every baseline unit, and a major (different colour)
-   * line every Nth unit (--baseline-grid-major-every), listed first so it paints
-   * on top where they coincide.
+   * One gradient, but with hard stops so it renders as five STRICT bands: each
+   * `color N, color N+1baseline` pair is a flat 4px step with no interpolation,
+   * and the next step starts exactly where the previous ends. 5 steps = a 20px
+   * cycle, repeated.
    */
   &::after {
     content: "";
+    display: block;
     position: absolute;
     inset: 0;
     block-size: 100%;
     min-block-size: 100%;
     pointer-events: none;
     z-index: 200;
-    background-image:
-      linear-gradient(
-        to top,
-        var(--addon-baseline-grid-major-color),
-        var(--addon-baseline-grid-major-color) 1px,
-        transparent 1px,
-        transparent
-      ),
-      linear-gradient(
-        to top,
-        var(--addon-baseline-grid-color),
-        var(--addon-baseline-grid-color) 1px,
-        transparent 1px,
-        transparent
-      );
-    background-size:
-      100% var(--addon-baseline-major),
-      100% var(--addon-baseline-height);
+    background-image: linear-gradient(
+      to bottom,
+      var(--addon-baseline-l1) 0,
+      var(--addon-baseline-l1) var(--addon-baseline-height),
+      var(--addon-baseline-l2) var(--addon-baseline-height),
+      var(--addon-baseline-l2) calc(var(--addon-baseline-height) * 2),
+      var(--addon-baseline-l3) calc(var(--addon-baseline-height) * 2),
+      var(--addon-baseline-l3) calc(var(--addon-baseline-height) * 3),
+      var(--addon-baseline-l4) calc(var(--addon-baseline-height) * 3),
+      var(--addon-baseline-l4) calc(var(--addon-baseline-height) * 4),
+      var(--addon-baseline-l5) calc(var(--addon-baseline-height) * 4),
+      var(--addon-baseline-l5) var(--addon-baseline-cycle)
+    );
+    background-size: 100% var(--addon-baseline-cycle);
     background-position: 0 var(--addon-baseline-shift);
     background-repeat: repeat;
   }

--- a/packages/styles/main/src/spacing.css
+++ b/packages/styles/main/src/spacing.css
@@ -16,10 +16,11 @@
 
 :root {
   /* ── Baseline grid ──────────────────────────────────────────────── */
-  --space-baseline: var(
-    --dimension-size-height-baseline,
-    0.5rem
-  ); /* 8px — bU */
+  /* SPIKE: the baseline unit is 4px (down from 8px). Set here in styles, NOT in
+     the design token — the token (--dimension-size-height-baseline) is left at
+     8px and intentionally no longer consumed, so this is the single place the
+     4px grid lives until it is promoted into design-tokens via its own PR. */
+  --space-baseline: 0.25rem; /* 4px — bU (was the 8px --dimension-size-height-baseline token) */
   --baseline-height: var(
     --space-baseline
   ); /* alias consumed by typography engine */

--- a/packages/styles/typography/example/index.html
+++ b/packages/styles/typography/example/index.html
@@ -9,7 +9,8 @@
     <link id="engine-metrics" rel="stylesheet" href="../src/baseline-metrics.css" disabled />
     <link id="engine-trim"    rel="stylesheet" href="../src/baseline-trim.css" disabled />
 
-    <!-- Example layout & debug styles -->
+    <!-- Example layout & debug styles. The baseline grid overlay lives in
+         layout.css (driven by --baseline-height, wired to the sidebar input). -->
     <link rel="stylesheet" href="./styles/layout.css" />
     <link rel="stylesheet" href="./styles/demo.css" />
 
@@ -20,54 +21,61 @@
        * src/index.css reads them to compute nudges.
        * Keep in sync with the input defaults in sidebar.js.
        *
-       * Baseline = 0.5rem
+       * Baseline = 4px. Set here as the initial value and driven live by the
+       * sidebar "Baseline grid → Height" input (which writes --baseline-height
+       * on :root); the overlay bands in layout.css read the same variable, so
+       * moving the input resizes both the grid and the type nudges together.
+       *
        * LH multiplier = lineHeight / baseline
        * space-after  = spaceAfter / baseline
        */
 
       :root {
-        --baseline-height: 0.5rem;
+        --baseline-height: 0.25rem;
       }
 
+      /* Line-height multipliers DOUBLED for the 4px baseline: a line that was N
+         8px-units tall is 2N 4px-units, so the multipliers double to keep the
+         same visual line-height. --space-after left as-is per instruction. */
       h1 {
         --font-size: 2.625rem;
-        --line-height-multiplier: 6;
+        --line-height-multiplier: 12;
         --space-after: 2;
       }
 
       h2 {
         --font-size: 2.625rem;
-        --line-height-multiplier: 6;
+        --line-height-multiplier: 12;
         --space-after: 2;
       }
 
       h3 {
         --font-size: 1.5rem;
-        --line-height-multiplier: 4;
+        --line-height-multiplier: 8;
         --space-after: 2;
       }
 
       h4 {
         --font-size: 1.5rem;
-        --line-height-multiplier: 4;
+        --line-height-multiplier: 8;
         --space-after: 2;
       }
 
       h5 {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
 
       h6 {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
 
       p {
         --font-size: 1rem;
-        --line-height-multiplier: 3;
+        --line-height-multiplier: 6;
         --space-after: 2;
       }
     </style>

--- a/packages/styles/typography/example/scripts/control-input.js
+++ b/packages/styles/typography/example/scripts/control-input.js
@@ -3,17 +3,40 @@
  *
  * Attributes:
  *   label, min, max, step, value, target-selector, css-variable, unit
+ *
+ * The initial value is READ FROM THE CSS: the input seeds itself from the
+ * computed value of `css-variable` on the first element matching
+ * `target-selector`, so the stylesheet is the single source of truth and the
+ * control stays in sync with it (two-way binding). The `value` attribute is only
+ * a fallback used when the CSS does not define the variable.
  */
 class ControlInput extends HTMLElement {
+  /** Read the current value of `cssVariable` on `targetSelector` from the CSS,
+   *  stripped of `unit`. Returns null if unset/unreadable. */
+  readCssValue(targetSelector, cssVariable, unit) {
+    const el = document.querySelector(targetSelector);
+    if (!el) return null;
+    const raw = getComputedStyle(el).getPropertyValue(cssVariable).trim();
+    if (!raw) return null;
+    // Drop the unit suffix (e.g. "0.25rem" -> "0.25") so it fits a number input.
+    const stripped = unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
+    const n = Number.parseFloat(stripped);
+    return Number.isNaN(n) ? null : String(n);
+  }
+
   connectedCallback() {
     const label = this.getAttribute("label");
     const min = this.getAttribute("min");
     const max = this.getAttribute("max");
     const step = this.getAttribute("step");
-    const value = this.getAttribute("value");
     const targetSelector = this.getAttribute("target-selector");
     const cssVariable = this.getAttribute("css-variable");
     const unit = this.getAttribute("unit") || "";
+
+    // Prefer the live CSS value; fall back to the `value` attribute.
+    const value =
+      this.readCssValue(targetSelector, cssVariable, unit) ??
+      this.getAttribute("value");
 
     this.innerHTML = `
       <div class="control">

--- a/packages/styles/typography/example/scripts/control-input.js
+++ b/packages/styles/typography/example/scripts/control-input.js
@@ -19,7 +19,8 @@ class ControlInput extends HTMLElement {
     const raw = getComputedStyle(el).getPropertyValue(cssVariable).trim();
     if (!raw) return null;
     // Drop the unit suffix (e.g. "0.25rem" -> "0.25") so it fits a number input.
-    const stripped = unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
+    const stripped =
+      unit && raw.endsWith(unit) ? raw.slice(0, -unit.length) : raw;
     const n = Number.parseFloat(stripped);
     return Number.isNaN(n) ? null : String(n);
   }

--- a/packages/styles/typography/example/scripts/sidebar.js
+++ b/packages/styles/typography/example/scripts/sidebar.js
@@ -169,6 +169,21 @@ class SettingsSidebar extends HTMLElement {
           <select id="content-select">${contentOptions}</select>
         </fieldset>
 
+        <!-- Global root font size (defines the rem unit) -->
+        <fieldset>
+          <legend>Global</legend>
+          <control-input
+            label="Root font size"
+            min="8"
+            max="32"
+            step="1"
+            value="16"
+            target-selector="html"
+            css-variable="--font-size"
+            unit="px"
+          ></control-input>
+        </fieldset>
+
         <!-- Baseline height -->
         <fieldset>
           <legend>Baseline grid</legend>
@@ -177,7 +192,7 @@ class SettingsSidebar extends HTMLElement {
             min="0.1"
             max="2"
             step="0.05"
-            value="0.5"
+            value="0.25"
             target-selector=":root"
             css-variable="--baseline-height"
             unit="rem"

--- a/packages/styles/typography/example/styles/demo.css
+++ b/packages/styles/typography/example/styles/demo.css
@@ -7,5 +7,8 @@ h4,
 h5,
 h6,
 p {
-  background: #fededebb;
+  /* Box highlight so the text box is visible against the baseline bands. Alpha
+     sits between the original opaque ~0.73 and a too-faint 0.25 — visible but
+     the grid still reads through. */
+  background: rgba(254, 222, 222, 0.5);
 }

--- a/packages/styles/typography/example/styles/layout.css
+++ b/packages/styles/typography/example/styles/layout.css
@@ -1,7 +1,10 @@
 /* ── Page shell ────────────────────────────────────────────────── */
 
 html {
-  --font-size: 32px;
+  /* Root font-size defines the rem unit. 16px so `--font-size: 1rem` on p is
+     16px (not 32px — the old value made 1rem = 32px, doubling every rem size).
+     Still overridable via the sidebar if a demo wants a different root. */
+  --font-size: 16px;
   font-size: var(--font-size);
   height: 100%;
 }
@@ -117,9 +120,27 @@ main {
   min-height: 100vh;
   padding: 0 1rem;
 
-  /* Baseline grid overlay */
-  background-image: linear-gradient(to bottom, #df1f00 1px, transparent 1px);
-  background-size: 100% var(--baseline-height);
+  /* Baseline grid overlay — strict stepped bands, five hard-edged steps per
+     cycle (level 1 faint → level 5 strong), matching the styles-debug plugin
+     used in the Storybook testbed. Copied inline (rather than linking the debug
+     package) so the static example needs no cross-package path, and driven
+     directly by --baseline-height so it is LINKED TO THE SIDEBAR INPUT: change
+     the "Baseline grid → Height" control and the bands resize with it. */
+  --bl: var(--baseline-height, 0.25rem);
+  background-image: linear-gradient(
+    to bottom,
+    rgba(223, 31, 0, 0.08) 0,
+    rgba(223, 31, 0, 0.08) var(--bl),
+    rgba(223, 31, 0, 0.14) var(--bl),
+    rgba(223, 31, 0, 0.14) calc(var(--bl) * 2),
+    rgba(223, 31, 0, 0.2) calc(var(--bl) * 2),
+    rgba(223, 31, 0, 0.2) calc(var(--bl) * 3),
+    rgba(223, 31, 0, 0.28) calc(var(--bl) * 3),
+    rgba(223, 31, 0, 0.28) calc(var(--bl) * 4),
+    rgba(223, 31, 0, 0.38) calc(var(--bl) * 4),
+    rgba(223, 31, 0, 0.38) calc(var(--bl) * 5)
+  );
+  background-size: 100% calc(var(--bl) * 5);
   background-repeat: repeat;
   background-attachment: local;
 }

--- a/packages/styles/typography/src/baseline-cap.css
+++ b/packages/styles/typography/src/baseline-cap.css
@@ -10,6 +10,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/baseline-metrics.css
+++ b/packages/styles/typography/src/baseline-metrics.css
@@ -15,6 +15,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/baseline-shim.css
+++ b/packages/styles/typography/src/baseline-shim.css
@@ -1,0 +1,18 @@
+/* @canonical/styles-typography — baseline unit shim
+ *
+ * The engine only CONSUMES --baseline-height; the value normally comes from
+ * @canonical/styles (spacing.css). A consumer that loads an engine without
+ * styles-main — or before it — would leave --baseline-height unset and every
+ * nudge would break. Registering the property with an initial-value makes 4px
+ * the fallback whenever nothing else sets it, while any real declaration
+ * (spacing.css, a theme, the testbed) still wins, regardless of load order.
+ *
+ * Single source for the 4px shim, imported by every engine so importing any one
+ * of them carries the fallback. Consumers no longer hardcode --baseline-height
+ * to keep the engine working.
+ */
+@property --baseline-height {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0.25rem;
+}

--- a/packages/styles/typography/src/baseline-trim.css
+++ b/packages/styles/typography/src/baseline-trim.css
@@ -10,6 +10,9 @@
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  */
 
+/* Baseline unit shim (--baseline-height 4px fallback) */
+@import url("./baseline-shim.css");
+
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 

--- a/packages/styles/typography/src/index.css
+++ b/packages/styles/typography/src/index.css
@@ -7,5 +7,9 @@
  *   - baseline-cap.css      — Uses the CSS `cap` unit (no extraction needed) [default]
  *   - baseline-metrics.css  — Uses extracted font metrics (ascender/descender/unitsPerEm)
  *   - baseline-trim.css     — Uses text-box-trim + cap unit hybrid
+ *
+ * Each engine registers the --baseline-height 4px shim itself (see the
+ * `@property` at the top of each), so importing any single engine — as the
+ * typography example does — carries the fallback with no consumer hardcoding.
  */
 @import url("./baseline-cap.css");

--- a/packages/styles/typography/src/mapper.css
+++ b/packages/styles/typography/src/mapper.css
@@ -63,7 +63,15 @@
   /* ── Line height shims ────────────────────────────────────────── *
    * number.tokens.json defines these as $type:"number" but the
    * terrazzo plugin does not emit them in sets.primitive.css.
-   * Hardcoded here until the build pipeline includes number tokens. */
+   * Hardcoded here until the build pipeline includes number tokens.
+   *
+   * These are unitless RATIOS (font-size × ratio = target line-height). The
+   * engine then does round(up, font-size × ratio, --baseline-height), which
+   * snaps the result onto the grid. So the 4px baseline needs NO change here:
+   * a 1rem × 1.5 = 24px line snaps to 24px at both 8px (3 units) and 4px
+   * (6 units) — the px is identical, only the unit COUNT differs. (An earlier
+   * pass wrongly doubled these, which doubled the actual line-height and drifted
+   * from the controls; reverted to the design-token ratios.) */
   --number-line-height-250: 1.3333;
   --number-line-height-300: 1.4286;
   --number-line-height-350: 1.5;


### PR DESCRIPTION
## Done

Third and central PR of the **baseline-alignment & density** stack. The density model itself, the form-channel token mapping, the density/`.editorial` composition, and the docs. Stacked on #804; review against `density/pr2-addon-toolbar`.

- **The model** (`density.css`) — a 2×3 matrix: context (`.app` / `.site` / `.docs`, where `docs` = `site`) × density (`.comfortable` / `.dense`). Context sets the `*-comfy`/`*-dense` pair; density picks generic `--density-*` primitives (line-height, padding-inline, `space-sm`/`md`/`lg`). Controls are fixed grid-multiple boxes, seated to `round(up, height × 2/3, --baseline-height)` on the 4px grid. Apps 32/24, sites·docs 36/28 — Diana's "32px apps / 36px sites" is the comfortable column.
- **The form mapping** (`index.css`) — the FORM layer maps its `--form-*` tokens onto the density primitives (`block-gap`→`space-lg`, `label-gap`→`space-md`, `group`→`space-sm`). Density stays domain-neutral and never references a `--form-*` token. Gaps are split by axis and a new `--form-field-label-gap` de-overloads the stacked Wrapper `row-gap` (which was borrowing an inline token for a vertical gap).
- **Components drop `.p`, adopt density** — Button (ds-global), Label / TextInput / TextareaInput (ds-global-form). The textarea joins the grid with a grid-multiple line-height so every row seats.
- **Composition** — density seats *controls* only; running prose (`p` / `h*` / `.editorial`) is left to the typography engine. Disjoint element sets, so `.editorial` composes with a density scope with no specificity war (and wrapped prose stays on-grid, which the old `line-height: 1` crush broke).
- **Docs** — two Storybook guides (*The Baseline Grid*; *Density & the Form Channel*) with worked arithmetic and live, overlay-on `<Canvas>` examples.

## QA

- `nx affected -t build` — green (9 projects). `ds-global` `dist` rebuilds with the Button `.p` removal.
- `nx affected -t test` — green (34 tests).
- Own files are biome/tsc clean. NB `nx affected -t check` reports pre-existing biome errors in `@canonical/react-hooks` (193 errors present on the base branch too, untouched by this PR).
- Eyeball in Storybook: Documentation → Guides (both render, live examples with the overlay on) and Documentation → Examples → Density (button label + input value share a baseline; app 32 vs site 36).

### PR readiness check

- [x] Label: `Feature 🎁`
- [x] Conventional-commit title
- [x] Follows code standards (tokens/calc-of-tokens; scoped; layered token direction)
- [x] `check` / `check:fix` / `test` present on the packages
- [ ] No new package
- [ ] `no visual change` — NOT applicable: the density seating is the change

## Screenshots

Live examples in Documentation → Examples → Density (baseline overlay on by default): the button label and input value seat on the same grid line; apps 32px vs sites 36px at comfortable density.
