### PR TITLE
feat(Spinner): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Spinner/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Spinner/styles.css
@@ -1,6 +1,6 @@
 .ds.spinner {
   transform-origin: center center;
-  animation: loading-spinner var(--lp-transition-duration-sleepy) infinite
+  animation: loading-spinner var(--ds-transition-duration-sleepy) infinite
     linear;
 }
 

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,5 +1,6 @@
 :root {
   --ds-transition-duration-fast: 165ms;
+  --ds-transition-duration-sleepy: 1s;
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -77,5 +78,6 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-sleepy: 0ms;
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,10 +1,7 @@
 :root {
   --ds-transition-duration-fast: 165ms;
-  --ds-transition-duration-snap: 100ms;
-  --ds-transition-duration-brisk: 333ms;
-  --ds-transition-duration-slow: 500ms;
-  --ds-transition-timing-ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
+  --ds-transition-duration-sleepy: 1s;
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -96,8 +93,7 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
-    --ds-transition-duration-snap: 0ms;
-    --ds-transition-duration-brisk: 0ms;
     --ds-transition-duration-slow: 0ms;
+    --ds-transition-duration-sleepy: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Migrated Spinner styles to design tokens
Added `--ds-transition-duration-sleepy` (1s) to the shim, with a `prefers-reduced-motion` override, until it is generated upstream

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Does not require screenshots. The only difference is animation token