### PR TITLE
chore(typescript-config): enforce verbatimModuleSyntax from the shared base config

### DIFF
--- a/configs/typescript-svelte/tsconfig.json
+++ b/configs/typescript-svelte/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@canonical/typescript-config",
   "compilerOptions": {
     "types": ["svelte", "vite/client"],
-    "verbatimModuleSyntax": true,
     "moduleResolution": "nodenext"
   }
 }

--- a/configs/typescript/tsconfig.json
+++ b/configs/typescript/tsconfig.json
@@ -3,6 +3,7 @@
     "lib": ["ES2023"],
     "module": "NodeNext",
     "target": "ES2023",
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/lit/ds-prototype/src/lib/LogoSection/types.ts
+++ b/packages/lit/ds-prototype/src/lib/LogoSection/types.ts
@@ -18,4 +18,4 @@ export interface Props {
   mode?: "default" | "minimal";
 }
 
-export default Props;
+export type { Props as default };

--- a/packages/react/ds-app-anbox/src/lib/Button/types.ts
+++ b/packages/react/ds-app-anbox/src/lib/Button/types.ts
@@ -29,4 +29,4 @@ export interface BaseProps {
 
 type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export default Props;
+export type { Props as default };

--- a/packages/react/ds-app-landscape/src/lib/Button/types.ts
+++ b/packages/react/ds-app-landscape/src/lib/Button/types.ts
@@ -29,4 +29,4 @@ export interface BaseProps {
 
 type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export default Props;
+export type { Props as default };

--- a/packages/react/ds-app-launchpad/src/lib/EditableBlock/types.ts
+++ b/packages/react/ds-app-launchpad/src/lib/EditableBlock/types.ts
@@ -31,4 +31,4 @@ export interface EditableBlockProps<T extends EditElementProps> {
   isReadOnly?: boolean;
 }
 
-export default EditableBlockProps;
+export type { EditableBlockProps as default };

--- a/packages/react/ds-app-lxd/src/lib/Button/types.ts
+++ b/packages/react/ds-app-lxd/src/lib/Button/types.ts
@@ -29,4 +29,4 @@ export interface BaseProps {
 
 type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export default Props;
+export type { Props as default };

--- a/packages/react/ds-app-portal/src/lib/Button/types.ts
+++ b/packages/react/ds-app-portal/src/lib/Button/types.ts
@@ -29,4 +29,4 @@ export interface BaseProps {
 
 type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export default Props;
+export type { Props as default };

--- a/packages/react/ds-global/src/lib/component/Button/types.ts
+++ b/packages/react/ds-global/src/lib/component/Button/types.ts
@@ -52,4 +52,4 @@ export interface BaseProps {
 
 type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export default Props;
+export type { Props as default };

--- a/packages/summon/core/src/types/AnyGenerator.ts
+++ b/packages/summon/core/src/types/AnyGenerator.ts
@@ -6,4 +6,4 @@ import type GeneratorDefinition from "./GeneratorDefinition.js";
 // biome-ignore lint/suspicious/noExplicitAny: Required for contravariant generator collections
 type AnyGenerator = GeneratorDefinition<any>;
 
-export default AnyGenerator;
+export type { AnyGenerator as default };

--- a/packages/summon/core/src/types/ForbidReserved.ts
+++ b/packages/summon/core/src/types/ForbidReserved.ts
@@ -20,4 +20,4 @@ type ForbidReserved<T> = {
     : T[K];
 };
 
-export default ForbidReserved;
+export type { ForbidReserved as default };

--- a/packages/summon/core/src/types/ReservedOption.ts
+++ b/packages/summon/core/src/types/ReservedOption.ts
@@ -20,4 +20,4 @@ type ReservedOption =
   | "verbose"
   | "generatedStamp";
 
-export default ReservedOption;
+export type { ReservedOption as default };


### PR DESCRIPTION
## Done

- Add `"verbatimModuleSyntax": true` to the shared base TS config (`configs/typescript/tsconfig.json`) so every framework config (`typescript-react`, `typescript-svelte`, `typescript-lit`) and every package inherits it — a single source of truth.
- Remove the now-redundant explicit `verbatimModuleSyntax` from `configs/typescript-svelte/tsconfig.json` (it already `extends` the base). This was previously the only place the flag was set.
- Fix the 10 type-only default exports this surfaces (TS1284 under `verbatimModuleSyntax`): rewrite `export default <Type>` → `export type { X as default }`. Every changed symbol is a pure type/interface and every consumer already imports it type-only, so there is **no runtime behaviour change**.

Why: `verbatimModuleSyntax` makes import/export emit deterministic (no elision guesswork), which is the modern default for ESM/TS libraries consumed by external bundlers. Biome's `useImportType` already keeps the codebase compliant for named imports, so upstreaming the flag repo-wide is low-risk.

Fixes #404

Changed source files (1 line each): `summon/core` (AnyGenerator, ForbidReserved, ReservedOption), `react/ds-global` Button/types, `react/ds-app-{anbox,landscape,lxd,portal}` Button/types, `react/ds-app-launchpad` EditableBlock/types, `lit/ds-prototype` LogoSection/types.

## QA

- `bun run check` from the repo root: **passes** (61 projects / 38 tasks — biome + `tsc --noEmit` + webarchitect).
- `bun run test` from the repo root: **passes**, with two environment-only flakes confirmed unrelated to this change:
  - `svelte-ds-global` — Playwright browser not installed in the CI sandbox (fails identically on clean `main`).
  - `pragma-cli` — a 5s byte-equality timeout under full parallel load; passes in isolation and on clean `main` (Nx flagged it flaky).
- Verified every one of the 10 changed modules exports a pure type, and a repo-wide grep found no value-position default import of them, so no consumer breaks.

### PR readiness check

- [x] PR label: `Maintenance 🔨`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts (no scripts changed; no new package).
- [ ] New package — n/a.
- [x] `no visual change` label added (no visual diff — config + type-modifier only).

## Screenshots

n/a — no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_