### PR TITLE
fix(summon-package): read the own version through a layout-proof walk, not a JSON self-import

### DIFF
--- a/packages/summon/package/src/shared/createTemplateContext.ts
+++ b/packages/summon/package/src/shared/createTemplateContext.ts
@@ -1,8 +1,8 @@
-import pkg from "../../package.json" with { type: "json" };
 import getEntryPoints from "./config/getEntryPoints.js";
 import getLicense from "./config/getLicense.js";
 import getRuleset from "./config/getRuleset.js";
 import getPackageShortName from "./getPackageShortName.js";
+import { packageVersion } from "./packageVersion.js";
 import type { MonorepoInfo, PackageAnswers, TemplateContext } from "./types.js";
 
 /**
@@ -28,7 +28,7 @@ export default function createTemplateContext(
     types: entryPoints.types,
     files: entryPoints.files,
     needsBuild: entryPoints.needsBuild,
-    canonicalVersion: pkg.version,
+    canonicalVersion: packageVersion(),
     ruleset: getRuleset(answers.type, answers.withReact),
     withReact: answers.withReact,
     withStorybook: answers.withStorybook,

--- a/packages/summon/package/src/shared/packageVersion.test.ts
+++ b/packages/summon/package/src/shared/packageVersion.test.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+import pkg from "../../package.json" with { type: "json" };
+import { findOwnVersion, packageVersion } from "./packageVersion.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const dir of roots) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("packageVersion", () => {
+  it("returns this package's manifest version, from src and dist layouts alike", () => {
+    // The cached entry point — and the regression this module exists to fix:
+    // a `../../package.json` JSON import resolved correctly from `src/shared`
+    // but not from the emitted `dist/esm/shared`, one level deeper. The walk
+    // is depth-independent, so both layouts find the same manifest.
+    expect(packageVersion()).toBe(pkg.version);
+    expect(packageVersion()).toBe(pkg.version); // second call: the cache line
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    expect(findOwnVersion(here)).toBe(pkg.version);
+    const distEsmShared = path.resolve(here, "../..", "dist", "esm", "shared");
+    expect(findOwnVersion(distEsmShared)).toBe(pkg.version);
+  });
+
+  it("walks past a manifest naming another package, and throws when the walk runs out", () => {
+    // A decoy manifest must not satisfy the lookup — the workspace root's own
+    // package.json is exactly such an ancestor in production.
+    const root = mkdtempSync(path.join(tmpdir(), "summon-pkg-version-"));
+    roots.push(root);
+    const nested = path.join(root, "a", "b");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "not-this-package", version: "9.9.9" }),
+    );
+    expect(() => findOwnVersion(nested)).toThrow(
+      /no package\.json naming @canonical\/summon-package/,
+    );
+  });
+
+  it("walks past a manifest with the right name but no version", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "summon-pkg-version-"));
+    roots.push(root);
+    writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "@canonical/summon-package" }),
+    );
+    expect(() => findOwnVersion(root)).toThrow(/no package\.json naming/);
+  });
+});

--- a/packages/summon/package/src/shared/packageVersion.ts
+++ b/packages/summon/package/src/shared/packageVersion.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { PACKAGE_NAME } from "./packageName.js";
+
+/**
+ * Walk up from `from` until a `package.json` names this package, and return
+ * its `version`. Exported for tests; production callers use
+ * {@link packageVersion}.
+ *
+ * A manifest that is unreadable, is not JSON, names another package, or
+ * carries no version is not a failure — it is an ancestor directory that
+ * happens to have a `package.json` (the workspace root, say), so the walk
+ * continues. Only running out of parents throws.
+ *
+ * @note Impure — reads the filesystem.
+ */
+export function findOwnVersion(from: string): string {
+  let dir = from;
+  for (;;) {
+    try {
+      const manifest = JSON.parse(
+        readFileSync(path.join(dir, "package.json"), "utf-8"),
+      ) as { name?: string; version?: string };
+      if (manifest.name === PACKAGE_NAME && manifest.version) {
+        return manifest.version;
+      }
+    } catch {
+      // No readable manifest at this level — keep walking.
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(
+        `packageVersion: no package.json naming ${PACKAGE_NAME} above ${from}`,
+      );
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * This package's own published version, used as the semver line for the
+ * `@canonical/*` config dependencies the templates emit (the fixed-version
+ * train means our version IS the train's version).
+ *
+ * Not a `package.json` JSON import: the relative path (`../../package.json`)
+ * is measured from the source file, and the `src → dist/esm` build emits this
+ * file one level deeper, so the same specifier resolves to `dist/package.json`
+ * — which does not exist. That breaks Node from `dist/esm` AND breaks any
+ * bundler that resolves the compiled entry (the CLI's `bun build --compile`
+ * fails outright). The sibling `PACKAGE_NAME` sidesteps this with a constant;
+ * the version cannot be a constant, because releases bump `package.json`
+ * mechanically and a constant would drift silently on the first one. Walking
+ * up from THIS module's location is correct from `src/` and from `dist/esm/`
+ * alike, with no build-layout coupling to re-break.
+ *
+ * Lazy and cached deliberately: nothing is read at module load, so importing
+ * this module (or bundling it into a compiled binary whose `create package`
+ * path is gated off) performs no IO and cannot throw at startup.
+ *
+ * @note Impure on first call — reads the filesystem, then caches.
+ */
+let cached: string | undefined;
+export function packageVersion(): string {
+  cached ??= findOwnVersion(path.dirname(fileURLToPath(import.meta.url)));
+  return cached;
+}


### PR DESCRIPTION
## Done

**Unbreaks `main` for the CLI graph** — red since #913 merged (2026-08-07 11:29Z). Full diagnosis was recorded on [#909's thread](https://github.com/canonical/pragma/pull/909#issuecomment-5216810210) when the breakage first surfaced; this PR is the fix offered there.

- #913 made `@canonical/summon-package` compiled (`main: dist/esm/index.js`), but `createTemplateContext.ts` still imported `../../package.json` — a path measured from `src/shared/` that the `src → dist/esm` build emits **one level deeper**, where it resolves to `dist/package.json`, which does not exist. The CLI's `bun build --compile` statically reaches this file through the create generators, so `@canonical/pragma-cli:build` fails ("Could not resolve: ../../package.json"), taking with it root `bun install` (whose `prepare` runs the build) and **every PR touching the CLI graph** — PRs elsewhere kept passing under nx affected, which is how it survived on `main` for five days.
- #913's own `packageName.ts` docblock names this exact hazard and sidesteps it with a constant; the **version** site was missed, and a constant can't cover it — releases bump `package.json` mechanically, so a hardcoded version would drift silently on the first train bump. `pkg.version` is the semver line templates emit for the `@canonical/*` config dependencies (`^<%= canonicalVersion %>`); drift means every generated package pins stale configs.
- The fix: `packageVersion()` walks up from **this module's own location** until a `package.json` names this package — correct from `src/` and `dist/esm/` alike, no build-layout coupling left to re-break. **Lazy and cached**: nothing reads at module load, so bundling it into a compiled binary (whose `create package` path is gated off, PRA-14) performs no IO and cannot throw at startup. An ancestor manifest naming another package — the workspace root, say — is walked past, not an error.
- `summon-monorepo`, converted in the same commit, carries no JSON self-import (checked — its `createTemplateContext` never read one).

This unblocks #909 (program L's PR7), which has been red on exactly this since the rebase onto `8a462450`. Same hazard class as PRA-138 (`dist/esm` sits deeper than `src`; nothing checks depth-coupled relative paths).

## QA

All on this tree (branch `claude/despec-hotfix-summon-package-version` @ `52fef697`, one commit off current `main` `73c610a7`):

- **The reproduction, closed:** root `bun install` completes with `prepare` building **all 52 projects** — it failed on this exact step before the fix.
- **The failing task, directly:** `packages/cli/pragma` `bun run build` emits `dist/pragma` and the binary runs (`--help` exits 0).
- **summon-package gates:** `bun run check` + `bun run test` PASS — **49 tests, 100 % coverage on all four axes.** `packageVersion.test.ts` pins the src/dist layout equivalence (the walk from `dist/esm/shared` finds the same manifest as from `src/shared`), the decoy-manifest walk-past, and the runs-out throw. The existing `createTemplateContext` test already pins `canonicalVersion === pkg.version`, now satisfied through the walk.

### PR readiness check

- [x] PR label: `Bug 🐛` (+ `no visual change`).
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts in `package.json` (existing package, unchanged).
- [ ] New package: n/a — none introduced.
- [x] No visual testing required — `no visual change` label added (generator internals only).

## Screenshots

n/a — build/packaging fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EwUvEW5ZgjAYc9KWPjHCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017EwUvEW5ZgjAYc9KWPjHCZ)_