### PR TITLE
chore(storybook): drop per-story autodocs tags now covered by the global preview default

### DIFF
--- a/configs/storybook/README.md
+++ b/configs/storybook/README.md
@@ -16,12 +16,19 @@ export default createConfig("react"); // or one of "svelte", "lit"
 
 ## Notes
 
-The [autodocs](https://storybook.js.org/docs/writing-docs/autodocs) feature is enabled by this config with ```typescript
-{
-    docs: {
-       autodocs: true,
-    },
-}
+The [autodocs](https://storybook.js.org/docs/writing-docs/autodocs) feature is enabled project-wide by setting `tags: ["autodocs"]` at preview level, so story files do not need to declare the tag themselves (a story can still opt out with `tags: ["!autodocs"]`).
+
+This package exports the shared preview configuration (`@canonical/storybook-config/preview`), which includes that default. However, Storybook statically parses each project's own `.storybook/preview.ts` and does not reliably pick up `tags` (or `storySort`) spread from an imported preview ([storybookjs/storybook#31842](https://github.com/storybookjs/storybook/issues/31842)). Consuming projects must therefore declare `tags: ["autodocs"]` inline in their own `.storybook/preview.ts`:
+
+```typescript
+import previewConfig from "@canonical/storybook-config/preview";
+
+const preview = {
+  ...previewConfig,
+  tags: ["autodocs"],
+};
+
+export default preview;
 ```
 
 

--- a/docs/explanations/COMPONENT_FOLDER_STRUCTURE.md
+++ b/docs/explanations/COMPONENT_FOLDER_STRUCTURE.md
@@ -228,7 +228,6 @@ import Component from "./Button.js";
 const meta = {
   title: "Button",
   component: Component,
-  tags: ["autodocs"],
   args: { onClick: fn() },
 } satisfies Meta<typeof Component>;
 
@@ -249,7 +248,7 @@ export const Positive: Story = {
 };
 ```
 
-The `tags: ["autodocs"]` directive tells Storybook to generate documentation from the component's JSDoc comments and TypeScript types. This provides API reference documentation without maintaining separate docs.
+Storybook generates an API reference page for every component (autodocs) from its JSDoc comments and TypeScript types. This is enabled project-wide by the `tags: ["autodocs"]` default in each package's `.storybook/preview.ts` (the shared configuration from `@canonical/storybook-config`), so individual story files do not declare the tag themselves. A story file can opt out with `tags: ["!autodocs"]`.
 
 Each exported story represents a distinct state or variant of the component. Story names become visible in Storybook's sidebar and in Chromatic's visual comparison interface. Descriptive names like `Positive` and `Negative` help reviewers understand what each screenshot should show.
 

--- a/packages/react/ds-app-anbox/src/lib/Button/Button.stories.tsx
+++ b/packages/react/ds-app-anbox/src/lib/Button/Button.stories.tsx
@@ -7,7 +7,6 @@ import Button from "./Button.js";
 const meta = {
   title: "Button",
   component: Component,
-  tags: ["autodocs"],
   // if using enum for appearance, you can use the following to generate controls
   // argTypes: {
   //   appearance: {

--- a/packages/react/ds-app-landscape/src/lib/Button/Button.stories.tsx
+++ b/packages/react/ds-app-landscape/src/lib/Button/Button.stories.tsx
@@ -7,7 +7,6 @@ import Button from "./Button.js";
 const meta = {
   title: "Button",
   component: Component,
-  tags: ["autodocs"],
   // if using enum for appearance, you can use the following to generate controls
   // argTypes: {
   //   appearance: {

--- a/packages/react/ds-app-launchpad/src/lib/DiffChangeMarker/DiffChangeMarker.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/DiffChangeMarker/DiffChangeMarker.stories.tsx
@@ -6,7 +6,6 @@ import Component from "./DiffChangeMarker.js";
 const meta = {
   title: "DiffChangeMarker",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     markerStyle: {
       options: ["simple", "detailed"],

--- a/packages/react/ds-app-launchpad/src/lib/EditableBlock/EditableBlock.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/EditableBlock/EditableBlock.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./EditableBlock.js";
 const meta = {
   title: "EditableBlock",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     tag: {
       control: "text",

--- a/packages/react/ds-app-launchpad/src/lib/FileTree/Provider.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/FileTree/Provider.stories.tsx
@@ -7,7 +7,6 @@ import type { FileTreeData, ProviderOptions } from "./types.js";
 
 const meta = {
   title: "FileTree",
-  tags: ["autodocs"],
   component: FileTree,
   argTypes: {
     expandable: {

--- a/packages/react/ds-app-launchpad/src/lib/FileTree/common/TreeView/TreeView.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/FileTree/common/TreeView/TreeView.stories.tsx
@@ -12,7 +12,6 @@ import type { TreeViewProps } from "./types.js";
 
 const meta = {
   title: "FileTree/TreeView",
-  tags: ["autodocs"],
   component: FileTree.TreeView,
 } satisfies Meta<typeof FileTree.TreeView>;
 

--- a/packages/react/ds-app-launchpad/src/lib/GitDiffViewer/Provider.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/GitDiffViewer/Provider.stories.tsx
@@ -8,7 +8,6 @@ import type { ProviderOptions } from "./types.js";
 
 const meta = {
   title: "GitDiffViewer",
-  tags: ["autodocs"],
   component: GitDiffViewer,
   argTypes: {
     isCollapsed: {

--- a/packages/react/ds-app-launchpad/src/lib/GitDiffViewer/common/CodeDiffViewer/CodeDiffViewer.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/GitDiffViewer/common/CodeDiffViewer/CodeDiffViewer.stories.tsx
@@ -9,7 +9,6 @@ import type { CodeDiffViewerProps } from "./types.js";
 
 const meta: Meta = {
   title: "GitDiffViewer/CodeDiffViewer",
-  tags: ["autodocs"],
   component: GitDiffViewer.CodeDiffViewer,
   argTypes: {
     diff: { table: { disable: true } },

--- a/packages/react/ds-app-launchpad/src/lib/GitDiffViewer/common/FileHeader/FileHeader.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/GitDiffViewer/common/FileHeader/FileHeader.stories.tsx
@@ -7,7 +7,6 @@ import { GitDiffViewer } from "../../index.js";
 
 const meta = {
   title: "GitDiffViewer/FileHeader",
-  tags: ["autodocs"],
   component: GitDiffViewer.FileHeader,
   decorators: [
     (Story) => {

--- a/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/MarkdownEditor.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/MarkdownEditor.stories.tsx
@@ -7,7 +7,6 @@ import type { EditMode, MarkdownEditorProps } from "./types.js";
 
 const meta = {
   title: "MarkdownEditor",
-  tags: ["autodocs"],
   component: MarkdownEditor,
 } satisfies Meta<MarkdownEditorProps>;
 

--- a/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/Toolbar/Toolbar.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/Toolbar/Toolbar.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Toolbar.js";
 
 const meta = {
   title: "MarkdownEditor/Toolbar",
-  tags: ["autodocs"],
   component: Component,
   decorators: [
     (Story, { args }) => (

--- a/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/Toolbar/common/Button/Button.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/Toolbar/common/Button/Button.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Button.js";
 
 const meta = {
   title: "MarkdownEditor/Toolbar/Button",
-  tags: ["autodocs"],
   component: Component,
   decorators: [
     (Story, { args }) => (

--- a/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/Toolbar/common/Group/Group.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/Toolbar/common/Group/Group.stories.tsx
@@ -6,7 +6,6 @@ import Component from "./Group.js";
 
 const meta = {
   title: "MarkdownEditor/Toolbar/Group",
-  tags: ["autodocs"],
   component: Component,
   decorators: [
     (Story, { args }) => (

--- a/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/Toolbar/common/Separator/Separator.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/Toolbar/common/Separator/Separator.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Separator.js";
 
 const meta = {
   title: "MarkdownEditor/Toolbar/Separator",
-  tags: ["autodocs"],
   component: Component,
   decorators: [
     (Story) => (

--- a/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/ViewModeTabs/ViewModeTabs.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/MarkdownEditor/common/ViewModeTabs/ViewModeTabs.stories.tsx
@@ -7,7 +7,6 @@ import "../../styles.css";
 
 const meta = {
   title: "MarkdownEditor/ViewModeTabs",
-  tags: ["autodocs"],
   component: Component,
   decorators: [
     (Story, { args }) => (

--- a/packages/react/ds-app-launchpad/src/lib/RelativeTime/RelativeTime.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/lib/RelativeTime/RelativeTime.stories.tsx
@@ -6,7 +6,6 @@ import Component from "./RelativeTime.js";
 
 const meta = {
   title: "RelativeTime",
-  tags: ["autodocs"],
   component: Component,
   parameters: {
     // this component has no visual representation, so we disable snapshot testing

--- a/packages/react/ds-app-lxd/src/lib/Button/Button.stories.tsx
+++ b/packages/react/ds-app-lxd/src/lib/Button/Button.stories.tsx
@@ -7,7 +7,6 @@ import Button from "./Button.js";
 const meta = {
   title: "Button",
   component: Component,
-  tags: ["autodocs"],
   // if using enum for appearance, you can use the following to generate controls
   // argTypes: {
   //   appearance: {

--- a/packages/react/ds-app-portal/src/lib/Button/Button.stories.tsx
+++ b/packages/react/ds-app-portal/src/lib/Button/Button.stories.tsx
@@ -7,7 +7,6 @@ import Button from "./Button.js";
 const meta = {
   title: "Button",
   component: Component,
-  tags: ["autodocs"],
   // if using enum for appearance, you can use the following to generate controls
   // argTypes: {
   //   appearance: {

--- a/packages/react/ds-app/src/lib/ApplicationLayout/ApplicationLayout.stories.tsx
+++ b/packages/react/ds-app/src/lib/ApplicationLayout/ApplicationLayout.stories.tsx
@@ -10,7 +10,6 @@ import ApplicationLayout from "./ApplicationLayout.js";
 const meta: Meta<typeof ApplicationLayout> = {
   title: "Layouts/ApplicationLayout",
   component: ApplicationLayout,
-  tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: layoutDecorators,
 };

--- a/packages/react/ds-app/src/lib/ContentLayout/ContentLayout.stories.tsx
+++ b/packages/react/ds-app/src/lib/ContentLayout/ContentLayout.stories.tsx
@@ -10,7 +10,6 @@ import ContentLayout from "./ContentLayout.js";
 const meta: Meta<typeof ContentLayout> = {
   title: "Layouts/ContentLayout",
   component: ContentLayout,
-  tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: layoutDecorators,
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
@@ -16,7 +16,6 @@ import SideNavigation from "./SideNavigation.js";
 const meta: Meta<typeof SideNavigation> = {
   title: "Components/SideNavigation",
   component: SideNavigation,
-  tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   // withNavigationRouterProps injects currentUrl + LinkComponent from the live
   // router and keys the story so active state follows navigation; withNavLayout

--- a/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.stories.tsx
@@ -6,7 +6,6 @@ import CollapseToggle from "./CollapseToggle.js";
 const meta: Meta<typeof CollapseToggle> = {
   title: "Components/SideNavigation/CollapseToggle",
   component: CollapseToggle,
-  tags: ["autodocs"],
   decorators: [withBaseLayer],
   args: { onClick: fn() },
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Content/Content.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Content/Content.stories.tsx
@@ -10,7 +10,6 @@ import Content from "./Content.js";
 const meta: Meta<typeof Content> = {
   title: "Components/SideNavigation/Content",
   component: Content,
-  tags: ["autodocs"],
   // Render flush to the canvas origin (no Storybook padding) so the baseline
   // overlay grid aligns to the component's own box.
   parameters: { layout: "fullscreen" },

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Footer/Footer.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Footer/Footer.stories.tsx
@@ -10,7 +10,6 @@ import Footer from "./Footer.js";
 const meta: Meta<typeof Footer> = {
   title: "Components/SideNavigation/Footer",
   component: Footer,
-  tags: ["autodocs"],
   // Render flush to the canvas origin (no Storybook padding) so the baseline
   // overlay grid aligns to the component's own box.
   parameters: { layout: "fullscreen" },

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.stories.tsx
@@ -9,7 +9,6 @@ import Header from "./Header.js";
 const meta: Meta<typeof Header> = {
   title: "Components/SideNavigation/Header",
   component: Header,
-  tags: ["autodocs"],
   // Render flush to the canvas origin (no Storybook padding) so the baseline
   // overlay grid aligns to the component's own box.
   parameters: { layout: "fullscreen" },

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.stories.tsx
@@ -9,7 +9,6 @@ import Item from "./Item.js";
 const meta: Meta<typeof Item> = {
   title: "Components/SideNavigation/Item",
   component: Item,
-  tags: ["autodocs"],
   // Render flush to the canvas origin (no Storybook padding) so the baseline
   // overlay grid aligns to the component's own box.
   parameters: { layout: "fullscreen" },

--- a/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.stories.tsx
@@ -13,7 +13,6 @@ import { NavTree } from "./index.js";
 const meta: Meta<typeof NavTree> = {
   title: "Components/SideNavigation/NavTree",
   component: NavTree,
-  tags: ["autodocs"],
   // Render flush to the canvas origin (no Storybook padding) so the baseline
   // overlay grid aligns to the component's own box.
   parameters: { layout: "fullscreen" },

--- a/packages/react/ds-app/src/lib/ViewLayout/ViewLayout.stories.tsx
+++ b/packages/react/ds-app/src/lib/ViewLayout/ViewLayout.stories.tsx
@@ -10,7 +10,6 @@ import ViewLayout from "./ViewLayout.js";
 const meta: Meta<typeof ViewLayout> = {
   title: "Layouts/ViewLayout",
   component: ViewLayout,
-  tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: layoutDecorators,
 };

--- a/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.stories.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/CanonicalLogo/CanonicalLogo.stories.tsx
@@ -5,7 +5,6 @@ import CanonicalLogo from "./CanonicalLogo.js";
 const meta: Meta<typeof CanonicalLogo> = {
   title: "Components/SideNavigation/CanonicalLogo",
   component: CanonicalLogo,
-  tags: ["autodocs"],
   // Render flush to the canvas origin (no Storybook padding) so the baseline
   // overlay grid aligns to the component's own box.
   parameters: { layout: "fullscreen" },

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/Wrapper.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/Wrapper.stories.tsx
@@ -19,7 +19,6 @@ const BoundTextarea = bindField(TextareaInput, "native");
 const meta = {
   title: "common/Wrapper",
   component: Component,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof Component>;
 

--- a/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/CheckboxField/CheckboxField.stories.tsx
@@ -8,7 +8,6 @@ import { CheckboxField } from "./index.js";
 const meta = {
   title: "components/CheckboxField",
   component: CheckboxField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof CheckboxField>;
 

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/ChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/ChoicesField.stories.tsx
@@ -8,7 +8,6 @@ import { ChoicesField } from "./index.js";
 const meta = {
   title: "components/ChoicesField",
   component: ChoicesField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof ChoicesField>;
 

--- a/packages/react/ds-global-form/src/lib/component/ChoicesField/common/Option/Option.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ChoicesField/common/Option/Option.stories.tsx
@@ -6,7 +6,6 @@ import Option from "./Option.js";
 const meta: Meta<typeof Option> = {
   title: "components/ChoicesField/Option",
   component: Option,
-  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <fieldset className="ds form-choices inline" style={{ border: "none" }}>

--- a/packages/react/ds-global-form/src/lib/component/ColorField/ColorField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ColorField/ColorField.stories.tsx
@@ -6,7 +6,6 @@ import { ColorField } from "./index.js";
 const meta = {
   title: "_work_in_progress/component/ColorField",
   component: ColorField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof ColorField>;
 

--- a/packages/react/ds-global-form/src/lib/component/ComboboxField/ComboboxField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/ComboboxField/ComboboxField.stories.tsx
@@ -7,7 +7,6 @@ import { ComboboxField } from "./index.js";
 const meta = {
   title: "_work_in_progress/component/ComboboxField",
   component: ComboboxField,
-  tags: ["autodocs"],
   decorators: [
     decorators.form({
       defaultValues: {

--- a/packages/react/ds-global-form/src/lib/component/DateField/DateField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/DateField/DateField.stories.tsx
@@ -7,7 +7,6 @@ import { DateField } from "./index.js";
 const meta = {
   title: "components/DateField",
   component: DateField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof DateField>;
 

--- a/packages/react/ds-global-form/src/lib/component/DateTimeField/DateTimeField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/DateTimeField/DateTimeField.stories.tsx
@@ -7,7 +7,6 @@ import { DateTimeField } from "./index.js";
 const meta = {
   title: "components/DateTimeField",
   component: DateTimeField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof DateTimeField>;
 

--- a/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/FileUploadField/FileUploadField.stories.tsx
@@ -6,7 +6,6 @@ import { FileUploadField } from "./index.js";
 const meta = {
   title: "components/FileUploadField",
   component: FileUploadField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof FileUploadField>;
 

--- a/packages/react/ds-global-form/src/lib/component/HiddenField/HiddenField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/HiddenField/HiddenField.stories.tsx
@@ -5,7 +5,6 @@ import { HiddenField } from "./index.js";
 const meta = {
   title: "components/HiddenField",
   component: HiddenField,
-  tags: ["autodocs"],
   decorators: [
     decorators.form({ defaultValues: { hidden_field: "hidden_value" } }),
   ],

--- a/packages/react/ds-global-form/src/lib/component/NumberField/NumberField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/NumberField/NumberField.stories.tsx
@@ -7,7 +7,6 @@ import { NumberField } from "./index.js";
 const meta = {
   title: "components/NumberField",
   component: NumberField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof NumberField>;
 

--- a/packages/react/ds-global-form/src/lib/component/PasswordField/PasswordField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/PasswordField/PasswordField.stories.tsx
@@ -7,7 +7,6 @@ import { PasswordField } from "./index.js";
 const meta = {
   title: "components/PasswordField",
   component: PasswordField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof PasswordField>;
 

--- a/packages/react/ds-global-form/src/lib/component/PhoneField/PhoneField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/PhoneField/PhoneField.stories.tsx
@@ -6,7 +6,6 @@ import { PhoneField } from "./index.js";
 const meta = {
   title: "components/PhoneField",
   component: PhoneField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof PhoneField>;
 

--- a/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RangeField/RangeField.stories.tsx
@@ -5,7 +5,6 @@ import { RangeField } from "./index.js";
 const meta = {
   title: "components/RangeField",
   component: RangeField,
-  tags: ["autodocs"],
   decorators: [decorators.form({ defaultValues: { volume: 50 } })],
 } satisfies Meta<typeof RangeField>;
 

--- a/packages/react/ds-global-form/src/lib/component/RatingField/RatingField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RatingField/RatingField.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./RatingField.js";
 const meta = {
   title: "_work_in_progress/component/RatingField",
   component: Component,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof Component>;
 

--- a/packages/react/ds-global-form/src/lib/component/RichChoicesField/RichChoicesField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RichChoicesField/RichChoicesField.stories.tsx
@@ -11,7 +11,6 @@ import { RichChoicesField } from "./index.js";
 const meta = {
   title: "components/RichChoicesField",
   component: RichChoicesField,
-  tags: ["autodocs"],
   parameters: { grid: "responsive" },
   decorators: [decorators.form()],
 } satisfies Meta<typeof RichChoicesField>;

--- a/packages/react/ds-global-form/src/lib/component/RichChoicesField/common/Option/Option.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/RichChoicesField/common/Option/Option.stories.tsx
@@ -6,7 +6,6 @@ import Option from "./Option.js";
 const meta: Meta<typeof Option> = {
   title: "components/RichChoicesField/Option",
   component: Option,
-  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <fieldset className="ds form-rich-choices" style={{ border: "none" }}>

--- a/packages/react/ds-global-form/src/lib/component/SelectField/SelectField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SelectField/SelectField.stories.tsx
@@ -8,7 +8,6 @@ import { SelectField } from "./index.js";
 const meta = {
   title: "components/SelectField",
   component: SelectField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof SelectField>;
 

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.stories.tsx
@@ -7,7 +7,6 @@ import { SwitchField } from "./index.js";
 const meta = {
   title: "components/SwitchField",
   component: SwitchField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof SwitchField>;
 

--- a/packages/react/ds-global-form/src/lib/component/TextField/TextField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/TextField/TextField.stories.tsx
@@ -7,7 +7,6 @@ import { TextField } from "./index.js";
 const meta = {
   title: "components/TextField",
   component: TextField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof TextField>;
 

--- a/packages/react/ds-global-form/src/lib/component/TextareaField/TextareaField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/TextareaField/TextareaField.stories.tsx
@@ -7,7 +7,6 @@ import { TextareaField } from "./index.js";
 const meta = {
   title: "components/TextareaField",
   component: TextareaField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof TextareaField>;
 

--- a/packages/react/ds-global-form/src/lib/component/TimeField/TimeField.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/component/TimeField/TimeField.stories.tsx
@@ -7,7 +7,6 @@ import { TimeField } from "./index.js";
 const meta = {
   title: "components/TimeField",
   component: TimeField,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof TimeField>;
 

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
@@ -13,7 +13,6 @@ import type { FieldProps } from "./types.js";
 const meta = {
   title: "patterns/Field",
   component: Component,
-  tags: ["autodocs"],
   decorators: [decorators.form()],
 } satisfies Meta<typeof Component>;
 

--- a/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/CheckboxInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/CheckboxInput/CheckboxInput.stories.tsx
@@ -5,7 +5,6 @@ import { CheckboxInput } from "./CheckboxInput.js";
 const meta = {
   title: "subcomponents/CheckboxInput",
   component: CheckboxInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof CheckboxInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/ColorInput/ColorInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ColorInput/ColorInput.stories.tsx
@@ -7,7 +7,6 @@ import { ColorInput } from "./ColorInput.js";
 const meta = {
   title: "_work_in_progress/subcomponent/ColorInput",
   component: ColorInput,
-  tags: ["autodocs"],
   render: (args) => {
     const [value, setValue] = useState(args.value ?? "#000000");
     return <ColorInput {...args} value={value} onChange={setValue} />;

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/ComboboxInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/ComboboxInput.stories.tsx
@@ -8,7 +8,6 @@ import { ComboboxInput } from "./ComboboxInput.js";
 const meta = {
   title: "_work_in_progress/subcomponent/ComboboxInput",
   component: ComboboxInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof ComboboxInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/List/List.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/List/List.stories.tsx
@@ -14,7 +14,6 @@ import Component from "./List.js";
 const meta = {
   title: "_work_in_progress/subcomponent/ComboboxInput/List",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/ResetButton/ResetButton.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/common/ResetButton/ResetButton.stories.tsx
@@ -11,7 +11,6 @@ import Component from "./ResetButton.js";
 const meta = {
   title: "_work_in_progress/subcomponent/ComboboxInput/ResetButton",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateInput/DateInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateInput/DateInput.stories.tsx
@@ -5,7 +5,6 @@ import { DateInput } from "./DateInput.js";
 const meta = {
   title: "subcomponents/DateInput",
   component: DateInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof DateInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/DateTimeInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/DateTimeInput/DateTimeInput.stories.tsx
@@ -5,7 +5,6 @@ import { DateTimeInput } from "./DateTimeInput.js";
 const meta = {
   title: "subcomponents/DateTimeInput",
   component: DateTimeInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof DateTimeInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Description/Description.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Description/Description.stories.tsx
@@ -11,7 +11,6 @@ import Component from "./Description.js";
 const meta = {
   title: "subcomponents/Field.Description",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Error/Error.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Error/Error.stories.tsx
@@ -11,7 +11,6 @@ import Component from "./Error.js";
 const meta = {
   title: "subcomponents/Field.Error",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/Field/Label/Label.stories.tsx
@@ -11,7 +11,6 @@ import Component from "./Label.js";
 const meta = {
   title: "subcomponents/Field.Label",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/FileUploadInput/FileUploadInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/FileUploadInput/FileUploadInput.stories.tsx
@@ -6,7 +6,6 @@ import { FileUploadInput } from "./FileUploadInput.js";
 const meta = {
   title: "subcomponents/FileUploadInput",
   component: FileUploadInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof FileUploadInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/HiddenInput/HiddenInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/HiddenInput/HiddenInput.stories.tsx
@@ -4,7 +4,6 @@ import { HiddenInput } from "./HiddenInput.js";
 const meta = {
   title: "subcomponents/HiddenInput",
   component: HiddenInput,
-  tags: ["autodocs"],
   parameters: { chromatic: { disableSnapshot: true } },
 } satisfies Meta<typeof HiddenInput>;
 

--- a/packages/react/ds-global-form/src/lib/subcomponent/NumberInput/NumberInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/NumberInput/NumberInput.stories.tsx
@@ -6,7 +6,6 @@ import { NumberInput } from "./NumberInput.js";
 const meta: Meta<typeof NumberInput> = {
   title: "subcomponents/NumberInput",
   component: NumberInput,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/PasswordInput/PasswordInput.stories.tsx
@@ -6,7 +6,6 @@ import { PasswordInput } from "./PasswordInput.js";
 const meta: Meta<typeof PasswordInput> = {
   title: "subcomponents/PasswordInput",
   component: PasswordInput,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/PhoneInput/PhoneInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/PhoneInput/PhoneInput.stories.tsx
@@ -7,7 +7,6 @@ import type { PhoneValue } from "./types.js";
 const meta = {
   title: "subcomponents/PhoneInput",
   component: PhoneInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof PhoneInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/RadioInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RadioInput/RadioInput.stories.tsx
@@ -6,7 +6,6 @@ import { RadioInput } from "./RadioInput.js";
 const meta: Meta<typeof RadioInput> = {
   title: "subcomponents/RadioInput",
   component: RadioInput,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/RangeInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RangeInput/RangeInput.stories.tsx
@@ -4,7 +4,6 @@ import { RangeInput } from "./RangeInput.js";
 const meta = {
   title: "subcomponents/RangeInput",
   component: RangeInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof RangeInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/RatingInput/RatingInput.stories.tsx
@@ -5,7 +5,6 @@ import { RatingInput } from "./RatingInput.js";
 const meta = {
   title: "_work_in_progress/subcomponent/RatingInput",
   component: RatingInput,
-  tags: ["autodocs"],
   args: { name: "rating", "aria-label": "Rate this article" },
 } satisfies Meta<typeof RatingInput>;
 

--- a/packages/react/ds-global-form/src/lib/subcomponent/SelectInput/SelectInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SelectInput/SelectInput.stories.tsx
@@ -6,7 +6,6 @@ import { SelectInput } from "./SelectInput.js";
 const meta = {
   title: "subcomponents/SelectInput",
   component: SelectInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof SelectInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SwitchInput/SwitchInput.stories.tsx
@@ -5,7 +5,6 @@ import { SwitchInput } from "./SwitchInput.js";
 const meta = {
   title: "subcomponents/SwitchInput",
   component: SwitchInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof SwitchInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/TextInput/TextInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TextInput/TextInput.stories.tsx
@@ -5,7 +5,6 @@ import { TextInput } from "./TextInput.js";
 const meta = {
   title: "subcomponents/TextInput",
   component: TextInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof TextInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/TextareaInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TextareaInput/TextareaInput.stories.tsx
@@ -5,7 +5,6 @@ import { TextareaInput } from "./TextareaInput.js";
 const meta = {
   title: "subcomponents/TextareaInput",
   component: TextareaInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof TextareaInput>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/TimeInput/TimeInput.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/TimeInput/TimeInput.stories.tsx
@@ -5,7 +5,6 @@ import { TimeInput } from "./TimeInput.js";
 const meta = {
   title: "subcomponents/TimeInput",
   component: TimeInput,
-  tags: ["autodocs"],
 } satisfies Meta<typeof TimeInput>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/_work_in_progress/CategoriesSection/CategoriesSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/CategoriesSection/CategoriesSection.stories.tsx
@@ -7,7 +7,6 @@ import CategoriesSection from "./CategoriesSection.js";
 const meta: Meta<typeof CategoriesSection> = {
   title: "_work_in_progress/other/CategoriesSection",
   component: CategoriesSection,
-  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     grid: "responsive",

--- a/packages/react/ds-global/src/lib/_work_in_progress/CategoriesSection/common/Category/Category.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/CategoriesSection/common/Category/Category.stories.tsx
@@ -7,7 +7,6 @@ import Category from "./Category.js";
 const meta: Meta<typeof Category> = {
   title: "_work_in_progress/other/CategoriesSection.Category",
   component: Category,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/ds-global/src/lib/_work_in_progress/ChatSection/ChatSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/ChatSection/ChatSection.stories.tsx
@@ -7,7 +7,6 @@ import ChatSection from "./ChatSection.js";
 const meta: Meta<typeof ChatSection> = {
   title: "_work_in_progress/other/ChatSection",
   component: ChatSection,
-  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     grid: "responsive",

--- a/packages/react/ds-global/src/lib/_work_in_progress/DescriptionSection/DescriptionSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/DescriptionSection/DescriptionSection.stories.tsx
@@ -7,7 +7,6 @@ import DescriptionSection from "./DescriptionSection.js";
 const meta: Meta<typeof DescriptionSection> = {
   title: "_work_in_progress/other/DescriptionSection",
   component: DescriptionSection,
-  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     grid: "responsive",

--- a/packages/react/ds-global/src/lib/_work_in_progress/IconSection/IconSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/IconSection/IconSection.stories.tsx
@@ -7,7 +7,6 @@ import IconSection from "./IconSection.js";
 const meta: Meta<typeof IconSection> = {
   title: "_work_in_progress/other/IconSection",
   component: IconSection,
-  tags: ["autodocs"],
   parameters: {
     grid: "responsive",
   },

--- a/packages/react/ds-global/src/lib/_work_in_progress/Label/Label.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Label/Label.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Label.js";
 const meta = {
   title: "_work_in_progress/other/Label",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     anticipation: {
       control: "select",

--- a/packages/react/ds-global/src/lib/_work_in_progress/Link/Link.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Link/Link.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Link.js";
 const meta = {
   title: "_work_in_progress/other/Link",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     children: {
       control: { type: "text" },

--- a/packages/react/ds-global/src/lib/_work_in_progress/Rule/Rule.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Rule/Rule.stories.tsx
@@ -4,7 +4,6 @@ import Component from "./Rule.js";
 const meta = {
   title: "_work_in_progress/component/Rule",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/_work_in_progress/Section/Section.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Section/Section.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Section.js";
 const meta = {
   title: "_work_in_progress/component/Section",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     children: {
       control: { type: "text" },

--- a/packages/react/ds-global/src/lib/_work_in_progress/TSection/TSection.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/TSection/TSection.stories.tsx
@@ -7,7 +7,6 @@ import TSection from "./TSection.js";
 const meta: Meta<typeof TSection> = {
   title: "_work_in_progress/other/TSection",
   component: TSection,
-  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
     grid: "responsive",

--- a/packages/react/ds-global/src/lib/_work_in_progress/grid/ApplicationLayout/ApplicationLayout.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/grid/ApplicationLayout/ApplicationLayout.stories.tsx
@@ -7,7 +7,6 @@ import { ApplicationLayout } from "./ApplicationLayout.js";
 const meta: Meta<typeof ApplicationLayout> = {
   title: "_work_in_progress/other/grid/ApplicationLayout",
   component: ApplicationLayout,
-  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/packages/react/ds-global/src/lib/_work_in_progress/grid/GridCard/GridCard.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/grid/GridCard/GridCard.stories.tsx
@@ -7,7 +7,6 @@ import { GridCard } from "./GridCard.js";
 const meta: Meta<typeof GridCard> = {
   title: "_work_in_progress/other/grid/GridCard",
   component: GridCard,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/ds-global/src/lib/_work_in_progress/grid/InnerGridDemo/InnerGridDemo.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/grid/InnerGridDemo/InnerGridDemo.stories.tsx
@@ -7,7 +7,6 @@ import { InnerGridDemo } from "./InnerGridDemo.js";
 const meta: Meta<typeof InnerGridDemo> = {
   title: "_work_in_progress/other/grid/InnerGridDemo",
   component: InnerGridDemo,
-  tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
   },

--- a/packages/react/ds-global/src/lib/_work_in_progress/grid/SettingsView/SettingsView.stories.tsx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/grid/SettingsView/SettingsView.stories.tsx
@@ -7,7 +7,6 @@ import { SettingsView } from "./SettingsView.js";
 const meta: Meta<typeof SettingsView> = {
   title: "_work_in_progress/other/grid/SettingsView",
   component: SettingsView,
-  tags: ["autodocs"],
   parameters: {
     grid: "responsive",
   },

--- a/packages/react/ds-global/src/lib/component/Accordion/Accordion.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Accordion/Accordion.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Accordion.js";
 const meta: Meta<typeof Component> = {
   title: "components/Accordion",
   component: Component,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/Item.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/Item.stories.tsx
@@ -4,7 +4,6 @@ import Component from "./Item.js";
 const meta = {
   title: "components/Accordion/Item",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     heading: {
       control: { type: "text" },

--- a/packages/react/ds-global/src/lib/component/Announcement/Announcement.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Announcement/Announcement.stories.tsx
@@ -6,7 +6,6 @@ import Component from "./Announcement.js";
 const meta = {
   title: "components/Announcement",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     criticality: {
       options: [undefined, ...MODIFIER_FAMILIES.criticality],

--- a/packages/react/ds-global/src/lib/component/Badge/Badge.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Badge/Badge.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Badge.js";
 const meta = {
   title: "_work_in_progress/component/Badge",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     value: { control: { type: "number" } },
     criticality: {

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -5,7 +5,6 @@ import type { BreadcrumbItem } from "./types.js";
 const meta = {
   title: "components/Breadcrumbs",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.stories.tsx
@@ -4,7 +4,6 @@ import Component from "./Item.js";
 const meta = {
   title: "components/Breadcrumbs/Item",
   component: Component,
-  tags: ["autodocs"],
   parameters: {
     docs: {
       description: {

--- a/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Button/Button.stories.tsx
@@ -30,7 +30,6 @@ const meta = {
   title: "components/Button",
   component: Component,
   decorators: [surface],
-  tags: ["autodocs"],
   argTypes: {
     // Importance is never blank — primary is the default hierarchy.
     importance: {

--- a/packages/react/ds-global/src/lib/component/Card/Card.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/Card.stories.tsx
@@ -16,7 +16,6 @@ import type { CardProps } from "./types.js";
 const meta = {
   title: "components/Card",
   component: Component,
-  tags: ["autodocs"],
   parameters: { grid: "showcase" },
 } satisfies Meta<typeof Component>;
 

--- a/packages/react/ds-global/src/lib/component/Card/common/Content/Content.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Content/Content.stories.tsx
@@ -4,7 +4,6 @@ import Component from "./Content.js";
 const meta = {
   title: "components/Card/Content",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     children: {
       control: { type: "text" },

--- a/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.stories.tsx.disabled
+++ b/packages/react/ds-global/src/lib/component/Card/common/Footer/Footer.stories.tsx.disabled
@@ -9,7 +9,6 @@ import Component from "./Footer.js";
 const meta = {
   title: "components/Card/Footer",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     children: {
       control: { type: "text" },

--- a/packages/react/ds-global/src/lib/component/Card/common/Header/Header.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Header/Header.stories.tsx
@@ -4,7 +4,6 @@ import Component from "./Header.js";
 const meta = {
   title: "components/Card/Header",
   component: Component,
-  tags: ["autodocs"],
   parameters: {
     docs: {
       description: {

--- a/packages/react/ds-global/src/lib/component/Card/common/Image/Image.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Card/common/Image/Image.stories.tsx
@@ -4,7 +4,6 @@ import Component from "./Image.js";
 const meta = {
   title: "components/Card/Image",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     src: {
       control: { type: "text" },

--- a/packages/react/ds-global/src/lib/component/Chip/Chip.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Chip/Chip.stories.tsx
@@ -6,7 +6,6 @@ import Component from "./Chip.js";
 const meta = {
   title: "_work_in_progress/component/Chip",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     criticality: {
       options: [undefined, ...MODIFIER_FAMILIES.criticality],

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
@@ -33,7 +33,6 @@ const meta = {
   title: "components/ContextualMenu",
   component: Component,
   decorators: [stage],
-  tags: ["autodocs"],
   parameters: {
     // Centre the trigger in the story canvas so the (portalled) menu is framed.
     layout: "centered",

--- a/packages/react/ds-global/src/lib/component/Heading/Heading.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Heading/Heading.stories.tsx
@@ -17,7 +17,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
  */
 const meta = {
   title: "components/Heading",
-  tags: ["autodocs"],
   parameters: { layout: "padded" },
 } satisfies Meta;
 

--- a/packages/react/ds-global/src/lib/component/Icon/Icon.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Icon/Icon.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Icon.js";
 const meta = {
   title: "components/Icon",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     icon: {
       options: ICON_NAMES,

--- a/packages/react/ds-global/src/lib/component/InlineCode/InlineCode.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/InlineCode/InlineCode.stories.tsx
@@ -4,7 +4,6 @@ import Component from "./InlineCode.js";
 const meta: Meta<typeof Component> = {
   title: "components/InlineCode",
   component: Component,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/ds-global/src/lib/component/KeyboardKey/KeyboardKey.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/KeyboardKey/KeyboardKey.stories.tsx
@@ -10,7 +10,6 @@ import Component from "./KeyboardKey.js";
 const meta = {
   title: "components/KeyboardKey",
   component: Component,
-  tags: ["autodocs"],
   argTypes: {
     keyValue: { control: { type: "select" } },
   },

--- a/packages/react/ds-global/src/lib/component/Popover/Popover.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Popover/Popover.stories.tsx
@@ -31,7 +31,6 @@ const meta = {
   title: "_work_in_progress/component/Popover",
   component: Component,
   decorators: [stage],
-  tags: ["autodocs"],
   parameters: {
     layout: "centered",
   },

--- a/packages/react/ds-global/src/lib/component/Tabs/Tabs.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tabs/Tabs.stories.tsx
@@ -15,7 +15,6 @@ import Component from "./Tabs.js";
 const meta = {
   title: "components/Tabs",
   component: Component,
-  tags: ["autodocs"],
   args: {
     "aria-label": "Sections",
   },

--- a/packages/react/ds-global/src/lib/component/Tile/Tile.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tile/Tile.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./Tile.js";
 const meta = {
   title: "components/Tile",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/component/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/Tooltip.stories.tsx
@@ -34,7 +34,6 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
@@ -89,7 +89,6 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/group/Cards/Cards.stories.tsx
+++ b/packages/react/ds-global/src/lib/group/Cards/Cards.stories.tsx
@@ -18,7 +18,6 @@ import Cards from "./Cards.js";
 const meta = {
   title: "groups/Cards",
   component: Cards,
-  tags: ["autodocs"],
   parameters: { grid: "responsive" },
   argTypes: {
     cardSpan: { control: { type: "number", min: 1, step: 1 } },

--- a/packages/react/ds-global/src/lib/group/KeyboardKeys/KeyboardKeys.stories.tsx
+++ b/packages/react/ds-global/src/lib/group/KeyboardKeys/KeyboardKeys.stories.tsx
@@ -5,7 +5,6 @@ import Component from "./KeyboardKeys.js";
 const meta = {
   title: "groups/KeyboardKeys",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/pattern/Timeline/Timeline.stories.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Timeline/Timeline.stories.tsx
@@ -5,7 +5,6 @@ import Timeline from "./Timeline.js";
 const meta = {
   title: "_work_in_progress/pattern/Timeline",
   component: Component,
-  tags: ["autodocs"],
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.stories.tsx
+++ b/packages/react/ds-global/src/lib/subcomponent/Spinner/Spinner.stories.tsx
@@ -4,7 +4,6 @@ import Component from "./Spinner.js";
 const meta = {
   title: "subcomponents/Spinner",
   component: Component,
-  tags: ["autodocs"],
   parameters: {
     docs: {
       description: {

--- a/packages/react/tokens/src/lib/TokenTable/TokenTable.stories.tsx
+++ b/packages/react/tokens/src/lib/TokenTable/TokenTable.stories.tsx
@@ -5,7 +5,6 @@ import { TokenTable as Component } from "./TokenTable.js";
 const meta: Meta<typeof Component> = {
   title: "Foundations/Tokens/Internal/TokenTable",
   component: Component,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/tokens/src/lib/TokenTable/common/TokenSwatch/TokenSwatch.stories.tsx
+++ b/packages/react/tokens/src/lib/TokenTable/common/TokenSwatch/TokenSwatch.stories.tsx
@@ -12,7 +12,6 @@ const derivedToken = mockTokens.find(
 const meta: Meta<typeof Component> = {
   title: "Foundations/Tokens/Internal/TokenSwatch",
   component: Component,
-  tags: ["autodocs"],
 };
 
 export default meta;

--- a/packages/react/tokens/src/lib/Tokens.stories.tsx
+++ b/packages/react/tokens/src/lib/Tokens.stories.tsx
@@ -173,7 +173,6 @@ const lensCards = [
 
 const meta = {
   title: "Foundation/Design Tokens",
-  tags: ["autodocs"],
   parameters: {
     layout: "padded",
     docs: {

--- a/packages/react/tokens/src/lib/Typography.stories.tsx
+++ b/packages/react/tokens/src/lib/Typography.stories.tsx
@@ -2,7 +2,6 @@ import "./Typography.css";
 
 const meta = {
   title: "Foundation/Typography",
-  tags: ["autodocs"],
   parameters: {
     layout: "padded",
     docs: {

--- a/packages/svelte/ds-global/src/lib/component/Example/Example.stories.svelte
+++ b/packages/svelte/ds-global/src/lib/component/Example/Example.stories.svelte
@@ -7,7 +7,6 @@
   const { Story } = defineMeta({
     title: "Components/Example",
     component: Example,
-    tags: ["autodocs"],
     parameters: {
       // This is an example component, no need for it to be snapshotted.
       chromatic: { disableSnapshot: true },


### PR DESCRIPTION
## Done

- Remove per-story-file `tags: ["autodocs"]` where they are redundant: the shared default lives in `configs/storybook/src/previewConfig.ts:34`, and — due to Storybook bug storybookjs/storybook#31842 — it takes effect wherever a package's `.storybook/preview.ts` re-declares `tags` **inline** (not merely spread from the imported config).
- **Stripped (redundant)** — packages whose preview inlines the tag: `react/ds-global-form` (46 files), `react/ds-global` (41), `react/ds-app-launchpad` (14), `react/ds-app` (11), `react/tokens` (4), the four `ds-app-{anbox,landscape,lxd,portal}` (1 each), `svelte/ds-global` (1). Plus 2 doc files updated (`configs/storybook/README.md`, `docs/explanations/COMPONENT_FOLDER_STRUCTURE.md`).
- **Deliberately kept (load-bearing)** — packages whose preview only spreads `previewConfig` with no inline `tags`, where removal would drop their docs pages: `lit/ds-prototype` (13), `svelte/ds-app-launchpad` (43), `svelte/ds-app-wpe` (2), `storybook/addon-msw` (1), `storybook/addon-utils` (1). Preview-level configs untouched everywhere.
- Net: 123 files, +14/−129.

Fixes #149 — task (a) is done here; task (b) ("as/tags consistency") turned out to be the polymorphic `as`-vs-`tag` prop naming inconsistency, a breaking API rename needing a policy decision, now split into #847 per the issue author's own suggestion to break the umbrella down.

## QA

- Storybook build on `react/ds-global` (representative stripped package): completes, and the generated `index.json` still contains **44 docs entries** — autodocs inherited from the preview default, confirming zero behavioral change.
- `bun run check` on touched packages: pass.
- Root `bun run check`: 61 projects pass.
- Repo-wide grep confirms remaining `tags: ["autodocs"]` occurrences match the "kept" list exactly.

### PR readiness check

- [x] PR label: `Maintenance 🔨`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] All packages define the required scripts (none changed).
- [ ] New package — n/a.
- [x] `no visual change` label added — docs pages render identically (verified via build).

## Screenshots

n/a — no visual change (storybook docs entries verified identical in count post-change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_