### PR TITLE
feat(DescriptionList): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/.storybook/launchpad-tokens.css
+++ b/packages/svelte/ds-app-launchpad/.storybook/launchpad-tokens.css
@@ -6,6 +6,7 @@
 
 .docs-story {
   background-color: var(--lp-color-background-default);
+  color-scheme: light dark;
 }
 
 .row {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/common/Item/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/common/Item/styles.css
@@ -1,18 +1,18 @@
 .ds.description-list-item {
   display: flex;
   flex-direction: column;
-  gap: var(--lp-dimension-spacing-block-xs);
+  gap: var(--dimension-100);
 
   dt {
     order: 1;
-    font: var(--lp-typography-paragraph-s-strong);
-    color: var(--lp-color-text-muted);
+    font: var(--ds-typography-text-secondary-bold);
+    color: var(--color-text-muted);
   }
 
   dd {
     order: 3;
-    font: var(--lp-typography-paragraph-s);
-    color: var(--lp-color-text-default);
+    font: var(--ds-typography-text-secondary);
+    color: var(--color-text);
   }
 
   /* Horizontal line for list layout */
@@ -23,7 +23,7 @@
     flex-grow: 1;
     background: repeating-linear-gradient(
       to right,
-      var(--lp-color-border-low-contrast) 0px 2px,
+      var(--color-border-muted) 0px 2px,
       transparent 2px 4px
     );
     flex-basis: 10%;
@@ -34,7 +34,7 @@
   &.list {
     flex-direction: row;
     align-items: baseline;
-    gap: var(--lp-dimension-spacing-inline-xs);
+    gap: var(--dimension-100);
 
     &::before {
       display: block;
@@ -50,7 +50,7 @@
     @container description-list (width <= 573px) {
       flex-direction: row;
       align-items: baseline;
-      gap: var(--lp-dimension-spacing-inline-xs);
+      gap: var(--dimension-100);
 
       &::before {
         display: block;

--- a/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/styles.css
@@ -4,8 +4,8 @@
 
 .ds.description-list {
   display: grid;
-  row-gap: var(--lp-dimension-spacing-block-xs);
-  column-gap: var(--lp-dimension-spacing-inline-xs);
+  row-gap: var(--dimension-100);
+  column-gap: var(--dimension-100);
   --min-width-description-list-item: 160px;
 
   &.grid {

--- a/packages/svelte/ds-app-launchpad/src/lib/index.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/index.css
@@ -1,4 +1,5 @@
 /* TODO: when the only import here is @canonical/styles delete this file. The consumer should import @canonical/styles directly. */
 @import "./styles/ds-tokens.css";
+@import "./styles/ds-shim.css";
 @import "./styles/index.css";
 @import "./modifier-families/styles/index.css";

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,0 +1,12 @@
+:root {
+  --ds-typography-text-secondary:
+    var(--typography-text-secondary-font-weight)
+    var(--typography-text-secondary-font-size) /
+    var(--typography-text-secondary-line-height)
+    var(--typography-text-secondary-font-family);
+  --ds-typography-text-secondary-bold:
+    var(--typography-text-secondary-bold-font-weight)
+    var(--typography-text-secondary-bold-font-size) /
+    var(--typography-text-secondary-bold-line-height)
+    var(--typography-text-secondary-bold-font-family);
+}


### PR DESCRIPTION
## Done

Updated DescriptionList styles to use design tokens
Created a shim for font shorthands
Update storybook

### Changes

Muted color differs
Responsive gaps are not responsive anymore
Bold font grew from 550 to 600

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots
Old
<img width="1629" height="486" alt="image" src="https://github.com/user-attachments/assets/f8a74fbb-7ef8-4f4f-ab81-a19d6490fa68" />

New
<img width="1629" height="486" alt="image" src="https://github.com/user-attachments/assets/3ed2d2c1-2a79-4766-bbd9-c2b3558d3ac6" />



Old
<img width="1058" height="486" alt="image" src="https://github.com/user-attachments/assets/5f7cde7a-8631-4a8b-8c4a-7919c18244f2" />

New
<img width="1058" height="486" alt="image" src="https://github.com/user-attachments/assets/646c3b41-60a4-4698-b104-15c3f0ad6c85" />
