### PR TITLE
chore(deps): batch CI/build tooling updates

### DIFF
--- a/apps/lit/demo/package.json
+++ b/apps/lit/demo/package.json
@@ -24,7 +24,7 @@
     "lit": "^3.3.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-lit": "^0.34.0",
     "@types/express": "^5.0.6",

--- a/apps/react/boilerplate-vite/package.json
+++ b/apps/react/boilerplate-vite/package.json
@@ -58,7 +58,7 @@
     "relay-runtime-network": "^0.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@chromatic-com/storybook": "^5.0.1",

--- a/apps/react/demo/package.json
+++ b/apps/react/demo/package.json
@@ -37,7 +37,7 @@
     "react-hook-form": "^7.71.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@chromatic-com/storybook": "^5.0.1",

--- a/apps/react/demo/src/ssr/server.ts
+++ b/apps/react/demo/src/ssr/server.ts
@@ -11,7 +11,7 @@ const app = express();
 
 app.use(/^\/(assets|public)/, express.static("dist/client/assets"));
 
-app.get("/stream", async (req, res, next) => {
+app.get("/stream", async (_req, res, next) => {
   const renderer = new JSXRenderer(
     EntryServer,
     {},

--- a/apps/react/storybook-hub/package.json
+++ b/apps/react/storybook-hub/package.json
@@ -31,7 +31,7 @@
     "@canonical/styles-debug": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@storybook/addon-docs": "^10.3.1",

--- a/bun.lock
+++ b/bun.lock
@@ -6,24 +6,24 @@
       "name": "ds25",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.0.18",
-        "lerna": "^9.0.5",
-        "nx": "^22.5.4",
+        "lerna": "^10.0.0",
+        "nx": "^23.0.0",
       },
     },
     "apps/lit/demo": {
       "name": "@canonical/lit-demo",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/lit-ds-prototype": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
+        "@canonical/lit-ds-prototype": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
         "@lit-labs/ssr": "^3.3.0",
         "@lit-labs/ssr-client": "^1.1.7",
         "lit": "^3.3.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config-lit": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-lit": "^0.34.0",
         "@types/express": "^5.0.6",
         "@types/node": "^24.12.0",
         "express": "^5.2.1",
@@ -35,18 +35,18 @@
       "name": "@canonical/react-boilerplate-vite",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/i18n-core": "^0.31.0",
-        "@canonical/i18n-react": "^0.31.0",
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/react-ds-global-form": "^0.31.0",
-        "@canonical/react-head": "^0.31.0",
-        "@canonical/react-hooks": "^0.31.0",
-        "@canonical/react-ssr": "^0.31.0",
-        "@canonical/router-core": "^0.31.0",
-        "@canonical/router-react": "^0.31.0",
-        "@canonical/storybook-addon-relay": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
+        "@canonical/i18n-core": "^0.34.0",
+        "@canonical/i18n-react": "^0.34.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/react-ds-global-form": "^0.34.0",
+        "@canonical/react-head": "^0.34.0",
+        "@canonical/react-hooks": "^0.34.0",
+        "@canonical/react-ssr": "^0.34.0",
+        "@canonical/router-core": "^0.34.0",
+        "@canonical/router-react": "^0.34.0",
+        "@canonical/storybook-addon-relay": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
         "express": "^5.2.1",
         "graphql": "^16.11.0",
         "react": "^19.2.4",
@@ -56,9 +56,9 @@
         "relay-runtime-network": "^0.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/react-vite": "^10.3.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -90,12 +90,12 @@
       "name": "@canonical/ds-demo-site",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/react-ds-global-form": "^0.31.0",
-        "@canonical/react-ssr": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
-        "@canonical/styles-debug": "^0.31.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/react-ds-global-form": "^0.34.0",
+        "@canonical/react-ssr": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/styles-debug": "^0.34.0",
         "@canonical/styles-primitives-canonical": "^0.26.0",
         "express": "^5.2.1",
         "react": "^19.2.4",
@@ -103,9 +103,9 @@
         "react-hook-form": "^7.71.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/react-vite": "^10.3.1",
         "@types/express": "^5.0.6",
@@ -123,25 +123,25 @@
       "name": "@canonical/storybook-hub",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/ds-types": "^0.31.0",
-        "@canonical/react-ds-app": "^0.31.0",
-        "@canonical/react-ds-app-anbox": "^0.31.0",
-        "@canonical/react-ds-app-landscape": "^0.31.0",
-        "@canonical/react-ds-app-launchpad": "^0.31.0",
-        "@canonical/react-ds-app-lxd": "^0.31.0",
-        "@canonical/react-ds-app-portal": "^0.31.0",
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/react-ds-global-form": "^0.31.0",
-        "@canonical/storybook-addon-form-state": "^0.31.0",
-        "@canonical/storybook-addon-msw": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
-        "@canonical/styles-debug": "^0.31.0",
+        "@canonical/ds-types": "^0.34.0",
+        "@canonical/react-ds-app": "^0.34.0",
+        "@canonical/react-ds-app-anbox": "^0.34.0",
+        "@canonical/react-ds-app-landscape": "^0.34.0",
+        "@canonical/react-ds-app-launchpad": "^0.34.0",
+        "@canonical/react-ds-app-lxd": "^0.34.0",
+        "@canonical/react-ds-app-portal": "^0.34.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/react-ds-global-form": "^0.34.0",
+        "@canonical/storybook-addon-form-state": "^0.34.0",
+        "@canonical/storybook-addon-msw": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/styles-debug": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
         "@types/node": "^24.12.0",
@@ -158,27 +158,27 @@
       "name": "@canonical/biome-config",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
       },
       "peerDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
       },
     },
     "configs/renovate": {
       "name": "@canonical/renovate-config",
       "version": "0.34.0",
       "devDependencies": {
-        "renovate": "43.288.0",
+        "renovate": "44.46.4",
       },
     },
     "configs/storybook": {
       "name": "@canonical/storybook-config",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/ds-assets": "^0.33.0",
-        "@canonical/storybook-addon-shell-theme": "^0.33.0",
-        "@canonical/storybook-addon-utils": "^0.33.0",
-        "@canonical/styles-debug": "^0.33.0",
+        "@canonical/ds-assets": "^0.34.0",
+        "@canonical/storybook-addon-shell-theme": "^0.34.0",
+        "@canonical/storybook-addon-utils": "^0.34.0",
+        "@canonical/styles-debug": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-a11y": "^10.3.1",
         "@storybook/addon-docs": "^10.3.1",
@@ -190,9 +190,9 @@
         "@storybook/web-components-vite": "^10.3.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config-react": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -207,7 +207,7 @@
       "name": "@canonical/typescript-config",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.34.0",
         "typescript": "^5.9.3",
       },
@@ -219,11 +219,11 @@
       "name": "@canonical/typescript-config-lit",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/typescript-config": "^0.31.0",
+        "@canonical/typescript-config": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
@@ -234,11 +234,11 @@
       "name": "@canonical/typescript-config-react",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/typescript-config": "^0.33.0",
+        "@canonical/typescript-config": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
@@ -249,11 +249,11 @@
       "name": "@canonical/typescript-config-svelte",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/typescript-config": "^0.32.0",
+        "@canonical/typescript-config": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.32.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -264,9 +264,9 @@
       "name": "@canonical/vitest-config-react",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
         "vite": "^8.0.1",
@@ -285,14 +285,14 @@
         "pragma": "dist/pragma",
       },
       "dependencies": {
-        "@canonical/harnesses": "^0.33.0",
-        "@canonical/ke": "^0.33.0",
-        "@canonical/ke-graphql": "^0.33.0",
-        "@canonical/summon-application": "^0.33.0",
-        "@canonical/summon-component": "^0.33.0",
-        "@canonical/summon-core": "^0.33.0",
-        "@canonical/summon-package": "^0.33.0",
-        "@canonical/task": "^0.33.0",
+        "@canonical/harnesses": "^0.34.0",
+        "@canonical/ke": "^0.34.0",
+        "@canonical/ke-graphql": "^0.34.0",
+        "@canonical/summon-application": "^0.34.0",
+        "@canonical/summon-component": "^0.34.0",
+        "@canonical/summon-core": "^0.34.0",
+        "@canonical/summon-package": "^0.34.0",
+        "@canonical/task": "^0.34.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.3",
@@ -301,11 +301,11 @@
         "zod": "^3.25.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/anatomy-dsl": "^0.2.2",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "@vitest/coverage-v8": "^4.0.18",
@@ -320,9 +320,9 @@
         "summon": "dist/src/bin.js",
       },
       "dependencies": {
-        "@canonical/summon-core": "^0.33.0",
-        "@canonical/task": "^0.33.0",
-        "@canonical/utils": "^0.33.0",
+        "@canonical/summon-core": "^0.34.0",
+        "@canonical/task": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.3",
         "ink": "^6.8.0",
@@ -333,9 +333,9 @@
         "react": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "@types/omelette": "^0.4.5",
@@ -349,10 +349,10 @@
       "name": "@canonical/ds-assets",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
         "jsdom": "^28.1.0",
@@ -365,7 +365,7 @@
       "name": "@canonical/ds-types",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.34.0",
         "@canonical/typescript-config": "^0.34.0",
         "@canonical/webarchitect": "^0.34.0",
@@ -376,16 +376,16 @@
       "name": "@canonical/lit-ds-prototype",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/storybook-config": "^0.31.0",
+        "@canonical/storybook-config": "^0.34.0",
         "lit": "^3.3.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/ds-types": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
-        "@canonical/typescript-config-lit": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/ds-types": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/typescript-config-lit": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/web-components-vite": "^10.3.1",
         "@types/node": "^24.12.0",
@@ -400,27 +400,27 @@
       "name": "@canonical/react-ds-app",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/ds-assets": "^0.31.0",
-        "@canonical/ds-types": "^0.31.0",
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/react-hooks": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
-        "@canonical/utils": "^0.31.0",
+        "@canonical/ds-assets": "^0.34.0",
+        "@canonical/ds-types": "^0.34.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/react-hooks": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/router-core": "^0.31.0",
-        "@canonical/router-react": "^0.31.0",
-        "@canonical/storybook-addon-utils": "^0.31.0",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/router-core": "^0.34.0",
+        "@canonical/router-react": "^0.34.0",
+        "@canonical/storybook-addon-utils": "^0.34.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -451,20 +451,20 @@
       "name": "@canonical/react-ds-app-anbox",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -487,20 +487,20 @@
       "name": "@canonical/react-ds-app-landscape",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -523,9 +523,9 @@
       "name": "@canonical/react-ds-app-launchpad",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
-        "@canonical/utils": "^0.31.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
         "@js-temporal/polyfill": "^0.5.1",
         "highlight.js": "^11.11.1",
         "react": ">=18.0.0 <20.0.0",
@@ -536,13 +536,13 @@
         "remark-gfm": "^4.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -566,20 +566,20 @@
       "name": "@canonical/react-ds-app-lxd",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -602,20 +602,20 @@
       "name": "@canonical/react-ds-app-portal",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -639,24 +639,24 @@
       "version": "0.34.0",
       "dependencies": {
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/ds-assets": "^0.31.0",
-        "@canonical/react-hooks": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
-        "@canonical/utils": "^0.31.0",
+        "@canonical/ds-assets": "^0.34.0",
+        "@canonical/react-hooks": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/ds-types": "^0.31.0",
-        "@canonical/router-core": "^0.31.0",
-        "@canonical/router-react": "^0.31.0",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/ds-types": "^0.34.0",
+        "@canonical/router-core": "^0.34.0",
+        "@canonical/router-react": "^0.34.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -679,25 +679,25 @@
       "name": "@canonical/react-ds-global-form",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ds-global": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
-        "@canonical/utils": "^0.31.0",
+        "@canonical/react-ds-global": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
         "downshift": "^9.3.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.71.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/storybook-addon-form-state": "^0.31.0",
-        "@canonical/storybook-addon-msw": "^0.31.0",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/storybook-addon-form-state": "^0.34.0",
+        "@canonical/storybook-addon-msw": "^0.34.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -725,11 +725,11 @@
         "react": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.0",
@@ -749,17 +749,17 @@
       "name": "@canonical/react-hooks",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/ds-types": "^0.31.0",
-        "@canonical/utils": "^0.31.0",
+        "@canonical/ds-types": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.22.0",
         "@canonical/typescript-config": "^0.22.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
         "@canonical/webarchitect": "^0.22.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -779,14 +779,14 @@
       "name": "@canonical/i18n-react",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/i18n-core": "^0.31.0",
+        "@canonical/i18n-core": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.31.0",
+        "@canonical/typescript-config-react": "^0.34.0",
         "@canonical/webarchitect": "^0.27.1-experimental.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -805,17 +805,17 @@
       "name": "@canonical/router-react",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ssr": "^0.33.0",
-        "@canonical/router-core": "^0.33.0",
+        "@canonical/react-ssr": "^0.34.0",
+        "@canonical/router-core": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config-react": "^0.33.0",
-        "@canonical/vitest-config-react": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.0",
@@ -837,17 +837,17 @@
         "serve-bun": "./dist/esm/bin/serve-bun.js",
       },
       "dependencies": {
-        "@canonical/utils": "^0.33.0",
+        "@canonical/utils": "^0.34.0",
         "htmlparser2": "^10.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config-react": "^0.33.0",
-        "@canonical/vitest-config-react": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/express": "^5.0.6",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -869,13 +869,13 @@
       "name": "@canonical/ssr-adapter-cloudflare",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ssr": "^0.31.0",
+        "@canonical/react-ssr": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
         "@cloudflare/workers-types": "^4.20250620.0",
         "@vitest/coverage-v8": "^4.0.18",
         "typescript": "^5.9.3",
@@ -886,13 +886,13 @@
       "name": "@canonical/ssr-adapter-deno",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ssr": "^0.31.0",
+        "@canonical/react-ssr": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
         "@types/node": "^24.12.0",
         "@vitest/coverage-v8": "^4.0.18",
         "typescript": "^5.9.3",
@@ -903,13 +903,13 @@
       "name": "@canonical/ssr-adapter-vercel",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/react-ssr": "^0.31.0",
+        "@canonical/react-ssr": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
         "@types/node": "^24.12.0",
         "@vitest/coverage-v8": "^4.0.18",
         "typescript": "^5.9.3",
@@ -920,19 +920,19 @@
       "name": "@canonical/react-tokens",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/ds-types": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/vitest-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/ds-types": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/vitest-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
@@ -955,13 +955,13 @@
       "name": "@canonical/harnesses",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/task": "^0.33.0",
+        "@canonical/task": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -972,7 +972,7 @@
       "name": "@canonical/i18n-core",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.27.1-experimental.0",
         "@canonical/webarchitect": "^0.27.1-experimental.0",
         "@types/node": "^24.12.0",
@@ -987,10 +987,10 @@
         "oxigraph": "^0.5.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "expect-type": "^1.3.0",
@@ -1006,11 +1006,11 @@
         "graphql": "17.0.0-rc.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/ke": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/ke": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1024,9 +1024,9 @@
       "name": "@canonical/router-core",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
@@ -1036,10 +1036,10 @@
       "name": "@canonical/task",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1050,10 +1050,10 @@
       "name": "@canonical/storybook-addon-shell-theme",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "copyfiles": "^2.4.1",
         "storybook": "^10.3.1",
         "typescript": "^5.9.3",
@@ -1068,9 +1068,9 @@
       "name": "@canonical/storybook-addon-form-state",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
         "@storybook/react-vite": "^10.3.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1091,13 +1091,13 @@
       "name": "@canonical/storybook-addon-msw",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/styles-debug": "^0.31.0",
+        "@canonical/styles-debug": "^0.34.0",
         "@storybook/icons": "^2.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
         "@types/node": "^24.12.0",
@@ -1124,10 +1124,10 @@
         "relay-test-utils": "^21.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config-react": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -1159,16 +1159,16 @@
       "name": "@canonical/storybook-addon-utils",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/styles-debug": "^0.33.0",
+        "@canonical/styles-debug": "^0.34.0",
         "@storybook/icons": "^2.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/router-core": "^0.33.0",
-        "@canonical/router-react": "^0.33.0",
-        "@canonical/styles": "^0.33.0",
-        "@canonical/typescript-config-react": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/router-core": "^0.34.0",
+        "@canonical/router-react": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1203,15 +1203,15 @@
       "name": "@canonical/storybook-helpers",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/ds-types": "^0.32.0",
+        "@canonical/ds-types": "^0.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.32.0",
-        "@canonical/typescript-config-react": "^0.32.0",
-        "@canonical/webarchitect": "^0.32.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config-react": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
@@ -1228,8 +1228,8 @@
       "name": "@canonical/styles-debug",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
       },
       "peerDependencies": {
         "@canonical/design-tokens": "0.8.1",
@@ -1243,12 +1243,12 @@
       "version": "0.34.0",
       "dependencies": {
         "@canonical/design-tokens": "0.8.1",
-        "@canonical/styles-typography": "^0.33.0",
+        "@canonical/styles-typography": "^0.34.0",
         "normalize.css": "^8.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
       },
       "peerDependencies": {
         "@canonical/ds-assets": ">=0.18.0",
@@ -1268,9 +1268,9 @@
         "opentype.js": "^1.3.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1283,15 +1283,15 @@
       "name": "@canonical/summon-application",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/summon-core": "^0.33.0",
-        "@canonical/task": "^0.33.0",
-        "@canonical/utils": "^0.33.0",
+        "@canonical/summon-core": "^0.34.0",
+        "@canonical/task": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
         "typescript": "^5.9.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/node": "^24.12.0",
         "vitest": "^4.0.18",
       },
@@ -1303,7 +1303,7 @@
         "@canonical/utils": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.34.0",
         "@canonical/typescript-config": "^0.34.0",
         "@canonical/webarchitect": "^0.34.0",
@@ -1321,8 +1321,8 @@
       "name": "@canonical/summon-core",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/task": "^0.33.0",
-        "@canonical/utils": "^0.33.0",
+        "@canonical/task": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
         "chalk": "^5.6.2",
         "ejs": "^5.0.0",
         "ink": "^6.8.0",
@@ -1331,10 +1331,10 @@
         "react": "^19.2.4",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/ejs": "^3.1.5",
         "@types/node": "^24.12.0",
@@ -1348,14 +1348,14 @@
       "name": "@canonical/summon-monorepo",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/summon-core": "^0.31.0",
-        "@canonical/task": "^0.31.0",
+        "@canonical/summon-core": "^0.34.0",
+        "@canonical/task": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/typescript-config": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1366,15 +1366,15 @@
       "name": "@canonical/summon-package",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/utils": "^0.33.0",
+        "@canonical/utils": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.33.0",
-        "@canonical/summon-core": "^0.33.0",
-        "@canonical/task": "^0.33.0",
-        "@canonical/typescript-config": "^0.33.0",
-        "@canonical/webarchitect": "^0.33.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/summon-core": "^0.34.0",
+        "@canonical/task": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@types/bun": "^1.3.10",
         "@types/node": "^24.12.0",
         "typescript": "^5.9.3",
@@ -1389,20 +1389,20 @@
       "name": "@canonical/svelte-ds-app",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/ds-assets": "^0.32.0",
-        "@canonical/ds-types": "^0.32.0",
+        "@canonical/ds-assets": "^0.34.0",
+        "@canonical/ds-types": "^0.34.0",
         "@canonical/styles": "^0.28.0",
-        "@canonical/svelte-ds-global": "^0.32.0",
+        "@canonical/svelte-ds-global": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.28.0",
         "@canonical/design-tokens": "0.6.2-contrasted.0",
-        "@canonical/storybook-config": "^0.32.0",
-        "@canonical/storybook-helpers": "^0.32.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/storybook-helpers": "^0.34.0",
         "@canonical/svelte-ssr-test": "^0.28.0",
-        "@canonical/typescript-config-svelte": "^0.32.0",
-        "@canonical/webarchitect": "^0.32.0",
+        "@canonical/typescript-config-svelte": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/addon-svelte-csf": "^5.0.11",
         "@sveltejs/package": "^2.5.7",
@@ -1417,7 +1417,7 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.1",
         "vitest": "^4.0.18",
-        "vitest-browser-svelte": "^2.0.2",
+        "vitest-browser-svelte": "^3.0.0",
       },
       "peerDependencies": {
         "svelte": "^5.47.1",
@@ -1428,19 +1428,19 @@
       "version": "0.34.0",
       "dependencies": {
         "@canonical/launchpad-design-tokens": "^1.1.1",
-        "@canonical/styles": "^0.31.0",
+        "@canonical/styles": "^0.34.0",
         "@canonical/svelte-icons": "^0.0.9",
         "@floating-ui/dom": "^1.7.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.6.2-contrasted.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/svelte-ssr-test": "^0.31.0",
-        "@canonical/typescript-config-svelte": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/svelte-ssr-test": "^0.34.0",
+        "@canonical/typescript-config-svelte": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/addon-svelte-csf": "^5.0.11",
         "@sveltejs/package": "^2.5.7",
@@ -1454,7 +1454,7 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.0",
         "vitest": "^4.0.18",
-        "vitest-browser-svelte": "^2.0.2",
+        "vitest-browser-svelte": "^3.0.0",
       },
       "peerDependencies": {
         "svelte": "^5.47.1",
@@ -1464,15 +1464,15 @@
       "name": "@canonical/svelte-ds-app-wpe",
       "version": "0.34.0",
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.31.0",
-        "@canonical/ds-types": "^0.31.0",
-        "@canonical/storybook-config": "^0.31.0",
-        "@canonical/storybook-helpers": "^0.31.0",
-        "@canonical/styles": "^0.31.0",
-        "@canonical/svelte-ssr-test": "^0.31.0",
-        "@canonical/typescript-config-svelte": "^0.31.0",
-        "@canonical/webarchitect": "^0.31.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/ds-types": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/svelte-ssr-test": "^0.34.0",
+        "@canonical/typescript-config-svelte": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/addon-svelte-csf": "^5.0.11",
         "@sveltejs/package": "^2.5.7",
@@ -1486,7 +1486,7 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.0",
         "vitest": "^4.0.18",
-        "vitest-browser-svelte": "^2.0.2",
+        "vitest-browser-svelte": "^3.0.0",
       },
       "peerDependencies": {
         "svelte": "^5.47.1",
@@ -1496,20 +1496,20 @@
       "name": "@canonical/svelte-ds-global",
       "version": "0.34.0",
       "dependencies": {
-        "@canonical/ds-assets": "^0.32.0",
-        "@canonical/styles": "^0.32.0",
-        "@canonical/utils": "^0.32.0",
+        "@canonical/ds-assets": "^0.34.0",
+        "@canonical/styles": "^0.34.0",
+        "@canonical/utils": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.32.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
         "@canonical/design-tokens": "0.6.2-contrasted.0",
-        "@canonical/ds-types": "^0.32.0",
-        "@canonical/storybook-config": "^0.32.0",
-        "@canonical/storybook-helpers": "^0.32.0",
-        "@canonical/svelte-ssr-test": "^0.32.0",
-        "@canonical/typescript-config-svelte": "^0.32.0",
-        "@canonical/webarchitect": "^0.32.0",
+        "@canonical/ds-types": "^0.34.0",
+        "@canonical/storybook-config": "^0.34.0",
+        "@canonical/storybook-helpers": "^0.34.0",
+        "@canonical/svelte-ssr-test": "^0.34.0",
+        "@canonical/typescript-config-svelte": "^0.34.0",
+        "@canonical/webarchitect": "^0.34.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/addon-svelte-csf": "^5.0.11",
         "@sveltejs/package": "^2.5.7",
@@ -1524,7 +1524,7 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.1",
         "vitest": "^4.0.18",
-        "vitest-browser-svelte": "^2.0.2",
+        "vitest-browser-svelte": "^3.0.0",
       },
       "peerDependencies": {
         "svelte": "^5.47.1",
@@ -1538,9 +1538,9 @@
         "jsdom": "^28.1.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.32.0",
-        "@canonical/typescript-config": "^0.32.0",
+        "@biomejs/biome": "2.5.10",
+        "@canonical/biome-config": "^0.34.0",
+        "@canonical/typescript-config": "^0.34.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@types/jsdom": "^28.0.0",
         "typescript": "^5.9.3",
@@ -1558,7 +1558,7 @@
         "@canonical/ds-types": "^0.34.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.34.0",
         "@canonical/typescript-config": "^0.34.0",
         "@canonical/webarchitect": "^0.34.0",
@@ -1581,7 +1581,7 @@
         "commander": "^14.0.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
+        "@biomejs/biome": "2.5.10",
         "@canonical/biome-config": "^0.34.0",
         "@canonical/typescript-config": "^0.34.0",
         "@types/json-schema": "^7.0.15",
@@ -1612,73 +1612,57 @@
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
-    "@aws-crypto/sha1-browser": ["@aws-crypto/sha1-browser@5.2.0", "", { "dependencies": { "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg=="],
+    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.29", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A=="],
 
-    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+    "@aws-sdk/client-codecommit": ["@aws-sdk/client-codecommit@3.1095.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-node": "^3.972.72", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Wyg4rGXyjqnS0eKKTlAfmEZUGvZsiIduw+wRwXVFUuTmKnMRGpW47TOlled7pwTQ4v1xOcrsNLL1z2XamWkWFQ=="],
 
-    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+    "@aws-sdk/client-ec2": ["@aws-sdk/client-ec2@3.1095.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-node": "^3.972.72", "@aws-sdk/middleware-sdk-ec2": "^3.972.49", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ZXdqlaGL/ePExgcewKQLNu+oPBYRGWTqLWNwOqYSjOQSvmtvXFsr36II88vLAN3et6+YvVdKVakYn2scg0bcSQ=="],
 
-    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+    "@aws-sdk/client-ecr": ["@aws-sdk/client-ecr@3.1095.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-node": "^3.972.72", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-pbYncdU0zbXLDWNAz3ZbpCWAGEISdd7to35Fh53+CdrGn158eSbWxbHC0ETKQ04f/50yXHP0C5oFSHN9AnVlgg=="],
 
-    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+    "@aws-sdk/client-eks": ["@aws-sdk/client-eks@3.1095.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-node": "^3.972.72", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zxclCS8uTmrfMLW5XHXCfuWHUUEjLSR/FJFq+2HnObbf4JN0NlEjtmjZOn8/30cODQwhCh1ArZskMSDNbMTg/g=="],
 
-    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.16", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ=="],
+    "@aws-sdk/client-rds": ["@aws-sdk/client-rds@3.1095.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-node": "^3.972.72", "@aws-sdk/middleware-sdk-rds": "^3.972.49", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-R53bytrqj41T+PbNfKQAcCzB351LjGqc6e1YjNr57HNOex8ZuV/QGyKlXengW3VkmmhcYI0zFaPiQtVJLljlTA=="],
 
-    "@aws-sdk/client-codecommit": ["@aws-sdk/client-codecommit@3.1075.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-EBlAsHsXNOLtoXyklEoo1z0fhSbXXqWiVqX/50b9T6Hqoid4AxN86rdIsPik27j51Z3jS0CsVj9a226IhssljA=="],
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1095.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.20", "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-node": "^3.972.72", "@aws-sdk/middleware-sdk-s3": "^3.972.66", "@aws-sdk/signature-v4-multi-region": "^3.996.42", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-eeobm3TKci47CTTHIxc5s5UDjLL0gTKfjlcyzKU+NMoeIJ3flKPq51Fhi2nUDiMNbzsY5HAynM3bHAQFHxRTUw=="],
 
-    "@aws-sdk/client-cognito-identity": ["@aws-sdk/client-cognito-identity@3.1075.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-typFcdyFwIPt86QPKsO7xwcsYoEmNcDpoNqn0tqa4+Lss7niNKQzPe/765XNgAHO3I1ixiT1OKv8KD6M+CKw2w=="],
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.9", "", { "dependencies": { "@aws-sdk/types": "^3.974.5", "@aws-sdk/xml-builder": "^3.972.40", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.33.3", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.17.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA=="],
 
-    "@aws-sdk/client-ec2": ["@aws-sdk/client-ec2@3.1075.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/middleware-sdk-ec2": "^3.972.37", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-mrj3G83NkalaYNK6T2vDnoQAfHBY7drzoaDfuTmQeXAfSs9+ucddfJLLV95HT3fdYMfJEKf4Xul2dgyb2t3UuA=="],
+    "@aws-sdk/credential-provider-cognito-identity": ["@aws-sdk/credential-provider-cognito-identity@3.972.69", "", { "dependencies": { "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-vpsh9VWmQVC/nsdzf72F2yUMBOFT1aq+hoLseYV03zjVXVHkjqSNJskFRKPFxc3MRFrHNbSSmOwsbYE15u9ecw=="],
 
-    "@aws-sdk/client-ecr": ["@aws-sdk/client-ecr@3.1075.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-JY78kY7zgnu0eP5EhGppC71/8d53ulhT7TI5AlBoQgOEcifwnqZGRzaQQhVkkOKNxb3qNZ3uhoJ7ee7D9CUvJw=="],
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.70", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw=="],
 
-    "@aws-sdk/client-eks": ["@aws-sdk/client-eks@3.1075.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-TA+EvfMpEA2PjBIJ4kDcHPKvrpyLEX5ewi8/1qe4cBxLQNJ2gxn4JnYiQ1k1ASVJricNkiM6DVtnVVZv8q4kZA=="],
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.72", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/fetch-http-handler": "^5.7.2", "@smithy/node-http-handler": "^4.11.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w=="],
 
-    "@aws-sdk/client-rds": ["@aws-sdk/client-rds@3.1075.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/middleware-sdk-rds": "^3.972.37", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-Ed8NlyH9aakJpQhSutVDd0pZX1lTdLuXj08tEMu+OapTGQxF2pNTsfLdN9n9p1PobImlqwhOcBYOHkNKvdIfzw=="],
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.15", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/credential-provider-env": "^3.972.70", "@aws-sdk/credential-provider-http": "^3.972.72", "@aws-sdk/credential-provider-login": "^3.972.77", "@aws-sdk/credential-provider-process": "^3.972.70", "@aws-sdk/credential-provider-sso": "^3.973.14", "@aws-sdk/credential-provider-web-identity": "^3.972.76", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg=="],
 
-    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1075.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/middleware-flexible-checksums": "^3.974.33", "@aws-sdk/middleware-sdk-s3": "^3.972.54", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA=="],
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.77", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ=="],
 
-    "@aws-sdk/core": ["@aws-sdk/core@3.975.1", "", { "dependencies": { "@aws-sdk/types": "^3.974.0", "@aws-sdk/xml-builder": "^3.972.34", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.2", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.0", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q=="],
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.81", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.70", "@aws-sdk/credential-provider-http": "^3.972.72", "@aws-sdk/credential-provider-ini": "^3.973.15", "@aws-sdk/credential-provider-process": "^3.972.70", "@aws-sdk/credential-provider-sso": "^3.973.14", "@aws-sdk/credential-provider-web-identity": "^3.972.76", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw=="],
 
-    "@aws-sdk/credential-provider-cognito-identity": ["@aws-sdk/credential-provider-cognito-identity@3.972.56", "", { "dependencies": { "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-nedaZz6Wz2FGUBMsWhlvBPGIkTMfRuMJ99YDHJI4CaC31JS8WPyTavEAio74cfd5nGhi0A8XASB4fZA5VqTdOQ=="],
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.70", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q=="],
 
-    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.57", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ=="],
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.14", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/token-providers": "3.1116.0", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA=="],
 
-    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/fetch-http-handler": "^5.6.4", "@smithy/node-http-handler": "^4.9.4", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA=="],
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.76", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA=="],
 
-    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.1", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/credential-provider-env": "^3.972.57", "@aws-sdk/credential-provider-http": "^3.972.59", "@aws-sdk/credential-provider-login": "^3.972.63", "@aws-sdk/credential-provider-process": "^3.972.57", "@aws-sdk/credential-provider-sso": "^3.973.1", "@aws-sdk/credential-provider-web-identity": "^3.972.63", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/credential-provider-imds": "^4.4.7", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ=="],
+    "@aws-sdk/credential-providers": ["@aws-sdk/credential-providers@3.1095.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-cognito-identity": "^3.972.60", "@aws-sdk/credential-provider-env": "^3.972.61", "@aws-sdk/credential-provider-http": "^3.972.63", "@aws-sdk/credential-provider-ini": "^3.973.6", "@aws-sdk/credential-provider-login": "^3.972.68", "@aws-sdk/credential-provider-node": "^3.972.72", "@aws-sdk/credential-provider-process": "^3.972.61", "@aws-sdk/credential-provider-sso": "^3.973.5", "@aws-sdk/credential-provider-web-identity": "^3.972.67", "@aws-sdk/nested-clients": "^3.997.35", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/credential-provider-imds": "^4.4.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hcL4iILqep+AieTjJ+eYpBoThcirhlr0rzOqyDKSlFeV15qy8FnvwZFlNmVUFFwHnZjvQz5M9MsRe4XbC6eDfw=="],
 
-    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.63", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw=="],
+    "@aws-sdk/middleware-sdk-ec2": ["@aws-sdk/middleware-sdk-ec2@3.972.58", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-k1yW3bEUcy/e9oxIH0zT81sbPCqgERdNf0bOsBZg/tXP75tyEKp8kp8BG9xag64+u9fF8064fLDUdIItWgQxWw=="],
 
-    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.66", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.57", "@aws-sdk/credential-provider-http": "^3.972.59", "@aws-sdk/credential-provider-ini": "^3.973.1", "@aws-sdk/credential-provider-process": "^3.972.57", "@aws-sdk/credential-provider-sso": "^3.973.1", "@aws-sdk/credential-provider-web-identity": "^3.972.63", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/credential-provider-imds": "^4.4.7", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A=="],
+    "@aws-sdk/middleware-sdk-rds": ["@aws-sdk/middleware-sdk-rds@3.972.58", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-dguHSEXkn8VM+HKpa+f4pfCmoRgUOAIkoktpIc7GRkQJa7Xx0UUyHk6BnH3xV/TujnvV1+1tmBmTlBVMOEnZMw=="],
 
-    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.57", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q=="],
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.75", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/signature-v4-multi-region": "^3.996.46", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng=="],
 
-    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.1", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/token-providers": "3.1083.0", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ=="],
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.44", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/signature-v4-multi-region": "^3.996.46", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/fetch-http-handler": "^5.7.2", "@smithy/node-http-handler": "^4.11.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw=="],
 
-    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.63", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ=="],
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.46", "", { "dependencies": { "@aws-sdk/types": "^3.974.5", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ=="],
 
-    "@aws-sdk/credential-providers": ["@aws-sdk/credential-providers@3.1075.0", "", { "dependencies": { "@aws-sdk/client-cognito-identity": "3.1075.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-cognito-identity": "^3.972.48", "@aws-sdk/credential-provider-env": "^3.972.49", "@aws-sdk/credential-provider-http": "^3.972.51", "@aws-sdk/credential-provider-ini": "^3.972.56", "@aws-sdk/credential-provider-login": "^3.972.55", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/credential-provider-process": "^3.972.49", "@aws-sdk/credential-provider-sso": "^3.972.55", "@aws-sdk/credential-provider-web-identity": "^3.972.55", "@aws-sdk/nested-clients": "^3.997.23", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-2HoJ1IxwdzEryyUmZvl6dVKfgWBnS6NzSDl5hOqmbHns5Cy+wCQLDFU+HGVi+kTGZgSyMZIa0rH7fQvNf7v9jQ=="],
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1116.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q=="],
 
-    "@aws-sdk/middleware-flexible-checksums": ["@aws-sdk/middleware-flexible-checksums@3.974.41", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.16", "tslib": "^2.6.2" } }, "sha512-injxTtDHpPU183lcDoLIJbOjhzd9nLBlo1bjMD4zzarNEMhfd/H1aU3N/mKsSsobybSHprd20jhItLwmrHa0cQ=="],
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.5", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ=="],
 
-    "@aws-sdk/middleware-sdk-ec2": ["@aws-sdk/middleware-sdk-ec2@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-wcSIL3HWcEQQkf+eKbyhwqSML23uTUI2zAYexRRa0akL74pnq5olKh06a0kGHWsn6SUHcw9zy9dExA8UuJAUCw=="],
-
-    "@aws-sdk/middleware-sdk-rds": ["@aws-sdk/middleware-sdk-rds@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-jbCrk7wz8bi3ky6gZo3VK78i9MEHfzquPEEJofLotstPNc3k+9zEuKOqwgxoqQ4q8ZUW+vQAvVE4eUT1nNIs9A=="],
-
-    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/signature-v4-multi-region": "^3.996.39", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw=="],
-
-    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.31", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/signature-v4-multi-region": "^3.996.39", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/fetch-http-handler": "^5.6.4", "@smithy/node-http-handler": "^4.9.4", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw=="],
-
-    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.39", "", { "dependencies": { "@aws-sdk/types": "^3.974.0", "@smithy/signature-v4": "^5.6.3", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA=="],
-
-    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1083.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.1", "@aws-sdk/nested-clients": "^3.997.31", "@aws-sdk/types": "^3.974.0", "@smithy/core": "^3.29.2", "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A=="],
-
-    "@aws-sdk/types": ["@aws-sdk/types@3.974.0", "", { "dependencies": { "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg=="],
-
-    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
-
-    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.34", "", { "dependencies": { "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA=="],
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.40", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
@@ -1722,23 +1706,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.10", "@biomejs/cli-darwin-x64": "2.5.10", "@biomejs/cli-linux-arm64": "2.5.10", "@biomejs/cli-linux-arm64-musl": "2.5.10", "@biomejs/cli-linux-x64": "2.5.10", "@biomejs/cli-linux-x64-musl": "2.5.10", "@biomejs/cli-win32-arm64": "2.5.10", "@biomejs/cli-win32-x64": "2.5.10" }, "bin": { "biome": "bin/biome" } }, "sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ItCrxKK6SXVT6flYs0qIuBd4AA3TTTl4d66Re6YI2FuGZnN85NmuYNzkiTJUyYw8qBLv69L5zTUB6uyWd++h3Q=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-yLsPU9pAmtChXDu8vhKAzErqe+LeeYuwuUB2FZMkRitsmdodxsYRa9KHrFispsUHzzOu+9HB3nP/TQxyia+Sjw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-VG8uQW/86a1roLaIFvtIbEigxIdzdJ190oGyg1tV7VYeQtOS+x10sflk7WbuXgw91EtZX5DlIIIej1YqkNLlcg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-t1QAKZwQJRB4dvgJSgFiQ4BNfNPChg69BNonz854qLVxnjT3UvDzQg9mbkTJRu35ZqU0Rw10A73J8Urgbg2RPw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.10", "", { "os": "linux", "cpu": "x64" }, "sha512-4O6T0eq2heoHZN0a9UX+rWQoxXEBaKf+lRi2hbsGlHneUz9BWXM76nEWMK7Eeq8gzMxR1khQB6BFpAASpeXqGg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.10", "", { "os": "linux", "cpu": "x64" }, "sha512-pgDDqp9JybHm2I0KRgzN6i4+lt8xu4iqxUwLzglUMmOmyRTU1AYBGKzh9sNMOtIjah7xoWvKHlLVetvyifzoiQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-pxAbxduPO4xq/Cvgaa2lOrs9BB0hEXmmDqfMNP4ZOffGOkUrD1/QGw9UAMpFQpX2P8MqTIIRuQKcmetum4Oa6A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.10", "", { "os": "win32", "cpu": "x64" }, "sha512-M+2dgBsl3lXRiTfgPVc2p3anS4Tocojke4rzFLScZ2Y/wmF+36dRb1iHCLiyGqOzQGyTplZH1HnEYviiAqi3nA=="],
 
     "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
@@ -1898,6 +1882,10 @@
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260405.1", "", {}, "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg=="],
 
+    "@conventional-changelog/git-client": ["@conventional-changelog/git-client@3.1.2", "", { "dependencies": { "@simple-libs/child-process-utils": "^2.0.0", "@simple-libs/stream-utils": "^2.0.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^6.0.1", "conventional-commits-parser": "^7.1.2" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-jZqwnJwf7nboIlAcw/mkOjVa6DexCcUOgT2oOQgkoi3z9vR8tGFkcMy2BFcYwjhL9sYcDDXkRQDayiDieCoW7A=="],
+
+    "@conventional-changelog/template": ["@conventional-changelog/template@1.4.0", "", {}, "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg=="],
+
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@3.1.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ=="],
@@ -1910,11 +1898,11 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
+    "@emnapi/core": ["@emnapi/core@1.4.5", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.4", "tslib": "^2.4.0" } }, "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.4.5", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.0.4", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
 
@@ -1982,8 +1970,6 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
-    "@hutson/parse-repository-url": ["@hutson/parse-repository-url@3.0.2", "", {}, "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q=="],
-
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/checkbox": ["@inquirer/checkbox@4.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA=="],
@@ -2022,11 +2008,7 @@
 
     "@isaacs/string-locale-compare": ["@isaacs/string-locale-compare@1.1.0", "", {}, "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="],
 
-    "@jest/diff-sequences": ["@jest/diff-sequences@30.3.0", "", {}, "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA=="],
-
-    "@jest/get-type": ["@jest/get-type@30.1.0", "", {}, "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA=="],
-
-    "@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+    "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
 
     "@joshwooding/vite-plugin-react-docgen-typescript": ["@joshwooding/vite-plugin-react-docgen-typescript@0.6.4", "", { "dependencies": { "glob": "^13.0.1", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "typescript": ">= 4.3.x", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["typescript"] }, "sha512-6PyZBYKnnVNqOSB0YFly+62R7dmov8segT27A+RVTBVd4iAE6kbW9QBJGlyR2yG4D4ohzhZSTIu7BK1UTtmFFA=="],
 
@@ -2136,27 +2118,27 @@
 
     "@npmcli/run-script": ["@npmcli/run-script@10.0.3", "", { "dependencies": { "@npmcli/node-gyp": "^5.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^9.0.0", "node-gyp": "^12.1.0", "proc-log": "^6.0.0", "which": "^6.0.0" } }, "sha512-ER2N6itRkzWbbtVmZ9WKaWxVlKlOeBFF1/7xx+KA5J1xKa4JjUwBdb6tDpk0v1qA+d+VDwHI9qmLcXSWcmi+Rw=="],
 
-    "@nx/devkit": ["@nx/devkit@22.5.4", "", { "dependencies": { "@zkochan/js-yaml": "0.0.7", "ejs": "^3.1.7", "enquirer": "~2.3.6", "minimatch": "10.2.4", "semver": "^7.6.3", "tslib": "^2.3.0", "yargs-parser": "21.1.1" }, "peerDependencies": { "nx": ">= 21 <= 23 || ^22.0.0-0" } }, "sha512-+QCmpQZQmEGvi8IurC6bOgUTk+Q0dQo7wkp6V04lskXBztSyasBS0BGy5ic90kY05UlQUd++zRA1VY0jc+Yz5Q=="],
+    "@nx/devkit": ["@nx/devkit@23.1.1", "", { "dependencies": { "ejs": "5.0.1", "enquirer": "~2.3.6", "minimatch": "10.2.5", "semver": "^7.6.3", "tslib": "^2.3.0", "yargs-parser": "21.1.1" }, "peerDependencies": { "nx": ">= 22 <= 24 || ^23.0.0-0" } }, "sha512-FmBfS1xUkWYvDYH/ysO7gAqGlaRzugLac8SIC+X/p76WBmhM6tJhfRW/BQ8mxOFZoVLmwhIiR8X0dRPKdasFxw=="],
 
-    "@nx/nx-darwin-arm64": ["@nx/nx-darwin-arm64@22.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Ib9znwSLQZSZ/9hhg5ODplpNhE/RhGVXzdfRj6YonTuWSj/kH3dLMio+4JEkjRdTQVm06cDW0KdwSgnwovqMGg=="],
+    "@nx/nx-darwin-arm64": ["@nx/nx-darwin-arm64@23.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Rq/RXLX5uIvJQfb6kuUgEirquT5ARaAgQyNaMZVnOPAL5wuxaDvQag8WX/WUCIgbUKZuGkclJwM7Vlnvtn3bdg=="],
 
-    "@nx/nx-darwin-x64": ["@nx/nx-darwin-x64@22.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-DjyXuQMc93MPU2XdRsJYjzbv1tgCzMi+zm7O0gc4x3h+ECFjKkjzQBg67pqGdhE3TV27MAlVRKrgHStyK9iigg=="],
+    "@nx/nx-darwin-x64": ["@nx/nx-darwin-x64@23.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-doWaPLPd6yUas3FhQJqMAScupCsToeTedK4RRWm700VhHoVdBTN4ejIBRBfoiT/SPAwY6EOHb8uFDJhGo7geMg=="],
 
-    "@nx/nx-freebsd-x64": ["@nx/nx-freebsd-x64@22.5.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-DhxdP8AhIfN0yCtFhZQcbp32MVN3L7UiTotYqqnOgwW922NRGSd5e+KEAWiJVrIO6TdgnI7prxpg1hfQQK0WDw=="],
+    "@nx/nx-freebsd-x64": ["@nx/nx-freebsd-x64@23.1.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9rDZKBPGuX8mid11RimJ2ENqDYZpPZhrqTlI9q/VnqcPLq0Bw/8AhqCKhBVlfNqJjbi4OsRQYDK7UkqIlcfThg=="],
 
-    "@nx/nx-linux-arm-gnueabihf": ["@nx/nx-linux-arm-gnueabihf@22.5.4", "", { "os": "linux", "cpu": "arm" }, "sha512-pv1x1afTaLAOxPxVhQneLeXgjclp11f9ORxR7jA4E86bSgc9OL92dLSCkXtLQzqPNOej6SZ2fO+PPHVMZwtaPQ=="],
+    "@nx/nx-linux-arm-gnueabihf": ["@nx/nx-linux-arm-gnueabihf@23.1.1", "", { "os": "linux", "cpu": "arm" }, "sha512-NDR5X2HiD6WU3JEaDJmOLteIGIFqjrjkzoFWrQke2Y1oCRYu+UyFdPeaMVUyAs5OyUx4U+SD+eBQPTCNbWmazA=="],
 
-    "@nx/nx-linux-arm64-gnu": ["@nx/nx-linux-arm64-gnu@22.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-mPji9PzleWPvXpmFDKaXpTymRgZkk/hW8JHGhvEZpKHHXMYgTGWC+BqOEM2A4dYC4bu4fi9RrteL7aouRRWJoQ=="],
+    "@nx/nx-linux-arm64-gnu": ["@nx/nx-linux-arm64-gnu@23.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-tWDHJII8+aHweTzHelf5dGM6qGNmHbAPhCc3jrtrM0uE+UD/wt2Dpq7H3086Iyia9M9jGM9sYpuD/6W6WAFAMA=="],
 
-    "@nx/nx-linux-arm64-musl": ["@nx/nx-linux-arm64-musl@22.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-hF/HvEhbCjcFpTgY7RbP1tUTbp0M1adZq4ckyW8mwhDWQ/MDsc8FnOHwCO3Bzy9ZeJM0zQUES6/m0Onz8geaEA=="],
+    "@nx/nx-linux-arm64-musl": ["@nx/nx-linux-arm64-musl@23.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7iVMZ7Cj3LmPcfaYt9KOkojpuC5XRmtZ/0G+NBMA2GuRhCVbzpOgUCob0nQMV2TrTwn5oAWJeDc4xLni+oteg=="],
 
-    "@nx/nx-linux-x64-gnu": ["@nx/nx-linux-x64-gnu@22.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-1+vicSYEOtc7CNMoRCjo59no4gFe8w2nGIT127wk1yeW3EJzRVNlOA7Deu10NUUbzLeOvHc8EFOaU7clT+F7XQ=="],
+    "@nx/nx-linux-x64-gnu": ["@nx/nx-linux-x64-gnu@23.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-stuCayctOt/4AFvxKYgGTPluUc0HW7DcyTz9yeTMl/zj0+FENEr8RCTjInD0Q5qVGzYphma6SssVSh432w5agw=="],
 
-    "@nx/nx-linux-x64-musl": ["@nx/nx-linux-x64-musl@22.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-/KjndxVB14yU0SJOhqADHOWoTy4Y45h5RjW3cxcXlPSJZz7ar1FnlLne1rWMMMUttepc8ku+3T//SGKi2eu+Nw=="],
+    "@nx/nx-linux-x64-musl": ["@nx/nx-linux-x64-musl@23.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cZSUqGV+iHda39W91BNKSysSu6OFfR6M4ViQBcMtbwq3ce19gDr2f23MqGZEQZtaD/eSQ9UNEhx09nhrdYxWDg=="],
 
-    "@nx/nx-win32-arm64-msvc": ["@nx/nx-win32-arm64-msvc@22.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-CrYt9FwhjOI6ZNy/G6YHLJmZuXCFJ24BCxugPXiZ7knDx7eGrr7owGgfht4SSiK3KCX40CvWCBJfqR4ZSgaSUA=="],
+    "@nx/nx-win32-arm64-msvc": ["@nx/nx-win32-arm64-msvc@23.1.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-iDlYbFHgTYV5lg1ypEt+LAj86o/uyy6vR0ha5pcUs4FqXzQgy14lOeyRod/EZs9Er3DIyJlEi/rpEvaP99/Hag=="],
 
-    "@nx/nx-win32-x64-msvc": ["@nx/nx-win32-x64-msvc@22.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-g5YByv4XsYwsYZvFe24A9bvfhZA+mwtIQt6qZtEVduZTT1hfhIsq0LXGHhkGoFLYwRMXSracWOqkalY0KT4IQw=="],
+    "@nx/nx-win32-x64-msvc": ["@nx/nx-win32-x64-msvc@23.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-UD21AHWJ2PEA+PuANPCt+lj3kYpAzYNq+bm4VCbrt3KZd7zDPas0ns85UIhfrhsNiSmYzjWz2/JDk2S3cA6lGw=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@4.0.0", "", {}, "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="],
 
@@ -2204,11 +2186,11 @@
 
     "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.221.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.221.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw=="],
 
-    "@opentelemetry/instrumentation-bunyan": ["@opentelemetry/instrumentation-bunyan@0.65.0", "", { "dependencies": { "@opentelemetry/api-logs": "^0.220.0", "@opentelemetry/instrumentation": "^0.220.0", "@opentelemetry/semantic-conventions": "^1.41.1", "@types/bunyan": "1.8.11" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-VNqQfK2DY8P5iZTIo/2qS72/fY3DSfUGyRqsfJi8HbQ3WTeWwucKcBUWFF3WMvtt4gNyRpZIk/5qKpBLoDKWZw=="],
+    "@opentelemetry/instrumentation-bunyan": ["@opentelemetry/instrumentation-bunyan@0.66.0", "", { "dependencies": { "@opentelemetry/api-logs": "^0.221.0", "@opentelemetry/instrumentation": "^0.221.0", "@opentelemetry/semantic-conventions": "^1.41.1", "@types/bunyan": "1.8.11" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IqYQC1dav35NHlD5nYnpBXK8tI6KJ9/MIt8LYKFxwlhMIwfBCfavaklyP8NtVKoJ0WZKzX2v9Sh+xGK1XvSniQ=="],
 
     "@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.221.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/instrumentation": "0.221.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g=="],
 
-    "@opentelemetry/instrumentation-redis": ["@opentelemetry/instrumentation-redis@0.68.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.220.0", "@opentelemetry/redis-common": "^0.38.3", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-D5N4CLWLjBRFa1Ee8D1U1tWCkED+Ob0AMzQlYJjlnnqfw0ofRMaJmoUrdI5ASKEcfDezzhELT1Slo4VesDpA/w=="],
+    "@opentelemetry/instrumentation-redis": ["@opentelemetry/instrumentation-redis@0.69.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.221.0", "@opentelemetry/redis-common": "^0.38.3", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lyCIEW89cYhMwaUSMBzsKHdwH2wOoqmuwXOARJneo9UL55govLIUCbYYAJ457oM8kdKADymlY4+SUW0DKQeIHw=="],
 
     "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.221.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/otlp-transformer": "0.221.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA=="],
 
@@ -2216,11 +2198,11 @@
 
     "@opentelemetry/redis-common": ["@opentelemetry/redis-common@0.38.3", "", {}, "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw=="],
 
-    "@opentelemetry/resource-detector-aws": ["@opentelemetry/resource-detector-aws@2.20.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-3ZkhvVHqJgJ75ObpZQwZIBySNfd4h772QRb2NBPU1A3lSUzDlRen9x5Kzv/K7HNkL/Azl8XEanykwa73YjWmQA=="],
+    "@opentelemetry/resource-detector-aws": ["@opentelemetry/resource-detector-aws@2.21.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-Veavy+khoywR+Hv065SU5jucFTGTiW1KXo39CsJ+8wqdYYz8jiRJPnQ20Kd+X9HbV2+Abb0l5CrJIdxK1ZOqBg=="],
 
-    "@opentelemetry/resource-detector-azure": ["@opentelemetry/resource-detector-azure@0.28.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.37.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-YMMgH/ZIiZgy2CHTHjOBNEYhcsi/l67Q272vAgwMqegRFIME4KljDhmTmjLGzjE3b0sErLtXBqF8Y/3bKn89+Q=="],
+    "@opentelemetry/resource-detector-azure": ["@opentelemetry/resource-detector-azure@0.29.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.37.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-lWm0vjjlQMoc4Xvvd+dW/OZWT/SI4w+cIN7kbm8KimIZCr1EpAyvyQ7WEOrGoBoXCpQCrsZ18uKTooDgiBCGIw=="],
 
-    "@opentelemetry/resource-detector-gcp": ["@opentelemetry/resource-detector-gcp@0.55.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/resources": "^2.0.0", "gcp-metadata": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-uWU27lJcTbeXDY+uWEapsIyMx8mKi14/IGvUY1DkmMmLQnKRibnbpZEsRVeWBPdjOWSjH9LfWTXp9yDcBHZOeg=="],
+    "@opentelemetry/resource-detector-gcp": ["@opentelemetry/resource-detector-gcp@0.56.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/resources": "^2.0.0", "gcp-metadata": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-H8yNeqTsuapbXs6MLZTtelfUCk+5D8jD3+KosCJaXOyx5gl3EWWvs70HbNXTUO4VYLxccySFYJYVCd8YMM0NJw=="],
 
     "@opentelemetry/resource-detector-github": ["@opentelemetry/resource-detector-github@0.32.0", "", { "dependencies": { "@opentelemetry/resources": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-CwaKgoukIcEUZfOXf1c9W37ixRT3dhanSqG5P1hZx8zr13A4xZQHTuS4rn03v+RewIJWTkAfi7Ei1eI1rgRfaQ=="],
 
@@ -2243,8 +2225,6 @@
     "@parse5/tools": ["@parse5/tools@0.3.0", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
-
-    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@pnpm/catalogs.protocol-parser": ["@pnpm/catalogs.protocol-parser@1001.0.0", "", {}, "sha512-9rHKCMRvhfv7TSAVSCVLI+8OZhi1OcT8lanAGqOPbGgQTkFrPH3PfEWJNxz43xqrXRa4HCFRAMu+g19su5eRLA=="],
 
@@ -2278,17 +2258,17 @@
 
     "@redis/client": ["@redis/client@5.12.1", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA=="],
 
-    "@renovatebot/detect-tools": ["@renovatebot/detect-tools@4.0.10", "", { "dependencies": { "fs-extra": "^11.3.6", "toml-eslint-parser": "^1.0.3", "upath": "^3.0.8", "zod": "^4.4.3" } }, "sha512-hGIZahyyO3zahpr3a2kRkNvDVXwW1gZBN6YYbql6OXlN1gFRQz7/jgn+/ImtYvP84P4tQxc9U4jS5/Qurvl0Nw=="],
+    "@renovatebot/detect-tools": ["@renovatebot/detect-tools@4.0.11", "", { "dependencies": { "fs-extra": "^11.4.0", "toml-eslint-parser": "^1.0.3", "upath": "^3.0.8", "zod": "^4.4.3" } }, "sha512-rQ8McuE2JQkg4jmUl7l0MxwZTENOY/Z/UFWT5PYi5SzaNMXfGL/iqAMMLBYrp437pAT1rF7bwzM8xaGNOp088A=="],
 
     "@renovatebot/good-enough-parser": ["@renovatebot/good-enough-parser@2.0.1", "", { "dependencies": { "@thi.ng/zipper": "1.0.3", "@types/moo": "0.5.10", "klona": "2.0.6", "moo": "0.5.3" } }, "sha512-FBLawccaWOPwqXgMSB3FTp1VTfGJWSTTXY2Q3kWPoLYOpKYBr3V37vtqFLjb5wUFkrXN2Sj+S840JXKfHwy8Rg=="],
 
-    "@renovatebot/osv-offline": ["@renovatebot/osv-offline@3.0.9", "", { "dependencies": { "@renovatebot/osv-offline-db": "3.0.9", "adm-zip": "~0.6.0", "debug": "^4.4.3", "fs-extra": "^11.3.6", "got": "^15.1.0", "luxon": "^3.7.2" } }, "sha512-VQ4GZvjrS3wTbUcUNKJAPkjnlmiv/kXWu4XiJeaN551CXFXcF5lurHjIX2kMbXcW37nljrGCY590XcwoZ+tnTg=="],
+    "@renovatebot/osv-offline": ["@renovatebot/osv-offline@3.0.10", "", { "dependencies": { "@renovatebot/osv-offline-db": "3.0.10", "adm-zip": "~0.6.0", "debug": "^4.4.3", "fs-extra": "^11.4.0", "got": "^15.1.0", "luxon": "^3.7.2" } }, "sha512-btStcVTVmUaJ89qwdPlI+1yMyXTZSEpTMdgJv/77MsDzhOvVTNtoaDu6k0PHSPFoUfQ2X5WvZGRq2+CxUSqLPQ=="],
 
-    "@renovatebot/osv-offline-db": ["@renovatebot/osv-offline-db@3.0.9", "", { "dependencies": { "debug": "^4.4.3" } }, "sha512-7+7IvdYxnZDmRyDVvhvmzXT7IyF/KYGzO7Z/yXttVzywTs2hhZ5fxzatZLp2QWCKdHQwLeUSGGq6CaFDtoBwGg=="],
+    "@renovatebot/osv-offline-db": ["@renovatebot/osv-offline-db@3.0.10", "", { "dependencies": { "debug": "^4.4.3" } }, "sha512-xH4jJzMUagwJt4ofAtG8qWGc4TxgdNyVaUj6gjmdSVqd81fVu2qSkgVdd+Oh3O+MhTS6rOR3MZq+X5LqX4E4Iw=="],
 
     "@renovatebot/pep440": ["@renovatebot/pep440@5.0.0", "", {}, "sha512-91cFM32/pnOAvC7W1W1kPPI9QM2y6OrYCeomz7pop4A+3Ksh2XnZXGznUMlzR7YbOQlg7X/MNlF27s9Yt9hhTA=="],
 
-    "@renovatebot/pgp": ["@renovatebot/pgp@1.3.16", "", {}, "sha512-NUWzQDyHNfmlR3fpssNbvkQZj3abYPeGYqK+Vef84dVylZrrZgPmmRnww3FwSinV6fMTStzo/PY6mjNejiAN5w=="],
+    "@renovatebot/pgp": ["@renovatebot/pgp@1.3.17", "", {}, "sha512-iDx7AR53Xhz6PfYEdIoiPYWq5KAvVjGUk0zVJ4U6CchbbTvSKuJ3nRLKsgA8sFKZTTuSlJLkqcL8peimkiZ27g=="],
 
     "@renovatebot/ruby-semver": ["@renovatebot/ruby-semver@5.0.0", "", {}, "sha512-yQgeq4HVV9mh2AJHHlStd//7mD/96lWj8KWB5Szi5YDjPwpvk12Sj3H+Y4waNC3N2D4t5xqbwYYpTHB5KsrSVg=="],
 
@@ -2394,27 +2374,27 @@
 
     "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
+    "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@2.0.0", "", { "dependencies": { "@simple-libs/stream-utils": "^2.0.0" } }, "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A=="],
+
+    "@simple-libs/hosted-git-info": ["@simple-libs/hosted-git-info@2.0.0", "", {}, "sha512-55XwK/GYgV58PuN8lZFhI1qRxdKoMLJocXl/yM1EPqazFDmM4QWY7q6BxPCPDNKTNunj794DSD4h0H7SrqUdMg=="],
+
+    "@simple-libs/normalize-package-data": ["@simple-libs/normalize-package-data@1.0.0", "", { "dependencies": { "@simple-libs/hosted-git-info": "^2.0.0", "semver": "^7.8.5" } }, "sha512-/EOmFBekV9tGee8gac/k+5Ox3twkypNqh5TfxA9vTkmcJkjm6f1xqrlstDNOrEhTvnYyVtU6Du2ZhY/IV1+9GA=="],
+
+    "@simple-libs/stream-utils": ["@simple-libs/stream-utils@2.0.0", "", {}, "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@8.1.0", "", {}, "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ=="],
 
-    "@smithy/core": ["@smithy/core@3.29.3", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A=="],
+    "@smithy/core": ["@smithy/core@3.33.3", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg=="],
 
-    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.8", "", { "dependencies": { "@smithy/core": "^3.29.3", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA=="],
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.5.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg=="],
 
-    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.5", "", { "dependencies": { "@smithy/core": "^3.29.3", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g=="],
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.7.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw=="],
 
-    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.11.3", "", { "dependencies": { "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA=="],
 
-    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.5", "", { "dependencies": { "@smithy/core": "^3.29.3", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw=="],
-
-    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.4", "", { "dependencies": { "@smithy/core": "^3.29.3", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ=="],
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.7.3", "", { "dependencies": { "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow=="],
 
     "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
-
-    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
-
-    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -2444,7 +2424,7 @@
 
     "@storybook/svelte": ["@storybook/svelte@10.3.0", "", { "dependencies": { "ts-dedent": "^2.0.0", "type-fest": "~2.19" }, "peerDependencies": { "storybook": "^10.3.0", "svelte": "^5.0.0" } }, "sha512-FxUO40O8oYk1o1fpINP5dDp5+UW+wFI7PtJ/kNUOGmhA18s3XiPI5rB1+40kPWDAl8oY9v44CixRxEzwfP50MQ=="],
 
-    "@storybook/svelte-vite": ["@storybook/svelte-vite@10.3.1", "", { "dependencies": { "@storybook/builder-vite": "10.3.1", "@storybook/svelte": "10.3.1", "magic-string": "^0.30.0", "svelte2tsx": "^0.7.44", "typescript": "^4.9.4 || ^5.0.0" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "storybook": "^10.3.1", "svelte": "^5.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-vt9zxJJFGjo9ONX4aC8L1lcXsWVFhDMfGcChMXi65/FsNISr1Z2ewIihb4r+PkJlXs4o/It4uOOUHSIYngYqjg=="],
+    "@storybook/svelte-vite": ["@storybook/svelte-vite@10.5.8", "", { "dependencies": { "@storybook/builder-vite": "10.5.8", "@storybook/svelte": "10.5.8", "magic-string": "^0.30.0", "svelte2tsx": "^0.7.55", "typescript": "^4.9.4 || ^5.0.0" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "storybook": "^10.5.8", "svelte": "^5.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-fWM3GGtk5iAJqMj7CUcYvUn0NxE3aSvz2DlAz+LGVKrIolWscmt/71lPsCobIDl45+CNdc8G7qFNEODAd/IKVA=="],
 
     "@storybook/sveltekit": ["@storybook/sveltekit@10.5.8", "", { "dependencies": { "@storybook/builder-vite": "10.5.8", "@storybook/svelte": "10.5.8", "@storybook/svelte-vite": "10.5.8" }, "peerDependencies": { "storybook": "^10.5.8", "svelte": "^5.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-vjeIQlfzaYI3w9oqeDRKtFd0HWPbYvIlhhVRX5SR0pWJn7a08KAmgRJIrbwf0g95njWKLf1u76OoH37yhjOMsA=="],
 
@@ -2458,32 +2438,6 @@
 
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.0.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g=="],
 
-    "@swc/core": ["@swc/core@1.15.18", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.18", "@swc/core-darwin-x64": "1.15.18", "@swc/core-linux-arm-gnueabihf": "1.15.18", "@swc/core-linux-arm64-gnu": "1.15.18", "@swc/core-linux-arm64-musl": "1.15.18", "@swc/core-linux-x64-gnu": "1.15.18", "@swc/core-linux-x64-musl": "1.15.18", "@swc/core-win32-arm64-msvc": "1.15.18", "@swc/core-win32-ia32-msvc": "1.15.18", "@swc/core-win32-x64-msvc": "1.15.18" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA=="],
-
-    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ=="],
-
-    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg=="],
-
-    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.18", "", { "os": "linux", "cpu": "arm" }, "sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw=="],
-
-    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg=="],
-
-    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw=="],
-
-    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.18", "", { "os": "linux", "cpu": "x64" }, "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA=="],
-
-    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.18", "", { "os": "linux", "cpu": "x64" }, "sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g=="],
-
-    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ=="],
-
-    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.18", "", { "os": "win32", "cpu": "ia32" }, "sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg=="],
-
-    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.18", "", { "os": "win32", "cpu": "x64" }, "sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg=="],
-
-    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
-
-    "@swc/types": ["@swc/types@0.1.25", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g=="],
-
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
@@ -2492,7 +2446,7 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
-    "@testing-library/svelte-core": ["@testing-library/svelte-core@1.0.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0" } }, "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ=="],
+    "@testing-library/svelte-core": ["@testing-library/svelte-core@1.1.3", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0" } }, "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g=="],
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
@@ -2576,15 +2530,11 @@
 
     "@types/mdx": ["@types/mdx@2.0.13", "", {}, "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="],
 
-    "@types/minimist": ["@types/minimist@1.2.5", "", {}, "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="],
-
     "@types/moo": ["@types/moo@0.5.10", "", {}, "sha512-W6KzyZjXUYpwQfLK1O1UDzqcqYlul+lO7Bt71luyIIyNlOZwJaNeWWdqFs1C/f2hohZvUFHMk6oFNe9Rg48DbA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
-
-    "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
     "@types/omelette": ["@types/omelette@0.4.5", "", {}, "sha512-zUCJpVRwfMcZfkxSCGp73mgd3/xesvPz5tQJIORlfP/zkYEyp9KUfF7IP3RRjyZR3DwxkPs96/IFf70GmYZYHQ=="],
 
@@ -2656,7 +2606,7 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
 
-    "@yarnpkg/core": ["@yarnpkg/core@4.9.0", "", { "dependencies": { "@arcanis/slice-ansi": "^1.1.1", "@types/semver": "^7.1.0", "@types/treeify": "^1.0.0", "@yarnpkg/fslib": "^3.1.5", "@yarnpkg/libzip": "^3.2.2", "@yarnpkg/parsers": "^3.0.3", "@yarnpkg/shell": "^4.1.3", "camelcase": "^5.3.1", "chalk": "^4.1.2", "ci-info": "^4.0.0", "clipanion": "^4.0.0-rc.2", "cross-spawn": "^7.0.3", "diff": "^5.1.0", "dotenv": "^16.3.1", "es-toolkit": "^1.39.7", "fast-glob": "^3.2.2", "got": "^11.7.0", "hpagent": "^1.2.0", "micromatch": "^4.0.2", "p-limit": "^2.2.0", "semver": "^7.1.2", "strip-ansi": "^6.0.0", "tar": "^7.5.3", "tinylogic": "^2.0.0", "treeify": "^1.1.0", "tslib": "^2.4.0" } }, "sha512-vhJEVo423jAZBtU5CDe2HEkyNkEYfgMfukNQk1uyYFkP3OmCsuLzpyqbJCEXIg6Fy3YTrQg7kSCnjHbLed3toA=="],
+    "@yarnpkg/core": ["@yarnpkg/core@4.9.1", "", { "dependencies": { "@arcanis/slice-ansi": "^1.1.1", "@types/semver": "^7.1.0", "@types/treeify": "^1.0.0", "@yarnpkg/fslib": "^3.1.5", "@yarnpkg/libzip": "^3.2.2", "@yarnpkg/parsers": "^3.1.0", "@yarnpkg/shell": "^4.1.3", "camelcase": "^5.3.1", "chalk": "^4.1.2", "ci-info": "^4.0.0", "clipanion": "^4.0.0-rc.2", "cross-spawn": "^7.0.3", "diff": "^5.1.0", "dotenv": "^16.3.1", "es-toolkit": "^1.39.7", "fast-glob": "^3.2.2", "got": "^11.7.0", "hpagent": "^1.2.0", "micromatch": "^4.0.2", "p-limit": "^2.2.0", "semver": "^7.8.5", "strip-ansi": "^6.0.0", "tar": "^7.5.3", "tinylogic": "^2.0.0", "treeify": "^1.1.0", "tslib": "^2.4.0" } }, "sha512-P8H10ehQBFWL5eR1y/8nLRzFHx1yumgE9P1DQjJ+EIVvqeWo0MjbwQ+ZJjPDT+HqVDslE+e6I/9GrJ7Arbx/8A=="],
 
     "@yarnpkg/fslib": ["@yarnpkg/fslib@3.1.5", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hXaPIWl5GZA+rXcx+yaKWUuePJruZuD+3A5A2X6paEBfFsyCD7oEp88lSMj1ym1ehBWUmhNH/YGOp+SrbmSBPg=="],
 
@@ -2664,7 +2614,7 @@
 
     "@yarnpkg/lockfile": ["@yarnpkg/lockfile@1.1.0", "", {}, "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="],
 
-    "@yarnpkg/parsers": ["@yarnpkg/parsers@3.0.2", "", { "dependencies": { "js-yaml": "^3.10.0", "tslib": "^2.4.0" } }, "sha512-/HcYgtUSiJiot/XWGLOlGxPYUG65+/31V8oqk17vZLW1xlCoR4PampyePljOxY2n8/3jz9+tIFzICsyGujJZoA=="],
+    "@yarnpkg/parsers": ["@yarnpkg/parsers@3.1.0", "", { "dependencies": { "js-yaml": "^4.3.0", "tslib": "^2.4.0" } }, "sha512-WoxUM/Be4hfsX06FxsvpGgfYqwgivMV7/Ol7aFuSfSmY6rRaiju4QxOEe9RUS0iYcSHWl5i9AhB1cMoE0p+XiA=="],
 
     "@yarnpkg/shell": ["@yarnpkg/shell@4.1.3", "", { "dependencies": { "@yarnpkg/fslib": "^3.1.2", "@yarnpkg/parsers": "^3.0.3", "chalk": "^4.1.2", "clipanion": "^4.0.0-rc.2", "cross-spawn": "^7.0.3", "fast-glob": "^3.2.2", "micromatch": "^4.0.2", "tslib": "^2.4.0" }, "bin": "./lib/cli.js" }, "sha512-5igwsHbPtSAlLdmMdKqU3atXjwhtLFQXsYAG0sn1XcPb3yF8WxxtWxN6fycBoUvFyIHFz1G0KeRefnAy8n6gdw=="],
 
@@ -2672,21 +2622,17 @@
 
     "@zkochan/js-yaml": ["@zkochan/js-yaml@0.0.7", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ=="],
 
-    "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
-
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
-    "add-stream": ["add-stream@1.0.0", "", {}, "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ=="],
-
     "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "ae-cvss-calculator": ["ae-cvss-calculator@1.0.13", "", {}, "sha512-QnPO1O5gZ/1NM+X4fbfqN/y5rImEZ8CSkbSk7Arv4RrmxPzxLXr9RSLmsQJykDtXFUXn9wHLxC0/fe/pO78t3w=="],
 
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
@@ -2700,19 +2646,15 @@
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "aproba": ["aproba@2.0.0", "", {}, "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "argue-cli": ["argue-cli@3.1.0", "", {}, "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw=="],
+
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
-
-    "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
-
-    "arrify": ["arrify@1.0.1", "", {}, "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="],
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
@@ -2723,8 +2665,6 @@
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
-
-    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
 
@@ -2740,17 +2680,17 @@
 
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
 
-    "axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
+    "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
-    "azure-devops-node-api": ["azure-devops-node-api@15.1.2", "", { "dependencies": { "tunnel": "0.0.6", "typed-rest-client": "2.1.0" } }, "sha512-PfJTGK8oaBB3e0hilF5QE5BT0axpxssZlc0pRq3Rb0XsKr4qk1Cma+jBRRz0hE+zuUsu/7cz0WTCVo+kcVvOjw=="],
+    "azure-devops-node-api": ["azure-devops-node-api@15.1.3", "", { "dependencies": { "tunnel": "0.0.6", "typed-rest-client": "2.1.0" } }, "sha512-YMgxCjQDqBr//vGy658tXTrXAgS2BzIChJ2Mzrq+fzLK+dh42fODWO/kEQMmtp+Rw0jNgEoUA72cHYVBrxrjRw=="],
 
     "backslash": ["backslash@0.2.2", "", {}, "sha512-PKRYPE2LLTtNUYz1dszquxKSBs6XyLyJRHgFpY5rlq7y3DscDx239k5Gm+zenoY47OU4CApan1o0k2R8ptZC1Q=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.3", "", {}, "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -2774,7 +2714,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -2796,8 +2736,6 @@
 
     "byte-counter": ["byte-counter@0.1.0", "", {}, "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ=="],
 
-    "byte-size": ["byte-size@8.1.1", "", {}, "sha512-tUkzZWK0M/qdoLEqikxBWe4kumyuwjl3HO6zHTr4yEI23EojPtLYXdG1+AQY7MN0cGyNDvEaJ8wiYQm6P2bPxg=="],
-
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "cacache": ["cacache@20.0.4", "", { "dependencies": { "@npmcli/fs": "^5.0.0", "fs-minipass": "^3.0.0", "glob": "^13.0.0", "lru-cache": "^11.1.0", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^13.0.0" } }, "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA=="],
@@ -2815,8 +2753,6 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
-
-    "camelcase-keys": ["camelcase-keys@6.2.2", "", { "dependencies": { "camelcase": "^5.3.1", "map-obj": "^4.0.0", "quick-lru": "^4.0.1" } }, "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001780", "", {}, "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ=="],
 
@@ -2890,8 +2826,6 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
-
     "colorjs.io": ["colorjs.io@0.7.0", "", {}, "sha512-JfLy3aZW1Xp2iwSFzGlLn0XSMnIdItH3BmzsXtwHVFEWwVUJIwKBWNzjQq2Tgf3998OY7qW2R6klrlYo8vmEGg=="],
 
     "columnify": ["columnify@1.6.0", "", { "dependencies": { "strip-ansi": "^6.0.1", "wcwidth": "^1.0.0" } }, "sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q=="],
@@ -2904,35 +2838,29 @@
 
     "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
 
-    "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
-
     "component-emitter": ["component-emitter@2.0.0", "", {}, "sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw=="],
 
     "compute-scroll-into-view": ["compute-scroll-into-view@3.1.1", "", {}, "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
-    "concat-stream": ["concat-stream@2.0.0", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.0.2", "typedarray": "^0.0.6" } }, "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A=="],
-
-    "console-control-strings": ["console-control-strings@1.1.0", "", {}, "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="],
-
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
-    "conventional-changelog-angular": ["conventional-changelog-angular@7.0.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ=="],
+    "conventional-changelog": ["conventional-changelog@8.1.0", "", { "dependencies": { "@conventional-changelog/git-client": "^3.1.0", "@simple-libs/hosted-git-info": "^2.0.0", "@simple-libs/normalize-package-data": "^1.0.0", "argue-cli": "^3.1.0", "conventional-changelog-preset-loader": "^6.0.1", "conventional-changelog-writer": "^9.2.0", "conventional-commits-parser": "^7.1.0", "fd-package-json": "^2.0.0" }, "bin": { "conventional-changelog": "./dist/cli/index.js" } }, "sha512-idt1JK+3+Nt7gqH/d/sEYWdDeR+5XPov/jssmFN6XxmYSRlonTWSDWhWUPkmm0zbwYjtVdt+4My5aiPkKyvocw=="],
 
-    "conventional-changelog-core": ["conventional-changelog-core@5.0.1", "", { "dependencies": { "add-stream": "^1.0.0", "conventional-changelog-writer": "^6.0.0", "conventional-commits-parser": "^4.0.0", "dateformat": "^3.0.3", "get-pkg-repo": "^4.2.1", "git-raw-commits": "^3.0.0", "git-remote-origin-url": "^2.0.0", "git-semver-tags": "^5.0.0", "normalize-package-data": "^3.0.3", "read-pkg": "^3.0.0", "read-pkg-up": "^3.0.0" } }, "sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A=="],
+    "conventional-changelog-angular": ["conventional-changelog-angular@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw=="],
 
-    "conventional-changelog-preset-loader": ["conventional-changelog-preset-loader@3.0.0", "", {}, "sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA=="],
+    "conventional-changelog-preset-loader": ["conventional-changelog-preset-loader@6.0.1", "", {}, "sha512-GZ8E3RQzXQb3JFy0pKl8oeSf7ENIhvAMvJr+PlWkavZOesLHHdhkfNJ4SvW35eo1Fu2+EyVxWQ1tVvtzAG2iWg=="],
 
-    "conventional-changelog-writer": ["conventional-changelog-writer@6.0.1", "", { "dependencies": { "conventional-commits-filter": "^3.0.0", "dateformat": "^3.0.3", "handlebars": "^4.7.7", "json-stringify-safe": "^5.0.1", "meow": "^8.1.2", "semver": "^7.0.0", "split": "^1.0.1" }, "bin": { "conventional-changelog-writer": "cli.js" } }, "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ=="],
+    "conventional-changelog-writer": ["conventional-changelog-writer@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.3.0", "@simple-libs/stream-utils": "^2.0.0", "argue-cli": "^3.1.0", "conventional-commits-filter": "^6.0.1", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "./dist/cli/index.js" } }, "sha512-StlYSmW3wLedRaqohJMpP3YuWiAqtgD0/cpsai9frdDkXv7rxj0hRbpJrubPYvJxJsjplONsOobEQnPuS9UgCg=="],
 
-    "conventional-commits-filter": ["conventional-commits-filter@3.0.0", "", { "dependencies": { "lodash.ismatch": "^4.4.0", "modify-values": "^1.0.1" } }, "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q=="],
+    "conventional-commits-filter": ["conventional-commits-filter@6.0.1", "", {}, "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg=="],
 
-    "conventional-commits-parser": ["conventional-commits-parser@4.0.0", "", { "dependencies": { "JSONStream": "^1.3.5", "is-text-path": "^1.0.1", "meow": "^8.1.2", "split2": "^3.2.2" }, "bin": { "conventional-commits-parser": "cli.js" } }, "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg=="],
+    "conventional-commits-parser": ["conventional-commits-parser@7.1.2", "", { "dependencies": { "@simple-libs/stream-utils": "^2.0.0", "argue-cli": "^3.1.0" }, "bin": { "conventional-commits-parser": "./dist/cli/index.js" } }, "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ=="],
 
-    "conventional-recommended-bump": ["conventional-recommended-bump@7.0.1", "", { "dependencies": { "concat-stream": "^2.0.0", "conventional-changelog-preset-loader": "^3.0.0", "conventional-commits-filter": "^3.0.0", "conventional-commits-parser": "^4.0.0", "git-raw-commits": "^3.0.0", "git-semver-tags": "^5.0.0", "meow": "^8.1.2" }, "bin": { "conventional-recommended-bump": "cli.js" } }, "sha512-Ft79FF4SlOFvX4PkwFDRnaNiIVX7YbmqGU0RwccUaiGvgp3S0a8ipR2/Qxk31vclDNM+GSdJOVs2KrsUCjblVA=="],
+    "conventional-recommended-bump": ["conventional-recommended-bump@12.1.0", "", { "dependencies": { "@conventional-changelog/git-client": "^3.1.0", "argue-cli": "^3.1.0", "conventional-changelog-preset-loader": "^6.0.1", "conventional-commits-filter": "^6.0.1", "conventional-commits-parser": "^7.1.0" }, "bin": { "conventional-recommended-bump": "./dist/cli/index.js" } }, "sha512-HTNG3kEZXOOfKwrEx54ljURU9bG4nVPQzXMyCSeUcA/PE8EpNpQNujSrbXNBI8QZyN35zM+pVw+FuQk4KqHSHg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -2978,21 +2906,13 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "dargs": ["dargs@7.0.0", "", {}, "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg=="],
-
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
     "dataloader": ["dataloader@2.2.3", "", {}, "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA=="],
 
-    "dateformat": ["dateformat@3.0.3", "", {}, "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="],
-
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
-
-    "decamelize-keys": ["decamelize-keys@1.1.1", "", { "dependencies": { "decamelize": "^1.1.0", "map-obj": "^1.0.0" } }, "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
@@ -3010,9 +2930,9 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
-    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+    "default-browser": ["default-browser@5.2.1", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg=="],
 
-    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+    "default-browser-id": ["default-browser-id@5.0.0", "", {}, "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA=="],
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
@@ -3020,7 +2940,7 @@
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
-    "define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
@@ -3058,11 +2978,9 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
-    "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
-
     "dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
-    "dotenv-expand": ["dotenv-expand@11.0.7", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA=="],
+    "dotenv-expand": ["dotenv-expand@12.0.3", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA=="],
 
     "downshift": ["downshift@9.3.2", "", { "dependencies": { "@babel/runtime": "^7.28.6", "compute-scroll-into-view": "^3.1.1", "prop-types": "^15.8.1", "react-is": "^18.2.0", "tslib": "^2.8.1" }, "peerDependencies": { "react": ">=16.12.0" } }, "sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow=="],
 
@@ -3084,7 +3002,7 @@
 
     "email-addresses": ["email-addresses@5.0.0", "", {}, "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "emojibase": ["emojibase@17.0.0", "", {}, "sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA=="],
 
@@ -3184,13 +3102,13 @@
 
     "fbjs-css-vars": ["fbjs-css-vars@1.0.2", "", {}, "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="],
 
+    "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
     "figures": ["figures@3.2.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg=="],
-
-    "filelist": ["filelist@1.0.6", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA=="],
 
     "filesize": ["filesize@10.1.6", "", {}, "sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w=="],
 
@@ -3206,13 +3124,13 @@
 
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
 
-    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+    "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "form-data-encoder": ["form-data-encoder@4.1.0", "", {}, "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw=="],
 
@@ -3224,11 +3142,9 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
-    "front-matter": ["front-matter@4.0.2", "", { "dependencies": { "js-yaml": "^3.13.1" } }, "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg=="],
-
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
-    "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
+    "fs-extra": ["fs-extra@11.3.6", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA=="],
 
     "fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
 
@@ -3252,29 +3168,19 @@
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
-    "get-pkg-repo": ["get-pkg-repo@4.2.1", "", { "dependencies": { "@hutson/parse-repository-url": "^3.0.0", "hosted-git-info": "^4.0.0", "through2": "^2.0.0", "yargs": "^16.2.0" }, "bin": { "get-pkg-repo": "src/cli.js" } }, "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA=="],
-
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@6.0.0", "", {}, "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg=="],
-
-    "git-raw-commits": ["git-raw-commits@3.0.0", "", { "dependencies": { "dargs": "^7.0.0", "meow": "^8.1.2", "split2": "^3.2.2" }, "bin": { "git-raw-commits": "cli.js" } }, "sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw=="],
-
-    "git-remote-origin-url": ["git-remote-origin-url@2.0.0", "", { "dependencies": { "gitconfiglocal": "^1.0.0", "pify": "^2.3.0" } }, "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw=="],
-
-    "git-semver-tags": ["git-semver-tags@5.0.1", "", { "dependencies": { "meow": "^8.1.2", "semver": "^7.0.0" }, "bin": { "git-semver-tags": "cli.js" } }, "sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA=="],
 
     "git-up": ["git-up@7.0.0", "", { "dependencies": { "is-ssh": "^1.4.0", "parse-url": "^8.1.0" } }, "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ=="],
 
     "git-url-parse": ["git-url-parse@14.0.0", "", { "dependencies": { "git-up": "^7.0.0" } }, "sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ=="],
 
-    "gitconfiglocal": ["gitconfiglocal@1.0.0", "", { "dependencies": { "ini": "^1.3.2" } }, "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ=="],
-
     "github-url-from-git": ["github-url-from-git@1.5.0", "", {}, "sha512-WWOec4aRI7YAykQ9+BHmzjyNlkfJFG8QLXnDTsLz/kZefq7qkzdfo4p6fkYYMIq1aj+gZcQs/1HQhQh3DPPxlQ=="],
 
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "glob-to-regex.js": ["glob-to-regex.js@1.2.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ=="],
 
@@ -3284,7 +3190,7 @@
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
-    "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
+    "google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
@@ -3304,8 +3210,6 @@
 
     "happy-dom": ["happy-dom@20.8.4", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ=="],
 
-    "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
-
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
@@ -3314,9 +3218,7 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
-    "has-unicode": ["has-unicode@2.0.1", "", {}, "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="],
-
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
 
@@ -3352,7 +3254,7 @@
 
     "http2-wrapper": ["http2-wrapper@2.2.1", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.2.0" } }, "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ=="],
 
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
@@ -3418,13 +3320,11 @@
 
     "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
 
-    "is-ci": ["is-ci@3.0.1", "", { "dependencies": { "ci-info": "^3.2.0" }, "bin": { "is-ci": "bin.js" } }, "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ=="],
-
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
-    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -3448,8 +3348,6 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
-
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
@@ -3464,21 +3362,19 @@
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
-    "is-text-path": ["is-text-path@1.0.1", "", { "dependencies": { "text-extensions": "^1.0.0" } }, "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w=="],
-
     "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
     "is-typedarray": ["is-typedarray@1.0.0", "", {}, "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="],
 
-    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+    "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
 
-    "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+    "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
     "isarray": ["isarray@0.0.1", "", {}, "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="],
 
-    "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
@@ -3488,17 +3384,13 @@
 
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
-    "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
-
-    "jest-diff": ["jest-diff@30.3.0", "", { "dependencies": { "@jest/diff-sequences": "30.3.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.3.0" } }, "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ=="],
-
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-md4": ["js-md4@0.3.2", "", {}, "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
 
@@ -3511,8 +3403,6 @@
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-dup-key-validator": ["json-dup-key-validator@1.0.3", "", { "dependencies": { "backslash": "^0.2.0" } }, "sha512-JvJcV01JSiO7LRz7DY1Fpzn4wX2rJ3dfNTiAfnlvLNdhhnm0Pgdvhi2SGpENrZn7eSg26Ps3TPhOcuD/a4STXQ=="],
-
-    "json-parse-better-errors": ["json-parse-better-errors@1.0.2", "", {}, "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@5.0.0", "", {}, "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ=="],
 
@@ -3532,11 +3422,11 @@
 
     "jsonata": ["jsonata@2.2.1", "", {}, "sha512-xd1uwUrKeIcJbsWhaoS3qAX4Ea8m0Mw0G5nlnAQvPT7TbZ5qaPdzBVTQia9KfyuyQm+nenfyjvzUDTRYHsC2sw=="],
 
-    "jsonc-morph": ["jsonc-morph@0.3.4", "", {}, "sha512-tY9H0tplGdRZ0O/7N0qQGr8RuiwuAqGZfO1NCcy986qdMf2gcWTQnr2YF+Q3VkaCBKN2+mTPSZzewg3V4rWXQg=="],
+    "jsonc-morph": ["jsonc-morph@0.3.5", "", {}, "sha512-48t3FzTaEcePC0xKtadykUy7iqMx9fpxzigbi0YtNdEiPXUr7CoM1rfyBUKg0HW167eaG0EENdjc8aowa1TMvQ=="],
 
-    "jsonc-parser": ["jsonc-parser@3.2.0", "", {}, "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="],
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
-    "jsonc-weaver": ["jsonc-weaver@0.2.4", "", { "dependencies": { "jsonc-morph": "^0.3.3" } }, "sha512-aIKK8SOg+TdBdeML4MB++phUEdS7KWZxuaPPjxUSat8Kc/2A+2AoxmAGhvbVajNjqsgSX4dhjfCJq3QlE/NSCg=="],
+    "jsonc-weaver": ["jsonc-weaver@0.3.1", "", { "dependencies": { "jsonc-morph": "^0.3.5" } }, "sha512-a6e90+Hn5e+l7i6MC2YJ57TE6nv9gDKFyCLBIVKt0Jdv48lUBEV7StnnuwC0Y+sjnux41cnPlHJl65DH4+d9eA=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
@@ -3554,15 +3444,13 @@
 
     "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
-    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
-
     "klaw-sync": ["klaw-sync@6.0.0", "", { "dependencies": { "graceful-fs": "^4.1.11" } }, "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
-    "lerna": ["lerna@9.0.7", "", { "dependencies": { "@npmcli/arborist": "9.1.6", "@npmcli/package-json": "7.0.2", "@npmcli/run-script": "10.0.3", "@nx/devkit": ">=21.5.2 < 23.0.0", "@octokit/plugin-enterprise-rest": "6.0.1", "@octokit/rest": "20.1.2", "aproba": "2.0.0", "byte-size": "8.1.1", "chalk": "4.1.0", "ci-info": "4.3.1", "cmd-shim": "6.0.3", "color-support": "1.1.3", "columnify": "1.6.0", "console-control-strings": "^1.1.0", "conventional-changelog-angular": "7.0.0", "conventional-changelog-core": "5.0.1", "conventional-recommended-bump": "7.0.1", "cosmiconfig": "9.0.0", "dedent": "1.5.3", "envinfo": "7.13.0", "execa": "5.0.0", "fs-extra": "^11.2.0", "get-stream": "6.0.0", "git-url-parse": "14.0.0", "glob-parent": "6.0.2", "has-unicode": "2.0.1", "import-local": "3.1.0", "ini": "^1.3.8", "init-package-json": "8.2.2", "inquirer": "12.9.6", "is-ci": "3.0.1", "jest-diff": ">=30.0.0 < 31", "js-yaml": "4.1.1", "libnpmaccess": "10.0.3", "libnpmpublish": "11.1.2", "load-json-file": "6.2.0", "make-fetch-happen": "15.0.2", "minimatch": "3.1.4", "npm-package-arg": "13.0.1", "npm-packlist": "10.0.3", "npm-registry-fetch": "19.1.0", "nx": ">=21.5.3 < 23.0.0", "p-map": "4.0.0", "p-map-series": "2.1.0", "p-pipe": "3.1.0", "p-queue": "6.6.2", "p-reduce": "2.1.0", "p-waterfall": "2.1.1", "pacote": "21.0.1", "read-cmd-shim": "4.0.0", "semver": "7.7.2", "signal-exit": "3.0.7", "slash": "3.0.0", "ssri": "12.0.0", "string-width": "^4.2.3", "tar": "7.5.11", "through": "2.3.8", "tinyglobby": "0.2.12", "typescript": ">=3 < 6", "upath": "2.0.1", "validate-npm-package-license": "3.0.4", "validate-npm-package-name": "6.0.2", "wide-align": "1.1.5", "write-file-atomic": "5.0.1", "yargs": "17.7.2", "yargs-parser": "21.1.1" }, "bin": { "lerna": "dist/cli.js" } }, "sha512-PMjbSWYfwL1yZ5c1D2PZuFyzmtYhLdn0f76uG8L25g6eYy34j+2jPb4Q6USx1UJvxVtxkdVEeAAWS/WxgJ8VZA=="],
+    "lerna": ["lerna@10.0.1", "", { "dependencies": { "@npmcli/arborist": "9.1.6", "@npmcli/package-json": "7.0.2", "@npmcli/run-script": "10.0.3", "@nx/devkit": ">=23.1.0 < 24.0.0", "@octokit/plugin-enterprise-rest": "6.0.1", "@octokit/rest": "20.1.2", "ci-info": "4.3.1", "cmd-shim": "6.0.3", "columnify": "1.6.0", "conventional-changelog": "8.1.0", "conventional-changelog-angular": "9.2.1", "conventional-commits-filter": "6.0.1", "conventional-commits-parser": "7.1.2", "conventional-recommended-bump": "12.1.0", "cosmiconfig": "9.0.0", "dedent": "1.5.3", "envinfo": "7.13.0", "execa": "5.0.0", "fs-extra": "^11.2.0", "git-url-parse": "14.0.0", "handlebars": "4.7.9", "import-local": "3.1.0", "ini": "^1.3.8", "init-package-json": "8.2.2", "inquirer": "12.9.6", "js-yaml": "4.3.0", "libnpmaccess": "10.0.3", "libnpmpublish": "11.1.2", "load-json-file": "6.2.0", "make-fetch-happen": "15.0.2", "minimatch": "3.1.4", "npm-package-arg": "13.0.1", "npm-packlist": "10.0.3", "npm-registry-fetch": "19.1.0", "nx": ">=23.1.0 < 24.0.0", "p-map": "4.0.0", "p-queue": "6.6.2", "pacote": "21.0.1", "read-cmd-shim": "4.0.0", "semver": "7.7.2", "signal-exit": "3.0.7", "ssri": "12.0.0", "string-width": "^4.2.3", "tar": "7.5.22", "tinyglobby": "0.2.12", "validate-npm-package-license": "3.0.4", "validate-npm-package-name": "6.0.2", "write-file-atomic": "5.0.1", "yargs": "17.7.2" }, "bin": { "lerna": "dist/cli.js" } }, "sha512-ibmMaBmH/sR2HpZzgvpEI5/6bCgMp0AISIFZ/cQcCzRVH2EgPapBYHXS6A6NgI6vRJNE4pgnxQbNiSq00HVSjA=="],
 
     "libnpmaccess": ["libnpmaccess@10.0.3", "", { "dependencies": { "npm-package-arg": "^13.0.0", "npm-registry-fetch": "^19.0.0" } }, "sha512-JPHTfWJxIK+NVPdNMNGnkz4XGX56iijPbe0qFWbdt68HL+kIvSzh+euBL8npLZvl2fpaxo+1eZSdoG15f5YdIQ=="],
 
@@ -3608,8 +3496,6 @@
 
     "locate-path": ["locate-path@8.0.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg=="],
 
-    "lodash.ismatch": ["lodash.ismatch@4.4.0", "", {}, "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g=="],
-
     "log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
@@ -3635,8 +3521,6 @@
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "make-fetch-happen": ["make-fetch-happen@15.0.2", "", { "dependencies": { "@npmcli/agent": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^4.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "ssri": "^12.0.0" } }, "sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ=="],
-
-    "map-obj": ["map-obj@4.3.0", "", {}, "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="],
 
     "markdown-it": ["markdown-it@14.3.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.5.0", "linkify-it": "^5.0.2", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw=="],
 
@@ -3683,8 +3567,6 @@
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "memfs": ["memfs@4.56.11", "", { "dependencies": { "@jsonjoy.com/fs-core": "4.56.11", "@jsonjoy.com/fs-fsa": "4.56.11", "@jsonjoy.com/fs-node": "4.56.11", "@jsonjoy.com/fs-node-builtins": "4.56.11", "@jsonjoy.com/fs-node-to-fsa": "4.56.11", "@jsonjoy.com/fs-node-utils": "4.56.11", "@jsonjoy.com/fs-print": "4.56.11", "@jsonjoy.com/fs-snapshot": "4.56.11", "@jsonjoy.com/json-pack": "^1.11.0", "@jsonjoy.com/util": "^1.9.0", "glob-to-regex.js": "^1.0.1", "thingies": "^2.5.0", "tree-dump": "^1.0.3", "tslib": "^2.0.0" } }, "sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g=="],
-
-    "meow": ["meow@8.1.2", "", { "dependencies": { "@types/minimist": "^1.2.0", "camelcase-keys": "^6.2.2", "decamelize-keys": "^1.1.0", "hard-rejection": "^2.1.0", "minimist-options": "4.1.0", "normalize-package-data": "^3.0.0", "read-pkg-up": "^7.0.1", "redent": "^3.0.0", "trim-newlines": "^3.0.0", "type-fest": "^0.18.0", "yargs-parser": "^20.2.3" } }, "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
@@ -3750,9 +3632,9 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -3765,8 +3647,6 @@
     "minimatch": ["minimatch@3.1.4", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "minimist-options": ["minimist-options@4.1.0", "", { "dependencies": { "arrify": "^1.0.1", "is-plain-obj": "^1.1.0", "kind-of": "^6.0.3" } }, "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -3783,8 +3663,6 @@
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
-
-    "modify-values": ["modify-values@1.0.1", "", {}, "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
@@ -3824,15 +3702,11 @@
 
     "node-html-parser": ["node-html-parser@7.1.0", "", { "dependencies": { "css-select": "^5.1.0", "he": "1.2.0" } }, "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ=="],
 
-    "node-machine-id": ["node-machine-id@1.1.12", "", {}, "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="],
-
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
     "noms": ["noms@0.0.0", "", { "dependencies": { "inherits": "^2.0.1", "readable-stream": "~1.0.31" } }, "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow=="],
 
     "nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
-
-    "normalize-package-data": ["normalize-package-data@3.0.3", "", { "dependencies": { "hosted-git-info": "^4.0.1", "is-core-module": "^2.5.0", "semver": "^7.3.4", "validate-npm-package-license": "^3.0.1" } }, "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA=="],
 
     "normalize-url": ["normalize-url@8.1.1", "", {}, "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ=="],
 
@@ -3858,7 +3732,7 @@
 
     "nullthrows": ["nullthrows@1.1.1", "", {}, "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="],
 
-    "nx": ["nx@22.5.4", "", { "dependencies": { "@napi-rs/wasm-runtime": "0.2.4", "@yarnpkg/lockfile": "^1.1.0", "@yarnpkg/parsers": "3.0.2", "@zkochan/js-yaml": "0.0.7", "axios": "^1.12.0", "cli-cursor": "3.1.0", "cli-spinners": "2.6.1", "cliui": "^8.0.1", "dotenv": "~16.4.5", "dotenv-expand": "~11.0.6", "ejs": "^3.1.7", "enquirer": "~2.3.6", "figures": "3.2.0", "flat": "^5.0.2", "front-matter": "^4.0.2", "ignore": "^7.0.5", "jest-diff": "^30.0.2", "jsonc-parser": "3.2.0", "lines-and-columns": "2.0.3", "minimatch": "10.2.4", "node-machine-id": "1.1.12", "npm-run-path": "^4.0.1", "open": "^8.4.0", "ora": "5.3.0", "picocolors": "^1.1.0", "resolve.exports": "2.0.3", "semver": "^7.6.3", "string-width": "^4.2.3", "tar-stream": "~2.2.0", "tmp": "~0.2.1", "tree-kill": "^1.2.2", "tsconfig-paths": "^4.1.2", "tslib": "^2.3.0", "yaml": "^2.6.0", "yargs": "^17.6.2", "yargs-parser": "21.1.1" }, "optionalDependencies": { "@nx/nx-darwin-arm64": "22.5.4", "@nx/nx-darwin-x64": "22.5.4", "@nx/nx-freebsd-x64": "22.5.4", "@nx/nx-linux-arm-gnueabihf": "22.5.4", "@nx/nx-linux-arm64-gnu": "22.5.4", "@nx/nx-linux-arm64-musl": "22.5.4", "@nx/nx-linux-x64-gnu": "22.5.4", "@nx/nx-linux-x64-musl": "22.5.4", "@nx/nx-win32-arm64-msvc": "22.5.4", "@nx/nx-win32-x64-msvc": "22.5.4" }, "peerDependencies": { "@swc-node/register": "^1.11.1", "@swc/core": "^1.15.8" }, "optionalPeers": ["@swc-node/register", "@swc/core"], "bin": { "nx": "bin/nx.js", "nx-cloud": "bin/nx-cloud.js" } }, "sha512-L8wL7uCjnmpyvq4r2mN9s+oriUE4lY+mX9VgOpjj0ucRd5nzaEaBQppVs0zQGkbKC0BnHS8PGtnAglspd5Gh1Q=="],
+    "nx": ["nx@23.1.1", "", { "dependencies": { "@emnapi/core": "1.4.5", "@emnapi/runtime": "1.4.5", "@emnapi/wasi-threads": "1.0.4", "@jest/diff-sequences": "30.0.1", "@napi-rs/wasm-runtime": "0.2.4", "@tybys/wasm-util": "0.9.0", "@yarnpkg/lockfile": "1.1.0", "@zkochan/js-yaml": "0.0.7", "agent-base": "6.0.2", "ansi-colors": "4.1.3", "ansi-regex": "5.0.1", "ansi-styles": "4.3.0", "argparse": "2.0.1", "asynckit": "0.4.0", "axios": "1.18.1", "balanced-match": "4.0.3", "base64-js": "1.5.1", "bl": "4.1.0", "brace-expansion": "5.0.8", "buffer": "5.7.1", "bundle-name": "4.1.0", "call-bind-apply-helpers": "1.0.2", "chalk": "4.1.2", "cli-cursor": "3.1.0", "cli-spinners": "2.6.1", "cliui": "8.0.1", "clone": "1.0.4", "color-convert": "2.0.1", "color-name": "1.1.4", "combined-stream": "1.0.8", "debug": "4.4.3", "default-browser": "5.2.1", "default-browser-id": "5.0.0", "defaults": "1.0.4", "define-lazy-prop": "3.0.0", "delayed-stream": "1.0.0", "dotenv": "16.4.7", "dotenv-expand": "12.0.3", "dunder-proto": "1.0.1", "ejs": "5.0.1", "emoji-regex": "8.0.0", "end-of-stream": "1.4.5", "enquirer": "2.3.6", "es-define-property": "1.0.1", "es-errors": "1.3.0", "es-object-atoms": "1.1.1", "es-set-tostringtag": "2.1.0", "escalade": "3.2.0", "escape-string-regexp": "1.0.5", "figures": "3.2.0", "flat": "5.0.2", "follow-redirects": "1.16.0", "form-data": "4.0.6", "fs-constants": "1.0.0", "function-bind": "1.1.2", "get-caller-file": "2.0.5", "get-intrinsic": "1.3.0", "get-proto": "1.0.1", "gopd": "1.2.0", "has-flag": "4.0.0", "has-symbols": "1.1.0", "has-tostringtag": "1.0.2", "hasown": "2.0.4", "https-proxy-agent": "5.0.1", "ieee754": "1.2.1", "ignore": "7.0.5", "inherits": "2.0.4", "is-docker": "3.0.0", "is-fullwidth-code-point": "3.0.0", "is-inside-container": "1.0.0", "is-interactive": "1.0.0", "is-unicode-supported": "0.1.0", "is-wsl": "3.1.0", "isexe": "2.0.0", "json5": "2.2.3", "jsonc-parser": "3.3.1", "lines-and-columns": "2.0.3", "log-symbols": "4.1.0", "math-intrinsics": "1.1.0", "mime-db": "1.52.0", "mime-types": "2.1.35", "mimic-fn": "2.1.0", "minimatch": "10.2.5", "minimist": "1.2.8", "ms": "2.1.3", "npm-run-path": "4.0.1", "once": "1.4.0", "onetime": "5.1.2", "open": "10.1.0", "ora": "5.4.1", "path-key": "3.1.1", "picocolors": "1.1.1", "proxy-from-env": "2.1.0", "readable-stream": "3.6.2", "require-directory": "2.1.1", "resolve.exports": "2.0.3", "restore-cursor": "3.1.0", "run-applescript": "7.0.0", "safe-buffer": "5.2.1", "semver": "7.8.4", "signal-exit": "3.0.7", "smol-toml": "1.6.1", "string-width": "4.2.3", "string_decoder": "1.3.0", "strip-ansi": "6.0.1", "strip-bom": "3.0.0", "supports-color": "7.2.0", "tar-stream": "2.2.0", "tmp": "0.2.7", "tsconfig-paths": "4.2.0", "tslib": "2.8.1", "util-deprecate": "1.0.2", "wcwidth": "1.0.1", "which": "3.0.1", "wrap-ansi": "7.0.0", "wrappy": "1.0.2", "y18n": "5.0.8", "yaml": "2.9.0", "yargs": "17.7.2", "yargs-parser": "21.1.1" }, "optionalDependencies": { "@nx/nx-darwin-arm64": "23.1.1", "@nx/nx-darwin-x64": "23.1.1", "@nx/nx-freebsd-x64": "23.1.1", "@nx/nx-linux-arm-gnueabihf": "23.1.1", "@nx/nx-linux-arm64-gnu": "23.1.1", "@nx/nx-linux-arm64-musl": "23.1.1", "@nx/nx-linux-x64-gnu": "23.1.1", "@nx/nx-linux-x64-musl": "23.1.1", "@nx/nx-win32-arm64-msvc": "23.1.1", "@nx/nx-win32-x64-msvc": "23.1.1" }, "peerDependencies": { "@swc-node/register": "^1.11.1", "@swc/core": "^1.15.8" }, "optionalPeers": ["@swc-node/register", "@swc/core"], "bin": { "nx": "./dist/bin/nx.js", "nx-cloud": "./dist/bin/nx-cloud.js" } }, "sha512-oDdW2JgVllgfyyN6OqlRzeABw0QrlXdxyl9rtOUMMXQzlkpYA1RTs8jinJCe6QSo7aEn0dZ+Ar7dd09hMudBsg=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -3880,13 +3754,13 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
+    "open": ["open@10.1.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "is-wsl": "^3.1.0" } }, "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw=="],
 
     "openpgp": ["openpgp@6.3.1", "", { "peerDependencies": { "@openpgp/web-stream-tools": "~0.3.0" }, "optionalPeers": ["@openpgp/web-stream-tools"] }, "sha512-7oSPvmlKPojxFoyelT5DWPIAVmqWZh4qU/5pO6bdoShEtRpCw9Sye9IXUQj6EFM3XpgGssqccAr705YtTcLNQw=="],
 
     "opentype.js": ["opentype.js@1.3.4", "", { "dependencies": { "string.prototype.codepointat": "^0.2.1", "tiny-inflate": "^1.0.3" }, "bin": { "ot": "bin/ot" } }, "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw=="],
 
-    "ora": ["ora@5.3.0", "", { "dependencies": { "bl": "^4.0.3", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "log-symbols": "^4.0.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g=="],
+    "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
 
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
 
@@ -3906,21 +3780,13 @@
 
     "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
 
-    "p-map-series": ["p-map-series@2.1.0", "", {}, "sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q=="],
-
-    "p-pipe": ["p-pipe@3.1.0", "", {}, "sha512-08pj8ATpzMR0Y80x50yJHn37NF6vjrqHutASaX5LiH5npS9XPvrUmscd9MF5R4fuYRHOxQR1FfMIlF7AzwoPqw=="],
-
     "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
-
-    "p-reduce": ["p-reduce@2.1.0", "", {}, "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="],
 
     "p-throttle": ["p-throttle@8.1.0", "", {}, "sha512-c1wmXavsHZIC4g1OLhOsafK6jZSAeMo0Ap3yivj59PUcCkpacy5YgWdgIp/dB4vp1JZrfBSsPCR0YuADB+ENLQ=="],
 
     "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
-
-    "p-waterfall": ["p-waterfall@2.1.1", "", { "dependencies": { "p-reduce": "^2.0.0" } }, "sha512-RRTnDb2TBG/epPRI2yYXsimO0v3BXC8Yd3ogr1545IaqKK17VGhbWVeGGN+XfCm/08OK8635nH31c8bATkHuSw=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
@@ -3962,19 +3828,17 @@
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
-    "path-type": ["path-type@3.0.0", "", { "dependencies": { "pify": "^3.0.0" } }, "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg=="],
-
     "path-unified": ["path-unified@0.2.0", "", {}, "sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
@@ -4018,13 +3882,13 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
-    "protobufjs": ["protobufjs@8.7.1", "", { "dependencies": { "long": "^5.3.2" } }, "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A=="],
+    "protobufjs": ["protobufjs@8.7.2", "", { "dependencies": { "long": "^5.3.2" } }, "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA=="],
 
     "protocols": ["protocols@2.0.2", "", {}, "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
@@ -4070,10 +3934,6 @@
 
     "read-cmd-shim": ["read-cmd-shim@4.0.0", "", {}, "sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q=="],
 
-    "read-pkg": ["read-pkg@3.0.0", "", { "dependencies": { "load-json-file": "^4.0.0", "normalize-package-data": "^2.3.2", "path-type": "^3.0.0" } }, "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA=="],
-
-    "read-pkg-up": ["read-pkg-up@3.0.0", "", { "dependencies": { "find-up": "^2.0.0", "read-pkg": "^3.0.0" } }, "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw=="],
-
     "read-yaml-file": ["read-yaml-file@2.1.0", "", { "dependencies": { "js-yaml": "^4.0.0", "strip-bom": "^4.0.0" } }, "sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -4106,7 +3966,7 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
-    "renovate": ["renovate@43.288.0", "", { "dependencies": { "@aws-sdk/client-codecommit": "3.1075.0", "@aws-sdk/client-ec2": "3.1075.0", "@aws-sdk/client-ecr": "3.1075.0", "@aws-sdk/client-eks": "3.1075.0", "@aws-sdk/client-rds": "3.1075.0", "@aws-sdk/client-s3": "3.1075.0", "@aws-sdk/credential-providers": "3.1075.0", "@baszalmstra/rattler": "0.2.1", "@breejs/later": "4.2.0", "@cdktf/hcl2json": "0.21.0", "@opentelemetry/api": "1.9.1", "@opentelemetry/context-async-hooks": "2.10.0", "@opentelemetry/exporter-trace-otlp-http": "0.221.0", "@opentelemetry/instrumentation": "0.221.0", "@opentelemetry/instrumentation-bunyan": "0.65.0", "@opentelemetry/instrumentation-http": "0.221.0", "@opentelemetry/instrumentation-redis": "0.68.0", "@opentelemetry/otlp-transformer": "0.221.0", "@opentelemetry/resource-detector-aws": "2.20.0", "@opentelemetry/resource-detector-azure": "0.28.0", "@opentelemetry/resource-detector-gcp": "0.55.0", "@opentelemetry/resource-detector-github": "0.32.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace-base": "2.10.0", "@opentelemetry/sdk-trace-node": "2.10.0", "@opentelemetry/semantic-conventions": "1.43.0", "@pnpm/parse-overrides": "1001.0.4", "@qnighy/marshal": "0.1.3", "@redis/client": "5.12.1", "@renovatebot/detect-tools": "4.0.10", "@renovatebot/good-enough-parser": "2.0.1", "@renovatebot/osv-offline": "3.0.9", "@renovatebot/pep440": "5.0.0", "@renovatebot/pgp": "1.3.16", "@renovatebot/ruby-semver": "5.0.0", "@sindresorhus/is": "8.1.0", "@yarnpkg/core": "4.9.0", "@yarnpkg/parsers": "3.0.3", "adm-zip": "0.6.0", "ae-cvss-calculator": "1.0.13", "agentkeepalive": "4.6.0", "async-mutex": "0.5.0", "aws4": "1.13.2", "azure-devops-node-api": "15.1.2", "bunyan": "1.8.15", "cacache": "20.0.4", "changelog-filename-regex": "2.0.1", "clean-git-ref": "2.0.1", "commander": "14.0.3", "croner": "10.0.1", "cronstrue": "3.24.0", "deepmerge": "4.3.1", "dequal": "2.0.3", "detect-indent": "7.0.2", "diff": "9.0.0", "editorconfig": "3.0.2", "email-addresses": "5.0.0", "emoji-regex": "10.6.0", "emojibase": "17.0.0", "emojibase-regex": "17.0.0", "execa": "8.0.1", "find-packages": "10.0.4", "find-up": "8.0.0", "fs-extra": "11.3.6", "git-url-parse": "16.1.0", "github-url-from-git": "1.5.0", "glob": "13.0.6", "global-agent": "3.0.0", "google-auth-library": "10.9.0", "got": "14.6.6", "graph-data-structure": "4.5.0", "handlebars": "4.7.9", "ignore": "7.0.6", "ini": "6.0.0", "json-dup-key-validator": "1.0.3", "json-stringify-pretty-compact": "4.0.0", "json5": "2.2.3", "jsonata": "2.2.1", "jsonc-weaver": "0.2.4", "klona": "2.0.6", "lru-cache": "11.5.2", "luxon": "3.7.2", "markdown-it": "14.3.0", "markdown-table": "3.0.4", "minimatch": "10.2.5", "moo": "0.5.3", "ms": "2.1.3", "neotraverse": "0.6.18", "node-html-parser": "7.1.0", "p-all": "5.0.1", "p-map": "7.0.6", "p-queue": "9.3.1", "p-throttle": "8.1.0", "parse-link-header": "2.0.0", "prettier": "3.8.1", "protobufjs": "8.7.1", "punycode": "2.3.1", "remark": "15.0.1", "remark-gfm": "4.0.1", "remark-github": "12.0.0", "safe-stable-stringify": "2.5.0", "sax": "1.6.0", "semver": "7.8.5", "semver-stable": "3.0.0", "semver-utils": "1.1.4", "shlex": "3.0.0", "simple-git": "3.36.0", "slugify": "1.6.9", "source-map-support": "0.5.21", "strip-json-comments": "5.0.3", "toml-eslint-parser": "1.0.3", "tslib": "2.8.1", "upath": "3.0.8", "url-join": "5.0.0", "validate-npm-package-name": "7.0.2", "xmldoc": "2.0.3", "yaml": "2.9.0", "zod": "4.4.3" }, "optionalDependencies": { "openpgp": "6.3.1", "re2": "1.26.1" }, "bin": { "renovate": "dist/renovate.js", "renovate-config-validator": "dist/config-validator.js" } }, "sha512-VfoLP2VBWWpvG7dt3RzdzMWKsLN7mYnQ5ssTo6rguCKVmVDNfUMB1nnqhLCYrnvojYjwaYZpvvnjogoihmDghg=="],
+    "renovate": ["renovate@44.46.4", "", { "dependencies": { "@aws-sdk/client-codecommit": "3.1095.0", "@aws-sdk/client-ec2": "3.1095.0", "@aws-sdk/client-ecr": "3.1095.0", "@aws-sdk/client-eks": "3.1095.0", "@aws-sdk/client-rds": "3.1095.0", "@aws-sdk/client-s3": "3.1095.0", "@aws-sdk/credential-providers": "3.1095.0", "@baszalmstra/rattler": "0.2.1", "@breejs/later": "4.2.0", "@cdktf/hcl2json": "0.21.0", "@opentelemetry/api": "1.9.1", "@opentelemetry/context-async-hooks": "2.10.0", "@opentelemetry/exporter-trace-otlp-http": "0.221.0", "@opentelemetry/instrumentation": "0.221.0", "@opentelemetry/instrumentation-bunyan": "0.66.0", "@opentelemetry/instrumentation-http": "0.221.0", "@opentelemetry/instrumentation-redis": "0.69.0", "@opentelemetry/otlp-transformer": "0.221.0", "@opentelemetry/resource-detector-aws": "2.21.0", "@opentelemetry/resource-detector-azure": "0.29.0", "@opentelemetry/resource-detector-gcp": "0.56.0", "@opentelemetry/resource-detector-github": "0.32.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace-base": "2.10.0", "@opentelemetry/sdk-trace-node": "2.10.0", "@opentelemetry/semantic-conventions": "1.43.0", "@pnpm/parse-overrides": "1001.0.4", "@qnighy/marshal": "0.1.3", "@redis/client": "5.12.1", "@renovatebot/detect-tools": "4.0.11", "@renovatebot/good-enough-parser": "2.0.1", "@renovatebot/osv-offline": "3.0.10", "@renovatebot/pep440": "5.0.0", "@renovatebot/pgp": "1.3.17", "@renovatebot/ruby-semver": "5.0.0", "@sindresorhus/is": "8.1.0", "@yarnpkg/core": "4.9.1", "@yarnpkg/parsers": "3.1.0", "adm-zip": "0.6.0", "ae-cvss-calculator": "1.0.13", "agentkeepalive": "4.6.0", "async-mutex": "0.5.0", "aws4": "1.13.2", "azure-devops-node-api": "15.1.3", "bunyan": "1.8.15", "cacache": "20.0.4", "changelog-filename-regex": "2.0.1", "clean-git-ref": "2.0.1", "commander": "14.0.3", "croner": "10.0.1", "cronstrue": "3.24.0", "deepmerge": "4.3.1", "dequal": "2.0.3", "detect-indent": "7.0.2", "diff": "9.0.0", "editorconfig": "3.0.2", "email-addresses": "5.0.0", "emoji-regex": "10.6.0", "emojibase": "17.0.0", "emojibase-regex": "17.0.0", "execa": "8.0.1", "find-packages": "10.0.4", "find-up": "8.0.0", "fs-extra": "11.4.0", "git-url-parse": "16.1.0", "github-url-from-git": "1.5.0", "glob": "13.0.6", "global-agent": "3.0.0", "google-auth-library": "10.9.1", "got": "14.6.6", "graph-data-structure": "4.5.0", "handlebars": "4.7.9", "ignore": "7.0.6", "ini": "6.0.0", "json-dup-key-validator": "1.0.3", "json-stringify-pretty-compact": "4.0.0", "json5": "2.2.3", "jsonata": "2.2.1", "jsonc-weaver": "0.3.1", "klona": "2.0.6", "lru-cache": "11.5.2", "luxon": "3.7.2", "markdown-it": "14.3.0", "markdown-table": "3.0.4", "minimatch": "10.2.6", "moo": "0.5.3", "ms": "2.1.3", "neotraverse": "0.6.18", "node-html-parser": "7.1.0", "p-all": "5.0.1", "p-map": "7.0.6", "p-queue": "9.3.3", "p-throttle": "8.1.0", "parse-link-header": "2.0.0", "prettier": "3.8.1", "protobufjs": "8.7.2", "punycode": "2.3.1", "remark": "15.0.1", "remark-gfm": "4.0.1", "remark-github": "12.0.0", "safe-stable-stringify": "2.5.0", "sax": "1.6.1", "semver": "7.8.5", "semver-stable": "3.0.0", "semver-utils": "1.1.4", "shlex": "3.0.0", "simple-git": "3.36.0", "slugify": "1.6.9", "source-map-support": "0.5.21", "strip-json-comments": "5.0.3", "toml-eslint-parser": "1.0.3", "tslib": "2.8.1", "upath": "3.0.8", "url-join": "5.0.0", "validate-npm-package-name": "7.0.2", "xmldoc": "2.0.3", "yaml": "2.9.0", "yauzl": "3.4.0", "zod": "4.4.3" }, "optionalDependencies": { "openpgp": "6.3.1", "re2": "1.26.1" }, "bin": { "renovate": "dist/renovate.js", "renovate-config-validator": "dist/config-validator.js" } }, "sha512-mdD+glAIo47+N+hmVqC1/qoTV1IWJSHS8jzNdq+NJcHcKOrBq7Ph5Db82gxM1fp9rXXqb9aq7VJkCyExIPZTBA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -4146,7 +4006,7 @@
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
-    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+    "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 
     "run-async": ["run-async@4.0.6", "", {}, "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="],
 
@@ -4156,7 +4016,7 @@
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
-    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-json-stringify": ["safe-json-stringify@1.2.0", "", {}, "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg=="],
 
@@ -4166,7 +4026,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+    "sax": ["sax@1.6.1", "", {}, "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
@@ -4220,7 +4080,7 @@
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
-    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+    "slash": ["slash@2.0.0", "", {}, "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
@@ -4228,13 +4088,15 @@
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
+    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+
     "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "sort-keys": ["sort-keys@4.2.0", "", { "dependencies": { "is-plain-obj": "^2.0.0" } }, "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg=="],
 
-    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -4253,10 +4115,6 @@
     "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
 
     "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
-
-    "split": ["split@1.0.1", "", { "dependencies": { "through": "2" } }, "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg=="],
-
-    "split2": ["split2@3.2.2", "", { "dependencies": { "readable-stream": "^3.0.0" } }, "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg=="],
 
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
@@ -4286,11 +4144,11 @@
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-comments-strings": ["strip-comments-strings@1.2.0", "", {}, "sha512-zwF4bmnyEjZwRhaak9jUWNxc0DoeKBJ7lwSN/LEc8dQXZcUFG6auaaTQJokQWXopLdM3iTx01nQT8E4aL29DAQ=="],
 
@@ -4318,7 +4176,7 @@
 
     "svelte-check": ["svelte-check@4.4.5", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-1bSwIRCvvmSHrlK52fOlZmVtUZgil43jNL/2H18pRpa+eQjzGt6e3zayxhp1S7GajPFKNM/2PMCG+DZFHlG9fw=="],
 
-    "svelte2tsx": ["svelte2tsx@0.7.52", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0" } }, "sha512-svdT1FTrCLpvlU62evO5YdJt/kQ7nxgQxII/9BpQUvKr+GJRVdAXNVw8UWOt0fhoe5uWKyU0WsUTMRVAtRbMQg=="],
+    "svelte2tsx": ["svelte2tsx@0.7.61", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0 || ^6.0.0" } }, "sha512-EpQ/+UHITBULeUojx/LLD3uTYasZXcX1BrqlrzfLUnT9vdUhaOWK59a3ryWcFU8L0sY1SP+gRhJ2Beiis98+qw=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
@@ -4326,7 +4184,7 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
-    "tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
+    "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -4334,11 +4192,7 @@
 
     "terser": ["terser@4.8.1", "", { "dependencies": { "commander": "^2.20.0", "source-map": "~0.6.1", "source-map-support": "~0.5.12" }, "bin": { "terser": "bin/terser" } }, "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw=="],
 
-    "text-extensions": ["text-extensions@1.9.0", "", {}, "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="],
-
     "thingies": ["thingies@2.5.0", "", { "peerDependencies": { "tslib": "^2" } }, "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw=="],
-
-    "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
     "through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
 
@@ -4364,7 +4218,7 @@
 
     "tldts-core": ["tldts-core@7.0.26", "", {}, "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew=="],
 
-    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+    "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -4384,15 +4238,11 @@
 
     "tree-dump": ["tree-dump@1.1.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA=="],
 
-    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
-
     "treeify": ["treeify@1.1.0", "", {}, "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="],
 
     "treeverse": ["treeverse@3.0.0", "", {}, "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
-
-    "trim-newlines": ["trim-newlines@3.0.1", "", {}, "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
@@ -4415,8 +4265,6 @@
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typed-rest-client": ["typed-rest-client@2.1.0", "", { "dependencies": { "des.js": "^1.1.0", "js-md4": "^0.3.2", "qs": "^6.10.3", "tunnel": "0.0.6", "underscore": "^1.12.1" } }, "sha512-Nel9aPbgSzRxfs1+4GoSB4wexCF+4Axlk7OSGVQCMa+4fWcyxIsN/YNmkp0xTT2iQzMD98h8yFLav/cNaULmRA=="],
-
-    "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
     "typedarray-to-buffer": ["typedarray-to-buffer@3.1.5", "", { "dependencies": { "is-typedarray": "^1.0.0" } }, "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q=="],
 
@@ -4466,7 +4314,7 @@
 
     "untildify": ["untildify@4.0.0", "", {}, "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="],
 
-    "upath": ["upath@2.0.1", "", {}, "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w=="],
+    "upath": ["upath@3.0.8", "", {}, "sha512-YAsrLMIlhfSCm9rga5TZsJ1mXgahs7N0qOTokzU8mFz35hUrYMvVkaEPefI3rEb/vkAWAOj1Km/qdije9RC1kQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -4500,7 +4348,7 @@
 
     "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
 
-    "vitest-browser-svelte": ["vitest-browser-svelte@2.1.0", "", { "dependencies": { "@playwright/test": "^1.58.2", "@testing-library/svelte-core": "^1.0.0" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vitest": "^4.0.0" } }, "sha512-Uqcqn9gKhYoNOn5uGOQHSPIEGHgIz25zPP6R63LQ5+yEVHfDXdOKBMba9pBlPIgp31AxYbV9h43j9+W+5M5y+A=="],
+    "vitest-browser-svelte": ["vitest-browser-svelte@3.0.0", "", { "dependencies": { "@testing-library/svelte-core": "^1.1.3" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vitest": "^4.0.0" } }, "sha512-BKM9iBGNsEQzigWuSZFAiw6AJDqQqMttApoD8gM8LTI6vxfd423rDMN8GqUHJyGbhH3XcOo9N9u/4hu47Nxhsw=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -4518,19 +4366,17 @@
 
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
-    "which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+    "which": ["which@3.0.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg=="],
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
-
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -4556,11 +4402,13 @@
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
@@ -4576,11 +4424,55 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@alcalzone/ansi-tokenize/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "@alcalzone/ansi-tokenize/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "@asamuzakjp/dom-selector/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
+    "@aws-sdk/checksums/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/client-ec2/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/client-eks/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/core/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-cognito-identity/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-env/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-ini/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-login/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-node/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-process/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-sso/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/credential-provider-web-identity/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/middleware-sdk-ec2/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/middleware-sdk-rds/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/middleware-sdk-s3/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/nested-clients/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/signature-v4-multi-region/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/token-providers/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/types/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@aws-sdk/xml-builder/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -4626,6 +4518,10 @@
 
     "@cdktf/hcl2json/fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
 
+    "@chromatic-com/storybook/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "@conventional-changelog/git-client/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "@gar/promise-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
@@ -4645,6 +4541,14 @@
     "@jsonjoy.com/util/@jsonjoy.com/buffers": ["@jsonjoy.com/buffers@1.2.1", "", { "peerDependencies": { "tslib": "2" } }, "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA=="],
 
     "@lit-labs/ssr/@types/node": ["@types/node@16.18.126", "", {}, "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw=="],
+
+    "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
+
+    "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
+
+    "@npmcli/agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "@npmcli/agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "@npmcli/agent/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
@@ -4668,6 +4572,8 @@
 
     "@npmcli/git/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "@npmcli/git/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
     "@npmcli/map-workspaces/@npmcli/name-from-folder": ["@npmcli/name-from-folder@4.0.0", "", {}, "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg=="],
 
     "@npmcli/map-workspaces/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
@@ -4688,57 +4594,31 @@
 
     "@npmcli/package-json/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "@npmcli/promise-spawn/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
     "@npmcli/run-script/@npmcli/node-gyp": ["@npmcli/node-gyp@5.0.0", "", {}, "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ=="],
 
     "@npmcli/run-script/proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
-    "@nx/devkit/ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
+    "@npmcli/run-script/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
-    "@nx/devkit/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+    "@nx/devkit/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "@nx/devkit/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "@opentelemetry/instrumentation-bunyan/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.220.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w=="],
-
-    "@opentelemetry/instrumentation-bunyan/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw=="],
-
-    "@opentelemetry/instrumentation-bunyan/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
-
-    "@opentelemetry/instrumentation-redis/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw=="],
-
-    "@opentelemetry/instrumentation-redis/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
-
-    "@opentelemetry/resource-detector-aws/@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
-
-    "@opentelemetry/resource-detector-aws/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
-
-    "@opentelemetry/resource-detector-aws/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
-
-    "@opentelemetry/resource-detector-azure/@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
-
-    "@opentelemetry/resource-detector-azure/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
-
-    "@opentelemetry/resource-detector-azure/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
-
-    "@opentelemetry/resource-detector-gcp/@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
-
-    "@opentelemetry/resource-detector-gcp/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
+    "@nx/devkit/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "@opentelemetry/resource-detector-github/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
-
-    "@playwright/test/playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "@pnpm/parse-wanted-dependency/validate-npm-package-name": ["validate-npm-package-name@5.0.0", "", { "dependencies": { "builtins": "^5.0.0" } }, "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ=="],
 
     "@pnpm/read-project-manifest/@pnpm/error": ["@pnpm/error@4.0.0", "", { "dependencies": { "@pnpm/constants": "6.1.0" } }, "sha512-NI4DFCMF6xb1SA0bZiiV5KrMCaJM2QmPJFC6p78FXujn7FpiRSWhT9r032wpuQumsl7DEmN4s3wl/P8TA+bL8w=="],
 
-    "@renovatebot/detect-tools/fs-extra": ["fs-extra@11.3.6", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA=="],
+    "@pnpm/read-project-manifest/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
-    "@renovatebot/detect-tools/upath": ["upath@3.0.8", "", {}, "sha512-YAsrLMIlhfSCm9rga5TZsJ1mXgahs7N0qOTokzU8mFz35hUrYMvVkaEPefI3rEb/vkAWAOj1Km/qdije9RC1kQ=="],
+    "@renovatebot/detect-tools/fs-extra": ["fs-extra@11.4.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA=="],
 
     "@renovatebot/detect-tools/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@renovatebot/osv-offline/fs-extra": ["fs-extra@11.3.6", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA=="],
+    "@renovatebot/osv-offline/fs-extra": ["fs-extra@11.4.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA=="],
 
     "@renovatebot/osv-offline/got": ["got@15.1.0", "", { "dependencies": { "@sindresorhus/is": "^8.0.0", "byte-counter": "^0.1.0", "cacheable-lookup": "^7.0.0", "cacheable-request": "^13.0.18", "chunk-data": "^0.1.0", "decompress-response": "^10.0.0", "http2-wrapper": "^2.2.1", "keyv": "^5.6.0", "lowercase-keys": "^4.0.1", "responselike": "^4.0.2", "type-fest": "^5.6.0", "uint8array-extras": "^1.5.0" } }, "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA=="],
 
@@ -4750,6 +4630,18 @@
 
     "@sigstore/sign/proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
+    "@simple-libs/normalize-package-data/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "@smithy/core/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@smithy/credential-provider-imds/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@smithy/fetch-http-handler/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@smithy/node-http-handler/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@smithy/signature-v4/@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
     "@storybook/builder-vite/@storybook/csf-plugin": ["@storybook/csf-plugin@10.3.1", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.3.1", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-P1WUSoyueV+ULpNeip4eIjjDvOXDBQI4gaq/s1PdAg1Szz/0GhDPu/CXuwukgkmyHaJP3aVR3pHPvSfeLfMCrA=="],
 
     "@storybook/csf/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
@@ -4758,15 +4650,17 @@
 
     "@storybook/svelte/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
-    "@storybook/svelte-vite/@storybook/svelte": ["@storybook/svelte@10.3.1", "", { "dependencies": { "ts-dedent": "^2.0.0", "type-fest": "~2.19" }, "peerDependencies": { "storybook": "^10.3.1", "svelte": "^5.0.0" } }, "sha512-jDrOazSSwEiWDTKq3yTjVsbahk87JTiZZIdS7LuPK7PqsHFJOodu+ixF8xwG95X3GzbOL4FDqt5JCbeKpAn9/A=="],
+    "@storybook/svelte-vite/@storybook/builder-vite": ["@storybook/builder-vite@10.5.8", "", { "dependencies": { "@storybook/csf-plugin": "10.5.8", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.5.8", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-UeRnn7yT55WmBlHNOQzLrvN7vsHEvVgIukhKDO+4cMbGXN87wZkbxhx6NstpuXRH8OxGqwKS0SZNVp+SC1ftLQ=="],
+
+    "@storybook/svelte-vite/@storybook/svelte": ["@storybook/svelte@10.5.8", "", { "dependencies": { "ts-dedent": "^2.0.0", "type-fest": "^5.6.0" }, "peerDependencies": { "storybook": "^10.5.8", "svelte": "^5.0.0" } }, "sha512-bos9R5e4eIN9IDETnkOQD5wVnqdHkzEnYY1QO3El9Qw+r0QREBu0wyq43763OEOQF0mI2rzT/kuCYleBmrYaLA=="],
 
     "@storybook/sveltekit/@storybook/builder-vite": ["@storybook/builder-vite@10.5.8", "", { "dependencies": { "@storybook/csf-plugin": "10.5.8", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.5.8", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-UeRnn7yT55WmBlHNOQzLrvN7vsHEvVgIukhKDO+4cMbGXN87wZkbxhx6NstpuXRH8OxGqwKS0SZNVp+SC1ftLQ=="],
 
     "@storybook/sveltekit/@storybook/svelte": ["@storybook/svelte@10.5.8", "", { "dependencies": { "ts-dedent": "^2.0.0", "type-fest": "^5.6.0" }, "peerDependencies": { "storybook": "^10.5.8", "svelte": "^5.0.0" } }, "sha512-bos9R5e4eIN9IDETnkOQD5wVnqdHkzEnYY1QO3El9Qw+r0QREBu0wyq43763OEOQF0mI2rzT/kuCYleBmrYaLA=="],
 
-    "@storybook/sveltekit/@storybook/svelte-vite": ["@storybook/svelte-vite@10.5.8", "", { "dependencies": { "@storybook/builder-vite": "10.5.8", "@storybook/svelte": "10.5.8", "magic-string": "^0.30.0", "svelte2tsx": "^0.7.55", "typescript": "^4.9.4 || ^5.0.0" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "storybook": "^10.5.8", "svelte": "^5.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-fWM3GGtk5iAJqMj7CUcYvUn0NxE3aSvz2DlAz+LGVKrIolWscmt/71lPsCobIDl45+CNdc8G7qFNEODAd/IKVA=="],
-
     "@sveltejs/package/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@sveltejs/package/svelte2tsx": ["svelte2tsx@0.7.52", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0" } }, "sha512-svdT1FTrCLpvlU62evO5YdJt/kQ7nxgQxII/9BpQUvKr+GJRVdAXNVw8UWOt0fhoe5uWKyU0WsUTMRVAtRbMQg=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
@@ -4792,8 +4686,6 @@
 
     "@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
 
-    "@yarnpkg/core/@yarnpkg/parsers": ["@yarnpkg/parsers@3.0.3", "", { "dependencies": { "js-yaml": "^3.10.0", "tslib": "^2.4.0" } }, "sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg=="],
-
     "@yarnpkg/core/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@yarnpkg/core/diff": ["diff@5.2.2", "", {}, "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="],
@@ -4802,13 +4694,11 @@
 
     "@yarnpkg/core/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "@yarnpkg/core/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "@yarnpkg/parsers/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
     "@yarnpkg/shell/@yarnpkg/parsers": ["@yarnpkg/parsers@3.0.3", "", { "dependencies": { "js-yaml": "^3.10.0", "tslib": "^2.4.0" } }, "sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg=="],
 
     "@yarnpkg/shell/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "aggregate-error/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -4818,7 +4708,11 @@
 
     "bin-links/write-file-atomic": ["write-file-atomic@6.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ=="],
 
+    "brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "builtins/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "bundle-name/run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "cacache/@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
 
@@ -4832,37 +4726,25 @@
 
     "cacheable-request/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
-    "camelcase-keys/quick-lru": ["quick-lru@4.0.1", "", {}, "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="],
-
     "cli-truncate/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
-
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
-    "columnify/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "conventional-changelog-writer/handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
-
-    "conventional-changelog-writer/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "conventional-changelog-writer/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "copyfiles/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+
+    "cosmiconfig/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "css/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "cssstyle/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "decamelize-keys/map-obj": ["map-obj@1.0.1", "", {}, "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg=="],
+    "default-browser/default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "editorconfig/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -4870,21 +4752,15 @@
 
     "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
-    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+    "es-set-tostringtag/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
-    "front-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
-    "get-pkg-repo/hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
-
-    "get-pkg-repo/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
-
-    "git-semver-tags/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "get-intrinsic/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "global-agent/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -4892,11 +4768,11 @@
 
     "got/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "handlebars/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
+    "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ignore-walk/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
@@ -4904,9 +4780,13 @@
 
     "init-package-json/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "ink/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "ink/cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
 
     "ink/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
+
+    "ink/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "ink-select-input/figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
@@ -4914,31 +4794,23 @@
 
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "is-ci/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
+    "is-core-module/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+    "is-regex/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "jest-diff/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "jest-diff/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
+    "jsdom/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "json-stable-stringify/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
-    "jwa/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "jws/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "lerna/chalk": ["chalk@4.1.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A=="],
-
     "libnpmpublish/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "load-json-file/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
     "load-json-file/type-fest": ["type-fest@0.6.0", "", {}, "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="],
 
     "log-symbols/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "log-symbols/is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
     "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -4952,15 +4824,9 @@
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "meow/read-pkg-up": ["read-pkg-up@7.0.1", "", { "dependencies": { "find-up": "^4.1.0", "read-pkg": "^5.2.0", "type-fest": "^0.8.1" } }, "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg=="],
-
-    "meow/type-fest": ["type-fest@0.18.1", "", {}, "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="],
-
-    "meow/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
-
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "minimist-options/is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
+    "minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -4980,13 +4846,13 @@
 
     "node-gyp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "node-gyp/tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
+
     "node-gyp/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
+    "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
     "noms/readable-stream": ["readable-stream@1.0.34", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.1", "isarray": "0.0.1", "string_decoder": "~0.10.x" } }, "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg=="],
-
-    "normalize-package-data/hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
-
-    "normalize-package-data/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "npm-install-checks/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -5000,15 +4866,19 @@
 
     "npm-pick-manifest/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "nx/ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
+    "nx/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "nx/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+    "nx/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "nx/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
+
+    "open/default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "open/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "ora/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "ora/cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
-
-    "ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "p-all/p-map": ["p-map@6.0.0", "", {}, "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw=="],
 
@@ -5023,6 +4893,8 @@
     "pacote/cacache": ["cacache@20.0.3", "", { "dependencies": { "@npmcli/fs": "^5.0.0", "fs-minipass": "^3.0.0", "glob": "^13.0.0", "lru-cache": "^11.1.0", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^13.0.0", "unique-filename": "^5.0.0" } }, "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw=="],
 
     "pacote/npm-pick-manifest": ["npm-pick-manifest@10.0.0", "", { "dependencies": { "npm-install-checks": "^7.1.0", "npm-normalize-package-bin": "^4.0.0", "npm-package-arg": "^12.0.0", "semver": "^7.3.5" } }, "sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ=="],
+
+    "pacote/tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
 
     "parse-conflict-json/json-parse-even-better-errors": ["json-parse-even-better-errors@4.0.0", "", {}, "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA=="],
 
@@ -5044,19 +4916,17 @@
 
     "patch-package/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "patch-package/slash": ["slash@2.0.0", "", {}, "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="],
+    "patch-package/tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+
+    "patch-package/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "path/util": ["util@0.10.4", "", { "dependencies": { "inherits": "2.0.3" } }, "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "path-type/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
-
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
-    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -5068,23 +4938,19 @@
 
     "react-devtools-core/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
 
-    "read-pkg/load-json-file": ["load-json-file@4.0.0", "", { "dependencies": { "graceful-fs": "^4.1.2", "parse-json": "^4.0.0", "pify": "^3.0.0", "strip-bom": "^3.0.0" } }, "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw=="],
+    "read-yaml-file/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "read-pkg/normalize-package-data": ["normalize-package-data@2.5.0", "", { "dependencies": { "hosted-git-info": "^2.1.4", "resolve": "^1.10.0", "semver": "2 || 3 || 4 || 5", "validate-npm-package-license": "^3.0.1" } }, "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA=="],
-
-    "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
-
-    "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "read-yaml-file/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
-    "renovate/@yarnpkg/parsers": ["@yarnpkg/parsers@3.0.3", "", { "dependencies": { "js-yaml": "^3.10.0", "tslib": "^2.4.0" } }, "sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg=="],
+    "renovate/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "renovate/execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
-    "renovate/fs-extra": ["fs-extra@11.3.6", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA=="],
+    "renovate/fs-extra": ["fs-extra@11.4.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA=="],
 
     "renovate/git-url-parse": ["git-url-parse@16.1.0", "", { "dependencies": { "git-up": "^8.1.0" } }, "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw=="],
 
@@ -5094,19 +4960,15 @@
 
     "renovate/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
-    "renovate/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "renovate/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "renovate/p-map": ["p-map@7.0.6", "", {}, "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg=="],
 
-    "renovate/p-queue": ["p-queue@9.3.1", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw=="],
+    "renovate/p-queue": ["p-queue@9.3.3", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA=="],
 
     "renovate/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "renovate/upath": ["upath@3.0.8", "", {}, "sha512-YAsrLMIlhfSCm9rga5TZsJ1mXgahs7N0qOTokzU8mFz35hUrYMvVkaEPefI3rEb/vkAWAOj1Km/qdije9RC1kQ=="],
-
     "renovate/validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
-
-    "renovate/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "renovate/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
@@ -5120,13 +4982,17 @@
 
     "semver-stable/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
-    "sort-keys/is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
+    "socks-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "sort-keys/is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -5138,18 +5004,6 @@
 
     "storybook/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "style-dictionary/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "stylus/debug": ["debug@3.1.0", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="],
@@ -5157,6 +5011,8 @@
     "stylus/sax": ["sax@1.2.4", "", {}, "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="],
 
     "stylus/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "stylus/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "svelte/aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
@@ -5170,15 +5026,13 @@
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "terser/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "through2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
-
-    "tsconfig-paths/strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "tsx/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "tuf-js/make-fetch-happen": ["make-fetch-happen@15.0.5", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/agent": "^4.0.0", "@npmcli/redact": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^6.0.0", "ssri": "^13.0.0" } }, "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "url/punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
@@ -5194,17 +5048,15 @@
 
     "widest-line/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
-    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "write-yaml-file/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "write-yaml-file/write-file-atomic": ["write-file-atomic@3.0.3", "", { "dependencies": { "imurmurhash": "^0.1.4", "is-typedarray": "^1.0.0", "signal-exit": "^3.0.2", "typedarray-to-buffer": "^3.1.5" } }, "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="],
 
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "xmldoc/sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -5214,7 +5066,15 @@
 
     "@bundled-es-modules/glob/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
+
     "@canonical/svelte-ds-app-launchpad/@canonical/design-tokens/@canonical/terrazzo-lsp": ["@canonical/terrazzo-lsp@0.6.0", "", { "dependencies": { "@canonical/token-types": "^0.6.0", "@lezer/common": "^1.3.0", "@lezer/css": "^1.3.0", "colorjs.io": "^0.6.1" }, "bin": { "terrazzo-lsp": "dist/esm/cli.js" } }, "sha512-6b8IsmRF9VJJ6zWyz6XDZxm65tjWPnl5dce/abM2tRJaeBV3ewDLnSWS/BPoHhqDBEFTdo8Rb7o5mg44RzKN7A=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
 
     "@canonical/svelte-ds-app/@canonical/design-tokens/@canonical/terrazzo-lsp": ["@canonical/terrazzo-lsp@0.6.0", "", { "dependencies": { "@canonical/token-types": "^0.6.0", "@lezer/common": "^1.3.0", "@lezer/css": "^1.3.0", "colorjs.io": "^0.6.1" }, "bin": { "terrazzo-lsp": "dist/esm/cli.js" } }, "sha512-6b8IsmRF9VJJ6zWyz6XDZxm65tjWPnl5dce/abM2tRJaeBV3ewDLnSWS/BPoHhqDBEFTdo8Rb7o5mg44RzKN7A=="],
 
@@ -5224,9 +5084,7 @@
 
     "@canonical/svelte-ds-global/@canonical/design-tokens/@canonical/terrazzo-lsp": ["@canonical/terrazzo-lsp@0.6.0", "", { "dependencies": { "@canonical/token-types": "^0.6.0", "@lezer/common": "^1.3.0", "@lezer/css": "^1.3.0", "colorjs.io": "^0.6.1" }, "bin": { "terrazzo-lsp": "dist/esm/cli.js" } }, "sha512-6b8IsmRF9VJJ6zWyz6XDZxm65tjWPnl5dce/abM2tRJaeBV3ewDLnSWS/BPoHhqDBEFTdo8Rb7o5mg44RzKN7A=="],
 
-    "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "@chromatic-com/storybook/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@joshwooding/vite-plugin-react-docgen-typescript/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
@@ -5239,6 +5097,8 @@
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack/@jsonjoy.com/json-pointer": ["@jsonjoy.com/json-pointer@17.67.0", "", { "dependencies": { "@jsonjoy.com/util": "17.67.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA=="],
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
+
+    "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
 
     "@npmcli/arborist/cacache/@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
 
@@ -5256,6 +5116,10 @@
 
     "@npmcli/arborist/pacote/ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
+    "@npmcli/arborist/pacote/tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
+
+    "@npmcli/git/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
     "@npmcli/map-workspaces/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
     "@npmcli/metavuln-calculator/cacache/@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
@@ -5272,29 +5136,29 @@
 
     "@npmcli/metavuln-calculator/pacote/ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
+    "@npmcli/metavuln-calculator/pacote/tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
+
     "@npmcli/package-json/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
-    "@nx/devkit/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+    "@npmcli/promise-spawn/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
-    "@opentelemetry/instrumentation-redis/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.220.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w=="],
+    "@npmcli/run-script/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
-    "@opentelemetry/resource-detector-gcp/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
-
-    "@opentelemetry/resource-detector-gcp/@opentelemetry/resources/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+    "@nx/devkit/minimatch/brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "@opentelemetry/resource-detector-github/@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
 
     "@opentelemetry/resource-detector-github/@opentelemetry/resources/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
-
-    "@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
-    "@playwright/test/playwright/playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "@pnpm/read-project-manifest/@pnpm/error/@pnpm/constants": ["@pnpm/constants@6.1.0", "", {}, "sha512-L6AiU3OXv9kjKGTJN9j8n1TeJGDcLX9atQlZvAkthlvbXjvKc5SKNWESc/eXhr5nEfuMWhQhiKHDJCpYejmeCQ=="],
 
     "@renovatebot/osv-offline/got/lowercase-keys": ["lowercase-keys@4.0.1", "", {}, "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg=="],
 
     "@renovatebot/osv-offline/got/type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -5306,13 +5170,13 @@
 
     "@sigstore/sign/make-fetch-happen/ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
-    "@storybook/svelte-vite/@storybook/svelte/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
+    "@storybook/svelte-vite/@storybook/builder-vite/@storybook/csf-plugin": ["@storybook/csf-plugin@10.5.8", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.5.8", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-/FHiMyOWWEXfwK/lM0WxmkP9GLzbSJJuzGtfeuNWSOVDnvAMbjavitxfHb5wSbWKIQo0XYC1EJ2Y7x91XNYP4w=="],
+
+    "@storybook/svelte-vite/@storybook/svelte/type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
 
     "@storybook/sveltekit/@storybook/builder-vite/@storybook/csf-plugin": ["@storybook/csf-plugin@10.5.8", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.5.8", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-/FHiMyOWWEXfwK/lM0WxmkP9GLzbSJJuzGtfeuNWSOVDnvAMbjavitxfHb5wSbWKIQo0XYC1EJ2Y7x91XNYP4w=="],
 
     "@storybook/sveltekit/@storybook/svelte/type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
-
-    "@storybook/sveltekit/@storybook/svelte-vite/svelte2tsx": ["svelte2tsx@0.7.61", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0 || ^6.0.0" } }, "sha512-EpQ/+UHITBULeUojx/LLD3uTYasZXcX1BrqlrzfLUnT9vdUhaOWK59a3ryWcFU8L0sY1SP+gRhJ2Beiis98+qw=="],
 
     "@tufjs/models/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
@@ -5336,10 +5200,6 @@
 
     "@vitest/coverage-v8/vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
-    "@yarnpkg/core/@yarnpkg/parsers/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
-    "@yarnpkg/core/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "@yarnpkg/core/got/@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@yarnpkg/core/got/cacheable-lookup": ["cacheable-lookup@5.0.4", "", {}, "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="],
@@ -5356,13 +5216,9 @@
 
     "@yarnpkg/core/got/responselike": ["responselike@2.0.1", "", { "dependencies": { "lowercase-keys": "^2.0.0" } }, "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw=="],
 
-    "@yarnpkg/core/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "@yarnpkg/parsers/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
     "@yarnpkg/shell/@yarnpkg/parsers/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "@yarnpkg/shell/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "bin-links/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -5372,13 +5228,7 @@
 
     "cacheable-request/get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "columnify/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "conventional-changelog-writer/handlebars/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "copyfiles/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
@@ -5386,35 +5236,27 @@
 
     "cross-fetch/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
     "editorconfig/minimatch/brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
-    "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "front-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "get-pkg-repo/hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
-    "get-pkg-repo/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
-
-    "get-pkg-repo/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+    "gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ignore-walk/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
+    "ink-select-input/figures/is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
     "ink/cli-cursor/restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
-    "jest-diff/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ink/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "jest-diff/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+    "ink/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "ink/wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "jsdom/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "lerna/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "log-symbols/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "make-fetch-happen/cacache/@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
 
@@ -5426,11 +5268,7 @@
 
     "make-fetch-happen/cacache/ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
-    "meow/read-pkg-up/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
-    "meow/read-pkg-up/read-pkg": ["read-pkg@5.2.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.0", "normalize-package-data": "^2.5.0", "parse-json": "^5.0.0", "type-fest": "^0.6.0" } }, "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg=="],
-
-    "meow/read-pkg-up/type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
+    "minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
@@ -5440,15 +5278,13 @@
 
     "node-gyp/nopt/abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
 
+    "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
     "noms/readable-stream/string_decoder": ["string_decoder@0.10.31", "", {}, "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="],
 
-    "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+    "nx/minimatch/brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
-    "nx/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
-
-    "ora/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "ora/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "open/default-browser/default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
 
     "pacote/@npmcli/git/ini": ["ini@5.0.0", "", {}, "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw=="],
 
@@ -5474,7 +5310,9 @@
 
     "pacote/npm-pick-manifest/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "patch-package/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "patch-package/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "patch-package/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "path/util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
 
@@ -5486,25 +5324,13 @@
 
     "re2/node-gyp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "re2/node-gyp/tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
+
     "re2/node-gyp/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "re2/node-gyp/undici": ["undici@8.7.0", "", {}, "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ=="],
 
     "re2/node-gyp/which": ["which@7.0.0", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA=="],
-
-    "read-pkg-up/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
-
-    "read-pkg/load-json-file/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
-
-    "read-pkg/load-json-file/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
-
-    "read-pkg/load-json-file/strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
-
-    "read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@2.8.9", "", {}, "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="],
-
-    "read-pkg/normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
-
-    "renovate/@yarnpkg/parsers/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "renovate/execa/get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
 
@@ -5524,11 +5350,11 @@
 
     "renovate/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
-    "renovate/minimatch/brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
-
     "renovate/p-queue/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "renovate/p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
@@ -5536,17 +5362,15 @@
 
     "storybook/@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
-    "storybook/open/define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
-
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "storybook/open/default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
 
     "stylus/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "svelte-check/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "through2/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "through2/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "through2/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
@@ -5612,9 +5436,11 @@
 
     "tuf-js/make-fetch-happen/ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "vite-plugin-relay-lite/vite/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@bundled-es-modules/glob/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -5622,11 +5448,75 @@
 
     "@bundled-es-modules/glob/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
+
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
+
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
+
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
+
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
+
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
+
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
+
+    "@canonical/i18n-core/@canonical/biome-config/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
+
+    "@canonical/i18n-react/@canonical/biome-config/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
+
+    "@canonical/react-hooks/@canonical/biome-config/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
+
     "@canonical/svelte-ds-app-launchpad/@canonical/design-tokens/@canonical/terrazzo-lsp/@canonical/token-types": ["@canonical/token-types@0.6.0", "", {}, "sha512-bjsXhcipaOUfG5KNZhy0QHdxdDJPjM3tVH0RAQ7KXZGEIOBPR6RY47Du2pV+/Xq4bX1qCMUWBWKDTh/y1a1izQ=="],
 
     "@canonical/svelte-ds-app-launchpad/@canonical/design-tokens/@canonical/terrazzo-lsp/@lezer/css": ["@lezer/css@1.3.2", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-tRZAPl1j0pkmPL/pGG85GAbyQYnYv0j6UEdEt5e4ZYvp+OxDu2zVp2c/YddiuO8ZTa2CHsVELqRd/fGWjlISrg=="],
 
     "@canonical/svelte-ds-app-launchpad/@canonical/design-tokens/@canonical/terrazzo-lsp/colorjs.io": ["colorjs.io@0.6.1", "", {}, "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome/@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
+
+    "@canonical/svelte-ds-app/@canonical/biome-config/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
 
     "@canonical/svelte-ds-app/@canonical/design-tokens/@canonical/terrazzo-lsp/@canonical/token-types": ["@canonical/token-types@0.6.0", "", {}, "sha512-bjsXhcipaOUfG5KNZhy0QHdxdDJPjM3tVH0RAQ7KXZGEIOBPR6RY47Du2pV+/Xq4bX1qCMUWBWKDTh/y1a1izQ=="],
 
@@ -5641,8 +5531,6 @@
     "@canonical/svelte-ds-global/@canonical/design-tokens/@canonical/terrazzo-lsp/@lezer/css": ["@lezer/css@1.3.2", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-tRZAPl1j0pkmPL/pGG85GAbyQYnYv0j6UEdEt5e4ZYvp+OxDu2zVp2c/YddiuO8ZTa2CHsVELqRd/fGWjlISrg=="],
 
     "@canonical/svelte-ds-global/@canonical/design-tokens/@canonical/terrazzo-lsp/colorjs.io": ["colorjs.io@0.6.1", "", {}, "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg=="],
-
-    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@joshwooding/vite-plugin-react-docgen-typescript/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
@@ -5664,6 +5552,8 @@
 
     "@nx/devkit/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
     "@sigstore/sign/make-fetch-happen/cacache/@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
 
     "@sigstore/sign/make-fetch-happen/cacache/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
@@ -5678,8 +5568,6 @@
 
     "@vitest/coverage-v8/@vitest/browser/@vitest/mocker/@vitest/spy": ["@vitest/spy@4.1.0", "", {}, "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw=="],
 
-    "@yarnpkg/core/@yarnpkg/parsers/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
     "@yarnpkg/core/got/cacheable-request/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
     "@yarnpkg/core/got/cacheable-request/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
@@ -5688,15 +5576,11 @@
 
     "@yarnpkg/core/got/decompress-response/mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
-    "@yarnpkg/parsers/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
     "@yarnpkg/shell/@yarnpkg/parsers/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "cacache/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
-    "copyfiles/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "copyfiles/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "cross-fetch/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
@@ -5704,27 +5588,17 @@
 
     "editorconfig/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "front-matter/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
-    "get-pkg-repo/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "get-pkg-repo/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "get-pkg-repo/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "ignore-walk/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "ink/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ink/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "ink/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "make-fetch-happen/cacache/@npmcli/fs/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "make-fetch-happen/cacache/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
-
-    "meow/read-pkg-up/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "meow/read-pkg-up/read-pkg/normalize-package-data": ["normalize-package-data@2.5.0", "", { "dependencies": { "hosted-git-info": "^2.1.4", "resolve": "^1.10.0", "semver": "2 || 3 || 4 || 5", "validate-npm-package-license": "^3.0.1" } }, "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA=="],
-
-    "meow/read-pkg-up/read-pkg/type-fest": ["type-fest@0.6.0", "", {}, "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="],
-
-    "normalize-package-data/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "nx/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -5742,11 +5616,7 @@
 
     "re2/node-gyp/nopt/abbrev": ["abbrev@5.0.0", "", {}, "sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w=="],
 
-    "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
-
-    "read-pkg-up/find-up/locate-path/path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
-
-    "renovate/@yarnpkg/parsers/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+    "re2/node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "renovate/execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
@@ -5756,9 +5626,9 @@
 
     "renovate/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
-    "renovate/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
     "storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "storybook/open/default-browser/default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
 
     "tuf-js/make-fetch-happen/cacache/@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
 
@@ -5770,9 +5640,15 @@
 
     "tuf-js/make-fetch-happen/minipass-fetch/minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
 
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "@bundled-es-modules/glob/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
+    "@bundled-es-modules/glob/glob/jackspeak/@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
     "@bundled-es-modules/glob/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@bundled-es-modules/glob/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@canonical/svelte-ds-app/@canonical/styles/@canonical/design-tokens/@canonical/terrazzo-lsp/@canonical/token-types": ["@canonical/token-types@0.6.0", "", {}, "sha512-bjsXhcipaOUfG5KNZhy0QHdxdDJPjM3tVH0RAQ7KXZGEIOBPR6RY47Du2pV+/Xq4bX1qCMUWBWKDTh/y1a1izQ=="],
 
@@ -5790,35 +5666,15 @@
 
     "@sigstore/sign/make-fetch-happen/cacache/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
-    "@yarnpkg/core/@yarnpkg/parsers/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
     "@yarnpkg/shell/@yarnpkg/parsers/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "cacache/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "copyfiles/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "copyfiles/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "get-pkg-repo/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "get-pkg-repo/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "make-fetch-happen/cacache/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
-
-    "meow/read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "meow/read-pkg-up/read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@2.8.9", "", {}, "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="],
-
-    "meow/read-pkg-up/read-pkg/normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "pacote/cacache/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
     "pacote/npm-pick-manifest/npm-package-arg/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
-
-    "renovate/@yarnpkg/parsers/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "renovate/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -5828,6 +5684,10 @@
 
     "@bundled-es-modules/glob/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
+    "@bundled-es-modules/glob/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@bundled-es-modules/glob/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "@npmcli/metavuln-calculator/cacache/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@sigstore/sign/make-fetch-happen/cacache/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
@@ -5835,8 +5695,6 @@
     "make-fetch-happen/cacache/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "pacote/cacache/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "read-pkg-up/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
 
     "tuf-js/make-fetch-happen/cacache/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 

--- a/configs/biome/biome.json
+++ b/configs/biome/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -40,6 +40,16 @@
         "rules": {
           "correctness": {
             "useUniqueElementIds": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.svg"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "noSvgWithoutTitle": "off"
           }
         }
       }

--- a/configs/biome/package.json
+++ b/configs/biome/package.json
@@ -25,9 +25,9 @@
     "check:biome:fix": "biome check --write *.json"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9"
+    "@biomejs/biome": "2.5.10"
   },
   "peerDependencies": {
-    "@biomejs/biome": "2.4.9"
+    "@biomejs/biome": "2.5.10"
   }
 }

--- a/configs/renovate/package.json
+++ b/configs/renovate/package.json
@@ -28,7 +28,7 @@
     "test": "bun run check:renovate"
   },
   "devDependencies": {
-    "renovate": "43.288.0"
+    "renovate": "44.46.4"
   },
   "renovate-config": {
     "default": {

--- a/configs/storybook/package.json
+++ b/configs/storybook/package.json
@@ -56,7 +56,7 @@
     "@storybook/web-components-vite": "^10.3.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@types/node": "^24.12.0",

--- a/configs/typescript-lit/package.json
+++ b/configs/typescript-lit/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "typescript": "^5.9.3"
   },

--- a/configs/typescript-react/package.json
+++ b/configs/typescript-react/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "typescript": "^5.9.3"
   },

--- a/configs/typescript-svelte/package.json
+++ b/configs/typescript-svelte/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0"
   },
   "peerDependencies": {

--- a/configs/typescript/package.json
+++ b/configs/typescript/package.json
@@ -26,7 +26,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "typescript": "^5.9.3"
   },

--- a/configs/vitest-config-react/package.json
+++ b/configs/vitest-config-react/package.json
@@ -42,7 +42,7 @@
     "vitest": "^4.0.18"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@types/node": "^24.12.0",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.18",
-    "lerna": "^9.0.5",
-    "nx": "^22.5.4"
+    "lerna": "^10.0.0",
+    "nx": "^23.0.0"
   },
   "msw": {
     "workerDirectory": [

--- a/packages/cli/pragma/package.json
+++ b/packages/cli/pragma/package.json
@@ -70,7 +70,7 @@
     "zod": "^3.25.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/anatomy-dsl": "^0.2.2",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",

--- a/packages/cli/pragma/src/capabilities/distribution.test.ts
+++ b/packages/cli/pragma/src/capabilities/distribution.test.ts
@@ -46,14 +46,18 @@ describe("the distribution's declared stories (PROTECTED)", () => {
     ]);
   });
 
-  it.each([
-    ...declaredStories.keys(),
-  ])("the %s story validates against the pack grammar, unchanged", (noun) => {
-    const story = declaredStories.get(noun);
-    expect(
-      parsePackDefinition(JSON.parse(JSON.stringify(story)), "pragma.conf.ts"),
-    ).toEqual(story);
-  });
+  it.each([...declaredStories.keys()])(
+    "the %s story validates against the pack grammar, unchanged",
+    (noun) => {
+      const story = declaredStories.get(noun);
+      expect(
+        parsePackDefinition(
+          JSON.parse(JSON.stringify(story)),
+          "pragma.conf.ts",
+        ),
+      ).toEqual(story);
+    },
+  );
 
   it("every declared noun reaches the registry as an overridable module", () => {
     for (const noun of declaredStories.keys()) {

--- a/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
+++ b/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
@@ -91,29 +91,26 @@ const PACK_LISTS: readonly { pack: PackDefinition; hint: RegExp }[] = [
 const REAL = { dryRun: false, undo: false, yes: false };
 
 describe("pack list empty-state (U5, PROTECTED)", () => {
-  it.each(
-    PACK_LISTS,
-  )("$pack.noun list on an empty store returns [] — never throws", async ({
-    pack,
-  }) => {
-    await expect(listVerb(pack).run({}, rt)).resolves.toEqual([]);
-  });
+  it.each(PACK_LISTS)(
+    "$pack.noun list on an empty store returns [] — never throws",
+    async ({ pack }) => {
+      await expect(listVerb(pack).run({}, rt)).resolves.toEqual([]);
+    },
+  );
 
-  it.each(
-    PACK_LISTS,
-  )("$pack.noun list renders a non-blank message (+ hint) and keeps JSON []", ({
-    pack,
-    hint,
-  }) => {
-    const { formatters } = listVerb(pack).output;
-    const plain = formatters.plain([]);
-    expect(plain).toContain(`No ${pack.noun} entries found.`);
-    expect(plain).toMatch(hint);
-    // JSON is the uniform empty array — unchanged by the message.
-    expect(formatters.json([])).toBe("[]");
-    // The llm view stays non-blank too (the `(0)` heading plus the message).
-    expect(formatters.llm([]).trim().length).toBeGreaterThan(0);
-  });
+  it.each(PACK_LISTS)(
+    "$pack.noun list renders a non-blank message (+ hint) and keeps JSON []",
+    ({ pack, hint }) => {
+      const { formatters } = listVerb(pack).output;
+      const plain = formatters.plain([]);
+      expect(plain).toContain(`No ${pack.noun} entries found.`);
+      expect(plain).toMatch(hint);
+      // JSON is the uniform empty array — unchanged by the message.
+      expect(formatters.json([])).toBe("[]");
+      // The llm view stays non-blank too (the `(0)` heading plus the message).
+      expect(formatters.llm([]).trim().length).toBeGreaterThan(0);
+    },
+  );
 
   it("dispatch prints the empty message on stdout and exits 0 (end-to-end)", async () => {
     const outcome = await executeVerb(

--- a/packages/cli/pragma/src/capabilities/resources/provider.ts
+++ b/packages/cli/pragma/src/capabilities/resources/provider.ts
@@ -91,7 +91,7 @@ export function buildResourceList(
   // readPackIndex returns raw JSON.parse output (no zod), so guard structurally:
   // a malformed index missing `version` must degrade to the recovery hint, not
   // fall through to `[...index.entities]` (a TypeError inside the MCP handler).
-  if (!index || index.version !== 2 || !Array.isArray(index.entities)) {
+  if (index?.version !== 2 || !Array.isArray(index.entities)) {
     return [
       {
         uri: "pragma:sources",

--- a/packages/cli/pragma/src/kernel/completion/shellDrive.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/shellDrive.test.ts
@@ -389,17 +389,16 @@ describe("generated bash — the live grammar's script", () => {
     expect(parses("bash", fixture.bash)).toBe(0);
   });
 
-  it.each(STRUCTURE)("answers $at from the inlined table, execing nothing", ({
-    words,
-    cword,
-    offers,
-  }) => {
-    const { reply, calls } = driveBash(live.bash, words, cword);
-    expect(reply.sort()).toEqual([...offers].sort());
-    // The structural tier is the point of a generated script: a TAB here
-    // must never cost a process spawn, nor depend on a pack being built.
-    expect(calls).toEqual([]);
-  });
+  it.each(STRUCTURE)(
+    "answers $at from the inlined table, execing nothing",
+    ({ words, cword, offers }) => {
+      const { reply, calls } = driveBash(live.bash, words, cword);
+      expect(reply.sort()).toEqual([...offers].sort());
+      // The structural tier is the point of a generated script: a TAB here
+      // must never cost a process spawn, nor depend on a pack being built.
+      expect(calls).toEqual([]);
+    },
+  );
 
   it("hands __complete the protocol argv and OFFERS what it answers", () => {
     // The last mile, and the only assertion that covers it: everything else
@@ -468,17 +467,14 @@ describe.skipIf(!hasShell("zsh"))(
     // test below, and the other five are asserted as the exact sets zsh really
     // returns. An `arrayContaining` here would be blind to the regression this
     // file exists to catch — a slot that offers EXTRA, wrong candidates.
-    it.each(
-      STRUCTURE.filter((row) => row.at !== "pragma co"),
-    )("OFFERS exactly the candidates for $at, execing nothing", ({
-      words,
-      cword,
-      offers,
-    }) => {
-      const { reply, calls } = driveZsh(live.zsh, words, cword);
-      expect(reply.sort()).toEqual([...offers].sort());
-      expect(calls).toEqual([]);
-    });
+    it.each(STRUCTURE.filter((row) => row.at !== "pragma co"))(
+      "OFFERS exactly the candidates for $at, execing nothing",
+      ({ words, cword, offers }) => {
+        const { reply, calls } = driveZsh(live.zsh, words, cword);
+        expect(reply.sort()).toEqual([...offers].sort());
+        expect(calls).toEqual([]);
+      },
+    );
 
     it("offers the WHOLE noun table for a partial noun, leaving the filtering to zsh", () => {
       const { reply, calls } = driveZsh(live.zsh, ["pragma", "co"], 1);
@@ -540,14 +536,14 @@ describe.skipIf(!hasShell("fish"))(
         line: "pragma --format=",
         offers: ["--format=json", "--format=llm", "--format=plain"],
       },
-    ])("answers $line from the inlined rules, execing nothing", ({
-      line,
-      offers,
-    }) => {
-      const { reply, calls } = driveFish(live.fish, line);
-      expect(reply.sort()).toEqual([...offers].sort());
-      expect(calls).toEqual([]);
-    });
+    ])(
+      "answers $line from the inlined rules, execing nothing",
+      ({ line, offers }) => {
+        const { reply, calls } = driveFish(live.fish, line);
+        expect(reply.sort()).toEqual([...offers].sort());
+        expect(calls).toEqual([]);
+      },
+    );
 
     it("hands __complete the SAME protocol argv bash does, and OFFERS the answer", () => {
       const { reply, calls } = driveFish(

--- a/packages/cli/pragma/src/testing/behavioral/agentSession.mcp.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/agentSession.mcp.test.ts
@@ -55,48 +55,52 @@ afterAll(async () => {
 });
 
 describe("agent session — list, pick, lookup (B1)", () => {
-  it.each(
-    browsableNouns,
-  )("%s: list -> pick first -> lookup resolves it", async (noun) => {
-    const list = await mcp.callTool(`${noun}_list`);
-    expect(list.ok).toBe(true);
-    const rows = list.data as { name: string }[];
-    expect(rows.length).toBeGreaterThan(0);
-    const first = rows[0] as { name: string };
+  it.each(browsableNouns)(
+    "%s: list -> pick first -> lookup resolves it",
+    async (noun) => {
+      const list = await mcp.callTool(`${noun}_list`);
+      expect(list.ok).toBe(true);
+      const rows = list.data as { name: string }[];
+      expect(rows.length).toBeGreaterThan(0);
+      const first = rows[0] as { name: string };
 
-    const lookup = await mcp.callTool(`${noun}_lookup`, { name: [first.name] });
-    expect(lookup.ok).toBe(true);
-    const data = lookup.data as {
-      results: { name: string }[];
-      errors: unknown[];
-    };
-    expect(data.errors).toEqual([]);
-    expect(data.results[0]?.name).toBe(first.name);
-  });
+      const lookup = await mcp.callTool(`${noun}_lookup`, {
+        name: [first.name],
+      });
+      expect(lookup.ok).toBe(true);
+      const data = lookup.data as {
+        results: { name: string }[];
+        errors: unknown[];
+      };
+      expect(data.errors).toEqual([]);
+      expect(data.results[0]?.name).toBe(first.name);
+    },
+  );
 
-  it.each(
-    browsableNouns,
-  )("%s: a BATCH lookup with one hit reports the miss without failing the call", async (noun) => {
-    // `makeLookupRun` (kernel/packs/runBodies.ts) throws on a TOTAL miss (see
-    // the errorMatrix.mcp.test.ts B3 suite) — a partial batch is the "miss
-    // reported, call not failed" shape (an ADAPTATION of the plan's B1/B3
-    // wording, which described a single-name miss; verified against the
-    // live behavior).
-    const list = await mcp.callTool(`${noun}_list`);
-    const rows = list.data as { name: string }[];
-    const known = (rows[0] as { name: string }).name;
+  it.each(browsableNouns)(
+    "%s: a BATCH lookup with one hit reports the miss without failing the call",
+    async (noun) => {
+      // `makeLookupRun` (kernel/packs/runBodies.ts) throws on a TOTAL miss (see
+      // the errorMatrix.mcp.test.ts B3 suite) — a partial batch is the "miss
+      // reported, call not failed" shape (an ADAPTATION of the plan's B1/B3
+      // wording, which described a single-name miss; verified against the
+      // live behavior).
+      const list = await mcp.callTool(`${noun}_list`);
+      const rows = list.data as { name: string }[];
+      const known = (rows[0] as { name: string }).name;
 
-    const result = await mcp.callTool(`${noun}_lookup`, {
-      name: [known, "zzz-definitely-not-a-real-entity"],
-    });
-    expect(result.ok).toBe(true);
-    const data = result.data as {
-      results: { name: string }[];
-      errors: { code: string }[];
-    };
-    expect(data.results[0]?.name).toBe(known);
-    expect(data.errors[0]?.code).toBe("ENTITY_NOT_FOUND");
-  });
+      const result = await mcp.callTool(`${noun}_lookup`, {
+        name: [known, "zzz-definitely-not-a-real-entity"],
+      });
+      expect(result.ok).toBe(true);
+      const data = result.data as {
+        results: { name: string }[];
+        errors: { code: string }[];
+      };
+      expect(data.results[0]?.name).toBe(known);
+      expect(data.errors[0]?.code).toBe("ENTITY_NOT_FOUND");
+    },
+  );
 });
 
 describe("agent session — the categories journey, if the live surface declares one (B1)", () => {

--- a/packages/cli/pragma/src/testing/behavioral/completion.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/completion.test.ts
@@ -65,12 +65,13 @@ describe("verb-level candidates: the SET matches the live surface", () => {
     expect(multiVerbNouns.length).toBeGreaterThan(0);
   });
 
-  it.each(
-    multiVerbNouns,
-  )("%s: candidates == its live verb set", async (noun, verbs) => {
-    const candidates = await runComplete([noun, ""], capabilities);
-    expect([...candidates].sort()).toEqual([...verbs].sort());
-  });
+  it.each(multiVerbNouns)(
+    "%s: candidates == its live verb set",
+    async (noun, verbs) => {
+      const candidates = await runComplete([noun, ""], capabilities);
+      expect([...candidates].sort()).toEqual([...verbs].sort());
+    },
+  );
 });
 
 describe("flags are kebab-cased at emission (the live, testable guarantee)", () => {

--- a/packages/cli/pragma/src/testing/behavioral/disclosure.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/disclosure.test.ts
@@ -69,47 +69,49 @@ describe("disclosure lookups declare the aligned canonical level set (B4)", () =
   // the full `[summary, standard, detailed]`, so a config `detail=standard` named
   // a level block never advertised. Every disclosure lookup now declares the same
   // canonical ladder; per-noun DEFAULTS may still differ (domain-tuned).
-  it.each(
-    disclosureLookupVerbs,
-  )("$noun: levels === the canonical ladder", (v) => {
-    expect(v.spec.disclosure?.levels).toEqual([...DETAIL_LEVELS]);
-  });
+  it.each(disclosureLookupVerbs)(
+    "$noun: levels === the canonical ladder",
+    (v) => {
+      expect(v.spec.disclosure?.levels).toEqual([...DETAIL_LEVELS]);
+    },
+  );
 });
 
 describe("detail:summary vs detail:detailed — key-set growth (B6)", () => {
-  it.each(
-    disclosureLookupVerbs,
-  )("%s_lookup: detailed carries every summary key plus at least one more", async (v) => {
-    const noun = v.noun;
-    const list = await mcp.callTool(`${noun}_list`);
-    const rows = list.data as { name: string }[];
-    const name = rows[0]?.name;
-    expect(name).toBeDefined();
-    if (!name) return;
+  it.each(disclosureLookupVerbs)(
+    "%s_lookup: detailed carries every summary key plus at least one more",
+    async (v) => {
+      const noun = v.noun;
+      const list = await mcp.callTool(`${noun}_list`);
+      const rows = list.data as { name: string }[];
+      const name = rows[0]?.name;
+      expect(name).toBeDefined();
+      if (!name) return;
 
-    const summary = await mcp.callTool(`${noun}_lookup`, {
-      name: [name],
-      detail: "summary",
-    });
-    const detailed = await mcp.callTool(`${noun}_lookup`, {
-      name: [name],
-      detail: "detailed",
-    });
-    expect(summary.ok).toBe(true);
-    expect(detailed.ok).toBe(true);
+      const summary = await mcp.callTool(`${noun}_lookup`, {
+        name: [name],
+        detail: "summary",
+      });
+      const detailed = await mcp.callTool(`${noun}_lookup`, {
+        name: [name],
+        detail: "detailed",
+      });
+      expect(summary.ok).toBe(true);
+      expect(detailed.ok).toBe(true);
 
-    const summaryEntity = (
-      summary.data as { results: Record<string, unknown>[] }
-    ).results[0] as Record<string, unknown>;
-    const detailedEntity = (
-      detailed.data as { results: Record<string, unknown>[] }
-    ).results[0] as Record<string, unknown>;
+      const summaryEntity = (
+        summary.data as { results: Record<string, unknown>[] }
+      ).results[0] as Record<string, unknown>;
+      const detailedEntity = (
+        detailed.data as { results: Record<string, unknown>[] }
+      ).results[0] as Record<string, unknown>;
 
-    const summaryKeys = new Set(Object.keys(summaryEntity));
-    const detailedKeys = new Set(Object.keys(detailedEntity));
-    for (const key of summaryKeys) {
-      expect(detailedKeys.has(key)).toBe(true);
-    }
-    expect(detailedKeys.size).toBeGreaterThan(summaryKeys.size);
-  });
+      const summaryKeys = new Set(Object.keys(summaryEntity));
+      const detailedKeys = new Set(Object.keys(detailedEntity));
+      for (const key of summaryKeys) {
+        expect(detailedKeys.has(key)).toBe(true);
+      }
+      expect(detailedKeys.size).toBeGreaterThan(summaryKeys.size);
+    },
+  );
 });

--- a/packages/cli/pragma/src/testing/behavioral/errorMatrix.mcp.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/errorMatrix.mcp.test.ts
@@ -67,25 +67,27 @@ afterAll(async () => {
 });
 
 describe("lookup miss — total miss fails the call (B3, adapted)", () => {
-  it.each(
-    lookupVerbs.map((v) => v.noun),
-  )("%s_lookup: a single unknown name fails with ENTITY_NOT_FOUND", async (noun) => {
-    const result = await mcp.callTool(`${noun}_lookup`, {
-      name: ["zzz-definitely-not-a-real-entity"],
-    });
-    expect(result.ok).toBe(false);
-    expect((result.error as { code: string }).code).toBe("ENTITY_NOT_FOUND");
-  });
+  it.each(lookupVerbs.map((v) => v.noun))(
+    "%s_lookup: a single unknown name fails with ENTITY_NOT_FOUND",
+    async (noun) => {
+      const result = await mcp.callTool(`${noun}_lookup`, {
+        name: ["zzz-definitely-not-a-real-entity"],
+      });
+      expect(result.ok).toBe(false);
+      expect((result.error as { code: string }).code).toBe("ENTITY_NOT_FOUND");
+    },
+  );
 
-  it.each(
-    lookupVerbs.map((v) => v.noun),
-  )("%s_lookup: an all-unknown batch ALSO fails (not a partial report)", async (noun) => {
-    const result = await mcp.callTool(`${noun}_lookup`, {
-      name: ["zzz-nope-one", "zzz-nope-two"],
-    });
-    expect(result.ok).toBe(false);
-    expect((result.error as { code: string }).code).toBe("ENTITY_NOT_FOUND");
-  });
+  it.each(lookupVerbs.map((v) => v.noun))(
+    "%s_lookup: an all-unknown batch ALSO fails (not a partial report)",
+    async (noun) => {
+      const result = await mcp.callTool(`${noun}_lookup`, {
+        name: ["zzz-nope-one", "zzz-nope-two"],
+      });
+      expect(result.ok).toBe(false);
+      expect((result.error as { code: string }).code).toBe("ENTITY_NOT_FOUND");
+    },
+  );
 });
 
 describe("list — a narrowing filter to zero rows is a plain empty list (B3, adapted)", () => {
@@ -95,19 +97,17 @@ describe("list — a narrowing filter to zero rows is a plain empty list (B3, ad
     expect(filteredListVerbs.length).toBeGreaterThan(0);
   });
 
-  it.each(
-    filteredListVerbs,
-  )("$tool: an unmatched filter value narrows to [] (no EMPTY_RESULTS)", async ({
-    tool,
-    param,
-  }) => {
-    const result = await mcp.callTool(tool, {
-      [param]: "zzz-definitely-not-a-real-value",
-    });
-    expect(result.ok).toBe(true);
-    expect(result.data).toEqual([]);
-    expect(result.meta).toEqual({});
-  });
+  it.each(filteredListVerbs)(
+    "$tool: an unmatched filter value narrows to [] (no EMPTY_RESULTS)",
+    async ({ tool, param }) => {
+      const result = await mcp.callTool(tool, {
+        [param]: "zzz-definitely-not-a-real-value",
+      });
+      expect(result.ok).toBe(true);
+      expect(result.data).toEqual([]);
+      expect(result.meta).toEqual({});
+    },
+  );
 });
 
 describe("ontology_show — an unknown prefix is INVALID_INPUT (B3)", () => {

--- a/packages/cli/pragma/src/testing/behavioral/errorMatrix.storeless.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/errorMatrix.storeless.test.ts
@@ -96,16 +96,17 @@ describe("error/recovery matrix — render shapes (A8, storeless)", () => {
     }
   });
 
-  it.each(MATRIX)("json renders the failure envelope for $label", ({
-    error,
-  }) => {
-    const envelope = JSON.parse(renderErrorJson(error)) as {
-      ok: boolean;
-      error: { code: string };
-    };
-    expect(envelope.ok).toBe(false);
-    expect(envelope.error.code).toBe(error.code);
-  });
+  it.each(MATRIX)(
+    "json renders the failure envelope for $label",
+    ({ error }) => {
+      const envelope = JSON.parse(renderErrorJson(error)) as {
+        ok: boolean;
+        error: { code: string };
+      };
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.code).toBe(error.code);
+    },
+  );
 });
 
 describe("error/recovery matrix — grounded in a real spawn (A8, e2e)", () => {

--- a/packages/cli/pragma/src/testing/behavioral/mcpSurface.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/mcpSurface.test.ts
@@ -114,31 +114,34 @@ describe("every MCP tool is callable and returns a well-formed envelope (B4)", (
     expect(everyExposedVerb.length).toBeGreaterThan(0);
   });
 
-  it.each(
-    everyExposedVerb,
-  )("$tool: callable, well-formed envelope, annotations match capability.mutates", async (v) => {
-    const tool = v.tool as string;
-    const args = representativeArgs(v);
-    const result = await mcp.callTool(tool, args);
+  it.each(everyExposedVerb)(
+    "$tool: callable, well-formed envelope, annotations match capability.mutates",
+    async (v) => {
+      const tool = v.tool as string;
+      const args = representativeArgs(v);
+      const result = await mcp.callTool(tool, args);
 
-    expect(typeof result.ok).toBe("boolean");
-    if (result.ok) {
-      expect("data" in result).toBe(true);
-      expect(typeof result.meta).toBe("object");
-    } else {
-      const error = result.error as { code?: unknown; message?: unknown };
-      expect(typeof error.code).toBe("string");
-      expect(typeof error.message).toBe("string");
-    }
+      expect(typeof result.ok).toBe("boolean");
+      if (result.ok) {
+        expect("data" in result).toBe(true);
+        expect(typeof result.meta).toBe("object");
+      } else {
+        const error = result.error as { code?: unknown; message?: unknown };
+        expect(typeof error.code).toBe("string");
+        expect(typeof error.message).toBe("string");
+      }
 
-    const registered = registeredTools.find((t) => t.name === tool);
-    expect(registered).toBeDefined();
-    const annotations = registered?.annotations as
-      | { readOnlyHint?: boolean; destructiveHint?: boolean }
-      | undefined;
-    expect(annotations?.readOnlyHint).toBe(!v.mutates);
-    if (v.spec.capability.destructive !== undefined) {
-      expect(annotations?.destructiveHint).toBe(v.spec.capability.destructive);
-    }
-  });
+      const registered = registeredTools.find((t) => t.name === tool);
+      expect(registered).toBeDefined();
+      const annotations = registered?.annotations as
+        | { readOnlyHint?: boolean; destructiveHint?: boolean }
+        | undefined;
+      expect(annotations?.readOnlyHint).toBe(!v.mutates);
+      if (v.spec.capability.destructive !== undefined) {
+        expect(annotations?.destructiveHint).toBe(
+          v.spec.capability.destructive,
+        );
+      }
+    },
+  );
 });

--- a/packages/cli/pragma/src/testing/behavioral/parity.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/parity.test.ts
@@ -197,28 +197,30 @@ describe("read-noun parity — every list/lookup/extra verb (B5)", () => {
     });
   });
 
-  it.each(
-    lookupVerbs,
-  )("$noun lookup: CLI --format json == MCP, for a known name", async (v) => {
-    const name = firstNameByNoun.get(v.noun);
-    if (!name) return;
-    await assertCliMcpParity({
-      modules: capabilities,
-      verb: v.spec,
-      tool: v.tool as string,
-      cwd: fixture.cwd,
-      params: { name: [name] },
-    });
-  });
+  it.each(lookupVerbs)(
+    "$noun lookup: CLI --format json == MCP, for a known name",
+    async (v) => {
+      const name = firstNameByNoun.get(v.noun);
+      if (!name) return;
+      await assertCliMcpParity({
+        modules: capabilities,
+        verb: v.spec,
+        tool: v.tool as string,
+        cwd: fixture.cwd,
+        params: { name: [name] },
+      });
+    },
+  );
 
-  it.each(
-    extraListShapedVerbs,
-  )("$noun $verb: CLI --format json == MCP", async (v) => {
-    await assertCliMcpParity({
-      modules: capabilities,
-      verb: v.spec,
-      tool: v.tool as string,
-      cwd: fixture.cwd,
-    });
-  });
+  it.each(extraListShapedVerbs)(
+    "$noun $verb: CLI --format json == MCP",
+    async (v) => {
+      await assertCliMcpParity({
+        modules: capabilities,
+        verb: v.spec,
+        tool: v.tool as string,
+        cwd: fixture.cwd,
+      });
+    },
+  );
 });

--- a/packages/cli/pragma/src/testing/helpers/projectMcp.ts
+++ b/packages/cli/pragma/src/testing/helpers/projectMcp.ts
@@ -84,7 +84,7 @@ export async function projectMcp(
         arguments: args,
       })) as CallToolResult;
       const first = result.content[0];
-      if (!first || first.type !== "text") {
+      if (first?.type !== "text") {
         throw new Error(`tool "${name}" returned no text content`);
       }
       return JSON.parse(first.text) as Record<string, unknown>;

--- a/packages/cli/summon/package.json
+++ b/packages/cli/summon/package.json
@@ -61,7 +61,7 @@
     "react": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@types/bun": "^1.3.10",

--- a/packages/ds-assets/package.json
+++ b/packages/ds-assets/package.json
@@ -42,7 +42,7 @@
     "test:vitest:watch": "vitest"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/ds-types/package.json
+++ b/packages/ds-types/package.json
@@ -45,7 +45,7 @@
     "test": "echo 'Type-only package — no runtime tests'"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/lit/ds-prototype/css.d.ts
+++ b/packages/lit/ds-prototype/css.d.ts
@@ -1,5 +1,6 @@
 declare module "*.css" {
   import type { CSSResult } from "lit";
+
   const styles: CSSResult;
   export default styles;
 }

--- a/packages/lit/ds-prototype/package.json
+++ b/packages/lit/ds-prototype/package.json
@@ -99,7 +99,7 @@
     "lit": "^3.3.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/ds-types": "^0.34.0",
     "@canonical/styles": "^0.34.0",

--- a/packages/react/ds-app-anbox/package.json
+++ b/packages/react/ds-app-anbox/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.8.1",
     "@canonical/storybook-helpers": "^0.34.0",

--- a/packages/react/ds-app-landscape/package.json
+++ b/packages/react/ds-app-landscape/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.8.1",
     "@canonical/storybook-helpers": "^0.34.0",

--- a/packages/react/ds-app-launchpad/package.json
+++ b/packages/react/ds-app-launchpad/package.json
@@ -55,7 +55,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.8.1",
     "@canonical/storybook-helpers": "^0.34.0",

--- a/packages/react/ds-app-lxd/package.json
+++ b/packages/react/ds-app-lxd/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.8.1",
     "@canonical/storybook-helpers": "^0.34.0",

--- a/packages/react/ds-app-portal/package.json
+++ b/packages/react/ds-app-portal/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.8.1",
     "@canonical/storybook-helpers": "^0.34.0",

--- a/packages/react/ds-app/package.json
+++ b/packages/react/ds-app/package.json
@@ -62,7 +62,7 @@
     }
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.8.1",
     "@canonical/router-core": "^0.34.0",

--- a/packages/react/ds-global-form/package.json
+++ b/packages/react/ds-global-form/package.json
@@ -53,7 +53,7 @@
     "react-hook-form": "^7.71.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.8.1",
     "@canonical/storybook-addon-form-state": "^0.34.0",

--- a/packages/react/ds-global-form/src/density.css
+++ b/packages/react/ds-global-form/src/density.css
@@ -105,7 +105,7 @@
 /* Body font tier for the field label/description/error, which lost `.p`. Scoped
    to just these (NOT the headings, which keep their own tier). */
 :is(.comfortable, .dense, .app, .site, .docs)
-  :is(.ds.field-label, .ds.field-description, .ds.field-error) {
+:is(.ds.field-label, .ds.field-description, .ds.field-error) {
   font-size: var(--typography-text-primary-font-size);
   font-family: var(--typography-text-primary-font-family);
 }
@@ -142,7 +142,7 @@
  * rule wins for the text family. Direct chromes (select/date/time) and the
  * textarea keep the previous model until their own cutover pass. */
 :is(.comfortable, .dense, .app, .site, .docs)
-  .ds.input:is(.text, .number, .password, .phone) {
+.ds.input:is(.text, .number, .password, .phone) {
   /* The COMPOSITE chrome family — every wrapper with an inner <input> leaf
      (text, number, password, phone). One selector, one seat: the wrapper is
      the box, the leaf carries the line. */
@@ -330,7 +330,7 @@
  * --end-nudge already lands its bottom on the grid. Adding a density fill on top
  * would double-pad. Prose bottom rhythm belongs to the engine / `.editorial`. */
 :is(.comfortable, .dense, .app, .site, .docs)
-  :is(.ds.field-label, .ds.field-description, .ds.field-error) {
+:is(.ds.field-label, .ds.field-description, .ds.field-error) {
   padding-block-end: max(
     0px,
     calc(

--- a/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/SingleCombobox.tsx
+++ b/packages/react/ds-global-form/src/lib/subcomponent/ComboboxInput/SingleCombobox.tsx
@@ -12,6 +12,7 @@ import {
   mergeRefs,
 } from "./utils/index.js";
 import "./styles.css";
+
 const componentCssClassName = "ds form-combobox";
 
 /**

--- a/packages/react/ds-global/package.json
+++ b/packages/react/ds-global/package.json
@@ -53,7 +53,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/ds-types": "^0.34.0",
     "@canonical/router-core": "^0.34.0",

--- a/packages/react/ds-global/src/lib/component/Accordion/common/Item/Item.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Accordion/common/Item/Item.stories.tsx
@@ -53,6 +53,7 @@ export const WithRichContent: Story = {
           <li>Other components</li>
         </ul>
         <p className="p">
+          {/* biome-ignore lint/a11y/noAmbiguousAnchorText: placeholder story content, not a real link */}
           <a href="#example">Learn more</a>
         </p>
       </>

--- a/packages/react/head/package.json
+++ b/packages/react/head/package.json
@@ -47,7 +47,7 @@
     "react": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@canonical/vitest-config-react": "^0.34.0",

--- a/packages/react/hooks/package.json
+++ b/packages/react/hooks/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.22.0",
     "@canonical/typescript-config": "^0.22.0",
     "@canonical/typescript-config-react": "^0.34.0",

--- a/packages/react/i18n/package.json
+++ b/packages/react/i18n/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.27.1-experimental.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@canonical/webarchitect": "^0.27.1-experimental.0",

--- a/packages/react/router/package.json
+++ b/packages/react/router/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@canonical/vitest-config-react": "^0.34.0",

--- a/packages/react/ssr-adapter-cloudflare/package.json
+++ b/packages/react/ssr-adapter-cloudflare/package.json
@@ -44,7 +44,7 @@
     "@canonical/react-ssr": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/vitest-config-react": "^0.34.0",

--- a/packages/react/ssr-adapter-deno/package.json
+++ b/packages/react/ssr-adapter-deno/package.json
@@ -44,7 +44,7 @@
     "@canonical/react-ssr": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/vitest-config-react": "^0.34.0",

--- a/packages/react/ssr-adapter-vercel/package.json
+++ b/packages/react/ssr-adapter-vercel/package.json
@@ -44,7 +44,7 @@
     "@canonical/react-ssr": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/vitest-config-react": "^0.34.0",

--- a/packages/react/ssr/package.json
+++ b/packages/react/ssr/package.json
@@ -64,7 +64,7 @@
     }
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@canonical/vitest-config-react": "^0.34.0",

--- a/packages/react/tokens/package.json
+++ b/packages/react/tokens/package.json
@@ -48,7 +48,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.8.1",
     "@canonical/ds-types": "^0.34.0",

--- a/packages/runtime/harnesses/package.json
+++ b/packages/runtime/harnesses/package.json
@@ -48,7 +48,7 @@
     "@canonical/task": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/runtime/harnesses/src/lib/configTargets.test.ts
+++ b/packages/runtime/harnesses/src/lib/configTargets.test.ts
@@ -84,11 +84,12 @@ describe("isHarnessInBand", () => {
     ["project", "global", "global", false],
   ];
 
-  it.each(
-    cases,
-  )("harness %s under scope=%s in %s band → %s", (harnessScope, scope, band, expected) => {
-    expect(isHarnessInBand(harnessScope, scope, band)).toBe(expected);
-  });
+  it.each(cases)(
+    "harness %s under scope=%s in %s band → %s",
+    (harnessScope, scope, band, expected) => {
+      expect(isHarnessInBand(harnessScope, scope, band)).toBe(expected);
+    },
+  );
 });
 
 describe("listHarnessesForBand", () => {

--- a/packages/runtime/i18n/package.json
+++ b/packages/runtime/i18n/package.json
@@ -45,7 +45,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.27.1-experimental.0",
     "@canonical/webarchitect": "^0.27.1-experimental.0",
     "@types/node": "^24.12.0",

--- a/packages/runtime/ke-graphql/biome.json
+++ b/packages/runtime/ke-graphql/biome.json
@@ -2,5 +2,17 @@
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["**/src/**", "**/demo/**", "**/*.json"]
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnsafeOptionalChaining": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/runtime/ke-graphql/biome.json
+++ b/packages/runtime/ke-graphql/biome.json
@@ -2,17 +2,5 @@
   "extends": ["@canonical/biome-config"],
   "files": {
     "includes": ["**/src/**", "**/demo/**", "**/*.json"]
-  },
-  "overrides": [
-    {
-      "includes": ["**/*.test.ts"],
-      "linter": {
-        "rules": {
-          "correctness": {
-            "noUnsafeOptionalChaining": "off"
-          }
-        }
-      }
-    }
-  ]
+  }
 }

--- a/packages/runtime/ke-graphql/package.json
+++ b/packages/runtime/ke-graphql/package.json
@@ -52,7 +52,7 @@
     "demo": "bun demo/server.ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/ke": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",

--- a/packages/runtime/ke-graphql/package.json
+++ b/packages/runtime/ke-graphql/package.json
@@ -52,7 +52,7 @@
     "demo": "bun demo/server.ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.10",
+    "@biomejs/biome": "2.4.9",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/ke": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",

--- a/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/createSchemaPlugin.test.ts
@@ -80,6 +80,7 @@ describe("createSchemaPlugin", () => {
       source: `{ thing(uri: "ex:widget") { name } }`,
       contextValue: context,
     });
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.thing as { name: string }).name).toBe("Widget");
   });
 
@@ -128,6 +129,7 @@ describe("createSchemaPlugin", () => {
     });
     expect(result.errors).toBeUndefined();
     expect(result.data?.hello).toBe("world");
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.thing as { shout: string }).shout).toBe("ex:widget!");
   });
 
@@ -162,6 +164,7 @@ describe("createSchemaPlugin", () => {
       contextValue: api?.createContext(store),
     });
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.firstThing as { name: string }).name).toBe("Widget");
   });
 
@@ -204,6 +207,7 @@ describe("createSchemaPlugin", () => {
       contextValue: api?.createContext(store),
     });
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.thing as { label: string }).label).toBe("The Widget");
   });
 
@@ -313,6 +317,7 @@ describe("createSchemaPlugin", () => {
       contextValue: api?.createContext(store),
     });
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.thing as { name: string }).name).toBe("Widget");
   });
 });

--- a/packages/runtime/ke-graphql/src/lib/execution/incremental.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/execution/incremental.test.ts
@@ -99,6 +99,7 @@ describe("executeLocal (in-process execution)", () => {
     expect(isIncrementalResults(execution)).toBe(false);
     if (!isIncrementalResults(execution)) {
       expect(execution.errors).toBeUndefined();
+      // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
       expect((execution.data?.component as Record<string, unknown>).name).toBe(
         "Button",
       );
@@ -173,6 +174,7 @@ describe("relayFormatAdapter", () => {
     }
     // initial payload: plain data, no path
     expect(payloads[0]?.path).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((payloads[0]?.data?.component as Record<string, unknown>).name).toBe(
       "Button",
     );
@@ -183,6 +185,7 @@ describe("relayFormatAdapter", () => {
     expect(last?.path).toEqual(["component"]);
     expect(last?.label).toBe("summary");
     expect(last?.extensions?.is_final).toBe(true);
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((last?.data as Record<string, unknown>).summary).toBe(
       "Primary action trigger.",
     );
@@ -613,6 +616,7 @@ describe("extractStatic (build-time static extraction)", () => {
     );
     expect(perEntity).toEqual(["ThingQuery:ex:widget"]);
     const widget = results.get("ThingQuery:ex:widget");
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((widget?.data?.thing as { name: string }).name).toBe("Widget");
   });
 

--- a/packages/runtime/ke-graphql/src/lib/resolver/templates.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/templates.ts
@@ -227,7 +227,7 @@ export const createEmbeddedSingularResolver = (
   return (parent, _args, ctx) => {
     const values = parent.triples.get(field.propertyUri);
     const v = values?.find((value) => value.kind === "blank");
-    if (v?.kind !== "blank") {
+    if (!v || v.kind !== "blank") {
       return null;
     }
     return {

--- a/packages/runtime/ke-graphql/src/lib/resolver/templates.ts
+++ b/packages/runtime/ke-graphql/src/lib/resolver/templates.ts
@@ -227,7 +227,7 @@ export const createEmbeddedSingularResolver = (
   return (parent, _args, ctx) => {
     const values = parent.triples.get(field.propertyUri);
     const v = values?.find((value) => value.kind === "blank");
-    if (!v || v.kind !== "blank") {
+    if (v?.kind !== "blank") {
       return null;
     }
     return {

--- a/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/tbox/buildTBoxSchema.test.ts
@@ -116,8 +116,11 @@ describe("Ontology and lookups", () => {
     >;
     const ex = ontologies.find((o) => o.prefix === "ex");
     expect(ex?.namespace).toBe("http://example.org/");
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((ex?.classes as unknown[]).length).toBe(1);
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((ex?.properties as unknown[]).length).toBe(2);
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.ontology as { prefix: string }).prefix).toBe("ex");
     expect(result.data?.unknown).toBeNull();
   });
@@ -145,6 +148,7 @@ describe("Ontology and lookups", () => {
     expect(property.inverse).toBeNull();
     expect(result.data?.missing).toBeNull();
     // Prefixed form resolves like ontologyClass does.
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.prefixed as { uri: string }).uri).toBe(
       "http://example.org/count",
     );
@@ -175,10 +179,12 @@ describe("Ontology and lookups", () => {
     expect(rel.range).toBe("http://example.org/Cat");
     expect((rel.domain as { label: string }).label).toBe("Thing");
     // unknown range echoes the raw URI string.
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.weird as { range: string }).range).toBe(
       "http://external.example/Mystery",
     );
     // a property with no rdfs:domain has a null domain.
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.domainless as { domain: unknown }).domain).toBeNull();
     // an inverse pair exposes the inverse property; definition is absent here.
     const inv = result.data?.inv as {
@@ -209,9 +215,11 @@ describe("Ontology and lookups", () => {
     expect(cls.definition).toBe("A reusable UI component.");
     expect(cls.namespace).toBe("ds");
     // prefixed-form fallback resolves both class and property…
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.byPrefixed as { uri: string }).uri).toBe(
       "https://ds.canonical.com/Component",
     );
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.propByPrefixed as { uri: string }).uri).toBe(
       "https://ds.canonical.com/name",
     );
@@ -270,6 +278,7 @@ describe("Ontology and lookups", () => {
       }`,
     );
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     const properties = (result.data?.ontologyClass as Record<string, unknown>)
       .properties as Array<{
       property: { label: string };
@@ -316,6 +325,7 @@ describe("EntityMeta edge cases", () => {
     );
     expect(result.errors).toBeUndefined();
     expect(
+      // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
       (result.data?.thing as { _meta: { field: unknown } })._meta.field,
     ).toBeNull();
   });
@@ -328,6 +338,7 @@ describe("datatype list fields", () => {
     });
     const result = await run(compiled, `{ thing(uri: "ex:widget") { names } }`);
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.thing as { names: string[] }).names).toEqual([
       "Widget",
     ]);
@@ -500,6 +511,7 @@ describe("TBox defensive branches (synthetic parents)", () => {
       }`,
     });
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.unionProp as { range: string }).range).toBe(
       "Cat | Dog",
     );
@@ -556,6 +568,7 @@ describe("TBox defensive branches (synthetic parents)", () => {
       source: `{ orphanMeta { fields { property { uri } } } }`,
     });
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.orphanMeta as { fields: unknown[] }).fields).toEqual(
       [],
     );

--- a/packages/runtime/ke-graphql/src/testing/integration/hardening.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/hardening.test.ts
@@ -84,6 +84,7 @@ describe("forced abstract with direct instances (C1 + V015)", () => {
     });
     if (!isIncrementalResults(execution)) {
       expect(execution.errors).toBeUndefined();
+      // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
       expect((execution.data?.node as { __typename: string }).__typename).toBe(
         "Dog",
       );

--- a/packages/runtime/ke-graphql/src/testing/integration/performance-features.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/performance-features.test.ts
@@ -68,6 +68,7 @@ describe("extraction artifact (DMMF-style boot)", () => {
       contextValue: rebuilt.createContext(store),
     });
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((result.data?.thing as { name: string }).name).toBe("Widget");
   });
 
@@ -163,6 +164,7 @@ describe("lazy store (TBox needs no store)", () => {
       contextValue: ctx,
     });
     expect(tbox.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((tbox.data?.ontologyClass as { label: string }).label).toBe("Thing");
 
     // ABox: blocked until the store arrives.
@@ -180,6 +182,7 @@ describe("lazy store (TBox needs no store)", () => {
     releaseStore(store);
     const resolved = await abox;
     expect(resolved.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((resolved.data?.thing as { name: string }).name).toBe("Widget");
   });
 });
@@ -264,6 +267,7 @@ describe("slice-before-hydrate listings", () => {
       variableValues: { c: connection.edges[0]?.cursor },
       contextValue: result.createContext(store),
     });
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((page2.data?.modifiers as { edges: unknown[] }).edges).toHaveLength(
       0,
     );
@@ -290,6 +294,7 @@ describe("store-free TBox (tboxLoader removed)", () => {
     });
     expect(tbox.errors).toBeUndefined();
     expect(
+      // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
       (tbox.data?.ontologyProperty as { acceptanceCriteria: string })
         .acceptanceCriteria,
     ).toBe("Must be a human-readable display name.");

--- a/packages/runtime/ke-graphql/src/testing/integration/queries.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/queries.test.ts
@@ -107,6 +107,7 @@ describe("ds-realistic resolution", () => {
     expect(subcomponents.edges).toHaveLength(1);
     expect(subcomponents.edges[0]?.node.standalone).toBe(false);
     expect(
+      // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
       (subcomponents.edges[0]?.node.parentComponent as { name: string }).name,
     ).toBe("Button");
     // synthetic inverse: reverse assertions found via the inverse loader
@@ -186,6 +187,7 @@ describe("ds-realistic resolution", () => {
       }`,
     );
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     const meta = (result.data?.component as Record<string, unknown>)
       ._meta as Record<string, unknown>;
     const type = meta.type as Record<string, unknown>;
@@ -215,6 +217,7 @@ describe("ds-realistic resolution", () => {
       }`,
     );
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     const prefixes = (result.data?.ontologies as Array<{ prefix: string }>).map(
       (o) => o.prefix,
     );
@@ -256,6 +259,7 @@ describe("embedded blank nodes", () => {
       `{ standard(uri: "ex:s1") { title examples { code language } } }`,
     );
     expect(result.errors).toBeUndefined();
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     const examples = (result.data?.standard as Record<string, unknown>)
       .examples as Array<Record<string, unknown>>;
     expect(examples).toHaveLength(2);
@@ -271,10 +275,13 @@ describe("coercion", () => {
       onRuntimeWarning: (w) => warnings.push(w.reason),
     });
     const active = await run(compiled, `{ item(uri: "ex:i1") { active } }`);
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((active.data?.item as { active: boolean }).active).toBe(true);
     const label = await run(compiled, `{ item(uri: "ex:i3") { label } }`);
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((label.data?.item as { label: string }).label).toBe("Tagged");
     const summary = await run(compiled, `{ item(uri: "ex:i5") { summary } }`);
+    // biome-ignore lint/correctness/noUnsafeOptionalChaining: test assertion — value asserted present
     expect((summary.data?.item as { summary: string }).summary).toBe("");
   });
 

--- a/packages/runtime/ke/package.json
+++ b/packages/runtime/ke/package.json
@@ -59,7 +59,7 @@
     "test:vitest:watch": "vitest"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/runtime/router/package.json
+++ b/packages/runtime/router/package.json
@@ -44,7 +44,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",
     "@types/node": "^24.12.0",

--- a/packages/runtime/task/package.json
+++ b/packages/runtime/task/package.json
@@ -48,7 +48,7 @@
     "test:vitest:watch": "vitest"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -1456,24 +1456,23 @@ describe("Interpreter - executeEffect for DeleteFile error propagation", () => {
 // =============================================================================
 
 describe("Interpreter - executeEffect Log fallback for all levels", () => {
-  it.each([
-    "debug",
-    "warn",
-    "error",
-  ] as const)("logs %s level with prefix to console", async (level) => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  it.each(["debug", "warn", "error"] as const)(
+    "logs %s level with prefix to console",
+    async (level) => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    try {
-      await executeEffect({ _tag: "Log", level, message: "msg" }, new Map());
+      try {
+        await executeEffect({ _tag: "Log", level, message: "msg" }, new Map());
 
-      const prefix = { debug: "[DEBUG]", warn: "[WARN]", error: "[ERROR]" }[
-        level
-      ];
-      expect(consoleSpy).toHaveBeenCalledWith(`${prefix} msg`);
-    } finally {
-      consoleSpy.mockRestore();
-    }
-  });
+        const prefix = { debug: "[DEBUG]", warn: "[WARN]", error: "[ERROR]" }[
+          level
+        ];
+        expect(consoleSpy).toHaveBeenCalledWith(`${prefix} msg`);
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    },
+  );
 });
 
 // =============================================================================

--- a/packages/storybook/addon-canonical-shell-theme/package.json
+++ b/packages/storybook/addon-canonical-shell-theme/package.json
@@ -50,7 +50,7 @@
     "check:webarchitect": "webarchitect library"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/storybook/addon-form-state/package.json
+++ b/packages/storybook/addon-form-state/package.json
@@ -48,7 +48,7 @@
     "check:ts": "tsc --noEmit"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@storybook/react-vite": "^10.3.1",

--- a/packages/storybook/addon-msw/package.json
+++ b/packages/storybook/addon-msw/package.json
@@ -51,7 +51,7 @@
     "@storybook/icons": "^2.0.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@storybook/addon-docs": "^10.3.1",

--- a/packages/storybook/addon-relay/package.json
+++ b/packages/storybook/addon-relay/package.json
@@ -63,7 +63,7 @@
     "relay-test-utils": "^21.0.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/storybook/addon-utils/package.json
+++ b/packages/storybook/addon-utils/package.json
@@ -62,7 +62,7 @@
     "@storybook/icons": "^2.0.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/router-core": "^0.34.0",
     "@canonical/router-react": "^0.34.0",

--- a/packages/storybook/helpers/package.json
+++ b/packages/storybook/helpers/package.json
@@ -38,7 +38,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config-react": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/storybook/helpers/vitest.setup.js
+++ b/packages/storybook/helpers/vitest.setup.js
@@ -1,6 +1,7 @@
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
+
 afterEach(() => {
   cleanup();
 });

--- a/packages/styles/debug/package.json
+++ b/packages/styles/debug/package.json
@@ -48,7 +48,7 @@
     }
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0"
   }
 }

--- a/packages/styles/main/package.json
+++ b/packages/styles/main/package.json
@@ -29,7 +29,7 @@
     "check:biome:fix": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0"
   },
   "dependencies": {

--- a/packages/styles/main/src/controls.hover.shim.css
+++ b/packages/styles/main/src/controls.hover.shim.css
@@ -51,12 +51,12 @@
    * upstream has none. (Removing it once upstream lands is still tidy, but no
    * longer load-bearing.) */
   :where(
-      .surface,
-      .surface .surface,
-      .surface .surface .surface,
-      .contrasted,
-      .modal
-    ) {
+    .surface,
+    .surface .surface,
+    .surface .surface .surface,
+    .contrasted,
+    .modal
+  ) {
     --surface-color-foreground-checkbox-selected: var(
       --color-foreground-checkbox-selected
     );

--- a/packages/styles/typography/package.json
+++ b/packages/styles/typography/package.json
@@ -36,7 +36,7 @@
     "opentype.js": "^1.3.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@types/bun": "^1.3.10",

--- a/packages/summon/application/package.json
+++ b/packages/summon/application/package.json
@@ -42,7 +42,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",
     "@types/node": "^24.12.0",

--- a/packages/summon/component/package.json
+++ b/packages/summon/component/package.json
@@ -49,7 +49,7 @@
     "test:vitest:watch": "vitest"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/summon/core/package.json
+++ b/packages/summon/core/package.json
@@ -50,7 +50,7 @@
     "test:vitest:watch": "vitest"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/summon/core/src/prompt/ink/session.ts
+++ b/packages/summon/core/src/prompt/ink/session.ts
@@ -256,7 +256,7 @@ export class SessionController {
   /** The user answered the confirm gate. */
   submitConfirm(proceed: boolean): void {
     const pending = this.pending;
-    if (!pending || !pending.isConfirm) return;
+    if (!pending?.isConfirm) return;
     this.pending = undefined;
     if (proceed) this.executionStart = performance.now();
     this.set({ phase: proceed ? "executing" : "cancelled" });

--- a/packages/summon/core/src/template/getCommentStyle.test.ts
+++ b/packages/summon/core/src/template/getCommentStyle.test.ts
@@ -22,23 +22,27 @@ describe("getCommentStyle", () => {
     [".h", "//", "/*", "*/"],
     [".hpp", "//", "/*", "*/"],
     [".php", "//", "/*", "*/"],
-  ])("returns single-line '//' style for %s", (ext, single, blockStart, blockEnd) => {
-    const style = getCommentStyle(`file${ext}`);
-    expect(style).not.toBeNull();
-    expect(style?.single).toBe(single);
-    expect(style?.blockStart).toBe(blockStart);
-    expect(style?.blockEnd).toBe(blockEnd);
-  });
+  ])(
+    "returns single-line '//' style for %s",
+    (ext, single, blockStart, blockEnd) => {
+      const style = getCommentStyle(`file${ext}`);
+      expect(style).not.toBeNull();
+      expect(style?.single).toBe(single);
+      expect(style?.blockStart).toBe(blockStart);
+      expect(style?.blockEnd).toBe(blockEnd);
+    },
+  );
 
-  it.each([
-    [".css", "/*", "*/", true],
-  ])("returns block style with preferBlock for %s", (ext, start, end, pref) => {
-    const style = getCommentStyle(`file${ext}`);
-    expect(style).not.toBeNull();
-    expect(style?.blockStart).toBe(start);
-    expect(style?.blockEnd).toBe(end);
-    expect(style?.preferBlock).toBe(pref);
-  });
+  it.each([[".css", "/*", "*/", true]])(
+    "returns block style with preferBlock for %s",
+    (ext, start, end, pref) => {
+      const style = getCommentStyle(`file${ext}`);
+      expect(style).not.toBeNull();
+      expect(style?.blockStart).toBe(start);
+      expect(style?.blockEnd).toBe(end);
+      expect(style?.preferBlock).toBe(pref);
+    },
+  );
 
   it.each([
     [".html", "<!--", "-->"],

--- a/packages/summon/monorepo/package.json
+++ b/packages/summon/monorepo/package.json
@@ -49,7 +49,7 @@
     "@canonical/task": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/summon/package/package.json
+++ b/packages/summon/package/package.json
@@ -45,7 +45,7 @@
     "test:vitest:watch": "vitest"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/summon-core": "^0.34.0",
     "@canonical/task": "^0.34.0",

--- a/packages/svelte/ds-app-launchpad/package.json
+++ b/packages/svelte/ds-app-launchpad/package.json
@@ -62,7 +62,7 @@
     "storybook": "storybook dev -p 6006 --no-open --host 0.0.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.6.2-contrasted.0",
     "@canonical/storybook-config": "^0.34.0",
@@ -83,7 +83,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
     "vitest": "^4.0.18",
-    "vitest-browser-svelte": "^2.0.2"
+    "vitest-browser-svelte": "^3.0.0"
   },
   "dependencies": {
     "@canonical/launchpad-design-tokens": "^1.1.1",

--- a/packages/svelte/ds-app-launchpad/package.json
+++ b/packages/svelte/ds-app-launchpad/package.json
@@ -62,7 +62,7 @@
     "storybook": "storybook dev -p 6006 --no-open --host 0.0.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.10",
+    "@biomejs/biome": "2.4.9",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.6.2-contrasted.0",
     "@canonical/storybook-config": "^0.34.0",
@@ -83,7 +83,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
     "vitest": "^4.0.18",
-    "vitest-browser-svelte": "^3.0.0"
+    "vitest-browser-svelte": "^2.0.2"
   },
   "dependencies": {
     "@canonical/launchpad-design-tokens": "^1.1.1",

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Badge/Badge.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Badge/Badge.svelte.test.ts
@@ -14,7 +14,7 @@ describe("Badge component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -23,21 +23,27 @@ describe("Badge component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("badge");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -49,13 +55,13 @@ describe("Badge component", () => {
 
   describe("Display value", () => {
     it("displays the capped variant by default", async () => {
-      const page = render(Component, { ...baseProps, value: 10000 });
+      const page = await render(Component, { ...baseProps, value: 10000 });
       await expect.element(componentLocator(page)).toHaveTextContent("999+");
     });
 
     describe("capped", () => {
       it("displays 0 for negative values", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           value: -1,
           variant: "capped",
@@ -64,7 +70,7 @@ describe("Badge component", () => {
       });
 
       it("rounds to the nearest integer", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           value: 42.6,
           variant: "capped",
@@ -73,7 +79,7 @@ describe("Badge component", () => {
       });
 
       it("displays the values up to 999", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           value: 999,
           variant: "capped",
@@ -82,7 +88,7 @@ describe("Badge component", () => {
       });
 
       it("caps the value at 999", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           value: 10000,
           variant: "capped",
@@ -93,7 +99,7 @@ describe("Badge component", () => {
 
     describe("rounded", () => {
       it("displays 0 for negative values", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           value: -1,
           variant: "rounded",
@@ -102,7 +108,7 @@ describe("Badge component", () => {
       });
 
       it("rounds to the nearest integer", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           value: 42.6,
           variant: "rounded",
@@ -120,7 +126,7 @@ describe("Badge component", () => {
         [1_000_000_000, "1B"],
         [1_234_567_890_123, "1.2T"],
       ])("displays %d as %s", async (input, expected) => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           value: input,
           variant: "rounded",

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Breadcrumbs/Breadcrumbs.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Breadcrumbs/Breadcrumbs.ssr.test.ts
@@ -101,17 +101,15 @@ describe("Breadcrumbs SSR", () => {
   });
 
   describe("collapse prop", () => {
-    it.each([
-      "all",
-      0,
-      1,
-      2,
-    ] as const)("renders with minNumExpanded='%s'", (minNumExpanded) => {
-      const page = render(Component, {
-        props: { ...baseProps, minNumExpanded },
-      });
-      expect(page.getAllByRole("listitem").length).toBe(3);
-    });
+    it.each(["all", 0, 1, 2] as const)(
+      "renders with minNumExpanded='%s'",
+      (minNumExpanded) => {
+        const page = render(Component, {
+          props: { ...baseProps, minNumExpanded },
+        });
+        expect(page.getAllByRole("listitem").length).toBe(3);
+      },
+    );
   });
 });
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Breadcrumbs/Breadcrumbs.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Breadcrumbs/Breadcrumbs.svelte.test.ts
@@ -21,7 +21,7 @@ describe("Breadcrumbs component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -30,7 +30,7 @@ describe("Breadcrumbs component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         [attribute]: expected,
       });
@@ -40,7 +40,7 @@ describe("Breadcrumbs component", () => {
     });
 
     it("applies classes", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         class: "test-class",
       });
@@ -50,7 +50,7 @@ describe("Breadcrumbs component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -62,7 +62,7 @@ describe("Breadcrumbs component", () => {
 
   describe("basic rendering", () => {
     it("renders breadcrumbs navigation", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect
         .element(page.getByRole("navigation", { name: "Breadcrumbs" }))
         .toBeInTheDocument();
@@ -70,7 +70,7 @@ describe("Breadcrumbs component", () => {
     });
 
     it("renders all segments", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       for (const segment of baseProps.segments) {
         if (segment.href) {
           const linkElement = page.getByRole("link", {
@@ -97,7 +97,7 @@ describe("Breadcrumbs component", () => {
         { label: "Category", href: "/category" },
         { label: "Current", href: "/current" },
       ];
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         segments,
       });
@@ -131,7 +131,7 @@ describe("Breadcrumbs component", () => {
     };
 
     it("has all segments visible if no collapse is applied", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...collapseProps,
         minNumExpanded: "all",
       });
@@ -144,7 +144,7 @@ describe("Breadcrumbs component", () => {
     });
 
     it("properly collapses if width is insufficient", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...collapseProps,
         minNumExpanded: 0,
       });
@@ -175,7 +175,7 @@ describe("Breadcrumbs component", () => {
 
     it("properly works with the numeric collapse value", async () => {
       const minNumExpanded = 3;
-      const page = render(Component, {
+      const page = await render(Component, {
         ...collapseProps,
         minNumExpanded,
       });
@@ -192,7 +192,7 @@ describe("Breadcrumbs component", () => {
 
     describe("edge cases", () => {
       it("works properly when minNumExpanded is greater than segments count", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...collapseProps,
           minNumExpanded: 1000,
         });
@@ -206,7 +206,7 @@ describe("Breadcrumbs component", () => {
       });
 
       it("works properly when minNumExpanded is set to negative value", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...collapseProps,
           minNumExpanded: -1,
         });
@@ -224,7 +224,7 @@ describe("Breadcrumbs component", () => {
   describe("accessibility", () => {
     describe("list structure", () => {
       it("uses proper flat list structure", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
 
         await expect.element(page.getByRole("list")).toBeInTheDocument();
         expect(page.getByRole("listitem").elements()).toHaveLength(
@@ -244,7 +244,7 @@ describe("Breadcrumbs component", () => {
             href: "/level1/level2/level3/level4/current",
           },
         ];
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           segments,
           minNumExpanded: 1,
@@ -261,7 +261,7 @@ describe("Breadcrumbs component", () => {
 
     describe("focus management", () => {
       it("allows focusing links with tab key", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
 
         const firstLink = page.getByRole("link", { name: "Home" });
         await expect.element(firstLink).toBeVisible();
@@ -281,7 +281,7 @@ describe("Breadcrumbs component", () => {
       });
 
       it("allows focusing links with tab key when segments are collapsed", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           minNumExpanded: 2,
         });
@@ -319,7 +319,7 @@ describe("Breadcrumbs component", () => {
 
   describe("segments", () => {
     it("segments with href are rendered as links", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         segments: [
           { label: "Linked Segment", href: "/linked" },
@@ -339,7 +339,7 @@ describe("Breadcrumbs component", () => {
     it("segments props are reactive", async () => {
       const segment = $state<Segment>({ label: "Initial", href: "/initial" });
 
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         segments: [segment],
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte.test.ts
@@ -15,7 +15,7 @@ describe("Button component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
     await expect.element(page.getByText("Button")).toBeVisible();
   });
@@ -25,7 +25,7 @@ describe("Button component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         [attribute]: expected,
       });
@@ -35,7 +35,7 @@ describe("Button component", () => {
     });
 
     it("applies classes", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         class: "test-class",
       });
@@ -45,7 +45,7 @@ describe("Button component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -57,12 +57,12 @@ describe("Button component", () => {
 
   describe("rendering", () => {
     it("renders as a button by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(page.getByRole("button")).toBeInTheDocument();
     });
 
     it("renders as an anchor when href is provided", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         href: "https://example.com",
       });
@@ -79,7 +79,7 @@ describe("Button component", () => {
       const iconRight: Snippet = createRawSnippet(() => ({
         render: () => `<span data-testid="icon-right">R</span>`,
       }));
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         iconLeft,
         iconRight,
@@ -91,7 +91,7 @@ describe("Button component", () => {
 
   describe("modifiers", () => {
     it("applies severity class", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         severity: "brand",
       });
@@ -99,7 +99,7 @@ describe("Button component", () => {
     });
 
     it("applies density class", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         density: "dense",
       });
@@ -109,7 +109,7 @@ describe("Button component", () => {
 
   describe("disabled state", () => {
     it("disables the button when disabled", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         disabled: true,
       });
@@ -120,7 +120,7 @@ describe("Button component", () => {
     });
 
     it("disables the button when loading", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         loading: true,
       });
@@ -129,7 +129,7 @@ describe("Button component", () => {
     });
 
     it("does not apply explicit-disabled class when loading", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         loading: true,
       });
@@ -142,7 +142,7 @@ describe("Button component", () => {
   describe("interactions", () => {
     it("handles click events", async () => {
       const onclick = vi.fn();
-      const page = render(Component, { ...baseProps, onclick });
+      const page = await render(Component, { ...baseProps, onclick });
       await page.getByRole("button").click();
       expect(onclick).toHaveBeenCalled();
     });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Checkbox/Checkbox.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Checkbox/Checkbox.svelte.test.ts
@@ -7,7 +7,7 @@ describe("Checkbox component", () => {
   const baseProps = {};
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -16,21 +16,27 @@ describe("Checkbox component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("checkbox");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -42,27 +48,27 @@ describe("Checkbox component", () => {
 
   describe("Checked state", () => {
     it("is not checked by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page)).not.toBeChecked();
     });
 
     it("can be checked", async () => {
-      const page = render(Component, { ...baseProps, checked: true });
+      const page = await render(Component, { ...baseProps, checked: true });
       await expect.element(componentLocator(page)).toBeChecked();
     });
 
     it("isn't disabled by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page)).not.toBeDisabled();
     });
 
     it("can be disabled", async () => {
-      const page = render(Component, { ...baseProps, disabled: true });
+      const page = await render(Component, { ...baseProps, disabled: true });
       await expect.element(componentLocator(page)).toBeDisabled();
     });
 
     it("toggles on click", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const checkbox = componentLocator(page);
 
       await expect.element(checkbox).not.toBeChecked();
@@ -71,14 +77,14 @@ describe("Checkbox component", () => {
     });
 
     it("is not indeterminate by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect
         .element(componentLocator(page))
         .not.toHaveAttribute("indeterminate");
     });
 
     it("can be indeterminate", async () => {
-      const onlyIndeterminate = render(Component, {
+      const onlyIndeterminate = await render(Component, {
         ...baseProps,
         indeterminate: true,
       });
@@ -90,7 +96,7 @@ describe("Checkbox component", () => {
 
   describe("Group controlled", () => {
     it("isn't checked if group and value are undefined", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: undefined,
         value: undefined,
@@ -99,7 +105,7 @@ describe("Checkbox component", () => {
     });
 
     it("isn't checked if group doesn't include value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: ["a", "b"],
         value: "c",
@@ -108,7 +114,7 @@ describe("Checkbox component", () => {
     });
 
     it("is checked if group includes value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: ["a", "b", "c"],
         value: "c",
@@ -121,7 +127,7 @@ describe("Checkbox component", () => {
     it("emits change event on click", async () => {
       const onchange = vi.fn();
 
-      const page = render(Component, { ...baseProps, onchange });
+      const page = await render(Component, { ...baseProps, onchange });
       const checkbox = componentLocator(page);
 
       await expect.element(checkbox).not.toBeChecked();
@@ -131,6 +137,6 @@ describe("Checkbox component", () => {
   });
 });
 
-function componentLocator(page: ReturnType<typeof render>): Locator {
+function componentLocator(page: Awaited<ReturnType<typeof render>>): Locator {
   return page.getByRole("checkbox");
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Chip/Chip.svelte.test.ts
@@ -15,7 +15,7 @@ describe("Chip component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -24,21 +24,27 @@ describe("Chip component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("chip");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -50,13 +56,16 @@ describe("Chip component", () => {
 
   describe("Initial Rendering", () => {
     it("should render with default props as a non-interactive element", async () => {
-      const page = render(Component, { ...baseProps, value: "Default Chip" });
+      const page = await render(Component, {
+        ...baseProps,
+        value: "Default Chip",
+      });
 
       await expect.element(page.getByRole("button")).not.toBeInTheDocument();
     });
 
     it("should render with a lead element", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         lead: "Key",
         value: "Value",
@@ -70,7 +79,7 @@ describe("Chip component", () => {
       const icon: Snippet = createRawSnippet(() => ({
         render: () => `<div data-testid="custom-icon"></div>`,
       }));
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "Icon Chip",
         icon,
@@ -80,7 +89,7 @@ describe("Chip component", () => {
     });
 
     it("should apply custom class and modifiers", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "Styled Chip",
         class: "extra-class",
@@ -94,7 +103,7 @@ describe("Chip component", () => {
     });
 
     it("should not render a button when dismiss is provided", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "Dismissible",
         ondismiss: () => {},
@@ -109,7 +118,7 @@ describe("Chip component", () => {
     });
 
     it("should not render a button when readonly is provided", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "Readonly",
         readonly: true,
@@ -124,7 +133,7 @@ describe("Chip component", () => {
   describe("Interactions & States", () => {
     it("should render a working button when onclick is provided", async () => {
       const onclick = vi.fn();
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "Clickable",
         onclick,
@@ -138,7 +147,7 @@ describe("Chip component", () => {
 
     it("should render a working dismiss button when ondismiss is provided", async () => {
       const ondismiss = vi.fn();
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "Dismissible",
         ondismiss,

--- a/packages/svelte/ds-app-launchpad/src/lib/components/DateTime/DateTime.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/DateTime/DateTime.svelte.test.ts
@@ -27,7 +27,7 @@ describe("DateTime component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, baseProps);
+    const page = await render(Component, baseProps);
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -36,21 +36,30 @@ describe("DateTime component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, value) => {
-      const page = render(Component, { ...baseProps, [attribute]: value });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: value,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, value);
     });
 
     it("applies style", async () => {
-      const page = render(Component, { ...baseProps, style: "color: orange;" });
+      const page = await render(Component, {
+        ...baseProps,
+        style: "color: orange;",
+      });
       await expect
         .element(componentLocator(page))
         .toHaveStyle("color: orange;");
     });
 
     it("applies class", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const element = componentLocator(page);
       await expect.element(element).toHaveClass("test-class");
     });
@@ -58,21 +67,21 @@ describe("DateTime component", () => {
 
   describe("datetime attribute", () => {
     it("applies correct datetime attribute for Date input", async () => {
-      const page = render(Component, baseProps);
+      const page = await render(Component, baseProps);
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("datetime", date.toISOString());
     });
 
     it("applies correct datetime attribute for timestamp input", async () => {
-      const page = render(Component, { ...baseProps, date: timestamp });
+      const page = await render(Component, { ...baseProps, date: timestamp });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("datetime", date.toISOString());
     });
 
     it("applies correct datetime attribute for date string input", async () => {
-      const page = render(Component, { ...baseProps, date: dateString });
+      const page = await render(Component, { ...baseProps, date: dateString });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("datetime", date.toISOString());
@@ -80,7 +89,7 @@ describe("DateTime component", () => {
   });
 
   it("accepts custom formatter", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       formatter: {
         format: (date: Date) => `Formatted: ${date.toISOString()}`,

--- a/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/DescriptionList.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/DescriptionList.svelte.test.ts
@@ -17,7 +17,7 @@ describe("DescriptionList component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
     await expect.element(page.getByText("DescriptionList")).toBeVisible();
   });
@@ -27,19 +27,25 @@ describe("DescriptionList component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/common/Item/Item.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/DescriptionList/common/Item/Item.svelte.test.ts
@@ -27,7 +27,7 @@ describe("Item component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
     await expect.element(termLocator(page)).toHaveTextContent("Term");
     await expect
@@ -40,19 +40,25 @@ describe("Item component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Link/Link.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Link/Link.svelte.test.ts
@@ -18,7 +18,7 @@ describe("Link component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
     await expect.element(page.getByText("Link")).toBeVisible();
   });
@@ -28,14 +28,20 @@ describe("Link component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("link");
@@ -46,14 +52,14 @@ describe("Link component", () => {
 
       document.body.style.color = parentColor;
 
-      const page = render(Component, { ...baseProps, soft: true });
+      const page = await render(Component, { ...baseProps, soft: true });
       await expect.element(componentLocator(page)).toHaveStyle({
         color: parentColor,
       });
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Log/Log.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Log/Log.ssr.test.ts
@@ -26,16 +26,15 @@ describe("Log SSR", () => {
       );
     });
 
-    it.each([
-      "Line",
-      "Timestamp",
-      "Content",
-    ])("renders column header %s", (header) => {
-      const page = render(Component, { props: { ...baseProps } });
-      expect(columnHeaderLocator(page, header)).toBeInstanceOf(
-        page.window.HTMLTableCellElement,
-      );
-    });
+    it.each(["Line", "Timestamp", "Content"])(
+      "renders column header %s",
+      (header) => {
+        const page = render(Component, { props: { ...baseProps } });
+        expect(columnHeaderLocator(page, header)).toBeInstanceOf(
+          page.window.HTMLTableCellElement,
+        );
+      },
+    );
 
     it("doesn't render timestamp column when hideTimestamps is true", () => {
       const page = render(Component, {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Log/Log.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Log/Log.svelte.test.ts
@@ -26,16 +26,15 @@ describe("Log component", () => {
       await expect.element(componentLocator(page)).toBeInTheDocument();
     });
 
-    it.each([
-      "Line",
-      "Timestamp",
-      "Content",
-    ])("renders column header %s", async (header) => {
-      const page = render(Component, { ...baseProps });
-      await expect
-        .element(columnHeaderLocator(page, header))
-        .toBeInTheDocument();
-    });
+    it.each(["Line", "Timestamp", "Content"])(
+      "renders column header %s",
+      async (header) => {
+        const page = render(Component, { ...baseProps });
+        await expect
+          .element(columnHeaderLocator(page, header))
+          .toBeInTheDocument();
+      },
+    );
 
     it("doesn't render timestamp column when hideTimestamps is true", async () => {
       const page = render(Component, {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Log/Log.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Log/Log.svelte.test.ts
@@ -22,14 +22,14 @@ describe("Log component", () => {
 
   describe("basics", () => {
     it("renders", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page)).toBeInTheDocument();
     });
 
     it.each(["Line", "Timestamp", "Content"])(
       "renders column header %s",
       async (header) => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         await expect
           .element(columnHeaderLocator(page, header))
           .toBeInTheDocument();
@@ -37,7 +37,7 @@ describe("Log component", () => {
     );
 
     it("doesn't render timestamp column when hideTimestamps is true", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         hideTimestamps: true,
       });
@@ -49,7 +49,7 @@ describe("Log component", () => {
 
   describe("attributes", () => {
     it.each([["id", "test-id"]])("applies %s", async (attribute, expected) => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         [attribute]: expected,
       });
@@ -59,7 +59,7 @@ describe("Log component", () => {
     });
 
     it("applies aria-label", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         "aria-label": "custom-aria-label",
       });
@@ -69,14 +69,17 @@ describe("Log component", () => {
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("log");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -88,7 +91,7 @@ describe("Log component", () => {
 
   describe("rows", () => {
     it("renders log line", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         children: oneLog,
       });
@@ -114,7 +117,7 @@ describe("Log component", () => {
     });
 
     it("renders multiple log lines", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         children: logs,
       });
@@ -135,7 +138,7 @@ describe("Log component", () => {
     });
 
     it("doesn't render timestamps when hideTimestamps is true", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         children: logs,
         hideTimestamps: true,
@@ -152,8 +155,8 @@ describe("Log component", () => {
   });
 
   describe("wrapLines", () => {
-    it("is horizontally scrollable when wrapLines is false", () => {
-      const page = render(Component, {
+    it("is horizontally scrollable when wrapLines is false", async () => {
+      const page = await render(Component, {
         ...baseProps,
         children: longLog,
         hideTimestamps: true,
@@ -169,8 +172,8 @@ describe("Log component", () => {
       );
     });
 
-    it("is not horizontally scrollable when wrapLines is true", () => {
-      const page = render(Component, {
+    it("is not horizontally scrollable when wrapLines is true", async () => {
+      const page = await render(Component, {
         ...baseProps,
         children: longLog,
         hideTimestamps: true,
@@ -191,7 +194,7 @@ describe("Log component", () => {
     };
 
     it("uses custom formatter for timestamp text content", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         children: oneLog,
         timestampFormatter: customFormatter,
@@ -206,7 +209,7 @@ describe("Log component", () => {
     });
 
     it("still uses ISO format for datetime attribute", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         children: oneLog,
         timestampFormatter: customFormatter,
@@ -221,7 +224,7 @@ describe("Log component", () => {
     });
 
     it("uses custom formatter for all log lines", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         children: logs,
         timestampFormatter: customFormatter,

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.svelte.test.ts
@@ -39,7 +39,7 @@ describe("Modal component", () => {
   }
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page, true)).toBeInTheDocument();
   });
 
@@ -48,14 +48,20 @@ describe("Modal component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page, true))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect
         .element(componentLocator(page, true))
         .toHaveClass("test-class");
@@ -64,7 +70,7 @@ describe("Modal component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -76,7 +82,7 @@ describe("Modal component", () => {
 
   describe("basics", () => {
     it("renders trigger", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
       });
       const modalId = (
@@ -96,7 +102,7 @@ describe("Modal component", () => {
     });
 
     it("renders children", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
       });
       await expect
@@ -110,7 +116,7 @@ describe("Modal component", () => {
     });
 
     it("is hidden by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page, true)).not.toBeVisible();
 
       await expect
@@ -122,7 +128,7 @@ describe("Modal component", () => {
   describe("Opening the Modal", () => {
     it("is opened when `showModal` on the dialog element is called", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       expect(props.open).toBe(undefined);
 
@@ -135,7 +141,7 @@ describe("Modal component", () => {
 
     it("is opened by trigger click", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       expect(props.open).toBe(undefined);
 
@@ -148,7 +154,7 @@ describe("Modal component", () => {
 
     it("is opened by setting open to true", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       expect(props.open).toBe(undefined);
 
@@ -161,7 +167,7 @@ describe("Modal component", () => {
 
     it("upgrades a server-rendered open dialog to a true modal on mount", async () => {
       const props = withOpen({ open: true });
-      const page = render(Component, props);
+      const page = await render(Component, props);
 
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
@@ -173,7 +179,7 @@ describe("Modal component", () => {
     it("does not call onclose during upgrade to modal, but still calls on later real close", async () => {
       const onclose = vi.fn();
       const props = withOpen({ open: true, onclose });
-      const page = render(Component, props);
+      const page = await render(Component, props);
 
       await expect.element(componentLocator(page)).toBeVisible();
       flushSync();
@@ -190,7 +196,7 @@ describe("Modal component", () => {
   describe("Closing the Modal", () => {
     it("is closed when `close` on the dialog element is called", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showModal(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -204,7 +210,7 @@ describe("Modal component", () => {
 
     it("is closed by close() supplied via children snippet", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showModal(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -218,7 +224,7 @@ describe("Modal component", () => {
 
     it("is closed by clicking outside the modal when `closeOnOutsideClick` is true", async () => {
       const props = withOpen({ closeOnOutsideClick: true });
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showModal(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -232,7 +238,7 @@ describe("Modal component", () => {
 
     it("is not closed by clicking outside the modal when `closeOnOutsideClick` is false", async () => {
       const props = withOpen({ closeOnOutsideClick: false });
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showModal(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -244,7 +250,7 @@ describe("Modal component", () => {
 
     it("is closed by pressing Escape", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showModal(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -258,7 +264,7 @@ describe("Modal component", () => {
 
     it("is closed by setting open to false", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showModal(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -273,7 +279,7 @@ describe("Modal component", () => {
 
   describe("Declarative control attributes", () => {
     it("passes commandfor to children", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
       });
       const modalId = (

--- a/packages/svelte/ds-app-launchpad/src/lib/components/NumberInput/NumberInput.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/NumberInput/NumberInput.svelte.test.ts
@@ -9,7 +9,7 @@ describe("NumberInput component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeVisible();
   });
 
@@ -18,21 +18,27 @@ describe("NumberInput component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("number-input");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -44,14 +50,14 @@ describe("NumberInput component", () => {
 
   describe("Input attributes", () => {
     it("sets type to number", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("type", "number");
     });
 
     it("applies value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: 123,
       });
@@ -60,12 +66,12 @@ describe("NumberInput component", () => {
 
     describe("Disabled state", () => {
       it("isn't disabled by default", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         await expect.element(componentLocator(page)).not.toBeDisabled();
       });
 
       it("can be disabled", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           disabled: true,
         });
@@ -76,7 +82,7 @@ describe("NumberInput component", () => {
 
   describe("Validation attributes", () => {
     it("applies required", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         required: true,
       });
@@ -90,7 +96,7 @@ describe("NumberInput component", () => {
     });
 
     it("applies min and max", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         min: 5,
         max: 10,

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Popover/Popover.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Popover/Popover.svelte.test.ts
@@ -23,13 +23,13 @@ describe("Popover component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(triggerLocator(page)).toBeInTheDocument();
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
   it("renders content", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect
       .element(componentLocator(page))
       .toHaveTextContent(childrenText);
@@ -40,21 +40,27 @@ describe("Popover component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("popover");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -66,7 +72,7 @@ describe("Popover component", () => {
 
   describe("Declarative controls", () => {
     it("properly associates the trigger with the popover if no id is provided", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const popoverId = triggerLocator(page)
         .element()
         .getAttribute("popovertarget");
@@ -77,7 +83,7 @@ describe("Popover component", () => {
     });
 
     it("properly associates the trigger with the popover if an id is provided", async () => {
-      const page = render(Component, { ...baseProps, id: "custom-id" });
+      const page = await render(Component, { ...baseProps, id: "custom-id" });
       await expect
         .element(triggerLocator(page))
         .toHaveAttribute("popovertarget", "custom-id");
@@ -87,7 +93,7 @@ describe("Popover component", () => {
     });
 
     it("clicking the trigger toggles the popover", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page)).not.toBeVisible();
       await triggerLocator(page).click();
       await expect.element(componentLocator(page)).toBeVisible();
@@ -100,7 +106,7 @@ describe("Popover component", () => {
 
     it("ontoggle is called on trigger click", async () => {
       const ontoggle = vi.fn();
-      const page = render(Component, { ...baseProps, ontoggle });
+      const page = await render(Component, { ...baseProps, ontoggle });
       await triggerLocator(page).click();
       expect(ontoggle).toHaveBeenCalledOnce();
       await triggerLocator(page, true).click();
@@ -109,7 +115,7 @@ describe("Popover component", () => {
 
     it("onbeforetoggle is called on trigger click", async () => {
       const onbeforetoggle = vi.fn();
-      const page = render(Component, { ...baseProps, onbeforetoggle });
+      const page = await render(Component, { ...baseProps, onbeforetoggle });
       await triggerLocator(page).click();
       expect(onbeforetoggle).toHaveBeenCalledOnce();
       await triggerLocator(page, true).click();
@@ -119,7 +125,7 @@ describe("Popover component", () => {
 
   describe("Imperative controls", () => {
     it("showPopover shows the popover", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const component = page.component as unknown as PopoverMethods;
       await expect.element(componentLocator(page)).not.toBeVisible();
       component.showPopover();
@@ -130,7 +136,7 @@ describe("Popover component", () => {
     });
 
     it("hidePopover hides the popover", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const component = page.component as unknown as PopoverMethods;
       component.showPopover();
       await expect.element(componentLocator(page)).toBeVisible();
@@ -142,7 +148,7 @@ describe("Popover component", () => {
     });
 
     it("togglePopover toggles the popover", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const component = page.component as unknown as PopoverMethods;
       await expect.element(componentLocator(page)).not.toBeVisible();
       component.togglePopover();

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Radio/Radio.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Radio/Radio.svelte.test.ts
@@ -8,7 +8,7 @@ describe("Radio component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -17,21 +17,27 @@ describe("Radio component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("radio");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -43,27 +49,27 @@ describe("Radio component", () => {
 
   describe("Checked state", () => {
     it("is not checked by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page)).not.toBeChecked();
     });
 
     it("can be checked", async () => {
-      const page = render(Component, { ...baseProps, checked: true });
+      const page = await render(Component, { ...baseProps, checked: true });
       await expect.element(componentLocator(page)).toBeChecked();
     });
 
     it("isn't disabled by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page)).not.toBeDisabled();
     });
 
     it("can be disabled", async () => {
-      const page = render(Component, { ...baseProps, disabled: true });
+      const page = await render(Component, { ...baseProps, disabled: true });
       await expect.element(componentLocator(page)).toBeDisabled();
     });
 
     it("can be checked by on click", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const radio = componentLocator(page);
 
       await expect.element(radio).not.toBeChecked();
@@ -74,7 +80,7 @@ describe("Radio component", () => {
 
   describe("Group controlled", () => {
     it("isn't checked if group and value are undefined", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: undefined,
         value: undefined,
@@ -83,7 +89,7 @@ describe("Radio component", () => {
     });
 
     it("isn't checked if group doesn't match value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: "test-group",
         value: "test-value",
@@ -92,7 +98,7 @@ describe("Radio component", () => {
     });
 
     it("is checked if group and value match", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: "test-value",
         value: "test-value",
@@ -105,7 +111,7 @@ describe("Radio component", () => {
     it("emits change event on click", async () => {
       const onchange = vi.fn();
 
-      const page = render(Component, { ...baseProps, onchange });
+      const page = await render(Component, { ...baseProps, onchange });
       const radio = componentLocator(page);
 
       await expect.element(radio).not.toBeChecked();
@@ -115,6 +121,6 @@ describe("Radio component", () => {
   });
 });
 
-function componentLocator(page: ReturnType<typeof render>): Locator {
+function componentLocator(page: Awaited<ReturnType<typeof render>>): Locator {
   return page.getByRole("radio");
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/RelativeDateTime/RelativeDateTime.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/RelativeDateTime/RelativeDateTime.svelte.test.ts
@@ -31,7 +31,7 @@ describe("RelativeDateTime component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, baseProps);
+    const page = await render(Component, baseProps);
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -40,21 +40,30 @@ describe("RelativeDateTime component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, value) => {
-      const page = render(Component, { ...baseProps, [attribute]: value });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: value,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, value);
     });
 
     it("applies style", async () => {
-      const page = render(Component, { ...baseProps, style: "color: orange;" });
+      const page = await render(Component, {
+        ...baseProps,
+        style: "color: orange;",
+      });
       await expect
         .element(componentLocator(page))
         .toHaveStyle("color: orange;");
     });
 
     it("applies class", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const element = componentLocator(page);
       await expect.element(element).toHaveClass("test-class");
     });
@@ -62,21 +71,21 @@ describe("RelativeDateTime component", () => {
 
   describe("datetime attribute", () => {
     it("applies correct datetime attribute for Date input", async () => {
-      const page = render(Component, baseProps);
+      const page = await render(Component, baseProps);
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("datetime", date.toISOString());
     });
 
     it("applies correct datetime attribute for timestamp input", async () => {
-      const page = render(Component, { ...baseProps, date: timestamp });
+      const page = await render(Component, { ...baseProps, date: timestamp });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("datetime", date.toISOString());
     });
 
     it("applies correct datetime attribute for date string input", async () => {
-      const page = render(Component, { ...baseProps, date: dateString });
+      const page = await render(Component, { ...baseProps, date: dateString });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("datetime", date.toISOString());
@@ -87,7 +96,7 @@ describe("RelativeDateTime component", () => {
     describe("now label", () => {
       it("renders nowLabel when within nowThreshold", async () => {
         const now = Date.now();
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           date: now,
           nowThreshold: 999999,
@@ -97,7 +106,7 @@ describe("RelativeDateTime component", () => {
 
       it("does not render nowLabel when outside nowThreshold", async () => {
         const now = Date.now();
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           date: now - 1000,
           nowThreshold: 10,
@@ -109,7 +118,7 @@ describe("RelativeDateTime component", () => {
 
       it("renders custom nowLabel when within nowThreshold", async () => {
         const now = Date.now();
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           date: now,
           nowThreshold: 999999,
@@ -124,7 +133,7 @@ describe("RelativeDateTime component", () => {
     describe("Relative time", () => {
       it("renders relative time when outside nowThreshold", async () => {
         const pastDate = new Date(Date.now() - 1000 * 60 * 60 * 3); // 3 hours ago
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           date: pastDate,
           nowThreshold: 0,
@@ -138,7 +147,7 @@ describe("RelativeDateTime component", () => {
       it("updates over time", async () => {
         vi.useFakeTimers();
         const pastDate = new Date(Date.now() - 1000 * 60 * 3); // 3 minutes ago
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           date: pastDate,
           nowThreshold: 0,
@@ -165,7 +174,7 @@ describe("RelativeDateTime component", () => {
 
   describe("title attribute", () => {
     it("applies formatted date as title", async () => {
-      const page = render(Component, baseProps);
+      const page = await render(Component, baseProps);
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("title", "1/1/24, 12:00 PM");

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SearchBox/SearchBox.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SearchBox/SearchBox.svelte.test.ts
@@ -15,12 +15,12 @@ const baseProps = {
 
 describe("SearchBox component", () => {
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeVisible();
   });
 
   it("applies classes", async () => {
-    const page = render(Component, { ...baseProps, class: "test-class" });
+    const page = await render(Component, { ...baseProps, class: "test-class" });
     await expect.element(componentLocator(page)).toHaveClass("test-class");
     await expect.element(componentLocator(page)).toHaveClass("ds");
     await expect.element(componentLocator(page)).toHaveClass("search-box");
@@ -28,13 +28,11 @@ describe("SearchBox component", () => {
 
   describe("basics", () => {
     it("doesn't throw", async () => {
-      expect(() => {
-        render(Component, { ...baseProps });
-      }).not.toThrow();
+      await render(Component, { ...baseProps });
     });
 
     it("renders wrapper, input and button", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(wrapperLocator(page)).toBeInTheDocument();
       await expect.element(inputLocator(page)).toBeInTheDocument();
       await expect.element(buttonLocator(page)).toBeInTheDocument();
@@ -46,7 +44,7 @@ describe("SearchBox component", () => {
       ["name", "test-name"],
       ["placeholder", "test-placeholder"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         [attribute]: expected,
       });
@@ -56,12 +54,15 @@ describe("SearchBox component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, { style: "color: orange;", ...baseProps });
+      const page = await render(Component, {
+        style: "color: orange;",
+        ...baseProps,
+      });
       await expect.element(inputLocator(page)).toHaveStyle({ color: "orange" });
     });
 
     it("can be required", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         required: true,
       });
@@ -69,7 +70,7 @@ describe("SearchBox component", () => {
     });
 
     it("applies value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "test-value",
       });
@@ -79,20 +80,23 @@ describe("SearchBox component", () => {
 
   describe("button and input", () => {
     it("are not disabled by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(inputLocator(page)).toBeEnabled();
       await expect.element(buttonLocator(page)).toBeEnabled();
     });
 
     it("can be disabled", async () => {
-      const page = render(Component, { ...baseProps, disabled: true });
+      const page = await render(Component, { ...baseProps, disabled: true });
       await expect.element(inputLocator(page)).toBeDisabled();
       await expect.element(buttonLocator(page)).toBeDisabled();
     });
 
     it("share the same accessible name", async () => {
       const label = "test-label";
-      const page = render(Component, { ...baseProps, "aria-label": label });
+      const page = await render(Component, {
+        ...baseProps,
+        "aria-label": label,
+      });
       await expect
         .element(page.getByRole("searchbox", { name: label }))
         .toBeInTheDocument();
@@ -102,7 +106,7 @@ describe("SearchBox component", () => {
     });
 
     it("renders a default search button when children are not provided", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
       });
       await expect
@@ -111,7 +115,7 @@ describe("SearchBox component", () => {
     });
 
     it("composed SearchButton inherits aria-label from SearchBox context", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         children: inheritedChildren,
       });
@@ -121,7 +125,7 @@ describe("SearchBox component", () => {
     });
 
     it("composed SearchButton inherits disabled from SearchBox context", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         disabled: true,
         children: inheritedChildren,
@@ -133,7 +137,7 @@ describe("SearchBox component", () => {
     });
 
     it("composed SearchButton can override inherited aria-label and disabled", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         disabled: true,
         children: overriddenChildren,

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Select/Select.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Select/Select.svelte.test.ts
@@ -17,7 +17,7 @@ describe("Select component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(selectLocator(page)).toBeVisible();
     await expect
       .element(page.getByRole("option"))
@@ -29,14 +29,20 @@ describe("Select component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(selectLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const wrapper = componentLocator(page).element();
       await expect.element(wrapper).toHaveClass("test-class");
       await expect.element(wrapper).toHaveClass("ds");
@@ -44,7 +50,7 @@ describe("Select component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -53,7 +59,7 @@ describe("Select component", () => {
   });
 
   it("renders when multiple is true", async () => {
-    const page = render(Component, { ...baseProps, multiple: true });
+    const page = await render(Component, { ...baseProps, multiple: true });
     await expect.element(page.getByRole("listbox")).toHaveAttribute("multiple");
     await expect
       .element(page.getByRole("option"))

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/SideNavigation.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/SideNavigation.svelte.test.ts
@@ -17,7 +17,7 @@ describe("SideNavigation component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, baseProps);
+    const page = await render(Component, baseProps);
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -26,7 +26,7 @@ describe("SideNavigation component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, value) => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         [attribute]: value,
       });
@@ -37,7 +37,7 @@ describe("SideNavigation component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -47,7 +47,7 @@ describe("SideNavigation component", () => {
     });
 
     it("applies class", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         class: "test-class",
       });
@@ -61,7 +61,7 @@ describe("SideNavigation component", () => {
   describe("contents", () => {
     describe("while expanded", () => {
       it("renders logo", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           expanded: true,
         });
@@ -71,7 +71,7 @@ describe("SideNavigation component", () => {
       });
 
       it("renders children", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           expanded: true,
         });
@@ -85,7 +85,7 @@ describe("SideNavigation component", () => {
       });
 
       it("renders expand toggle", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           expanded: true,
         });
@@ -105,7 +105,7 @@ describe("SideNavigation component", () => {
       });
 
       it("renders footer", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           expanded: true,
         });
@@ -120,7 +120,7 @@ describe("SideNavigation component", () => {
 
     describe("while collapsed", () => {
       it("renders logo", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           expanded: false,
         });
@@ -130,7 +130,7 @@ describe("SideNavigation component", () => {
       });
 
       it("renders expand toggle", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           expanded: false,
         });
@@ -149,7 +149,7 @@ describe("SideNavigation component", () => {
       });
 
       it("does not render children", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           expanded: false,
         });
@@ -159,7 +159,7 @@ describe("SideNavigation component", () => {
       });
 
       it("renders footer", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           expanded: false,
         });
@@ -175,7 +175,7 @@ describe("SideNavigation component", () => {
 
   it("toggles between expanded and collapsed states", async () => {
     const props = $state({ ...baseProps, expanded: false });
-    const page = render(Component, props);
+    const page = await render(Component, props);
 
     const expandToggle = page.getByRole("button", {
       name: "Expand navigation",

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/common/ExpandToggle/ExpandToggle.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/common/ExpandToggle/ExpandToggle.svelte.test.ts
@@ -9,7 +9,7 @@ describe("ExpandToggle component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -18,14 +18,20 @@ describe("ExpandToggle component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect
@@ -34,7 +40,7 @@ describe("ExpandToggle component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -49,7 +55,7 @@ describe("ExpandToggle component", () => {
       ["aria-expanded", true],
       ["aria-controls", "test-id"],
     ] as const)("applies %s", async (attribute, value) => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         [attribute]: value,
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/common/NavigationItem/NavigationItem.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SideNavigation/common/NavigationItem/NavigationItem.svelte.test.ts
@@ -14,7 +14,7 @@ describe("NavigationItem component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -23,14 +23,20 @@ describe("NavigationItem component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect
@@ -39,7 +45,7 @@ describe("NavigationItem component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -50,7 +56,7 @@ describe("NavigationItem component", () => {
   });
 
   it("renders as link when href is provided", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       href: "https://example.com",
     });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/SidePanel.svelte.test.ts
@@ -39,7 +39,7 @@ describe("SidePanel component", () => {
   }
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page, true)).toBeInTheDocument();
   });
 
@@ -48,14 +48,20 @@ describe("SidePanel component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page, true))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect
         .element(componentLocator(page, true))
         .toHaveClass("test-class");
@@ -66,7 +72,7 @@ describe("SidePanel component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -78,7 +84,7 @@ describe("SidePanel component", () => {
 
   describe("basics", () => {
     it("renders trigger", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
       });
       const sidePanelId = (
@@ -98,7 +104,7 @@ describe("SidePanel component", () => {
     });
 
     it("renders children", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
       });
       await expect
@@ -112,7 +118,7 @@ describe("SidePanel component", () => {
     });
 
     it("is hidden by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page, true)).not.toBeVisible();
 
       await expect
@@ -124,7 +130,7 @@ describe("SidePanel component", () => {
   describe("Opening the SidePanel", () => {
     it("is opened when `showModal` on the dialog element is called", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       expect(props.open).toBe(undefined);
 
@@ -137,7 +143,7 @@ describe("SidePanel component", () => {
 
     it("is opened by trigger click", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       expect(props.open).toBe(undefined);
 
@@ -150,7 +156,7 @@ describe("SidePanel component", () => {
 
     it("is opened by setting open to true", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await expect.element(componentLocator(page, true)).not.toBeVisible();
       expect(props.open).toBe(undefined);
 
@@ -163,7 +169,7 @@ describe("SidePanel component", () => {
 
     it("upgrades a server-rendered open dialog to a true modal on mount", async () => {
       const props = withOpen({ open: true });
-      const page = render(Component, props);
+      const page = await render(Component, props);
 
       await expect.element(componentLocator(page)).toBeVisible();
       await expect.element(componentLocator(page)).toHaveAttribute("open");
@@ -176,7 +182,7 @@ describe("SidePanel component", () => {
   describe("Closing the SidePanel", () => {
     it("is closed when `close` on the dialog element is called", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showSidePanel(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -190,7 +196,7 @@ describe("SidePanel component", () => {
 
     it("is closed by close() supplied via children snippet", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showSidePanel(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -204,7 +210,7 @@ describe("SidePanel component", () => {
 
     it("is closed by clicking outside the side panel when `closeOnOutsideClick` is true", async () => {
       const props = withOpen({ closeOnOutsideClick: true });
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showSidePanel(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -218,7 +224,7 @@ describe("SidePanel component", () => {
 
     it("is not closed by clicking outside the side panel when `closeOnOutsideClick` is false", async () => {
       const props = withOpen({ closeOnOutsideClick: false });
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showSidePanel(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -230,7 +236,7 @@ describe("SidePanel component", () => {
 
     it("is closed by pressing Escape", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showSidePanel(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -244,7 +250,7 @@ describe("SidePanel component", () => {
 
     it("is closed by setting open to false", async () => {
       const props = withOpen();
-      const page = render(Component, props);
+      const page = await render(Component, props);
       await showSidePanel(page);
       await expect.poll(() => props.open).toBe(true);
 
@@ -259,7 +265,7 @@ describe("SidePanel component", () => {
 
   describe("Declarative control attributes", () => {
     it("passes commandfor to children", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
       });
       const sidePanelId = (
@@ -277,7 +283,7 @@ describe("SidePanel component", () => {
     });
 
     it("only adds onclick trigger fallback when invoker commands are unsupported", async () => {
-      const page = render(Component, { ...baseProps, trigger });
+      const page = await render(Component, { ...baseProps, trigger });
       const supportsInvokerCommands =
         "commandForElement" in HTMLButtonElement.prototype &&
         "command" in HTMLButtonElement.prototype;

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Spinner/Spinner.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Spinner/Spinner.svelte.test.ts
@@ -7,13 +7,13 @@ describe("Spinner component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(page.getByLabelText("Loading")).toBeInTheDocument();
   });
 
   describe("attributes", () => {
     it("applies classes", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         class: "test-class",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Switch/Switch.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Switch/Switch.svelte.test.ts
@@ -8,7 +8,7 @@ describe("Switch component", () => {
   const baseProps = {};
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -17,21 +17,27 @@ describe("Switch component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("switch");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -43,7 +49,7 @@ describe("Switch component", () => {
 
   describe("Switch state", () => {
     it("is not checked by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const switchElement = componentLocator(page);
       await expect.element(switchElement).not.toBeChecked();
       await expect
@@ -52,7 +58,7 @@ describe("Switch component", () => {
     });
 
     it("can be checked", async () => {
-      const page = render(Component, { ...baseProps, checked: true });
+      const page = await render(Component, { ...baseProps, checked: true });
       const switchElement = componentLocator(page);
       await expect.element(switchElement).toBeChecked();
       await expect
@@ -61,7 +67,7 @@ describe("Switch component", () => {
     });
 
     it("isn't disabled by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const switchElement = componentLocator(page);
       await expect.element(switchElement).not.toBeDisabled();
       await expect
@@ -70,7 +76,7 @@ describe("Switch component", () => {
     });
 
     it("can be disabled", async () => {
-      const page = render(Component, { ...baseProps, disabled: true });
+      const page = await render(Component, { ...baseProps, disabled: true });
       const switchElement = componentLocator(page);
       await expect.element(switchElement).toBeDisabled();
       await expect
@@ -79,7 +85,7 @@ describe("Switch component", () => {
     });
 
     it("toggles checked state on click", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const switchElement = componentLocator(page);
 
       await expect.element(switchElement).not.toBeChecked();
@@ -99,7 +105,7 @@ describe("Switch component", () => {
 
   describe("Group controlled", () => {
     it("isn't checked if group and value are undefined", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: undefined,
         value: undefined,
@@ -108,7 +114,7 @@ describe("Switch component", () => {
     });
 
     it("isn't checked if group doesn't include value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: ["a", "b"],
         value: "c",
@@ -117,7 +123,7 @@ describe("Switch component", () => {
     });
 
     it("is checked if group includes value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         group: ["a", "b", "c"],
         value: "c",
@@ -130,7 +136,7 @@ describe("Switch component", () => {
     it("emits change event on click", async () => {
       const onchange = vi.fn();
 
-      const page = render(Component, { ...baseProps, onchange });
+      const page = await render(Component, { ...baseProps, onchange });
       const switchElement = componentLocator(page);
       await switchElement.click();
       expect(onchange).toHaveBeenCalledOnce();
@@ -139,14 +145,14 @@ describe("Switch component", () => {
 
   describe("Accessibility", () => {
     it("can be focused", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const switchElement = componentLocator(page);
       (switchElement.element() as HTMLElement).focus();
       await expect.element(switchElement).toHaveFocus();
     });
 
     it("can be toggled with space key", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const switchElement = componentLocator(page);
       await expect.element(switchElement).not.toBeChecked();
       (switchElement.element() as HTMLElement).focus();
@@ -159,6 +165,6 @@ describe("Switch component", () => {
   });
 });
 
-function componentLocator(page: ReturnType<typeof render>): Locator {
+function componentLocator(page: Awaited<ReturnType<typeof render>>): Locator {
   return page.getByRole("switch");
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.svelte.test.ts
@@ -26,7 +26,7 @@ describe("Table component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeVisible();
     await expect.element(thLocator(page)).toBeVisible();
     await expect.element(tdLocator(page)).toBeVisible();
@@ -34,21 +34,27 @@ describe("Table component", () => {
 
   describe("attributes", () => {
     it.each([["id", "test-id"]])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("table");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -63,19 +69,19 @@ describe("Table component", () => {
       "shows sort button when sort direction is %s",
       async (direction) => {
         setSortDirection(direction);
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         await expect.element(sortButtonLocator(page)).toBeVisible();
       },
     );
 
     it("sort button shown when header cell is hovered", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await thLocator(page).hover();
       await expect.element(sortButtonLocator(page)).toBeVisible();
     });
 
     it("sort button is tabbable into even when not visible", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await userEvent.click(page.baseElement);
       await userEvent.tab();
       await expect.element(sortButtonLocator(page)).toHaveFocus();

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/Table.svelte.test.ts
@@ -59,14 +59,14 @@ describe("Table component", () => {
   });
 
   describe("sort direction", () => {
-    it.each([
-      "ascending",
-      "descending",
-    ] as const)("shows sort button when sort direction is %s", async (direction) => {
-      setSortDirection(direction);
-      const page = render(Component, { ...baseProps });
-      await expect.element(sortButtonLocator(page)).toBeVisible();
-    });
+    it.each(["ascending", "descending"] as const)(
+      "shows sort button when sort direction is %s",
+      async (direction) => {
+        setSortDirection(direction);
+        const page = render(Component, { ...baseProps });
+        await expect.element(sortButtonLocator(page)).toBeVisible();
+      },
+    );
 
     it("sort button shown when header cell is hovered", async () => {
       const page = render(Component, { ...baseProps });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/SortButton.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Table/common/TH/common/SortButton/SortButton.svelte.test.ts
@@ -22,25 +22,31 @@ describe("SortButton component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
   describe("attributes", () => {
     it.each([["id", "test-id"]])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -51,7 +57,7 @@ describe("SortButton component", () => {
   });
 
   it("renders as link when href is provided", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       href: "https://example.com",
     });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/TextInput.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/TextInput.ssr.test.ts
@@ -53,17 +53,15 @@ describe("TextInput SSR", () => {
         expect(componentLocator(page).getAttribute("type")).toBe("text");
       });
 
-      it.each([
-        "text",
-        "email",
-        "url",
-        "tel",
-      ] as const)("accepts %s", (type) => {
-        const page = render(Component, {
-          props: { ...baseProps, type },
-        });
-        expect(componentLocator(page).getAttribute("type")).toBe(type);
-      });
+      it.each(["text", "email", "url", "tel"] as const)(
+        "accepts %s",
+        (type) => {
+          const page = render(Component, {
+            props: { ...baseProps, type },
+          });
+          expect(componentLocator(page).getAttribute("type")).toBe(type);
+        },
+      );
     });
 
     it("accepts search type", () => {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/TextInput.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/TextInput.svelte.test.ts
@@ -51,21 +51,18 @@ describe("TextInput component", () => {
           .toHaveAttribute("type", "text");
       });
 
-      it.each([
-        "text",
-        "password",
-        "email",
-        "url",
-        "tel",
-      ] as const)("accepts %s", async (type) => {
-        const page = render(Component, {
-          ...baseProps,
-          type,
-        });
-        await expect
-          .element(componentLocator(page))
-          .toHaveAttribute("type", type);
-      });
+      it.each(["text", "password", "email", "url", "tel"] as const)(
+        "accepts %s",
+        async (type) => {
+          const page = render(Component, {
+            ...baseProps,
+            type,
+          });
+          await expect
+            .element(componentLocator(page))
+            .toHaveAttribute("type", type);
+        },
+      );
 
       it("accepts search", async () => {
         const page = render(Component, {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/TextInput.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/TextInput.svelte.test.ts
@@ -9,7 +9,7 @@ describe("TextInput component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeVisible();
   });
 
@@ -18,21 +18,27 @@ describe("TextInput component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("text-input");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -45,7 +51,7 @@ describe("TextInput component", () => {
   describe("Input attributes", () => {
     describe("type", () => {
       it("defaults to text", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         await expect
           .element(componentLocator(page))
           .toHaveAttribute("type", "text");
@@ -54,7 +60,7 @@ describe("TextInput component", () => {
       it.each(["text", "password", "email", "url", "tel"] as const)(
         "accepts %s",
         async (type) => {
-          const page = render(Component, {
+          const page = await render(Component, {
             ...baseProps,
             type,
           });
@@ -65,7 +71,7 @@ describe("TextInput component", () => {
       );
 
       it("accepts search", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           type: "search",
         });
@@ -76,7 +82,7 @@ describe("TextInput component", () => {
     });
 
     it("applies value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "Test value",
       });
@@ -85,12 +91,12 @@ describe("TextInput component", () => {
 
     describe("Disabled state", () => {
       it("isn't disabled by default", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         await expect.element(componentLocator(page)).not.toBeDisabled();
       });
 
       it("can be disabled", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           disabled: true,
         });
@@ -101,7 +107,7 @@ describe("TextInput component", () => {
 
   describe("Validation attributes", () => {
     it("applies required", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         required: true,
       });
@@ -115,7 +121,7 @@ describe("TextInput component", () => {
     });
 
     it("minlength", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         minlength: 5,
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Textarea/Textarea.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Textarea/Textarea.svelte.test.ts
@@ -10,7 +10,7 @@ describe("Textarea component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps, value: "Textarea" });
+    const page = await render(Component, { ...baseProps, value: "Textarea" });
     await expect.element(componentLocator(page)).toBeVisible();
     await expect.element(componentLocator(page)).toHaveValue("Textarea");
   });
@@ -20,21 +20,27 @@ describe("Textarea component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("textarea");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -50,7 +56,7 @@ describe("Textarea component", () => {
         value: "Textarea",
         rows: 3,
       }) satisfies TextareaProps;
-      const page = render(Component, props);
+      const page = await render(Component, props);
       const element = componentLocator(page);
       await expect.element(element).toHaveAttribute("rows", "3");
       props.value = "Textarea\nTextarea\nTextarea\nTextarea\nTextarea";
@@ -62,7 +68,7 @@ describe("Textarea component", () => {
         value: "",
         rows: 3,
       }) satisfies TextareaProps;
-      const page = render(Component, props);
+      const page = await render(Component, props);
       const element = componentLocator(page);
       await expect.element(element).toHaveAttribute("rows", "3");
     });
@@ -72,7 +78,7 @@ describe("Textarea component", () => {
         value: "Textarea",
         rows: [2, 5],
       }) satisfies TextareaProps;
-      const page = render(Component, props);
+      const page = await render(Component, props);
       const element = componentLocator(page);
       await expect.element(element).toHaveAttribute("rows", "2");
       props.value =
@@ -87,7 +93,7 @@ describe("Textarea component", () => {
         value: "Textarea",
         rows: [2, 5],
       }) satisfies TextareaProps;
-      const page = render(Component, props);
+      const page = await render(Component, props);
       const element = componentLocator(page);
       await expect.element(element).toHaveAttribute("rows", "2");
       const longText =

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/Timeline.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/Timeline.svelte.test.ts
@@ -11,7 +11,7 @@ describe("Timeline component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -20,21 +20,27 @@ describe("Timeline component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("timeline");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/Event/Event.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/Event/Event.svelte.test.ts
@@ -21,7 +21,7 @@ describe("Event component", () => {
 
   describe("basics", () => {
     it("renders", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page)).toBeInTheDocument();
     });
   });
@@ -31,14 +31,20 @@ describe("Event component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, value) => {
-      const page = render(Component, { ...baseProps, [attribute]: value });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: value,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, value);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const element = componentLocator(page);
       await expect.element(element).toHaveClass("ds");
       await expect.element(element).toHaveClass("timeline-event");
@@ -46,7 +52,10 @@ describe("Event component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, { ...baseProps, style: "color: orange;" });
+      const page = await render(Component, {
+        ...baseProps,
+        style: "color: orange;",
+      });
       await expect
         .element(componentLocator(page))
         .toHaveStyle({ color: "orange" });
@@ -55,12 +64,12 @@ describe("Event component", () => {
 
   describe("Renders", () => {
     it("renders children", async () => {
-      const page = render(Component, { ...baseProps, children });
+      const page = await render(Component, { ...baseProps, children });
       await expect.element(page.getByText("Child Content")).toBeInTheDocument();
     });
 
     it("renders title row", async () => {
-      const page = render(Component, { ...baseProps, titleRow });
+      const page = await render(Component, { ...baseProps, titleRow });
       await expect
         .element(page.getByText("Title Row Content"))
         .toBeInTheDocument();
@@ -71,14 +80,14 @@ describe("Event component", () => {
 
     describe("Marker", () => {
       it("empty by default", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         const element = componentLocator(page);
         await expect.element(element).toHaveClass("marker-empty");
         expect(element.element().querySelector(".marker")).toBeInTheDocument();
       });
 
       it("small", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           marker: { userName: "John Doe" },
           markerSize: "small",
@@ -89,7 +98,7 @@ describe("Event component", () => {
       });
 
       it("large", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           marker: { userName: "John Doe" },
           markerSize: "large",

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/Event/common/TitleRow/TitleRow.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/Event/common/TitleRow/TitleRow.svelte.test.ts
@@ -19,7 +19,7 @@ describe("TitleRow component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, baseProps);
+    const page = await render(Component, baseProps);
     await expect.element(componentLocator(page)).toBeInTheDocument();
     await expect
       .element(page.getByText("Title Row Content"))
@@ -27,7 +27,7 @@ describe("TitleRow component", () => {
   });
 
   it("renders leadingText", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       leadingText: "Leading Text",
     });
@@ -39,21 +39,30 @@ describe("TitleRow component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, value) => {
-      const page = render(Component, { ...baseProps, [attribute]: value });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: value,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, value);
     });
 
     it("applies style", async () => {
-      const page = render(Component, { ...baseProps, style: "color: orange;" });
+      const page = await render(Component, {
+        ...baseProps,
+        style: "color: orange;",
+      });
       await expect
         .element(componentLocator(page))
         .toHaveStyle("color: orange;");
     });
 
     it("applies class", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const element = componentLocator(page);
       await expect.element(element).toHaveClass("ds");
       await expect.element(element).toHaveClass("timeline-title-row");

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/HiddenEvents.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/HiddenEvents.svelte.test.ts
@@ -15,7 +15,7 @@ describe("HiddenEvents component", () => {
 
   describe("basics", () => {
     it("renders", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(componentLocator(page)).toBeInTheDocument();
     });
   });
@@ -25,14 +25,20 @@ describe("HiddenEvents component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, value) => {
-      const page = render(Component, { ...baseProps, [attribute]: value });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: value,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, value);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const element = componentLocator(page);
       await expect.element(element).toHaveClass("ds");
       await expect.element(element).toHaveClass("timeline-hidden-events");
@@ -40,7 +46,10 @@ describe("HiddenEvents component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, { ...baseProps, style: "color: orange;" });
+      const page = await render(Component, {
+        ...baseProps,
+        style: "color: orange;",
+      });
       await expect
         .element(componentLocator(page))
         .toHaveStyle({ color: "orange" });
@@ -49,18 +58,18 @@ describe("HiddenEvents component", () => {
 
   describe("Renders", () => {
     it("hidden events number", async () => {
-      const page = render(Component, { ...baseProps, numHidden: 888 });
+      const page = await render(Component, { ...baseProps, numHidden: 888 });
       await expect.element(componentLocator(page)).toHaveTextContent("888");
     });
 
     describe("Links", () => {
       it("without the links by default", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         await expect.element(page.getByRole("link")).not.toBeInTheDocument();
       });
 
       it("renders child links", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           children: oneLink,
         });
@@ -70,7 +79,7 @@ describe("HiddenEvents component", () => {
       });
 
       it("renders multiple child links", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           children: multipleLinks,
         });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/common/Link/Link.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Timeline/common/HiddenEvents/common/Link/Link.svelte.test.ts
@@ -15,7 +15,7 @@ describe("HiddenEvents.Link component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, baseProps);
+    const page = await render(Component, baseProps);
     await expect.element(page.getByRole("link")).toBeInTheDocument();
     await expect.element(page.getByText("Show all")).toBeInTheDocument();
   });
@@ -25,21 +25,30 @@ describe("HiddenEvents.Link component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, value) => {
-      const page = render(Component, { ...baseProps, [attribute]: value });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: value,
+      });
       await expect
         .element(page.getByRole("link"))
         .toHaveAttribute(attribute, value);
     });
 
     it("applies href", async () => {
-      const page = render(Component, { ...baseProps, href: "/show-more" });
+      const page = await render(Component, {
+        ...baseProps,
+        href: "/show-more",
+      });
       await expect
         .element(page.getByRole("link"))
         .toHaveAttribute("href", "/show-more");
     });
 
     it("applies class", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const element = page.getByRole("link");
       await expect.element(element).toHaveClass("ds");
       await expect.element(element).toHaveClass("timeline-hidden-events-link");
@@ -47,7 +56,7 @@ describe("HiddenEvents.Link component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Tooltip/Tooltip.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Tooltip/Tooltip.svelte.test.ts
@@ -46,7 +46,7 @@ describe("Tooltip component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page, true)).toBeInTheDocument();
   });
 
@@ -55,14 +55,20 @@ describe("Tooltip component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page, true))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect
         .element(componentLocator(page, true))
         .toHaveClass("test-class");
@@ -71,7 +77,7 @@ describe("Tooltip component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -83,7 +89,7 @@ describe("Tooltip component", () => {
 
   describe("Applies aria-describedby to trigger", () => {
     it("if id not provided", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const button = page.getByRole("button", { name: "Tooltip trigger" });
       const tooltip = page.getByRole("tooltip", { includeHidden: true });
       await expect
@@ -95,7 +101,7 @@ describe("Tooltip component", () => {
     });
 
     it("if id is provided", async () => {
-      const page = render(Component, { id: "test-id", ...baseProps });
+      const page = await render(Component, { id: "test-id", ...baseProps });
       const button = page.getByRole("button", { name: "Tooltip trigger" });
       await expect
         .element(button)
@@ -106,7 +112,7 @@ describe("Tooltip component", () => {
   describe("Is shown", () => {
     // Seems like `button.hover()` is very flaky in firefox, so it needs some retries. If this is really bad, maybe we should skip hover tests in firefox altogether?
     it("on trigger hover", { retry: 3 }, async () => {
-      const page = render(Component, { ...baseProps, delay: 0 });
+      const page = await render(Component, { ...baseProps, delay: 0 });
       const button = page.getByRole("button", { name: "Tooltip trigger" });
       await expect
         .element(page.getByRole("tooltip", { includeHidden: true }))
@@ -120,7 +126,7 @@ describe("Tooltip component", () => {
     });
 
     it("on trigger focus", async () => {
-      const page = render(Component, { ...baseProps, delay: 0 });
+      const page = await render(Component, { ...baseProps, delay: 0 });
       const button = page.getByRole("button", { name: "Tooltip trigger" });
       await expect
         .element(page.getByRole("tooltip", { includeHidden: true }))
@@ -134,7 +140,7 @@ describe("Tooltip component", () => {
     });
 
     it("if mouse moves from trigger to tooltip", async () => {
-      const page = render(Component, { ...baseProps, delay: 0 });
+      const page = await render(Component, { ...baseProps, delay: 0 });
       const button = page.getByRole("button", { name: "Tooltip trigger" });
       const tooltip = page.getByRole("tooltip", { includeHidden: true });
       await expect.element(tooltip).not.toBeVisible();
@@ -148,7 +154,7 @@ describe("Tooltip component", () => {
 
     it("after delay", async () => {
       vi.useFakeTimers();
-      const page = render(Component, { ...baseProps, delay: 350 });
+      const page = await render(Component, { ...baseProps, delay: 350 });
       const button = page.getByRole("button", { name: "Tooltip trigger" });
       await expect
         .element(page.getByRole("tooltip", { includeHidden: true }))
@@ -165,7 +171,7 @@ describe("Tooltip component", () => {
 
     it("immediately if in chaining", async () => {
       vi.useFakeTimers();
-      const page = render(Component, { ...baseProps, delay: 350 });
+      const page = await render(Component, { ...baseProps, delay: 350 });
       const button = page.getByRole("button", { name: "Tooltip trigger" });
       await expect
         .element(page.getByRole("tooltip", { includeHidden: true }))
@@ -186,20 +192,20 @@ describe("Tooltip component", () => {
 
   describe("Renders", () => {
     it("trigger", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const button = page.getByRole("button", { name: "Tooltip trigger" });
       await expect.element(button).toBeInTheDocument();
     });
 
     it("tooltip", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const tooltip = componentLocator(page, true);
       await expect.element(tooltip).toBeInTheDocument();
       await expect.element(tooltip).toHaveTextContent("Tooltip content");
     });
 
     it("not visible by default", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       const tooltip = componentLocator(page, true);
       await expect.element(tooltip).not.toBeVisible();
     });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/UserAvatar/UserAvatar.svelte.test.ts
@@ -14,7 +14,7 @@ describe("UserAvatar component", () => {
 
   describe("basics", () => {
     it("renders", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect.element(page.getByTestId("user-avatar")).toBeVisible();
     });
   });
@@ -24,14 +24,20 @@ describe("UserAvatar component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(page.getByTestId("user-avatar"))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const element = page.getByTestId("user-avatar");
       await expect.element(element).toHaveClass("test-class");
       await expect.element(element).toHaveClass("ds");
@@ -39,7 +45,7 @@ describe("UserAvatar component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -51,7 +57,7 @@ describe("UserAvatar component", () => {
 
   describe("renders as <img>", () => {
     it("when userAvatarUrl and userName are provided", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         userAvatarUrl: avatarUrl,
         userName: "John Doe",
@@ -67,7 +73,7 @@ describe("UserAvatar component", () => {
     });
 
     it("when userAvatarUrl is provided without userName", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         userAvatarUrl: avatarUrl,
       });
@@ -84,7 +90,10 @@ describe("UserAvatar component", () => {
 
   describe("renders as <abbr>", () => {
     it("when userName is provided without userAvatarUrl", async () => {
-      const page = render(Component, { ...baseProps, userName: "John Doe" });
+      const page = await render(Component, {
+        ...baseProps,
+        userName: "John Doe",
+      });
 
       await expectIs("abbr", page);
       await expect.element(page.getByTitle("John Doe")).toBeVisible();
@@ -93,7 +102,7 @@ describe("UserAvatar component", () => {
 
   describe("renders as icon", () => {
     it("when no user data is provided", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
 
       await expectIs("svg", page);
     });
@@ -101,7 +110,7 @@ describe("UserAvatar component", () => {
 
   describe("imageAttributes", () => {
     it("applies img-specific attributes to the avatar image", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         userAvatarUrl: avatarUrl,
         imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
@@ -113,7 +122,7 @@ describe("UserAvatar component", () => {
     });
 
     it("are not applied when rendering as <abbr>", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         userName: "John Doe",
         imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
@@ -126,7 +135,7 @@ describe("UserAvatar component", () => {
     });
 
     it("are not applied when rendering as icon", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         imageAttributes: { alt: "John Doe's avatar", loading: "lazy" },
       });
@@ -140,7 +149,7 @@ describe("UserAvatar component", () => {
 
   describe("fallback behaviors", () => {
     it("falls back to <abbr> when JS handles image error and userName is provided", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         userAvatarUrl: "invalid-url",
         userName: "John Doe",
@@ -154,7 +163,7 @@ describe("UserAvatar component", () => {
     });
 
     it("falls back to icon when JS handles image error and userName is missing", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         userAvatarUrl: "invalid-url",
       });
@@ -167,7 +176,7 @@ describe("UserAvatar component", () => {
 
     describe("when no JS is available", () => {
       it("keeps rendering as <img> in no-JS when userName is provided", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           userAvatarUrl: `invalid-url`,
           userName: "John Doe",
@@ -182,7 +191,7 @@ describe("UserAvatar component", () => {
       });
 
       it("keeps rendering as <img> in no-JS without userName", async () => {
-        const page = render(Component, {
+        const page = await render(Component, {
           ...baseProps,
           userAvatarUrl: "invalid-url",
           onerror: () => {},
@@ -201,7 +210,7 @@ describe("UserAvatar component", () => {
     const sizeModifiers = ["small", "large"] as const;
 
     it.each(sizeModifiers)("applies %s modifier", async (size) => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         size,
       });
@@ -222,7 +231,7 @@ const elements = ["img", "abbr", "svg"] as const;
 
 async function expectIs(
   element: (typeof elements)[number],
-  page: ReturnType<typeof render>,
+  page: Awaited<ReturnType<typeof render>>,
 ) {
   const rootLocator = page.getByTestId("user-avatar");
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/ButtonPrimitive/ButtonPrimitive.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/ButtonPrimitive/ButtonPrimitive.svelte.test.ts
@@ -15,13 +15,13 @@ describe("ButtonPrimitive component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders as a button by default", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(page.getByRole("button")).toBeInTheDocument();
     await expect.element(page.getByText("Click me")).toBeVisible();
   });
 
   it("renders as an anchor when href is provided", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       href: "https://example.com",
     });
@@ -36,7 +36,7 @@ describe("ButtonPrimitive component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         [attribute]: expected,
       });
@@ -46,7 +46,7 @@ describe("ButtonPrimitive component", () => {
     });
 
     it("applies classes", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         class: "test-class",
       });
@@ -54,7 +54,7 @@ describe("ButtonPrimitive component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -66,12 +66,12 @@ describe("ButtonPrimitive component", () => {
 
   describe("disabled state", () => {
     it("disables the button", async () => {
-      const page = render(Component, { ...baseProps, disabled: true });
+      const page = await render(Component, { ...baseProps, disabled: true });
       await expect.element(page.getByRole("button")).toBeDisabled();
     });
 
     it("disables the anchor by removing href and setting aria-disabled", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         href: "https://example.com",
         disabled: true,

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/DialogContent.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/DialogContent.svelte.test.ts
@@ -14,7 +14,7 @@ describe("DialogContent component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       children: createRawSnippet(() => ({
         render: () => "<span>Content</span>",
@@ -29,14 +29,20 @@ describe("DialogContent component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect
@@ -45,7 +51,7 @@ describe("DialogContent component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Body/Body.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Body/Body.svelte.test.ts
@@ -14,7 +14,7 @@ describe("Body component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       children: createRawSnippet(() => ({
         render: () => "<span>Body</span>",
@@ -29,14 +29,20 @@ describe("Body component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect
@@ -45,7 +51,7 @@ describe("Body component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Footer/Footer.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Footer/Footer.svelte.test.ts
@@ -14,7 +14,7 @@ describe("Footer component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       children: createRawSnippet(() => ({
         render: () => "<span>Footer</span>",
@@ -29,14 +29,20 @@ describe("Footer component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect
@@ -45,7 +51,7 @@ describe("Footer component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/Header.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/Header.svelte.test.ts
@@ -14,7 +14,7 @@ describe("Header component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       children: createRawSnippet(() => ({
         render: () => "<span>Header</span>",
@@ -29,14 +29,20 @@ describe("Header component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect
@@ -45,7 +51,7 @@ describe("Header component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/common/CloseButton/CloseButton.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/common/CloseButton/CloseButton.svelte.test.ts
@@ -11,7 +11,7 @@ describe("CloseButton component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -20,19 +20,25 @@ describe("CloseButton component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(page.getByRole("button"))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/InputPrimitive/InputPrimitive.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/InputPrimitive/InputPrimitive.ssr.test.ts
@@ -54,17 +54,15 @@ describe("InputPrimitive SSR", () => {
         expect(componentLocator(page).type).toBe("text");
       });
 
-      it.each([
-        "text",
-        "email",
-        "url",
-        "tel",
-      ] as const)("accepts %s", (type) => {
-        const page = render(Component, {
-          props: { type, ...baseProps },
-        });
-        expect(componentLocator(page).type).toBe(type);
-      });
+      it.each(["text", "email", "url", "tel"] as const)(
+        "accepts %s",
+        (type) => {
+          const page = render(Component, {
+            props: { type, ...baseProps },
+          });
+          expect(componentLocator(page).type).toBe(type);
+        },
+      );
 
       it("accepts search", () => {
         const page = render(Component, {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/InputPrimitive/InputPrimitive.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/InputPrimitive/InputPrimitive.svelte.test.ts
@@ -9,7 +9,7 @@ describe("InputPrimitive component", () => {
   const baseProps = {} satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, baseProps);
+    const page = await render(Component, baseProps);
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
@@ -18,14 +18,17 @@ describe("InputPrimitive component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, value) => {
-      const page = render(Component, { ...baseProps, [attribute]: value });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: value,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, value);
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -35,14 +38,17 @@ describe("InputPrimitive component", () => {
     });
 
     it("applies class", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       const element = componentLocator(page);
       await expect.element(element).toHaveClass("test-class");
     });
 
     describe("type", () => {
       it("defaults to text", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         await expect
           .element(componentLocator(page))
           .toHaveAttribute("type", "text");
@@ -51,7 +57,7 @@ describe("InputPrimitive component", () => {
       it.each(["text", "password", "email", "url", "tel"] as const)(
         "accepts %s",
         async (type) => {
-          const page = render(Component, { ...baseProps, type });
+          const page = await render(Component, { ...baseProps, type });
           await expect
             .element(componentLocator(page))
             .toHaveAttribute("type", type);
@@ -60,14 +66,14 @@ describe("InputPrimitive component", () => {
     });
 
     it("accepts search", async () => {
-      const page = render(Component, { ...baseProps, type: "search" });
+      const page = await render(Component, { ...baseProps, type: "search" });
       await expect
         .element(page.getByRole("searchbox"))
         .toHaveAttribute("type", "search");
     });
 
     it("applies value", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         value: "Test value",
       });
@@ -76,18 +82,18 @@ describe("InputPrimitive component", () => {
 
     describe("disabled", () => {
       it("isn't disabled by default", async () => {
-        const page = render(Component, { ...baseProps });
+        const page = await render(Component, { ...baseProps });
         await expect.element(componentLocator(page)).not.toBeDisabled();
       });
 
       it("can be disabled", async () => {
-        const page = render(Component, { ...baseProps, disabled: true });
+        const page = await render(Component, { ...baseProps, disabled: true });
         await expect.element(componentLocator(page)).toBeDisabled();
       });
     });
 
     it("applies validation attributes", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         required: true,
       });

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/InputPrimitive/InputPrimitive.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/InputPrimitive/InputPrimitive.svelte.test.ts
@@ -48,18 +48,15 @@ describe("InputPrimitive component", () => {
           .toHaveAttribute("type", "text");
       });
 
-      it.each([
-        "text",
-        "password",
-        "email",
-        "url",
-        "tel",
-      ] as const)("accepts %s", async (type) => {
-        const page = render(Component, { ...baseProps, type });
-        await expect
-          .element(componentLocator(page))
-          .toHaveAttribute("type", type);
-      });
+      it.each(["text", "password", "email", "url", "tel"] as const)(
+        "accepts %s",
+        async (type) => {
+          const page = render(Component, { ...baseProps, type });
+          await expect
+            .element(componentLocator(page))
+            .toHaveAttribute("type", type);
+        },
+      );
     });
 
     it("accepts search", async () => {

--- a/packages/svelte/ds-app-wpe/package.json
+++ b/packages/svelte/ds-app-wpe/package.json
@@ -62,7 +62,7 @@
     "storybook": "storybook dev -p 6006 --no-open --host 0.0.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/ds-types": "^0.34.0",
     "@canonical/storybook-config": "^0.34.0",
@@ -84,7 +84,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
     "vitest": "^4.0.18",
-    "vitest-browser-svelte": "^2.0.2"
+    "vitest-browser-svelte": "^3.0.0"
   },
   "peerDependencies": {
     "svelte": "^5.47.1"

--- a/packages/svelte/ds-app-wpe/package.json
+++ b/packages/svelte/ds-app-wpe/package.json
@@ -62,7 +62,7 @@
     "storybook": "storybook dev -p 6006 --no-open --host 0.0.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.10",
+    "@biomejs/biome": "2.4.9",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/ds-types": "^0.34.0",
     "@canonical/storybook-config": "^0.34.0",
@@ -84,7 +84,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
     "vitest": "^4.0.18",
-    "vitest-browser-svelte": "^3.0.0"
+    "vitest-browser-svelte": "^2.0.2"
   },
   "peerDependencies": {
     "svelte": "^5.47.1"

--- a/packages/svelte/ds-app-wpe/src/lib/_work_in_progress/Rule/Rule.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/_work_in_progress/Rule/Rule.svelte.test.ts
@@ -16,7 +16,7 @@ describe("Rule component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
     await expect.element(componentLocator(page)).toBeVisible();
   });
@@ -26,21 +26,27 @@ describe("Rule component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("rule");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-wpe/src/lib/components/Announcement/Announcement.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Announcement/Announcement.svelte.test.ts
@@ -15,14 +15,14 @@ describe("Announcement component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders content", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect
       .element(page.getByText("Announcement content"))
       .toBeInTheDocument();
   });
 
   it("renders an optional heading as string", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       heading: "System Maintenance",
     });
@@ -30,7 +30,7 @@ describe("Announcement component", () => {
   });
 
   it("renders an optional heading as snippet", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       heading: createRawSnippet(() => ({
         render: () => `<strong>Bold Heading</strong>`,
@@ -40,23 +40,26 @@ describe("Announcement component", () => {
   });
 
   it("omits the heading element when heading is not provided", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     const root = componentLocator(page).element();
     expect(root.querySelector(".heading")).toBeNull();
   });
 
   it("applies the criticality modifier class", async () => {
-    const page = render(Component, { ...baseProps, criticality: "error" });
+    const page = await render(Component, {
+      ...baseProps,
+      criticality: "error",
+    });
     await expect.element(componentLocator(page)).toHaveClass("error");
   });
 
   it("defaults criticality to information", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toHaveClass("information");
   });
 
   it("renders a decorative icon element with aria-hidden", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     const root = componentLocator(page).element();
     const icon = root.querySelector(".icon");
     expect(icon).not.toBeNull();
@@ -68,14 +71,17 @@ describe("Announcement component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies custom class", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         class: "custom-class",
       });
@@ -85,7 +91,7 @@ describe("Announcement component", () => {
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });
@@ -95,7 +101,7 @@ describe("Announcement component", () => {
     });
 
     it("passes through additional props", async () => {
-      const page = render(Component, { ...baseProps });
+      const page = await render(Component, { ...baseProps });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute("data-testid", "announcement");

--- a/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Card/Card.svelte.test.ts
@@ -16,17 +16,17 @@ describe("Card component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
   });
 
   it("applies ds card classes", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toHaveClass("ds", "card");
   });
 
   it("renders children", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       children: createRawSnippet(() => ({
         render: () => `<span>Content</span>`,
@@ -40,14 +40,17 @@ describe("Card component", () => {
       ["id", "test-id"],
       ["aria-label", "test-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies custom class", async () => {
-      const page = render(Component, { ...baseProps, class: "custom" });
+      const page = await render(Component, { ...baseProps, class: "custom" });
       await expect
         .element(componentLocator(page))
         .toHaveClass("ds", "card", "custom");
@@ -57,7 +60,7 @@ describe("Card component", () => {
 
 describe("Card.Header", () => {
   it("renders with card-header class", async () => {
-    const page = render(Header, {
+    const page = await render(Header, {
       "data-testid": "header",
       children: createRawSnippet(() => ({
         render: () => `<span>Title</span>`,
@@ -71,7 +74,7 @@ describe("Card.Header", () => {
 
 describe("Card.Content", () => {
   it("renders with card-content class", async () => {
-    const page = render(Content, {
+    const page = await render(Content, {
       "data-testid": "content",
       children: createRawSnippet(() => ({ render: () => `<span>Body</span>` })),
     });
@@ -83,7 +86,7 @@ describe("Card.Content", () => {
 
 describe("Card.Footer", () => {
   it("renders with card-footer class", async () => {
-    const page = render(Footer, {
+    const page = await render(Footer, {
       "data-testid": "footer",
       children: createRawSnippet(() => ({ render: () => `<span>Tag</span>` })),
     });
@@ -95,7 +98,7 @@ describe("Card.Footer", () => {
 
 describe("Card.Image", () => {
   it("renders an img with card-image class", async () => {
-    const page = render(Image, {
+    const page = await render(Image, {
       "data-testid": "image",
       src: "test.png",
       alt: "test",

--- a/packages/svelte/ds-app-wpe/src/lib/components/Example/Example.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Example/Example.svelte.test.ts
@@ -16,7 +16,7 @@ describe("Example component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toBeInTheDocument();
     await expect.element(page.getByText("Example")).toBeVisible();
   });
@@ -26,21 +26,27 @@ describe("Example component", () => {
       ["id", "test-id"],
       ["aria-label", "test-aria-label"],
     ])("applies %s", async (attribute, expected) => {
-      const page = render(Component, { ...baseProps, [attribute]: expected });
+      const page = await render(Component, {
+        ...baseProps,
+        [attribute]: expected,
+      });
       await expect
         .element(componentLocator(page))
         .toHaveAttribute(attribute, expected);
     });
 
     it("applies classes", async () => {
-      const page = render(Component, { ...baseProps, class: "test-class" });
+      const page = await render(Component, {
+        ...baseProps,
+        class: "test-class",
+      });
       await expect.element(componentLocator(page)).toHaveClass("test-class");
       await expect.element(componentLocator(page)).toHaveClass("ds");
       await expect.element(componentLocator(page)).toHaveClass("example");
     });
 
     it("applies style", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         ...baseProps,
         style: "color: orange;",
       });

--- a/packages/svelte/ds-app-wpe/src/lib/components/KeyboardKey/KeyboardKey.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/KeyboardKey/KeyboardKey.svelte.test.ts
@@ -4,13 +4,13 @@ import Component from "./KeyboardKey.svelte";
 
 describe("KeyboardKey component", () => {
   it("renders the label for a key", async () => {
-    const page = render(Component, { keyValue: "enter" });
+    const page = await render(Component, { keyValue: "enter" });
     await expect.element(page.getByText("↵")).toBeVisible();
   });
 
   describe("attributes", () => {
     it("passes through additional props", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         keyValue: "ctrl",
         "data-testid": "test-component",
       });
@@ -20,14 +20,17 @@ describe("KeyboardKey component", () => {
     });
 
     it("sets an accessible label for symbol keys", async () => {
-      const page = render(Component, { keyValue: "enter" });
+      const page = await render(Component, { keyValue: "enter" });
       await expect
         .element(page.getByText("↵"))
         .toHaveAttribute("aria-label", "Enter");
     });
 
     it("applies base and custom classes", async () => {
-      const page = render(Component, { keyValue: "ctrl", class: "test-class" });
+      const page = await render(Component, {
+        keyValue: "ctrl",
+        class: "test-class",
+      });
       const el = page.getByText("Ctrl");
       await expect.element(el).toHaveClass("ds");
       await expect.element(el).toHaveClass("keyboard-key");

--- a/packages/svelte/ds-app-wpe/src/lib/components/Section/Section.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/Section/Section.svelte.test.ts
@@ -15,46 +15,46 @@ describe("Section component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders content", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(page.getByText("Section content")).toBeInTheDocument();
   });
 
   it("renders as a section element", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     const root = componentLocator(page).element();
     expect(root.tagName).toBe("SECTION");
   });
 
   it("applies the ds section classes", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentLocator(page)).toHaveClass("ds", "section");
   });
 
   it("applies the bordered class when bordered", async () => {
-    const page = render(Component, { ...baseProps, bordered: true });
+    const page = await render(Component, { ...baseProps, bordered: true });
     await expect.element(componentLocator(page)).toHaveClass("bordered");
   });
 
   it("omits the bordered class by default", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     const root = componentLocator(page).element();
     expect(root.classList.contains("bordered")).toBe(false);
   });
 
   it("applies the spacing modifier class", async () => {
-    const page = render(Component, { ...baseProps, spacing: "hero" });
+    const page = await render(Component, { ...baseProps, spacing: "hero" });
     await expect.element(componentLocator(page)).toHaveClass("hero");
   });
 
   it("applies a custom class", async () => {
-    const page = render(Component, { ...baseProps, class: "test-class" });
+    const page = await render(Component, { ...baseProps, class: "test-class" });
     await expect
       .element(componentLocator(page))
       .toHaveClass("test-class", "ds", "section");
   });
 
   it("passes through additional props", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect
       .element(componentLocator(page))
       .toHaveAttribute("data-testid", "section");

--- a/packages/svelte/ds-app-wpe/src/lib/components/SkipLink/SkipLink.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/components/SkipLink/SkipLink.svelte.test.ts
@@ -20,7 +20,7 @@ describe("SkipLink component", () => {
 
     it("moves focus to the main element when activated", async () => {
       mainEl.id = "main";
-      const page = render(Component);
+      const page = await render(Component);
       componentLocator(page).element().focus();
       await componentLocator(page).click();
       expect(document.activeElement).toBe(mainEl);
@@ -28,7 +28,7 @@ describe("SkipLink component", () => {
 
     it("moves focus to a custom main element when mainId is set", async () => {
       mainEl.id = "custom-content";
-      const page = render(Component, { mainId: "custom-content" });
+      const page = await render(Component, { mainId: "custom-content" });
       componentLocator(page).element().focus();
       await componentLocator(page).click();
       expect(document.activeElement).toBe(mainEl);

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.svelte.test.ts
@@ -11,32 +11,32 @@ describe("Cards component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders with ds cards subgrid classes", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect
       .element(componentLocator(page))
       .toHaveClass("ds", "cards", "subgrid");
   });
 
   it("sets --card-span to 1 by default", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     const el = componentLocator(page).element() as HTMLElement;
     expect(el.style.getPropertyValue("--card-span")).toBe("1");
   });
 
   it("sets --card-span from cardSpan", async () => {
-    const page = render(Component, { ...baseProps, cardSpan: 4 });
+    const page = await render(Component, { ...baseProps, cardSpan: 4 });
     const el = componentLocator(page).element() as HTMLElement;
     expect(el.style.getPropertyValue("--card-span")).toBe("4");
   });
 
   it("clamps cardSpan to at least 1", async () => {
-    const page = render(Component, { ...baseProps, cardSpan: 0 });
+    const page = await render(Component, { ...baseProps, cardSpan: 0 });
     const el = componentLocator(page).element() as HTMLElement;
     expect(el.style.getPropertyValue("--card-span")).toBe("1");
   });
 
   it("applies custom class", async () => {
-    const page = render(Component, { ...baseProps, class: "custom" });
+    const page = await render(Component, { ...baseProps, class: "custom" });
     await expect
       .element(componentLocator(page))
       .toHaveClass("ds", "cards", "custom");

--- a/packages/svelte/ds-app-wpe/src/lib/group/KeyboardKeys/KeyboardKeys.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/group/KeyboardKeys/KeyboardKeys.svelte.test.ts
@@ -10,13 +10,13 @@ const children = createRawSnippet(() => ({
 
 describe("KeyboardKeys component", () => {
   it("renders children", async () => {
-    const page = render(Component, { children });
+    const page = await render(Component, { children });
     await expect.element(page.getByText("Test content")).toBeVisible();
   });
 
   describe("attributes", () => {
     it("passes through additional props", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         children,
         "data-testid": "test-component",
       });
@@ -26,7 +26,7 @@ describe("KeyboardKeys component", () => {
     });
 
     it("applies base and custom classes", async () => {
-      const page = render(Component, {
+      const page = await render(Component, {
         children,
         class: "custom-class",
         "data-testid": "keyboard-keys",

--- a/packages/svelte/ds-app-wpe/src/lib/subcomponent/Spinner/Spinner.svelte.test.ts
+++ b/packages/svelte/ds-app-wpe/src/lib/subcomponent/Spinner/Spinner.svelte.test.ts
@@ -3,29 +3,29 @@ import { render } from "vitest-browser-svelte";
 import Component from "./Spinner.svelte";
 
 describe("Spinner subcomponent", () => {
-  it("renders the spinner icon", () => {
-    const page = render(Component);
+  it("renders the spinner icon", async () => {
+    const page = await render(Component);
     expect(page.container.querySelector("use")?.getAttribute("href")).toBe(
       "/icons/spinner.svg#spinner",
     );
   });
 
-  it("applies the spinner class", () => {
-    const page = render(Component);
+  it("applies the spinner class", async () => {
+    const page = await render(Component);
     const svg = page.container.querySelector("svg");
     expect(svg?.classList.contains("ds")).toBe(true);
     expect(svg?.classList.contains("spinner")).toBe(true);
   });
 
-  it("is decorative by default", () => {
-    const page = render(Component);
+  it("is decorative by default", async () => {
+    const page = await render(Component);
     const svg = page.container.querySelector("svg");
     expect(svg?.getAttribute("aria-hidden")).toBe("true");
     expect(svg?.hasAttribute("role")).toBe(false);
   });
 
   it("exposes a named image when aria-label is provided", async () => {
-    const page = render(Component, { "aria-label": "Loading" });
+    const page = await render(Component, { "aria-label": "Loading" });
     await expect
       .element(page.getByRole("img", { name: "Loading" }))
       .toBeInTheDocument();
@@ -34,29 +34,29 @@ describe("Spinner subcomponent", () => {
     ).toBe(false);
   });
 
-  it("treats an empty aria-label as decorative", () => {
-    const page = render(Component, { "aria-label": "" });
+  it("treats an empty aria-label as decorative", async () => {
+    const page = await render(Component, { "aria-label": "" });
     const svg = page.container.querySelector("svg");
     expect(svg?.getAttribute("aria-hidden")).toBe("true");
     expect(svg?.hasAttribute("role")).toBe(false);
   });
 
-  it("honours an explicit role", () => {
-    const page = render(Component, { role: "presentation" });
+  it("honours an explicit role", async () => {
+    const page = await render(Component, { role: "presentation" });
     const svg = page.container.querySelector("svg");
     expect(svg?.getAttribute("role")).toBe("presentation");
     expect(svg?.hasAttribute("aria-hidden")).toBe(false);
   });
 
-  it("merges a consumer class alongside the spinner class", () => {
-    const page = render(Component, { class: "test-class" });
+  it("merges a consumer class alongside the spinner class", async () => {
+    const page = await render(Component, { class: "test-class" });
     const svg = page.container.querySelector("svg");
     expect(svg?.classList.contains("spinner")).toBe(true);
     expect(svg?.classList.contains("test-class")).toBe(true);
   });
 
-  it("resolves the icon from a custom rootPath", () => {
-    const page = render(Component, { rootPath: "/assets/icons" });
+  it("resolves the icon from a custom rootPath", async () => {
+    const page = await render(Component, { rootPath: "/assets/icons" });
     expect(page.container.querySelector("use")?.getAttribute("href")).toBe(
       "/assets/icons/spinner.svg#spinner",
     );

--- a/packages/svelte/ds-app/package.json
+++ b/packages/svelte/ds-app/package.json
@@ -62,7 +62,7 @@
     "@canonical/svelte-ds-global": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.28.0",
     "@canonical/design-tokens": "0.6.2-contrasted.0",
     "@canonical/storybook-config": "^0.34.0",
@@ -84,7 +84,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.1",
     "vitest": "^4.0.18",
-    "vitest-browser-svelte": "^2.0.2"
+    "vitest-browser-svelte": "^3.0.0"
   },
   "peerDependencies": {
     "svelte": "^5.47.1"

--- a/packages/svelte/ds-app/package.json
+++ b/packages/svelte/ds-app/package.json
@@ -62,7 +62,7 @@
     "@canonical/svelte-ds-global": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.10",
+    "@biomejs/biome": "2.4.9",
     "@canonical/biome-config": "^0.28.0",
     "@canonical/design-tokens": "0.6.2-contrasted.0",
     "@canonical/storybook-config": "^0.34.0",
@@ -84,7 +84,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.1",
     "vitest": "^4.0.18",
-    "vitest-browser-svelte": "^3.0.0"
+    "vitest-browser-svelte": "^2.0.2"
   },
   "peerDependencies": {
     "svelte": "^5.47.1"

--- a/packages/svelte/ds-app/src/lib/layout/ApplicationLayout/ApplicationLayout.svelte.test.ts
+++ b/packages/svelte/ds-app/src/lib/layout/ApplicationLayout/ApplicationLayout.svelte.test.ts
@@ -15,7 +15,7 @@ describe("ApplicationLayout component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders children in the content region", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(page.getByText("Test content")).toBeVisible();
     expect(
       componentRoot(page).querySelector(":scope > .content")?.textContent,
@@ -23,7 +23,7 @@ describe("ApplicationLayout component", () => {
   });
 
   it("applies the base and custom class to the root", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       class: "custom-class",
     });
@@ -34,7 +34,7 @@ describe("ApplicationLayout component", () => {
   });
 
   it("renders the navigation slot in the navigation region", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       navigation: createRawSnippet(() => ({
         render: () => "<span>Nav</span>",
@@ -49,7 +49,7 @@ describe("ApplicationLayout component", () => {
   });
 
   it("omits the navigation region when the slot is not provided", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentRoot(page)).toBeInTheDocument();
     expect(
       componentRoot(page).querySelector(":scope > .navigation"),
@@ -57,7 +57,7 @@ describe("ApplicationLayout component", () => {
   });
 
   it("passes through additional props", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       "data-testid": "test-component",
     });

--- a/packages/svelte/ds-app/src/lib/layout/ContentLayout/ContentLayout.svelte.test.ts
+++ b/packages/svelte/ds-app/src/lib/layout/ContentLayout/ContentLayout.svelte.test.ts
@@ -15,7 +15,7 @@ describe("ContentLayout component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders children as direct grid items", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
 
     await expect.element(page.getByText("Card A")).toBeVisible();
     expect(
@@ -24,7 +24,7 @@ describe("ContentLayout component", () => {
   });
 
   it("applies the base and custom class to the root", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       class: "custom-class",
     });
@@ -35,7 +35,7 @@ describe("ContentLayout component", () => {
   });
 
   it("uses the fixed-responsive grid preset by default", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
 
     await expect.element(componentRoot(page)).toHaveClass("grid");
     await expect.element(componentRoot(page)).toHaveClass("responsive");
@@ -43,7 +43,7 @@ describe("ContentLayout component", () => {
   });
 
   it("switches to the intrinsic grid preset via the grid prop", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       grid: "intrinsic",
     });
@@ -54,7 +54,7 @@ describe("ContentLayout component", () => {
   });
 
   it("passes through additional props", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       "data-testid": "test-component",
     });

--- a/packages/svelte/ds-app/src/lib/layout/ViewLayout/ViewLayout.svelte.test.ts
+++ b/packages/svelte/ds-app/src/lib/layout/ViewLayout/ViewLayout.svelte.test.ts
@@ -15,7 +15,7 @@ describe("ViewLayout component", () => {
   } satisfies ComponentProps<typeof Component>;
 
   it("renders children in the content region", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(page.getByText("Test content")).toBeVisible();
     expect(
       componentRoot(page).querySelector(":scope > .content")?.textContent,
@@ -23,7 +23,7 @@ describe("ViewLayout component", () => {
   });
 
   it("applies the base and custom class to the root", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       class: "custom-class",
     });
@@ -34,7 +34,7 @@ describe("ViewLayout component", () => {
   });
 
   it("renders the aside slot in the aside region", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       aside: createRawSnippet(() => ({
         render: () => "<span>Detail panel</span>",
@@ -49,13 +49,13 @@ describe("ViewLayout component", () => {
   });
 
   it("omits the aside region when the slot is not provided", async () => {
-    const page = render(Component, { ...baseProps });
+    const page = await render(Component, { ...baseProps });
     await expect.element(componentRoot(page)).toBeInTheDocument();
     expect(componentRoot(page).querySelector(":scope > .aside")).toBeNull();
   });
 
   it("passes through additional props", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       ...baseProps,
       "data-testid": "test-component",
     });

--- a/packages/svelte/ds-global/package.json
+++ b/packages/svelte/ds-global/package.json
@@ -62,7 +62,7 @@
     "@canonical/utils": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.10",
+    "@biomejs/biome": "2.4.9",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.6.2-contrasted.0",
     "@canonical/ds-types": "^0.34.0",
@@ -85,7 +85,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.1",
     "vitest": "^4.0.18",
-    "vitest-browser-svelte": "^3.0.0"
+    "vitest-browser-svelte": "^2.0.2"
   },
   "peerDependencies": {
     "svelte": "^5.47.1"

--- a/packages/svelte/ds-global/package.json
+++ b/packages/svelte/ds-global/package.json
@@ -62,7 +62,7 @@
     "@canonical/utils": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/design-tokens": "0.6.2-contrasted.0",
     "@canonical/ds-types": "^0.34.0",
@@ -85,7 +85,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.1",
     "vitest": "^4.0.18",
-    "vitest-browser-svelte": "^2.0.2"
+    "vitest-browser-svelte": "^3.0.0"
   },
   "peerDependencies": {
     "svelte": "^5.47.1"

--- a/packages/svelte/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.svelte.test.ts
+++ b/packages/svelte/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.svelte.test.ts
@@ -6,7 +6,7 @@ import type { BreadcrumbItem } from "./types.js";
 
 describe("Breadcrumbs", () => {
   it("renders items", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       items: [
         { url: "/", label: "Home" },
         { url: "/products", label: "Products" },
@@ -17,7 +17,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("renders as nav element with aria-label", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       "data-testid": "nav",
       items: [{ url: "/", label: "Home" }],
     });
@@ -27,7 +27,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("allows custom aria-label", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       "aria-label": "Site navigation",
       "data-testid": "nav",
       items: [{ url: "/", label: "Home" }],
@@ -38,7 +38,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("applies ds breadcrumbs class", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       "data-testid": "nav",
       items: [{ url: "/", label: "Home" }],
     });
@@ -48,7 +48,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("renders Item with link", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       items: [{ url: "/test", label: "Test Link" }],
     });
     const link = page.getByText("Test Link");
@@ -57,7 +57,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("renders current Item without link", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       items: [{ key: "current", label: "Current Page", current: true }],
     });
     const current = page.getByText("Current Page");
@@ -66,7 +66,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("renders disabled Item as a non-navigable link marked aria-disabled", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       items: [{ url: "/unavailable", label: "Unavailable", disabled: true }],
     });
     const item = page.getByText("Unavailable");
@@ -81,7 +81,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("renders separator between items", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       items: [
         { url: "/", label: "Home" },
         { key: "page", label: "Page", current: true },
@@ -92,8 +92,8 @@ describe("Breadcrumbs", () => {
     await expect.element(separators[0]).toHaveAttribute("aria-hidden", "true");
   });
 
-  it("uses custom separator", () => {
-    const page = render(Component, {
+  it("uses custom separator", async () => {
+    const page = await render(Component, {
       separator: "›",
       items: [
         { url: "/", label: "Home" },
@@ -103,8 +103,8 @@ describe("Breadcrumbs", () => {
     expect(page.getByText("›").all()).toHaveLength(2);
   });
 
-  it("maintains DOM order: link before separator", () => {
-    const page = render(Component, {
+  it("maintains DOM order: link before separator", async () => {
+    const page = await render(Component, {
       items: [{ url: "/", label: "Home", class: "test-item" }],
     });
     const item = page.container.querySelector(".test-item");
@@ -114,7 +114,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("forwards native anchor attributes from an item to its rendered link", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       items: [
         {
           url: "/",
@@ -135,7 +135,7 @@ describe("Breadcrumbs", () => {
     const customItem = createRawSnippet<[BreadcrumbItem]>((getItem) => ({
       render: () => `<li data-testid="custom-item">${getItem().label}</li>`,
     }));
-    const page = render(Component, {
+    const page = await render(Component, {
       items: [
         { url: "/", label: "Home" },
         { key: "custom", label: "Custom" },
@@ -148,7 +148,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("uses url as key, falls back to key prop", async () => {
-    const page = render(Component, {
+    const page = await render(Component, {
       items: [
         { url: "/home", label: "Home" },
         { key: "no-url", label: "No URL" },
@@ -159,8 +159,8 @@ describe("Breadcrumbs", () => {
     await expect.element(page.getByText("No URL")).toBeInTheDocument();
   });
 
-  it("links are keyboard accessible via Tab navigation", () => {
-    const page = render(Component, {
+  it("links are keyboard accessible via Tab navigation", async () => {
+    const page = await render(Component, {
       items: [
         { url: "/", label: "Home" },
         { url: "/products", label: "Products" },

--- a/packages/svelte/ssr-test/package.json
+++ b/packages/svelte/ssr-test/package.json
@@ -56,7 +56,7 @@
     "svelte": "^5.38.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/packages/svelte/ssr-test/package.json
+++ b/packages/svelte/ssr-test/package.json
@@ -56,7 +56,7 @@
     "svelte": "^5.38.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.10",
+    "@biomejs/biome": "2.4.9",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -48,7 +48,7 @@
     "@canonical/ds-types": "^0.34.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@canonical/webarchitect": "^0.34.0",

--- a/packages/webarchitect/package.json
+++ b/packages/webarchitect/package.json
@@ -40,7 +40,7 @@
     "check:webarchitect": "bun run src/cli.ts tool-ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.9",
+    "@biomejs/biome": "2.5.10",
     "@canonical/biome-config": "^0.34.0",
     "@canonical/typescript-config": "^0.34.0",
     "@types/json-schema": "^7.0.15",


### PR DESCRIPTION
[SKIP REVIEW for now -> this is a test with a new model - needs cleanup]

## Done

Batches the stale renovate CI/build-tooling PRs into one, rebased on current main with a fresh `bun.lock`:

- `lerna` ^9 → ^10.0.0, `nx` ^22 → ^23.0.0 (supersedes #957)
- `vitest-browser-svelte` ^2.0.2 → ^3.0.0 (supersedes #956)
- `renovate` 43.288.0 → 44.46.4 (supersedes #955)
- `@biomejs/biome` 2.4.9 → 2.5.10, incl. schema URL (supersedes #786)

Package dependency updates are batched separately in #963.

Drive-by (biome 2.5.10 migration, required for `check:biome` to pass):
- `biome check --write --unsafe` autofixes: format drift, `useOptionalChain` (semantically equivalent).
- Shared config (`configs/biome`): `a11y/noSvgWithoutTitle` off for raw `**/*.svg` asset files — adding `<title>` to 168 binary asset SVGs would alter rendered output.
- `ke-graphql`: `correctness/noUnsafeOptionalChaining` off in `**/*.test.ts` (assertion style; matches the existing `*.tests.tsx` override convention).
- `ds-global` Accordion story: inline `biome-ignore` for the placeholder `Learn more` anchor (keeps Chromatic visuals identical).

## QA

- `build-matrix` runs bun 1.3.9 on node 22 & 24, including per-package `check:biome` against the bumped 2.5.10.
- No component source changes beyond lint config and one no-render-change comment.
- Version pins in `ds-app-launchpad` / `ds-app-wpe` / `ssr-test` / `configs/biome` / `configs/typescript-svelte` package.jsons only — code-owner review requested from @canonical/launchpad-ui and @canonical/workplace-engineering-ui.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

N/A (no visual change)