### PR TITLE
test(prism): the proof — the core lenses render against a provider that has never heard of pragma

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,16 @@ jobs:
       - name: Test
         run: bunx nx affected -t test --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD
 
+      # The despecialisation proof: boot the docsite against
+      # `@canonical/prism-graph-example` and assert the core lenses render.
+      # A separate target from `test` because it spawns two real servers and
+      # takes ~30s — it has no business inside the unit run — and separate
+      # from `test:e2e` because that suite needs the pragma refs cache, which
+      # no runner has. `nx affected` is a no-op for projects lacking the
+      # target, so this step only ever runs the docsite.
+      - name: Despecialisation proof
+        run: bunx nx affected -t test:proof --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD
+
   build-gate:
     runs-on: ubuntu-latest
     needs: build-matrix

--- a/apps/react/pragma-docs/package.json
+++ b/apps/react/pragma-docs/package.json
@@ -35,6 +35,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "test:proof": "vitest run --config vitest.e2e.config.ts metro.e2e",
     "storybook": "storybook dev -p 6010 --no-open --host 0.0.0.0"
   },
   "dependencies": {
@@ -85,5 +86,10 @@
     "vite": "^8.0.1",
     "vite-plugin-relay-lite": "^0.12.0",
     "vitest": "^4.0.18"
+  },
+  "nx": {
+    "implicitDependencies": [
+      "@canonical/prism-graph-example"
+    ]
   }
 }

--- a/apps/react/pragma-docs/src/lib/graphBindings/deployments.tests.ts
+++ b/apps/react/pragma-docs/src/lib/graphBindings/deployments.tests.ts
@@ -1,0 +1,101 @@
+/**
+ * The selector's fail-safe rule, and the key-set contract every deployment
+ * has to satisfy.
+ *
+ * WHAT WOULD BREAK WITHOUT THESE. `GRAPH_BINDINGS` is resolved once at module
+ * scope from an environment variable, in three independent module registries
+ * (Bun native prepare, Vite SSR render, the client bundle). The consequence of
+ * getting the rule wrong is not an exception — it is a lens quietly querying
+ * the wrong class, or a store that does not fulfil the operation the renderer
+ * runs. `selectDeployment` takes its name as an ARGUMENT precisely so that
+ * rule can be pinned here rather than discovered in a browser.
+ *
+ * The specific pins on the `metro` table are dataset facts, not preferences:
+ * they are the reason `test/e2e/metro.e2e.ts` can assert what it asserts, and
+ * changing either one silently weakens that proof.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DEPLOYMENT,
+  DEPLOYMENT_ENV_VAR,
+  DEPLOYMENTS,
+  selectDeployment,
+} from "./deployments.js";
+
+describe("selectDeployment", () => {
+  it("falls back to pragma for an unset, empty or unknown name", () => {
+    // FAIL-SAFE is the whole design. A misspelt variable must degrade to the
+    // shipped default, never to an empty page — which is what a lookup that
+    // returned `undefined` and got spread into a query variable would give.
+    for (const name of [undefined, "", "pragmaa", "metro "]) {
+      expect(selectDeployment(name)).toBe(DEPLOYMENTS.pragma);
+    }
+  });
+
+  it("selects the named deployment", () => {
+    expect(selectDeployment("metro")).toBe(DEPLOYMENTS.metro);
+    expect(selectDeployment(DEFAULT_DEPLOYMENT)).toBe(DEPLOYMENTS.pragma);
+  });
+
+  it("names its own default among the deployments it can select", () => {
+    // `DEFAULT_DEPLOYMENT` is a string, so nothing stops it drifting away
+    // from a real key — after which the "fall back to the default" arm would
+    // be unreachable and every unknown name would resolve to `pragma` only
+    // by the literal that happens to be written in the fallback.
+    expect(Object.keys(DEPLOYMENTS)).toContain(DEFAULT_DEPLOYMENT);
+  });
+});
+
+describe("DEPLOYMENTS", () => {
+  it("gives every deployment the SAME key set", () => {
+    // Consumers read `GRAPH_BINDINGS.components` without knowing which
+    // deployment answered. A missing key is `undefined.classUri` at module
+    // scope — a boot crash in the SSR brick, not a degraded page.
+    const keySets = Object.values(DEPLOYMENTS).map((table) =>
+      Object.keys(table).sort().join(","),
+    );
+    expect(new Set(keySets).size).toBe(1);
+  });
+
+  it("leaves pragma exactly as it shipped before deployments existed", () => {
+    // The one place literal strings ARE pinned. Every existing test, story
+    // and fixture in the app was written against these three values, and the
+    // whole claim of this seam is that an unset environment changes nothing.
+    expect(DEPLOYMENTS.pragma).toEqual({
+      standards: { classUri: "cs:CodeStandard" },
+      components: { classUri: "ds:Component" },
+      patterns: { classUri: "ds:Pattern" },
+    });
+  });
+
+  it("binds metro's standards lens to a class with SUBCLASSED instances", () => {
+    // `metro:Station` has 14 direct instances plus 2 `metro:Interchange`
+    // (a Station subclass), so the standards index renders TWO group sections
+    // and its jump-nav is exercised. `metro:Stop` would render one group and
+    // no rail at all — the lens would go green having shown none of its
+    // structure. Dataset fact:
+    // packages/docsite/graph-example/src/lib/provider/dataset.ts
+    expect(DEPLOYMENTS.metro.standards.classUri).toBe("metro:Station");
+  });
+
+  it("binds metro's components lens to a class with NO instances", () => {
+    // The metro deployment has no components lens. `geo:GeoPoint` appears in
+    // the dataset only as an embedded `location` value and has zero
+    // instances, so the term inspector's D31 landing rule can never fire and
+    // never link a reader to `/components/:uri`, a route metro cannot serve.
+    // `test/e2e/metro.e2e.ts` asserts that outcome over HTTP; this pins the
+    // choice that makes it true. Dataset fact:
+    // packages/docsite/graph-example/src/lib/provider/dataset.ts
+    expect(DEPLOYMENTS.metro.components.classUri).toBe("geo:GeoPoint");
+  });
+});
+
+describe("DEPLOYMENT_ENV_VAR", () => {
+  it("carries the VITE_ prefix a client bundle requires", () => {
+    // Vite exposes only `VITE_*` to the browser. Without the prefix the
+    // client would silently read nothing while the server read the value,
+    // and the two registries would prepare and render different classes.
+    expect(DEPLOYMENT_ENV_VAR.startsWith("VITE_")).toBe(true);
+  });
+});

--- a/apps/react/pragma-docs/src/lib/graphBindings/deployments.ts
+++ b/apps/react/pragma-docs/src/lib/graphBindings/deployments.ts
@@ -1,0 +1,125 @@
+/**
+ * THE CLOSED TABLE OF DEPLOYMENTS — every lens→class binding this build can
+ * be pointed at, and the pure rule that picks one.
+ *
+ * `#lib/graphBindings/index.js` selects from here at module scope and
+ * re-exports the chosen table as `GRAPH_BINDINGS`. That split is the point:
+ * READING the environment is impure and effectively untestable, CHOOSING a
+ * table is neither. {@link selectDeployment} takes the name as an argument,
+ * so the fail-safe behaviour below is pinned by a unit test rather than
+ * discovered in production with an empty page.
+ *
+ * WHY A TABLE AND NOT A URI. A deployment names a KEY, never a class. A typo
+ * therefore cannot produce a *wrong* binding — only the default — and no
+ * value from outside the build can make a lens query a class this repo never
+ * declared. That closure is what makes selecting by environment variable
+ * defensible at all; see the trade-off recorded in `index.ts`'s header.
+ *
+ * WHAT WOULD BREAK WITHOUT IT. The despecialisation proof
+ * (`test/e2e/metro.e2e.ts`) boots the real app against
+ * `@canonical/prism-graph-example`. The Definitions lens takes its variables
+ * from the URL and needs nothing from here, but the Standards lens roots at
+ * `ontologyClass(uri:)` with a class supplied from outside the graph. Without
+ * a second table the Standards lens can only ever be shown against pragma,
+ * and the neutrality claim stops one lens short of the two it can make.
+ */
+
+/** One lens's binding to the class it enumerates. */
+export interface LensBinding {
+  /** The class this lens enumerates. Prefixed form. */
+  readonly classUri: string;
+}
+
+/**
+ * The lenses every deployment must bind — ONE key set, enforced by the
+ * compiler rather than by convention.
+ *
+ * A deployment that has no lens for a key still has to name a class for it
+ * (see `metro.components`), because the key set is what lets consumers read
+ * `GRAPH_BINDINGS.components` without knowing which deployment answered.
+ */
+export interface DeploymentBindings {
+  /** The reading lens's class. Its instances are the standards. */
+  readonly standards: LensBinding;
+  /**
+   * The components lens's class. Also the term inspector's D31 landing rule:
+   * an instance links to `/components/:uri` only when its own class IS this
+   * one.
+   */
+  readonly components: LensBinding;
+  /** The lobby's third counted door. */
+  readonly patterns: LensBinding;
+}
+
+/** The deployment used when nothing selects one. */
+export const DEFAULT_DEPLOYMENT = "pragma";
+
+/**
+ * The variable that selects a deployment.
+ *
+ * `VITE_` is mandatory, not decorative: Vite exposes only `VITE_*`-prefixed
+ * variables to a client bundle, and the client is one of this table's three
+ * readers (see `index.ts`'s header for the other two and for why they have
+ * to agree).
+ */
+export const DEPLOYMENT_ENV_VAR = "VITE_PRISM_DEPLOYMENT";
+
+/**
+ * Every deployment this build knows how to be.
+ *
+ * PREFIXED FORM THROUGHOUT. These are ARGUMENTS to `ontologyClass(uri:)`,
+ * which echoes back the ABSOLUTE IRI — so nothing may compare a value from
+ * here against a `uri` the graph returned without running it through
+ * `toPrefixedUri` first.
+ */
+export const DEPLOYMENTS = {
+  /** The docsite's own graph: pragma's design-system ontologies. */
+  pragma: {
+    standards: { classUri: "cs:CodeStandard" },
+    components: { classUri: "ds:Component" },
+    patterns: { classUri: "ds:Pattern" },
+  },
+
+  /**
+   * `@canonical/prism-graph-example` — a fictional metro network, and the
+   * only provider in this repo written by someone who has never heard of
+   * pragma. Selecting it is how the despecialisation proof points the
+   * Standards lens at a foreign graph.
+   *
+   * `metro:Station` rather than `metro:Stop`: the dataset holds 14 Stations
+   * and 2 Interchanges (a Station subclass), so the index renders TWO group
+   * sections and the jump-nav is exercised. `metro:Stop` yields one group and
+   * a rail that never appears — a lens that renders is not the same as a lens
+   * that renders its structure. (Dataset facts —
+   * `packages/docsite/graph-example/src/lib/provider/dataset.ts`.)
+   *
+   * `geo:GeoPoint` for `components` is chosen because it has ZERO instances
+   * in that dataset: it appears only as an embedded `location` value. This
+   * deployment has no components lens, so the key must be filled with a class
+   * whose instances can never make the D31 landing rule link a reader into a
+   * route metro cannot serve. `metro.e2e.ts` asserts that outcome directly —
+   * zero `href="/components/` across every metro response.
+   */
+  metro: {
+    standards: { classUri: "metro:Station" },
+    components: { classUri: "geo:GeoPoint" },
+    patterns: { classUri: "geo:Zone" },
+  },
+} as const satisfies Record<string, DeploymentBindings>;
+
+/**
+ * The deployment `name` selects, or {@link DEFAULT_DEPLOYMENT} when it names
+ * nothing this build knows.
+ *
+ * FAIL-SAFE, DELIBERATELY: an unset, empty or unrecognised name yields
+ * exactly the table this app shipped before deployments existed. A misspelt
+ * variable degrades to the default rather than to an empty page, and every
+ * test written against the pragma bindings keeps passing untouched.
+ */
+export function selectDeployment(name: string | undefined): DeploymentBindings {
+  if (name === undefined || name.length === 0) return DEPLOYMENTS.pragma;
+  return (
+    (DEPLOYMENTS as Record<string, DeploymentBindings>)[name] ??
+    DEPLOYMENTS.pragma
+  );
+}

--- a/apps/react/pragma-docs/src/lib/graphBindings/graphBindings.tests.ts
+++ b/apps/react/pragma-docs/src/lib/graphBindings/graphBindings.tests.ts
@@ -3,6 +3,12 @@
  * names, pinned here so a fork that edits the table gets told rather than
  * finding out at runtime with an empty page.
  *
+ * The two structural invariants run over EVERY deployment, not only the one
+ * this process selected. A build reaches `GRAPH_BINDINGS` through exactly one
+ * entry of `DEPLOYMENTS`, so an entry the test process did not select would
+ * otherwise ship entirely unchecked and fail in the only environment that
+ * uses it.
+ *
  * There is deliberately NO assertion on the literal strings beyond their
  * shape. The values are the deployment's to choose; pinning
  * `"cs:CodeStandard"` would make a fork's first edit red for no reason and
@@ -15,31 +21,32 @@ import {
   LOBBY_PATTERN_CLASS,
   LOBBY_STANDARD_CLASS,
 } from "#domains/marketing/lobbyQuery.js";
+import { DEPLOYMENTS } from "./deployments.js";
 import { GRAPH_BINDINGS } from "./index.js";
 
 /** `prefix:local` — a declared prefix and a local name, never a scheme. */
 const PREFIXED_FORM = /^[A-Za-z][\w.-]*:[^/][^\s]*$/;
 
-describe("GRAPH_BINDINGS", () => {
+describe.each(Object.entries(DEPLOYMENTS))("DEPLOYMENTS.%s", (_name, table) => {
   it("states every binding in the PREFIXED form, never an absolute IRI", () => {
     // `ontologyClass(uri:)` accepts both forms, so an absolute IRI here
     // would WORK — and then silently defeat every `toPrefixedUri`
     // comparison written against these values, because the graph echoes
     // the absolute IRI back either way.
     expect(
-      Object.entries(GRAPH_BINDINGS)
+      Object.entries(table)
         .filter(([, binding]) => !PREFIXED_FORM.test(binding.classUri))
         .map(([lens]) => lens),
     ).toEqual([]);
   });
 
   it("binds each lens to a DISTINCT class", () => {
-    const classUris = Object.values(GRAPH_BINDINGS).map(
-      (binding) => binding.classUri,
-    );
+    const classUris = Object.values(table).map((binding) => binding.classUri);
     expect(new Set(classUris).size).toBe(classUris.length);
   });
+});
 
+describe("GRAPH_BINDINGS", () => {
   it("is the single source the lobby's three doors read", () => {
     // The lobby kept its three exported names (nothing in
     // `domains/marketing` had to move), but they are no longer a second

--- a/apps/react/pragma-docs/src/lib/graphBindings/index.ts
+++ b/apps/react/pragma-docs/src/lib/graphBindings/index.ts
@@ -5,8 +5,9 @@
  * `ontologies`, `ontology`, `ontologyClass`, `ontologyProperty`) and NONE
  * of them names a subject. A lens that enumerates things therefore needs a
  * class URI supplied from OUTSIDE the graph, and this module is that
- * outside. A fork points the docsite at its own ontology by editing this
- * file and nothing else — no query, no component, no route, no test.
+ * outside. A fork points the docsite at its own ontology by adding a
+ * deployment to `deployments.ts` and nothing else — no query, no component,
+ * no route, no test.
  *
  * This generalises an answer the app had already reached rather than
  * inventing one: `domains/marketing/lobbyQuery.ts` has shipped its three
@@ -24,15 +25,42 @@
  * server-normalised IRIs against each other, or run the string through
  * `toPrefixedUri` first.
  *
- * NOT AN ENV VAR, DELIBERATELY. These strings become GraphQL *variables*,
- * and the SSR prepare step and the client hydration must compute
- * byte-identical variables or the warmed store does not fulfil the
- * client's operation. `graphqlEndpoint.ts` documents that `VITE_*`
- * resolves DIFFERENTLY in the client build (misses, falls back) and in the
- * SSR renderer (reads `process.env` at runtime) — harmless for an endpoint
- * URL, silently corrupting for a query variable. A module constant cannot
- * diverge. If a deployment ever needs an override it is added HERE, behind
- * the same export.
+ * A CLOSED TABLE, SELECTED BY NAME — NEVER A URI FROM THE ENVIRONMENT.
+ * These strings become GraphQL *variables*, and the SSR prepare step and the
+ * client hydration must compute byte-identical variables or the warmed store
+ * does not fulfil the client's operation. That is why the environment may
+ * name a KEY of {@link DEPLOYMENTS} and may never supply a class: a typo
+ * cannot produce a *wrong* binding, only the default, and no value from
+ * outside the build can point a lens at a class this repo never declared.
+ *
+ * The paragraph this replaces said "NOT AN ENV VAR, DELIBERATELY", on the
+ * grounds that `VITE_*` resolves differently in the client build and in the
+ * SSR renderer. That failure mode is real but narrower than it read, and it
+ * is worth stating exactly where it does and does not bite:
+ *
+ * - In `dev:*`, Vite injects `VITE_*` into the transformed client module
+ *   straight from `process.env` (measured: the served
+ *   `/src/relay/graphqlEndpoint.ts` carries the value inline), and Bun
+ *   populates `import.meta.env` from `process.env` too. All three registries
+ *   — Bun native prepare, Vite SSR render, Vite dev client — read one value.
+ * - In `preview:*`, the client build and the server run in ONE process
+ *   environment (`bun run build:client && … bun preview.bun.ts`), so the
+ *   build-time replacement and the runtime read see the same value.
+ * - THE RESIDUAL HAZARD is "build in environment A, run in environment B":
+ *   the built bundle froze A's value while the renderer reads B's, and the
+ *   two registries diverge. This repo has no pipeline that does that, so the
+ *   hazard is documented rather than pretended away. The fix, when a real
+ *   deployment appears, is to stop resolving this per registry: have the
+ *   server resolve once and transport the answer on `__INITIAL_DATA__`, with
+ *   `entry.tsx` and `hydrateApp.tsx` setting it before the router, exactly as
+ *   they already do for the prefetch environment.
+ *
+ * Divergence is OBSERVABLE, not silent: `test/e2e/metro.e2e.ts` asserts, for
+ * each Standards route, both that the warmed store carries the provider's
+ * records AND that the rendered HTML carries them. If the two registries ever
+ * disagree the store fills, the render misses, `entry.tsx`'s `fetchFn`
+ * rejects, and the page serves its suspense fallback — which is precisely the
+ * records-present-content-absent pair that test turns red.
  *
  * THE ACCEPTANCE GATE MUST NEVER READ IT. `packages/docsite/graph-example`
  * supplies its own binding (`metro:Station`) through
@@ -42,24 +70,62 @@
  * green because the app agreed with itself.
  */
 
-/** One lens's binding to the class it enumerates. */
-export interface LensBinding {
-  /** The class this lens enumerates. Prefixed form. */
-  readonly classUri: string;
-}
+import {
+  DEPLOYMENT_ENV_VAR,
+  type DeploymentBindings,
+  selectDeployment,
+} from "./deployments.js";
+
+// The table itself, its default and its selector stay in `deployments.js`;
+// this module re-exports only the TYPES, which were part of its surface
+// before deployments existed. Re-exporting the values too would give every
+// consumer two names for one thing.
+export type { DeploymentBindings, LensBinding } from "./deployments.js";
 
 /**
- * The deployment's lens → class table. Prefixed form throughout (see the
- * module header): these are ARGUMENTS to `ontologyClass(uri:)`, never
- * values to compare a returned `uri` against.
+ * Which deployment this runtime was started as, or `undefined` for the
+ * default.
+ *
+ * Reads the two sources for the same six-runtime reason
+ * `#relay/graphqlEndpoint.js` documents at length: `import.meta.env` is a
+ * Vite/Bun construct that plain Node does not have, and `process` does not
+ * exist in a browser bundle.
+ *
+ * @note Impure — reads the ambient environment.
+ */
+const readDeploymentName = (): string | undefined => {
+  // The LITERAL member access is required: Vite's static replacement only
+  // matches `import.meta.env.VITE_PRISM_DEPLOYMENT` spelled out. A computed
+  // key (`import.meta.env[DEPLOYMENT_ENV_VAR]`) would keep working in dev and
+  // silently resolve to nothing in a build — which, for a query VARIABLE,
+  // means the client asks for a different class than the server prepared.
+  const fromVite: unknown = import.meta.env?.VITE_PRISM_DEPLOYMENT;
+  if (typeof fromVite === "string" && fromVite.length > 0) return fromVite;
+  // The `typeof process` guard is NOT optional: a bare `process.env.X` is a
+  // ReferenceError in the browser bundle, which would take the client entry
+  // down before React mounts.
+  const fromProcess: string | undefined =
+    /* v8 ignore next -- runtime detection: the browser bundle has no `process`, unreachable under the node test environment */
+    typeof process === "undefined"
+      ? undefined
+      : process.env[DEPLOYMENT_ENV_VAR];
+  return typeof fromProcess === "string" && fromProcess.length > 0
+    ? fromProcess
+    : undefined;
+};
+
+/**
+ * The deployment's lens → class table.
+ *
+ * `pragma` unless {@link DEPLOYMENT_ENV_VAR} names another entry of
+ * {@link DEPLOYMENTS} — so an unset environment yields byte-identical values
+ * to the ones this module exported before deployments existed.
  *
  * `standards` is the only entry a lens roots at today; `components` and
  * `patterns` are read by the lobby's counted doors, and `components`
  * additionally by the term inspector's D31 landing rule (an instance links
  * to `/components/:uri` only when its own class IS the components class).
  */
-export const GRAPH_BINDINGS = {
-  standards: { classUri: "cs:CodeStandard" },
-  components: { classUri: "ds:Component" },
-  patterns: { classUri: "ds:Pattern" },
-} as const satisfies Record<string, LensBinding>;
+export const GRAPH_BINDINGS: DeploymentBindings = selectDeployment(
+  readDeploymentName(),
+);

--- a/apps/react/pragma-docs/test/e2e/metro.e2e.ts
+++ b/apps/react/pragma-docs/test/e2e/metro.e2e.ts
@@ -45,7 +45,10 @@
  * `bun run test:proof`.
  */
 import { describe, expect, it } from "vitest";
-import { GRAPH_BINDINGS } from "#lib/graphBindings/index.js";
+import {
+  DEPLOYMENT_ENV_VAR,
+  DEPLOYMENTS,
+} from "#lib/graphBindings/deployments.js";
 import { startMetroProvider, startServer } from "./serverHarness.js";
 
 const CWD = process.cwd();
@@ -69,9 +72,9 @@ const DEV_READY_MS = 90_000;
 const TEST_TIMEOUT_MS = DEV_READY_MS + 90_000;
 
 /**
- * PRAGMA'S OWN VOCABULARY, taken from the app's shipped binding table rather
- * than retyped, so the negative control provably blocks the real prefixes.
- * A hand-written blocklist of invented strings would pass forever.
+ * PRAGMA'S OWN VOCABULARY, taken from the pragma deployment table rather than
+ * retyped, so the negative control provably blocks the real prefixes. A
+ * hand-written blocklist of invented strings would pass forever.
  *
  * This is the one place the proof imports an app module — `servers.e2e.ts`
  * keeps the server a black box, and that rule is worth bending exactly here:
@@ -83,7 +86,7 @@ const TEST_TIMEOUT_MS = DEV_READY_MS + 90_000;
  */
 const PRAGMA_PREFIXES = [
   ...new Set(
-    Object.values(GRAPH_BINDINGS).map(
+    Object.values(DEPLOYMENTS.pragma).map(
       (binding) => `${binding.classUri.split(":")[0]}:`,
     ),
   ),
@@ -147,14 +150,37 @@ function storeMentionsMetro(records: Record<string, unknown>): boolean {
   return JSON.stringify(records).includes("metro:");
 }
 
+/** Poll until the provider's hit counter shows `count` of `source`. */
+async function waitForHits(
+  provider: { hits: (source: "ssr" | "client") => number },
+  source: "client" | "ssr",
+  count: number,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (provider.hits(source) < count) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `only ${provider.hits(source)} ${source} hits seen within ${timeoutMs}ms (wanted ${count})`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
 describe("the core lenses render against a provider that has never heard of pragma", () => {
   it(
-    "dev:bun serves Definitions from @canonical/prism-graph-example",
+    "dev:bun serves Definitions and Standards from @canonical/prism-graph-example",
     async () => {
       const provider = await startMetroProvider(GRAPH_EXAMPLE_CWD);
       const server = await startServer("dev:bun", CWD, {
         timeoutMs: DEV_READY_MS,
         graphqlUrl: provider.url,
+        // The Standards lens roots at a class named from OUTSIDE the graph,
+        // so it is the one lens that needs the deployment said out loud.
+        // Definitions takes its variables from the URL and would render
+        // against metro with this unset.
+        env: { [DEPLOYMENT_ENV_VAR]: "metro" },
       });
       try {
         // 1. THE PRECONDITION, stated as an assertion rather than a skip: the
@@ -285,6 +311,129 @@ describe("the core lenses render against a provider that has never heard of prag
         expect(termHtml).toContain("<h3>Instances</h3>");
         expect(termHtml).toContain("metro:northgate");
         expectNoPragmaVocabulary("/definitions/metro:Station", termHtml);
+
+        // 6. /standards — the lens that could NOT render against metro before
+        //    the deployment table existed. Its root class comes from
+        //    `GRAPH_BINDINGS`, so with the pragma table it asked for
+        //    `cs:CodeStandard`, a class metro does not have, and rendered its
+        //    honest "No standards in the graph." This block is the deployment
+        //    seam's whole reason for existing.
+        const standardsIndex = await fetch(`${server.base}/standards`);
+        expect(standardsIndex.status).toBe(200);
+        const standardsIndexHtml = await standardsIndex.text();
+        expectPortableFrame(standardsIndexHtml);
+        //    THE CROSS-REGISTRY PAIR. The prepare step runs in the Bun-native
+        //    registry and the render in the Vite SSR one; if they resolved
+        //    different deployments the store would fill while
+        //    `useLazyLoadQuery` missed, and the page would serve
+        //    `Loading the standards…` with a full record map underneath.
+        //    Records AND content, therefore, or neither proves anything.
+        expect(
+          storeMentionsMetro(initialRelayRecords(standardsIndexHtml)),
+        ).toBe(true);
+        expect(standardsIndexHtml).not.toContain("No standards in the graph");
+
+        //    Grouping is by the instance's own CLASS. `metro:Station` has 14
+        //    direct instances and 2 `metro:Interchange` (a Station subclass),
+        //    so there are exactly TWO groups — a dataset fact
+        //    (`packages/docsite/graph-example/src/lib/provider/dataset.ts`),
+        //    and the reason this class was bound rather than `metro:Stop`,
+        //    which yields one group and never renders the jump-nav at all.
+        const groupSections =
+          standardsIndexHtml.match(/<section[^>]*id="standards-group-/g) ?? [];
+        expect(groupSections).toHaveLength(2);
+        expect(standardsIndexHtml).toContain('id="standards-group-station"');
+        expect(standardsIndexHtml).toContain(
+          'id="standards-group-interchange"',
+        );
+        //    The jump rail lists one anchor per group when there is more than
+        //    one group — derived from THIS response, so the relation holds as
+        //    the dataset grows.
+        const groupJumpLinkCount = (
+          standardsIndexHtml.match(/href="#standards-group-/g) ?? []
+        ).length;
+        expect(groupJumpLinkCount).toBe(groupSections.length);
+        //    A group exists only because standards fill it, so links strictly
+        //    exceed sections. Both counted from this response.
+        const standardLinkCount = (
+          standardsIndexHtml.match(/href="\/standards\/https%3A/g) ?? []
+        ).length;
+        expect(standardLinkCount).toBeGreaterThan(groupSections.length);
+
+        //    THE COMPACT IDENTITY. The link text is `_meta.title` and the
+        //    href the absolute IRI, so without this the reader could lose the
+        //    curie form entirely while every href assertion still passed.
+        expect(standardsIndexHtml).toContain("<code>metro:northgate</code>");
+        //    The D31 href: the percent-encoded ABSOLUTE IRI, the only address
+        //    `node(id:)` accepts — over a namespace pragma has never seen.
+        expect(standardsIndexHtml).toContain(
+          'href="/standards/https%3A%2F%2Fmetro.example%2Fonto%23northgate"',
+        );
+        //    Deliberately NO `Load more` assertion: 16 instances sit under the
+        //    app's 100-item page size, so `hasNextPage` is false and the
+        //    button correctly does not render. Asserting it would be asserting
+        //    a pragma-scale fact about a metro-scale graph.
+        expectNoPragmaVocabulary("/standards", standardsIndexHtml);
+
+        // 7. /standards/<northgate> — the reading page over a foreign entity.
+        const standardReading = await fetch(
+          `${server.base}/standards/${encodeURIComponent(
+            "https://metro.example/onto#northgate",
+          )}`,
+        );
+        expect(standardReading.status).toBe(200);
+        const standardReadingHtml = await standardReading.text();
+        expectPortableFrame(standardReadingHtml);
+        expect(
+          storeMentionsMetro(initialRelayRecords(standardReadingHtml)),
+        ).toBe(true);
+        //    The other half of the cross-registry pair, and the sharpest one
+        //    on this route: before the seam, the prepare step already warmed
+        //    the store with `metro:northgate` and the page STILL said "No
+        //    standard found" — because the `boundClass` guard compared
+        //    against pragma's class. Records without content is exactly that
+        //    failure, so it is named explicitly rather than left to a
+        //    positive assertion to imply.
+        expect(standardReadingHtml).not.toContain("No standard found");
+        expect(standardReadingHtml).toContain('data-slot="reading-canvas"');
+        expect(standardReadingHtml).toContain("Northgate");
+        expect(standardReadingHtml).toContain("metro:northgate");
+        //    The article's one piece of graph metadata outside the prose.
+        //    React splits the text node, hence the comment marker.
+        expect(standardReadingHtml).toContain("class: <!-- -->");
+        //    The prose arrives through `_meta.definition` and SSRs verbatim.
+        expect(standardReadingHtml).toContain("The northern terminus.");
+        expectNoPragmaVocabulary("/standards/<northgate>", standardReadingHtml);
+
+        // 8. WHO MADE THE REQUESTS. Every page above was fetched with plain
+        //    `fetch` — no browser, no client JS — yet six data-bearing routes
+        //    rendered real metro data. So the provider must have been hit
+        //    MANY times by the SERVER and NEVER by a client. Without this the
+        //    proof cannot distinguish "the server fetched and rendered" from
+        //    "the HTML happened to contain the right strings".
+        //
+        //    Deliberately no exact N: the page count drifts with the routes.
+        expect(provider.hits("ssr")).toBeGreaterThan(5);
+        const clientHitsBefore = provider.hits("client");
+        expect(clientHitsBefore).toBe(0);
+
+        //    Teeth, as a STRICT DELTA: a direct POST with no `x-pragma-ssr`
+        //    header is what a browser looks like, and it must move the client
+        //    counter by exactly one. Without this the zero above could be
+        //    vacuous — a counter that never counts anything reads as zero
+        //    forever.
+        const browserLikePost = await fetch(provider.url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ query: "{ __typename }" }),
+        });
+        expect(browserLikePost.status).toBe(200);
+        await browserLikePost.text();
+        await waitForHits(provider, "client", clientHitsBefore + 1);
+        //    Counters grow from async pipe chunks, so give trailing chunks a
+        //    beat to flush before asserting nothing ELSE arrived.
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(provider.hits("client")).toBe(clientHitsBefore + 1);
       } finally {
         await server.stop();
         await provider.stop();

--- a/apps/react/pragma-docs/test/e2e/metro.e2e.ts
+++ b/apps/react/pragma-docs/test/e2e/metro.e2e.ts
@@ -37,9 +37,13 @@
  * by design — so the page renders its SUSPENSE FALLBACK, not an error.
  *
  * Records-present-plus-content-absent is exactly that divergence. So each
- * data-bearing route asserts BOTH that `__INITIAL_DATA__.relay.records`
- * carries metro data AND that the rendered HTML carries it. Content present
- * proves both registries agreed; nothing can paper over a miss by refetching.
+ * data-bearing route asserts BOTH that `__INITIAL_DATA__.relay.records` holds
+ * records the METRO PROVIDER MINTED — keyed by its absolute IRIs, a form the
+ * app never sends, so no request can forge them — AND that the rendered HTML
+ * carries metro data. Content present proves both registries agreed; nothing
+ * can paper over a miss by refetching. See {@link storeEvidence}, which keeps
+ * the weaker variable-echo check as a separate, separately-named answer rather
+ * than letting it stand in for proof that data arrived.
  *
  * Kept out of the default `test` run by the `*.e2e.ts` name. Run it with
  * `bun run test:proof`.
@@ -112,6 +116,15 @@ const FOREIGN_MARKERS = [
   'href="/components/',
 ];
 
+/**
+ * The metro graph's IRI namespace — the form only the PROVIDER emits.
+ *
+ * The app addresses metro entities by their prefixed CURIE (`metro:Station`),
+ * so this absolute form never appears in an outbound variable. That asymmetry
+ * is what makes it usable as proof-of-response in {@link storeEvidence}.
+ */
+const METRO_IRI_PREFIX = "https://metro.example/";
+
 /** The frame every page must paint, whatever provider fills the canvas. */
 function expectPortableFrame(html: string): void {
   expect(html).toContain('data-region="primary-nav"');
@@ -145,9 +158,42 @@ function initialRelayRecords(html: string): Record<string, unknown> {
   return records as Record<string, unknown>;
 }
 
-/** Does the warmed store hold anything from the metro graph at all? */
-function storeMentionsMetro(records: Record<string, unknown>): boolean {
-  return JSON.stringify(records).includes("metro:");
+/**
+ * What the warmed store proves about the metro graph — two answers, because
+ * they witness two DIFFERENT things and only one of them is forgeable.
+ *
+ * `askedForMetro` — Relay formats ROOT storage keys from the operation's own
+ * arguments, so a hit here reads `ontologyClass(uri:"metro:Station")`. That
+ * argument came from `GRAPH_BINDINGS.standards.classUri` inside the BUN-NATIVE
+ * prepare step, which is the one registry nothing else in this file can see:
+ * if `server.bun.ts`'s copy of `#lib/graphBindings` resolved `pragma` while
+ * the Vite SSR copy resolved `metro`, this reads `cs:CodeStandard` and goes
+ * red. It is the cross-registry detector.
+ *
+ * It cannot, however, tell a warmed store from one whose every field came back
+ * null — the normalizer writes the key either way, so the request alone
+ * satisfies it. Hence:
+ *
+ * `holdsMetroRecords` — record IDs are `uri`, the ABSOLUTE IRI (R-2), and the
+ * app only ever SENDS the prefixed form. So an `https://metro.example/` key
+ * can only have been minted by the provider's response. No request can forge
+ * it, and no null-filled store contains one.
+ *
+ * Assert both wherever the operation carries a bound class; a route whose
+ * variables mention no class can only assert the second.
+ */
+function storeEvidence(records: Record<string, unknown>): {
+  askedForMetro: boolean;
+  holdsMetroRecords: boolean;
+} {
+  return {
+    askedForMetro: JSON.stringify(records["client:root"] ?? {}).includes(
+      "metro:",
+    ),
+    holdsMetroRecords: Object.keys(records).some((key) =>
+      key.startsWith(METRO_IRI_PREFIX),
+    ),
+  };
 }
 
 /** Poll until the provider's hit counter shows `count` of `source`. */
@@ -292,9 +338,12 @@ describe("the core lenses render against a provider that has never heard of prag
         expect(definitionsHtml).not.toContain("is-selected");
         //    The cross-registry pair: metro records in the store AND metro
         //    data in the HTML the reader receives.
-        expect(storeMentionsMetro(initialRelayRecords(definitionsHtml))).toBe(
-          true,
-        );
+        //    This route's operation sends no bound class, so there is no
+        //    variable echo to read — identity is the whole of the store-side
+        //    evidence here, and it is the strong half anyway.
+        expect(
+          storeEvidence(initialRelayRecords(definitionsHtml)).holdsMetroRecords,
+        ).toBe(true);
         expect(definitionsHtml).toContain("metro:");
         expectNoPragmaVocabulary("/definitions", definitionsHtml);
 
@@ -304,7 +353,13 @@ describe("the core lenses render against a provider that has never heard of prag
         expect(term.status).toBe(200);
         const termHtml = await term.text();
         expectPortableFrame(termHtml);
-        expect(storeMentionsMetro(initialRelayRecords(termHtml))).toBe(true);
+        expect(storeEvidence(initialRelayRecords(termHtml))).toEqual({
+          //    `uri: "metro:Station"` reaches the root storage key only if the
+          //    router percent-DECODED the `:term` param — nothing else on this
+          //    route pins that.
+          askedForMetro: true,
+          holdsMetroRecords: true,
+        });
 
         //    The well draws exactly one node per class the rail lists, so the
         //    two counts must agree — both derived from THIS response, never
@@ -381,9 +436,10 @@ describe("the core lenses render against a provider that has never heard of prag
         //    `useLazyLoadQuery` missed, and the page would serve
         //    `Loading the standards…` with a full record map underneath.
         //    Records AND content, therefore, or neither proves anything.
-        expect(
-          storeMentionsMetro(initialRelayRecords(standardsIndexHtml)),
-        ).toBe(true);
+        expect(storeEvidence(initialRelayRecords(standardsIndexHtml))).toEqual({
+          askedForMetro: true,
+          holdsMetroRecords: true,
+        });
         expect(standardsIndexHtml).not.toContain("No standards in the graph");
 
         //    Grouping is by the instance's own CLASS. `metro:Station` has 14
@@ -437,9 +493,9 @@ describe("the core lenses render against a provider that has never heard of prag
         expect(standardReading.status).toBe(200);
         const standardReadingHtml = await standardReading.text();
         expectPortableFrame(standardReadingHtml);
-        expect(
-          storeMentionsMetro(initialRelayRecords(standardReadingHtml)),
-        ).toBe(true);
+        expect(storeEvidence(initialRelayRecords(standardReadingHtml))).toEqual(
+          { askedForMetro: true, holdsMetroRecords: true },
+        );
         //    The other half of the cross-registry pair, and the sharpest one
         //    on this route: before the seam, the prepare step already warmed
         //    the store with `metro:northgate` and the page STILL said "No

--- a/apps/react/pragma-docs/test/e2e/metro.e2e.ts
+++ b/apps/react/pragma-docs/test/e2e/metro.e2e.ts
@@ -168,6 +168,59 @@ async function waitForHits(
   }
 }
 
+/**
+ * THE SERVED FRAME: the shell chrome around one page's canvas.
+ *
+ * Cut precisely, in two pieces, never by regex over the whole document:
+ * everything from `<body` up to and including the `<main data-region="canvas">`
+ * OPEN TAG, plus everything from `</main>` up to the first `<script` after it.
+ *
+ * The trailing cut is what `frameStability.tests.tsx` does not need. It renders
+ * in-process, so it never sees the hydration payload; a served page carries
+ * `__INITIAL_DATA__` and the module scripts inside `<body>` after the shell,
+ * and those are per-page DATA by construction. Cutting at the first script
+ * after the canvas removes them without a normalisation rule that could hide a
+ * real difference — the footer between `</main>` and that script stays in.
+ */
+function frameOf(html: string): string {
+  const bodyStart = html.indexOf("<body");
+  const bodyEnd = html.lastIndexOf("</body>");
+  expect(bodyStart).toBeGreaterThan(-1);
+  expect(bodyEnd).toBeGreaterThan(bodyStart);
+  const body = html.slice(bodyStart, bodyEnd);
+  // The canvas's structural identity must be unique for the cut to be exact.
+  expect(body.split("<main").length - 1).toBe(1);
+  expect(body.split("</main>").length - 1).toBe(1);
+  const open = body.indexOf("<main");
+  const openEnd = body.indexOf(">", open);
+  expect(body.slice(open, openEnd)).toContain('data-region="canvas"');
+  const tail = body.slice(body.lastIndexOf("</main>"));
+  const firstScript = tail.indexOf("<script");
+  expect(firstScript).toBeGreaterThan(-1);
+  return body.slice(0, openEnd + 1) + tail.slice(0, firstScript);
+}
+
+/** The strip's three claimed slots — the only frame content a lens owns. */
+const STRIP_CONTEXT_PATTERN =
+  /(<div class="strip-context" data-slot="context">)([\s\S]*?)(<\/div><div class="strip-controls")/;
+const STRIP_CONTROLS_PATTERN =
+  /(<div class="strip-controls" data-slot="controls">)([\s\S]*?)(<\/div><div class="strip-status")/;
+const STRIP_STATUS_PATTERN =
+  /(<div class="strip-status" data-slot="status">)([\s\S]*?)(<\/div><\/header>)/;
+
+/**
+ * Forgive exactly the accounted-for deltas, nothing else — the same three
+ * strip slots and the same router attribute `frameStability.tests.tsx`
+ * forgives, so this measures its property rather than a weaker one.
+ */
+function normalizeFrame(frame: string): string {
+  return frame
+    .replaceAll(' aria-current="page"', "")
+    .replace(STRIP_CONTEXT_PATTERN, "$1$3")
+    .replace(STRIP_CONTROLS_PATTERN, "$1$3")
+    .replace(STRIP_STATUS_PATTERN, "$1$3");
+}
+
 describe("the core lenses render against a provider that has never heard of pragma", () => {
   it(
     "dev:bun serves Definitions and Standards from @canonical/prism-graph-example",
@@ -434,6 +487,26 @@ describe("the core lenses render against a provider that has never heard of prag
         //    beat to flush before asserting nothing ELSE arrived.
         await new Promise((resolve) => setTimeout(resolve, 200));
         expect(provider.hits("client")).toBe(clientHitsBefore + 1);
+
+        // 9. THE PORTABLE SKELETON, measured rather than asserted. Every
+        //    route above got `expectPortableFrame`, which only proves the two
+        //    regions exist. This is the stronger claim `frameStability.tests
+        //    .tsx` makes in-process: the served frame is BYTE-IDENTICAL
+        //    between two different lenses once the three slots a lens owns
+        //    are blanked. That fixture-driven suite seeds itself from pragma
+        //    records and never contacts a provider, so it cannot say this
+        //    about a foreign graph. This can.
+        const standardsFrame = frameOf(standardsIndexHtml);
+        const definitionsFrame = frameOf(definitionsHtml);
+        //    Teeth first: the RAW frames must DIFFER. Without this the
+        //    equality below would also pass if the cut returned nothing, or
+        //    if the normaliser wiped everything that varies AND everything
+        //    that does not.
+        expect(standardsFrame).not.toBe(definitionsFrame);
+        expect(normalizeFrame(standardsFrame).length).toBeGreaterThan(1_000);
+        expect(normalizeFrame(standardsFrame)).toBe(
+          normalizeFrame(definitionsFrame),
+        );
       } finally {
         await server.stop();
         await provider.stop();

--- a/apps/react/pragma-docs/test/e2e/metro.e2e.ts
+++ b/apps/react/pragma-docs/test/e2e/metro.e2e.ts
@@ -1,0 +1,295 @@
+// @vitest-environment node
+
+/**
+ * THE DESPECIALISATION PROOF: the core lenses render against a provider that
+ * has never heard of pragma.
+ *
+ * The app is booted — its real `dev:bun` script, its real prepare step, its
+ * real renderer — against `@canonical/prism-graph-example`, a hand-written
+ * GraphQL provider over a fictional metro network whose only relationship to
+ * this repo is `@canonical/prism-contract`. Nothing in it knows what a
+ * component, a code standard, a job or a persona is.
+ *
+ * WHAT IS PROVEN, EXACTLY. Two lenses, four routes — Definitions
+ * (`/definitions`, `/definitions/:term`) and Standards (`/standards`,
+ * `/standards/:iri`) — plus the frame and the sitemap. NOT "the docsite" and
+ * NOT "the four lenses": Components is pragma-specific by owner decision, and
+ * Home's `LobbyQuery` carries `... on Component`, which the metro endpoint
+ * rejects with `Unknown type "Component".` Home is therefore asserted for its
+ * FRAME only, and nothing here claims otherwise.
+ *
+ * WITHOUT THIS FILE the neutrality claim rests on the acceptance gate in
+ * `packages/docsite/graph-example`, which executes the app's four operation
+ * texts against the example provider but never renders anything. A query can
+ * be neutral while the components reading it are not — a `uri.startsWith`,
+ * a hard-coded prefix, a lens that assumes pragma's shape. This is the only
+ * check in the repo that runs the real app end to end against a foreign
+ * graph.
+ *
+ * ── THE CROSS-REGISTRY PAIR: why every route asserts TWO things ──
+ *
+ * `#lib/graphBindings` is instantiated in three independent module
+ * registries in this cell: Bun native (`server.bun.ts` → `prepareRelayData`),
+ * Vite SSR (`ssrLoadModule("/src/server/entry.tsx")`), and the Vite client
+ * bundle. Prepare runs in the first, render in the second. If they resolve
+ * different bindings the prepare step warms the store with records the
+ * renderer's operation does not match, and `entry.tsx`'s `fetchFn` rejects
+ * by design — so the page renders its SUSPENSE FALLBACK, not an error.
+ *
+ * Records-present-plus-content-absent is exactly that divergence. So each
+ * data-bearing route asserts BOTH that `__INITIAL_DATA__.relay.records`
+ * carries metro data AND that the rendered HTML carries it. Content present
+ * proves both registries agreed; nothing can paper over a miss by refetching.
+ *
+ * Kept out of the default `test` run by the `*.e2e.ts` name. Run it with
+ * `bun run test:proof`.
+ */
+import { describe, expect, it } from "vitest";
+import { GRAPH_BINDINGS } from "#lib/graphBindings/index.js";
+import { startMetroProvider, startServer } from "./serverHarness.js";
+
+const CWD = process.cwd();
+
+/** Where the example provider's demo server lives, relative to this app. */
+const GRAPH_EXAMPLE_CWD = new URL(
+  "../../../../../packages/docsite/graph-example",
+  import.meta.url,
+).pathname;
+
+/**
+ * Readiness budget. A cold Vite dep-optimisation dominates the boot (~20 s
+ * measured, logging "Re-optimizing dependencies"); no graph is compiled,
+ * because the launcher spawns none when `VITE_GRAPHQL_URL` is set. If this
+ * cell ever fails with "server did not respond on <port> within Nms", raise
+ * the budget before suspecting anything else.
+ */
+const DEV_READY_MS = 90_000;
+
+/** Readiness plus a dozen server-rendered pages, each executing a query. */
+const TEST_TIMEOUT_MS = DEV_READY_MS + 90_000;
+
+/**
+ * PRAGMA'S OWN VOCABULARY, taken from the app's shipped binding table rather
+ * than retyped, so the negative control provably blocks the real prefixes.
+ * A hand-written blocklist of invented strings would pass forever.
+ *
+ * This is the one place the proof imports an app module — `servers.e2e.ts`
+ * keeps the server a black box, and that rule is worth bending exactly here:
+ * the assertion IS "the strings this app binds to are absent", so it has to
+ * read them from where they are bound.
+ *
+ * The colon is load-bearing. A bare `ds` matches `class="ds standards-page"`
+ * and `class="ds lobby"`, which are stylesheet names, not graph data.
+ */
+const PRAGMA_PREFIXES = [
+  ...new Set(
+    Object.values(GRAPH_BINDINGS).map(
+      (binding) => `${binding.classUri.split(":")[0]}:`,
+    ),
+  ),
+];
+
+/**
+ * Everything a metro response must never contain.
+ *
+ * The first entries are pragma's class prefixes (above). `sem://` is the
+ * journeys addon's scheme and `pragma.canonical.com` the code-standards
+ * namespace — neither is bound through the table, so both are named here.
+ *
+ * `href="/components/` is the sharpest one: the term inspector's D31 landing
+ * rule links an instance to `/components/:uri` when its class IS the
+ * components binding, and the metro deployment binds `components` to a class
+ * with no instances precisely so the rule can never fire. A single such href
+ * would mean the app had linked a reader into a lens metro cannot serve.
+ */
+const FOREIGN_MARKERS = [
+  ...PRAGMA_PREFIXES,
+  "sem://",
+  "pragma.canonical.com",
+  'href="/components/',
+];
+
+/** The frame every page must paint, whatever provider fills the canvas. */
+function expectPortableFrame(html: string): void {
+  expect(html).toContain('data-region="primary-nav"');
+  expect(html).toContain('data-region="canvas"');
+}
+
+/** No pragma vocabulary may reach a page served from the metro graph. */
+function expectNoPragmaVocabulary(label: string, html: string): void {
+  for (const marker of FOREIGN_MARKERS) {
+    expect(html.includes(marker), `${label} must not contain ${marker}`).toBe(
+      false,
+    );
+  }
+}
+
+/**
+ * The serialised Relay store the prepare step embedded for hydration.
+ *
+ * PARSED, not string-matched: `expect(html).toContain('"records"')` passes on
+ * an empty record map, and an empty map is exactly what a prepare step that
+ * silently fetched nothing produces.
+ */
+function initialRelayRecords(html: string): Record<string, unknown> {
+  const script = /__INITIAL_DATA__ = ([\s\S]*?);?<\/script>/.exec(html)?.[1];
+  expect(script, "the page must embed __INITIAL_DATA__").toBeTruthy();
+  const parsed = JSON.parse(script as string) as {
+    relay?: { records?: Record<string, unknown> };
+  };
+  const records = parsed.relay?.records;
+  expect(records, "__INITIAL_DATA__ must carry relay.records").toBeTruthy();
+  return records as Record<string, unknown>;
+}
+
+/** Does the warmed store hold anything from the metro graph at all? */
+function storeMentionsMetro(records: Record<string, unknown>): boolean {
+  return JSON.stringify(records).includes("metro:");
+}
+
+describe("the core lenses render against a provider that has never heard of pragma", () => {
+  it(
+    "dev:bun serves Definitions from @canonical/prism-graph-example",
+    async () => {
+      const provider = await startMetroProvider(GRAPH_EXAMPLE_CWD);
+      const server = await startServer("dev:bun", CWD, {
+        timeoutMs: DEV_READY_MS,
+        graphqlUrl: provider.url,
+      });
+      try {
+        // 1. THE PRECONDITION, stated as an assertion rather than a skip: the
+        //    provider is serving the contract. Every literal below is a claim
+        //    about metro data, so without the provider they all fail for the
+        //    same uninformative reason.
+        const providerUp = await fetch(provider.url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-pragma-ssr": "1",
+          },
+          body: JSON.stringify({ query: "{ __typename }" }),
+        });
+        expect(providerUp.status).toBe(200);
+        expect(providerUp.headers.get("content-type")).toMatch(
+          /application\/json/,
+        );
+
+        // 2. HOME: the frame only. `LobbyQuery` carries `... on Component`,
+        //    which this provider rejects — so the lobby's canvas suspends and
+        //    NOTHING about home's data may be asserted here. What IS proven is
+        //    the portable skeleton: the shell, the nav and the canvas plate
+        //    render from authored code, independent of any graph.
+        const home = await fetch(`${server.base}/`);
+        expect(home.status).toBe(200);
+        const homeHtml = await home.text();
+        expect(homeHtml).toContain('id="root"');
+        expectPortableFrame(homeHtml);
+        expectNoPragmaVocabulary("/", homeHtml);
+
+        // 3. /sitemap.xml: the second renderer, picked by path, involves no
+        //    graph at all — so it must be unaffected by which provider is
+        //    behind the app. A regression here would mean the metro boot broke
+        //    routing itself rather than data.
+        const sitemap = await fetch(`${server.base}/sitemap.xml`);
+        expect(sitemap.status).toBe(200);
+        expect(sitemap.headers.get("content-type")).toMatch(/xml/);
+        const xml = await sitemap.text();
+        expect(xml).toContain("<urlset");
+        expect(xml).toContain("<loc>");
+
+        // 4. /definitions — the term-LESS explorer. Its variables come from
+        //    the URL, not from the binding table, which is why this lens needs
+        //    no configuration to point at metro at all.
+        const definitions = await fetch(`${server.base}/definitions`);
+        expect(definitions.status).toBe(200);
+        const definitionsHtml = await definitions.text();
+        expectPortableFrame(definitionsHtml);
+        expect(definitionsHtml).toContain('data-slot="explorer-rail"');
+        //    The honest empty inspector: no default term, no redirect.
+        expect(definitionsHtml).toContain("Select a term");
+        //    …and nothing is selected, so nothing fades. Same graph as the
+        //    term page below, no privileged centre.
+        expect(definitionsHtml).not.toContain("is-faded");
+        expect(definitionsHtml).not.toContain("is-selected");
+        //    The cross-registry pair: metro records in the store AND metro
+        //    data in the HTML the reader receives.
+        expect(storeMentionsMetro(initialRelayRecords(definitionsHtml))).toBe(
+          true,
+        );
+        expect(definitionsHtml).toContain("metro:");
+        expectNoPragmaVocabulary("/definitions", definitionsHtml);
+
+        // 5. /definitions/metro%3AStation — the full triptych over a foreign
+        //    ontology: rail, hierarchy well, term inspector.
+        const term = await fetch(`${server.base}/definitions/metro%3AStation`);
+        expect(term.status).toBe(200);
+        const termHtml = await term.text();
+        expectPortableFrame(termHtml);
+        expect(storeMentionsMetro(initialRelayRecords(termHtml))).toBe(true);
+
+        //    The well draws exactly one node per class the rail lists, so the
+        //    two counts must agree — both derived from THIS response, never
+        //    pinned, so the assertion survives the dataset growing and breaks
+        //    only when the well renders partially. The floor closes the case
+        //    a bare equality waves through (0 === 0).
+        const nodeCount = (termHtml.match(/hierarchy-node-shell/g) ?? [])
+          .length;
+        const railClassLinkCount = (
+          termHtml.match(/<h3>Classes[\s\S]*?<h3>Properties/g) ?? []
+        )
+          .map(
+            (section) => (section.match(/href="\/definitions\//g) ?? []).length,
+          )
+          .reduce((sum, count) => sum + count, 0);
+        expect(nodeCount).toBeGreaterThan(0);
+        expect(nodeCount).toBe(railClassLinkCount);
+
+        //    THE SELECTION'S EGO-FADE IS SERVER-RENDERED, because the term is
+        //    in the URL. Some nodes fade and some do NOT: a fade that
+        //    swallowed everything would convey nothing, so the spared one-hop
+        //    neighbourhood is what proves the rule is a neighbourhood.
+        const fadedCount = (
+          termHtml.match(/hierarchy-node-shell[^"]*is-faded/g) ?? []
+        ).length;
+        expect(fadedCount).toBeGreaterThan(0);
+        expect(fadedCount).toBeLessThan(nodeCount);
+        expect(termHtml).toContain("is-selected");
+        //    The rail dims, it never hides: server-side the filter is the
+        //    no-op, so no rail item may carry the dim marker.
+        expect(termHtml).not.toContain('data-dimmed="true"');
+
+        //    THE STRIP IS CLAIMED AND USEFUL, over metro's ontologies: both
+        //    sockets carry content and the status figure counts real classes.
+        //    The figure agrees with the graph the well drew — both sides
+        //    derived from this response — so it can never flatter the graph.
+        expect(termHtml).toContain('data-slot="explorer-controls"');
+        expect(termHtml).toContain('data-slot="explorer-status"');
+        const abstractNodeCount = (termHtml.match(/hierarchy-node-tag/g) ?? [])
+          .length;
+        expect(abstractNodeCount).toBeGreaterThan(0);
+        const statusCaption = /<figcaption>([\s\S]*?)<\/figcaption>/
+          .exec(termHtml)?.[1]
+          ?.replaceAll("<!-- -->", "");
+        expect(statusCaption).toBe(
+          `${nodeCount} of ${nodeCount} classes · ${abstractNodeCount} abstract`,
+        );
+
+        //    THE INSPECTOR reads metro's own vocabulary: the class's title,
+        //    its compact identity, a property row the METRO dataset defines
+        //    (`platform count` — `packages/docsite/graph-example/src/lib/
+        //    provider/dataset.ts`), and its instance list. Nothing here has a
+        //    pragma equivalent, which is the point.
+        expect(termHtml).toContain('<h2 id="term-inspector-title">Station');
+        expect(termHtml).toContain("metro:Station");
+        expect(termHtml).toContain("platform count");
+        expect(termHtml).toContain("<h3>Instances</h3>");
+        expect(termHtml).toContain("metro:northgate");
+        expectNoPragmaVocabulary("/definitions/metro:Station", termHtml);
+      } finally {
+        await server.stop();
+        await provider.stop();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/apps/react/pragma-docs/test/e2e/serverHarness.ts
+++ b/apps/react/pragma-docs/test/e2e/serverHarness.ts
@@ -31,6 +31,50 @@ export interface RunningServer {
   hits: (source: "ssr" | "client") => number;
 }
 
+/**
+ * Incremental `[graphql] http hit #N ssr|client` counters.
+ *
+ * Tallied per COMPLETE line so a bounded log tail can never under-count: one
+ * failing-prepare probe sequence emits ~92 KB of stack traces, which scrolls
+ * early hit lines out of the 16 KB display tail (observed: 14 of 17 ssr hits
+ * lost). Counters survive truncation; `logs()` stays a bounded tail for
+ * diagnostics only.
+ *
+ * One {@link HitTally.sink} PER STREAM. Each keeps its own partial-line
+ * buffer — interleaving stdout and stderr chunks through a shared buffer
+ * would corrupt lines split across data events.
+ *
+ * Shared by {@link startServer} and {@link startMetroProvider}: the docsite's
+ * own graph server and `@canonical/prism-graph-example`'s demo endpoint emit
+ * the identical line, which is what lets the proof ask "who fetched this?" of
+ * a provider that has never heard of pragma.
+ */
+interface HitTally {
+  /** A per-stream chunk consumer. Call once per stream, never share one. */
+  sink: () => (chunkText: string) => void;
+  hits: (source: "ssr" | "client") => number;
+}
+
+function createHitTally(): HitTally {
+  const counts = { ssr: 0, client: 0 };
+  return {
+    sink: () => {
+      let remainder = "";
+      return (chunkText: string): void => {
+        const lines = (remainder + chunkText).split("\n");
+        remainder = lines.pop() ?? "";
+        for (const line of lines) {
+          const match = line.match(/\[graphql] http hit #\d+ (ssr|client)/);
+          if (match) {
+            counts[match[1] === "ssr" ? "ssr" : "client"] += 1;
+          }
+        }
+      };
+    },
+    hits: (source) => counts[source],
+  };
+}
+
 /** Reserve a free TCP port by opening an ephemeral listener and reading it back. */
 export function getFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -96,22 +140,57 @@ async function waitForServer(
 export async function startServer(
   script: string,
   cwd: string,
-  { timeoutMs = 180_000 }: { timeoutMs?: number } = {},
+  {
+    timeoutMs = 180_000,
+    graphqlUrl,
+    env,
+  }: {
+    timeoutMs?: number;
+    /**
+     * An endpoint that is ALREADY serving. When given, the launcher spawns
+     * no graph of its own (`withGraph.ts` treats a set `VITE_GRAPHQL_URL`
+     * as "an endpoint already exists"), and `graphBase` names this URL's
+     * origin rather than a port this harness reserved.
+     *
+     * This is how a cell points the app at a FOREIGN provider — the
+     * despecialisation proof runs `@canonical/prism-graph-example` here.
+     */
+    graphqlUrl?: string;
+    /**
+     * Extra environment for the child, merged LAST so a cell can override
+     * anything above it. Used by the proof to select a deployment.
+     */
+    env?: Record<string, string>;
+  } = {},
 ): Promise<RunningServer> {
   const port = await getFreePort();
   // A SECOND reserved port for the graph server every script now launches
   // (`src/server/withGraph.ts`), so the six cells never collide on it either.
-  const graphPort = await getFreePort();
+  // Not reserved when the caller brought its own endpoint: nothing would
+  // listen on it, and holding a port the launcher will never use is a lie
+  // `graphBase` would then tell.
+  const graphPort = graphqlUrl === undefined ? await getFreePort() : undefined;
   const base = `http://localhost:${port}`;
-  const graphBase = `http://127.0.0.1:${graphPort}`;
-  // Deliberately NOT passing VITE_GRAPHQL_URL — and stripping an inherited
-  // one. The launcher treats a set VITE_GRAPHQL_URL as "an endpoint already
-  // exists" and spawns no graph at all, so leaving a developer's shell value
-  // in place would silently test a different graph than GRAPH_PORT names.
+  const graphBase =
+    graphqlUrl === undefined
+      ? `http://127.0.0.1:${graphPort}`
+      : new URL(graphqlUrl).origin;
+  // Without a caller-supplied endpoint: deliberately NOT passing
+  // VITE_GRAPHQL_URL — and stripping an inherited one. The launcher treats a
+  // set VITE_GRAPHQL_URL as "an endpoint already exists" and spawns no graph
+  // at all, so leaving a developer's shell value in place would silently
+  // test a different graph than GRAPH_PORT names.
+  //
+  // WITH one, the same hazard is closed the other way round: the value is
+  // SET explicitly, never inherited, so a developer's shell cannot redirect
+  // the proof at their own graph.
   const childEnv: NodeJS.ProcessEnv = {
     ...process.env,
     PORT: String(port),
-    GRAPH_PORT: String(graphPort),
+  };
+  delete childEnv.VITE_GRAPHQL_URL;
+  if (graphqlUrl === undefined) {
+    childEnv.GRAPH_PORT = String(graphPort);
     // Keep the LAUNCHER's graph-readiness budget strictly under this cell's,
     // so the launcher is always the one that gives up first. Its default is
     // deliberately generous for real use (120s), which is above every budget
@@ -119,9 +198,14 @@ export async function startServer(
     // `waitForServer`'s bare "did not respond within Nms" instead of the
     // launcher saying so, the web server booting anyway, and the probe
     // assertions failing with their own refs-cache diagnosis.
-    GRAPH_READY_MS: String(Math.floor(timeoutMs / 2)),
-  };
-  delete childEnv.VITE_GRAPHQL_URL;
+    //
+    // Neither variable is set for a caller-supplied endpoint: no graph child
+    // is spawned, so there is no boot to budget and no port to name.
+    childEnv.GRAPH_READY_MS = String(Math.floor(timeoutMs / 2));
+  } else {
+    childEnv.VITE_GRAPHQL_URL = graphqlUrl;
+  }
+  Object.assign(childEnv, env);
   // Capture stderr so a boot crash surfaces the real cause instead of an opaque
   // readiness timeout, and stdout too for request-log assertions (`logs()`).
   const child: ChildProcess = spawn("bun", ["run", script], {
@@ -133,29 +217,9 @@ export async function startServer(
 
   let stderrTail = "";
   let logTail = "";
-  // Graph hit counters, tallied incrementally per COMPLETE line so the bounded
-  // logTail can never under-count: one failing-prepare probe sequence emits
-  // ~92 KB of stack traces, which scrolls early hit lines out of the 16 KB
-  // display tail (observed: 14 of 17 ssr hits lost). Counters survive
-  // truncation; logs() stays a bounded tail for diagnostics only. One line
-  // buffer per stream — interleaving stdout and stderr chunks through a shared
-  // buffer would corrupt lines split across data events.
-  const hitCounts = { ssr: 0, client: 0 };
-  const makeHitTally = (): ((chunkText: string) => void) => {
-    let remainder = "";
-    return (chunkText: string): void => {
-      const lines = (remainder + chunkText).split("\n");
-      remainder = lines.pop() ?? "";
-      for (const line of lines) {
-        const match = line.match(/\[graphql] http hit #\d+ (ssr|client)/);
-        if (match) {
-          hitCounts[match[1] === "ssr" ? "ssr" : "client"] += 1;
-        }
-      }
-    };
-  };
-  const tallyStdout = makeHitTally();
-  const tallyStderr = makeHitTally();
+  const tally = createHitTally();
+  const tallyStdout = tally.sink();
+  const tallyStderr = tally.sink();
   const appendLog = (chunk: Buffer): void => {
     logTail = (logTail + chunk.toString()).slice(-16_000);
   };
@@ -230,6 +294,137 @@ export async function startServer(
     graphBase,
     stop,
     logs: () => logTail,
-    hits: (source: "ssr" | "client") => hitCounts[source],
+    hits: tally.hits,
   };
+}
+
+/**
+ * A running `@canonical/prism-graph-example` demo endpoint — a GraphQL
+ * provider over a fictional metro network that has never heard of pragma.
+ *
+ * This is the foreign half of the despecialisation proof. It is spawned
+ * directly rather than through `withGraph.ts` because it is not the app's
+ * graph: it has no refs cache, no schema to compile, and no relationship to
+ * this app beyond `@canonical/prism-contract`. Pass its `url` to
+ * {@link startServer}'s `graphqlUrl` and the launcher will spawn no graph of
+ * its own.
+ */
+export interface RunningProvider {
+  /** The GraphQL endpoint, e.g. `http://127.0.0.1:54125/graphql`. */
+  url: string;
+  /** Stop the provider and its whole process group. */
+  stop: () => Promise<void>;
+  /** `[graphql] http hit` totals by source, tallied from its stdout. */
+  hits: (source: "ssr" | "client") => number;
+}
+
+/**
+ * Boot the example provider's demo server on a free port and wait until it
+ * answers a real operation.
+ *
+ * Readiness is probed with a POST of `{ __typename }` rather than a GET,
+ * because the endpoint answers a GET with a 404 — a "the port accepts
+ * connections" probe would pass against the wrong process entirely.
+ *
+ * Detached spawn + process-GROUP kill in `stop()`, exactly as
+ * {@link startServer}: a leaked provider would hold its port into the next
+ * run and the app would then render against a stale dataset.
+ */
+export async function startMetroProvider(
+  cwd: string,
+  { timeoutMs = 30_000 }: { timeoutMs?: number } = {},
+): Promise<RunningProvider> {
+  const port = await getFreePort();
+  const url = `http://127.0.0.1:${port}/graphql`;
+  const tally = createHitTally();
+  const tallyStdout = tally.sink();
+  const tallyStderr = tally.sink();
+  const child: ChildProcess = spawn("bun", ["demo/server.ts"], {
+    cwd,
+    env: { ...process.env, PORT: String(port) },
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderrTail = "";
+  child.stdout?.on("data", (chunk: Buffer) => tallyStdout(chunk.toString()));
+  child.stderr?.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    stderrTail = (stderrTail + text).slice(-4000);
+    tallyStderr(text);
+  });
+
+  let ready = false;
+  const exited = new Promise<never>((_, reject) => {
+    child.once("exit", (code) => {
+      if (ready) return;
+      reject(
+        new Error(
+          `the example provider exited early (code ${code}) before serving.\n${stderrTail}`,
+        ),
+      );
+    });
+  });
+
+  const stop = (): Promise<void> =>
+    new Promise((resolve) => {
+      const { pid } = child;
+      if (pid == null || child.exitCode != null) {
+        resolve();
+        return;
+      }
+      child.once("exit", () => resolve());
+      try {
+        if (process.platform === "win32") {
+          spawn("taskkill", ["/pid", String(pid), "/T", "/F"], {
+            stdio: "ignore",
+          });
+        } else {
+          process.kill(-pid, "SIGKILL");
+        }
+      } catch {
+        resolve();
+      }
+    });
+
+  const waitForProvider = async (): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      try {
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            // Infrastructure traffic, so the readiness probe never reports a
+            // phantom client hit into the inversion the proof asserts.
+            "x-pragma-ssr": "1",
+          },
+          body: JSON.stringify({ query: "{ __typename }" }),
+          signal: AbortSignal.timeout(1_000),
+        });
+        if (response.status === 200) {
+          await response.text();
+          return;
+        }
+      } catch {
+        // Not up yet — the deadline below decides when to give up.
+      }
+      if (Date.now() > deadline) {
+        throw new Error(
+          `the example provider did not answer at ${url} within ${timeoutMs}ms`,
+        );
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  };
+
+  try {
+    await Promise.race([waitForProvider(), exited]);
+    ready = true;
+  } catch (error) {
+    await stop();
+    throw error;
+  }
+  exited.catch(() => {});
+
+  return { url, stop, hits: tally.hits };
 }

--- a/apps/react/pragma-docs/test/e2e/servers.e2e.ts
+++ b/apps/react/pragma-docs/test/e2e/servers.e2e.ts
@@ -300,7 +300,7 @@ describe("server matrix (2×3) serves correctly", () => {
 
             // 5c. Definitions block (P-5): the ontology explorer SSRs
             //     from the live graph. The term page carries the
-            //     inspector's class record, the React Flow well's
+            //     inspector's class record, the hierarchy well's
             //     server-rendered node DOM, and the serialised store —
             //     all in the raw HTML, before any client JS.
             const definitionsTerm = await fetch(
@@ -310,7 +310,7 @@ describe("server matrix (2×3) serves correctly", () => {
             const definitionsTermHtml = await definitionsTerm.text();
             expect(definitionsTermHtml).toContain("UI Block");
             expect(definitionsTermHtml).toContain("ds:UIBlock");
-            expect(definitionsTermHtml).toContain("react-flow__node-term");
+            expect(definitionsTermHtml).toContain("hierarchy-node-shell");
             expect(definitionsTermHtml).toContain("__INITIAL_DATA__");
             expect(definitionsTermHtml).toContain('"records"');
 
@@ -333,15 +333,28 @@ describe("server matrix (2×3) serves correctly", () => {
             //     class-link count, both derived from THIS response
             //     (drift-proof, catches a partial well). Floors catch the
             //     both-surfaces-rot-to-zero case the equality alone would
-            //     wave through (0 === 0), and edges stay strictly below
-            //     nodes — each edge is one non-root class's superclass
-            //     link, and every non-empty ontology has a root.
+            //     wave through (0 === 0).
+            //
+            //     THE EDGE COUNT IS THE STRUCTURAL FAMILY ONLY, and the
+            //     bound moved with it. Until AV-364 the well was a tree,
+            //     so "edges strictly below nodes" held of every edge it
+            //     drew. It is not a tree any more: `buildClassGraph` adds
+            //     a SEMANTIC arc per domain→range pair of drawn classes,
+            //     and those can outnumber the classes. The surviving
+            //     invariant is about subclass links — one per non-root
+            //     class, and every non-empty ontology has a root — so it
+            //     is stated over `hierarchy-edge-structural` alone, which
+            //     is the same quantity `HierarchyWell.ssr.tests.tsx:66`
+            //     pins against its fixture. The semantic family is
+            //     asserted present separately; its absence is what made
+            //     the old well an organigram.
             const wellNodeCount = (
-              definitionsTermHtml.match(/react-flow__node-term/g) ?? []
+              definitionsTermHtml.match(/hierarchy-node-shell/g) ?? []
             ).length;
             const wellEdgeCount = (
-              definitionsTermHtml.match(/react-flow__edge-path/g) ?? []
+              definitionsTermHtml.match(/hierarchy-edge-structural/g) ?? []
             ).length;
+            expect(definitionsTermHtml).toContain("hierarchy-edge-semantic");
             const railClassLinkCount =
               // The headings now carry a match count ("Classes 17 of 17"),
               // so the opening tag is matched loosely up to its close.
@@ -370,9 +383,8 @@ describe("server matrix (2×3) serves correctly", () => {
             //   convey nothing, so the spared one-hop neighbourhood is
             //   what proves the rule is a neighbourhood and not a wash.
             const fadedNodeCount = (
-              definitionsTermHtml.match(
-                /react-flow__node-term[^"]*is-faded/g,
-              ) ?? []
+              definitionsTermHtml.match(/hierarchy-node-shell[^"]*is-faded/g) ??
+              []
             ).length;
             expect(fadedNodeCount).toBeGreaterThan(0);
             expect(fadedNodeCount).toBeLessThan(wellNodeCount);

--- a/packages/docsite/graph-example/demo/server.ts
+++ b/packages/docsite/graph-example/demo/server.ts
@@ -24,6 +24,25 @@ const handler = createExampleHandler(provider, {
   endpoint: `http://127.0.0.1:${port}${GRAPHQL_PATH}`,
 });
 
+/**
+ * Operations served since boot, logged per hit as
+ * `[graphql] http hit #N ssr|client` — the SAME line shape the docsite's own
+ * graph server emits (`apps/react/pragma-docs/src/server/graph.ts`).
+ *
+ * It is here so a consumer's e2e harness can tally WHO asked. The
+ * despecialisation proof turns on that tally: a page fetched with plain
+ * `fetch` (no browser, no client JS) that renders real metro data must have
+ * been filled by many `ssr` hits and zero `client` ones. Without this line
+ * the proof can only say the HTML looked right, not that the server is what
+ * fetched it.
+ *
+ * `x-pragma-ssr: 1` is the consumer's own marker for infrastructure traffic;
+ * this provider never reads it for anything but the log word. CORS
+ * preflights are skipped — the browser sends one per cross-origin POST and
+ * counting them would double every client hit.
+ */
+let hits = 0;
+
 Bun.serve({
   port,
   fetch: async (request: Request): Promise<Response> => {
@@ -35,6 +54,12 @@ Bun.serve({
         },
         { status: 404 },
       );
+    }
+    if (request.method !== "OPTIONS") {
+      hits += 1;
+      const source =
+        request.headers.get("x-pragma-ssr") === "1" ? "ssr" : "client";
+      console.info(`[graphql] http hit #${hits} ${source}`);
     }
     return handler(request);
   },


### PR DESCRIPTION
## Done

**Stacked on #910.** Review that one first; this PR's diff is only its own 8 commits.

This is the despecialization train's goal made runnable. The app is booted — its real `dev:bun` script, its real prepare step, its real renderer — against `@canonical/prism-graph-example`, a hand-written GraphQL provider over a fictional metro network whose only relationship to this repo is `@canonical/prism-contract`. Nothing in it knows what a component, a code standard, a job or a persona is.

**What is proven, exactly: two lenses, four routes** — Definitions (`/definitions`, `/definitions/:term`) and Standards (`/standards`, `/standards/:iri`) — plus the frame and the sitemap.

⚠️ **This is narrower than R.01 §8's "the four lenses", and deliberately so.** Components is pragma-specific by ruling. Home is *provably* not neutral: its committed `LobbyQuery` carries `... on Component { uri _meta { curie } name }`, and POSTing that operation text to the metro endpoint returns `Unknown type "Component".` It also links every exemplar to `/components/:uri`, a route metro cannot serve. Home is asserted for its **frame only**, and no artifact here claims otherwise. **R.01 §8 needs an amendment; this PR does not make it.**

### Why this exists when the acceptance gate already passes

`packages/docsite/graph-example`'s gate executes the app's four operation texts against the example provider but **never renders anything**. A query can be neutral while the components reading it are not — a `uri.startsWith`, a hard-coded prefix, a lens that assumes pragma's shape. This is the only check in the repo that runs the real app end to end against a foreign graph.

### The binding seam

`#lib/graphBindings` gains a **closed table** of named deployments and one selector reading `VITE_PRISM_DEPLOYMENT`. Three alternatives were rejected with reasons:

| Option | Verdict |
| -- | -- |
| Vite `resolve.alias` in the harness | **Cannot work.** It reaches the Vite SSR and client registries but not the **native** prepare step, so prepare warms `cs:CodeStandard` while the renderer asks for `metro:Station` — and it fails *quietly*, rendering the Suspense fallback into SSR HTML. |
| `--conditions` on package `imports` | Needs setting in three places across two runtimes. Fragile. |
| SSR-transported bindings | Principled and divergence-proof by construction, but touches six modules and drags R.01 §4's move 3 into this PR. **Recorded in the header as the fix when a real deployment appears.** |
| **Closed table + env selector, defaulting to `pragma`** | **Shipped.** |

It names a **table**, never a class, so a typo yields the default rather than a wrong binding; an unset variable gives byte-identical behaviour to today, so every existing test passes untouched.

The header's "NOT AN ENV VAR, DELIBERATELY" paragraph was **rewritten, not deleted**. Its reasoning turned out to be overstated for the runtime the proof uses — measured, Vite dev injects `VITE_*` straight from `process.env` into the client module, so all three registries read the same value in `dev:bun`. The failure mode is real but specific to a **built** client that did not see the variable at build time; the header now says so, and names the residual build-in-A/run-in-B hazard rather than pretending it away.

### The cross-registry pair — what makes this a proof and not a smoke test

`#lib/graphBindings` is instantiated in **three independent module registries**: Bun native (prepare), Vite SSR (render), and the client bundle. If prepare and render disagree, the store fills while `useLazyLoadQuery` misses and the page serves `Loading the standards…` with a full record map underneath. So every data-bearing route asserts **both** the rendered HTML and the embedded store.

The anneal found that the store half was weaker than it looked, and it is fixed here (`ee8574b`). The original check stringified the whole record map looking for `metro:` — but Relay formats root storage keys from the operation's own **arguments**, so on three of four routes the substring was satisfied by the *request*, whether or not any data came back. It is now two separately-named answers:

- **`askedForMetro`** reads `client:root`'s storage keys, so it still sees the argument the *Bun-native prepare step* chose. That is the cross-registry detector, and it is the only thing in the file that sees that registry.
- **`holdsMetroRecords`** checks for record IDs in `https://metro.example/`. Record IDs are `uri`, the absolute IRI (R-2), and the app only ever *sends* the prefixed CURIE — so such a key can only have been minted by the provider's response. **No request can forge it.**

Verified by mutation: pointing the namespace constant at an absent host turns the proof red, so the identity keys are genuinely present rather than the assertion being vacuous.

### Drive-by: `servers.e2e.ts` was already stale at HEAD

It asserted `react-flow__node-term` / `react-flow__edge-path` in the `/definitions/:term` SSR HTML. `HierarchyWell.tsx` **retired React Flow** (`a612f25`, AV-364) and now emits `hierarchy-node-shell` / `hierarchy-edge` / `hierarchy-cluster-caption`. Measured against a live render: `react-flow` appears **zero** times. Nobody noticed because `grep -rn "test:e2e" .github/` returns nothing — the suite is in no workflow.

⚠️ **One assertion there needed more than a rename, and it wants a reviewer's eye.** `wellEdgeCount < wellNodeCount` was justified by *"each edge is one non-root class's superclass link"* — but AV-364's own commit message says the well **stopped being a tree**; semantic arcs are drawn per domain→range pair and can outnumber the classes. The count is now `hierarchy-edge-structural` only (the same quantity `HierarchyWell.ssr.tests.tsx:66` pins), with semantic edges asserted separately. **This is unverifiable in the agent container** (no refs cache). If CI goes red there, the fix is the floor, not the selector.

## QA

| Suite | Baseline | Final |
| -- | -- | -- |
| `pragma-docs` `test` | 95 files / 440 | **96 / 450** |
| `pragma-docs` `check` | biome 376, tsc clean | biome 379, tsc clean |
| `pragma-docs` `test:proof` | did not exist | **green** |
| `relay-compiler --validate` | 23 reader / 10 norm / 23 op text | identical |
| `graph-example` | 227, 100% | 227, 100% |
| `contract` / `pragma-provider` | 32 / 45 | 32 / 45 |
| `servers.e2e` (pragma cells) | 4 failed / 2 passed | 4 failed / 2 passed, **identical messages** — pre-existing, no refs cache |

`apps/react/pragma-docs/src/relay/schema.graphql` verified clean after every e2e run and at the end; census unchanged at 174 type + 6 interface + 1 enum + 2 directive = **183**.

The proof measured **10 SSR hits / 0 client hits** on the metro provider, asserted as `> 5` / `=== 0` plus a strict-delta check that a direct POST moves the client counter by exactly one — so a counter that never counts cannot pass.

**Reproduce it by hand:**
```bash
cd packages/docsite/graph-example && PORT=5199 bun demo/server.ts
cd apps/react/pragma-docs && VITE_GRAPHQL_URL=http://127.0.0.1:5199/graphql \
  VITE_PRISM_DEPLOYMENT=metro PORT=5198 bun run dev:bun
curl -s http://localhost:5198/definitions/metro%3AStation | grep -c hierarchy-node-shell
```

**CI note, stated plainly:** `test:proof` is added to `pr.yml` and the step is correct, but CI on this base is blocked by an unrelated Playwright defect — see #911, which merges `main`'s fix. **This step's first green run may come after that merge.**

**Known open, for the owner:** the nx edge added so the proof reruns when the provider changes is a real task-graph edge, not just an `affected` hint — `pragma-docs:check` now runs 49 tasks (45 cached). The alternative leaves the proof blind to provider changes. Both directions cannot be closed without a cycle.

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged; `pragma-docs` gains `test:proof` alongside its existing `check`/`test`.
- [x] **New package: N/A.** No package is introduced.
- [x] `no visual change` — no component or style file is touched; the diff is the binding table, the e2e harness, two e2e specs, the demo server's request log, and CI config.

## Screenshots

Not applicable — no rendered output changes. The proof asserts on server-rendered HTML, and its assertions are the artifact.

---
_Generated by [Claude Code](https://claude.ai/code/session_019VVct8koTvTWrCzABQp3i2)_