### PR TITLE
feat(Switch): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Switch/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Switch/styles.css
@@ -4,10 +4,10 @@
   cursor: pointer;
   outline-offset: 0;
 
-  width: var(--lp-dimension-size-l);
-  height: var(--lp-dimension-size-xs);
-  background-color: var(--lp-color-border-high-contrast);
-  border-radius: var(--lp-dimension-radius-full);
+  width: var(--dimension-400);
+  height: var(--dimension-200);
+  background-color: var(--color-foreground-switch-unselected);
+  border-radius: var(--dimension-radius-full);
 
   &::after {
     content: "";
@@ -15,27 +15,40 @@
     top: 50%;
     left: 0;
     transform: translateY(-50%);
-    width: var(--lp-dimension-size-xs);
-    height: var(--lp-dimension-size-xs);
-    background-color: var(--lp-color-background-default);
-    border-radius: var(--lp-dimension-radius-full);
-    border: var(--lp-dimension-stroke-thickness-default) solid
-      var(--lp-color-border-high-contrast);
-    transition: transform var(--lp-transition-duration-slow)
-      var(--lp-transition-timing-ease-out);
+    width: var(--dimension-200);
+    height: var(--dimension-200);
+    background-color: var(--color-foreground-switch-knob);
+    border-radius: var(--dimension-radius-full);
+    border: var(--dimension-stroke-thickness-medium) solid
+      var(--color-foreground-switch-unselected);
+    transition: transform var(--ds-transition-duration-slow)
+      var(--ds-transition-timing-ease-out);
   }
 
   &:checked {
-    background-color: var(--lp-color-text-link-default);
+    background-color: var(--color-foreground-switch-selected);
 
     &::after {
-      border-color: var(--lp-color-text-link-default);
-      transform: translate(calc(var(--lp-dimension-size-l) / 2), -50%);
+      border-color: var(--color-foreground-switch-selected);
+      transform: translate(calc(var(--dimension-400) / 2), -50%);
     }
   }
 
   &:disabled {
-    opacity: var(--lp-opacity-muted);
     cursor: not-allowed;
+    background-color: var(--color-foreground-switch-unselected-disabled);
+
+    &::after {
+      background-color: var(--color-foreground-switch-knob-disabled);
+      border-color: var(--color-foreground-switch-unselected-disabled);
+    }
+
+    &:checked {
+      background-color: var(--color-foreground-switch-selected-disabled);
+
+      &::after {
+        border-color: var(--color-foreground-switch-selected-disabled);
+      }
+    }
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,5 +1,7 @@
 :root {
   --ds-transition-duration-fast: 165ms;
+  --ds-transition-duration-slow: 500ms;
+  --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -77,5 +79,6 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-slow: 0ms;
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -2,6 +2,7 @@
   --ds-transition-duration-fast: 165ms;
   --ds-transition-duration-snap: 100ms;
   --ds-transition-duration-brisk: 333ms;
+  --ds-transition-duration-slow: 500ms;
   --ds-transition-timing-ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
   --ds-color-foreground-tooltip: light-dark(
@@ -97,5 +98,6 @@
     --ds-transition-duration-fast: 0ms;
     --ds-transition-duration-snap: 0ms;
     --ds-transition-duration-brisk: 0ms;
+    --ds-transition-duration-slow: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Migrated Switch styles to design tokens
Added `--ds-transition-duration-slow` (500ms) and `--ds-transition-timing-ease-out` to the shim, with a `prefers-reduced-motion` override for the former, until they are generated upstream
Disabled state no longer fades the whole control with `opacity`; it uses the explicit disabled members of the switch family instead

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now
<img width="416" height="275" alt="image" src="https://github.com/user-attachments/assets/f94f1039-fb18-4c15-9322-e3b620fd697a" />

Was
<img width="416" height="275" alt="image" src="https://github.com/user-attachments/assets/f4b566b1-909d-4980-9e36-7abefc73d968" />


Now
<img width="416" height="275" alt="image" src="https://github.com/user-attachments/assets/18739d55-a1e5-4373-8ae3-9f865dba9ca5" />

Was
<img width="416" height="275" alt="image" src="https://github.com/user-attachments/assets/a8a5d8ae-0efd-4f46-b534-34d14fa4a5bf" />

