### PR TITLE
feat(Modal): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/styles.css
@@ -11,15 +11,14 @@
   z-index: 10;
   width: min(100vw, var(--dimension-width-modal));
 
-  border: var(--lp-dimension-stroke-thickness-default) solid
-    var(--lp-color-border-high-contrast);
+  border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
 
   &,
   &::backdrop {
     opacity: 0;
     transition-behavior: allow-discrete;
     transition-property: display, opacity, overlay;
-    transition-duration: var(--lp-transition-duration-fast);
+    transition-duration: var(--ds-transition-duration-fast);
   }
 
   &.no-transition {
@@ -30,10 +29,7 @@
   }
 
   &::backdrop {
-    background-color: var(
-      --modal-backdrop-color,
-      var(--lp-color-background-overlay)
-    );
+    background-color: var(--modal-backdrop-color, var(--color-backdrop));
   }
 
   /*
@@ -62,10 +58,7 @@
 .ds.modal-non-modal-backdrop {
   position: fixed;
   inset: 0;
-  background-color: var(
-    --modal-backdrop-color,
-    var(--lp-color-background-overlay)
-  );
+  background-color: var(--modal-backdrop-color, var(--color-backdrop));
   display: none;
   /* TODO: Add z-index tokens */
   z-index: 10;

--- a/packages/svelte/ds-app-launchpad/src/lib/modifier-families/constants.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/modifier-families/constants.ts
@@ -1,5 +1,9 @@
 export const MODIFIER_FAMILIES = {
   criticality: ["success", "error", "warning", "information"],
+  // TODO: old modifier family. Remove severity after its no longer used
   severity: ["neutral", "positive", "negative", "caution", "information"],
+  // TODO: new modifier family is also used density, but the values 
+  // are different. Keep in mind when updating a component that uses it
+  // New values: comfortable, dense
   density: ["dense", "compact", "medium"],
 } as const satisfies Record<string, readonly string[]>;

--- a/packages/svelte/ds-app-launchpad/src/lib/modifier-families/constants.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/modifier-families/constants.ts
@@ -2,7 +2,7 @@ export const MODIFIER_FAMILIES = {
   criticality: ["success", "error", "warning", "information"],
   // TODO: old modifier family. Remove severity after its no longer used
   severity: ["neutral", "positive", "negative", "caution", "information"],
-  // TODO: new modifier family is also used density, but the values 
+  // TODO: new modifier family is also used density, but the values
   // are different. Keep in mind when updating a component that uses it
   // New values: comfortable, dense
   density: ["dense", "compact", "medium"],

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,4 +1,5 @@
 :root {
+  --ds-transition-duration-fast: 165ms;
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -70,5 +71,11 @@
     --modifier-color-foreground-primary: var(
       --color-foreground-primary-information
     );
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ds-transition-duration-fast: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Updated Modal styles to use design tokens
Added a transition duration to the shim, together with the `prefers-reduced-motion: reduce` block that zeroes it

The design tokens package ships no motion tokens at all, so the shim also has to reproduce what launchpad's `transition/preferred.css` was doing.

### Changes

Launchpad's overlay was `rgba(17, 17, 17, .85)` in both themes, `--color-backdrop` is black at 15% in the light theme and white at 15% in the dark one:

## QA

- Visual check
- With `prefers-reduced-motion: reduce` emulated, opening and closing should be instant

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots
