### PR TITLE
feat(Table): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/styles.css
@@ -1,12 +1,11 @@
 .ds.table-th-sort.button-primitive {
-  padding: var(--lp-dimension-spacing-block-xxxs)
-    var(--lp-dimension-spacing-inline-xxxs);
+  padding: var(--dimension-025) var(--dimension-025);
   background: none;
   border: none;
   min-width: fit-content;
 
-  font-size: var(--lp-typography-font-size-m);
-  color: var(--lp-color-icon-status-queued);
+  font-size: var(--typography-text-primary-font-size);
+  color: var(--color-icon-muted);
 
   --color-background-button-hover: transparent;
   --color-background-button-active: transparent;
@@ -14,6 +13,6 @@
   &:hover,
   &:focus-visible,
   &.sorted {
-    color: var(--lp-color-text-default);
+    color: var(--color-text);
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/styles.css
@@ -4,7 +4,7 @@
     flex-flow: row wrap;
     align-items: center;
     justify-content: space-between;
-    gap: var(--lp-dimension-spacing-inline-xxs);
+    gap: var(--dimension-050);
   }
 
   &:not([aria-sort]),

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/styles.css
@@ -1,10 +1,10 @@
 .ds.table {
   border-collapse: collapse;
 
-  --border-table-row: var(--lp-dimension-stroke-thickness-default) solid
-    var(--lp-color-border-low-contrast);
-  --dimension-padding-block-table-cell: var(--lp-dimension-spacing-block-xs);
-  --dimension-padding-inline-table-cell: var(--lp-dimension-spacing-inline-xs);
+  --border-table-row: var(--dimension-stroke-thickness-medium) solid
+    var(--color-border-muted);
+  --dimension-padding-block-table-cell: var(--dimension-100);
+  --dimension-padding-inline-table-cell: var(--dimension-100);
 
   th,
   td {
@@ -14,11 +14,11 @@
 
   th {
     text-align: start;
-    font: var(--lp-typography-paragraph-s-strong);
+    font: var(--ds-typography-text-secondary-bold);
   }
 
   td {
-    font: var(--lp-typography-paragraph-s);
+    font: var(--ds-typography-text-secondary);
   }
 
   thead,
@@ -37,10 +37,10 @@
       content: "";
       position: absolute;
       height: calc(100% - var(--dimension-padding-block-table-cell) * 2);
-      width: var(--lp-dimension-stroke-thickness-default);
-      inset-inline-end: calc(var(--lp-dimension-stroke-thickness-default) / -2);
+      width: var(--dimension-stroke-thickness-medium);
+      inset-inline-end: calc(var(--dimension-stroke-thickness-medium) / -2);
       inset-block-start: var(--dimension-padding-block-table-cell);
-      background-color: var(--lp-color-border-default);
+      background-color: var(--color-border);
     }
   }
 }


### PR DESCRIPTION
## Done

Migrated Table styles to design tokens

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now

Was
