### PR TITLE
fix(router): runtime hardening — navigation adapter, async prefetch control flow, SSR status

### DIFF
--- a/packages/react/ssr/src/lib/renderer/JSXRenderer.tests.ts
+++ b/packages/react/ssr/src/lib/renderer/JSXRenderer.tests.ts
@@ -393,4 +393,40 @@ describe("JSXRenderer", () => {
       expect(renderer.statusCode).toBe(200);
     });
   });
+
+  describe("options.statusCode", () => {
+    it("reports the configured status for a successful readable stream render", async () => {
+      const renderer = new JSXRenderer(TestComponent, {}, { statusCode: 404 });
+      await renderer.renderToReadableStream();
+      expect(renderer.statusCode).toBe(404);
+    });
+
+    it("reports the configured status for a successful pipeable stream render", async () => {
+      const renderer = new JSXRenderer(TestComponent, {}, { statusCode: 404 });
+      renderer.renderToPipeableStream();
+      await renderer.statusReady;
+      expect(renderer.statusCode).toBe(404);
+    });
+
+    it("reports the configured status for renderToString", () => {
+      const renderer = new JSXRenderer(TestComponent, {}, { statusCode: 404 });
+      renderer.renderToString();
+      expect(renderer.statusCode).toBe(404);
+    });
+
+    it("still reports 500 on shell error regardless of the option", async () => {
+      const ErrorComponent: React.FC<
+        ServerEntrypointProps<Record<string, unknown>>
+      > = () => {
+        throw new Error("Shell error");
+      };
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const renderer = new JSXRenderer(ErrorComponent, {}, { statusCode: 404 });
+      await renderer.renderToReadableStream();
+      expect(renderer.statusCode).toBe(500);
+      consoleSpy.mockRestore();
+    });
+  });
 });

--- a/packages/react/ssr/src/lib/renderer/JSXRenderer.ts
+++ b/packages/react/ssr/src/lib/renderer/JSXRenderer.ts
@@ -258,7 +258,7 @@ export default class JSXRenderer<
         },
       });
 
-      this.statusCode = 200;
+      this.statusCode = this.options.statusCode ?? 200;
       this.statusReady = Promise.resolve();
       return stream;
     } catch (error) {
@@ -332,7 +332,9 @@ export default class JSXRenderer<
       onShellReady: () => {
         onShellReadyCallback?.();
         /* v8 ignore next -- errorRef.current is set by onError which fires before onShellReady in edge cases */
-        this.statusCode = errorRef.current ? 500 : 200;
+        this.statusCode = errorRef.current
+          ? 500
+          : (this.options.statusCode ?? 200);
         resolveStatus();
       },
       onAllReady() {
@@ -360,7 +362,7 @@ export default class JSXRenderer<
     const props = this.getComponentProps();
     const jsx = createElement(this.Component, props);
     const html = reactRenderToString(jsx);
-    this.statusCode = 200;
+    this.statusCode = this.options.statusCode ?? 200;
     this.statusReady = Promise.resolve();
     return html;
   };

--- a/packages/react/ssr/src/lib/renderer/types.ts
+++ b/packages/react/ssr/src/lib/renderer/types.ts
@@ -68,6 +68,16 @@ export interface RendererOptions {
    * between the two option types).
    */
   renderToReadableStreamOptions?: RenderToReadableStreamOptions;
+
+  /**
+   * HTTP status code reported for a *successful* render. Defaults to 200.
+   *
+   * Lets the server reflect the routed document's real status — e.g. a
+   * matched not-found route rendering with 404, or an error route with its
+   * status — instead of always claiming 200. Shell errors still report 500
+   * regardless of this option.
+   */
+  statusCode?: number;
 }
 
 // ─── Server entrypoint ───────────────────────────────────────────────────────

--- a/packages/runtime/router/src/lib/createNavigationAdapter.test.ts
+++ b/packages/runtime/router/src/lib/createNavigationAdapter.test.ts
@@ -14,6 +14,11 @@ function createFakeNavigationWindow(initialHref = "https://example.com/") {
 
   const navigationWindow = {
     location: { href: initialHref },
+    // Set to emulate the real Navigation API's `{ committed, finished }`
+    // return value; `undefined` emulates environments without it.
+    nextNavigateResult: undefined as
+      | { committed?: Promise<unknown>; finished?: Promise<unknown> }
+      | undefined,
     navigation: {
       currentEntry: { url: initialHref },
       navigate(url: string, options?: { history?: "push" | "replace" }) {
@@ -22,6 +27,8 @@ function createFakeNavigationWindow(initialHref = "https://example.com/") {
           navigationWindow.location.href,
         ).href;
         void options;
+
+        return navigationWindow.nextNavigateResult;
       },
       addEventListener(_type: "navigate", listener: typeof navigateListener) {
         navigateListener = listener;
@@ -153,5 +160,44 @@ describe("createNavigationAdapter (Navigation API)", () => {
     void getListener;
 
     expect(listener).toHaveBeenCalledTimes(0);
+  });
+
+  it("catches rejections from the navigation transition promises", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const navigationWindow = createFakeNavigationWindow();
+      const adapter = createNavigationAdapter(navigationWindow);
+
+      // A superseded navigation rejects both transition promises.
+      navigationWindow.nextNavigateResult = {
+        committed: Promise.reject(new Error("aborted")),
+        finished: Promise.reject(new Error("superseded")),
+      };
+      adapter.navigate("/docs");
+
+      // Partial results (either promise absent) must also be tolerated.
+      navigationWindow.nextNavigateResult = {
+        committed: Promise.resolve(null),
+      };
+      adapter.navigate("/docs?page=2");
+
+      navigationWindow.nextNavigateResult = {
+        finished: Promise.reject(new Error("superseded")),
+      };
+      adapter.navigate("/guides", { replace: true });
+
+      // Drain microtasks twice so any unhandled rejection gets reported.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
   });
 });

--- a/packages/runtime/router/src/lib/createNavigationAdapter.ts
+++ b/packages/runtime/router/src/lib/createNavigationAdapter.ts
@@ -1,8 +1,16 @@
 import type { PlatformAdapter, PlatformNavigateOptions } from "./types.js";
 
+interface NavigationResultLike {
+  readonly committed?: Promise<unknown>;
+  readonly finished?: Promise<unknown>;
+}
+
 interface NavigationLike {
   readonly currentEntry: { readonly url: string | null } | null;
-  navigate(url: string, options?: { history?: "push" | "replace" }): void;
+  navigate(
+    url: string,
+    options?: { history?: "push" | "replace" },
+  ): NavigationResultLike | undefined;
   addEventListener(
     type: "navigate",
     listener: (event: NavigateEventLike) => void,
@@ -25,6 +33,19 @@ interface NavigationWindowLike {
   readonly navigation: NavigationLike;
   readonly location: { readonly href: string };
 }
+
+/**
+ * Intentional no-op `.catch()` handler for the Navigation API's transition
+ * promises.
+ *
+ * `navigation.navigate()` returns a `{ committed, finished }` promise pair;
+ * either can reject when a navigation is superseded, aborted, or immediately
+ * cancelled.  Those rejections are harmless to the router — subscribers were
+ * already notified and a superseding navigation carries its own notification —
+ * so this handler only prevents unhandled promise rejections without
+ * swallowing errors that matter.
+ */
+function ignoreNavigationTransitionError(_error: unknown): void {}
 
 function getDefaultNavigationWindow(): NavigationWindowLike {
   const win = globalThis as { window?: NavigationWindowLike };
@@ -79,9 +100,12 @@ export default function createNavigationAdapter(
       return getLocation();
     },
     navigate(url, navigationOptions?: PlatformNavigateOptions) {
-      navigation.navigate(url, {
+      const result = navigation.navigate(url, {
         history: navigationOptions?.replace ? "replace" : "push",
       });
+
+      result?.committed?.catch(ignoreNavigationTransitionError);
+      result?.finished?.catch(ignoreNavigationTransitionError);
 
       notify();
     },

--- a/packages/runtime/router/src/lib/createRouter.test.ts
+++ b/packages/runtime/router/src/lib/createRouter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import createMemoryAdapter from "./createMemoryAdapter.js";
 import createRouter from "./createRouter.js";
+import createStaticRouter from "./createStaticRouter.js";
 import group from "./group.js";
 import redirect from "./redirect.js";
 import route from "./route.js";
@@ -2162,6 +2163,279 @@ describe("createRouter", () => {
       expect(result.error).toBeInstanceOf(StatusResponse);
       expect((result.error as StatusResponse<unknown>).status).toBe(400);
       expect(router.getState().location.status).toBe(400);
+    });
+  });
+
+  describe("async prefetch control flow", () => {
+    it("applies a redirect rejected from an async prefetch after the load commits", async () => {
+      let releasePrefetch!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releasePrefetch = resolve;
+      });
+
+      const router = createRouter(
+        {
+          guarded: route({
+            url: "/guarded",
+            content: () => "guarded",
+            prefetch: async () => {
+              await gate;
+              redirect("/login");
+            },
+          }),
+          login: route({ url: "/login", content: () => "login" }),
+        },
+        { adapter: createMemoryAdapter("/") },
+      );
+
+      // Fire-and-forget: the load commits before the rejection arrives.
+      const result = await router.load("/guarded");
+
+      expect(result.location.pathname).toBe("/guarded");
+
+      releasePrefetch();
+
+      await vi.waitFor(() => {
+        expect(router.getState().location.pathname).toBe("/login");
+      });
+    });
+
+    it("commits the status of a StatusResponse rejected from an async prefetch", async () => {
+      let releasePrefetch!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releasePrefetch = resolve;
+      });
+
+      const router = createRouter(
+        {
+          failing: route({
+            url: "/failing",
+            content: () => "fail",
+            prefetch: async () => {
+              await gate;
+              throw new StatusResponse(403, "forbidden");
+            },
+          }),
+        },
+        { adapter: createMemoryAdapter("/") },
+      );
+
+      const result = await router.load("/failing");
+
+      expect(result.status).toBe(200);
+
+      releasePrefetch();
+
+      await vi.waitFor(() => {
+        expect(router.getState().location.status).toBe(403);
+      });
+      expect(router.dehydrate()?.status).toBe(403);
+    });
+
+    it("drops late control flow when the user navigated elsewhere meanwhile", async () => {
+      let releasePrefetch!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releasePrefetch = resolve;
+      });
+
+      const router = createRouter(
+        {
+          guarded: route({
+            url: "/guarded",
+            content: () => "guarded",
+            prefetch: async () => {
+              await gate;
+              redirect("/login");
+            },
+          }),
+          about: route({ url: "/about", content: () => "about" }),
+          login: route({ url: "/login", content: () => "login" }),
+        },
+        { adapter: createMemoryAdapter("/") },
+      );
+
+      await router.load("/guarded");
+      await router.load("/about");
+
+      releasePrefetch();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState().location.pathname).toBe("/about");
+    });
+
+    it("folds an async status rejection into a still-cached prefetch entry", async () => {
+      let releasePrefetch!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releasePrefetch = resolve;
+      });
+
+      const router = createRouter(
+        {
+          home: route({ url: "/", content: () => "home" }),
+          failing: route({
+            url: "/failing",
+            content: () => "fail",
+            prefetch: async () => {
+              await gate;
+              throw new StatusResponse(410, "gone");
+            },
+          }),
+        },
+        { adapter: createMemoryAdapter("/") },
+      );
+
+      await router.load("/");
+      await router.prefetch("failing");
+
+      releasePrefetch();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const result = await router.load("/failing");
+
+      expect(result.status).toBe(410);
+    });
+
+    it("applies a status live when its prefetch entry was already consumed", async () => {
+      let releasePrefetch!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releasePrefetch = resolve;
+      });
+
+      const router = createRouter(
+        {
+          home: route({ url: "/", content: () => "home" }),
+          failing: route({
+            url: "/failing",
+            content: () => "fail",
+            prefetch: async () => {
+              await gate;
+              throw new StatusResponse(410, "gone");
+            },
+          }),
+        },
+        { adapter: createMemoryAdapter("/") },
+      );
+
+      await router.load("/");
+      await router.prefetch("failing");
+
+      // Consumes the cached entry; the prefetch hook does not re-run.
+      const result = await router.load("/failing");
+
+      expect(result.status).toBe(200);
+
+      releasePrefetch();
+
+      await vi.waitFor(() => {
+        expect(router.getState().location.status).toBe(410);
+      });
+    });
+
+    it("redirects via a still-cached prefetch entry on the eventual navigation", async () => {
+      let releasePrefetch!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releasePrefetch = resolve;
+      });
+
+      const router = createRouter(
+        {
+          home: route({ url: "/", content: () => "home" }),
+          guarded: route({
+            url: "/guarded",
+            content: () => "guarded",
+            prefetch: async () => {
+              await gate;
+              redirect("/login");
+            },
+          }),
+          login: route({ url: "/login", content: () => "login" }),
+        },
+        { adapter: createMemoryAdapter("/") },
+      );
+
+      await router.load("/");
+      await router.prefetch("guarded");
+
+      releasePrefetch();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The redirect target is prefetched in place of the guarded entry; the
+      // eventual navigation re-learns the redirect and applies it late —
+      // identical to navigating without a prior hover-prefetch.
+      const result = await router.load("/guarded");
+
+      expect(result.location.pathname).toBe("/guarded");
+
+      await vi.waitFor(() => {
+        expect(router.getState().location.pathname).toBe("/login");
+      });
+    });
+
+    it("tolerates async prefetch control flow on a static router", async () => {
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandled);
+
+      try {
+        const router = createStaticRouter(
+          {
+            guarded: route({
+              url: "/guarded",
+              content: () => "guarded",
+              prefetch: async () => {
+                redirect("/login");
+              },
+            }),
+            login: route({ url: "/login", content: () => "login" }),
+          },
+          "/guarded",
+        );
+
+        await router.load("/guarded");
+
+        await vi.waitFor(() => {
+          expect(router.getState().location.pathname).toBe("/login");
+        });
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+      }
+    });
+
+    it("keeps ignoring async rejections that carry no control flow", async () => {
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandled);
+
+      try {
+        const router = createRouter(
+          {
+            failing: route({
+              url: "/failing",
+              content: () => "fail",
+              prefetch: async () => {
+                throw new Error("cache warm failed");
+              },
+            }),
+          },
+          { adapter: createMemoryAdapter("/") },
+        );
+
+        const result = await router.load("/failing");
+
+        expect(result.status).toBe(200);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(router.getState().location.status).toBe(200);
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+      }
     });
   });
 });

--- a/packages/runtime/router/src/lib/createRouter.ts
+++ b/packages/runtime/router/src/lib/createRouter.ts
@@ -497,6 +497,22 @@ function isRedirectMatch(value: unknown): value is {
  */
 function ignoreScheduledLoadError(_error: unknown): void {}
 
+/**
+ * Rejections from async prefetch hooks that carry control flow rather than a
+ * side-effect failure: a runtime redirect or a typed status.  They receive
+ * the same meaning as their synchronous counterparts, applied late.
+ */
+type ScheduledControlFlowError =
+  | RouteRedirect
+  | StatusResponse<unknown>
+  | Response;
+
+interface ScheduledControlFlow {
+  /** Latch — only the first control-flow signal of a load is applied. */
+  applied: boolean;
+  apply(error: ScheduledControlFlowError): void;
+}
+
 function createDehydratedState<
   TRoutes extends RouteMap,
   TNotFound extends AnyRoute | undefined,
@@ -692,8 +708,38 @@ export default function createRouter<
   async function resolveLoadData(
     currentMatch: RouterMatch<TRoutes, TNotFound> | null,
     signal: AbortSignal,
+    scheduledControlFlow: ScheduledControlFlow,
   ): Promise<ResolvedLoadData<TRoutes, TNotFound>> {
     const nextRoute = currentMatch?.route;
+
+    // A rejection from an async prefetch hook is honoured when it carries
+    // control flow (a runtime redirect or a typed status): the first one wins
+    // and is applied late by the caller's guard.  Any other rejection is an
+    // ordinary side-effect failure and is deliberately ignored — prefetch
+    // never blocks rendering.
+    const handleScheduledRejection = (thrownError: unknown): void => {
+      if (
+        scheduledControlFlow.applied ||
+        !(
+          thrownError instanceof RouteRedirect ||
+          thrownError instanceof StatusResponse ||
+          thrownError instanceof Response
+        )
+      ) {
+        ignoreScheduledLoadError(thrownError);
+        return;
+      }
+
+      scheduledControlFlow.applied = true;
+
+      try {
+        scheduledControlFlow.apply(thrownError);
+      } catch (applyError) {
+        // Applying late control flow must never surface as an unhandled
+        // rejection (e.g. an adapter that cannot navigate).
+        ignoreScheduledLoadError(applyError);
+      }
+    };
 
     // Fire prefetch hooks as fire-and-forget side effects.
     // Wrapper prefetches run for all wrappers (no caching/reuse).
@@ -710,7 +756,7 @@ export default function createRouter<
         if (currentWrapper.prefetch) {
           void Promise.resolve(
             currentWrapper.prefetch(rawWrapperParams, { signal }),
-          ).catch(ignoreScheduledLoadError);
+          ).catch(handleScheduledRejection);
         }
       }
 
@@ -719,7 +765,7 @@ export default function createRouter<
           nextRoute.prefetch(currentMatch.params, currentMatch.search, {
             signal,
           }),
-        ).catch(ignoreScheduledLoadError);
+        ).catch(handleScheduledRejection);
       }
     }
 
@@ -767,14 +813,59 @@ export default function createRouter<
     }
 
     const prefetchPromise = (async () => {
+      // Same stash discipline as navigation loads: a rejection arriving
+      // before the entry is cached would otherwise miss the cache and be
+      // dropped by the location guard.
+      const lateControlFlow: {
+        pending: ScheduledControlFlowError | null;
+        cached: boolean;
+      } = { pending: null, cached: false };
+
+      const applyPrefetchControlFlow = (
+        thrownError: ScheduledControlFlowError,
+      ): void => {
+        applyLatePrefetchControlFlow(thrownError, {
+          href,
+          url,
+          currentMatch,
+          redirectDepth,
+        });
+      };
+
+      const scheduledControlFlow: ScheduledControlFlow = {
+        applied: false,
+        apply: (thrownError) => {
+          if (!lateControlFlow.cached) {
+            lateControlFlow.pending = thrownError;
+
+            return;
+          }
+
+          applyPrefetchControlFlow(thrownError);
+        },
+      };
+
       try {
         const prefetchedLoad = await resolveLoadData(
           currentMatch,
           createIdleSignal(),
+          scheduledControlFlow,
         );
 
         prefetchedLoads.set(href, prefetchedLoad);
+        lateControlFlow.cached = true;
+
+        const pendingControlFlow = lateControlFlow.pending;
+
+        if (pendingControlFlow) {
+          lateControlFlow.pending = null;
+          applyPrefetchControlFlow(pendingControlFlow);
+        }
       } catch (thrownError) {
+        scheduledControlFlow.applied = true;
+        lateControlFlow.cached = true;
+        lateControlFlow.pending = null;
+
         if (thrownError instanceof RouteRedirect) {
           await prefetchHref(thrownError.to, redirectDepth + 1);
           return;
@@ -800,6 +891,133 @@ export default function createRouter<
 
     ignoredAdapterHref = href;
     currentAdapter.navigate(href, navigationOptions);
+  }
+
+  /**
+   * Apply a control-flow rejection (redirect / status) that arrived from an
+   * async prefetch hook after its navigation already committed.  Prefetch is
+   * fire-and-forget, so a late arrival is expected: the page may render
+   * briefly before the redirect or error status lands.  The guards drop the
+   * rejection when the load was superseded or the user moved on.
+   */
+  function applyLateNavigationControlFlow(
+    thrownError: ScheduledControlFlowError,
+    context: {
+      url: URL;
+      currentMatch: RouterMatch<TRoutes, TNotFound> | null;
+      signal: AbortSignal;
+      redirectDepth: number;
+      shouldSyncAdapter: boolean;
+      mode: NavigationMode;
+    },
+  ): void {
+    if (
+      context.signal.aborted ||
+      store.getState().location.href !== toHref(context.url)
+    ) {
+      return;
+    }
+
+    if (thrownError instanceof RouteRedirect) {
+      void performLoad(
+        thrownError.to,
+        context.redirectDepth + 1,
+        context.shouldSyncAdapter,
+        context.mode,
+      )
+        .then((redirectedResult) => {
+          if (
+            context.shouldSyncAdapter &&
+            adapter &&
+            toHref(adapter.getLocation()) !== redirectedResult.location.href
+          ) {
+            syncAdapterLocation(redirectedResult.location.href, {
+              replace: true,
+            });
+          }
+        })
+        .catch(ignoreScheduledLoadError);
+
+      return;
+    }
+
+    const status = getErrorStatus(thrownError);
+
+    currentLoadResult = createLoadResult<TRoutes, TNotFound>({
+      error: thrownError,
+      location: store.commit(context.url, context.currentMatch, status)
+        .location,
+      match: context.currentMatch,
+      status,
+    });
+  }
+
+  /**
+   * Apply a control-flow rejection from an async prefetch hook that ran for a
+   * hover/manual prefetch.  A still-cached entry absorbs the outcome so the
+   * eventual navigation observes it; an entry already consumed by a
+   * navigation to that href applies live; otherwise the user went elsewhere
+   * and the rejection is dropped.
+   */
+  function applyLatePrefetchControlFlow(
+    thrownError: ScheduledControlFlowError,
+    context: {
+      href: string;
+      url: URL;
+      currentMatch: RouterMatch<TRoutes, TNotFound> | null;
+      redirectDepth: number;
+    },
+  ): void {
+    if (thrownError instanceof RouteRedirect) {
+      if (prefetchedLoads.delete(context.href)) {
+        void prefetchHref(thrownError.to, context.redirectDepth + 1).catch(
+          ignoreScheduledLoadError,
+        );
+
+        return;
+      }
+
+      if (store.getState().location.href === context.href) {
+        void performLoad(
+          thrownError.to,
+          context.redirectDepth + 1,
+          true,
+          "push",
+        )
+          .then((redirectedResult) => {
+            if (
+              adapter &&
+              toHref(adapter.getLocation()) !== redirectedResult.location.href
+            ) {
+              syncAdapterLocation(redirectedResult.location.href, {
+                replace: true,
+              });
+            }
+          })
+          .catch(ignoreScheduledLoadError);
+      }
+
+      return;
+    }
+
+    const status = getErrorStatus(thrownError);
+    const cachedLoad = prefetchedLoads.get(context.href);
+
+    if (cachedLoad) {
+      prefetchedLoads.set(context.href, { ...cachedLoad, status });
+
+      return;
+    }
+
+    if (store.getState().location.href === context.href) {
+      currentLoadResult = createLoadResult<TRoutes, TNotFound>({
+        error: thrownError,
+        location: store.commit(context.url, context.currentMatch, status)
+          .location,
+        match: context.currentMatch,
+        status,
+      });
+    }
   }
 
   function saveScrollPosition(): void {
@@ -1097,6 +1315,41 @@ export default function createRouter<
     previousController?.abort();
     store.setNavigationState("loading");
 
+    // A control-flow rejection can land while this load is still in flight
+    // (an already-settled async hook rejects on the next microtask).  Stash it
+    // until the load commits, then apply — otherwise the location-currency
+    // guard would see the previous location and wrongly drop it.
+    const lateControlFlow: {
+      pending: ScheduledControlFlowError | null;
+      committed: boolean;
+    } = { pending: null, committed: false };
+
+    const applyNavigationControlFlow = (
+      thrownError: ScheduledControlFlowError,
+    ): void => {
+      applyLateNavigationControlFlow(thrownError, {
+        url,
+        currentMatch,
+        signal: abortController.signal,
+        redirectDepth,
+        shouldSyncAdapter,
+        mode,
+      });
+    };
+
+    const scheduledControlFlow: ScheduledControlFlow = {
+      applied: false,
+      apply: (thrownError) => {
+        if (!lateControlFlow.committed) {
+          lateControlFlow.pending = thrownError;
+
+          return;
+        }
+
+        applyNavigationControlFlow(thrownError);
+      },
+    };
+
     try {
       const pendingPrefetch = pendingPrefetches.get(href);
 
@@ -1111,7 +1364,11 @@ export default function createRouter<
       const prefetchedLoad = prefetchedLoads.get(href);
       const resolvedLoad =
         prefetchedLoad ??
-        (await resolveLoadData(currentMatch, abortController.signal));
+        (await resolveLoadData(
+          currentMatch,
+          abortController.signal,
+          scheduledControlFlow,
+        ));
 
       prefetchedLoads.delete(href);
 
@@ -1131,8 +1388,23 @@ export default function createRouter<
       });
       scheduleAccessibilityEffects(result, mode);
 
+      lateControlFlow.committed = true;
+
+      const pendingControlFlow = lateControlFlow.pending;
+
+      if (pendingControlFlow) {
+        lateControlFlow.pending = null;
+        applyNavigationControlFlow(pendingControlFlow);
+      }
+
       return result;
     } catch (thrownError) {
+      // A synchronous throw already carried the load's control flow — a late
+      // async rejection must not apply on top of it.
+      scheduledControlFlow.applied = true;
+      lateControlFlow.committed = true;
+      lateControlFlow.pending = null;
+
       if (thrownError instanceof RouteRedirect) {
         abortController.abort();
         const redirectedResult = await performLoad(


### PR DESCRIPTION
## Done

First PR of a three-PR router-hardening train (runtime fixes → pre-1.0 API consolidation → reference-app alignment + docs overhaul), addressing externally reported router issues. This one fixes the three runtime defects:

- **`fix(router-core)`: catch Navigation API transition promise rejections.** `navigation.navigate()` returns a `{ committed, finished }` promise pair; either rejects when a navigation is superseded, aborted, or immediately cancelled. The adapter discarded the return value, so every such rejection surfaced as an unhandled promise rejection (the externally reported "uncaught promises from prefetch with the default Navigation API adapter"). The test fake modelled `navigate()` as `void`, so no test could observe this; it now returns a real promise pair, and a regression test asserts no unhandled rejections.
- **`feat(router-core)`: honor control-flow rejections from async prefetch hooks.** Synchronous `redirect()`/`StatusResponse` throws from `prefetch` already became redirects / statuses on the committed location, but an async hook's rejection was silently swallowed — one `async` keyword disabled a route's auth guard with no error, and every async example in our own docs was a runtime no-op. Async `RouteRedirect`/`StatusResponse`/`Response` rejections now get the same meaning as their sync counterparts, applied late and guarded (stash-until-commit for mid-flight arrivals; superseded/abandoned loads drop them; first control-flow rejection wins; all other rejections stay deliberately ignored — prefetch remains fire-and-forget and never blocks rendering).
- **`fix(react-ssr)`: let the caller supply the success status code.** `JSXRenderer` hardcoded `statusCode = 200` on every successful render, so a server routing a matched not-found page had no way to respond with the document's real status (reference apps serve soft 404s today — fixed in PR3 of the train). `RendererOptions.statusCode` now sets the reported status for successful renders on all three render paths; shell errors still report 500.

## QA

- `bun run check` and `bun run test` green from the repo root.
- `packages/runtime/router`: new regression test fails on the previous adapter (verified), 195 tests green; async control-flow matrix covers late redirect, late status (incl. `dehydrate()`), superseded-navigation drop, hover-prefetch cache stamping, consumed-entry live application, static-router safety, and non-control-flow rejections staying ignored.
- `packages/react/ssr`: `options.statusCode` covered on all three render paths + shell-error override, 194 tests green.

### PR readiness check

- [x] PR label: `Bug 🐛`
- [x] PR title follows Conventional Commits
- [x] Code follows the code standards
- [x] All packages define required scripts (no new packages)
- [x] No new package
- [x] `no visual change` label (no visual diff)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)