### PR TITLE
feat(cli): pragma setup detects already-present config (idempotent, state-aware)

### DIFF
--- a/packages/cli/pragma/src/capabilities/setup/operations/setupCompletions.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupCompletions.ts
@@ -10,6 +10,7 @@
  * `setup completions`").
  */
 
+import { existsSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import {
   deleteFile,
@@ -26,15 +27,39 @@ import {
   detectShell,
   type ShellId,
 } from "../shell.js";
+import type { CompletionsState } from "../types.js";
 
 /**
  * The detected completion install target: the shell, the absolute script path,
- * and the emitted script body — all `null` when no shell could be detected.
+ * the emitted script body — all `null` when no shell could be detected — and the
+ * prior on-disk {@link CompletionsState} (whether an up-to-date/stale script is
+ * already installed), read up front so the recap and a `--dry-run` are accurate
+ * and an identical rewrite is skipped.
  */
 export interface CompletionsDetection {
   readonly shell: ShellId | null;
   readonly path: string | null;
   readonly script: string | null;
+  readonly state: CompletionsState;
+}
+
+/**
+ * Classify the completion script already at `path` against the body we would
+ * write: `installed` when byte-identical (a re-run skips it), `stale` when a
+ * different script is present, `absent` when no file exists.
+ *
+ * @param path - The install path.
+ * @param script - The body a write would emit.
+ * @returns The prior {@link CompletionsState}.
+ * @note Impure — reads the install path.
+ */
+function classifyCompletions(path: string, script: string): CompletionsState {
+  if (!existsSync(path)) return "absent";
+  try {
+    return readFileSync(path, "utf8") === script ? "installed" : "stale";
+  } catch {
+    return "stale";
+  }
 }
 
 /**
@@ -52,7 +77,7 @@ export async function detectCompletions(
   cwd: string,
 ): Promise<CompletionsDetection> {
   const shell = detectShell();
-  if (!shell) return { shell: null, path: null, script: null };
+  if (!shell) return { shell: null, path: null, script: null, state: "absent" };
 
   const [{ capabilities }, { emitScripts }, { readConfig }] = await Promise.all(
     [
@@ -68,18 +93,16 @@ export async function detectCompletions(
         .filter(([, enabled]) => enabled === false)
         .map(([family]) => family)
     : undefined;
-  return {
-    shell,
-    path: completionScriptPath(shell),
-    script: emitScripts(capabilities, {
-      ...(completion?.minChars !== undefined
-        ? { minChars: completion.minChars }
-        : {}),
-      ...(disabledFamilies && disabledFamilies.length > 0
-        ? { disabledFamilies }
-        : {}),
-    })[shell],
-  };
+  const path = completionScriptPath(shell);
+  const script = emitScripts(capabilities, {
+    ...(completion?.minChars !== undefined
+      ? { minChars: completion.minChars }
+      : {}),
+    ...(disabledFamilies && disabledFamilies.length > 0
+      ? { disabledFamilies }
+      : {}),
+  })[shell];
+  return { shell, path, script, state: classifyCompletions(path, script) };
 }
 
 /**
@@ -88,6 +111,12 @@ export async function detectCompletions(
  * Built from re-runnable combinators (NOT a single-use `gen`): `execute`
  * interprets a generator's task TWICE — once for the confirm-gate preview and
  * once to perform it — so the composed task must survive a second drive.
+ *
+ * The prior `state` drives the MESSAGE only ("already up to date" / "Updating" /
+ * "Installing"), NOT whether the write happens: the (idempotent) write is always
+ * composed so it carries its `undo` — `--undo` reverses the SAME task and must
+ * find the reversible effect, and `execute` interprets the task twice. A
+ * byte-identical rewrite in the `installed` case is harmless.
  *
  * @param d - The detection gathered up front.
  * @returns A Task that writes the script (with an undo), or warns if no shell.
@@ -98,9 +127,13 @@ export function composeCompletions(d: CompletionsDetection): Task<void> {
       "Could not detect your shell — set $SHELL to zsh, bash, or fish.",
     );
   }
-  const { path, script, shell } = d;
+  const { path, script, shell, state } = d;
+  const opening =
+    state === "installed"
+      ? `${shell} completions already up to date at ${path}.`
+      : `${state === "stale" ? "Updating" : "Installing"} ${shell} completions to ${path}...`;
   return sequence_([
-    info(`Installing ${shell} completions to ${path}...`),
+    info(opening),
     mkdir(dirname(path), true),
     writeFile(path, script, { undo: deleteFile(path) }),
     info(activationHint(shell)),

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
@@ -30,18 +30,24 @@ import type {
 import { sequence_, type Task, when } from "@canonical/task";
 import type { PragmaRuntime } from "../../../kernel/runtime/types.js";
 import { guardMissingBinary } from "../../shared/assertExecOk.js";
-import type { ScopeSelection, SetupMode, SetupResult } from "../types.js";
+import type {
+  LspState,
+  ScopeSelection,
+  SetupMode,
+  SetupResult,
+} from "../types.js";
 import {
   type CompletionsDetection,
   composeCompletions,
   detectCompletions,
 } from "./setupCompletions.js";
-import { composeLsp } from "./setupLsp.js";
+import { composeLsp, detectLsp, type LspDetection } from "./setupLsp.js";
 import {
   composeMcp,
   detectMcp,
   type McpDetection,
   mcpConfigured,
+  mcpGroupState,
   mcpTargets,
   selectedGroups,
 } from "./setupMcp.js";
@@ -69,6 +75,7 @@ export interface SetupPlan {
 /** The union of every step's detection, gathered up front for the run-all. */
 interface SetupDetection {
   readonly completions: CompletionsDetection;
+  readonly lsp: LspDetection;
   readonly mcp: McpDetection;
   readonly skills: SkillsDetection;
 }
@@ -101,14 +108,14 @@ const selectChosenGroups = (
  * exec (no spawn) — and re-runnable (the guard is a `recover`, and `composeLsp`
  * is combinator-built), so it survives `execute`'s double interpretation.
  */
-const composeGuardedLsp = (rt: PragmaRuntime): Task<void> =>
+const composeGuardedLsp = (rt: PragmaRuntime, state: LspState): Task<void> =>
   guardMissingBinary(
     "bunx",
     {
       message:
         "Install Bun (https://bun.sh) to provide `bunx`, then run this again.",
     },
-    composeLsp(rt.cwd),
+    composeLsp(rt.cwd, state),
   );
 
 /** Build a generator's `meta` (no stamping — the version is just header text). */
@@ -133,7 +140,24 @@ const buildCustomizePrompt = (
   when,
 });
 
-/** The per-file MCP multiselect — one row per deduped {@link TargetGroup} file. */
+/** The suffix a group's prior state adds to its multiselect label. */
+const mcpStateSuffix = (d: McpDetection, path: string): string => {
+  switch (mcpGroupState(d, path)) {
+    case "configured":
+      return " — already configured";
+    case "drifted":
+      return " — needs update";
+    default:
+      return "";
+  }
+};
+
+/**
+ * The per-file MCP multiselect — one row per deduped {@link TargetGroup} file.
+ * A row's label carries its prior state, and an already-`configured` file is
+ * DEFAULT-DESELECTED (so a re-run does not re-offer to rewrite what is already
+ * current); `absent`/`drifted` files stay selected by default.
+ */
 const buildMcpTargetsPrompt = (
   d: McpDetection,
   when?: PromptDefinition["when"],
@@ -143,10 +167,12 @@ const buildMcpTargetsPrompt = (
   message: "Configure MCP for which files?",
   when,
   choices: d.groups.map((g) => ({
-    label: `${g.path} — ${g.harnessNames.join(", ")} [${g.scope}]`,
+    label: `${g.path} — ${g.harnessNames.join(", ")} [${g.scope}]${mcpStateSuffix(d, g.path)}`,
     value: g.path,
   })),
-  default: d.groups.map((g) => g.path),
+  default: d.groups
+    .filter((g) => mcpGroupState(d, g.path) !== "configured")
+    .map((g) => g.path),
 });
 
 // =============================================================================
@@ -158,12 +184,13 @@ async function gatherDetection(
   rt: PragmaRuntime,
   scope: ScopeSelection,
 ): Promise<SetupDetection> {
-  const [completions, mcp, skills] = await Promise.all([
+  const [completions, lsp, mcp, skills] = await Promise.all([
     detectCompletions(rt.cwd),
+    detectLsp(rt.cwd),
     detectMcp(rt, scope),
     detectSkills(rt),
   ]);
-  return { completions, mcp, skills };
+  return { completions, lsp, mcp, skills };
 }
 
 /**
@@ -264,7 +291,7 @@ function buildRunAllPlan(
           chosen.includes("completions"),
           composeCompletions(detected.completions),
         ),
-        when(chosen.includes("lsp"), composeGuardedLsp(rt)),
+        when(chosen.includes("lsp"), composeGuardedLsp(rt, detected.lsp.state)),
         when(
           chosen.includes("mcp"),
           composeMcp(detected.mcp, selectChosenGroups(detected.mcp, answers)),
@@ -323,17 +350,20 @@ export async function buildSetupPlan(
           shell: d.shell,
           path: d.path,
           installed: d.shell !== null,
+          state: d.state,
         }),
       };
     }
 
-    case "lsp":
+    case "lsp": {
+      const d = await detectLsp(rt.cwd);
       return {
         generator: buildSingleStep(rt, "pragma setup lsp", [], () =>
-          composeGuardedLsp(rt),
+          composeGuardedLsp(rt, d.state),
         ),
-        toResult: () => ({ kind: "lsp" }),
+        toResult: () => ({ kind: "lsp", state: d.state }),
       };
+    }
 
     case "mcp": {
       const d = await detectMcp(rt, scope);
@@ -353,7 +383,7 @@ export async function buildSetupPlan(
           return {
             kind: "mcp",
             configured: mcpConfigured(sel),
-            targets: mcpTargets(sel),
+            targets: mcpTargets(d, sel),
           };
         },
       };

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
@@ -1,10 +1,13 @@
 /**
  * `setup lsp` — ensure the Terrazzo LSP VS Code extension is installed.
  *
- * There is nothing to detect (the installer is a single idempotent `exec`), so
- * `detectLsp` is a trivial marker and `composeLsp` holds the sole mutation —
- * mocked under `--dry-run`, run for real otherwise. A successful run reports it
- * installed (up to date), not a fresh install.
+ * `detectLsp` probes for the extension FOR REAL up front — it runs
+ * `code --list-extensions` (via the `exec` seam, over `runTask`) and matches the
+ * `terrazzo` extension id — so a re-run of an already-installed extension is a
+ * true no-op and the recap says so, rather than always shelling out. When the
+ * `code` CLI is absent from PATH the state is `unknown` (we cannot enumerate,
+ * so the installer still runs). `composeLsp` holds the sole mutation, mocked
+ * under `--dry-run` and skipped when detection already found the extension.
  */
 
 import {
@@ -17,18 +20,51 @@ import {
   type Task,
 } from "@canonical/task";
 import { assertExecOk } from "../../shared/assertExecOk.js";
+import type { LspState } from "../types.js";
 
-/** LSP has no real detection — the install is one idempotent subprocess. */
+/** The VS Code CLI queried for the installed-extensions list. */
+const VSCODE_CLI = "code";
+
+/** The substring an installed Terrazzo extension id contains (publisher-agnostic). */
+const TERRAZZO_EXTENSION_MATCH = "terrazzo";
+
+/**
+ * The detected LSP state: whether the Terrazzo extension is already `installed`,
+ * `absent`, or `unknown` (the `code` CLI is not on PATH, so we cannot enumerate).
+ */
 export interface LspDetection {
   readonly available: true;
+  readonly state: LspState;
 }
 
 /**
- * "Detect" the LSP step. Always available — kept for symmetry with the other
- * steps' detect phase (so the run-all can gather every step uniformly).
+ * Probe VS Code for the Terrazzo extension. Runs `code --list-extensions` and
+ * matches the `terrazzo` id; an absent `code` CLI (spawn ENOENT) or a nonzero
+ * exit yields `unknown` (we fall through to running the installer).
+ *
+ * @param cwd - The directory the probe runs in.
+ * @returns The detected {@link LspState}.
+ * @note Impure — spawns `code --list-extensions`.
  */
-export function detectLsp(): LspDetection {
-  return { available: true };
+export async function detectLsp(cwd: string): Promise<LspDetection> {
+  const { runTask } = await import("@canonical/task/node");
+  let state: LspState = "unknown";
+  try {
+    const result = (await runTask(
+      exec(VSCODE_CLI, ["--list-extensions"], cwd),
+    )) as ExecResult;
+    if (result.exitCode === 0) {
+      const installed = result.stdout
+        .toLowerCase()
+        .includes(TERRAZZO_EXTENSION_MATCH);
+      state = installed ? "installed" : "absent";
+    }
+  } catch {
+    // `code` absent from PATH (ENOENT) or any spawn failure → we cannot tell;
+    // leave `unknown` so the installer still runs.
+    state = "unknown";
+  }
+  return { available: true, state };
 }
 
 /**
@@ -37,12 +73,20 @@ export function detectLsp(): LspDetection {
  * Built from re-runnable combinators (NOT a single-use `gen`) because `execute`
  * interprets the task twice (preview + perform). Under the dry-run preview the
  * `exec` is MOCKED to `exitCode 0`, so `assertExecOk` passes there; a real run's
- * nonzero exit still fails loudly.
+ * nonzero exit still fails loudly. When detection already found the extension
+ * `installed`, the install is SKIPPED — a re-run is a true no-op.
  *
  * @param cwd - The directory to run the installer in.
- * @returns A Task that execs the extension installer, failing loudly on nonzero.
+ * @param state - The prior state from {@link detectLsp} (defaults to `unknown`).
+ * @returns A Task that execs the installer (or reports already-installed).
  */
-export function composeLsp(cwd: string): Task<void> {
+export function composeLsp(
+  cwd: string,
+  state: LspState = "unknown",
+): Task<void> {
+  if (state === "installed") {
+    return info("Terrazzo LSP VS Code extension already installed — skipped.");
+  }
   return sequence_([
     info("Ensuring the Terrazzo LSP VS Code extension is installed..."),
     // The interpreter RESOLVES on a nonzero exit — a failed installer must fail

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
@@ -8,13 +8,30 @@
  * a distinct `(path, mcpKey)` so two harnesses sharing a file (VS Code + Cline)
  * each preserve the other; every group emits a band-prefixed `info()` manifest
  * line, so the recap and a `--dry-run` show which band each file belongs to.
+ *
+ * Detection ALSO reads each group's existing config (via `readMcpConfigFrom`,
+ * FOR REAL up front) and classifies every group as `absent` (no pragma entry
+ * yet), `configured` (the pragma entry already matches what we'd write), or
+ * `drifted` (a pragma entry exists but differs). The wizard shows that prior
+ * state in each row and DEFAULT-DESELECTS the already-`configured` files; the
+ * write itself stays idempotent (a re-merge of the identical entry is
+ * byte-for-byte), so a re-run is a no-op the recap reports as "unchanged" — the
+ * same state-awareness `setup skills` has always had.
  */
 
-import type { PlatformEnv, TargetGroup } from "@canonical/harnesses";
+import type {
+  McpServerConfig,
+  PlatformEnv,
+  TargetGroup,
+} from "@canonical/harnesses";
 import { info, sequence_, type Task, warn } from "@canonical/task";
 import { MCP_SERVER_NAME } from "../../../constants.js";
 import type { PragmaRuntime } from "../../../kernel/runtime/types.js";
-import type { ConfiguredTarget, ScopeSelection } from "../types.js";
+import type {
+  ConfiguredTarget,
+  McpTargetState,
+  ScopeSelection,
+} from "../types.js";
 
 /** The `writeMcpConfigTargets` builder, captured from the dynamic harness import. */
 type WriteMcpConfigTargets =
@@ -22,24 +39,96 @@ type WriteMcpConfigTargets =
 
 /**
  * The detected MCP state: the per-file target groups (already scoped to the
- * requested `--scope`), the project root, and the (dynamically imported)
- * target-based writer the pure `composeMcp` needs synchronously.
+ * requested `--scope`), a by-path map of each group's prior
+ * {@link McpTargetState} (read up front), the project root, and the
+ * (dynamically imported) target-based writer the pure `composeMcp` needs
+ * synchronously. Keeping `groups` a plain {@link TargetGroup}[] leaves every
+ * existing `.groups` consumer (path/harnessNames/scope) unchanged; the state
+ * rides alongside, keyed by the group's `path`.
  */
 export interface McpDetection {
   readonly groups: readonly TargetGroup[];
+  readonly stateByPath: ReadonlyMap<string, McpTargetState>;
   readonly cwd: string;
   readonly platform: PlatformEnv;
   readonly writeMcpConfigTargets: WriteMcpConfigTargets;
 }
 
 /**
- * Detect the AI harnesses present in the project (real reads, up front) and
- * resolve+dedup their config targets for the chosen scope.
+ * The pragma MCP server entry we register — the SINGLE source of truth both the
+ * classifier (does the existing entry match this?) and the writer (`composeMcp`)
+ * consume, so "already configured" means byte-for-byte what a write would emit.
+ *
+ * @param cwd - The project root recorded on the entry.
+ * @returns The pragma {@link McpServerConfig}.
+ */
+export function pragmaMcpEntry(cwd: string): McpServerConfig {
+  return { command: "pragma", args: ["mcp"], cwd };
+}
+
+/**
+ * Whether an existing MCP entry equals the pragma entry we would write, over the
+ * fields we control (`command`/`args`/`cwd`). A shallow structural compare — a
+ * harness that carries extra keys (e.g. `env`) still reads as `configured` as
+ * long as our three fields match, so we never churn a file we did not author.
+ */
+function entryMatches(
+  existing: McpServerConfig,
+  want: McpServerConfig,
+): boolean {
+  const sameArgs =
+    (existing.args ?? []).length === (want.args ?? []).length &&
+    (want.args ?? []).every((a, i) => existing.args?.[i] === a);
+  return (
+    existing.command === want.command && existing.cwd === want.cwd && sameArgs
+  );
+}
+
+/**
+ * Classify one target group against its on-disk config: `absent` when no pragma
+ * entry exists in ANY of the group's writes, `configured` when EVERY write
+ * already carries a matching pragma entry, `drifted` otherwise (present in at
+ * least one write but not matching everywhere). Reads each write's file for real
+ * via `readMcpConfigFrom`.
+ *
+ * @param group - The target group whose writes to inspect.
+ * @param want - The pragma entry a write would emit.
+ * @param readMcpConfigFrom - The harness reader (dynamically imported).
+ * @param runTask - The node Task interpreter.
+ * @returns The group's {@link McpTargetState}.
+ * @note Impure — reads each write's config file.
+ */
+async function classifyGroup(
+  group: TargetGroup,
+  want: McpServerConfig,
+  readMcpConfigFrom: typeof import("@canonical/harnesses").readMcpConfigFrom,
+  runTask: typeof import("@canonical/task/node").runTask,
+): Promise<McpTargetState> {
+  let present = 0;
+  let matching = 0;
+  for (const write of group.writes) {
+    const servers = await runTask(readMcpConfigFrom(write));
+    const existing = servers[MCP_SERVER_NAME];
+    if (existing === undefined) continue;
+    present += 1;
+    if (entryMatches(existing, want)) matching += 1;
+  }
+  if (present === 0) return "absent";
+  if (matching === group.writes.length) return "configured";
+  return "drifted";
+}
+
+/**
+ * Detect the AI harnesses present in the project (real reads, up front),
+ * resolve+dedup their config targets for the chosen scope, AND read each
+ * group's existing config to classify it `absent`/`configured`/`drifted` — so
+ * the wizard can show prior state and default-deselect already-`configured`
+ * files.
  *
  * @param rt - The per-invocation runtime.
  * @param scope - The resolved `--scope` selection.
- * @returns The scoped target groups + the writer used to compose config writes.
- * @note Impure — reads the filesystem via `detectHarnesses`.
+ * @returns The scoped target groups, their prior states, + the config writer.
+ * @note Impure — reads the filesystem via `detectHarnesses` + `readMcpConfigFrom`.
  */
 export async function detectMcp(
   rt: PragmaRuntime,
@@ -50,6 +139,7 @@ export async function detectMcp(
     {
       detectHarnesses,
       groupTargetsForScope,
+      readMcpConfigFrom,
       readPlatformEnv,
       writeMcpConfigTargets,
     },
@@ -61,7 +151,33 @@ export async function detectMcp(
   const platform = readPlatformEnv();
   const detected = await runTask(detectHarnesses(cwd, platform));
   const groups = groupTargetsForScope(detected, cwd, scope, platform);
-  return { groups, cwd, platform, writeMcpConfigTargets };
+
+  // Read each group's existing config (for real, up front) so the recap/preview
+  // and the default selection reflect true prior state — the same discipline
+  // `detectSkills` uses for its per-link create/skip/replace decision.
+  const want = pragmaMcpEntry(cwd);
+  const stateByPath = new Map<string, McpTargetState>();
+  await Promise.all(
+    groups.map(async (group) => {
+      const state = await classifyGroup(
+        group,
+        want,
+        readMcpConfigFrom,
+        runTask,
+      );
+      stateByPath.set(group.path, state);
+    }),
+  );
+
+  return { groups, stateByPath, cwd, platform, writeMcpConfigTargets };
+}
+
+/**
+ * The prior state of a group, defaulting to `absent` for an unknown path (so a
+ * caller never has to guard the map lookup).
+ */
+export function mcpGroupState(d: McpDetection, path: string): McpTargetState {
+  return d.stateByPath.get(path) ?? "absent";
 }
 
 /** The target groups the user selected (by path), or all when none recorded. */
@@ -74,8 +190,13 @@ export function selectedGroups(
 
 /**
  * Compose the per-target config writes for the SELECTED groups (pure —
- * re-runnable; builds ABSOLUTE config paths itself). Every distinct `(path,
- * mcpKey)` is written once; each group emits a band-prefixed manifest line.
+ * re-runnable; builds ABSOLUTE config paths itself). The prior
+ * {@link McpTargetState} drives the manifest MESSAGE (already-configured /
+ * updated / added) but NOT whether the write runs: the idempotent
+ * read-modify-write is always composed so it carries its `undo` and a re-run is
+ * byte-identical when already `configured`. The wizard already default-DESELECTS
+ * `configured` files (so they are usually not in `groups` at all); a `configured`
+ * file that IS selected is still rewritten idempotently.
  *
  * @param d - The detection gathered up front.
  * @param groups - The target groups the user chose (a subset of `d.groups`).
@@ -88,18 +209,26 @@ export function composeMcp(
   if (groups.length === 0) {
     return warn("No AI harnesses selected — nothing to configure.");
   }
-  const pragmaMcpConfig = { command: "pragma", args: ["mcp"], cwd: d.cwd };
+  const pragmaMcpConfig = pragmaMcpEntry(d.cwd);
   // Re-runnable combinators (NOT a single-use `gen`): `execute` interprets the
   // task twice (preview + perform). One combined write per file keeps a shared
   // file (VS Code + Cline) a single read-modify-write — dry-run safe.
   const tasks: Task<unknown>[] = [];
   for (const group of groups) {
+    const state = mcpGroupState(d, group.path);
+    const names = group.harnessNames.join(", ");
     tasks.push(
       d.writeMcpConfigTargets(group.writes, MCP_SERVER_NAME, pragmaMcpConfig),
     );
+    const verb =
+      state === "configured"
+        ? "already configured →"
+        : state === "drifted"
+          ? "updated →"
+          : "→";
     tasks.push(
       info(
-        `[${group.scope}] pragma MCP server → ${group.path} (${group.harnessNames.join(", ")})`,
+        `[${group.scope}] pragma MCP server ${verb} ${group.path} (${names})`,
       ),
     );
   }
@@ -115,11 +244,19 @@ export function mcpConfigured(groups: readonly TargetGroup[]): string[] {
   return [...names].sort();
 }
 
-/** The per-file {@link ConfiguredTarget}s for a selection (for the result). */
-export function mcpTargets(groups: readonly TargetGroup[]): ConfiguredTarget[] {
+/**
+ * The per-file {@link ConfiguredTarget}s for a selection (for the result), each
+ * carrying its prior {@link McpTargetState} so the recap distinguishes newly
+ * added, updated, and already-configured targets.
+ */
+export function mcpTargets(
+  d: McpDetection,
+  groups: readonly TargetGroup[],
+): ConfiguredTarget[] {
   return groups.map((group) => ({
     name: group.harnessNames.join(", "),
     band: group.scope,
     path: group.path,
+    state: mcpGroupState(d, group.path),
   }));
 }

--- a/packages/cli/pragma/src/capabilities/setup/setup.render.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.render.test.ts
@@ -12,7 +12,10 @@ import { describe, expect, it } from "vitest";
 import { setupFormatters } from "./setup.render.js";
 import type { SetupResult } from "./types.js";
 
-/** A two-band MCP result: a global (Windsurf) and a project (Cursor) target. */
+/**
+ * A two-band MCP result: a global (Windsurf) and a project (Cursor) target,
+ * both newly `absent`→added — the clean first-run recap (no state tally).
+ */
 const BOTH_BANDS: SetupResult = {
   kind: "mcp",
   configured: ["Cursor", "Windsurf"],
@@ -21,8 +24,14 @@ const BOTH_BANDS: SetupResult = {
       name: "Windsurf",
       band: "global",
       path: "/home/u/.codeium/windsurf/mcp_config.json",
+      state: "absent",
     },
-    { name: "Cursor", band: "project", path: "/proj/.cursor/mcp.json" },
+    {
+      name: "Cursor",
+      band: "project",
+      path: "/proj/.cursor/mcp.json",
+      state: "absent",
+    },
   ],
 };
 
@@ -50,11 +59,42 @@ describe("setup render — MCP recap banded by Global/Project", () => {
       kind: "mcp",
       configured: ["Cursor"],
       targets: [
-        { name: "Cursor", band: "project", path: "/p/.cursor/mcp.json" },
+        {
+          name: "Cursor",
+          band: "project",
+          path: "/p/.cursor/mcp.json",
+          state: "absent",
+        },
       ],
     };
     expect(setupFormatters.plain(projectOnly)).toBe(
       "Configured MCP — Project: Cursor.",
+    );
+  });
+
+  it("appends the state tally when a target was already present (re-run)", () => {
+    // A mix of already-configured + drifted + newly-added surfaces the
+    // idempotency breakdown, so a re-run reads as a no-op rather than a rewrite.
+    const rerun: SetupResult = {
+      kind: "mcp",
+      configured: ["Cursor", "Windsurf"],
+      targets: [
+        {
+          name: "Windsurf",
+          band: "global",
+          path: "/home/u/.codeium/windsurf/mcp_config.json",
+          state: "configured",
+        },
+        {
+          name: "Cursor",
+          band: "project",
+          path: "/proj/.cursor/mcp.json",
+          state: "drifted",
+        },
+      ],
+    };
+    expect(setupFormatters.plain(rerun)).toBe(
+      "Configured MCP — Global: Windsurf · Project: Cursor (0 added, 1 updated, 1 unchanged).",
     );
   });
 

--- a/packages/cli/pragma/src/capabilities/setup/setup.render.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.render.ts
@@ -24,6 +24,11 @@ function summarizeSkills(result: SetupSkillsResult): string {
  * before the project (per-repo) band — so the recap shows which files at which
  * level got the pragma server. The Global/Project labels match the doctor
  * report and the CLI's `--global`/`--local` grammar (see {@link BAND_LABELS}).
+ *
+ * A trailing state tally is appended ONLY when something was already present
+ * (an `updated` or `unchanged` target) — a clean first run (every target newly
+ * `added`) keeps the plain `Configured MCP — …` line, so the idempotency detail
+ * surfaces exactly when it is informative (a re-run made clear it was a no-op).
  */
 function summarizeMcpTargets(targets: readonly ConfiguredTarget[]): string {
   if (targets.length === 0) return "No harnesses configured.";
@@ -37,18 +42,36 @@ function summarizeMcpTargets(targets: readonly ConfiguredTarget[]): string {
   ]
     .filter((p) => p.length > 0)
     .join(" · ");
-  return `Configured MCP — ${parts}.`;
+  const updated = targets.filter((t) => t.state === "drifted").length;
+  const unchanged = targets.filter((t) => t.state === "configured").length;
+  if (updated === 0 && unchanged === 0) {
+    // Clean first run — every target newly added; keep the original recap line.
+    return `Configured MCP — ${parts}.`;
+  }
+  const added = targets.filter((t) => t.state === "absent").length;
+  return `Configured MCP — ${parts} (${added} added, ${updated} updated, ${unchanged} unchanged).`;
 }
 
 /** Render a setup result to a single human line (shared by plain/llm). */
 function renderSetupLine(data: SetupResult): string {
   switch (data.kind) {
-    case "completions":
-      return data.installed
-        ? `Installed ${data.shell} completions at ${data.path}.`
-        : "No shell detected — completions were not installed.";
+    case "completions": {
+      if (!data.installed) {
+        return "No shell detected — completions were not installed.";
+      }
+      switch (data.state) {
+        case "installed":
+          return `${data.shell} completions already up to date at ${data.path}.`;
+        case "stale":
+          return `Updated ${data.shell} completions at ${data.path}.`;
+        default:
+          return `Installed ${data.shell} completions at ${data.path}.`;
+      }
+    }
     case "lsp":
-      return "Terrazzo LSP extension is installed (up to date).";
+      return data.state === "installed"
+        ? "Terrazzo LSP extension already installed (up to date)."
+        : "Terrazzo LSP extension is installed (up to date).";
     case "mcp":
       return summarizeMcpTargets(data.targets);
     case "skills":

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -466,6 +466,152 @@ describe("setup lsp — missing-binary guard (bunx absent)", () => {
   });
 });
 
+describe("setup — idempotent detection of already-present config", () => {
+  // Isolate PATH so an ambient harness can't inject via a `process` signal.
+  let prevPath: string | undefined;
+  beforeEach(() => {
+    prevPath = process.env.PATH;
+    process.env.PATH = tmp("pragma-idem-path-");
+  });
+  afterEach(() => {
+    process.env.PATH = prevPath;
+  });
+
+  it("mcp: a second run detects the already-configured file (byte-identical rewrite)", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".cursor"), { recursive: true });
+    const configPath = join(cwd, ".cursor", "mcp.json");
+
+    // First run writes the pragma entry.
+    await executeVerb(verbOf("mcp"), {}, YES, bootRuntime(FLAGS, cwd));
+    const firstBody = readFileSync(configPath, "utf-8");
+
+    // Detection now classifies the group `configured`.
+    const { toResult } = await buildSetupPlan(
+      bootRuntime(FLAGS, cwd),
+      "mcp",
+      "both",
+    );
+    const result = toResult({});
+    expect(result.kind).toBe("mcp");
+    if (result.kind === "mcp") {
+      expect(result.targets.at(0)?.state).toBe("configured");
+    }
+
+    // The wizard default-DESELECTS a configured target (so a plain re-run offers
+    // it unchecked) — proven on the generated multiselect's default.
+    const { generator } = await buildSetupPlan(
+      bootRuntime(FLAGS, cwd),
+      "mcp",
+      "both",
+    );
+    const multiselect = generator.prompts.find((p) => p.name === "mcpTargets");
+    expect(multiselect?.default).toEqual([]); // the only file is configured
+    expect(
+      (multiselect?.choices ?? []).some((c) =>
+        typeof c === "object" && "label" in c
+          ? c.label.includes("already configured")
+          : false,
+      ),
+    ).toBe(true);
+
+    // A real second run is idempotent: the file stays byte-identical (the
+    // read-modify-write re-merges the SAME pragma entry).
+    await executeVerb(verbOf("mcp"), {}, YES, bootRuntime(FLAGS, cwd));
+    expect(readFileSync(configPath, "utf-8")).toBe(firstBody);
+  });
+
+  it("mcp: a drifted pragma entry (wrong cwd) reads as `drifted` and is updated", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".cursor"), { recursive: true });
+    const configPath = join(cwd, ".cursor", "mcp.json");
+    // Seed a stale pragma entry pointing at a different cwd.
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          mcpServers: {
+            pragma: { command: "pragma", args: ["mcp"], cwd: "/old" },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const { toResult, generator } = await buildSetupPlan(
+      bootRuntime(FLAGS, cwd),
+      "mcp",
+      "both",
+    );
+    const result = toResult({});
+    if (result.kind === "mcp") {
+      expect(result.targets.at(0)?.state).toBe("drifted");
+    }
+    // A drifted target stays SELECTED by default (it needs the update).
+    const multiselect = generator.prompts.find((p) => p.name === "mcpTargets");
+    expect(multiselect?.default).toEqual([configPath]);
+
+    await executeVerb(verbOf("mcp"), {}, YES, bootRuntime(FLAGS, cwd));
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(config.mcpServers.pragma.cwd).toBe(cwd); // updated to the real cwd
+  });
+
+  it("completions: a second run detects the up-to-date script (state=installed)", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    const path = completionScriptPath("zsh");
+    // First install.
+    await executeVerb(completionsVerb, {}, YES, bootRuntime(FLAGS, cwd));
+    const firstBody = readFileSync(path, "utf-8");
+
+    // Detection now classifies the installed script `installed`.
+    const { toResult } = await buildSetupPlan(
+      bootRuntime(FLAGS, cwd),
+      "completions",
+      "both",
+    );
+    const result = toResult({});
+    if (result.kind === "completions") {
+      expect(result.state).toBe("installed");
+    }
+
+    // A real second run is idempotent — the byte-identical script survives.
+    await executeVerb(completionsVerb, {}, YES, bootRuntime(FLAGS, cwd));
+    expect(readFileSync(path, "utf-8")).toBe(firstBody);
+  });
+
+  it("completions: a stale script (different body) reads as `stale`", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    const path = completionScriptPath("zsh");
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, "# stale hand-edited completion\n");
+    const { toResult } = await buildSetupPlan(
+      bootRuntime(FLAGS, cwd),
+      "completions",
+      "both",
+    );
+    const result = toResult({});
+    if (result.kind === "completions") {
+      expect(result.state).toBe("stale");
+    }
+  });
+
+  it("lsp: reports `unknown` when the `code` CLI is absent from PATH", async () => {
+    // PATH is the isolated empty dir (beforeEach), so `code` is unresolvable:
+    // detection cannot enumerate and reports `unknown` (installer still runs).
+    const { toResult } = await buildSetupPlan(
+      bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
+      "lsp",
+      "both",
+    );
+    const result = toResult({});
+    expect(result.kind).toBe("lsp");
+    if (result.kind === "lsp") {
+      expect(result.state).toBe("unknown");
+    }
+  });
+});
+
 describe("setup (run-all wizard)", () => {
   it("--dry-run previews every DETECTED step (completions + lsp + mcp), writing nothing", async () => {
     const cwd = tmp("pragma-setup-proj-");

--- a/packages/cli/pragma/src/capabilities/setup/types.ts
+++ b/packages/cli/pragma/src/capabilities/setup/types.ts
@@ -27,14 +27,41 @@ export type ScopeBand = "project" | "global";
 export type ScopeSelection = "project" | "global" | "both";
 
 /**
+ * The prior state of an MCP target file, read up front by `detectMcp`:
+ * `absent` (no pragma entry yet), `configured` (a matching pragma entry already
+ * present in every write — a re-run skips it), or `drifted` (a pragma entry
+ * exists but differs, so a write updates it). Mirrors the skills step's
+ * created/skipped/replaced idempotency at the file grain.
+ */
+export type McpTargetState = "absent" | "configured" | "drifted";
+
+/**
  * One configured MCP target in a result: the file that was written, which band
- * it belongs to, and the harness name(s) that share it.
+ * it belongs to, the harness name(s) that share it, and its prior
+ * {@link McpTargetState} (so the recap can report new vs updated vs unchanged).
  */
 export interface ConfiguredTarget {
   readonly name: string;
   readonly band: ScopeBand;
   readonly path: string;
+  readonly state: McpTargetState;
 }
+
+/**
+ * The prior on-disk state of the shell-completion script, read up front by
+ * `detectCompletions`: `absent` (no script), `installed` (a byte-identical
+ * script is already present — a re-run skips it), or `stale` (a different
+ * script is present, so a write updates it).
+ */
+export type CompletionsState = "absent" | "installed" | "stale";
+
+/**
+ * The detected state of the Terrazzo LSP VS Code extension, probed up front by
+ * `detectLsp`: `installed` (already present — a re-run skips it), `absent` (not
+ * present, so the installer runs), or `unknown` (the `code` CLI is not on PATH,
+ * so we cannot enumerate and the installer runs regardless).
+ */
+export type LspState = "installed" | "absent" | "unknown";
 
 /** One symlink create/skip/replace action performed during skill setup. */
 export interface SymlinkAction {
@@ -60,8 +87,9 @@ export type SetupResult =
       readonly shell: ShellId | null;
       readonly path: string | null;
       readonly installed: boolean;
+      readonly state: CompletionsState;
     }
-  | { readonly kind: "lsp" }
+  | { readonly kind: "lsp"; readonly state: LspState }
   | {
       readonly kind: "mcp";
       readonly configured: readonly string[];


### PR DESCRIPTION
## What

`pragma setup` previously offered and (re)wrote **every** target on every run, regardless of whether the pragma MCP server / completion script / LSP extension was already configured. Only the `skills` step read prior state. This brings the other three steps up to the same state-awareness — the thing that motivated it: *setup should detect what's already present.*

## Per-step changes

| Step | Before | After |
|------|--------|-------|
| **mcp** | detected which harnesses exist, never read their config | reads each target's config via harness `readMcpConfigFrom` → classifies **absent / configured / drifted** (`McpTargetState`); wizard shows state per row and **default-deselects** already-configured files; recap tallies added/updated/unchanged |
| **completions** | always "Installing…", always rewrote | reads the installed script → **installed (byte-identical) / stale / absent** (`CompletionsState`); message reflects up-to-date vs updating vs installing |
| **lsp** | no detection; always shelled out | probes `code --list-extensions` for the terrazzo extension → **installed / absent / unknown** (`LspState`); installer still runs when `unknown` (no `code` CLI on PATH) |

## Design note (undo-safety)

State drives the **message** and the **default selection**, *not* whether the write runs. The idempotent write is always composed so it keeps its `undo` — `--undo` reverses the same task and must find the reversible effect, and a re-run stays byte-identical. (`MutationRuntime` only signals `preview`/dry-run, not undo, so compose can't branch on undo mode.)

`pragmaMcpEntry(cwd)` is the single source of truth both the classifier ("does the existing entry match?") and the writer consume.

## Tests

- 6 new idempotency cases: configured/drifted re-runs, default-deselect of configured targets, stale-script detection, lsp-`unknown` when `code` absent.
- Render goldens updated for the new state tally.
- Full setup suite (35) + package `check` (biome / tsc / webarchitect) green.

The `.at()`, `constants`-style entry, verb-first names, and `@note` on impure functions follow the repo cs: standards.