### PR TITLE
docs(adoption): add 26.10 adoption track guides (A1–A3, B)

### DIFF
--- a/docs/how-to-guides/adoption/README.md
+++ b/docs/how-to-guides/adoption/README.md
@@ -1,0 +1,35 @@
+# Pragma adoption for 26.10
+
+This directory contains the track guides for the 26.10 pragma adoption program. The program is organised in two independent families:
+
+- **Family A — consume pragma in your application.** Three ordered tracks: [A1 (styles, tokens, assets)](./TRACK_A1_STYLES_TOKENS_ASSETS.md) → [A2 (base components)](./TRACK_A2_BASE_COMPONENTS.md) → [A3 (form components)](./TRACK_A3_FORM_COMPONENTS.md). A1 is a prerequisite for A2 and A3.
+- **Family B — document your components** in the design-system documentation database. *Guide in preparation.*
+
+Expected effort per team: about one week of engineering time and half a week of design time across all four tracks.
+
+Every guide follows the same structure — *who this is for*, *what "done" means*, *the path*, *verify*, *if you get stuck*, *next* — so you always know where to look.
+
+## Requirements
+
+- **React ≥ 19.2.4.** The pragma React packages currently declare `react: ^19.2.4` as a direct dependency; on older React 19 minors your package manager installs a second React copy, which breaks hooks. Once React moves to `peerDependencies` this requirement relaxes to "React 19".
+- **A bundler that resolves package specifiers in CSS `@import`s** (Vite does this out of the box).
+
+## Suggested tooling
+
+None of these are required for adoption, but they make it faster. Commands are shown with `bun`; substitute `npm install` for `bun add` losslessly.
+
+| Tool | Install | What it gives you |
+|---|---|---|
+| [`@canonical/typescript-config`](https://www.npmjs.com/package/@canonical/typescript-config) | `bun add -D @canonical/typescript-config` | The reference tsconfig for pragma projects — one less thing to maintain, easier upstreaming. |
+| [`@canonical/summon`](https://www.npmjs.com/package/@canonical/summon) + generators | `bun add -g @canonical/summon @canonical/summon-component @canonical/summon-application` | Scaffolding: `summon component react src/lib/MyComponent` for components (see [Create a React component](../CREATE_A_REACT_COMPONENT.md)), `summon application react my-app` for a reference app to learn the conventions from. |
+| [`@canonical/pragma-cli`](https://www.npmjs.com/package/@canonical/pragma-cli) | `bun add -g @canonical/pragma-cli`, then `pragma setup all` | The pragma CLI and MCP server: project setup (shell completions, token LSP, MCP wiring for your AI tooling), the design-system knowledge graph, and the code standards (`pragma standard list`). **Currently Linux x64 only.** |
+| Terrazzo token LSP | `pragma setup lsp`, or directly `bunx @canonical/terrazzo-lsp-extension` | VS Code autocompletion and documentation for pragma design tokens. The direct `bunx` form works on any OS. |
+| [web-code-standards](https://github.com/canonical/web-code-standards) | `pragma standard list`, or browse the repo | The code standards pragma follows — structured data your AI tooling can consume directly. |
+
+## Design counterpart
+
+Designers adopt pragma by consuming the *Pragma — Core component library* in Figma instead of the Vanilla library. Where a pragma component exists, use it rather than its Vanilla counterpart, and watch for renamed or split components.
+
+## Registering progress
+
+Details on how teams report adoption progress are communicated separately by the program.

--- a/docs/how-to-guides/adoption/README.md
+++ b/docs/how-to-guides/adoption/README.md
@@ -26,6 +26,13 @@ None of these are required for adoption, but they make it faster. Commands are s
 | Terrazzo token LSP | `pragma setup lsp`, or directly `bunx @canonical/terrazzo-lsp-extension` | VS Code autocompletion and documentation for pragma design tokens. The direct `bunx` form works on any OS. |
 | [web-code-standards](https://github.com/canonical/web-code-standards) | `pragma standard list`, or browse the repo | The code standards pragma follows — structured data your AI tooling can consume directly. |
 
+## Discover the components
+
+Both component libraries are browsable directly in their live Storybooks (latest Chromatic build):
+
+- [ds-react-global.canonical.com](https://ds-react-global.canonical.com/) — global components ([Track A2](./TRACK_A2_BASE_COMPONENTS.md))
+- [ds-react-global-form.canonical.com](https://ds-react-global-form.canonical.com/) — form components ([Track A3](./TRACK_A3_FORM_COMPONENTS.md))
+
 ## Design counterpart
 
 Designers adopt pragma by consuming the *Pragma — Core component library* in Figma instead of the Vanilla library. Where a pragma component exists, use it rather than its Vanilla counterpart, and watch for renamed or split components.

--- a/docs/how-to-guides/adoption/README.md
+++ b/docs/how-to-guides/adoption/README.md
@@ -3,7 +3,7 @@
 This directory contains the track guides for the 26.10 pragma adoption program. The program is organised in two independent families:
 
 - **Family A — consume pragma in your application.** Three ordered tracks: [A1 (styles, tokens, assets)](./TRACK_A1_STYLES_TOKENS_ASSETS.md) → [A2 (base components)](./TRACK_A2_BASE_COMPONENTS.md) → [A3 (form components)](./TRACK_A3_FORM_COMPONENTS.md). A1 is a prerequisite for A2 and A3.
-- **Family B — document your components** in the design-system documentation database. *Guide in preparation.*
+- **Family B — document your components** in the design-system documentation database: [Track B (documentation)](./TRACK_B_DOCUMENTATION.md). Independent of family A.
 
 Expected effort per team: about one week of engineering time and half a week of design time across all four tracks.
 

--- a/docs/how-to-guides/adoption/TRACK_A1_STYLES_TOKENS_ASSETS.md
+++ b/docs/how-to-guides/adoption/TRACK_A1_STYLES_TOKENS_ASSETS.md
@@ -57,6 +57,8 @@ Notes:
 
 Storybook users get all of this for free: [`@canonical/storybook-config`](https://www.npmjs.com/package/@canonical/storybook-config) serves `@canonical/ds-assets` via `staticDirs` and loads `@canonical/styles/fonts` through its bundled addon, so fonts and icons work with no extra `.storybook` configuration.
 
+There is also capacity to host additional Storybooks on the company's Chromatic account — if your team would like its Storybook published alongside pragma's, [open an issue](https://github.com/canonical/pragma/issues) to get set up.
+
 ## Verify
 
 1. **Fonts** — in the browser dev tools, check that body text computes to the `Ubuntu Sans` font family.

--- a/docs/how-to-guides/adoption/TRACK_A1_STYLES_TOKENS_ASSETS.md
+++ b/docs/how-to-guides/adoption/TRACK_A1_STYLES_TOKENS_ASSETS.md
@@ -1,0 +1,77 @@
+# Track A1 — Add the styles, tokens, and assets to your project
+
+Install pragma's stylesheet, fonts, and icon assets so that pragma components can render correctly — without changing how your application looks today.
+
+| | |
+|---|---|
+| **Track** | A1 (family A) |
+| **Difficulty** | Low, but may require iterations |
+| **Estimated time** | ~5 minutes on the happy path; allow a few days if visual regressions need iterating on |
+| **Prerequisites** | React ≥ 19.2.4 app, bundler that resolves package specifiers in CSS (see the [program requirements](./README.md#requirements)) |
+
+## Who this is for
+
+Engineers on a team adopting pragma for 26.10. This is the first track: [A2 (base components)](./TRACK_A2_BASE_COMPONENTS.md) and [A3 (form components)](./TRACK_A3_FORM_COMPONENTS.md) both depend on it, because pragma components resolve their colours, spacing, typography, and icons through what you install here.
+
+## What "done" means
+
+- [ ] `@canonical/styles` and `@canonical/ds-assets` are installed and imported.
+- [ ] Text renders in Ubuntu Sans (unless your app already loads it another way).
+- [ ] `GET /icons/<name>.svg` serves the corresponding icon from `@canonical/ds-assets`.
+- [ ] Your application has **no visual regressions** compared to before this track.
+
+## The path
+
+### 1. Install the packages
+
+```bash
+bun add @canonical/styles @canonical/ds-assets
+# or: npm install @canonical/styles @canonical/ds-assets
+```
+
+`@canonical/styles` is the single stylesheet entry point: a deterministic cascade (`normalize`, `ds.reset`, `ds.modifiers`, `ds.components` layers) that loads the reset, the typography engine, and the design tokens. `@canonical/ds-assets` carries the Ubuntu Sans variable fonts and the icon SVGs.
+
+### 2. Import the styles — fonts first
+
+In your main CSS file, add the fonts import **above** the styles import:
+
+```css
+@import "@canonical/styles/fonts"; /* skip if Ubuntu fonts are already loaded, e.g. by vanilla-framework */
+@import "@canonical/styles";
+```
+
+`@canonical/styles` loads the design tokens and base CSS but **not** the `@font-face` rules — those live in the separate `@canonical/styles/fonts` subpath, and their `url()`s resolve into `@canonical/ds-assets`, which is why that package must be installed.
+
+### 3. Serve the icons at `/icons`
+
+Pragma's `Icon`, `Spinner`, and any icon-bearing component (for example the `Accordion` caret) reference SVGs at runtime by URL — `/icons/<name>.svg#<name>` — rather than bundling them. Your app must serve the `@canonical/ds-assets` `icons/` directory at `/icons`.
+
+How you do that depends on your serving setup: copy or symlink `node_modules/@canonical/ds-assets/icons` into whatever your framework serves as static files, or point a static-file route at it. The contract is simply that `GET /icons/<name>.svg` returns the corresponding file.
+
+Notes:
+
+- If the icons are not served, icon components mount but render **empty** (the SVG `<use>` resolves to nothing) — there is no error.
+- `Icon` and `Spinner` accept a `rootPath` prop (default `/icons`) to serve from a different path per instance, e.g. `<Spinner rootPath="/assets/icons" />`. CSS-referenced icons (like the `Accordion` caret) are fixed at `/icons`.
+
+### 4. Storybook (if you use it)
+
+Storybook users get all of this for free: [`@canonical/storybook-config`](https://www.npmjs.com/package/@canonical/storybook-config) serves `@canonical/ds-assets` via `staticDirs` and loads `@canonical/styles/fonts` through its bundled addon, so fonts and icons work with no extra `.storybook` configuration.
+
+## Verify
+
+1. **Fonts** — in the browser dev tools, check that body text computes to the `Ubuntu Sans` font family.
+2. **Icons** — with your dev server running (adjust the port to yours):
+
+   ```bash
+   curl -sI http://localhost:5173/icons/chevron-down.svg | head -1   # expect HTTP 200
+   ```
+
+3. **No regressions** — run your visual regression suite (or do a manual sweep of your main screens). The styles ship a reset and base rules; if they collide with your existing global CSS, iterate until your app looks the way it did before, and report anything that can't be resolved locally (see below).
+
+## If you get stuck
+
+File an issue at [canonical/pragma/issues](https://github.com/canonical/pragma/issues) with a screenshot and the smallest reproducing CSS. Style collisions with existing global stylesheets are exactly the feedback the design team needs from this track.
+
+## Next
+
+[Track A2 — implement the base components](./TRACK_A2_BASE_COMPONENTS.md).

--- a/docs/how-to-guides/adoption/TRACK_A2_BASE_COMPONENTS.md
+++ b/docs/how-to-guides/adoption/TRACK_A2_BASE_COMPONENTS.md
@@ -22,23 +22,25 @@ Components pragma does **not** yet provide are out of scope: keep your current i
 
 ## The covered set
 
-As of `@canonical/react-ds-global` 0.30.0, the global tier exports these components:
+As of `@canonical/react-ds-global` 0.30.0, the 26.10 program covers:
 
-<!-- adoption:covered-set:begin package=@canonical/react-ds-global -->
+<!-- adoption:covered-set:begin package=@canonical/react-ds-global note=curated -->
 
 | Components | | |
 |---|---|---|
 | Accordion | Announcement | Badge |
 | Breadcrumbs | Button | Card |
-| Chip | ContextualMenu | Icon |
-| InlineCode | KeyboardKey | Popover |
-| Tabs | Tile | Tooltip |
+| ContextualMenu | Icon | InlineCode |
+| KeyboardKey | Tabs | Tile |
+| Tooltip | | |
 
-Plus `Spinner` from the subcomponent tier.
+Plus the `Cards` and `KeyboardKeys` groups (sets of components that operate together, from the group tier) and `Spinner` from the subcomponent tier.
 
 <!-- adoption:covered-set:end -->
 
-The package also exports a work-in-progress tier (components not yet promoted to a stable tier). WIP components are **not** part of the covered set — adopt them only by explicit agreement with the pragma team.
+`Popover` and `Chip` are exported by the package but are **not** part of the 26.10 covered set — keep your existing versions for now.
+
+The package also exports a work-in-progress tier: experimental components not yet promoted to a stable tier. You **can** use them, but expect their APIs, names, and visuals to change without notice — and they must **not** be part of a public release. See *"What's in this folder?"* at the root of the `_work_in_progress` section in Storybook.
 
 ## The path
 

--- a/docs/how-to-guides/adoption/TRACK_A2_BASE_COMPONENTS.md
+++ b/docs/how-to-guides/adoption/TRACK_A2_BASE_COMPONENTS.md
@@ -1,0 +1,98 @@
+# Track A2 — Implement the base components
+
+Replace the components in your application that pragma provides in the global tier (except form components — that's [Track A3](./TRACK_A3_FORM_COMPONENTS.md)) so that, for the covered set, nothing is imported from Vanilla, `@canonical/react-components`, or home-grown equivalents any more.
+
+| | |
+|---|---|
+| **Track** | A2 (family A) |
+| **Difficulty** | Low |
+| **Estimated time** | Depends on how many covered components your app uses; each swap is mechanical |
+| **Prerequisites** | [Track A1](./TRACK_A1_STYLES_TOKENS_ASSETS.md) completed — components resolve tokens and icons through it |
+
+## Who this is for
+
+Engineers on a team adopting pragma for 26.10, after finishing Track A1.
+
+## What "done" means
+
+- [ ] For every component in the covered set below, your application imports the pragma version — no equivalent remains from `@canonical/react-components`, vanilla-framework markup, or your own codebase.
+- [ ] Replaced screens pass your visual review and basic keyboard navigation.
+
+Components pragma does **not** yet provide are out of scope: keep your current implementation and do not block on this track.
+
+## The covered set
+
+As of `@canonical/react-ds-global` 0.30.0, the global tier exports these components:
+
+<!-- adoption:covered-set:begin package=@canonical/react-ds-global -->
+
+| Components | | |
+|---|---|---|
+| Accordion | Announcement | Badge |
+| Breadcrumbs | Button | Card |
+| Chip | ContextualMenu | Icon |
+| InlineCode | KeyboardKey | Popover |
+| Tabs | Tile | Tooltip |
+
+Plus `Spinner` from the subcomponent tier.
+
+<!-- adoption:covered-set:end -->
+
+The package also exports a work-in-progress tier (components not yet promoted to a stable tier). WIP components are **not** part of the covered set — adopt them only by explicit agreement with the pragma team.
+
+## The path
+
+### 1. Install the package
+
+```bash
+bun add @canonical/react-ds-global
+# or: npm install @canonical/react-ds-global
+```
+
+### 2. Inventory what you use
+
+List your imports from the old sources and intersect them with the covered set:
+
+```bash
+grep -rEn "from ['\"]@canonical/react-components['\"]" src/
+```
+
+Also look for home-grown versions of covered components (your own `Button.tsx`, tooltip wrappers, and so on) and vanilla-framework class-based markup.
+
+### 3. Replace one component type at a time
+
+Work through your inventory component by component — one small PR per component type is easier to review and to bisect if something regresses.
+
+```tsx
+import { Accordion, Button } from "@canonical/react-ds-global";
+```
+
+Be mindful that names and boundaries changed relative to Vanilla: some components were renamed, and some Vanilla components are split into several pragma components (for example, `Card` and `Tile` are distinct components in pragma). Check each component's props in its Storybook stories or type definitions before swapping — do not assume prop-for-prop compatibility.
+
+To browse the components, run the package's Storybook from a pragma checkout ([repository quick start](../../../README.md#quick-start)):
+
+```bash
+cd packages/react/ds-global && bun run storybook
+```
+
+### 4. Mind the icons
+
+Icon-bearing components (`Icon`, `Spinner`, the `Accordion` caret) render empty if `/icons` is not served — that is a Track A1 gap, not a component bug. See [Track A1, step 3](./TRACK_A1_STYLES_TOKENS_ASSETS.md#3-serve-the-icons-at-icons).
+
+### 5. Accessibility is part of the contract
+
+Pragma components ship their accessibility behaviour as part of the API — for example, icon-only `Button`s warn unless you pass an explicit `aria-label`. Fix these warnings during the swap rather than suppressing them.
+
+## Verify
+
+1. The inventory grep from step 2 returns no remaining old-source imports for covered components.
+2. Replaced screens render correctly and are keyboard-operable.
+3. Your visual regression suite (or a manual sweep) passes.
+
+## If you get stuck
+
+File an issue at [canonical/pragma/issues](https://github.com/canonical/pragma/issues). If a covered component is missing a capability you need, say so in the issue — capability gaps found during adoption are prioritised.
+
+## Next
+
+[Track A3 — implement the form components](./TRACK_A3_FORM_COMPONENTS.md).

--- a/docs/how-to-guides/adoption/TRACK_A2_BASE_COMPONENTS.md
+++ b/docs/how-to-guides/adoption/TRACK_A2_BASE_COMPONENTS.md
@@ -22,7 +22,7 @@ Components pragma does **not** yet provide are out of scope: keep your current i
 
 ## The covered set
 
-As of `@canonical/react-ds-global` 0.30.0, the 26.10 program covers:
+For the authoritative, always-current set, refer to the components available directly in the live Storybook: [ds-react-global.canonical.com](https://ds-react-global.canonical.com/) (latest Chromatic build). As a snapshot, as of `@canonical/react-ds-global` 0.30.0 the 26.10 program covers:
 
 <!-- adoption:covered-set:begin package=@canonical/react-ds-global note=curated -->
 
@@ -40,7 +40,7 @@ Plus the `Cards` and `KeyboardKeys` groups (sets of components that operate toge
 
 `Popover` and `Chip` are exported by the package but are **not** part of the 26.10 covered set — keep your existing versions for now.
 
-The package also exports a work-in-progress tier: experimental components not yet promoted to a stable tier. You **can** use them, but expect their APIs, names, and visuals to change without notice — and they must **not** be part of a public release. See *"What's in this folder?"* at the root of the `_work_in_progress` section in Storybook.
+The package also exports a work-in-progress tier: experimental components not yet promoted to a stable tier. You **can** use them, but expect their APIs, names, and visuals to change without notice — and they must **not** be part of a public release. See *"What's in this folder?"* at the root of the `_work_in_progress` section in [Storybook](https://ds-react-global.canonical.com/).
 
 ## The path
 
@@ -69,13 +69,7 @@ Work through your inventory component by component — one small PR per componen
 import { Accordion, Button } from "@canonical/react-ds-global";
 ```
 
-Be mindful that names and boundaries changed relative to Vanilla: some components were renamed, and some Vanilla components are split into several pragma components (for example, `Card` and `Tile` are distinct components in pragma). Check each component's props in its Storybook stories or type definitions before swapping — do not assume prop-for-prop compatibility.
-
-To browse the components, run the package's Storybook from a pragma checkout ([repository quick start](../../../README.md#quick-start)):
-
-```bash
-cd packages/react/ds-global && bun run storybook
-```
+Be mindful that names and boundaries changed relative to Vanilla: some components were renamed, and some Vanilla components are split into several pragma components (for example, `Card` and `Tile` are distinct components in pragma). Check each component's props in its stories at [ds-react-global.canonical.com](https://ds-react-global.canonical.com/) before swapping — do not assume prop-for-prop compatibility.
 
 ### 4. Mind the icons
 

--- a/docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md
+++ b/docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md
@@ -29,21 +29,22 @@ Pragma forms are built on **React Hook Form**. The package's public surface is d
 
 ## The covered set
 
-As of `@canonical/react-ds-global-form` 0.30.0, `Field` supports these `inputType`s:
+As of `@canonical/react-ds-global-form` 0.30.0, `Field` supports these stable (non-WIP) `inputType`s:
 
-<!-- adoption:covered-set:begin package=@canonical/react-ds-global-form -->
+<!-- adoption:covered-set:begin package=@canonical/react-ds-global-form note=stable-only -->
 
 | `inputType` values | | | |
 |---|---|---|---|
 | `text` (and other native text-like types) | `password` | `number` | `checkbox` |
-| `switch` | `hidden` | `range` | `rating` |
-| `select` | `combobox` | `choices` | `rich-choices` |
-| `textarea` | `date` | `time` | `datetime` |
-| `file` | `color` | `phone` | `custom` |
+| `switch` | `hidden` | `range` | `select` |
+| `choices` | `rich-choices` | `textarea` | `date` |
+| `time` | `datetime` | `file` | `phone` |
 
 <!-- adoption:covered-set:end -->
 
-`custom` takes a `CustomComponent` prop — the escape hatch for inputs pragma doesn't provide, so one exotic widget never blocks migrating the rest of the form. `RatingInput` is additionally exported standalone (work in progress) for use outside the `Field` pattern.
+`custom` takes a `CustomComponent` prop — the escape hatch for inputs pragma doesn't provide, so one exotic widget never blocks migrating the rest of the form.
+
+Three further `inputType`s — `color`, `combobox`, and `rating` (plus the standalone `RatingInput`) — are **work in progress**. You **can** use them, but they are experimental — APIs, names, and visuals may change without notice — and they must **not** be part of a public release. See *"What's in this folder?"* at the root of the `_work_in_progress` section in Storybook.
 
 ## The path
 
@@ -66,23 +67,30 @@ In your main CSS, below the imports from Track A1:
 
 ### 3. Migrate form by form
 
-Rebuild each form from the patterns:
+Define your fields **as data** and map over them — this is the recommended pattern. It takes full advantage of `Field`'s `inputType` switch: a form becomes a list of field descriptions, and changing an input type is a one-word change in data rather than a component rewrite.
 
 ```tsx
-import { Field, Form } from "@canonical/react-ds-global-form";
+import { Field, Form, type FieldProps } from "@canonical/react-ds-global-form";
 import { Button } from "@canonical/react-ds-global";
 
-function RenameBoard() {
+const fields: FieldProps[] = [
+  { name: "full_name", inputType: "text", label: "Full name" },
+  {
+    name: "email",
+    inputType: "text",
+    label: "Email address",
+    registerProps: { required: "Email is required" },
+  },
+  { name: "newsletter", inputType: "checkbox", label: "Subscribe to the newsletter" },
+];
+
+function SignUp() {
   return (
-    <Form defaultValues={{ board_name: "" }} onSubmit={(data) => save(data)}>
-      <Field
-        name="board_name"
-        inputType="text"
-        registerProps={{
-          required: { value: true, message: "A board name is required" },
-        }}
-      />
-      <Button type="submit">Save</Button>
+    <Form onSubmit={(data) => save(data)} mode="onBlur">
+      {fields.map((props) => (
+        <Field key={props.name} {...props} />
+      ))}
+      <Button type="submit">Sign up</Button>
     </Form>
   );
 }

--- a/docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md
+++ b/docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md
@@ -1,0 +1,115 @@
+# Track A3 — Implement the form components
+
+Replace the forms in your application with pragma's form patterns, so that every form is built from `Form` and `Field` instead of Vanilla or home-grown form components.
+
+| | |
+|---|---|
+| **Track** | A3 (family A) |
+| **Difficulty** | Medium — requires switching to [React Hook Form](https://react-hook-form.com/) |
+| **Estimated time** | Proportional to the number and complexity of your forms; the state-management switch is the bulk of the work |
+| **Prerequisites** | [Track A1](./TRACK_A1_STYLES_TOKENS_ASSETS.md) completed; [Track A2](./TRACK_A2_BASE_COMPONENTS.md) recommended first |
+
+## Who this is for
+
+Engineers on a team adopting pragma for 26.10, after finishing Track A1 (and ideally A2).
+
+## What "done" means
+
+- [ ] Every form in your application is built from pragma's `Form` and `Field` patterns.
+- [ ] No form components remain from `@canonical/react-components`, vanilla-framework markup, or your own codebase.
+- [ ] Migrated forms submit, validate, and report errors as before.
+
+## The model
+
+Pragma forms are built on **React Hook Form**. The package's public surface is deliberately small:
+
+- **`Form`** wraps `react-hook-form`'s `FormProvider`. Give it `defaultValues`, an `onSubmit` callback, and optionally a validation `mode` — or pass your own `useForm` instance via the `methods` prop if you need external control.
+- **`Field`** is the type-safe entry point to every input. It dispatches on `inputType` to the matching field implementation, so one component drives text, select, checkbox, range, date, file, and custom inputs — with per-field validation, required/optional marking, and conditional display. The individual `*Field` components are internal: you consume them through `Field`, not by importing them directly.
+- Validation is expressed through `registerProps` — standard React Hook Form [register options](https://react-hook-form.com/docs/useform/register) (`required`, `minLength`, `pattern`, …).
+
+## The covered set
+
+As of `@canonical/react-ds-global-form` 0.30.0, `Field` supports these `inputType`s:
+
+<!-- adoption:covered-set:begin package=@canonical/react-ds-global-form -->
+
+| `inputType` values | | | |
+|---|---|---|---|
+| `text` (and other native text-like types) | `password` | `number` | `checkbox` |
+| `switch` | `hidden` | `range` | `rating` |
+| `select` | `combobox` | `choices` | `rich-choices` |
+| `textarea` | `date` | `time` | `datetime` |
+| `file` | `color` | `phone` | `custom` |
+
+<!-- adoption:covered-set:end -->
+
+`custom` takes a `CustomComponent` prop — the escape hatch for inputs pragma doesn't provide, so one exotic widget never blocks migrating the rest of the form. `RatingInput` is additionally exported standalone (work in progress) for use outside the `Field` pattern.
+
+## The path
+
+### 1. Install the package
+
+```bash
+bun add @canonical/react-ds-global-form
+# or: npm install @canonical/react-ds-global-form
+```
+
+React Hook Form ships with the package — you don't install it separately.
+
+### 2. Import the form styles
+
+In your main CSS, below the imports from Track A1:
+
+```css
+@import "@canonical/react-ds-global-form/dist/esm/index.css";
+```
+
+### 3. Migrate form by form
+
+Rebuild each form from the patterns:
+
+```tsx
+import { Field, Form } from "@canonical/react-ds-global-form";
+import { Button } from "@canonical/react-ds-global";
+
+function RenameBoard() {
+  return (
+    <Form defaultValues={{ board_name: "" }} onSubmit={(data) => save(data)}>
+      <Field
+        name="board_name"
+        inputType="text"
+        registerProps={{
+          required: { value: true, message: "A board name is required" },
+        }}
+      />
+      <Button type="submit">Save</Button>
+    </Form>
+  );
+}
+```
+
+The state-management switch is where the effort goes: hand-rolled `useState`-per-input wiring and controlled-component plumbing disappear, replaced by `defaultValues` + `Field` registration. Migrate the simplest form first to learn the shape, then batch the rest.
+
+For forms whose state must be driven from outside (multi-step wizards, programmatic resets), create the `useForm` instance yourself and hand it to `Form` via `methods`.
+
+### 4. Browse the fields
+
+To see every field type with its props and states, run the package's Storybook from a pragma checkout ([repository quick start](../../../README.md#quick-start)):
+
+```bash
+cd packages/react/ds-global-form && bun run storybook
+```
+
+## Verify
+
+1. No form-component imports remain from old sources (re-run your Track A2 inventory grep for form components).
+2. Each migrated form submits with the expected payload, validates, and shows error messages.
+3. Keyboard-only interaction works end to end: tab order, error focus, submit.
+
+## If you get stuck
+
+File an issue at [canonical/pragma/issues](https://github.com/canonical/pragma/issues). If a form control you need has no `inputType`, use `inputType="custom"` to keep moving and file the gap — field-type gaps found during adoption are prioritised.
+
+## Next
+
+Family A is complete. Track B (documenting your components in the design-system documentation database) is guided separately — see the [adoption index](./README.md).

--- a/docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md
+++ b/docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md
@@ -116,4 +116,4 @@ File an issue at [canonical/pragma/issues](https://github.com/canonical/pragma/i
 
 ## Next
 
-Family A is complete. Track B (documenting your components in the design-system documentation database) is guided separately — see the [adoption index](./README.md).
+Family A is complete. If your team hasn't done it yet, [Track B — document your components](./TRACK_B_DOCUMENTATION.md) runs independently and completes the program.

--- a/docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md
+++ b/docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md
@@ -44,7 +44,7 @@ As of `@canonical/react-ds-global-form` 0.30.0, `Field` supports these stable (n
 
 `custom` takes a `CustomComponent` prop — the escape hatch for inputs pragma doesn't provide, so one exotic widget never blocks migrating the rest of the form.
 
-Three further `inputType`s — `color`, `combobox`, and `rating` (plus the standalone `RatingInput`) — are **work in progress**. You **can** use them, but they are experimental — APIs, names, and visuals may change without notice — and they must **not** be part of a public release. See *"What's in this folder?"* at the root of the `_work_in_progress` section in Storybook.
+Three further `inputType`s — `color`, `combobox`, and `rating` (plus the standalone `RatingInput`) — are **work in progress**. You **can** use them, but they are experimental — APIs, names, and visuals may change without notice — and they must **not** be part of a public release. See *"What's in this folder?"* at the root of the `_work_in_progress` section in [Storybook](https://ds-react-global-form.canonical.com/).
 
 ## The path
 
@@ -102,11 +102,7 @@ For forms whose state must be driven from outside (multi-step wizards, programma
 
 ### 4. Browse the fields
 
-To see every field type with its props and states, run the package's Storybook from a pragma checkout ([repository quick start](../../../README.md#quick-start)):
-
-```bash
-cd packages/react/ds-global-form && bun run storybook
-```
+Every field type, with its props and states, is available directly in the live Storybook: [ds-react-global-form.canonical.com](https://ds-react-global-form.canonical.com/) (latest Chromatic build).
 
 ## Verify
 

--- a/docs/how-to-guides/adoption/TRACK_B_DOCUMENTATION.md
+++ b/docs/how-to-guides/adoption/TRACK_B_DOCUMENTATION.md
@@ -1,0 +1,74 @@
+# Track B — Document your components
+
+Document every component your team has built in the [Design System Database](https://coda.io/d/Design-System-Database_dNyzE_TLZDh) on Coda, so your work becomes part of pragma's knowledge graph.
+
+| | |
+|---|---|
+| **Track** | B (family B — independent of family A, can run in parallel) |
+| **Difficulty** | Medium |
+| **Estimated time** | Proportional to your component count; this is the design-side half-week of the program estimate |
+| **Prerequisites** | Access to the Design System Database on Coda; an inventory of the components your team has built |
+
+## Why this matters
+
+By doing this you contribute to the knowledge graph of pragma: the database syncs into the design-system graph, where your components become queryable alongside everything else. It also gives the design system team the right visibility to understand your project and your needs — a full view of the components you have developed, your UX practice, and the opportunities to upstream your components and deduplicate work with other teams.
+
+Coda is the **system of record** for this data. Do not hand-edit the synced files in the design-system repository — they are regenerated from Coda and your edits would be overwritten.
+
+## Who this is for
+
+Designers and engineers of adopting teams — whoever knows the component set best. The anatomy step (Figma embeds) is usually designer-led; the inventory is usually engineer-led. Pairing works well.
+
+## What "done" means
+
+- [ ] Your app exists as a tier in the database.
+- [ ] Every component your team has built has an entry in your tier.
+- [ ] Every entry has, at minimum, a **summary** and a **screenshot** — a fuller Coda page per component is even better.
+- [ ] Every entry carries the tag `documentation status: initial_app_documentation`.
+
+## The path
+
+Everything below happens in the [Design System Database](https://coda.io/d/Design-System-Database_dNyzE_TLZDh).
+
+### 1. Make sure your app exists in the list of tiers
+
+Check the **Tier** view for your app. *(screenshot to follow)*
+
+> **If your app is confidential, stop here and get in touch with the design system team instead. Do NOT enter confidential information on Coda.**
+
+### 2. Open "Components by tier"
+
+It is in the left menu.
+
+### 3. Filter by your tier
+
+Use the view's filters to show only your own tier. *(screenshot to follow)*
+
+### 4. Bootstrap your tier — skip this step if your tier is already visible
+
+A tier with no components yet does not show up in the filtered view. To bootstrap it: create a component using the **+** icon, open it in the single view, then select **Tier** and pick your newly created tier. From then on, your tier appears in the filter.
+
+### 5. Document each component
+
+For each component your team has built:
+
+1. **Add an entry in your tier.** *(screenshot to follow)*
+2. **Open it in the single view** — click the expand icon on the left side of the row. *(screenshot to follow)*
+3. **Fill the category** — `subcomponent`, `component`, or `pattern`. If you are wondering which applies, the definitions are in the categories table. <!-- TODO: link the categories table -->
+4. **Fill the summary** — instructions are given in the database. Overall: just a few lines that properly define and disambiguate the component.
+5. **Fill the anatomy** — in *Anatomy classic*, add a Figma embed (preferable) or screenshots. *(screenshot to follow)*
+6. **Tag it done** — add the tag `documentation status: initial_app_documentation`. *(screenshot to follow)*
+
+## Verify
+
+1. The filtered "Components by tier" view lists every component your team has built — cross-check the count against your codebase (for example, your component folders under `src/lib`).
+2. Every entry has a category, a summary, and a Figma embed or screenshot.
+3. Every entry carries the `initial_app_documentation` tag — the tag is how the program tracks Track B progress.
+
+## If you get stuck
+
+Get in touch with the design system team — and always take that route for confidential apps. For everything else, [file an issue](https://github.com/canonical/pragma/issues).
+
+## Next
+
+That completes family B. If family A is still in progress on your team, the [adoption index](./README.md) has the remaining tracks.

--- a/packages/react/ds-global-form/src/lib/_work_in_progress/WhatsInThisFolder.mdx
+++ b/packages/react/ds-global-form/src/lib/_work_in_progress/WhatsInThisFolder.mdx
@@ -1,0 +1,24 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="_work_in_progress/What's in this folder?" />
+
+# What's in this folder?
+
+Everything under `_work_in_progress` is **experimental**: it is being designed
+and built in the open, and has not yet been promoted to a stable tier
+(component, group, pattern, or subcomponent).
+
+Concretely:
+
+- **APIs, names, and visuals may change without notice** — including breaking
+  changes in any release, renames, or removal.
+- **You can use these components** if they solve a problem for you today;
+  feedback from real usage is what gets them promoted.
+- **They must not be part of a public release.** Keep them to internal tools
+  and prototypes, or behind a feature flag, until they graduate.
+
+When a component graduates, it moves out of this folder and its stories move
+to the matching tier section.
+
+Need a work-in-progress component stabilised for your use case, or found a
+problem? [File an issue](https://github.com/canonical/pragma/issues).

--- a/packages/react/ds-global/src/lib/_work_in_progress/WhatsInThisFolder.mdx
+++ b/packages/react/ds-global/src/lib/_work_in_progress/WhatsInThisFolder.mdx
@@ -1,0 +1,24 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="_work_in_progress/What's in this folder?" />
+
+# What's in this folder?
+
+Everything under `_work_in_progress` is **experimental**: it is being designed
+and built in the open, and has not yet been promoted to a stable tier
+(component, group, pattern, or subcomponent).
+
+Concretely:
+
+- **APIs, names, and visuals may change without notice** — including breaking
+  changes in any release, renames, or removal.
+- **You can use these components** if they solve a problem for you today;
+  feedback from real usage is what gets them promoted.
+- **They must not be part of a public release.** Keep them to internal tools
+  and prototypes, or behind a feature flag, until they graduate.
+
+When a component graduates, it moves out of this folder and its stories move
+to the matching tier section.
+
+Need a work-in-progress component stabilised for your use case, or found a
+problem? [File an issue](https://github.com/canonical/pragma/issues).

--- a/packages/svelte/ds-global/src/lib/_work_in_progress/WhatsInThisFolder.mdx
+++ b/packages/svelte/ds-global/src/lib/_work_in_progress/WhatsInThisFolder.mdx
@@ -1,0 +1,24 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="_work_in_progress/What's in this folder?" />
+
+# What's in this folder?
+
+Everything under `_work_in_progress` is **experimental**: it is being designed
+and built in the open, and has not yet been promoted to a stable tier
+(component, group, pattern, or subcomponent).
+
+Concretely:
+
+- **APIs, names, and visuals may change without notice** — including breaking
+  changes in any release, renames, or removal.
+- **You can use these components** if they solve a problem for you today;
+  feedback from real usage is what gets them promoted.
+- **They must not be part of a public release.** Keep them to internal tools
+  and prototypes, or behind a feature flag, until they graduate.
+
+When a component graduates, it moves out of this folder and its stories move
+to the matching tier section.
+
+Need a work-in-progress component stabilised for your use case, or found a
+problem? [File an issue](https://github.com/canonical/pragma/issues).


### PR DESCRIPTION
## Done

- `docs/how-to-guides/adoption/README.md` — program index: the two track families, requirements, suggested tooling table, live-Storybook discovery links, design counterpart, progress-registration pointer.
- `docs/how-to-guides/adoption/TRACK_A1_STYLES_TOKENS_ASSETS.md` — styles, fonts, and icon assets: install, fonts-above-styles import order, the `/icons/<name>.svg#<name>` serving contract, `rootPath` escape hatch, Storybook via `@canonical/storybook-config`, note on Chromatic capacity for hosting additional team Storybooks.
- `docs/how-to-guides/adoption/TRACK_A2_BASE_COMPONENTS.md` — base components: discovery via the live Storybook (ds-react-global.canonical.com), curated covered set (13 component-tier components + the `Cards` and `KeyboardKeys` groups + `Spinner`; `Popover` and `Chip` explicitly out of the 26.10 set), inventory→swap workflow, naming/split caveats (`Card` vs `Tile`), icons and a11y notes.
- `docs/how-to-guides/adoption/TRACK_A3_FORM_COMPONENTS.md` — form components: the `Form`/`Field` pattern model on React Hook Form, **fields-as-data + `fields.map(...)` as the recommended migration pattern** (mirrors the Form stories fixture), the stable-only `inputType` covered set (`color`/`combobox`/`rating` + standalone `RatingInput` called out as WIP), form styles import, external-`methods` note, discovery via ds-react-global-form.canonical.com.
- `docs/how-to-guides/adoption/TRACK_B_DOCUMENTATION.md` — document your components in the Design System Database on Coda (system of record; already publicly referenced in design-system's issue template): tier check with a prominent confidentiality warning, Components-by-tier filtering, empty-tier bootstrap, and the per-component loop (category, summary, Anatomy classic via Figma embed or screenshot, `documentation status: initial_app_documentation` tag). Screenshot placeholders marked where the program will insert them.
- `WhatsInThisFolder.mdx` — an identical *"What's in this folder?"* docs page at the root of the `_work_in_progress` section in every Storybook that has the tier (`react/ds-global`, `react/ds-global-form`, `svelte/ds-global`): WIP components are usable but experimental, and must not be part of a public release.

All five guides share one fixed structure (who this is for / what "done" means / the path / verify / if you get stuck / next). Every command, package name, import path, and API shape was verified against the published 0.30.0 packages — including a clean-room `npm install` of the getting-started set outside the monorepo — and the covered-set tables match the package barrels and Storybook WIP story titles. Covered-set tables carry `adoption:covered-set` marker comments so they can later be generated instead of hand-written.

Deviations from the program spec draft, on purpose: the CLI is `@canonical/pragma-cli` (not `@canonical/pragma`) and Linux x64 only; the effective React floor is `^19.2.4` while `react` remains in `dependencies`; the token LSP has a CLI-free `bunx @canonical/terrazzo-lsp-extension` path that works on any OS.

## QA

- Markdown/MDX only; no runtime code changes. The three MDX files add a docs page to each package's Storybook sidebar (picked up by the shared `../src/**/*.mdx` stories glob) — no story snapshots affected.
- Internal relative links and anchors resolve; Coda links are already excluded in `lychee.toml` (auth-walled). The two `*.canonical.com` Storybook domains could not be reached from the sandbox used to author this PR — if the weekly external lychee run flags them as gated, add an exclude.
- Code blocks re-verified against source: `@canonical/styles` exports `.`/`./fonts`; `Icon.tsx` `rootPath = "/icons"` and `<use href>` scheme; ds-global component/group/subcomponent barrels; `FieldProps` `inputType` union and WIP story titles; `FormProps` (`onSubmit`/`mode`/`methods`); the `fields.map` example mirrors `Form.stories.tsx` (`FieldProps[]` + `key={props.name}`) and the `label`/`registerProps` usage in the SignUp story.

### PR readiness check

- [x] PR should have one of the following labels: `Documentation 📝`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`: N/A — docs/MDX only, no package.json changes.
- [x] No new package introduced.
- [x] `no visual change` label added to skip Chromatic (docs only).

## Screenshots

N/A — documentation only. (Track B contains marked placeholders for the program's Coda screenshots.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYsedAqG1BijZpbvV9c8Aq