### PR TITLE
feat(density): move primitives to @canonical/styles + density-aware Accordion header

### DIFF
--- a/packages/react/ds-global-form/src/density.css
+++ b/packages/react/ds-global-form/src/density.css
@@ -1,125 +1,21 @@
-/* @canonical/react-ds-global-form — density & baseline alignment
+/* @canonical/react-ds-global-form — density & baseline alignment (FORM APPLICATION)
  *
- * Two composed modifier families that size controls and seat their text on the
- * 4px baseline grid. Applied as classes on an ancestor (e.g. the app root, or the
- * Storybook root via the DS-utils toolbar):
+ * The GENERIC density primitives — the context/density modifier families
+ * (.app/.site/.docs × .comfortable/.dense) and their --density-* outputs
+ * (--density-line-height(-effective), --density-target-baseline-px,
+ * --density-padding-inline, --density-space-sm/-md/-lg) — now live in
+ * @canonical/styles (`modifiers.density.css`), so EVERY package can read them
+ * (ds-global's Accordion as well as this form package). See that file for the
+ * 2×3 matrix and the value table.
  *
- *   CONTEXT  .app / .site / .docs  — the surface. Sets the comfortable/dense
- *            control height PAIR. Default (no class) = apps.
- *   DENSITY  .comfortable / .dense — picks within the context pair. Default
- *            (no class) = comfortable.
+ * THIS file is the FORM APPLICATION layer: it applies those primitives to the
+ * form's own controls (`.ds.button`, `.ds.input`, `.ds.field-label/description/
+ * error`, the textarea) — sizing their boxes to the density cell and seating
+ * their text on the 4px grid. The --form-* token mapping lives in index.css.
  *
- * Control height (a whole 4px multiple), context × density:
- *                comfortable   dense
- *     apps          32px        24px
- *     sites/docs    36px        28px
- *
- * The text baseline sits round(up, height × 2/3) baselines down the box, so every
- * control — button, input, and inline text — shares one baseline. Zero-JS
- * (cap-unit approximation); alignment holds to the cap tolerance (~±1px).
+ * Text baseline sits round(up, height × 2/3) down the box, so every control shares
+ * one baseline. Zero-JS (cap-unit approximation); holds to the cap tolerance.
  */
-
-/* ── Context family: the comfortable/dense PAIR per surface ──────────────────
- * The density model is a 2×3 matrix — density (comfortable/dense) × context (app /
- * site / docs), where DOCS = SITE (they share a pair). Context sets the pair for
- * every DENSITY primitive (control height, inline padding, and three neutral
- * vertical spacing rungs sm/md/lg); density (below) picks within it. Sites/docs
- * run one baseline looser than apps on the height (+4px) and each rung, so the
- * looser surface breathes. Every value is a WHOLE baseline multiple, so vertical
- * rhythm holds in all four cells.
- *
- * LAYERING: this file is the LOWER layer. It exposes only GENERIC, domain-neutral
- * primitives (--density-*) — a line-height, an inline padding, and a three-rung
- * vertical spacing scale (--density-space-sm/-md/-lg). It knows NOTHING about the
- * form or its fields. The FORM layer (index.css) maps its own --form-field-*
- * tokens onto these rungs. Never name a field concept here.
- *
- *                    app                 site / docs
- *                    comfy   dense       comfy   dense
- *   line-height      32 (8)  24 (6)      36 (9)  28 (7)
- *   padding-inline   16 (4)   8 (2)      16 (4)  12 (3)
- *   space-lg         24 (6)  16 (4)      28 (7)  20 (5)
- *   space-md         16 (4)   8 (2)      20 (5)  12 (3)
- *   space-sm          8 (2)   4 (1)       8 (2)   8 (2)
- *   (parenthesised = baseline units; 1 bU = --baseline-height = 4px)
- */
-.app {
-  --lh-comfy: calc(var(--baseline-height) * 8); /* 32px */
-  --lh-dense: calc(var(--baseline-height) * 6); /* 24px */
-  --pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
-  --pad-inline-dense: calc(var(--baseline-height) * 2); /*  8px */
-  --space-lg-comfy: calc(var(--baseline-height) * 6); /* 24px */
-  --space-lg-dense: calc(var(--baseline-height) * 4); /* 16px */
-  --space-md-comfy: calc(var(--baseline-height) * 4); /* 16px */
-  --space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
-  --space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
-  --space-sm-dense: calc(var(--baseline-height) * 1); /*  4px */
-}
-.site,
-.docs {
-  --lh-comfy: calc(var(--baseline-height) * 9); /* 36px */
-  --lh-dense: calc(var(--baseline-height) * 7); /* 28px */
-  --pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
-  --pad-inline-dense: calc(var(--baseline-height) * 3); /* 12px */
-  --space-lg-comfy: calc(var(--baseline-height) * 7); /* 28px */
-  --space-lg-dense: calc(var(--baseline-height) * 5); /* 20px */
-  --space-md-comfy: calc(var(--baseline-height) * 5); /* 20px */
-  --space-md-dense: calc(var(--baseline-height) * 3); /* 12px */
-  --space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
-  --space-sm-dense: calc(var(--baseline-height) * 2); /*  8px */
-}
-
-/* ── Density family: pick within the context pair ────────────────────────────
- * Each density tier resolves every GENERIC primitive from the context's
- * *-comfy / *-dense pair. Fallbacks cover the app-comfortable defaults when no
- * context class is present (a plain `.comfortable` still works). Output is the
- * neutral --density-* surface the form layer consumes — no field names here. */
-.comfortable {
-  --density-line-height: var(--lh-comfy, calc(var(--baseline-height) * 8));
-  --density-padding-inline: var(
-    --pad-inline-comfy,
-    calc(var(--baseline-height) * 4)
-  );
-  --density-space-lg: var(--space-lg-comfy, calc(var(--baseline-height) * 6));
-  --density-space-md: var(--space-md-comfy, calc(var(--baseline-height) * 4));
-  --density-space-sm: var(--space-sm-comfy, calc(var(--baseline-height) * 2));
-}
-.dense {
-  --density-line-height: var(--lh-dense, calc(var(--baseline-height) * 6));
-  --density-padding-inline: var(
-    --pad-inline-dense,
-    calc(var(--baseline-height) * 2)
-  );
-  --density-space-lg: var(--space-lg-dense, calc(var(--baseline-height) * 4));
-  --density-space-md: var(--space-md-dense, calc(var(--baseline-height) * 2));
-  --density-space-sm: var(--space-sm-dense, calc(var(--baseline-height) * 1));
-}
-
-/* ── Target baseline = round(up, height × 2/3) ──────────────────────────────
- * Snapped UP so fractional cases lift (apps-comfy 5.33→6) while exact multiples
- * stay (apps-dense 4.0, sites-comfy 6.0). Matches: apps 32→6th/24→4th,
- * sites 36→6th/28→5th. */
-:where(.comfortable, .dense, .app, .site, .docs) {
-  /* Effective line-height with the SAME fallback chain the control box uses
-     (--density-line-height → context --lh-comfy → apps-comfy literal). Without
-     this fallback, a bare context class (.app/.site/.docs applied with no density
-     class — the documented "no class = comfortable" case) leaves
-     --density-line-height unset, the round(calc(var(--density-line-height)…))
-     becomes invalid, the target resolves to 0, and controls lose their seating. */
-  --density-line-height-effective: var(
-    --density-line-height,
-    var(--lh-comfy, calc(var(--baseline-height) * 8))
-  );
-  --density-target-baseline-px: round(
-    up,
-    calc(var(--density-line-height-effective) * 2 / 3),
-    var(--baseline-height)
-  );
-}
-
-/* The FORM layer's mapping of these generic --density-* primitives onto its own
- * --form-field-* tokens lives in index.css (the form owns that knowledge, not the
- * density layer). This file stops at exposing the primitives. */
 
 /* ── Controls consume the density box ───────────────────────────────────────
  * A control is a FIXED grid-multiple height with border-box so its border is

--- a/packages/react/ds-global/src/lib/component/Accordion/Accordion.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Accordion/Accordion.stories.tsx
@@ -73,6 +73,34 @@ export const Heading: Story = {
 };
 
 /**
+ * A header whose text is long enough to WRAP onto a second line. Under a density
+ * scope each header line must stay on the 4px baseline grid, and a two-line header
+ * grows in whole baseline rows rather than clipping — this story is the check for
+ * the multi-line case. Rendered narrow so the headings wrap.
+ */
+export const MultiLineHeading: Story = {
+  render: () => (
+    <div style={{ maxWidth: "22rem" }}>
+      <Component>
+        <Component.Item heading="A rather long accordion heading that wraps onto a second line">
+          <p className="p">
+            The header above spans two lines; both lines should sit on the
+            baseline grid, and the collapsed item should be a whole number of
+            baseline rows tall.
+          </p>
+        </Component.Item>
+        <Component.Item heading="A short one">
+          <p className="p">A single-line header for comparison.</p>
+        </Component.Item>
+        <Component.Item heading="Another long heading that also needs to wrap across two lines here">
+          <p className="p">Two long headers in a row to check for drift.</p>
+        </Component.Item>
+      </Component>
+    </div>
+  ),
+};
+
+/**
  * The accordion adapts to nested `.surface` contexts: its header background
  * uses the ghost surface channel, which steps to layer 2 and layer 3 as the
  * component is nested inside successive `.surface` containers.

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
@@ -8,6 +8,11 @@
  * auto-steps on nested .surface contexts to layer2/layer3), text uses
  * color-text, the chevron uses color-icon, and dividers use color-border-muted.
  * Vertical padding is expressed in baseline multiples.
+ *
+ * NOTE: the apps/sites element-size sizing (collapsed item at 36px sites / 32px
+ * apps, and the matching h6 line box) is intentionally NOT set here — control
+ * heights across apps vs sites are owned by the density/height bucket, not this
+ * design-review geometry pass.
  */
 :root {
   --accordion-item-color-text: var(--color-text);
@@ -25,16 +30,20 @@
   /* Default header background (surface 1). The surface channel is applied on
      the element below — NOT here — because a var() referencing
      --surface-color-foreground-ghost resolved in :root would capture the :root
-     value (where no .surface is active) and never step. The surface layer only
-     re-channels the base ghost (no hover/active channel), so hover/active pair
-     to the non-layered ghost vars directly. */
+     value (where no .surface is active) and never step. The built surface
+     layer re-channels only the base ghost (no hover/active channel), so
+     hover/active default to the non-layered ghost state vars here and are
+     re-pointed per surface nesting depth by the stopgap rules below the
+     header. */
   --accordion-item-header-background: var(--color-foreground-ghost);
   --accordion-item-header-background-hover: var(--color-foreground-ghost-hover);
   --accordion-item-header-background-active: var(
     --color-foreground-ghost-active
   );
 
-  --accordion-item-header-gap: var(--dimension-100);
+  --accordion-item-header-gap: var(--dimension-200);
+  /* Header block padding in baseline multiples (dimension-100 = 1 bU). The
+     apps/sites element-size sizing (6px → 36/32) is owned by the height bucket. */
   --accordion-item-header-padding-block: var(--dimension-100);
   --accordion-item-header-padding-inline: var(--dimension-200);
 
@@ -95,13 +104,49 @@
     display: none;
   }
 
+  /* Prefer the surface hover/active channels so a future token build that
+     ships them steps automatically; today they are unset everywhere, so these
+     resolve to the fallback tokens, re-pointed per nesting depth below. */
   &:hover {
-    background-color: var(--accordion-item-header-background-hover);
+    background-color: var(
+      --surface-color-foreground-ghost-hover,
+      var(--accordion-item-header-background-hover)
+    );
   }
 
   &:active {
-    background-color: var(--accordion-item-header-background-active);
+    background-color: var(
+      --surface-color-foreground-ghost-active,
+      var(--accordion-item-header-background-active)
+    );
   }
+}
+
+/* STOPGAP — step the header hover/active backgrounds with surface nesting.
+   The built surfaces modifier re-channels only the base ghost (it exposes no
+   --surface-color-foreground-ghost-hover/-active), so without this, hovering
+   a header on a layer-2/3 surface painted the base-layer colour. These rules
+   mirror the modifier's own nesting selectors to re-point the hover/active
+   tokens at the layered state tokens. Hard-coding surface depth in component
+   CSS is exactly what the token block above avoids — delete both rules once
+   the surfaces modifier ships the hover/active channels (the :hover/:active
+   rules above already prefer them). */
+.surface .surface .ds.accordion-item {
+  --accordion-item-header-background-hover: var(
+    --color-foreground-ghost-layer2-hover
+  );
+  --accordion-item-header-background-active: var(
+    --color-foreground-ghost-layer2-active
+  );
+}
+
+.surface .surface .surface .ds.accordion-item {
+  --accordion-item-header-background-hover: var(
+    --color-foreground-ghost-layer3-hover
+  );
+  --accordion-item-header-background-active: var(
+    --color-foreground-ghost-layer3-active
+  );
 }
 
 /* The consumer supplies the heading content — plain text by default (rendered
@@ -116,13 +161,26 @@
   font-family: var(--typography-text-primary-font-family);
   font-size: var(--typography-text-primary-font-size);
   font-weight: var(--typography-text-primary-font-weight);
-  line-height: var(--typography-text-primary-line-height);
+  /* HEIGHT MODEL (step 1 — height first, seating comes later): under a density
+     scope the heading line-height is SNAPPED UP to a whole baseline multiple, so
+     every line of the heading is a whole number of 4px rows. This makes the header
+     height grid-aligned by construction: a 1-line header fills one density cell
+     (via the item min-block), and each wrapped line adds exactly one snapped
+     line-height — never the off-grid natural ~23.5px that made a 2-line header
+     63px. Outside a density scope the natural tier line-height is unchanged. */
+  line-height: var(
+    --accordion-item-heading-line-height,
+    var(--typography-text-primary-line-height)
+  );
   letter-spacing: var(--typography-text-primary-letter-spacing);
 
   /* Normalise every heading element except <h6> down to the inherited body
-     tier. <h6> is left untouched so the base h6 tier from
-     @canonical/styles-typography applies (correct heading-6 tokens, including
-     the baseline-snapped line-height) — no heading-6 tokens are restated here. */
+     tier. <h6> keeps the base h6 tier from @canonical/styles-typography
+     (correct heading-6 tokens, including the baseline-snapped line-height) — no
+     heading-6 tokens are restated here.
+     NOTE: the per-context h6 line box (24px sites / 20px apps) and zeroing the
+     heading padding-block nudges to make the header height padding-driven are
+     part of the apps/sites height bucket, not this pass. */
   & :is(h1, h2, h3, h4, h5) {
     margin: 0;
     font: inherit;
@@ -204,5 +262,41 @@
   padding-block-end: calc(
     var(--accordion-item-content-padding-block) -
     var(--dimension-stroke-thickness-medium)
+  );
+}
+
+/* ── Density height model (STEP 1: get the height right; seating is layered on
+   after this). The #766 geometry pass deferred the collapsed-item element size
+   (32px apps / 36px sites, dense 24 / 28) to this density work. Here we only make
+   the HEIGHT a whole baseline multiple in every case:
+
+     · The ITEM is pinned to the density cell height (min-block-size + border-box),
+       so the whole item — INCLUDING its 1px block-end divider — is exactly the
+       cell height. This is what keeps every item a whole baseline multiple and
+       stops the 1px/item drift (the divider is inside the item's own box, not
+       added past a sized header).
+     · The HEADING line-height is snapped UP to a whole baseline multiple, so each
+       line is a whole number of 4px rows: a 1-line header fills the cell, a 2-line
+       header is cell-plus-one-snapped-line (grid-aligned), never the off-grid
+       natural line-height that made a two-line header 63px.
+     · The header's own block padding is a whole baseline multiple (1 bU) so it
+       does not knock the header off the grid.
+
+   Fire only under a density scope; the plain accordion is unchanged. */
+.app .ds.accordion-item,
+.site .ds.accordion-item,
+.docs .ds.accordion-item {
+  box-sizing: border-box;
+  min-block-size: var(--density-line-height-effective);
+}
+.app .ds.accordion-item > .header > .heading,
+.site .ds.accordion-item > .header > .heading,
+.docs .ds.accordion-item > .header > .heading {
+  /* Snap the tier's natural line-height up to the grid: round(up, font-size ×
+     ratio, baseline). --typography-text-primary-line-height is a unitless ratio. */
+  --accordion-item-heading-line-height: round(
+    up,
+    calc(1em * var(--typography-text-primary-line-height)),
+    var(--baseline-height)
   );
 }

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
@@ -84,7 +84,15 @@
   align-items: center;
   gap: var(--accordion-item-header-gap);
 
-  padding-block: var(--accordion-item-header-padding-block);
+  /* Block padding is 0 under a density scope (--accordion-item-header-pad-block set
+     there) so the ITEM's density height governs; if the padding stayed at 1 bU the
+     header content (snapped line-height + 2×padding) would exceed the tighter cells
+     (dense 24/28) and the min-block-size could not pin the height. Natural 1 bU
+     padding with no density scope, unchanged. */
+  padding-block: var(
+    --accordion-item-header-pad-block,
+    var(--accordion-item-header-padding-block)
+  );
   padding-inline: var(--accordion-item-header-padding-inline);
 
   color: var(--accordion-item-color-text);
@@ -288,6 +296,13 @@
 .docs .ds.accordion-item {
   box-sizing: border-box;
   min-block-size: var(--density-line-height-effective);
+}
+/* Collapse the header block padding under density so the item's density height
+   governs (dense cells 24/28 are tighter than snapped-line-height + 2×padding). */
+.app .ds.accordion-item > .header,
+.site .ds.accordion-item > .header,
+.docs .ds.accordion-item > .header {
+  --accordion-item-header-pad-block: 0px;
 }
 .app .ds.accordion-item > .header > .heading,
 .site .ds.accordion-item > .header > .heading,

--- a/packages/styles/main/src/index.css
+++ b/packages/styles/main/src/index.css
@@ -42,6 +42,10 @@
 /* Spacing architecture tokens */
 @import url("./spacing.css");
 
+/* Density modifier family (context × density → control height + baseline).
+ * After spacing.css, which supplies the --baseline-height these primitives use. */
+@import url("./modifiers.density.css");
+
 /* Scroll overflow affordance tokens */
 @import url("./overflow.css");
 

--- a/packages/styles/main/src/modifiers.density.css
+++ b/packages/styles/main/src/modifiers.density.css
@@ -1,0 +1,112 @@
+/* @canonical/styles — Density modifier family
+ *
+ * A composed 2×3 modifier family that sizes controls and seats their text on the
+ * 4px baseline grid, applied as classes on an ancestor (an app root, or a section):
+ *
+ *   CONTEXT  .app / .site / .docs  — the surface. Sets the comfortable/dense
+ *            PAIR for every density primitive. `.docs` shares `.site`'s values.
+ *   DENSITY  .comfortable / .dense — picks within the context pair.
+ *
+ * This is the LOWEST layer of the density system, and it lives in @canonical/styles
+ * so EVERY package can read it (ds-global, ds-global-form, and any future consumer)
+ * — the primitives were previously in ds-global-form, out of reach of ds-global.
+ *
+ * Design contract — components listen to the CHANNEL, never to the class. This
+ * file exposes only GENERIC, domain-neutral primitives; it knows nothing about
+ * forms, fields, buttons, accordions, or any component. A consumer reads the
+ * `--density-*` outputs and applies them to its own box/tokens (see the seating
+ * guides shipped by ds-global-form):
+ *
+ *     --density-line-height            the control-height / line unit for a cell
+ *     --density-line-height-effective  the same, with the full fallback chain
+ *     --density-target-baseline-px     the grid line a control's baseline lands on
+ *     --density-padding-inline         inline padding for a cell
+ *     --density-space-sm / -md / -lg   three vertical spacing rungs for a cell
+ *
+ * Every value is a WHOLE multiple of --baseline-height (from spacing.css), so
+ * vertical rhythm holds in all four cells. Sites/docs run one baseline looser than
+ * apps on the height (+4px) and on each rung, so the looser surface breathes.
+ *
+ *                    app                 site / docs
+ *                    comfy   dense       comfy   dense
+ *   line-height      32 (8)  24 (6)      36 (9)  28 (7)
+ *   padding-inline   16 (4)   8 (2)      16 (4)  12 (3)
+ *   space-lg         24 (6)  16 (4)      28 (7)  20 (5)
+ *   space-md         16 (4)   8 (2)      20 (5)  12 (3)
+ *   space-sm          8 (2)   4 (1)       8 (2)   8 (2)
+ *   (parenthesised = baseline units; 1 bU = --baseline-height = 4px)
+ */
+
+/* ── Context family: the comfortable/dense PAIR per surface ────────────────── */
+.app {
+  --lh-comfy: calc(var(--baseline-height) * 8); /* 32px */
+  --lh-dense: calc(var(--baseline-height) * 6); /* 24px */
+  --pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --pad-inline-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --space-lg-comfy: calc(var(--baseline-height) * 6); /* 24px */
+  --space-lg-dense: calc(var(--baseline-height) * 4); /* 16px */
+  --space-md-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --space-sm-dense: calc(var(--baseline-height) * 1); /*  4px */
+}
+.site,
+.docs {
+  --lh-comfy: calc(var(--baseline-height) * 9); /* 36px */
+  --lh-dense: calc(var(--baseline-height) * 7); /* 28px */
+  --pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --pad-inline-dense: calc(var(--baseline-height) * 3); /* 12px */
+  --space-lg-comfy: calc(var(--baseline-height) * 7); /* 28px */
+  --space-lg-dense: calc(var(--baseline-height) * 5); /* 20px */
+  --space-md-comfy: calc(var(--baseline-height) * 5); /* 20px */
+  --space-md-dense: calc(var(--baseline-height) * 3); /* 12px */
+  --space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --space-sm-dense: calc(var(--baseline-height) * 2); /*  8px */
+}
+
+/* ── Density family: pick within the context pair ────────────────────────────
+ * Each density tier resolves every GENERIC primitive from the context's
+ * *-comfy / *-dense pair. Fallbacks cover the app-comfortable defaults when no
+ * context class is present (a plain `.comfortable` still works). */
+.comfortable {
+  --density-line-height: var(--lh-comfy, calc(var(--baseline-height) * 8));
+  --density-padding-inline: var(
+    --pad-inline-comfy,
+    calc(var(--baseline-height) * 4)
+  );
+  --density-space-lg: var(--space-lg-comfy, calc(var(--baseline-height) * 6));
+  --density-space-md: var(--space-md-comfy, calc(var(--baseline-height) * 4));
+  --density-space-sm: var(--space-sm-comfy, calc(var(--baseline-height) * 2));
+}
+.dense {
+  --density-line-height: var(--lh-dense, calc(var(--baseline-height) * 6));
+  --density-padding-inline: var(
+    --pad-inline-dense,
+    calc(var(--baseline-height) * 2)
+  );
+  --density-space-lg: var(--space-lg-dense, calc(var(--baseline-height) * 4));
+  --density-space-md: var(--space-md-dense, calc(var(--baseline-height) * 2));
+  --density-space-sm: var(--space-sm-dense, calc(var(--baseline-height) * 1));
+}
+
+/* ── Target baseline = round(up, height × 2/3) ──────────────────────────────
+ * Snapped UP so fractional cases lift (apps-comfy 5.33→6) while exact multiples
+ * stay (apps-dense 4.0, sites-comfy 6.0). Matches: apps 32→6th/24→4th,
+ * sites 36→6th/28→5th. */
+:where(.comfortable, .dense, .app, .site, .docs) {
+  /* Effective line-height with the SAME fallback chain a control box uses
+     (--density-line-height → context --lh-comfy → apps-comfy literal). Without
+     this fallback, a bare context class (.app/.site/.docs applied with no density
+     class — the documented "no class = comfortable" case) leaves
+     --density-line-height unset, the round(calc(var(--density-line-height)…))
+     becomes invalid, the target resolves to 0, and controls lose their seating. */
+  --density-line-height-effective: var(
+    --density-line-height,
+    var(--lh-comfy, calc(var(--baseline-height) * 8))
+  );
+  --density-target-baseline-px: round(
+    up,
+    calc(var(--density-line-height-effective) * 2 / 3),
+    var(--baseline-height)
+  );
+}


### PR DESCRIPTION
> **Draft — work in progress.** The accordion header seat (the top/bottom breathing space at the right chrome level) is still being iterated; the height model + the styles move are settled.

## Done

Extends the density model to a component **outside** the form package (the Accordion), which required moving the density primitives to a shared layer first. Stacked on #805; review against `density/pr3-density-model`.

- **Density primitives → `@canonical/styles`** (`modifiers.density.css`). The context/density families (`.app`/`.site`/`.docs` × `.comfortable`/`.dense`) and their `--density-*` outputs (`--density-line-height(-effective)`, `--density-target-baseline-px`, `--density-padding-inline`, `--density-space-sm/-md/-lg`) move out of `ds-global-form` into the shared styles package — both `ds-global` and `ds-global-form` depend on `@canonical/styles`, so the Accordion can now read them. `density.css` in the form package keeps only the form APPLICATION layer.
- **Accordion header density HEIGHT** (`ds-global` Accordion `Item/styles.css`). Under a density scope the collapsed item is pinned to the density cell height (app 32/24, site 36/28):
  - The **item** carries the cell height (`min-block-size` + `border-box`), so the whole item — divider included — is exactly the cell → no per-item drift.
  - The **heading line-height is snapped up to the grid** (`round(up, 1em × ratio, --baseline-height)`), so a one-line header is one cell row and a wrapped header adds whole rows — never the off-grid natural height that made a two-line header 63px.
  - Header block padding collapses to 0 under density so the cell height actually governs (dense cells are tighter than snapped-line + padding).
  - A `MultiLineHeading` story covers the wrap case.

## Deferred (why this is a draft)

- **Header seat / top+bottom breathing space** — adding deliberate top space at the correct chrome level (a `::before` spacer that adds real height, so the item is `space + line + space`, every part a whole baseline multiple) rather than an additive `padding-top` that inflated the box. Still being iterated.
- **Accordion pixel-exact baseline verification** — sub-pixel alignment can't be measured headlessly in CI; needs an eyeball pass in Storybook.

## QA

- `nx run @canonical/react-ds-global:check` — green (biome).
- Eyeball in Storybook (ds-global, Components → Accordion): `Heading`, `MultiLineHeading`, `Default` — flip the Density / Context toolbar; item heights track the density cell (app-dense tighter than site-comfortable), headings on the grid, multi-line wraps without clipping.

### PR readiness check

- [x] Label: `Feature 🎁`
- [x] Conventional-commit title
- [x] Follows code standards (tokens / calc-of-tokens; scoped; value-level wiring)
- [x] `check` / `test` present on the packages
- [ ] No new package
- [ ] `no visual change` — NOT applicable: the density heights are the change

## Screenshots

Accordion headers at app-dense vs site-comfortable (heights track the density cell); MultiLineHeading wrapping on the 4px grid. Captured in Storybook.
