### PR TITLE
feat(Log): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Log/common/Line/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Log/common/Line/styles.css
@@ -3,17 +3,17 @@
   display: grid;
   grid-column: 1 / -1;
   grid-template-columns: subgrid;
-  font: var(--lp-typography-code-s);
-  color: var(--lp-color-text-default);
+  font: var(--ds-typography-text-secondary-code);
+  color: var(--color-text);
 
-  --log-line-background-color: var(--lp-color-background-alt);
-  --log-line-target-highlight-color: var(--lp-color-background-active);
+  --log-line-background-color: var(--color-foreground-secondary);
+  --log-line-target-highlight-color: var(--active--color-foreground-secondary);
   --log-line-target-highlight-time: 5s;
 
   > td,
   > th {
-    padding-block: var(--lp-dimension-spacing-block-xxxs);
-    font-weight: var(--lp-typography-weight-regular);
+    padding-block: var(--dimension-025);
+    font-weight: var(--typography-weight-regular);
     background-color: var(--log-line-background-color);
   }
 
@@ -23,7 +23,7 @@
       animation:
         target-highlight-hold var(--log-line-target-highlight-time) step-end
         forwards,
-        target-highlight-fade var(--lp-transition-duration-sleepy) ease-out
+        target-highlight-fade var(--ds-transition-duration-sleepy) ease-out
         var(--log-line-target-highlight-time) forwards;
     }
   }
@@ -31,18 +31,18 @@
   > .line-number {
     grid-column: line-number;
     text-align: right;
-    color: var(--lp-color-text-muted);
+    color: var(--color-text-muted);
     position: sticky;
     left: 0;
     padding-inline-start: var(--log-padding-inline);
-    padding-inline-end: var(--lp-dimension-spacing-inline-s);
+    padding-inline-end: var(--dimension-150);
   }
 
   > .timestamp {
     grid-column: timestamp;
     white-space: nowrap;
 
-    padding-inline-end: var(--lp-dimension-spacing-inline-m);
+    padding-inline-end: var(--dimension-200);
   }
 
   > .content {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Log/common/Line/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Log/common/Line/styles.css
@@ -6,8 +6,8 @@
   font: var(--ds-typography-text-secondary-code);
   color: var(--color-text);
 
-  --log-line-background-color: var(--color-foreground-secondary);
-  --log-line-target-highlight-color: var(--active--color-foreground-secondary);
+  --log-line-background-color: var(--color-foreground-input);
+  --log-line-target-highlight-color: var(--color-foreground-input-hover);
   --log-line-target-highlight-time: 5s;
 
   > td,

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Log/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Log/styles.css
@@ -5,7 +5,7 @@
 
   --log-padding-inline: var(--dimension-200);
 
-  background-color: var(--color-foreground-secondary);
+  background-color: var(--color-foreground-input);
   padding-inline-end: var(--log-padding-inline);
   padding-block-end: var(--dimension-400);
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Log/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Log/styles.css
@@ -3,11 +3,11 @@
   contain: inline-size layout paint;
   overflow: auto;
 
-  --log-padding-inline: var(--lp-dimension-spacing-inline-m);
+  --log-padding-inline: var(--dimension-200);
 
-  background-color: var(--lp-color-background-alt);
+  background-color: var(--color-foreground-secondary);
   padding-inline-end: var(--log-padding-inline);
-  padding-block-end: var(--lp-dimension-spacing-block-xxxl);
+  padding-block-end: var(--dimension-400);
 
   tbody {
     display: grid;

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,10 +1,7 @@
 :root {
   --ds-transition-duration-fast: 165ms;
-  --ds-transition-duration-snap: 100ms;
-  --ds-transition-duration-brisk: 333ms;
-  --ds-transition-duration-slow: 500ms;
-  --ds-transition-timing-ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
+  --ds-transition-duration-sleepy: 1s;
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -24,6 +21,11 @@
     var(--typography-text-secondary-bold-font-size) /
     var(--typography-text-secondary-bold-line-height)
     var(--typography-text-secondary-bold-font-family);
+  --ds-typography-text-secondary-code:
+    var(--typography-text-secondary-code-font-weight)
+    var(--typography-text-secondary-code-font-size) /
+    var(--typography-text-secondary-code-line-height)
+    var(--typography-text-secondary-code-font-family);
   --ds-typography-text-primary-bold:
     var(--typography-text-primary-bold-font-weight)
     var(--typography-text-primary-bold-font-size) /
@@ -96,8 +98,7 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
-    --ds-transition-duration-snap: 0ms;
-    --ds-transition-duration-brisk: 0ms;
     --ds-transition-duration-slow: 0ms;
+    --ds-transition-duration-sleepy: 0ms;
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,5 +1,6 @@
 :root {
   --ds-transition-duration-fast: 165ms;
+  --ds-transition-duration-sleepy: 1s;
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -19,6 +20,11 @@
     var(--typography-text-secondary-bold-font-size) /
     var(--typography-text-secondary-bold-line-height)
     var(--typography-text-secondary-bold-font-family);
+  --ds-typography-text-secondary-code:
+    var(--typography-text-secondary-code-font-weight)
+    var(--typography-text-secondary-code-font-size) /
+    var(--typography-text-secondary-code-line-height)
+    var(--typography-text-secondary-code-font-family);
   --ds-typography-text-primary-bold:
     var(--typography-text-primary-bold-font-weight)
     var(--typography-text-primary-bold-font-size) /
@@ -77,5 +83,6 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-sleepy: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Migrated Log styles to design tokens
Added `--ds-transition-duration-sleepy` (1s) and `--ds-typography-text-secondary-code` to the shim, with a `prefers-reduced-motion` override for the former, until they are generated upstream

Tokens used seem WRONG semantically. But that is the closest design match I could find that also makes sense.

- There is an --active foreground channel that is almost invisible
- There is a "background-layer2" that i don't know what to pair with. If I pair it with level3 it will be "white" in light mode, not darker than layer2.

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now
<img width="1811" height="304" alt="image" src="https://github.com/user-attachments/assets/1b69d6b0-decc-41bc-9b57-d28ee9f245a9" />

Was
<img width="1811" height="304" alt="image" src="https://github.com/user-attachments/assets/c24ee1d2-097d-4676-9f35-a66a1f7e6a8e" />
