### PR TITLE
feat(Timeline): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/Timeline.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/Timeline.stories.svelte
@@ -95,7 +95,7 @@
       {/snippet}
       {#snippet titleRow()}
         <Timeline.Event.TitleRow>
-          The MP was <span style="color: var(--lp-color-text-default)"
+          The MP was <span style="color: var(--color-text)"
             >Merged</span
           >
           {#snippet date()}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/Event/common/TitleRow/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/Event/common/TitleRow/styles.css
@@ -1,14 +1,12 @@
 .ds.timeline-title-row {
-  --dimension-gap-timeline-event-title-row: var(
-    --lp-dimension-spacing-inline-xs
-  );
+  --dimension-gap-timeline-event-title-row: var(--dimension-100);
   /* TODO(@Enzo): Add a missing token */
   --dimension-basis-timeline-event-title-row-description: 10rem;
 
   display: flex;
   align-items: baseline;
 
-  font: var(--lp-typography-paragraph-s);
+  font: var(--ds-typography-text-secondary);
   line-height: var(--typography-line-height-timeline-event-title-row);
   gap: var(--dimension-gap-timeline-event-title-row);
 
@@ -21,18 +19,18 @@
     gap: var(--dimension-gap-timeline-event-title-row);
 
     > .leading-text {
-      color: var(--lp-color-text-default);
+      color: var(--color-text);
     }
 
     > .description {
-      color: var(--lp-color-text-muted);
+      color: var(--color-text-muted);
       flex-basis: var(--dimension-basis-timeline-event-title-row-description);
       flex-grow: 1;
     }
   }
 
   > .date {
-    color: var(--lp-color-text-muted);
+    color: var(--color-text-muted);
     flex: none;
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/Event/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/Event/styles.css
@@ -1,6 +1,7 @@
 .ds.timeline-event {
-  --typography-line-height-timeline-event-title-row: var(
-    --lp-typography-line-height-s
+  --typography-line-height-timeline-event-title-row: calc(
+    var(--typography-text-secondary-line-height) *
+    var(--typography-text-secondary-font-size)
   );
 
   grid-column: 1 / -1;
@@ -13,15 +14,15 @@
   }
 
   &.marker-small {
-    --marker-size: var(--lp-dimension-size-s);
+    --marker-size: var(--dimension-250);
   }
 
   &.marker-large {
-    --marker-size: var(--lp-dimension-size-l);
+    --marker-size: var(--dimension-400);
   }
 
   &.marker-empty {
-    --marker-size: var(--lp-dimension-size-xxxs);
+    --marker-size: var(--dimension-100);
   }
 
   --marker-title-row-alignment-difference: 0px;
@@ -82,9 +83,17 @@
 
     width: var(--marker-size);
     height: var(--marker-size);
-    border: var(--lp-dimension-stroke-thickness-default) solid
-      var(--lp-color-border-default);
-    background-color: var(--lp-color-background-alt);
+    border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
+    /* TODO: Figma uses --color-background-layer2 */
+    /* I read it as "one level above the surface" and foreground-input is exactly this */
+    /* However, marker is not input. But -layer2 looks like internal token */
+    /* that we're not supposed to use directly */
+    /* We might need to have a token --surface-color-foreground */
+    /* https://chat.canonical.com/canonical/pl/m3hcwry1i3frtgifu6kw6nbnoa*/
+    background-color: var(
+      --surface-color-foreground-input,
+      var(--color-foreground-input)
+    );
 
     margin-block-start: var(--marker-alignment-adjustment);
 
@@ -108,7 +117,7 @@
       );
 
       &:not(:only-child) {
-        margin-block-end: var(--lp-dimension-spacing-block-xs);
+        margin-block-end: var(--dimension-100);
       }
     }
   }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/HiddenEvents.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/HiddenEvents.stories.svelte
@@ -14,7 +14,7 @@
 </script>
 
 {#snippet dummyChild()}
-  <div style="width: var(--lp-dimension-size-l)"></div>
+  <div style="width: var(--dimension-400)"></div>
 {/snippet}
 
 <Story name="Default">

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/common/Link/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/common/Link/styles.css
@@ -1,9 +1,9 @@
 .ds.timeline-hidden-events-link {
-  font: var(--lp-typography-paragraph-xs);
+  font: var(--ds-typography-text-tertiary);
 }
 
 .ds.timeline-hidden-events-link-separator {
-  font: var(--lp-typography-paragraph-xs);
-  color: var(--lp-color-text-muted);
-  margin-inline: var(--lp-dimension-spacing-inline-xs);
+  font: var(--ds-typography-text-tertiary);
+  color: var(--color-text-muted);
+  margin-inline: var(--dimension-100);
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/styles.css
@@ -3,7 +3,7 @@
   grid-column: 1 / -1;
   display: grid;
   grid-template-columns: subgrid;
-  font: var(--lp-typography-paragraph-xs-strong);
+  font: var(--ds-typography-text-tertiary-bold);
 
   &:not(:last-child)::after {
     /* Line spanning to the next element */
@@ -22,10 +22,10 @@
     grid-column: 1 / -1;
     justify-self: start;
     display: flex;
-    padding-block: var(--lp-dimension-spacing-block-xs);
-    padding-inline: var(--lp-dimension-spacing-inline-m);
-    border-block: var(--lp-dimension-stroke-thickness-default) solid
-      var(--lp-color-border-default);
+    padding-block: var(--dimension-100);
+    padding-inline: var(--dimension-200);
+    border-block: var(--dimension-stroke-thickness-medium) solid
+      var(--color-border);
   }
 
   &:first-child {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/styles.css
@@ -1,12 +1,12 @@
 .ds.timeline {
-  --dimension-gap-row-timeline: calc(var(--lp-dimension-spacing-block-s) * 2);
-  --color-background-timeline-line: var(--lp-color-border-default);
-  --dimension-width-timeline-line: var(--lp-dimension-stroke-thickness-default);
+  --dimension-gap-row-timeline: calc(var(--dimension-150) * 2);
+  --color-background-timeline-line: var(--color-border);
+  --dimension-width-timeline-line: var(--dimension-stroke-thickness-medium);
 
   display: grid;
   grid-template-columns: [marker-start] auto [marker-end content-start] 1fr [content-end];
   list-style: none;
 
   row-gap: var(--dimension-gap-row-timeline);
-  column-gap: var(--lp-dimension-spacing-inline-m);
+  column-gap: var(--dimension-200);
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -19,6 +19,16 @@
     var(--typography-text-primary-bold-font-size) /
     var(--typography-text-primary-bold-line-height)
     var(--typography-text-primary-bold-font-family);
+  --ds-typography-text-tertiary:
+    var(--typography-text-tertiary-font-weight)
+    var(--typography-text-tertiary-font-size) /
+    var(--typography-text-tertiary-line-height)
+    var(--typography-text-tertiary-font-family);
+  --ds-typography-text-tertiary-bold:
+    var(--typography-text-tertiary-bold-font-weight)
+    var(--typography-text-tertiary-bold-font-size) /
+    var(--typography-text-tertiary-bold-line-height)
+    var(--typography-text-tertiary-bold-font-family);
   --ds-typography-heading-4:
     var(--typography-heading-4-font-weight)
     var(--typography-heading-4-font-size) /


### PR DESCRIPTION
## Done

Updated Timeline styles to use design tokens
Added text-tertiary and text-tertiary-bold shorthands to the shim
Kept the title row line height a length, composed from the DS ratio and font size, so the marker alignment math holds
Updated storybook inline styles

### Changes

Responsive spacings are not responsive anymore
Line and marker border colors are opaque now (#717171 light, #8c8c8c dark, was 20% black)
HiddenEvents label weight grew from 550 to 600
Muted color differs
Marker fill is surface aware now, based on foreground-input (resolves to the same value as background-layer2 outside surfaces)

Line, marker border, marker fill, spacings and both type roles were checked against the Timeline component sets in Figma and match.

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots
Was
<img width="1999" height="1499" alt="image" src="https://github.com/user-attachments/assets/e8a17305-cdbe-48ee-86ed-95239267bc77" />
Is
<img width="1999" height="1499" alt="image" src="https://github.com/user-attachments/assets/7ad5a938-881d-4560-90de-73c0dbb464ce" />
