### PR TITLE
fix(pragma-cli): restore oxigraph WASM embed in the compiled binary

### DIFF
--- a/packages/cli/pragma/src/kernel/runtime/graphpack/read.ts
+++ b/packages/cli/pragma/src/kernel/runtime/graphpack/read.ts
@@ -12,6 +12,12 @@
  * fast path.
  */
 
+// Side-effect import — MUST precede the `@canonical/ke` import below so the
+// oxigraph WASM is embedded / its `readFileSync` patched before ke's
+// `createStore` (→ `loadOxigraph`) runs. `read.ts` is the single funnel every
+// store-boot path reaches (normal load and the __store-probe), and it is only
+// dynamic-imported on store boot, so this keeps the storeless hot paths clean.
+import "../wasmEmbed.js";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createStore } from "@canonical/ke";

--- a/packages/cli/pragma/src/kernel/runtime/wasmEmbed.ts
+++ b/packages/cli/pragma/src/kernel/runtime/wasmEmbed.ts
@@ -1,0 +1,57 @@
+/**
+ * Embed oxigraph WASM for `bun build --compile`.
+ *
+ * Bun's bundler does not automatically embed WASM files that an npm dependency
+ * loads via `readFileSync(`${__dirname}/node_bg.wasm`)` — the `__dirname` is
+ * frozen to the build-time path and `readFileSync` is not redirected to
+ * embedded data at runtime. So the compiled `dist/pragma` binary, run on any
+ * machine other than the CI runner it was built on, throws:
+ *
+ *   Failed to load oxigraph. Make sure it is installed:
+ *   ENOENT … /oxigraph@x/node_modules/oxigraph/node_bg.wasm
+ *
+ * This module fixes that. Importing it (for its side effects) BEFORE any code
+ * that loads oxigraph:
+ *
+ *   1. Dynamically imports the WASM with `{ type: "file" }`, the only mechanism
+ *      bun supports for embedding an arbitrary file into the compiled binary's
+ *      `$bunfs` virtual filesystem. In interpreted mode this resolves to the
+ *      real on-disk path, so the patch below is a harmless no-op (same bytes).
+ *   2. Reads the embedded bytes once, then patches CJS `require("fs").readFileSync`
+ *      so oxigraph's `node.js` wrapper — which does exactly that — gets the
+ *      pre-loaded bytes for `node_bg.wasm` instead of hitting a stale path.
+ *
+ * `oxigraph` is a direct dependency of `@canonical/pragma-cli` so
+ * `oxigraph/node_bg.wasm` resolves regardless of workspace hoisting.
+ *
+ * Regression note: this was originally #584; it was dropped in the CLI rename
+ * (#879) while its compile-smoke test (`wasmEmbed.test.ts`) survived. Restored
+ * here. The test compiles a fresh binary and boots the store, so a future
+ * removal fails loudly again.
+ *
+ * @note Impure — reads a file at module init and mutates the CJS `fs` module.
+ */
+
+import { readFileSync } from "node:fs";
+
+// @ts-expect-error — bun-specific import attribute for file embedding.
+const { default: wasmPath } = await import("oxigraph/node_bg.wasm", {
+  with: { type: "file" },
+});
+const wasmBytes = readFileSync(wasmPath);
+
+// Oxigraph's CJS wrapper loads the WASM via `require("fs").readFileSync(...)`.
+// Patch the CJS `fs` module (mutable, unlike ESM bindings) so reads targeting
+// `node_bg.wasm` return the pre-loaded bytes.
+const cjsFs = import.meta.require("fs");
+const origReadFileSync = cjsFs.readFileSync;
+
+cjsFs.readFileSync = function patchedReadFileSync(
+  path: string,
+  ...args: unknown[]
+) {
+  if (typeof path === "string" && path.endsWith("/node_bg.wasm")) {
+    return wasmBytes;
+  }
+  return origReadFileSync(path, ...args);
+};


### PR DESCRIPTION
## The bug
A clean install of `@canonical/pragma-cli` (a `bun --compile` standalone binary) fails on any machine other than the CI runner it was built on:

```
Error: Internal error: Failed to load oxigraph. Make sure it is installed:
ENOENT … /node_modules/oxigraph/node_bg.wasm
```

Bun's `--compile` does not embed the WASM that oxigraph loads via `readFileSync(`${__dirname}/node_bg.wasm`)` — `__dirname` is frozen to the build-time path, so the file isn't found at runtime.

## Root cause: a regression
This was fixed once (**#584**, `embedWasm.ts`), but the module was **dropped in the CLI rename/rewrite (#879)** while its compile-smoke test (`kernel/runtime/wasmEmbed.test.ts`) survived **orphaned** — so the binary regressed and that protected test has been red.

## Fix
- Restore `kernel/runtime/wasmEmbed.ts`: embed the WASM via `import("oxigraph/node_bg.wasm", { with: { type: "file" } })` (bun's file-embed → `$bunfs`), then patch CJS `readFileSync` to return those bytes for `node_bg.wasm`.
- Wire it as a **side-effect import at the top of `graphpack/read.ts`** — the single funnel every store-boot path (normal load *and* `__store-probe`) reaches before `createStore`, so it runs before oxigraph loads and never touches the storeless hot paths (no cold-start cost).

## Verification
A fresh `bun build --compile` binary boots the store from an **isolated cwd**:
```
$ pragma __store-probe
{"ok":true,"entities":6,"triples":"23"}
```
Confirmed the **embedded** copy is used by moving the on-disk WASM away and re-running (still `ok:true`). The orphaned `wasmEmbed.test.ts` guards this end-to-end in CI (it compiles a binary and boots the store).

Typecheck clean. Separate PR (unrelated to the DS-component work).