### PR TITLE
fix(react/ds-global-form): re-render field error when message changes on cross-field revalidation

### DIFF
--- a/packages/react/ds-global-form/src/lib/utils/hooks/useFieldError.crossField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/utils/hooks/useFieldError.crossField.tests.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithForm } from "../../../testing/renderWithForm.js";
+import { TextField } from "../../component/TextField/index.js";
+
+// Regression test for https://github.com/canonical/pragma/issues/236 —
+// cross-field revalidation: changing one field (country) tightens another
+// field's minimum-age constraint. The age field stays in an error state, but
+// its error MESSAGE text must re-render rather than remain stale.
+//
+// A form-level resolver is the constraint source (its message is recomputed on
+// every validation, unlike a per-field `validate` closure which the field
+// wrapper freezes), and `deps` makes the country change revalidate the age
+// field. The age field lives inside a nested group so its error sits deep in
+// the `errors` tree: the previous `useFieldError` memoised the resolved error
+// against a hand-unrolled, fixed-depth list of parent references, so a
+// message-only change beyond that depth left the rendered message stale.
+
+type Values = {
+  country: string;
+  applicant: { contact: { details: { age: string } } };
+};
+
+const AGE_FIELD = "applicant.contact.details.age";
+
+const resolver = (values: Values) => {
+  const min = values.country === "ca" ? 18 : 13;
+  const age = Number(values.applicant?.contact?.details?.age);
+  const errors =
+    age >= min
+      ? {}
+      : {
+          applicant: {
+            contact: {
+              details: {
+                age: { type: "min", message: `Age must be at least ${min}` },
+              },
+            },
+          },
+        };
+  return { values, errors };
+};
+
+const CrossFieldForm = () => (
+  <>
+    <TextField
+      name="country"
+      label="Country"
+      registerProps={{ deps: [AGE_FIELD] }}
+    />
+    <TextField name={AGE_FIELD} label="Age" />
+  </>
+);
+
+describe("useFieldError cross-field revalidation", () => {
+  it("re-renders the error message when it changes while the field stays errored", async () => {
+    renderWithForm(<CrossFieldForm />, {
+      formProps: {
+        mode: "onChange",
+        // biome-ignore lint/suspicious/noExplicitAny: local resolver shape
+        resolver: resolver as any,
+        defaultValues: {
+          country: "us",
+          applicant: { contact: { details: { age: "" } } },
+        },
+      },
+    });
+
+    const [countryInput, ageInput] = screen.getAllByRole("textbox");
+
+    // Put the (nested) age field into an error state under the default (13) constraint.
+    fireEvent.change(ageInput, { target: { value: "10" } });
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Age must be at least 13",
+      );
+    });
+
+    // Changing the country tightens the age constraint: the age field stays
+    // errored, but its message text must update from 13 to 18.
+    fireEvent.change(countryInput, { target: { value: "ca" } });
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Age must be at least 18",
+      );
+    });
+  });
+});

--- a/packages/react/ds-global-form/src/lib/utils/hooks/useFieldError.crossField.tests.tsx
+++ b/packages/react/ds-global-form/src/lib/utils/hooks/useFieldError.crossField.tests.tsx
@@ -66,7 +66,10 @@ describe("useFieldError cross-field revalidation", () => {
       },
     });
 
-    const [countryInput, ageInput] = screen.getAllByRole("textbox");
+    // Query by label (TextField wires label→input via htmlFor) rather than by
+    // textbox order, so adding another field can't silently break this test.
+    const countryInput = screen.getByLabelText("Country");
+    const ageInput = screen.getByLabelText("Age");
 
     // Put the (nested) age field into an error state under the default (13) constraint.
     fireEvent.change(ageInput, { target: { value: "10" } });

--- a/packages/react/ds-global-form/src/lib/utils/hooks/useFieldError.ts
+++ b/packages/react/ds-global-form/src/lib/utils/hooks/useFieldError.ts
@@ -1,8 +1,8 @@
 import {
   type FieldError,
-  type FieldErrorsImpl,
   type FieldValues,
   get,
+  type Path,
   useFormState,
 } from "react-hook-form";
 
@@ -23,7 +23,11 @@ import {
 function useFieldError<TFieldValues extends FieldValues = FieldValues>(
   name: string,
 ): FieldError | undefined {
-  const { errors } = useFormState({ name }) as FieldErrorsImpl<TFieldValues>;
+  // `errors` is correctly typed as FieldErrors<TFieldValues> from the generic;
+  // only the runtime `name` path is asserted to a Path of the field values.
+  const { errors } = useFormState<TFieldValues>({
+    name: name as Path<TFieldValues>,
+  });
 
   return get(errors, name) as FieldError | undefined;
 }

--- a/packages/react/ds-global-form/src/lib/utils/hooks/useFieldError.ts
+++ b/packages/react/ds-global-form/src/lib/utils/hooks/useFieldError.ts
@@ -1,44 +1,31 @@
-import { useMemo } from "react";
 import {
   type FieldError,
-  type FieldErrors,
   type FieldErrorsImpl,
   type FieldValues,
+  get,
   useFormState,
 } from "react-hook-form";
 
+/**
+ * Field-scoped subscription to a single field's error.
+ *
+ * Subscribes via `useFormState({ name })` so only this field's slice of form
+ * state triggers a re-render, then resolves the error at `name` from the
+ * (possibly nested) `errors` tree on every render with RHF's own `get`.
+ *
+ * Resolving on render — rather than memoising against a fixed, hand-unrolled
+ * list of parent references — is what lets a *message-only* change surface: on
+ * cross-field revalidation a field can stay errored while its message text
+ * changes (e.g. a min-age constraint tightens), and `get` reflects the new
+ * message at any nesting depth. `useFormState`'s field-scoped subscription
+ * still gates the re-render, so efficiency is preserved.
+ */
 function useFieldError<TFieldValues extends FieldValues = FieldValues>(
   name: string,
-) {
-  type ErrorTree = FieldErrors<TFieldValues> | FieldError | undefined;
-
+): FieldError | undefined {
   const { errors } = useFormState({ name }) as FieldErrorsImpl<TFieldValues>;
 
-  const fieldTree = name.split(".");
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: using a proxy
-  const fieldError = useMemo(
-    (): FieldError | undefined =>
-      // @ts-expect-error TODO
-      fieldTree.reduce<ErrorTree>((acc: FieldErrors<TFieldValues>, key) => {
-        if (acc) {
-          return acc[key];
-        }
-        return undefined;
-      }, errors),
-    [
-      name, //proxy for errors
-      // Below, those dependencies are lazily referenced, hence the need to explicitly evaluate them
-      // We assume that three levels of nesting is enough for most use cases
-      // @ts-expect-error TODO
-      errors[fieldTree[0]],
-      // @ts-expect-error TODO
-      errors[fieldTree[0]]?.[fieldTree[1]],
-      // @ts-expect-error TODO
-      errors[fieldTree[0]]?.[fieldTree[1]]?.[fieldTree[2]],
-    ],
-  );
-  return fieldError;
+  return get(errors, name) as FieldError | undefined;
 }
 
 export default useFieldError;


### PR DESCRIPTION
## Done

Fix `useFieldError` so a field re-renders when its error **message** changes while the field stays in an error state (cross-field revalidation).

**Root cause (verified empirically):** `useFieldError` subscribed via `useFormState({ name })` and then resolved the error inside a `useMemo` whose dependency array was a hand-unrolled, fixed list of parent references (`errors[a]`, `errors[a][b]`, `errors[a][b][c]` — commented "three levels of nesting is enough"). On cross-field revalidation the subscription *does* re-render, but for errors nested deeper than the tracked levels no memoised parent reference changes, so the memo returns the stale error object and the message never updates.

**Fix:** replace the fixed-depth memo with react-hook-form's own `get(errors, name)`, resolved every render — surfacing message-only changes at any nesting depth while keeping the field-scoped `useFormState({ name })` subscription intact (no loss of re-render efficiency). Removes the `useMemo` and three `@ts-expect-error` hacks it needed.

Fixes #236

> **Reviewer note (honest scope):** the exact country/age example in the issue text **already works on `main`** — the old 3-level memo happened to cover top-level fields. The residual bug this fixes is fields nested **4+ segments deep**, which reproduce the "field stays errored, message goes stale" symptom. The regression test targets that case.

## QA

- New regression test (`useFieldError.crossField.tests.tsx`, resolver-driven so the message actually recomputes): a nested age field errors under min 13, then changing `country` (with `deps`) tightens the min to 18 — field stays errored, rendered message must move 13 → 18. **Fails without the fix, passes with it** (verified by reverting). Probes confirmed the fix corrects depths 1–4 and doesn't regress the working top-level cases.
- `@canonical/react-ds-global-form` `test`: **268 pass** (69 files).
- `@canonical/react-ds-global-form` `check` (biome + tsc + webarchitect): pass (one pre-existing unrelated `density.css` specificity warning, untouched).

### PR readiness check

- [x] PR label: `Bug 🐛`.
- [x] PR title follows Conventional Commits.
- [x] Code follows the code standards.
- [x] All packages define the required scripts (none changed).
- [ ] New package — n/a.
- [x] `no visual change` label added.

## Screenshots

n/a — no visual change (form-logic fix; no new stories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2dyJ9Yk8zNVZpjKyhoCc)_