### PR TITLE
feat(Chip)!: Migrate to design tokens. Modifiers updated

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.ssr.test.ts
@@ -85,6 +85,13 @@ describe("Chip SSR", () => {
       expect(componentLocator(page).classList.contains("readonly")).toBe(true);
       expect(page.queryByRole("button")).toBeNull();
     });
+
+    it("applies the criticality class", () => {
+      const page = render(Component, {
+        props: { ...baseProps, criticality: "warning" },
+      });
+      expect(componentLocator(page).classList).toContain("warning");
+    });
   });
 });
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.stories.svelte
@@ -23,14 +23,14 @@
   }}
 />
 
-<Story name="Severities">
+<Story name="Criticalities">
   {#snippet template(args)}
-    {#each MODIFIER_FAMILIES.severity as severity (severity)}
+    {#each [undefined, ...MODIFIER_FAMILIES.criticality] as criticality (criticality)}
       <Chip
         {...args}
-        lead="Severity"
-        value={severity}
-        {severity}
+        lead="Criticality"
+        value={criticality ?? "default"}
+        {criticality}
         onclick={fn()}
       />
       <br />
@@ -44,7 +44,7 @@
   args={{
     lead: "Lead",
     value: "Value",
-    severity: "caution",
+    criticality: "warning",
   }}
 >
   {#snippet template(args)}
@@ -83,13 +83,13 @@
 
 <Story name="Read-only">
   {#snippet template(args)}
-    {#each MODIFIER_FAMILIES.severity as severity (severity)}
+    {#each [undefined, ...MODIFIER_FAMILIES.criticality] as criticality (criticality)}
       <Chip
         {...args}
-        lead="Severity"
-        value={severity || "default"}
+        lead="Criticality"
+        value={criticality ?? "default"}
         readonly
-        {severity}
+        {criticality}
       >
         {#snippet badge()}
           <Badge value={420} />

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.svelte
@@ -9,8 +9,7 @@
 
   const {
     class: className,
-    density,
-    severity,
+    criticality,
     readonly,
     lead,
     value,
@@ -31,7 +30,7 @@
 
 <svelte:element
   this={rootElement}
-  class={[componentCssClassName, className, density, severity, { readonly }]}
+  class={[componentCssClassName, className, criticality, { readonly }]}
   type={rootElement === "button" ? "button" : undefined}
   {onclick}
   {...rest}
@@ -73,13 +72,12 @@
 ```svelte
 <Chip value="Value"/>
 <Chip lead="Lead" value="Value" />
-<Chip lead="Lead" value="Value" severity="caution" />
+<Chip lead="Lead" value="Value" criticality="warning" />
 <Chip
   lead="Lead"
   value="Value"
   readonly
-  density="dense"
-  severity="caution"
+  criticality="warning"
 />
 ```
 -->

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.svelte.test.ts
@@ -84,13 +84,11 @@ describe("Chip component", () => {
         ...baseProps,
         value: "Styled Chip",
         class: "extra-class",
-        density: "dense",
-        severity: "caution",
+        criticality: "warning",
       });
 
       await expect.element(componentLocator(page)).toHaveClass("extra-class");
-      await expect.element(componentLocator(page)).toHaveClass("dense");
-      await expect.element(componentLocator(page)).toHaveClass("caution");
+      await expect.element(componentLocator(page)).toHaveClass("warning");
     });
 
     it("should not render a button when dismiss is provided", async () => {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Chip/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Chip/styles.css
@@ -3,26 +3,23 @@
 .ds.chip {
   display: inline-flex;
   align-items: center;
-  font: var(--lp-typography-paragraph-s);
-  color: var(--lp-color-text-secondary-context, var(--lp-color-text-default));
-  border-radius: var(--lp-dimension-radius-full);
-  border: var(--lp-dimension-stroke-thickness-default) solid
-    var(--lp-color-border-secondary-context, var(--lp-color-border-default));
+  font: var(--ds-typography-text-secondary);
+  color: var(
+    --modifier-color-text-onForegroundSecondary,
+    var(--color-text-onForegroundSecondary)
+  );
+  border-radius: var(--dimension-radius-full);
+  border: var(--dimension-stroke-thickness-medium) solid
+    var(--modifier-color-border, var(--color-border));
   background-color: var(
-    --lp-color-background-secondary-context,
-    var(--lp-color-background-neutral-default)
+    --modifier-color-foreground-secondary,
+    var(--color-foreground-secondary)
   );
-  padding-block: var(
-    --lp-dimension-padding-block-context,
-    var(--lp-dimension-spacing-block-xxxs)
-  );
-  padding-inline: var(
-    --lp-dimension-padding-inline-context,
-    var(--lp-dimension-spacing-inline-s)
-  );
-  transition-duration: var(--lp-transition-duration-snap);
+  padding-block: 0;
+  padding-inline: var(--dimension-150);
+  transition-duration: var(--ds-transition-duration-snap);
   transition-property: background-color, border-color;
-  transition-timing-function: var(--lp-transition-timing-ease-in);
+  transition-timing-function: var(--ds-transition-timing-ease-in);
 
   &:is(button),
   .dismiss {
@@ -30,15 +27,15 @@
 
     &:hover {
       background-color: var(
-        --lp-color-background-secondary-hover-context,
-        var(--lp-color-background-neutral-hover)
+        --hover--color-foreground-secondary,
+        var(--color-foreground-secondary-hover)
       );
     }
 
     &:active {
       background-color: var(
-        --lp-color-background-secondary-active-context,
-        var(--lp-color-background-neutral-active)
+        --active--color-foreground-secondary,
+        var(--color-foreground-secondary-active)
       );
     }
   }
@@ -47,13 +44,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-right: var(--lp-dimension-spacing-inline-xxs);
+    margin-right: var(--dimension-050);
   }
 
   > .lead {
     font-variant-caps: all-small-caps;
     font-variant-numeric: oldstyle-nums;
-    letter-spacing: var(--lp-typography-letter-spacing-l);
+    letter-spacing: var(--dimension-letterSpacing-wide);
 
     & + .value::before {
       content: ": ";
@@ -61,8 +58,7 @@
   }
 
   > .badge {
-    margin-inline: var(--lp-dimension-spacing-inline-xs)
-      var(--lp-dimension-spacing-inline-minimum);
+    margin-inline: var(--dimension-100) 0;
   }
 
   > .dismiss {
@@ -70,20 +66,23 @@
     align-items: center;
     justify-content: center;
     background-color: transparent;
-    color: var(--lp-color-text-default);
+    color: var(
+      --modifier-color-text-onForegroundSecondary,
+      var(--color-text-onForegroundSecondary)
+    );
     cursor: pointer;
-    border-radius: var(--lp-dimension-radius-full);
-    width: var(--lp-dimension-size-xs);
-    height: var(--lp-dimension-size-xs);
-    padding-block: var(--lp-dimension-spacing-block-xxxs);
-    padding-inline: var(--lp-dimension-spacing-inline-xxxs);
-    margin-left: var(--lp-dimension-spacing-inline-xxs);
-    border: var(--lp-dimension-stroke-thickness-default) solid transparent;
+    border-radius: var(--dimension-radius-full);
+    width: var(--dimension-200);
+    height: var(--dimension-200);
+    padding-block: var(--dimension-025);
+    padding-inline: var(--dimension-025);
+    margin-left: var(--dimension-050);
+    border: var(--dimension-stroke-thickness-medium) solid transparent;
   }
 
   /* TODO: Consider splitting the chip component into two separate components */
   /* Where the read-only local modifier won't be needed anymore. */
   &.readonly {
-    --lp-color-border-secondary-context: var(--lp-color-background-default);
+    border-color: var(--surface-color-background, var(--color-background));
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Chip/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Chip/types.ts
@@ -16,7 +16,7 @@ type ChipClickOptions = {
 
 export interface ChipProps
   extends Omit<HTMLAttributes<HTMLElement>, "onclick" | "children">,
-    ModifierFamily<["density", "severity"]>,
+    ModifierFamily<"criticality">,
     ChipClickOptions {
   /** The value of the chip */
   value: string;

--- a/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/DescriptionList.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/DescriptionList.stories.svelte
@@ -25,7 +25,7 @@
       layout handles it.
     </DescriptionList.Item>
     <DescriptionList.Item name="Status">
-      <Chip value="Active" readonly severity="positive" />
+      <Chip value="Active" readonly criticality="success" />
     </DescriptionList.Item>
     <DescriptionList.Item name="Artifact">
       <Link href="#">View Artifact</Link>

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,5 +1,7 @@
 :root {
   --ds-transition-duration-fast: 165ms;
+  --ds-transition-duration-snap: 100ms;
+  --ds-transition-timing-ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -46,24 +48,35 @@
     var(--typography-heading-5-font-family);
 }
 
-/* The criticality modifier exposes every colour channel except the solid fill,
- * so a component painting a solid criticality surface has nothing to read.
+/* The criticality modifier exposes every color channel except the solid fill
+ * and the on-surface text pairing, so a component painting a solid criticality
+ * surface has nothing to read.
  * Upstream fix: https://github.com/canonical/design-tokens/pull/104
- * Delete this block once it lands and the design-tokens pin is bumped. */
+ * Delete each line once its channel is generated upstream and the
+ * design-tokens pin is bumped. */
 @layer ds.modifiers {
   .success {
     --modifier-color-foreground-primary: var(
       --color-foreground-primary-success
     );
+    --modifier-color-text-onForegroundSecondary: var(
+      --color-text-onForegroundSecondary-success
+    );
   }
 
   .error {
     --modifier-color-foreground-primary: var(--color-foreground-primary-error);
+    --modifier-color-text-onForegroundSecondary: var(
+      --color-text-onForegroundSecondary-error
+    );
   }
 
   .warning {
     --modifier-color-foreground-primary: var(
       --color-foreground-primary-warning
+    );
+    --modifier-color-text-onForegroundSecondary: var(
+      --color-text-onForegroundSecondary-warning
     );
   }
 
@@ -71,11 +84,15 @@
     --modifier-color-foreground-primary: var(
       --color-foreground-primary-information
     );
+    --modifier-color-text-onForegroundSecondary: var(
+      --color-text-onForegroundSecondary-information
+    );
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-snap: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Updated Chip styles to use design tokens
Moved Chip off the launchpad `severity` modifier family onto the design system's `criticality` family, per the [Chip design](https://www.figma.com/design/WGHcOmGMEUF9hMAEoRafL8/%F0%9F%93%95-Pragma---documentation-visuals?node-id=2093-9647&m=dev)
Dropped the `density` prop for now; the default chip is the dense design
Added the on-surface text channel to the shim, in `@layer ds.modifiers`, until it is generated upstream

Upstream fix: https://github.com/canonical/design-tokens/pull/104 — delete the block once it lands and the design-tokens pin is bumped.

### Changes

Breaking: the `severity` prop is replaced by `criticality`; `positive` => `success`, `negative` => `error`, `caution` => `warning`, `information` stays, and `neutral` is gone since the absence of a criticality is the neutral state
Breaking: the `density` prop is removed. The default chip is dense: block padding 2px => 0, inline padding unchanged at 12px
Border and text now follow the criticality. `severity.css` pinned both to the default for all four values, so only the background was tinted
The label reads the on-surface text channel (`--modifier-color-text-onForegroundSecondary`), not the standalone criticality text colour, which is the same hue as the chip's own surface and fails contrast against it
Hover and active tints come from `states.css`, which derives them from the applied criticality on its own
The read-only chip keeps losing its border regardless of criticality, now by setting `border-color` directly so the modifier channel cannot win over it
Letter spacing on the lead is `.05rem` instead of `.05em`, so it no longer scales with the chip's font size
The default chip does not move otherwise: same fill, border, text and inline padding as before

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now
<img width="446" height="514" alt="image" src="https://github.com/user-attachments/assets/8d89c21a-a872-45ab-9f6a-bf19d53d4014" />
Was
<img width="446" height="514" alt="image" src="https://github.com/user-attachments/assets/2577748c-3915-499a-b356-c5e4ec4280fd" />


Now
<img width="446" height="514" alt="image" src="https://github.com/user-attachments/assets/7332eaef-9b94-4a08-8e25-ff0809952cab" />
Was
<img width="446" height="514" alt="image" src="https://github.com/user-attachments/assets/0cbe188a-3230-48a4-9892-efdd393e3e8a" />
