### PR TITLE
feat(cli): package-declared prefixes + bare-core boot (P0)

### DIFF
--- a/packages/cli/pragma/src/constants.ts
+++ b/packages/cli/pragma/src/constants.ts
@@ -7,7 +7,9 @@
  */
 
 import pkg from "../package.json" with { type: "json" };
-import { PREFIX_MAP } from "./domains/shared/prefixes.js";
+// DEFAULT_PREFIX_MAP carries the transitional DS prefixes (ds/cs) this map
+// still keys on; remove in P4 when DS prefixes ship from their packages.
+import { DEFAULT_PREFIX_MAP as PREFIX_MAP } from "./domains/shared/prefixes.js";
 
 /** CLI program name used in help text and error messages. */
 const PROGRAM_NAME = "pragma";

--- a/packages/cli/pragma/src/domains/block/formatters/list.test.ts
+++ b/packages/cli/pragma/src/domains/block/formatters/list.test.ts
@@ -1,11 +1,11 @@
 import type { URI } from "@canonical/ke";
 import { describe, expect, it } from "vitest";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import type { BlockSummary } from "../../shared/types/index.js";
 import formatters from "./list.js";
 
 const BUTTON: BlockSummary = {
-  uri: `${PREFIX_MAP.ds}button` as URI,
+  uri: `${DEFAULT_PREFIX_MAP.ds}button` as URI,
   name: "Button",
   tier: "global",
   modifiers: ["importance", "density"],
@@ -18,7 +18,7 @@ const BUTTON: BlockSummary = {
 };
 
 const CARD: BlockSummary = {
-  uri: `${PREFIX_MAP.ds}card` as URI,
+  uri: `${DEFAULT_PREFIX_MAP.ds}card` as URI,
   name: "Card",
   tier: "global",
   modifiers: [],

--- a/packages/cli/pragma/src/domains/block/formatters/lookup.test.ts
+++ b/packages/cli/pragma/src/domains/block/formatters/lookup.test.ts
@@ -1,12 +1,12 @@
 import type { URI } from "@canonical/ke";
 import { describe, expect, it } from "vitest";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import type { BlockDetailed } from "../../shared/types/index.js";
 import type { AspectFlags } from "../types.js";
 import formatters from "./lookup.js";
 
 const BUTTON_DETAILED: BlockDetailed = {
-  uri: `${PREFIX_MAP.ds}global.component.button` as URI,
+  uri: `${DEFAULT_PREFIX_MAP.ds}global.component.button` as URI,
   name: "Button",
   type: "component",
   tier: "global",
@@ -40,7 +40,7 @@ const BUTTON_DETAILED: BlockDetailed = {
   ],
   modifierFamilies: [
     {
-      uri: `${PREFIX_MAP.ds}modifier_family.importance` as URI,
+      uri: `${DEFAULT_PREFIX_MAP.ds}modifier_family.importance` as URI,
       name: "importance",
       values: ["default", "primary", "secondary"],
     },
@@ -56,7 +56,7 @@ const BUTTON_DETAILED: BlockDetailed = {
   ],
   subcomponents: [
     {
-      uri: `${PREFIX_MAP.ds}global.subcomponent.button.icon` as URI,
+      uri: `${DEFAULT_PREFIX_MAP.ds}global.subcomponent.button.icon` as URI,
       name: "Button Icon",
     },
   ],
@@ -65,7 +65,7 @@ const BUTTON_DETAILED: BlockDetailed = {
   ],
   tokens: [
     {
-      uri: `${PREFIX_MAP.ds}token.color.primary` as URI,
+      uri: `${DEFAULT_PREFIX_MAP.ds}token.color.primary` as URI,
       name: "color.primary",
     },
   ],

--- a/packages/cli/pragma/src/domains/graph/commands/inspect.test.ts
+++ b/packages/cli/pragma/src/domains/graph/commands/inspect.test.ts
@@ -2,7 +2,7 @@ import type { CommandDefinition } from "@canonical/cli-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import createTestRuntime from "../../../testing/helpers/createTestRuntime.js";
 import type { PragmaContext } from "../../shared/context.js";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import type { PragmaRuntime } from "../../shared/runtime.js";
 import type { InspectResult } from "../../shared/types/index.js";
 import buildInspectCommand from "./inspect.js";
@@ -37,7 +37,7 @@ async function executeOutput(
 }
 
 describe("graph inspect command", () => {
-  const uri = `${PREFIX_MAP.ds}global.component.button`;
+  const uri = `${DEFAULT_PREFIX_MAP.ds}global.component.button`;
 
   it("returns inspect results", async () => {
     const ctx = makeCtx();

--- a/packages/cli/pragma/src/domains/graph/formatters/inspect.ts
+++ b/packages/cli/pragma/src/domains/graph/formatters/inspect.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { formatHeading } from "#pipeline";
 import compactUri from "../../shared/compactUri.js";
 import type { Formatters } from "../../shared/formatters.js";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import type { InspectResult } from "../../shared/types/index.js";
 
 /**
@@ -15,13 +15,13 @@ import type { InspectResult } from "../../shared/types/index.js";
 const formatters: Formatters<InspectResult> = {
   plain(result) {
     const lines: string[] = [];
-    lines.push(formatHeading(compactUri(result.uri, PREFIX_MAP)));
+    lines.push(formatHeading(compactUri(result.uri, DEFAULT_PREFIX_MAP)));
 
     for (const g of result.groups) {
       lines.push("");
-      lines.push(chalk.bold(compactUri(g.predicate, PREFIX_MAP)));
+      lines.push(chalk.bold(compactUri(g.predicate, DEFAULT_PREFIX_MAP)));
       for (const o of g.objects) {
-        lines.push(`  ${compactUri(o, PREFIX_MAP)}`);
+        lines.push(`  ${compactUri(o, DEFAULT_PREFIX_MAP)}`);
       }
     }
 
@@ -30,13 +30,13 @@ const formatters: Formatters<InspectResult> = {
 
   llm(result) {
     const lines = [
-      `## ${compactUri(result.uri, PREFIX_MAP)} (${result.uri})`,
+      `## ${compactUri(result.uri, DEFAULT_PREFIX_MAP)} (${result.uri})`,
       "",
     ];
     for (const g of result.groups) {
-      lines.push(`**${compactUri(g.predicate, PREFIX_MAP)}:**`);
+      lines.push(`**${compactUri(g.predicate, DEFAULT_PREFIX_MAP)}:**`);
       for (const o of g.objects) {
-        lines.push(`  - ${compactUri(o, PREFIX_MAP)}`);
+        lines.push(`  - ${compactUri(o, DEFAULT_PREFIX_MAP)}`);
       }
     }
     return lines.join("\n");

--- a/packages/cli/pragma/src/domains/graph/operations/inspectUri.test.ts
+++ b/packages/cli/pragma/src/domains/graph/operations/inspectUri.test.ts
@@ -2,7 +2,7 @@ import type { Store } from "@canonical/ke";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { PragmaError } from "#error";
 import { createTestStore, DS_ALL_TTL } from "#testing";
-import { P, PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP, P } from "../../shared/prefixes.js";
 import inspectUri from "./inspectUri.js";
 
 let store: Store;
@@ -19,7 +19,7 @@ afterAll(() => cleanup());
 describe("inspectUri", () => {
   it("returns grouped triples for a known URI", async () => {
     const result = await inspectUri(store, `${P.ds}global.component.button`);
-    expect(result.uri).toBe(`${PREFIX_MAP.ds}global.component.button`);
+    expect(result.uri).toBe(`${DEFAULT_PREFIX_MAP.ds}global.component.button`);
     expect(result.groups.length).toBeGreaterThan(0);
 
     const predicates = result.groups.map((g) => g.predicate);
@@ -30,15 +30,15 @@ describe("inspectUri", () => {
 
   it("resolves prefixed URIs", async () => {
     const result = await inspectUri(store, `${P.ds}global.component.button`);
-    expect(result.uri).toBe(`${PREFIX_MAP.ds}global.component.button`);
+    expect(result.uri).toBe(`${DEFAULT_PREFIX_MAP.ds}global.component.button`);
   });
 
   it("accepts full URIs", async () => {
     const result = await inspectUri(
       store,
-      `${PREFIX_MAP.ds}global.component.button`,
+      `${DEFAULT_PREFIX_MAP.ds}global.component.button`,
     );
-    expect(result.uri).toBe(`${PREFIX_MAP.ds}global.component.button`);
+    expect(result.uri).toBe(`${DEFAULT_PREFIX_MAP.ds}global.component.button`);
     expect(result.groups.length).toBeGreaterThan(0);
   });
 

--- a/packages/cli/pragma/src/domains/graphql/helpers/parsePrefixes.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/parsePrefixes.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import parsePrefixes from "./parsePrefixes.js";
 
 describe("parsePrefixes", () => {
   it("returns the default prefix map for no entries", () => {
     const prefixes = parsePrefixes([]);
-    expect(prefixes).toEqual(PREFIX_MAP);
+    expect(prefixes).toEqual(DEFAULT_PREFIX_MAP);
   });
 
   it("merges entries on top of the defaults", () => {
     const prefixes = parsePrefixes(["ex=http://example.org/"]);
     expect(prefixes.ex).toBe("http://example.org/");
-    expect(prefixes.ds).toBe(PREFIX_MAP.ds);
+    expect(prefixes.ds).toBe(DEFAULT_PREFIX_MAP.ds);
   });
 
   it("lets entries override default prefixes", () => {

--- a/packages/cli/pragma/src/domains/graphql/helpers/parsePrefixes.ts
+++ b/packages/cli/pragma/src/domains/graphql/helpers/parsePrefixes.ts
@@ -1,11 +1,11 @@
 import { PragmaError } from "#error";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 
 /**
  * Parse repeated `--prefix name=namespace` entries into a prefix map.
  *
  * User-supplied prefixes are merged on top of pragma's default
- * {@link PREFIX_MAP}, so `ds:` and the W3C vocabularies stay available
+ * {@link DEFAULT_PREFIX_MAP}, so `ds:` and the W3C vocabularies stay available
  * unless explicitly overridden.
  *
  * @param entries - Raw `name=namespace` strings from the CLI.
@@ -15,7 +15,7 @@ import { PREFIX_MAP } from "../../shared/prefixes.js";
 export default function parsePrefixes(
   entries: readonly string[],
 ): Record<string, string> {
-  const prefixes: Record<string, string> = { ...PREFIX_MAP };
+  const prefixes: Record<string, string> = { ...DEFAULT_PREFIX_MAP };
 
   for (const entry of entries) {
     const separator = entry.indexOf("=");

--- a/packages/cli/pragma/src/domains/graphql/operations/compileSchema.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/compileSchema.test.ts
@@ -6,10 +6,10 @@ import {
   GRAPHQL_ERROR_TTL,
   GRAPHQL_FATAL_TTL,
 } from "#testing";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import compileSchema from "./compileSchema.js";
 
-const PREFIXES = { ...PREFIX_MAP, ex: EX_NAMESPACE };
+const PREFIXES = { ...DEFAULT_PREFIX_MAP, ex: EX_NAMESPACE };
 
 const inline = (content: string, path: string) => ({
   content,

--- a/packages/cli/pragma/src/domains/graphql/operations/createSchemaServer.test.ts
+++ b/packages/cli/pragma/src/domains/graphql/operations/createSchemaServer.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { EX_NAMESPACE, GRAPHQL_CLEAN_TTL } from "#testing";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import createSchemaServer, { type SchemaServer } from "./createSchemaServer.js";
 
-const PREFIXES = { ...PREFIX_MAP, ex: EX_NAMESPACE };
+const PREFIXES = { ...DEFAULT_PREFIX_MAP, ex: EX_NAMESPACE };
 
 describe("createSchemaServer", () => {
   let server: SchemaServer | undefined;

--- a/packages/cli/pragma/src/domains/ontology/formatters/list.ts
+++ b/packages/cli/pragma/src/domains/ontology/formatters/list.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import compactUri from "../../shared/compactUri.js";
 import type { Formatters } from "../../shared/formatters.js";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import type { OntologySummary } from "../../shared/types/index.js";
 
 /**
@@ -16,7 +16,7 @@ const formatters: Formatters<readonly OntologySummary[]> = {
     return ontologies
       .map(
         (o) =>
-          `${chalk.bold(`${o.prefix}:`)} ${compactUri(o.namespace, PREFIX_MAP)} classes: ${o.classCount} properties: ${o.propertyCount} anatomy: ${o.anatomyCount}`,
+          `${chalk.bold(`${o.prefix}:`)} ${compactUri(o.namespace, DEFAULT_PREFIX_MAP)} classes: ${o.classCount} properties: ${o.propertyCount} anatomy: ${o.anatomyCount}`,
       )
       .join("\n");
   },
@@ -25,7 +25,7 @@ const formatters: Formatters<readonly OntologySummary[]> = {
     const lines = ["## Ontologies", ""];
     for (const o of ontologies) {
       lines.push(
-        `- **${o.prefix}:** \`${compactUri(o.namespace, PREFIX_MAP)}\` | classes: ${o.classCount} | properties: ${o.propertyCount} | anatomy: ${o.anatomyCount}`,
+        `- **${o.prefix}:** \`${compactUri(o.namespace, DEFAULT_PREFIX_MAP)}\` | classes: ${o.classCount} | properties: ${o.propertyCount} | anatomy: ${o.anatomyCount}`,
       );
     }
     return lines.join("\n");

--- a/packages/cli/pragma/src/domains/ontology/formatters/show.ts
+++ b/packages/cli/pragma/src/domains/ontology/formatters/show.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../pipeline/formatTerminal.js";
 import compactUri from "../../shared/compactUri.js";
 import type { Formatters } from "../../shared/formatters.js";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import type { OntologyDetailed } from "../../shared/types/index.js";
 
 /**
@@ -24,7 +24,7 @@ const formatters: Formatters<OntologyDetailed> = {
 
     lines.push(
       formatHeading(
-        `${data.prefix}: ${compactUri(data.namespace, PREFIX_MAP)}`,
+        `${data.prefix}: ${compactUri(data.namespace, DEFAULT_PREFIX_MAP)}`,
       ),
     );
 
@@ -32,9 +32,11 @@ const formatters: Formatters<OntologyDetailed> = {
       const classLines = data.classes
         .map((c) => {
           const sup = c.superclass
-            ? chalk.dim(` extends ${compactUri(c.superclass, PREFIX_MAP)}`)
+            ? chalk.dim(
+                ` extends ${compactUri(c.superclass, DEFAULT_PREFIX_MAP)}`,
+              )
             : "";
-          return `  ${chalk.bold(c.label)} ${chalk.dim(`(${compactUri(c.uri, PREFIX_MAP)})`)}${sup}`;
+          return `  ${chalk.bold(c.label)} ${chalk.dim(`(${compactUri(c.uri, DEFAULT_PREFIX_MAP)})`)}${sup}`;
         })
         .join("\n");
       lines.push("");
@@ -45,12 +47,12 @@ const formatters: Formatters<OntologyDetailed> = {
       const propLines = data.properties
         .map((p) => {
           const domain = p.domain
-            ? chalk.dim(` domain: ${compactUri(p.domain, PREFIX_MAP)}`)
+            ? chalk.dim(` domain: ${compactUri(p.domain, DEFAULT_PREFIX_MAP)}`)
             : "";
           const range = p.range
-            ? chalk.dim(` range: ${compactUri(p.range, PREFIX_MAP)}`)
+            ? chalk.dim(` range: ${compactUri(p.range, DEFAULT_PREFIX_MAP)}`)
             : "";
-          return `  ${chalk.bold(p.label)} ${chalk.dim(`(${compactUri(p.uri, PREFIX_MAP)})`)} (${p.type})${domain}${range}`;
+          return `  ${chalk.bold(p.label)} ${chalk.dim(`(${compactUri(p.uri, DEFAULT_PREFIX_MAP)})`)} (${p.type})${domain}${range}`;
         })
         .join("\n");
       lines.push("");
@@ -62,7 +64,7 @@ const formatters: Formatters<OntologyDetailed> = {
 
   llm(data) {
     const lines = [
-      `## ${data.prefix}: ${compactUri(data.namespace, PREFIX_MAP)}`,
+      `## ${data.prefix}: ${compactUri(data.namespace, DEFAULT_PREFIX_MAP)}`,
       "",
     ];
 
@@ -70,10 +72,10 @@ const formatters: Formatters<OntologyDetailed> = {
       lines.push("### Classes");
       for (const c of data.classes) {
         const sup = c.superclass
-          ? ` extends ${compactUri(c.superclass, PREFIX_MAP)}`
+          ? ` extends ${compactUri(c.superclass, DEFAULT_PREFIX_MAP)}`
           : "";
         lines.push(
-          `- \`${compactUri(c.uri, PREFIX_MAP)}\` — **${c.label}**${sup}`,
+          `- \`${compactUri(c.uri, DEFAULT_PREFIX_MAP)}\` — **${c.label}**${sup}`,
         );
       }
       lines.push("");
@@ -83,13 +85,13 @@ const formatters: Formatters<OntologyDetailed> = {
       lines.push("### Properties");
       for (const p of data.properties) {
         const domain = p.domain
-          ? ` domain: ${compactUri(p.domain, PREFIX_MAP)}`
+          ? ` domain: ${compactUri(p.domain, DEFAULT_PREFIX_MAP)}`
           : "";
         const range = p.range
-          ? ` range: ${compactUri(p.range, PREFIX_MAP)}`
+          ? ` range: ${compactUri(p.range, DEFAULT_PREFIX_MAP)}`
           : "";
         lines.push(
-          `- \`${compactUri(p.uri, PREFIX_MAP)}\` — **${p.label}** (${p.type})${domain}${range}`,
+          `- \`${compactUri(p.uri, DEFAULT_PREFIX_MAP)}\` — **${p.label}** (${p.type})${domain}${range}`,
         );
       }
     }

--- a/packages/cli/pragma/src/domains/ontology/operations/listOntologies.test.ts
+++ b/packages/cli/pragma/src/domains/ontology/operations/listOntologies.test.ts
@@ -1,7 +1,7 @@
 import type { Store } from "@canonical/ke";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createTestStore, DS_ALL_TTL } from "#testing";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import listOntologies from "./listOntologies.js";
 
 let store: Store;
@@ -22,7 +22,7 @@ describe("listOntologies", () => {
 
     const ds = result.find((o) => o.prefix === "ds");
     expect(ds).toBeDefined();
-    expect(ds?.namespace).toBe(PREFIX_MAP.ds);
+    expect(ds?.namespace).toBe(DEFAULT_PREFIX_MAP.ds);
     expect(ds?.classCount).toBeGreaterThan(0);
     expect(ds?.propertyCount).toBeGreaterThan(0);
     expect(ds?.anatomyCount).toBeGreaterThan(0);

--- a/packages/cli/pragma/src/domains/ontology/operations/showOntology.test.ts
+++ b/packages/cli/pragma/src/domains/ontology/operations/showOntology.test.ts
@@ -2,7 +2,7 @@ import type { Store } from "@canonical/ke";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { PragmaError } from "#error";
 import { createTestStore, DS_ALL_TTL } from "#testing";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import showOntology from "./showOntology.js";
 
 let store: Store;
@@ -20,7 +20,7 @@ describe("showOntology", () => {
   it("returns classes and properties for a prefix", async () => {
     const result = await showOntology(store, "ds");
     expect(result.prefix).toBe("ds");
-    expect(result.namespace).toBe(PREFIX_MAP.ds);
+    expect(result.namespace).toBe(DEFAULT_PREFIX_MAP.ds);
     expect(result.classes.length).toBeGreaterThan(0);
     expect(result.properties.length).toBeGreaterThan(0);
   });
@@ -41,7 +41,7 @@ describe("showOntology", () => {
   });
 
   it("resolves full namespace URI", async () => {
-    const result = await showOntology(store, PREFIX_MAP.ds);
+    const result = await showOntology(store, DEFAULT_PREFIX_MAP.ds);
     expect(result.prefix).toBe("ds");
     expect(result.classes.length).toBeGreaterThan(0);
   });

--- a/packages/cli/pragma/src/domains/ontology/operations/showOntologyRaw.test.ts
+++ b/packages/cli/pragma/src/domains/ontology/operations/showOntologyRaw.test.ts
@@ -2,7 +2,7 @@ import type { Store } from "@canonical/ke";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { PragmaError } from "#error";
 import { createTestStore, DS_ALL_TTL } from "#testing";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import showOntologyRaw from "./showOntologyRaw.js";
 
 let store: Store;
@@ -21,7 +21,9 @@ describe("showOntologyRaw", () => {
     const triples = await showOntologyRaw(store, "ds");
     expect(triples.length).toBeGreaterThan(0);
 
-    const hasDs = triples.some((t) => t.subject.startsWith(PREFIX_MAP.ds));
+    const hasDs = triples.some((t) =>
+      t.subject.startsWith(DEFAULT_PREFIX_MAP.ds),
+    );
     expect(hasDs).toBe(true);
   });
 

--- a/packages/cli/pragma/src/domains/shared/bootStore.bareCore.test.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.bareCore.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Bare-core boot — pragma must serve the generic `graph`, `graphql`, and
+ * `ontology` surfaces with zero semantic packages loaded. This pins the P0
+ * invariant that the core no longer depends on the design-system packages:
+ * a store booted with no packages resolves generic queries and each
+ * generic operation returns cleanly instead of crashing.
+ */
+
+import type { Store } from "@canonical/ke";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { EX_NAMESPACE, GRAPHQL_CLEAN_TTL } from "#testing";
+import inspectUri from "../graph/operations/inspectUri.js";
+import compileSchema from "../graphql/operations/compileSchema.js";
+import listOntologies from "../ontology/operations/listOntologies.js";
+import { bootStore } from "./bootStore.js";
+import { PREFIX_MAP, resolvePrefixes } from "./prefixes.js";
+
+let store: Store;
+
+beforeAll(async () => {
+  // The `sources` override boots with zero resolved packages (bare core).
+  const boot = await bootStore({ sources: [] });
+  store = boot.store;
+  expect(boot.packages).toEqual([]);
+});
+
+afterAll(() => store?.dispose());
+
+describe("bare-core boot", () => {
+  it("carries the generic core prefixes on the store", () => {
+    expect(store.prefixes.rdf).toBe(PREFIX_MAP.rdf);
+    expect(store.prefixes.owl).toBe(PREFIX_MAP.owl);
+  });
+
+  it("serves generic SPARQL without any packages loaded", async () => {
+    const result = await store.query(
+      "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }",
+    );
+    expect(result.type).toBe("select");
+  });
+
+  it("serves `ontology` — listOntologies returns cleanly, not a crash", async () => {
+    await expect(listOntologies(store)).resolves.toEqual([]);
+  });
+
+  it("serves `graph` — inspecting an unknown URI reports not-found, not a crash", async () => {
+    await expect(
+      inspectUri(store, "https://example.org/nothing"),
+    ).rejects.toMatchObject({ code: "ENTITY_NOT_FOUND" });
+  });
+
+  it("serves `graphql` — compiles a generic ontology with core-only prefixes", async () => {
+    const outcome = await compileSchema({
+      sources: [
+        { content: GRAPHQL_CLEAN_TTL, format: "turtle", path: "x.ttl" },
+      ],
+      // Package-style prefix layered over the bare core — no DS packages.
+      prefixes: resolvePrefixes([{ prefixes: { ex: EX_NAMESPACE } }]),
+    });
+    expect(outcome.status).toBe("ok");
+    expect(outcome.compiled?.sdl).toContain("type Thing");
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/bootStore.ts
+++ b/packages/cli/pragma/src/domains/shared/bootStore.ts
@@ -23,7 +23,7 @@ import {
   createLocalLoader,
 } from "./loaders/index.js";
 import { DEFAULT_PACKAGES } from "./packages.js";
-import { PREFIX_MAP } from "./prefixes.js";
+import { resolvePrefixes } from "./prefixes.js";
 import type { GraphContent, SemanticPackage } from "./semanticPackage.js";
 import { resolveSemanticPackages } from "./semanticPackage.js";
 
@@ -61,13 +61,14 @@ export interface BootResult {
 export async function bootStore(
   options: BootStoreOptions = {},
 ): Promise<BootResult> {
-  const prefixes = { ...PREFIX_MAP, ...options.prefixes };
   try {
-    // Testing/programmatic override — use explicit sources
+    // Testing/programmatic override — use explicit sources. No packages are
+    // resolved, so the prefix map is the core base plus the transitional DS
+    // fallback and any caller override.
     if (options.sources) {
       const store = await createStore({
         sources: options.sources,
-        prefixes,
+        prefixes: resolvePrefixes([], options.prefixes),
         cache: options.cache,
         cwd: options.cwd,
       });
@@ -103,9 +104,12 @@ export async function bootStore(
       plugins.push(createTracePlugin({ traceDir: traceDir() }));
     }
 
+    // Merge every resolved package's declared prefixes (and the transitional
+    // DS fallback) over the generic core, then config overrides — so the
+    // store and every query see the packages' own namespaces.
     const store = await createStore({
       sources: [],
-      prefixes,
+      prefixes: resolvePrefixes(packages, options.prefixes),
       cache: options.cache,
       cwd: options.cwd,
       plugins,

--- a/packages/cli/pragma/src/domains/shared/extractLocalName.test.ts
+++ b/packages/cli/pragma/src/domains/shared/extractLocalName.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import extractLocalName from "./extractLocalName.js";
-import { PREFIX_MAP } from "./prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "./prefixes.js";
 
 describe("extractLocalName", () => {
   it("extracts after hash", () => {
@@ -8,7 +8,7 @@ describe("extractLocalName", () => {
   });
 
   it("extracts after last slash", () => {
-    expect(extractLocalName(`${PREFIX_MAP.ds}global`)).toBe("global");
+    expect(extractLocalName(`${DEFAULT_PREFIX_MAP.ds}global`)).toBe("global");
   });
 
   it("returns full string when no separator", () => {
@@ -16,6 +16,6 @@ describe("extractLocalName", () => {
   });
 
   it("handles nested path", () => {
-    expect(extractLocalName(`${PREFIX_MAP.ds}apps/lxd`)).toBe("lxd");
+    expect(extractLocalName(`${DEFAULT_PREFIX_MAP.ds}apps/lxd`)).toBe("lxd");
   });
 });

--- a/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
@@ -96,12 +96,14 @@ export default function createBundledLoader(): PackageLoader {
       if (graphs.length === 0 && stories.length === 0) return undefined;
 
       const version = await readEmbeddedVersion(blobs);
+      const prefixes = await readEmbeddedPrefixes(blobs);
 
       cached = {
         name: "(bundled)",
         version,
         source: "bundled",
         graphs,
+        ...(prefixes ? { prefixes } : {}),
         skills: [],
         stories,
       };
@@ -178,6 +180,42 @@ async function readEmbeddedStories(
 // ---------------------------------------------------------------------------
 // Version reading
 // ---------------------------------------------------------------------------
+
+/**
+ * Aggregate `pragma.prefixes` declared across embedded package manifests.
+ *
+ * The bundled loader collapses every embedded package into one aggregate
+ * SemanticPackage, so their prefix declarations are merged here (later
+ * manifests win on key collisions). Only string→string entries are kept;
+ * malformed shapes are ignored so one bad manifest cannot break boot.
+ *
+ * @returns The merged prefix map, or `undefined` when none is declared.
+ */
+async function readEmbeddedPrefixes(
+  blobs: ReadonlyArray<Blob & { name: string }>,
+): Promise<Readonly<Record<string, string>> | undefined> {
+  const prefixes: Record<string, string> = {};
+
+  for (const blob of blobs) {
+    if (!isPackageManifest(blob.name)) continue;
+
+    try {
+      const parsed = JSON.parse(await blob.text()) as { pragma?: unknown };
+      const pragma = parsed.pragma;
+      if (typeof pragma !== "object" || pragma === null) continue;
+      const raw = (pragma as { prefixes?: unknown }).prefixes;
+      if (typeof raw !== "object" || raw === null) continue;
+      for (const [name, namespace] of Object.entries(raw)) {
+        if (typeof namespace === "string") prefixes[name] = namespace;
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      warn(`skipping prefixes in embedded manifest "${blob.name}": ${reason}`);
+    }
+  }
+
+  return Object.keys(prefixes).length > 0 ? prefixes : undefined;
+}
 
 async function readEmbeddedVersion(
   blobs: ReadonlyArray<Blob & { name: string }>,

--- a/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/bundledLoader.ts
@@ -206,7 +206,17 @@ async function readEmbeddedPrefixes(
       const raw = (pragma as { prefixes?: unknown }).prefixes;
       if (typeof raw !== "object" || raw === null) continue;
       for (const [name, namespace] of Object.entries(raw)) {
-        if (typeof namespace === "string") prefixes[name] = namespace;
+        if (typeof namespace !== "string") continue;
+        // These collapse into one aggregate package, so a cross-manifest
+        // collision would never reach resolvePrefixes' warning — surface it
+        // here, naming the manifest, instead of silently last-winning.
+        if (name in prefixes && prefixes[name] !== namespace) {
+          warn(
+            `embedded manifest "${blob.name}" overrides prefix "${name}" ` +
+              `(was <${prefixes[name]}>, now <${namespace}>)`,
+          );
+        }
+        prefixes[name] = namespace;
       }
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);

--- a/packages/cli/pragma/src/domains/shared/loaders/gitLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/gitLoader.ts
@@ -24,8 +24,7 @@ export default function createGitLoader(): PackageLoader {
       const dir = gitCacheDir(ref.pkg, ref.ref);
       if (!existsSync(dir)) return undefined;
 
-      const { version, graphs, skills, stories } = readPackageDir(dir);
-      return { name: ref.pkg, version, source: "git", graphs, skills, stories };
+      return { name: ref.pkg, source: "git", ...readPackageDir(dir) };
     },
   };
 }

--- a/packages/cli/pragma/src/domains/shared/loaders/localLoader.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/localLoader.ts
@@ -28,30 +28,14 @@ export default function createLocalLoader(): PackageLoader {
       // file:// refs → direct path check first
       if (ref.kind === "file") {
         if (!existsSync(ref.path)) return undefined;
-        const { version, graphs, skills, stories } = readPackageDir(ref.path);
-        return {
-          name: ref.pkg,
-          version,
-          source: "local",
-          graphs,
-          skills,
-          stories,
-        };
+        return { name: ref.pkg, source: "local", ...readPackageDir(ref.path) };
       }
 
       // All ref kinds → try node_modules walk
       const dir = findPackageDir(ref.pkg);
       if (!dir) return undefined;
 
-      const { version, graphs, skills, stories } = readPackageDir(dir);
-      return {
-        name: ref.pkg,
-        version,
-        source: "local",
-        graphs,
-        skills,
-        stories,
-      };
+      return { name: ref.pkg, source: "local", ...readPackageDir(dir) };
     },
   };
 }

--- a/packages/cli/pragma/src/domains/shared/loaders/readPackageDir.test.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/readPackageDir.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import readPackageDir from "./readPackageDir.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pragma-readpkg-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Write a package.json into the temp package root. */
+function writeManifest(manifest: unknown): void {
+  writeFileSync(join(dir, "package.json"), JSON.stringify(manifest), "utf-8");
+}
+
+describe("readPackageDir — prefixes", () => {
+  it("reads package-declared prefixes from package.json pragma.prefixes", () => {
+    writeManifest({
+      version: "1.2.3",
+      pragma: { prefixes: { ds: "https://ds.canonical.com/" } },
+    });
+    const { version, prefixes } = readPackageDir(dir);
+    expect(version).toBe("1.2.3");
+    expect(prefixes).toEqual({ ds: "https://ds.canonical.com/" });
+  });
+
+  it("omits prefixes when the package declares none", () => {
+    writeManifest({ version: "1.0.0" });
+    expect(readPackageDir(dir).prefixes).toBeUndefined();
+  });
+
+  it("ignores a malformed pragma.prefixes field", () => {
+    writeManifest({ version: "1.0.0", pragma: { prefixes: "not-an-object" } });
+    expect(readPackageDir(dir).prefixes).toBeUndefined();
+  });
+
+  it("keeps only string-valued prefix entries", () => {
+    writeManifest({
+      version: "1.0.0",
+      pragma: { prefixes: { ds: "https://ds.canonical.com/", bad: 42 } },
+    });
+    expect(readPackageDir(dir).prefixes).toEqual({
+      ds: "https://ds.canonical.com/",
+    });
+  });
+
+  it("returns a default version and no prefixes when package.json is absent", () => {
+    const contents = readPackageDir(dir);
+    expect(contents.version).toBe("0.0.0");
+    expect(contents.prefixes).toBeUndefined();
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/loaders/readPackageDir.ts
+++ b/packages/cli/pragma/src/domains/shared/loaders/readPackageDir.ts
@@ -38,6 +38,7 @@ const TTL_DIRS: readonly { dir: string; glob: string }[] = [
 export interface PackageDirContents {
   readonly version: string;
   readonly graphs: GraphContent[];
+  readonly prefixes?: Readonly<Record<string, string>>;
   readonly skills: SkillEntry[];
   readonly stories: StoryFileEntry[];
 }
@@ -46,12 +47,15 @@ export interface PackageDirContents {
  * Read semantic package content from a directory.
  *
  * @param dir - Absolute path to the package root directory.
- * @returns Package version, TTL graph content, and skill entries.
+ * @returns Package version, TTL graph content, declared prefixes, and skills.
  */
 export default function readPackageDir(dir: string): PackageDirContents {
+  const manifest = readManifest(dir);
+  const prefixes = parsePrefixesField(manifest);
   return {
-    version: readVersion(dir),
+    version: typeof manifest.version === "string" ? manifest.version : "0.0.0",
     graphs: readGraphs(dir),
+    ...(prefixes ? { prefixes } : {}),
     skills: readSkills(dir),
     stories: readStories(dir),
   };
@@ -61,15 +65,49 @@ export default function readPackageDir(dir: string): PackageDirContents {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function readVersion(dir: string): string {
-  const pjsonPath = join(dir, "package.json");
+/** A package.json shape with the fields this loader reads. */
+interface PackageManifest {
+  readonly version?: unknown;
+  readonly pragma?: unknown;
+}
+
+/** Read and parse `package.json`, returning an empty object on failure. */
+function readManifest(dir: string): PackageManifest {
   try {
-    const raw = readFileSync(pjsonPath, "utf-8");
-    const parsed = JSON.parse(raw) as { version?: string };
-    return parsed.version ?? "0.0.0";
+    return JSON.parse(
+      readFileSync(join(dir, "package.json"), "utf-8"),
+    ) as PackageManifest;
   } catch {
-    return "0.0.0";
+    return {};
   }
+}
+
+/**
+ * Extract package-declared prefixes from a parsed manifest.
+ *
+ * Convention: a package declares its namespaces under
+ * `pragma.prefixes` in `package.json`, e.g.
+ * `{ "pragma": { "prefixes": { "ds": "https://ds.canonical.com/" } } }`.
+ * Chosen over a separate file because the manifest is already read for the
+ * version, keeping the convention zero-extra-file and discoverable. Only
+ * string→string entries are kept; malformed shapes are ignored so one bad
+ * field cannot break boot.
+ *
+ * @returns The declared prefix map, or `undefined` when none is present.
+ */
+function parsePrefixesField(
+  manifest: PackageManifest,
+): Readonly<Record<string, string>> | undefined {
+  const pragma = manifest.pragma;
+  if (typeof pragma !== "object" || pragma === null) return undefined;
+  const raw = (pragma as { prefixes?: unknown }).prefixes;
+  if (typeof raw !== "object" || raw === null) return undefined;
+
+  const prefixes: Record<string, string> = {};
+  for (const [name, namespace] of Object.entries(raw)) {
+    if (typeof namespace === "string") prefixes[name] = namespace;
+  }
+  return Object.keys(prefixes).length > 0 ? prefixes : undefined;
 }
 
 function readGraphs(dir: string): GraphContent[] {

--- a/packages/cli/pragma/src/domains/shared/namespaces.ts
+++ b/packages/cli/pragma/src/domains/shared/namespaces.ts
@@ -6,12 +6,20 @@
  */
 
 import { createNamespace } from "@canonical/ke";
-import { PREFIX_MAP } from "./prefixes.js";
+import { PREFIX_MAP, TRANSITIONAL_DS_PREFIX_MAP } from "./prefixes.js";
 
-/** Design system namespace — classes, properties, and instances (e.g., `ds:Component`). */
-export const ds = createNamespace(PREFIX_MAP.ds);
-/** Component specification namespace — component-level metadata (e.g., `cs:anatomy`). */
-export const cs = createNamespace(PREFIX_MAP.cs);
+/**
+ * Design system namespace — classes, properties, and instances (e.g., `ds:Component`).
+ * @remarks transitional — sourced from the bundled DS fallback until the
+ * design-system package declares its own prefixes (remove in P4).
+ */
+export const ds = createNamespace(TRANSITIONAL_DS_PREFIX_MAP.ds);
+/**
+ * Component specification namespace — component-level metadata (e.g., `cs:anatomy`).
+ * @remarks transitional — sourced from the bundled DS fallback until the
+ * code-standards package declares its own prefixes (remove in P4).
+ */
+export const cs = createNamespace(TRANSITIONAL_DS_PREFIX_MAP.cs);
 /** RDF Schema namespace — core vocabulary (e.g., `rdfs:label`, `rdfs:subClassOf`). */
 export const rdfs = createNamespace(PREFIX_MAP.rdfs);
 /** OWL namespace — ontology constructs (e.g., `owl:Class`, `owl:ObjectProperty`). */

--- a/packages/cli/pragma/src/domains/shared/prefixes.test.ts
+++ b/packages/cli/pragma/src/domains/shared/prefixes.test.ts
@@ -196,6 +196,14 @@ describe("resolvePrefixes — injection & shadowing hardening", () => {
     expect(warnings.join("")).toContain("overrides an earlier declaration");
   });
 
+  it("names the declaring package in collision warnings when available", () => {
+    resolvePrefixes([
+      { name: "@canonical/one", prefixes: { a: "https://one.example/" } },
+      { name: "@canonical/two", prefixes: { a: "https://two.example/" } },
+    ]);
+    expect(warnings.join("")).toContain('package "@canonical/two"');
+  });
+
   it("does not warn when a package overrides the trusted DS fallback", () => {
     resolvePrefixes([{ prefixes: { ds: "https://packaged-ds.example/" } }]);
     expect(warnings).toHaveLength(0);

--- a/packages/cli/pragma/src/domains/shared/prefixes.test.ts
+++ b/packages/cli/pragma/src/domains/shared/prefixes.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PREFIX_MAP,
+  P,
+  PREFIX_MAP,
+  resolvePrefixes,
+  TRANSITIONAL_DS_PREFIX_MAP,
+  TTL_PREFIXES,
+} from "./prefixes.js";
+
+describe("core PREFIX_MAP", () => {
+  it("ships only generic RDF vocabularies — no design-system prefixes", () => {
+    expect(Object.keys(PREFIX_MAP).sort()).toEqual([
+      "owl",
+      "rdf",
+      "rdfs",
+      "skos",
+      "xsd",
+    ]);
+    expect(PREFIX_MAP).not.toHaveProperty("ds");
+    expect(PREFIX_MAP).not.toHaveProperty("cs");
+  });
+});
+
+describe("TRANSITIONAL_DS_PREFIX_MAP", () => {
+  it("bundles the design-system prefixes separately from the core", () => {
+    expect(TRANSITIONAL_DS_PREFIX_MAP).toEqual({
+      ds: "https://ds.canonical.com/",
+      cs: "http://pragma.canonical.com/codestandards#",
+    });
+  });
+});
+
+describe("DEFAULT_PREFIX_MAP (display set)", () => {
+  it("reproduces the pre-P0 compaction set — ds/cs plus rdfs/owl/skos", () => {
+    expect(Object.keys(DEFAULT_PREFIX_MAP).sort()).toEqual([
+      "cs",
+      "ds",
+      "owl",
+      "rdfs",
+      "skos",
+    ]);
+  });
+
+  it("omits rdf/xsd so URI compaction in output is unchanged", () => {
+    expect(DEFAULT_PREFIX_MAP).not.toHaveProperty("rdf");
+    expect(DEFAULT_PREFIX_MAP).not.toHaveProperty("xsd");
+  });
+});
+
+describe("P accessor", () => {
+  it("exposes prefixed-name accessors including the transitional ds/cs", () => {
+    expect(P.ds).toBe("ds:");
+    expect(P.cs).toBe("cs:");
+    expect(P.rdfs).toBe("rdfs:");
+    expect(P.owl).toBe("owl:");
+    expect(P.skos).toBe("skos:");
+  });
+});
+
+describe("TTL_PREFIXES", () => {
+  it("declares every display prefix plus xsd", () => {
+    expect(TTL_PREFIXES).toContain("@prefix ds: <https://ds.canonical.com/> .");
+    expect(TTL_PREFIXES).toContain(
+      "@prefix cs: <http://pragma.canonical.com/codestandards#> .",
+    );
+    expect(TTL_PREFIXES).toContain(
+      "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
+    );
+  });
+});
+
+describe("resolvePrefixes", () => {
+  it("returns core plus the transitional DS fallback for a bare core", () => {
+    const resolved = resolvePrefixes([]);
+    expect(resolved).toEqual({ ...PREFIX_MAP, ...TRANSITIONAL_DS_PREFIX_MAP });
+  });
+
+  it("layers package-declared prefixes over the fallback", () => {
+    const resolved = resolvePrefixes([
+      { prefixes: { ex: "https://example.org/" } },
+    ]);
+    expect(resolved.ex).toBe("https://example.org/");
+    // core + fallback still present
+    expect(resolved.ds).toBe(TRANSITIONAL_DS_PREFIX_MAP.ds);
+    expect(resolved.rdf).toBe(PREFIX_MAP.rdf);
+  });
+
+  it("lets a package override the transitional DS fallback", () => {
+    const resolved = resolvePrefixes([
+      { prefixes: { ds: "https://packaged-ds.example/" } },
+    ]);
+    expect(resolved.ds).toBe("https://packaged-ds.example/");
+  });
+
+  it("lets config prefixes win over both packages and the fallback", () => {
+    const resolved = resolvePrefixes(
+      [{ prefixes: { ds: "https://packaged-ds.example/" } }],
+      { ds: "https://config-ds.example/" },
+    );
+    expect(resolved.ds).toBe("https://config-ds.example/");
+  });
+
+  it("merges multiple packages in array order", () => {
+    const resolved = resolvePrefixes([
+      { prefixes: { a: "https://one.example/" } },
+      { prefixes: { a: "https://two.example/", b: "https://b.example/" } },
+    ]);
+    expect(resolved.a).toBe("https://two.example/");
+    expect(resolved.b).toBe("https://b.example/");
+  });
+
+  it("tolerates packages that declare no prefixes", () => {
+    const resolved = resolvePrefixes([{}, { prefixes: undefined }]);
+    expect(resolved).toEqual({ ...PREFIX_MAP, ...TRANSITIONAL_DS_PREFIX_MAP });
+  });
+});

--- a/packages/cli/pragma/src/domains/shared/prefixes.test.ts
+++ b/packages/cli/pragma/src/domains/shared/prefixes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_PREFIX_MAP,
   P,
@@ -113,5 +113,91 @@ describe("resolvePrefixes", () => {
   it("tolerates packages that declare no prefixes", () => {
     const resolved = resolvePrefixes([{}, { prefixes: undefined }]);
     expect(resolved).toEqual({ ...PREFIX_MAP, ...TRANSITIONAL_DS_PREFIX_MAP });
+  });
+});
+
+describe("resolvePrefixes — injection & shadowing hardening", () => {
+  let warnings: string[];
+  let write: typeof process.stderr.write;
+
+  beforeEach(() => {
+    warnings = [];
+    write = process.stderr.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      warnings.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = write;
+  });
+
+  it("drops a namespace that could break out of the SPARQL IRIREF", () => {
+    // A `>` would close `<...>` early and inject arbitrary SPARQL into every
+    // query the store runs.
+    const resolved = resolvePrefixes([
+      { prefixes: { evil: "http://e> SELECT * WHERE {?s ?p ?o} #" } },
+    ]);
+    expect(resolved).not.toHaveProperty("evil");
+    expect(warnings.join("")).toContain("not valid in an IRI");
+  });
+
+  it("rejects namespaces containing whitespace or angle/quote/brace chars", () => {
+    const resolved = resolvePrefixes([
+      {
+        prefixes: {
+          space: "http://e /x",
+          quote: 'http://e"x',
+          brace: "http://e{x}",
+        },
+      },
+    ]);
+    expect(resolved).not.toHaveProperty("space");
+    expect(resolved).not.toHaveProperty("quote");
+    expect(resolved).not.toHaveProperty("brace");
+  });
+
+  it("keeps a clean namespace untouched", () => {
+    const resolved = resolvePrefixes([
+      { prefixes: { ex: "https://example.org/ns#" } },
+    ]);
+    expect(resolved.ex).toBe("https://example.org/ns#");
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("refuses to let a package redefine a reserved core prefix", () => {
+    const resolved = resolvePrefixes([
+      { prefixes: { rdf: "https://evil.example/rdf#" } },
+    ]);
+    expect(resolved.rdf).toBe(PREFIX_MAP.rdf);
+    expect(warnings.join("")).toContain("reserved");
+  });
+
+  it("refuses reserved prefixes from config too", () => {
+    const resolved = resolvePrefixes([], { owl: "https://evil.example/owl#" });
+    expect(resolved.owl).toBe(PREFIX_MAP.owl);
+  });
+
+  it("skips a malformed prefix name", () => {
+    const resolved = resolvePrefixes([
+      { prefixes: { "bad name!": "https://example.org/" } },
+    ]);
+    expect(resolved).not.toHaveProperty("bad name!");
+    expect(warnings.join("")).toContain("not a valid prefix name");
+  });
+
+  it("warns on a last-wins collision between two packages", () => {
+    const resolved = resolvePrefixes([
+      { prefixes: { a: "https://one.example/" } },
+      { prefixes: { a: "https://two.example/" } },
+    ]);
+    expect(resolved.a).toBe("https://two.example/");
+    expect(warnings.join("")).toContain("overrides an earlier declaration");
+  });
+
+  it("does not warn when a package overrides the trusted DS fallback", () => {
+    resolvePrefixes([{ prefixes: { ds: "https://packaged-ds.example/" } }]);
+    expect(warnings).toHaveLength(0);
   });
 });

--- a/packages/cli/pragma/src/domains/shared/prefixes.ts
+++ b/packages/cli/pragma/src/domains/shared/prefixes.ts
@@ -63,6 +63,78 @@ export const DEFAULT_PREFIX_MAP = {
 } as const satisfies PrefixMap;
 
 /**
+ * Core prefixes reserved for pragma's own vocabularies. Packages and config
+ * may not redefine these — every query and the RDF/OWL/SKOS toolchain depend
+ * on them resolving to the canonical W3C namespaces, so a package that shadows
+ * `rdf:` (accidentally or maliciously) would silently corrupt every query.
+ */
+const RESERVED_PREFIXES: ReadonlySet<string> = new Set(Object.keys(PREFIX_MAP));
+
+/** A syntactically safe SPARQL prefix name (PN_PREFIX subset we accept). */
+const SAFE_PREFIX_NAME = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+/**
+ * Reject a namespace that cannot appear inside a SPARQL `<IRIREF>` unescaped.
+ * ke injects prefixes verbatim as `PREFIX name: <iri>`; a namespace containing
+ * `>` (or whitespace/control/`<"{}|^`\``) would break out of the IRI and inject
+ * arbitrary SPARQL into every query. SPARQL's IRIREF grammar forbids exactly
+ * these, so anything matching is both unsafe and invalid Turtle/SPARQL.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: IRIREF forbids U+0000–U+0020 by grammar
+const UNSAFE_NAMESPACE = /[\x00-\x20<>"{}|^`\\]/;
+
+/**
+ * Validate and merge one source of declared prefixes onto an accumulator.
+ *
+ * Skips (with a stderr warning) any entry that is unsafe to inject: a
+ * malformed prefix name, a namespace that could break out of the SPARQL
+ * IRIREF, or an attempt to redefine a reserved core prefix. Also warns when a
+ * later source silently overrides an already-declared prefix (last-wins
+ * collision), so a name clash between two packages is visible rather than
+ * mysterious.
+ *
+ * @note Impure — writes warnings to stderr.
+ */
+function mergePrefixSource(
+  acc: Record<string, string>,
+  claimed: Set<string>,
+  source: Readonly<Record<string, string>> | undefined,
+  origin: string,
+): void {
+  if (!source) return;
+  for (const [name, namespace] of Object.entries(source)) {
+    if (!SAFE_PREFIX_NAME.test(name)) {
+      process.stderr.write(
+        `Warning: ignoring prefix "${name}" from ${origin} — not a valid prefix name.\n`,
+      );
+      continue;
+    }
+    if (RESERVED_PREFIXES.has(name)) {
+      process.stderr.write(
+        `Warning: ignoring prefix "${name}" from ${origin} — "${name}:" is reserved for a core RDF vocabulary and cannot be redefined.\n`,
+      );
+      continue;
+    }
+    if (UNSAFE_NAMESPACE.test(namespace)) {
+      process.stderr.write(
+        `Warning: ignoring prefix "${name}" from ${origin} — namespace contains characters that are not valid in an IRI.\n`,
+      );
+      continue;
+    }
+    // Warn only on a collision between two *validated* sources (package vs.
+    // package/config). Silently overriding the trusted DS fallback is the
+    // expected transitional handoff, not a clash.
+    if (claimed.has(name) && acc[name] !== namespace) {
+      process.stderr.write(
+        `Warning: prefix "${name}" from ${origin} overrides an earlier declaration (was <${acc[name]}>, now <${namespace}>).\n`,
+      );
+    }
+    acc[name] = namespace;
+    claimed.add(name);
+  }
+}
+
+/**
  * Resolve the effective prefix map for a boot.
  *
  * Precedence (lowest → highest): the generic {@link PREFIX_MAP}, the
@@ -70,6 +142,12 @@ export const DEFAULT_PREFIX_MAP = {
  * array order), then config-level overrides. A package that declares its
  * own `ds:`/`cs:` therefore overrides the bundled fallback, and a user's
  * `pragma.config.json` `prefixes` wins over everything.
+ *
+ * Package- and config-declared prefixes are validated before they reach the
+ * store: unsafe names/namespaces are skipped (they would otherwise be injected
+ * verbatim into every SPARQL query), reserved core prefixes cannot be
+ * redefined, and last-wins collisions are surfaced as warnings. The bundled
+ * core and DS fallback are trusted and merged as-is.
  *
  * @param packages - Resolved packages, each optionally declaring prefixes.
  * @param configPrefixes - Config-level prefix overrides.
@@ -81,16 +159,18 @@ export function resolvePrefixes(
   }[] = [],
   configPrefixes?: Readonly<Record<string, string>>,
 ): Record<string, string> {
-  const packagePrefixes = Object.assign(
-    {},
-    ...packages.map((pkg) => pkg.prefixes ?? {}),
-  );
-  return {
+  const merged: Record<string, string> = {
     ...PREFIX_MAP,
     ...TRANSITIONAL_DS_PREFIX_MAP,
-    ...packagePrefixes,
-    ...configPrefixes,
   };
+  // Keys claimed by a validated source, so collisions between two such
+  // sources warn while overriding the trusted seed stays silent.
+  const claimed = new Set<string>();
+  for (const pkg of packages) {
+    mergePrefixSource(merged, claimed, pkg.prefixes, "a semantic package");
+  }
+  mergePrefixSource(merged, claimed, configPrefixes, "pragma.config.json");
+  return merged;
 }
 
 /**

--- a/packages/cli/pragma/src/domains/shared/prefixes.ts
+++ b/packages/cli/pragma/src/domains/shared/prefixes.ts
@@ -1,37 +1,120 @@
 /**
- * Prefix map for ke store creation.
+ * Prefix maps for ke store creation and display compaction.
  *
- * Registered as PREFIX declarations in every SPARQL query.
- * Single source of truth — rename a key here and P updates automatically.
+ * The core ships only generic RDF vocabularies. Domain prefixes (e.g. the
+ * design system's `ds:`/`cs:`) are supplied by the loaded semantic
+ * packages and merged over the core at boot via {@link resolvePrefixes}.
+ * Renaming a key here updates every derived accessor automatically.
  */
 
 import type { PrefixMap } from "@canonical/ke";
 
+/**
+ * Core prefix map — the generic RDF vocabularies pragma itself ships.
+ *
+ * Registered as PREFIX declarations in every SPARQL query and used as the
+ * base of the effective prefix map. Contains no domain-specific prefixes:
+ * `ds:`/`cs:` and any other package namespaces arrive from the resolved
+ * semantic packages (see {@link resolvePrefixes}).
+ */
 export const PREFIX_MAP = {
-  ds: "https://ds.canonical.com/",
-  cs: "http://pragma.canonical.com/codestandards#",
+  rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
   rdfs: "http://www.w3.org/2000/01/rdf-schema#",
   owl: "http://www.w3.org/2002/07/owl#",
   skos: "http://www.w3.org/2004/02/skos/core#",
+  xsd: "http://www.w3.org/2001/XMLSchema#",
 } as const satisfies PrefixMap;
 
 /**
- * SPARQL prefix accessors derived from {@link PREFIX_MAP}.
+ * Transitional design-system prefixes bundled with the core.
  *
- * Use in query templates: `${P.ds}Component` → `"ds:Component"`.
- * Renaming a key in PREFIX_MAP automatically updates every query.
+ * @remarks transitional — remove in P4. These belong to the
+ * `@canonical/design-system` and `@canonical/code-standards` packages and
+ * must move into their own prefix declarations. Until those packages
+ * declare `pragma.prefixes`, this bundled fallback keeps existing DS
+ * queries resolving and DS IRIs compacting in output. Package-declared
+ * prefixes (and config overrides) win over this fallback.
  */
-export const P = Object.fromEntries(
-  Object.keys(PREFIX_MAP).map((k) => [k, `${k}:`]),
-) as { readonly [K in keyof typeof PREFIX_MAP]: `${K}:` };
+export const TRANSITIONAL_DS_PREFIX_MAP = {
+  ds: "https://ds.canonical.com/",
+  cs: "http://pragma.canonical.com/codestandards#",
+} as const satisfies PrefixMap;
 
 /**
- * Turtle `@prefix` declarations derived from {@link PREFIX_MAP}.
+ * The default display/compaction prefix set and the base of the derived
+ * accessors — the exact set compacted before P0 split the core from the
+ * design system, kept stable during the transition.
  *
- * Includes `xsd:` which TTL data files commonly use but SPARQL queries
- * don't need (ke auto-injects PREFIX_MAP for queries).
+ * Deliberately omits `rdf:`/`xsd:` (present in {@link PREFIX_MAP}) so URI
+ * compaction in output is unchanged from pre-P0 behavior; the store's
+ * query prefix map (see {@link resolvePrefixes}) still carries them.
+ *
+ * @remarks transitional — the `ds:`/`cs:` members move to their packages
+ * in P4, at which point this collapses toward {@link PREFIX_MAP}. Runtime
+ * code should prefer the map from {@link resolvePrefixes}, which layers in
+ * package-declared and config prefixes over the store base.
+ */
+export const DEFAULT_PREFIX_MAP = {
+  ds: TRANSITIONAL_DS_PREFIX_MAP.ds,
+  cs: TRANSITIONAL_DS_PREFIX_MAP.cs,
+  rdfs: PREFIX_MAP.rdfs,
+  owl: PREFIX_MAP.owl,
+  skos: PREFIX_MAP.skos,
+} as const satisfies PrefixMap;
+
+/**
+ * Resolve the effective prefix map for a boot.
+ *
+ * Precedence (lowest → highest): the generic {@link PREFIX_MAP}, the
+ * transitional DS fallback, prefixes declared by resolved packages (in
+ * array order), then config-level overrides. A package that declares its
+ * own `ds:`/`cs:` therefore overrides the bundled fallback, and a user's
+ * `pragma.config.json` `prefixes` wins over everything.
+ *
+ * @param packages - Resolved packages, each optionally declaring prefixes.
+ * @param configPrefixes - Config-level prefix overrides.
+ * @returns The merged prefix map for the store and every query.
+ */
+export function resolvePrefixes(
+  packages: readonly {
+    readonly prefixes?: Readonly<Record<string, string>>;
+  }[] = [],
+  configPrefixes?: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const packagePrefixes = Object.assign(
+    {},
+    ...packages.map((pkg) => pkg.prefixes ?? {}),
+  );
+  return {
+    ...PREFIX_MAP,
+    ...TRANSITIONAL_DS_PREFIX_MAP,
+    ...packagePrefixes,
+    ...configPrefixes,
+  };
+}
+
+/**
+ * SPARQL prefix accessors derived from {@link DEFAULT_PREFIX_MAP}.
+ *
+ * Use in query templates: `${P.ds}Component` → `"ds:Component"`.
+ * Renaming a key in the underlying maps automatically updates every query.
+ *
+ * @remarks The `ds:`/`cs:` accessors are transitional (see
+ * {@link TRANSITIONAL_DS_PREFIX_MAP}); they resolve at query time against
+ * the store's merged prefix map, which the packages now supply.
+ */
+export const P = Object.fromEntries(
+  Object.keys(DEFAULT_PREFIX_MAP).map((k) => [k, `${k}:`]),
+) as { readonly [K in keyof typeof DEFAULT_PREFIX_MAP]: `${K}:` };
+
+/**
+ * Turtle `@prefix` declarations derived from {@link DEFAULT_PREFIX_MAP},
+ * plus `xsd:` — commonly used by TTL data files but omitted from the
+ * display set (SPARQL queries auto-inject the store prefix map).
  */
 export const TTL_PREFIXES = [
-  ...Object.entries(PREFIX_MAP).map(([k, uri]) => `@prefix ${k}: <${uri}> .`),
-  "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
+  ...Object.entries(DEFAULT_PREFIX_MAP).map(
+    ([k, uri]) => `@prefix ${k}: <${uri}> .`,
+  ),
+  `@prefix xsd: <${PREFIX_MAP.xsd}> .`,
 ].join("\n");

--- a/packages/cli/pragma/src/domains/shared/prefixes.ts
+++ b/packages/cli/pragma/src/domains/shared/prefixes.ts
@@ -155,6 +155,7 @@ function mergePrefixSource(
  */
 export function resolvePrefixes(
   packages: readonly {
+    readonly name?: string;
     readonly prefixes?: Readonly<Record<string, string>>;
   }[] = [],
   configPrefixes?: Readonly<Record<string, string>>,
@@ -167,7 +168,10 @@ export function resolvePrefixes(
   // sources warn while overriding the trusted seed stays silent.
   const claimed = new Set<string>();
   for (const pkg of packages) {
-    mergePrefixSource(merged, claimed, pkg.prefixes, "a semantic package");
+    // Name the declaring package in the origin so collision/injection
+    // warnings point at the actual source, not a generic placeholder.
+    const origin = pkg.name ? `package "${pkg.name}"` : "a semantic package";
+    mergePrefixSource(merged, claimed, pkg.prefixes, origin);
   }
   mergePrefixSource(merged, claimed, configPrefixes, "pragma.config.json");
   return merged;

--- a/packages/cli/pragma/src/domains/shared/renderers.ts
+++ b/packages/cli/pragma/src/domains/shared/renderers.ts
@@ -13,7 +13,7 @@ import type {
   RenderLookupOptions,
   SectionDef,
 } from "./contracts.js";
-import { PREFIX_MAP } from "./prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "./prefixes.js";
 
 type RenderMode = "plain" | "llm";
 
@@ -21,7 +21,7 @@ export function renderListPlain<T>(
   items: readonly T[],
   options: RenderListOptions<T>,
 ): string {
-  const prefixes = options.prefixes ?? PREFIX_MAP;
+  const prefixes = options.prefixes ?? DEFAULT_PREFIX_MAP;
   const rows = items.map((item) =>
     options.columns
       .map((column) => ({
@@ -52,7 +52,7 @@ export function renderListLlm<T>(
   items: readonly T[],
   options: RenderListOptions<T>,
 ): string {
-  const prefixes = options.prefixes ?? PREFIX_MAP;
+  const prefixes = options.prefixes ?? DEFAULT_PREFIX_MAP;
   const lines = [`## ${options.heading} (${items.length})`, ""];
 
   for (const item of items) {
@@ -121,7 +121,7 @@ function renderLookupFields<T>(
   options: RenderLookupOptions<T>,
   mode: RenderMode,
 ): string[] {
-  const prefixes = options.prefixes ?? PREFIX_MAP;
+  const prefixes = options.prefixes ?? DEFAULT_PREFIX_MAP;
   return options.fields.flatMap((field) => {
     const value = field.value(entity);
     if (isEmptyValue(value)) {
@@ -173,7 +173,7 @@ function renderSectionValue<T>(
   options: RenderLookupOptions<T>,
   mode: RenderMode,
 ): string | null {
-  const prefixes = options.prefixes ?? PREFIX_MAP;
+  const prefixes = options.prefixes ?? DEFAULT_PREFIX_MAP;
 
   switch (section.kind) {
     case "field":

--- a/packages/cli/pragma/src/domains/shared/semanticPackage.ts
+++ b/packages/cli/pragma/src/domains/shared/semanticPackage.ts
@@ -53,6 +53,13 @@ export interface SemanticPackage {
   readonly source: "local" | "git" | "bundled";
   /** TTL graph content to load into the ke store. */
   readonly graphs: GraphContent[];
+  /**
+   * Namespace prefixes this package declares, merged over the core prefix
+   * map at boot (see {@link resolvePrefixes}). Read from the package's
+   * `package.json` `pragma.prefixes` field. Absent when the package
+   * declares none.
+   */
+  readonly prefixes?: Readonly<Record<string, string>>;
   /** Skills available in this package. */
   readonly skills: SkillEntry[];
   /**

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackCommands.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackCommands.ts
@@ -1,6 +1,6 @@
 import type { CommandDefinition } from "@canonical/cli-core";
 import type { PragmaContext } from "../../context.js";
-import { PREFIX_MAP } from "../../prefixes.js";
+import { resolvePrefixes } from "../../prefixes.js";
 import compileLookupCommand from "../compileLookupCommand.js";
 import compileReadCommand from "../compileReadCommand.js";
 import collectPackStories from "./collectPackStories.js";
@@ -23,8 +23,8 @@ export default function compilePackCommands(
   ctx: PragmaContext,
   reserved: ReservedVerbs,
 ): CommandDefinition[] {
-  const prefixes = { ...PREFIX_MAP, ...ctx.config.prefixes };
-  const entries = collectPackStories(ctx.config, ctx.packages, reserved);
+  const prefixes = resolvePrefixes(ctx.packages ?? [], ctx.config.prefixes);
+  const entries = collectPackStories(ctx.config, ctx.packages ?? [], reserved);
 
   return entries.flatMap((entry) => {
     const compiled = compilePackStories(

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackStories.test.ts
@@ -7,11 +7,11 @@ import {
   RECIPE_STORY,
   RECIPE_TTL,
 } from "#testing";
-import { PREFIX_MAP } from "../../prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../prefixes.js";
 import type { PragmaRuntime } from "../../types/index.js";
 import compilePackStories from "./compilePackStories.js";
 
-const PREFIXES = { ...PREFIX_MAP, ...RECIPE_PREFIXES };
+const PREFIXES = { ...DEFAULT_PREFIX_MAP, ...RECIPE_PREFIXES };
 
 let store: Store;
 let cleanup: () => void;

--- a/packages/cli/pragma/src/domains/shared/stories/pack/compilePackToolSpecs.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/compilePackToolSpecs.ts
@@ -1,4 +1,4 @@
-import { PREFIX_MAP } from "../../prefixes.js";
+import { resolvePrefixes } from "../../prefixes.js";
 import type { ToolSpec } from "../../ToolSpec.js";
 import type { PragmaRuntime } from "../../types/index.js";
 import compileLookupTool from "../compileLookupTool.js";
@@ -22,10 +22,13 @@ export default function compilePackToolSpecs(
   runtime: PragmaRuntime,
   reserved: ReservedVerbs,
 ): ToolSpec[] {
-  const prefixes = { ...PREFIX_MAP, ...runtime.config.prefixes };
+  const prefixes = resolvePrefixes(
+    runtime.packages ?? [],
+    runtime.config.prefixes,
+  );
   const entries = collectPackStories(
     runtime.config,
-    runtime.packages,
+    runtime.packages ?? [],
     reserved,
   );
 

--- a/packages/cli/pragma/src/domains/shared/stories/pack/standardParity.test.ts
+++ b/packages/cli/pragma/src/domains/shared/stories/pack/standardParity.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../../../standard/stories.js";
 import { bootStore } from "../../bootStore.js";
 import compactUri from "../../compactUri.js";
-import { PREFIX_MAP } from "../../prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../prefixes.js";
 import type { PragmaRuntime, StandardDetailed } from "../../types/index.js";
 import type { LookupStoryView } from "../types.js";
 import compilePackStories, {
@@ -63,7 +63,7 @@ beforeAll(async () => {
   rt = { store } as PragmaRuntime;
 
   const compiled = compilePackStories(STANDARD_PACK_STORY, PACK_SOURCE, {
-    ...PREFIX_MAP,
+    ...DEFAULT_PREFIX_MAP,
   });
   packList = compiled.list;
   const lookup = compiled.lookup;
@@ -273,11 +273,11 @@ describe("standard lookup parity — cs:extends divergence", () => {
     // raw IRI. Compacting the pack value restores byte-level agreement.
     expect({
       ...packParsed,
-      extends: compactUri(packExtends, PREFIX_MAP),
+      extends: compactUri(packExtends, DEFAULT_PREFIX_MAP),
     }).toEqual(builtinParsed);
     expect(
       JSON.stringify(
-        { ...packParsed, extends: compactUri(packExtends, PREFIX_MAP) },
+        { ...packParsed, extends: compactUri(packExtends, DEFAULT_PREFIX_MAP) },
         null,
         2,
       ),

--- a/packages/cli/pragma/src/domains/standard/operations/categories.test.ts
+++ b/packages/cli/pragma/src/domains/standard/operations/categories.test.ts
@@ -1,7 +1,7 @@
 import type { Store } from "@canonical/ke";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createTestStore, DS_ALL_TTL } from "#testing";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import listCategories from "./categories.js";
 
 let store: Store;
@@ -36,7 +36,7 @@ describe("listCategories", () => {
 
   it("includes categories with zero standards", async () => {
     const ttlWithEmptyCategory = `
-      @prefix cs: <${PREFIX_MAP.cs}> .
+      @prefix cs: <${DEFAULT_PREFIX_MAP.cs}> .
       cs:empty_cat a cs:Category ; cs:slug "empty" .
       cs:filled_cat a cs:Category ; cs:slug "filled" .
       cs:s1 a cs:CodeStandard ;

--- a/packages/cli/pragma/src/domains/tier/formatters/list.ts
+++ b/packages/cli/pragma/src/domains/tier/formatters/list.ts
@@ -1,6 +1,6 @@
 import compactUri from "../../shared/compactUri.js";
 import type { Formatters } from "../../shared/formatters.js";
-import { PREFIX_MAP } from "../../shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../shared/prefixes.js";
 import type { TierEntry } from "../../shared/types/index.js";
 
 /**
@@ -19,7 +19,7 @@ const formatters: Formatters<TierEntry[]> = {
       const indent = "  ".repeat(t.depth);
       const parent = t.parent ? ` (parent: ${t.parent})` : "";
       lines.push(
-        `${compactUri(t.uri, PREFIX_MAP)}  ${indent}${t.path}${parent}`,
+        `${compactUri(t.uri, DEFAULT_PREFIX_MAP)}  ${indent}${t.path}${parent}`,
       );
     }
     return lines.join("\n");
@@ -33,7 +33,7 @@ const formatters: Formatters<TierEntry[]> = {
       const indent = "  ".repeat(t.depth);
       const parent = t.parent ? ` (parent: ${t.parent})` : "";
       lines.push(
-        `${indent}- **${t.path}** \`${compactUri(t.uri, PREFIX_MAP)}\`${parent}`,
+        `${indent}- **${t.path}** \`${compactUri(t.uri, DEFAULT_PREFIX_MAP)}\`${parent}`,
       );
     }
     return lines.join("\n");

--- a/packages/cli/pragma/src/mcp/registerResources.test.ts
+++ b/packages/cli/pragma/src/mcp/registerResources.test.ts
@@ -1,7 +1,7 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createTestMcpClient, createTestStore } from "#testing";
-import { P, PREFIX_MAP } from "../domains/shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP, P } from "../domains/shared/prefixes.js";
 import type { PragmaRuntime } from "../domains/shared/runtime.js";
 import createClientFromRuntime from "../testing/helpers/createTestMcpClient.js";
 import {
@@ -227,7 +227,7 @@ describe("resource listing — capping", () => {
       { length: overflow },
       (_, i) => `ds:widget_${i} a ds:Gadget ; ds:name "Widget ${i}" .`,
     ).join("\n");
-    const ttl = `@prefix ds: <${PREFIX_MAP.ds}> .
+    const ttl = `@prefix ds: <${DEFAULT_PREFIX_MAP.ds}> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/packages/cli/pragma/src/mcp/resources/pickPrimaryType.test.ts
+++ b/packages/cli/pragma/src/mcp/resources/pickPrimaryType.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { PREFIX_MAP } from "../../domains/shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../../domains/shared/prefixes.js";
 import pickPrimaryType from "./pickPrimaryType.js";
 
-const COMPONENT = `${PREFIX_MAP.ds}Component`;
-const BLOCK = `${PREFIX_MAP.ds}Block`;
-const NAMED_INDIVIDUAL = `${PREFIX_MAP.owl}NamedIndividual`;
-const OWL_THING = `${PREFIX_MAP.owl}Thing`;
+const COMPONENT = `${DEFAULT_PREFIX_MAP.ds}Component`;
+const BLOCK = `${DEFAULT_PREFIX_MAP.ds}Block`;
+const NAMED_INDIVIDUAL = `${DEFAULT_PREFIX_MAP.owl}NamedIndividual`;
+const OWL_THING = `${DEFAULT_PREFIX_MAP.owl}Thing`;
 
 describe("pickPrimaryType", () => {
   it("returns null for no types", () => {

--- a/packages/cli/pragma/src/testing/dsFixtures.ts
+++ b/packages/cli/pragma/src/testing/dsFixtures.ts
@@ -5,16 +5,19 @@
  * that D3 operations query against.
  *
  * All @prefix declarations derived from {@link TTL_PREFIXES} so that
- * a namespace rename in PREFIX_MAP propagates here automatically.
+ * a namespace rename in DEFAULT_PREFIX_MAP propagates here automatically.
  */
 
-import { PREFIX_MAP, TTL_PREFIXES } from "../domains/shared/prefixes.js";
+import {
+  DEFAULT_PREFIX_MAP,
+  TTL_PREFIXES,
+} from "../domains/shared/prefixes.js";
 
 /** Turtle @prefix block for ds: only (most data fixtures). */
-const dsPrefix = `@prefix ds: <${PREFIX_MAP.ds}> .`;
+const dsPrefix = `@prefix ds: <${DEFAULT_PREFIX_MAP.ds}> .`;
 
 /** Turtle @prefix block for cs: only (standards fixtures). */
-const csPrefix = `@prefix cs: <${PREFIX_MAP.cs}> .`;
+const csPrefix = `@prefix cs: <${DEFAULT_PREFIX_MAP.cs}> .`;
 
 // =============================================================================
 // Ontology (TBox) — class and property definitions

--- a/packages/cli/pragma/src/testing/store.ts
+++ b/packages/cli/pragma/src/testing/store.ts
@@ -2,12 +2,12 @@
  * Test store bridge — createTestStore, PragmaTestStoreOptions.
  *
  * Wraps `@canonical/ke/testing` with pragma's default prefix map
- * pre-configured so test authors do not need to repeat PREFIX_MAP.
+ * pre-configured so test authors do not need to repeat DEFAULT_PREFIX_MAP.
  */
 
 import type { TestStoreOptions, TestStoreResult } from "@canonical/ke/testing";
 import { createTestStore as keCreateTestStore } from "@canonical/ke/testing";
-import { PREFIX_MAP } from "../domains/shared/prefixes.js";
+import { DEFAULT_PREFIX_MAP } from "../domains/shared/prefixes.js";
 
 /** Options for creating a test store, with pragma prefixes pre-applied. */
 interface PragmaTestStoreOptions extends Omit<TestStoreOptions, "prefixes"> {
@@ -18,7 +18,7 @@ interface PragmaTestStoreOptions extends Omit<TestStoreOptions, "prefixes"> {
  * Create a test ke store with pragma's default prefix map.
  *
  * @param options - Optional overrides; additional prefixes are merged
- *   on top of the default PREFIX_MAP.
+ *   on top of the default DEFAULT_PREFIX_MAP.
  * @returns The test store result from ke/testing.
  *
  * @note Impure
@@ -29,7 +29,7 @@ async function createTestStore(
   return keCreateTestStore({
     ...options,
     prefixes: {
-      ...PREFIX_MAP,
+      ...DEFAULT_PREFIX_MAP,
       ...options.prefixes,
     },
   });


### PR DESCRIPTION
## Done

First slice of decoupling the pragma CLI core from the design system. **P0 only** — no behavior change for existing DS usage; the pack-migration slices (tier/standard/token/…) land separately.

- **Core ships only generic RDF vocabularies** (`rdf/rdfs/owl/skos/xsd`). The design-system `ds:`/`cs:` namespaces move to a clearly-labelled `TRANSITIONAL_DS_PREFIX_MAP` fallback (to be removed in a later slice once the DS packages declare their own prefixes).
- **Packages declare their own prefixes.** A semantic package can carry `pragma.prefixes` in its `package.json`; the loader chain reads them and `resolvePrefixes` merges them (over the core, under config) into the store and every SPARQL query at boot.
- **Bare-core boot.** With zero DS packages the store still boots and serves the generic `graph`/`graphql`/`ontology` surface.
- **Prefix input is validated before it reaches SPARQL.** ke injects prefixes verbatim as `PREFIX name: <iri>` on every query, so an unvalidated namespace containing `>` (malicious or a typo) could break out of the IRIREF and inject arbitrary SPARQL. `resolvePrefixes` now skips unsafe names/namespaces, refuses to let packages/config redefine reserved core prefixes, and warns on genuine last-wins collisions between two declaring sources (while overriding the trusted transitional fallback stays silent).

Display compaction is deliberately frozen to the pre-P0 set (`DEFAULT_PREFIX_MAP`, rdf/xsd-free) so terminal/MCP output is unchanged where it should be; the display-vs-query prefix-map split is finished in the later bare-core slice.

## QA

- `bun run check` (biome + tsc + webarchitect) — green.
- `bun run test` — full suite green (1533 passing), including new `prefixes.test.ts` (validation/shadowing/collision) and `bootStore.bareCore.test.ts` (0-package boot) and `readPackageDir.test.ts` (package prefix parsing).
- `bun run build` — `dist/pragma` builds with all embedded assets.
- Manual: a package declaring `pragma.prefixes` resolves its IRIs in queries; a bare checkout with no DS packages boots and answers `pragma graph`/`ontology`.

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁` (suggested).
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] All packages define the required scripts in `package.json` (`check`, `check:fix`, `test`, `build`, `build:all`).
- [x] No new package introduced.
- [x] No visual change — safe to add the `no visual change` label to skip Chromatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WrkZXTopfNP1ogcpSJRKi)_