### PR TITLE
feat(Textarea): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Textarea/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Textarea/styles.css
@@ -1,27 +1,24 @@
 .ds.textarea {
-  --color-background-textarea-input-active: var(--lp-color-background-active);
-  --color-background-textarea-input-hover: var(--lp-color-background-hover);
-  --color-background-textarea-input: var(--lp-color-background-input);
-  --dimension-padding-inline-textarea-input: var(
-    --lp-dimension-spacing-inline-m
+  --color-background-textarea-input-active: var(
+    --color-foreground-input-active
   );
-  --dimension-padding-block-textarea-input: var(
-    --lp-dimension-spacing-block-xxs
-  );
-  --color-border-textarea-input: var(--lp-color-border-high-contrast);
+  --color-background-textarea-input-hover: var(--color-foreground-input-hover);
+  --color-background-textarea-input: var(--color-foreground-input);
+  --dimension-padding-inline-textarea-input: var(--dimension-200);
+  --dimension-padding-block-textarea-input: var(--dimension-050);
+  --color-border-textarea-input: var(--color-border);
   --border-style-textarea-input: none none solid none;
   --dimension-border-width-textarea-input: var(
-    --lp-dimension-stroke-thickness-default
+    --dimension-stroke-thickness-medium
   );
-  --color-text-textarea-input: var(--lp-color-text-default);
-  --color-text-textarea-input-placeholder: var(--lp-color-text-muted);
-  --typography-textarea-input: var(--lp-typography-paragraph-default);
-  --opacity-textarea-input-disabled: var(--lp-opacity-muted);
+  --color-text-textarea-input: var(--color-text);
+  --color-text-textarea-input-placeholder: var(--color-text-muted);
+  --typography-textarea-input: var(--ds-typography-text-primary);
   --color-background-textarea-input-invalid: var(
-    --lp-color-background-negative-default
+    --color-foreground-input-error
   );
-  --color-border-textarea-input-invalid: var(--lp-color-border-negative);
-  --color-outline-textarea-input-invalid: var(--lp-color-border-negative);
+  --color-border-textarea-input-invalid: var(--color-border-error);
+  --color-outline-textarea-input-invalid: var(--color-border-error);
 
   background-color: var(--color-background-textarea-input);
   border-color: var(--color-border-textarea-input);
@@ -31,9 +28,9 @@
   font: var(--typography-textarea-input);
   padding-block: var(--dimension-padding-block-textarea-input);
   padding-inline: var(--dimension-padding-inline-textarea-input);
-  transition-duration: var(--lp-transition-duration-snap);
+  transition-duration: var(--ds-transition-duration-snap);
   transition-property: background-color, border-color;
-  transition-timing-function: var(--lp-transition-timing-ease-in);
+  transition-timing-function: var(--ds-transition-timing-ease-in);
 
   &::placeholder {
     color: var(--color-text-textarea-input-placeholder);
@@ -50,7 +47,8 @@
 
   &:disabled {
     cursor: not-allowed;
-    opacity: var(--opacity-textarea-input-disabled);
+    background-color: var(--color-foreground-input-disabled);
+    border-color: var(--disabled--color-border);
   }
 
   &:user-invalid,

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,5 +1,7 @@
 :root {
   --ds-transition-duration-fast: 165ms;
+  --ds-transition-duration-snap: 100ms;
+  --ds-transition-timing-ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -77,5 +79,6 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-snap: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Migrated Textarea styles to design tokens
Added `--ds-transition-duration-snap` (100ms) and `--ds-transition-timing-ease-in` to the shim, with a `prefers-reduced-motion` override for the former, until they are generated upstream
Disabled state no longer fades the whole control with `opacity`; it uses the explicit `--color-foreground-input-disabled` / `--disabled--color-border` pair instead

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now

Was
