### PR TITLE
fix(density): seat ds-global Button + restore control sizes (re-target of #813)

### DIFF
--- a/packages/react/ds-global-form/src/density.css
+++ b/packages/react/ds-global-form/src/density.css
@@ -9,9 +9,13 @@
  * 2×3 matrix and the value table.
  *
  * THIS file is the FORM APPLICATION layer: it applies those primitives to the
- * form's own controls (`.ds.button`, `.ds.input`, `.ds.field-label/description/
- * error`, the textarea) — sizing their boxes to the density cell and seating
- * their text on the 4px grid. The --form-* token mapping lives in index.css.
+ * form's own controls (`.ds.input`, `.ds.field-label/description/error`, the
+ * textarea) — sizing their boxes to the density cell and seating their text on the
+ * 4px grid. The --form-* token mapping lives in index.css.
+ *
+ * NB the BUTTON is a ds-global component, so its density seat lives in ds-global
+ * (Button/styles.css), reading the same shared --density-* primitives — an app
+ * that ships ds-global without the form package still gets a seated button.
  *
  * Text baseline sits round(up, height × 2/3) down the box, so every control shares
  * one baseline. Zero-JS (cap-unit approximation); holds to the cap tolerance.
@@ -25,15 +29,11 @@
  *
  * Controls no longer carry `.p` — the density system supplies the body font tier
  * (font-size / weight / family) here, and the baseline placement below. */
-/* `:is()` on the density scope (0,1,0) so `:is(...) .ds.button` (0,2,0) beats the
- * Button's own `.ds.button { align-items: center }` (0,1,0) — otherwise the label
- * stays flex-CENTRED and the padding-based baseline placement can't govern. */
 /* NB `.ds.input.textarea` is EXCLUDED: a textarea is a multi-line control whose
  * height is intrinsic (its `min-height: 5lh`), not a single density line — the
  * single-line crush below would flatten it. It gets its own placement further
  * down (grid-multiple line-height so every row sits on the grid). */
-:is(.comfortable, .dense, .app, .site, .docs)
-  :is(.ds.button, .ds.input:not(.textarea)) {
+:is(.comfortable, .dense, .app, .site, .docs) .ds.input:not(.textarea) {
   box-sizing: border-box;
   /* Same effective line-height the target-baseline uses (single source of the
      fallback chain), so a bare context class keeps a valid box height too. */
@@ -107,7 +107,6 @@
   font-family: var(--typography-text-primary-font-family);
 }
 
-:is(.comfortable, .dense, .app, .site, .docs) .ds.button,
 :is(.comfortable, .dense, .app, .site, .docs) .ds.input > input,
 :is(.comfortable, .dense, .app, .site, .docs)
   :is(.ds.field-label, .ds.field-description, .ds.field-error) {
@@ -143,7 +142,7 @@
 :is(.comfortable, .dense, .app, .site, .docs) .ds.input.textarea {
   --td-line-height: var(
     --density-line-height,
-    var(--lh-comfy, calc(var(--baseline-height) * 8))
+    var(--density-lh-comfy, calc(var(--baseline-height) * 8))
   );
   line-height: var(--td-line-height);
   font-size: var(--typography-text-primary-font-size);
@@ -204,22 +203,12 @@
     calc(
       var(
         --density-line-height,
-        var(--lh-comfy, calc(var(--baseline-height) * 8))
+        var(--density-lh-comfy, calc(var(--baseline-height) * 8))
       ) -
       var(--space-before) -
       1em
     )
   );
-}
-
-/* The box's top border sits above the content and counts toward the target, so
- * subtract it once. The NOMINAL --button-border-width (1px) is what put the button
- * ON the baseline — subtract it for BOTH importances. The primary's 0-outline
- * (borderless) is handled by the grid maths, NOT by zeroing this term: switching
- * to `calc(--modifier-outline × width)` lifts the primary a pixel and breaks the
- * alignment (regression found & reverted). Leave the nominal term alone. */
-:where(.comfortable, .dense, .app, .site, .docs) .ds.button {
-  --border-top-width: var(--button-border-width, 0px);
 }
 
 /* ── --control-text-drift-AVOID-USAGE — the one honest patch ──────────────────

--- a/packages/react/ds-global-form/src/docs/Density.mdx
+++ b/packages/react/ds-global-form/src/docs/Density.mdx
@@ -109,9 +109,10 @@ just taller.
 
 The model is layered so each layer knows only about the one below it:
 
-1. **Context classes** set raw pairs — `--lh-comfy` / `--lh-dense`,
-   `--pad-inline-comfy` / `--pad-inline-dense`, and the three vertical rungs
-   `--space-{sm,md,lg}-comfy` / `-dense`.
+1. **Context classes** set raw pairs — `--density-lh-comfy` / `--density-lh-dense`,
+   `--density-pad-inline-comfy` / `--density-pad-inline-dense`, and the three
+   vertical rungs `--density-space-{sm,md,lg}-comfy` / `-dense`. (The pre-namespace
+   bare names — `--lh-comfy` etc. — remain as back-compat aliases.)
 2. **Density classes** pick within each pair and expose _generic, domain-neutral_
    primitives: `--density-line-height`, `--density-padding-inline`, and
    `--density-space-{sm,md,lg}`. This layer knows nothing about "form" or

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/styles.css
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/styles.css
@@ -41,8 +41,8 @@
     & > input[type="radio"] {
       appearance: none;
       box-sizing: border-box;
-      width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
-      height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+      width: var(--dimension-200); /* 16px */
+      height: var(--dimension-200); /* 16px */
       border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
       border-radius: 50%;
       background-color: var(
@@ -107,8 +107,8 @@
       appearance: none;
       box-sizing: border-box;
       position: relative;
-      width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
-      height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+      width: var(--dimension-200); /* 16px */
+      height: var(--dimension-200); /* 16px */
       border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
       border-radius: var(--dimension-radius-small);
       background-color: var(

--- a/packages/react/ds-global-form/src/lib/component/ComboboxField/ComboboxField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ComboboxField/ComboboxField.stories.tsx
@@ -5,7 +5,7 @@ import { ComboboxField } from "./index.js";
 
 // Field-tier stories: the combobox bound to react-hook-form, inside a form.
 const meta = {
-  title: "components/ComboboxField",
+  title: "_work_in_progress/component/ComboboxField",
   component: ComboboxField,
   tags: ["autodocs"],
   decorators: [

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/styles.css
@@ -6,8 +6,12 @@
   /* Align to the field edge like the label (no side margin by default), not to
    * the input's inner padding. Overridable via the shared variable. */
   margin-inline: var(--form-label-padding-inline, 0);
-  width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
-  height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+  /* A 16px control — a fixed element size, NOT a baseline multiple. It was
+     `--space-baseline × 2` (16px when the baseline was 8px), but the 4px-baseline
+     spike halved it to 8px. Size to the stable --dimension-200 (16px) so the
+     control size is decoupled from the baseline grid unit. */
+  width: var(--dimension-200);
+  height: var(--dimension-200);
   border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
   border-radius: var(--dimension-radius-small);
   background: var(

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/ComboboxInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/ComboboxInput.stories.tsx
@@ -6,7 +6,7 @@ import { ComboboxInput } from "./ComboboxInput.js";
 
 // Presentational stories: the combobox is controlled directly, no form.
 const meta = {
-  title: "subcomponents/ComboboxInput",
+  title: "_work_in_progress/subcomponent/ComboboxInput",
   component: ComboboxInput,
   tags: ["autodocs"],
 } satisfies Meta<typeof ComboboxInput>;

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/List/List.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/List/List.stories.tsx
@@ -12,7 +12,7 @@ import Component from "./List.js";
 // import type { StoryFn } from '@storybook/react-vite'
 
 const meta = {
-  title: "subcomponents/ComboboxInput/List",
+  title: "_work_in_progress/subcomponent/ComboboxInput/List",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/ResetButton/ResetButton.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/ResetButton/ResetButton.stories.tsx
@@ -9,7 +9,7 @@ import Component from "./ResetButton.js";
 // import type { StoryFn } from '@storybook/react-vite'
 
 const meta = {
-  title: "subcomponents/ComboboxInput/ResetButton",
+  title: "_work_in_progress/subcomponent/ComboboxInput/ResetButton",
   component: Component,
   tags: ["autodocs"],
 } satisfies Meta<typeof Component>;

--- a/packages/react/ds-global-form/src/lib/subcomponent/FileUploadInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/FileUploadInput/styles.css
@@ -8,7 +8,7 @@
     align-items: center;
     justify-content: center;
     box-sizing: border-box;
-    min-height: calc(var(--space-baseline) * 16); /* 128px — 16bU */
+    min-height: calc(var(--dimension-400) * 4); /* 128px */
     /* Compensate padding for border so total stays on baseline grid */
     padding: calc(
         var(--form-input-padding-block) -
@@ -85,8 +85,8 @@
   }
 
   & > .file-list > .file-item > .file-preview {
-    width: calc(var(--space-baseline) * 4); /* 32px — 4bU */
-    height: calc(var(--space-baseline) * 4); /* 32px — 4bU */
+    width: var(--dimension-400); /* 32px */
+    height: var(--dimension-400); /* 32px */
     object-fit: cover;
     border-radius: var(--form-input-border-radius);
     flex-shrink: 0;

--- a/packages/react/ds-global-form/src/lib/subcomponent/PasswordInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/PasswordInput/styles.css
@@ -33,8 +33,8 @@
     cursor: pointer;
 
     & > .reveal-icon {
-      width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
-      height: calc(var(--space-baseline) * 2);
+      width: var(--dimension-200); /* 16px */
+      height: var(--dimension-200);
       background-color: currentColor;
       mask-repeat: no-repeat;
       mask-position: center;

--- a/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/styles.css
@@ -6,8 +6,10 @@
   appearance: none;
   box-sizing: border-box;
   margin-inline: var(--form-input-padding-inline);
-  width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
-  height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+  /* 16px control — a fixed element size, not a baseline multiple (the 4px-baseline
+     spike halved the old `--space-baseline × 2`). Stable --dimension-200 (16px). */
+  width: var(--dimension-200);
+  height: var(--dimension-200);
   border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
   border-radius: 50%;
   background-color: var(

--- a/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/styles.css
@@ -4,7 +4,7 @@
   /* Element box is as tall as the THUMB (16px), so the thumb and its focus
    * ring are never clipped in a flex row; the visible 8px track is painted by
    * the track pseudo-elements below, vertically centred within this box. */
-  height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+  height: var(--dimension-200); /* 16px */
   background: transparent;
   border: none;
   outline: none;
@@ -14,7 +14,7 @@
    * border even after `appearance: none` on the element — THIS is the visible
    * border. Style the track here: flat, no border, 8px tall. */
   &::-webkit-slider-runnable-track {
-    height: var(--space-baseline); /* 8px — 1bU */
+    height: var(--dimension-100); /* 8px */
     background: var(--color-foreground-slider-track);
     border: none;
     border-radius: var(--dimension-radius-small);
@@ -23,7 +23,7 @@
   /* Firefox draws the track via its own pseudo-element with its own UA border —
    * zero it and paint the flat track here to match WebKit. */
   &::-moz-range-track {
-    height: var(--space-baseline); /* 8px — 1bU */
+    height: var(--dimension-100); /* 8px */
     background: var(--color-foreground-slider-track);
     border: none;
     border-radius: var(--dimension-radius-small);
@@ -31,10 +31,11 @@
 
   &::-webkit-slider-thumb {
     appearance: none;
-    width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
-    height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
-    /* Re-centre the 16px thumb on the 8px runnable-track: (8 − 16) / 2 = −4px. */
-    margin-top: calc((var(--space-baseline) - var(--space-baseline) * 2) / 2);
+    width: var(--dimension-200); /* 16px */
+    height: var(--dimension-200); /* 16px */
+    /* Re-centre the 16px thumb on the 8px runnable-track: (8 − 16) / 2 = −4px.
+       Derived from the actual track/thumb dimension tokens, not the baseline unit. */
+    margin-top: calc((var(--dimension-100) - var(--dimension-200)) / 2);
     border-radius: 50%;
     background: var(--color-foreground-slider-progress);
     border: none;
@@ -42,8 +43,8 @@
   }
 
   &::-moz-range-thumb {
-    width: calc(var(--space-baseline) * 2); /* 16px — 2bU */
-    height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+    width: var(--dimension-200); /* 16px */
+    height: var(--dimension-200); /* 16px */
     border-radius: 50%;
     background: var(--color-foreground-slider-progress);
     border: none;

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/styles.css
@@ -3,9 +3,12 @@
  * slides from left (off) to right (on). Colours come from the switch token
  * channel; the geometry is in baseline multiples. */
 .ds.form-switch {
-  /* Geometry, all derived from the track size and a 1px inset. */
-  --switch-track-width: calc(var(--space-baseline) * 4); /* 32px — 4bU */
-  --switch-track-height: calc(var(--space-baseline) * 2); /* 16px — 2bU */
+  /* Geometry, all derived from the track size and a 1px inset. Fixed element sizes
+     (32×16px), NOT baseline multiples — the 4px-baseline spike halved the old
+     `--space-baseline × 4 / × 2`. Stable dimension tokens decouple the switch size
+     from the baseline grid unit. */
+  --switch-track-width: var(--dimension-400); /* 32px */
+  --switch-track-height: var(--dimension-200); /* 16px */
   --switch-knob-inset: 1px;
   --switch-knob-size: calc(
     var(--switch-track-height) -

--- a/packages/react/ds-global/.storybook/preview.ts
+++ b/packages/react/ds-global/.storybook/preview.ts
@@ -20,6 +20,11 @@ const preview = {
     ...previewConfig.parameters,
     options: {
       storySort: {
+        // Alphabetical WITHIN each group, while the `order` array below still
+        // pins the top-level tier order. Without a method, items in a group that
+        // aren't listed (every component under `components`) keep their file-
+        // discovery order — which floated Tooltip to the top of the sidebar.
+        method: "alphabetical",
         order: [
           // Keep Introduction first inside the Documentation folder.
           "Documentation",

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -82,13 +82,11 @@
      a borderless importance simply resolves to 0 with no separate rule. */
   border-width: calc(var(--modifier-outline, 0) * var(--button-border-width));
 
-  /* Typography and block padding come from the `.p` baseline utility on the
-     element (font-family and the padding-block nudges that align the box to
-     the baseline grid). The button re-points the engine's --font-size/
-     --line-height variables at its text-secondary component tokens —
-     `.ds.button` (0,2,0) outranks `.p` (0,1,0) on the same element — so the
-     label is 14px while the baseline-grid maths stay intact. Declaring
-     font-size/line-height/padding-block directly would bypass the engine. */
+  /* Label typography tokens (text-secondary tier, 14px). The block placement that
+     lands the label on the baseline grid comes from the density seat at the end of
+     this file (the button no longer carries `.p`, so the engine's on-element nudges
+     don't apply — without the seat the label is flat/unaligned). --font-size /
+     --line-height are still exposed for any consumer that reads them. */
   --font-size: var(--button-font-size);
   --line-height: var(--button-line-height);
   font-weight: var(--button-font-weight);
@@ -231,4 +229,50 @@
     background-color: transparent;
     border-color: transparent;
   }
+}
+
+/* ── Density seat (apps 32 / sites 36, dense 24 / 28) ────────────────────────
+ * The button consumes the density primitives from @canonical/styles (context ×
+ * density on an ancestor) to size its box to the cell and seat its label on the
+ * 4px baseline grid. This lives HERE (ds-global) and not in
+ * @canonical/react-ds-global-form's density.css, because the Button is a ds-global
+ * component: an app that ships ds-global without the form package must still get a
+ * seated button, not a flat one. The primitives are read from the shared styles
+ * layer, so there is no form dependency.
+ *
+ * `:is()` on the density scope (0,1,0) so `:is(...) .ds.button` (0,2,0) beats the
+ * button's own `.ds.button { align-items: center }` (0,1,0) — otherwise the label
+ * stays flex-CENTRED and the padding-based baseline placement can't govern. */
+:is(.comfortable, .dense, .app, .site, .docs) .ds.button {
+  box-sizing: border-box;
+  /* Fixed grid-multiple height (the density cell), border-box so the border is
+     absorbed into the height — a bordered and a borderless button of one density
+     are the same height. Top-referenced so the space-before below governs. */
+  block-size: var(--density-line-height-effective);
+  min-block-size: var(--density-line-height-effective);
+  align-items: flex-start;
+  justify-content: flex-start;
+  /* Kill only the UA bottom padding; the placement below owns padding-block-start
+     (a `padding-block: 0` shorthand would out-specify and wipe the start). */
+  padding-block-end: 0;
+
+  /* Crush to line-height:1 for the seat; the baseline within that box is the cap
+     approximation (1em + 1cap)/2. The label font tier (--font-size/--font-family)
+     is the button's own (text-secondary, 14px), set on the base rule. */
+  line-height: 1;
+  --natural-baseline: calc((1em + 1cap) / 2);
+  /* The box's top border sits above the label and counts toward the target, so
+     subtract the NOMINAL --button-border-width for BOTH importances — the primary's
+     0-outline (borderless) is handled by the grid maths, not by zeroing this term
+     (a per-importance term lifts the primary a pixel; regression, reverted). */
+  --border-top-width: var(--button-border-width, 0px);
+  --space-before: max(
+    0px,
+    calc(
+      var(--density-target-baseline-px, 0px) -
+      var(--natural-baseline) -
+      var(--border-top-width, 0px)
+    )
+  );
+  padding-block-start: var(--space-before);
 }

--- a/packages/react/ds-global/src/lib/component/Popover/Popover.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Popover/Popover.stories.tsx
@@ -28,7 +28,7 @@ const stage: Decorator = (Story) => (
 );
 
 const meta = {
-  title: "components/Popover",
+  title: "_work_in_progress/component/Popover",
   component: Component,
   decorators: [stage],
   tags: ["autodocs"],

--- a/packages/styles/main/src/modifiers.density.css
+++ b/packages/styles/main/src/modifiers.density.css
@@ -37,31 +37,61 @@
  *   (parenthesised = baseline units; 1 bU = --baseline-height = 4px)
  */
 
-/* ── Context family: the comfortable/dense PAIR per surface ────────────────── */
+/* ── Context family: the comfortable/dense PAIR per surface ──────────────────
+ * The internal pair-vars are namespaced `--density-*-comfy/-dense` — they ship on
+ * the global @canonical/styles surface, so a bare name like `--lh-comfy` would be
+ * an easy collision with an app-level variable. The pre-namespace names are kept
+ * as back-compat ALIASES (an app or an older ds-global-form that read `--lh-comfy`
+ * directly still resolves) — same computed values, no output change. Read the
+ * namespaced name in new code; the aliases exist only for the transition. */
 .app {
-  --lh-comfy: calc(var(--baseline-height) * 8); /* 32px */
-  --lh-dense: calc(var(--baseline-height) * 6); /* 24px */
-  --pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
-  --pad-inline-dense: calc(var(--baseline-height) * 2); /*  8px */
-  --space-lg-comfy: calc(var(--baseline-height) * 6); /* 24px */
-  --space-lg-dense: calc(var(--baseline-height) * 4); /* 16px */
-  --space-md-comfy: calc(var(--baseline-height) * 4); /* 16px */
-  --space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
-  --space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
-  --space-sm-dense: calc(var(--baseline-height) * 1); /*  4px */
+  --density-lh-comfy: calc(var(--baseline-height) * 8); /* 32px */
+  --density-lh-dense: calc(var(--baseline-height) * 6); /* 24px */
+  --density-pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --density-pad-inline-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-lg-comfy: calc(var(--baseline-height) * 6); /* 24px */
+  --density-space-lg-dense: calc(var(--baseline-height) * 4); /* 16px */
+  --density-space-md-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --density-space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-sm-dense: calc(var(--baseline-height) * 1); /*  4px */
+
+  /* Back-compat aliases (pre-namespace names). Remove once no consumer reads them. */
+  --lh-comfy: var(--density-lh-comfy);
+  --lh-dense: var(--density-lh-dense);
+  --pad-inline-comfy: var(--density-pad-inline-comfy);
+  --pad-inline-dense: var(--density-pad-inline-dense);
+  --space-lg-comfy: var(--density-space-lg-comfy);
+  --space-lg-dense: var(--density-space-lg-dense);
+  --space-md-comfy: var(--density-space-md-comfy);
+  --space-md-dense: var(--density-space-md-dense);
+  --space-sm-comfy: var(--density-space-sm-comfy);
+  --space-sm-dense: var(--density-space-sm-dense);
 }
 .site,
 .docs {
-  --lh-comfy: calc(var(--baseline-height) * 9); /* 36px */
-  --lh-dense: calc(var(--baseline-height) * 7); /* 28px */
-  --pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
-  --pad-inline-dense: calc(var(--baseline-height) * 3); /* 12px */
-  --space-lg-comfy: calc(var(--baseline-height) * 7); /* 28px */
-  --space-lg-dense: calc(var(--baseline-height) * 5); /* 20px */
-  --space-md-comfy: calc(var(--baseline-height) * 5); /* 20px */
-  --space-md-dense: calc(var(--baseline-height) * 3); /* 12px */
-  --space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
-  --space-sm-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --density-lh-comfy: calc(var(--baseline-height) * 9); /* 36px */
+  --density-lh-dense: calc(var(--baseline-height) * 7); /* 28px */
+  --density-pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
+  --density-pad-inline-dense: calc(var(--baseline-height) * 3); /* 12px */
+  --density-space-lg-comfy: calc(var(--baseline-height) * 7); /* 28px */
+  --density-space-lg-dense: calc(var(--baseline-height) * 5); /* 20px */
+  --density-space-md-comfy: calc(var(--baseline-height) * 5); /* 20px */
+  --density-space-md-dense: calc(var(--baseline-height) * 3); /* 12px */
+  --density-space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-sm-dense: calc(var(--baseline-height) * 2); /*  8px */
+
+  /* Back-compat aliases (pre-namespace names). Remove once no consumer reads them. */
+  --lh-comfy: var(--density-lh-comfy);
+  --lh-dense: var(--density-lh-dense);
+  --pad-inline-comfy: var(--density-pad-inline-comfy);
+  --pad-inline-dense: var(--density-pad-inline-dense);
+  --space-lg-comfy: var(--density-space-lg-comfy);
+  --space-lg-dense: var(--density-space-lg-dense);
+  --space-md-comfy: var(--density-space-md-comfy);
+  --space-md-dense: var(--density-space-md-dense);
+  --space-sm-comfy: var(--density-space-sm-comfy);
+  --space-sm-dense: var(--density-space-sm-dense);
 }
 
 /* ── Density family: pick within the context pair ────────────────────────────
@@ -69,24 +99,48 @@
  * *-comfy / *-dense pair. Fallbacks cover the app-comfortable defaults when no
  * context class is present (a plain `.comfortable` still works). */
 .comfortable {
-  --density-line-height: var(--lh-comfy, calc(var(--baseline-height) * 8));
+  --density-line-height: var(
+    --density-lh-comfy,
+    calc(var(--baseline-height) * 8)
+  );
   --density-padding-inline: var(
-    --pad-inline-comfy,
+    --density-pad-inline-comfy,
     calc(var(--baseline-height) * 4)
   );
-  --density-space-lg: var(--space-lg-comfy, calc(var(--baseline-height) * 6));
-  --density-space-md: var(--space-md-comfy, calc(var(--baseline-height) * 4));
-  --density-space-sm: var(--space-sm-comfy, calc(var(--baseline-height) * 2));
-}
-.dense {
-  --density-line-height: var(--lh-dense, calc(var(--baseline-height) * 6));
-  --density-padding-inline: var(
-    --pad-inline-dense,
+  --density-space-lg: var(
+    --density-space-lg-comfy,
+    calc(var(--baseline-height) * 6)
+  );
+  --density-space-md: var(
+    --density-space-md-comfy,
+    calc(var(--baseline-height) * 4)
+  );
+  --density-space-sm: var(
+    --density-space-sm-comfy,
     calc(var(--baseline-height) * 2)
   );
-  --density-space-lg: var(--space-lg-dense, calc(var(--baseline-height) * 4));
-  --density-space-md: var(--space-md-dense, calc(var(--baseline-height) * 2));
-  --density-space-sm: var(--space-sm-dense, calc(var(--baseline-height) * 1));
+}
+.dense {
+  --density-line-height: var(
+    --density-lh-dense,
+    calc(var(--baseline-height) * 6)
+  );
+  --density-padding-inline: var(
+    --density-pad-inline-dense,
+    calc(var(--baseline-height) * 2)
+  );
+  --density-space-lg: var(
+    --density-space-lg-dense,
+    calc(var(--baseline-height) * 4)
+  );
+  --density-space-md: var(
+    --density-space-md-dense,
+    calc(var(--baseline-height) * 2)
+  );
+  --density-space-sm: var(
+    --density-space-sm-dense,
+    calc(var(--baseline-height) * 1)
+  );
 }
 
 /* ── Target baseline = round(up, height × 2/3) ──────────────────────────────
@@ -95,14 +149,14 @@
  * sites 36→6th/28→5th. */
 :where(.comfortable, .dense, .app, .site, .docs) {
   /* Effective line-height with the SAME fallback chain a control box uses
-     (--density-line-height → context --lh-comfy → apps-comfy literal). Without
-     this fallback, a bare context class (.app/.site/.docs applied with no density
-     class — the documented "no class = comfortable" case) leaves
+     (--density-line-height → context --density-lh-comfy → apps-comfy literal).
+     Without this fallback, a bare context class (.app/.site/.docs applied with no
+     density class — the documented "no class = comfortable" case) leaves
      --density-line-height unset, the round(calc(var(--density-line-height)…))
      becomes invalid, the target resolves to 0, and controls lose their seating. */
   --density-line-height-effective: var(
     --density-line-height,
-    var(--lh-comfy, calc(var(--baseline-height) * 8))
+    var(--density-lh-comfy, calc(var(--baseline-height) * 8))
   );
   --density-target-baseline-px: round(
     up,


### PR DESCRIPTION
## Done

**Re-targets #813 to `main`.** #813 was accidentally merged into its stacked base (`density/pr5a-styles-move`, the already-merged #812 branch) instead of `main`, so its work never reached `main`. This is the same diff, cherry-picked cleanly onto current `main` (which has #812 as squash `45e46e3b`). No content change from the reviewed #813 — see that PR for the full review thread.

- **Seat the flat Button on the density grid** (`ds-global` `Button/styles.css`), reading the shared `--density-*` primitives from `@canonical/styles`. Fixes the flat/unaligned button in ds-global-only apps. Removes the old `.p` machinery.
- **Control-size regression fix** (`ds-global-form`): checkbox/radio/switch/range/password/file-upload/choices re-pinned to stable `--dimension-*` tokens (the 4px-baseline spike had halved their `--space-baseline`-based sizes).
- **Namespacing follow-up** (from #812/#813 Copilot review): context pair-vars → `--density-*-comfy/-dense` with back-compat aliases; no computed-output change.
- **Drive-bys:** Storybook alphabetical sort; Popover + Combobox stories → `_work_in_progress`; stale `bU` comment cleanup.

Dep-range floor (`@canonical/styles` `^0.30.0` → the version shipping `modifiers.density.css`) is deferred to the release that bumps the styles version — the workspace pins real semver, so bumping the range ahead of the version fails to resolve (CI-verified). Tracked for the version bump.

## QA

- `ds-global` Storybook: **components/Button → Matrix** — toggle Density/Context + baseline overlay; label seats on the 4px grid. Tooltip alphabetical; Popover under `_work_in_progress`.
- `ds-global-form`: checkbox/radio 16px, switch 32×16, range thumb 16px.

### PR readiness check

- [x] Label: `Bug 🐛`
- [x] Conventional Commits title
- [x] Code standards
- [x] `check` / `check:fix` / `test` present
- [ ] N/A new package

## Screenshots

_Verified in Storybook (6199 / 6200)._
