### PR TITLE
feat(components): intrinsic control seat — one seat, no fixed heights (AV-323, AV-327)

### DIFF
--- a/packages/react/ds-global-form/src/density.css
+++ b/packages/react/ds-global-form/src/density.css
@@ -17,22 +17,25 @@
  * (Button/styles.css), reading the same shared --density-* primitives — an app
  * that ships ds-global without the form package still gets a seated button.
  *
- * Text baseline sits round(up, height × 2/3) down the box, so every control shares
- * one baseline. Zero-JS (cap-unit approximation); holds to the cap tolerance.
+ * Text baseline sits on the density target — round(nearest, height × 2/3) — so
+ * every control shares one baseline index. Controls use the INTRINSIC seat from
+ * @canonical/styles (--control-seat-line/-basis): no fixed heights; border +
+ * seat pads + line-height add up to the density cell. Zero-JS (cap-unit
+ * approximation); holds to the cap tolerance.
  */
 
-/* ── Controls consume the density box ───────────────────────────────────────
- * A control is a FIXED grid-multiple height with border-box so its border is
- * absorbed into that height (not added past it) — so a bordered and a borderless
- * control of the same density are the same height. Top-referenced so the
- * space-before below (not flex centre/stretch) governs the text.
+/* ── TRANSITIONAL: the fixed-height box (direct date/time chromes only) ──────
+ * The ORIGINAL density box: a FIXED grid-multiple height with border-box so the
+ * border is absorbed into the height. The composite text family, the select and
+ * the textarea have all moved OFF this rule onto the intrinsic seat (their
+ * equal-specificity rules further down override it); it still governs the
+ * remaining direct chromes — date, time, datetime — whose multi-part UA
+ * internals need their own measured pass before they join.
  *
  * Controls no longer carry `.p` — the density system supplies the body font tier
- * (font-size / weight / family) here, and the baseline placement below. */
-/* NB `.ds.input.textarea` is EXCLUDED: a textarea is a multi-line control whose
- * height is intrinsic (its `min-height: 5lh`), not a single density line — the
- * single-line crush below would flatten it. It gets its own placement further
- * down (grid-multiple line-height so every row sits on the grid). */
+ * (font-size / weight / family) here. */
+/* NB `.ds.input.textarea` is EXCLUDED: the textarea seats intrinsically (its own
+ * rule below) and must keep its multi-row min-height. */
 :is(.comfortable, .dense, .app, .site, .docs) .ds.input:not(.textarea) {
   box-sizing: border-box;
   /* Same effective line-height the target-baseline uses (single source of the
@@ -107,7 +110,6 @@
   font-family: var(--typography-text-primary-font-family);
 }
 
-:is(.comfortable, .dense, .app, .site, .docs) .ds.input > input,
 :is(.comfortable, .dense, .app, .site, .docs)
   :is(.ds.field-label, .ds.field-description, .ds.field-error) {
   line-height: 1;
@@ -127,58 +129,189 @@
   padding-block-end: 0;
 }
 
-/* ── Textarea: a multi-line control on the grid ──────────────────────────────
- * Unlike the single-line input, a textarea has MANY text rows, so it needs a
- * line-height that is itself a whole baseline multiple — then EVERY row sits on
- * a grid line, not just the first. It's excluded from the single-line box crush
- * (keeps its intrinsic `5lh` height) and from the `line-height: 1` placement
- * above; here it gets its own placement:
- *   · line-height = the density line-height (a whole baseline multiple), so rows
- *     advance one grid interval each.
- *   · the FIRST row is seated on the density target the same way as everything
- *     else: nudge onto the nearest grid line, then space-before to the target,
- *     less the border (0 — border is on the chrome box) and the drift knob.
- * The chrome supplies the box's own block padding; we ADD the seating on top. */
-:is(.comfortable, .dense, .app, .site, .docs) .ds.input.textarea {
-  --td-line-height: var(
-    --density-line-height,
-    var(--density-lh-comfy, calc(var(--baseline-height) * 8))
+/* ── Intrinsic control seat: the composite text-input family ─────────────────
+ * The single-line <input> no longer uses the line-height:1 crush + space-before
+ * padding above (that rule is now labels-only). Instead it consumes the SHARED
+ * control seat from @canonical/styles (modifiers.density.css): the input's own
+ * line box (cell − 2 baselines) is the control interior, `--control-seat-before`
+ * seats its baseline on the density target, and the CHROME closes the box with
+ * `--control-seat-after` — so the chrome's height is INTRINSIC (no fixed
+ * block-size) yet lands exactly on the density cell, both edges on the grid.
+ *
+ * Placed AFTER the fixed-height box rule above so this (equal-specificity)
+ * rule wins for the text family. Direct chromes (select/date/time) and the
+ * textarea keep the previous model until their own cutover pass. */
+:is(.comfortable, .dense, .app, .site, .docs)
+  .ds.input:is(.text, .number, .password, .phone) {
+  /* The COMPOSITE chrome family — every wrapper with an inner <input> leaf
+     (text, number, password, phone). One selector, one seat: the wrapper is
+     the box, the leaf carries the line. */
+
+  /* NO drift term here — deliberately. The old ~2px "native input renders low"
+     compensation was an artifact of the line-height:1 crush structure: give the
+     <input> a real line box (--control-seat-line below) and it renders its text
+     exactly like a <span> (measured; see the drift note at the end of this
+     file). Subtracting the stale 2px lifted the text 2px too high. */
+
+  /* The UA enforces a line-height FLOOR of `normal` (1.2em for Ubuntu) on a
+     single-line <input> — a specified line-height below it is silently clamped
+     (measured: dense's 16px line rendered 16.8px tall, pushing the chrome to
+     24.8). So the seat computes with the FLOORED line the UA will actually
+     use; the box then closes to the cell exactly in every density cell. */
+  --seat-line-floored: max(var(--control-seat-line), 1.2em);
+
+  /* The chrome's border folds in HERE (a var() inside a custom property
+     substitutes at its declaring element, so the shared layer cannot read it).
+     Derived from the target directly — not --control-seat-basis — because the
+     basis assumes the unfloored line. Both the leaf's top pad and the chrome's
+     closing pad read this SAME `--seat-before`, keeping the complement
+     consistent. Rounded to ¼px so the pad is exactly representable in 1/64px
+     layout units (the fractional 1cap term otherwise leaves ~1/60px residues
+     on the box height). */
+  --seat-before: round(
+    nearest,
+    max(
+      0px,
+      calc(
+        var(--density-target-baseline-px, 0px) -
+        (var(--seat-line-floored) + 1cap) /
+        2 -
+        var(--form-input-border-width, 0px)
+      )
+    ),
+    0.25px
   );
-  line-height: var(--td-line-height);
+  --seat-after: max(
+    0px,
+    calc(
+      var(--density-line-height-effective) -
+      var(--seat-line-floored) -
+      var(--seat-before) -
+      2 *
+      var(--form-input-border-width, 0px)
+    )
+  );
+
+  block-size: auto;
+  min-block-size: 0;
+  padding-block-end: var(--seat-after);
+  /* Stretch (not the box rule's flex-start): a prefix/suffix — the password's
+     reveal-toggle, the number's unit affix — spans the leaf's column and its
+     own `align-items: center` centres its icon on the TEXT, which is the
+     optical pairing (centring on the box would float it into the asymmetric
+     closing pad). The old fixed-height model needed flex-start to top-pin the
+     crushed leaf; the intrinsic leaf seats itself, so stretch is safe again. */
+  align-items: stretch;
+}
+:is(.comfortable, .dense, .app, .site, .docs)
+  .ds.input:is(.text, .number, .password, .phone)
+  > input {
+  line-height: var(--seat-line-floored);
+  padding-block-start: var(--seat-before);
+  padding-block-end: 0;
+}
+
+/* ── Textarea: many rows of the SAME intrinsic seat ──────────────────────────
+ * The textarea is a single element (it carries the chrome itself), so it seats
+ * like the button: the interior line box is `--control-seat-line` — which is a
+ * WHOLE baseline multiple in every cell (cell − 2 bU) — so EVERY row advances
+ * one grid interval, not just the first. The complement pad closes the box so
+ * border + seat-before + N·line + seat-after + border ends on a grid line for
+ * ANY row count N: the N-independent part equals (cell − line) ≡ 0 (mod 1 bU).
+ * One seat, no multi-line special case.
+ *
+ * Two deliberate differences from the single-line input:
+ *   · NO line-height floor — the UA's `normal` clamp is specific to single-line
+ *     <input>; a textarea honours its specified line-height, and a floored
+ *     16.8px line would knock every dense row off the grid.
+ *   · NO drift term — like the single-line input, the old ~2px knob was an
+ *     artifact of the crush-era structure (see the drift note below).
+ *
+ * The previous revision seated the first row via --td-space-before ON TOP of
+ * the chrome's 8px block padding, targeting the OLD round(up) table; under the
+ * round(nearest) targets that formula clamps to zero in every cell (the full
+ * cell line-height puts the natural baseline below the target), which left the
+ * textarea unseated entirely. The interior line box makes the target reachable
+ * again. */
+:is(.comfortable, .dense, .app, .site, .docs) .ds.input.textarea {
+  line-height: var(--control-seat-line);
   font-size: var(--typography-text-primary-font-size);
   font-family: var(--typography-text-primary-font-family);
 
-  /* Same form-control drift as the single-line input (see the knob's KLAXON note
-     below). Set locally so this stays self-contained — the button path is never
-     touched. */
-  --control-text-drift-AVOID-USAGE: 2px;
-  /* First row's baseline within its own line-box, then lift to the target. */
-  --natural-baseline: calc((var(--td-line-height) + 1cap) / 2);
-  /* Unlike the single-line input (a borderless inner <input> inside a bordered
-     wrapper), the textarea IS the chrome: it carries `.ds.input.chrome`, whose
-     top border-width occupies layout space above the text even when the top
-     border colour is transparent. So subtract that top border — exactly as the
-     button subtracts its own — or the first row seats ~1px low versus the
-     button/input target. */
-  --td-border-top: var(
-    --form-input-border-width-top,
-    var(--form-input-border-width, 0px)
+  --seat-before: round(
+    nearest,
+    max(
+      0px,
+      calc(var(--control-seat-basis) - var(--form-input-border-width, 0px))
+    ),
+    0.25px
   );
-  --td-space-before: max(
+  --seat-after: max(
     0px,
     calc(
-      var(--density-target-baseline-px, 0px) -
-      var(--natural-baseline) -
-      var(--td-border-top) -
-      var(--control-text-drift-AVOID-USAGE, 0px)
+      var(--density-line-height-effective) -
+      var(--control-seat-line) -
+      var(--seat-before) -
+      2 *
+      var(--form-input-border-width, 0px)
     )
   );
-  /* Seat the first row ON TOP OF the chrome's block padding (don't replace it —
-     that padding is the box inset; this is the grid seating). */
-  padding-block-start: calc(
-    var(--form-input-padding-block, 0px) +
-    var(--td-space-before)
+
+  block-size: auto;
+  padding-block: var(--seat-before) var(--seat-after);
+  /* Five whole rows + the closing geometry (border-box), so the default box
+     ends on-grid with the last row fully visible: 4·line + cell. */
+  min-block-size: calc(
+    4 *
+    var(--control-seat-line) +
+    var(--density-line-height-effective)
   );
+}
+
+/* ── Select: a single-element direct chrome on the intrinsic seat ────────────
+ * The <select> IS the chrome (border and text on one element), so it seats
+ * like the button: interior line box + seat pads, height emerging as exactly
+ * the density cell. Replaces the old fixed-height + 8px-block-padding path,
+ * which never seated the option text at all and CLIPPED it in apps/dense
+ * (24px fixed box − 8px pad left too little room for the line).
+ * The line is floored like the single-line input's: a <select> shows one line,
+ * so if the UA imposes a `normal` floor the formula already matches it, and if
+ * it does not the specified floor is simply what renders — correct either way
+ * (unlike the textarea, where flooring would break the multi-row rhythm).
+ * Remaining direct chromes (date/time/datetime) stay on the previous model
+ * until their own pass — their multi-part UA internals need their own
+ * measurement. */
+:is(.comfortable, .dense, .app, .site, .docs) .ds.input.select {
+  --seat-line-floored: max(var(--control-seat-line), 1.2em);
+  line-height: var(--seat-line-floored);
+
+  --seat-before: round(
+    nearest,
+    max(
+      0px,
+      calc(
+        var(--density-target-baseline-px, 0px) -
+        (var(--seat-line-floored) + 1cap) /
+        2 -
+        var(--form-input-border-width, 0px)
+      )
+    ),
+    0.25px
+  );
+  --seat-after: max(
+    0px,
+    calc(
+      var(--density-line-height-effective) -
+      var(--seat-line-floored) -
+      var(--seat-before) -
+      2 *
+      var(--form-input-border-width, 0px)
+    )
+  );
+
+  block-size: auto;
+  min-block-size: 0;
+  padding-block: var(--seat-before) var(--seat-after);
 }
 
 /* ── Bottom rhythm: density-seated flow text only (NOT prose) ─────────────────
@@ -211,24 +344,14 @@
   );
 }
 
-/* ── --control-text-drift-AVOID-USAGE — the one honest patch ──────────────────
- * A native form control (<input>, <textarea>) renders its text a couple of px
- * LOWER than a <span>/<button> label at byte-identical CSS — a UA metrics quirk
- * of editable controls, NOT a border and NOT captured by the cap-unit maths. The
- * cap approximation is exact for real text runs but optimistic for a form
- * control's internal text box, so the leaf needs a small lift to share the grid
- * line with the button/label.
- *
- * The name is a deliberate KLAXON: this is empirical (calibrated by eye, may vary
- * by browser/font), never a knob to reach for in app code. 🔴 TODO(#15): find the
- * structural cause (line-box rounding? UA control metrics?) and delete it.
- *
- * It feeds the SAME `--border-top-width` term the shared placement formula reads
- * (a larger subtraction ⇒ less space-before ⇒ text lifts UP). Doing it this way —
- * rather than adding a separate term to the shared formula — keeps the BUTTON's
- * placement byte-identical to its known-good state: the button never sets this
- * knob, so its `--border-top-width` stays the pure border calc above. */
-:where(.comfortable, .dense, .app, .site, .docs) .ds.input > input {
-  --control-text-drift-AVOID-USAGE: 2px;
-  --border-top-width: var(--control-text-drift-AVOID-USAGE);
-}
+/* ── The native-control text drift — RESOLVED for single-line inputs ──────────
+ * The old ~2px "native <input> renders its text lower than a <span> at
+ * byte-identical CSS" compensation (--control-text-drift-AVOID-USAGE) turned
+ * out to be an artifact of the line-height:1 crush structure, NOT an inherent
+ * UA quirk: with a real line box (line-height: --control-seat-line, the
+ * intrinsic seat above) the <input> positions its text exactly like a <span>
+ * (measured: input baseline == label baseline to 0.01px with no drift term).
+ * That answers TODO(#15)'s "find the structural cause and delete it": the
+ * intrinsic seat carries NO drift anywhere — the textarea's local copy went
+ * with its old parallel seat when it joined the intrinsic model. The knob no
+ * longer exists in this file. */

--- a/packages/react/ds-global-form/src/docs/BaselineGrid.mdx
+++ b/packages/react/ds-global-form/src/docs/BaselineGrid.mdx
@@ -67,30 +67,41 @@ control-height = --baseline-height × 8 = 32px   (8 bU)
 ```
 
 The density model seats a control's single baseline on its **target line**, which
-is two-thirds of the box height, rounded _up_ to the next baseline:
+is two-thirds of the box height, rounded to the _nearest_ baseline:
 
 ```
-target = round(up, control-height × 2/3, --baseline-height)
-       = round(up, 32 × 2/3, 4)
-       = round(up, 21.33px, 4)
-       = 24px                                    (6 bU)
+target = round(nearest, control-height × 2/3, --baseline-height)
+       = round(nearest, 32 × 2/3, 4)
+       = round(nearest, 21.33px, 4)
+       = 20px                                    (5 bU)
 ```
 
-Rounding up is deliberate — a fractional case such as this one (21.33) lifts to
-the next whole line (24), while an already-exact case stays put (apps-dense's
-`24 × 2/3 = 16` is exact, so it stays on the 4th baseline).
+Rounding to the nearest line (not up) is deliberate. Two-thirds of the height is
+the optical centre a control's text wants; snapping to the _nearest_ grid line
+stays as close to it as the grid allows. An earlier revision rounded _up_, which
+over-lifted the one cell where `height × 2/3` is fractional — apps-comfortable's
+21.33 was forced a whole step down the page to 24, a baseline too low (the
+design-review "move text one baseline up" finding). The exact-multiple cells are
+unaffected either way:
+
+```
+apps-comfortable   32 × 2/3 = 21.33  →  20   (the fix; was 24)
+apps-dense         24 × 2/3 = 16.00  →  16   (exact)
+sites-comfortable  36 × 2/3 = 24.00  →  24   (exact)
+sites-dense        28 × 2/3 = 18.67  →  20   (nearest = up here)
+```
 
 Now seat a 14px label into that box. With a cap height of roughly 10px for the
 body face:
 
 ```
 natural-baseline = (1em + 1cap) / 2 = (14 + 10) / 2 = 12px
-space-before     = max(0px, 24 − 12 − border-top)
+space-before     = max(0px, 20 − 12 − border-top)
 ```
 
-For a borderless label (`border-top = 0`) that is `24 − 12 = 12px` of top
-padding, and the baseline lands exactly on the 6th grid line. Change the font
-size and both terms move together, so the arithmetic still lands on `24px` — the
+For a borderless label (`border-top = 0`) that is `20 − 12 = 8px` of top
+padding, and the baseline lands exactly on the 5th grid line. Change the font
+size and both terms move together, so the arithmetic still lands on `20px` — the
 target never has to be re-tuned per size.
 
 The stories below force the baseline overlay on, so this seating can be read
@@ -126,11 +137,13 @@ The system seats text through two distinct mechanisms, applied to two disjoint
 sets of elements. Knowing which owns a given element is the key to the whole
 model.
 
-- **Controls** — a button label, an input's text, a field label / description /
-  error. These are seated by the **density model**: crushed to `line-height: 1`,
-  then padded so their single baseline lands on the density _target_ line
-  (`round(up, height × 2/3, baseline)`, as worked above). This is what makes a
-  32px button's label and a 32px input's value share one line.
+- **Controls** — seated by the **density model** on the density _target_ line
+  (`round(nearest, height × 2/3, baseline)`, as worked above). This is what
+  makes a 32px button's label and a 32px input's value share one line. Boxed
+  controls (the button, the single-line input) use the **intrinsic seat**
+  described below — their text carries a real line box that _is_ the control
+  interior. The field label / description / error, which are bare text rather
+  than boxes, use the simpler `line-height: 1` crush + `--space-before` pad.
 
 - **Running prose** — bare `p`, `h1`–`h6`, and anything in an `.editorial`
   context. These are seated by the **typography engine**: each keeps its tier's
@@ -144,19 +157,75 @@ specificity war between them — a point returned to below. A paragraph placed n
 to a control will sit on _a_ grid line, but not necessarily the control's target
 line — controls and prose answer to different seating rules by design.
 
-## The seat is computed against the box, not the border
+## The intrinsic control seat
 
-The target baseline is measured from the top of the **control box**, and the box
-is `border-box` sized: a control's border is absorbed into its fixed height, not
-added past it. So a bordered and a borderless control of the same density are the
-same height, and their text seats on the same line.
+A boxed control (the button, the single-line input chrome) does **not** set a
+height. Its height _emerges_: the text's own line box is the control interior,
+and border + padding + line-height add up to exactly the density cell.
 
-The border only enters the placement as the `border-top` term subtracted in
-`--space-before` — it accounts for the border occupying part of the space above
-the text, nothing more. A borderless primary button (`border-top = 0`) and a
-bordered secondary (a 1px top border) therefore share one baseline: the secondary
-simply contributes 1px of border where the primary contributes 1px more padding.
-The example below places the two side by side against the overlay.
+The shared styles layer (`@canonical/styles`, `modifiers.density.css`) exports
+two pieces:
+
+```css
+/* The control's interior line box: the cell minus one baseline of headroom
+   per side. 32px cell → 24px line; 24px cell → 16px line. */
+--control-seat-line: calc(
+  var(--density-line-height-effective) - 2 * var(--baseline-height)
+);
+/* The unclamped distance from just inside the box's top border down to the
+   target baseline, for a --control-seat-line line box. */
+--control-seat-basis: calc(
+  var(--density-target-baseline-px) - (var(--control-seat-line) + 1cap) / 2
+);
+```
+
+Each control folds its **own** border into that basis and closes the box with a
+complement pad — the fold must happen at the component, because a `var()` inside
+a custom property is substituted where the property is _declared_ (the density
+scope), so the shared layer can never read a component's border width:
+
+```css
+--seat-before: round(
+  nearest,
+  max(0px, calc(var(--control-seat-basis) - <border-width>)),
+  0.25px
+);
+--seat-after: max(0px, calc(
+  var(--density-line-height-effective) - var(--control-seat-line) -
+  var(--seat-before) - 2 * <border-width>
+));
+line-height: var(--control-seat-line);
+padding-block: var(--seat-before) var(--seat-after);
+```
+
+The invariant: `border + seat-before + line + seat-after + border = the cell`,
+with no `block-size` anywhere. Both outer edges land on grid lines, and the text
+baseline lands on the target — at any font size, because `1cap`/`1em` resolve at
+the element that applies the seat. (`--seat-before` is rounded to ¼px so the pad
+is exactly representable in the browser's 1/64px layout units; the fractional
+cap term otherwise leaves ~1/60px residues on the box height.)
+
+## The border is always present
+
+For the geometry above to be _one_ formula, the border must be a **constant** of
+the control, not a variant knob: every importance carries the same nominal
+border width, and a "borderless" variant paints it `transparent` rather than
+removing it. The button implements exactly this — its outline flag toggles the
+border's **colour**, never its width:
+
+```css
+border-width: var(--button-border-width);          /* constant, both importances */
+border-color: color-mix(in srgb,
+  var(--modifier-color-border) calc(var(--modifier-outline, 0) * 100%),
+  transparent);
+```
+
+A width-toggled border (an earlier revision multiplied the width by the flag)
+makes the borderless variant 2px shorter and seats its label a pixel high — the
+box geometry forks per importance, which is precisely what the constant border
+exists to prevent. A borderless primary and a bordered secondary are now
+byte-identical boxes; only the paint differs. The example below places the two
+side by side against the overlay.
 
 <Canvas of={Examples.BorderlessAndBordered} />
 
@@ -168,29 +237,49 @@ running prose two ways: it removes the leading that makes multi-line text
 readable, and — because a crushed line-height is not a whole baseline multiple —
 it lets every _wrapped_ line drift off the grid.
 
-The fix (call it "Stage A") was to **partition** the two mechanisms: density
-seats controls only, and the typography engine owns prose. Because the two now
-write to disjoint element sets, `.editorial` composes with density without a
-specificity war, and — since the engine snaps prose line-height to a whole
-baseline multiple — wrapped-prose drift is gone as well. The current model keeps
-`line-height: 1` only where it is safe (single-line controls) and hands prose to
-the engine.
+The first fix (call it "Stage A") was to **partition** the two mechanisms:
+density seats controls only, and the typography engine owns prose. Because the
+two now write to disjoint element sets, `.editorial` composes with density
+without a specificity war, and — since the engine snaps prose line-height to a
+whole baseline multiple — wrapped-prose drift is gone as well.
 
-## An honest rough edge: control text drift
+The second ("Stage B", the intrinsic seat above) retired the crush from the
+**boxed** controls too: the button and the single-line input now carry a real
+line box (`--control-seat-line`) instead of `line-height: 1` + a fixed box
+height. The crush survives only on the field label / description / error — bare
+single-line text where it is harmless — and even there it is an implementation
+detail of their seat, not a box model.
 
-The cap-unit maths is exact for a real text run such as a `<span>` or a button
-label, but native form controls are less obliging: an `<input>` or `<textarea>`
-renders its text roughly **2px lower** than a `<span>` at byte-identical CSS — a
-user-agent metrics quirk of editable controls, not a border and not something the
-cap approximation captures.
+## The "control text drift", solved
 
-To keep the input's value on the same grid line as the button's label, a small
-lift is applied through a knob deliberately named
-`--control-text-drift-AVOID-USAGE`. The name is a klaxon: the value is empirical
-(calibrated by eye, may vary by browser and font), it is set only on the input
-and textarea paths — never in app code, and never on the button — and it is
-tracked for a structural fix rather than treated as a permanent design lever. It
-is documented here honestly because the alignment depends on it.
+Earlier revisions carried an empirical knob, `--control-text-drift-AVOID-USAGE`
+(~2px), to explain why a native `<input>` rendered its text lower than a
+`<span>` at byte-identical CSS. The intrinsic seat exposed the real mechanism —
+it was never a metrics quirk of editable controls:
+
+> **The user agent enforces a `line-height` floor of `normal` (≈1.2em) on a
+> single-line `<input>`.** A specified line-height below the floor is silently
+> clamped.
+
+Under the old `line-height: 1` crush, the input's 14px line was silently
+rendered as a 16.8px line — the extra 2.8px of half-leading pushed the glyphs
+down, and the "drift" knob was hand-calibrated to cancel a clamp nobody had
+identified. Give the input a **real** line box (the intrinsic seat's
+`--control-seat-line`, ≥ the floor in the comfortable cells) and it positions
+text exactly like a `<span>`: measured, the input's baseline lands on the
+label's to within 0.01px with **no** drift term.
+
+The floor still exists, so the input's seat computes with the line the UA will
+actually use:
+
+```css
+--seat-line-floored: max(var(--control-seat-line), 1.2em);
+```
+
+In dense cells (16px line < 16.8px floor) the clamped line is what enters both
+the seat and the closing pad, so the box still lands on the cell. The knob
+survives only on the textarea path, pending the same treatment — expect it to be
+the same artifact.
 
 ## The debug overlay
 

--- a/packages/react/ds-global-form/src/docs/Density.mdx
+++ b/packages/react/ds-global-form/src/docs/Density.mdx
@@ -171,24 +171,28 @@ disturbing the other. Giving the vertical gap its own block token
 
 ## Control height
 
-A density control is a fixed grid-multiple box: `block-size` is the density
-line-height, with `box-sizing: border-box` so a bordered and a borderless control
-of the same density are the same height. The control is top-referenced, and its
-label is seated to the density _target_ baseline —
-`round(up, height × 2/3, --baseline-height)` — so text at any font size lands on
-the grid.
+A density control's height is **intrinsic**: no `block-size` anywhere. The
+control's text carries an interior line box (`--control-seat-line`, the cell
+minus one baseline of headroom per side), a seat pad lands its baseline on the
+density _target_ — `round(nearest, height × 2/3, --baseline-height)` — and a
+complement pad closes the box so border + pads + line-height add up to
+**exactly** the density cell (32px apps-comfortable, 24px apps-dense, …). Text
+at any font size lands on the grid, and the height is a result, not an input.
+See [The Baseline Grid](?path=/docs/documentation-guides-the-baseline-grid--docs)
+for the full formula.
 
 <Canvas of={Examples.ButtonAndInput} />
 
-A borderless importance (e.g. a primary button) and a bordered one (a secondary)
-seat **identically**, because the seat is computed against the box, not the
-border. This was a subtle earlier bug: the placement formula subtracted the
-border only for bordered controls, so the borderless primary — with nothing to
-subtract — sat a pixel high against its bordered neighbour. The fix was to
-subtract a _nominal_ border width (`--button-border-width`, 1px) for **both**
-importances and let the grid maths absorb it; switching the borderless case to
-its real 0-width outline lifted it a pixel again (regression found and reverted).
-The nominal term stays.
+A borderless importance (e.g. a primary button) and a bordered one (a
+secondary) are the same height and seat **identically**, because the border is
+a **constant of the control**: every importance carries the same nominal border
+width, and the borderless variant paints it `transparent` rather than removing
+it (the outline flag toggles the border's colour, never its width). The
+history of getting here is instructive — first the seat subtracted the border
+only when rendered (the borderless primary sat a pixel high), then a nominal
+subtraction papered over a width-toggled border (under intrinsic height the
+primary came out 2px _shorter_). Both bugs had one root: per-importance
+geometry. The constant border removes the fork entirely.
 
 ## Composition: density and running prose
 
@@ -215,11 +219,16 @@ Practically:
   up with controls (as the spike testbed does for its measuring lead), seat that
   one element explicitly; do not change how prose ships.
 
-## Known rough edge
+## A former rough edge, resolved
 
-Native form controls (`input`, `textarea`) render their text a couple of pixels
-lower than a `span` at identical CSS — a browser metrics quirk of editable
-controls, not captured by the cap approximation. The model lifts them with a
-single, deliberately-named knob, `--control-text-drift-AVOID-USAGE` (currently
-2px). The name is a warning: it is an empirical constant, may vary by browser and
-font, and is tracked for a structural fix. Never reach for it in application code.
+Earlier revisions lifted native form controls by an empirical ~2px knob
+(`--control-text-drift-AVOID-USAGE`) because an `<input>` rendered its text
+lower than a `<span>` at identical CSS. The intrinsic seat exposed the real
+mechanism: the user agent enforces a `line-height` floor of `normal` (≈1.2em)
+on single-line `<input>`s, and the old `line-height: 1` crush was being
+silently clamped — the "drift" was the clamp's extra half-leading. With a real
+line box the input renders exactly like a `<span>`; where the interior line
+would dip below the floor (dense cells) the seat computes with the floored
+value (`max(--control-seat-line, 1.2em)`). The knob is deleted. See
+[Seating by Element Type](?path=/docs/documentation-guides-seating-by-element-type--docs)
+for the full account.

--- a/packages/react/ds-global-form/src/docs/Density.mdx
+++ b/packages/react/ds-global-form/src/docs/Density.mdx
@@ -34,9 +34,10 @@ The matrix, in baseline units (1 bU = `--baseline-height` = 4px):
                    comfy   dense       comfy   dense
   line-height      32 (8)  24 (6)      36 (9)  28 (7)
   padding-inline   16 (4)   8 (2)      16 (4)  12 (3)
-  space-lg         24 (6)  16 (4)      28 (7)  20 (5)   ← between fields
-  space-md         16 (4)   8 (2)      20 (5)  12 (3)   ← label → control
+  space-lg         40 (10) 32 (8)      44 (11) 36 (9)   ← between fields
+  space-md          8 (2)   4 (1)       8 (2)   8 (2)   ← label → control
   space-sm          8 (2)   4 (1)       8 (2)   8 (2)   ← desc/error → input
+  space-xs          4 (1)   4 (1)       4 (1)   4 (1)   ← label → description
 ```
 
 Context sets the `*-comfy` / `*-dense` pair for every value; density picks within
@@ -52,13 +53,15 @@ the site's pairs. Read straight down that column:
 - **line-height** — 28px, so a control is a 7 bU box (`--baseline-height * 7`).
 - **padding-inline** — 12px = 3 bU of inline padding inside the control and on
   the horizontal label↔input gap.
-- **space-lg** — 20px = 5 bU between one field and the next.
-- **space-md** — 12px = 3 bU from a field's label down to its control.
+- **space-lg** — 36px = 9 bU between one field and the next.
+- **space-md** — 8px = 2 bU from a field's label down to its control.
 - **space-sm** — 8px = 2 bU from a description or error across to the input.
+- **space-xs** — 4px = 1 bU from a field's label down to a leading description.
 
-Compare that to **app / dense** one baseline tighter: the box is 24px (6 bU) and
-the inline padding drops to 8px (2 bU). The site column never goes below its 8px
-`space-sm` — a site stays a touch airier than an app even when dense.
+Compare that to **app / dense** one baseline tighter: the box is 24px (6 bU), the
+inline padding drops to 8px (2 bU), and the label→control / desc→input gaps
+tighten to 4px. The site column never goes below its 8px `space-md`/`space-sm` —
+a site stays a touch airier than an app even when dense.
 
 ## How to apply density
 
@@ -121,11 +124,12 @@ The model is layered so each layer knows only about the one below it:
    place a field concept meets a density value:
 
 ```css
---form-input-padding-inline: var(--density-padding-inline);   /* inline */
---form-field-inline-gap:     var(--density-padding-inline);   /* inline */
---form-field-block-gap:      var(--density-space-lg);         /* between fields   */
---form-field-label-gap:      var(--density-space-md);         /* label → control  */
---form-group-gap:            var(--density-space-sm);         /* desc/error → input */
+--form-input-padding-inline:       var(--density-padding-inline); /* inline */
+--form-field-inline-gap:           var(--density-padding-inline); /* inline */
+--form-field-block-gap:            var(--density-space-lg);  /* between fields    */
+--form-field-label-gap:            var(--density-space-md);  /* label → control   */
+--form-group-gap:                  var(--density-space-sm);  /* desc/error → input */
+--form-field-label-description-gap: var(--density-space-xs); /* label → description */
 ```
 
 ### Why the layering direction matters

--- a/packages/react/ds-global-form/src/docs/SeatingByElement.mdx
+++ b/packages/react/ds-global-form/src/docs/SeatingByElement.mdx
@@ -19,17 +19,22 @@ first; this guide assumes the seating formula and the density matrix.
 
 ## The one rule that governs all three
 
-Every element is seated by the same two-part expression:
+Every element is seated by the same two-part expression, in its general form:
 
 ```css
---natural-baseline: calc((1em + 1cap) / 2);   /* baseline offset in a lh:1 box */
---space-before: max(0px, calc(target − --natural-baseline − border-top));
-padding-block-start: var(--space-before);
+--natural-baseline: calc((line-height + 1cap) / 2); /* baseline offset in the line box */
+--seat-before: max(0px, calc(target − --natural-baseline − border-top));
+padding-block-start: var(--seat-before);
 ```
 
-The three element types differ only in **what plays the part of `target`,
-`border-top`, and the box** — and in one case, whether this expression governs at
-all. Everything below is a variation on this.
+For a `line-height: 1` element (the field label / description / error) the first
+term reduces to `(1em + 1cap) / 2`. For a boxed control the line-height is the
+**intrinsic seat's** interior line, `--control-seat-line` — the density cell
+minus one baseline of headroom per side — and a complement pad closes the box to
+exactly the cell with no `block-size` anywhere (see
+[The Baseline Grid](?path=/docs/documentation-guides-the-baseline-grid--docs)).
+The element types differ only in **what plays the part of `target`,
+`border-top`, and the box**. Everything below is a variation on this.
 
 ---
 
@@ -73,128 +78,139 @@ reach for the global prose tags.
 
 ## Buttons
 
-**Route: the density box, seated against the box.**
+**Route: the intrinsic seat, on the button element itself.**
 
-A button is a fixed grid-multiple box: its `block-size` is the density
-line-height, `box-sizing: border-box`, top-referenced (`align-items: flex-start`),
-and its label is the text run seated by the formula. `target` is the density
-target line, `round(up, height × 2/3, --baseline-height)`.
+A button sets **no height**. Its label carries the interior line box
+(`line-height: var(--control-seat-line)`), the seat pad lands the baseline on
+the density target — `round(nearest, height × 2/3, --baseline-height)` — and a
+complement pad closes the box to exactly the density cell:
+`border + seat-before + line + seat-after + border = the cell`. An earlier
+revision instead fixed `block-size` to the cell (border-box, `line-height: 1`
+crush); the intrinsic seat replaced it so the height is a *result*, not an
+input, and taller content can never be cropped by a hard-coded height.
 
 <Canvas of={Examples.BorderlessAndBordered} />
 
-### The border term, and the bug that taught us how it works
+### The border, and the two bugs that taught us how it works
 
-The subtle part of a button is the `border-top` term. A button's border and its
-label live on the **same element**, so a top border pushes the label down and must
-be subtracted from `--space-before`. The instinct was to subtract the button's
-*actual* rendered border:
+A button's border and its label live on the **same element**, so the border
+occupies space above the label and enters the seat as the subtracted
+`border-top` term. Both historical bugs here came from letting the border
+*vary* per importance:
+
+- **Bug one — subtracting the rendered border.** The seat first subtracted
+  `calc(var(--modifier-outline, 0) * var(--button-border-width))` — 0 for a
+  borderless primary, 1px for a bordered secondary. The primary seated a pixel
+  higher; the two importances no longer shared a line. The fix at the time:
+  subtract a **nominal** border for both.
+- **Bug two — rendering a width-toggled border.** The nominal subtraction was
+  still built on sand, because the border *itself* was width-toggled
+  (`border-width: calc(outline × width)`). Under the intrinsic seat — where the
+  border is real layout, not absorbed into a fixed height — the borderless
+  primary became **2px shorter** than the secondary and its label sat a pixel
+  high again.
+
+The structural resolution: the border is a **constant** of the control. Every
+importance carries the same nominal width; the outline flag toggles the border's
+**colour**, never its width:
 
 ```css
-/* The tempting version — and the bug. */
---border-top-width: calc(var(--modifier-outline, 0) * var(--button-border-width));
+border-width: var(--button-border-width);            /* constant, both importances */
+border-color: color-mix(in srgb,
+  var(--modifier-color-border) calc(var(--modifier-outline, 0) * 100%),
+  transparent);
 ```
 
-This looks correct — a borderless importance (`--modifier-outline: 0`) subtracts 0,
-a bordered one subtracts its 1px. But it made the **borderless primary button sit
-one pixel higher** than the bordered secondary beside it. The two no longer shared
-a baseline.
-
-The reason: the density `target` is measured from the top of the *box*, and the
-box is `border-box`, so the border is already absorbed into the fixed height. The
-label's seat should be computed **against the box, not against whether a border
-happens to render**. The version that works subtracts a **nominal** border for
-both importances and lets the grid maths place them identically:
-
-```css
-/* The version that ships. */
---border-top-width: var(--button-border-width, 0px);   /* nominal, both importances */
-```
-
-So a borderless primary and a bordered secondary contribute the same amount to the
-seat: the secondary as 1px of real border, the primary as 1px more padding. They
-share the line. The `modifier-outline` version was reverted; the nominal term is
-load-bearing and should be left alone.
-
-### A related trap: the box padding shorthand
-
-The box rule sets the control height; the placement rule sets
-`padding-block-start`. When the box rule used the `padding-block: 0` **shorthand**,
-a specificity quirk let it out-specify the placement rule's `padding-block-start`
-and wipe the seat, pinning the label to the box top. The box rule now clears only
-`padding-block-end`; the placement rule owns the start. If a control's label ever
-jumps to the top of its box, this shorthand-vs-longhand interaction is the first
-thing to check.
+A borderless primary and a bordered secondary are now byte-identical boxes —
+only the paint differs — and the seat subtracts one constant. This is
+load-bearing: reintroducing any per-importance geometry (width toggles,
+importance-conditional seat terms) forks the box model again.
 
 ---
 
 ## Inputs
 
-**Route: the chrome box is the density box; the text leaf is seated inside it.**
+**Route: the intrinsic seat, split between chrome and leaf.**
 
-An input is not one element but two: the **chrome** (the bordered box —
-`.ds.input.text` wrapper for a text input, or the `<textarea>`/`<select>` element
-itself) and the **text leaf** (the inner `<input>`, or the textarea's own text).
-The chrome is the density box (fixed height, border-box, border absorbed); the
-leaf is the text run seated inside it. So unlike the button, the input's
-`border-top` term is a **true 0** — the border lives on the chrome, not on the leaf
-that carries the text.
+A composite input is not one element but two: the **chrome** (the bordered
+wrapper — `.ds.input:is(.text, .number, .password, .phone)`) and the **text
+leaf** (the inner `<input>`). The seat splits by role: the **leaf** carries the
+interior line box and the seat pad (`line-height: --seat-line-floored`,
+`padding-block-start: --seat-before`); the **chrome** owns the box edges — the
+border and the closing `--seat-after` pad — and sets no height. The chrome's
+border width is subtracted in `--seat-before` (declared on the chrome, inherited
+by the leaf) because the border sits above the leaf in the same stack. Both
+pads read the *same* variable, so the complement always closes the box to the
+cell.
+
+A single-element chrome — the `<select>`, the `<textarea>` — is simpler still:
+border and text live on one element, so it seats exactly like the button.
 
 <Canvas of={Examples.ButtonAndInput} />
 
-### The single-line input and the drift knob
+### The drift knob, and what it turned out to be
 
-With the border accounted for by the chrome, a text input's inner `<input>` should
-seat exactly like a button label. It nearly does — but a native `<input>` renders
-its text roughly **2px lower** than a `<span>` at byte-identical CSS. This is a
-user-agent metrics quirk of editable controls, not a border and not something the
-cap approximation predicts.
+For years the model carried `--control-text-drift-AVOID-USAGE` (~2px): a native
+`<input>` rendered its text visibly lower than a `<span>` at byte-identical CSS.
+The options considered at the time — folding it into a fake border term
+(rejected: lies), a JS metrics engine (rejected: forks the zero-JS model), an
+honest quarantined knob (chosen) — are kept here as a record, because the
+eventual resolution reframes them:
 
-The considered options, and what was chosen:
+> **The drift was never a metrics quirk. The user agent enforces a
+> `line-height` floor of `normal` (≈1.2em) on single-line `<input>`s, and the
+> crush-era `line-height: 1` was being silently clamped to it.** The extra
+> half-leading pushed the glyphs down; the knob was hand-calibrated against a
+> clamp nobody had identified.
 
-- **Rejected — fold it into the border term.** The first attempt expressed the 2px
-  as a fake `border-top-width` on the input. It worked but lied: the input has no
-  such border, and the number would not generalise to the textarea.
-- **Rejected — a metrics engine / text-box-trim.** A precise fix would measure the
-  control's actual text box. This was explicitly out of scope: the whole model is a
-  zero-JS cap approximation, and swapping the seating method for form controls
-  alone would fork it.
-- **Chosen — one honest, self-shaming knob.** The lift is applied through
-  `--control-text-drift-AVOID-USAGE` (currently 2px), set only on the input and
-  textarea paths. The name is the documentation: it is empirical, may vary by
-  browser and font, is never for app code, and is tracked for a structural fix. It
-  is a calibrated constant, deliberately quarantined, not a design lever.
+Under the intrinsic seat the input's line box is real (≥ the floor in
+comfortable cells), and the input positions text **exactly like a `<span>`** —
+measured: input baseline = label baseline to 0.01px, no drift term. Where the
+interior line would dip below the floor (dense cells: 16px < 16.8px), the seat
+computes with the floored value the UA will actually use:
 
-### The textarea: many rows, so the invariant bites
+```css
+--seat-line-floored: max(var(--control-seat-line), 1.2em);
+```
 
-A single-line input only has to seat its first baseline. A `<textarea>` has many
-rows, so the whole-multiple invariant applies: **every** row must land on a grid
-line, not just the first. That forces two departures from the single-line path:
+The knob is deleted from every single-line path. The lesson worth carrying:
+_when a calibrated constant refuses to generalise, suspect a hidden UA rule
+being fought, not a metrics mystery._
 
-- It is **excluded from the single-line box crush** — it keeps its intrinsic
-  `min-height: 5lh` rather than being flattened to one density line.
-- It is seated with a **grid-multiple line-height** (the density line-height)
-  rather than `line-height: 1`, so each successive row advances by exactly one grid
-  interval. Its first row is placed on the density target on top of the chrome's
-  own block padding; the rest follow the grid for free.
+### The textarea: the invariant comes free
 
-The textarea is where the generalised form of the seating formula first appeared —
-`(--seat-line-height + 1cap) / 2` instead of `(1em + 1cap) / 2` — because its
-line-height is not 1. That generalisation is the seed of a possible future unifying
-of all three routes under one formula, but it is deliberately not taken further
-yet: the single-line controls stay on the exact `1em` form so their pixel-tuned
-seating is not disturbed.
+A `<textarea>` has many rows, so every row must land on a grid line — the
+whole-multiple invariant. Under the old model this forced a **parallel seat**
+(its own `--td-*` variables, the density line-height, a private drift copy) —
+and that seat silently died when the target table moved to `round(nearest)`:
+its full-cell line box put the natural baseline *below* every new target, the
+`max(0px, …)` clamped, and the textarea stopped being seated at all.
+
+The intrinsic seat absorbs it with **no special case**: `--control-seat-line`
+(cell − 2 bU) is a whole baseline multiple in every density cell, so the same
+line box that seats the first row keeps every subsequent row advancing exactly
+one grid interval. The complement pad is row-count-independent — the
+N-independent part of the box (`2·border + seat-before + seat-after`) equals
+`cell − line`, itself a whole multiple — so the box bottom lands on-grid at any
+size. The only textarea-specific lines left are its `min-block-size` (five
+whole rows plus the closing geometry) and the deliberate **absence** of the
+line-height floor: a textarea honours its specified line-height, and flooring
+dense's 16px line to 16.8px would knock every row off the grid.
 
 ---
 
 ## Summary
 
-| Element | Box | `target` | `border-top` | Notable |
+| Element | Box | `target` | border in the seat | Notable |
 | --- | --- | --- | --- | --- |
 | Prose / `.editorial` | — (engine-owned) | nearest grid line | — | Not density-seated; snapped line-height keeps every wrapped line on-grid |
-| Button | the button element | `round(up, h × 2/3)` | nominal `--button-border-width` (both importances) | Seat is against the box, not the rendered border |
-| Input (single-line) | chrome wrapper | `round(up, h × 2/3)` | 0 (border on the chrome) | `--control-text-drift-AVOID-USAGE` lifts the ~2px UA quirk |
-| Textarea | the element (chrome + leaf) | first row on target | 0 | Grid-multiple line-height so every row seats; generalised formula |
+| Field label / description / error | bare text | `round(nearest, h × 2/3)` | 0 | The remaining `line-height: 1` crush seat |
+| Button | the button element | `round(nearest, h × 2/3)` | constant `--button-border-width`, colour-toggled | Intrinsic: no height; box closes to the cell |
+| Input (single-line, composite) | chrome wrapper + inner leaf | `round(nearest, h × 2/3)` | chrome border, folded into the shared `--seat-before` | Line floored at `1.2em` (the UA `<input>` floor); no drift knob |
+| Select | the element | `round(nearest, h × 2/3)` | own border | Single-element intrinsic seat; gradient-drawn caret takes the theme colour |
+| Textarea | the element | first row on target | own border | Same seat, N rows: `--control-seat-line` is a whole multiple, so the invariant comes free |
 
-The through-line: **seat against the box, keep the line-height a whole baseline
-multiple wherever more than one line matters, and give each element type only the
-compensation its own metrics genuinely need — no more.**
+The through-line: **one seat — the interior line box plus its complement — with
+each element contributing only its real constants: its border width, and the
+line-height floor the UA genuinely imposes. No fixed heights, no calibrated
+mysteries.**

--- a/packages/react/ds-global-form/src/index.css
+++ b/packages/react/ds-global-form/src/index.css
@@ -39,15 +39,19 @@
      then tune each axis independently, and the names stay honest):
        BLOCK (vertical):  field-block-gap · field-label-gap · group-gap
        INLINE (horizontal): field-inline-gap                                    */
-  --form-field-block-gap: var(
-    --container-gap-loose
-  ); /* 24px — block: gap BETWEEN fields */
-  /* Design review (15/07): flat 8px label→input gap (was --container-gap-default,
-   * 16px). See the density-channel mapping below for the matrix-vs-review note. */
+  /* No-density-class defaults — mirror the density matrix's app/comfortable cell
+     (F-O4, 15/07 review). The density-scoped block further down re-derives these
+     per cell when a context/density class is present. */
+  --form-field-block-gap: calc(
+    var(--baseline-height) *
+    10
+  ); /* 40px — block: gap BETWEEN fields */
   --form-field-label-gap: var(
     --space-100
   ); /* 8px — block: gap from a field's LABEL down to its control */
-  /* --form-field-label-gap: var(--container-gap-default); */ /* 16px (pre-review) */
+  --form-field-label-description-gap: var(
+    --space-050
+  ); /* 4px — block: gap from a LABEL down to a leading description */
   --form-group-gap: var(
     --space-100
   ); /* 8px — block: gap from desc/error to the input */
@@ -126,7 +130,10 @@
 
   /* ── Description ────────────────────────────────────────────────── */
 
-  --form-description-font-size: var(--typography-text-primary-font-size);
+  /* Description reads the SECONDARY type ramp (design review): it is subordinate
+     supporting text, so it takes the smaller secondary size, not the primary
+     body size. Colour is already the muted token. */
+  --form-description-font-size: var(--typography-text-secondary-font-size);
   --form-description-color: var(--color-text-muted);
 
   /* ── Error ──────────────────────────────────────────────────────── */
@@ -166,29 +173,30 @@
  *   INLINE (horizontal): control padding + label↔input / prefix-suffix gap
  *     → --density-padding-inline
  *   BLOCK (vertical), by magnitude:
- *     between-fields   → --density-space-lg   (widest structural gap)
- *     label → control  → --density-space-md   (label to its own control)
- *     desc/error → input → --density-space-sm (tight annotation gap)
- *   All rungs are whole baseline multiples, so vertical rhythm holds. */
+ *     between-fields     → --density-space-lg  (widest structural gap, 40px app)
+ *     label → control    → --density-space-md  (label to its own control, 8px app)
+ *     desc/error → input → --density-space-sm  (tight annotation gap, 8px)
+ *     label → description → --density-space-xs (tightest, 4px)
+ *   All rungs are whole baseline multiples, so vertical rhythm holds.
+ *   (space-md/-lg were retuned + space-xs added per the 15/07 review — F-O4;
+ *    the density matrix now carries Diana's numbers directly, so the form maps
+ *    straight onto the rungs rather than pinning literals.) */
 :where(.comfortable, .dense, .app, .site, .docs) {
   --form-input-padding-inline: var(--density-padding-inline, var(--space-200));
   --form-field-inline-gap: var(--density-padding-inline, var(--space-200));
   --form-field-block-gap: var(
     --density-space-lg,
-    calc(var(--baseline-height) * 6)
+    calc(var(--baseline-height) * 10)
   );
-  /* Design review (15/07): the label→input gap should be a flat 8px, not the
-   * density `space-md` rung (16px app / 20px site). Diana's 15/07 field-spacing
-   * numbers diverge from the shipped density matrix (see pragma-adrs U.01); until
-   * that matrix-vs-review tension is resolved we pin 8px here and KEEP the
-   * density mapping below, commented, so it can be restored in one line once the
-   * matrix decision lands. 8px = one `space-md`-equivalent held at 2 baseline units. */
-  --form-field-label-gap: calc(var(--baseline-height) * 2); /* 8px */
-  /* --form-field-label-gap: var(
+  --form-field-label-gap: var(
     --density-space-md,
-    calc(var(--baseline-height) * 4)
-  ); */
+    calc(var(--baseline-height) * 2)
+  );
   --form-group-gap: var(--density-space-sm, calc(var(--baseline-height) * 2));
+  --form-field-label-description-gap: var(
+    --density-space-xs,
+    calc(var(--baseline-height) * 1)
+  );
 }
 
 /* ── .ds.input.chrome — shared input chrome ─────────────────────────

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.css
@@ -31,5 +31,13 @@
       text-align: start;
       cursor: pointer;
     }
+
+    /* Label BEFORE the control (switch convention): the DOM stays
+       control-then-label for accessibility, so `row-reverse` moves the control
+       to the trailing (right) edge and the label to the leading (left) edge.
+       Logical `row-reverse` mirrors correctly in RTL. */
+    &.label-before {
+      flex-direction: row-reverse;
+    }
   }
 }

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/ToggleWrapper.tsx
@@ -39,6 +39,7 @@ const ToggleWrapper = <ComponentProps extends BaseInputProps>({
   description,
   label,
   controlLabel,
+  labelPosition = "after",
   isOptional,
   requiredIndicator,
   registerProps: userRegisterProps,
@@ -90,8 +91,13 @@ const ToggleWrapper = <ComponentProps extends BaseInputProps>({
       )}
 
       {/* The control and its inline true label, side by side. The label is
-          often a full sentence, so it wraps as prose beside the control. */}
-      <div className="field-toggle-control">
+          often a full sentence, so it wraps as prose beside the control. DOM
+          order stays control-then-label; `labelPosition: "before"` visually
+          moves the label to the LEFT via CSS (the switch convention), keeping
+          the accessible order stable. */}
+      <div
+        className={["field-toggle-control", `label-${labelPosition}`].join(" ")}
+      >
         <Component {...componentProps} />
         <Label
           name={name}

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/styles.css
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/styles.css
@@ -3,9 +3,21 @@
   grid-template-columns: subgrid;
   grid-column: var(--form-field-columns, 1 / -1);
   /* Vertical gap from the label row down to the payload row. Uses the block-axis
-     label-gap token — NOT --form-field-inline-gap (that is horizontal-only now). */
+     label-gap token — NOT --form-field-inline-gap (that is horizontal-only now).
+     Default is the label→control gap (--form-field-label-gap, 8px); when a
+     description LEADS the payload the row below tightens it to the label→
+     description gap (--form-field-label-description-gap, 4px), per the 15/07
+     review's field-spacing spec. */
   row-gap: var(--form-field-label-gap);
   align-items: baseline;
+
+  /* Label sits closer to a leading description than to a bare control. */
+  &:has(> .payload > .ds.field-description:first-child) {
+    row-gap: var(
+      --form-field-label-description-gap,
+      var(--form-field-label-gap)
+    );
+  }
 
   & > .ds.field-label {
     grid-column: var(--form-label-columns, 1 / -1);

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/withToggleWrapper.tsx
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/withToggleWrapper.tsx
@@ -25,13 +25,25 @@ type ToggleWrapperProps<ComponentProps extends BaseInputProps> = Omit<
  * here — in the HOC's return type — keeps it out of the shared `withWrapper`
  * generics, which would otherwise widen the union back to all-optional.
  *
+ * `defaults` are per-field defaults (e.g. SwitchField's `labelPosition: "before"`).
+ * They are spread UNDER the caller's props, so a consumer can still override them.
+ *
  * `import { withToggleWrapper } from "@canonical/react-ds-global-form";`
  */
 const withToggleWrapper = <ComponentProps extends BaseInputProps>(
   Component: ComponentType<ComponentProps>,
-): FC<ToggleWrapperProps<ComponentProps>> =>
-  withWrapper<ComponentProps>(Component, undefined, ToggleWrapper) as FC<
-    ToggleWrapperProps<ComponentProps>
-  >;
+  defaults?: Partial<ToggleWrapperProps<ComponentProps>>,
+): FC<ToggleWrapperProps<ComponentProps>> => {
+  const Wrapped = withWrapper<ComponentProps>(
+    Component,
+    undefined,
+    ToggleWrapper,
+  ) as FC<ToggleWrapperProps<ComponentProps>>;
+  if (!defaults) return Wrapped;
+  const WithDefaults: FC<ToggleWrapperProps<ComponentProps>> = (props) => (
+    <Wrapped {...defaults} {...props} />
+  );
+  return WithDefaults;
+};
 
 export default withToggleWrapper;

--- a/packages/react/ds-global-form/src/lib/common/types.ts
+++ b/packages/react/ds-global-form/src/lib/common/types.ts
@@ -64,6 +64,13 @@ export type WrapperProps<ComponentProps> = BaseWrapperProps<ComponentProps> & {
    * `controlLabel` the inline control label. */
   controlLabel?: string;
 
+  /* Toggle fields only: which side of the control the inline label sits on.
+   * "after" (default) — label follows the control, the checkbox convention.
+   * "before" — label leads, to the LEFT of the control; the switch convention,
+   * where a label before the switch names its PURPOSE (a label after would
+   * instead read as the switch's state). */
+  labelPosition?: "before" | "after";
+
   /* Is the field optional */
   isOptional?: boolean;
 

--- a/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
+++ b/packages/react/ds-global-form/src/lib/component/SwitchField/SwitchField.tsx
@@ -12,8 +12,14 @@ type SwitchInputFieldProps = InputProps<SwitchInputProps>;
  * middleware/conditional-display support. Requires at least one of
  * `label`/`controlLabel`.
  *
+ * The label defaults to the LEFT of the switch (`labelPosition: "before"`): a
+ * label before a switch names its purpose, which is the switch convention (a
+ * label after would read as the switch's state). Callers can override with
+ * `labelPosition="after"`.
+ *
  * `import { SwitchField } from "@canonical/react-ds-global-form";`
  */
 export default withToggleWrapper<SwitchInputFieldProps>(
   bindField<SwitchInputFieldProps>(SwitchInput, "native"),
+  { labelPosition: "before" },
 );

--- a/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
+++ b/packages/react/ds-global-form/src/lib/pattern/Field/Field.stories.tsx
@@ -14,6 +14,17 @@ const meta = {
   title: "patterns/Field",
   component: Component,
   decorators: [decorators.form()],
+  // `description` is editable from the Controls panel — type text to see the
+  // field's description slot (its type ramp and the label→description gap) live.
+  argTypes: {
+    description: {
+      control: "text",
+      description: "Supporting text shown under the label, above the control.",
+    },
+  },
+  args: {
+    description: "Supporting help text for this field.",
+  },
 } satisfies Meta<typeof Component>;
 
 export default meta;

--- a/packages/react/ds-global-form/src/lib/subcomponent/SelectInput/styles.css
+++ b/packages/react/ds-global-form/src/lib/subcomponent/SelectInput/styles.css
@@ -1,10 +1,38 @@
-/* Chevron indicator sourced from @canonical/ds-assets icons/chevron-down.svg */
+/* Chevron indicator, painted with CSS gradients so it takes the theme colour.
+ * A `background-image` SVG cannot be recoloured by CSS (no inheritance into
+ * the image document), which left the caret black on dark themes — the same
+ * reason the checkbox/accordion glyphs are masks. A <select> is a replaced
+ * element with no ::before/::after to mask, so the chevron is drawn instead:
+ * two diagonally-striped gradient squares butted together form a down-chevron
+ * STROKE (transparent → colour → transparent along each diagonal), coloured by
+ * --color-icon like every other control glyph. */
 .ds.input.select {
   appearance: none;
-  background-image: url("/icons/chevron-down.svg#chevron-down");
+  --select-caret-color: var(--color-icon, currentColor);
+  --select-caret-half: 0.4em; /* each square; the chevron is two halves wide */
+  /* left half: rising stroke ╱ */
+  background-image:
+    linear-gradient(
+      45deg,
+      transparent 42%,
+      var(--select-caret-color) 42%,
+      var(--select-caret-color) 58%,
+      transparent 58%
+    ),
+    /* right half: falling stroke ╲ */
+    linear-gradient(
+      135deg,
+      transparent 42%,
+      var(--select-caret-color) 42%,
+      var(--select-caret-color) 58%,
+      transparent 58%
+    );
   background-repeat: no-repeat;
-  background-position: right var(--form-input-padding-inline) center;
-  background-size: 1em;
+  background-position:
+    right calc(var(--form-input-padding-inline) + var(--select-caret-half))
+    center,
+    right var(--form-input-padding-inline) center;
+  background-size: var(--select-caret-half) var(--select-caret-half);
   /* This element IS the text-bearing leaf, so it carries the inline padding
    * (`.ds.input.chrome` provides only the block padding). The end side leaves
    * room for the chevron. */

--- a/packages/react/ds-global/.storybook/styles.css
+++ b/packages/react/ds-global/.storybook/styles.css
@@ -1,8 +1,1 @@
 @import url("@canonical/styles");
-
-:root {
-  /* For debug */
-  --baseline-grid-color: orange;
-  /* Temporary, waiting for a better understanding */
-  --baseline-shift: 1px;
-}

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/styles.css
@@ -254,3 +254,73 @@
     var(--dimension-stroke-thickness-medium)
   );
 }
+
+/* ── Density seat (intrinsic) — the header is a control-height row ───────────
+ * Inside a density scope the header takes the SHARED control seat from
+ * @canonical/styles (modifiers.density.css), exactly like the Button and the
+ * form inputs: the heading's own line box (`--control-seat-line`, the cell
+ * minus one baseline of headroom per side) is the header interior;
+ * `--seat-before` lands its baseline on the density target; `--seat-after`
+ * closes the row to EXACTLY the density cell (32px apps-comfortable, 24px
+ * apps-dense, …) with no block-size anywhere. So an accordion header, a
+ * button, and an input in the same cell are the same height and their text
+ * shares one baseline index.
+ *
+ * The header carries no border of its own — the item's DIVIDER plays that
+ * role, and only on the collapsed face: collapsed, the divider renders
+ * directly under the header, so the closing pad absorbs its thickness
+ * (header + divider = the cell); expanded, the divider sits after the content
+ * and the content's own compensation above owns it — the header keeps the full
+ * closing pad. This is the per-state split the pre-density compensation rules
+ * above apply to the legacy (non-density) look.
+ *
+ * The chevron needs no new rule: the header's `align-items: center` centres it
+ * on the flex line, whose cross-size IS the heading's line box — the same
+ * "centre on the glyph run" pairing the input affixes use.
+ *
+ * KNOWN LIMIT: an <h6> heading keeps its own engine line-height (see the
+ * heading rule above), so its line box may differ from --control-seat-line;
+ * the h6-in-header case is owned by a later pass. The default (body-tier)
+ * heading is exact. */
+:is(.comfortable, .dense, .app, .site, .docs) .ds.accordion-item {
+  /* The CONTENT panel consumes the density system's semantic spacing rung for
+     its block padding — space-md (16px apps-comfortable, 8px apps-dense,
+     20/12px sites) — instead of the fixed 1 bU, so the panel's breathing room
+     follows the density cell. Every rung is a whole baseline multiple, so the
+     rhythm holds; the [open] divider compensation reads this same token, so it
+     follows automatically. Outside a density scope the :root default stands. */
+  --accordion-item-content-padding-block: var(
+    --density-space-md,
+    var(--dimension-100)
+  );
+}
+
+:is(.comfortable, .dense, .app, .site, .docs) .ds.accordion-item > .header {
+  /* No border above the heading inside the header, so no border term. Rounded
+     to ¼px for exact layout-unit representability (see the shared seat). */
+  --seat-before: round(nearest, max(0px, var(--control-seat-basis)), 0.25px);
+  --seat-after: max(
+    0px,
+    calc(
+      var(--density-line-height-effective) -
+      var(--control-seat-line) -
+      var(--seat-before)
+    )
+  );
+  padding-block: var(--seat-before) var(--seat-after);
+}
+:is(.comfortable, .dense, .app, .site, .docs)
+  .ds.accordion-item:not([open])
+  > .header {
+  /* Collapsed: absorb the item divider below, keeping header + divider = cell. */
+  padding-block-end: max(
+    0px,
+    calc(var(--seat-after) - var(--dimension-stroke-thickness-medium))
+  );
+}
+:is(.comfortable, .dense, .app, .site, .docs)
+  .ds.accordion-item
+  > .header
+  > .heading {
+  line-height: var(--control-seat-line);
+}

--- a/packages/react/ds-global/src/lib/component/Button/styles.css
+++ b/packages/react/ds-global/src/lib/component/Button/styles.css
@@ -76,11 +76,20 @@
 
   color: var(--modifier-color-text, var(--button-color-text));
   background-color: var(--modifier-surface, var(--button-color-background));
-  border-color: var(--modifier-color-border, var(--button-color-border));
+  /* The outline flag (0/1) toggles the border's COLOUR, not its width: the
+     border is ALWAYS present at the nominal width (transparent when hidden), so
+     a bordered and a borderless importance share byte-identical geometry and
+     the density seat below subtracts one constant. (The previous
+     width-multiplied toggle left the primary 2px shorter than the secondary
+     and seated its label ~1px high.) */
+  border-color: color-mix(
+    in srgb,
+    var(--modifier-color-border, var(--button-color-border))
+      calc(var(--modifier-outline, 0) * 100%),
+    transparent
+  );
   border-style: solid;
-  /* The outline flag (0/1) toggles the border on: multiplying the width means
-     a borderless importance simply resolves to 0 with no separate rule. */
-  border-width: calc(var(--modifier-outline, 0) * var(--button-border-width));
+  border-width: var(--button-border-width);
 
   /* Label typography tokens (text-secondary tier, 14px). The block placement that
      lands the label on the baseline grid comes from the density seat at the end of
@@ -231,48 +240,55 @@
   }
 }
 
-/* ── Density seat (apps 32 / sites 36, dense 24 / 28) ────────────────────────
- * The button consumes the density primitives from @canonical/styles (context ×
- * density on an ancestor) to size its box to the cell and seat its label on the
- * 4px baseline grid. This lives HERE (ds-global) and not in
- * @canonical/react-ds-global-form's density.css, because the Button is a ds-global
- * component: an app that ships ds-global without the form package must still get a
- * seated button, not a flat one. The primitives are read from the shared styles
- * layer, so there is no form dependency.
+/* ── Density seat (apps 32 / sites 36, dense 24 / 28) — intrinsic ────────────
+ * The button consumes the SHARED control seat from @canonical/styles
+ * (modifiers.density.css): the label's own line box (cell − 2 baselines) is the
+ * button interior, `--control-seat-before` puts its baseline on the density
+ * target, `--control-seat-after` closes the box to EXACTLY the density cell.
+ * The height is INTRINSIC — no block-size: border + pads + line-height add up
+ * to the cell, and both outer edges land on grid lines.
  *
- * `:is()` on the density scope (0,1,0) so `:is(...) .ds.button` (0,2,0) beats the
- * button's own `.ds.button { align-items: center }` (0,1,0) — otherwise the label
- * stays flex-CENTRED and the padding-based baseline placement can't govern. */
+ * This lives HERE (ds-global) and not in ds-global-form's density.css, because
+ * the Button is a ds-global component: an app that ships ds-global without the
+ * form package must still get a seated button. The seat vars come from the
+ * shared styles layer, so there is no form dependency.
+ *
+ * The seat subtracts the NOMINAL --button-border-width for BOTH importances —
+ * the border is constant width and transparent when not shown (the
+ * --modifier-outline pattern), so a bordered and a borderless button share one
+ * geometry; no per-importance branch.
+ *
+ * `:is()` on the density scope (0,1,0) so `:is(...) .ds.button` (0,2,0) beats
+ * the button's own `.ds.button { align-items: center }` (0,1,0) — otherwise the
+ * label stays flex-CENTRED and the padding-based seat can't govern. */
 :is(.comfortable, .dense, .app, .site, .docs) .ds.button {
-  box-sizing: border-box;
-  /* Fixed grid-multiple height (the density cell), border-box so the border is
-     absorbed into the height — a bordered and a borderless button of one density
-     are the same height. Top-referenced so the space-before below governs. */
-  block-size: var(--density-line-height-effective);
-  min-block-size: var(--density-line-height-effective);
-  align-items: flex-start;
-  justify-content: flex-start;
-  /* Kill only the UA bottom padding; the placement below owns padding-block-start
-     (a `padding-block: 0` shorthand would out-specify and wipe the start). */
-  padding-block-end: 0;
-
-  /* Crush to line-height:1 for the seat; the baseline within that box is the cap
-     approximation (1em + 1cap)/2. The label font tier (--font-size/--font-family)
-     is the button's own (text-secondary, 14px), set on the base rule. */
-  line-height: 1;
-  --natural-baseline: calc((1em + 1cap) / 2);
-  /* The box's top border sits above the label and counts toward the target, so
-     subtract the NOMINAL --button-border-width for BOTH importances — the primary's
-     0-outline (borderless) is handled by the grid maths, not by zeroing this term
-     (a per-importance term lifts the primary a pixel; regression, reverted). */
-  --border-top-width: var(--button-border-width, 0px);
-  --space-before: max(
+  /* Fold the button's own border into the shared basis HERE (a var() inside a
+     custom property substitutes at its declaring element, so the shared layer
+     cannot read this border). `1cap` in the basis resolves against the button's
+     own label font. */
+  /* Rounded to ¼px so the pad is exactly representable in the browser's 1/64px
+     layout units — the fractional 1cap term otherwise leaves ~1/60px residues
+     on the box height. */
+  --seat-before: round(
+    nearest,
+    max(0px, calc(var(--control-seat-basis) - var(--button-border-width, 0px))),
+    0.25px
+  );
+  --seat-after: max(
     0px,
     calc(
-      var(--density-target-baseline-px, 0px) -
-      var(--natural-baseline) -
-      var(--border-top-width, 0px)
+      var(--density-line-height-effective) -
+      var(--control-seat-line) -
+      var(--seat-before) -
+      2 *
+      var(--button-border-width, 0px)
     )
   );
-  padding-block-start: var(--space-before);
+
+  box-sizing: border-box;
+  block-size: auto;
+  align-items: flex-start;
+  justify-content: flex-start;
+  line-height: var(--control-seat-line);
+  padding-block: var(--seat-before) var(--seat-after);
 }

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import { useMemo } from "react";
 import { createPortal } from "react-dom";
 import {
-  MENU_PLACEMENT,
+  MENU_ROOT_PLACEMENT,
   useContextualMenu,
   useIsMounted,
 } from "../../hooks/index.js";
@@ -55,10 +55,11 @@ const ContextualMenu = ({
   const menu = useContextualMenu({
     root,
     isOpen: open,
-    // Open toward the trigger's leading edge, top-aligned, flipping side/
-    // alignment as space runs out. MENU_PLACEMENT is logical (inline-*), so the
-    // hook mirrors it in RTL automatically — no direction read here.
-    preferredDirections: preferredDirections ?? MENU_PLACEMENT,
+    // Open BELOW the trigger, leading-aligned, flipping above then to the side
+    // as space runs out (design review). MENU_ROOT_PLACEMENT is logical, so the
+    // hook mirrors alignment in RTL automatically — no direction read here.
+    // (Submenus keep the side-opening MENU_PLACEMENT — see SubMenu.)
+    preferredDirections: preferredDirections ?? MENU_ROOT_PLACEMENT,
     distance,
     gutter,
     maxWidth,

--- a/packages/react/ds-global/src/lib/component/Tabs/common/Item/styles.css
+++ b/packages/react/ds-global/src/lib/component/Tabs/common/Item/styles.css
@@ -15,6 +15,8 @@
   --tabs-tab-padding-inline: var(--space-200); /* 16px */
   /* 5bU = 40px tab height on the 8px baseline grid. */
   --tabs-tab-min-block-size: calc(var(--baseline-height) * 5);
+  --tabs-tab-focus-ring-width: var(--dimension-strokeThickness-large, 2px);
+  --tabs-tab-focus-ring-color: var(--color-focusRing);
 }
 
 .ds.tabs-item {
@@ -38,6 +40,16 @@
   /* Transparent underline reserved so the row never shifts when a border
      appears on hover/active. */
   border-bottom: var(--tabs-tab-border-width) solid transparent;
+
+  /* Keyboard focus: a design-system focus ring (design review) instead of the
+     UA default outline. Inset offset so the ring hugs the tab and the row's
+     `overflow` never clips it; :focus-visible only, so pointer clicks stay
+     quiet. */
+  &:focus-visible {
+    outline: var(--tabs-tab-focus-ring-width) solid
+      var(--tabs-tab-focus-ring-color);
+    outline-offset: calc(-1 * var(--tabs-tab-focus-ring-width));
+  }
 }
 
 /* Hover: a muted bottom border hints the tab is navigable, and settles faster

--- a/packages/react/ds-global/src/lib/hooks/useWindowFitment/readingDirection.ts
+++ b/packages/react/ds-global/src/lib/hooks/useWindowFitment/readingDirection.ts
@@ -1,10 +1,26 @@
 import type { WindowFitmentPlacement, WindowFitmentSide } from "./types.js";
 
 /**
- * Contextual-menu placements: open toward the trigger's reading-flow (leading)
- * edge, top-aligned, flipping alignment then side as space runs out. Logical, so
- * it mirrors automatically — resolves to the historical right-start/… order in
- * LTR and left-start/… in RTL.
+ * ROOT contextual-menu placements: open BELOW the trigger, leading-aligned
+ * (design review), flipping to above then to the side as space runs out.
+ * Logical, so alignment mirrors automatically (leading = left in LTR, right in
+ * RTL). Used by the top-level menu opened from a trigger.
+ */
+export const MENU_ROOT_PLACEMENT: WindowFitmentPlacement[] = [
+  { side: "block-end", align: "start" }, //   below, leading-aligned (default)
+  { side: "block-end", align: "end" }, //     horizontal overflow → trailing-aligned
+  { side: "block-start", align: "start" }, //  vertical overflow → flip above
+  { side: "block-start", align: "end" },
+  { side: "inline-end", align: "start" }, //   no room above/below → to the side
+  { side: "inline-start", align: "start" },
+];
+
+/**
+ * SUBMENU (nested) placements: expand toward the trigger's reading-flow
+ * (leading) edge, top-aligned, flipping alignment then side as space runs out —
+ * standard cascade behaviour, a submenu opens beside its parent item, not below
+ * it. Logical, so it mirrors automatically (right-start… in LTR, left-start… in
+ * RTL).
  */
 export const MENU_PLACEMENT: WindowFitmentPlacement[] = [
   { side: "inline-end", align: "start" }, // right-start LTR / left-start RTL

--- a/packages/styles/main/src/modifiers.density.css
+++ b/packages/styles/main/src/modifiers.density.css
@@ -191,4 +191,44 @@
     calc(var(--density-line-height-effective) * 2 / 3),
     var(--baseline-height)
   );
+
+  /* ── Control seat (intrinsic) ──────────────────────────────────────────────
+   * ONE seat for every control (button, input chrome, accordion header, …):
+   * the text's own line box — the density cell minus one baseline of headroom
+   * per side (`--control-seat-line`) — IS the control interior. The height is
+   * INTRINSIC: no block-size; border + pads + line-height add up to the cell,
+   * and both outer edges land on grid lines.
+   *
+   * The shared layer exports the two BORDER-AGNOSTIC pieces. A var() inside a
+   * custom property is substituted where the property is DECLARED — here, the
+   * density scope — so a component's border can never be a formula input at
+   * this level; each component folds its own border in at the application site
+   * (single-line <input>/<select> also floor the line at the UA's `normal`
+   * minimum — see the form package's density.css):
+   *
+   *     --seat-before: max(0px, calc(
+   *       var(--control-seat-basis) - <border-width>));
+   *     --seat-after: max(0px, calc(
+   *       var(--density-line-height-effective) - var(--control-seat-line) -
+   *       var(--seat-before) - 2 * <border-width>));
+   *     line-height: var(--control-seat-line);
+   *     padding-block: var(--seat-before) var(--seat-after);
+   *
+   * `1cap` below stays an unresolved token inside the custom property and only
+   * resolves where the seat is APPLIED — each component's own font — so
+   * components with different fonts still seat on the SAME grid index. The
+   * border must be the control's CONSTANT nominal width (transparent where no
+   * border shows), so bordered and borderless variants share one geometry. */
+  --control-seat-line: calc(
+    var(--density-line-height-effective) -
+    2 *
+    var(--baseline-height)
+  );
+  /* Unclamped distance from just inside the box's top border down to the
+     target baseline, for a --control-seat-line line box. */
+  --control-seat-basis: calc(
+    var(--density-target-baseline-px) -
+    (var(--control-seat-line) + 1cap) /
+    2
+  );
 }

--- a/packages/styles/main/src/modifiers.density.css
+++ b/packages/styles/main/src/modifiers.density.css
@@ -161,10 +161,20 @@
   );
 }
 
-/* ── Target baseline = round(up, height × 2/3) ──────────────────────────────
- * Snapped UP so fractional cases lift (apps-comfy 5.33→6) while exact multiples
- * stay (apps-dense 4.0, sites-comfy 6.0). Matches: apps 32→6th/24→4th,
- * sites 36→6th/28→5th. */
+/* ── Target baseline = round(nearest, height × 2/3) ─────────────────────────
+ * The control text seats where line-height × 2/3 lands on the grid — the optical
+ * centre of the box — snapped to the NEAREST grid line, not the next one up.
+ * Nearest (not up) because up over-lifts the one cell where lh × 2/3 is
+ * fractional: apps-comfortable is 32 × 2/3 = 21.33px, which round(up) forced a
+ * whole step onto the 24px line (6th), a baseline too low. round(nearest) seats
+ * it on the 20px line (5th) — Diana's F-O2 "move text 1 baseline up in
+ * apps/comfortable" (AV-323). The exact-multiple cells are unaffected:
+ *   apps-comfy   21.33 → 20 (5th)   ← the fix; was 24
+ *   apps-dense   16.00 → 16 (4th)   unchanged (exact)
+ *   sites-comfy  24.00 → 24 (6th)   unchanged (exact)
+ *   sites-dense  18.67 → 20 (5th)   unchanged (nearest == up here)
+ * So it's a self-correcting rule, not a per-cell offset: any future fractional
+ * cell snaps to its nearest line too. */
 :where(.comfortable, .dense, .app, .site, .docs) {
   /* Effective line-height with the SAME fallback chain a control box uses
      (--density-line-height → context --density-lh-comfy → apps-comfy literal).
@@ -177,7 +187,7 @@
     var(--density-lh-comfy, calc(var(--baseline-height) * 8))
   );
   --density-target-baseline-px: round(
-    up,
+    nearest,
     calc(var(--density-line-height-effective) * 2 / 3),
     var(--baseline-height)
   );

--- a/packages/styles/main/src/modifiers.density.css
+++ b/packages/styles/main/src/modifiers.density.css
@@ -31,10 +31,16 @@
  *                    comfy   dense       comfy   dense
  *   line-height      32 (8)  24 (6)      36 (9)  28 (7)
  *   padding-inline   16 (4)   8 (2)      16 (4)  12 (3)
- *   space-lg         24 (6)  16 (4)      28 (7)  20 (5)
- *   space-md         16 (4)   8 (2)      20 (5)  12 (3)
- *   space-sm          8 (2)   4 (1)       8 (2)   8 (2)
+ *   space-lg         40 (10) 32 (8)      44 (11) 36 (9)   ← between fields
+ *   space-md          8 (2)   4 (1)       8 (2)   8 (2)   ← label → control
+ *   space-sm          8 (2)   4 (1)       8 (2)   8 (2)   ← desc/error → input
+ *   space-xs          4 (1)   4 (1)       4 (1)   4 (1)   ← label → description
  *   (parenthesised = baseline units; 1 bU = --baseline-height = 4px)
+ *
+ * NB the space-lg / space-md values were retuned from Diana's 15/07 review
+ * (label→input 8px, between-fields 40px), and space-xs (label→description 4px)
+ * added, replacing the earlier graded 16/24 rungs. The values stay whole
+ * baseline multiples, so vertical rhythm holds.
  */
 
 /* ── Context family: the comfortable/dense PAIR per surface ──────────────────
@@ -49,12 +55,14 @@
   --density-lh-dense: calc(var(--baseline-height) * 6); /* 24px */
   --density-pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
   --density-pad-inline-dense: calc(var(--baseline-height) * 2); /*  8px */
-  --density-space-lg-comfy: calc(var(--baseline-height) * 6); /* 24px */
-  --density-space-lg-dense: calc(var(--baseline-height) * 4); /* 16px */
-  --density-space-md-comfy: calc(var(--baseline-height) * 4); /* 16px */
-  --density-space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-lg-comfy: calc(var(--baseline-height) * 10); /* 40px */
+  --density-space-lg-dense: calc(var(--baseline-height) * 8); /* 32px */
+  --density-space-md-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-md-dense: calc(var(--baseline-height) * 1); /*  4px */
   --density-space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
   --density-space-sm-dense: calc(var(--baseline-height) * 1); /*  4px */
+  --density-space-xs-comfy: calc(var(--baseline-height) * 1); /*  4px */
+  --density-space-xs-dense: calc(var(--baseline-height) * 1); /*  4px */
 
   /* Back-compat aliases (pre-namespace names). Remove once no consumer reads them. */
   --lh-comfy: var(--density-lh-comfy);
@@ -74,12 +82,14 @@
   --density-lh-dense: calc(var(--baseline-height) * 7); /* 28px */
   --density-pad-inline-comfy: calc(var(--baseline-height) * 4); /* 16px */
   --density-pad-inline-dense: calc(var(--baseline-height) * 3); /* 12px */
-  --density-space-lg-comfy: calc(var(--baseline-height) * 7); /* 28px */
-  --density-space-lg-dense: calc(var(--baseline-height) * 5); /* 20px */
-  --density-space-md-comfy: calc(var(--baseline-height) * 5); /* 20px */
-  --density-space-md-dense: calc(var(--baseline-height) * 3); /* 12px */
+  --density-space-lg-comfy: calc(var(--baseline-height) * 11); /* 44px */
+  --density-space-lg-dense: calc(var(--baseline-height) * 9); /* 36px */
+  --density-space-md-comfy: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-md-dense: calc(var(--baseline-height) * 2); /*  8px */
   --density-space-sm-comfy: calc(var(--baseline-height) * 2); /*  8px */
   --density-space-sm-dense: calc(var(--baseline-height) * 2); /*  8px */
+  --density-space-xs-comfy: calc(var(--baseline-height) * 1); /*  4px */
+  --density-space-xs-dense: calc(var(--baseline-height) * 1); /*  4px */
 
   /* Back-compat aliases (pre-namespace names). Remove once no consumer reads them. */
   --lh-comfy: var(--density-lh-comfy);
@@ -109,15 +119,19 @@
   );
   --density-space-lg: var(
     --density-space-lg-comfy,
-    calc(var(--baseline-height) * 6)
+    calc(var(--baseline-height) * 10)
   );
   --density-space-md: var(
     --density-space-md-comfy,
-    calc(var(--baseline-height) * 4)
+    calc(var(--baseline-height) * 2)
   );
   --density-space-sm: var(
     --density-space-sm-comfy,
     calc(var(--baseline-height) * 2)
+  );
+  --density-space-xs: var(
+    --density-space-xs-comfy,
+    calc(var(--baseline-height) * 1)
   );
 }
 .dense {
@@ -131,14 +145,18 @@
   );
   --density-space-lg: var(
     --density-space-lg-dense,
-    calc(var(--baseline-height) * 4)
+    calc(var(--baseline-height) * 8)
   );
   --density-space-md: var(
     --density-space-md-dense,
-    calc(var(--baseline-height) * 2)
+    calc(var(--baseline-height) * 1)
   );
   --density-space-sm: var(
     --density-space-sm-dense,
+    calc(var(--baseline-height) * 1)
+  );
+  --density-space-xs: var(
+    --density-space-xs-dense,
     calc(var(--baseline-height) * 1)
   );
 }

--- a/packages/styles/typography/src/mapper.css
+++ b/packages/styles/typography/src/mapper.css
@@ -175,6 +175,16 @@ h5 {
   font-family: var(--typography-heading-5-font-family);
   font-weight: var(--font-weight);
   letter-spacing: var(--typography-heading-5-letter-spacing);
+  /* Heading 5 is styled as small-caps with old-style figures (design review):
+     the design tokens carry these under `--typography-heading-5-font-variant(-numeric)`
+     — small-caps in :root/.app/.site, normal in docs — so the tier difference
+     flows automatically. `normal` fallbacks keep h5 unchanged if a theme ships
+     without the tokens. */
+  font-variant: var(--typography-heading-5-font-variant, normal);
+  font-variant-numeric: var(
+    --typography-heading-5-font-variant-numeric,
+    normal
+  );
   padding-inline: var(--heading-padding-inline, 0);
 }
 


### PR DESCRIPTION
## Baseline seating: intrinsic control seat (AV-323, AV-327)

Replaces the fixed-height + border-box control seating with an **intrinsic seat**: no `block-size` anywhere — a control's text carries its interior line box, a seat pad lands the baseline on the density target, and a complement pad closes the box to exactly the density cell. Buttons, inputs, the select, the textarea and the accordion header now share one seat, one height per cell, and one baseline index.

### The target fix (AV-323, Diana F-O2)

`--density-target-baseline-px` snaps `height × ⅔` to the **nearest** grid line instead of rounding up. apps/comfortable — the only fractional cell — moves one baseline up (24 → 20px), exactly Diana's "move control text 1 baseline up"; the other three cells are byte-identical. Self-correcting for any future fractional cell.

### The intrinsic seat (`@canonical/styles`, `modifiers.density.css`)

```
--control-seat-line  = cell − 2·baseline      (interior line box; whole multiple in every cell)
--control-seat-basis = target − (line + 1cap)/2
```

Components fold their **own** border into the basis at the application site (a `var()` inside a custom property substitutes at its declaring element, so the shared layer cannot read component borders) and close with the complement:

```
border + seat-before + line + seat-after + border = the cell
```

`1em`/`1cap` resolve at the applying element, so different fonts still seat on the same grid index. Seat pads are rounded to ¼px (exact in 1/64px layout units).

### Converted surfaces

- **Button** (ds-global) — crush seat deleted. Plus a root-cause fix: the outline flag now toggles the border's **colour** (`color-mix`), never its width. The width-multiplied toggle made the borderless primary 2px shorter and seated its label ~1px high; primary and secondary are now byte-identical boxes.
- **Composite inputs** `.ds.input:is(.text, .number, .password, .phone)` — chrome owns the box edges, the inner `<input>` owns the line. Chrome restored to `align-items: stretch`, so affix icons (password reveal-toggle, number prefix/suffix) centre on the glyph run.
- **Select** — single-element seat; fixes the never-seated option text and the apps/dense clipping (24px fixed box − 8px padding). The caret is now **drawn** with gradient strokes in `--color-icon` (a `background-image` SVG can't be recoloured, which broke dark theme; a `<select>` can't host pseudo-elements to mask). Caveat: drawn stroke, not the icon file — icon-exact fidelity would need a wrapper element.
- **Textarea** — the old parallel `--td-*` seat had silently died under the new targets (its full-cell line box put the natural baseline below every target; the clamp left it unseated). It now rides the same seat with **no multi-line special case**: `--control-seat-line` is a whole baseline multiple in every cell, so N rows advance N grid intervals and the closing geometry is row-count-independent.
- **Accordion header** (ds-global) — same seat, same cell height as button/input, text on the same baseline index. The item divider is absorbed by the header's closing pad **only when collapsed**; expanded, the divider follows the content and the content's existing compensation owns it. The content panel's block padding maps to the semantic density rung (`--density-space-md`: 16px apps-comfortable / 8px apps-dense) instead of the fixed 1 bU, so the panel breathes with the cell.

Not converted (deliberate, follow-up): date/time/datetime direct chromes (multi-part UA internals need their own measured pass); h6-in-accordion-heading.

### The drift knob, deleted (TODO #15 resolved)

`--control-text-drift-AVOID-USAGE` (~2px) turned out to be an artifact, not a metrics quirk: **the UA enforces a `line-height` floor of `normal` (≈1.2em) on single-line `<input>`s**, and the crush-era `line-height: 1` was silently clamped — the knob was hand-calibrated against the clamp. With a real line box the input renders text exactly like a `<span>` (measured: input baseline = label baseline to 0.01px). Where the interior line dips below the floor (dense cells) the seat computes with `max(--control-seat-line, 1.2em)`. The knob is gone from every path.

### Verification (headless chromium, computed styles + 4× screenshots against the grid overlay)

| surface | apps/comfortable | apps/dense |
|---|---|---|
| button (primary = secondary) | h 32.000, baseline ≈ target | h 24.000 |
| text input chrome | h 32.000, input baseline = label ±0.1px | h 23.98 |
| select | h 32.000, not clipped | h 23.98, **not clipped** (was clipped) |
| textarea | h 128 (5 rows, = 32 bU), first row on the label line | rows on-grid |
| password eye | centred on glyph run (Δ0.3px) | Δ0.03px |

### Docs

`BaselineGrid.mdx`, `SeatingByElement.mdx`, `Density.mdx` rewritten to the intrinsic model — including the target-rounding rationale, the constant-border rule, the UA-floor finding, and the per-element summary table.

Linear: AV-323 (done here), AV-327 (model + Button/inputs/select/textarea/accordion-header seating). AV-325 ships separately as #870.
