### PR TITLE
fix(summon-package): library template emits a buildable, discoverable package

### DIFF
--- a/packages/summon/package/README.md
+++ b/packages/summon/package/README.md
@@ -115,8 +115,9 @@ Creates:
 
 ```
 packages/my-lib/
-├── package.json      # type: module, main: dist/esm/index.js
-├── tsconfig.json     # extends workspace config, outDir: dist
+├── package.json         # type: module, main: dist/esm/index.js
+├── tsconfig.json        # extends workspace config
+├── tsconfig.build.json  # emit: dist/esm (JS) + dist/types (declarations)
 ├── biome.json
 ├── README.md
 └── src/
@@ -131,14 +132,21 @@ Example package.json:
   "version": "0.1.0",
   "type": "module",
   "main": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
   "license": "LGPL-3.0",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "check": "biome check .",
     "check:fix": "biome check --write ."
   },
-  "files": ["dist", "README.md"]
+  "files": ["dist"]
 }
 ```
 

--- a/packages/summon/package/src/generators.test.ts
+++ b/packages/summon/package/src/generators.test.ts
@@ -2,10 +2,40 @@
  * Tests for summon-package generator (dry-run)
  */
 
+import { readFileSync } from "node:fs";
+import { renderString } from "@canonical/summon-core";
 import { dryRun } from "@canonical/task";
 import { describe, expect, it } from "vitest";
+import pkg from "../package.json" with { type: "json" };
 import { generator } from "./package/index.js";
-import type { PackageAnswers } from "./shared/index.js";
+import {
+  createTemplateContext,
+  type MonorepoInfo,
+  type PackageAnswers,
+} from "./shared/index.js";
+
+interface Manifest {
+  main?: string;
+  module?: string;
+  types?: string;
+  exports?: unknown;
+  scripts: Record<string, string>;
+  devDependencies: Record<string, string>;
+}
+
+/** Render the package.json template the way the generator does, and parse it. */
+const renderManifest = (
+  answers: PackageAnswers,
+  monorepoInfo: MonorepoInfo = { isMonorepo: false },
+): Manifest => {
+  const source = readFileSync(
+    new URL("./templates/package.json.ejs", import.meta.url),
+    "utf-8",
+  );
+  return JSON.parse(
+    renderString(source, createTemplateContext(answers, monorepoInfo)),
+  );
+};
 
 describe("package generator", () => {
   it("has correct meta information", () => {
@@ -51,6 +81,33 @@ describe("package generator", () => {
     expect(writePaths.some((p) => p.endsWith("README.md"))).toBe(true);
 
     expect(writePaths.some((p) => p.endsWith("cli.ts"))).toBe(false);
+    expect(writePaths.some((p) => p.endsWith("tsconfig.build.json"))).toBe(
+      false,
+    );
+  });
+
+  it("generates tsconfig.build.json for library package", () => {
+    const answers: PackageAnswers = {
+      name: "@canonical/my-lib",
+      type: "library",
+      description: "My library",
+      withReact: false,
+      withStorybook: false,
+      withCli: false,
+      withPrTemplate: false,
+      runInstall: false,
+    };
+
+    const task = generator.generate(answers);
+    const result = dryRun(task);
+
+    const writePaths = result.effects
+      .filter((e) => e._tag === "WriteFile")
+      .map((e) => (e as { path: string }).path);
+
+    expect(writePaths.some((p) => p.endsWith("tsconfig.build.json"))).toBe(
+      true,
+    );
   });
 
   it("generates CLI file when withCli is true", () => {
@@ -124,5 +181,59 @@ describe("package generator", () => {
 
     expect(mkdirPaths.some((p) => p === "my-pkg")).toBe(true);
     expect(mkdirPaths.some((p) => p.endsWith("src"))).toBe(true);
+  });
+});
+
+describe("generated manifest", () => {
+  const libraryAnswers: PackageAnswers = {
+    name: "@canonical/my-lib",
+    type: "library",
+    description: "My library",
+    withReact: false,
+    withStorybook: false,
+    withCli: false,
+    withPrTemplate: false,
+    runInstall: false,
+  };
+
+  it("declares main for a library, so summon can discover the package", () => {
+    // `processPackage` in @canonical/summon-core reads `main` and returns
+    // early when it is absent; `module` and `types` are never consulted.
+    expect(renderManifest(libraryAnswers).main).toBe("dist/esm/index.js");
+  });
+
+  it("declares module, types and an exports map for a library", () => {
+    const manifest = renderManifest(libraryAnswers);
+
+    expect(manifest.module).toBe("dist/esm/index.js");
+    expect(manifest.types).toBe("dist/types/index.d.ts");
+    expect(manifest.exports).toEqual({
+      ".": {
+        types: "./dist/types/index.d.ts",
+        import: "./dist/esm/index.js",
+      },
+    });
+  });
+
+  it("builds a library with the tsconfig the generator emits", () => {
+    expect(renderManifest(libraryAnswers).scripts.build).toBe(
+      "tsc -p tsconfig.build.json",
+    );
+  });
+
+  it("ranges @canonical/* dependencies on the generator's own version", () => {
+    // The host repository's version says nothing about which versions of
+    // @canonical/* exist on npm, so it must not leak into the ranges.
+    const manifest = renderManifest(libraryAnswers, {
+      isMonorepo: true,
+      version: "0.0.1",
+    });
+
+    expect(manifest.devDependencies["@canonical/biome-config"]).toBe(
+      `^${pkg.version}`,
+    );
+    expect(manifest.devDependencies["@canonical/typescript-config"]).toBe(
+      `^${pkg.version}`,
+    );
   });
 });

--- a/packages/summon/package/src/package/index.ts
+++ b/packages/summon/package/src/package/index.ts
@@ -34,6 +34,7 @@ const templates = {
   packageJson: path.join(templatesDir, "package.json.ejs"),
   tsconfig: path.join(templatesDir, "tsconfig.json.ejs"),
   tsconfigReact: path.join(templatesDir, "tsconfig-react.json.ejs"),
+  tsconfigBuild: path.join(templatesDir, "tsconfig.build.json.ejs"),
   biome: path.join(templatesDir, "biome.json.ejs"),
   indexTs: path.join(templatesDir, "index.ts.ejs"),
   indexCss: path.join(templatesDir, "index.css.ejs"),
@@ -211,6 +212,16 @@ The generator auto-detects:
           template({
             source: templates.tsconfig,
             dest: path.join(packageDir, "tsconfig.json"),
+            vars: ctx,
+          }),
+        ),
+
+        // Create tsconfig.build.json (only for types that emit to dist/)
+        when(
+          ctx.needsBuild,
+          template({
+            source: templates.tsconfigBuild,
+            dest: path.join(packageDir, "tsconfig.build.json"),
             vars: ctx,
           }),
         ),

--- a/packages/summon/package/src/shared/createTemplateContext.test.ts
+++ b/packages/summon/package/src/shared/createTemplateContext.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import pkg from "../../package.json" with { type: "json" };
 import createTemplateContext from "./createTemplateContext.js";
 import type { MonorepoInfo, PackageAnswers } from "./types.js";
 
@@ -39,6 +40,14 @@ describe("createTemplateContext", () => {
     const ctx = createTemplateContext(baseAnswers, monorepoInfo);
 
     expect(ctx.version).toBe("0.1.0");
+  });
+
+  it("keeps the @canonical/* dependency line separate from the host version", () => {
+    const monorepoInfo: MonorepoInfo = { isMonorepo: true, version: "0.0.1" };
+    const ctx = createTemplateContext(baseAnswers, monorepoInfo);
+
+    expect(ctx.version).toBe("0.0.1");
+    expect(ctx.canonicalVersion).toBe(pkg.version);
   });
 
   it("handles unscoped package names", () => {

--- a/packages/summon/package/src/shared/createTemplateContext.ts
+++ b/packages/summon/package/src/shared/createTemplateContext.ts
@@ -1,3 +1,4 @@
+import pkg from "../../package.json" with { type: "json" };
 import getEntryPoints from "./config/getEntryPoints.js";
 import getLicense from "./config/getLicense.js";
 import getRuleset from "./config/getRuleset.js";
@@ -27,11 +28,11 @@ export default function createTemplateContext(
     types: entryPoints.types,
     files: entryPoints.files,
     needsBuild: entryPoints.needsBuild,
+    canonicalVersion: pkg.version,
     ruleset: getRuleset(answers.type, answers.withReact),
     withReact: answers.withReact,
     withStorybook: answers.withStorybook,
     withCli: answers.withCli,
-    monorepoVersion: monorepoInfo.version,
     generatorName: "@canonical/summon-package",
     generatorVersion: "0.1.0",
   };

--- a/packages/summon/package/src/shared/types.ts
+++ b/packages/summon/package/src/shared/types.ts
@@ -47,6 +47,16 @@ export interface TemplateContext {
   files: string[];
   /** Whether this package type needs a build step */
   needsBuild: boolean;
+  /**
+   * Version line to depend on for `@canonical/*` packages.
+   *
+   * Taken from this generator's own version, not from the host repository:
+   * the generator ships from the same fixed-version monorepo as the config
+   * packages it scaffolds a dependency on, so its version is the published
+   * line those packages exist on. The host repository's version says nothing
+   * about them.
+   */
+  canonicalVersion: string;
   /** Webarchitect ruleset */
   ruleset: string;
   /** Include React */
@@ -55,8 +65,6 @@ export interface TemplateContext {
   withStorybook: boolean;
   /** Include CLI */
   withCli: boolean;
-  /** Monorepo version (if applicable) */
-  monorepoVersion?: string;
   /** Generator name */
   generatorName: string;
   /** Generator version */

--- a/packages/summon/package/src/templates/package.json.ejs
+++ b/packages/summon/package/src/templates/package.json.ejs
@@ -9,8 +9,15 @@
 <% } else if (type === 'css') { -%>
   "module": "src/index.css",
 <% } else { -%>
+  "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
 <% } -%>
 <% if (withCli && type !== 'css') { -%>
   "bin": {
@@ -74,11 +81,11 @@
 <% if (type !== 'css') { -%>
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
-    "@canonical/biome-config": "^<%= monorepoVersion || '0.1.0' %>",
+    "@canonical/biome-config": "^<%= canonicalVersion %>",
 <% if (withReact) { -%>
-    "@canonical/typescript-config-react": "^<%= monorepoVersion || '0.1.0' %>",
+    "@canonical/typescript-config-react": "^<%= canonicalVersion %>",
 <% } else { -%>
-    "@canonical/typescript-config": "^<%= monorepoVersion || '0.1.0' %>",
+    "@canonical/typescript-config": "^<%= canonicalVersion %>",
 <% } -%>
 <% if (withStorybook) { -%>
     "@chromatic-com/storybook": "^5.0.0",
@@ -96,7 +103,7 @@
   },
   "dependencies": {
 <% if (withStorybook) { -%>
-    "@canonical/storybook-config": "^<%= monorepoVersion || '0.1.0' %>",
+    "@canonical/storybook-config": "^<%= canonicalVersion %>",
 <% } -%>
 <% if (withReact) { -%>
     "react": "^19.0.0",
@@ -106,7 +113,7 @@
 <% } else { -%>
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
-    "@canonical/biome-config": "^<%= monorepoVersion || '0.1.0' %>"
+    "@canonical/biome-config": "^<%= canonicalVersion %>"
   }
 <% } -%>
 }

--- a/packages/summon/package/src/templates/tsconfig.build.json.ejs
+++ b/packages/summon/package/src/templates/tsconfig.build.json.ejs
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+<% if (withReact) { -%>
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+<% } else { -%>
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+<% } -%>
+}


### PR DESCRIPTION
## Done

`summon package --type library` emits a package that can neither be built nor found again by `summon`. Three faults compound. This PR fixes all three in `@canonical/summon-package`.

**1. `tsconfig.build.json` was referenced but never written.**

The emitted manifest carries `"build": "tsc -p tsconfig.build.json"`, and no template produced that file, so the very first `bun run build` in a freshly generated package failed:

```
$ tsc -p tsconfig.build.json
error TS5058: The specified path does not exist: 'tsconfig.build.json'.
```

Added `src/templates/tsconfig.build.json.ejs`, emitted for any package type whose entry points need a build (`ctx.needsBuild`). It follows the shape already used by the built packages in this repo — `packages/utils`, `packages/summon/application`, `packages/summon/component`: `rootDir: src`, `outDir: dist/esm`, declarations to `dist/types`, declaration and source maps, tests excluded. React packages additionally include `.tsx`.

**2. `main` was absent from the emitted manifest.** This is the load-bearing one.

`packages/summon/core/src/discovery/discoverGeneratorTree.ts` → `processPackage` reads `pkgJson.main` and returns early when it is missing:

```ts
const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, "utf-8"));
mainEntry = pkgJson.main;
...
if (!mainEntry) return;
```

`module`, `types` and `exports` are never consulted. A `summon-*` package generated by `summon package` was therefore invisible to `summon` even after fixing (1) and building it — and the failure is silent: the generator simply never appears in `summon --help`.

Library manifests now declare `"main": "dist/esm/index.js"` and a conditional `exports` map alongside the existing `module` and `types`, matching `packages/summon/application` and `packages/summon/component`.

**3. `@canonical/*` dependency ranges were interpolated from the host repository's version.**

`createTemplateContext` fed the version read from the host repo's `lerna.json` (falling back to `0.1.0`) into every `@canonical/*` range in the manifest template. That version describes the repository being generated *into*; it says nothing about which versions of `@canonical/biome-config`, `@canonical/typescript-config`, `@canonical/typescript-config-react` or `@canonical/storybook-config` exist on npm. It happens to be right inside this repo and wrong everywhere else — generating into a plain directory produced `"@canonical/biome-config": "^0.1.0"`, which does not resolve:

```
$ bun install
error: No version matching "^0.1.0" found for specifier "@canonical/biome-config" (but package exists)
error: No version matching "^0.1.0" found for specifier "@canonical/typescript-config" (but package exists)
```

Ranges now come from a new `canonicalVersion` context field taken from the generator's own version. The generator ships from the same fixed-version monorepo as the config packages it scaffolds a dependency on, so its version *is* the published line those packages exist on. The now-unused `monorepoVersion` context field is removed. The generated package's own `version` still comes from the host `lerna.json` as before — that is the correct source for that field, and it is unchanged.

This also brings the templates back in line with the generator's own `CONVENTIONS.md`, where both behaviours were already documented but not implemented: **P3.2** (`tsconfig.build.json` outputs to `dist/esm/` and `dist/types/`) and **P6.8** (library packages have a conditional `exports` map).

### Files

- `src/templates/tsconfig.build.json.ejs` — new.
- `src/templates/package.json.ejs` — library branch gains `main` + `exports`; `@canonical/*` ranges use `canonicalVersion`.
- `src/package/index.ts` — emits `tsconfig.build.json` when `ctx.needsBuild`.
- `src/shared/createTemplateContext.ts`, `src/shared/types.ts` — add `canonicalVersion`, drop `monorepoVersion`.
- `src/generators.test.ts`, `src/shared/createTemplateContext.test.ts` — tests.
- `README.md` — the documented library layout and example manifest now match what the generator actually emits.

### Deliberately out of scope

Real, but separate concerns that would widen this PR:

- `tool-ts` and `css` manifests also omit `main`, so `summon-*` packages of those types are equally undiscoverable. Same root cause, different template branch.
- `@canonical/summon`'s bin carries a `node` shebang while `summon-monorepo` and `summon-package` ship raw TypeScript, so those generators load silently as nothing under plain Node.
- The generated manifest's stale `@biomejs/biome` (`2.4.6`, repo is on `2.4.9`) and `vitest` (`^3.2.4`, repo is on `^4`) pins.

## QA

All of this runs in a scratch directory outside the repo. `summon` is invoked under `bun` throughout, since the generator packages ship raw TypeScript; `-g` makes it load generators only from this branch's checkout.

**Reproduce the failure on `main`** (published `@canonical/summon` 0.33.0):

```bash
mkdir /tmp/before && cd /tmp/before
bun $(which summon) package --name @example/widget-kit --type library --no-run-install --yes
cd widget-kit
bun install   # error: No version matching "^0.1.0" found for "@canonical/biome-config"
bun run build # error TS5058: The specified path does not exist: 'tsconfig.build.json'.
grep '"main"' package.json  # no match
```

**Verify the fix — a generated library builds:**

```bash
mkdir /tmp/after && cd /tmp/after
bun $(which summon) -g <repo>/packages/summon/package package \
  --name @example/widget-kit --type library --no-run-install --yes
cd widget-kit
bun install    # resolves; @canonical/* pinned to ^0.33.0
bun run build  # exits 0
find dist -type f
# dist/esm/index.js
# dist/esm/index.js.map
# dist/types/index.d.ts
# dist/types/index.d.ts.map
```

**Verify the fix — a generated library is discoverable.** Generate `@example/summon-widget` the same way, add a trivial `generators` export to `src/index.ts`, build it, and stage the result as an installed dependency of a consumer project:

```bash
mkdir -p /tmp/consumer/node_modules/@example/summon-widget
cp -r package.json dist /tmp/consumer/node_modules/@example/summon-widget/
cd /tmp/consumer && bun $(which summon) --help
```

```
Commands:
  ...
  widget [options]         Example generator used to verify discovery
```

Now delete just `"main"` from the staged `package.json` — exactly what the template emitted before this PR, with `module`, `types` and `exports` all still pointing at the built output — and re-run:

```
Commands:
  init [options]           Create a new Summon generator
  example                  example generators
  monorepo [options]       ...
  package [options]        ...
  help [command]           display help for command
```

`widget` is gone. That is the early return in `processPackage`, and it is why `main` specifically is the fix.

The `--with-react` library variant was generated and built the same way; its `tsconfig.build.json` additionally covers `.tsx`.

The generated library also passes its own `bun run check` — `biome`, `tsc --noEmit`, and `webarchitect library`'s `package-structure` and `package-license` rules all pass. (The scratch package is named `@example/…`, so only webarchitect's `^@canonical/` name pattern objects, which is expected outside the repo.)

**Gates** — `packages/summon/package`:

```
$ bun run check
$ bun run check:biome && bun run check:ts && bun run check:webarchitect
$ biome check
Checked 27 files in 16ms. No fixes applied.
$ tsc --noEmit
$ webarchitect base
Summary: All 0 validations passed

$ bun run test
 Test Files  9 passed (9)
      Tests  46 passed (46)
All files          |     100 |      100 |     100 |     100 |
```

Root `bun run check` is green across all 62 projects:

```
Lerna (powered by Nx)   Successfully ran target check for 62 projects and 39 tasks they depend on
```

Root `bun run test` has pre-existing failures on this machine — `@canonical/pragma-cli` and others hit `Test timed out in 5000ms` on real-generation and eval suites. Confirmed identical on a clean `origin/main` checkout (same 7 tests, same timeouts), so unrelated to this diff. `nx affected` for this branch is `@canonical/summon-package` and `@canonical/pragma-cli`; `@canonical/summon-package:test` passes.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
  - N/A — no new package; this changes templates inside the existing `@canonical/summon-package`.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A — generator templates, no rendered surface.
