### PR TITLE
feat(Radio): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Radio/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Radio/styles.css
@@ -6,37 +6,41 @@
   flex-shrink: 0;
   outline-offset: 1px;
 
-  width: var(--lp-dimension-size-xs);
-  height: var(--lp-dimension-size-xs);
-  border-radius: var(--lp-dimension-radius-full);
-  border: var(--lp-dimension-stroke-thickness-default) solid
-    var(--lp-color-border-high-contrast);
-  background-color: var(--lp-color-background-default);
-  transition: background-color var(--lp-transition-duration-brisk)
-    var(--lp-transition-timing-ease-out);
+  width: var(--dimension-200);
+  height: var(--dimension-200);
+  border-radius: var(--dimension-radius-full);
+  border: var(--dimension-stroke-thickness-medium) solid var(--color-border);
+  background-color: var(--color-foreground-radio-unselected);
+  transition: background-color var(--ds-transition-duration-brisk)
+    var(--ds-transition-timing-ease-out);
 
   &::after {
     content: "";
     position: absolute;
-    inset: calc(var(--lp-dimension-stroke-thickness-default) * -1);
-    border-radius: var(--lp-dimension-radius-full);
-    border: calc(var(--lp-dimension-size-xs) * 0.3125) solid transparent;
-    transition: border-color var(--lp-transition-duration-brisk)
-      var(--lp-transition-timing-ease-out);
+    inset: calc(var(--dimension-stroke-thickness-medium) * -1);
+    border-radius: var(--dimension-radius-full);
+    border: calc(var(--dimension-200) * 0.3125) solid transparent;
+    transition: border-color var(--ds-transition-duration-brisk)
+      var(--ds-transition-timing-ease-out);
   }
 
   &:disabled {
     cursor: not-allowed;
-    opacity: var(--lp-opacity-muted);
+    background-color: var(--color-foreground-radio-unselected-disabled);
+    border-color: var(--disabled--color-border);
+
+    &:checked::after {
+      border-color: var(--color-foreground-radio-selected-disabled);
+    }
   }
 
   &:hover:not(:disabled) {
-    background-color: var(--lp-color-background-hover);
+    background-color: var(--color-foreground-radio-unselected-hover);
   }
 
   &:checked {
     &::after {
-      border-color: var(--lp-color-text-link-default);
+      border-color: var(--color-foreground-radio-selected);
     }
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,5 +1,7 @@
 :root {
   --ds-transition-duration-fast: 165ms;
+  --ds-transition-duration-brisk: 333ms;
+  --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -77,5 +79,6 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-brisk: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Migrated Radio styles to design tokens
Added `--ds-transition-duration-brisk` (333ms) and `--ds-transition-timing-ease-out` to the shim, with a `prefers-reduced-motion` override for the former, until they are generated upstream
Disabled state no longer fades the whole control with `opacity`; it uses the explicit disabled members of the radio family instead

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now
<img width="389" height="247" alt="image" src="https://github.com/user-attachments/assets/1b90e9bb-91e0-4603-adbe-f263fa93f5ba" />

Was
<img width="354" height="281" alt="image" src="https://github.com/user-attachments/assets/6e19ce08-8b82-444d-93c5-ce887cf0b666" />

