### PR TITLE
fix(react-ds-global): Fixes `Section` padding being bound to nonexistent tokens

### DIFF
--- a/packages/react/ds-global/src/lib/_work_in_progress/Section/styles.css
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Section/styles.css
@@ -1,11 +1,9 @@
 /* Component tokens — sourced from @canonical/design-tokens */
 :root {
-  --section-padding-bottom-spacing-shallow: var(--spacing-vertical-xlarge);
-  --section-padding-bottom-spacing-default: var(--spacing-vertical-xxlarge);
-  --section-padding-bottom-spacing-deep: var(--spacing-vertical-xxxlarge);
-  --section-padding-bottom-spacing-hero: var(
-    --section-padding-bottom-spacing-default
-  );
+  --section-padding-bottom-spacing-shallow: var(--dimension-300);
+  --section-padding-bottom-spacing-default: var(--dimension-400);
+  --section-padding-bottom-spacing-deep: var(--dimension-800);
+  --section-padding-bottom-spacing-hero: var(--dimension-400);
   --section-padding-top-spacing-default: 0px;
   --section-padding-top-bordered-default: 0px;
   --section-padding-top-bordered-true: calc(
@@ -14,11 +12,11 @@
   );
   --section-padding-top-spacing-shallow: 0px;
   --section-padding-top-spacing-deep: 0px;
-  --section-padding-top-spacing-hero: var(--spacing-vertical-xlarge);
+  --section-padding-top-spacing-hero: var(--dimension-200);
   --section-border-start-color: var(--color-border-muted);
   --section-border-start-style: solid;
   --section-border-start-width: var(--rule-height);
-  --section-border-start-width-with-padding: var(--spacing-vertical-small);
+  --section-border-start-width-with-padding: var(--dimension-100);
 }
 
 .ds.section {

--- a/packages/react/ds-global/src/lib/_work_in_progress/Section/styles.css
+++ b/packages/react/ds-global/src/lib/_work_in_progress/Section/styles.css
@@ -3,7 +3,9 @@
   --section-padding-bottom-spacing-shallow: var(--dimension-300);
   --section-padding-bottom-spacing-default: var(--dimension-400);
   --section-padding-bottom-spacing-deep: var(--dimension-800);
-  --section-padding-bottom-spacing-hero: var(--dimension-400);
+  --section-padding-bottom-spacing-hero: var(
+    --section-padding-bottom-spacing-default
+  );
   --section-padding-top-spacing-default: 0px;
   --section-padding-top-bordered-default: 0px;
   --section-padding-top-bordered-true: calc(


### PR DESCRIPTION
## Done

At some point there was a regression that removed the spacing tokens depended on by `Section` without updating Section's stylesheet accordingly. This causes all spacing variants to use the same spacing. 

This change updates the component to use new design tokens for Section to replicate the same spacing values seen in [Vanilla Framework](https://vanillaframework.io/docs/patterns/section). 

## QA

- Open the [Section stories](https://67be30a0b85c4e44b6744158-gvcziqdrqi.chromatic.com/?path=/story/work-in-progress-component-section--spacing&globals=scheme:light)
- Look through all the spacing variants and ensure they have the expected padding.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Before

<img width="760" height="95" alt="image" src="https://github.com/user-attachments/assets/e9540107-5ec1-4fa2-94a7-039d455b571a" />

After

<img width="760" height="256" alt="image" src="https://github.com/user-attachments/assets/1be57fd9-36c5-470c-9190-166d8ac46059" />

See [Chromatic diff](https://www.chromatic.com/test?appId=67be30a0b85c4e44b6744158&id=6a7d16480cc3456368415da9)

