### PR TITLE
chore(repo): add @advl alongside workplace-engineering-ui for ds-app-wpe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 /packages/svelte/ds-app-launchpad/   @canonical/launchpad-ui
-/packages/svelte/ds-app-wpe/         @canonical/workplace-engineering-ui
+/packages/svelte/ds-app-wpe/         @canonical/workplace-engineering-ui  @advl
 
 /packages/svelte/ssr-test/    @canonical/launchpad-ui  @canonical/workplace-engineering-ui
 /configs/typescript-svelte/   @canonical/launchpad-ui  @canonical/workplace-engineering-ui


### PR DESCRIPTION
## Done

- Adds `@advl` **additively** to the `/packages/svelte/ds-app-wpe/` CODEOWNERS entry — `@canonical/workplace-engineering-ui`'s ownership and review auto-request are unchanged; either party's review now satisfies the code-owner requirement for that path.
- Why: monorepo-infrastructure fixes sometimes touch this package's manifest — the immediate case is #901 (playwright version convergence that unblocks `main`'s CI, red since `7f6fe7c`), whose only owned-path edit is one dependency-range line in `ds-app-wpe/package.json`.
- Follows the existing precedent in this file: `/configs/biome/` already lists `@advl` alongside both team owners.

## QA

- One-line change to `.github/CODEOWNERS`; no code paths affected.

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards) — n/a, repo metadata only.
- [ ] New package: n/a.
- [x] No visual testing required — repo metadata only.

## Screenshots

n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EwUvEW5ZgjAYc9KWPjHCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017EwUvEW5ZgjAYc9KWPjHCZ)_