### PR TITLE
feat(UserAvatar): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.stories.svelte
@@ -94,3 +94,56 @@
     onerror: () => {},
   }}
 />
+
+<Story
+  name="Surface elevation"
+  tags={["!autodocs"]}
+  args={{ userName: "John Doe" }}
+>
+  {#snippet template(args)}
+    <div class="stack">
+      <div class="box dashed">
+        <code>no .surface</code>
+        <UserAvatar {...args} />
+      </div>
+
+      <div class="surface box">
+        <code>.surface</code>
+        <UserAvatar {...args} />
+
+        <div class="surface box">
+          <code>.surface .surface</code>
+          <UserAvatar {...args} />
+
+          <div class="surface box">
+            <code>.surface .surface .surface</code>
+            <UserAvatar {...args} />
+          </div>
+        </div>
+      </div>
+    </div>
+  {/snippet}
+</Story>
+
+<style>
+  .stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 34rem;
+  }
+
+  .box {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.25rem;
+    border: 1px solid var(--color-border);
+    background-color: var(--surface-color-background);
+  }
+
+  .dashed {
+    border-style: dashed;
+    background-color: transparent;
+  }
+</style>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/styles.css
@@ -2,25 +2,32 @@
   display: inline-grid;
   flex: none;
 
-  border: var(--lp-dimension-stroke-thickness-default) solid
-    var(--lp-color-border-default);
-  background-color: var(--lp-color-background-alt);
-  color: var(--lp-color-text-default);
+  border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
+  /* TODO: Check with Enzo. Figma uses --color-background-layer2 */
+  /* I read it as "one level above the surface" and foreground-input is exactly this */
+  /* However, avatar is not input. But -layer2 looks like internal token */
+  /* that we're not supposed to use directly */
+  background-color: var(
+    --surface-color-foreground-input,
+    var(--color-foreground-input)
+  );
+  color: var(--surface-color-text, var(--color-text));
 
-  width: var(--lp-dimension-size-m);
-  height: var(--lp-dimension-size-m);
-  font: var(--lp-typography-paragraph-default-strong);
+  width: var(--dimension-300);
+  height: var(--dimension-300);
+  font: var(--ds-typography-text-primary-bold);
 
   &.small {
-    width: var(--lp-dimension-size-s);
-    height: var(--lp-dimension-size-s);
-    font: var(--lp-typography-paragraph-s-strong);
+    width: var(--dimension-250);
+    height: var(--dimension-250);
+    font: var(--ds-typography-text-secondary-bold);
   }
 
   &.large {
-    width: var(--lp-dimension-size-l);
-    height: var(--lp-dimension-size-l);
-    font: var(--lp-typography-h5);
+    width: var(--dimension-400);
+    height: var(--dimension-400);
+    font: var(--ds-typography-heading-5);
+    letter-spacing: var(--typography-heading-5-letter-spacing);
   }
 
   &:is(img) {

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -9,4 +9,14 @@
     var(--typography-text-secondary-bold-font-size) /
     var(--typography-text-secondary-bold-line-height)
     var(--typography-text-secondary-bold-font-family);
+  --ds-typography-text-primary-bold:
+    var(--typography-text-primary-bold-font-weight)
+    var(--typography-text-primary-bold-font-size) /
+    var(--typography-text-primary-bold-line-height)
+    var(--typography-text-primary-bold-font-family);
+  --ds-typography-heading-5:
+    var(--typography-heading-5-font-weight)
+    var(--typography-heading-5-font-size) /
+    var(--typography-heading-5-line-height)
+    var(--typography-heading-5-font-family);
 }


### PR DESCRIPTION
## Done

Updated UserAvatar styles to use design tokens
Added text-primary-bold and heading-5 shorthands to the shim
Added a surface elevation story to storybook

### Changes

Bold font grew from 550 to 600
Large avatar font changed from 18px/450 to 16px/600 with letter spacing
Fill is surface aware now, based on foreground-input (resolves to the same value as background-layer2 outside surfaces)

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Old
<img width="255" height="254" alt="image" src="https://github.com/user-attachments/assets/8e6aa128-db88-4686-9931-9b01cda33bdf" />
New
<img width="255" height="254" alt="image" src="https://github.com/user-attachments/assets/77db3bb5-7c54-4584-814c-5f0b9cf9b22e" />

Old
<img width="255" height="254" alt="image" src="https://github.com/user-attachments/assets/3fc16eb0-10b8-49b8-b41d-ec0d97487847" />
New
<img width="255" height="254" alt="image" src="https://github.com/user-attachments/assets/1c1df440-c2b4-4eb8-81aa-2772d2ddb57c" />

New on surface
<img width="1172" height="908" alt="image" src="https://github.com/user-attachments/assets/f8fd5e6f-9b59-45ae-b134-f60b89075460" />
<img width="1172" height="908" alt="image" src="https://github.com/user-attachments/assets/fdcae50a-f4e6-4900-985d-1255f3bfe723" />

