### PR TITLE
feat(chromatic): Optimize Chromatic Usage

### DIFF
--- a/.github/workflows/chromatic._template.yml
+++ b/.github/workflows/chromatic._template.yml
@@ -22,7 +22,8 @@ jobs:
   publish-to-chromatic:
     if: >-
       github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'no visual change')
+      (!github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'no visual change'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/chromatic.demo.yml
+++ b/.github/workflows/chromatic.demo.yml
@@ -11,6 +11,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -23,6 +24,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.demo.yml
+++ b/.github/workflows/chromatic.demo.yml
@@ -1,23 +1,28 @@
 name: "ds-demo-site/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-global/**
       - apps/react/demo/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
     paths:
       - configs/storybook/**
-      - packages/tokens/**
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-global/**
-      - packages/react/ds-app-anbox/**
+      - apps/react/demo/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -27,7 +32,7 @@ jobs:
       working-directory: apps/react/demo
       externals: '[
         "configs/storybook/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-lit-poc.yml
+++ b/.github/workflows/chromatic.ds-lit-poc.yml
@@ -1,7 +1,7 @@
 name: "lit-ds-prototype/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -9,6 +9,8 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/lit/ds-prototype/**
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -19,6 +21,8 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/lit/ds-prototype/**
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -29,7 +33,7 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
         ]'

--- a/.github/workflows/chromatic.ds-lit-poc.yml
+++ b/.github/workflows/chromatic.ds-lit-poc.yml
@@ -11,6 +11,7 @@ on:
       - packages/lit/ds-prototype/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -23,6 +24,7 @@ on:
       - packages/lit/ds-prototype/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-anbox.yml
+++ b/.github/workflows/chromatic.ds-react-app-anbox.yml
@@ -1,7 +1,7 @@
 name: "react-ds-app-anbox/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-anbox/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-anbox/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-react-app-anbox.yml
+++ b/.github/workflows/chromatic.ds-react-app-anbox.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-landscape.yml
+++ b/.github/workflows/chromatic.ds-react-app-landscape.yml
@@ -1,7 +1,7 @@
 name: "react-ds-app-landscape/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-landscape/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-landscape/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-react-app-landscape.yml
+++ b/.github/workflows/chromatic.ds-react-app-landscape.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-launchpad.yml
+++ b/.github/workflows/chromatic.ds-react-app-launchpad.yml
@@ -1,7 +1,7 @@
 name: "react-ds-app-launchpad/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-launchpad/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-launchpad/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-react-app-launchpad.yml
+++ b/.github/workflows/chromatic.ds-react-app-launchpad.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-lxd.yml
+++ b/.github/workflows/chromatic.ds-react-app-lxd.yml
@@ -1,7 +1,7 @@
 name: "react-ds-app-lxd/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-lxd/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-lxd/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-react-app-lxd.yml
+++ b/.github/workflows/chromatic.ds-react-app-lxd.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app-portal.yml
+++ b/.github/workflows/chromatic.ds-react-app-portal.yml
@@ -1,7 +1,7 @@
 name: "react-ds-app-portal/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-portal/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app-portal/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-react-app-portal.yml
+++ b/.github/workflows/chromatic.ds-react-app-portal.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-app.yml
+++ b/.github/workflows/chromatic.ds-react-app.yml
@@ -1,7 +1,7 @@
 name: "react-ds-app/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-app/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-react-app.yml
+++ b/.github/workflows/chromatic.ds-react-app.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-global-form.yml
+++ b/.github/workflows/chromatic.ds-react-global-form.yml
@@ -1,7 +1,7 @@
 name: "react-ds-global-form/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-global-form/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - packages/react/ds-global-form/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-react-global-form.yml
+++ b/.github/workflows/chromatic.ds-react-global-form.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-react-global.yml
+++ b/.github/workflows/chromatic.ds-react-global.yml
@@ -1,7 +1,7 @@
 name: "react-ds-global/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -9,6 +9,8 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-global/**
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -19,6 +21,8 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/react/ds-global/**
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -29,7 +33,7 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-react-global.yml
+++ b/.github/workflows/chromatic.ds-react-global.yml
@@ -11,6 +11,7 @@ on:
       - packages/react/ds-global/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -23,6 +24,7 @@ on:
       - packages/react/ds-global/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-svelte-app-launchpad.yml
+++ b/.github/workflows/chromatic.ds-svelte-app-launchpad.yml
@@ -13,6 +13,7 @@ on:
       - packages/svelte/ds-app-launchpad/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - packages/svelte/ds-app-launchpad/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-svelte-app-launchpad.yml
+++ b/.github/workflows/chromatic.ds-svelte-app-launchpad.yml
@@ -1,7 +1,7 @@
 name: "svelte-ds-app-launchpad/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -11,6 +11,8 @@ on:
       # TODO: Uncomment once the launchpad package consumes ds-global
       # - packages/svelte/ds-global/**
       - packages/svelte/ds-app-launchpad/**
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -23,6 +25,8 @@ on:
       # TODO: Uncomment once the launchpad package consumes ds-global
       # - packages/svelte/ds-global/**
       - packages/svelte/ds-app-launchpad/**
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -34,7 +38,7 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-svelte-app-wpe.yml
+++ b/.github/workflows/chromatic.ds-svelte-app-wpe.yml
@@ -15,6 +15,7 @@ on:
       - packages/svelte/ds-app-wpe/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -31,6 +32,7 @@ on:
       - packages/svelte/ds-app-wpe/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-svelte-app-wpe.yml
+++ b/.github/workflows/chromatic.ds-svelte-app-wpe.yml
@@ -1,7 +1,7 @@
 name: "svelte-ds-app-wpe/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -13,6 +13,8 @@ on:
       # TODO: Uncomment once package consumes ds-app package
       # - packages/svelte/ds-app/**
       - packages/svelte/ds-app-wpe/**
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -27,6 +29,8 @@ on:
       # TODO: Uncomment once package consumes ds-app package
       # - packages/svelte/ds-app/**
       - packages/svelte/ds-app-wpe/**
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -39,7 +43,7 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-svelte-app.yml
+++ b/.github/workflows/chromatic.ds-svelte-app.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/svelte/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/svelte/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-svelte-app.yml
+++ b/.github/workflows/chromatic.ds-svelte-app.yml
@@ -1,7 +1,7 @@
 name: "svelte-ds-app/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/svelte/ds-global/**
       - packages/svelte/ds-app/**
+      - "!packages/svelte/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/svelte/ds-global/**
       - packages/svelte/ds-app/**
+      - "!packages/svelte/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/svelte/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/svelte/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.ds-svelte-global.yml
+++ b/.github/workflows/chromatic.ds-svelte-global.yml
@@ -11,6 +11,7 @@ on:
       - packages/svelte/ds-global/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -23,6 +24,7 @@ on:
       - packages/svelte/ds-global/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.ds-svelte-global.yml
+++ b/.github/workflows/chromatic.ds-svelte-global.yml
@@ -1,7 +1,7 @@
 name: "svelte-ds-global/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -9,6 +9,8 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/svelte/ds-global/**
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -19,6 +21,8 @@ on:
       - packages/styles/**
       - packages/utils/**
       - packages/svelte/ds-global/**
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -29,7 +33,7 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.react-boilerplate-vite.yml
+++ b/.github/workflows/chromatic.react-boilerplate-vite.yml
@@ -1,7 +1,7 @@
 name: "react-boilerplate-vite/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - apps/react/boilerplate-vite/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +24,9 @@ on:
       - packages/utils/**
       - packages/react/ds-global/**
       - apps/react/boilerplate-vite/**
+      - "!packages/react/ds-global/**/*.stories.*"
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +37,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/ds-global/**"
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/ds-global/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.react-boilerplate-vite.yml
+++ b/.github/workflows/chromatic.react-boilerplate-vite.yml
@@ -13,6 +13,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - "!packages/react/ds-global/**/*.stories.*"
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/.github/workflows/chromatic.storybook-hub.yml
+++ b/.github/workflows/chromatic.storybook-hub.yml
@@ -1,7 +1,7 @@
 name: "storybook-hub/chromatic"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - configs/storybook/**
       - packages/ds-assets/**
@@ -10,6 +10,8 @@ on:
       - packages/utils/**
       - packages/react/**
       - apps/react/storybook-hub/**
+      - "!**/*.test.*"
+      - "!**/*.md"
   push:
     branches:
       - main
@@ -21,6 +23,8 @@ on:
       - packages/utils/**
       - packages/react/**
       - apps/react/storybook-hub/**
+      - "!**/*.test.*"
+      - "!**/*.md"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml
@@ -31,8 +35,8 @@ jobs:
       externals: '[
         "configs/storybook/**",
         "packages/ds-assets/**",
-        "packages/tokens/**",
-        "packages/styles/**",
-        "packages/utils/**",
-        "packages/react/**",
+        "packages/tokens/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/styles/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/utils/**/!(*.test.*|*.stories.*|*.md|*.mdx)",
+        "packages/react/**/!(*.test.*|*.stories.*|*.md|*.mdx)"
       ]'

--- a/.github/workflows/chromatic.storybook-hub.yml
+++ b/.github/workflows/chromatic.storybook-hub.yml
@@ -12,6 +12,7 @@ on:
       - apps/react/storybook-hub/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
   push:
     branches:
       - main
@@ -25,6 +26,7 @@ on:
       - apps/react/storybook-hub/**
       - "!**/*.test.*"
       - "!**/*.md"
+      - "!**/*.mdx"
 jobs:
   test-compile:
     uses: ./.github/workflows/chromatic._template.yml

--- a/configs/renovate/default.json
+++ b/configs/renovate/default.json
@@ -12,7 +12,10 @@
     },
     {
       "description": "Group TypeScript toolchain",
-      "matchPackageNames": ["typescript", "@canonical/typescript-config-{/,}**"],
+      "matchPackageNames": [
+        "typescript",
+        "@canonical/typescript-config-{/,}**"
+      ],
       "groupName": "typescript"
     },
     {
@@ -54,6 +57,17 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
+    },
+    {
+      "description": "Toolchain-only updates cannot change rendered UI. Chromatic workflows skip builds on this label",
+      "matchPackageNames": [
+        "@biomejs/biome",
+        "@canonical/biome-config",
+        "vitest",
+        "@vitest/{/,}**",
+        "renovate"
+      ],
+      "addLabels": ["no visual change"]
     }
   ]
 }


### PR DESCRIPTION
## Done

Chromatic usage has more frequently been encountering "Monthly free snapshot limit reached"

Tunes Chromatic CI to skip visual regression builds that can't change the UI.

Across all chromatic workflow files: skip the build on draft PRs, add ready_for_review to the trigger types, and tighten the triggers in two ways. Workflow paths filters now exclude test and markdown/MDX files, so changes to those no longer trigger builds at all. Chromatic externals filters now exclude test, story, and markdown/MDX files in dependency packages, so changes to those no longer force a full re-snapshot. demo.yml also gets corrected push paths.

In renovate default.json: auto-apply the "no visual change" label to toolchain-only bumps (biome, vitest, renovate) so those Chromatic builds are skipped too.

## QA

- Since these are CI/config changes, I'm not sure of a great way to QA other than monitoring future PRs

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.