### PR TITLE
feat(react/ds-global): add animate modifier family to Icon (spin)

### DIFF
--- a/data/ds-types/implementationObjects.ttl
+++ b/data/ds-types/implementationObjects.ttl
@@ -5,6 +5,10 @@
 
 ds:implementation.library.canonical-ds-types ds:hasImplementation [
         a ds:ImplementationObject;
+        ds:implementsBlock ds:global.modifier_family.animate;
+        ds:headLink "src/modifierFamilies/constants.ts"
+    ], [
+        a ds:ImplementationObject;
         ds:implementsBlock ds:global.modifier_family.anticipation;
         ds:headLink "src/modifierFamilies/constants.ts"
     ], [

--- a/packages/ds-types/src/modifierFamilies/constants.ts
+++ b/packages/ds-types/src/modifierFamilies/constants.ts
@@ -1,4 +1,6 @@
 export const MODIFIER_FAMILIES = {
+  /** @implements ds:global.modifier_family.animate */
+  animate: ["spin"],
   /** @implements ds:global.modifier_family.anticipation */
   anticipation: ["constructive", "caution", "destructive"],
   /** @implements ds:global.modifier_family.criticality */

--- a/packages/react/ds-global/src/lib/component/Icon/Icon.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Icon/Icon.stories.tsx
@@ -98,6 +98,21 @@ export const Size: Story = {
   ),
 };
 
+export const Animate: Story = {
+  args: {
+    icon: "spinner",
+    animate: "spin",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Set `animate="spin"` to rotate the icon continuously, e.g. as a loading spinner. The animation is disabled for users who prefer reduced motion.',
+      },
+    },
+  },
+};
+
 export const Color: Story = {
   args: {
     icon: "user",

--- a/packages/react/ds-global/src/lib/component/Icon/Icon.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Icon/Icon.tests.tsx
@@ -39,4 +39,11 @@ describe("Icon component", () => {
     );
     expect(container.querySelector("svg")).toHaveClass("test-class");
   });
+
+  it("applies the animate modifier class", () => {
+    const { container } = render(
+      <Component icon={"spinner"} animate={"spin"} />,
+    );
+    expect(container.querySelector("svg")).toHaveClass("spin");
+  });
 });

--- a/packages/react/ds-global/src/lib/component/Icon/Icon.tsx
+++ b/packages/react/ds-global/src/lib/component/Icon/Icon.tsx
@@ -22,6 +22,7 @@ const Icon = ({
   className,
   rootPath = "/icons",
   role,
+  animate,
   ...props
 }: IconProps): ReactElement => {
   // Icons are decorative by default and hidden from assistive technology.
@@ -37,7 +38,9 @@ const Icon = ({
     <svg
       xmlns={xmlns}
       viewBox={viewBox}
-      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      className={[componentCssClassName, animate, className]
+        .filter(Boolean)
+        .join(" ")}
       role={role ?? (isLabelled ? "img" : undefined)}
       aria-hidden={isLabelled || role ? undefined : true}
       {...props}

--- a/packages/react/ds-global/src/lib/component/Icon/styles.css
+++ b/packages/react/ds-global/src/lib/component/Icon/styles.css
@@ -21,3 +21,37 @@
   width: var(--icon-size, var(--size-icon-default, 1rem));
   height: var(--icon-size, var(--size-icon-default, 1rem));
 }
+
+/**
+ * animate modifier family
+ * @implements ds:global.modifier_family.animate
+ */
+
+/* A full 0→360deg turn. Keep it a full turn: Chromatic freezes infinite
+   animations at the last frame of the cycle, so a complete rotation lands on
+   360deg (visually identical to 0deg) and the snapshot stays deterministic. A
+   partial arc here would make visual tests flaky. */
+@keyframes ds-icon-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* animate: spin — rotate the icon continuously, e.g. as a loading spinner.
+   The linear, infinite cycle reads as steady rather than eased. Default to
+   ~1s/turn via a var() fallback (not a hard declaration) so a consumer can
+   retune the cycle from :root or an ancestor with --icon-spin-duration. */
+.ds.icon.spin {
+  animation: ds-icon-spin var(--icon-spin-duration, 1s) linear infinite;
+}
+
+/* Honour users who have asked for reduced motion: hold the icon still rather
+   than spinning it. The icon remains visible as a static glyph. */
+@media (prefers-reduced-motion: reduce) {
+  .ds.icon.spin {
+    animation: none;
+  }
+}

--- a/packages/react/ds-global/src/lib/component/Icon/types.ts
+++ b/packages/react/ds-global/src/lib/component/Icon/types.ts
@@ -1,4 +1,5 @@
 import type { IconName } from "@canonical/ds-assets";
+import type { ModifierFamily } from "@canonical/ds-types";
 import type { SVGAttributes } from "react";
 
 /**
@@ -16,4 +17,12 @@ export interface IconProps extends SVGAttributes<HTMLOrSVGElement> {
   icon: IconName;
   /** Root path to the icons (default: /icons). Must be exposed to the user. */
   rootPath?: string;
+  /**
+   * Animation modifier for the icon.
+   * - "spin": Rotates the icon continuously, e.g. as a loading spinner.
+   *
+   * When omitted, the icon is rendered static. The animation honours the
+   * user's `prefers-reduced-motion` setting.
+   */
+  animate?: ModifierFamily<"animate">;
 }


### PR DESCRIPTION
## Done

- Add an `animate` modifier family (`["spin"]`) to the shared `@canonical/ds-types` `MODIFIER_FAMILIES` (plus the matching TTL implementation object), so it's consumable by any component — same pattern as `criticality`.
- Wire it into `Icon`: new `animate?: ModifierFamily<"animate">` prop applied as a CSS class on the `<svg>`.
- Implement the spin animation in `Icon/styles.css`:
  - `@keyframes ds-icon-spin` — a full `0deg → 360deg` turn (kept a *complete* turn so Chromatic's last-frame freeze lands on 360° ≡ 0° and snapshots stay deterministic).
  - `.ds.icon.spin { animation: ds-icon-spin var(--icon-spin-duration, 1s) linear infinite; }` — retunable via `--icon-spin-duration`.
  - `@media (prefers-reduced-motion: reduce)` → `animation: none` (holds the icon static), mirroring the existing `Spinner` subcomponent.
- Add an `Animate` Storybook story and a unit test asserting the `spin` class is applied.

Fixes #338

## QA

- `@canonical/react-ds-global` `check` (biome + tsc + webarchitect): **pass**.
- `@canonical/react-ds-global` `test`: **348 pass**, 5 skipped.
- `@canonical/ds-types` `check`: **pass**.
- The `animate` family is additive to the published `ds-types` (non-breaking).

### PR readiness check

- [x] PR label: `Feature 🎁`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] All packages define the required scripts (none changed).
- [ ] New package — n/a.
- [x] Visual change — the new `Icon` "Animate" story adds a spinning icon; **Chromatic should run** (no `no visual change` label).

## Screenshots

The new `Icon` → `Animate` story renders a continuously spinning icon (static under `prefers-reduced-motion`). Chromatic will capture it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_