### PR TITLE
chore(packages): chain check:ts into check where it was defined but skipped

### DIFF
--- a/packages/react/ssr/package.json
+++ b/packages/react/ssr/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:all": "tsc -p tsconfig.build.json",
-    "check": "bun run check:biome && bun run check:webarchitect",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
     "check:webarchitect": "webarchitect library",
     "check:fix": "bun run check:biome:fix && bun run check:ts",
     "check:biome": "biome check",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:all": "tsc -p tsconfig.build.json",
-    "check": "bun run check:biome && bun run check:webarchitect",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
     "check:webarchitect": "webarchitect library",
     "check:fix": "bun run check:biome:fix && bun run check:ts",
     "check:biome": "biome check",


### PR DESCRIPTION
## Done

- `packages/react/ssr` and `packages/utils` both **defined** a `check:ts` script (`tsc --noEmit`) but did not chain it into `check` — so `bun run check` in those two packages silently skipped type-checking. Fixed to the conventional `check:biome && check:ts && check:webarchitect` order (matching compliant siblings like `packages/react/head`).
- Swept the whole monorepo for the same pattern: of 47 packages defining `check:ts`, these were the **only two** with the gap; none inline `tsc` in `check` to bypass the indirection.
- Diff is 2 files / 2 lines. With `tsc --noEmit` now actually running, **both packages pass cleanly — no latent type errors** were hiding behind the gap.

(Gap originally flagged during the webarchitect adoption work in #840.)

## QA

- `bun run --filter '@canonical/utils' check` → biome + tsc + webarchitect all pass.
- `bun run --filter '@canonical/react-ssr' check` → all pass.
- Root `bun run check` → 61 projects pass.

### PR readiness check

- [x] PR label: `Maintenance 🔨`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] All packages define the required scripts — this PR makes two `check` scripts honest.
- [ ] New package — n/a.
- [x] `no visual change` label added.

## Screenshots

n/a — script wiring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_