### PR TITLE
fix(summon): compile summon-monorepo and summon-package to JavaScript

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1391,6 +1391,8 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
         "@canonical/biome-config": "^0.33.0",
+        "@canonical/summon-core": "^0.33.0",
+        "@canonical/task": "^0.33.0",
         "@canonical/typescript-config": "^0.33.0",
         "@canonical/webarchitect": "^0.33.0",
         "@types/bun": "^1.3.10",

--- a/packages/summon/monorepo/package.json
+++ b/packages/summon/monorepo/package.json
@@ -3,7 +3,18 @@
   "description": "Monorepo generator for Summon - scaffold new Bun + Lerna monorepos with CI, release, and shared config",
   "version": "0.33.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "dist/esm/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"
@@ -21,7 +32,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "echo 'No build needed - runs directly from TypeScript'",
+    "build": "tsc -p tsconfig.build.json && bun ../../../scripts/copy-templates.ts src dist/esm",
     "build:all": "bun run build",
     "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
     "check:fix": "bun run check:biome:fix && bun run check:ts",

--- a/packages/summon/monorepo/src/monorepo/index.ts
+++ b/packages/summon/monorepo/src/monorepo/index.ts
@@ -14,11 +14,11 @@ import {
   template,
 } from "@canonical/summon-core";
 import { exec, flatMap, info, mkdir, sequence_, when } from "@canonical/task";
-import pkg from "../../package.json" with { type: "json" };
 
 import {
   createTemplateContext,
   type MonorepoAnswers,
+  PACKAGE_NAME,
   validateMonorepoName,
   validateRepository,
 } from "../shared/index.js";
@@ -139,7 +139,7 @@ const prompts: PromptDefinition[] = [
 export const generator: GeneratorDefinition<MonorepoAnswers> = {
   meta: {
     name: "monorepo",
-    displayName: `${pkg.name}`,
+    displayName: PACKAGE_NAME,
     description:
       "Generate a new Bun + Lerna monorepo with CI, release, and shared config",
     version: "0.1.0",

--- a/packages/summon/monorepo/src/shared/index.ts
+++ b/packages/summon/monorepo/src/shared/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { default as createTemplateContext } from "./createTemplateContext.js";
+export { PACKAGE_NAME } from "./packageName.js";
 export type * from "./types.js";
 export { default as validateMonorepoName } from "./validateMonorepoName.js";
 export { default as validateRepository } from "./validateRepository.js";

--- a/packages/summon/monorepo/src/shared/packageName.ts
+++ b/packages/summon/monorepo/src/shared/packageName.ts
@@ -1,0 +1,10 @@
+/**
+ * The published package name, used in generator `displayName` labels.
+ *
+ * Kept as a plain constant rather than a `package.json` JSON import: the import
+ * path (`../../package.json`) is relative to the source file, but after the
+ * `src → dist/esm` build it would resolve one level too shallow (`dist/` instead
+ * of the package root), breaking at runtime under Node. A constant sidesteps the
+ * build-layout coupling entirely.
+ */
+export const PACKAGE_NAME = "@canonical/summon-monorepo";

--- a/packages/summon/monorepo/tsconfig.build.json
+++ b/packages/summon/monorepo/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/testing/**", "src/**/templates/**"]
+}

--- a/packages/summon/package/package.json
+++ b/packages/summon/package/package.json
@@ -3,7 +3,18 @@
   "description": "Package generator for Summon - scaffold new npm packages with proper configuration",
   "version": "0.33.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "dist/esm/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"
@@ -21,7 +32,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "echo 'No build needed - runs directly from TypeScript'",
+    "build": "tsc -p tsconfig.build.json && bun ../../../scripts/copy-templates.ts src dist/esm",
     "build:all": "bun run build",
     "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
     "check:fix": "bun run check:biome:fix && bun run check:ts",
@@ -36,6 +47,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.9",
     "@canonical/biome-config": "^0.33.0",
+    "@canonical/summon-core": "^0.33.0",
+    "@canonical/task": "^0.33.0",
     "@canonical/typescript-config": "^0.33.0",
     "@canonical/webarchitect": "^0.33.0",
     "@types/bun": "^1.3.10",

--- a/packages/summon/package/src/package/index.ts
+++ b/packages/summon/package/src/package/index.ts
@@ -12,13 +12,13 @@ import {
   template,
 } from "@canonical/summon-core";
 import { exec, flatMap, info, mkdir, sequence_, when } from "@canonical/task";
-import pkg from "../../package.json" with { type: "json" };
 
 import {
   createTemplateContext,
   detectMonorepo,
   detectPackageManager,
   getPackageShortName,
+  PACKAGE_NAME,
   type PackageAnswers,
   validatePackageName,
 } from "../shared/index.js";
@@ -129,7 +129,7 @@ const prompts: PromptDefinition[] = [
 export const generator: GeneratorDefinition<PackageAnswers> = {
   meta: {
     name: "package",
-    displayName: `${pkg.name}`,
+    displayName: PACKAGE_NAME,
     description:
       "Generate a new npm package with proper configuration for the pragma monorepo",
     version: "0.1.0",

--- a/packages/summon/package/src/shared/index.ts
+++ b/packages/summon/package/src/shared/index.ts
@@ -6,5 +6,6 @@ export * from "./config/index.js";
 export { default as createTemplateContext } from "./createTemplateContext.js";
 export * from "./detection/index.js";
 export { default as getPackageShortName } from "./getPackageShortName.js";
+export { PACKAGE_NAME } from "./packageName.js";
 export type * from "./types.js";
 export { default as validatePackageName } from "./validatePackageName.js";

--- a/packages/summon/package/src/shared/packageName.ts
+++ b/packages/summon/package/src/shared/packageName.ts
@@ -1,0 +1,10 @@
+/**
+ * The published package name, used in generator `displayName` labels.
+ *
+ * Kept as a plain constant rather than a `package.json` JSON import: the import
+ * path (`../../package.json`) is relative to the source file, but after the
+ * `src → dist/esm` build it would resolve one level too shallow (`dist/` instead
+ * of the package root), breaking at runtime under Node. A constant sidesteps the
+ * build-layout coupling entirely.
+ */
+export const PACKAGE_NAME = "@canonical/summon-package";

--- a/packages/summon/package/tsconfig.build.json
+++ b/packages/summon/package/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/testing/**", "src/**/templates/**"]
+}


### PR DESCRIPTION
## Done

`@canonical/summon-monorepo` and `@canonical/summon-package` shipped raw TypeScript
(`"main": "src/index.ts"`, `"build": "echo 'No build needed - runs directly from
TypeScript'"`). The published `summon` CLI cannot load them, so from an npm/bun global
install the `monorepo` and `package` commands do not exist.

This gives both packages the same build treatment `@canonical/summon-application` and
`@canonical/summon-component` already have:

- **`tsconfig.build.json`** in each package — `rootDir: src`, `outDir: dist/esm`,
  declarations to `dist/types`, excluding tests and `templates/`.
- **`"build": "tsc -p tsconfig.build.json && bun ../../../scripts/copy-templates.ts src dist/esm"`.**
  The template copy is load-bearing: both generators resolve `src/templates/*.ejs`
  relative to `__dirname`, so compiling without carrying the `.ejs` files would produce a
  package that loads and then fails at generation time.
- **`"main"`/`"module"`/`"types"`/`"exports"` pointing at `dist`, and `"files": ["dist"]`.**
  `main` is the field summon's discovery actually reads (`processPackage` in
  `discoverGeneratorTree`), so it has to be the compiled entry.
- **Replaced `import pkg from "../../package.json"` with a `PACKAGE_NAME` constant** in each
  package's `src/shared/`. This is forced by the build, not a drive-by: the JSON import sits
  outside `rootDir`, and its relative path would resolve one level too shallow after the
  `src → dist/esm` move. `summon-component` hit exactly this and solved it the same way —
  `packages/summon/component/src/shared/packageName.ts` carries the explanatory comment,
  which the two new files reuse verbatim. Each is used in exactly one place, the generator's
  `meta.displayName`.

- **Added `@canonical/summon-core` and `@canonical/task` to `summon-package`'s
  devDependencies**, alongside the peerDependencies it already declared. This is the
  task-graph wiring the compile step forces. `summon-package` declared those two *only* as
  peers, and Nx does not derive project-graph edges from `peerDependencies`, so it had no
  edge to `summon-core` at all — Nx was free to build it first. That was harmless while it
  ran from source and became a hard failure the moment it needed `summon-core`'s emitted
  `dist/types` to typecheck. `summon-monorepo` already declares both as real dependencies
  (which is why it was unaffected), and `summon-component` already declares them in *both*
  devDependencies and peerDependencies — this makes `summon-package` match.

  This one only shows up on a clean checkout. Locally the first `bun install` runs the root
  `prepare` build, so `summon-core/dist` already exists and the ordering never gets tested;
  CI caught it on the first push. Verified after the fix by deleting the whole dependency
  chain's `dist/` and running `nx run @canonical/summon-package:build:all --skip-nx-cache`,
  which now orders `task → utils → summon-core → summon-package`.

No `nx.json` change was needed — the existing `targetDefaults` already declare
`build`/`check`/`test` as depending on `^build`, so once the graph edges are right the
ordering follows. The only in-repo consumer, `@canonical/pragma-cli` (which imports
`@canonical/summon-package` in `src/capabilities/create/pickGenerator.ts`), was already a
real edge. I also confirmed that an Nx cache *hit* restores `dist/` rather than leaving a
dependent to bundle against a missing directory. `@canonical/summon-monorepo` has no
in-repo consumer at all.

### The cost, stated plainly

**Two packages that previously ran straight from source now need a build step.** That is a
real regression in the inner loop, and it is almost certainly why they were left
uncompiled. Concretely: after `bun install`, `summon monorepo` and `summon package` resolved
from a workspace checkout now need `bun run build` in those packages before the CLI can
discover them, where before an edit to `src/` was live immediately. The root `prepare` hook
covers the install path, but an edit-then-run cycle now has a step in it.

**The alternative I am not proposing.** Changing the bin's shebang from
`#!/usr/bin/env node` to `#!/usr/bin/env bun` would resolve the same contradiction in one
line and keep both packages running from source. I am not proposing it because it makes bun
a hard runtime requirement for every consumer of the published CLI, not just for people
working in this repo.

The case for compiling instead:

1. **Consistency.** Two of the four generator packages in this repo
   (`summon-application`, `summon-component`) already compile, with this exact
   `tsconfig.build.json` + `copy-templates` recipe. This makes the remaining two match
   rather than introducing anything new.
2. **The plugin contract.** Summon discovers any `@scope/summon-*` package in
   `node_modules`. That contract only holds if a third party can ship a generator package
   the *published* CLI can load — which means compiled JS, since Node refuses to strip types
   under `node_modules`. Our own packages should meet the bar we ask of others.
3. **The shebang already promises node.** `dist/src/bin.js` starts with
   `#!/usr/bin/env node`. Compiling makes that promise true rather than changing the promise.

That trade is a judgement call and reviewers may weigh the inner-loop cost differently — the
one-line shebang change is a legitimate option and I have not tried to close it off.

### Deliberately left alone

- **The `node` shebang.** Unchanged.
- **The silent failure.** With the packages uncompiled, `summon --help` under node listed
  neither command and printed no warning at all. That is not a missing code path — it is
  deliberate: `processPackage` in `packages/summon/core/src/discovery/discoverGeneratorTree.ts`
  catches the import error, matches `"Stripping types"` / `"Unknown file extension"`, and
  returns early unless `SUMMON_DEBUG` is set. With `SUMMON_DEBUG=1` the warning does fire:

  ```
  Warning: Could not load generators from '@canonical/summon-monorepo': Stripping types is
  currently unsupported for files under node_modules, for ".../summon-monorepo/src/index.ts"
  ```

  The suppression is reasonable on its own terms (the end user cannot act on it), but it is
  why this defect went unnoticed. Whether an unloadable generator package should be silent
  by default is a separate question and a separate PR; nothing in this diff touches it.
- **`summon-monorepo`'s root `tsconfig.json`** still extends `@canonical/typescript-config`.
  `tsconfig.build.json` extends the existing config rather than replacing it.
- **The `library` template.** #912 is in flight on `packages/summon/package/src/templates/`.
  This PR does not touch that directory. It does touch that package's
  `src/package/index.ts`, but at different hunks (the import block and `meta.displayName`,
  vs. #912's `templates` map and task list), so the two should merge cleanly in either
  order.
- **`summon-package`'s stale peer range.** Its `peerDependencies` still say
  `"^0.18.0 || ^0.20.0"` for `summon-core` and `task` while the package is at `0.33.0`, so
  installing it emits `warn: incorrect peer dependency`. Pre-existing, unrelated to
  compiling, and not something this PR needs — but worth someone's attention, since
  `summon-component` keeps its peer ranges in lockstep at `^0.33.0` and these were left
  behind.

## QA

The proof has to be under **node**, not bun — under bun everything already worked, which is
why this was invisible from inside the workspace.

**Before** (published `@canonical/summon@0.33.0` + `@canonical/summon-monorepo@0.33.0` +
`@canonical/summon-package@0.33.0`, installed globally, run with `node $(which summon) --help`):

```
Usage: summon [options] [command]

A monadic task-centric code generator framework

Options:
  -V, --version            output the version number
  -g, --generators <path>  Load generators ONLY from this path (for testing)
  --setup-completion       Install shell autocompletion
  --cleanup-completion     Remove shell autocompletion
  -h, --help               display help for command

Commands:
  example                  example generators
  init [options]           Create a new Summon generator
  help [command]           display help for command
```

No `monorepo`, no `package`, and no warning. The same binary under `bun $(which summon) --help`
listed both — that discrepancy is the bug.

**After** (this branch's two packages packed with `bun pm pack` and installed globally
alongside the published CLI, same `node $(which summon) --help`):

```
Usage: summon [options] [command]

A monadic task-centric code generator framework

Options:
  -V, --version            output the version number
  -g, --generators <path>  Load generators ONLY from this path (for testing)
  --setup-completion       Install shell autocompletion
  --cleanup-completion     Remove shell autocompletion
  -h, --help               display help for command

Commands:
  example                  example generators
  init [options]           Create a new Summon generator
  monorepo [options]       Generate a new Bun + Lerna monorepo with CI, release,
                           and shared config
  package [options]        Generate a new npm package with proper configuration
                           for the pragma monorepo
  help [command]           display help for command
```

To reproduce:

```bash
# Build and pack from this branch
cd packages/summon/monorepo && bun run build && bun pm pack --destination /tmp/tarballs
cd ../package          && bun run build && bun pm pack --destination /tmp/tarballs

# Install globally into a scratch prefix, alongside the published CLI
export BUN_INSTALL=/tmp/summon-scratch
bun add -g @canonical/summon \
  /tmp/tarballs/canonical-summon-monorepo-0.33.0.tgz \
  /tmp/tarballs/canonical-summon-package-0.33.0.tgz

# Both commands must appear under PLAIN NODE
node $(which summon) --help
```

Listing the commands is necessary but not sufficient — it does not prove the `.ejs` files
came along. Both generators were run for real, under node, from that global install:

```bash
node $(which summon) monorepo --name example-monorepo \
  --description "An example monorepo" --license GPL-3.0 \
  --typescript-config @canonical/typescript-config-base \
  --repository https://example.com/example/example-monorepo \
  --bun-version 1.3.13 --no-init-git --no-run-install -y
# → Created 19 files, 9 directories, 1 command  (19 = all 19 templates)

cd example-monorepo
node $(which summon) package --name @example/widgets --type library \
  --description "An example library package" --no-run-install -y
# → Created 5 files, 2 directories
```

Both generated trees were checked for leftover `<%` tags — none, so every template was found
on disk and rendered.

Gates, from the repo root:

- `bun run check` — pass across all projects.
- `bun run test` — pass for the affected projects (`@canonical/summon-monorepo` 22 tests /
  5 files, `@canonical/summon-package` 40 tests / 9 files, both at 100% coverage;
  `@canonical/pragma-cli` as the one in-repo consumer).

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details. — both packages now have a real `build`; `build:all` delegates to it, matching `summon-application` and `summon-component`.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions. — n/a, no new packages; both already publish.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

n/a — CLI-only change, no visual surface.
