### PR TITLE
ci: the publish lane builds the pragma binary and proves what it published

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -146,4 +146,72 @@ jobs:
             DIST_TAG="latest"
           fi
           echo "Publishing $VERSION to dist-tag '$DIST_TAG'"
+          echo "DIST_TAG=$DIST_TAG" >> "$GITHUB_ENV"
           lerna publish --yes --no-private --dist-tag "$DIST_TAG" from-package
+
+      - name: Smoke the published CLI
+        # `lerna publish` exiting 0 proves the tarballs uploaded — not that the
+        # compiled `pragma` binary inside @canonical/pragma-cli was built from
+        # this tag and actually runs. Install the just-published version from
+        # the registry in a fresh directory and exercise it, retrying while the
+        # registry propagates. `doctor` is the functional probe because it
+        # exits 0 outside a project (store-dependent verbs exit 3 there).
+        env:
+          VERSION: ${{ needs.version.outputs.VERSION }}
+        run: |
+          echo "Smoking @canonical/pragma-cli@$VERSION (published to dist-tag '$DIST_TAG')"
+          cd "$(mktemp -d)"
+          for attempt in 1 2 3 4 5; do
+            if REPORTED="$(npm exec --yes "@canonical/pragma-cli@$VERSION" -- --version)"; then
+              break
+            fi
+            REPORTED=""
+            if [[ "$attempt" -eq 5 ]]; then
+              echo "Error: could not install and run @canonical/pragma-cli@$VERSION from the registry after $attempt attempts."
+              exit 1
+            fi
+            echo "Registry has not served @canonical/pragma-cli@$VERSION yet (attempt $attempt/5); retrying in 15s..."
+            sleep 15
+          done
+          if [[ "$REPORTED" != "$VERSION" ]]; then
+            echo "Error: the published binary reports version '$REPORTED', expected '$VERSION' — the publish shipped a stale or unbuilt dist/pragma."
+            exit 1
+          fi
+          npm exec --yes "@canonical/pragma-cli@$VERSION" -- doctor
+          echo "Smoke passed: @canonical/pragma-cli@$VERSION runs from the registry and 'pragma doctor' exits 0."
+
+      - name: Publish status & provenance
+        # `bun run publish:status` prints the workspace-vs-registry table but
+        # cannot gate a release: it always exits 0, and it compares against the
+        # registry's `latest` dist-tag, which pre-releases deliberately never
+        # move. Gate directly instead: every public package must serve its
+        # local (just-released) version from the registry, carrying a
+        # provenance attestation — the public proof that OIDC trusted
+        # publishing was in effect.
+        run: |
+          bun run publish:status
+          bun run --silent lerna list --no-private --json \
+            | jq -r '.[] | "\(.name) \(.version)"' > /tmp/public-packages.txt
+          if [[ ! -s /tmp/public-packages.txt ]]; then
+            echo "Error: could not list the public packages — an empty list can only mean the listing failed, not that there is nothing to verify."
+            exit 1
+          fi
+          STATUS=0
+          while read -r name version; do
+            got="$(npm view "$name@$version" version --prefer-online 2>/dev/null || true)"
+            if [[ "$got" != "$version" ]]; then
+              echo "FAIL: $name@$version is not on the registry (npm view reports '${got:-nothing}')."
+              STATUS=1
+              continue
+            fi
+            prov="$(npm view "$name@$version" dist.attestations.provenance.predicateType --prefer-online 2>/dev/null || true)"
+            if [[ -z "$prov" ]]; then
+              echo "FAIL: $name@$version is on the registry but has no provenance attestation."
+              STATUS=1
+            fi
+          done < /tmp/public-packages.txt
+          if [[ "$STATUS" -ne 0 ]]; then
+            echo "Error: the registry does not match the released workspace (see FAIL lines above)."
+            exit 1
+          fi
+          echo "All $(wc -l < /tmp/public-packages.txt) public packages serve their released version with provenance."

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -66,7 +66,7 @@ CI uses `actions/cache` in the `setup-env` composite action to persist three thi
 - **`~/.bun/install/cache/`** — Bun's global download cache. Speeds up `bun install` even when `node_modules` misses.
 - **`.nx/cache/`** — Nx's local computation cache. Allows Nx to skip rebuilding or re-checking packages whose inputs haven't changed, even on fresh CI runners.
 
-The `setup-env` action is responsible only for toolchain setup (Node, Bun), cache restoration, and dependency installation. It does not build, check, or test. In CI, `bun install` runs with `--ignore-scripts` to prevent the `prepare` lifecycle hook from triggering a full monorepo build. Workflows that need a build invoke it explicitly (e.g. `lerna run build:all` in `pr.yml`) or rely on Nx's transitive `dependsOn` configuration (e.g. `test` depends on `^build`).
+The `setup-env` action is responsible for toolchain setup (Node, Bun), cache restoration, dependency installation, and the build: its final step runs the `build-command` input, which defaults to `bunx lerna run build:all` and which workflows can override (`pr.yml` passes an `nx affected -t build:all` command so PRs only build what changed). It does not check or test. In CI, `bun install` runs with `--ignore-scripts` to prevent the `prepare` lifecycle hook from triggering an implicit monorepo build — the build happens only as that explicit final step.
 
 Locally, `bun install` still triggers the `prepare` hook and builds the workspace automatically. This divergence is intentional: local development prioritises convenience, while CI prioritises explicit, cacheable steps.
 
@@ -97,11 +97,13 @@ The tag workflow creates releases. It runs manually from GitHub Actions and only
 
 The workflow accepts a release type input with five options: `experimental`, `alpha`, `beta`, `rc`, and `stable`. This determines how versions are bumped. Pre-release types append an identifier and increment a pre-release number (e.g., `0.11.0` → `0.12.0-beta.0` → `0.12.0-beta.1`). The stable type graduates the current pre-release to a stable version (e.g., `0.12.0-rc.0` → `0.12.0`).
 
-The workflow has three jobs:
+The workflow has five jobs:
 
-1. **build** runs checks and tests to verify the release candidate
-2. **version** bumps version numbers, generates changelogs, commits, and creates a git tag
-3. **publish** checks out the tagged commit, builds all packages, and publishes them to npm via OIDC trusted publishing (`id-token: write`; no `NODE_AUTH_TOKEN`)
+1. **build** installs dependencies and builds all packages (`lerna run build:all`, which includes compiling the `pragma` CLI binary) to verify the release candidate builds
+2. **check** runs code quality checks
+3. **test** runs the full test suite, including the browser suites
+4. **version** bumps version numbers, generates changelogs, commits, and creates a git tag
+5. **publish** checks out the tagged commit, builds all packages again from the tag (the same `build:all`, so the published `@canonical/pragma-cli` ships a binary compiled from the released source), and publishes them to npm via OIDC trusted publishing (`id-token: write`; no `NODE_AUTH_TOKEN`). Two verification steps follow the publish: a smoke test installs the just-published `@canonical/pragma-cli` from the registry (retrying while the registry propagates) and asserts that `pragma --version` reports the released version and `pragma doctor` exits 0, and a status check prints the `bun run publish:status` table and fails the workflow if any public package is missing its released version on the registry or lacks a provenance attestation
 
 The version job uses Lerna's conventional commit analysis to determine version bumps. A `feat:` commit triggers a minor bump, a `fix:` commit triggers a patch bump, and a `BREAKING CHANGE:` footer triggers a major bump.
 

--- a/packages/cli/pragma/package.json
+++ b/packages/cli/pragma/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "build": "bun run scripts/build.ts",
+    "build:all": "bun run build",
     "bundle": "bun run scripts/bundle.ts",
     "gen:reference": "bun run scripts/genReference.ts",
     "build:compile": "bun build --compile --minify --target=bun-linux-x64 src/bin.ts --outfile dist/pragma",

--- a/packages/react/ds-app/package.json
+++ b/packages/react/ds-app/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/canonical/pragma/issues"
   },
   "homepage": "https://github.com/canonical/pragma#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "bun run build:package",
     "build:all": "bun run build:package && bun run build:storybook",

--- a/packages/summon/application/package.json
+++ b/packages/summon/application/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/canonical/pragma"
   },
   "license": "GPL-3.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && bun ../../../scripts/copy-templates.ts src dist/esm",
     "build:all": "bun run build",


### PR DESCRIPTION
## Done

- **The publish lane now provably builds the compiled `pragma` binary.** `@canonical/pragma-cli` gains the `build:all` script every other `packages/{cli,runtime,summon}` package already had — it was the only build-step package missing it, so `setup-env`'s `bunx lerna run build:all` skipped it in every lane and `lerna publish from-package` shipped whatever `dist/pragma` happened to exist (nothing depends on the CLI, so Nx's `^build` never reached it either).
- **Post-publish smoke** (`tag.yml`): installs the just-published `@canonical/pragma-cli@<version>` from the registry in a fresh temp dir (5 propagation retries), asserts `pragma --version` reports exactly the released version, then runs `pragma doctor` — chosen empirically because it exits 0 outside a project, unlike the store-dependent verbs (exit 3).
- **Post-publish status & provenance gate** (`tag.yml`): prints the `bun run publish:status` table, then fails the workflow unless every public package serves its released `name@version` from the registry with a provenance attestation. The direct query exists because `publish:status` cannot gate: it always exits 0 and compares against the `latest` dist-tag, which pre-releases deliberately never move.
- **`docs/CI.md` tells the truth again**: the tag-lane section now describes the real five jobs and the two new verification steps, and the `setup-env` paragraph no longer claims the action "does not build" (its final step has run the `build-command` input — default `bunx lerna run build:all` — all along).
- Drive-by: `@canonical/summon-application` and `@canonical/react-ds-app` declare `publishConfig: { "access": "public" }` like every other public package. Both are already public on the registry, so this is load-bearing only at a future first publish of a renamed/split package.

## QA

- YAML re-parsed cleanly (`js-yaml`), all three new `run` scripts pass `bash -n`, touched manifests parse, biome clean per-package.
- The smoke invocation was executed verbatim against the live registry for the already-published `0.33.0`: install succeeded, the version assertion passed, and `doctor` via `npm exec` exited 0 in an empty directory (also with scrubbed `HOME`/XDG to simulate a fresh runner).
- The provenance field path was validated live: `@canonical/pragma-cli@0.33.0` reports predicateType `https://slsa.dev/provenance/v1`; a nonexistent version trips the FAIL path.
- End-to-end proof comes from the next `tag.yml` dispatch of any release type — the two new steps gate it.

### PR readiness check

- [x] PR has one of the required labels: `Maintenance 🔨` (plus `no visual change`).
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards.
- [x] All packages define the required scripts — this PR closes the repo's one remaining gap on that very checklist item: `@canonical/pragma-cli` was the only build-step package without `build:all`.
- [x] No new package is introduced.
- [x] `no visual change` label added to skip Chromatic.

## Screenshots

Not relevant — CI/workflow and manifest changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EwUvEW5ZgjAYc9KWPjHCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017EwUvEW5ZgjAYc9KWPjHCZ)_