### PR TITLE
feat(Checkbox): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Checkbox/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Checkbox/styles.css
@@ -6,28 +6,27 @@
   flex-shrink: 0;
   outline-offset: 1px;
 
-  width: var(--lp-dimension-size-xs);
-  height: var(--lp-dimension-size-xs);
-  border: var(--lp-dimension-stroke-thickness-default) solid
-    var(--lp-color-border-high-contrast);
-  background-color: var(--lp-color-background-default);
+  width: var(--dimension-200);
+  height: var(--dimension-200);
+  border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
+  background-color: var(--color-foreground-checkbox-unselected);
   transition:
-    background-color var(--lp-transition-duration-brisk)
-    var(--lp-transition-timing-ease-out),
-    border-color var(--lp-transition-duration-brisk)
-    var(--lp-transition-timing-ease-out);
+    background-color var(--ds-transition-duration-brisk)
+    var(--ds-transition-timing-ease-out),
+    border-color var(--ds-transition-duration-brisk)
+    var(--ds-transition-timing-ease-out);
 
   &::after {
     content: "";
     position: absolute;
-    inset: calc(var(--lp-dimension-size-xs) * 0.1);
+    inset: calc(var(--dimension-200) * 0.1);
     display: none;
-    background-color: var(--lp-color-background-default);
+    background-color: var(--color-foreground-checkbox-checkmark);
   }
 
   &:checked {
-    background-color: var(--lp-color-text-link-default);
-    border-color: var(--lp-color-text-link-default);
+    background-color: var(--color-foreground-checkbox-selected);
+    border-color: var(--color-foreground-checkbox-selected);
 
     &::after {
       display: block;
@@ -44,16 +43,27 @@
 
   &:disabled {
     cursor: not-allowed;
-    opacity: var(--lp-opacity-muted);
+    background-color: var(--color-foreground-checkbox-unselected-disabled);
+    border-color: var(--disabled--color-border);
+
+    &:checked,
+    &:indeterminate {
+      background-color: var(--color-foreground-checkbox-selected-disabled);
+      border-color: var(--color-foreground-checkbox-selected-disabled);
+    }
+
+    &::after {
+      background-color: var(--color-foreground-checkbox-checkmark-disabled);
+    }
   }
 
   &:hover:not(:disabled):not(:checked):not(:indeterminate) {
-    background-color: var(--lp-color-background-hover);
+    background-color: var(--color-foreground-checkbox-unselected-hover);
   }
 
   &:indeterminate {
-    background-color: var(--lp-color-text-link-default);
-    border-color: var(--lp-color-text-link-default);
+    background-color: var(--color-foreground-checkbox-selected);
+    border-color: var(--color-foreground-checkbox-selected);
 
     &::after {
       display: block;

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,5 +1,7 @@
 :root {
   --ds-transition-duration-fast: 165ms;
+  --ds-transition-duration-brisk: 333ms;
+  --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -77,5 +79,6 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-brisk: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Migrated Checkbox styles to design tokens
Added `--ds-transition-duration-brisk` (333ms) and `--ds-transition-timing-ease-out` to the shim, with a `prefers-reduced-motion` override for the former, until they are generated upstream
Disabled state no longer fades the whole control with `opacity`; it uses the explicit disabled members of the checkbox family instead

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now
<img width="389" height="247" alt="image" src="https://github.com/user-attachments/assets/60341542-3c21-4fc3-8713-31da964cf3b8" />

Was
<img width="389" height="247" alt="image" src="https://github.com/user-attachments/assets/3d13e833-cba7-4002-9c84-24ac8ef79f2c" />

