### PR TITLE
feat(SideNavigation): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/common/NavigationItem/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/common/NavigationItem/styles.css
@@ -5,19 +5,15 @@
   border: none;
 
   --dimension-padding-inline-button: 0;
-  --dimension-padding-block-button: var(--lp-dimension-spacing-block-xxs);
-  --dimension-padding-inline-start-button-label: var(
-    --lp-dimension-spacing-inline-xs
-  );
+  --dimension-padding-block-button: var(--dimension-050);
+  --dimension-padding-inline-start-button-label: var(--dimension-100);
   --color-background-button-selected: var(
-    --tmp-color-background-neutral-active
+    --color-foreground-navigation-primary-active
   );
   --dimension-width-button-selected-indicator: var(
-    --lp-dimension-stroke-thickness-large
+    --dimension-stroke-thickness-large
   );
-  --color-background-button-selected-indicator: var(
-    --tmp-color-border-highlight
-  );
+  --color-background-button-selected-indicator: var(--color-border-highlighted);
 
   grid-template-columns: subgrid;
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/styles.css
@@ -1,21 +1,17 @@
 .ds.side-navigation {
-  --color-background-side-navigation: var(--lp-color-background-alt);
-  --transition-duration-side-navigation: var(--lp-transition-duration-brisk);
-  --transition-easing-side-navigation: var(--lp-transition-timing-ease-out);
-  --dimension-padding-side-navigation: var(--lp-dimension-spacing-inline-s);
+  --color-background-side-navigation: var(
+    --color-foreground-navigation-primary
+  );
+  --transition-duration-side-navigation: var(--ds-transition-duration-brisk);
+  --transition-easing-side-navigation: var(--ds-transition-timing-ease-out);
+  --dimension-padding-side-navigation: var(--dimension-150);
   --dimension-width-side-navigation-logo-column: 21px;
   --dimension-width-side-navigation-expanded: 240px;
   --dimension-padding-block-start-side-navigation-nav: 40px;
-  --dimension-padding-block-end-side-navigation-footer: var(
-    --lp-dimension-spacing-block-xs
-  );
-  --dimension-padding-block-end-side-navigation-nav: var(
-    --lp-dimension-spacing-block-xxl
-  );
-  --dimension-padding-block-side-navigation-item: var(
-    --lp-dimension-spacing-block-xxs
-  );
-  --typography-side-navigation: var(--lp-typography-paragraph-default);
+  --dimension-padding-block-end-side-navigation-footer: var(--dimension-100);
+  --dimension-padding-block-end-side-navigation-nav: var(--dimension-500);
+  --dimension-padding-block-side-navigation-item: var(--dimension-050);
+  --typography-side-navigation: var(--ds-typography-text-primary);
 
   width: var(--dimension-width-side-navigation-expanded);
   background-color: var(--color-background-side-navigation);
@@ -97,7 +93,7 @@
       grid-template-columns: subgrid;
       align-self: self-start;
 
-      margin-block-start: var(--lp-dimension-spacing-block-m);
+      margin-block-start: var(--dimension-200);
 
       & .expand-icon {
         grid-column: logo;

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,7 +1,9 @@
 :root {
   --ds-transition-duration-fast: 165ms;
   --ds-transition-duration-snap: 100ms;
+  --ds-transition-duration-brisk: 333ms;
   --ds-transition-timing-ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -94,5 +96,6 @@
   :root {
     --ds-transition-duration-fast: 0ms;
     --ds-transition-duration-snap: 0ms;
+    --ds-transition-duration-brisk: 0ms;
   }
 }


### PR DESCRIPTION
## Done

Migrated SideNavigation styles to design tokens
Added `--ds-transition-duration-brisk` (333ms) and `--ds-transition-timing-ease-out` to the shim, with a `prefers-reduced-motion` override for the former, until they are generated upstream
Fixed the selected state, which referenced two `--tmp-*` tokens that no longer exist and resolved to nothing: the row highlight now reads `--color-foreground-navigation-primary-active` and the indicator bar `--color-border-highlighted`, restoring the removed intent

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Now
<img width="520" height="1255" alt="image" src="https://github.com/user-attachments/assets/a4945cbc-f549-4354-a780-e0ee0d2b1629" />
Was
<img width="520" height="1255" alt="image" src="https://github.com/user-attachments/assets/6e601e6f-5164-4136-83f8-66c136857872" />
Now
<img width="520" height="1255" alt="image" src="https://github.com/user-attachments/assets/a32e8d18-8c94-47de-a404-20ae84554ec7" />
Was
<img width="520" height="1255" alt="image" src="https://github.com/user-attachments/assets/437d658e-ce84-47d9-b65d-fb9f266bda43" />