### PR TITLE
feat(lit): per-component export paths for tree-shaking

### DIFF
--- a/packages/lit/ds-prototype/package.json
+++ b/packages/lit/ds-prototype/package.json
@@ -10,6 +10,54 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js"
+    },
+    "./BasicSection": {
+      "types": "./dist/types/lib/BasicSection/index.d.ts",
+      "import": "./dist/esm/lib/BasicSection/index.js"
+    },
+    "./Button": {
+      "types": "./dist/types/lib/Button/index.d.ts",
+      "import": "./dist/esm/lib/Button/index.js"
+    },
+    "./CTABlock": {
+      "types": "./dist/types/lib/CTABlock/index.d.ts",
+      "import": "./dist/esm/lib/CTABlock/index.js"
+    },
+    "./CTASection": {
+      "types": "./dist/types/lib/CTASection/index.d.ts",
+      "import": "./dist/esm/lib/CTASection/index.js"
+    },
+    "./Example": {
+      "types": "./dist/types/lib/Example/index.d.ts",
+      "import": "./dist/esm/lib/Example/index.js"
+    },
+    "./Hero": {
+      "types": "./dist/types/lib/Hero/index.d.ts",
+      "import": "./dist/esm/lib/Hero/index.js"
+    },
+    "./Link": {
+      "types": "./dist/types/lib/Link/index.d.ts",
+      "import": "./dist/esm/lib/Link/index.js"
+    },
+    "./List": {
+      "types": "./dist/types/lib/List/index.d.ts",
+      "import": "./dist/esm/lib/List/index.js"
+    },
+    "./LogoSection": {
+      "types": "./dist/types/lib/LogoSection/index.d.ts",
+      "import": "./dist/esm/lib/LogoSection/index.js"
+    },
+    "./Navigation": {
+      "types": "./dist/types/lib/Navigation/index.d.ts",
+      "import": "./dist/esm/lib/Navigation/index.js"
+    },
+    "./SiteLayout": {
+      "types": "./dist/types/lib/SiteLayout/index.d.ts",
+      "import": "./dist/esm/lib/SiteLayout/index.js"
+    },
+    "./TieredList": {
+      "types": "./dist/types/lib/TieredList/index.d.ts",
+      "import": "./dist/esm/lib/TieredList/index.js"
     }
   },
   "files": [

--- a/packages/lit/ds-prototype/vite.config.ts
+++ b/packages/lit/ds-prototype/vite.config.ts
@@ -16,6 +16,9 @@ const packageDir = dirname(fileURLToPath(import.meta.url));
 const libDir = resolve(packageDir, "src/lib");
 const componentEntries = readdirSync(libDir, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
+  // Sort by name: readdirSync order is filesystem-dependent, so sorting keeps
+  // the rollup input (and emitted chunk order) stable across platforms.
+  .sort((a, b) => a.name.localeCompare(b.name))
   .map((entry) => resolve(libDir, entry.name, "index.ts"));
 const entry = [resolve(packageDir, "src/index.ts"), ...componentEntries];
 

--- a/packages/lit/ds-prototype/vite.config.ts
+++ b/packages/lit/ds-prototype/vite.config.ts
@@ -1,9 +1,23 @@
+import { readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import { litCss } from "./vite-plugin-lit-css.js";
 
 const packageDir = dirname(fileURLToPath(import.meta.url));
+
+// Build a list of library entry points: the root barrel plus every component's
+// own barrel (src/lib/<Component>/index.ts). Treating each component index as
+// an entry point means rollup preserves its public export interface instead of
+// hoisting the re-exports up to the root bundle, so the per-component subpaths
+// in package.json "exports" resolve to files that actually re-export the
+// component. Combined with output.preserveModules below, each component
+// compiles to its own JS file for better tree-shaking. See issue #480.
+const libDir = resolve(packageDir, "src/lib");
+const componentEntries = readdirSync(libDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => resolve(libDir, entry.name, "index.ts"));
+const entry = [resolve(packageDir, "src/index.ts"), ...componentEntries];
 
 export default defineConfig({
   plugins: [
@@ -19,12 +33,21 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: "src/index.ts",
+      entry,
       formats: ["es"],
-      fileName: () => "esm/index.js",
     },
     rollupOptions: {
       external: [/^lit($|\/)/],
+      output: {
+        // Emit one JS file per source module (mirroring src/) instead of a
+        // single bundle, so consumers can import individual components via the
+        // per-component subpaths in package.json "exports" for better
+        // tree-shaking and smaller bundles. See issue #480.
+        preserveModules: true,
+        preserveModulesRoot: "src",
+        dir: "dist/esm",
+        entryFileNames: "[name].js",
+      },
     },
   },
 });


### PR DESCRIPTION
## Done

- Change the `@canonical/lit-ds-prototype` build to emit **per-component modules** and expose **per-component export subpaths**, so consumers can import individual components (`@canonical/lit-ds-prototype/Button`) for better tree-shaking / smaller bundles.
- `vite.config.ts`: multiple entry points (root barrel + each `src/lib/<Component>/index.ts`, discovered via `readdirSync`) **plus** rollup `output.preserveModules` (`preserveModulesRoot: "src"`, `dir: "dist/esm"`). Multi-entry is required alongside `preserveModules`: with `preserveModules` alone rollup hoisted every re-export into the root `index.js` and reduced each component `index.js` to a bare side-effect import (breaking subpath imports); making each component barrel an entry preserves its named export interface.
- `package.json`: keep the root `.` export; add 12 per-component subpaths, each with `types` + `import`. The `main`/`module`/`types` roots are unchanged so webarchitect's `package-structure` rule stays satisfied. Per-component `.d.ts` were already emitted by the existing `tsc --emitDeclarationOnly` step.

Fixes #480

## QA

- Build emits per-component JS — e.g. `dist/esm/lib/Button/index.js` correctly re-exports the `Button` LitElement class; all 13 export targets resolve to real emitted files (validated programmatically). Root bundle drops 30.5 kB → ~0.74 kB.
- Runtime sanity: `import { Button } from ".../lib/Button/index.js"` resolves to the class.
- `check` (biome + tsc + webarchitect `library`): **pass** (no formatting fixes needed).
- `test` (vitest): **80 pass** across 13 files.

### PR readiness check

- [x] PR label: `Maintenance 🔨`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] All packages define the required scripts (build unchanged in shape; `build`/`build:all` still present).
- [ ] New package — n/a.
- [x] `no visual change` label added.

## Screenshots

n/a — packaging change, no visual output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_