### PR TITLE
feat(DialogContent): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
@@ -69,5 +69,6 @@
 
   &.base {
     --lp-color-border-context: transparent;
+    --lp-color-background-context: transparent;
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Body/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Body/styles.css
@@ -1,5 +1,5 @@
 .ds.dialog-content-body {
   /* Sanity reset, so that the dialog doesn't inherit unwanted styles from the context it's used in. */
-  font: var(--lp-typography-paragraph-default);
-  color: var(--lp-color-text-default);
+  font: var(--ds-typography-text-primary);
+  color: var(--color-text);
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Footer/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Footer/styles.css
@@ -4,5 +4,5 @@
   align-items: center;
   flex-wrap: wrap;
 
-  gap: var(--lp-dimension-spacing-inline-m);
+  gap: var(--dimension-200);
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/styles.css
@@ -3,8 +3,8 @@
   align-items: start;
   text-wrap: balance;
 
-  font: var(--lp-typography-h4);
-  color: var(--lp-color-text-default);
+  font: var(--ds-typography-heading-4);
+  color: var(--color-text);
 
   > .ds.dialog-content-close-button {
     margin-inline-start: auto;

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/styles.css
@@ -5,7 +5,7 @@
   flex-direction: column;
   gap: var(--dimension-200);
 
-  background-color: var(--surface-color-background, var(--color-background));
+  background-color: var(--color-background);
   padding-block: var(--dimension-300);
   padding-inline: var(--dimension-300);
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/styles.css
@@ -3,9 +3,9 @@
 .ds.dialog-content {
   display: flex;
   flex-direction: column;
-  gap: var(--lp-dimension-spacing-block-m);
+  gap: var(--dimension-200);
 
-  background-color: var(--lp-color-background-default);
-  padding-block: var(--lp-dimension-spacing-block-l);
-  padding-inline: var(--lp-dimension-spacing-inline-l);
+  background-color: var(--surface-color-background, var(--color-background));
+  padding-block: var(--dimension-300);
+  padding-inline: var(--dimension-300);
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,4 +1,9 @@
 :root {
+  --ds-typography-text-primary:
+    var(--typography-text-primary-font-weight)
+    var(--typography-text-primary-font-size) /
+    var(--typography-text-primary-line-height)
+    var(--typography-text-primary-font-family);
   --ds-typography-text-secondary:
     var(--typography-text-secondary-font-weight)
     var(--typography-text-secondary-font-size) /
@@ -14,9 +19,15 @@
     var(--typography-text-primary-bold-font-size) /
     var(--typography-text-primary-bold-line-height)
     var(--typography-text-primary-bold-font-family);
+  --ds-typography-heading-4:
+    var(--typography-heading-4-font-weight)
+    var(--typography-heading-4-font-size) /
+    var(--typography-heading-4-line-height)
+    var(--typography-heading-4-font-family);
   --ds-typography-heading-5:
     var(--typography-heading-5-font-weight)
     var(--typography-heading-5-font-size) /
     var(--typography-heading-5-line-height)
     var(--typography-heading-5-font-family);
+
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -29,5 +29,4 @@
     var(--typography-heading-5-font-size) /
     var(--typography-heading-5-line-height)
     var(--typography-heading-5-font-family);
-
 }


### PR DESCRIPTION
## Done

Updated DialogContent styles to use design tokens
Added text-primary and heading-4 shorthands to the shim
Made base severity buttons transparent

### Changes

Responsive spacings and fonts are not responsive anymore
Dark background changed from #262626 to #1d1d1d
Header weight grew from 200 to 300
Base severity buttons no longer paint an opaque background-default, which was showing as a box behind the close button on the darker dialog

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots
Was
<img width="1283" height="533" alt="image" src="https://github.com/user-attachments/assets/1a031185-39c4-43cc-a613-fc0d00171cbd" />
Now
<img width="1283" height="533" alt="image" src="https://github.com/user-attachments/assets/8fd020aa-55fe-499a-9f72-914be21d49a8" />

