### PR TITLE
feat(svelte-wpe): Add `Card` component and `Cards` group

### DIFF
--- a/packages/svelte/ds-app-wpe/.storybook/preview.ts
+++ b/packages/svelte/ds-app-wpe/.storybook/preview.ts
@@ -4,6 +4,31 @@ import "../src/lib/index.css";
 
 const preview = {
   ...previewConfig,
+  // Storybook statically parses `preview.ts` for `storySort` and requires the
+  // order to be an inline literal — an imported const is rejected — and it does
+  // not reliably merge `tags`/`parameters` spread from an imported preview. So
+  // both `tags` and the `storySort` order are declared inline here rather than
+  // inherited from `@canonical/storybook-config`.
+  // https://github.com/storybookjs/storybook/issues/31842
+  tags: ["autodocs"],
+  parameters: {
+    ...previewConfig.parameters,
+    options: {
+      storySort: {
+        order: [
+          "Documentation",
+          ["Introduction", "*"],
+          "subcomponents",
+          "components",
+          "groups",
+          "patterns",
+          "common",
+          "utils",
+          "_work_in_progress",
+        ],
+      },
+    },
+  },
 };
 
 export default preview;

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.ssr.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.ssr.test.ts
@@ -1,0 +1,44 @@
+import { render } from "@canonical/svelte-ssr-test";
+import type { ComponentProps } from "svelte";
+import { describe, expect, it } from "vitest";
+import Component from "./Card.svelte";
+
+describe("Card SSR", () => {
+  const baseProps = {} satisfies ComponentProps<typeof Component>;
+
+  describe("basics", () => {
+    it("doesn't throw", () => {
+      expect(() => {
+        render(Component, { props: { ...baseProps } });
+      }).not.toThrow();
+    });
+
+    it("renders as a div", () => {
+      const page = render(Component, { props: { ...baseProps } });
+      expect(componentLocator(page)).toBeInstanceOf(page.window.HTMLDivElement);
+    });
+
+    it("applies ds card classes", () => {
+      const page = render(Component, { props: { ...baseProps } });
+      const root = componentLocator(page);
+      expect(root.classList).toContain("ds");
+      expect(root.classList).toContain("card");
+    });
+  });
+
+  describe("attributes", () => {
+    it.each([
+      ["id", "test-id"],
+      ["aria-label", "test-label"],
+    ])("applies %s", (attribute, expected) => {
+      const page = render(Component, {
+        props: { ...baseProps, [attribute]: expected },
+      });
+      expect(componentLocator(page).getAttribute(attribute)).toBe(expected);
+    });
+  });
+});
+
+function componentLocator(page: ReturnType<typeof render>): HTMLElement {
+  return page.container.querySelector(".ds.card") as HTMLElement;
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.stories.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.stories.svelte
@@ -1,0 +1,140 @@
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import { Card } from "./index.js";
+
+  const { Story } = defineMeta({
+    title: "Components/Card",
+    component: Card,
+    tags: ["autodocs"],
+    parameters: {
+      grid: "showcase",
+      controls: { exclude: /.*/ },
+      docs: {
+        description: {
+          component:
+            "A Card is a subgrid, so it needs a grid parent. That parent is supplied by the addon's `grid` story param — the single grid mechanism — NOT a local grid decorator, which would nest a second grid inside the addon's and crush the card into one column. `\"showcase\"` frames a lone card the way it should read: a single ~22rem column, centred in a tall canvas, at its intrinsic height. It works identically on the story canvas and the autodocs page (switch it from the toolbar). Stories that want a different layout (surfaces) override per-story.",
+        },
+      },
+    },
+  });
+</script>
+
+<!--
+  The base card: a single padded content block. `Card.Content` is the core
+  API — the header, image, and footer shown in other stories are optional
+  extras, not part of the base card.
+-->
+<Story name="Default" asChild>
+  <Card>
+    <Card.Content>
+      <h4>Build a bare-metal cloud on a Raspberry Pi cluster with MAAS</h4>
+      <p class="p">
+        The Raspberry Pi 4, with its fast CPU cores, up to 8 GB of RAM and tiny
+        footprint, is a great option to run a cluster on. Provisioning is easy
+        with <a href="https://maas.io">MAAS</a>.
+      </p>
+    </Card.Content>
+  </Card>
+</Story>
+
+<!--
+  A full-bleed image above the content block.
+
+  `Card.Image` is not part of the core API.
+-->
+<Story name="With Image" asChild>
+  <Card>
+    <Card.Image src="https://assets.ubuntu.com/v1/5ce214a4-rpi.png" alt="" />
+    <Card.Content>
+      <h4>Build a bare-metal cloud on a Raspberry Pi cluster with MAAS</h4>
+      <p class="p">
+        The Raspberry Pi 4 is a great option to run a cluster on, and
+        provisioning is easy with <a href="https://maas.io">MAAS</a>.
+      </p>
+    </Card.Content>
+  </Card>
+</Story>
+
+<!--
+  A card with a header, content and footer. Only the content-bearing sections
+  pad themselves; the card frame applies no general padding and the image
+  bleeds edge to edge. The header is not a separate visual section: no divider
+  is drawn under it and it merges with the content below, so title and body
+  read as one region. The footer holds tags and labels, not actions — CTAs
+  belong in `Card.Content`.
+
+  `Card.Header`, `Card.Image` and `Card.Footer` are **not core API** — the base
+  card is just `Card.Content`; these are optional sections layered on top.
+-->
+<Story name="Header Content Footer" asChild>
+  <Card>
+    <Card.Image src="https://assets.ubuntu.com/v1/5ce214a4-rpi.png" alt="" />
+    <Card.Header>
+      <h4>Ubuntu 24.04 LTS</h4>
+      <span class="p">Noble Numbat</span>
+    </Card.Header>
+    <Card.Content>
+      <p class="p">
+        The latest long-term support release, with ten years of security
+        maintenance and a refreshed toolchain for developers and operators.
+        <a href="https://ubuntu.com/download">Download</a> or read the
+        <a href="https://ubuntu.com/blog">release notes</a>.
+      </p>
+    </Card.Content>
+    <Card.Footer>
+      <span class="p">LTS</span>
+      <span class="p">Desktop</span>
+      <span class="p">Server</span>
+    </Card.Footer>
+  </Card>
+</Story>
+
+<!--
+  The Card is not a surface: it sets no background of its own, so on each
+  surface it takes the *same* background as its container and reads as flush —
+  delimited only by its border and radius. Placed on three different surface
+  levels, the card blends with each rather than stepping to the next layer.
+-->
+<Story name="On Surfaces" parameters={{ grid: "responsive" }} asChild>
+  <div style="min-height: 100vh; overflow: auto; grid-column: 1 / -1">
+    <div
+      class="surface"
+      style="background: var(--surface-color-background, var(--color-background)); display: flex; flex-direction: column; align-items: stretch;"
+    >
+      <div class="subgrid" style="padding: 5rem">
+        <Card>
+          <Card.Content>
+            <h4>On surface level 1</h4>
+            <p class="p">The card takes the same background as the surface it sits on.</p>
+          </Card.Content>
+        </Card>
+      </div>
+      <div
+        class="surface"
+        style="background: var(--surface-color-background, var(--color-background)); display: flex; flex-direction: column; align-items: stretch;"
+      >
+        <div class="subgrid" style="padding: 5rem">
+          <Card>
+            <Card.Content>
+              <h4>On surface level 2</h4>
+              <p class="p">The card takes the same background as the surface it sits on.</p>
+            </Card.Content>
+          </Card>
+        </div>
+        <div
+          class="surface"
+          style="background: var(--surface-color-background, var(--color-background)); display: flex; flex-direction: column; align-items: stretch;"
+        >
+          <div class="subgrid" style="padding: 5rem">
+            <Card>
+              <Card.Content>
+                <h4>On surface level 3</h4>
+                <p class="p">The card takes the same background as the surface it sits on.</p>
+              </Card.Content>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</Story>

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { CardProps } from "./types.js";
+  import "./styles.css";
+
+  const componentCssClassName = "ds card";
+
+  let { children, class: className, ...rest }: CardProps = $props();
+</script>
+
+<div class={[componentCssClassName, className]} {...rest}>
+  {@render children?.()}
+</div>
+
+<!-- @component
+The `Card` component is a container designed to represent data objects that share
+the same structure. Unlike the more flexible Tile, a card is designed to have
+multiple units displayed beside one another, with a predictable structure that
+allows the user to compare attributes across data objects.
+
+A Card is always a grid participant: it is a ROW SUBGRID spanning four fixed
+section tracks (image / header / content / footer), inheriting them from its
+parent grid. Use inside a `Cards` group to align sections across a row.
+
+`import { Card } from "@canonical/svelte-ds-app-wpe";`
+
+## Example Usage
+```svelte
+<Card>
+  <Card.Content>
+    <h4>Card title</h4>
+    <p>Card body text.</p>
+  </Card.Content>
+</Card>
+```
+
+@implements ds:global.component.card
+-->

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.svelte.test.ts
@@ -1,0 +1,111 @@
+import type { Locator } from "@vitest/browser/context";
+import type { ComponentProps } from "svelte";
+import { createRawSnippet } from "svelte";
+import { describe, expect, it } from "vitest";
+import type { RenderResult } from "vitest-browser-svelte";
+import { render } from "vitest-browser-svelte";
+import Component from "./Card.svelte";
+import Content from "./common/Content/Content.svelte";
+import Footer from "./common/Footer/Footer.svelte";
+import Header from "./common/Header/Header.svelte";
+import Image from "./common/Image/Image.svelte";
+
+describe("Card component", () => {
+  const baseProps = {
+    "data-testid": "card",
+  } satisfies ComponentProps<typeof Component>;
+
+  it("renders", async () => {
+    const page = render(Component, { ...baseProps });
+    await expect.element(componentLocator(page)).toBeInTheDocument();
+  });
+
+  it("applies ds card classes", async () => {
+    const page = render(Component, { ...baseProps });
+    await expect.element(componentLocator(page)).toHaveClass("ds", "card");
+  });
+
+  it("renders children", async () => {
+    const page = render(Component, {
+      ...baseProps,
+      children: createRawSnippet(() => ({
+        render: () => `<span>Content</span>`,
+      })),
+    });
+    await expect.element(page.getByText("Content")).toBeInTheDocument();
+  });
+
+  describe("attributes", () => {
+    it.each([
+      ["id", "test-id"],
+      ["aria-label", "test-label"],
+    ])("applies %s", async (attribute, expected) => {
+      const page = render(Component, { ...baseProps, [attribute]: expected });
+      await expect
+        .element(componentLocator(page))
+        .toHaveAttribute(attribute, expected);
+    });
+
+    it("applies custom class", async () => {
+      const page = render(Component, { ...baseProps, class: "custom" });
+      await expect
+        .element(componentLocator(page))
+        .toHaveClass("ds", "card", "custom");
+    });
+  });
+});
+
+describe("Card.Header", () => {
+  it("renders with card-header class", async () => {
+    const page = render(Header, {
+      "data-testid": "header",
+      children: createRawSnippet(() => ({
+        render: () => `<span>Title</span>`,
+      })),
+    });
+    await expect
+      .element(page.getByTestId("header"))
+      .toHaveClass("ds", "card-header");
+  });
+});
+
+describe("Card.Content", () => {
+  it("renders with card-content class", async () => {
+    const page = render(Content, {
+      "data-testid": "content",
+      children: createRawSnippet(() => ({ render: () => `<span>Body</span>` })),
+    });
+    await expect
+      .element(page.getByTestId("content"))
+      .toHaveClass("ds", "card-content");
+  });
+});
+
+describe("Card.Footer", () => {
+  it("renders with card-footer class", async () => {
+    const page = render(Footer, {
+      "data-testid": "footer",
+      children: createRawSnippet(() => ({ render: () => `<span>Tag</span>` })),
+    });
+    await expect
+      .element(page.getByTestId("footer"))
+      .toHaveClass("ds", "card-footer");
+  });
+});
+
+describe("Card.Image", () => {
+  it("renders an img with card-image class", async () => {
+    const page = render(Image, {
+      "data-testid": "image",
+      src: "test.png",
+      alt: "test",
+    });
+    const img = page.getByTestId("image");
+    await expect.element(img).toHaveClass("ds", "card-image");
+    expect(img.element().tagName).toBe("IMG");
+  });
+});
+
+function componentLocator(page: RenderResult<typeof Component>): Locator {
+  return page.getByTestId("card");
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/Content.stories.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/Content.stories.svelte
@@ -1,0 +1,39 @@
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import { Content } from "./index.js";
+
+  const { Story } = defineMeta({
+    title: "Components/Card/Content",
+    component: Content,
+    tags: ["autodocs"],
+    argTypes: {
+      children: {
+        control: { disable: true },
+        description: "Content to display in the content area",
+      },
+      class: {
+        control: { type: "text" },
+        description: "Additional CSS classes",
+      },
+    },
+    parameters: {
+      controls: { include: ["children", "class"] },
+      docs: {
+        description: {
+          component:
+            "`Card.Content` is the main content area within a Card, providing the default slot for card content.",
+        },
+      },
+    },
+  });
+</script>
+
+<Story name="Default">
+  <h4>Card content</h4>
+  <p>This is the main content area of the card.</p>
+  <ul>
+    <li>First item</li>
+    <li>Second item</li>
+    <li>Third item</li>
+  </ul>
+</Story>

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/Content.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/Content.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { ContentProps } from "./types.js";
+  import "./styles.css";
+
+  const componentCssClassName = "ds card-content";
+
+  let { children, class: className, ...rest }: ContentProps = $props();
+</script>
+
+<div class={[componentCssClassName, className]} {...rest}>
+  {@render children()}
+</div>

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/index.ts
@@ -1,0 +1,2 @@
+export { default as Content } from "./Content.svelte";
+export type { ContentProps } from "./types.js";

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/styles.css
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/styles.css
@@ -1,0 +1,20 @@
+/**
+ * Card.Content styles
+ * @implements ds:global.subcomponent.card-content
+ */
+:root {
+  --card-content-gap: var(--dimension-100);
+  --card-content-padding-block-start: var(--dimension-100);
+  --card-content-padding-block-end: var(--dimension-200);
+  --card-content-padding-inline: var(--dimension-200);
+}
+
+.ds.card-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--card-content-gap);
+
+  padding-block-start: var(--card-content-padding-block-start);
+  padding-block-end: var(--card-content-padding-block-end);
+  padding-inline: var(--card-content-padding-inline);
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/types.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Content/types.ts
@@ -1,0 +1,12 @@
+import type { Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type BaseProps = SvelteHTMLElements["div"];
+
+/**
+ * Props for Card.Content
+ * @implements ds:global.subcomponent.card-content
+ */
+export interface ContentProps extends BaseProps {
+  children: Snippet;
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Footer/Footer.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Footer/Footer.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { FooterProps } from "./types.js";
+  import "./styles.css";
+
+  const componentCssClassName = "ds card-footer";
+
+  let { children, class: className, ...rest }: FooterProps = $props();
+</script>
+
+<div class={[componentCssClassName, className]} {...rest}>
+  {@render children()}
+</div>

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Footer/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Footer/index.ts
@@ -1,0 +1,2 @@
+export { default as Footer } from "./Footer.svelte";
+export type { FooterProps } from "./types.js";

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Footer/styles.css
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Footer/styles.css
@@ -1,0 +1,24 @@
+/**
+ * Card.Footer styles
+ * @implements ds:global.subcomponent.card-footer
+ */
+:root {
+  --card-footer-gap: var(--dimension-100);
+  --card-footer-padding-block: var(--dimension-200);
+  --card-footer-padding-inline: var(--dimension-200);
+}
+
+.ds.card-footer {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--card-footer-gap);
+
+  padding-block: var(--card-footer-padding-block);
+  padding-inline: var(--card-footer-padding-inline);
+
+  & > * {
+    flex: 0 0 auto;
+  }
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Footer/types.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Footer/types.ts
@@ -1,0 +1,13 @@
+import type { Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type BaseProps = SvelteHTMLElements["div"];
+
+/**
+ * Props for Card.Footer
+ * @implements ds:global.subcomponent.card-footer
+ */
+export interface FooterProps extends BaseProps {
+  /** Required child contents: tags and labels (e.g. chips), not CTAs or links. */
+  children: Snippet;
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/Header.stories.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/Header.stories.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import { Header } from "./index.js";
+
+  const { Story } = defineMeta({
+    title: "Components/Card/Header",
+    component: Header,
+    tags: ["autodocs"],
+    argTypes: {
+      children: {
+        control: { disable: true },
+        description: "Header content (required).",
+      },
+    },
+    parameters: {
+      docs: {
+        description: {
+          component:
+            "Card.Header provides a header section for cards. Implements `ds:global.subcomponent.card-header`.",
+        },
+      },
+    },
+  });
+</script>
+
+<!-- Default header with content. -->
+<Story name="Default" asChild>
+  <div class="ds card" style="max-width: 400px; border: 1px solid #e5e5e5;">
+    <Header>Card Header</Header>
+  </div>
+</Story>

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/Header.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/Header.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { HeaderProps } from "./types.js";
+  import "./styles.css";
+
+  const componentCssClassName = "ds card-header";
+
+  let { children, class: className, ...rest }: HeaderProps = $props();
+</script>
+
+<div class={[componentCssClassName, className]} {...rest}>
+  {@render children()}
+</div>

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/index.ts
@@ -1,0 +1,2 @@
+export { default as Header } from "./Header.svelte";
+export type { HeaderProps } from "./types.js";

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/styles.css
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/styles.css
@@ -1,0 +1,20 @@
+/**
+ * Card.Header styles
+ * @implements ds:global.subcomponent.card-header
+ */
+:root {
+  --card-header-gap: var(--dimension-200);
+  --card-header-padding-block: var(--dimension-200);
+  --card-header-padding-inline: var(--dimension-200);
+}
+
+.ds.card-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--card-header-gap);
+
+  padding-block: var(--card-header-padding-block);
+  padding-inline: var(--card-header-padding-inline);
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/types.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Header/types.ts
@@ -1,0 +1,12 @@
+import type { Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type BaseProps = SvelteHTMLElements["div"];
+
+/**
+ * Props for Card.Header
+ * @implements ds:global.subcomponent.card-header
+ */
+export interface HeaderProps extends BaseProps {
+  children: Snippet;
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/Image.stories.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/Image.stories.svelte
@@ -1,0 +1,46 @@
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import { Image } from "./index.js";
+
+  const { Story } = defineMeta({
+    title: "Components/Card/Image",
+    component: Image,
+    tags: ["autodocs"],
+    argTypes: {
+      src: {
+        control: { type: "text" },
+        description: "Image source URL",
+      },
+      alt: {
+        control: { type: "text" },
+        description: "Alternative text for the image",
+      },
+      class: {
+        control: { type: "text" },
+        description: "Additional CSS classes",
+      },
+      width: {
+        control: { type: "number" },
+        description: "Image width",
+      },
+      height: {
+        control: { type: "number" },
+        description: "Image height",
+      },
+    },
+    parameters: {
+      controls: { include: ["src", "alt", "class", "width", "height"] },
+      docs: {
+        description: {
+          component:
+            "`Card.Image` is used for images that span the width of the card.<br><br>Any valid HTML image attribute can be passed to `Card.Image`; the props shown below are the most commonly used, for your convenience.",
+        },
+      },
+    },
+  });
+</script>
+
+<Story
+  name="Default"
+  args={{ src: "https://assets.ubuntu.com/v1/5ce214a4-rpi.png" }}
+/>

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/Image.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/Image.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { ImageProps } from "./types.js";
+  import "./styles.css";
+
+  const componentCssClassName = "ds card-image";
+
+  let { class: className, ...rest }: ImageProps = $props();
+</script>
+
+<img class={[componentCssClassName, className]} {...rest} />

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/index.ts
@@ -1,0 +1,2 @@
+export { default as Image } from "./Image.svelte";
+export type { ImageProps } from "./types.js";

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/styles.css
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/styles.css
@@ -1,0 +1,5 @@
+.ds.card-image {
+  display: block;
+  height: auto;
+  width: 100%;
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/types.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/Image/types.ts
@@ -1,0 +1,5 @@
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type BaseProps = SvelteHTMLElements["img"];
+
+export interface ImageProps extends BaseProps {}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/common/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/common/index.ts
@@ -1,0 +1,4 @@
+export * from "./Content/index.js";
+export * from "./Footer/index.js";
+export * from "./Header/index.js";
+export * from "./Image/index.js";

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/index.ts
@@ -1,0 +1,22 @@
+import CardRoot from "./Card.svelte";
+import { Content, Footer, Header, Image } from "./common/index.js";
+
+const Card = CardRoot as typeof CardRoot & {
+  Content: typeof Content;
+  Footer: typeof Footer;
+  Header: typeof Header;
+  Image: typeof Image;
+};
+Card.Content = Content;
+Card.Footer = Footer;
+Card.Header = Header;
+Card.Image = Image;
+
+export type {
+  ContentProps,
+  FooterProps,
+  HeaderProps,
+  ImageProps,
+} from "./common/index.js";
+export type { CardProps } from "./types.js";
+export { Card };

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/styles.css
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/styles.css
@@ -1,0 +1,52 @@
+/**
+ * Card styles
+ * @implements ds:global.component.card
+ *
+ * A Card is a ROW SUBGRID spanning four fixed section tracks
+ * (image / header / content / footer), inheriting them from the parent grid.
+ * Inside a `Cards` group the shared tracks align sections across every card in
+ * the row. The card sets no background of its own (it is not a surface).
+ */
+:root {
+  --card-color-border: var(--color-border-muted);
+  --card-border-width: var(--dimension-stroke-thickness-medium);
+  --card-border-radius: var(--dimension-radius-medium);
+}
+
+.ds.card {
+  grid-column: span var(--card-span, 1);
+  grid-row: span 4;
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-template-columns: minmax(0, 1fr);
+
+  border: var(--card-border-width) solid var(--card-color-border);
+  border-radius: var(--card-border-radius);
+  overflow: hidden;
+}
+
+.ds.card > .card-image {
+  grid-row: 1;
+  grid-column: 1 / -1;
+}
+.ds.card > .card-header {
+  grid-row: 2;
+  grid-column: 1 / -1;
+}
+.ds.card > .card-content {
+  grid-row: 3;
+  grid-column: 1 / -1;
+}
+.ds.card > .card-footer {
+  grid-row: 4;
+  grid-column: 1 / -1;
+}
+
+.ds.card > :is(.card-content, .card-footer, .card-image):not(:last-child) {
+  border-block-end: var(--card-border-width) solid var(--card-color-border);
+}
+
+/* Collapse the header/content seam so title and body read as one region. */
+.ds.card > .card-header:has(+ .card-content) {
+  padding-block-end: 0;
+}

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/types.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/types.ts
@@ -1,0 +1,5 @@
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type BaseProps = SvelteHTMLElements["div"];
+
+export interface CardProps extends BaseProps {}

--- a/packages/svelte/ds-app-wpe/src/lib/components/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./Announcement/index.js";
+export * from "./Card/index.js";
 export * from "./Example/index.js";
 export * from "./KeyboardKey/index.js";
 export * from "./SkipLink/index.js";

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.ssr.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.ssr.test.ts
@@ -1,0 +1,60 @@
+import { render } from "@canonical/svelte-ssr-test";
+import type { ComponentProps } from "svelte";
+import { describe, expect, it } from "vitest";
+import Component from "./Cards.svelte";
+
+describe("Cards SSR", () => {
+  const baseProps = {} satisfies ComponentProps<typeof Component>;
+
+  it("doesn't throw", () => {
+    expect(() => {
+      render(Component, { props: { ...baseProps } });
+    }).not.toThrow();
+  });
+
+  it("renders as a div with ds cards subgrid classes", () => {
+    const page = render(Component, { props: { ...baseProps } });
+    const root = componentLocator(page);
+    expect(root).toBeInstanceOf(page.window.HTMLDivElement);
+    expect(root.classList).toContain("ds");
+    expect(root.classList).toContain("cards");
+    expect(root.classList).toContain("subgrid");
+  });
+
+  it("sets --card-span to 1 by default", () => {
+    const page = render(Component, { props: { ...baseProps } });
+    expect(componentLocator(page).style.getPropertyValue("--card-span")).toBe(
+      "1",
+    );
+  });
+
+  it("sets --card-span from cardSpan", () => {
+    const page = render(Component, { props: { cardSpan: 4 } });
+    expect(componentLocator(page).style.getPropertyValue("--card-span")).toBe(
+      "4",
+    );
+  });
+
+  it("clamps cardSpan to at least 1", () => {
+    const page = render(Component, { props: { cardSpan: 0 } });
+    expect(componentLocator(page).style.getPropertyValue("--card-span")).toBe(
+      "1",
+    );
+  });
+
+  describe("attributes", () => {
+    it.each([
+      ["id", "test-id"],
+      ["aria-label", "test-label"],
+    ])("applies %s", (attribute, expected) => {
+      const page = render(Component, {
+        props: { ...baseProps, [attribute]: expected },
+      });
+      expect(componentLocator(page).getAttribute(attribute)).toBe(expected);
+    });
+  });
+});
+
+function componentLocator(page: ReturnType<typeof render>): HTMLElement {
+  return page.container.querySelector(".ds.cards") as HTMLElement;
+}

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.stories.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.stories.svelte
@@ -1,0 +1,336 @@
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import { Card } from "../../components/Card/index.js";
+  import Component from "./Cards.svelte";
+
+  const { Story } = defineMeta({
+    title: "Groups/Cards",
+    component: Component,
+    tags: ["autodocs"],
+    parameters: {
+      grid: "responsive",
+      controls: { include: ["children", "cardSpan"] },
+      docs: {
+        description: {
+          component:
+            '`Cards` lays out a set of `Card`s on a shared grid so every card\'s sections (image, header, content, footer) line up across the row.\n\nIt **requires a top-level `.grid`** because it is a subgrid — it inherits the master columns and defines the shared section rows. The `grid` story param (`"responsive"` here → fixed 4/8/12 tracks) supplies it on both the canvas and the autodocs page; switch it to `"intrinsic"` / `"none"` from the toolbar.\n\n`cardSpan` sets how many master columns each card spans. The component default is `1` (packs the most cards per row); the stories here use `2`+ for legible demos. Sample content is drawn from the Canonical / Ubuntu 26.04 LTS universe.',
+        },
+      },
+    },
+    argTypes: {
+      cardSpan: { control: { type: "number", min: 1, step: 1 } },
+      children: { control: { disable: true } },
+    },
+    args: { cardSpan: 2 },
+  });
+
+  // ── Products ──────────────────────────────────────────────────────────────
+
+  const placeholderImageSrc =
+    "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='800'%20height='450'%3E%3Crect%20width='100%25'%20height='100%25'%20fill='%23d9d9d9'/%3E%3C/svg%3E";
+
+  interface CardFixture {
+    title: string;
+    href: string;
+    body: string;
+    count: number;
+  }
+
+  const canonicalFixtures: CardFixture[] = [
+    {
+      title: "Ubuntu 26.04 LTS",
+      href: "https://ubuntu.com/download",
+      body: "The next long-term support release, with ten years of security maintenance, a refreshed toolchain and the latest GNOME for desktop and server alike.",
+      count: 12,
+    },
+    {
+      title: "MAAS",
+      href: "https://maas.io",
+      body: "Self-service, remote installation of bare-metal servers — turn your data centre into a cloud.",
+      count: 3,
+    },
+    {
+      title: "Juju",
+      href: "https://juju.is",
+      body: "An open-source orchestration engine for software operators: deploy, configure, integrate and scale applications across any cloud or on-prem estate.",
+      count: 8,
+    },
+    {
+      title: "Landscape",
+      href: "https://ubuntu.com/landscape",
+      body: "Systems management for Ubuntu estates — patching, compliance and monitoring across physical, virtual and cloud instances at scale.",
+      count: 5,
+    },
+    {
+      title: "Ubuntu Core",
+      href: "https://ubuntu.com/core",
+      body: "A minimal, containerised Ubuntu for IoT and edge devices, with transactional over-the-air updates and secure boot.",
+      count: 2,
+    },
+    {
+      title: "Charmed Kubernetes",
+      href: "https://ubuntu.com/kubernetes",
+      body: "Conformant, multi-cloud Kubernetes with Canonical support and automated operations.",
+      count: 6,
+    },
+  ];
+
+  // ── MAAS machines ─────────────────────────────────────────────────────────
+
+  type MaasStatus =
+    | "Deployed"
+    | "Ready"
+    | "Allocated"
+    | "Deploying"
+    | "Commissioning"
+    | "Failed";
+
+  interface MaasFixture {
+    hostname: string;
+    status: MaasStatus;
+    os: string;
+    spec: string;
+    alerts: number;
+  }
+
+  const maasFixtures: MaasFixture[] = [
+    {
+      hostname: "able-mackerel",
+      status: "Deployed",
+      os: "Ubuntu 26.04 LTS",
+      spec: "32 cores · 128 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "brave-gecko",
+      status: "Ready",
+      os: "—",
+      spec: "16 cores · 64 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "calm-otter",
+      status: "Commissioning",
+      os: "ephemeral",
+      spec: "8 cores · 32 GB",
+      alerts: 1,
+    },
+    {
+      hostname: "deft-heron",
+      status: "Deployed",
+      os: "Ubuntu 26.04 LTS",
+      spec: "24 cores · 96 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "eager-lynx",
+      status: "Allocated",
+      os: "—",
+      spec: "12 cores · 48 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "fair-marmot",
+      status: "Deploying",
+      os: "Ubuntu 26.04 LTS",
+      spec: "48 cores · 256 GB",
+      alerts: 2,
+    },
+    {
+      hostname: "glad-puffin",
+      status: "Deployed",
+      os: "Ubuntu 26.04 LTS",
+      spec: "64 cores · 512 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "hardy-ibex",
+      status: "Failed",
+      os: "—",
+      spec: "commissioning error",
+      alerts: 5,
+    },
+    {
+      hostname: "ideal-quokka",
+      status: "Ready",
+      os: "—",
+      spec: "20 cores · 80 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "jolly-numbat",
+      status: "Deployed",
+      os: "Ubuntu 26.04 LTS",
+      spec: "16 cores · 64 GB",
+      alerts: 1,
+    },
+    {
+      hostname: "keen-raven",
+      status: "Commissioning",
+      os: "ephemeral",
+      spec: "8 cores · 32 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "lively-shrew",
+      status: "Allocated",
+      os: "—",
+      spec: "36 cores · 144 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "merry-teal",
+      status: "Deployed",
+      os: "Ubuntu 26.04 LTS",
+      spec: "40 cores · 192 GB",
+      alerts: 0,
+    },
+    {
+      hostname: "noble-vole",
+      status: "Deploying",
+      os: "Ubuntu 26.04 LTS",
+      spec: "28 cores · 112 GB",
+      alerts: 3,
+    },
+    {
+      hostname: "olive-wren",
+      status: "Deployed",
+      os: "Ubuntu 26.04 LTS",
+      spec: "32 cores · 128 GB",
+      alerts: 0,
+    },
+  ];
+</script>
+
+<!-- Default: cards spanning 2 columns. Despite different copy lengths, images,
+     headings and footers still line up on shared rows. -->
+<Story name="Default" args={{ cardSpan: 2 }}>
+  {#snippet template(args)}
+    <Component {...args}>
+      {#each canonicalFixtures.slice(0, 3) as f (f.title)}
+        <Card>
+          <Card.Image src={placeholderImageSrc} alt="" />
+          <Card.Content>
+            <h4><a href={f.href}>{f.title}</a></h4>
+            <p class="p">{f.body}</p>
+          </Card.Content>
+          <Card.Footer>
+            <span class="p">{f.count}</span>
+          </Card.Footer>
+        </Card>
+      {/each}
+    </Component>
+  {/snippet}
+</Story>
+
+<!-- `cardSpan={2}` — medium cards, more per row than the wide layout. -->
+<Story name="Span Two" args={{ cardSpan: 2 }}>
+  {#snippet template(args)}
+    <Component {...args}>
+      {#each canonicalFixtures.slice(0, 4) as f (f.title)}
+        <Card>
+          <Card.Image src={placeholderImageSrc} alt="" />
+          <Card.Content>
+            <h4><a href={f.href}>{f.title}</a></h4>
+            <p class="p">{f.body}</p>
+          </Card.Content>
+          <Card.Footer>
+            <span class="p">{f.count}</span>
+          </Card.Footer>
+        </Card>
+      {/each}
+    </Component>
+  {/snippet}
+</Story>
+
+<!-- `cardSpan={4}` — wide cards (3 per row on a 12-column grid). -->
+<Story name="Span Four" args={{ cardSpan: 4 }}>
+  {#snippet template(args)}
+    <Component {...args}>
+      {#each canonicalFixtures as f (f.title)}
+        <Card>
+          <Card.Image src={placeholderImageSrc} alt="" />
+          <Card.Content>
+            <h4><a href={f.href}>{f.title}</a></h4>
+            <p class="p">{f.body}</p>
+          </Card.Content>
+          <Card.Footer>
+            <span class="p">{f.count}</span>
+          </Card.Footer>
+        </Card>
+      {/each}
+    </Component>
+  {/snippet}
+</Story>
+
+<!-- ── Scale: 3 → 15 MAAS machines (one system) ───────────────────────────── -->
+
+<!-- Three machines — a small MAAS console view. -->
+<Story name="Three Machines" args={{ cardSpan: 4 }}>
+  {#snippet template(args)}
+    <Component {...args}>
+      {#each maasFixtures.slice(0, 3) as m (m.hostname)}
+        <Card>
+          <Card.Header>
+            <h5>{m.hostname}</h5>
+            <span class="p">{m.status}</span>
+          </Card.Header>
+          <Card.Content>
+            <p class="p">{m.os}<br />{m.spec}</p>
+          </Card.Content>
+          <Card.Footer>
+            <span class="p">{m.alerts}</span>
+          </Card.Footer>
+        </Card>
+      {/each}
+    </Component>
+  {/snippet}
+</Story>
+
+<!-- Six machines. -->
+<Story name="Six Machines" args={{ cardSpan: 4 }}>
+  {#snippet template(args)}
+    <Component {...args}>
+      {#each maasFixtures.slice(0, 6) as m (m.hostname)}
+        <Card>
+          <Card.Header>
+            <h5>{m.hostname}</h5>
+            <span class="p">{m.status}</span>
+          </Card.Header>
+          <Card.Content>
+            <p class="p">{m.os}<br />{m.spec}</p>
+          </Card.Content>
+          <Card.Footer>
+            <span class="p">{m.alerts}</span>
+          </Card.Footer>
+        </Card>
+      {/each}
+    </Component>
+  {/snippet}
+</Story>
+
+<!--
+  Fifteen MAAS machines — a full fleet listing. `cardSpan={2}` tiles them
+  densely while the shared rows keep every hostname, spec and status aligned
+  across the grid.
+-->
+<Story name="Fifteen Machines" args={{ cardSpan: 2 }}>
+  {#snippet template(args)}
+    <Component {...args}>
+      {#each maasFixtures as m (m.hostname)}
+        <Card>
+          <Card.Header>
+            <h5>{m.hostname}</h5>
+            <span class="p">{m.status}</span>
+          </Card.Header>
+          <Card.Content>
+            <p class="p">{m.os}<br />{m.spec}</p>
+          </Card.Content>
+          <Card.Footer>
+            <span class="p">{m.alerts}</span>
+          </Card.Footer>
+        </Card>
+      {/each}
+    </Component>
+  {/snippet}
+</Story>

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { CardsProps } from "./types.js";
+  import "./styles.css";
+
+  const componentCssClassName = "ds cards subgrid";
+
+  let {
+    cardSpan = 1,
+    class: className,
+    children,
+    ...rest
+  }: CardsProps = $props();
+
+  const span = $derived(Math.max(1, Math.floor(Number(cardSpan) || 1)));
+</script>
+
+<div
+  class={[componentCssClassName, className]}
+  style:--card-span={span}
+  {...rest}
+>
+  {@render children?.()}
+</div>
+
+<!-- @component
+The `Cards` component lays out a set of `Card`s on a shared grid so that each
+card's sections (image, header, content, footer) line up across the row.
+
+Requires a top-level `.grid` parent — `Cards` is a subgrid and inherits the
+master columns. Outside a grid it degrades to a plain block.
+
+`cardSpan` sets how many master columns each card spans (default: `1`).
+
+`import { Cards } from "@canonical/svelte-ds-app-wpe";`
+
+## Example Usage
+```svelte
+<div class="grid">
+  <Cards cardSpan={2}>
+    <Card>…</Card>
+    <Card>…</Card>
+  </Cards>
+</div>
+```
+
+@implements dso:global.group.cards
+-->

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.svelte.test.ts
@@ -1,0 +1,48 @@
+import type { Locator } from "@vitest/browser/context";
+import type { ComponentProps } from "svelte";
+import { describe, expect, it } from "vitest";
+import type { RenderResult } from "vitest-browser-svelte";
+import { render } from "vitest-browser-svelte";
+import Component from "./Cards.svelte";
+
+describe("Cards component", () => {
+  const baseProps = {
+    "data-testid": "cards",
+  } satisfies ComponentProps<typeof Component>;
+
+  it("renders with ds cards subgrid classes", async () => {
+    const page = render(Component, { ...baseProps });
+    await expect
+      .element(componentLocator(page))
+      .toHaveClass("ds", "cards", "subgrid");
+  });
+
+  it("sets --card-span to 1 by default", async () => {
+    const page = render(Component, { ...baseProps });
+    const el = componentLocator(page).element() as HTMLElement;
+    expect(el.style.getPropertyValue("--card-span")).toBe("1");
+  });
+
+  it("sets --card-span from cardSpan", async () => {
+    const page = render(Component, { ...baseProps, cardSpan: 4 });
+    const el = componentLocator(page).element() as HTMLElement;
+    expect(el.style.getPropertyValue("--card-span")).toBe("4");
+  });
+
+  it("clamps cardSpan to at least 1", async () => {
+    const page = render(Component, { ...baseProps, cardSpan: 0 });
+    const el = componentLocator(page).element() as HTMLElement;
+    expect(el.style.getPropertyValue("--card-span")).toBe("1");
+  });
+
+  it("applies custom class", async () => {
+    const page = render(Component, { ...baseProps, class: "custom" });
+    await expect
+      .element(componentLocator(page))
+      .toHaveClass("ds", "cards", "custom");
+  });
+});
+
+function componentLocator(page: RenderResult<typeof Component>): Locator {
+  return page.getByTestId("cards");
+}

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/index.ts
@@ -1,0 +1,2 @@
+export { default as Cards } from "./Cards.svelte";
+export type { CardsProps } from "./types.js";

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/styles.css
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/styles.css
@@ -1,0 +1,23 @@
+/**
+ * Cards styles
+ * @implements dso:global.group.cards
+ *
+ * A two-level subgrid: the parent `.grid` supplies columns; `Cards` inherits
+ * them and defines four shared section row tracks (image / header / content /
+ * footer). Each `Card` spans `--card-span` columns × 4 rows and row-subgrids,
+ * so sections snap to the shared tracks and line up across the row.
+ */
+.ds.cards {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+
+  grid-auto-flow: row;
+  grid-auto-rows: auto;
+
+  align-self: start;
+  align-content: start;
+
+  gap: var(--grid-row-gap, var(--grid-gutter))
+    var(--grid-column-gap, var(--grid-gutter));
+}

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/types.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/types.ts
@@ -1,0 +1,17 @@
+import type { Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+
+type BaseProps = SvelteHTMLElements["div"];
+
+export interface CardsProps extends BaseProps {
+  /** The `Card` elements to lay out. */
+  children?: Snippet;
+  /**
+   * How many master-grid columns each card spans (NOT a pixel width). Fed to the
+   * `--card-span` CSS custom property. Larger spans mean fewer, wider cards per
+   * row on the 4/8/12-column responsive grid — e.g. on a 12-column grid `1` = 12
+   * per row, `2` = 6, `4` = 3.
+   * @default 1
+   */
+  cardSpan?: number;
+}

--- a/packages/svelte/ds-app-wpe/src/lib/group/index.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/group/index.ts
@@ -1,1 +1,2 @@
+export * from "./Cards/index.js";
 export * from "./KeyboardKeys/index.js";


### PR DESCRIPTION
## Done

- Adds a `Card` component. This is a direct Svelte port of the existing [global React `Card`](https://github.com/canonical/pragma/tree/main/packages/react/ds-global/src/lib/component/Card). 
- Adds a `Cards` group. This is a direct Svelte port of the existing [global React `Cards`](https://github.com/canonical/pragma/tree/main/packages/react/ds-global/src/lib/group/Cards). 

## QA

- Open [stories](https://6a1f1b4ab915d9a04a321108-xljazikkev.chromatic.com/)
- Follow QA from:
    - https://github.com/canonical/pragma/pull/314
    - https://github.com/canonical/pragma/pull/736
    - https://github.com/canonical/pragma/pull/807
- Compare the docs / behavior against the [global card](https://ds-react-global.canonical.com/?path=/docs/components-card--docs) and verify they are in line

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

_Storybook stories added; render captured via Chromatic on this PR._