### PR TITLE
feat(cli)!: setup --scope band model + doctor local/global grouping

### DIFF
--- a/packages/cli/next/src/capabilities/doctor/checks/checkMcpCommands.ts
+++ b/packages/cli/next/src/capabilities/doctor/checks/checkMcpCommands.ts
@@ -4,6 +4,7 @@ import type { DetectedHarness } from "@canonical/harnesses";
 import { detectHarnesses, readMcpConfig } from "@canonical/harnesses";
 import { runTask } from "@canonical/task/node";
 import type { CheckItem, CheckResult } from "../types.js";
+import { deriveBand } from "./deriveBand.js";
 
 const NAME = "MCP commands";
 
@@ -56,6 +57,9 @@ export async function checkMcpCommands(cwd: string): Promise<CheckResult> {
     return { name: NAME, status: "skip", detail: "no MCP configs found" };
   }
 
+  // Band the finding by the harnesses whose configs were actually examined, so
+  // a global-scope harness's broken command is reported under the global band.
+  const band = deriveBand(withConfig);
   const broken: CheckItem[] = [];
   let checked = 0;
 
@@ -94,6 +98,7 @@ export async function checkMcpCommands(cwd: string): Promise<CheckResult> {
       name: NAME,
       status: "pass",
       detail: `${checked} command${checked === 1 ? "" : "s"} resolve on PATH`,
+      band,
     };
   }
 
@@ -104,5 +109,6 @@ export async function checkMcpCommands(cwd: string): Promise<CheckResult> {
     items: broken,
     remedy:
       "Install the missing command or remove the entry — every agent session tries and fails to boot it.",
+    band,
   };
 }

--- a/packages/cli/next/src/capabilities/doctor/checks/checkMcpConfigured.ts
+++ b/packages/cli/next/src/capabilities/doctor/checks/checkMcpConfigured.ts
@@ -2,9 +2,13 @@ import type { DetectedHarness } from "@canonical/harnesses";
 import { detectHarnesses, readMcpConfig } from "@canonical/harnesses";
 import { runTask } from "@canonical/task/node";
 import type { CheckResult } from "../types.js";
+import { deriveBand } from "./deriveBand.js";
 
 /**
- * Check that at least one AI harness has pragma configured as an MCP server.
+ * Check that at least one AI harness has pragma configured as an MCP server. The
+ * result's band is derived from the harnesses actually found (Windsurf ⇒ global,
+ * Cursor ⇒ project), not the check name — so a global-scope harness is not
+ * mislabeled PROJECT.
  *
  * @param cwd - The project root to detect harnesses against.
  * @returns A CheckResult listing configured harnesses, or fail with a remedy.
@@ -32,12 +36,12 @@ export async function checkMcpConfigured(cwd: string): Promise<CheckResult> {
     };
   }
 
-  const configured: string[] = [];
+  const configured: DetectedHarness[] = [];
   for (const d of detected) {
     if (!d.configExists) continue;
     try {
       const servers = await runTask(readMcpConfig(d.harness, cwd));
-      if ("pragma" in servers) configured.push(d.harness.name);
+      if ("pragma" in servers) configured.push(d);
     } catch {
       // Config unreadable — skip.
     }
@@ -47,7 +51,8 @@ export async function checkMcpConfigured(cwd: string): Promise<CheckResult> {
     return {
       name: "MCP configured",
       status: "pass",
-      detail: configured.join(", "),
+      detail: configured.map((d) => d.harness.name).join(", "),
+      band: deriveBand(configured),
     };
   }
 
@@ -57,5 +62,6 @@ export async function checkMcpConfigured(cwd: string): Promise<CheckResult> {
     status: "fail",
     detail: `detected ${names} but pragma not configured`,
     remedy: "pragma setup mcp",
+    band: deriveBand(detected),
   };
 }

--- a/packages/cli/next/src/capabilities/doctor/checks/deriveBand.test.ts
+++ b/packages/cli/next/src/capabilities/doctor/checks/deriveBand.test.ts
@@ -1,0 +1,42 @@
+/**
+ * `deriveBand` — band a doctor check by the harnesses it actually found.
+ *
+ * Fixtures wrap REAL harness definitions (via `findHarnessById`, no casts), so
+ * the scope→band mapping is exercised against the true `scope` fields: the
+ * regression this guards is a global-scope harness (Windsurf) being mislabeled
+ * PROJECT by a static per-name guess.
+ */
+
+import type { DetectedHarness } from "@canonical/harnesses";
+import { findHarnessById } from "@canonical/harnesses";
+import { describe, expect, it } from "vitest";
+import { deriveBand } from "./deriveBand.js";
+
+/** A minimal {@link DetectedHarness} over a real definition (no `as` casts). */
+function detect(id: string): DetectedHarness {
+  const harness = findHarnessById(id);
+  if (!harness) throw new Error(`unknown harness fixture: ${id}`);
+  return { harness, confidence: "high", configExists: true, configPath: "x" };
+}
+
+describe("deriveBand", () => {
+  it("bands a project-scope harness (Cursor) as project", () => {
+    expect(deriveBand([detect("cursor")])).toBe("project");
+  });
+
+  it("bands a global-scope harness (Windsurf) as global — the fixed mislabel", () => {
+    expect(deriveBand([detect("windsurf")])).toBe("global");
+  });
+
+  it("bands a dual-scope harness (Claude Code) by its default band (project)", () => {
+    expect(deriveBand([detect("claude-code")])).toBe("project");
+  });
+
+  it("leaves a set spanning BOTH bands unbanded (general, not mislabeled)", () => {
+    expect(deriveBand([detect("cursor"), detect("windsurf")])).toBeUndefined();
+  });
+
+  it("leaves an empty set unbanded", () => {
+    expect(deriveBand([])).toBeUndefined();
+  });
+});

--- a/packages/cli/next/src/capabilities/doctor/checks/deriveBand.ts
+++ b/packages/cli/next/src/capabilities/doctor/checks/deriveBand.ts
@@ -1,0 +1,28 @@
+/**
+ * Derive a doctor check's config band from the harnesses it actually found,
+ * rather than a static per-check-name guess. The aggregate MCP checks read each
+ * harness's DEFAULT-band file (`defaultBandOf` — the home config for a
+ * global-only harness like Windsurf, the project file otherwise), so the band a
+ * finding belongs to is exactly that default band.
+ */
+
+import type { DetectedHarness } from "@canonical/harnesses";
+import { defaultBandOf } from "@canonical/harnesses";
+import type { ScopeBand } from "../types.js";
+
+/**
+ * The single config band a set of detected harnesses shares, or `undefined` when
+ * the set is empty or genuinely spans BOTH bands. A two-band finding stays
+ * unbanded (rendered in the general section) instead of being mislabeled as one
+ * band — faithful to the two-band model: band by what was found, never a guess.
+ *
+ * @param harnesses - The detected harnesses the check reports on.
+ * @returns The shared {@link ScopeBand}, or `undefined` when none/mixed.
+ */
+export function deriveBand(
+  harnesses: readonly DetectedHarness[],
+): ScopeBand | undefined {
+  const bands = new Set<ScopeBand>();
+  for (const detected of harnesses) bands.add(defaultBandOf(detected.harness));
+  return bands.size === 1 ? bands.values().next().value : undefined;
+}

--- a/packages/cli/next/src/capabilities/doctor/doctor.render.test.ts
+++ b/packages/cli/next/src/capabilities/doctor/doctor.render.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Render goldens for `pragma doctor` — the band-grouped report.
+ *
+ * The banded MACHINE/PROJECT grouping (`partitionByBand` → sections) previously
+ * shipped executed-but-never-asserted; this pins the ACTUAL banded output text
+ * for BOTH the plain and llm formatters, and locks the unified Global/Project
+ * vocabulary (the report no longer says MACHINE/PROJECT). Forces `chalk.level =
+ * 0` for deterministic, color-free output (the colophon-render pattern).
+ */
+
+import chalk from "chalk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { doctorFormatters } from "./doctor.render.js";
+import type { DoctorData } from "./types.js";
+
+/** A fixture spanning all three groups: environment (no band), global, project. */
+const DATA: DoctorData = {
+  checks: [
+    { name: "Node version", status: "pass", detail: "v20 detected" },
+    {
+      name: "Shell completions",
+      status: "pass",
+      detail: "zsh installed and resolving",
+      band: "global",
+    },
+    {
+      name: "MCP configured",
+      status: "fail",
+      detail: "detected Windsurf but pragma not configured",
+      remedy: "pragma setup mcp",
+      band: "global",
+    },
+    {
+      name: "Skills symlinked",
+      status: "skip",
+      detail: "no AI harnesses detected",
+      band: "project",
+    },
+  ],
+  passed: 2,
+  failed: 1,
+  skipped: 1,
+};
+
+let prevLevel: number;
+beforeAll(() => {
+  prevLevel = chalk.level;
+  chalk.level = 0; // color-free ⇒ deterministic text
+});
+afterAll(() => {
+  chalk.level = prevLevel;
+});
+
+describe("doctor render — banded plain report", () => {
+  it("groups checks under Global then Project headers (unified labels)", () => {
+    const out = doctorFormatters.plain(DATA);
+    const lines = out.split("\n");
+    // The two banded section headers use the unified Global/Project vocabulary.
+    expect(lines).toContain("Global");
+    expect(lines).toContain("Project");
+    // The superseded MACHINE/PROJECT labels are gone.
+    expect(out).not.toContain("MACHINE");
+    expect(out).not.toMatch(/^PROJECT$/m);
+  });
+
+  it("orders environment → Global → Project, banding each check correctly", () => {
+    const out = doctorFormatters.plain(DATA);
+    // Environment check leads with no header; the two global-band checks sit
+    // under Global; the project-band check sits under Project.
+    const at = (needle: string): number => out.indexOf(needle);
+    expect(at("Node version")).toBeGreaterThanOrEqual(0);
+    expect(at("Node version")).toBeLessThan(at("Global"));
+    expect(at("Global")).toBeLessThan(at("Shell completions"));
+    expect(at("MCP configured")).toBeLessThan(at("Project"));
+    expect(at("Project")).toBeLessThan(at("Skills symlinked"));
+    // A failing banded check keeps its inline remedy under its band.
+    expect(out).toContain("fix: pragma setup mcp");
+    // The tally closes the report.
+    expect(out).toContain("2 passed");
+  });
+});
+
+describe("doctor render — banded llm report", () => {
+  it("groups checks under ### Global then ### Project headers", () => {
+    const out = doctorFormatters.llm(DATA);
+    expect(out).toContain("### Global");
+    expect(out).toContain("### Project");
+    expect(out).not.toContain("### Machine");
+    const at = (needle: string): number => out.indexOf(needle);
+    // Environment leads (no section header), then the two banded sections.
+    expect(at("Node version")).toBeLessThan(at("### Global"));
+    expect(at("### Global")).toBeLessThan(at("Shell completions"));
+    expect(at("Shell completions")).toBeLessThan(at("### Project"));
+    expect(at("### Project")).toBeLessThan(at("Skills symlinked"));
+    expect(out).toContain("_2 passed, 1 failed, 1 skipped_");
+  });
+});
+
+describe("doctor render — json", () => {
+  it("is the exact DoctorData round-trip", () => {
+    expect(JSON.parse(doctorFormatters.json(DATA))).toEqual(DATA);
+  });
+});

--- a/packages/cli/next/src/capabilities/doctor/doctor.render.ts
+++ b/packages/cli/next/src/capabilities/doctor/doctor.render.ts
@@ -7,6 +7,7 @@
 
 import chalk from "chalk";
 import type { Formatters } from "../../kernel/spec/types.js";
+import { BAND_LABELS } from "../shared/bands.js";
 import type { CheckResult, CheckStatus, DoctorData } from "./types.js";
 
 /** Status icons for pass/fail/skip results (checks and sub-items). */
@@ -71,8 +72,8 @@ function formatSummary(data: DoctorData): string {
 }
 
 /**
- * Partition checks into ordered bands: environment (no band), MACHINE (global),
- * PROJECT (project). Declaration order is preserved within each band, so the
+ * Partition checks into ordered bands: environment (no band), then the global
+ * and project bands. Declaration order is preserved within each band, so the
  * report stays deterministic.
  */
 function partitionByBand(checks: readonly CheckResult[]): {
@@ -99,11 +100,11 @@ export const doctorFormatters: Formatters<DoctorData> = {
         lines.push(...formatCheckPlain(check, nameWidth));
       lines.push("");
     };
-    // Environment checks lead (no header); MACHINE then PROJECT are the two
-    // banded sections before the tally.
+    // Environment checks lead (no header); the global then project bands are the
+    // two banded sections before the tally.
     section("", environment);
-    section("MACHINE", machine);
-    section("PROJECT", project);
+    section(BAND_LABELS.global, machine);
+    section(BAND_LABELS.project, project);
     lines.push(formatSummary(data));
     return lines.join("\n");
   },
@@ -139,8 +140,8 @@ export const doctorFormatters: Formatters<DoctorData> = {
       for (const check of checks) lines.push(...renderCheck(check));
     };
     section("", environment);
-    section("Machine", machine);
-    section("Project", project);
+    section(BAND_LABELS.global, machine);
+    section(BAND_LABELS.project, project);
     lines.push(
       "",
       `_${data.passed} passed, ${data.failed} failed, ${data.skipped} skipped_`,

--- a/packages/cli/next/src/capabilities/doctor/doctor.render.ts
+++ b/packages/cli/next/src/capabilities/doctor/doctor.render.ts
@@ -70,23 +70,49 @@ function formatSummary(data: DoctorData): string {
   return `  ${parts.join(chalk.dim(" · "))}`;
 }
 
+/**
+ * Partition checks into ordered bands: environment (no band), MACHINE (global),
+ * PROJECT (project). Declaration order is preserved within each band, so the
+ * report stays deterministic.
+ */
+function partitionByBand(checks: readonly CheckResult[]): {
+  environment: CheckResult[];
+  machine: CheckResult[];
+  project: CheckResult[];
+} {
+  return {
+    environment: checks.filter((c) => c.band === undefined),
+    machine: checks.filter((c) => c.band === "global"),
+    project: checks.filter((c) => c.band === "project"),
+  };
+}
+
 export const doctorFormatters: Formatters<DoctorData> = {
   plain(data) {
     const nameWidth = Math.max(...data.checks.map((c) => c.name.length), 0);
     const lines: string[] = [chalk.bold("pragma doctor"), ""];
-    for (const check of data.checks) {
-      lines.push(...formatCheckPlain(check, nameWidth));
-    }
-    lines.push("", formatSummary(data));
+    const { environment, machine, project } = partitionByBand(data.checks);
+    const section = (heading: string, checks: CheckResult[]): void => {
+      if (checks.length === 0) return;
+      if (heading) lines.push(chalk.bold(heading));
+      for (const check of checks)
+        lines.push(...formatCheckPlain(check, nameWidth));
+      lines.push("");
+    };
+    // Environment checks lead (no header); MACHINE then PROJECT are the two
+    // banded sections before the tally.
+    section("", environment);
+    section("MACHINE", machine);
+    section("PROJECT", project);
+    lines.push(formatSummary(data));
     return lines.join("\n");
   },
 
   llm(data) {
-    const lines: string[] = ["## Doctor", ""];
-    for (const check of data.checks) {
+    const renderCheck = (check: CheckResult): string[] => {
       const icon =
         check.status === "pass" ? "✓" : check.status === "fail" ? "✗" : "○";
-      lines.push(`- ${icon} **${check.name}**: ${check.detail}`);
+      const out = [`- ${icon} **${check.name}**: ${check.detail}`];
       for (const item of check.items ?? []) {
         const itemIcon =
           item.status === "pass"
@@ -97,12 +123,24 @@ export const doctorFormatters: Formatters<DoctorData> = {
                 ? "○ "
                 : "";
         const detail = item.detail ? `: ${item.detail}` : "";
-        lines.push(`  - ${itemIcon}${item.label}${detail}`);
+        out.push(`  - ${itemIcon}${item.label}${detail}`);
       }
       if (check.status === "fail" && check.remedy) {
-        lines.push(`  - _fix:_ \`${check.remedy}\``);
+        out.push(`  - _fix:_ \`${check.remedy}\``);
       }
-    }
+      return out;
+    };
+
+    const lines: string[] = ["## Doctor", ""];
+    const { environment, machine, project } = partitionByBand(data.checks);
+    const section = (heading: string, checks: CheckResult[]): void => {
+      if (checks.length === 0) return;
+      if (heading) lines.push(`### ${heading}`, "");
+      for (const check of checks) lines.push(...renderCheck(check));
+    };
+    section("", environment);
+    section("Machine", machine);
+    section("Project", project);
     lines.push(
       "",
       `_${data.passed} passed, ${data.failed} failed, ${data.skipped} skipped_`,

--- a/packages/cli/next/src/capabilities/doctor/doctor.test.ts
+++ b/packages/cli/next/src/capabilities/doctor/doctor.test.ts
@@ -50,17 +50,24 @@ const tmp = (prefix: string): string => {
 
 let prevHome: string | undefined;
 let prevXdg: string | undefined;
+let prevPath: string | undefined;
 beforeEach(() => {
   prevHome = process.env.HOME;
   prevXdg = process.env.XDG_CONFIG_HOME;
+  prevPath = process.env.PATH;
   // Empty HOME/XDG so `~`-based harness signals, rc files, and the global config
   // are all absent — the harness/config/completion checks become deterministic.
   process.env.HOME = tmp("pragma-doctor-home-");
   process.env.XDG_CONFIG_HOME = tmp("pragma-doctor-xdg-");
+  // Point PATH at an empty dir so no harness `process` signal fires off the
+  // ambient PATH (e.g. a `claude`/`codex` binary on the CI/dev host) — keeping
+  // "no harnesses detected" deterministic regardless of what is installed.
+  process.env.PATH = tmp("pragma-doctor-path-");
 });
 afterEach(() => {
   process.env.HOME = prevHome;
   process.env.XDG_CONFIG_HOME = prevXdg;
+  process.env.PATH = prevPath;
   for (const dir of roots) rmSync(dir, { recursive: true, force: true });
   roots.length = 0;
 });

--- a/packages/cli/next/src/capabilities/doctor/doctor.test.ts
+++ b/packages/cli/next/src/capabilities/doctor/doctor.test.ts
@@ -8,7 +8,7 @@
  * the MCP read-only envelope.
  */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -28,6 +28,7 @@ import {
 } from "../../testing/fixtures/graph/canonical.js";
 import { bootFixtureRuntime } from "../../testing/helpers/fixtureGraph.js";
 import { projectMcp } from "../../testing/helpers/projectMcp.js";
+import { checkMcpConfigured } from "./checks/checkMcpConfigured.js";
 import { doctorModule } from "./index.js";
 import { runChecks } from "./runChecks.js";
 import type { DoctorData } from "./types.js";
@@ -182,5 +183,27 @@ describe("doctor — dispatch & MCP", () => {
     await mcp.cleanup();
     expect(envelope.ok).toBe(true);
     expect((envelope.data as DoctorData).checks).toHaveLength(9);
+  });
+});
+
+describe("doctor — MCP checks band by detected harness scope, not check name", () => {
+  it("bands a configured GLOBAL-scope harness (Windsurf) as global", async () => {
+    // Windsurf is a global-only harness whose MCP config lives in the home band.
+    // The old static map tagged every "MCP configured" result PROJECT; the fix
+    // derives the band from the harness's real scope, so this reports `global`.
+    const cwd = tmp("pragma-doctor-proj-");
+    mkdirSync(join(cwd, ".windsurf"), { recursive: true }); // ⇒ Windsurf detected
+    const home = process.env.HOME ?? "";
+    const wsDir = join(home, ".codeium", "windsurf");
+    mkdirSync(wsDir, { recursive: true });
+    writeFileSync(
+      join(wsDir, "mcp_config.json"),
+      JSON.stringify({ mcpServers: { pragma: { command: "pragma" } } }),
+    );
+
+    const check = await checkMcpConfigured(cwd);
+    expect(check.status).toBe("pass");
+    expect(check.detail).toContain("Windsurf");
+    expect(check.band).toBe("global"); // NOT the old static "project"
   });
 });

--- a/packages/cli/next/src/capabilities/doctor/runChecks.ts
+++ b/packages/cli/next/src/capabilities/doctor/runChecks.ts
@@ -18,7 +18,27 @@ import { checkPackageRefs } from "./checks/checkPackageRefs.js";
 import { checkPragmaVersion } from "./checks/checkPragmaVersion.js";
 import { checkShellCompletions } from "./checks/checkShellCompletions.js";
 import { checkSkillsSymlinked } from "./checks/checkSkillsSymlinked.js";
-import type { CheckResult, DoctorData } from "./types.js";
+import type { CheckResult, DoctorData, ScopeBand } from "./types.js";
+
+/**
+ * Which band each check concerns, by name. Per-project config checks (MCP,
+ * skills) are project-band; the shell-completion check is global (user/machine).
+ * The rest are environment checks with no band. (A simplification: an aggregate
+ * MCP/skills check spans whatever harnesses were detected, but the default band
+ * for the common project/both harnesses is `project`.)
+ */
+const CHECK_BANDS: Record<string, ScopeBand> = {
+  "MCP configured": "project",
+  "MCP commands": "project",
+  "Skills symlinked": "project",
+  "Shell completions": "global",
+};
+
+/** Attach a band tag to a check result by name, if one is defined. */
+function withBand(result: CheckResult): CheckResult {
+  const band = CHECK_BANDS[result.name];
+  return band ? { ...result, band } : result;
+}
 
 /**
  * Each check paired with the display name used if it rejects. The fallback name
@@ -53,16 +73,16 @@ export async function runChecks(rt: PragmaRuntime): Promise<DoctorData> {
   const checks: CheckResult[] = await Promise.all(
     buildChecks(rt).map(async ([name, promise]): Promise<CheckResult> => {
       try {
-        return await promise;
+        return withBand(await promise);
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
-        return {
+        return withBand({
           name,
           status: "fail",
           detail: `Check threw an unexpected error: ${reason}`,
           remedy:
             "Re-run `pragma doctor`; if it persists, report this as a bug.",
-        };
+        });
       }
     }),
   );

--- a/packages/cli/next/src/capabilities/doctor/runChecks.ts
+++ b/packages/cli/next/src/capabilities/doctor/runChecks.ts
@@ -21,21 +21,25 @@ import { checkSkillsSymlinked } from "./checks/checkSkillsSymlinked.js";
 import type { CheckResult, DoctorData, ScopeBand } from "./types.js";
 
 /**
- * Which band each check concerns, by name. Per-project config checks (MCP,
- * skills) are project-band; the shell-completion check is global (user/machine).
- * The rest are environment checks with no band. (A simplification: an aggregate
- * MCP/skills check spans whatever harnesses were detected, but the default band
- * for the common project/both harnesses is `project`.)
+ * The band a check statically concerns, by name — for checks whose band is
+ * fixed by construction: skills always symlink into the per-repo project dir
+ * (`skillsPath` is project-rooted), and completions install into the user/home
+ * shell dir. The MCP checks are NOT here: they detect harnesses across BOTH
+ * bands, so each derives its own band from what it found (see `deriveBand`) and
+ * sets it on its own result — {@link attachBand} preserves that.
  */
 const CHECK_BANDS: Record<string, ScopeBand> = {
-  "MCP configured": "project",
-  "MCP commands": "project",
   "Skills symlinked": "project",
   "Shell completions": "global",
 };
 
-/** Attach a band tag to a check result by name, if one is defined. */
-function withBand(result: CheckResult): CheckResult {
+/**
+ * Attach a band tag to a check result. A check that already set its own band
+ * (the harness-derived MCP checks) keeps it; otherwise the static
+ * {@link CHECK_BANDS} map fills one in by name, if defined.
+ */
+function attachBand(result: CheckResult): CheckResult {
+  if (result.band !== undefined) return result;
   const band = CHECK_BANDS[result.name];
   return band ? { ...result, band } : result;
 }
@@ -73,10 +77,10 @@ export async function runChecks(rt: PragmaRuntime): Promise<DoctorData> {
   const checks: CheckResult[] = await Promise.all(
     buildChecks(rt).map(async ([name, promise]): Promise<CheckResult> => {
       try {
-        return withBand(await promise);
+        return attachBand(await promise);
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
-        return withBand({
+        return attachBand({
           name,
           status: "fail",
           detail: `Check threw an unexpected error: ${reason}`,

--- a/packages/cli/next/src/capabilities/doctor/types.ts
+++ b/packages/cli/next/src/capabilities/doctor/types.ts
@@ -2,6 +2,13 @@
  * Data shapes for `pragma doctor` (ported verbatim from the old shell).
  */
 
+/**
+ * One of the two config bands a check can concern. Mirrors the harnesses
+ * `ScopeBand` structurally but is redeclared here so this statically-reachable
+ * type module never pulls the harnesses runtime into the fast-path module graph.
+ */
+export type ScopeBand = "project" | "global";
+
 /** Status of a doctor check or one of its sub-items. */
 export type CheckStatus = "pass" | "fail" | "skip";
 
@@ -30,6 +37,13 @@ export interface CheckResult {
   readonly items?: readonly CheckItem[];
   /** Remedial instruction shown inline under a failing check. */
   readonly remedy?: string;
+  /**
+   * Which config band the check concerns, if any: `global` for the user/machine
+   * level (shell completions), `project` for per-repo config (MCP, skills). The
+   * renderer groups banded checks into MACHINE/PROJECT sections; environment
+   * checks (Node, versions, store) carry no band.
+   */
+  readonly band?: ScopeBand;
 }
 
 /** Aggregated results from all doctor checks. */

--- a/packages/cli/next/src/capabilities/doctor/types.ts
+++ b/packages/cli/next/src/capabilities/doctor/types.ts
@@ -38,10 +38,11 @@ export interface CheckResult {
   /** Remedial instruction shown inline under a failing check. */
   readonly remedy?: string;
   /**
-   * Which config band the check concerns, if any: `global` for the user/machine
-   * level (shell completions), `project` for per-repo config (MCP, skills). The
-   * renderer groups banded checks into MACHINE/PROJECT sections; environment
-   * checks (Node, versions, store) carry no band.
+   * Which config band the check concerns, if any: `global` for the user/home
+   * level (shell completions), `project` for per-repo config (skills). The MCP
+   * checks derive their band from the harnesses they found. The renderer groups
+   * banded checks into Global/Project sections; environment checks (Node,
+   * versions, store) carry no band.
    */
   readonly band?: ScopeBand;
 }

--- a/packages/cli/next/src/capabilities/scopeTypeSync.test.ts
+++ b/packages/cli/next/src/capabilities/scopeTypeSync.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Type-sync pin (PROTECTED): the CLI's redeclared `ScopeBand`/`ScopeSelection`
+ * mirrors must stay structurally EQUAL to the `@canonical/harnesses` types.
+ *
+ * The CLI redeclares these in `doctor/types.ts` and `setup/types.ts` on purpose
+ * — so those statically-reachable type modules never pull the harnesses runtime
+ * onto the fast-path module graph (the lazy-dispatch invariant). That freedom is
+ * only safe if the mirrors do not DRIFT from the source of truth, which this
+ * `expectTypeOf` pin enforces at `tsc` time.
+ *
+ * Every harnesses import here is `import type` (type-only, erased at emit), so
+ * this file loads no harnesses runtime — the `lazy.test` no-runtime-import guard
+ * stays green (it also never reaches this test file: it walks the graph from
+ * `capabilities/index`, which imports no test).
+ */
+
+import type {
+  ScopeBand as HarnessScopeBand,
+  ScopeSelection as HarnessScopeSelection,
+} from "@canonical/harnesses";
+import { describe, expectTypeOf, it } from "vitest";
+import type { ScopeBand as DoctorScopeBand } from "./doctor/types.js";
+import type {
+  ScopeBand as SetupScopeBand,
+  ScopeSelection as SetupScopeSelection,
+} from "./setup/types.js";
+
+describe("scope type-sync — CLI mirrors == @canonical/harnesses", () => {
+  it("both ScopeBand mirrors equal the harnesses ScopeBand", () => {
+    expectTypeOf<DoctorScopeBand>().toEqualTypeOf<HarnessScopeBand>();
+    expectTypeOf<SetupScopeBand>().toEqualTypeOf<HarnessScopeBand>();
+  });
+
+  it("the setup ScopeSelection mirror equals the harnesses ScopeSelection", () => {
+    expectTypeOf<SetupScopeSelection>().toEqualTypeOf<HarnessScopeSelection>();
+  });
+});

--- a/packages/cli/next/src/capabilities/setup/index.ts
+++ b/packages/cli/next/src/capabilities/setup/index.ts
@@ -3,4 +3,10 @@
  */
 
 export { setupModule } from "./setup.verb.js";
-export type { SetupResult, SetupSkillsResult, SymlinkAction } from "./types.js";
+export type {
+  ConfiguredTarget,
+  ScopeSelection,
+  SetupResult,
+  SetupSkillsResult,
+  SymlinkAction,
+} from "./types.js";

--- a/packages/cli/next/src/capabilities/setup/operations/setupGenerator.ts
+++ b/packages/cli/next/src/capabilities/setup/operations/setupGenerator.ts
@@ -11,10 +11,11 @@
  * it more than once (the confirm-gate preview + the build), so all real reads
  * belong in detection, never in `generate`.
  *
- * The `--scope` selection is threaded through detection so `availableSteps` only
- * offers steps whose band the scope runs, and the MCP step targets exactly the
- * deduped files for that scope. Per-file narrowing is opt-in (Item 6): the "all"
- * default never springs a per-file question — it configures every deduped file.
+ * The `--scope` selection is threaded through detection AND step-offering so
+ * `listAvailableSteps` only offers steps whose band the scope runs, and the MCP
+ * step targets exactly the deduped files for that scope. Per-file narrowing is
+ * opt-in (Item 6): the "all" default never springs a per-file question — it
+ * configures every deduped file.
  *
  * This module carries NO static import of `@canonical/summon-core` VALUES or of
  * React/Ink — it only `import type`s the generator shape and builds plain object
@@ -73,11 +74,11 @@ interface SetupDetection {
 }
 
 /** Read `answers.steps` (the run-all multiselect) as a string array. */
-const stepsOf = (answers: Record<string, unknown>): string[] =>
+const readSteps = (answers: Record<string, unknown>): string[] =>
   Array.isArray(answers.steps) ? (answers.steps as string[]) : [];
 
 /** Read `answers.mcpTargets` (selected file paths), falling back to ALL files. */
-const mcpPathSelection = (
+const resolveMcpPaths = (
   d: McpDetection,
   answers: Record<string, unknown>,
 ): string[] =>
@@ -86,8 +87,10 @@ const mcpPathSelection = (
     : d.groups.map((g) => g.path);
 
 /** The groups the user chose (or all, under the "all" default). */
-const chosenGroups = (d: McpDetection, answers: Record<string, unknown>) =>
-  selectedGroups(d, mcpPathSelection(d, answers));
+const selectChosenGroups = (
+  d: McpDetection,
+  answers: Record<string, unknown>,
+) => selectedGroups(d, resolveMcpPaths(d, answers));
 
 /**
  * The LSP-install step, guarded at its use site. An absent `bunx` (no Bun on
@@ -109,7 +112,7 @@ const composeGuardedLsp = (rt: PragmaRuntime): Task<void> =>
   );
 
 /** Build a generator's `meta` (no stamping — the version is just header text). */
-const metaFor = (
+const buildMeta = (
   rt: PragmaRuntime,
   title: string,
 ): GeneratorDefinition["meta"] => ({
@@ -120,7 +123,7 @@ const metaFor = (
 });
 
 /** The opt-in "customize which files" gate (Item 6) — defaults to false. */
-const customizePrompt = (
+const buildCustomizePrompt = (
   when?: PromptDefinition["when"],
 ): PromptDefinition => ({
   name: "customize",
@@ -131,7 +134,7 @@ const customizePrompt = (
 });
 
 /** The per-file MCP multiselect — one row per deduped {@link TargetGroup} file. */
-const mcpTargetsPrompt = (
+const buildMcpTargetsPrompt = (
   d: McpDetection,
   when?: PromptDefinition["when"],
 ): PromptDefinition => ({
@@ -168,9 +171,15 @@ async function gatherDetection(
  * undetectable step is omitted so the run-all degrades gracefully instead of
  * throwing a mid-wizard EMPTY_RESULTS; a step whose band the scope does not run
  * is omitted too (completions/lsp are global-band, skills are project-band, MCP
- * spans both via its resolved groups).
+ * spans both via its resolved groups). Threading `scope` here is what makes
+ * `setup --local` skip completions+lsp and `setup --global` skip skills — the
+ * MCP groups are already scoped by {@link detectMcp}.
+ *
+ * @param detected - Every step's up-front detection.
+ * @param scope - The resolved `--scope` selection (project/global/both).
+ * @returns The offerable steps, in composition/display order.
  */
-function availableSteps(
+function listAvailableSteps(
   detected: SetupDetection,
   scope: ScopeSelection,
 ): { label: string; value: StepId }[] {
@@ -205,9 +214,18 @@ function availableSteps(
 // Plan builders
 // =============================================================================
 
-/** The run-all self-verb: a step multiselect + per-step composition. */
-function runAllPlan(rt: PragmaRuntime, detected: SetupDetection): SetupPlan {
-  const steps = availableSteps(detected, "both");
+/**
+ * The run-all self-verb: a step multiselect + per-step composition. The resolved
+ * `scope` narrows BOTH the offered steps (via {@link listAvailableSteps}) and the
+ * MCP target groups (already scoped by {@link detectMcp}), so `--local` omits the
+ * global-band completions+lsp and `--global` omits the project-band skills.
+ */
+function buildRunAllPlan(
+  rt: PragmaRuntime,
+  detected: SetupDetection,
+  scope: ScopeSelection,
+): SetupPlan {
+  const steps = listAvailableSteps(detected, scope);
   const prompts: PromptDefinition[] = [
     {
       name: "steps",
@@ -223,10 +241,10 @@ function runAllPlan(rt: PragmaRuntime, detected: SetupDetection): SetupPlan {
   // default configures every deduped file without an extra question.
   if (detected.mcp.groups.length > 0) {
     prompts.push(
-      customizePrompt((a) => stepsOf(a).includes("mcp")),
-      mcpTargetsPrompt(
+      buildCustomizePrompt((a) => readSteps(a).includes("mcp")),
+      buildMcpTargetsPrompt(
         detected.mcp,
-        (a) => a.customize === true && stepsOf(a).includes("mcp"),
+        (a) => a.customize === true && readSteps(a).includes("mcp"),
       ),
     );
   }
@@ -237,10 +255,10 @@ function runAllPlan(rt: PragmaRuntime, detected: SetupDetection): SetupPlan {
   // reads already happened up front). Composing an unchosen step is harmless:
   // `when(false, …)` discards the (side-effect-free) task it was handed.
   const generator: GeneratorDefinition = {
-    meta: metaFor(rt, "pragma setup"),
+    meta: buildMeta(rt, "pragma setup"),
     prompts,
     generate: (answers) => {
-      const chosen = stepsOf(answers);
+      const chosen = readSteps(answers);
       return sequence_([
         when(
           chosen.includes("completions"),
@@ -249,7 +267,7 @@ function runAllPlan(rt: PragmaRuntime, detected: SetupDetection): SetupPlan {
         when(chosen.includes("lsp"), composeGuardedLsp(rt)),
         when(
           chosen.includes("mcp"),
-          composeMcp(detected.mcp, chosenGroups(detected.mcp, answers)),
+          composeMcp(detected.mcp, selectChosenGroups(detected.mcp, answers)),
         ),
         when(chosen.includes("skills"), composeSkills(detected.skills)),
       ]);
@@ -258,18 +276,18 @@ function runAllPlan(rt: PragmaRuntime, detected: SetupDetection): SetupPlan {
 
   return {
     generator,
-    toResult: (answers) => ({ kind: "all", steps: stepsOf(answers) }),
+    toResult: (answers) => ({ kind: "all", steps: readSteps(answers) }),
   };
 }
 
 /** A single-step generator (no run-all multiselect) for one sub-verb. */
-function singleStep(
+function buildSingleStep(
   rt: PragmaRuntime,
   title: string,
   prompts: PromptDefinition[],
   generate: (answers: Record<string, unknown>) => Task<void>,
 ): GeneratorDefinition {
-  return { meta: metaFor(rt, title), prompts, generate };
+  return { meta: buildMeta(rt, title), prompts, generate };
 }
 
 /**
@@ -292,12 +310,12 @@ export async function buildSetupPlan(
 ): Promise<SetupPlan> {
   switch (mode) {
     case "all":
-      return runAllPlan(rt, await gatherDetection(rt, scope));
+      return buildRunAllPlan(rt, await gatherDetection(rt, scope), scope);
 
     case "completions": {
       const d = await detectCompletions(rt.cwd);
       return {
-        generator: singleStep(rt, "pragma setup completions", [], () =>
+        generator: buildSingleStep(rt, "pragma setup completions", [], () =>
           composeCompletions(d),
         ),
         toResult: () => ({
@@ -311,7 +329,7 @@ export async function buildSetupPlan(
 
     case "lsp":
       return {
-        generator: singleStep(rt, "pragma setup lsp", [], () =>
+        generator: buildSingleStep(rt, "pragma setup lsp", [], () =>
           composeGuardedLsp(rt),
         ),
         toResult: () => ({ kind: "lsp" }),
@@ -322,16 +340,16 @@ export async function buildSetupPlan(
       const prompts: PromptDefinition[] =
         d.groups.length > 0
           ? [
-              customizePrompt(),
-              mcpTargetsPrompt(d, (a) => a.customize === true),
+              buildCustomizePrompt(),
+              buildMcpTargetsPrompt(d, (a) => a.customize === true),
             ]
           : [];
       return {
-        generator: singleStep(rt, "pragma setup mcp", prompts, (answers) =>
-          composeMcp(d, chosenGroups(d, answers)),
+        generator: buildSingleStep(rt, "pragma setup mcp", prompts, (answers) =>
+          composeMcp(d, selectChosenGroups(d, answers)),
         ),
         toResult: (answers) => {
-          const sel = chosenGroups(d, answers);
+          const sel = selectChosenGroups(d, answers);
           return {
             kind: "mcp",
             configured: mcpConfigured(sel),
@@ -345,7 +363,7 @@ export async function buildSetupPlan(
       const d = await detectSkills(rt);
       if (!d.available) throw skillsEmptyError();
       return {
-        generator: singleStep(rt, "pragma setup skills", [], () =>
+        generator: buildSingleStep(rt, "pragma setup skills", [], () =>
           composeSkills(d),
         ),
         toResult: () => ({ kind: "skills", result: toSkillsResult(d) }),

--- a/packages/cli/next/src/capabilities/setup/operations/setupGenerator.ts
+++ b/packages/cli/next/src/capabilities/setup/operations/setupGenerator.ts
@@ -11,6 +11,11 @@
  * it more than once (the confirm-gate preview + the build), so all real reads
  * belong in detection, never in `generate`.
  *
+ * The `--scope` selection is threaded through detection so `availableSteps` only
+ * offers steps whose band the scope runs, and the MCP step targets exactly the
+ * deduped files for that scope. Per-file narrowing is opt-in (Item 6): the "all"
+ * default never springs a per-file question — it configures every deduped file.
+ *
  * This module carries NO static import of `@canonical/summon-core` VALUES or of
  * React/Ink — it only `import type`s the generator shape and builds plain object
  * literals over `@canonical/task`. It is itself reached only through the verb's
@@ -24,7 +29,7 @@ import type {
 import { sequence_, type Task, when } from "@canonical/task";
 import type { PragmaRuntime } from "../../../kernel/runtime/types.js";
 import { guardMissingBinary } from "../../shared/assertExecOk.js";
-import type { SetupMode, SetupResult } from "../types.js";
+import type { ScopeSelection, SetupMode, SetupResult } from "../types.js";
 import {
   type CompletionsDetection,
   composeCompletions,
@@ -36,6 +41,8 @@ import {
   detectMcp,
   type McpDetection,
   mcpConfigured,
+  mcpTargets,
+  selectedGroups,
 } from "./setupMcp.js";
 import {
   composeSkills,
@@ -69,14 +76,18 @@ interface SetupDetection {
 const stepsOf = (answers: Record<string, unknown>): string[] =>
   Array.isArray(answers.steps) ? (answers.steps as string[]) : [];
 
-/** Read `answers.mcpHarnesses`, falling back to ALL detected ids. */
-const mcpSelection = (
+/** Read `answers.mcpTargets` (selected file paths), falling back to ALL files. */
+const mcpPathSelection = (
   d: McpDetection,
   answers: Record<string, unknown>,
 ): string[] =>
-  Array.isArray(answers.mcpHarnesses)
-    ? (answers.mcpHarnesses as string[])
-    : d.harnesses.map((h) => h.harness.id);
+  Array.isArray(answers.mcpTargets)
+    ? (answers.mcpTargets as string[])
+    : d.groups.map((g) => g.path);
+
+/** The groups the user chose (or all, under the "all" default). */
+const chosenGroups = (d: McpDetection, answers: Record<string, unknown>) =>
+  selectedGroups(d, mcpPathSelection(d, answers));
 
 /**
  * The LSP-install step, guarded at its use site. An absent `bunx` (no Bun on
@@ -108,20 +119,31 @@ const metaFor = (
   version: rt.version,
 });
 
-/** The MCP-harness multiselect follow-up (offered only when harnesses exist). */
-const mcpHarnessesPrompt = (
+/** The opt-in "customize which files" gate (Item 6) — defaults to false. */
+const customizePrompt = (
+  when?: PromptDefinition["when"],
+): PromptDefinition => ({
+  name: "customize",
+  type: "confirm",
+  message: "Customize which files pragma configures?",
+  default: false,
+  when,
+});
+
+/** The per-file MCP multiselect — one row per deduped {@link TargetGroup} file. */
+const mcpTargetsPrompt = (
   d: McpDetection,
   when?: PromptDefinition["when"],
 ): PromptDefinition => ({
-  name: "mcpHarnesses",
+  name: "mcpTargets",
   type: "multiselect",
-  message: "Configure MCP for which harnesses?",
+  message: "Configure MCP for which files?",
   when,
-  choices: d.harnesses.map((h) => ({
-    label: h.harness.name,
-    value: h.harness.id,
+  choices: d.groups.map((g) => ({
+    label: `${g.path} — ${g.harnessNames.join(", ")} [${g.scope}]`,
+    value: g.path,
   })),
-  default: d.harnesses.map((h) => h.harness.id),
+  default: d.groups.map((g) => g.path),
 });
 
 // =============================================================================
@@ -129,39 +151,48 @@ const mcpHarnessesPrompt = (
 // =============================================================================
 
 /** Gather EVERY step's detection up front (real reads), for the run-all. */
-async function gatherDetection(rt: PragmaRuntime): Promise<SetupDetection> {
+async function gatherDetection(
+  rt: PragmaRuntime,
+  scope: ScopeSelection,
+): Promise<SetupDetection> {
   const [completions, mcp, skills] = await Promise.all([
     detectCompletions(rt.cwd),
-    detectMcp(rt),
+    detectMcp(rt, scope),
     detectSkills(rt),
   ]);
   return { completions, mcp, skills };
 }
 
 /**
- * The steps worth OFFERING, given detection — undetectable steps are omitted so
- * the run-all degrades gracefully instead of throwing a mid-wizard
- * EMPTY_RESULTS (skills with no skills, mcp with no harnesses, completions with
- * no shell). LSP is always offered (its install is a self-contained exec).
+ * The steps worth OFFERING, given detection AND the scope selection. An
+ * undetectable step is omitted so the run-all degrades gracefully instead of
+ * throwing a mid-wizard EMPTY_RESULTS; a step whose band the scope does not run
+ * is omitted too (completions/lsp are global-band, skills are project-band, MCP
+ * spans both via its resolved groups).
  */
 function availableSteps(
   detected: SetupDetection,
+  scope: ScopeSelection,
 ): { label: string; value: StepId }[] {
+  const hasProject = scope !== "global";
+  const hasGlobal = scope !== "project";
   const choices: { label: string; value: StepId }[] = [];
-  if (detected.completions.shell) {
+  if (detected.completions.shell && hasGlobal) {
     choices.push({
       label: `Shell completions (${detected.completions.shell})`,
       value: "completions",
     });
   }
-  choices.push({ label: "Terrazzo LSP extension", value: "lsp" });
-  if (detected.mcp.harnesses.length > 0) {
+  if (hasGlobal) {
+    choices.push({ label: "Terrazzo LSP extension", value: "lsp" });
+  }
+  if (detected.mcp.groups.length > 0) {
     choices.push({
-      label: `MCP config (${detected.mcp.harnesses.length} harness(es))`,
+      label: `MCP config (${detected.mcp.groups.length} file(s))`,
       value: "mcp",
     });
   }
-  if (detected.skills.available) {
+  if (detected.skills.available && hasProject) {
     choices.push({
       label: `Link skills (${detected.skills.skillCount})`,
       value: "skills",
@@ -176,7 +207,7 @@ function availableSteps(
 
 /** The run-all self-verb: a step multiselect + per-step composition. */
 function runAllPlan(rt: PragmaRuntime, detected: SetupDetection): SetupPlan {
-  const steps = availableSteps(detected);
+  const steps = availableSteps(detected, "both");
   const prompts: PromptDefinition[] = [
     {
       name: "steps",
@@ -186,11 +217,16 @@ function runAllPlan(rt: PragmaRuntime, detected: SetupDetection): SetupPlan {
       default: steps.map((c) => c.value), // --yes / non-TTY ⇒ every step
     },
   ];
-  if (detected.mcp.harnesses.length > 0) {
+  // Item 6: per-file narrowing is opt-in. The "customize?" gate (default false)
+  // only surfaces when MCP is chosen and there is more than one file; the
+  // per-file multiselect only surfaces after an explicit yes — so the "all"
+  // default configures every deduped file without an extra question.
+  if (detected.mcp.groups.length > 0) {
     prompts.push(
-      mcpHarnessesPrompt(
+      customizePrompt((a) => stepsOf(a).includes("mcp")),
+      mcpTargetsPrompt(
         detected.mcp,
-        (a) => stepsOf(a).includes("mcp"), // only when mcp is chosen
+        (a) => a.customize === true && stepsOf(a).includes("mcp"),
       ),
     );
   }
@@ -213,7 +249,7 @@ function runAllPlan(rt: PragmaRuntime, detected: SetupDetection): SetupPlan {
         when(chosen.includes("lsp"), composeGuardedLsp(rt)),
         when(
           chosen.includes("mcp"),
-          composeMcp(detected.mcp, mcpSelection(detected.mcp, answers)),
+          composeMcp(detected.mcp, chosenGroups(detected.mcp, answers)),
         ),
         when(chosen.includes("skills"), composeSkills(detected.skills)),
       ]);
@@ -244,6 +280,7 @@ function singleStep(
  *
  * @param rt - The per-invocation runtime.
  * @param mode - The entry point (`all` or one sub-verb).
+ * @param scope - The resolved `--scope` selection (project/global/both).
  * @returns The generator + result mapper.
  * @throws PragmaError EMPTY_RESULTS for a direct `setup skills` with no skills.
  * @note Impure — performs each step's real detection.
@@ -251,10 +288,11 @@ function singleStep(
 export async function buildSetupPlan(
   rt: PragmaRuntime,
   mode: SetupMode,
+  scope: ScopeSelection,
 ): Promise<SetupPlan> {
   switch (mode) {
     case "all":
-      return runAllPlan(rt, await gatherDetection(rt));
+      return runAllPlan(rt, await gatherDetection(rt, scope));
 
     case "completions": {
       const d = await detectCompletions(rt.cwd);
@@ -280,16 +318,26 @@ export async function buildSetupPlan(
       };
 
     case "mcp": {
-      const d = await detectMcp(rt);
-      const prompts = d.harnesses.length > 0 ? [mcpHarnessesPrompt(d)] : [];
+      const d = await detectMcp(rt, scope);
+      const prompts: PromptDefinition[] =
+        d.groups.length > 0
+          ? [
+              customizePrompt(),
+              mcpTargetsPrompt(d, (a) => a.customize === true),
+            ]
+          : [];
       return {
         generator: singleStep(rt, "pragma setup mcp", prompts, (answers) =>
-          composeMcp(d, mcpSelection(d, answers)),
+          composeMcp(d, chosenGroups(d, answers)),
         ),
-        toResult: (answers) => ({
-          kind: "mcp",
-          configured: mcpConfigured(d, mcpSelection(d, answers)),
-        }),
+        toResult: (answers) => {
+          const sel = chosenGroups(d, answers);
+          return {
+            kind: "mcp",
+            configured: mcpConfigured(sel),
+            targets: mcpTargets(sel),
+          };
+        },
       };
     }
 

--- a/packages/cli/next/src/capabilities/setup/operations/setupMcp.ts
+++ b/packages/cli/next/src/capabilities/setup/operations/setupMcp.ts
@@ -2,84 +2,124 @@
  * `setup mcp` — register the pragma MCP server in detected AI harnesses.
  *
  * Split into `detectMcp` (harness detection runs FOR REAL up front, via
- * `runTask` over safe reads, so the wizard recap and a `--dry-run` describe
- * writes against the TRUE harness set) and `composeMcp` (a pure, re-runnable
- * write body driven by the harnesses the user SELECTED — the per-harness confirm
- * is gone; selection now comes from the wizard's multiselect). The covenant
- * sub-verb carries no force-flags, so harness selection is detection-only.
+ * `runTask` over safe reads, and the resolved config targets are deduplicated
+ * into per-file {@link TargetGroup}s for the chosen `--scope`) and `composeMcp`
+ * (a pure, re-runnable write body driven by the SELECTED groups). Each write is
+ * a distinct `(path, mcpKey)` so two harnesses sharing a file (VS Code + Cline)
+ * each preserve the other; every group emits a band-prefixed `info()` manifest
+ * line, so the recap and a `--dry-run` show which band each file belongs to.
  */
 
-import type { DetectedHarness } from "@canonical/harnesses";
+import type { PlatformEnv, TargetGroup } from "@canonical/harnesses";
 import { info, sequence_, type Task, warn } from "@canonical/task";
 import { MCP_SERVER_NAME } from "../../../constants.js";
 import type { PragmaRuntime } from "../../../kernel/runtime/types.js";
+import type { ConfiguredTarget, ScopeSelection } from "../types.js";
 
-/** The `writeMcpConfig` Task-builder, captured from the dynamic harness import. */
-type WriteMcpConfig = typeof import("@canonical/harnesses").writeMcpConfig;
+/** The `writeMcpConfigTargets` builder, captured from the dynamic harness import. */
+type WriteMcpConfigTargets =
+  typeof import("@canonical/harnesses").writeMcpConfigTargets;
 
 /**
- * The detected MCP state: the harnesses found, the project root the config is
- * written against, and the (dynamically imported) config-writer the pure
- * `composeMcp` needs synchronously.
+ * The detected MCP state: the per-file target groups (already scoped to the
+ * requested `--scope`), the project root, and the (dynamically imported)
+ * target-based writer the pure `composeMcp` needs synchronously.
  */
 export interface McpDetection {
-  readonly harnesses: readonly DetectedHarness[];
+  readonly groups: readonly TargetGroup[];
   readonly cwd: string;
-  readonly writeMcpConfig: WriteMcpConfig;
+  readonly platform: PlatformEnv;
+  readonly writeMcpConfigTargets: WriteMcpConfigTargets;
 }
 
 /**
- * Detect the AI harnesses present in the project (real reads, up front).
+ * Detect the AI harnesses present in the project (real reads, up front) and
+ * resolve+dedup their config targets for the chosen scope.
  *
  * @param rt - The per-invocation runtime.
- * @returns The detected harnesses + the writer used to compose config writes.
+ * @param scope - The resolved `--scope` selection.
+ * @returns The scoped target groups + the writer used to compose config writes.
  * @note Impure — reads the filesystem via `detectHarnesses`.
  */
-export async function detectMcp(rt: PragmaRuntime): Promise<McpDetection> {
+export async function detectMcp(
+  rt: PragmaRuntime,
+  scope: ScopeSelection,
+): Promise<McpDetection> {
   const cwd = rt.cwd;
-  const [{ detectHarnesses, writeMcpConfig }, { runTask }] = await Promise.all([
+  const [
+    {
+      detectHarnesses,
+      groupTargetsForScope,
+      readPlatformEnv,
+      writeMcpConfigTargets,
+    },
+    { runTask },
+  ] = await Promise.all([
     import("@canonical/harnesses"),
     import("@canonical/task/node"),
   ]);
-  const harnesses = await runTask(detectHarnesses(cwd));
-  return { harnesses, cwd, writeMcpConfig };
+  const platform = readPlatformEnv();
+  const detected = await runTask(detectHarnesses(cwd, platform));
+  const groups = groupTargetsForScope(detected, cwd, scope, platform);
+  return { groups, cwd, platform, writeMcpConfigTargets };
+}
+
+/** The target groups the user selected (by path), or all when none recorded. */
+export function selectedGroups(
+  d: McpDetection,
+  selectedPaths: readonly string[],
+): TargetGroup[] {
+  return d.groups.filter((g) => selectedPaths.includes(g.path));
 }
 
 /**
- * Compose the per-harness config writes for the SELECTED harnesses (pure —
- * re-runnable; builds ABSOLUTE config paths itself).
+ * Compose the per-target config writes for the SELECTED groups (pure —
+ * re-runnable; builds ABSOLUTE config paths itself). Every distinct `(path,
+ * mcpKey)` is written once; each group emits a band-prefixed manifest line.
  *
  * @param d - The detection gathered up front.
- * @param selectedIds - Harness ids the user chose (a subset of `d.harnesses`).
- * @returns A Task that writes the pragma MCP config into each chosen harness.
+ * @param groups - The target groups the user chose (a subset of `d.groups`).
+ * @returns A Task that writes the pragma MCP config into each chosen file.
  */
 export function composeMcp(
   d: McpDetection,
-  selectedIds: readonly string[],
+  groups: readonly TargetGroup[],
 ): Task<void> {
-  const chosen = d.harnesses.filter((h) => selectedIds.includes(h.harness.id));
-  if (chosen.length === 0) {
+  if (groups.length === 0) {
     return warn("No AI harnesses selected — nothing to configure.");
   }
   const pragmaMcpConfig = { command: "pragma", args: ["mcp"], cwd: d.cwd };
   // Re-runnable combinators (NOT a single-use `gen`): `execute` interprets the
-  // task twice (preview + perform).
+  // task twice (preview + perform). One combined write per file keeps a shared
+  // file (VS Code + Cline) a single read-modify-write — dry-run safe.
   const tasks: Task<unknown>[] = [];
-  for (const h of chosen) {
+  for (const group of groups) {
     tasks.push(
-      d.writeMcpConfig(h.harness, d.cwd, MCP_SERVER_NAME, pragmaMcpConfig),
+      d.writeMcpConfigTargets(group.writes, MCP_SERVER_NAME, pragmaMcpConfig),
     );
-    tasks.push(info(`✓ pragma MCP server added to ${h.configPath}`));
+    tasks.push(
+      info(
+        `[${group.scope}] pragma MCP server → ${group.path} (${group.harnessNames.join(", ")})`,
+      ),
+    );
   }
   return sequence_(tasks);
 }
 
-/** The harness names configured for a given selection (for the result shape). */
-export function mcpConfigured(
-  d: McpDetection,
-  selectedIds: readonly string[],
-): string[] {
-  return d.harnesses
-    .filter((h) => selectedIds.includes(h.harness.id))
-    .map((h) => h.harness.name);
+/** The harness names configured across a selection (for the result summary). */
+export function mcpConfigured(groups: readonly TargetGroup[]): string[] {
+  const names = new Set<string>();
+  for (const group of groups) {
+    for (const name of group.harnessNames) names.add(name);
+  }
+  return [...names].sort();
+}
+
+/** The per-file {@link ConfiguredTarget}s for a selection (for the result). */
+export function mcpTargets(groups: readonly TargetGroup[]): ConfiguredTarget[] {
+  return groups.map((group) => ({
+    name: group.harnessNames.join(", "),
+    band: group.scope,
+    path: group.path,
+  }));
 }

--- a/packages/cli/next/src/capabilities/setup/operations/setupSkills.ts
+++ b/packages/cli/next/src/capabilities/setup/operations/setupSkills.ts
@@ -148,6 +148,10 @@ export async function detectSkills(
  * interprets the task twice (preview + perform). `created` links carry an undo;
  * a `replaced` link is delete-then-relink (idempotent); `skipped` is a no-op.
  *
+ * FOLLOW-UP(AV-284): global-band skills — skills only link into per-project
+ * harness dirs today; a `--scope global` machine-band skills location is
+ * deferred. The manifest line is `[project]`-prefixed to make that explicit.
+ *
  * @param d - The detection gathered up front.
  * @returns A Task that mkdirs each target and creates/replaces each symlink.
  */
@@ -168,7 +172,9 @@ export function composeSkills(d: SkillsDetection): Task<void> {
     }
   }
   tasks.push(
-    info(`Linked ${d.skillCount} skill(s) into ${d.targets.length} dir(s).`),
+    info(
+      `[project] Linked ${d.skillCount} skill(s) into ${d.targets.length} dir(s).`,
+    ),
   );
   return sequence_(tasks);
 }

--- a/packages/cli/next/src/capabilities/setup/setup.render.test.ts
+++ b/packages/cli/next/src/capabilities/setup/setup.render.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Render goldens for `pragma setup` — the MCP recap grouped by band.
+ *
+ * `summarizeMcpTargets` (the recap's band grouping) previously shipped
+ * executed-but-never-asserted; this pins the ACTUAL banded recap text for BOTH
+ * the plain and llm formatters, and locks the unified Global/Project vocabulary
+ * (the recap no longer says MACHINE/PROJECT). The setup formatters use no
+ * colour, so no chalk level dance is needed.
+ */
+
+import { describe, expect, it } from "vitest";
+import { setupFormatters } from "./setup.render.js";
+import type { SetupResult } from "./types.js";
+
+/** A two-band MCP result: a global (Windsurf) and a project (Cursor) target. */
+const BOTH_BANDS: SetupResult = {
+  kind: "mcp",
+  configured: ["Cursor", "Windsurf"],
+  targets: [
+    {
+      name: "Windsurf",
+      band: "global",
+      path: "/home/u/.codeium/windsurf/mcp_config.json",
+    },
+    { name: "Cursor", band: "project", path: "/proj/.cursor/mcp.json" },
+  ],
+};
+
+describe("setup render — MCP recap banded by Global/Project", () => {
+  it("plain lists the global band before the project band", () => {
+    expect(setupFormatters.plain(BOTH_BANDS)).toBe(
+      "Configured MCP — Global: Windsurf · Project: Cursor.",
+    );
+  });
+
+  it("llm is the same banded recap prefixed with a bullet", () => {
+    expect(setupFormatters.llm(BOTH_BANDS)).toBe(
+      "- Configured MCP — Global: Windsurf · Project: Cursor.",
+    );
+  });
+
+  it("uses the unified labels, never MACHINE/PROJECT", () => {
+    const out = setupFormatters.plain(BOTH_BANDS);
+    expect(out).not.toContain("MACHINE");
+    expect(out).not.toContain("PROJECT");
+  });
+
+  it("a single-band selection lists only that band", () => {
+    const projectOnly: SetupResult = {
+      kind: "mcp",
+      configured: ["Cursor"],
+      targets: [
+        { name: "Cursor", band: "project", path: "/p/.cursor/mcp.json" },
+      ],
+    };
+    expect(setupFormatters.plain(projectOnly)).toBe(
+      "Configured MCP — Project: Cursor.",
+    );
+  });
+
+  it("no targets → a plain 'nothing configured' line", () => {
+    const none: SetupResult = { kind: "mcp", configured: [], targets: [] };
+    expect(setupFormatters.plain(none)).toBe("No harnesses configured.");
+  });
+
+  it("json is the exact SetupResult round-trip", () => {
+    expect(JSON.parse(setupFormatters.json(BOTH_BANDS))).toEqual(BOTH_BANDS);
+  });
+});

--- a/packages/cli/next/src/capabilities/setup/setup.render.ts
+++ b/packages/cli/next/src/capabilities/setup/setup.render.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Formatters } from "../../kernel/spec/types.js";
+import { BAND_LABELS } from "../shared/bands.js";
 import type {
   ConfiguredTarget,
   SetupResult,
@@ -11,7 +12,7 @@ import type {
 } from "./types.js";
 
 /** Summarize a skills result: created / skipped / replaced counts. */
-function skillsSummary(result: SetupSkillsResult): string {
+function summarizeSkills(result: SetupSkillsResult): string {
   const created = result.actions.filter((a) => a.action === "created").length;
   const skipped = result.actions.filter((a) => a.action === "skipped").length;
   const replaced = result.actions.filter((a) => a.action === "replaced").length;
@@ -19,24 +20,28 @@ function skillsSummary(result: SetupSkillsResult): string {
 }
 
 /**
- * Summarize the MCP targets grouped by band — MACHINE (the user/home band)
- * before PROJECT (the per-repo band) — so the recap shows which files at which
- * level got the pragma server.
+ * Summarize the MCP targets grouped by band — the global (user/home) band
+ * before the project (per-repo) band — so the recap shows which files at which
+ * level got the pragma server. The Global/Project labels match the doctor
+ * report and the CLI's `--global`/`--local` grammar (see {@link BAND_LABELS}).
  */
-function mcpSummary(targets: readonly ConfiguredTarget[]): string {
+function summarizeMcpTargets(targets: readonly ConfiguredTarget[]): string {
   if (targets.length === 0) return "No harnesses configured.";
   const section = (band: ConfiguredTarget["band"], label: string): string => {
     const names = targets.filter((t) => t.band === band).map((t) => t.name);
     return names.length > 0 ? `${label}: ${names.join(", ")}` : "";
   };
-  const parts = [section("global", "MACHINE"), section("project", "PROJECT")]
+  const parts = [
+    section("global", BAND_LABELS.global),
+    section("project", BAND_LABELS.project),
+  ]
     .filter((p) => p.length > 0)
     .join(" · ");
   return `Configured MCP — ${parts}.`;
 }
 
 /** Render a setup result to a single human line (shared by plain/llm). */
-function line(data: SetupResult): string {
+function renderSetupLine(data: SetupResult): string {
   switch (data.kind) {
     case "completions":
       return data.installed
@@ -45,9 +50,9 @@ function line(data: SetupResult): string {
     case "lsp":
       return "Terrazzo LSP extension is installed (up to date).";
     case "mcp":
-      return mcpSummary(data.targets);
+      return summarizeMcpTargets(data.targets);
     case "skills":
-      return `Skills: ${skillsSummary(data.result)}.`;
+      return `Skills: ${summarizeSkills(data.result)}.`;
     case "all":
       return data.steps.length > 0
         ? `Setup complete — ran: ${data.steps.join(", ")}.`
@@ -57,10 +62,10 @@ function line(data: SetupResult): string {
 
 export const setupFormatters: Formatters<SetupResult> = {
   plain(data) {
-    return line(data);
+    return renderSetupLine(data);
   },
   llm(data) {
-    return `- ${line(data)}`;
+    return `- ${renderSetupLine(data)}`;
   },
   json(data) {
     return JSON.stringify(data);

--- a/packages/cli/next/src/capabilities/setup/setup.render.ts
+++ b/packages/cli/next/src/capabilities/setup/setup.render.ts
@@ -4,7 +4,11 @@
  */
 
 import type { Formatters } from "../../kernel/spec/types.js";
-import type { SetupResult, SetupSkillsResult } from "./types.js";
+import type {
+  ConfiguredTarget,
+  SetupResult,
+  SetupSkillsResult,
+} from "./types.js";
 
 /** Summarize a skills result: created / skipped / replaced counts. */
 function skillsSummary(result: SetupSkillsResult): string {
@@ -12,6 +16,23 @@ function skillsSummary(result: SetupSkillsResult): string {
   const skipped = result.actions.filter((a) => a.action === "skipped").length;
   const replaced = result.actions.filter((a) => a.action === "replaced").length;
   return `${created} created, ${replaced} replaced, ${skipped} unchanged across ${result.harnessCount} harness(es)`;
+}
+
+/**
+ * Summarize the MCP targets grouped by band — MACHINE (the user/home band)
+ * before PROJECT (the per-repo band) — so the recap shows which files at which
+ * level got the pragma server.
+ */
+function mcpSummary(targets: readonly ConfiguredTarget[]): string {
+  if (targets.length === 0) return "No harnesses configured.";
+  const section = (band: ConfiguredTarget["band"], label: string): string => {
+    const names = targets.filter((t) => t.band === band).map((t) => t.name);
+    return names.length > 0 ? `${label}: ${names.join(", ")}` : "";
+  };
+  const parts = [section("global", "MACHINE"), section("project", "PROJECT")]
+    .filter((p) => p.length > 0)
+    .join(" · ");
+  return `Configured MCP — ${parts}.`;
 }
 
 /** Render a setup result to a single human line (shared by plain/llm). */
@@ -24,9 +45,7 @@ function line(data: SetupResult): string {
     case "lsp":
       return "Terrazzo LSP extension is installed (up to date).";
     case "mcp":
-      return data.configured.length > 0
-        ? `Configured MCP for: ${data.configured.join(", ")}.`
-        : "No harnesses configured.";
+      return mcpSummary(data.targets);
     case "skills":
       return `Skills: ${skillsSummary(data.result)}.`;
     case "all":

--- a/packages/cli/next/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/next/src/capabilities/setup/setup.test.ts
@@ -185,7 +185,11 @@ describe("setup mcp — recap gate", () => {
     mkdirSync(join(cwd, ".cursor"), { recursive: true });
     const configPath = join(cwd, ".cursor", "mcp.json");
 
-    const { generator } = await buildSetupPlan(bootRuntime(FLAGS, cwd), "mcp");
+    const { generator } = await buildSetupPlan(
+      bootRuntime(FLAGS, cwd),
+      "mcp",
+      "both",
+    );
     // A handler that declines EVERYTHING (incl. execute's "Proceed?" gate) must
     // fail the run cleanly — the GENERATOR_CANCELLED code the boundary renders
     // as a plain "Cancelled." — and write nothing.
@@ -194,6 +198,76 @@ describe("setup mcp — recap gate", () => {
       runTask(task as Task<unknown>, { promptHandler: async () => false }),
     ).rejects.toMatchObject({ code: "GENERATOR_CANCELLED" });
     expect(existsSync(configPath)).toBe(false);
+  });
+});
+
+describe("setup mcp — scope & dedup", () => {
+  // Isolate PATH so a `claude`/`codex` on the host PATH can't inject harnesses
+  // via a `process` signal — detection is driven only by the dirs each test makes.
+  let prevPath: string | undefined;
+  beforeEach(() => {
+    prevPath = process.env.PATH;
+    process.env.PATH = tmp("pragma-scope-path-");
+  });
+  afterEach(() => {
+    process.env.PATH = prevPath;
+  });
+
+  it("writes both VS Code and Cline keys into one .vscode/mcp.json (7a dedup)", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".vscode"), { recursive: true }); // VS Code + Cline
+    const outcome = await executeVerb(
+      verbOf("mcp"),
+      {},
+      YES,
+      bootRuntime(FLAGS, cwd),
+    );
+    expect(outcome.exitCode).toBe(0);
+    const config = JSON.parse(
+      readFileSync(join(cwd, ".vscode", "mcp.json"), "utf-8"),
+    );
+    // VS Code writes under `servers`, Cline under `mcpServers` — the two-level
+    // dedup makes two writes to one file, each preserving the other's key.
+    expect(config.servers?.pragma?.command).toBe("pragma");
+    expect(config.mcpServers?.pragma?.command).toBe("pragma");
+  });
+
+  it("--local writes the project config and skips a global-only harness", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    const home = process.env.HOME ?? "";
+    mkdirSync(join(cwd, ".cursor"), { recursive: true }); // project scope
+    mkdirSync(join(cwd, ".windsurf"), { recursive: true }); // global scope
+    await executeVerb(
+      verbOf("mcp"),
+      { local: true },
+      YES,
+      bootRuntime(FLAGS, cwd),
+    );
+    expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(true);
+    expect(
+      existsSync(join(home, ".codeium", "windsurf", "mcp_config.json")),
+    ).toBe(false);
+  });
+
+  it("--global writes a global harness's home config, skipping project harnesses", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    const home = process.env.HOME ?? "";
+    mkdirSync(join(cwd, ".windsurf"), { recursive: true }); // global scope
+    mkdirSync(join(cwd, ".cursor"), { recursive: true }); // project scope
+    await executeVerb(
+      verbOf("mcp"),
+      { global: true },
+      YES,
+      bootRuntime(FLAGS, cwd),
+    );
+    const windsurfHome = JSON.parse(
+      readFileSync(
+        join(home, ".codeium", "windsurf", "mcp_config.json"),
+        "utf-8",
+      ),
+    );
+    expect(windsurfHome.mcpServers?.pragma?.command).toBe("pragma");
+    expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(false);
   });
 });
 

--- a/packages/cli/next/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/next/src/capabilities/setup/setup.test.ts
@@ -215,7 +215,19 @@ describe("setup mcp — scope & dedup", () => {
 
   it("writes both VS Code and Cline keys into one .vscode/mcp.json (7a dedup)", async () => {
     const cwd = tmp("pragma-setup-proj-");
-    mkdirSync(join(cwd, ".vscode"), { recursive: true }); // VS Code + Cline
+    mkdirSync(join(cwd, ".vscode"), { recursive: true }); // VS Code (dir signal)
+    // Cline is detected by its extension (NOT the .vscode dir), so install a fake
+    // one under the isolated HOME — both harnesses then resolve to the SAME
+    // .vscode/mcp.json, which is what the two-level dedup write must handle. The
+    // extension is matched by its `package.json` manifest, so write one.
+    const clineExt = join(
+      process.env.HOME ?? "",
+      ".vscode",
+      "extensions",
+      "saoudrizwan.claude-dev-1.0.0",
+    );
+    mkdirSync(clineExt, { recursive: true });
+    writeFileSync(join(clineExt, "package.json"), "{}");
     const outcome = await executeVerb(
       verbOf("mcp"),
       {},
@@ -268,6 +280,125 @@ describe("setup mcp — scope & dedup", () => {
     );
     expect(windsurfHome.mcpServers?.pragma?.command).toBe("pragma");
     expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(false);
+  });
+
+  // The `--scope <enum>` values (project/global/both) resolve independently of
+  // the `--global`/`--local` boolean sugars above — a distinct resolveScope arm.
+  it("--scope project (the enum) writes the project config, skipping a global harness", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    const home = process.env.HOME ?? "";
+    mkdirSync(join(cwd, ".cursor"), { recursive: true }); // project scope
+    mkdirSync(join(cwd, ".windsurf"), { recursive: true }); // global scope
+    await executeVerb(
+      verbOf("mcp"),
+      { scope: "project" },
+      YES,
+      bootRuntime(FLAGS, cwd),
+    );
+    expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(true);
+    expect(
+      existsSync(join(home, ".codeium", "windsurf", "mcp_config.json")),
+    ).toBe(false);
+  });
+
+  it("--scope global (the enum) writes the home config, skipping a project harness", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    const home = process.env.HOME ?? "";
+    mkdirSync(join(cwd, ".windsurf"), { recursive: true }); // global scope
+    mkdirSync(join(cwd, ".cursor"), { recursive: true }); // project scope
+    await executeVerb(
+      verbOf("mcp"),
+      { scope: "global" },
+      YES,
+      bootRuntime(FLAGS, cwd),
+    );
+    expect(
+      existsSync(join(home, ".codeium", "windsurf", "mcp_config.json")),
+    ).toBe(true);
+    expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(false);
+  });
+});
+
+describe("setup mcp — customize opt-in gate (Item 6)", () => {
+  it("gates the per-file multiselect behind an explicit customize=true", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".cursor"), { recursive: true }); // ⇒ one MCP target group
+    const { generator } = await buildSetupPlan(
+      bootRuntime(FLAGS, cwd),
+      "mcp",
+      "both",
+    );
+    const customize = generator.prompts.find((p) => p.name === "customize");
+    const targets = generator.prompts.find((p) => p.name === "mcpTargets");
+    // The gate is an opt-in confirm that defaults to NOT customizing.
+    expect(customize?.type).toBe("confirm");
+    expect(customize?.default).toBe(false);
+    // The per-file multiselect only surfaces after an explicit yes — so the
+    // "all" default configures every deduped file without an extra question.
+    expect(targets?.when?.({})).toBe(false);
+    expect(targets?.when?.({ customize: false })).toBe(false);
+    expect(targets?.when?.({ customize: true })).toBe(true);
+  });
+});
+
+describe("setup (run-all wizard) — scope threading", () => {
+  // Isolate PATH so an ambient `claude`/`codex` can't inject a harness via a
+  // `process` signal — detection is driven only by the dirs each test makes.
+  let prevPath: string | undefined;
+  beforeEach(() => {
+    prevPath = process.env.PATH;
+    process.env.PATH = tmp("pragma-runall-path-");
+  });
+  afterEach(() => {
+    process.env.PATH = prevPath;
+  });
+
+  /** Seed a discoverable skill so the project-band skills step is offerable. */
+  const seedSkill = (cwd: string): void => {
+    const dir = join(cwd, ".pragma", "skills", "s");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "SKILL.md"),
+      "---\nname: s\ndescription: A skill.\n---\n",
+    );
+  };
+
+  it("--local omits the global-band completions + lsp steps, keeping project steps", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".cursor"), { recursive: true }); // project-band MCP target
+    seedSkill(cwd); // project-band skills step
+    const outcome = await executeVerb(
+      setupSelfVerb,
+      { local: true },
+      DRY,
+      bootRuntime(FLAGS, cwd),
+    );
+    expect(outcome.exitCode).toBe(0);
+    const plan = outcome.stdout ?? "";
+    // The global-band steps are gone under --local (the bug: they used to run).
+    expect(plan).not.toContain(completionScriptPath("zsh"));
+    expect(plan).not.toContain("terrazzo-lsp-extension");
+    // The project-band steps remain: MCP into .cursor, skills into .agents/skills.
+    expect(plan).toContain("mcp.json");
+    expect(plan).toContain(".agents/skills");
+  });
+
+  it("--global omits the project-band skills step, keeping global steps", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    seedSkill(cwd); // WOULD be offered under the default `both`
+    const outcome = await executeVerb(
+      setupSelfVerb,
+      { global: true },
+      DRY,
+      bootRuntime(FLAGS, cwd),
+    );
+    expect(outcome.exitCode).toBe(0);
+    const plan = outcome.stdout ?? "";
+    // The global-band steps are present under --global.
+    expect(plan).toContain(completionScriptPath("zsh"));
+    expect(plan).toContain("terrazzo-lsp-extension");
+    // The project-band skills step is gone (the bug: it used to run under --global).
+    expect(plan).not.toContain(".agents/skills");
   });
 });
 

--- a/packages/cli/next/src/capabilities/setup/setup.verb.ts
+++ b/packages/cli/next/src/capabilities/setup/setup.verb.ts
@@ -23,9 +23,52 @@ import type { GeneratorResult } from "@canonical/summon-core";
 import { $, gen, type Task } from "@canonical/task";
 import type { PragmaRuntime } from "../../kernel/runtime/types.js";
 import { asVerb } from "../../kernel/spec/asVerb.js";
-import type { CapabilityModule, VerbSpec } from "../../kernel/spec/types.js";
+import type {
+  CapabilityModule,
+  ParamSpec,
+  VerbSpec,
+} from "../../kernel/spec/types.js";
 import { setupFormatters } from "./setup.render.js";
-import type { SetupMode, SetupResult } from "./types.js";
+import type { ScopeSelection, SetupMode, SetupResult } from "./types.js";
+
+/**
+ * The `--scope` flag + its `--global`/`--local` boolean sugars, shared by the
+ * band-aware verbs (`setup`/`mcp`/`skills`). `completions`/`lsp` never carry
+ * them — they are single-band installers.
+ */
+const SCOPE_PARAMS: readonly ParamSpec[] = [
+  {
+    kind: "enum",
+    name: "scope",
+    doc: "Which config band(s) to configure: project, global, or both.",
+    values: ["project", "global", "both"],
+    default: "both",
+  },
+  {
+    kind: "boolean",
+    name: "global",
+    doc: "Shorthand for --scope global (configure the user/home band).",
+  },
+  {
+    kind: "boolean",
+    name: "local",
+    doc: "Shorthand for --scope project (configure the per-project band).",
+  },
+];
+
+/**
+ * Resolve the `--scope`/`--global`/`--local` params into a single selection.
+ * The boolean sugars win over `--scope`; `--global` wins over `--local`.
+ *
+ * @param params - The coerced param bag.
+ * @returns The resolved scope selection (defaults to `both`).
+ */
+function resolveScope(params: Record<string, unknown>): ScopeSelection {
+  if (params.global === true) return "global";
+  if (params.local === true) return "project";
+  const scope = params.scope;
+  return scope === "global" || scope === "project" ? scope : "both";
+}
 
 /** The exposed-to-MCP capability the run-all self-verb declares. */
 const SELF_CAPABILITY = {
@@ -76,6 +119,7 @@ const SUB_CAPABILITY = {
 async function runSetup(
   mode: SetupMode,
   rt: PragmaRuntime,
+  scope: ScopeSelection,
 ): Promise<Task<SetupResult>> {
   // Lazy dynamic imports (R1 lazy-React discipline): summon-core's barrel is
   // React-free, and the non-TTY branch picks autoPrompt/mcpPrompt (never mounts
@@ -85,7 +129,7 @@ async function runSetup(
     import("./operations/setupGenerator.js"),
   ]);
 
-  const { generator, toResult } = await ops.buildSetupPlan(rt, mode);
+  const { generator, toResult } = await ops.buildSetupPlan(rt, mode, scope);
 
   const { isTTY, transport, yes, signal, abort } = rt.interaction ?? {
     isTTY: false,
@@ -149,7 +193,8 @@ function setupVerb(
     output: { formatters: setupFormatters },
     capability,
     ...extras,
-    run: (_params, rt) => runSetup(mode, rt) as unknown as Task<SetupResult>,
+    run: (params, rt) =>
+      runSetup(mode, rt, resolveScope(params)) as unknown as Task<SetupResult>,
   };
 }
 
@@ -159,10 +204,15 @@ const setupAllVerb = setupVerb(
   "all",
   SELF_CAPABILITY,
   {
-    doc: "Runs the shell-completions, LSP, MCP, and skills installers as a single wizard: pick the steps, review the recap, then apply.",
+    params: SCOPE_PARAMS,
+    doc: "Runs the shell-completions, LSP, MCP, and skills installers as a single wizard: pick the steps, review the recap, then apply. The scope option targets the project band, the user/home band, or both.",
     examples: [
       { cmd: "pragma setup" },
       { cmd: "pragma setup --dry-run", note: "preview every step's effects" },
+      {
+        cmd: "pragma setup --global",
+        note: "configure only the user/home band",
+      },
       { cmd: "pragma setup mcp", note: "just the MCP server registration" },
     ],
   },
@@ -173,6 +223,7 @@ const mcpVerb = setupVerb(
   "Register the pragma MCP server in detected AI harnesses.",
   "mcp",
   SUB_CAPABILITY,
+  { params: SCOPE_PARAMS },
 );
 
 const completionsVerb = setupVerb(
@@ -187,6 +238,7 @@ const skillsVerb = setupVerb(
   "Symlink discovered skills into each AI harness.",
   "skills",
   SUB_CAPABILITY,
+  { params: SCOPE_PARAMS },
 );
 
 const lspVerb = setupVerb(

--- a/packages/cli/next/src/capabilities/setup/types.ts
+++ b/packages/cli/next/src/capabilities/setup/types.ts
@@ -11,6 +11,31 @@ import type { ShellId } from "./shell.js";
  */
 export type SetupMode = "all" | "completions" | "lsp" | "mcp" | "skills";
 
+/**
+ * One of the two config bands: the per-user/home `global` band or the per-repo
+ * `project` band. Mirrors `@canonical/harnesses`' `ScopeBand` structurally, but
+ * is redeclared here so this statically-reachable type module never pulls the
+ * harnesses runtime into the fast-path module graph (the lazy-dispatch invariant).
+ */
+export type ScopeBand = "project" | "global";
+
+/**
+ * The resolved `--scope` selection: which config band(s) a run touches. `both`
+ * (the default) runs each detected harness's default band; `global`/`project`
+ * run only that band. Structurally mirrors the harnesses `ScopeSelection`.
+ */
+export type ScopeSelection = "project" | "global" | "both";
+
+/**
+ * One configured MCP target in a result: the file that was written, which band
+ * it belongs to, and the harness name(s) that share it.
+ */
+export interface ConfiguredTarget {
+  readonly name: string;
+  readonly band: ScopeBand;
+  readonly path: string;
+}
+
 /** One symlink create/skip/replace action performed during skill setup. */
 export interface SymlinkAction {
   readonly skillName: string;
@@ -37,6 +62,10 @@ export type SetupResult =
       readonly installed: boolean;
     }
   | { readonly kind: "lsp" }
-  | { readonly kind: "mcp"; readonly configured: readonly string[] }
+  | {
+      readonly kind: "mcp";
+      readonly configured: readonly string[];
+      readonly targets: readonly ConfiguredTarget[];
+    }
   | { readonly kind: "skills"; readonly result: SetupSkillsResult }
   | { readonly kind: "all"; readonly steps: readonly string[] };

--- a/packages/cli/next/src/capabilities/shared/bands.ts
+++ b/packages/cli/next/src/capabilities/shared/bands.ts
@@ -1,0 +1,16 @@
+/**
+ * User-facing labels for the two config bands, shared by the setup recap
+ * ({@link ../setup/setup.render}) and the doctor report
+ * ({@link ../doctor/doctor.render}) so ONE consistent vocabulary appears across
+ * both. The pair matches the CLI grammar users already meet elsewhere: the
+ * `--global`/`--local` flags, the `--scope project|global|both` enum, config
+ * show's `[global]`/`[project]` origin markers, and the `setup` manifest's
+ * `[global]`/`[project]` lines. (Earlier these two surfaces said MACHINE/PROJECT
+ * — a third term for the same bands; this is the single source that unifies it.)
+ */
+
+/** The user-facing display label for each of the two config bands. */
+export const BAND_LABELS: Record<"project" | "global", string> = {
+  global: "Global",
+  project: "Project",
+};

--- a/packages/cli/next/src/capabilities/surface.test.ts
+++ b/packages/cli/next/src/capabilities/surface.test.ts
@@ -146,11 +146,28 @@ describe("surface conformance — capabilities ⊆ covenant (PROTECTED)", () => 
   it("emits setup as a mixed self+sub noun (self is a tool, sub-verbs are mcp:false)", () => {
     // The one covenant noun both directly runnable AND with sub-verbs. The self
     // verb is the `setup` tool; the four installers are CLI-only (mcp:false).
+    // The band-aware verbs (setup/mcp/skills) carry the --scope/--global/--local
+    // flags; completions/lsp are single-band installers with no scope.
     expect(emitted.nouns.setup?.verbs).toEqual([
-      { v: "setup", mutates: true, mcp: "setup" },
-      { v: "mcp", mutates: true, mcp: false },
+      {
+        v: "setup",
+        flags: ["--scope", "--global", "--local"],
+        mutates: true,
+        mcp: "setup",
+      },
+      {
+        v: "mcp",
+        flags: ["--scope", "--global", "--local"],
+        mutates: true,
+        mcp: false,
+      },
       { v: "completions", mutates: true, mcp: false },
-      { v: "skills", mutates: true, mcp: false },
+      {
+        v: "skills",
+        flags: ["--scope", "--global", "--local"],
+        mutates: true,
+        mcp: false,
+      },
       { v: "lsp", mutates: true, mcp: false },
     ]);
   });

--- a/packages/cli/next/surface/surface.v2.json
+++ b/packages/cli/next/surface/surface.v2.json
@@ -196,10 +196,25 @@
     },
     "setup": {
       "verbs": [
-        { "v": "setup", "mutates": true, "mcp": "setup" },
-        { "v": "mcp", "mutates": true, "mcp": false },
+        {
+          "v": "setup",
+          "flags": ["--scope", "--global", "--local"],
+          "mutates": true,
+          "mcp": "setup"
+        },
+        {
+          "v": "mcp",
+          "flags": ["--scope", "--global", "--local"],
+          "mutates": true,
+          "mcp": false
+        },
         { "v": "completions", "mutates": true, "mcp": false },
-        { "v": "skills", "mutates": true, "mcp": false },
+        {
+          "v": "skills",
+          "flags": ["--scope", "--global", "--local"],
+          "mutates": true,
+          "mcp": false
+        },
         { "v": "lsp", "mutates": true, "mcp": false }
       ]
     },

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -12,10 +12,12 @@ import {
   removeMcpConfig,
   resolveConfigTarget,
   writeMcpConfig,
+  writeMcpConfigTargets,
 } from "./config.js";
 import findHarnessById from "./findHarnessById.js";
 import harnesses from "./harnesses.js";
 import type { PlatformEnv } from "./platformPaths.js";
+import type { ConfigTarget } from "./types.js";
 
 const claude = harnesses[0];
 
@@ -513,6 +515,68 @@ describe("scope-aware read/write (explicit band + platform)", () => {
     const written = JSON.parse(writeEffects[0].content);
     expect(written.mcpServers.pragma).toBeUndefined();
     expect(written.mcpServers.keep).toEqual({ command: "k" });
+  });
+});
+
+describe("writeMcpConfigTargets — shared-file multi-key write", () => {
+  const vscodeTarget: ConfigTarget = {
+    path: "/project/.vscode/mcp.json",
+    configFormat: "json",
+    mcpKey: "servers",
+    scope: "project",
+  };
+  const clineTarget: ConfigTarget = {
+    path: "/project/.vscode/mcp.json",
+    configFormat: "json",
+    mcpKey: "mcpServers",
+    scope: "project",
+  };
+
+  it("creates one file with the server under BOTH keys in a single write", () => {
+    const result = dryRunWith(
+      writeMcpConfigTargets([clineTarget, vscodeTarget], "pragma", {
+        command: "pragma",
+        args: ["mcp"],
+      }),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    expect(writeEffects.length).toBe(1); // single read-modify-write
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.servers.pragma.command).toBe("pragma");
+    expect(written.mcpServers.pragma.command).toBe("pragma");
+  });
+
+  it("merges into an existing shared file, preserving the other key", () => {
+    const existing = JSON.stringify({
+      servers: { existing: { command: "other" } },
+    });
+    const result = dryRunWith(
+      writeMcpConfigTargets([clineTarget, vscodeTarget], "pragma", {
+        command: "pragma",
+      }),
+      buildMocks({
+        Exists: existsMock(() => true),
+        ReadFile: readFileMock(existing),
+        WriteFile: writeMock,
+      }),
+    );
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    expect(writeEffects.length).toBe(1);
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.servers.existing).toEqual({ command: "other" });
+    expect(written.servers.pragma).toEqual({ command: "pragma" });
+    expect(written.mcpServers.pragma).toEqual({ command: "pragma" });
+  });
+
+  it("throws when given no targets", () => {
+    expect(() =>
+      writeMcpConfigTargets([], "pragma", { command: "pragma" }),
+    ).toThrow(/at least one target/);
   });
 });
 

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -578,6 +578,32 @@ describe("writeMcpConfigTargets — shared-file multi-key write", () => {
       writeMcpConfigTargets([], "pragma", { command: "pragma" }),
     ).toThrow(/at least one target/);
   });
+
+  it("forces env to an object for a normalizeEnv (OpenDesign) target (7g)", () => {
+    const odTarget: ConfigTarget = {
+      path: "/project/.od/mcp-config.json",
+      configFormat: "json",
+      mcpKey: "mcpServers",
+      scope: "both",
+      normalizeEnv: true,
+    };
+    const result = dryRunWith(
+      // pragma writes no env — normalization must add an empty object, not omit it.
+      writeMcpConfigTargets([odTarget], "pragma", {
+        command: "pragma",
+        args: ["mcp"],
+      }),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    const written = JSON.parse(writeEffects[0].content);
+    expect(typeof written.mcpServers.pragma.env).toBe("object");
+    expect(written.mcpServers.pragma.env).toEqual({});
+  });
 });
 
 // SEC-1: a JSONC config (comments, trailing commas — valid in Cursor/VS Code/

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -6,10 +6,29 @@ import {
   filterEffects,
 } from "@canonical/task";
 import { describe, expect, it } from "vitest";
-import { readMcpConfig, removeMcpConfig, writeMcpConfig } from "./config.js";
+import {
+  defaultBandOf,
+  readMcpConfig,
+  removeMcpConfig,
+  resolveConfigTarget,
+  writeMcpConfig,
+} from "./config.js";
+import findHarnessById from "./findHarnessById.js";
 import harnesses from "./harnesses.js";
+import type { PlatformEnv } from "./platformPaths.js";
 
 const claude = harnesses[0];
+
+/** A fixed host so home-band paths resolve deterministically. */
+const PLATFORM: PlatformEnv = {
+  platform: "linux",
+  env: {},
+  home: "/home/tester",
+  isWsl: false,
+};
+
+const cursor = findHarnessById("cursor") as (typeof harnesses)[number];
+const windsurf = findHarnessById("windsurf") as (typeof harnesses)[number];
 
 type MockSpec = Record<string, (effect: Effect) => unknown>;
 
@@ -398,6 +417,102 @@ describe("TOML config (Codex)", () => {
     expect(writeEffects.length).toBe(1);
     expect(writeEffects[0].content).toContain("[mcp_servers.figma]");
     expect(writeEffects[0].content).not.toContain("[mcp_servers.pragma]");
+  });
+});
+
+describe("defaultBandOf", () => {
+  it("defaults a global-only harness to the global band", () => {
+    expect(defaultBandOf(windsurf)).toBe("global");
+  });
+
+  it("defaults project and both harnesses to the project band", () => {
+    expect(defaultBandOf(cursor)).toBe("project");
+    expect(defaultBandOf(claude)).toBe("project");
+  });
+});
+
+describe("resolveConfigTarget", () => {
+  it("resolves the project band to the harness project path", () => {
+    const target = resolveConfigTarget(claude, "/project", "project", PLATFORM);
+    expect(target.path).toBe("/project/.mcp.json");
+    expect(target.mcpKey).toBe("mcpServers");
+    expect(target.scope).toBe("both");
+  });
+
+  it("resolves the global band to the harness home path", () => {
+    const target = resolveConfigTarget(claude, "/project", "global", PLATFORM);
+    expect(target.path).toBe("/home/tester/.claude.json");
+  });
+
+  it("throws for a global band on a harness with no homeConfigPath", () => {
+    expect(() =>
+      resolveConfigTarget(cursor, "/project", "global", PLATFORM),
+    ).toThrow(/homeConfigPath/);
+  });
+});
+
+describe("scope-aware read/write (explicit band + platform)", () => {
+  it("writes the pragma server into the home config for the global band", () => {
+    const result = dryRunWith(
+      writeMcpConfig(
+        claude,
+        "/project",
+        "pragma",
+        { command: "pragma", args: ["mcp"] },
+        "global",
+        PLATFORM,
+      ),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    expect(writeEffects.length).toBe(1);
+    expect(writeEffects[0].path).toBe("/home/tester/.claude.json");
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.mcpServers.pragma).toEqual({
+      command: "pragma",
+      args: ["mcp"],
+    });
+  });
+
+  it("reads the home config for the global band", () => {
+    const result = dryRunWith(
+      readMcpConfig(claude, "/project", "global", PLATFORM),
+      buildMocks({
+        Exists: existsMock((path) => path === "/home/tester/.claude.json"),
+        ReadFile: readFileMock(
+          JSON.stringify({ mcpServers: { pragma: { command: "pragma" } } }),
+        ),
+      }),
+    );
+    expect(result.value).toEqual({ pragma: { command: "pragma" } });
+  });
+
+  it("removes from the home config for the global band", () => {
+    const result = dryRunWith(
+      removeMcpConfig(claude, "/project", "pragma", "global", PLATFORM),
+      buildMocks({
+        Exists: existsMock((path) => path === "/home/tester/.claude.json"),
+        ReadFile: readFileMock(
+          JSON.stringify({
+            mcpServers: {
+              pragma: { command: "pragma" },
+              keep: { command: "k" },
+            },
+          }),
+        ),
+        WriteFile: writeMock,
+      }),
+    );
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    expect(writeEffects[0].path).toBe("/home/tester/.claude.json");
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.mcpServers.pragma).toBeUndefined();
+    expect(written.mcpServers.keep).toEqual({ command: "k" });
   });
 });
 

--- a/packages/runtime/harnesses/src/lib/config.ts
+++ b/packages/runtime/harnesses/src/lib/config.ts
@@ -21,6 +21,7 @@ import {
   mkdir,
   pure,
   readFile,
+  sequence_,
   type Task,
   writeFile,
 } from "@canonical/task";
@@ -151,11 +152,85 @@ export const readMcpConfigFrom = (
   );
 };
 
+/** The TOML field record for a server config (command + optional args/cwd). */
+const tomlFields = (config: McpServerConfig): Record<string, unknown> => {
+  const fields: Record<string, unknown> = { command: config.command };
+  if (config.args) fields.args = config.args;
+  if (config.cwd) fields.cwd = config.cwd;
+  return fields;
+};
+
+/**
+ * Write or merge one server entry under EVERY `mcpKey` of a shared config file,
+ * in a SINGLE read-modify-write. Preserves every other server and every other
+ * top-level key (so two harnesses sharing a file under different keys each
+ * preserve the other), and — being one write per file — never re-reads a file
+ * it just created, so a dry-run of a multi-key group is well-defined. A file
+ * that is not valid JSON/JSONC fails closed rather than being overwritten.
+ *
+ * @param path - The config file path.
+ * @param configFormat - Its serialization format.
+ * @param mcpKeys - The server-map keys to write the entry under (≥1).
+ * @param serverName - The server entry name.
+ * @param config - The server config.
+ * @param undoTask - The task that reverses this write.
+ * @returns A Task performing the merge/create (with an undo).
+ * @note Impure — reads and writes the filesystem via Task effects.
+ */
+const writeServerUnderKeys = (
+  path: string,
+  configFormat: ConfigTarget["configFormat"],
+  mcpKeys: readonly string[],
+  serverName: string,
+  config: McpServerConfig,
+  undoTask: Task<void>,
+): Task<void> => {
+  if (configFormat === "toml") {
+    const fields = tomlFields(config);
+    return ifElseM(
+      exists(path),
+      flatMap(readFile(path), (content) => {
+        let merged = content;
+        for (const key of mcpKeys) {
+          merged = mergeTomlSection(merged, key, serverName, fields);
+        }
+        return writeFile(path, merged, { undo: undoTask });
+      }),
+      flatMap(mkdir(dirname(path), true), () => {
+        const body = mcpKeys
+          .map((key) => serializeTomlSection(key, { [serverName]: fields }))
+          .join("");
+        return writeFile(path, body, { undo: undoTask });
+      }),
+    );
+  }
+
+  return ifElseM(
+    exists(path),
+    flatMap(readFile(path), (content) => {
+      const parsed = parseJsonc(content);
+      if (parsed === undefined) {
+        return unparseableConfig(path);
+      }
+      for (const key of mcpKeys) {
+        const servers = asServerRecord(parsed[key]);
+        servers[serverName] = config;
+        parsed[key] = servers;
+      }
+      return writeFile(path, formatJson(parsed), { undo: undoTask });
+    }),
+    flatMap(mkdir(dirname(path), true), () => {
+      const initial: Record<string, unknown> = {};
+      for (const key of mcpKeys) initial[key] = { [serverName]: config };
+      return writeFile(path, formatJson(initial), { undo: undoTask });
+    }),
+  );
+};
+
 /**
  * Write or merge an MCP server entry into a resolved config target. Preserves
- * every other server (and every other top-level key, so two harnesses that
- * share a file but use different `mcpKey`s never clobber each other). A file
- * that is not valid JSON/JSONC fails closed rather than being overwritten.
+ * every other server (and every other top-level key). A file that is not valid
+ * JSON/JSONC fails closed rather than being overwritten.
  *
  * @param target - The resolved config location.
  * @param serverName - The server entry name to write.
@@ -170,54 +245,47 @@ export const writeMcpConfigTo = (
   target: ConfigTarget,
   serverName: string,
   config: McpServerConfig,
+): Task<void> =>
+  writeServerUnderKeys(
+    target.path,
+    target.configFormat,
+    [target.mcpKey],
+    serverName,
+    config,
+    removeMcpConfigFrom(target, serverName),
+  );
+
+/**
+ * Write one server entry across a group of targets that share ONE file under
+ * (possibly) different `mcpKey`s — VS Code (`servers`) + Cline (`mcpServers`) in
+ * `.vscode/mcp.json` — in a single read-modify-write, so each key preserves the
+ * other and a dry-run of the group is well-defined.
+ *
+ * @param targets - The group's per-key targets (non-empty, sharing a file).
+ * @param serverName - The server entry name to write.
+ * @param config - The server config to write.
+ * @returns A Task writing the entry under every target's `mcpKey`.
+ * @note Impure — reads and writes the filesystem via Task effects.
+ */
+export const writeMcpConfigTargets = (
+  targets: readonly ConfigTarget[],
+  serverName: string,
+  config: McpServerConfig,
 ): Task<void> => {
-  const undoTask = removeMcpConfigFrom(target, serverName);
-
-  if (target.configFormat === "toml") {
-    const fields: Record<string, unknown> = { command: config.command };
-    if (config.args) fields.args = config.args;
-    if (config.cwd) fields.cwd = config.cwd;
-
-    return ifElseM(
-      exists(target.path),
-      flatMap(readFile(target.path), (content) => {
-        const merged = mergeTomlSection(
-          content,
-          target.mcpKey,
-          serverName,
-          fields,
-        );
-        return writeFile(target.path, merged, { undo: undoTask });
-      }),
-      flatMap(mkdir(dirname(target.path), true), () =>
-        writeFile(
-          target.path,
-          serializeTomlSection(target.mcpKey, { [serverName]: fields }),
-          { undo: undoTask },
-        ),
-      ),
-    );
+  const first = targets.at(0);
+  if (first === undefined) {
+    throw new Error("writeMcpConfigTargets: at least one target is required");
   }
-
-  return ifElseM(
-    exists(target.path),
-    flatMap(readFile(target.path), (content) => {
-      const parsed = parseJsonc(content);
-      if (parsed === undefined) {
-        return unparseableConfig(target.path);
-      }
-      const servers = asServerRecord(parsed[target.mcpKey]);
-      servers[serverName] = config;
-      parsed[target.mcpKey] = servers;
-      return writeFile(target.path, formatJson(parsed), { undo: undoTask });
-    }),
-    flatMap(mkdir(dirname(target.path), true), () =>
-      writeFile(
-        target.path,
-        formatJson({ [target.mcpKey]: { [serverName]: config } }),
-        { undo: undoTask },
-      ),
-    ),
+  const undoTask = sequence_(
+    targets.map((t) => removeMcpConfigFrom(t, serverName)),
+  );
+  return writeServerUnderKeys(
+    first.path,
+    first.configFormat,
+    targets.map((t) => t.mcpKey),
+    serverName,
+    config,
+    undoTask,
   );
 };
 

--- a/packages/runtime/harnesses/src/lib/config.ts
+++ b/packages/runtime/harnesses/src/lib/config.ts
@@ -116,6 +116,16 @@ export const resolveConfigTarget = (
   configFormat: harness.configFormat,
   mcpKey: harness.mcpKey,
   scope: harness.scope,
+  normalizeEnv: harness.normalizeEnv,
+});
+
+/**
+ * Coerce a server config's `env` to a JSON object/map — dropping a non-object
+ * `env` to `{}` — for harnesses (OpenDesign, 7g) that reject a non-map `env`.
+ */
+const normalizeOdEnv = (config: McpServerConfig): McpServerConfig => ({
+  ...config,
+  env: asServerRecord(config.env) as Record<string, string>,
 });
 
 /**
@@ -182,9 +192,11 @@ const writeServerUnderKeys = (
   configFormat: ConfigTarget["configFormat"],
   mcpKeys: readonly string[],
   serverName: string,
-  config: McpServerConfig,
+  rawConfig: McpServerConfig,
+  normalizeEnv: boolean,
   undoTask: Task<void>,
 ): Task<void> => {
+  const config = normalizeEnv ? normalizeOdEnv(rawConfig) : rawConfig;
   if (configFormat === "toml") {
     const fields = tomlFields(config);
     return ifElseM(
@@ -252,6 +264,7 @@ export const writeMcpConfigTo = (
     [target.mcpKey],
     serverName,
     config,
+    target.normalizeEnv === true,
     removeMcpConfigFrom(target, serverName),
   );
 
@@ -285,6 +298,7 @@ export const writeMcpConfigTargets = (
     targets.map((t) => t.mcpKey),
     serverName,
     config,
+    first.normalizeEnv === true,
     undoTask,
   );
 };

--- a/packages/runtime/harnesses/src/lib/config.ts
+++ b/packages/runtime/harnesses/src/lib/config.ts
@@ -2,6 +2,13 @@
  * MCP config read/write/remove as Task values.
  * All effects go through @canonical/task primitives — no raw fs calls.
  * Supports both JSON and TOML config formats.
+ *
+ * The bodies act on a resolved {@link ConfigTarget} (the `*To`/`*From` helpers),
+ * so a caller picks the band once (`resolveConfigTarget`) and the read/write
+ * logic never re-consults the harness definition. The `readMcpConfig` /
+ * `writeMcpConfig` / `removeMcpConfig` wrappers keep the harness-oriented
+ * signature (band + platform default to the harness's own default band and the
+ * live host), so existing callers are unchanged.
  */
 
 import { dirname } from "node:path";
@@ -18,13 +25,19 @@ import {
   writeFile,
 } from "@canonical/task";
 import parseJsonc from "./parseJsonc.js";
+import { type PlatformEnv, readPlatformEnv } from "./platformPaths.js";
 import {
   mergeTomlSection,
   parseTomlSection,
   removeTomlSection,
   serializeTomlSection,
 } from "./toml/index.js";
-import type { HarnessDefinition, McpServerConfig } from "./types.js";
+import type {
+  ConfigTarget,
+  HarnessDefinition,
+  McpServerConfig,
+  ScopeBand,
+} from "./types.js";
 
 /**
  * Serialize a record to formatted JSON with a trailing newline.
@@ -54,21 +67,71 @@ const unparseableConfig = (configPath: string): Task<void> =>
   );
 
 /**
- * Read existing MCP server entries from a harness config file.
+ * The band a harness writes to by default: the home config for a global-only
+ * harness, the project file for a `project`/`both` harness (a `both` harness
+ * writes its project file unless a global band is explicitly requested).
  *
- * @note This function is impure — it reads from the filesystem via Task effects.
+ * @param harness - The harness definition.
+ * @returns Its default {@link ScopeBand}.
  */
-export const readMcpConfig = (
+export const defaultBandOf = (harness: HarnessDefinition): ScopeBand =>
+  harness.scope === "global" ? "global" : "project";
+
+/** Resolve a global-band harness's home config path, asserting it declares one. */
+const homeConfigPathOf = (
+  harness: HarnessDefinition,
+  platform: PlatformEnv,
+): string => {
+  const build = harness.homeConfigPath;
+  if (build === undefined) {
+    throw new Error(
+      `harness "${harness.id}" requested a global-band config target but declares no homeConfigPath`,
+    );
+  }
+  return build(platform);
+};
+
+/**
+ * Resolve a harness + band into the concrete {@link ConfigTarget} a read/write
+ * acts on: the project config path for the project band, the home config path
+ * (which every global/both harness declares) for the global band.
+ *
+ * @param harness - The harness definition.
+ * @param projectRoot - The project root for the project band.
+ * @param band - Which band to resolve.
+ * @param platform - The captured host, for the home path.
+ * @returns The resolved config target.
+ */
+export const resolveConfigTarget = (
   harness: HarnessDefinition,
   projectRoot: string,
-): Task<Record<string, McpServerConfig>> => {
-  const configPath = harness.configPath(projectRoot);
+  band: ScopeBand,
+  platform: PlatformEnv,
+): ConfigTarget => ({
+  path:
+    band === "global"
+      ? homeConfigPathOf(harness, platform)
+      : harness.configPath(projectRoot),
+  configFormat: harness.configFormat,
+  mcpKey: harness.mcpKey,
+  scope: harness.scope,
+});
 
-  if (harness.configFormat === "toml") {
+/**
+ * Read existing MCP server entries from a resolved config target.
+ *
+ * @param target - The resolved config location.
+ * @returns The server map (empty when the file is absent/unparseable).
+ * @note Impure — reads from the filesystem via Task effects.
+ */
+export const readMcpConfigFrom = (
+  target: ConfigTarget,
+): Task<Record<string, McpServerConfig>> => {
+  if (target.configFormat === "toml") {
     return ifElseM(
-      exists(configPath),
-      map(readFile(configPath), (content) => {
-        const sections = parseTomlSection(content, harness.mcpKey);
+      exists(target.path),
+      map(readFile(target.path), (content) => {
+        const sections = parseTomlSection(content, target.mcpKey);
         return sections as unknown as Record<string, McpServerConfig>;
       }),
       pure({} as Record<string, McpServerConfig>),
@@ -76,10 +139,10 @@ export const readMcpConfig = (
   }
 
   return ifElseM(
-    exists(configPath),
-    map(readFile(configPath), (content) => {
+    exists(target.path),
+    map(readFile(target.path), (content) => {
       const parsed = parseJsonc(content) ?? {};
-      return asServerRecord(parsed[harness.mcpKey]) as Record<
+      return asServerRecord(parsed[target.mcpKey]) as Record<
         string,
         McpServerConfig
       >;
@@ -89,46 +152,47 @@ export const readMcpConfig = (
 };
 
 /**
- * Write or merge an MCP server entry into a harness config file.
- * If the file exists, the new entry is merged into existing servers, preserving
- * every other server. If the file does not exist, it is created with the entry.
- * A file that is not valid JSON/JSONC fails closed rather than being overwritten.
+ * Write or merge an MCP server entry into a resolved config target. Preserves
+ * every other server (and every other top-level key, so two harnesses that
+ * share a file but use different `mcpKey`s never clobber each other). A file
+ * that is not valid JSON/JSONC fails closed rather than being overwritten.
  *
- * @note This function is impure — it reads and writes the filesystem
- * via Task effects.
+ * @param target - The resolved config location.
+ * @param serverName - The server entry name to write.
+ * @param config - The server config to write.
+ * @returns A Task performing the merge/create (with an undo).
+ * @note Impure — reads and writes the filesystem via Task effects.
  * @note A JSON merge is written back as formatted JSON, so a JSONC config's
  * comments and custom formatting are not preserved across the write — only its
  * server entries are.
  */
-export const writeMcpConfig = (
-  harness: HarnessDefinition,
-  projectRoot: string,
+export const writeMcpConfigTo = (
+  target: ConfigTarget,
   serverName: string,
   config: McpServerConfig,
 ): Task<void> => {
-  const configPath = harness.configPath(projectRoot);
-  const undoTask = removeMcpConfig(harness, projectRoot, serverName);
+  const undoTask = removeMcpConfigFrom(target, serverName);
 
-  if (harness.configFormat === "toml") {
+  if (target.configFormat === "toml") {
     const fields: Record<string, unknown> = { command: config.command };
     if (config.args) fields.args = config.args;
     if (config.cwd) fields.cwd = config.cwd;
 
     return ifElseM(
-      exists(configPath),
-      flatMap(readFile(configPath), (content) => {
+      exists(target.path),
+      flatMap(readFile(target.path), (content) => {
         const merged = mergeTomlSection(
           content,
-          harness.mcpKey,
+          target.mcpKey,
           serverName,
           fields,
         );
-        return writeFile(configPath, merged, { undo: undoTask });
+        return writeFile(target.path, merged, { undo: undoTask });
       }),
-      flatMap(mkdir(dirname(configPath), true), () =>
+      flatMap(mkdir(dirname(target.path), true), () =>
         writeFile(
-          configPath,
-          serializeTomlSection(harness.mcpKey, { [serverName]: fields }),
+          target.path,
+          serializeTomlSection(target.mcpKey, { [serverName]: fields }),
           { undo: undoTask },
         ),
       ),
@@ -136,21 +200,21 @@ export const writeMcpConfig = (
   }
 
   return ifElseM(
-    exists(configPath),
-    flatMap(readFile(configPath), (content) => {
+    exists(target.path),
+    flatMap(readFile(target.path), (content) => {
       const parsed = parseJsonc(content);
       if (parsed === undefined) {
-        return unparseableConfig(configPath);
+        return unparseableConfig(target.path);
       }
-      const servers = asServerRecord(parsed[harness.mcpKey]);
+      const servers = asServerRecord(parsed[target.mcpKey]);
       servers[serverName] = config;
-      parsed[harness.mcpKey] = servers;
-      return writeFile(configPath, formatJson(parsed), { undo: undoTask });
+      parsed[target.mcpKey] = servers;
+      return writeFile(target.path, formatJson(parsed), { undo: undoTask });
     }),
-    flatMap(mkdir(dirname(configPath), true), () =>
+    flatMap(mkdir(dirname(target.path), true), () =>
       writeFile(
-        configPath,
-        formatJson({ [harness.mcpKey]: { [serverName]: config } }),
+        target.path,
+        formatJson({ [target.mcpKey]: { [serverName]: config } }),
         { undo: undoTask },
       ),
     ),
@@ -158,45 +222,108 @@ export const writeMcpConfig = (
 };
 
 /**
- * Remove an MCP server entry from a harness config file.
- * If the file does not exist, this is a no-op. A file that is not valid
- * JSON/JSONC fails closed rather than being overwritten.
+ * Remove an MCP server entry from a resolved config target. A no-op when the
+ * file is absent; fails closed on an unparseable JSON/JSONC config.
  *
- * @note This function is impure — it reads and writes the filesystem
- * via Task effects.
- * @note As with {@link writeMcpConfig}, a JSON rewrite does not preserve a
- * JSONC config's comments or formatting — only its server entries.
+ * @param target - The resolved config location.
+ * @param serverName - The server entry name to remove.
+ * @returns A Task performing the removal.
+ * @note Impure — reads and writes the filesystem via Task effects.
  */
-export const removeMcpConfig = (
-  harness: HarnessDefinition,
-  projectRoot: string,
+export const removeMcpConfigFrom = (
+  target: ConfigTarget,
   serverName: string,
 ): Task<void> => {
-  const configPath = harness.configPath(projectRoot);
-
-  if (harness.configFormat === "toml") {
+  if (target.configFormat === "toml") {
     return ifElseM(
-      exists(configPath),
-      flatMap(readFile(configPath), (content) => {
-        const removed = removeTomlSection(content, harness.mcpKey, serverName);
-        return writeFile(configPath, removed);
+      exists(target.path),
+      flatMap(readFile(target.path), (content) => {
+        const removed = removeTomlSection(content, target.mcpKey, serverName);
+        return writeFile(target.path, removed);
       }),
       pure(undefined),
     );
   }
 
   return ifElseM(
-    exists(configPath),
-    flatMap(readFile(configPath), (content) => {
+    exists(target.path),
+    flatMap(readFile(target.path), (content) => {
       const parsed = parseJsonc(content);
       if (parsed === undefined) {
-        return unparseableConfig(configPath);
+        return unparseableConfig(target.path);
       }
-      const servers = asServerRecord(parsed[harness.mcpKey]);
+      const servers = asServerRecord(parsed[target.mcpKey]);
       delete servers[serverName];
-      parsed[harness.mcpKey] = servers;
-      return writeFile(configPath, formatJson(parsed));
+      parsed[target.mcpKey] = servers;
+      return writeFile(target.path, formatJson(parsed));
     }),
     pure(undefined),
   );
 };
+
+/**
+ * Read existing MCP server entries from a harness config file.
+ *
+ * @param harness - The harness whose config to read.
+ * @param projectRoot - The project root.
+ * @param band - The band to read (defaults to the harness's default band).
+ * @param platform - The captured host (defaults to the live reader).
+ * @returns The server map.
+ * @note Impure — reads from the filesystem via Task effects.
+ */
+export const readMcpConfig = (
+  harness: HarnessDefinition,
+  projectRoot: string,
+  band: ScopeBand = defaultBandOf(harness),
+  platform: PlatformEnv = readPlatformEnv(),
+): Task<Record<string, McpServerConfig>> =>
+  readMcpConfigFrom(resolveConfigTarget(harness, projectRoot, band, platform));
+
+/**
+ * Write or merge an MCP server entry into a harness config file.
+ *
+ * @param harness - The harness whose config to write.
+ * @param projectRoot - The project root.
+ * @param serverName - The server entry name.
+ * @param config - The server config.
+ * @param band - The band to write (defaults to the harness's default band).
+ * @param platform - The captured host (defaults to the live reader).
+ * @returns A Task performing the merge/create.
+ * @note Impure — reads and writes the filesystem via Task effects.
+ */
+export const writeMcpConfig = (
+  harness: HarnessDefinition,
+  projectRoot: string,
+  serverName: string,
+  config: McpServerConfig,
+  band: ScopeBand = defaultBandOf(harness),
+  platform: PlatformEnv = readPlatformEnv(),
+): Task<void> =>
+  writeMcpConfigTo(
+    resolveConfigTarget(harness, projectRoot, band, platform),
+    serverName,
+    config,
+  );
+
+/**
+ * Remove an MCP server entry from a harness config file.
+ *
+ * @param harness - The harness whose config to modify.
+ * @param projectRoot - The project root.
+ * @param serverName - The server entry name to remove.
+ * @param band - The band to modify (defaults to the harness's default band).
+ * @param platform - The captured host (defaults to the live reader).
+ * @returns A Task performing the removal.
+ * @note Impure — reads and writes the filesystem via Task effects.
+ */
+export const removeMcpConfig = (
+  harness: HarnessDefinition,
+  projectRoot: string,
+  serverName: string,
+  band: ScopeBand = defaultBandOf(harness),
+  platform: PlatformEnv = readPlatformEnv(),
+): Task<void> =>
+  removeMcpConfigFrom(
+    resolveConfigTarget(harness, projectRoot, band, platform),
+    serverName,
+  );

--- a/packages/runtime/harnesses/src/lib/configTargets.test.ts
+++ b/packages/runtime/harnesses/src/lib/configTargets.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  bandsForScope,
   groupConfigTargets,
   groupTargetsForScope,
-  harnessesForBand,
-  harnessInBand,
+  isHarnessInBand,
+  listHarnessesForBand,
+  resolveBandsForScope,
 } from "./configTargets.js";
 import findHarnessById from "./findHarnessById.js";
 import type { PlatformEnv } from "./platformPaths.js";
@@ -54,21 +54,21 @@ const vscode = detected(requireHarness("vscode"));
 const cline = detected(requireHarness("cline"));
 const windsurf = detected(requireHarness("windsurf"));
 
-describe("bandsForScope", () => {
+describe("resolveBandsForScope", () => {
   it("runs both bands (project first) for scope=both", () => {
-    expect(bandsForScope("both")).toEqual(["project", "global"]);
+    expect(resolveBandsForScope("both")).toEqual(["project", "global"]);
   });
 
   it("runs only the global band for scope=global", () => {
-    expect(bandsForScope("global")).toEqual(["global"]);
+    expect(resolveBandsForScope("global")).toEqual(["global"]);
   });
 
   it("runs only the project band for scope=project", () => {
-    expect(bandsForScope("project")).toEqual(["project"]);
+    expect(resolveBandsForScope("project")).toEqual(["project"]);
   });
 });
 
-describe("harnessInBand", () => {
+describe("isHarnessInBand", () => {
   const cases: [HarnessScope, HarnessScope, "project" | "global", boolean][] = [
     // project band takes project + both, never global
     ["project", "both", "project", true],
@@ -87,18 +87,18 @@ describe("harnessInBand", () => {
   it.each(
     cases,
   )("harness %s under scope=%s in %s band → %s", (harnessScope, scope, band, expected) => {
-    expect(harnessInBand(harnessScope, scope, band)).toBe(expected);
+    expect(isHarnessInBand(harnessScope, scope, band)).toBe(expected);
   });
 });
 
-describe("harnessesForBand", () => {
+describe("listHarnessesForBand", () => {
   it("keeps project + both harnesses in the project band", () => {
-    const list = harnessesForBand([vscode, windsurf], "both", "project");
+    const list = listHarnessesForBand([vscode, windsurf], "both", "project");
     expect(list.map((d) => d.harness.id)).toEqual(["vscode"]);
   });
 
   it("keeps only global harnesses in the global band under scope=both", () => {
-    const list = harnessesForBand([vscode, windsurf], "both", "global");
+    const list = listHarnessesForBand([vscode, windsurf], "both", "global");
     expect(list.map((d) => d.harness.id)).toEqual(["windsurf"]);
   });
 });

--- a/packages/runtime/harnesses/src/lib/configTargets.test.ts
+++ b/packages/runtime/harnesses/src/lib/configTargets.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  bandsForScope,
+  groupConfigTargets,
+  groupTargetsForScope,
+  harnessesForBand,
+  harnessInBand,
+} from "./configTargets.js";
+import findHarnessById from "./findHarnessById.js";
+import type { PlatformEnv } from "./platformPaths.js";
+import type {
+  DetectedHarness,
+  HarnessDefinition,
+  HarnessScope,
+} from "./types.js";
+
+const PLATFORM: PlatformEnv = {
+  platform: "linux",
+  env: {},
+  home: "/home/tester",
+  isWsl: false,
+};
+
+/** Build a minimal harness definition fixture. */
+const harness = (overrides: Partial<HarnessDefinition>): HarnessDefinition => ({
+  id: "fixture",
+  name: "Fixture",
+  version: "*",
+  scope: "project",
+  detect: [{ type: "directory", path: ".fixture" }],
+  configPath: (root) => `${root}/.fixture/mcp.json`,
+  configFormat: "json",
+  mcpKey: "mcpServers",
+  skillsPath: (root) => `${root}/.fixture/skills`,
+  ...overrides,
+});
+
+/** Wrap a harness definition as a (high-confidence) detection. */
+const detected = (h: HarnessDefinition): DetectedHarness => ({
+  harness: h,
+  confidence: "high",
+  configExists: false,
+  configPath: h.configPath("/project"),
+});
+
+/** Look up a registered harness, asserting it exists. */
+const requireHarness = (id: string): HarnessDefinition => {
+  const found = findHarnessById(id);
+  if (!found) throw new Error(`missing harness fixture: ${id}`);
+  return found;
+};
+
+const vscode = detected(requireHarness("vscode"));
+const cline = detected(requireHarness("cline"));
+const windsurf = detected(requireHarness("windsurf"));
+
+describe("bandsForScope", () => {
+  it("runs both bands (project first) for scope=both", () => {
+    expect(bandsForScope("both")).toEqual(["project", "global"]);
+  });
+
+  it("runs only the global band for scope=global", () => {
+    expect(bandsForScope("global")).toEqual(["global"]);
+  });
+
+  it("runs only the project band for scope=project", () => {
+    expect(bandsForScope("project")).toEqual(["project"]);
+  });
+});
+
+describe("harnessInBand", () => {
+  const cases: [HarnessScope, HarnessScope, "project" | "global", boolean][] = [
+    // project band takes project + both, never global
+    ["project", "both", "project", true],
+    ["both", "both", "project", true],
+    ["global", "both", "project", false],
+    // global band under scope=both takes global only (no dual-scope double-write)
+    ["global", "both", "global", true],
+    ["both", "both", "global", false],
+    ["project", "both", "global", false],
+    // global band under scope=global flips dual-scope to home
+    ["global", "global", "global", true],
+    ["both", "global", "global", true],
+    ["project", "global", "global", false],
+  ];
+
+  it.each(
+    cases,
+  )("harness %s under scope=%s in %s band → %s", (harnessScope, scope, band, expected) => {
+    expect(harnessInBand(harnessScope, scope, band)).toBe(expected);
+  });
+});
+
+describe("harnessesForBand", () => {
+  it("keeps project + both harnesses in the project band", () => {
+    const list = harnessesForBand([vscode, windsurf], "both", "project");
+    expect(list.map((d) => d.harness.id)).toEqual(["vscode"]);
+  });
+
+  it("keeps only global harnesses in the global band under scope=both", () => {
+    const list = harnessesForBand([vscode, windsurf], "both", "global");
+    expect(list.map((d) => d.harness.id)).toEqual(["windsurf"]);
+  });
+});
+
+describe("groupConfigTargets", () => {
+  it("merges VS Code + Cline into one file with two distinct-key writes", () => {
+    const groups = groupConfigTargets(
+      [vscode, cline],
+      "/project",
+      "project",
+      PLATFORM,
+    );
+    expect(groups).toHaveLength(1);
+    const group = groups[0];
+    expect(group.path).toBe("/project/.vscode/mcp.json");
+    expect(group.harnessNames).toEqual(["Cline", "VS Code"]);
+    expect(group.writes.map((w) => w.mcpKey).sort()).toEqual([
+      "mcpServers",
+      "servers",
+    ]);
+    expect(group.scope).toBe("project");
+  });
+
+  it("collapses two harnesses sharing a path AND mcpKey to a single write", () => {
+    const a = detected(harness({ id: "a", name: "A" }));
+    const b = detected(harness({ id: "b", name: "B" }));
+    const groups = groupConfigTargets([a, b], "/project", "project", PLATFORM);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].harnessNames).toEqual(["A", "B"]);
+    expect(groups[0].writes).toHaveLength(1);
+  });
+
+  it("returns one group per distinct file, sorted by path", () => {
+    const first = detected(
+      harness({ id: "z", name: "Z", configPath: () => "/project/z.json" }),
+    );
+    const second = detected(
+      harness({ id: "a", name: "A", configPath: () => "/project/a.json" }),
+    );
+    const groups = groupConfigTargets(
+      [first, second],
+      "/project",
+      "project",
+      PLATFORM,
+    );
+    expect(groups.map((g) => g.path)).toEqual([
+      "/project/a.json",
+      "/project/z.json",
+    ]);
+  });
+
+  it("resolves the home config in the global band", () => {
+    const groups = groupConfigTargets(
+      [windsurf],
+      "/project",
+      "global",
+      PLATFORM,
+    );
+    expect(groups[0].path).toBe(
+      "/home/tester/.codeium/windsurf/mcp_config.json",
+    );
+    expect(groups[0].scope).toBe("global");
+  });
+});
+
+describe("groupTargetsForScope", () => {
+  it("groups project then global bands for scope=both", () => {
+    const groups = groupTargetsForScope(
+      [vscode, windsurf],
+      "/project",
+      "both",
+      PLATFORM,
+    );
+    // VS Code (project band) then Windsurf (global band).
+    expect(groups.map((g) => g.scope)).toEqual(["project", "global"]);
+    expect(groups.map((g) => g.path)).toEqual([
+      "/project/.vscode/mcp.json",
+      "/home/tester/.codeium/windsurf/mcp_config.json",
+    ]);
+  });
+
+  it("emits only project-band groups for scope=project (global harness dropped)", () => {
+    const groups = groupTargetsForScope(
+      [vscode, windsurf],
+      "/project",
+      "project",
+      PLATFORM,
+    );
+    expect(groups.map((g) => g.path)).toEqual(["/project/.vscode/mcp.json"]);
+  });
+});

--- a/packages/runtime/harnesses/src/lib/configTargets.ts
+++ b/packages/runtime/harnesses/src/lib/configTargets.ts
@@ -38,7 +38,7 @@ export interface TargetGroup {
 }
 
 /** The bands a `--scope` selection runs, in project→global order. */
-export const bandsForScope = (scope: ScopeSelection): ScopeBand[] =>
+export const resolveBandsForScope = (scope: ScopeSelection): ScopeBand[] =>
   scope === "both"
     ? ["project", "global"]
     : scope === "global"
@@ -57,7 +57,7 @@ export const bandsForScope = (scope: ScopeSelection): ScopeBand[] =>
  * @param band - The band being resolved.
  * @returns Whether the harness writes in this band.
  */
-export const harnessInBand = (
+export const isHarnessInBand = (
   harnessScope: HarnessScope,
   scope: ScopeSelection,
   band: ScopeBand,
@@ -70,12 +70,12 @@ export const harnessInBand = (
 };
 
 /** The detected harnesses that participate in `band` under the `scope` selection. */
-export const harnessesForBand = (
+export const listHarnessesForBand = (
   detected: readonly DetectedHarness[],
   scope: ScopeSelection,
   band: ScopeBand,
 ): DetectedHarness[] =>
-  detected.filter((d) => harnessInBand(d.harness.scope, scope, band));
+  detected.filter((d) => isHarnessInBand(d.harness.scope, scope, band));
 
 /**
  * Group a band's detected harnesses into per-file {@link TargetGroup}s: one
@@ -127,7 +127,7 @@ export const groupConfigTargets = (
 
 /**
  * All target groups for a `--scope` selection, across every band it runs.
- * Convenience over {@link bandsForScope} + {@link harnessesForBand} +
+ * Convenience over {@link resolveBandsForScope} + {@link listHarnessesForBand} +
  * {@link groupConfigTargets} for the common "give me every file to configure"
  * caller.
  *
@@ -143,9 +143,9 @@ export const groupTargetsForScope = (
   scope: ScopeSelection,
   platform: PlatformEnv,
 ): TargetGroup[] =>
-  bandsForScope(scope).flatMap((band) =>
+  resolveBandsForScope(scope).flatMap((band) =>
     groupConfigTargets(
-      harnessesForBand(detected, scope, band),
+      listHarnessesForBand(detected, scope, band),
       projectRoot,
       band,
       platform,

--- a/packages/runtime/harnesses/src/lib/configTargets.ts
+++ b/packages/runtime/harnesses/src/lib/configTargets.ts
@@ -1,0 +1,153 @@
+/**
+ * Config-target grouping for scope-aware `setup mcp`/`skills`. Detected
+ * harnesses often share one config file (VS Code and Cline both live in
+ * `.vscode/mcp.json`), so writes are deduplicated at two levels: PROMPT-dedup by
+ * path (one choice per file, labelled with every harness that shares it) and
+ * WRITE-dedup by `(path, mcpKey)` (one write per distinct key — the JSON writer
+ * only touches its own key, so two keys in one file each preserve the other).
+ * The scope→band mapping (which harnesses run in which band for a `--scope`
+ * selection) lives here too, since it decides which targets are grouped.
+ */
+
+import { resolveConfigTarget } from "./config.js";
+import type { PlatformEnv } from "./platformPaths.js";
+import type {
+  ConfigTarget,
+  DetectedHarness,
+  HarnessScope,
+  ScopeBand,
+} from "./types.js";
+
+/**
+ * The user's `--scope` selection. Shares the value set of {@link HarnessScope}:
+ * `both` runs each harness's default band, `global`/`project` run only that
+ * band (flipping dual-scope harnesses to the matching config).
+ */
+export type ScopeSelection = HarnessScope;
+
+/** A file to configure, with the harnesses sharing it and its distinct writes. */
+export interface TargetGroup {
+  /** The shared config file path (the prompt-dedup key). */
+  readonly path: string;
+  /** Every detected harness name that resolves to this file. */
+  readonly harnessNames: readonly string[];
+  /** One {@link ConfigTarget} per distinct `mcpKey` written to this file. */
+  readonly writes: readonly ConfigTarget[];
+  /** The band this group belongs to. */
+  readonly scope: ScopeBand;
+}
+
+/** The bands a `--scope` selection runs, in project→global order. */
+export const bandsForScope = (scope: ScopeSelection): ScopeBand[] =>
+  scope === "both"
+    ? ["project", "global"]
+    : scope === "global"
+      ? ["global"]
+      : ["project"];
+
+/**
+ * Whether a harness of `harnessScope` participates in `band` under the user's
+ * `scope` selection. The project band always takes project + both harnesses;
+ * the global band takes global-only under `both` (a dual-scope harness has
+ * already written its project file — no double-write), and global + both under
+ * an explicit `global` selection (dual-scope flips to its home config).
+ *
+ * @param harnessScope - The harness's declared scope.
+ * @param scope - The user's `--scope` selection.
+ * @param band - The band being resolved.
+ * @returns Whether the harness writes in this band.
+ */
+export const harnessInBand = (
+  harnessScope: HarnessScope,
+  scope: ScopeSelection,
+  band: ScopeBand,
+): boolean => {
+  if (band === "project") {
+    return harnessScope === "project" || harnessScope === "both";
+  }
+  if (scope === "both") return harnessScope === "global";
+  return harnessScope === "global" || harnessScope === "both";
+};
+
+/** The detected harnesses that participate in `band` under the `scope` selection. */
+export const harnessesForBand = (
+  detected: readonly DetectedHarness[],
+  scope: ScopeSelection,
+  band: ScopeBand,
+): DetectedHarness[] =>
+  detected.filter((d) => harnessInBand(d.harness.scope, scope, band));
+
+/**
+ * Group a band's detected harnesses into per-file {@link TargetGroup}s: one
+ * group per config path, carrying every sharing harness name and one write per
+ * distinct `mcpKey`. Groups (and each group's names) are sorted for stable
+ * output.
+ *
+ * @param detected - Harnesses already filtered to this band.
+ * @param projectRoot - The project root for project-band paths.
+ * @param band - The band whose target each harness resolves to.
+ * @param platform - The captured host, for home-band paths.
+ * @returns The deduplicated target groups, sorted by path.
+ */
+export const groupConfigTargets = (
+  detected: readonly DetectedHarness[],
+  projectRoot: string,
+  band: ScopeBand,
+  platform: PlatformEnv,
+): TargetGroup[] => {
+  const byPath = new Map<
+    string,
+    { names: Set<string>; keys: Set<string>; writes: ConfigTarget[] }
+  >();
+
+  for (const d of detected) {
+    const target = resolveConfigTarget(d.harness, projectRoot, band, platform);
+    const group = byPath.get(target.path) ?? {
+      names: new Set<string>(),
+      keys: new Set<string>(),
+      writes: [],
+    };
+    group.names.add(d.harness.name);
+    if (!group.keys.has(target.mcpKey)) {
+      group.keys.add(target.mcpKey);
+      group.writes.push(target);
+    }
+    byPath.set(target.path, group);
+  }
+
+  return [...byPath.entries()]
+    .map(([path, group]) => ({
+      path,
+      harnessNames: [...group.names].sort(),
+      writes: group.writes,
+      scope: band,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+};
+
+/**
+ * All target groups for a `--scope` selection, across every band it runs.
+ * Convenience over {@link bandsForScope} + {@link harnessesForBand} +
+ * {@link groupConfigTargets} for the common "give me every file to configure"
+ * caller.
+ *
+ * @param detected - All detected harnesses.
+ * @param projectRoot - The project root.
+ * @param scope - The user's `--scope` selection.
+ * @param platform - The captured host.
+ * @returns Every target group, project band before global, each sorted by path.
+ */
+export const groupTargetsForScope = (
+  detected: readonly DetectedHarness[],
+  projectRoot: string,
+  scope: ScopeSelection,
+  platform: PlatformEnv,
+): TargetGroup[] =>
+  bandsForScope(scope).flatMap((band) =>
+    groupConfigTargets(
+      harnessesForBand(detected, scope, band),
+      projectRoot,
+      band,
+      platform,
+    ),
+  );

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
@@ -118,17 +118,46 @@ describe("detectHarnesses", () => {
     }
   });
 
-  // Cline is re-enabled (7a): it shares .vscode/mcp.json with VS Code, and both
-  // are detected off the `.vscode` directory (dedup happens at write time).
-  it("detects Cline and VS Code together from the .vscode directory", () => {
+  // Cline is re-enabled (7a) but detected ONLY by its extension: a bare
+  // `.vscode` directory belongs to VS Code, so it must detect VS Code alone and
+  // never co-detect Cline (which would write an inert `mcpServers` block).
+  it("detects VS Code but NOT Cline from a bare .vscode directory", () => {
     const result = dryRunWith(
       detectHarnesses("/project", PLATFORM),
       mocks((path) => path.includes(".vscode")),
     );
 
     const ids = result.value.map((d) => d.harness.id);
-    expect(ids).toContain("cline");
     expect(ids).toContain("vscode");
+    expect(ids).not.toContain("cline");
+  });
+
+  it("detects Cline when its saoudrizwan.claude-dev extension is installed", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", PLATFORM),
+      new Map<string, (effect: Effect) => unknown>([
+        [
+          "Exists",
+          (effect) =>
+            (effect as Effect & { _tag: "Exists"; path: string }).path ===
+            "/home/tester/.vscode/extensions",
+        ],
+        [
+          "Glob",
+          (effect) =>
+            (effect as Effect & { _tag: "Glob"; pattern: string }).pattern ===
+            "saoudrizwan.claude-dev-*"
+              ? ["saoudrizwan.claude-dev-3.20.0"]
+              : [],
+        ],
+      ]),
+    );
+
+    const cline = result.value.find((d) => d.harness.id === "cline");
+    expect(cline).toBeDefined();
+    expect(cline?.confidence).toBe("medium");
+    // A bare extension must not drag in VS Code (no `.vscode` dir here).
+    expect(result.value.map((d) => d.harness.id)).not.toContain("vscode");
   });
 
   it("reports configExists as false when config file is missing", () => {

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
@@ -118,15 +118,17 @@ describe("detectHarnesses", () => {
     }
   });
 
-  // Cline is disabled: it shares .vscode/mcp.json with VS Code
-  it("does not detect Cline (disabled harness)", () => {
+  // Cline is re-enabled (7a): it shares .vscode/mcp.json with VS Code, and both
+  // are detected off the `.vscode` directory (dedup happens at write time).
+  it("detects Cline and VS Code together from the .vscode directory", () => {
     const result = dryRunWith(
       detectHarnesses("/project", PLATFORM),
       mocks((path) => path.includes(".vscode")),
     );
 
-    const cline = result.value.find((d) => d.harness.id === "cline");
-    expect(cline).toBeUndefined();
+    const ids = result.value.map((d) => d.harness.id);
+    expect(ids).toContain("cline");
+    expect(ids).toContain("vscode");
   });
 
   it("reports configExists as false when config file is missing", () => {

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
@@ -6,6 +6,18 @@ import {
 } from "@canonical/task";
 import { describe, expect, it } from "vitest";
 import detectHarnesses from "./detectHarnesses.js";
+import type { PlatformEnv } from "./platformPaths.js";
+
+/**
+ * A fixed platform so the `~/…` signal paths and any `PATH`-based process probe
+ * resolve deterministically (never against the CI host's real HOME/PATH).
+ */
+const PLATFORM: PlatformEnv = {
+  platform: "linux",
+  env: { PATH: "/usr/bin:/bin" },
+  home: "/home/tester",
+  isWsl: false,
+};
 
 const mockExists =
   (predicate: (path: string) => boolean) =>
@@ -26,7 +38,7 @@ describe("detectHarnesses", () => {
 
   it("detects Claude Code when ~/.claude and .mcp.json exist", () => {
     const result = dryRunWith(
-      detectHarnesses("/project"),
+      detectHarnesses("/project", PLATFORM),
       mocks(
         (path) => path.includes(".claude") || path === "/project/.mcp.json",
       ),
@@ -41,7 +53,7 @@ describe("detectHarnesses", () => {
 
   it("detects Cursor when .cursor directory exists", () => {
     const result = dryRunWith(
-      detectHarnesses("/project"),
+      detectHarnesses("/project", PLATFORM),
       mocks((path) => path.includes(".cursor")),
     );
 
@@ -52,7 +64,7 @@ describe("detectHarnesses", () => {
 
   it("detects Windsurf when .windsurf directory exists", () => {
     const result = dryRunWith(
-      detectHarnesses("/project"),
+      detectHarnesses("/project", PLATFORM),
       mocks((path) => path.includes(".windsurf")),
     );
 
@@ -63,7 +75,7 @@ describe("detectHarnesses", () => {
 
   it("detects multiple harnesses simultaneously", () => {
     const result = dryRunWith(
-      detectHarnesses("/project"),
+      detectHarnesses("/project", PLATFORM),
       mocks(
         (path) =>
           path.includes(".claude") ||
@@ -80,7 +92,7 @@ describe("detectHarnesses", () => {
 
   it("returns empty array when no signals match", () => {
     const result = dryRunWith(
-      detectHarnesses("/project"),
+      detectHarnesses("/project", PLATFORM),
       mocks(() => false),
     );
 
@@ -89,7 +101,7 @@ describe("detectHarnesses", () => {
 
   it("sorts results by confidence (high first)", () => {
     const result = dryRunWith(
-      detectHarnesses("/project"),
+      detectHarnesses("/project", PLATFORM),
       mocks(
         (path) =>
           path.includes(".claude") ||
@@ -109,7 +121,7 @@ describe("detectHarnesses", () => {
   // Cline is disabled: it shares .vscode/mcp.json with VS Code
   it("does not detect Cline (disabled harness)", () => {
     const result = dryRunWith(
-      detectHarnesses("/project"),
+      detectHarnesses("/project", PLATFORM),
       mocks((path) => path.includes(".vscode")),
     );
 
@@ -119,7 +131,7 @@ describe("detectHarnesses", () => {
 
   it("reports configExists as false when config file is missing", () => {
     const result = dryRunWith(
-      detectHarnesses("/project"),
+      detectHarnesses("/project", PLATFORM),
       mocks((path) => path.includes(".cursor") && !path.endsWith("mcp.json")),
     );
 

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
@@ -146,8 +146,8 @@ describe("detectHarnesses", () => {
           "Glob",
           (effect) =>
             (effect as Effect & { _tag: "Glob"; pattern: string }).pattern ===
-            "saoudrizwan.claude-dev-*"
-              ? ["saoudrizwan.claude-dev-3.20.0"]
+            "saoudrizwan.claude-dev-*/package.json"
+              ? ["saoudrizwan.claude-dev-3.20.0/package.json"]
               : [],
         ],
       ]),

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.ts
@@ -1,6 +1,7 @@
 /**
  * Harness detection expressed as Task values.
- * All filesystem checks go through @canonical/task primitives.
+ * All environment probes go through {@link checkSignal} (filesystem, PATH, and
+ * process checks via @canonical/task primitives), scored by {@link scoreConfidence}.
  */
 
 import {
@@ -12,86 +13,35 @@ import {
   traverse,
 } from "@canonical/task";
 import harnesses from "./harnesses.js";
+import { type PlatformEnv, readPlatformEnv } from "./platformPaths.js";
+import {
+  CONFIDENCE_RANK,
+  checkSignal,
+  type DetectContext,
+  scoreConfidence,
+} from "./signals.js";
 import type {
   DetectedHarness,
   DetectionSignal,
   HarnessDefinition,
 } from "./types.js";
 
-const resolveSignalPath = (
-  signal: DetectionSignal & { type: "directory" | "file" },
-  projectRoot: string,
-): string => {
-  if (signal.path.startsWith("~")) {
-    /* v8 ignore next -- ?? "" defensive: HOME always set in test environments */
-    return signal.path.replace("~", process.env.HOME ?? "");
-  }
-  return `${projectRoot}/${signal.path}`;
-};
-
-/**
- * Check a single detection signal — returns true if the signal matches.
- *
- * @note This function is impure for "directory" and "file" signals — it
- * checks the filesystem via Task effects. "extension", "process", and "env"
- * signals are not yet implemented and return false.
- */
-const checkSignal = (
-  signal: DetectionSignal,
-  projectRoot: string,
-): Task<boolean> => {
-  switch (signal.type) {
-    case "directory":
-    case "file": {
-      const resolved = resolveSignalPath(signal, projectRoot);
-      return exists(resolved);
-    }
-    default:
-      return pure(false);
-  }
-};
-
-const CONFIDENCE_ORDER = { high: 0, medium: 1, low: 2 } as const;
-
-/**
- * Score an array of signal check results into a confidence level.
- * Returns null if no signals matched.
- */
-const scoreConfidence = (
-  results: readonly boolean[],
-  signals: readonly DetectionSignal[],
-): "high" | "medium" | "low" | null => {
-  const matched = results.filter(Boolean).length;
-  if (matched === 0) return null;
-
-  /* v8 ignore start -- all matched signals are directory/file type; hasHighSignal always true when matched > 0 */
-  const hasHighSignal = signals.some(
-    (s, i) => results[i] && (s.type === "directory" || s.type === "file"),
-  );
-  if (hasHighSignal) return "high";
-  /* v8 ignore stop */
-  /* v8 ignore start -- unreachable: extension/process/env signals always return false */
-  if (matched > 1) return "medium";
-  return "low";
-  /* v8 ignore stop */
-};
-
 /**
  * Detect a single harness by checking all its signals and scoring confidence.
  */
 const detectOne = (
   harness: HarnessDefinition,
-  projectRoot: string,
+  ctx: DetectContext,
 ): Task<DetectedHarness | null> =>
   flatMap(
     traverse(harness.detect as DetectionSignal[], (signal) =>
-      checkSignal(signal, projectRoot),
+      checkSignal(signal, ctx),
     ),
     (results) => {
       const confidence = scoreConfidence(results, harness.detect);
       if (!confidence) return pure(null);
 
-      const configPath = harness.configPath(projectRoot);
+      const configPath = harness.configPath(ctx.projectRoot);
       return map(
         exists(configPath),
         (configExists): DetectedHarness => ({
@@ -108,22 +58,26 @@ const detectOne = (
  * Detect all known harnesses in the given project root.
  * Returns detected harnesses sorted by confidence (high first).
  *
- * @note This function is impure — it checks the filesystem for harness
- * signals via Task effects.
+ * @param projectRoot - The project root probed for project-relative signals.
+ * @param platform - The captured host (defaults to the live reader); injected in
+ *   tests to drive OS/env branches deterministically.
+ * @returns A Task yielding the detected harnesses, sorted by confidence.
+ * @note Impure — checks the filesystem / PATH for harness signals via Task
+ * effects (and, via the default `platform`, reads the live host once).
  */
 export default function detectHarnesses(
   projectRoot: string,
+  platform: PlatformEnv = readPlatformEnv(),
 ): Task<DetectedHarness[]> {
+  const ctx: DetectContext = { projectRoot, platform };
   return map(
-    traverse(harnesses as HarnessDefinition[], (h) =>
-      detectOne(h, projectRoot),
-    ),
+    traverse(harnesses as HarnessDefinition[], (h) => detectOne(h, ctx)),
     (results) =>
       results
         .filter((r): r is DetectedHarness => r !== null)
         .sort(
           (a, b) =>
-            CONFIDENCE_ORDER[a.confidence] - CONFIDENCE_ORDER[b.confidence],
+            CONFIDENCE_RANK[a.confidence] - CONFIDENCE_RANK[b.confidence],
         ),
   );
 }

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.ts
@@ -12,6 +12,7 @@ import {
   type Task,
   traverse,
 } from "@canonical/task";
+import { defaultBandOf, resolveConfigTarget } from "./config.js";
 import harnesses from "./harnesses.js";
 import { type PlatformEnv, readPlatformEnv } from "./platformPaths.js";
 import {
@@ -41,7 +42,15 @@ const detectOne = (
       const confidence = scoreConfidence(results, harness.detect);
       if (!confidence) return pure(null);
 
-      const configPath = harness.configPath(ctx.projectRoot);
+      // Report the harness's DEFAULT-band file (the home config for a
+      // global-only harness, the project file otherwise) so the recap and
+      // doctor point at the location the default `setup` would write.
+      const { path: configPath } = resolveConfigTarget(
+        harness,
+        ctx.projectRoot,
+        defaultBandOf(harness),
+        ctx.platform,
+      );
       return map(
         exists(configPath),
         (configExists): DetectedHarness => ({

--- a/packages/runtime/harnesses/src/lib/harnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.test.ts
@@ -3,7 +3,7 @@ import harnesses from "./harnesses.js";
 
 describe("harnesses registry", () => {
   it("contains all known harnesses", () => {
-    expect(harnesses).toHaveLength(9);
+    expect(harnesses).toHaveLength(10);
     const ids = harnesses.map((h) => h.id);
     expect(ids).toEqual([
       "claude-code",
@@ -15,6 +15,7 @@ describe("harnesses registry", () => {
       "gemini-cli",
       "codex",
       "vscode",
+      "opendesign",
     ]);
   });
 
@@ -54,6 +55,22 @@ describe("harnesses registry", () => {
     expect(vscode?.configPath("/project")).toBe("/project/.vscode/mcp.json");
     expect(cline?.mcpKey).toBe("mcpServers");
     expect(vscode?.mcpKey).toBe("servers");
+  });
+
+  it("opendesign is dual-scope with project + home config and skills paths (7g)", () => {
+    const od = harnesses.find((h) => h.id === "opendesign");
+    expect(od?.scope).toBe("both");
+    expect(od?.normalizeEnv).toBe(true);
+    expect(od?.configPath("/project")).toBe("/project/.od/mcp-config.json");
+    expect(
+      od?.homeConfigPath?.({
+        platform: "linux",
+        env: {},
+        home: "/home/tester",
+        isWsl: false,
+      }),
+    ).toBe("/home/tester/.od/mcp-config.json");
+    expect(od?.skillsPath("/project")).toBe("/project/.od/skills");
   });
 
   it("configPath returns project-relative path", () => {

--- a/packages/runtime/harnesses/src/lib/harnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.test.ts
@@ -3,12 +3,13 @@ import harnesses from "./harnesses.js";
 
 describe("harnesses registry", () => {
   it("contains all known harnesses", () => {
-    expect(harnesses).toHaveLength(8);
+    expect(harnesses).toHaveLength(9);
     const ids = harnesses.map((h) => h.id);
     expect(ids).toEqual([
       "claude-code",
       "cursor",
       "windsurf",
+      "cline",
       "roo-code",
       "opencode",
       "gemini-cli",
@@ -28,6 +29,31 @@ describe("harnesses registry", () => {
       expect(h.mcpKey).toBeTruthy();
       expect(typeof h.skillsPath).toBe("function");
     }
+  });
+
+  it("declares a valid scope, and global/both harnesses have a home config", () => {
+    for (const h of harnesses) {
+      expect(h.scope).toMatch(/^(project|global|both)$/);
+      if (h.scope === "global" || h.scope === "both") {
+        expect(typeof h.homeConfigPath).toBe("function");
+      }
+    }
+  });
+
+  it("windsurf is global, claude-code is both", () => {
+    const windsurf = harnesses.find((h) => h.id === "windsurf");
+    const claude = harnesses.find((h) => h.id === "claude-code");
+    expect(windsurf?.scope).toBe("global");
+    expect(claude?.scope).toBe("both");
+  });
+
+  it("cline shares .vscode/mcp.json with VS Code under a different mcpKey", () => {
+    const cline = harnesses.find((h) => h.id === "cline");
+    const vscode = harnesses.find((h) => h.id === "vscode");
+    expect(cline?.configPath("/project")).toBe("/project/.vscode/mcp.json");
+    expect(vscode?.configPath("/project")).toBe("/project/.vscode/mcp.json");
+    expect(cline?.mcpKey).toBe("mcpServers");
+    expect(vscode?.mcpKey).toBe("servers");
   });
 
   it("configPath returns project-relative path", () => {

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -60,10 +60,11 @@ const harnesses: readonly HarnessDefinition[] = [
     name: "Cline",
     version: "*",
     scope: "project",
-    detect: [
-      { type: "directory", path: ".vscode" },
-      { type: "extension", id: "saoudrizwan.claude-dev" },
-    ],
+    // Cline is a VS Code EXTENSION, not a directory owner — a bare `.vscode`
+    // directory belongs to VS Code itself, so keying off it would false-detect
+    // Cline in every VS Code project (and write an inert `mcpServers` block
+    // there). Detect Cline ONLY by its installed extension.
+    detect: [{ type: "extension", id: "saoudrizwan.claude-dev" }],
     configPath: (root) => `${root}/.vscode/mcp.json`,
     // VERIFY(7a): if Cline reads 'servers' (like VS Code) rather than
     // 'mcpServers', collapse this to a single shared write with VS Code. Today

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -6,6 +6,7 @@
  * ranges to handle config format changes across versions.
  */
 
+import { userHome } from "./platformPaths.js";
 import type { HarnessDefinition } from "./types.js";
 
 const harnesses: readonly HarnessDefinition[] = [
@@ -13,11 +14,15 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "claude-code",
     name: "Claude Code",
     version: "*",
+    scope: "both",
     detect: [
       { type: "directory", path: "~/.claude" },
       { type: "file", path: ".mcp.json" },
+      { type: "process", name: "claude" },
     ],
     configPath: (root) => `${root}/.mcp.json`,
+    // VERIFY(7b): claude-code reads the user MCP config from ~/.claude.json.
+    homeConfigPath: (p) => `${userHome(p)}/.claude.json`,
     configFormat: "json",
     mcpKey: "mcpServers",
     skillsPath: (root) => `${root}/.claude/skills`,
@@ -26,6 +31,7 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "cursor",
     name: "Cursor",
     version: "*",
+    scope: "project",
     detect: [{ type: "directory", path: ".cursor" }],
     configPath: (root) => `${root}/.cursor/mcp.json`,
     configFormat: "json",
@@ -36,37 +42,24 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "windsurf",
     name: "Windsurf",
     version: "*",
+    scope: "global",
     detect: [
       { type: "directory", path: ".windsurf" },
       { type: "file", path: "~/.codeium/windsurf/mcp_config.json" },
     ],
-    /* v8 ignore start -- ?? "" defensive: HOME is always set in test environments */
-    configPath: () =>
-      `${process.env.HOME ?? ""}/.codeium/windsurf/mcp_config.json`,
-    /* v8 ignore stop */
+    // Windsurf is global-only; this project path is never resolved (its band is
+    // always global) but the type requires one.
+    configPath: (root) => `${root}/.windsurf/mcp_config.json`,
+    homeConfigPath: (p) => `${userHome(p)}/.codeium/windsurf/mcp_config.json`,
     configFormat: "json",
     mcpKey: "mcpServers",
     skillsPath: (root) => `${root}/.windsurf/skills`,
   },
-  // Cline is disabled: it shares .vscode/mcp.json with VS Code, causing
-  // duplicate prompts and double-writes during `pragma setup mcp`.
-  // {
-  //   id: "cline",
-  //   name: "Cline",
-  //   version: "*",
-  //   detect: [
-  //     { type: "directory", path: ".vscode" },
-  //     { type: "extension", id: "saoudrizwan.claude-dev" },
-  //   ],
-  //   configPath: (root) => `${root}/.vscode/mcp.json`,
-  //   configFormat: "json",
-  //   mcpKey: "mcpServers",
-  //   skillsPath: (root) => `${root}/.agents/skills`,
-  // },
   {
     id: "roo-code",
     name: "Roo Code",
     version: "*",
+    scope: "project",
     detect: [
       { type: "directory", path: ".roo" },
       { type: "extension", id: "rooveterinaryinc.roo-cline" },
@@ -80,7 +73,11 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "opencode",
     name: "OpenCode",
     version: "*",
-    detect: [{ type: "file", path: "opencode.json" }],
+    scope: "project",
+    detect: [
+      { type: "file", path: "opencode.json" },
+      { type: "process", name: "opencode" },
+    ],
     configPath: (root) => `${root}/opencode.json`,
     configFormat: "json",
     mcpKey: "mcp",
@@ -90,7 +87,11 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "gemini-cli",
     name: "Gemini CLI",
     version: "*",
-    detect: [{ type: "directory", path: ".gemini" }],
+    scope: "project",
+    detect: [
+      { type: "directory", path: ".gemini" },
+      { type: "process", name: "gemini" },
+    ],
     configPath: (root) => `${root}/.gemini/settings.json`,
     configFormat: "json",
     mcpKey: "mcpServers",
@@ -100,7 +101,11 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "codex",
     name: "Codex",
     version: "*",
-    detect: [{ type: "directory", path: ".codex" }],
+    scope: "project",
+    detect: [
+      { type: "directory", path: ".codex" },
+      { type: "process", name: "codex" },
+    ],
     configPath: (root) => `${root}/.codex/config.toml`,
     configFormat: "toml",
     mcpKey: "mcp_servers",
@@ -110,6 +115,7 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "vscode",
     name: "VS Code",
     version: "*",
+    scope: "project",
     detect: [
       { type: "directory", path: ".vscode" },
       { type: "file", path: ".vscode/mcp.json" },

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -143,6 +143,30 @@ const harnesses: readonly HarnessDefinition[] = [
     mcpKey: "servers",
     skillsPath: (root) => `${root}/.agents/skills`,
   },
+  {
+    id: "opendesign",
+    name: "OpenDesign",
+    version: "*",
+    scope: "both",
+    // VERIFY(7g): OpenDesign requires the MCP server `env` to be a JSON map.
+    normalizeEnv: true,
+    detect: [
+      { type: "directory", path: ".od" },
+      {
+        type: "process",
+        name: "od",
+        // VERIFY(7g): guard the Unix `od` (octal dump) false-positive — only a
+        // binary whose --version identifies OpenDesign counts.
+        verify: { args: ["--version"], match: /open-?design/i },
+      },
+    ],
+    // VERIFY(7g): OpenDesign project + home MCP config paths and skills dir.
+    configPath: (root) => `${root}/.od/mcp-config.json`,
+    homeConfigPath: (p) => `${userHome(p)}/.od/mcp-config.json`,
+    configFormat: "json",
+    mcpKey: "mcpServers",
+    skillsPath: (root) => `${root}/.od/skills`,
+  },
 ];
 
 export default harnesses;

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -56,6 +56,24 @@ const harnesses: readonly HarnessDefinition[] = [
     skillsPath: (root) => `${root}/.windsurf/skills`,
   },
   {
+    id: "cline",
+    name: "Cline",
+    version: "*",
+    scope: "project",
+    detect: [
+      { type: "directory", path: ".vscode" },
+      { type: "extension", id: "saoudrizwan.claude-dev" },
+    ],
+    configPath: (root) => `${root}/.vscode/mcp.json`,
+    // VERIFY(7a): if Cline reads 'servers' (like VS Code) rather than
+    // 'mcpServers', collapse this to a single shared write with VS Code. Today
+    // Cline uses `mcpServers` and VS Code uses `servers`, so the two-level dedup
+    // writes both keys into .vscode/mcp.json, each preserving the other.
+    configFormat: "json",
+    mcpKey: "mcpServers",
+    skillsPath: (root) => `${root}/.agents/skills`,
+  },
+  {
     id: "roo-code",
     name: "Roo Code",
     version: "*",

--- a/packages/runtime/harnesses/src/lib/index.ts
+++ b/packages/runtime/harnesses/src/lib/index.ts
@@ -10,11 +10,11 @@ export {
   writeMcpConfigTo,
 } from "./config.js";
 export {
-  bandsForScope,
   groupConfigTargets,
   groupTargetsForScope,
-  harnessesForBand,
-  harnessInBand,
+  isHarnessInBand,
+  listHarnessesForBand,
+  resolveBandsForScope,
   type ScopeSelection,
   type TargetGroup,
 } from "./configTargets.js";
@@ -28,7 +28,6 @@ export {
   userConfigBase,
   userDataBase,
   userHome,
-  windowsHostUserBase,
 } from "./platformPaths.js";
 export type { DetectContext } from "./signals.js";
 export type {

--- a/packages/runtime/harnesses/src/lib/index.ts
+++ b/packages/runtime/harnesses/src/lib/index.ts
@@ -6,6 +6,7 @@ export {
   removeMcpConfigFrom,
   resolveConfigTarget,
   writeMcpConfig,
+  writeMcpConfigTargets,
   writeMcpConfigTo,
 } from "./config.js";
 export {

--- a/packages/runtime/harnesses/src/lib/index.ts
+++ b/packages/runtime/harnesses/src/lib/index.ts
@@ -1,14 +1,32 @@
 export {
+  defaultBandOf,
   readMcpConfig,
+  readMcpConfigFrom,
   removeMcpConfig,
+  removeMcpConfigFrom,
+  resolveConfigTarget,
   writeMcpConfig,
+  writeMcpConfigTo,
 } from "./config.js";
 export { default as detectHarnesses } from "./detectHarnesses.js";
 export { default as findHarnessById } from "./findHarnessById.js";
 export { default as harnesses } from "./harnesses.js";
+export {
+  type PlatformEnv,
+  type PlatformId,
+  readPlatformEnv,
+  userConfigBase,
+  userDataBase,
+  userHome,
+  windowsHostUserBase,
+} from "./platformPaths.js";
+export type { DetectContext } from "./signals.js";
 export type {
+  ConfigTarget,
   DetectedHarness,
   DetectionSignal,
   HarnessDefinition,
+  HarnessScope,
   McpServerConfig,
+  ScopeBand,
 } from "./types.js";

--- a/packages/runtime/harnesses/src/lib/index.ts
+++ b/packages/runtime/harnesses/src/lib/index.ts
@@ -8,6 +8,15 @@ export {
   writeMcpConfig,
   writeMcpConfigTo,
 } from "./config.js";
+export {
+  bandsForScope,
+  groupConfigTargets,
+  groupTargetsForScope,
+  harnessesForBand,
+  harnessInBand,
+  type ScopeSelection,
+  type TargetGroup,
+} from "./configTargets.js";
 export { default as detectHarnesses } from "./detectHarnesses.js";
 export { default as findHarnessById } from "./findHarnessById.js";
 export { default as harnesses } from "./harnesses.js";

--- a/packages/runtime/harnesses/src/lib/platformPaths.test.ts
+++ b/packages/runtime/harnesses/src/lib/platformPaths.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPlatformEnv,
   detectWsl,
   type PlatformEnv,
   type PlatformId,
   userConfigBase,
   userDataBase,
   userHome,
-  windowsHostUserBase,
 } from "./platformPaths.js";
 
 /** Build a {@link PlatformEnv} fixture, overriding only the fields under test. */
@@ -61,10 +61,10 @@ describe("userConfigBase", () => {
     expect(userConfigBase(platform())).toBe("/home/tester/.config");
   });
 
-  it("uses ~/Library/Application Support on darwin", () => {
+  it("uses ~/Library/Preferences on darwin (distinct from the data base)", () => {
     expect(
       userConfigBase(platform({ platform: "darwin", home: "/Users/ada" })),
-    ).toBe("/Users/ada/Library/Application Support");
+    ).toBe("/Users/ada/Library/Preferences");
   });
 
   it("uses %APPDATA% on win32 when set", () => {
@@ -122,18 +122,52 @@ describe("userDataBase", () => {
   });
 });
 
-describe("windowsHostUserBase", () => {
-  it("returns null when not under WSL", () => {
-    expect(windowsHostUserBase(platform({ isWsl: false }))).toBeNull();
+describe("buildPlatformEnv", () => {
+  it("maps darwin through unchanged and never probes WSL off-linux", () => {
+    let probed = false;
+    const result = buildPlatformEnv("darwin", { A: "1" }, "/Users/ada", () => {
+      probed = true;
+      return "";
+    });
+    expect(result).toEqual({
+      platform: "darwin",
+      env: { A: "1" },
+      home: "/Users/ada",
+      isWsl: false,
+    });
+    // platform !== "linux" short-circuits the `&&`, so /proc is never read.
+    expect(probed).toBe(false);
   });
 
-  it("resolves /mnt/c/Users/<user> under WSL with $USER set", () => {
+  it("maps win32 through unchanged", () => {
     expect(
-      windowsHostUserBase(platform({ isWsl: true, env: { USER: "ada" } })),
-    ).toBe("/mnt/c/Users/ada");
+      buildPlatformEnv("win32", {}, "C:/Users/Ada", () => "").platform,
+    ).toBe("win32");
   });
 
-  it("returns null under WSL when $USER is unset", () => {
-    expect(windowsHostUserBase(platform({ isWsl: true }))).toBeNull();
+  it("treats an unknown platform (e.g. freebsd) as linux", () => {
+    expect(
+      buildPlatformEnv("freebsd", {}, "/home/tester", () => "").platform,
+    ).toBe("linux");
+  });
+
+  it("flags WSL on a linux host whose /proc/version carries the signature", () => {
+    const result = buildPlatformEnv(
+      "linux",
+      {},
+      "/home/tester",
+      () => "Linux version 5.15.0-microsoft-standard-WSL2",
+    );
+    expect(result.isWsl).toBe(true);
+  });
+
+  it("leaves isWsl false on a native linux host", () => {
+    const result = buildPlatformEnv(
+      "linux",
+      {},
+      "/home/tester",
+      () => "Linux version 6.1.0-generic",
+    );
+    expect(result.isWsl).toBe(false);
   });
 });

--- a/packages/runtime/harnesses/src/lib/platformPaths.test.ts
+++ b/packages/runtime/harnesses/src/lib/platformPaths.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectWsl,
+  type PlatformEnv,
+  type PlatformId,
+  userConfigBase,
+  userDataBase,
+  userHome,
+  windowsHostUserBase,
+} from "./platformPaths.js";
+
+/** Build a {@link PlatformEnv} fixture, overriding only the fields under test. */
+const platform = (overrides: Partial<PlatformEnv> = {}): PlatformEnv => ({
+  platform: "linux" as PlatformId,
+  env: {},
+  home: "/home/tester",
+  isWsl: false,
+  ...overrides,
+});
+
+describe("detectWsl", () => {
+  it("returns true when WSL_DISTRO_NAME is set (no /proc read)", () => {
+    let read = false;
+    const result = detectWsl({ WSL_DISTRO_NAME: "Ubuntu" }, () => {
+      read = true;
+      return "";
+    });
+    expect(result).toBe(true);
+    expect(read).toBe(false);
+  });
+
+  it("returns true when WSL_INTEROP is set", () => {
+    expect(detectWsl({ WSL_INTEROP: "/run/WSL/1" }, () => "")).toBe(true);
+  });
+
+  it("returns true when /proc/version carries the microsoft signature", () => {
+    expect(
+      detectWsl({}, () => "Linux version 5.15.0-microsoft-standard-WSL2"),
+    ).toBe(true);
+  });
+
+  it("returns false on a native linux kernel version", () => {
+    expect(detectWsl({}, () => "Linux version 6.1.0-generic")).toBe(false);
+  });
+});
+
+describe("userHome", () => {
+  it("returns the captured home directory", () => {
+    expect(userHome(platform({ home: "/Users/ada" }))).toBe("/Users/ada");
+  });
+});
+
+describe("userConfigBase", () => {
+  it("uses $XDG_CONFIG_HOME on linux when set", () => {
+    expect(
+      userConfigBase(platform({ env: { XDG_CONFIG_HOME: "/xdg/config" } })),
+    ).toBe("/xdg/config");
+  });
+
+  it("falls back to ~/.config on linux when XDG is unset", () => {
+    expect(userConfigBase(platform())).toBe("/home/tester/.config");
+  });
+
+  it("uses ~/Library/Application Support on darwin", () => {
+    expect(
+      userConfigBase(platform({ platform: "darwin", home: "/Users/ada" })),
+    ).toBe("/Users/ada/Library/Application Support");
+  });
+
+  it("uses %APPDATA% on win32 when set", () => {
+    expect(
+      userConfigBase(
+        platform({
+          platform: "win32",
+          home: "C:/Users/Ada",
+          env: { APPDATA: "C:/Users/Ada/AppData/Roaming" },
+        }),
+      ),
+    ).toBe("C:/Users/Ada/AppData/Roaming");
+  });
+
+  it("falls back to ~/AppData/Roaming on win32 when APPDATA is unset", () => {
+    expect(
+      userConfigBase(platform({ platform: "win32", home: "C:/Users/Ada" })),
+    ).toBe("C:/Users/Ada/AppData/Roaming");
+  });
+});
+
+describe("userDataBase", () => {
+  it("uses $XDG_DATA_HOME on linux when set", () => {
+    expect(
+      userDataBase(platform({ env: { XDG_DATA_HOME: "/xdg/data" } })),
+    ).toBe("/xdg/data");
+  });
+
+  it("falls back to ~/.local/share on linux when XDG is unset", () => {
+    expect(userDataBase(platform())).toBe("/home/tester/.local/share");
+  });
+
+  it("uses ~/Library/Application Support on darwin", () => {
+    expect(
+      userDataBase(platform({ platform: "darwin", home: "/Users/ada" })),
+    ).toBe("/Users/ada/Library/Application Support");
+  });
+
+  it("uses %LOCALAPPDATA% on win32 when set", () => {
+    expect(
+      userDataBase(
+        platform({
+          platform: "win32",
+          home: "C:/Users/Ada",
+          env: { LOCALAPPDATA: "C:/Users/Ada/AppData/Local" },
+        }),
+      ),
+    ).toBe("C:/Users/Ada/AppData/Local");
+  });
+
+  it("falls back to ~/AppData/Local on win32 when LOCALAPPDATA is unset", () => {
+    expect(
+      userDataBase(platform({ platform: "win32", home: "C:/Users/Ada" })),
+    ).toBe("C:/Users/Ada/AppData/Local");
+  });
+});
+
+describe("windowsHostUserBase", () => {
+  it("returns null when not under WSL", () => {
+    expect(windowsHostUserBase(platform({ isWsl: false }))).toBeNull();
+  });
+
+  it("resolves /mnt/c/Users/<user> under WSL with $USER set", () => {
+    expect(
+      windowsHostUserBase(platform({ isWsl: true, env: { USER: "ada" } })),
+    ).toBe("/mnt/c/Users/ada");
+  });
+
+  it("returns null under WSL when $USER is unset", () => {
+    expect(windowsHostUserBase(platform({ isWsl: true }))).toBeNull();
+  });
+});

--- a/packages/runtime/harnesses/src/lib/platformPaths.ts
+++ b/packages/runtime/harnesses/src/lib/platformPaths.ts
@@ -1,0 +1,141 @@
+/**
+ * The injectable platform-paths seam. One impure reader
+ * ({@link readPlatformEnv}) captures the host — OS family, environment, home
+ * directory, and whether the process runs under WSL — into a plain
+ * {@link PlatformEnv} value; every other export is a PURE function of that
+ * value. Detection and config resolution take a `PlatformEnv` rather than
+ * touching `process`/`os` directly, so a test drives any OS + env matrix by
+ * handing in a fixture. That is what lets the 100%-coverage platform layer
+ * exercise the linux / darwin / win32 / WSL branches with no real machine.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+
+/** The three host families the harnesses layer resolves paths for. */
+export type PlatformId = "linux" | "darwin" | "win32";
+
+/**
+ * A captured snapshot of the host platform: the OS family, the process
+ * environment, the home directory, and whether the process runs inside WSL
+ * (a linux platform reaching a Windows host filesystem under `/mnt/c`).
+ */
+export interface PlatformEnv {
+  readonly platform: PlatformId;
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly home: string;
+  readonly isWsl: boolean;
+}
+
+/**
+ * Detect whether the environment is WSL: an explicit WSL env marker wins,
+ * otherwise the kernel version string is probed for the "microsoft" signature.
+ *
+ * @param env - The process environment to inspect.
+ * @param readProcVersion - Reader for `/proc/version` (injected for testability).
+ * @returns True when running under the Windows Subsystem for Linux.
+ */
+export const detectWsl = (
+  env: Readonly<Record<string, string | undefined>>,
+  readProcVersion: () => string,
+): boolean => {
+  if (env.WSL_DISTRO_NAME !== undefined || env.WSL_INTEROP !== undefined) {
+    return true;
+  }
+  return /microsoft/i.test(readProcVersion());
+};
+
+/* v8 ignore start -- reads /proc/version off the real host; detectWsl is unit-tested with an injected reader */
+const readProcVersion = (): string => {
+  try {
+    return readFileSync("/proc/version", "utf8");
+  } catch {
+    return "";
+  }
+};
+/* v8 ignore stop */
+
+/**
+ * Capture the live host into a {@link PlatformEnv} — the ONE impure reader the
+ * pure path helpers are threaded from.
+ *
+ * @returns The captured platform snapshot.
+ * @note Impure — reads `process.platform`, `process.env`, `os.homedir()`, and
+ * (on linux) `/proc/version` via {@link detectWsl}.
+ */
+/* v8 ignore start -- the single host reader; every pure consumer receives an injected PlatformEnv in tests */
+export const readPlatformEnv = (): PlatformEnv => {
+  const platform: PlatformId =
+    process.platform === "darwin" || process.platform === "win32"
+      ? process.platform
+      : "linux";
+  const env = process.env;
+  return {
+    platform,
+    env,
+    home: homedir(),
+    isWsl: platform === "linux" && detectWsl(env, readProcVersion),
+  };
+};
+/* v8 ignore stop */
+
+/**
+ * The user's home directory.
+ *
+ * @param p - The captured platform.
+ * @returns The absolute home path.
+ */
+export const userHome = (p: PlatformEnv): string => p.home;
+
+/**
+ * The per-user configuration base directory for the platform: linux
+ * `$XDG_CONFIG_HOME ?? ~/.config`, darwin `~/Library/Application Support`,
+ * win32 `%APPDATA%` (falling back to `~/AppData/Roaming`).
+ *
+ * @param p - The captured platform.
+ * @returns The absolute config base path.
+ */
+export const userConfigBase = (p: PlatformEnv): string => {
+  switch (p.platform) {
+    case "darwin":
+      return `${p.home}/Library/Application Support`;
+    case "win32":
+      return p.env.APPDATA ?? `${p.home}/AppData/Roaming`;
+    default:
+      return p.env.XDG_CONFIG_HOME ?? `${p.home}/.config`;
+  }
+};
+
+/**
+ * The per-user data base directory for the platform: linux
+ * `$XDG_DATA_HOME ?? ~/.local/share`, darwin `~/Library/Application Support`,
+ * win32 `%LOCALAPPDATA%` (falling back to `~/AppData/Local`).
+ *
+ * @param p - The captured platform.
+ * @returns The absolute data base path.
+ */
+export const userDataBase = (p: PlatformEnv): string => {
+  switch (p.platform) {
+    case "darwin":
+      return `${p.home}/Library/Application Support`;
+    case "win32":
+      return p.env.LOCALAPPDATA ?? `${p.home}/AppData/Local`;
+    default:
+      return p.env.XDG_DATA_HOME ?? `${p.home}/.local/share`;
+  }
+};
+
+/**
+ * The Windows host user-profile base as seen from inside WSL
+ * (`/mnt/c/Users/<user>`), or null when not under WSL or the Windows user
+ * cannot be determined. The Windows user is taken from `$USER` — WSL shares the
+ * login name across the interop boundary in the common single-user setup.
+ *
+ * @param p - The captured platform.
+ * @returns The `/mnt/c/Users/<user>` base, or null.
+ */
+export const windowsHostUserBase = (p: PlatformEnv): string | null => {
+  if (!p.isWsl) return null;
+  const user = p.env.USER ?? "";
+  return user.length > 0 ? `/mnt/c/Users/${user}` : null;
+};

--- a/packages/runtime/harnesses/src/lib/platformPaths.ts
+++ b/packages/runtime/harnesses/src/lib/platformPaths.ts
@@ -5,8 +5,15 @@
  * {@link PlatformEnv} value; every other export is a PURE function of that
  * value. Detection and config resolution take a `PlatformEnv` rather than
  * touching `process`/`os` directly, so a test drives any OS + env matrix by
- * handing in a fixture. That is what lets the 100%-coverage platform layer
- * exercise the linux / darwin / win32 / WSL branches with no real machine.
+ * handing in a fixture.
+ *
+ * Exercised is not validated: the fixture seam lets the unit tests EXERCISE the
+ * linux / darwin / win32 / WSL arms deterministically, and this file reports
+ * 100% coverage — but coverage only proves the code ran, not that the paths are
+ * right. Only the linux arm runs on the CI host; the darwin / win32 / WSL /
+ * `$USER` mappings are the conventional best-guess locations (env-paths style)
+ * and have NOT been confirmed against a real macOS / Windows / WSL machine.
+ * Treat them as unproven guesses until AV-287 validates them on real hosts.
  */
 
 import { readFileSync } from "node:fs";
@@ -24,6 +31,12 @@ export interface PlatformEnv {
   readonly platform: PlatformId;
   readonly env: Readonly<Record<string, string | undefined>>;
   readonly home: string;
+  /**
+   * Whether the process runs under WSL. Captured host state: no path currently
+   * resolves through it (WSL-aware path resolution is an unproven guess deferred
+   * to AV-287), but it is snapshotted here with the rest of the host so that
+   * resolution has a single place to read from when it lands.
+   */
   readonly isWsl: boolean;
 }
 
@@ -56,27 +69,50 @@ const readProcVersion = (): string => {
 /* v8 ignore stop */
 
 /**
+ * Assemble a {@link PlatformEnv} from raw host readings — the PURE core of
+ * {@link readPlatformEnv}. Maps a Node `process.platform` string to a
+ * {@link PlatformId} (anything other than `darwin`/`win32` is treated as linux)
+ * and wires up the WSL flag (only a linux host is probed). Extracted so this
+ * mapping and the WSL wiring — the layer's only real branches — stay
+ * coverage-checked, while {@link readPlatformEnv} keeps nothing but the
+ * genuinely untestable live host reads.
+ *
+ * @param nodePlatform - The raw `process.platform` value.
+ * @param env - The process environment.
+ * @param home - The home directory.
+ * @param readProcVersion - Reader for `/proc/version` (injected for testability).
+ * @returns The assembled platform snapshot.
+ */
+export const buildPlatformEnv = (
+  nodePlatform: string,
+  env: Readonly<Record<string, string | undefined>>,
+  home: string,
+  readProcVersion: () => string,
+): PlatformEnv => {
+  const platform: PlatformId =
+    nodePlatform === "darwin" || nodePlatform === "win32"
+      ? nodePlatform
+      : "linux";
+  return {
+    platform,
+    env,
+    home,
+    isWsl: platform === "linux" && detectWsl(env, readProcVersion),
+  };
+};
+
+/**
  * Capture the live host into a {@link PlatformEnv} — the ONE impure reader the
- * pure path helpers are threaded from.
+ * pure path helpers are threaded from. All logic lives in
+ * {@link buildPlatformEnv}; only the live `process`/`os`/`/proc` reads are here.
  *
  * @returns The captured platform snapshot.
  * @note Impure — reads `process.platform`, `process.env`, `os.homedir()`, and
  * (on linux) `/proc/version` via {@link detectWsl}.
  */
-/* v8 ignore start -- the single host reader; every pure consumer receives an injected PlatformEnv in tests */
-export const readPlatformEnv = (): PlatformEnv => {
-  const platform: PlatformId =
-    process.platform === "darwin" || process.platform === "win32"
-      ? process.platform
-      : "linux";
-  const env = process.env;
-  return {
-    platform,
-    env,
-    home: homedir(),
-    isWsl: platform === "linux" && detectWsl(env, readProcVersion),
-  };
-};
+/* v8 ignore start -- live host reads only (process.platform/env, os.homedir, /proc/version); all logic is in the unit-tested buildPlatformEnv */
+export const readPlatformEnv = (): PlatformEnv =>
+  buildPlatformEnv(process.platform, process.env, homedir(), readProcVersion);
 /* v8 ignore stop */
 
 /**
@@ -89,8 +125,11 @@ export const userHome = (p: PlatformEnv): string => p.home;
 
 /**
  * The per-user configuration base directory for the platform: linux
- * `$XDG_CONFIG_HOME ?? ~/.config`, darwin `~/Library/Application Support`,
- * win32 `%APPDATA%` (falling back to `~/AppData/Roaming`).
+ * `$XDG_CONFIG_HOME ?? ~/.config`, darwin `~/Library/Preferences`, win32
+ * `%APPDATA%` (falling back to `~/AppData/Roaming`). Follows the env-paths
+ * convention, under which the darwin CONFIG base is `~/Library/Preferences` —
+ * distinct from the DATA base (`~/Library/Application Support`, see
+ * {@link userDataBase}).
  *
  * @param p - The captured platform.
  * @returns The absolute config base path.
@@ -98,7 +137,7 @@ export const userHome = (p: PlatformEnv): string => p.home;
 export const userConfigBase = (p: PlatformEnv): string => {
   switch (p.platform) {
     case "darwin":
-      return `${p.home}/Library/Application Support`;
+      return `${p.home}/Library/Preferences`;
     case "win32":
       return p.env.APPDATA ?? `${p.home}/AppData/Roaming`;
     default:
@@ -123,19 +162,4 @@ export const userDataBase = (p: PlatformEnv): string => {
     default:
       return p.env.XDG_DATA_HOME ?? `${p.home}/.local/share`;
   }
-};
-
-/**
- * The Windows host user-profile base as seen from inside WSL
- * (`/mnt/c/Users/<user>`), or null when not under WSL or the Windows user
- * cannot be determined. The Windows user is taken from `$USER` — WSL shares the
- * login name across the interop boundary in the common single-user setup.
- *
- * @param p - The captured platform.
- * @returns The `/mnt/c/Users/<user>` base, or null.
- */
-export const windowsHostUserBase = (p: PlatformEnv): string | null => {
-  if (!p.isWsl) return null;
-  const user = p.env.USER ?? "";
-  return user.length > 0 ? `/mnt/c/Users/${user}` : null;
 };

--- a/packages/runtime/harnesses/src/lib/signals.test.ts
+++ b/packages/runtime/harnesses/src/lib/signals.test.ts
@@ -88,12 +88,14 @@ describe("checkSignal — extension", () => {
       Glob: (effect) => {
         const glob = effect as Effect & { _tag: "Glob" };
         seen.push({ pattern: glob.pattern, cwd: glob.cwd });
-        return ["rooveterinaryinc.roo-cline-1.2.3"];
+        return ["rooveterinaryinc.roo-cline-1.2.3/package.json"];
       },
     });
     expect(result).toBe(true);
+    // The pattern targets the manifest inside the versioned dir (the glob effect
+    // lists files only, so the directory entry itself would never match).
     expect(seen[0]).toEqual({
-      pattern: "rooveterinaryinc.roo-cline-*",
+      pattern: "rooveterinaryinc.roo-cline-*/package.json",
       cwd: "/home/tester/.vscode/extensions",
     });
   });
@@ -127,14 +129,14 @@ describe("checkSignal — extension", () => {
       Glob: (effect) => {
         const glob = effect as Effect & { _tag: "Glob" };
         seen.push({ pattern: glob.pattern, cwd: glob.cwd });
-        return ["rooveterinaryinc.roo-cline-9.9.9"];
+        return ["rooveterinaryinc.roo-cline-9.9.9/package.json"];
       },
     });
     expect(result).toBe(true);
-    // Only the one existing fork dir is globbed, under the shared <id>-* pattern.
+    // Only the one existing fork dir is globbed, under the shared manifest pattern.
     expect(seen).toEqual([
       {
-        pattern: "rooveterinaryinc.roo-cline-*",
+        pattern: "rooveterinaryinc.roo-cline-*/package.json",
         cwd: "/home/tester/.cursor/extensions",
       },
     ]);

--- a/packages/runtime/harnesses/src/lib/signals.test.ts
+++ b/packages/runtime/harnesses/src/lib/signals.test.ts
@@ -1,4 +1,4 @@
-import { dryRunWith, type Effect } from "@canonical/task";
+import { dryRunWith, type Effect, TaskExecutionError } from "@canonical/task";
 import { describe, expect, it } from "vitest";
 import type { PlatformEnv } from "./platformPaths.js";
 import {
@@ -155,25 +155,49 @@ describe("checkSignal — process", () => {
     ).toBe(false);
   });
 
-  it("appends .exe and splits on ; under win32", () => {
+  it("probes every PATHEXT suffix (finds a .cmd npm shim) and splits PATH on ; under win32", () => {
     const seen: string[] = [];
     const result = check(
       { type: "process", name: "codex" },
       ctx({
         platform: platform({
           platform: "win32",
-          env: { PATH: "C:/bin;C:/tools" },
+          env: { PATH: "C:/bin;C:/tools", PATHEXT: ".EXE;.CMD;.BAT" },
         }),
       }),
       {
         Exists: existsAt((path) => {
           seen.push(path);
-          return path.endsWith("codex.exe");
+          // npm installs the harness as a .cmd shim, NOT a .exe.
+          return path === "C:/bin/codex.CMD";
         }),
       },
     );
     expect(result).toBe(true);
-    expect(seen.some((p) => p.includes("codex.exe"))).toBe(true);
+    // Every PATH dir × every PATHEXT suffix is a candidate.
+    expect(seen).toContain("C:/bin/codex.EXE");
+    expect(seen).toContain("C:/bin/codex.CMD");
+    expect(seen).toContain("C:/tools/codex.BAT");
+  });
+
+  it("falls back to the default PATHEXT when it is unset under win32", () => {
+    const seen: string[] = [];
+    const result = check(
+      { type: "process", name: "codex" },
+      ctx({
+        platform: platform({ platform: "win32", env: { PATH: "C:/bin" } }),
+      }),
+      {
+        Exists: existsAt((path) => {
+          seen.push(path);
+          return path === "C:/bin/codex.EXE";
+        }),
+      },
+    );
+    expect(result).toBe(true);
+    // The default set still covers the npm-shim suffixes.
+    expect(seen).toContain("C:/bin/codex.CMD");
+    expect(seen).toContain("C:/bin/codex.BAT");
   });
 
   it("runs verify and matches stdout against the pattern", () => {
@@ -203,6 +227,29 @@ describe("checkSignal — process", () => {
       {
         Exists: existsAt(() => true),
         Exec: () => ({ stdout: "some other tool", stderr: "", exitCode: 0 }),
+      },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("recovers to false when the verify exec fails to spawn (no crash)", () => {
+    const result = check(
+      {
+        type: "process",
+        name: "od",
+        verify: { args: ["--version"], match: /open-?design/i },
+      },
+      linux,
+      {
+        Exists: existsAt(() => true),
+        Exec: () => {
+          // A spawn failure (ENOENT/EACCES) surfaces as a task failure — it must
+          // be recovered to `false`, never propagate out of detection.
+          throw new TaskExecutionError({
+            code: "ENOENT",
+            message: "spawn od ENOENT",
+          });
+        },
       },
     );
     expect(result).toBe(false);

--- a/packages/runtime/harnesses/src/lib/signals.test.ts
+++ b/packages/runtime/harnesses/src/lib/signals.test.ts
@@ -84,6 +84,7 @@ describe("checkSignal — extension", () => {
   it("globs the home VS Code extensions dir and matches when non-empty", () => {
     const seen: { pattern: string; cwd: string }[] = [];
     const result = check(signal, ctx(), {
+      Exists: existsAt((path) => path === "/home/tester/.vscode/extensions"),
       Glob: (effect) => {
         const glob = effect as Effect & { _tag: "Glob" };
         seen.push({ pattern: glob.pattern, cwd: glob.cwd });
@@ -97,8 +98,26 @@ describe("checkSignal — extension", () => {
     });
   });
 
-  it("returns false when no extension directory matches", () => {
-    expect(check(signal, ctx(), { Glob: () => [] })).toBe(false);
+  it("returns false (without globbing) when the extensions dir is absent", () => {
+    let globbed = false;
+    const result = check(signal, ctx(), {
+      Exists: existsAt(() => false),
+      Glob: () => {
+        globbed = true;
+        return [];
+      },
+    });
+    expect(result).toBe(false);
+    expect(globbed).toBe(false);
+  });
+
+  it("returns false when the dir exists but no extension matches", () => {
+    expect(
+      check(signal, ctx(), {
+        Exists: existsAt(() => true),
+        Glob: () => [],
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/runtime/harnesses/src/lib/signals.test.ts
+++ b/packages/runtime/harnesses/src/lib/signals.test.ts
@@ -5,7 +5,7 @@ import {
   checkSignal,
   type DetectContext,
   scoreConfidence,
-  signalTier,
+  toSignalTier,
 } from "./signals.js";
 import type { DetectionSignal } from "./types.js";
 
@@ -118,6 +118,50 @@ describe("checkSignal — extension", () => {
         Glob: () => [],
       }),
     ).toBe(false);
+  });
+
+  it("matches an extension installed in a fork dir (Cursor) with vscode absent", () => {
+    const seen: { pattern: string; cwd: string }[] = [];
+    const result = check(signal, ctx(), {
+      Exists: existsAt((path) => path === "/home/tester/.cursor/extensions"),
+      Glob: (effect) => {
+        const glob = effect as Effect & { _tag: "Glob" };
+        seen.push({ pattern: glob.pattern, cwd: glob.cwd });
+        return ["rooveterinaryinc.roo-cline-9.9.9"];
+      },
+    });
+    expect(result).toBe(true);
+    // Only the one existing fork dir is globbed, under the shared <id>-* pattern.
+    expect(seen).toEqual([
+      {
+        pattern: "rooveterinaryinc.roo-cline-*",
+        cwd: "/home/tester/.cursor/extensions",
+      },
+    ]);
+  });
+
+  it("probes every VS Code-family fork extensions dir (guarded by exists)", () => {
+    let globbed = false;
+    const probed: string[] = [];
+    const result = check(signal, ctx(), {
+      Exists: existsAt((path) => {
+        probed.push(path);
+        return false;
+      }),
+      Glob: () => {
+        globbed = true;
+        return [];
+      },
+    });
+    expect(result).toBe(false);
+    // A missing dir is never globbed (globbing an absent dir throws).
+    expect(globbed).toBe(false);
+    expect(probed).toEqual([
+      "/home/tester/.vscode/extensions",
+      "/home/tester/.cursor/extensions",
+      "/home/tester/.vscode-oss/extensions",
+      "/home/tester/.windsurf/extensions",
+    ]);
   });
 });
 
@@ -292,19 +336,19 @@ describe("checkSignal — env", () => {
   });
 });
 
-describe("signalTier", () => {
+describe("toSignalTier", () => {
   it("scores directory and file as high", () => {
-    expect(signalTier({ type: "directory", path: ".x" })).toBe("high");
-    expect(signalTier({ type: "file", path: ".x" })).toBe("high");
+    expect(toSignalTier({ type: "directory", path: ".x" })).toBe("high");
+    expect(toSignalTier({ type: "file", path: ".x" })).toBe("high");
   });
 
   it("scores extension and process as medium", () => {
-    expect(signalTier({ type: "extension", id: "a.b" })).toBe("medium");
-    expect(signalTier({ type: "process", name: "a" })).toBe("medium");
+    expect(toSignalTier({ type: "extension", id: "a.b" })).toBe("medium");
+    expect(toSignalTier({ type: "process", name: "a" })).toBe("medium");
   });
 
   it("scores env as low", () => {
-    expect(signalTier({ type: "env", key: "A" })).toBe("low");
+    expect(toSignalTier({ type: "env", key: "A" })).toBe("low");
   });
 });
 

--- a/packages/runtime/harnesses/src/lib/signals.test.ts
+++ b/packages/runtime/harnesses/src/lib/signals.test.ts
@@ -1,0 +1,273 @@
+import { dryRunWith, type Effect } from "@canonical/task";
+import { describe, expect, it } from "vitest";
+import type { PlatformEnv } from "./platformPaths.js";
+import {
+  checkSignal,
+  type DetectContext,
+  scoreConfidence,
+  signalTier,
+} from "./signals.js";
+import type { DetectionSignal } from "./types.js";
+
+/** Build a {@link PlatformEnv} fixture. */
+const platform = (overrides: Partial<PlatformEnv> = {}): PlatformEnv => ({
+  platform: "linux",
+  env: {},
+  home: "/home/tester",
+  isWsl: false,
+  ...overrides,
+});
+
+/** Build a {@link DetectContext} fixture. */
+const ctx = (overrides: Partial<DetectContext> = {}): DetectContext => ({
+  projectRoot: "/project",
+  platform: platform(),
+  ...overrides,
+});
+
+type MockSpec = Record<string, (effect: Effect) => unknown>;
+const mocks = (spec: MockSpec): Map<string, (effect: Effect) => unknown> =>
+  new Map(Object.entries(spec));
+
+/** Run a single signal check to its boolean value. */
+const check = (
+  signal: DetectionSignal,
+  context: DetectContext,
+  spec: MockSpec,
+): boolean => dryRunWith(checkSignal(signal, context), mocks(spec)).value;
+
+const existsAt =
+  (predicate: (path: string) => boolean) =>
+  (effect: Effect): unknown =>
+    predicate((effect as Effect & { _tag: "Exists" }).path);
+
+describe("checkSignal — directory / file", () => {
+  it("resolves a project-relative path against the project root", () => {
+    const seen: string[] = [];
+    const result = check({ type: "directory", path: ".cursor" }, ctx(), {
+      Exists: existsAt((path) => {
+        seen.push(path);
+        return path === "/project/.cursor";
+      }),
+    });
+    expect(result).toBe(true);
+    expect(seen).toContain("/project/.cursor");
+  });
+
+  it("resolves a ~/ path against the platform home", () => {
+    const seen: string[] = [];
+    const result = check({ type: "file", path: "~/.claude.json" }, ctx(), {
+      Exists: existsAt((path) => {
+        seen.push(path);
+        return path === "/home/tester/.claude.json";
+      }),
+    });
+    expect(result).toBe(true);
+    expect(seen).toContain("/home/tester/.claude.json");
+  });
+
+  it("returns false when the path is absent", () => {
+    expect(
+      check({ type: "directory", path: ".roo" }, ctx(), {
+        Exists: existsAt(() => false),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("checkSignal — extension", () => {
+  const signal: DetectionSignal = {
+    type: "extension",
+    id: "rooveterinaryinc.roo-cline",
+  };
+
+  it("globs the home VS Code extensions dir and matches when non-empty", () => {
+    const seen: { pattern: string; cwd: string }[] = [];
+    const result = check(signal, ctx(), {
+      Glob: (effect) => {
+        const glob = effect as Effect & { _tag: "Glob" };
+        seen.push({ pattern: glob.pattern, cwd: glob.cwd });
+        return ["rooveterinaryinc.roo-cline-1.2.3"];
+      },
+    });
+    expect(result).toBe(true);
+    expect(seen[0]).toEqual({
+      pattern: "rooveterinaryinc.roo-cline-*",
+      cwd: "/home/tester/.vscode/extensions",
+    });
+  });
+
+  it("returns false when no extension directory matches", () => {
+    expect(check(signal, ctx(), { Glob: () => [] })).toBe(false);
+  });
+});
+
+describe("checkSignal — process", () => {
+  const linux = ctx({ platform: platform({ env: { PATH: "/usr/bin:/bin" } }) });
+
+  it("matches a bare name found on PATH (no verify)", () => {
+    const seen: string[] = [];
+    const result = check({ type: "process", name: "codex" }, linux, {
+      Exists: existsAt((path) => {
+        seen.push(path);
+        return path === "/usr/bin/codex";
+      }),
+    });
+    expect(result).toBe(true);
+    expect(seen).toContain("/usr/bin/codex");
+    expect(seen).toContain("/bin/codex");
+  });
+
+  it("returns false when the name is on no PATH dir", () => {
+    expect(
+      check({ type: "process", name: "codex" }, linux, {
+        Exists: existsAt(() => false),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when PATH is empty", () => {
+    expect(
+      check(
+        { type: "process", name: "codex" },
+        ctx({ platform: platform({ env: {} }) }),
+        { Exists: existsAt(() => true) },
+      ),
+    ).toBe(false);
+  });
+
+  it("appends .exe and splits on ; under win32", () => {
+    const seen: string[] = [];
+    const result = check(
+      { type: "process", name: "codex" },
+      ctx({
+        platform: platform({
+          platform: "win32",
+          env: { PATH: "C:/bin;C:/tools" },
+        }),
+      }),
+      {
+        Exists: existsAt((path) => {
+          seen.push(path);
+          return path.endsWith("codex.exe");
+        }),
+      },
+    );
+    expect(result).toBe(true);
+    expect(seen.some((p) => p.includes("codex.exe"))).toBe(true);
+  });
+
+  it("runs verify and matches stdout against the pattern", () => {
+    const result = check(
+      {
+        type: "process",
+        name: "od",
+        verify: { args: ["--version"], match: /open-?design/i },
+      },
+      linux,
+      {
+        Exists: existsAt(() => true),
+        Exec: () => ({ stdout: "OpenDesign 1.4.0", stderr: "", exitCode: 0 }),
+      },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("fails verify when stdout does not match", () => {
+    const result = check(
+      {
+        type: "process",
+        name: "od",
+        verify: { args: ["--version"], match: /open-?design/i },
+      },
+      linux,
+      {
+        Exists: existsAt(() => true),
+        Exec: () => ({ stdout: "some other tool", stderr: "", exitCode: 0 }),
+      },
+    );
+    expect(result).toBe(false);
+  });
+});
+
+describe("checkSignal — env", () => {
+  it("matches presence when no value is required", () => {
+    expect(
+      check(
+        { type: "env", key: "MY_HARNESS" },
+        ctx({ platform: platform({ env: { MY_HARNESS: "1" } }) }),
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when the key is absent", () => {
+    expect(check({ type: "env", key: "MY_HARNESS" }, ctx(), {})).toBe(false);
+  });
+
+  it("matches an exact value when required", () => {
+    expect(
+      check(
+        { type: "env", key: "TERM_PROGRAM", value: "vscode" },
+        ctx({ platform: platform({ env: { TERM_PROGRAM: "vscode" } }) }),
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when the value differs", () => {
+    expect(
+      check(
+        { type: "env", key: "TERM_PROGRAM", value: "vscode" },
+        ctx({ platform: platform({ env: { TERM_PROGRAM: "iTerm" } }) }),
+        {},
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("signalTier", () => {
+  it("scores directory and file as high", () => {
+    expect(signalTier({ type: "directory", path: ".x" })).toBe("high");
+    expect(signalTier({ type: "file", path: ".x" })).toBe("high");
+  });
+
+  it("scores extension and process as medium", () => {
+    expect(signalTier({ type: "extension", id: "a.b" })).toBe("medium");
+    expect(signalTier({ type: "process", name: "a" })).toBe("medium");
+  });
+
+  it("scores env as low", () => {
+    expect(signalTier({ type: "env", key: "A" })).toBe("low");
+  });
+});
+
+describe("scoreConfidence", () => {
+  const dir: DetectionSignal = { type: "directory", path: ".x" };
+  const proc: DetectionSignal = { type: "process", name: "x" };
+  const env: DetectionSignal = { type: "env", key: "X" };
+
+  it("returns null when nothing matched", () => {
+    expect(scoreConfidence([false, false], [dir, proc])).toBeNull();
+  });
+
+  it("returns high for a matched directory (ignoring an unmatched sibling)", () => {
+    expect(scoreConfidence([true, false], [dir, proc])).toBe("high");
+  });
+
+  it("returns medium for a process-only match", () => {
+    expect(scoreConfidence([true], [proc])).toBe("medium");
+  });
+
+  it("returns low for an env-only match", () => {
+    expect(scoreConfidence([true], [env])).toBe("low");
+  });
+
+  it("takes the strongest tier when a weaker one precedes a stronger", () => {
+    expect(scoreConfidence([true, true], [env, proc])).toBe("medium");
+  });
+
+  it("keeps the strongest tier when a weaker one follows a stronger", () => {
+    expect(scoreConfidence([true, true], [proc, env])).toBe("medium");
+  });
+});

--- a/packages/runtime/harnesses/src/lib/signals.ts
+++ b/packages/runtime/harnesses/src/lib/signals.ts
@@ -118,11 +118,17 @@ const VSCODE_FAMILY_EXTENSION_ROOTS = [
 
 /**
  * Check an `extension` signal: whether any installed VS Code-family extension
- * directory matches `<id>-<version>`. VS Code and its forks (Cursor, VSCodium,
- * Windsurf) keep extensions under the same `<root>/extensions` layout, so every
- * known family root ({@link VSCODE_FAMILY_EXTENSION_ROOTS}) is probed and ANY
- * match counts. Each directory is confirmed to exist before it is globbed, since
- * globbing a missing directory throws.
+ * directory `<id>-<version>/` is present. VS Code and its forks (Cursor,
+ * VSCodium, Windsurf) keep extensions under the same `<root>/extensions` layout,
+ * so every known family root ({@link VSCODE_FAMILY_EXTENSION_ROOTS}) is probed
+ * and ANY match counts. Each directory is confirmed to exist before it is
+ * globbed, since globbing a missing directory throws.
+ *
+ * The pattern targets the `package.json` MANIFEST inside each versioned
+ * extension directory, not the directory itself: the `glob` effect lists files
+ * only, so a bare `<id>-<version>` directory entry would never match — but every
+ * VS Code extension carries a `package.json` at its root, so globbing for that
+ * manifest under each versioned directory reliably resolves an installed one.
  */
 const checkExtension = (
   signal: Extract<DetectionSignal, { type: "extension" }>,
@@ -137,7 +143,7 @@ const checkExtension = (
       flatMap(exists(extensionsDir), (dirExists) =>
         dirExists
           ? map(
-              glob(`${signal.id}-*`, extensionsDir),
+              glob(`${signal.id}-*/package.json`, extensionsDir),
               (matches) => matches.length > 0,
             )
           : pure(false),

--- a/packages/runtime/harnesses/src/lib/signals.ts
+++ b/packages/runtime/harnesses/src/lib/signals.ts
@@ -103,23 +103,47 @@ const checkProcess = (
 };
 
 /**
+ * The VS Code-family extension roots probed for an `extension` signal, relative
+ * to home. VS Code and its forks each keep their own extensions directory in the
+ * identical `<id>-<version>` layout, so an extension installed under ANY of them
+ * counts: stock VS Code (`~/.vscode`), Cursor (`~/.cursor`), VSCodium
+ * (`~/.vscode-oss`), and Windsurf (`~/.windsurf`).
+ */
+const VSCODE_FAMILY_EXTENSION_ROOTS = [
+  ".vscode",
+  ".cursor",
+  ".vscode-oss",
+  ".windsurf",
+] as const;
+
+/**
  * Check an `extension` signal: whether any installed VS Code-family extension
- * directory matches `<id>-<version>`. Extensions live under `~/.vscode/extensions`
- * (the same layout on every platform), so that home-based dir is globbed — but
- * only after confirming it exists, since globbing a missing directory throws.
+ * directory matches `<id>-<version>`. VS Code and its forks (Cursor, VSCodium,
+ * Windsurf) keep extensions under the same `<root>/extensions` layout, so every
+ * known family root ({@link VSCODE_FAMILY_EXTENSION_ROOTS}) is probed and ANY
+ * match counts. Each directory is confirmed to exist before it is globbed, since
+ * globbing a missing directory throws.
  */
 const checkExtension = (
   signal: Extract<DetectionSignal, { type: "extension" }>,
   ctx: DetectContext,
 ): Task<boolean> => {
-  const extensionsDir = join(userHome(ctx.platform), ".vscode", "extensions");
-  return flatMap(exists(extensionsDir), (dirExists) =>
-    dirExists
-      ? map(
-          glob(`${signal.id}-*`, extensionsDir),
-          (matches) => matches.length > 0,
-        )
-      : pure(false),
+  const home = userHome(ctx.platform);
+  const extensionDirs = VSCODE_FAMILY_EXTENSION_ROOTS.map((root) =>
+    join(home, root, "extensions"),
+  );
+  return map(
+    traverse(extensionDirs, (extensionsDir) =>
+      flatMap(exists(extensionsDir), (dirExists) =>
+        dirExists
+          ? map(
+              glob(`${signal.id}-*`, extensionsDir),
+              (matches) => matches.length > 0,
+            )
+          : pure(false),
+      ),
+    ),
+    (results) => results.some(Boolean),
   );
 };
 
@@ -168,7 +192,7 @@ export const checkSignal = (
  * @param signal - The matched signal.
  * @returns Its confidence tier.
  */
-export const signalTier = (signal: DetectionSignal): Confidence => {
+export const toSignalTier = (signal: DetectionSignal): Confidence => {
   switch (signal.type) {
     case "directory":
     case "file":
@@ -195,7 +219,7 @@ export const scoreConfidence = (
 ): Confidence | null => {
   const matched = signals
     .filter((_signal, index) => results.at(index) === true)
-    .map(signalTier);
+    .map(toSignalTier);
   if (matched.length === 0) return null;
   return matched.reduce((best, tier) =>
     CONFIDENCE_RANK[tier] < CONFIDENCE_RANK[best] ? tier : best,

--- a/packages/runtime/harnesses/src/lib/signals.ts
+++ b/packages/runtime/harnesses/src/lib/signals.ts
@@ -1,0 +1,173 @@
+/**
+ * Signal checking + confidence scoring for harness detection. Each
+ * {@link DetectionSignal} arm resolves to a `Task<boolean>` over
+ * `@canonical/task` effects (so detection stays dry-runnable), and the matched
+ * signals score into a confidence tier. Split out of `detectHarnesses` so the
+ * per-arm probes (a process on `PATH`, an editor extension, an env var) and the
+ * tier table are unit-tested against injected platform fixtures at 100%
+ * coverage, independent of the harness registry.
+ */
+
+import { join } from "node:path";
+import {
+  exec,
+  exists,
+  flatMap,
+  glob,
+  map,
+  pure,
+  type Task,
+  traverse,
+} from "@canonical/task";
+import { type PlatformEnv, userHome } from "./platformPaths.js";
+import type { DetectionSignal } from "./types.js";
+
+/** The context threaded through every signal check: the project root + host. */
+export interface DetectContext {
+  readonly projectRoot: string;
+  readonly platform: PlatformEnv;
+}
+
+/** A detection confidence tier. */
+export type Confidence = "high" | "medium" | "low";
+
+/** Ordering weight for a tier — lower is stronger (high wins). */
+export const CONFIDENCE_RANK: Record<Confidence, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+/**
+ * Resolve a directory/file signal path: a `~/…` path against the platform home,
+ * anything else against the project root.
+ */
+const resolveFsPath = (path: string, ctx: DetectContext): string =>
+  path.startsWith("~/")
+    ? join(userHome(ctx.platform), path.slice(2))
+    : join(ctx.projectRoot, path);
+
+/**
+ * Check a `process` signal: whether `name` resolves on the platform `PATH`
+ * (with a `.exe` suffix on win32) and, when a `verify` is given, whether running
+ * it produces stdout matching `verify.match`.
+ */
+const checkProcess = (
+  signal: Extract<DetectionSignal, { type: "process" }>,
+  ctx: DetectContext,
+): Task<boolean> => {
+  const isWindows = ctx.platform.platform === "win32";
+  const separator = isWindows ? ";" : ":";
+  const binary = isWindows ? `${signal.name}.exe` : signal.name;
+  const candidates = (ctx.platform.env.PATH ?? "")
+    .split(separator)
+    .filter((dir) => dir.length > 0)
+    .map((dir) => join(dir, binary));
+
+  return flatMap(
+    traverse(candidates, (candidate) => exists(candidate)),
+    (results) => {
+      if (!results.some(Boolean)) return pure(false);
+      const verify = signal.verify;
+      if (!verify) return pure(true);
+      return map(exec(signal.name, [...verify.args]), (result) =>
+        verify.match.test(result.stdout),
+      );
+    },
+  );
+};
+
+/**
+ * Check an `extension` signal: whether any installed VS Code-family extension
+ * directory matches `<id>-<version>`. Extensions live under `~/.vscode/extensions`
+ * (the same layout on every platform), so that home-based dir is globbed.
+ */
+const checkExtension = (
+  signal: Extract<DetectionSignal, { type: "extension" }>,
+  ctx: DetectContext,
+): Task<boolean> => {
+  const extensionsDir = join(userHome(ctx.platform), ".vscode", "extensions");
+  return map(
+    glob(`${signal.id}-*`, extensionsDir),
+    (matches) => matches.length > 0,
+  );
+};
+
+/** Check an `env` signal: the key is present (and equals `value` when given). */
+const checkEnv = (
+  signal: Extract<DetectionSignal, { type: "env" }>,
+  ctx: DetectContext,
+): Task<boolean> => {
+  const actual = ctx.platform.env[signal.key];
+  if (signal.value !== undefined) return pure(actual === signal.value);
+  return pure(actual !== undefined);
+};
+
+/**
+ * Resolve a single detection signal to a `Task<boolean>` — true when it matches.
+ *
+ * @param signal - The signal to check.
+ * @param ctx - The project root + captured platform.
+ * @returns A Task yielding whether the signal matches.
+ * @note Impure for directory/file/extension/process signals — they probe the
+ * filesystem / `PATH` / process table via Task effects; `env` is pure over the
+ * captured platform environment.
+ */
+export const checkSignal = (
+  signal: DetectionSignal,
+  ctx: DetectContext,
+): Task<boolean> => {
+  switch (signal.type) {
+    case "directory":
+    case "file":
+      return exists(resolveFsPath(signal.path, ctx));
+    case "extension":
+      return checkExtension(signal, ctx);
+    case "process":
+      return checkProcess(signal, ctx);
+    case "env":
+      return checkEnv(signal, ctx);
+  }
+};
+
+/**
+ * The confidence tier a signal type contributes when matched: a directory/file
+ * is high (a config lives there), an extension/process is medium (the tool is
+ * installed but the project may not use it), an env var is low.
+ *
+ * @param signal - The matched signal.
+ * @returns Its confidence tier.
+ */
+export const signalTier = (signal: DetectionSignal): Confidence => {
+  switch (signal.type) {
+    case "directory":
+    case "file":
+      return "high";
+    case "extension":
+    case "process":
+      return "medium";
+    case "env":
+      return "low";
+  }
+};
+
+/**
+ * Score signal check results into the strongest (MAX) confidence tier among the
+ * matched signals, or null when none matched.
+ *
+ * @param results - Per-signal match booleans, index-aligned with `signals`.
+ * @param signals - The signals that produced `results`.
+ * @returns The strongest matched tier, or null when nothing matched.
+ */
+export const scoreConfidence = (
+  results: readonly boolean[],
+  signals: readonly DetectionSignal[],
+): Confidence | null => {
+  const matched = signals
+    .filter((_signal, index) => results.at(index) === true)
+    .map(signalTier);
+  if (matched.length === 0) return null;
+  return matched.reduce((best, tier) =>
+    CONFIDENCE_RANK[tier] < CONFIDENCE_RANK[best] ? tier : best,
+  );
+};

--- a/packages/runtime/harnesses/src/lib/signals.ts
+++ b/packages/runtime/harnesses/src/lib/signals.ts
@@ -16,6 +16,7 @@ import {
   glob,
   map,
   pure,
+  recover,
   type Task,
   traverse,
 } from "@canonical/task";
@@ -48,9 +49,22 @@ const resolveFsPath = (path: string, ctx: DetectContext): string =>
     : join(ctx.projectRoot, path);
 
 /**
- * Check a `process` signal: whether `name` resolves on the platform `PATH`
- * (with a `.exe` suffix on win32) and, when a `verify` is given, whether running
- * it produces stdout matching `verify.match`.
+ * The executable suffixes probed on win32 when `PATHEXT` is unset — the usual
+ * Windows default. Crucially includes `.CMD`/`.BAT`: npm installs CLI harnesses
+ * (`claude`, `codex`, `od`…) as `.cmd` shims, never `.exe`, so an `.exe`-only
+ * probe would miss every npm-installed harness on Windows.
+ */
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/**
+ * Check a `process` signal: whether `name` resolves on the platform `PATH` (on
+ * win32, under any `PATHEXT` suffix — not just `.exe`) and, when a `verify` is
+ * given, whether running it produces stdout matching `verify.match`.
+ *
+ * The `verify` SPAWNS the binary, so its exec is wrapped in {@link recover}: a
+ * spawn failure (ENOENT/EACCES, or the process itself erroring) resolves to an
+ * unverified `false` rather than rejecting — one harness's probe must never be
+ * able to reject all of `detectHarnesses` and crash `setup`/`doctor`.
  */
 const checkProcess = (
   signal: Extract<DetectionSignal, { type: "process" }>,
@@ -58,11 +72,19 @@ const checkProcess = (
 ): Task<boolean> => {
   const isWindows = ctx.platform.platform === "win32";
   const separator = isWindows ? ";" : ":";
-  const binary = isWindows ? `${signal.name}.exe` : signal.name;
+  // On win32 an executable matches under any PATHEXT suffix; elsewhere the bare
+  // name is the sole candidate (the empty suffix).
+  const suffixes = isWindows
+    ? (ctx.platform.env.PATHEXT ?? DEFAULT_PATHEXT)
+        .split(";")
+        .filter((suffix) => suffix.length > 0)
+    : [""];
   const candidates = (ctx.platform.env.PATH ?? "")
     .split(separator)
     .filter((dir) => dir.length > 0)
-    .map((dir) => join(dir, binary));
+    .flatMap((dir) =>
+      suffixes.map((suffix) => join(dir, `${signal.name}${suffix}`)),
+    );
 
   return flatMap(
     traverse(candidates, (candidate) => exists(candidate)),
@@ -70,8 +92,11 @@ const checkProcess = (
       if (!results.some(Boolean)) return pure(false);
       const verify = signal.verify;
       if (!verify) return pure(true);
-      return map(exec(signal.name, [...verify.args]), (result) =>
-        verify.match.test(result.stdout),
+      return recover(
+        map(exec(signal.name, [...verify.args]), (result) =>
+          verify.match.test(result.stdout),
+        ),
+        () => pure(false),
       );
     },
   );

--- a/packages/runtime/harnesses/src/lib/signals.ts
+++ b/packages/runtime/harnesses/src/lib/signals.ts
@@ -80,16 +80,21 @@ const checkProcess = (
 /**
  * Check an `extension` signal: whether any installed VS Code-family extension
  * directory matches `<id>-<version>`. Extensions live under `~/.vscode/extensions`
- * (the same layout on every platform), so that home-based dir is globbed.
+ * (the same layout on every platform), so that home-based dir is globbed — but
+ * only after confirming it exists, since globbing a missing directory throws.
  */
 const checkExtension = (
   signal: Extract<DetectionSignal, { type: "extension" }>,
   ctx: DetectContext,
 ): Task<boolean> => {
   const extensionsDir = join(userHome(ctx.platform), ".vscode", "extensions");
-  return map(
-    glob(`${signal.id}-*`, extensionsDir),
-    (matches) => matches.length > 0,
+  return flatMap(exists(extensionsDir), (dirExists) =>
+    dirExists
+      ? map(
+          glob(`${signal.id}-*`, extensionsDir),
+          (matches) => matches.length > 0,
+        )
+      : pure(false),
   );
 };
 

--- a/packages/runtime/harnesses/src/lib/types.ts
+++ b/packages/runtime/harnesses/src/lib/types.ts
@@ -69,6 +69,12 @@ export interface HarnessDefinition {
   readonly configFormat: "json" | "jsonc" | "toml";
   readonly mcpKey: string;
   readonly skillsPath: (projectRoot: string) => string;
+  /**
+   * When true, a written server entry's `env` is forced to a JSON object/map
+   * (OpenDesign requires it — see VERIFY(7g)). Omitted (falsy) for harnesses
+   * that leave `env` as authored.
+   */
+  readonly normalizeEnv?: boolean;
 }
 
 /**
@@ -81,6 +87,8 @@ export interface ConfigTarget {
   readonly configFormat: "json" | "jsonc" | "toml";
   readonly mcpKey: string;
   readonly scope: HarnessScope;
+  /** Force a written entry's `env` to a JSON object/map (OpenDesign — 7g). */
+  readonly normalizeEnv?: boolean;
 }
 
 /**

--- a/packages/runtime/harnesses/src/lib/types.ts
+++ b/packages/runtime/harnesses/src/lib/types.ts
@@ -9,7 +9,19 @@ export type DetectionSignal =
   | { readonly type: "directory"; readonly path: string }
   | { readonly type: "file"; readonly path: string }
   | { readonly type: "extension"; readonly id: string }
-  | { readonly type: "process"; readonly name: string }
+  | {
+      readonly type: "process";
+      readonly name: string;
+      /**
+       * When present, a bare PATH hit is not enough: the binary is run with
+       * `args` and its stdout must match `match` (guards against a same-named
+       * binary belonging to a different tool).
+       */
+      readonly verify?: {
+        readonly args: readonly string[];
+        readonly match: RegExp;
+      };
+    }
   | { readonly type: "env"; readonly key: string; readonly value?: string };
 
 /**

--- a/packages/runtime/harnesses/src/lib/types.ts
+++ b/packages/runtime/harnesses/src/lib/types.ts
@@ -2,6 +2,8 @@
  * Core types for AI harness detection and MCP configuration.
  */
 
+import type { PlatformEnv } from "./platformPaths.js";
+
 /**
  * A signal used to detect whether a harness is present in the environment.
  */
@@ -31,6 +33,19 @@ export type DetectionSignal =
 export type VersionRange = string;
 
 /**
+ * Where a harness stores its MCP config: `project` writes only a per-repo file,
+ * `global` writes only the user's home config, `both` can write either band
+ * (defaulting to the project file — see `defaultBandOf`).
+ */
+export type HarnessScope = "project" | "global" | "both";
+
+/**
+ * One of the two config bands a scope resolves to: the per-repo `project` file
+ * or the per-user `global` (home) file.
+ */
+export type ScopeBand = "project" | "global";
+
+/**
  * Definition of an AI harness (editor/agent) with its detection signals,
  * configuration format, and known paths.
  *
@@ -41,11 +56,31 @@ export interface HarnessDefinition {
   readonly id: string;
   readonly name: string;
   readonly version: VersionRange;
+  /** Which config band(s) this harness supports. */
+  readonly scope: HarnessScope;
   readonly detect: readonly DetectionSignal[];
   readonly configPath: (projectRoot: string) => string;
+  /**
+   * The per-user (home) config path. Required for `global`/`both` scopes —
+   * `resolveConfigTarget` asserts its presence when a global-band target is
+   * requested — and omitted for `project`-only harnesses.
+   */
+  readonly homeConfigPath?: (platform: PlatformEnv) => string;
   readonly configFormat: "json" | "jsonc" | "toml";
   readonly mcpKey: string;
   readonly skillsPath: (projectRoot: string) => string;
+}
+
+/**
+ * A resolved, band-specific config location — the concrete file a read/write
+ * acts on, produced by `resolveConfigTarget`. Carries everything the JSON/TOML
+ * bodies need without re-consulting the harness definition.
+ */
+export interface ConfigTarget {
+  readonly path: string;
+  readonly configFormat: "json" | "jsonc" | "toml";
+  readonly mcpKey: string;
+  readonly scope: HarnessScope;
 }
 
 /**


### PR DESCRIPTION
## Done

The CLI consumer of the harness-scope model — **PR 2 of 2**, stacked on #867 (merge that first). Turns the two-band scope model into user-facing `setup`/`doctor` behaviour.

- **`--scope {project|global|both}`** (default `both`) + `--global`/`--local` sugars on `setup` / `setup mcp` / `setup skills` — scope is intrinsic per action: completions + LSP are machine/global; MCP + skills are per-harness (project for Cursor/VS Code/local-Claude, global for Windsurf).
- **Banded recap + `doctor` grouping** under **Global** / **Project**, each with its resolved path; the doctor bands each MCP check by the scope of the harness it actually found.
- **Wizard opt-in narrowing** — bare `setup` honours "all"; the per-target multiselect only appears when you choose to customise.

Review-pass fixes folded in: run-all `--scope`/`--global`/`--local` now threads through `buildRunAllPlan` → `listAvailableSteps` (so `--local` skips global completions+LSP and `--global` skips project skills); the doctor band is derived from the harness scope (a global-only harness like Windsurf is banded **Global**, not mislabeled Project); `doctor.render` / `setup.render` output-assertion tests added; an `expectTypeOf` pin keeps the CLI scope-type mirrors in sync with `@canonical/harnesses`; Global/Project terminology unified; verb-first renames.

Covenant: `--scope`/`--global`/`--local` on the `setup`/`mcp`/`skills` verbs only; `globalFlags` untouched; MCP tool count unchanged at **40**; `surface.v2.json` + conformance updated.

Related: AV-284.

## QA

- `cd packages/cli/next`
- `bun run check` — biome + tsc + webarchitect, all pass
- `bun run test:vitest` — 803 tests
- `bun run test:perf` — 8/8 budgets
- Requires #867's `@canonical/harnesses` built first (`bun run build`).

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`. → **`Breaking Change 💣`** (new `setup` flags on the frozen surface).
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` / `build:all`.
- [ ] If this PR introduces a **new package**: N/A — no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — CLI / MCP only.

---
_Generated by [Claude Code](https://claude.ai/code/session_012B41xiqaum5nwecX5mVghF)_