### PR TITLE
feat(cli): add the `concept` noun (list/lookup/sample over ds:Concept)

### DIFF
--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -121,6 +121,85 @@ pragma colophon  # the toolchain + active domain story
 pragma colophon --format llm  # condensed Markdown for agents
 ```
 
+## concept
+
+### pragma concept list
+
+List design-system concepts (standalone documentation).
+
+List design-system concepts — standalone documentation not bound to a single component (foundations, disambiguations, decision guides). Use when browsing cross-cutting design guidance. Example: concept_list {}.
+
+```
+pragma concept list [options]
+```
+
+**Flags**
+
+| Flag | Value | Description |
+| --- | --- | --- |
+| `--search` | `<string>` | Search in name, summary, type. |
+
+- Store: reads the local store (`pragma sources update` builds it).
+- MCP: exposed as the `concept_list` tool.
+
+**Examples**
+
+```bash
+pragma concept list
+pragma concept list --format llm
+```
+
+### pragma concept lookup
+
+Look up concept details by name, IRI, or glob.
+
+Get the full documentation body of one or more concepts by name — the Markdown content, summary, type, and tier. Use when you need the actual guidance a concept documents. Example: concept_lookup { names: ["Foundations: Grid"] }.
+
+```
+pragma concept lookup <name...>
+```
+
+**Arguments**
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<name...>` | yes | Concept names, prefixed names/IRIs, or glob patterns. |
+
+- Store: reads the local store (`pragma sources update` builds it).
+- MCP: exposed as the `concept_lookup` tool.
+
+**Examples**
+
+```bash
+pragma concept lookup <name>
+```
+
+### pragma concept sample
+
+Return randomly selected complete concept entries as exemplars.
+
+Return randomly selected complete concepts (with their Markdown body) as exemplars. Use BEFORE writing queries to see actual data shapes.
+
+```
+pragma concept sample [count]
+```
+
+**Arguments**
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[count]` | no | Number of samples (1–5, default 2). |
+
+- Store: reads the local store (`pragma sources update` builds it).
+- MCP: exposed as the `concept_sample` tool.
+
+**Examples**
+
+```bash
+pragma concept sample
+pragma concept sample 3
+```
+
 ## config
 
 ### pragma config set

--- a/packages/cli/pragma/docs/reference/index.md
+++ b/packages/cli/pragma/docs/reference/index.md
@@ -4,9 +4,9 @@ Machine-generated reference for the `pragma` CLI and MCP server, projected from 
 
 ## At a glance
 
-- **18** command nouns
-- **42** CLI commands
-- **38** MCP tools
+- **19** command nouns
+- **45** CLI commands
+- **41** MCP tools
 - **1** resource template(s)
 
 ## Pages

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -59,6 +59,42 @@ Read-only.
 
 _No input parameters._
 
+### concept_list
+
+List design-system concepts — standalone documentation not bound to a single component (foundations, disambiguations, decision guides). Use when browsing cross-cutting design guidance. Example: concept_list {}.
+
+Read-only.
+
+**Input**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `search` | string | no | Search in name, summary, type. |
+
+### concept_lookup
+
+Get the full documentation body of one or more concepts by name — the Markdown content, summary, type, and tier. Use when you need the actual guidance a concept documents. Example: concept_lookup { names: ["Foundations: Grid"] }.
+
+Read-only.
+
+**Input**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string[] | yes | Concept names, prefixed names/IRIs, or glob patterns. |
+
+### concept_sample
+
+Return randomly selected complete concepts (with their Markdown body) as exemplars. Use BEFORE writing queries to see actual data shapes.
+
+Read-only.
+
+**Input**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `count` | string | no | Number of samples (1–5, default 2). |
+
 ### config_set
 
 Write a global config field by name — the one-command form of the per-field setters. `key` is one of `tier`, `channel`, or `detail`; the field's own reset rules apply (e.g. `set tier none` clears it). Written to the global layer only — project configs are authored by hand.

--- a/packages/cli/pragma/src/capabilities/capabilities/hints.ts
+++ b/packages/cli/pragma/src/capabilities/capabilities/hints.ts
@@ -60,6 +60,21 @@ export const TOOL_HINTS: Record<string, ToolHint> = {
     use_when:
       "Understanding how pragma and the active domain are built — the toolchain + design-system colophon, for onboarding or a demo",
   },
+  concept_list: {
+    category: "read",
+    use_when:
+      "Browsing standalone design-system documentation (foundations, disambiguations, decision guides) not bound to a single component",
+  },
+  concept_lookup: {
+    category: "read",
+    use_when:
+      "Need the full Markdown documentation body of specific concepts by name — the actual cross-cutting guidance",
+  },
+  concept_sample: {
+    category: "read",
+    use_when:
+      "See actual concept data shapes (with their Markdown body) before querying — returns random instances each call",
+  },
   config_show: {
     category: "read",
     use_when: "Checking active tier and channel before querying",

--- a/packages/cli/pragma/src/capabilities/concept/concept.test.ts
+++ b/packages/cli/pragma/src/capabilities/concept/concept.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The bundled `concept` pack — list + lookup over `ds:Concept` (standalone
+ * documentation), exercised against a real fixture graph through the MCP
+ * projection (the same path the CLI dispatches).
+ *
+ * Proves the SPARQL list surfaces name/type/tier, the SPARQL lookup renders the
+ * Markdown `ds:content` body as a code section plus summary/type/tier, and an
+ * unknown name errors with the entity-not-found recovery.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  bootFixtureRuntime,
+  type FixtureGraph,
+} from "../../testing/helpers/fixtureGraph.js";
+import type { McpHarness } from "../../testing/helpers/projectMcp.js";
+import { projectMcp } from "../../testing/helpers/projectMcp.js";
+import { capabilities } from "../index.js";
+
+/** A minimal graph: two concepts (one with a content body), a type, a tier. */
+const CONCEPT_TTL = `
+@prefix ds: <https://ds.canonical.com/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ds:Concept a rdfs:Class .
+ds:ConceptType a rdfs:Class .
+ds:Tier a rdfs:Class .
+
+ds:global a ds:Tier ; ds:name "global" .
+ds:concepttype.Explanation a ds:ConceptType ; ds:name "Explanation" .
+
+ds:concept.Foundations-Grid a ds:Concept ;
+    ds:name "Foundations: Grid" ;
+    ds:summary "The shared column system and per-tier grid rules." ;
+    ds:content "## Grid\\n\\nColumn counts are 4, 8, or 16 only." ;
+    ds:conceptType ds:concepttype.Explanation ;
+    ds:tier ds:global .
+
+ds:concept.Intentional-friction a ds:Concept ;
+    ds:name "Intentional friction" ;
+    ds:tier ds:global .
+`;
+
+let fixture: FixtureGraph;
+let mcp: McpHarness;
+
+beforeAll(async () => {
+  fixture = await bootFixtureRuntime({ ttl: CONCEPT_TTL });
+  mcp = await projectMcp(capabilities, fixture.cwd);
+});
+
+afterAll(async () => {
+  await mcp.cleanup();
+  await fixture.dispose();
+});
+
+describe("concept_list", () => {
+  it("lists every concept with its name, type, and tier", async () => {
+    const result = await mcp.callTool("concept_list", {});
+    expect(result.ok).toBe(true);
+    const rows = result.data as {
+      name: string;
+      type?: string;
+      tier?: string;
+    }[];
+    const names = rows.map((r) => r.name);
+    expect(names).toContain("Foundations: Grid");
+    expect(names).toContain("Intentional friction");
+    const grid = rows.find((r) => r.name === "Foundations: Grid");
+    expect(grid?.type).toBe("Explanation");
+    expect(grid?.tier).toBe("global");
+  });
+});
+
+describe("concept_lookup", () => {
+  it("returns the full Markdown content body plus summary/type/tier", async () => {
+    const result = await mcp.callTool("concept_lookup", {
+      name: ["Foundations: Grid"],
+    });
+    expect(result.ok).toBe(true);
+    const data = JSON.stringify(result.data);
+    expect(data).toContain("Column counts are 4, 8, or 16 only.");
+    expect(data).toContain("The shared column system");
+    expect(data).toContain("Explanation");
+  });
+
+  // The unknown-name miss (ENTITY_NOT_FOUND) is covered uniformly for every
+  // lookup noun by the parameterized errorMatrix.mcp.test.ts — a colon-bearing
+  // name is the concept-specific wrinkle, guarded above.
+});

--- a/packages/cli/pragma/src/capabilities/concept/index.ts
+++ b/packages/cli/pragma/src/capabilities/concept/index.ts
@@ -1,0 +1,15 @@
+/**
+ * The `concept` capability module — the bundled pack (SPARQL list, SPARQL
+ * lookup with a Markdown content section) compiled to verbs.
+ */
+
+import { compilePack } from "../../kernel/packs/compile.js";
+import { DEFAULT_PREFIX_MAP } from "../../kernel/render/prefixes.js";
+import type { CapabilityModule } from "../../kernel/spec/types.js";
+import { conceptPack } from "./pack.js";
+
+/** The `concept` capability module (`list`, `lookup`, `sample`). */
+export const conceptModule: CapabilityModule = {
+  name: "concept",
+  verbs: compilePack(conceptPack, "bundled:concept", DEFAULT_PREFIX_MAP),
+};

--- a/packages/cli/pragma/src/capabilities/concept/pack.ts
+++ b/packages/cli/pragma/src/capabilities/concept/pack.ts
@@ -1,0 +1,80 @@
+/**
+ * The bundled `concept` pack — standalone design-system documentation as data.
+ *
+ * A `ds:Concept` is documentation NOT bound to a single UIBlock: cross-cutting
+ * guides, disambiguations, foundations, decisions (e.g. "Foundations: Grid",
+ * "How to differentiate components"). `concept list` is a SPARQL SELECT over
+ * `ds:Concept`; `concept lookup` renders the long-form Markdown `ds:content`
+ * body as a fenced code section, alongside the summary, type, and tier.
+ */
+
+import type { PackDefinition } from "../../kernel/packs/types.js";
+
+export const conceptPack: PackDefinition = {
+  noun: "concept",
+  description: "List design-system concepts (standalone documentation).",
+  toolDescription:
+    "List design-system concepts — standalone documentation not bound to a single component (foundations, disambiguations, decision guides). Use when browsing cross-cutting design guidance. Example: concept_list {}.",
+  list: {
+    query: [
+      "SELECT ?uri ?name ?type ?tier ?summary",
+      "WHERE {",
+      "  ?uri a ds:Concept ;",
+      "       ds:name ?name .",
+      "  OPTIONAL { ?uri ds:conceptType ?typeUri . ?typeUri ds:name ?type }",
+      "  OPTIONAL { ?uri ds:tier ?tierUri . ?tierUri ds:name ?tier }",
+      "  OPTIONAL { ?uri ds:summary ?summary }",
+      "}",
+      "ORDER BY ?name",
+    ].join("\n"),
+    columns: [
+      { field: "uri", label: "IRI" },
+      { field: "name", label: "Name" },
+      { field: "type", label: "Type" },
+      { field: "tier", label: "Tier" },
+    ],
+    search: {
+      variables: ["name", "summary", "type"],
+    },
+    emptyRecovery: {
+      message:
+        "No concepts in the store. Build it from the configured design-system packages.",
+      cli: "pragma sources update",
+    },
+  },
+  lookup: {
+    source: "sparql",
+    by: "ds:name",
+    type: "ds:Concept",
+    toolDescription:
+      'Get the full documentation body of one or more concepts by name — the Markdown content, summary, type, and tier. Use when you need the actual guidance a concept documents. Example: concept_lookup { name: ["Foundations: Grid"] }.',
+    fields: [
+      { name: "type", property: "ds:conceptType", label: "Type" },
+      { name: "tier", property: "ds:tier", label: "Tier" },
+    ],
+    sections: [
+      {
+        name: "summary",
+        property: "ds:summary",
+        label: "Summary",
+        kind: "field",
+      },
+      {
+        name: "content",
+        property: "ds:content",
+        label: "Content",
+        kind: "code",
+      },
+      {
+        name: "knownEdgeCases",
+        property: "ds:knownEdgeCases",
+        label: "Known edge cases",
+        kind: "field",
+      },
+    ],
+    sample: {
+      toolDescription:
+        "Return randomly selected complete concepts (with their Markdown body) as exemplars. Use BEFORE writing queries to see actual data shapes.",
+    },
+  },
+};

--- a/packages/cli/pragma/src/capabilities/index.ts
+++ b/packages/cli/pragma/src/capabilities/index.ts
@@ -13,6 +13,7 @@ import type { CapabilityModule } from "../kernel/spec/types.js";
 import { blockModule } from "./block/index.js";
 import { capabilitiesModule } from "./capabilities/index.js";
 import { colophonModule } from "./colophon/index.js";
+import { conceptModule } from "./concept/index.js";
 import { configModule } from "./config/index.js";
 import { createModule } from "./create/index.js";
 import { doctorModule } from "./doctor/index.js";
@@ -41,6 +42,7 @@ export const capabilities: readonly CapabilityModule[] = [
   modifierModule,
   tokenModule,
   blockModule,
+  conceptModule,
   ontologyModule,
   skillModule,
   graphModule,

--- a/packages/cli/pragma/src/capabilities/surface.test.ts
+++ b/packages/cli/pragma/src/capabilities/surface.test.ts
@@ -209,14 +209,14 @@ describe("surface COMPLETE — emitted == covenant (PROTECTED)", () => {
   // The CLOSING direction: assertConforms already proves emitted ⊆ covenant;
   // this proves covenant ⊆ emitted, so together the tool sets are EQUAL — the
   // surface-complete milestone. After PR7, every covenant tool is realized.
-  it("emits every covenant tool (all 38) — set equality with the covenant", () => {
+  it("emits every covenant tool (all 41) — set equality with the covenant", () => {
     const emittedTools = new Set(emitted.mcpSurface.tools);
     const missing = golden.mcpSurface.tools.filter((t) => !emittedTools.has(t));
     expect(missing).toEqual([]);
     expect([...emitted.mcpSurface.tools].sort()).toEqual(
       [...golden.mcpSurface.tools].sort(),
     );
-    expect(emitted.mcpSurface.tools).toHaveLength(38);
+    expect(emitted.mcpSurface.tools).toHaveLength(41);
   });
 
   // The covenant edit: the non-tool MCP surface is frozen too.

--- a/packages/cli/pragma/src/kernel/completion/complete.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/complete.test.ts
@@ -16,6 +16,7 @@ describe("runComplete — the __complete pipeline", () => {
   it("resolves against the live capabilities (storeless static matches)", async () => {
     await expect(runComplete(["co"], capabilities)).resolves.toEqual([
       "colophon",
+      "concept",
       "config",
     ]);
     // The live `config` sub-verbs, prefix-filtered and sorted by the resolver.
@@ -38,6 +39,7 @@ describe("runComplete — the __complete pipeline", () => {
   it("strips a leading bin name", async () => {
     await expect(runComplete(["pragma", "co"], capabilities)).resolves.toEqual([
       "colophon",
+      "concept",
       "config",
     ]);
   });
@@ -93,7 +95,7 @@ describe("runComplete — never-throw guard (PROTECTED)", () => {
     await runComplete(["co"], capabilities);
     const lines = write.mock.calls.map((call) => String(call[0]));
     expect(lines.join("")).toMatch(
-      /\[complete\] context=noun partial="co" candidates=2 in \d+(\.\d+)?ms/,
+      /\[complete\] context=noun partial="co" candidates=3 in \d+(\.\d+)?ms/,
     );
   });
 });

--- a/packages/cli/pragma/src/kernel/completion/safety.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/safety.test.ts
@@ -346,7 +346,7 @@ describe("storeless guarantee (PROTECTED)", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe("colophon\nconfig\n");
+    expect(result.stdout).toBe("colophon\nconcept\nconfig\n");
     expect(result.stderr).toBe("");
     // Storeless and config-free: no first-run marker, no config cache, no
     // store artifacts — the fast path must leave the environment untouched.

--- a/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
+++ b/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
@@ -212,12 +212,21 @@ function buildEntityQuery(
   return buildLookupByIriQuery(lookup, resolved, level);
 }
 
+/**
+ * A CURIE-shaped `prefix:local` head: an NCName-like prefix followed by `:` and
+ * a non-space local part. Deliberately strict so a plain entity NAME that merely
+ * contains a colon (e.g. a concept titled "Foundations: Grid", where the colon
+ * is followed by a space) is NOT mistaken for a prefixed IRI and is looked up by
+ * name. A real prefixed name (`ds:global.component.button`) still matches.
+ */
+const PREFIXED_NAME_PATTERN = /^[A-Za-z][\w.-]*:[^\s:][^\s]*$/;
+
 /** Whether a lookup query addresses an entity by IRI or prefixed name. */
 function looksLikeIri(query: string): boolean {
   return (
     query.startsWith("http://") ||
     query.startsWith("https://") ||
-    query.includes(":")
+    PREFIXED_NAME_PATTERN.test(query)
   );
 }
 

--- a/packages/cli/pragma/src/kernel/spec/surfaceConformance.test.ts
+++ b/packages/cli/pragma/src/kernel/spec/surfaceConformance.test.ts
@@ -84,8 +84,8 @@ describe("surface conformance (PROTECTED)", () => {
     );
   });
 
-  it("freezes exactly 38 designed MCP tools including info, config_show, config_set, colophon", () => {
-    expect(golden.mcpSurface.tools).toHaveLength(38);
+  it("freezes exactly 41 designed MCP tools including info, config_show, config_set, colophon", () => {
+    expect(golden.mcpSurface.tools).toHaveLength(41);
     expect(golden.mcpSurface.tools).toContain("info");
     expect(golden.mcpSurface.tools).toContain("config_show");
     expect(golden.mcpSurface.tools).toContain("config_set");

--- a/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
+++ b/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
@@ -73,6 +73,23 @@ ds:token.spacing.medium a ds:Token ;
   ds:tokenType ds:type.spacing ;
   ds:valueLight "16px" ;
   ds:valueDark "16px" .
+
+# ---- Concepts (standalone documentation) ----
+ds:Concept a owl:Class .
+ds:ConceptType a owl:Class .
+ds:content a owl:DatatypeProperty ; rdfs:domain ds:Concept ; rdfs:range xsd:string .
+ds:knownEdgeCases a owl:DatatypeProperty ; rdfs:domain ds:Concept ; rdfs:range xsd:string .
+ds:conceptType a owl:ObjectProperty ; rdfs:domain ds:Concept ; rdfs:range ds:ConceptType .
+
+ds:concepttype.Explanation a ds:ConceptType ; ds:name "Explanation" .
+
+# Name carries a colon — exercises the by-name (not prefixed-IRI) lookup path.
+ds:concept.Foundations-Grid a ds:Concept ;
+  ds:name "Foundations: Grid" ;
+  ds:summary "The shared column system and per-tier grid rules." ;
+  ds:content "## Grid\\n\\nColumn counts are 4, 8, or 16 only." ;
+  ds:conceptType ds:concepttype.Explanation ;
+  ds:tier ds:global .
 `;
 
 /** The `cs:` (code standards) section — reused verbatim from `standard/parity.test.ts`'s

--- a/packages/cli/pragma/surface/surface.v2.json
+++ b/packages/cli/pragma/surface/surface.v2.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "FROZEN designed surface (covenant) for pragma v2. Each PR emits only the entries it has built and asserts emitted ⊆ covenant (see kernel/spec/surfaceConformance.ts). PR7 is the surface-completion PR: it emits ALL tools (emitted == covenant); PR9 extended this to 39 tools (added config_set, 38→39) and extends mcpSurface with the non-tool surfaces — resources (the pragma:{+uri} template), prompts (the native prompts/* capability), and instructions (the handshake orientation); PR10 extended it to 40 tools (added the colophon self-verb + its tool, 39→40); AV-228 B1 blesses `ontology_lookup` (the ratified by-name read name) and keeps `ontology_show` as a deprecated alias, 40→41; AV-228 B3 RETIRES the per-field setters `config_tier`/`config_channel`/`config_detail` in favour of `config_set <key> <value>`, 41→38; AV-228 B8 unifies ALL `create application` include-flags on the `--with-X` convention (`--ssr`/`--router`/`--forms`/`--relay` → `--with-ssr`/`--with-router`/`--with-forms`/`--with-relay`; tool count unchanged). Prompt NAMES are graph data, guarded by the prompt tests, not frozen here. The fixed sections mirror FIXED_SURFACE in kernel/spec/emitSurface.ts verbatim.",
+  "$comment": "FROZEN designed surface (covenant) for pragma v2. Each PR emits only the entries it has built and asserts emitted ⊆ covenant (see kernel/spec/surfaceConformance.ts). PR7 is the surface-completion PR: it emits ALL tools (emitted == covenant); PR9 extended this to 39 tools (added config_set, 38→39) and extends mcpSurface with the non-tool surfaces — resources (the pragma:{+uri} template), prompts (the native prompts/* capability), and instructions (the handshake orientation); PR10 extended it to 40 tools (added the colophon self-verb + its tool, 39→40); AV-228 B1 blesses `ontology_lookup` (the ratified by-name read name) and keeps `ontology_show` as a deprecated alias, 40→41; AV-228 B3 RETIRES the per-field setters `config_tier`/`config_channel`/`config_detail` in favour of `config_set <key> <value>`, 41→38; AV-228 B8 unifies ALL `create application` include-flags on the `--with-X` convention (`--ssr`/`--router`/`--forms`/`--relay` → `--with-ssr`/`--with-router`/`--with-forms`/`--with-relay`; tool count unchanged); the `concept` noun (standalone `ds:Concept` documentation — list/lookup/sample) adds `concept_list`/`concept_lookup`/`concept_sample`, 38→41. Prompt NAMES are graph data, guarded by the prompt tests, not frozen here. The fixed sections mirror FIXED_SURFACE in kernel/spec/emitSurface.ts verbatim.",
   "nouns": {
     "block": {
       "verbs": [
@@ -16,6 +16,28 @@
           "mcp": "block_lookup"
         },
         { "v": "sample", "needsStore": true, "mcp": "block_sample" }
+      ]
+    },
+    "concept": {
+      "verbs": [
+        {
+          "v": "list",
+          "flags": ["--search"],
+          "needsStore": true,
+          "mcp": "concept_list"
+        },
+        {
+          "v": "lookup",
+          "args": ["<name...>"],
+          "needsStore": true,
+          "mcp": "concept_lookup"
+        },
+        {
+          "v": "sample",
+          "args": ["[count]"],
+          "needsStore": true,
+          "mcp": "concept_sample"
+        }
       ]
     },
     "standard": {
@@ -256,6 +278,9 @@
       "block_sample",
       "capabilities",
       "colophon",
+      "concept_list",
+      "concept_lookup",
+      "concept_sample",
       "config_set",
       "config_show",
       "create_application",


### PR DESCRIPTION
## What

Surfaces the standalone **`ds:Concept`** documentation — cross-cutting guides, disambiguations, foundations, decisions that aren't bound to a single UIBlock (e.g. "Foundations: Grid", "How to differentiate components") — as a first-class read noun, projected to the CLI, MCP, and generated reference from one bundled pack.

```
pragma concept list                       # SPARQL: name / type / tier, with --search
pragma concept lookup "Foundations: Grid" # renders the Markdown ds:content body + summary/type/tier
pragma concept sample                      # exemplars
```

MCP tools: `concept_list` / `concept_lookup` / `concept_sample`.

## Changes

- **New bundled pack** `src/capabilities/concept/` (pack + module + test), registered in the capability array. `lookup` renders `ds:content` as a fenced **code** section so the long-form Markdown body reads cleanly.
- **Covenant + goldens:** `surface.v2.json` blessed 38 → 41 tools; `TOOL_HINTS`, the generated `docs/reference/*`, the completion goldens (`colophon → concept → config`), and the surface-count test expectations updated. The canonical fixture gains a `Concept` (with a colon in its name) so the parameterized noun suites (errorMatrix / agentSession / roundtrip) cover it.

## Shared kernel fix (beyond concept)

The pack lookup resolver classified **any** name containing a colon as a prefixed IRI — `resolveEntity.looksLikeIri` used `query.includes(":")`. A concept titled `Foundations: Grid` therefore failed with `INVALID_INPUT: Invalid prefix "Foundations"`. It now uses a strict CURIE pattern (`prefix:local`, no space after the colon), so a plain entity name that merely contains a colon is looked up **by name**, while `ds:global.component.button` still resolves as a prefixed IRI. Guarded by the concept lookup test and the colon-bearing canonical fixture name.

## Dependency & verification

Depends on the `ds:Concept` data landing via **canonical/design-system#64**; until then `concept list` is a clean empty result (not an error). The pack is exercised end-to-end against a fixture graph through the MCP projection. Full package `check` (biome / tsc / webarchitect) green; the concept + surface + completion + parameterized-noun suites pass. (Pre-existing create/doctor timeout flakes under full-suite parallel load are unrelated and pass in isolation.)