### PR TITLE
fix(react/ds-global-form): restore FieldProps discriminated union with wrapper props

### DIFF
--- a/apps/react/demo/src/data/fields.ts
+++ b/apps/react/demo/src/data/fields.ts
@@ -1,9 +1,16 @@
-/** Global field settings for commonly-used fields. */
+/**
+ * Global field settings for commonly-used fields.
+ *
+ * Declared with `satisfies` (not a type annotation) so each const keeps its
+ * narrow `inputType` variant: `ExampleControlField` embeds the `FieldProps`
+ * discriminated union, and a widened const could no longer be spread with
+ * per-example overrides (e.g. a different `defaultValue`).
+ */
 
 import type { ExampleControlField } from "../ui/index.js";
 import * as transformers from "./transformers.js";
 
-export const FONT_FAMILY_FIELD: ExampleControlField = {
+export const FONT_FAMILY_FIELD = {
   name: "--font-family",
   label: "Font family",
   inputType: "select",
@@ -13,9 +20,9 @@ export const FONT_FAMILY_FIELD: ExampleControlField = {
     { value: "Times New Roman", label: "Times New Roman" },
     { value: "Ubuntu variable", label: "Ubuntu" },
   ],
-};
+} satisfies ExampleControlField;
 
-export const FONT_SIZE_FIELD: ExampleControlField = {
+export const FONT_SIZE_FIELD = {
   name: "--font-size",
   inputType: "range",
   label: "Root font size",
@@ -24,14 +31,14 @@ export const FONT_SIZE_FIELD: ExampleControlField = {
   max: 24,
   step: 1,
   transformer: transformers.convertToPixels,
-};
+} satisfies ExampleControlField;
 
 /**
  * A field for the baseline height.
  * This is hidden and held constant to simplify the other settings, as many things currently depend on the baseline height.
  * By including it in the form, it will be included in the exported CSS, and usable as part of `calc()` expressions in exports.
  */
-export const BASELINE_HEIGHT_FIELD: ExampleControlField = {
+export const BASELINE_HEIGHT_FIELD = {
   name: "--baseline-height",
   inputType: "hidden",
   label: "Baseline height",
@@ -40,9 +47,9 @@ export const BASELINE_HEIGHT_FIELD: ExampleControlField = {
   max: 2,
   step: 0.25,
   transformer: transformers.convertToRems,
-};
+} satisfies ExampleControlField;
 
-export const LINE_HEIGHT_FIELD: ExampleControlField = {
+export const LINE_HEIGHT_FIELD = {
   name: "--line-height",
   inputType: "hidden",
   label: "Root line height",
@@ -50,4 +57,4 @@ export const LINE_HEIGHT_FIELD: ExampleControlField = {
   min: 1,
   max: 12,
   step: 0.25,
-};
+} satisfies ExampleControlField;

--- a/apps/react/demo/src/ui/Showcase/common/Example/types.ts
+++ b/apps/react/demo/src/ui/Showcase/common/Example/types.ts
@@ -81,22 +81,28 @@ export type TransformerFns = {
   ) => ExampleSettingValue;
 };
 
-export interface ExampleControlField extends FieldProps, TransformerFns {
-  /**
-   * The field's name. Used directly as the key within the active example's
-   * react-hook-form state, and (for CSS output) as the emitted variable name.
-   */
-  name: string;
-  /** Formats for which output is disabled */
-  disabledOutputFormats?: {
-    [key in ExampleOutputFormat]?: boolean;
+/**
+ * A showcase control: any of the `Field` variants (`FieldProps` is a
+ * discriminated union, so this must be a type intersection — an interface
+ * cannot extend a union) plus the showcase-specific transformer/output members.
+ */
+export type ExampleControlField = FieldProps &
+  TransformerFns & {
+    /**
+     * The field's name. Used directly as the key within the active example's
+     * react-hook-form state, and (for CSS output) as the emitted variable name.
+     */
+    name: string;
+    /** Formats for which output is disabled */
+    disabledOutputFormats?: {
+      [key in ExampleOutputFormat]?: boolean;
+    };
+    /**
+     * A default value for the control field.
+     * This is not directly consumed by the field, but it is used to set the initial value in the form state.
+     */
+    defaultValue?: ExampleSettingValue;
   };
-  /**
-   * A default value for the control field.
-   * This is not directly consumed by the field, but it is used to set the initial value in the form state.
-   */
-  defaultValue?: ExampleSettingValue;
-}
 
 /** The actual component that is rendered for an example. */
 export type ShowcaseComponent = (state: FormValues) => ReactElement;

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/withToggleWrapper.ts
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/withToggleWrapper.ts
@@ -1,37 +1,23 @@
 import type { ComponentType, FC } from "react";
-import type {
-  BaseInputProps,
-  ToggleLabelProps,
-  WrapperProps,
-} from "../types.js";
+import type { BaseInputProps, ToggleWrappedFieldProps } from "../types.js";
 import ToggleWrapper from "./ToggleWrapper.js";
 import withWrapper from "./withWrapper.js";
 
 /**
- * Public props of a toggle field: everything the wrapper accepts, but with the
- * optional `label`/`controlLabel` replaced by the "at least one" union so a
- * label-less toggle is a compile error.
- */
-type ToggleWrapperProps<ComponentProps extends BaseInputProps> = Omit<
-  WrapperProps<ComponentProps>,
-  "Component" | "label" | "controlLabel"
-> &
-  ToggleLabelProps;
-
-/**
  * Field HOC for toggle inputs (checkbox, switch). Like `withWrapper`, but bakes
  * in `ToggleWrapper` (control inline with its label) and types the result to
- * require at least one of `label`/`controlLabel`. Applying the label constraint
- * here — in the HOC's return type — keeps it out of the shared `withWrapper`
- * generics, which would otherwise widen the union back to all-optional.
+ * require at least one of `label`/`controlLabel` (see
+ * `ToggleWrappedFieldProps`). Applying the label constraint here — in the HOC's
+ * return type — keeps it out of the shared `withWrapper` generics, which would
+ * otherwise widen the union back to all-optional.
  *
  * `import { withToggleWrapper } from "@canonical/react-ds-global-form";`
  */
 const withToggleWrapper = <ComponentProps extends BaseInputProps>(
   Component: ComponentType<ComponentProps>,
-): FC<ToggleWrapperProps<ComponentProps>> =>
+): FC<ToggleWrappedFieldProps<ComponentProps>> =>
   withWrapper<ComponentProps>(Component, undefined, ToggleWrapper) as FC<
-    ToggleWrapperProps<ComponentProps>
+    ToggleWrappedFieldProps<ComponentProps>
   >;
 
 export default withToggleWrapper;

--- a/packages/react/ds-global-form/src/lib/common/types.ts
+++ b/packages/react/ds-global-form/src/lib/common/types.ts
@@ -114,3 +114,30 @@ export type WrappedComponentProps<
     BaseWrapperProps<ComponentProps> = WrapperProps<ComponentProps>,
 > = ComponentWrapperProps &
   WrapperHOCAdditionalProps<ComponentProps, ComponentWrapperProps>;
+
+/**
+ * The full public prop surface of a field component produced by `withWrapper`:
+ * the wrapped input's own props plus the wrapper chrome (`label`,
+ * `description`, `isOptional`, `requiredIndicator`, …) and the HOC extras
+ * (`middleware`, `WrapperComponent`, `condition`). Only the HOC-supplied
+ * `Component` is excluded. This is what `<XxxField {...props} />` accepts, and
+ * what each `FieldProps` variant is built from.
+ */
+export type WrappedFieldProps<
+  ComponentProps extends BaseInputProps,
+  ComponentWrapperProps extends
+    BaseWrapperProps<ComponentProps> = WrapperProps<ComponentProps>,
+> = Omit<
+  WrappedComponentProps<ComponentProps, ComponentWrapperProps>,
+  "Component"
+>;
+
+/**
+ * Public props of a toggle field (checkbox, switch) produced by
+ * `withToggleWrapper`: everything `WrappedFieldProps` accepts, but with the
+ * optional `label`/`controlLabel` replaced by the "at least one" union so a
+ * label-less toggle is a compile error rather than a runtime check.
+ */
+export type ToggleWrappedFieldProps<ComponentProps extends BaseInputProps> =
+  Omit<WrappedFieldProps<ComponentProps>, "label" | "controlLabel"> &
+    ToggleLabelProps;

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useMemo } from "react";
 import * as decorators from "storybook/decorators.js";
 import Component from "./Field.js";
-import type { FieldProps } from "./types.js";
+import type { FieldProps, InputProps } from "./types.js";
 
 /**
  * `Field` is the type-safe entry point to every form input: it dispatches on
@@ -102,6 +102,8 @@ export const TypeCheckbox: Story = {
   args: {
     name: "subscribe",
     inputType: "checkbox",
+    // Toggle fields require at least one of `label`/`controlLabel`.
+    controlLabel: "Subscribe to the newsletter",
   },
 };
 
@@ -150,10 +152,10 @@ export const TypeColor: Story = {
 const StarRating = ({
   value,
   onChange,
-}: {
+}: InputProps<{
   value?: number;
   onChange?: (value: number) => void;
-}) => (
+}>) => (
   <div role="radiogroup" aria-label="Rating">
     {[1, 2, 3, 4, 5].map((star) => (
       <button
@@ -185,7 +187,9 @@ export const TypeCustom: Story = {
   },
 };
 
-export const ConditionalDisplay: Story = {
+// Render-only story (it drives its own `Field`s), so it takes no args — typed
+// as a plain `StoryObj` since `Story` would require the component's args.
+export const ConditionalDisplay: StoryObj = {
   render: () => {
     const emailField: FieldProps = useMemo(
       () => ({
@@ -206,10 +210,9 @@ export const ConditionalDisplay: Story = {
         isOptional: true,
         condition: [
           ["email"],
-          (values: string[]) => {
-            const value = values[0] as string;
-            if (!value) return false;
-            return value.endsWith("@gmail.com");
+          (values: unknown[]) => {
+            const value = values[0];
+            return typeof value === "string" && value.endsWith("@gmail.com");
           },
         ],
       }),

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.tsx
@@ -27,57 +27,97 @@ import type { FieldProps } from "./types.js";
  *
  * `import { Field } from "@canonical/react-ds-global-form";`
  */
-const Field = ({
-  inputType,
-  CustomComponent,
-  ...props
-}: FieldProps): React.ReactElement => {
-  switch (inputType) {
-    case "textarea":
-      return <TextareaField {...props} />;
-    case "checkbox":
-      return <CheckboxField {...props} />;
-    case "switch":
-      return <SwitchField {...props} />;
-    case "rating":
-      return <RatingField {...props} />;
-    case "range":
-      return <RangeField {...props} />;
-    case "select":
-      return <SelectField {...props} />;
-    case "choices":
-      return <ChoicesField {...props} />;
-    case "combobox":
-      return <ComboboxField {...props} />;
-    case "hidden":
-      return <HiddenField {...props} />;
-    case "date":
-      return <DateField {...props} />;
-    case "time":
-      return <TimeField {...props} />;
-    case "datetime":
-      return <DateTimeField {...props} />;
-    case "file":
-      return <FileUploadField {...props} />;
-    case "color":
-      return <ColorField {...props} />;
-    case "phone":
-      return <PhoneField {...props} />;
-    case "password":
-      return <PasswordField {...props} />;
-    case "number":
-      return <NumberField {...props} />;
-    case "rich-choices":
-      return <RichChoicesField {...props} />;
-    case "custom":
+// Each branch destructures `inputType` (and, for "custom", `CustomComponent`)
+// out of the already-narrowed props, so the spread it forwards is exactly the
+// dispatched component's own prop surface. Destructuring before the switch
+// would break the discriminated-union narrowing on the rest object.
+const Field = (props: FieldProps): React.ReactElement => {
+  switch (props.inputType) {
+    case "textarea": {
+      const { inputType, ...rest } = props;
+      return <TextareaField {...rest} />;
+    }
+    case "checkbox": {
+      const { inputType, ...rest } = props;
+      return <CheckboxField {...rest} />;
+    }
+    case "switch": {
+      const { inputType, ...rest } = props;
+      return <SwitchField {...rest} />;
+    }
+    case "rating": {
+      const { inputType, ...rest } = props;
+      return <RatingField {...rest} />;
+    }
+    case "range": {
+      const { inputType, ...rest } = props;
+      return <RangeField {...rest} />;
+    }
+    case "select": {
+      const { inputType, ...rest } = props;
+      return <SelectField {...rest} />;
+    }
+    case "choices": {
+      const { inputType, ...rest } = props;
+      return <ChoicesField {...rest} />;
+    }
+    case "combobox": {
+      const { inputType, ...rest } = props;
+      return <ComboboxField {...rest} />;
+    }
+    case "hidden": {
+      const { inputType, ...rest } = props;
+      return <HiddenField {...rest} />;
+    }
+    case "date": {
+      const { inputType, ...rest } = props;
+      return <DateField {...rest} />;
+    }
+    case "time": {
+      const { inputType, ...rest } = props;
+      return <TimeField {...rest} />;
+    }
+    case "datetime": {
+      const { inputType, ...rest } = props;
+      return <DateTimeField {...rest} />;
+    }
+    case "file": {
+      const { inputType, ...rest } = props;
+      return <FileUploadField {...rest} />;
+    }
+    case "color": {
+      const { inputType, ...rest } = props;
+      return <ColorField {...rest} />;
+    }
+    case "phone": {
+      const { inputType, ...rest } = props;
+      return <PhoneField {...rest} />;
+    }
+    case "password": {
+      const { inputType, ...rest } = props;
+      return <PasswordField {...rest} />;
+    }
+    case "number": {
+      const { inputType, ...rest } = props;
+      return <NumberField {...rest} />;
+    }
+    case "rich-choices": {
+      const { inputType, ...rest } = props;
+      return <RichChoicesField {...rest} />;
+    }
+    case "custom": {
+      const { inputType, CustomComponent, ...rest } = props;
       if (!CustomComponent) {
         throw new Error(
           'Field with inputType="custom" requires a CustomComponent prop.',
         );
       }
-      return <CustomComponent {...props} />;
+      return <CustomComponent {...rest} />;
+    }
     default:
-      return <TextField inputType={inputType} {...props} />;
+      // Text-like native types ("text" | "email" | "tel" | "url"): TextField
+      // consumes `inputType` itself, so the discriminant stays in the spread.
+      return <TextField {...props} />;
   }
 };
 

--- a/packages/react/ds-global-form/src/lib/pattern/Field/types.ts
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/types.ts
@@ -1,5 +1,8 @@
-import type { InputProps } from "../../common/types.js";
-import type { CheckboxFieldProps } from "../../component/CheckboxField/index.js";
+import type {
+  InputProps,
+  ToggleWrappedFieldProps,
+  WrappedFieldProps,
+} from "../../common/types.js";
 import type { ChoicesFieldProps } from "../../component/ChoicesField/index.js";
 import type { ColorFieldProps } from "../../component/ColorField/index.js";
 import type { ComboboxFieldProps } from "../../component/ComboboxField/index.js";
@@ -14,10 +17,11 @@ import type { RangeFieldProps } from "../../component/RangeField/index.js";
 import type { RatingFieldProps } from "../../component/RatingField/index.js";
 import type { RichChoicesFieldProps } from "../../component/RichChoicesField/index.js";
 import type { SelectFieldProps } from "../../component/SelectField/index.js";
-import type { SwitchFieldProps } from "../../component/SwitchField/index.js";
 import type { TextareaFieldProps } from "../../component/TextareaField/index.js";
 import type { TextFieldProps } from "../../component/TextField/index.js";
 import type { TimeFieldProps } from "../../component/TimeField/index.js";
+import type { CheckboxInputProps } from "../../subcomponent/CheckboxInput/index.js";
+import type { SwitchInputProps } from "../../subcomponent/SwitchInput/index.js";
 import type { NativeInputType } from "../../subcomponent/types.js";
 
 export type {
@@ -26,7 +30,9 @@ export type {
   Condition,
   InputProps,
   Middleware,
+  ToggleWrappedFieldProps,
   WrappedComponentProps,
+  WrappedFieldProps,
   WrapperHOCAdditionalProps,
   WrapperProps,
 } from "../../common/types.js";
@@ -41,31 +47,54 @@ export type {
   OptionsProps,
 } from "../../subcomponent/types.js";
 
+/**
+ * Props of the `Field` router, as a discriminated union on `inputType`: each
+ * variant is exactly what the dispatched `*Field` component accepts — the
+ * input's own props plus the wrapper chrome (`label`, `description`,
+ * `isOptional`, …) and the HOC extras (`middleware`, `WrapperComponent`,
+ * `condition`) — plus the discriminant (see `WrappedFieldProps` /
+ * `ToggleWrappedFieldProps`). Narrowing on `inputType` therefore yields the
+ * full prop surface of that field.
+ *
+ * The `custom` variant is the exception: `Field` renders the supplied
+ * `CustomComponent` directly (no wrapper chrome is applied by `Field` itself),
+ * forwarding `name`, the registration props and any extra props as-is — so a
+ * custom component opts into label/description/error chrome by applying
+ * `withWrapper` internally.
+ */
 export type FieldProps =
   | ({
       inputType: Exclude<NativeInputType, "password" | "number">;
-    } & TextFieldProps)
-  | ({ inputType: "password" } & PasswordFieldProps)
-  | ({ inputType: "number" } & NumberFieldProps)
-  | ({ inputType: "checkbox" } & CheckboxFieldProps)
-  | ({ inputType: "switch" } & SwitchFieldProps)
-  | ({ inputType: "hidden" } & HiddenFieldProps)
-  | ({ inputType: "range" } & RangeFieldProps)
-  | ({ inputType: "rating" } & RatingFieldProps)
-  | ({ inputType: "select" } & SelectFieldProps)
-  | ({ inputType: "combobox" } & ComboboxFieldProps)
-  | ({ inputType: "choices" } & ChoicesFieldProps)
-  | ({ inputType: "textarea" } & TextareaFieldProps)
-  | ({ inputType: "date" } & DateFieldProps)
-  | ({ inputType: "time" } & TimeFieldProps)
-  | ({ inputType: "datetime" } & DateTimeFieldProps)
-  | ({ inputType: "file" } & FileUploadFieldProps)
-  | ({ inputType: "color" } & ColorFieldProps)
-  | ({ inputType: "phone" } & PhoneFieldProps)
-  | ({ inputType: "rich-choices" } & RichChoicesFieldProps)
+    } & WrappedFieldProps<TextFieldProps>)
+  | ({ inputType: "password" } & WrappedFieldProps<PasswordFieldProps>)
+  | ({ inputType: "number" } & WrappedFieldProps<NumberFieldProps>)
+  | ({
+      inputType: "checkbox";
+    } & ToggleWrappedFieldProps<InputProps<CheckboxInputProps>>)
+  | ({
+      inputType: "switch";
+    } & ToggleWrappedFieldProps<InputProps<SwitchInputProps>>)
+  | ({ inputType: "hidden" } & WrappedFieldProps<HiddenFieldProps>)
+  | ({ inputType: "range" } & WrappedFieldProps<RangeFieldProps>)
+  | ({ inputType: "rating" } & WrappedFieldProps<RatingFieldProps>)
+  | ({ inputType: "select" } & WrappedFieldProps<SelectFieldProps>)
+  | ({ inputType: "combobox" } & WrappedFieldProps<ComboboxFieldProps>)
+  | ({ inputType: "choices" } & WrappedFieldProps<ChoicesFieldProps>)
+  | ({ inputType: "textarea" } & WrappedFieldProps<TextareaFieldProps>)
+  | ({ inputType: "date" } & WrappedFieldProps<DateFieldProps>)
+  | ({ inputType: "time" } & WrappedFieldProps<TimeFieldProps>)
+  | ({ inputType: "datetime" } & WrappedFieldProps<DateTimeFieldProps>)
+  | ({ inputType: "file" } & WrappedFieldProps<FileUploadFieldProps>)
+  | ({ inputType: "color" } & WrappedFieldProps<ColorFieldProps>)
+  | ({ inputType: "phone" } & WrappedFieldProps<PhoneFieldProps>)
+  | ({ inputType: "rich-choices" } & WrappedFieldProps<RichChoicesFieldProps>)
   | ({
       inputType: "custom";
-      // biome-ignore lint/suspicious/noExplicitAny: In the case of a custom component, we'd expect
-      CustomComponent: React.ComponentType<InputProps<any>>;
-      // biome-ignore lint/suspicious/noExplicitAny: In the case of a custom component, we'd expect
-    } & InputProps<any>);
+      /**
+       * The input to render. It must accept the base `InputProps` (`name`,
+       * `registerProps` and the aria props); `Field` renders it directly with
+       * every remaining prop, so any extra props passed to `Field` are
+       * forwarded to it as-is.
+       */
+      CustomComponent: React.ComponentType<InputProps>;
+    } & InputProps<Record<string, unknown>>);

--- a/packages/react/ds-global-form/src/lib/pattern/Form/Form.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Form/Form.stories.tsx
@@ -288,7 +288,12 @@ export const SideLayout: Story = {
 
 type TemplateProps = {
   fieldMap: FieldProps[];
-  otherProps?: Partial<FieldProps>;
+  /**
+   * Extra props merged into every field. Typed as the concrete cross-variant
+   * props these stories use — spreading a `Partial` of the whole union would
+   * pollute the `inputType` discriminant and defeat the narrowing.
+   */
+  otherProps?: { disabled?: boolean; isOptional?: boolean };
 };
 
 const FixtureTemplate: StoryFn<TemplateProps> = ({

--- a/packages/react/ds-global-form/src/lib/utils/middleware/middleware.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/utils/middleware/middleware.stories.tsx
@@ -56,6 +56,9 @@ export const RESTOptions: Story = {
   args: {
     name: "optionsField",
     inputType: "select",
+    // Start empty: the addRESTOptions middleware replaces `options` with the
+    // fetched set before the select renders.
+    options: [],
     middleware: [
       middleware.addRESTOptions("/api/options", {
         transformData: (data) => data.options,

--- a/packages/react/ds-global-form/src/storybook/fixtures.fields.ts
+++ b/packages/react/ds-global-form/src/storybook/fixtures.fields.ts
@@ -1,6 +1,8 @@
+import type React from "react";
+import type { FieldProps } from "../lib/pattern/Field/types.js";
 import * as options from "./fixtures.options.js";
 
-export const base = [
+export const base: FieldProps[] = [
   {
     name: "text_field",
     inputType: "text",
@@ -106,17 +108,17 @@ export const base = [
     name: "telephone_field_area",
     inputType: "number",
     label: "Area Code",
-    style: { "--form-field-columns": "1 / 5" },
+    style: { "--form-field-columns": "1 / 5" } as React.CSSProperties,
   },
   {
     name: "telephone_field_number",
     inputType: "tel",
     label: "Phone Number",
-    style: { "--form-field-columns": "5 / -1" },
+    style: { "--form-field-columns": "5 / -1" } as React.CSSProperties,
   },
 ];
 
-export const withDisabled = [
+export const withDisabled: FieldProps[] = [
   { name: "text_field", inputType: "text", label: "Text Field" },
   {
     name: "email_field",
@@ -133,17 +135,17 @@ export const withDisabled = [
   },
 ];
 
-export const phone = [
+export const phone: FieldProps[] = [
   {
     name: "telephone_field_area",
     inputType: "number",
     label: "Area Code",
-    style: { "--form-field-columns": "1 / 5" },
+    style: { "--form-field-columns": "1 / 5" } as React.CSSProperties,
   },
   {
     name: "telephone_field_number",
     inputType: "tel",
     label: "Phone Number",
-    style: { "--form-field-columns": "5 / -1" },
+    style: { "--form-field-columns": "5 / -1" } as React.CSSProperties,
   },
 ];


### PR DESCRIPTION
> **Stacked on #834** (shared `ExampleControlField` migration) — merge #834 first; GitHub will retarget this PR to `main` automatically. The diff below shows only the FieldProps delta.

## Done

**Root cause (#235):** `FieldProps` silently evaluated to **`any`**. The `custom` variant intersected `InputProps<any>`, and since `X & any = any` and `T | any = any`, the entire ~20-variant union collapsed — so the public type gave consumers **no hints and no type-checking at all**.

**The redesign:**
- Each union variant now carries the full prop surface its wrapped component genuinely accepts: two new helpers in `common/types.ts` are the single source of truth — `WrappedFieldProps<P> = Omit<WrappedComponentProps<P>, "Component">` (input props + wrapper chrome + `middleware`/`WrapperComponent`/`condition`) and `ToggleWrappedFieldProps<P>` (same, with the `label`/`controlLabel` "at least one" union). `withToggleWrapper`'s return type fixed accordingly (type-only; runtime untouched).
- Both `InputProps<any>` usages (and their biome-ignores) are gone; the `custom` variant uses `ComponentType<InputProps>` + a `Record<string, unknown>` passthrough, matching the documented custom-field contract.
- `Field.tsx` reworked to narrow properly: switch on `props.inputType`, destructure `{ inputType, ...rest }` **inside each narrowed branch** (top-level rest-destructuring does not narrow — verified), spread `rest`. Compiled JS forwards the identical prop set; the custom branch's runtime `throw` guard is kept verbatim.
- Stories/fixtures that only compiled under `any` fixed for real (checkbox story gains required `controlLabel`; `Partial<FieldProps>` spread removed — it pollutes the discriminant; select middleware story gains `options`; no casts to `any` anywhere).
- Demo: `ExampleControlField` converted `interface extends` → intersection type (interfaces can't extend unions); field consts use `satisfies ExampleControlField`.

Fixes #235

**Reviewer note:** consumers regain real type-checking, which is *stricter than the accidental `any`* — e.g. a checkbox field must now provide `label` or `controlLabel`, a select must provide `options`. That's the bug being fixed, but downstream code that leaned on the collapse may surface new (legitimate) type errors.

## QA

- **IsAny proof**: before — `IsAny<FieldProps> = true` and `{ totally: "bogus" }` accepted; after — `IsAny<FieldProps> = false`, garbage rejected, `inputType: "text"` narrows to show `label`/`description`/`placeholder`, `"select"` requires `options`. Proven package-side **and** consumer-side through the built `dist/types`.
- `@canonical/react-ds-global-form` `check` + `test`: **pass** (68 files / 267 tests).
- Package `build`, then `@canonical/ds-demo-site` `check` + `build`: **pass** (one pre-existing ssr warning, present without these changes).
- Root `bun run check`: **all 61 projects pass**, including `react-boilerplate-vite` (the other `<Field>` consumer — zero changes needed).

### PR readiness check

- [x] PR label: `Bug 🐛`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] All packages define the required scripts (none changed).
- [ ] New package — n/a.
- [x] `no visual change` label added — types-first refactor; emitted JS forwards identical props.

## Screenshots

n/a — no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_