### PR TITLE
fix(react/ds-global): SSR-safe portal gating via shared useIsMounted hook

### DIFF
--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.hydration.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.hydration.tests.tsx
@@ -1,0 +1,45 @@
+import { act } from "@testing-library/react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ContextualMenu from "./ContextualMenu.js";
+import type { MenuItem } from "./types.js";
+
+const groups: MenuItem[] = [
+  {
+    key: "g",
+    label: "Edit",
+    items: [{ key: "cut", label: "Cut", url: "#cut" }],
+  },
+];
+
+/**
+ * The menu is portalled to the document body only after mount. Before that gate
+ * it rendered the portal on the first client render (via a `typeof window`
+ * check that is already truthy there), which mismatched the inline server
+ * output and forced a hydration recovery. This guards against that regression:
+ * a mismatch surfaces through React 19's `onRecoverableError`.
+ */
+describe("ContextualMenu (hydration)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hydrates server HTML with no recoverable error", () => {
+    const ui = <ContextualMenu trigger="Actions" groups={groups} />;
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(ui);
+    document.body.appendChild(container);
+
+    const onRecoverableError = vi.fn();
+    act(() => {
+      hydrateRoot(container, ui, { onRecoverableError });
+    });
+
+    expect(onRecoverableError).not.toHaveBeenCalled();
+    // The trigger is still present after hydration — the tree was reused, not
+    // replaced by a mismatch recovery.
+    expect(container.querySelector(".trigger")?.textContent).toBe("Actions");
+  });
+});

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
@@ -3,7 +3,11 @@ import { getItemId } from "@canonical/utils";
 import type React from "react";
 import { useMemo } from "react";
 import { createPortal } from "react-dom";
-import { MENU_PLACEMENT, useContextualMenu } from "../../hooks/index.js";
+import {
+  MENU_PLACEMENT,
+  useContextualMenu,
+  useIsMounted,
+} from "../../hooks/index.js";
 import MenuContext from "./common/MenuContext.js";
 import SubMenu from "./common/SubMenu/index.js";
 import type { ContextualMenuProps, MenuItem } from "./types.js";
@@ -44,6 +48,10 @@ const ContextualMenu = ({
     () => ({ key: "contextual-menu-root", items: groups }),
     [groups],
   );
+  // Portal only after mount so the server and first client render agree —
+  // `typeof window` is already truthy on the first client render, which would
+  // portal the menu on render 0 and mismatch the inline server output.
+  const mounted = useIsMounted();
   const menu = useContextualMenu({
     root,
     isOpen: open,
@@ -176,9 +184,7 @@ const ContextualMenu = ({
         >
           {trigger}
         </button>
-        {typeof window !== "undefined"
-          ? createPortal(menuElement, document.body)
-          : menuElement}
+        {mounted ? createPortal(menuElement, document.body) : menuElement}
       </div>
     </MenuContext.Provider>
   );

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/common/SubMenu/SubMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/common/SubMenu/SubMenu.tsx
@@ -3,7 +3,11 @@ import { getItemId } from "@canonical/utils";
 import type React from "react";
 import { type ReactElement, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { MENU_PLACEMENT, useWindowFitment } from "../../../../hooks/index.js";
+import {
+  MENU_PLACEMENT,
+  useIsMounted,
+  useWindowFitment,
+} from "../../../../hooks/index.js";
 import type { MenuItem } from "../../types.js";
 import Item from "../Item/index.js";
 import { useMenuContext } from "../MenuContext.js";
@@ -54,6 +58,9 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
   const keyboardOpen = status.inHighlightedBranch && !status.highlighted;
   const [hovered, setHovered] = useState(false);
   const open = keyboardOpen || hovered;
+  // Portal only after mount so the server and first client render agree —
+  // `typeof window` is already truthy on the first client render.
+  const mounted = useIsMounted();
 
   // MENU_PLACEMENT is a stable module constant and logical, so the hook mirrors
   // it in RTL from this item's own writing direction — no per-submenu dir read.
@@ -165,7 +172,7 @@ const SubMenuParent = ({ item }: { item: _Item<MenuItem> }): ReactElement => {
         itemProps={itemProps}
         onSelect={() => onSelectItem(item)}
       />
-      {submenuSurface && typeof window !== "undefined"
+      {submenuSurface && mounted
         ? createPortal(submenuSurface, document.body)
         : null}
     </div>

--- a/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.hydration.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.hydration.tests.tsx
@@ -1,0 +1,46 @@
+import { act } from "@testing-library/react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TooltipArea from "./TooltipArea.js";
+
+/**
+ * Unlike TooltipArea.tests.tsx, this file deliberately does NOT mock
+ * `createPortal` — it exercises the real server/client contract: server HTML
+ * must hydrate without a recoverable-error (React 19 reports hydration
+ * mismatches through `onRecoverableError`, not `console.error`), and the
+ * message must portal into the document body only after mount.
+ */
+describe("TooltipArea (hydration)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hydrates server HTML with no recoverable error and portals the message after mount", () => {
+    const ui = (
+      <TooltipArea Message="Helpful message">
+        <button type="button">Trigger</button>
+      </TooltipArea>
+    );
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(ui);
+    document.body.appendChild(container);
+
+    // The message is not in the server HTML — it is deferred until after mount.
+    expect(container.textContent).not.toContain("Helpful message");
+
+    // A hydration mismatch surfaces here in React 19; assert it never fires.
+    const onRecoverableError = vi.fn();
+    act(() => {
+      hydrateRoot(container, ui, { onRecoverableError });
+    });
+    expect(onRecoverableError).not.toHaveBeenCalled();
+
+    // After mount the message is portalled to the document body, outside the
+    // inline tooltip-area wrapper.
+    const message = document.body.querySelector(".ds.tooltip .text");
+    expect(message?.textContent).toBe("Helpful message");
+    expect(message?.closest(".ds.tooltip-area")).toBeNull();
+  });
+});

--- a/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.ssr.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.ssr.tests.tsx
@@ -1,0 +1,36 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import TooltipArea from "./TooltipArea.js";
+
+/**
+ * The server-rendered floor. The portalled message is deferred until after
+ * mount, so the server HTML carries the target and its `aria-describedby`
+ * association but not the message itself — the same output the first client
+ * render produces, which is what keeps hydration free of mismatches.
+ */
+describe("TooltipArea (SSR)", () => {
+  it("renders to static HTML without throwing", () => {
+    expect(() =>
+      renderToString(
+        <TooltipArea Message="Helpful message">
+          <span>Target</span>
+        </TooltipArea>,
+      ),
+    ).not.toThrow();
+  });
+
+  it("emits the target with aria-describedby but not the deferred message", () => {
+    const html = renderToString(
+      <TooltipArea Message="Helpful message">
+        <span>Target</span>
+      </TooltipArea>,
+    );
+
+    expect(html).toContain("ds tooltip-area");
+    expect(html).toContain("Target");
+    expect(html).toContain("aria-describedby");
+    // The message is portalled only after mount, so it must be absent on the
+    // server — emitting it here would mismatch the first client render.
+    expect(html).not.toContain("Helpful message");
+  });
+});

--- a/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.tsx
@@ -1,11 +1,6 @@
-import {
-  type CSSProperties,
-  type ReactElement,
-  useEffect,
-  useState,
-} from "react";
+import type { CSSProperties, ReactElement } from "react";
 import { createPortal } from "react-dom";
-import { useDisclosure } from "../../../../hooks/index.js";
+import { useDisclosure, useIsMounted } from "../../../../hooks/index.js";
 import { Tooltip } from "../../index.js";
 import type { TooltipAreaProps } from "./types.js";
 
@@ -61,10 +56,9 @@ const TooltipArea = ({
   // on the first client render) would differ from the post-mount portal output
   // and force a hydration mismatch + full re-mount — which resets the fitment
   // refs to null and re-triggers the unpositioned first frame. Deferring to a
-  // `mounted` gate makes the server and first client render identical (nothing
+  // mounted gate makes the server and first client render identical (nothing
   // at the call site); the tooltip mounts once, cleanly, after hydration.
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  const mounted = useIsMounted();
 
   // The always-on arrow offset keeps the arrow pointing at the target centre
   // for every placement, not only when auto-fit clamps.

--- a/packages/react/ds-global/src/lib/component/Tooltip/withTooltip.mdx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/withTooltip.mdx
@@ -278,7 +278,7 @@ The gap only bites if _your_ component needs a ref for its own reasons — imper
 
 ### SSR renders nothing but the trigger
 
-`TooltipArea` renders the tooltip message through `createPortal` into `document.body` (or a `parentElement` you supply). Because `document` does not exist on the server, the portal is guarded behind `typeof window !== "undefined"`: on the server the message element is rendered inline instead of portalled, and because the disclosure is closed by default it produces no visible overlay. In effect the tooltip is dormant until hydration — the trigger renders on the server, the floating bubble is a client-only concern. This is intentional and keeps the component build-safe in server environments.
+`TooltipArea` renders the tooltip message through `createPortal` into `document.body` (or a `parentElement` you supply). The portal is gated on a `useIsMounted` flag, which is `false` during server rendering **and** the first client render, then `true` after mount — so the server HTML and the first client render agree (neither emits the message) and hydration never mismatches. The server therefore renders only the trigger and its `aria-describedby` target wrapper; the message portals in after hydration. In effect the tooltip is dormant until hydration — the trigger renders on the server, the floating bubble is a client-only concern. This keeps the component build-safe in server environments and hydration-clean on the client.
 
 ### How positioning actually anchors
 

--- a/packages/react/ds-global/src/lib/hooks/index.ts
+++ b/packages/react/ds-global/src/lib/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from "./useContextualMenu/index.js";
 export * from "./useDelayedToggle/index.js";
 export * from "./useDisclosure/index.js";
+export * from "./useIsMounted/index.js";
 export * from "./useResizeObserver/index.js";
 export * from "./useWindowDimensions/index.js";
 export * from "./useWindowFitment/index.js";

--- a/packages/react/ds-global/src/lib/hooks/useIsMounted/index.ts
+++ b/packages/react/ds-global/src/lib/hooks/useIsMounted/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export { default as useIsMounted } from "./useIsMounted.js";

--- a/packages/react/ds-global/src/lib/hooks/useIsMounted/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useIsMounted/types.ts
@@ -1,0 +1,5 @@
+/**
+ * Result of the `useIsMounted` hook: `false` during server rendering and the
+ * initial client render, `true` once the component has mounted.
+ */
+export type UseIsMountedResult = boolean;

--- a/packages/react/ds-global/src/lib/hooks/useIsMounted/useIsMounted.tests.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useIsMounted/useIsMounted.tests.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { useIsMounted } from "./index.js";
+
+describe("useIsMounted", () => {
+  it("is true after the component mounts on the client", () => {
+    const { result } = renderHook(() => useIsMounted());
+    expect(result.current).toBe(true);
+  });
+
+  it("is false during server rendering (no mount effect runs)", () => {
+    // renderToString never flushes effects, so the hook stays at its initial
+    // value — the contract callers rely on to defer portals until hydration.
+    const Probe = () => <>{String(useIsMounted())}</>;
+    expect(renderToString(<Probe />)).toBe("false");
+  });
+});

--- a/packages/react/ds-global/src/lib/hooks/useIsMounted/useIsMounted.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useIsMounted/useIsMounted.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import type { UseIsMountedResult } from "./types.js";
+
+/**
+ * Reports whether the component has mounted on the client.
+ *
+ * Returns `false` during server rendering and the initial client render, then
+ * `true` after the mount effect runs. Gate client-only output — portals in
+ * particular — on this so the server-rendered HTML and the first client render
+ * are identical and hydration does not mismatch.
+ *
+ * @returns `false` until mounted, then `true`.
+ * @note Impure — schedules a mount effect that updates component state.
+ */
+const useIsMounted = (): UseIsMountedResult => {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return isMounted;
+};
+
+export default useIsMounted;


### PR DESCRIPTION
## Done

Makes the ds-global overlay portals SSR/hydration-safe and de-duplicates the mounted-gate logic behind a shared hook.

- Add a shared `useIsMounted` hook (`hooks/useIsMounted/`) — `false` during SSR and the first client render, `true` after mount — exported from `hooks/index.ts`.
- Fix a real hydration bug in **ContextualMenu** and **SubMenu**: they gated `createPortal` on `typeof window !== "undefined"`, which is already truthy on the first client render, so they portalled on render 0 and mismatched the inline server output. Both now gate on `useIsMounted`.
- Refactor **TooltipArea** to consume the shared hook instead of its own inline `useState`/`useEffect` mounted flag (behaviour-preserving).
- Add real SSR + hydration tests (no `createPortal` mock) for TooltipArea and ContextualMenu. The pre-existing tooltip test stubbed the portal to a passthrough and never exercised `renderToString`/`hydrate`. The hydration tests assert React 19's `onRecoverableError` never fires — a `console.error` spy does **not** catch React 19 mismatches — and both were confirmed to fail if the mounted gate is reverted.
- Update `withTooltip.mdx` to describe the mounted-gate SSR contract (it documented the removed `typeof window` mechanism).

Salvaged from the stale #663 (~124 commits behind main). That PR's `@canonical/react-head` refactor and resurrected ds-global tests already landed on main; only this residual value (the shared hook, the two overlay hydration fixes, and real SSR/hydration tests) remained. **#663 can be closed as superseded.**

Fixes the ContextualMenu/SubMenu first-render hydration mismatch.

## QA

1. `bun run check` in `packages/react/ds-global` — biome + tsc + webarchitect pass.
2. `bunx vitest run` in `packages/react/ds-global` — full suite green (347 passed, 5 pre-existing skips).
3. Targeted: `bunx vitest run src/lib/hooks/useIsMounted src/lib/component/Tooltip/common/TooltipArea src/lib/component/ContextualMenu` — 30 tests pass, including the SSR/hydration files.
4. Regression proof: reverting either `mounted` gate back to `typeof window` makes the corresponding `*.hydration.tests.tsx` fail.

### PR readiness check

- [x] Label: `Bug 🐛`
- [x] Conventional Commits title
- [x] Follows code standards (shared hook mirrors `useDelayedToggle`; `@note Impure` on the effect)
- [x] `check`, `check:fix`, `test` scripts already defined for `@canonical/react-ds-global`
- [x] No new package
- [ ] `no visual change` — no visual change; SSR/hydration only (safe to skip Chromatic)

## Screenshots

N/A — SSR/hydration behaviour only, no visual change.
