### PR TITLE
chore(svelte): use extends: true for self-referential vite test projects

### DIFF
--- a/packages/svelte/ds-app-launchpad/vite.config.ts
+++ b/packages/svelte/ds-app-launchpad/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     include: ["src/**/*.tests.ts"],
     projects: [
       {
-        extends: "./vite.config.ts",
+        extends: true,
         test: {
           name: "client",
           browser: {
@@ -37,7 +37,7 @@ export default defineConfig({
         },
       },
       {
-        extends: "./vite.config.ts",
+        extends: true,
         test: {
           name: "ssr",
           environment: "node",
@@ -45,7 +45,7 @@ export default defineConfig({
         },
       },
       {
-        extends: "./vite.config.ts",
+        extends: true,
         test: {
           name: "server",
           environment: "node",

--- a/packages/svelte/ds-app-wpe/vite.config.ts
+++ b/packages/svelte/ds-app-wpe/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     include: ["src/**/*.tests.ts"],
     projects: [
       {
-        extends: "./vite.config.ts",
+        extends: true,
         test: {
           name: "client",
           browser: {
@@ -37,7 +37,7 @@ export default defineConfig({
         },
       },
       {
-        extends: "./vite.config.ts",
+        extends: true,
         test: {
           name: "ssr",
           environment: "node",
@@ -45,7 +45,7 @@ export default defineConfig({
         },
       },
       {
-        extends: "./vite.config.ts",
+        extends: true,
         test: {
           name: "server",
           environment: "node",


### PR DESCRIPTION
## Done

- Replace the self-referential `extends: "./vite.config.ts"` with `extends: true` in the `test.projects` of the Svelte app Vite configs. A project defined inside `vite.config.ts` that extends that same file should use `true`, not a string re-reference.
- Applied to both files carrying the pattern (per the maintainer's "apply across the monorepo" note in the issue):
  - `packages/svelte/ds-app-launchpad/vite.config.ts` — 3 projects (client, ssr, server)
  - `packages/svelte/ds-app-wpe/vite.config.ts` — 3 projects
- A repo-wide `git grep 'extends: "./vite.config.ts"'` now returns nothing; these were the only two, and both are genuine self-references (no project legitimately extending a *different* config was touched).

Fixes #747

## QA

- `@canonical/svelte-ds-app-launchpad`: **383 tests pass**, `check` passes.
- `@canonical/svelte-ds-app-wpe`: **13 tests pass**, `check` passes.
- Vitest still resolves every project, confirming `extends: true` behaves identically.

### PR readiness check

- [x] PR label: `Maintenance 🔨`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] All packages define the required scripts (none changed).
- [ ] New package — n/a.
- [x] `no visual change` label added.

## Screenshots

n/a — no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_