### PR TITLE
feat(webarchitect): require exports map in the svelte package ruleset

### DIFF
--- a/packages/webarchitect/rulesets/package-svelte.ruleset.json
+++ b/packages/webarchitect/rulesets/package-svelte.ruleset.json
@@ -24,6 +24,32 @@
           "types": {
             "const": "dist/index.d.ts"
           },
+          "exports": {
+            "type": "object",
+            "description": "Svelte packages must declare an exports map. svelte-package relies on the 'svelte' export condition for consumers to resolve components; dropping exports while keeping 'module'/'types' breaks resolution.",
+            "properties": {
+              ".": {
+                "type": "object",
+                "description": "Root entry point exposing the 'types', 'import' and 'svelte' conditions",
+                "properties": {
+                  "types": {
+                    "type": "string",
+                    "pattern": "^\\./dist/"
+                  },
+                  "import": {
+                    "type": "string",
+                    "pattern": "^\\./dist/"
+                  },
+                  "svelte": {
+                    "type": "string",
+                    "pattern": "^\\./dist/"
+                  }
+                },
+                "required": ["types", "import", "svelte"]
+              }
+            },
+            "required": ["."]
+          },
           "files": {
             "type": "array",
             "contains": { "const": "dist" }
@@ -54,6 +80,7 @@
           "type",
           "module",
           "types",
+          "exports",
           "files",
           "scripts"
         ]


### PR DESCRIPTION
## Done

- Add a required `exports`-map check to the Svelte webarchitect ruleset (`packages/webarchitect/rulesets/package-svelte.ruleset.json`). A Svelte package must now declare an `exports` object with a `.` root entry exposing the `types`, `import`, and `svelte` conditions (each targeting `./dist/`).
- Config-only — **no engine change**. Rules compile as draft-2020-12 JSON Schema via AJV, so enforcing `exports` is pure ruleset JSON.

Why: `svelte-package` relies on the `svelte` export condition for consumers to resolve components. Dropping `exports` while keeping `module`/`types` silently breaks downstream resolution (the exact failure #407 flags). This makes the contract machine-enforced.

Fixes #407

Scope: enforces only the common `.` root entry (the load-bearing, shared part). Package-specific subpaths like `./styles.css` and `./internal` vary per package and are intentionally not required. Uses `pattern: "^\\./dist/"` rather than exact `const` because packages legitimately differ in the types target (`.d.ts` vs `.d.js`) — a `const` would break a currently-passing package.

## QA

- **Passes** on compliant packages: `check:webarchitect` on `@canonical/svelte-ds-global` and `@canonical/svelte-ds-app-launchpad` → all validations pass.
- **Rule fires** on violations: removing `exports` (or just the `svelte` condition) from a Svelte package's `package.json` fails with `must have required property 'exports'` (exit 1); restored afterward, tree clean.
- `@canonical/webarchitect` tests: **87 pass**.
- Root `bun run check`: **passes** (61 projects).

### PR readiness check

- [x] PR label: `Maintenance 🔨`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] All packages define the required scripts (none changed).
- [ ] New package — n/a.
- [x] `no visual change` label added.

## Screenshots

n/a — no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_