### PR TITLE
chore(svelte-wpe): Configure client tests 

### DIFF
--- a/packages/svelte/ds-app-wpe/package.json
+++ b/packages/svelte/ds-app-wpe/package.json
@@ -88,5 +88,10 @@
   },
   "peerDependencies": {
     "svelte": "^5.47.1"
+  },
+  "nx": {
+    "tags": [
+      "playwright"
+    ]
   }
 }

--- a/packages/svelte/ds-app-wpe/package.json
+++ b/packages/svelte/ds-app-wpe/package.json
@@ -50,7 +50,7 @@
     "check:biome:fix": "biome check --write",
     "check:ts": "svelte-check --tsconfig ./tsconfig.json",
     "check:webarchitect": "webarchitect package-svelte -v",
-    "test": "vitest --run --project=ssr",
+    "test": "vitest --run",
     "test:watch": "vitest",
     "test:server": "vitest --run --project=server",
     "test:client": "vitest --run --project=client",

--- a/packages/svelte/ds-app-wpe/src/lib/components/SkipLink/SkipLink.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/SkipLink/SkipLink.svelte.test.ts
@@ -21,6 +21,7 @@ describe("SkipLink component", () => {
     it("moves focus to the main element when activated", async () => {
       mainEl.id = "main";
       const page = render(Component);
+      componentLocator(page).element().focus();
       await componentLocator(page).click();
       expect(document.activeElement).toBe(mainEl);
     });
@@ -28,6 +29,7 @@ describe("SkipLink component", () => {
     it("moves focus to a custom main element when mainId is set", async () => {
       mainEl.id = "custom-content";
       const page = render(Component, { mainId: "custom-content" });
+      componentLocator(page).element().focus();
       await componentLocator(page).click();
       expect(document.activeElement).toBe(mainEl);
     });


### PR DESCRIPTION
## Done

- Modified `packages/svelte/ds-app-wpe/package.json` to run client tests as well as the existing ssr tests

Fixes

- Client test cases for `packages/svelte/ds-app-wpe/SkipLink` now focus the element before attempting to click
    -  `Locator.click()` will fail if element is outside the viewport

## QA

- Navigate to `packages/svelte/ds-app-wpe`
- Run `bun run check`
- Run `bun run test`

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.