### PR TITLE
fix(components): design-review batch — h5 small-caps, SwitchField, Tabs, ContextualMenu, Field.Description, density retune

### DIFF
--- a/packages/react/ds-global-form/src/docs/Density.mdx
+++ b/packages/react/ds-global-form/src/docs/Density.mdx
@@ -34,9 +34,10 @@ The matrix, in baseline units (1 bU = `--baseline-height` = 4px):
                    comfy   dense       comfy   dense
   line-height      32 (8)  24 (6)      36 (9)  28 (7)
   padding-inline   16 (4)   8 (2)      16 (4)  12 (3)
-  space-lg         24 (6)  16 (4)      28 (7)  20 (5)   ← between fields
-  space-md         16 (4)   8 (2)      20 (5)  12 (3)   ← label → control
+  space-lg         40 (10) 32 (8)      44 (11) 36 (9)   ← between fields
+  space-md          8 (2)   4 (1)       8 (2)   8 (2)   ← label → control
   space-sm          8 (2)   4 (1)       8 (2)   8 (2)   ← desc/error → input
+  space-xs          4 (1)   4 (1)       4 (1)   4 (1)   ← label → description
 ```
 
 Context sets the `*-comfy` / `*-dense` pair for every value; density picks within
@@ -52,13 +53,15 @@ the site's pairs. Read straight down that column:
 - **line-height** — 28px, so a control is a 7 bU box (`--baseline-height * 7`).
 - **padding-inline** — 12px = 3 bU of inline padding inside the control and on
   the horizontal label↔input gap.
-- **space-lg** — 20px = 5 bU between one field and the next.
-- **space-md** — 12px = 3 bU from a field's label down to its control.
+- **space-lg** — 36px = 9 bU between one field and the next.
+- **space-md** — 8px = 2 bU from a field's label down to its control.
 - **space-sm** — 8px = 2 bU from a description or error across to the input.
+- **space-xs** — 4px = 1 bU from a field's label down to a leading description.
 
-Compare that to **app / dense** one baseline tighter: the box is 24px (6 bU) and
-the inline padding drops to 8px (2 bU). The site column never goes below its 8px
-`space-sm` — a site stays a touch airier than an app even when dense.
+Compare that to **app / dense** one baseline tighter: the box is 24px (6 bU), the
+inline padding drops to 8px (2 bU), and the label→control / desc→input gaps
+tighten to 4px. The site column never goes below its 8px `space-md`/`space-sm` —
+a site stays a touch airier than an app even when dense.
 
 ## How to apply density
 
@@ -121,11 +124,12 @@ The model is layered so each layer knows only about the one below it:
    place a field concept meets a density value:
 
 ```css
---form-input-padding-inline: var(--density-padding-inline);   /* inline */
---form-field-inline-gap:     var(--density-padding-inline);   /* inline */
---form-field-block-gap:      var(--density-space-lg);         /* between fields   */
---form-field-label-gap:      var(--density-space-md);         /* label → control  */
---form-group-gap:            var(--density-space-sm);         /* desc/error → input */
+--form-input-padding-inline:       var(--density-padding-inline); /* inline */
+--form-field-inline-gap:           var(--density-padding-inline); /* inline */
+--form-field-block-gap:            var(--density-space-lg);  /* between fields    */
+--form-field-label-gap:            var(--density-space-md);  /* label → control   */
+--form-group-gap:                  var(--density-space-sm);  /* desc/error → input */
+--form-field-label-description-gap: var(--density-space-xs); /* label → description */
 ```
 
 ### Why the layering direction matters

--- a/packages/react/ds-global-form/src/index.css
+++ b/packages/react/ds-global-form/src/index.css
@@ -39,15 +39,19 @@
      then tune each axis independently, and the names stay honest):
        BLOCK (vertical):  field-block-gap · field-label-gap · group-gap
        INLINE (horizontal): field-inline-gap                                    */
-  --form-field-block-gap: var(
-    --container-gap-loose
-  ); /* 24px — block: gap BETWEEN fields */
-  /* Design review (15/07): flat 8px label→input gap (was --container-gap-default,
-   * 16px). See the density-channel mapping below for the matrix-vs-review note. */
+  /* No-density-class defaults — mirror the density matrix's app/comfortable cell
+     (F-O4, 15/07 review). The density-scoped block further down re-derives these
+     per cell when a context/density class is present. */
+  --form-field-block-gap: calc(
+    var(--baseline-height) *
+    10
+  ); /* 40px — block: gap BETWEEN fields */
   --form-field-label-gap: var(
     --space-100
   ); /* 8px — block: gap from a field's LABEL down to its control */
-  /* --form-field-label-gap: var(--container-gap-default); */ /* 16px (pre-review) */
+  --form-field-label-description-gap: var(
+    --space-050
+  ); /* 4px — block: gap from a LABEL down to a leading description */
   --form-group-gap: var(
     --space-100
   ); /* 8px — block: gap from desc/error to the input */
@@ -126,7 +130,10 @@
 
   /* ── Description ────────────────────────────────────────────────── */
 
-  --form-description-font-size: var(--typography-text-primary-font-size);
+  /* Description reads the SECONDARY type ramp (design review): it is subordinate
+     supporting text, so it takes the smaller secondary size, not the primary
+     body size. Colour is already the muted token. */
+  --form-description-font-size: var(--typography-text-secondary-font-size);
   --form-description-color: var(--color-text-muted);
 
   /* ── Error ──────────────────────────────────────────────────────── */
@@ -166,29 +173,30 @@
  *   INLINE (horizontal): control padding + label↔input / prefix-suffix gap
  *     → --density-padding-inline
  *   BLOCK (vertical), by magnitude:
- *     between-fields   → --density-space-lg   (widest structural gap)
- *     label → control  → --density-space-md   (label to its own control)
- *     desc/error → input → --density-space-sm (tight annotation gap)
- *   All rungs are whole baseline multiples, so vertical rhythm holds. */
+ *     between-fields     → --density-space-lg  (widest structural gap, 40px app)
+ *     label → control    → --density-space-md  (label to its own control, 8px app)
+ *     desc/error → input → --density-space-sm  (tight annotation gap, 8px)
+ *     label → description → --density-space-xs (tightest, 4px)
+ *   All rungs are whole baseline multiples, so vertical rhythm holds.
+ *   (space-md/-lg were retuned + space-xs added per the 15/07 review — F-O4;
+ *    the density matrix now carries Diana's numbers directly, so the form maps
+ *    straight onto the rungs rather than pinning literals.) */
 :where(.comfortable, .dense, .app, .site, .docs) {
   --form-input-padding-inline: var(--density-padding-inline, var(--space-200));
   --form-field-inline-gap: var(--density-padding-inline, var(--space-200));
   --form-field-block-gap: var(
     --density-space-lg,
-    calc(var(--baseline-height) * 6)
+    calc(var(--baseline-height) * 10)
   );
-  /* Design review (15/07): the label→input gap should be a flat 8px, not the
-   * density `space-md` rung (16px app / 20px site). Diana's 15/07 field-spacing
-   * numbers diverge from the shipped density matrix (see pragma-adrs U.01); until
-   * that matrix-vs-review tension is resolved we pin 8px here and KEEP the
-   * density mapping below, commented, so it can be restored in one line once the
-   * matrix decision lands. 8px = one `space-md`-equivalent held at 2 baseline units. */
-  --form-field-label-gap: calc(var(--baseline-height) * 2); /* 8px */
-  /* --form-field-label-gap: var(
+  --form-field-label-gap: var(
     --density-space-md,
-    calc(var(--baseline-height) * 4)
-  ); */
+    calc(var(--baseline-height) * 2)
+  );
   --form-group-gap: var(--density-space-sm, calc(var(--baseline-height) * 2));
+  --form-field-label-description-gap: var(
+    --density-space-xs,
+    calc(var(--baseline-height) * 1)
+  );
 }
 
 /* ── .ds.input.chrome — shared input chrome ─────────────────────────

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
@@ -31,5 +31,13 @@
       text-align: start;
       cursor: pointer;
     }
+
+    /* Label BEFORE the control (switch convention): the DOM stays
+       control-then-label for accessibility, so `row-reverse` moves the control
+       to the trailing (right) edge and the label to the leading (left) edge.
+       Logical `row-reverse` mirrors correctly in RTL. */
+    &.label-before {
+      flex-direction: row-reverse;
+    }
   }
 }

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
@@ -39,6 +39,7 @@ const ToggleWrapper = <ComponentProps extends BaseInputProps>({
   description,
   label,
   controlLabel,
+  labelPosition = "after",
   isOptional,
   requiredIndicator,
   registerProps: userRegisterProps,
@@ -90,8 +91,13 @@ const ToggleWrapper = <ComponentProps extends BaseInputProps>({
       )}
 
       {/* The control and its inline true label, side by side. The label is
-          often a full sentence, so it wraps as prose beside the control. */}
-      <div className="field-toggle-control">
+          often a full sentence, so it wraps as prose beside the control. DOM
+          order stays control-then-label; `labelPosition: "before"` visually
+          moves the label to the LEFT via CSS (the switch convention), keeping
+          the accessible order stable. */}
+      <div
+        className={["field-toggle-control", `label-${labelPosition}`].join(" ")}
+      >
         <Component {...componentProps} />
         <Label
           name={name}

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/styles.css
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/styles.css
@@ -3,9 +3,21 @@
   grid-template-columns: subgrid;
   grid-column: var(--form-field-columns, 1 / -1);
   /* Vertical gap from the label row down to the payload row. Uses the block-axis
-     label-gap token — NOT --form-field-inline-gap (that is horizontal-only now). */
+     label-gap token — NOT --form-field-inline-gap (that is horizontal-only now).
+     Default is the label→control gap (--form-field-label-gap, 8px); when a
+     description LEADS the payload the row below tightens it to the label→
+     description gap (--form-field-label-description-gap, 4px), per the 15/07
+     review's field-spacing spec. */
   row-gap: var(--form-field-label-gap);
   align-items: baseline;
+
+  /* Label sits closer to a leading description than to a bare control. */
+  &:has(> .payload > .ds.field-description:first-child) {
+    row-gap: var(
+      --form-field-label-description-gap,
+      var(--form-field-label-gap)
+    );
+  }
 
   & > .ds.field-label {
     grid-column: var(--form-label-columns, 1 / -1);

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/withToggleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/withToggleWrapper.tsx
@@ -25,13 +25,25 @@ type ToggleWrapperProps<ComponentProps extends BaseInputProps> = Omit<
  * here — in the HOC's return type — keeps it out of the shared `withWrapper`
  * generics, which would otherwise widen the union back to all-optional.
  *
+ * `defaults` are per-field defaults (e.g. SwitchField's `labelPosition: "before"`).
+ * They are spread UNDER the caller's props, so a consumer can still override them.
+ *
  * `import { withToggleWrapper } from "@canonical/react-ds-global-form";`
  */
 const withToggleWrapper = <ComponentProps extends BaseInputProps>(
   Component: ComponentType<ComponentProps>,
-): FC<ToggleWrapperProps<ComponentProps>> =>
-  withWrapper<ComponentProps>(Component, undefined, ToggleWrapper) as FC<
-    ToggleWrapperProps<ComponentProps>
-  >;
+  defaults?: Partial<ToggleWrapperProps<ComponentProps>>,
+): FC<ToggleWrapperProps<ComponentProps>> => {
+  const Wrapped = withWrapper<ComponentProps>(
+    Component,
+    undefined,
+    ToggleWrapper,
+  ) as FC<ToggleWrapperProps<ComponentProps>>;
+  if (!defaults) return Wrapped;
+  const WithDefaults: FC<ToggleWrapperProps<ComponentProps>> = (props) => (
+    <Wrapped {...defaults} {...props} />
+  );
+  return WithDefaults;
+};
 
 export default withToggleWrapper;

--- a/packages/react/ds-global-form/src/lib/common/types.ts
+++ b/packages/react/ds-global-form/src/lib/common/types.ts
@@ -64,6 +64,13 @@ export type WrapperProps<ComponentProps> = BaseWrapperProps<ComponentProps> & {
    * `controlLabel` the inline control label. */
   controlLabel?: string;
 
+  /* Toggle fields only: which side of the control the inline label sits on.
+   * "after" (default) — label follows the control, the checkbox convention.
+   * "before" — label leads, to the LEFT of the control; the switch convention,
+   * where a label before the switch names its PURPOSE (a label after would
+   * instead read as the switch's state). */
+  labelPosition?: "before" | "after";
+
   /* Is the field optional */
   isOptional?: boolean;
 

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
@@ -12,8 +12,14 @@ type SwitchInputFieldProps = InputProps<SwitchInputProps>;
  * middleware/conditional-display support. Requires at least one of
  * `label`/`controlLabel`.
  *
+ * The label defaults to the LEFT of the switch (`labelPosition: "before"`): a
+ * label before a switch names its purpose, which is the switch convention (a
+ * label after would read as the switch's state). Callers can override with
+ * `labelPosition="after"`.
+ *
  * `import { SwitchField } from "@canonical/react-ds-global-form";`
  */
 export default withToggleWrapper<SwitchInputFieldProps>(
   bindField<SwitchInputFieldProps>(SwitchInput, "native"),
+  { labelPosition: "before" },
 );

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
@@ -14,6 +14,17 @@ const meta = {
   title: "patterns/Field",
   component: Component,
   decorators: [decorators.form()],
+  // `description` is editable from the Controls panel — type text to see the
+  // field's description slot (its type ramp and the label→description gap) live.
+  argTypes: {
+    description: {
+      control: "text",
+      description: "Supporting text shown under the label, above the control.",
+    },
+  },
+  args: {
+    description: "Supporting help text for this field.",
+  },
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import { useMemo } from "react";
 import { createPortal } from "react-dom";
 import {
-  MENU_PLACEMENT,
+  MENU_ROOT_PLACEMENT,
   useContextualMenu,
   useIsMounted,
 } from "../../hooks/index.js";
@@ -55,10 +55,11 @@ const ContextualMenu = ({
   const menu = useContextualMenu({
     root,
     isOpen: open,
-    // Open toward the trigger's leading edge, top-aligned, flipping side/
-    // alignment as space runs out. MENU_PLACEMENT is logical (inline-*), so the
-    // hook mirrors it in RTL automatically — no direction read here.
-    preferredDirections: preferredDirections ?? MENU_PLACEMENT,
+    // Open BELOW the trigger, leading-aligned, flipping above then to the side
+    // as space runs out (design review). MENU_ROOT_PLACEMENT is logical, so the
+    // hook mirrors alignment in RTL automatically — no direction read here.
+    // (Submenus keep the side-opening MENU_PLACEMENT — see SubMenu.)
+    preferredDirections: preferredDirections ?? MENU_ROOT_PLACEMENT,
     distance,
     gutter,
     maxWidth,

--- a/packages/react/ds-global/src/lib/component/Tabs/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Tabs/common/Item/styles.css
@@ -15,6 +15,8 @@
   --tabs-tab-padding-inline: var(--space-200); /* 16px */
   /* 5bU = 40px tab height on the 8px baseline grid. */
   --tabs-tab-min-block-size: calc(var(--baseline-height) * 5);
+  --tabs-tab-focus-ring-width: var(--dimension-strokeThickness-large, 2px);
+  --tabs-tab-focus-ring-color: var(--color-focusRing);
 }
 
 .ds.tabs-item {
@@ -38,6 +40,16 @@
   /* Transparent underline reserved so the row never shifts when a border
      appears on hover/active. */
   border-bottom: var(--tabs-tab-border-width) solid transparent;
+
+  /* Keyboard focus: a design-system focus ring (design review) instead of the
+     UA default outline. Inset offset so the ring hugs the tab and the row's
+     `overflow` never clips it; :focus-visible only, so pointer clicks stay
+     quiet. */
+  &:focus-visible {
+    outline: var(--tabs-tab-focus-ring-width) solid
+      var(--tabs-tab-focus-ring-color);
+    outline-offset: calc(-1 * var(--tabs-tab-focus-ring-width));
+  }
 }
 
 /* Hover: a muted bottom border hints the tab is navigable, and settles faster

--- a/packages/react/ds-global/src/lib/hooks/useWindowFitment/readingDirection.ts
+++ b/packages/react/ds-global/src/lib/hooks/useWindowFitment/readingDirection.ts
@@ -1,10 +1,26 @@
 import type { WindowFitmentPlacement, WindowFitmentSide } from "./types.js";
 
 /**
- * Contextual-menu placements: open toward the trigger's reading-flow (leading)
- * edge, top-aligned, flipping alignment then side as space runs out. Logical, so
- * it mirrors automatically — resolves to the historical right-start/… order in
- * LTR and left-start/… in RTL.
+ * ROOT contextual-menu placements: open BELOW the trigger, leading-aligned
+ * (design review), flipping to above then to the side as space runs out.
+ * Logical, so alignment mirrors automatically (leading = left in LTR, right in
+ * RTL). Used by the top-level menu opened from a trigger.
+ */
+export const MENU_ROOT_PLACEMENT: WindowFitmentPlacement[] = [
+  { side: "block-end", align: "start" }, //   below, leading-aligned (default)
+  { side: "block-end", align: "end" }, //     horizontal overflow → trailing-aligned
+  { side: "block-start", align: "start" }, //  vertical overflow → flip above
+  { side: "block-start", align: "end" },
+  { side: "inline-end", align: "start" }, //   no room above/below → to the side
+  { side: "inline-start", align: "start" },
+];
+
+/**
+ * SUBMENU (nested) placements: expand toward the trigger's reading-flow
+ * (leading) edge, top-aligned, flipping alignment then side as space runs out —
+ * standard cascade behaviour, a submenu opens beside its parent item, not below
+ * it. Logical, so it mirrors automatically (right-start… in LTR, left-start… in
+ * RTL).
  */
 export const MENU_PLACEMENT: WindowFitmentPlacement[] = [
   { side: "inline-end", align: "start" }, // right-start LTR / left-start RTL

--- a/packages/styles/main/src/modifiers.density.css
+++ b/packages/styles/main/src/modifiers.density.css
@@ -31,10 +31,16 @@
  *                    comfy   dense       comfy   dense
  *   line-height      32 (8)  24 (6)      36 (9)  28 (7)
  *   padding-inline   16 (4)   8 (2)      16 (4)  12 (3)
- *   space-lg         24 (6)  16 (4)      28 (7)  20 (5)
- *   space-md         16 (4)   8 (2)      20 (5)  12 (3)
- *   space-sm          8 (2)   4 (1)       8 (2)   8 (2)
+ *   space-lg         40 (10) 32 (8)      44 (11) 36 (9)   ← between fields
+ *   space-md          8 (2)   4 (1)       8 (2)   8 (2)   ← label → control
+ *   space-sm          8 (2)   4 (1)       8 (2)   8 (2)   ← desc/error → input
+ *   space-xs          4 (1)   4 (1)       4 (1)   4 (1)   ← label → description
  *   (parenthesised = baseline units; 1 bU = --baseline-height = 4px)
+ *
+ * NB the space-lg / space-md values were retuned from Diana's 15/07 review
+ * (label→input 8px, between-fields 40px), and space-xs (label→description 4px)
+ * added, replacing the earlier graded 16/24 rungs. The values stay whole
+ * baseline multiples, so vertical rhythm holds.
  */
 
 /* ── Context family: the comfortable/dense PAIR per surface ──────────────────
@@ -49,12 +55,14 @@
   --density-lh-dense: calc(var(--baseline-height) * 6); /* 24px */
   --density-pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
   --density-pad-inline-dense: calc(var(--baseline-height) * 2); /*  8px */
-  --density-space-lg-comfy: calc(var(--baseline-height) * 6); /* 24px */
-  --density-space-lg-dense: calc(var(--baseline-height) * 4); /* 16px */
-  --density-space-md-comfy: calc(var(--baseline-height) * 4); /* 16px */
-  --density-space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-lg-comfy: calc(var(--baseline-height) * 10); /* 40px */
+  --density-space-lg-dense: calc(var(--baseline-height) * 8); /* 32px */
+  --density-space-md-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-md-dense: calc(var(--baseline-height) * 1); /*  4px */
   --density-space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
   --density-space-sm-dense: calc(var(--baseline-height) * 1); /*  4px */
+  --density-space-xs-comfy: calc(var(--baseline-height) * 1); /*  4px */
+  --density-space-xs-dense: calc(var(--baseline-height) * 1); /*  4px */
 
   /* Back-compat aliases (pre-namespace names). Remove once no consumer reads them. */
   --lh-comfy: var(--density-lh-comfy);
@@ -74,12 +82,14 @@
   --density-lh-dense: calc(var(--baseline-height) * 7); /* 28px */
   --density-pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
   --density-pad-inline-dense: calc(var(--baseline-height) * 3); /* 12px */
-  --density-space-lg-comfy: calc(var(--baseline-height) * 7); /* 28px */
-  --density-space-lg-dense: calc(var(--baseline-height) * 5); /* 20px */
-  --density-space-md-comfy: calc(var(--baseline-height) * 5); /* 20px */
-  --density-space-md-dense: calc(var(--baseline-height) * 3); /* 12px */
+  --density-space-lg-comfy: calc(var(--baseline-height) * 11); /* 44px */
+  --density-space-lg-dense: calc(var(--baseline-height) * 9); /* 36px */
+  --density-space-md-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
   --density-space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
   --density-space-sm-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-xs-comfy: calc(var(--baseline-height) * 1); /*  4px */
+  --density-space-xs-dense: calc(var(--baseline-height) * 1); /*  4px */
 
   /* Back-compat aliases (pre-namespace names). Remove once no consumer reads them. */
   --lh-comfy: var(--density-lh-comfy);
@@ -109,15 +119,19 @@
   );
   --density-space-lg: var(
     --density-space-lg-comfy,
-    calc(var(--baseline-height) * 6)
+    calc(var(--baseline-height) * 10)
   );
   --density-space-md: var(
     --density-space-md-comfy,
-    calc(var(--baseline-height) * 4)
+    calc(var(--baseline-height) * 2)
   );
   --density-space-sm: var(
     --density-space-sm-comfy,
     calc(var(--baseline-height) * 2)
+  );
+  --density-space-xs: var(
+    --density-space-xs-comfy,
+    calc(var(--baseline-height) * 1)
   );
 }
 .dense {
@@ -131,14 +145,18 @@
   );
   --density-space-lg: var(
     --density-space-lg-dense,
-    calc(var(--baseline-height) * 4)
+    calc(var(--baseline-height) * 8)
   );
   --density-space-md: var(
     --density-space-md-dense,
-    calc(var(--baseline-height) * 2)
+    calc(var(--baseline-height) * 1)
   );
   --density-space-sm: var(
     --density-space-sm-dense,
+    calc(var(--baseline-height) * 1)
+  );
+  --density-space-xs: var(
+    --density-space-xs-dense,
     calc(var(--baseline-height) * 1)
   );
 }

--- a/packages/styles/typography/src/mapper.css
+++ b/packages/styles/typography/src/mapper.css
@@ -175,6 +175,16 @@ h5 {
   font-family: var(--typography-heading-5-font-family);
   font-weight: var(--font-weight);
   letter-spacing: var(--typography-heading-5-letter-spacing);
+  /* Heading 5 is styled as small-caps with old-style figures (design review):
+     the design tokens carry these under `--typography-heading-5-font-variant(-numeric)`
+     — small-caps in :root/.app/.site, normal in docs — so the tier difference
+     flows automatically. `normal` fallbacks keep h5 unchanged if a theme ships
+     without the tokens. */
+  font-variant: var(--typography-heading-5-font-variant, normal);
+  font-variant-numeric: var(
+    --typography-heading-5-font-variant-numeric,
+    normal
+  );
   padding-inline: var(--heading-padding-inline, 0);
 }
 


### PR DESCRIPTION
Six design-review items (Linear **AV-317, AV-318, AV-319, AV-320, AV-321, AV-322**), plus a Storybook control tweak.

## Changes
- **AV-317 — h5 small-caps.** Wire `font-variant: small-caps` + old-style figures onto bare `h5` in the typography mapper, reading the design-tokens vars (live via 0.8.1). Small-caps in `:root`/`.app`/`.site`, normal in `docs`.
- **AV-318 — SwitchField label on the left.** New `labelPosition` prop (`before`/`after`) on the toggle wrapper; SwitchField defaults to `before` (label names the switch's purpose). DOM order stays control-then-label for a11y; CSS `row-reverse` moves it visually. Checkbox unchanged. Overridable.
- **AV-319 — Tabs focus border.** Design-system `:focus-visible` ring instead of the UA default outline.
- **AV-320 — ContextualMenu opens below.** Root menu uses a new `MENU_ROOT_PLACEMENT` (below → above → side); submenus keep side expansion (`MENU_PLACEMENT`).
- **AV-321 — Field.Description ramp.** `--form-description-font-size` → secondary type ramp.
- **AV-322 — density matrix retune (F-O4).** Retune `@canonical/styles` `modifiers.density.css` to Diana's field spacing: label→input **8px**, between-fields **40px**, new **4px** label→description rung (`space-xs`). Form maps straight onto the rungs; `Density.mdx` updated. **Note:** this changes published density values every consumer reads.
- **chore:** make the patterns/Field `description` an editable Storybook control.

## Gate
ds-global (348 tests) + ds-global-form (268 tests) build + typecheck + biome green. (Pre-existing `density.css` noDescendingSpecificity warning aside.)

## Review in Storybook
- ds-global-form → SwitchField (label left), Patterns/Field (edit `description` → secondary ramp + 4px gap), Patterns/Form + Density guide (40px between-fields, 8px label→input).
- ds-global → Tabs (keyboard focus ring), ContextualMenu (opens below; submenu to the side), Heading 5 (small-caps; normal in docs context).

Project: pragma components (DR).