### PR TITLE
feat(Tooltip): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Tooltip/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Tooltip/styles.css
@@ -1,16 +1,16 @@
 .ds.tooltip {
-  --color-background-tooltip: var(--lp-color-background-alt-reversed);
-  --dimension-offset-tooltip-arrow: var(--lp-dimension-spacing-inline-m);
-  --dimension-height-tooltip-arrow: var(--lp-dimension-size-xxxs);
+  --color-background-tooltip: var(--ds-color-foreground-tooltip);
+  --dimension-offset-tooltip-arrow: var(--dimension-200);
+  --dimension-height-tooltip-arrow: var(--dimension-100);
   position: absolute;
   width: max-content;
   /* TODO(z-index-tokens): Should we tokenize z-indexes? What would they be used for except the tooltip? */
   z-index: 10;
   background-color: var(--color-background-tooltip);
-  font: var(--lp-typography-paragraph-s);
-  color: var(--lp-color-text-reversed);
-  padding-inline: var(--lp-dimension-spacing-inline-m);
-  padding-block: var(--lp-dimension-spacing-block-xs);
+  font: var(--ds-typography-text-secondary);
+  color: var(--color-text-onForegroundPrimary);
+  padding-inline: var(--dimension-200);
+  padding-block: var(--dimension-100);
 
   &::before {
     /* Filler to allow moving the hover from the trigger to the tooltip */

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,4 +1,8 @@
 :root {
+  --ds-color-foreground-tooltip: light-dark(
+    var(--color-palette-gray-930),
+    var(--color-palette-gray-40)
+  );
   --ds-typography-text-primary:
     var(--typography-text-primary-font-weight)
     var(--typography-text-primary-font-size) /


### PR DESCRIPTION
## Done

Updated Tooltip styles to use design tokens
Added `--ds-color-foreground-tooltip` to the shim, written theme inverse (the dark grey sits in the light slot), since no shipped DS token runs opposite the page

### Changes

Responsive paddings and the arrow offset are not responsive anymore
Bubble fill is a touch darker in both themes (#202020 to #1d1d1d light, #f7f7f7 to #f1f1f1 dark)
Text color, arrow size and type role do not move

The bubble is not `--color-foreground-primary`: that token is theme inverse too, but pure black/white, while the design models the tooltip fill as its own `color/foreground/tooltip` variable at gray-920/gray-40. Its text pair `--color-text-onForegroundPrimary` is still the right text token here, and matches the LP values exactly.

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots
Was
<img width="352" height="193" alt="image" src="https://github.com/user-attachments/assets/5919605a-8776-4e8b-8807-58ce34e9d93c" />


Now
<img width="358" height="195" alt="image" src="https://github.com/user-attachments/assets/cdd90e57-e44d-4514-9b87-58295cdb73fa" />
