### PR TITLE
feat(ButtonPrimitive): migrate to design tokens

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/ButtonPrimitive/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/ButtonPrimitive/styles.css
@@ -1,15 +1,14 @@
 .ds.button-primitive {
   --border-style-button: solid;
-  --color-background-button-active: var(--lp-color-background-neutral-active);
-  --color-background-button-hover: var(--lp-color-background-neutral-hover);
+  --color-background-button-active: var(--color-foreground-ghost-active);
+  --color-background-button-hover: var(--color-foreground-ghost-hover);
   --color-background-button: transparent;
   --color-border-button-active: var(--color-border-button);
   --color-border-button-hover: var(--color-border-button);
   --color-border-button: transparent;
-  --color-text-button: var(--lp-color-text-default);
-  --dimension-border-width-button: var(--lp-dimension-stroke-thickness-default);
-  --opacity-button-disabled: var(--lp-opacity-muted);
-  --typography-button: var(--lp-typography-paragraph-default);
+  --color-text-button: var(--color-text);
+  --dimension-border-width-button: var(--dimension-stroke-thickness-medium);
+  --typography-button: var(--ds-typography-text-primary);
 
   cursor: pointer;
   display: inline-block;
@@ -20,12 +19,12 @@
     var(--color-border-button);
   font: var(--typography-button);
   color: var(--color-text-button);
-  padding-inline: var(--lp-dimension-spacing-inline-s);
-  padding-block: var(--lp-dimension-spacing-block-xxs);
+  padding-inline: var(--dimension-150);
+  padding-block: var(--dimension-050);
 
-  transition-duration: var(--lp-transition-duration-snap);
+  transition-duration: var(--ds-transition-duration-snap);
   transition-property: background-color, border-color;
-  transition-timing-function: var(--lp-transition-timing-ease-in);
+  transition-timing-function: var(--ds-transition-timing-ease-in);
 
   &:not(:disabled):not([aria-disabled="true"]) {
     &:hover {
@@ -42,6 +41,7 @@
   &:disabled,
   &[aria-disabled="true"] {
     cursor: not-allowed;
-    opacity: var(--opacity-button-disabled);
+    color: var(--disabled--color-text);
+    border-color: var(--disabled--color-border);
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,5 +1,7 @@
 :root {
   --ds-transition-duration-fast: 165ms;
+  --ds-transition-duration-snap: 100ms;
+  --ds-transition-timing-ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -77,5 +79,6 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-snap: 0ms;
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-shim.css
@@ -1,7 +1,9 @@
 :root {
   --ds-transition-duration-fast: 165ms;
-  --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
+  --ds-transition-duration-snap: 100ms;
   --ds-transition-duration-sleepy: 1s;
+  --ds-transition-timing-ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  --ds-transition-timing-ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
   --ds-color-foreground-tooltip: light-dark(
     var(--color-palette-gray-930),
     var(--color-palette-gray-40)
@@ -98,6 +100,7 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --ds-transition-duration-fast: 0ms;
+    --ds-transition-duration-snap: 0ms;
     --ds-transition-duration-slow: 0ms;
     --ds-transition-duration-sleepy: 0ms;
   }


### PR DESCRIPTION
## Done

Migrated ButtonPrimitive styles to design tokens
Added `--ds-transition-duration-snap` (100ms) and `--ds-transition-timing-ease-in` to the shim, with a `prefers-reduced-motion` override for the former, until they are generated upstream
Disabled state no longer fades the whole element with `opacity`; it uses the `--disabled--color-text` / `--disabled--color-border` pair from `states.css` instead

## QA

- Visual check

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots
Has no storybook entry
