### PR TITLE
fix(cli): flag & command UX — unknown-verb, --version, config, graph query

### DIFF
--- a/packages/cli/pragma/src/domains/config/commands/channel.test.ts
+++ b/packages/cli/pragma/src/domains/config/commands/channel.test.ts
@@ -60,6 +60,22 @@ describe("config channel command", () => {
     }
   });
 
+  it("rejects a value combined with --reset", async () => {
+    const ctx = makeCtx(dir);
+    const cmd = buildChannelCommand(ctx);
+    await expect(
+      cmd.execute({ value: "experimental", reset: true }, ctx),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+  });
+
+  it("rejects an explicit empty-string value", async () => {
+    const ctx = makeCtx(dir);
+    const cmd = buildChannelCommand(ctx);
+    await expect(cmd.execute({ value: "" }, ctx)).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+    });
+  });
+
   it("resets channel via --reset flag", async () => {
     writeFileSync(
       join(dir, "pragma.config.json"),

--- a/packages/cli/pragma/src/domains/config/commands/channel.ts
+++ b/packages/cli/pragma/src/domains/config/commands/channel.ts
@@ -5,6 +5,7 @@ import {
 } from "@canonical/cli-core";
 import { runTask } from "@canonical/task/node";
 import { readConfig } from "#config";
+import { PragmaError } from "#error";
 import type { PragmaContext } from "../../shared/context.js";
 import { selectFormatter } from "../../shared/formatters.js";
 import { channelFormatters } from "../formatters/index.js";
@@ -56,6 +57,16 @@ export default function buildChannelCommand(
       const reset = params.reset === true;
       const value = params.value as string | undefined;
 
+      // Contradictory input: a value AND --reset. Reject rather than silently
+      // letting one win.
+      if (reset && value !== undefined) {
+        throw PragmaError.invalidInput("channel", value, {
+          recovery: {
+            message: "Pass either a channel value or --reset, not both.",
+          },
+        });
+      }
+
       if (reset) {
         const result = await runTask(setChannelTask(ctx.cwd, undefined, scope));
         const format = selectFormatter(ctx, channelFormatters.reset);
@@ -65,7 +76,9 @@ export default function buildChannelCommand(
         );
       }
 
-      if (!value) {
+      // No value at all → query the current channel. An explicit empty string
+      // is invalid input, not a query.
+      if (value === undefined) {
         const config = readConfig(ctx.cwd);
         const format = selectFormatter(ctx, channelFormatters.query);
         return createOutputResult(config.channel, {

--- a/packages/cli/pragma/src/domains/config/commands/framework.ts
+++ b/packages/cli/pragma/src/domains/config/commands/framework.ts
@@ -5,6 +5,7 @@ import {
 } from "@canonical/cli-core";
 import { runTask } from "@canonical/task/node";
 import { readConfig } from "#config";
+import { PragmaError } from "#error";
 import type { PragmaContext } from "../../shared/context.js";
 import { selectFormatter } from "../../shared/formatters.js";
 import { frameworkFormatters } from "../formatters/index.js";
@@ -59,6 +60,16 @@ export default function buildFrameworkCommand(
       const reset = params.reset === true;
       const value = params.value as string | undefined;
 
+      // Contradictory input: a value AND --reset. Reject rather than silently
+      // letting one win.
+      if (reset && value !== undefined) {
+        throw PragmaError.invalidInput("framework", value, {
+          recovery: {
+            message: "Pass either a framework value or --reset, not both.",
+          },
+        });
+      }
+
       if (reset) {
         const result = await runTask(
           setFrameworkTask(ctx.cwd, undefined, scope),
@@ -70,7 +81,8 @@ export default function buildFrameworkCommand(
         );
       }
 
-      if (!value) {
+      // No value at all → query. An explicit empty string is invalid input.
+      if (value === undefined) {
         const config = readConfig(ctx.cwd);
         const format = selectFormatter(ctx, frameworkFormatters.query);
         return createOutputResult(config.framework ?? "none", {

--- a/packages/cli/pragma/src/domains/config/commands/tier.ts
+++ b/packages/cli/pragma/src/domains/config/commands/tier.ts
@@ -5,6 +5,7 @@ import {
 } from "@canonical/cli-core";
 import { runTask } from "@canonical/task/node";
 import { readConfig } from "#config";
+import { PragmaError } from "#error";
 import type { PragmaContext } from "../../shared/context.js";
 import { selectFormatter } from "../../shared/formatters.js";
 import { tierFormatters } from "../formatters/index.js";
@@ -53,6 +54,16 @@ export default function buildTierCommand(
       const reset = params.reset === true;
       const tierPath = params.path as string | undefined;
 
+      // Contradictory input: a tier path AND --reset. Reject rather than
+      // silently letting one win.
+      if (reset && tierPath !== undefined) {
+        throw PragmaError.invalidInput("tier", tierPath, {
+          recovery: {
+            message: "Pass either a tier path or --reset, not both.",
+          },
+        });
+      }
+
       if (reset) {
         const result = await runTask(setTierTask(ctx.cwd, undefined, scope));
         const format = selectFormatter(ctx, tierFormatters.reset);
@@ -62,7 +73,9 @@ export default function buildTierCommand(
         );
       }
 
-      if (!tierPath) {
+      // No path at all → query. An explicit empty string is invalid input and
+      // is rejected by validateTier below.
+      if (tierPath === undefined) {
         const config = readConfig(ctx.cwd);
         const format = selectFormatter(ctx, tierFormatters.query);
         return createOutputResult(config.tier, {

--- a/packages/cli/pragma/src/domains/create/commands/component.ts
+++ b/packages/cli/pragma/src/domains/create/commands/component.ts
@@ -97,11 +97,10 @@ export default function buildComponentCommand(): CommandDefinition {
 
       const gen = COMPONENT_GENERATORS[framework];
       if (!gen) {
+        // validOptions already renders the valid frameworks; a recovery message
+        // repeating them would print the list twice.
         throw PragmaError.invalidInput("framework", framework, {
           validOptions: Object.keys(COMPONENT_GENERATORS),
-          recovery: {
-            message: `Valid frameworks: ${Object.keys(COMPONENT_GENERATORS).join(", ")}`,
-          },
         });
       }
 

--- a/packages/cli/pragma/src/domains/graph/commands/query.test.ts
+++ b/packages/cli/pragma/src/domains/graph/commands/query.test.ts
@@ -58,15 +58,17 @@ describe("graph query command", () => {
     expect(text).toContain("n");
   });
 
-  it("renders llm output", async () => {
+  it("renders llm output as a Markdown table for SELECT", async () => {
     const ctx = makeCtx({
       globalFlags: { llm: true, format: "text" as const, verbose: false },
     });
     const cmd = buildQueryCommand(ctx);
     const { text } = await executeOutput(cmd, { sparql }, ctx);
 
-    const parsed = JSON.parse(text) as QueryResult;
-    expect(parsed.type).toBe("select");
+    // Condensed Markdown, not a raw JSON dump.
+    expect(text).toContain("| n |");
+    expect(text).toContain("| --- |");
+    expect(() => JSON.parse(text)).toThrow();
   });
 
   it("renders json output", async () => {

--- a/packages/cli/pragma/src/domains/graph/formatters/query.ts
+++ b/packages/cli/pragma/src/domains/graph/formatters/query.ts
@@ -2,11 +2,32 @@ import type { QueryResult } from "@canonical/ke";
 import type { Formatters } from "../../shared/formatters.js";
 
 /**
+ * Render CONSTRUCT triples as readable `subject  predicate  object` lines,
+ * collapsing any newlines in literal objects so each triple stays on one line.
+ */
+function formatTriples(
+  triples: ReadonlyArray<{
+    subject: string;
+    predicate: string;
+    object: string;
+  }>,
+): string {
+  if (triples.length === 0) return "No triples.";
+  return triples
+    .map((t) => {
+      const object = t.object.replace(/\s*\n\s*/g, " ").trim();
+      return `${t.subject}\t${t.predicate}\t${object}`;
+    })
+    .join("\n");
+}
+
+/**
  * Formatters for `pragma graph query` output.
  *
- * - **plain**: tab-separated table for SELECT results, `ASK: true/false` for ASK
- *   queries, JSON fallback for CONSTRUCT.
- * - **llm**: indented JSON for all query types.
+ * - **plain**: tab-separated table for SELECT, `ASK: true/false` for ASK, and
+ *   readable triple lines for CONSTRUCT.
+ * - **llm**: condensed Markdown (table for SELECT, one line for ASK, a triple
+ *   list for CONSTRUCT) rather than a raw JSON dump.
  * - **json**: serialized {@link QueryResult} as indented JSON.
  */
 const formatters: Formatters<QueryResult> = {
@@ -22,11 +43,27 @@ const formatters: Formatters<QueryResult> = {
     if (result.type === "ask") {
       return `ASK: ${String(result.result)}`;
     }
-    return JSON.stringify(result, null, 2);
+    return formatTriples(result.triples);
   },
 
   llm(result) {
-    return JSON.stringify(result, null, 2);
+    if (result.type === "select") {
+      if (result.bindings.length === 0) return "_No results._";
+      const cols = Object.keys(result.bindings[0] ?? {});
+      const header = `| ${cols.join(" | ")} |`;
+      const divider = `| ${cols.map(() => "---").join(" | ")} |`;
+      const rows = result.bindings.map(
+        (b) => `| ${cols.map((c) => b[c] ?? "").join(" | ")} |`,
+      );
+      return [header, divider, ...rows].join("\n");
+    }
+    if (result.type === "ask") {
+      return `**ASK** → ${String(result.result)}`;
+    }
+    return formatTriples(result.triples)
+      .split("\n")
+      .map((line) => (line.includes("\t") ? `- ${line}` : line))
+      .join("\n");
   },
 
   json(result) {

--- a/packages/cli/pragma/src/domains/info/formatters/upgrade.test.ts
+++ b/packages/cli/pragma/src/domains/info/formatters/upgrade.test.ts
@@ -8,7 +8,9 @@ import {
 
 function createUpgradeData(overrides: Partial<UpgradeData> = {}): UpgradeData {
   return {
-    pm: "bun",
+    // `pm` is the install label, which already carries the scope (as the
+    // command populates it from source.label).
+    pm: "bun (global)",
     current: "0.18.0",
     latest: "0.19.0",
     command: "bun update -g @canonical/pragma-cli",
@@ -21,9 +23,10 @@ function createUpgradeData(overrides: Partial<UpgradeData> = {}): UpgradeData {
 }
 
 describe("renderUpgradePlain", () => {
-  it("shows PM info", () => {
+  it("shows PM info without doubling the scope suffix", () => {
     const output = renderUpgradePlain(createUpgradeData());
-    expect(output).toContain("bun (global)");
+    expect(output).toContain("Installed via: bun (global)");
+    expect(output).not.toContain("(global) (global)");
   });
 
   it("shows version transition", () => {
@@ -107,7 +110,7 @@ describe("renderUpgradeJson", () => {
   it("produces valid JSON", () => {
     const data = createUpgradeData();
     const parsed = JSON.parse(renderUpgradeJson(data));
-    expect(parsed.pm).toBe("bun");
+    expect(parsed.pm).toBe("bun (global)");
     expect(parsed.current).toBe("0.18.0");
     expect(parsed.latest).toBe("0.19.0");
   });

--- a/packages/cli/pragma/src/domains/info/formatters/upgrade.ts
+++ b/packages/cli/pragma/src/domains/info/formatters/upgrade.ts
@@ -12,7 +12,9 @@ import type { UpgradeData } from "../types.js";
 function renderUpgradePlain(data: UpgradeData): string {
   const lines: string[] = [];
 
-  lines.push(`Installed via: ${data.pm} (global)`);
+  // `data.pm` is the install label (e.g. "bun (global)"), which already carries
+  // the scope — do not append another "(global)".
+  lines.push(`Installed via: ${data.pm}`);
 
   if (data.offline) {
     lines.push("Could not reach registry");

--- a/packages/cli/pragma/src/pipeline/runCli.orchestration.test.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.orchestration.test.ts
@@ -262,19 +262,30 @@ describe("runCli orchestration", () => {
     expect(dispose).toHaveBeenCalledTimes(1);
   });
 
-  it("treats version commander errors as success", async () => {
-    const parseAsync = vi.fn(async () => {
-      throw new CommanderError(0, "commander.version", "version");
-    });
+  it("prints the version directly and never reaches the program", async () => {
+    // --version is a global flag handled before command dispatch, so it neither
+    // boots the store nor builds a Commander program.
+    const stdout: string[] = [];
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdout.push(String(chunk));
+        return true;
+      });
 
     resolveCommandKindMock.mockReturnValue({ kind: "store-skip" });
-    setupCommandsMock.mockReturnValue([{ path: ["setup", "skills"] }]);
-    createProgramMock.mockReturnValue({ parseAsync });
+    createProgramMock.mockClear();
 
-    const { default: runCli } = await import("./runCli.js");
-    await runCli(["node", "pragma", "--version"]);
+    try {
+      const { default: runCli } = await import("./runCli.js");
+      await runCli(["node", "pragma", "--version"]);
+    } finally {
+      stdoutSpy.mockRestore();
+    }
 
-    expect(process.exitCode).toBe(0);
+    expect(stdout.join("")).toContain(".");
+    expect(createProgramMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
   });
 
   it("renders pragma errors from the program using mapped exit codes", async () => {

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -111,7 +111,7 @@ async function handleRootHelp(globalFlags: GlobalFlags): Promise<void> {
   try {
     await program.parseAsync(["node", "pragma", "--help"]);
   } catch (err) {
-    handleProgramError(err, globalFlags);
+    await handleProgramError(err, globalFlags, ["node", "pragma", "--help"]);
   }
 }
 
@@ -181,7 +181,7 @@ async function bootAndRun(
     const program = createProgram(commands, ctx);
     await program.parseAsync(stripGlobalFlags(argv));
   } catch (err) {
-    handleProgramError(err, globalFlags);
+    await handleProgramError(err, globalFlags, argv);
   } finally {
     runtime.dispose();
   }
@@ -213,11 +213,53 @@ async function runStoreSkip(
   try {
     await program.parseAsync(stripGlobalFlags(argv));
   } catch (err) {
-    handleProgramError(err, globalFlags);
+    await handleProgramError(err, globalFlags, argv);
   }
 }
 
-function handleProgramError(err: unknown, globalFlags: GlobalFlags): void {
+/**
+ * First non-flag token in argv — the command noun, if any.
+ *
+ * Global flags are stripped first so a flag *value* (e.g. the `json` in
+ * `--format json`) is never mistaken for the noun; otherwise
+ * `pragma --format json standard frobnicate` would scan `json` and fail to
+ * suggest `standard`'s verbs.
+ */
+function findNoun(argv: readonly string[]): string | undefined {
+  return stripGlobalFlags(argv)
+    .slice(2)
+    .find((arg) => !arg.startsWith("-"));
+}
+
+/**
+ * When an unknown command/verb is entered under a known noun, print that noun's
+ * valid verbs so the user can recover — "defer to the category that exists".
+ *
+ * @note Impure — writes the noun's verb list to stderr.
+ */
+async function suggestNounVerbs(argv: readonly string[]): Promise<void> {
+  const noun = findNoun(argv);
+  if (!noun) return;
+  const stubCtx: PragmaContext = {
+    store: {} as PragmaRuntime["store"],
+    ...(await resolveHelpConfig()),
+    cwd: process.cwd(),
+    dispose: () => {},
+    globalFlags: { llm: false, autoLlm: false, format: "text", verbose: false },
+    promptSession: createInteractivePromptSession,
+  };
+  const commands = collectCommands(stubCtx);
+  const hasNoun = commands.some((cmd) => cmd.path.at(0) === noun);
+  if (!hasNoun) return;
+  const { formatNounHelp } = await import("@canonical/cli-core");
+  process.stderr.write(`\n${formatNounHelp(PROGRAM_NAME, noun, commands)}\n`);
+}
+
+async function handleProgramError(
+  err: unknown,
+  globalFlags: GlobalFlags,
+  argv: readonly string[],
+): Promise<void> {
   if (err instanceof CommanderError) {
     if (
       err.code === "commander.helpDisplayed" ||
@@ -225,6 +267,9 @@ function handleProgramError(err: unknown, globalFlags: GlobalFlags): void {
     ) {
       process.exitCode = 0;
       return;
+    }
+    if (err.code === "commander.unknownCommand") {
+      await suggestNounVerbs(argv);
     }
     process.exitCode = err.exitCode;
     return;

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -1,6 +1,6 @@
 import type { GlobalFlags } from "@canonical/cli-core";
 import { CommanderError } from "commander";
-import { PROGRAM_NAME } from "../constants.js";
+import { PROGRAM_NAME, VERSION } from "../constants.js";
 import { commands as createCommands } from "../domains/create/index.js";
 import { commands as graphqlCommands } from "../domains/graphql/index.js";
 import { buildCapabilitiesCommand } from "../domains/llm/index.js";
@@ -320,20 +320,24 @@ export default async function runCli(argv: readonly string[]): Promise<void> {
     return handleCompletionsServer();
   }
 
-  const explicitHelpOrVersion = argv
-    .slice(2)
-    .some(
-      (arg) =>
-        arg === "--help" || arg === "-h" || arg === "--version" || arg === "-V",
-    );
+  // `--version`/`-V` is a global flag: print the version and exit regardless
+  // of where it appears (root or after a command/verb), so `block list -V`
+  // behaves like the root `pragma --version` instead of erroring.
+  if (argv.slice(2).some((arg) => arg === "--version" || arg === "-V")) {
+    process.stdout.write(`${VERSION}\n`);
+    return;
+  }
 
-  // Reject an unknown --format value early (completion queries are exempt
-  // above, so tab-completion never errors). Skip when the user asked for help
-  // or version — those should print regardless of a bad --format. Only
-  // text/json are supported.
+  const explicitHelp = argv
+    .slice(2)
+    .some((arg) => arg === "--help" || arg === "-h");
+
+  // Reject an unknown --format value early (completion queries and --version
+  // are handled above, so neither errors). Skip when the user asked for help —
+  // it should print regardless of a bad --format. Only text/json are supported.
   const rawFormat = readRawFormat(argv);
   if (
-    !explicitHelpOrVersion &&
+    !explicitHelp &&
     rawFormat !== undefined &&
     rawFormat !== "text" &&
     rawFormat !== "json"
@@ -346,7 +350,7 @@ export default async function runCli(argv: readonly string[]): Promise<void> {
     return;
   }
 
-  if (!hasCommandArg(argv) && !explicitHelpOrVersion) {
+  if (!hasCommandArg(argv) && !explicitHelp) {
     return handleRootHelp(globalFlags);
   }
 

--- a/packages/cli/pragma/src/testing/integration/cli-user-stories.test.ts
+++ b/packages/cli/pragma/src/testing/integration/cli-user-stories.test.ts
@@ -196,6 +196,17 @@ describe("CLI user stories", () => {
     expect(readFileSync(indexFile, "utf-8")).toContain("./MySth");
   }, 20_000);
 
+  it("story: --version works at the root, noun, and verb levels", () => {
+    const workspace = createWorkspace();
+    const root = runCommand(["--version"], workspace);
+    const verb = runCommand(["block", "list", "--version"], workspace);
+
+    expectSuccess(root);
+    expectSuccess(verb);
+    expect(root.stdout.trim()).toBe(verb.stdout.trim());
+    expect(root.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  }, 20_000);
+
   it("story: an unknown verb under a known noun lists that noun's verbs", () => {
     const workspace = createWorkspace();
 

--- a/packages/cli/pragma/src/testing/integration/cli-user-stories.test.ts
+++ b/packages/cli/pragma/src/testing/integration/cli-user-stories.test.ts
@@ -195,4 +195,32 @@ describe("CLI user stories", () => {
     expect(existsSync(indexFile)).toBe(true);
     expect(readFileSync(indexFile, "utf-8")).toContain("./MySth");
   }, 20_000);
+
+  it("story: an unknown verb under a known noun lists that noun's verbs", () => {
+    const workspace = createWorkspace();
+
+    const result = runCommand(["standard", "frobnicate"], workspace);
+
+    expect(result.exitCode).not.toBe(0);
+    // Errors, then defers to the category that exists.
+    expect(result.stderr).toContain("unknown command 'frobnicate'");
+    expect(result.stderr).toContain("pragma standard <verb>");
+    expect(result.stderr).toContain("list");
+    expect(result.stderr).toContain("lookup");
+  }, 20_000);
+
+  it("story: a global flag before the noun still lists that noun's verbs", () => {
+    const workspace = createWorkspace();
+
+    // `--format json` sits before the noun; the flag *value* (`json`) must not
+    // be mistaken for the noun, or no verbs would be suggested.
+    const result = runCommand(
+      ["--format", "json", "standard", "frobnicate"],
+      workspace,
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("pragma standard <verb>");
+    expect(result.stderr).toContain("lookup");
+  }, 20_000);
 });


### PR DESCRIPTION
> **Stacked PR 3 of 6** — base `cli/2-generators-validation` (#816). Merge #815, #816 first. This part covers flag- and command-level UX.

## Done

- **auto-LLM shapes formatting only**: an auto-inferred (non-TTY) LLM mode never flips a generator into dry-run preview, so a script running `create` off-TTY still writes files (`GlobalFlags.autoLlm`).
- **Unknown verb defers to the category**: `pragma standard bogus` errors *and* lists that noun's valid verbs.
- **`--version`/`-V` works at any level**, not just the root (e.g. `block list --version`).
- **config footguns**: `channel`/`framework`/`tier` reject a value combined with `--reset`, and reject an explicit empty string, instead of silently favouring reset / treating `""` as a query.
- **`upgrade`** no longer prints a doubled `(global)`; **invalid `create` framework** lists the valid options once.
- **`graph query --llm`** is condensed Markdown (was raw JSON); CONSTRUCT plain output prints readable triples (was a verbose quad dump).

## QA

```sh
bun run check && bun run test

bun src/bin.ts standard bogus                 # errors + lists standard verbs, exit 1
bun src/bin.ts block list --version           # 0.30.0, exit 0
bun src/bin.ts config channel x --reset --local; echo $?   # → 3
bun src/bin.ts graph query "ASK { ?s ?p ?o }" --llm         # **ASK** → true
```

### PR readiness check

- [x] Label: **Bug 🐛**.
- [x] Conventional Commits title.
- [x] Code standards (`bun run check` green; coverage gates met).
- [x] Required scripts present; no script changes.
- [x] No new package.
- [ ] `no visual change` — label not in repo; CLI-only change.

## Screenshots

N/A — CLI behaviour; see QA.
