### PR TITLE
feat(cli): first-run onboarding — welcome note + global config creation

### DIFF
--- a/packages/cli/pragma/src/pipeline/firstRun.test.ts
+++ b/packages/cli/pragma/src/pipeline/firstRun.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ensureFirstRun from "./firstRun.js";
+
+let xdg: string;
+let savedXdg: string | undefined;
+let lines: string[];
+
+const write = (line: string) => {
+  lines.push(line);
+};
+
+beforeEach(() => {
+  savedXdg = process.env.XDG_CONFIG_HOME;
+  xdg = mkdtempSync(join(tmpdir(), "pragma-firstrun-"));
+  process.env.XDG_CONFIG_HOME = xdg;
+  lines = [];
+});
+
+afterEach(() => {
+  process.env.XDG_CONFIG_HOME = savedXdg;
+  rmSync(xdg, { recursive: true, force: true });
+});
+
+const configPath = () => join(xdg, "pragma", "config.json");
+
+describe("ensureFirstRun", () => {
+  it("creates the global config with defaults and greets on first run", async () => {
+    await ensureFirstRun(write);
+
+    expect(existsSync(configPath())).toBe(true);
+    expect(JSON.parse(readFileSync(configPath(), "utf-8"))).toEqual({});
+
+    const text = lines.join("\n");
+    expect(text).toContain("pre-release pragma CLI");
+    expect(text).toContain("github.com/canonical/pragma");
+    expect(text).toContain(configPath());
+    expect(text).toContain("pragma.config.json");
+  });
+
+  it("is silent and leaves the config untouched on subsequent runs", async () => {
+    await ensureFirstRun(write);
+    lines = [];
+
+    await ensureFirstRun(write);
+
+    expect(lines).toEqual([]);
+    expect(readFileSync(configPath(), "utf-8")).toBe("{}\n");
+  });
+
+  it("never overwrites an existing config", async () => {
+    await ensureFirstRun(write);
+    const custom = '{ "channel": "experimental" }\n';
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(configPath(), custom);
+    lines = [];
+
+    await ensureFirstRun(write);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(custom);
+    expect(lines).toEqual([]);
+  });
+
+  it("degrades to a warning instead of throwing when the config cannot be created", async () => {
+    // Point XDG at a path whose parent is a FILE, so mkdir must fail.
+    const blocker = join(xdg, "blocker");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(blocker, "not a directory");
+    process.env.XDG_CONFIG_HOME = join(blocker, "nested");
+
+    await expect(ensureFirstRun(write)).resolves.toBeUndefined();
+    expect(
+      lines.some((l) =>
+        l.includes("could not create the global pragma config"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/cli/pragma/src/pipeline/firstRun.test.ts
+++ b/packages/cli/pragma/src/pipeline/firstRun.test.ts
@@ -71,10 +71,10 @@ describe("ensureFirstRun", () => {
     process.env.XDG_CONFIG_HOME = join(blocker, "nested");
 
     await expect(ensureFirstRun(write)).resolves.toBeUndefined();
-    expect(
-      lines.some((l) =>
-        l.includes("could not create the global pragma config"),
-      ),
-    ).toBe(true);
+    // Exactly one warning line and no welcome banner: creation is attempted
+    // before the greeting, so a failure degrades to a single stderr warning.
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("could not create the global pragma config");
+    expect(lines.join("\n")).not.toContain("pre-release pragma CLI");
   });
 });

--- a/packages/cli/pragma/src/pipeline/firstRun.ts
+++ b/packages/cli/pragma/src/pipeline/firstRun.ts
@@ -1,0 +1,93 @@
+/**
+ * First-run onboarding — welcome note + global config creation.
+ *
+ * On the first invocation of pragma (detected by the absence of the global
+ * config file), print a short welcome to stderr and create
+ * `$XDG_CONFIG_HOME/pragma/config.json` with defaults. Modeled as a
+ * {@link Task} so the effects (exists/mkdir/write/log) stay declarative and
+ * testable, mirroring the config domain's write tasks.
+ *
+ * The banner goes to STDERR: stdout belongs to command output (`--format
+ * json` consumers, MCP stdio), and the note must never corrupt it.
+ */
+
+import { dirname } from "node:path";
+import {
+  $,
+  exists,
+  gen,
+  info,
+  mkdir,
+  type Task,
+  writeFile,
+} from "@canonical/task";
+import { runTask } from "@canonical/task/node";
+import { resolveGlobalConfigPath } from "../config/index.js";
+
+/**
+ * Seed content for a fresh global config: an empty object, so every field
+ * keeps its built-in default and `config show` reports honest provenance
+ * (nothing is pinned that the user did not choose).
+ */
+const SEED_CONFIG = "{}\n";
+
+/** Build the welcome note. The resolved path is shown so it is copyable. */
+function welcomeLines(path: string): string[] {
+  return [
+    "Hello! Thanks for taking the time to try the pre-release pragma CLI.",
+    "Please file issues, suggestions, and feedback at https://github.com/canonical/pragma/issues.",
+    `Pragma stores its configuration in ${path} (just created with defaults).`,
+    "A `pragma.config.json` in the current directory or any directory above it overrides it per project.",
+    "",
+  ];
+}
+
+/**
+ * The first-run task: create the global config, announcing it on first run.
+ *
+ * @returns Task yielding whether the config was created and its path.
+ * @note Impure — checks/creates the global config file, emits log effects.
+ */
+export function firstRunTask(): Task<{ created: boolean; path: string }> {
+  return gen(function* () {
+    const path = resolveGlobalConfigPath();
+
+    if (yield* $(exists(path))) {
+      return { created: false, path };
+    }
+
+    for (const line of welcomeLines(path)) {
+      yield* $(info(line));
+    }
+    yield* $(mkdir(dirname(path)));
+    yield* $(writeFile(path, SEED_CONFIG));
+
+    return { created: true, path };
+  });
+}
+
+/**
+ * Run the first-run task, tolerating every failure.
+ *
+ * Onboarding must never break the CLI: a read-only home, a weird XDG path,
+ * or a race with a concurrent first run degrade to a single stderr warning
+ * and the invocation proceeds normally (the config layers treat a missing
+ * global file as defaults anyway).
+ *
+ * @param write - Stderr sink, injectable for tests.
+ * @note Impure — filesystem effects + stderr.
+ */
+export default async function ensureFirstRun(
+  write: (line: string) => void = (line) => process.stderr.write(`${line}\n`),
+): Promise<void> {
+  try {
+    await runTask(firstRunTask(), {
+      // Route log effects to stderr without the interpreter's [INFO] prefix —
+      // this is a greeting, not diagnostics.
+      onLog: (_level, message) => write(message),
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    write(`Warning: could not create the global pragma config — ${reason}`);
+  }
+}

--- a/packages/cli/pragma/src/pipeline/firstRun.ts
+++ b/packages/cli/pragma/src/pipeline/firstRun.ts
@@ -56,11 +56,17 @@ export function firstRunTask(): Task<{ created: boolean; path: string }> {
       return { created: false, path };
     }
 
+    // Create the config first, then greet: if creation fails the effects throw
+    // before any line is emitted, so onboarding degrades to the single stderr
+    // warning ensureFirstRun writes — never a "just created" banner alongside a
+    // failure. `mkdir` is recursive (its default), so a missing XDG parent is
+    // created rather than being treated as an error.
+    yield* $(mkdir(dirname(path), true));
+    yield* $(writeFile(path, SEED_CONFIG));
+
     for (const line of welcomeLines(path)) {
       yield* $(info(line));
     }
-    yield* $(mkdir(dirname(path)));
-    yield* $(writeFile(path, SEED_CONFIG));
 
     return { created: true, path };
   });

--- a/packages/cli/pragma/src/pipeline/runCli.ts
+++ b/packages/cli/pragma/src/pipeline/runCli.ts
@@ -14,6 +14,7 @@ import { commands as traceCommands } from "../domains/trace/index.js";
 import { PragmaError } from "../error/index.js";
 import collectCommands from "./collectCommands.js";
 import createProgram from "./createProgram.js";
+import ensureFirstRun from "./firstRun.js";
 import mapExitCode from "./mapExitCode.js";
 import parseGlobalFlags, {
   readRawFormat,
@@ -319,6 +320,13 @@ export default async function runCli(argv: readonly string[]): Promise<void> {
   if (commandKind.kind === "completions-server") {
     return handleCompletionsServer();
   }
+
+  // First-run onboarding: when the global config does not exist yet, greet on
+  // stderr and create it with defaults. After the completions early-exits so
+  // the note can never leak into a shell completion buffer; stderr-only so
+  // stdout (command output, --format json, MCP stdio) stays untouched; and
+  // failure-tolerant — onboarding must never break an invocation.
+  await ensureFirstRun();
 
   // `--version`/`-V` is a global flag: print the version and exit regardless
   // of where it appears (root or after a command/verb), so `block list -V`

--- a/packages/cli/pragma/src/testing/cli.ts
+++ b/packages/cli/pragma/src/testing/cli.ts
@@ -6,7 +6,9 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 /** Captured output from a CLI subprocess invocation. */
 interface CommandResult {
@@ -16,20 +18,46 @@ interface CommandResult {
 }
 
 /**
+ * XDG home whose global config already exists, shared by all default
+ * invocations in this file's worker.
+ *
+ * Subprocesses would otherwise trigger the first-run greeting in whichever
+ * test happens to spawn first (the setup-file XDG is fresh per file), making
+ * stderr assertions ordering-dependent. Seeding the config keeps every
+ * default `runCommand` past first-run; tests that WANT the first-run path
+ * pass their own fresh XDG via `env`.
+ */
+let seededXdg: string | undefined;
+function seededXdgHome(): string {
+  if (!seededXdg) {
+    seededXdg = mkdtempSync(join(tmpdir(), "pragma-cli-xdg-"));
+    mkdirSync(join(seededXdg, "pragma"), { recursive: true });
+    writeFileSync(join(seededXdg, "pragma", "config.json"), "{}\n");
+  }
+  return seededXdg;
+}
+
+/**
  * Spawn the pragma CLI binary synchronously and capture its output.
  *
  * @param args - CLI arguments to pass after the binary path.
  * @param cwd - Optional working directory for the subprocess.
+ * @param env - Extra environment overrides (merged over the seeded default).
  * @returns Captured stdout, stderr, and exit code.
  *
  * @note Impure
  */
-function runCommand(args: string[], cwd?: string): CommandResult {
+function runCommand(
+  args: string[],
+  cwd?: string,
+  env?: Record<string, string>,
+): CommandResult {
   const binPath = resolve(import.meta.dirname, "../bin.ts");
   const result = spawnSync("bun", ["run", binPath, ...args], {
     cwd,
     encoding: "utf-8",
     timeout: 20_000,
+    env: { ...process.env, XDG_CONFIG_HOME: seededXdgHome(), ...env },
   });
 
   return {

--- a/packages/cli/pragma/src/testing/integration/cli-user-stories.test.ts
+++ b/packages/cli/pragma/src/testing/integration/cli-user-stories.test.ts
@@ -52,6 +52,30 @@ function parseJson<T>(result: CommandResult): T {
 }
 
 describe("CLI user stories", () => {
+  it("story: a first-time user is greeted once and gets a global config", () => {
+    const workspace = createWorkspace();
+    const freshXdg = mkdtempSync(join(tmpdir(), "pragma-firstrun-e2e-"));
+    tempDirs.add(freshXdg);
+    const env = { XDG_CONFIG_HOME: freshXdg };
+
+    // First invocation: greeting on stderr, config created, stdout untouched.
+    const first = runCommand(["info", "--format", "json"], workspace, env);
+    expect(first.exitCode).toBe(0);
+    expect(first.stderr).toContain("pre-release pragma CLI");
+    expect(first.stderr).toContain(join(freshXdg, "pragma", "config.json"));
+    expect(() => JSON.parse(first.stdout)).not.toThrow();
+    expect(
+      JSON.parse(
+        readFileSync(join(freshXdg, "pragma", "config.json"), "utf-8"),
+      ),
+    ).toEqual({});
+
+    // Second invocation: no greeting — first-run happens once.
+    const second = runCommand(["info", "--format", "json"], workspace, env);
+    expect(second.exitCode).toBe(0);
+    expect(second.stderr.trim()).toBe("");
+  }, 40_000);
+
   it("story: a new contributor verifies the local installation with info", () => {
     const workspace = createWorkspace();
 


### PR DESCRIPTION
## Done

On the first invocation of pragma (global config absent), greet the user and create the config:

```
Hello! Thanks for taking the time to try the pre-release pragma CLI.
Please file issues, suggestions, and feedback at https://github.com/canonical/pragma/issues.
Pragma stores its configuration in ~/.config/pragma/config.json (just created with defaults).
A `pragma.config.json` in the current directory or any directory above it overrides it per project.
```

- Modeled as a **`@canonical/task` Task** (`exists` → `info` logs → `mkdir` → `writeFile` effects) run at CLI initialization via `runTask`, with an `onLog` handler routing the greeting to **stderr** — stdout stays byte-pure for `--format json` consumers and MCP stdio (verified: first run greets *and* emits parseable JSON).
- Creates `$XDG_CONFIG_HOME/pragma/config.json` seeded with `{}` so every field keeps its built-in default and `config show` provenance stays honest.
- Wired into `runCli` after the completions early-exits, so the note can never leak into a shell completion buffer.
- Failure-tolerant: an unwritable home degrades to a single warning; onboarding never breaks an invocation. Greeting-once idempotent.

## QA

- `bun run check` — green; `bun run test` — full suite green (1,544 passing) incl. new unit tests (create/greet, idempotence, no-overwrite, failure degradation) and a first-time-user story against the real binary (greeting once + config created + clean stdout).
- `runCommand` test helper now seeds its subprocess XDG so existing stories are deterministic instead of ordering-dependent on which spawn triggers first-run.
- Manual smoke: fresh `XDG_CONFIG_HOME` → banner + `{}` created; second run silent; `info --format json` stdout parses on first run.

### PR readiness check

- [x] Label: `Feature 🎁` (suggested).
- [x] Conventional Commits title.
- [x] Follows the code standards.
- [x] Package scripts present.
- [x] No new package.
- [x] No visual change — safe to add `no visual change`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WrkZXTopfNP1ogcpSJRKi)_