### PR TITLE
feat(SearchBox): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/SearchBox/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SearchBox/styles.css
@@ -1,6 +1,6 @@
 .ds.search-box {
-  --dimension-width-search-box-button: var(--lp-dimension-size-l);
-  --dimension-gap-search-box: var(--lp-dimension-spacing-inline-xs);
+  --dimension-width-search-box-button: var(--dimension-400);
+  --dimension-gap-search-box: var(--dimension-100);
 
   display: grid;
   grid-template-areas: "main";


### PR DESCRIPTION
Needs migrated input primitive for proper screenshots

## Done

Migrated SearchBox styles to design tokens

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now

Was
