### PR TITLE
fix(svelte-ds-app-launchpad): suppress "upgrade to modal" close event

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte
@@ -83,7 +83,15 @@
       if (open) {
         if (dialogEl.open && !dialogEl.matches(":modal")) {
           // `open === true` during SSR case
-          // `showModal` throws when called on open non-modal dialog so we need to close it first.
+          // `showModal` throws when called on open non-modal dialog so we need to close it first
+          dialogEl.addEventListener(
+            "close",
+            (e) => {
+              // Suppress the "upgrade" close event.
+              e.stopImmediatePropagation();
+            },
+            { once: true, capture: true },
+          );
           dialogEl.close();
         }
         dialogEl.showModal();

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
@@ -1,7 +1,7 @@
 /* @canonical/generator-ds 0.10.0-experimental.5 */
 
 import { type ComponentProps, flushSync } from "svelte";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Locator } from "vitest/browser";
 import { userEvent } from "vitest/browser";
 import type { RenderResult } from "vitest-browser-svelte";
@@ -168,6 +168,22 @@ describe("Modal component", () => {
       await expect.element(page.getByText(contentText)).toBeVisible();
       flushSync();
       expect(componentLocator(page).element().matches(":modal")).toBe(true);
+    });
+
+    it("does not call onclose during upgrade to modal, but still calls on later real close", async () => {
+      const onclose = vi.fn();
+      const props = withOpen({ open: true, onclose });
+      const page = render(Component, props);
+
+      await expect.element(componentLocator(page)).toBeVisible();
+      flushSync();
+      expect(componentLocator(page).element().matches(":modal")).toBe(true);
+      expect(onclose).not.toHaveBeenCalled();
+
+      (componentLocator(page).element() as HTMLDialogElement).close();
+      await expect.element(componentLocator(page, true)).not.toBeVisible();
+      await expect.poll(() => props.open).toBe(false);
+      expect(onclose).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Done

Suppresses the `close` event fired during `Modal` hydration when an SSR-rendered open dialog is upgraded to a true modal.

The fix adds a one-time capture `close` listener around the internal upgrade `close()` call so consumer `onclose` handlers are not triggered by this internal transition.

Also adds a regression test confirming the upgrade close is suppressed and a later real close still triggers `onclose`.

## QA

- `bun run check && bun run test`

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.
