### PR TITLE
chore(density): baseline / density testbed (work in progress)

### DIFF
--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/DensityTestbed.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/DensityTestbed.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  BaselineProofLine,
+  BoxedProofLine,
+  ControlsLine,
+  EditorialLine,
+  ListsLine,
+  NavigationLine,
+  TypographyLine,
+} from "./Testbed.js";
+
+/**
+ * # Baseline-alignment spike (work in progress)
+ *
+ * Line-based spike surface. Each story is ONE bucket rendered on a single
+ * horizontal line: a few letters of paragraph text at the start (baseline
+ * reference), then the components inline. No cards, no labels — just alignment.
+ *
+ * The 4px baseline grid (strict stepped bands) is drawn by the styles-debug
+ * plugin, applied automatically via `parameters: { baseline: true }`. Every
+ * bucket renders the shipped engine model (no current ↔ proposed toggle — the
+ * alternative model was dropped); Typography is pure engine output at several
+ * sizes, and Editorial shows prose composing inside a density scope.
+ */
+const meta = {
+  title: "_work_in_progress/BaselineAlignmentSpike",
+  tags: ["!autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    baseline: true,
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Controls — buttons + inputs on one line. */
+export const Controls: Story = { render: () => <ControlsLine /> };
+
+/** Navigation — tab / side-nav items on one line. */
+export const Navigation: Story = { render: () => <NavigationLine /> };
+
+/** Lists — list/table rows (shared border) on one line. */
+export const Lists: Story = { render: () => <ListsLine /> };
+
+/** Typography — real paragraph text at several sizes; witness the 4px baseline. */
+export const Typography: Story = { render: () => <TypographyLine /> };
+
+/**
+ * Editorial — `.editorial` prose inside the density scope. Witnesses DS.04: prose
+ * keeps its engine-owned natural leading + inter-block margins and stays on-grid,
+ * while density seats controls. Toggle context/density — prose rhythm must not
+ * change, proving they compose instead of collide.
+ */
+export const Editorial: Story = { render: () => <EditorialLine /> };
+
+/**
+ * DS.01 — the size-agnostic `.baseline` class. Arbitrary off-scale font sizes,
+ * each snapped to the grid by `.baseline` alone (no tier). Proves the alignment
+ * machinery is decoupled from any particular font size.
+ */
+export const BaselineClass: Story = { render: () => <BaselineProofLine /> };
+
+/**
+ * DS.02 — `.spike-baseline-boxed` (prototype) fixed box. Dense (24px) and
+ * comfortable (32px) rows; within each, mixed sizes share a box height snapped to
+ * the grid (a fixed `block-size` plus `.baseline` line-height snapping), so the
+ * seated baselines line up regardless of font size.
+ */
+export const BoxedBaseline: Story = { render: () => <BoxedProofLine /> };

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/SPIKE.md
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/SPIKE.md
@@ -1,0 +1,198 @@
+# Baseline-alignment spike — findings
+
+Exploratory spike, not a production refactor. It covers two linked changes:
+
+1. Moving the baseline unit from **8px to 4px**.
+2. An alternative baseline-alignment model for **boxed controls** (buttons,
+   inputs, nav items, list/table rows) that stops forcing the bottom border onto
+   the grid.
+
+Everything is scoped to `_work_in_progress`; the only shared-package edits are
+the 4px default (in `styles`, not tokens) and the grid overlay (in
+`styles-debug`), both called out below.
+
+---
+
+## 1. What the shipped engine does today
+
+The typography engine (`@canonical/styles-typography`, default
+`baseline-cap.css`) snaps each text element's box to the grid with two padding
+nudges computed live in CSS:
+
+```
+--start-nudge = baseline − mod(baseline-position, baseline)   /* seat the text baseline */
+--end-nudge   = baseline − start-nudge                        /* fill to a whole grid multiple */
+
+padding-block-start: var(--start-nudge);
+padding-block-end:   var(--end-nudge);
+```
+
+Because `start-nudge + end-nudge = baseline`, the box height is always a whole
+number of baseline units **and both the top and bottom borders sit on the grid**.
+
+The cost: whenever `start-nudge ≠ end-nudge`, the interior is asymmetric — the
+text is nudged down from the top by one amount and up from the bottom by a
+different amount. On a control with a visible border and a fixed look (a 24px or
+32px button), that reads as the label sitting slightly high or low in its box.
+
+## 2. The proposed model
+
+Keep the top alignment; make the interior symmetric; move the leftover outside
+the box:
+
+```
+padding-block-start: var(--start-nudge);   /* unchanged — seat the baseline */
+padding-block-end:   var(--start-nudge);   /* MIRROR the top nudge, not end-nudge */
+
+/* the box is now NOT a whole grid multiple, so compensate outside it */
+--visible: calc(2*border + 2*start-nudge + line-height);
+margin-block-end: calc(round(up, var(--visible), var(--baseline-height)) − var(--visible));
+```
+
+- Top border stays on the grid.
+- Interior spacing above and below the text is equal → visually balanced.
+- Bottom border floats where it naturally lands.
+- External `margin-block-end` (0…<1 baseline) pads the *occupied* height back to
+  a 4px multiple, so downstream layout rhythm is preserved.
+
+Worked example (the brief's numbers): borders + top nudge + line-height + bottom
+nudge come to a 21px visible box → `margin-block-end: 3px` → 24px occupied.
+
+The alternative (top-align + external-margin) model was prototyped and then
+dropped: the testbed now renders the **shipped engine model only** (the asymmetric
+start/end nudges), with no `.model-current` / `.model-proposed` toggle. This
+section is kept as the record of what was considered and why the external-margin
+approach was not adopted (see §4).
+
+---
+
+## 3. Architectural & token changes required
+
+**Baseline unit (4px).** Set in `packages/styles/main/src/spacing.css`:
+`--space-baseline: 0.25rem`, no longer reading `--dimension-size-height-baseline`
+(which stays 8px). Promoting 4px into `@canonical/design-tokens` is a **separate
+tokens PR** — not done here on purpose. The engine reads `--baseline-height`
+live, so nothing else changed to move the grid.
+
+**Grid overlay (debug).** `packages/styles/debug/src/baseline-grid.css` now
+defaults to 4px and paints **alternating bands** (tinted 4px / clear 4px) plus a
+major line every 4th baseline, so the denser grid stays readable. Applied only
+via the plugin — the story opts in with `parameters: { baseline: true }` and
+`storybook-addon-utils` toggles `.with-baseline-grid`. (The addon was extended to
+honor that parameter, not just the toolbar global; its `dist` must be rebuilt for
+the change to take effect.)
+
+**The alignment model itself** would live in the engine
+(`baseline-cap.css` / `-metrics` / `-trim`), because that is where `start-nudge`
+/ `end-nudge` are defined. Concretely:
+
+- Add an opt-in mode (class or custom property, e.g. `.baseline-boxed` /
+  `--baseline-mode: boxed`) that swaps `padding-block-end` from `--end-nudge` to
+  `--start-nudge` and emits the compensating `margin-block-end`.
+- The engine currently reserves `margin-block-end` for `--space-after`
+  (editorial). The boxed mode has to **add to** that margin, not overwrite it:
+  `margin-block-end: calc(space-after-margin + compensation)`. This is the one
+  real coupling to untangle.
+- `round()` is already relied on elsewhere in the engine, so no new browser
+  floor.
+
+**Per-component.** Boxed controls (`Button`, form inputs, future Tabs/SideNav
+items, list/table rows) opt into the boxed mode on their outer element. Their
+own `padding-block` (where they set it) must be reconciled with the nudges so the
+two don't stack.
+
+---
+
+## 4. Risks introduced by external margin compensation
+
+- **Margin collapsing.** `margin-block-end` collapses with adjacent block
+  margins and through empty parents. In flex/grid containers margins don't
+  collapse (safe — that is where most controls live), but in plain block flow a
+  control's compensation can merge with a following sibling's top margin and the
+  rhythm silently shifts. The engine deliberately used *padding* to avoid exactly
+  this; the proposed model reintroduces the hazard by design.
+- **Last-child / container edges.** Trailing compensation adds phantom space at
+  the bottom of a container (extra gap under the last row of a table, below the
+  last field in a form). Needs a `:last-child` reset in boxed contexts —
+  analogous to the existing `.content-flow > :last-child { margin-bottom: 0 }`.
+- **`gap` double-counts.** In a flex/grid layout that already sets `gap`, each
+  item's external margin **adds to** the gap, so spacing between controls grows
+  by the compensation amount. Either the layout drops `gap` in favour of the
+  margins, or boxed controls suppress their margin when a gap owns the spacing.
+  (The testbed sets `gap: 0` on the control column precisely so the compensation
+  stays visible instead of being masked.)
+- **Backgrounds / borders / dividers.** The compensation is outside the box, so
+  a full-bleed row background or a shared list divider stops at the border, not
+  at the occupied edge — a 3px unpainted strip appears between rows. The
+  shared-border list case in the testbed is there to show this.
+- **Vertical centering.** Anything relying on the control's *box* being a grid
+  multiple to center it (icon next to label, absolutely-positioned affordances)
+  now centers against a non-grid box; the external margin doesn't participate.
+- **Sticky / scroll math.** Occupied height ≠ border-box height means
+  `scroll-margin`, sticky offsets and `IntersectionObserver` thresholds computed
+  from `getBoundingClientRect()` are off by the compensation.
+
+## 5. Where this model should NOT be used
+
+- **Inline text / prose.** Paragraphs and inline runs already balance naturally;
+  the whole point of the symmetric-interior model is boxed controls with a
+  visible border. Prose keeps the current engine (`.p`, headings unchanged).
+- **Controls whose height is externally fixed** (`height: 32px`, icon-only
+  square buttons). If the height is pinned, interior symmetry is governed by
+  `align-items`, not the nudges, and the external margin just adds stray space.
+- **Grid/flex items that must fill a track** (`align-items: stretch`, table cells
+  with row-spanning). Stretch overrides the box height and the compensation
+  margin is ignored or fights the track.
+- **Anything inside `gap`-based layouts** unless the gap-vs-margin
+  double-count is resolved for that container.
+- **Overlapping / absolutely positioned** elements — margin does nothing there.
+
+## 6. Recommended implementation strategy
+
+Ship it as an **opt-in engine mode**, defaulted off, so nothing changes until a
+component asks for it.
+
+1. **Engine flag.** Add `--baseline-mode: grid | boxed` (default `grid`). In
+   `boxed`, `padding-block-end` mirrors `--start-nudge` and the engine emits
+   `margin-block-end: calc(var(--space-after-margin) + var(--baseline-compensation))`.
+   Keep `grid` byte-for-byte as today.
+2. **Container reset.** Provide a `.baseline-boxed-flow` (or reuse
+   `content-flow`) that zeroes the trailing compensation on the last child and
+   documents the gap-vs-margin rule.
+3. **Adopt on one control first** (Button), verify against prose in the testbed
+   at several sizes, then inputs, then nav items, then list/table rows (the
+   shared-border case last, since it exposes the divider gap).
+4. **Only then** consider promoting 4px + a `density: boxed` token set into
+   `@canonical/design-tokens`.
+
+### Before / after
+
+```css
+/* BEFORE — grid mode (ships today): both borders on grid, interior can be asymmetric */
+.ds.button > .p {
+  padding-block-start: var(--start-nudge);   /* e.g. 3px */
+  padding-block-end:   var(--end-nudge);     /* e.g. 1px  → text sits high */
+}
+
+/* AFTER — boxed mode: symmetric interior, bottom border free, rhythm via margin */
+.ds.button {
+  --visible: calc(2px + calc(2 * var(--start-nudge)) + var(--computed-line-height));
+  margin-block-end: calc(
+    var(--space-after-margin, 0px) +
+    (round(up, var(--visible), var(--baseline-height)) - var(--visible))
+  );
+}
+.ds.button > .p {
+  padding-block-start: var(--start-nudge);   /* 3px */
+  padding-block-end:   var(--start-nudge);   /* 3px  → text balanced */
+}
+```
+
+### Caveat surfaced by the testbed
+
+At the default body size on a 4px grid, `start-nudge ≈ end-nudge`, so the two
+models render nearly identically — the asymmetry the model fixes only becomes
+visible at particular font-size / line-height / border combinations. Any adoption
+decision should be made against a size where the current asymmetry is actually
+visible, not the default paragraph tier. The testbed should grow a row at such a
+size before this is taken forward.

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/Testbed.tsx
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/Testbed.tsx
@@ -1,0 +1,176 @@
+import { Button } from "@canonical/react-ds-global";
+import type { ReactNode } from "react";
+import { Label } from "../../subcomponent/Field/Label/index.js";
+import { TextInput } from "../../subcomponent/TextInput/index.js";
+import { SpikeBox, SpikeRows } from "./mocks.js";
+import "./density.testbed.css";
+import "./baseline-system.css";
+
+/**
+ * Baseline-alignment spike harness (WORK IN PROGRESS)
+ *
+ * Line-based: each bucket renders as ONE horizontal line (its own story), with
+ * a few letters of paragraph-style text at the start (the baseline reference)
+ * followed by the components inline. No cards, no labels. The 4px baseline grid
+ * is supplied by the styles-debug plugin (story parameter).
+ */
+
+/**
+ * A bucket = a short prose prefix + the components, laid out inline with the
+ * NORMAL component structure (no flattening, no overrides) so what we see is what
+ * ships. `align-items: baseline` lines them up; nothing else is customised.
+ */
+const Line = ({ lead, children }: { lead: string; children: ReactNode }) => (
+  <div className="density-testbed">
+    <div className="density-testbed__row">
+      {/* The lead is a REFERENCE marker meant to sit on the controls' baseline.
+          Prose is no longer density-seated (Stage A: the engine owns running
+          text, seated to the NEAREST grid line — a different line from the
+          controls' density TARGET). So this testbed-only class re-seats the lead
+          to the density target, purely so the reference agrees with the controls
+          it is measuring against. Not a change to the shipping model. */}
+      <p className="p density-testbed__lead">{lead}</p>
+      {children}
+    </div>
+  </div>
+);
+
+/** Controls bucket — real Button + a standalone Label and TextInput (used
+ *  separately, so there's no stacked Field grid to flatten). */
+export const ControlsLine = () => (
+  <Line lead="Sample">
+    <Button importance="primary">Re</Button>
+    <Button importance="secondary">Se</Button>
+    <Label name="n">Label</Label>
+    <TextInput name="n" placeholder="In" />
+  </Line>
+);
+
+/** Navigation bucket — tab / side-nav item stand-ins on one line. */
+export const NavigationLine = () => (
+  <Line lead="Ov">
+    <SpikeBox>Ov</SpikeBox>
+    <SpikeBox>In</SpikeBox>
+    <SpikeBox>St</SpikeBox>
+    <SpikeBox>Ne</SpikeBox>
+  </Line>
+);
+
+/** Lists bucket — list/table rows (shared border) on one line. */
+export const ListsLine = () => (
+  <Line lead="Ro">
+    <SpikeRows rows={["n1", "n2", "n3"]} />
+  </Line>
+);
+
+const PROSE =
+  "The quick brown fox jumps over the lazy dog. Pack my box with five dozen " +
+  "liquor jugs, and watch how each line of real prose seats itself on the 4px " +
+  "baseline grid as the size changes.";
+
+/** The real typography tiers the engine styles — h1..h6 + p (mapper.css). No
+ *  custom size classes: each tag IS its tier. */
+const TIERS = ["h1", "h2", "h3", "h4", "h5", "h6", "p"] as const;
+
+/**
+ * Typography bucket — pure engine output, using the package's own tags (h1..h6,
+ * p). First an inline row of each tier side by side (to compare their baselines),
+ * then full stacked paragraphs of each tier (to witness how a real prose block
+ * of each tier sits on the 4px grid).
+ */
+export const TypographyLine = () => (
+  <div className="density-testbed">
+    <div className="density-testbed__type">
+      {TIERS.map((Tag) => (
+        <Tag key={Tag}>The quick brown fox</Tag>
+      ))}
+    </div>
+
+    <div className="density-testbed__prose">
+      {TIERS.map((Tag) => (
+        <Tag key={Tag}>{PROSE}</Tag>
+      ))}
+    </div>
+  </div>
+);
+
+const EDITORIAL_BODY =
+  "Running prose belongs to the typography engine, not the density system. Each " +
+  "line keeps its tier's snapped line-height, so every baseline lands on the 4px " +
+  "grid — and, unlike a line-height:1 crush, WRAPPED lines stay on the grid too.";
+
+/**
+ * Editorial bucket — a real `.editorial` prose document (mixed headings + body)
+ * rendered INSIDE the density scope the story toolbar applies. This witnesses the
+ * DS.04 composition: density seats controls, but leaves prose to the engine, so
+ * `.editorial` here keeps its natural multi-line leading, seats every line on the
+ * grid, AND gets its whole-baseline inter-block margins (--space-after) — with no
+ * density override fighting it. Flip context/density in the toolbar: the prose
+ * rhythm must NOT change (it is engine-owned), proving density and editorial
+ * compose rather than collide.
+ */
+export const EditorialLine = () => (
+  <div className="density-testbed">
+    <article className="editorial density-testbed__prose">
+      <h2>Editorial composes with density</h2>
+      <p>{EDITORIAL_BODY}</p>
+      <h3>Inter-block rhythm</h3>
+      <p>{PROSE}</p>
+      <p>
+        A second paragraph, so the `--space-after` margin between blocks is
+        visible: each block still opens and closes on a grid line.
+      </p>
+    </article>
+  </div>
+);
+
+/** Deliberately off-scale sizes — none is a tier. Each is only a `.baseline`
+ *  element with an inline font-size; if they all seat on the grid, `.baseline`
+ *  is genuinely size-agnostic (DS.01). */
+const OFF_SCALE = [19, 27, 35, 43, 53, 61];
+
+/**
+ * DS.01 proof — the size-agnostic `.baseline` class. A row of arbitrary,
+ * off-scale font sizes, each snapped to the 4px grid by `.baseline` alone (no
+ * tier, no engine size class). The tags h1..h6/p are untouched and still nudge
+ * by default — this is additive.
+ */
+export const BaselineProofLine = () => (
+  <div className="density-testbed">
+    <div className="baseline-proof">
+      {OFF_SCALE.map((px) => (
+        <span key={px} className="baseline" style={{ fontSize: `${px}px` }}>
+          {px}px
+        </span>
+      ))}
+    </div>
+  </div>
+);
+
+/** Mixed sizes in the density box, at both densities. Kept within what a dense
+ *  (24px) / comfortable (32px) line-height can hold without clipping. */
+const BOXED_SIZES = [16, 18, 20, 22];
+
+/**
+ * DS.02 proof — `.spike-baseline-boxed` (PROTOTYPE, not core API). Two density
+ * line-heights: dense (24px) and comfortable (32px). Each box snaps to the grid
+ * via the existing start/end nudge; top-referenced, so the boxes share the top
+ * rhythm (a fixed baseline-from-bottom is NOT what the existing calc produces).
+ */
+export const BoxedProofLine = () => (
+  <div className="density-testbed">
+    {(["is-dense", "is-comfortable"] as const).map((density) => (
+      <div key={density} className={`boxed-proof ${density}`}>
+        {BOXED_SIZES.map((px) => (
+          <span
+            key={px}
+            className="baseline spike-baseline-boxed"
+            style={{ fontSize: `${px}px` }}
+          >
+            {px}
+          </span>
+        ))}
+      </div>
+    ))}
+  </div>
+);

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/baseline-system.css
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/baseline-system.css
@@ -1,0 +1,81 @@
+/**
+ * Testbed chrome for the baseline/density spike (WORK IN PROGRESS).
+ *
+ * The density + baseline MODEL now lives in the package: src/density.css
+ * (imported by src/index.css), so real components consume it by default. This
+ * file keeps only the TESTBED-ONLY helpers: the size-agnostic `.baseline` proof
+ * class and the `.spike-baseline-boxed` prototype + their proof surfaces.
+ */
+
+/* ── DS.01 — .baseline: snap any element to the grid, whatever its size ──────
+ * Reads whatever --font-size / --line-height is present and computes the same
+ * cap-unit nudges the engine uses on h1..h6/p, without assigning a tier. The
+ * maths is font-relative, so it holds at any size. */
+.baseline {
+  --bl-line-height-ratio: var(--line-height-ratio, 1.4);
+  --bl-computed-line-height: var(
+    --line-height,
+    round(up, calc(1em * var(--bl-line-height-ratio)), var(--baseline-height))
+  );
+  line-height: var(--bl-computed-line-height);
+
+  --bl-baseline-position: calc((var(--bl-computed-line-height) + 1cap) / 2);
+  --bl-start-nudge: calc(
+    var(--baseline-height) -
+    mod(var(--bl-baseline-position), var(--baseline-height))
+  );
+  --bl-end-nudge: calc(var(--baseline-height) - var(--bl-start-nudge));
+
+  padding-block-start: var(--bl-start-nudge);
+  padding-block-end: var(--bl-end-nudge);
+  margin-block: 0;
+}
+
+/* ── DS.02 — .spike-baseline-boxed: PROTOTYPE ONLY, NOT CORE API ─────────────
+ * `.baseline` with a density-chosen line-height; the box height is snapped to the
+ * grid (intrinsic snap via calc-size where supported, fixed grid-multiple
+ * fallback). Testbed only; never export. */
+.spike-baseline-boxed {
+  --line-height: var(--density-line-height, calc(var(--baseline-height) * 6));
+  box-sizing: border-box;
+  block-size: var(--density-line-height, calc(var(--baseline-height) * 6));
+}
+@supports (block-size: calc-size(min-content, size)) {
+  .spike-baseline-boxed {
+    block-size: calc-size(min-content, round(up, size, var(--baseline-height)));
+  }
+}
+
+/* ── Proof surface for .baseline (DS.01) — off-scale sizes on one line ─────── */
+.baseline-proof {
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--baseline-height) * 4);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.baseline-proof > .baseline {
+  font-family: inherit;
+}
+
+/* ── Proof surface for .spike-baseline-boxed (DS.02) — mixed sizes, 2 densities ── */
+.boxed-proof {
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--baseline-height) * 3);
+  overflow-x: auto;
+  white-space: nowrap;
+  margin-block: calc(var(--baseline-height) * 2);
+}
+.boxed-proof > .spike-baseline-boxed {
+  border: 1px solid var(--color-border, #b3b3b3);
+  border-radius: var(--dimension-radius-100, 0.25rem);
+  padding-inline: calc(var(--baseline-height) * 2);
+  background: transparent; /* let the grid overlay show through */
+}
+.boxed-proof.is-dense {
+  --density-line-height: calc(var(--baseline-height) * 6); /* 24px */
+}
+.boxed-proof.is-comfortable {
+  --density-line-height: calc(var(--baseline-height) * 8); /* 32px */
+}

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/density.testbed.css
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/density.testbed.css
@@ -1,0 +1,153 @@
+/**
+ * Baseline-alignment spike — testbed stylesheet (WORK IN PROGRESS)
+ *
+ * SPIKE surface, not shipping CSS. Scoped under `.density-testbed`.
+ *
+ * Layout philosophy (per session S TODOs 2–4, 7):
+ *   · No cards, no field labels — zero chrome noise.
+ *   · LINE-BASED: each bucket is ONE horizontal line of inline-block elements.
+ *     Overflow-x scroll is fine; we are reading vertical alignment, not layout.
+ *   · One bucket per story.
+ *   · Every line starts with a few letters of paragraph-style text (the `.p`
+ *     reference), so controls can be read against prose on the same baseline.
+ *
+ * The baseline grid overlay comes from the styles-debug plugin (story
+ * `parameters.baseline`); the box seat uses the shipped engine model (the
+ * alternative top-align + external-margin model lives in SPIKE.md).
+ */
+
+/* ── The testbed root ── */
+.density-testbed {
+  /* --baseline-height is 4px. Source of truth, in order:
+     1. @canonical/styles-typography's baseline-shim.css registers it via
+        `@property … initial-value: 0.25rem`, so the engine ALWAYS has 4px even
+        if styles-main did not load (order-independent — learned from the
+        typography example, which loads an engine standalone). Then
+     2. @canonical/styles' spacing.css sets it explicitly to 0.25rem when present.
+     The literal fallback below is belt-and-suspenders; the @property makes it
+     redundant. Nothing to override here. */
+  padding: 0 var(--baseline-height, 0.25rem);
+  color: var(--color-text, #1a1a1a);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Bucket row — REGULAR component layout, no flattening or overrides
+ *
+ * A simple inline row: a short prose lead, then the components in their NORMAL
+ * structure laid inline. Controls are top-referenced density boxes (the density
+ * system seats each one's text on the grid INTERNALLY), so the row aligns the
+ * boxes by their TOPS. No block padding — the row must sit at the canvas origin
+ * so what we read is the density system's own grid registration, not a nudge. */
+.density-testbed__row {
+  display: flex;
+  flex-wrap: nowrap; /* one horizontal line — overflow scrolls, never wraps */
+  align-items: flex-start;
+  gap: calc(var(--baseline-height) * 3); /* 12px */
+  overflow-x: auto;
+}
+.density-testbed__row > * {
+  flex: 0 0 auto; /* natural width, don't grow/shrink; the row scrolls instead */
+}
+.density-testbed__row > .p {
+  margin: 0;
+}
+
+/* Re-seat the reference LEAD to the density target (TESTBED ONLY) ──────────────
+ * Prose is engine-seated now (Stage A), which lands it on the NEAREST grid line —
+ * one baseline off from the controls' density TARGET line. The lead only exists to
+ * be read against the controls, so here (and only here) we opt it back into the
+ * exact density seat the controls use: crush to line-height 1, then pad the top by
+ * the same `target − (1em+1cap)/2` the shipping controls use. This is calibration
+ * of a measuring stick, NOT a change to how prose ships. */
+.density-testbed__row > .density-testbed__lead.p {
+  line-height: 1;
+  padding-block-start: max(
+    0px,
+    calc(var(--density-target-baseline-px, 0px) - calc((1em + 1cap) / 2))
+  );
+  padding-block-end: 0;
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Boxed controls — the two alignment models
+ *
+ * `.spike-box` is a bordered box whose interior is a single line of `.p` text
+ * (button label, input value, nav item, table cell). Inline-block so it sits on
+ * the line. The text seat reads the engine's --start-nudge / --end-nudge.
+ * ─────────────────────────────────────────────────────────────────────────── */
+.density-testbed .spike-box {
+  --box-border-width: 1px;
+  --box-padding-inline: var(--density-padding-inline, 0.75rem);
+
+  display: inline-flex;
+  align-items: stretch;
+  box-sizing: border-box;
+  vertical-align: baseline;
+  border: var(--box-border-width) solid var(--color-border, #b3b3b3);
+  border-radius: var(--dimension-radius-100, 0.25rem);
+  padding-inline: var(--box-padding-inline);
+  background: var(--color-background, #fff);
+}
+
+.density-testbed .spike-box > .seat {
+  display: block;
+  white-space: nowrap;
+}
+
+/* Shared-border stack (list/table rows) — laid horizontally on the line here,
+   each cell a box; the shared-border collapse is between inline siblings. */
+.density-testbed .spike-rows {
+  display: inline-flex;
+  vertical-align: baseline;
+}
+.density-testbed .spike-rows > .spike-box {
+  border-radius: 0;
+}
+.density-testbed .spike-rows > .spike-box + .spike-box {
+  border-inline-start: none;
+}
+
+/* Box seat — the shipped engine model: engine's asymmetric nudges, both borders
+ * on the grid. (The current/proposed model toggle was removed; the alternative
+ * top-align + external-margin model is documented in SPIKE.md.) */
+.density-testbed .spike-box > .seat {
+  padding-block-start: var(--start-nudge);
+  padding-block-end: var(--end-nudge);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Typography bucket (TODO 5) — real paragraph text at several sizes on one line,
+ * to witness how the 4px baseline affects cap-based nudges (TODO 6). Inline so
+ * the sizes sit next to each other and can be read against the grid together.
+ * ─────────────────────────────────────────────────────────────────────────── */
+.density-testbed__type {
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--baseline-height) * 4);
+  overflow-x: auto;
+  white-space: nowrap;
+  padding-block: calc(var(--baseline-height) * 2);
+}
+
+/* Stacked full paragraphs of each tier, one after another, below the inline
+   row — so a real prose BLOCK of each tier can be read against the grid. */
+.density-testbed__prose {
+  max-width: 40rem;
+  margin-top: calc(var(--baseline-height) * 4);
+}
+
+/* Both sections use the package's own tags (h1..h6, p). The engine sizes each
+   tier; we only reset the demo margins so the grid reading is clean. No custom
+   size classes — each tag IS its tier. */
+.density-testbed__type > :where(h1, h2, h3, h4, h5, h6, p),
+.density-testbed__prose > :where(h1, h2, h3, h4, h5, h6, p) {
+  margin: 0;
+}
+
+/* ── Density inline lever (retained) ── */
+.density-comfortable {
+  --density-padding-inline: 0.75rem;
+}
+.density-dense {
+  --density-padding-inline: 0.5rem;
+}

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/mocks.tsx
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/DensityTestbed/mocks.tsx
@@ -1,0 +1,47 @@
+import type React from "react";
+
+/**
+ * Baseline-alignment spike — boxed-control primitive + mocks (WORK IN PROGRESS)
+ *
+ * `SpikeBox` is the unit under test: a bordered box whose interior is a single
+ * line of `.p`-tier text (a stand-in for a button label, input value, nav-item
+ * text or table-cell text). Its seat uses the shipped engine model (the
+ * asymmetric start/end nudges from `density.testbed.css`); the alternative
+ * external-margin model was dropped, so there is no model toggle. Using one
+ * primitive keeps buckets comparing like-for-like; the real Button/inputs are
+ * shown alongside in the story for reference.
+ */
+
+/** A boxed control: border + a `.p` text seat, seated on the grid by the engine's
+ *  start/end nudges (see density.testbed.css). */
+export const SpikeBox = ({
+  children,
+  as = "div",
+  role,
+}: {
+  children: React.ReactNode;
+  as?: "div" | "button";
+  role?: string;
+}): React.ReactElement => {
+  const Tag = as;
+  return (
+    <Tag
+      className="spike-box"
+      role={role}
+      type={as === "button" ? "button" : undefined}
+    >
+      <span className="seat p">{children}</span>
+    </Tag>
+  );
+};
+
+/** A run of boxed cells sharing one border — the list/table-row case, laid out
+ *  inline on the bucket line (the CSS collapses the between-borders). Exercises
+ *  how per-cell external margin interacts with a shared border. */
+export const SpikeRows = ({ rows }: { rows: string[] }): React.ReactElement => (
+  <div className="spike-rows">
+    {rows.map((r) => (
+      <SpikeBox key={r}>{r}</SpikeBox>
+    ))}
+  </div>
+);


### PR DESCRIPTION
## Done

Last PR of the **baseline-alignment & density** stack — the spike harness, kept in `_work_in_progress` so it never enters the public API. Stacked on #805; review against `density/pr3-density-model`.

- **Stories** (`DensityTestbed.stories.tsx`) — Controls / Navigation / Lists / Typography / Editorial, plus the DS.01 `.baseline` and DS.02 boxed-baseline proofs. All render with the 4px overlay on by default.
- **Harness** (`Testbed.tsx`, `density.testbed.css`, `baseline-system.css`, `mocks.tsx`) — a line-based surface for reading controls and prose against the grid. The Editorial story witnesses the density/`.editorial` composition (prose keeps engine rhythm inside a density scope).
- **`SPIKE.md`** — the findings write-up: the shipped model, the risks, and where the model should *not* be used.

## QA

- `nx affected -t build` — green (3 projects).
- Eyeball in Storybook: `_work_in_progress` → BaselineAlignmentSpike — each story on the 4px grid; flip the Density/Context toolbar and read the controls against the overlay.

### PR readiness check

- [x] Label: `Maintenance 🔨`
- [x] Conventional-commit title
- [x] Follows code standards
- [x] `check` / `test` present on the package
- [ ] No new package
- [x] `no visual change` — the testbed is WIP-only, not a shipped surface

## Screenshots

`_work_in_progress` → BaselineAlignmentSpike stories (overlay on): Controls, Editorial, and the DS.01/DS.02 proofs.
