### PR TITLE
feat(router-core): history-delegate option for the memory adapter

### DIFF
--- a/packages/runtime/router/README.md
+++ b/packages/runtime/router/README.md
@@ -316,6 +316,24 @@ const testRouter = createRouter(routes, {
 });
 ```
 
+### Externally owned location
+
+By default `createMemoryAdapter()` owns its location: it keeps an internal entries array and index that `navigate`, `back`, and `forward` mutate. Some hosts already own navigation state and need the router as a pure resolver rather than a second state owner — an application store that decides what is shown, a replay harness driving location from a recorded sequence, a state machine where "where we are" is derived state. For those, pass a `history` delegate and the adapter keeps no entries array and no index of its own:
+
+```ts
+const adapter = createMemoryAdapter("/", {
+  history: {
+    getLocation: () => store.currentUrl, // the single source of the current location
+    onNavigate: (url, options) => store.go(url, options), // every navigate forwards here
+    subscribe: (listener) => store.subscribe(listener), // host announces location changes
+    onBack: () => store.back(), // optional — omit and back() becomes a no-op
+    onForward: () => store.forward(), // optional — omit and forward() becomes a no-op
+  },
+});
+```
+
+With a delegate, `getLocation` reads the delegate, `navigate(to, options)` forwards to `onNavigate` and mutates nothing locally, and the adapter's `subscribe` is the seam through which the host announces changes. `back` and `forward` forward to the optional `onBack`/`onForward` hooks; when the host omits them they are no-ops, because a host that owns location owns its own history model. The `initialUrl` argument is ignored when a delegate is present. The entire route-resolution surface — matching, params, group wrappers — is unchanged.
+
 ## Accessibility
 
 The router auto-wires browser-side accessibility orchestration:

--- a/packages/runtime/router/README.md
+++ b/packages/runtime/router/README.md
@@ -334,6 +334,12 @@ const adapter = createMemoryAdapter("/", {
 
 With a delegate, `getLocation` reads the delegate, `navigate(to, options)` forwards to `onNavigate` and mutates nothing locally, and the adapter's `subscribe` is the seam through which the host announces changes. `back` and `forward` forward to the optional `onBack`/`onForward` hooks; when the host omits them they are no-ops, because a host that owns location owns its own history model. The `initialUrl` argument is ignored when a delegate is present. The entire route-resolution surface — matching, params, group wrappers — is unchanged.
 
+Host values are normalized at the boundary: `getLocation` reads and subscription notifications both hand consumers a fresh `URL`, so a host mutating its own URL object cannot reach router internals, and a delegate may return bare path strings. An error thrown by `onNavigate` propagates to the `navigate` caller.
+
+**The host must notify synchronously.** When the router navigates, it suppresses the echo of its own navigation through a guard that only holds for a notification fired synchronously within `onNavigate`. A host that batches change notifications (microtask, animation frame, or later) will miss the guard and every router-initiated navigation will resolve twice. If your store batches, notify the adapter's listener directly and synchronously inside `onNavigate`.
+
+`createMemoryRouter(routes, initialUrl, { history })` forwards the delegate to its internal adapter, so the convenience factory supports externally owned location too.
+
 ## Accessibility
 
 The router auto-wires browser-side accessibility orchestration:

--- a/packages/runtime/router/src/lib/createMemoryAdapter.test.ts
+++ b/packages/runtime/router/src/lib/createMemoryAdapter.test.ts
@@ -193,4 +193,89 @@ describe("createMemoryAdapter with a history delegate", () => {
     }).not.toThrow();
     expect(adapter.getLocation().pathname).toBe("/only");
   });
+
+  it("notifies subscribers with a fresh URL a host-side mutation cannot reach", () => {
+    const listeners = new Set<(location: string | URL) => void>();
+    const hostUrl = new URL("https://example.com/original");
+    const adapter = createMemoryAdapter("/", {
+      history: {
+        getLocation: () => hostUrl,
+        onNavigate: () => {},
+        subscribe: (listener) => {
+          listeners.add(listener);
+
+          return () => {
+            listeners.delete(listener);
+          };
+        },
+      },
+    });
+    const listener = vi.fn<(location: string | URL) => void>();
+
+    adapter.subscribe(listener);
+
+    for (const notify of listeners) {
+      notify(hostUrl);
+    }
+
+    hostUrl.pathname = "/mutated-by-host";
+
+    const received = listener.mock.calls[0]?.[0] as URL;
+
+    expect(received).not.toBe(hostUrl);
+    expect(received.pathname).toBe("/original");
+    // getLocation gives the same fresh-value guarantee.
+    expect(adapter.getLocation()).not.toBe(hostUrl);
+  });
+
+  it("resolves a bare-string location from the delegate against the local base", () => {
+    const listeners = new Set<(location: string | URL) => void>();
+    const adapter = createMemoryAdapter("/", {
+      history: {
+        getLocation: () => "/reports?range=30d",
+        onNavigate: () => {},
+        subscribe: (listener) => {
+          listeners.add(listener);
+
+          return () => {
+            listeners.delete(listener);
+          };
+        },
+      },
+    });
+    const listener = vi.fn<(location: string | URL) => void>();
+
+    adapter.subscribe(listener);
+
+    const location = adapter.getLocation();
+
+    expect(location).toBeInstanceOf(URL);
+    expect(location.pathname).toBe("/reports");
+    expect(location.search).toBe("?range=30d");
+
+    for (const notify of listeners) {
+      notify("/exports");
+    }
+
+    expect(listener.mock.calls[0]?.[0]).toBeInstanceOf(URL);
+    expect(listener.mock.calls[0]?.[0]).toMatchObject({ pathname: "/exports" });
+  });
+
+  it("propagates an error thrown by onNavigate to the navigate caller", () => {
+    const host = createHostStore("/stable");
+    const adapter = createMemoryAdapter("/", {
+      history: {
+        getLocation: () => host.read(),
+        onNavigate: () => {
+          throw new Error("host rejected the navigation");
+        },
+        subscribe: host.subscribe,
+      },
+    });
+
+    expect(() => {
+      adapter.navigate("/anywhere");
+    }).toThrowError("host rejected the navigation");
+    expect(adapter.getLocation().pathname).toBe("/stable");
+  });
 });

--- a/packages/runtime/router/src/lib/createMemoryAdapter.test.ts
+++ b/packages/runtime/router/src/lib/createMemoryAdapter.test.ts
@@ -1,5 +1,32 @@
 import { describe, expect, it, vi } from "vitest";
 import createMemoryAdapter from "./createMemoryAdapter.js";
+import type { MemoryHistoryDelegate } from "./types.js";
+
+/** A minimal host that owns location state behind a delegate. */
+function createHostStore(initialUrl: string) {
+  const listeners = new Set<(location: string | URL) => void>();
+  let current = new URL(initialUrl, "http://localhost");
+
+  return {
+    set(url: string): void {
+      current = new URL(url, "http://localhost");
+
+      for (const listener of listeners) {
+        listener(new URL(current.href));
+      }
+    },
+    read(): URL {
+      return current;
+    },
+    subscribe(listener: (location: string | URL) => void): () => void {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
 
 describe("createMemoryAdapter", () => {
   it("tracks push and replace navigations in memory", () => {
@@ -62,5 +89,108 @@ describe("createMemoryAdapter", () => {
 
     expect(adapter.getLocation().pathname).toBe("/second");
     expect(adapter.getLocation().search).toBe("?tab=1");
+  });
+});
+
+describe("createMemoryAdapter with a history delegate", () => {
+  it("reads the current location through the delegate, not a local copy", () => {
+    const host = createHostStore("/dashboard");
+    const adapter = createMemoryAdapter("/ignored-initial-url", {
+      history: {
+        getLocation: () => host.read(),
+        onNavigate: () => {},
+        subscribe: host.subscribe,
+      },
+    });
+
+    expect(adapter.getLocation().pathname).toBe("/dashboard");
+
+    host.set("/settings");
+
+    expect(adapter.getLocation().pathname).toBe("/settings");
+  });
+
+  it("forwards navigate to onNavigate with options intact and mutates nothing locally", () => {
+    const host = createHostStore("/home");
+    const onNavigate = vi.fn<MemoryHistoryDelegate["onNavigate"]>();
+    const adapter = createMemoryAdapter("/", {
+      history: {
+        getLocation: () => host.read(),
+        onNavigate,
+        subscribe: host.subscribe,
+      },
+    });
+
+    adapter.navigate("/profile", { replace: true, state: { from: "menu" } });
+
+    expect(onNavigate).toHaveBeenCalledExactlyOnceWith("/profile", {
+      replace: true,
+      state: { from: "menu" },
+    });
+    // The adapter kept no entry of its own: location still reads what the host
+    // holds, because a delegated adapter owns no entries array or index.
+    expect(adapter.getLocation().pathname).toBe("/home");
+  });
+
+  it("propagates host-driven location changes through the adapter's own subscribe surface", () => {
+    const host = createHostStore("/start");
+    const adapter = createMemoryAdapter("/", {
+      history: {
+        getLocation: () => host.read(),
+        onNavigate: () => {},
+        subscribe: host.subscribe,
+      },
+    });
+    const listener = vi.fn<(location: string | URL) => void>();
+    const unsubscribe = adapter.subscribe(listener);
+
+    host.set("/next");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0]).toMatchObject({ pathname: "/next" });
+
+    unsubscribe();
+    host.set("/after-unsubscribe");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(adapter.getLocation().pathname).toBe("/after-unsubscribe");
+  });
+
+  it("forwards back and forward to the optional delegate hooks", () => {
+    const host = createHostStore("/a");
+    const onBack = vi.fn<() => void>();
+    const onForward = vi.fn<() => void>();
+    const adapter = createMemoryAdapter("/", {
+      history: {
+        getLocation: () => host.read(),
+        onNavigate: () => {},
+        subscribe: host.subscribe,
+        onBack,
+        onForward,
+      },
+    });
+
+    adapter.back();
+    adapter.forward();
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(onForward).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats back and forward as no-ops when the delegate omits the history hooks", () => {
+    const host = createHostStore("/only");
+    const adapter = createMemoryAdapter("/", {
+      history: {
+        getLocation: () => host.read(),
+        onNavigate: () => {},
+        subscribe: host.subscribe,
+      },
+    });
+
+    expect(() => {
+      adapter.back();
+      adapter.forward();
+    }).not.toThrow();
+    expect(adapter.getLocation().pathname).toBe("/only");
   });
 });

--- a/packages/runtime/router/src/lib/createMemoryAdapter.ts
+++ b/packages/runtime/router/src/lib/createMemoryAdapter.ts
@@ -27,6 +27,15 @@ function resolveUrl(input: string | URL, base: string | URL): URL {
  * `onBack`/`onForward` hooks when the host provides them; when it does not they
  * are no-ops, because a host that owns location owns its own history model and
  * the adapter has no stack of its own to walk.
+ *
+ * Host values are normalized at the boundary: `getLocation` reads and
+ * subscription notifications both hand consumers a fresh `URL` resolved
+ * against the router-local base, matching the fresh-value guarantee of the
+ * default path, so a host mutating its own URL object afterwards cannot reach
+ * consumers through the adapter.
+ *
+ * An error thrown by `onNavigate` propagates to the `navigate` caller; the
+ * adapter neither catches nor retries.
  */
 function createDelegatedMemoryAdapter(
   delegate: MemoryHistoryDelegate,
@@ -39,13 +48,15 @@ function createDelegatedMemoryAdapter(
       delegate.onForward?.();
     },
     getLocation() {
-      return delegate.getLocation();
+      return resolveUrl(delegate.getLocation(), ROUTER_LOCAL_BASE);
     },
     navigate(url, navigationOptions) {
       delegate.onNavigate(url, navigationOptions);
     },
     subscribe(callback) {
-      return delegate.subscribe(callback);
+      return delegate.subscribe((location) => {
+        callback(resolveUrl(location, ROUTER_LOCAL_BASE));
+      });
     },
   };
 }

--- a/packages/runtime/router/src/lib/createMemoryAdapter.ts
+++ b/packages/runtime/router/src/lib/createMemoryAdapter.ts
@@ -1,5 +1,10 @@
 import { ROUTER_LOCAL_BASE } from "./constants.js";
-import type { MemoryAdapter, PlatformNavigateOptions } from "./types.js";
+import type {
+  MemoryAdapter,
+  MemoryAdapterOptions,
+  MemoryHistoryDelegate,
+  PlatformNavigateOptions,
+} from "./types.js";
 
 function resolveUrl(input: string | URL, base: string | URL): URL {
   if (input instanceof URL) {
@@ -13,10 +18,54 @@ function resolveUrl(input: string | URL, base: string | URL): URL {
   return new URL(input, base);
 }
 
-/** Create an in-memory history adapter for tests and non-browser runtimes. */
+/**
+ * Create a memory adapter whose location is owned by a host through a delegate.
+ *
+ * The adapter keeps no entries array and no index: `getLocation` reads the
+ * delegate, `navigate` forwards to the delegate, and change notification is the
+ * delegate's own subscription surface. Back and forward forward to the optional
+ * `onBack`/`onForward` hooks when the host provides them; when it does not they
+ * are no-ops, because a host that owns location owns its own history model and
+ * the adapter has no stack of its own to walk.
+ */
+function createDelegatedMemoryAdapter(
+  delegate: MemoryHistoryDelegate,
+): MemoryAdapter {
+  return {
+    back() {
+      delegate.onBack?.();
+    },
+    forward() {
+      delegate.onForward?.();
+    },
+    getLocation() {
+      return delegate.getLocation();
+    },
+    navigate(url, navigationOptions) {
+      delegate.onNavigate(url, navigationOptions);
+    },
+    subscribe(callback) {
+      return delegate.subscribe(callback);
+    },
+  };
+}
+
+/**
+ * Create an in-memory history adapter for tests and non-browser runtimes.
+ *
+ * By default the adapter owns its location state: it keeps an internal entries
+ * array and index that `navigate`, `back`, and `forward` mutate. Pass
+ * `options.history` to delegate location ownership to a host instead, turning
+ * the adapter into a pure resolver over a location the host supplies.
+ */
 export default function createMemoryAdapter(
   initialUrl: string | URL = "/",
+  options?: MemoryAdapterOptions,
 ): MemoryAdapter {
+  if (options?.history) {
+    return createDelegatedMemoryAdapter(options.history);
+  }
+
   const subscribers = new Set<(location: string | URL) => void>();
   const entries = [resolveUrl(initialUrl, ROUTER_LOCAL_BASE)];
   let index = 0;

--- a/packages/runtime/router/src/lib/createMemoryRouter.test.ts
+++ b/packages/runtime/router/src/lib/createMemoryRouter.test.ts
@@ -43,4 +43,48 @@ describe("createMemoryRouter", () => {
       expect(router.getState().location.pathname).toBe("/about");
     });
   });
+
+  it("forwards the history delegate to the memory adapter", async () => {
+    const listeners = new Set<(location: string | URL) => void>();
+    let current = "/about";
+    const onNavigate = vi.fn((url: string) => {
+      current = url;
+
+      for (const listener of listeners) {
+        listener(current);
+      }
+    });
+    const router = createMemoryRouter(
+      {
+        home: route({ url: "/", content: () => "home" }),
+        about: route({ url: "/about", content: () => "about" }),
+      },
+      "/ignored-when-delegated",
+      {
+        history: {
+          getLocation: () => current,
+          onNavigate,
+          subscribe: (listener) => {
+            listeners.add(listener);
+
+            return () => {
+              listeners.delete(listener);
+            };
+          },
+        },
+      },
+    );
+
+    // The initial load reads the delegate, not the initialUrl argument.
+    await vi.waitFor(() => {
+      expect(router.getState().location.pathname).toBe("/about");
+    });
+
+    router.navigate("home");
+
+    await vi.waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+      expect(router.getState().location.pathname).toBe("/");
+    });
+  });
 });

--- a/packages/runtime/router/src/lib/createMemoryRouter.ts
+++ b/packages/runtime/router/src/lib/createMemoryRouter.ts
@@ -1,11 +1,20 @@
 import createMemoryAdapter from "./createMemoryAdapter.js";
 import createRouter from "./createRouter.js";
-import type { AnyRoute, RouteMap, Router, RouterOptions } from "./types.js";
+import type {
+  AnyRoute,
+  MemoryAdapterOptions,
+  RouteMap,
+  Router,
+  RouterOptions,
+} from "./types.js";
 
 /**
  * Create an in-memory router for testing.
  *
  * Equivalent to `createRouter(routes, { adapter: createMemoryAdapter(initialUrl), ...options })`.
+ *
+ * Pass `options.history` to delegate location ownership to a host instead of
+ * the adapter's internal stack; see `createMemoryAdapter`.
  */
 export default function createMemoryRouter<
   const TRoutes extends RouteMap,
@@ -13,10 +22,12 @@ export default function createMemoryRouter<
 >(
   routes: TRoutes,
   initialUrl: string | URL = "/",
-  options?: Omit<RouterOptions<TNotFound>, "adapter">,
+  options?: Omit<RouterOptions<TNotFound>, "adapter"> & MemoryAdapterOptions,
 ): Router<TRoutes, TNotFound> {
+  const { history, ...routerOptions } = options ?? {};
+
   return createRouter(routes, {
-    ...options,
-    adapter: createMemoryAdapter(initialUrl),
+    ...routerOptions,
+    adapter: createMemoryAdapter(initialUrl, history ? { history } : undefined),
   });
 }

--- a/packages/runtime/router/src/lib/types.ts
+++ b/packages/runtime/router/src/lib/types.ts
@@ -643,6 +643,28 @@ export interface MemoryAdapter extends PlatformAdapter {
   forward(): void;
 }
 
+/**
+ * A host-supplied source of location state for the memory adapter.
+ *
+ * When a delegate is provided, the adapter owns no location state of its own:
+ * `getLocation` reads the delegate, `onNavigate` receives every navigation, and
+ * `subscribe` is the seam through which the host announces location changes.
+ * `onBack` and `onForward` are optional history hooks---omit them and the
+ * adapter's `back`/`forward` become no-ops, because a host that owns location
+ * owns its own history model.
+ */
+export interface MemoryHistoryDelegate {
+  getLocation(): string | URL;
+  onNavigate(url: string, options?: PlatformNavigateOptions): void;
+  subscribe(listener: (location: string | URL) => void): () => void;
+  onBack?(): void;
+  onForward?(): void;
+}
+
+export interface MemoryAdapterOptions {
+  readonly history?: MemoryHistoryDelegate;
+}
+
 export interface RouterDehydratedState<TRoutes extends RouteMap = RouteMap> {
   readonly href: string;
   readonly kind: "route" | "not-found" | "unmatched";

--- a/packages/runtime/router/src/lib/types.ts
+++ b/packages/runtime/router/src/lib/types.ts
@@ -654,8 +654,24 @@ export interface MemoryAdapter extends PlatformAdapter {
  * owns its own history model.
  */
 export interface MemoryHistoryDelegate {
+  /** The single source of the current location. */
   getLocation(): string | URL;
+  /**
+   * Receives every navigation the adapter is asked to perform.
+   *
+   * The host must apply the navigation and notify `subscribe` listeners
+   * synchronously, before `onNavigate` returns. The router core suppresses the
+   * echo of its own navigations through a single-slot guard that only holds
+   * for a synchronous notification; a host that batches notifications
+   * (microtask or later) will cause router-initiated navigations to resolve
+   * twice. An error thrown here propagates to the `navigate` caller.
+   */
   onNavigate(url: string, options?: PlatformNavigateOptions): void;
+  /**
+   * The seam through which the host announces location changes. Must fire
+   * synchronously within `onNavigate` for navigations the adapter forwarded;
+   * see `onNavigate` for why.
+   */
   subscribe(listener: (location: string | URL) => void): () => void;
   onBack?(): void;
   onForward?(): void;


### PR DESCRIPTION
## Motivation

Hosts that already own navigation state need the router as a pure resolver, not a second state owner:

- embedded multi-view containers where an application-level store decides what is shown;
- replay and test harnesses that drive location deterministically from a recorded sequence;
- state-machine-driven UIs where "where we are" is derived state.

Today such a host must fight the memory adapter's internal entries array — two copies of one truth, kept in sync by hand. This change lets the adapter's location be externally owned while keeping the entire route-resolution surface (matching, params, group wrappers) intact.

## Design

`createMemoryAdapter(initialUrl?, options?)` gains an optional `options.history` delegate. The first positional argument is unchanged; the delegate is a second, optional argument, so every existing call site is untouched.

```ts
export interface MemoryHistoryDelegate {
  getLocation(): string | URL;
  onNavigate(url: string, options?: PlatformNavigateOptions): void;
  subscribe(listener: (location: string | URL) => void): () => void;
  onBack?(): void;
  onForward?(): void;
}

export interface MemoryAdapterOptions {
  readonly history?: MemoryHistoryDelegate;
}
```

**Ownership semantics.** With a delegate the adapter keeps **no entries array and no index**:

- `getLocation()` reads the delegate — the single source of the current location;
- `navigate(to, options)` forwards to `onNavigate(to, options)` with options intact and mutates nothing locally;
- the adapter's own `subscribe` surface delegates to the host's `subscribe`, so a host-driven location change propagates through the adapter's existing change-subscription mechanism — the same seam the History and Navigation adapters already use;
- the `initialUrl` argument is ignored when a delegate is present, because the host owns the location.

**Boundary normalization.** Host values are normalized at the delegated boundary: `getLocation` reads and subscription notifications both hand consumers a fresh `URL` resolved against the router-local base, matching the fresh-value guarantee of the default path. A host-mutated URL object cannot leak through the adapter, and a delegate may return bare path strings.

**Synchrony contract (documented).** The router core suppresses the echo of its own navigations through a single-slot guard that only holds for a notification fired synchronously within `onNavigate`. A host that batches change notifications (microtask or later) would cause router-initiated navigations to resolve twice. This constraint is stated explicitly in the `MemoryHistoryDelegate` TSDoc and the README rather than papered over adapter-side: synthesizing a synchronous notification for a location the host has not committed yet would fabricate state the adapter does not own, and the router core is deliberately out of scope here.

**Error contract.** An error thrown by `onNavigate` propagates to the `navigate` caller; the adapter neither catches nor retries. Pinned by a test and stated in the TSDoc.

**Back/forward ruling.** `back` and `forward` forward to the optional `onBack`/`onForward` delegate hooks. When the host omits them they are **documented no-ops** — a host that owns location owns its own history model, and a delegated adapter has no internal stack to walk, so there is nothing to fabricate. The constraint is documented where it lives, in `createDelegatedMemoryAdapter`.

**Convenience factory.** `createMemoryRouter(routes, initialUrl, { history })` forwards the delegate to its internal adapter (`options` widened additively with `MemoryAdapterOptions`; the `history` key is stripped before the rest is passed to `createRouter`).

**Strictly additive.** Without `options.history`, behaviour is byte-for-byte unchanged. The default path still owns its entries array and index exactly as before.

## Done

- `MemoryHistoryDelegate` + `MemoryAdapterOptions` types, exported through the existing barrel.
- Delegated branch in `createMemoryAdapter` with no local location state.
- Boundary normalization to fresh `URL`s on both read and notify paths.
- Synchrony requirement documented in TSDoc and README.
- `onNavigate` throw-propagation contract pinned in TSDoc and test.
- `createMemoryRouter` forwards the `history` option.
- README section "Externally owned location" covering usage, normalization, synchrony, and the factory.

## Test evidence / QA

Delegate-path suite in `createMemoryAdapter.test.ts` (8 tests):

- location always reads through `getLocation`, including a host-driven change with no `navigate` call — proving the adapter holds no local copy;
- `navigate` forwards to `onNavigate` with options intact, and `getLocation` still reflects the host afterward (structural absence of a local entry);
- host-driven changes propagate through the adapter's own `subscribe`, and stop after `unsubscribe`;
- `back`/`forward` forward to `onBack`/`onForward` when present, and are no-ops when omitted;
- subscribers receive a fresh `URL` a host-side mutation cannot reach (and `getLocation` returns a distinct object);
- a bare-string delegate location resolves against the local base on both read and notify paths;
- an `onNavigate` throw propagates to the `navigate` caller.

Plus `createMemoryRouter.test.ts`: the factory forwards the delegate — initial load reads the delegate (not `initialUrl`), and `router.navigate` reaches `onNavigate`, with the host notifying synchronously so the echo guard is exercised end-to-end.

The three existing default-path adapter tests and the three existing factory tests are untouched.

```
Test Files  27 passed (27)
     Tests  186 passed (186)

check:biome  ✓   check:ts  ✓   check:webarchitect  ✓ (biome, package-structure, package-license)
```
