### PR TITLE
feat(summon): preview the undo plan and confirm before reversing

### DIFF
--- a/packages/cli/summon/src/components/App.tsx
+++ b/packages/cli/summon/src/components/App.tsx
@@ -895,7 +895,10 @@ export const App = ({
             setState({ phase: "undoPreview", planEffects });
             return;
           }
-          if (yes) {
+          // Same gate contract as the forward run: flags only pre-fill
+          // answers; `--yes` skips the gate, and so does `--no-preview` —
+          // the forward flow goes straight to executing in both cases.
+          if (yes || !preview) {
             runUndoPlan(undos, unreversible, promptAnswers);
             return;
           }

--- a/packages/cli/summon/src/components/App.tsx
+++ b/packages/cli/summon/src/components/App.tsx
@@ -23,6 +23,11 @@ import { useCallback, useEffect, useState } from "react";
 import { ExecutionProgress, type TimedEffect } from "./ExecutionProgress.js";
 import { PromptSequence } from "./PromptSequence.js";
 import { Spinner } from "./Spinner.js";
+import {
+  describeUndoSteps,
+  isUnreversibleExec,
+  shouldSkipUndoGate,
+} from "./undoPlan.js";
 
 // =============================================================================
 // Effect Tree - Hierarchical display with action labels and tree connectors
@@ -785,22 +790,6 @@ export type AppState =
   | { phase: "complete"; effects: TimedEffect[]; duration: number }
   | { phase: "error"; error: TaskError; answers?: Record<string, unknown> };
 
-/**
- * The effects an undo plan would perform, minus the read/log plumbing an undo
- * task walks through (a remove-line undo reads the file before rewriting it —
- * the read is not part of what gets reversed).
- */
-const UNDO_PLAN_PLUMBING = new Set([
-  "Log",
-  "ReadFile",
-  "Exists",
-  "ReadContext",
-]);
-const listUndoPlanEffects = (undos: readonly Task<void>[]): Effect[] =>
-  undos
-    .flatMap((undoTask) => dryRun(undoTask).effects)
-    .filter((effect) => !UNDO_PLAN_PLUMBING.has(effect._tag));
-
 export interface AppProps {
   /** The generator to run */
   generator: GeneratorDefinition;
@@ -880,7 +869,7 @@ export const App = ({
           const undos = collectUndos(task, {
             resolveExists: hostExistsResolver(),
             onForwardEffect: (effect) => {
-              if (effect._tag === "Exec") unreversible.push(effect);
+              if (isUnreversibleExec(effect)) unreversible.push(effect);
             },
           });
           if (undos.length === 0) {
@@ -890,7 +879,7 @@ export const App = ({
             });
             return;
           }
-          const planEffects = listUndoPlanEffects(undos);
+          const planEffects = describeUndoSteps(undos);
           if (dryRunOnly) {
             setState({ phase: "undoPreview", planEffects });
             return;
@@ -898,7 +887,7 @@ export const App = ({
           // Same gate contract as the forward run: flags only pre-fill
           // answers; `--yes` skips the gate, and so does `--no-preview` —
           // the forward flow goes straight to executing in both cases.
-          if (yes || !preview) {
+          if (shouldSkipUndoGate({ yes, preview })) {
             runUndoPlan(undos, unreversible, promptAnswers);
             return;
           }

--- a/packages/cli/summon/src/components/App.tsx
+++ b/packages/cli/summon/src/components/App.tsx
@@ -796,7 +796,7 @@ const UNDO_PLAN_PLUMBING = new Set([
   "Exists",
   "ReadContext",
 ]);
-const undoPlanEffects = (undos: readonly Task<void>[]): Effect[] =>
+const listUndoPlanEffects = (undos: readonly Task<void>[]): Effect[] =>
   undos
     .flatMap((undoTask) => dryRun(undoTask).effects)
     .filter((effect) => !UNDO_PLAN_PLUMBING.has(effect._tag));
@@ -890,7 +890,7 @@ export const App = ({
             });
             return;
           }
-          const planEffects = undoPlanEffects(undos);
+          const planEffects = listUndoPlanEffects(undos);
           if (dryRunOnly) {
             setState({ phase: "undoPreview", planEffects });
             return;

--- a/packages/cli/summon/src/components/App.tsx
+++ b/packages/cli/summon/src/components/App.tsx
@@ -11,12 +11,13 @@ import {
   type StampConfig,
 } from "@canonical/summon-core";
 import {
+  collectUndos,
   dryRun,
   type Effect,
   type Task,
   type TaskError,
 } from "@canonical/task";
-import { runUndo } from "@canonical/task/node";
+import { hostExistsResolver, runCollectedUndos } from "@canonical/task/node";
 import { Box, Text, useApp, useInput } from "ink";
 import { useCallback, useEffect, useState } from "react";
 import { ExecutionProgress, type TimedEffect } from "./ExecutionProgress.js";
@@ -772,9 +773,33 @@ export type AppState =
       effects: Effect[];
       promptAnswers: Record<string, unknown>;
     }
+  | { phase: "undoPreview"; planEffects: Effect[] }
+  | {
+      phase: "confirmingUndo";
+      undos: Task<void>[];
+      planEffects: Effect[];
+      unreversible: Effect[];
+    }
+  | { phase: "undone"; undoCount: number; unreversible: Effect[] }
   | { phase: "executing"; task: Task<void> }
   | { phase: "complete"; effects: TimedEffect[]; duration: number }
   | { phase: "error"; error: TaskError; answers?: Record<string, unknown> };
+
+/**
+ * The effects an undo plan would perform, minus the read/log plumbing an undo
+ * task walks through (a remove-line undo reads the file before rewriting it —
+ * the read is not part of what gets reversed).
+ */
+const UNDO_PLAN_PLUMBING = new Set([
+  "Log",
+  "ReadFile",
+  "Exists",
+  "ReadContext",
+]);
+const undoPlanEffects = (undos: readonly Task<void>[]): Effect[] =>
+  undos
+    .flatMap((undoTask) => dryRun(undoTask).effects)
+    .filter((effect) => !UNDO_PLAN_PLUMBING.has(effect._tag));
 
 export interface AppProps {
   /** The generator to run */
@@ -789,6 +814,8 @@ export interface AppProps {
   verbose?: boolean;
   /** Pre-filled answers (for non-interactive mode) */
   answers?: Record<string, unknown>;
+  /** Skip confirmation gates (`--yes`) */
+  yes?: boolean;
   /** Stamp configuration for generated files (undefined = no stamps) */
   stamp?: StampConfig;
 }
@@ -800,6 +827,7 @@ export const App = ({
   undo = false,
   verbose = false,
   answers: prefilledAnswers,
+  yes = false,
   stamp,
 }: AppProps) => {
   const { exit } = useApp();
@@ -811,6 +839,31 @@ export const App = ({
   );
   const [showFiles, setShowFiles] = useState(false);
 
+  const runUndoPlan = useCallback(
+    (
+      undos: Task<void>[],
+      unreversible: Effect[],
+      promptAnswers: Record<string, unknown>,
+    ) => {
+      (async () => {
+        try {
+          const { undoCount } = await runCollectedUndos(undos);
+          setState({ phase: "undone", undoCount, unreversible });
+        } catch (err) {
+          setState({
+            phase: "error",
+            error:
+              err instanceof Error
+                ? { code: "UNDO_ERROR", message: err.message }
+                : { code: "UNKNOWN_ERROR", message: String(err) },
+            answers: promptAnswers,
+          });
+        }
+      })();
+    },
+    [],
+  );
+
   const handlePromptsComplete = useCallback(
     (promptAnswers: Record<string, unknown>) => {
       setAnswers(promptAnswers);
@@ -818,33 +871,50 @@ export const App = ({
       // Generate the task
       const task = generator.generate(promptAnswers);
 
-      // Undo mode: run undo directly
+      // Undo mode: collect the plan ONCE (host-backed Exists resolution, so
+      // branch selection matches the run being undone), show it, and execute
+      // exactly the collected undos — never re-walk the task in between.
       if (undo) {
-        (async () => {
-          try {
-            const result = await runUndo(task);
-            setState({
-              phase: "complete",
-              effects: [],
-              duration: 0,
-            });
-            if (result.undoCount === 0) {
-              setState({
-                phase: "error",
-                error: { code: "NOTHING_TO_UNDO", message: "Nothing to undo." },
-              });
-            }
-          } catch (err) {
+        try {
+          const unreversible: Effect[] = [];
+          const undos = collectUndos(task, {
+            resolveExists: hostExistsResolver(),
+            onForwardEffect: (effect) => {
+              if (effect._tag === "Exec") unreversible.push(effect);
+            },
+          });
+          if (undos.length === 0) {
             setState({
               phase: "error",
-              error:
-                err instanceof Error
-                  ? { code: "UNDO_ERROR", message: err.message }
-                  : { code: "UNKNOWN_ERROR", message: String(err) },
-              answers: promptAnswers,
+              error: { code: "NOTHING_TO_UNDO", message: "Nothing to undo." },
             });
+            return;
           }
-        })();
+          const planEffects = undoPlanEffects(undos);
+          if (dryRunOnly) {
+            setState({ phase: "undoPreview", planEffects });
+            return;
+          }
+          if (yes) {
+            runUndoPlan(undos, unreversible, promptAnswers);
+            return;
+          }
+          setState({
+            phase: "confirmingUndo",
+            undos,
+            planEffects,
+            unreversible,
+          });
+        } catch (err) {
+          setState({
+            phase: "error",
+            error:
+              err instanceof Error
+                ? { code: "UNDO_ERROR", message: err.message }
+                : { code: "UNKNOWN_ERROR", message: String(err) },
+            answers: promptAnswers,
+          });
+        }
         return;
       }
 
@@ -875,7 +945,7 @@ export const App = ({
         setState({ phase: "executing", task });
       }
     },
-    [generator, preview, dryRunOnly, undo],
+    [generator, preview, dryRunOnly, undo, yes, runUndoPlan],
   );
 
   const handleConfirm = useCallback(() => {
@@ -914,7 +984,12 @@ export const App = ({
     setState({ phase: "prompting" });
   }, []);
 
-  // Handle confirm/cancel/back/show-files input when in confirming state
+  const handleUndoConfirm = useCallback(() => {
+    if (state.phase !== "confirmingUndo") return;
+    runUndoPlan(state.undos, state.unreversible, answers);
+  }, [state, runUndoPlan, answers]);
+
+  // Handle confirm/cancel/back/show-files input when in a confirming state
   useInput(
     (input, key) => {
       if (state.phase === "confirming") {
@@ -929,9 +1004,18 @@ export const App = ({
         } else if (input.toLowerCase() === "n") {
           handleCancel();
         }
+      } else if (state.phase === "confirmingUndo") {
+        if (key.return || input.toLowerCase() === "y") {
+          handleUndoConfirm();
+        } else if (key.escape || input.toLowerCase() === "n") {
+          handleCancel();
+        }
       }
     },
-    { isActive: state.phase === "confirming" },
+    {
+      isActive:
+        state.phase === "confirming" || state.phase === "confirmingUndo",
+    },
   );
 
   return (
@@ -968,6 +1052,66 @@ export const App = ({
           <Box marginTop={1}>
             <Text dimColor>Dry-run complete. No files were modified.</Text>
           </Box>
+        </Box>
+      )}
+
+      {state.phase === "undoPreview" && (
+        <Box flexDirection="column">
+          <DryRunTimeline
+            effects={state.planEffects}
+            title="Undo plan (dry-run):"
+            verbose={verbose}
+          />
+          <Box marginTop={1}>
+            <Text dimColor>Dry-run complete. No files were modified.</Text>
+          </Box>
+        </Box>
+      )}
+
+      {state.phase === "confirmingUndo" && (
+        <Box flexDirection="column">
+          <DryRunTimeline
+            effects={state.planEffects}
+            title={`Undo will reverse ${state.undos.length} step${state.undos.length === 1 ? "" : "s"}:`}
+            verbose={verbose}
+          />
+          {state.unreversible.length > 0 && (
+            <Box marginTop={1}>
+              <Text color="yellow">
+                {state.unreversible.length} exec step
+                {state.unreversible.length === 1 ? "" : "s"} (e.g. installs)
+                cannot be reversed; artifacts may remain.
+              </Text>
+            </Box>
+          )}
+          <Box marginTop={1}>
+            <Text color="magenta">› </Text>
+            <Text bold>Reverse these steps? </Text>
+            <Text dimColor>(y/N) </Text>
+            <Text dimColor italic>
+              esc to cancel
+            </Text>
+          </Box>
+        </Box>
+      )}
+
+      {state.phase === "undone" && (
+        <Box flexDirection="column">
+          <Box>
+            <Text color="green">
+              ✓ Undo complete ({state.undoCount} step
+              {state.undoCount === 1 ? "" : "s"} reversed).
+            </Text>
+          </Box>
+          {state.unreversible.length > 0 && (
+            <Box marginTop={1}>
+              <Text dimColor>
+                Note: {state.unreversible.length} exec step
+                {state.unreversible.length === 1 ? "" : "s"} were not reversed;
+                their artifacts may remain.
+              </Text>
+            </Box>
+          )}
         </Box>
       )}
 

--- a/packages/cli/summon/src/components/undoPlan.test.ts
+++ b/packages/cli/summon/src/components/undoPlan.test.ts
@@ -1,0 +1,100 @@
+import {
+  deleteFile,
+  type Effect,
+  execEffect,
+  flatMap,
+  pure,
+  readFile,
+  type Task,
+} from "@canonical/task";
+import { describe, expect, it } from "vitest";
+import {
+  describeUndoSteps,
+  isUnreversibleExec,
+  shouldSkipUndoGate,
+} from "./undoPlan.js";
+
+describe("describeUndoSteps", () => {
+  it("lists the plan in execution order (reverse of collection order)", () => {
+    const undos: Task<void>[] = [
+      deleteFile("first-created.ts"),
+      deleteFile("second-created.ts"),
+    ];
+
+    const plan = describeUndoSteps(undos);
+
+    expect(plan.map((effect) => "path" in effect && effect.path)).toEqual([
+      "second-created.ts",
+      "first-created.ts",
+    ]);
+  });
+
+  it("shows a revert line for an undo whose dry-run yields only reads", () => {
+    // Shaped like removeLineFromFile's undo: reads the file, and because
+    // dry-run mocks reads the target line is absent, so no write surfaces.
+    const removeLineShaped: Task<void> = flatMap(
+      readFile("parent/index.ts"),
+      () => pure(undefined),
+    );
+
+    const plan = describeUndoSteps([removeLineShaped]);
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]).toMatchObject({
+      _tag: "Log",
+      message: "Revert changes in parent/index.ts",
+    });
+  });
+
+  it("shows one entry per step, mixing visible and revert lines", () => {
+    const removeLineShaped: Task<void> = flatMap(
+      readFile("parent/index.ts"),
+      () => pure(undefined),
+    );
+    const plan = describeUndoSteps([
+      deleteFile("Button/index.ts"),
+      removeLineShaped,
+    ]);
+
+    expect(plan).toHaveLength(2);
+    expect(plan[0]?._tag).toBe("Log");
+    expect(plan[1]).toMatchObject({ _tag: "DeleteFile" });
+  });
+});
+
+describe("isUnreversibleExec", () => {
+  it("flags an exec without an undo as residue", () => {
+    expect(isUnreversibleExec(execEffect("bun", ["install"]))).toBe(true);
+  });
+
+  it("does not flag an exec that carries its own undo", () => {
+    const reversible = execEffect("git", ["init"], undefined, {
+      undo: pure(undefined),
+    });
+    expect(isUnreversibleExec(reversible)).toBe(false);
+  });
+
+  it("ignores non-exec effects", () => {
+    const write: Effect = {
+      _tag: "WriteFile",
+      path: "a.ts",
+      content: "",
+      overwrite: true,
+    };
+    expect(isUnreversibleExec(write)).toBe(false);
+  });
+});
+
+describe("shouldSkipUndoGate", () => {
+  it("gates when answers came from flags alone", () => {
+    expect(shouldSkipUndoGate({ yes: false, preview: true })).toBe(false);
+  });
+
+  it("skips the gate with --yes", () => {
+    expect(shouldSkipUndoGate({ yes: true, preview: true })).toBe(true);
+  });
+
+  it("skips the gate with --no-preview", () => {
+    expect(shouldSkipUndoGate({ yes: false, preview: false })).toBe(true);
+  });
+});

--- a/packages/cli/summon/src/components/undoPlan.ts
+++ b/packages/cli/summon/src/components/undoPlan.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure helpers for presenting and gating an undo plan — shared by the Ink
+ * wizard and the batch path so both executors show the SAME plan under the
+ * SAME rules. Kept free of Ink/Commander so the contract is unit-testable
+ * without a terminal.
+ */
+
+import { dryRun, type Effect, type Task } from "@canonical/task";
+
+/** Effects an undo task walks through that are not part of what it reverses. */
+const PLUMBING = new Set(["Log", "ReadFile", "Exists", "ReadContext"]);
+
+/**
+ * Describe an undo plan in EXECUTION order (last collected step first —
+ * `runCollectedUndos` executes LIFO, and the preview must show the order
+ * that will actually run). Each undo contributes its visible effects; an
+ * undo whose dry-run yields only plumbing (e.g. a remove-line undo, whose
+ * reads are mocked so no write surfaces) contributes a synthetic Log line
+ * naming the file it will revert, so the plan never under-reports a step.
+ *
+ * @param undos - Undo tasks in forward collection order, as `collectUndos`
+ *   returns them.
+ * @returns Effects describing the plan, in execution (reversed) order.
+ */
+export function describeUndoSteps(undos: readonly Task<void>[]): Effect[] {
+  return [...undos].reverse().flatMap((undoTask) => {
+    const effects = dryRun(undoTask).effects;
+    const visible = effects.filter((effect) => !PLUMBING.has(effect._tag));
+    if (visible.length > 0) {
+      return visible;
+    }
+    const touched = effects.find(
+      (effect): effect is Effect & { path: string } =>
+        "path" in effect && typeof effect.path === "string",
+    );
+    if (touched === undefined) {
+      return [];
+    }
+    return [
+      {
+        _tag: "Log",
+        level: "info",
+        message: `Revert changes in ${touched.path}`,
+      } as Effect,
+    ];
+  });
+}
+
+/**
+ * Whether a forward effect will be left behind by the undo: an `Exec` with
+ * no undo of its own. An exec that carries an explicit `undo` is reversed
+ * like any other effect and must not be reported as residue.
+ */
+export function isUnreversibleExec(effect: Effect): boolean {
+  return (
+    effect._tag === "Exec" && !("undo" in effect && effect.undo !== undefined)
+  );
+}
+
+/**
+ * Whether to skip the undo confirmation gate — the SAME contract the
+ * forward run applies to its preview gate: flags only pre-fill answers,
+ * while `--yes` and `--no-preview` both go straight to executing.
+ */
+export function shouldSkipUndoGate(options: {
+  readonly yes: boolean;
+  readonly preview: boolean;
+}): boolean {
+  return options.yes || !options.preview;
+}

--- a/packages/cli/summon/src/registration/registerFromBarrel.tsx
+++ b/packages/cli/summon/src/registration/registerFromBarrel.tsx
@@ -18,8 +18,13 @@ import {
   type PromptDefinition,
   type StampConfig,
 } from "@canonical/summon-core";
-import { dryRun } from "@canonical/task";
-import { runUndo } from "@canonical/task/node";
+import {
+  collectUndos,
+  describeEffect,
+  dryRun,
+  type Effect,
+} from "@canonical/task";
+import { hostExistsResolver, runCollectedUndos } from "@canonical/task/node";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { render } from "ink";
@@ -356,16 +361,48 @@ const configureGeneratorCommand = (
         ? createGeneratorStamp(generator)
         : undefined;
 
-      // Undo mode (non-interactive batch)
+      // Undo mode (non-interactive batch): collect the plan ONCE with
+      // host-backed Exists resolution, show it, then execute exactly the
+      // collected undos — never re-walk the task between preview and run.
       if (hasAllAnswers && actualOptions.undo && !isTTY) {
         const task = generator.generate(answersWithDefaults);
         try {
-          const result = await runUndo(task);
-          if (result.undoCount === 0) {
+          const unreversible: Effect[] = [];
+          const undos = collectUndos(task, {
+            resolveExists: hostExistsResolver(),
+            onForwardEffect: (effect) => {
+              if (effect._tag === "Exec") unreversible.push(effect);
+            },
+          });
+          if (undos.length === 0) {
             console.log("Nothing to undo.");
-          } else {
-            console.log(
-              `Undo complete (${result.undoCount} step${result.undoCount === 1 ? "" : "s"} reversed).`,
+            return;
+          }
+          const plumbing = new Set([
+            "Log",
+            "ReadFile",
+            "Exists",
+            "ReadContext",
+          ]);
+          const planLines = undos
+            .flatMap((undoTask) => dryRun(undoTask).effects)
+            .filter((effect) => !plumbing.has(effect._tag))
+            .map(describeEffect);
+          // Diagnostics go to stderr so stdout stays a clean data stream.
+          process.stderr.write(
+            `Undo will reverse ${undos.length} step${undos.length === 1 ? "" : "s"}:\n${planLines.map((line) => `  - ${line}`).join("\n")}\n`,
+          );
+          if (actualOptions.dryRun) {
+            console.log("Dry-run complete. Nothing was reversed.");
+            return;
+          }
+          const result = await runCollectedUndos(undos);
+          console.log(
+            `Undo complete (${result.undoCount} step${result.undoCount === 1 ? "" : "s"} reversed).`,
+          );
+          if (unreversible.length > 0) {
+            process.stderr.write(
+              `Note: ${unreversible.length} exec step${unreversible.length === 1 ? "" : "s"} were not reversed (e.g. installs); their artifacts may remain.\n`,
             );
           }
         } catch (err) {
@@ -454,6 +491,7 @@ const configureGeneratorCommand = (
             preview={shouldShowPreview}
             dryRunOnly={actualOptions.dryRun as boolean}
             undo={actualOptions.undo as boolean}
+            yes={skipPrompts}
             verbose={actualOptions.verbose as boolean}
             answers={passedAnswers}
             stamp={stamp}

--- a/packages/cli/summon/src/registration/registerFromBarrel.tsx
+++ b/packages/cli/summon/src/registration/registerFromBarrel.tsx
@@ -29,6 +29,10 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import { render } from "ink";
 import { App } from "../components/App.js";
+import {
+  describeUndoSteps,
+  isUnreversibleExec,
+} from "../components/undoPlan.js";
 import type { CommandEntry, OptionInfo } from "./types.js";
 
 // =============================================================================
@@ -371,23 +375,16 @@ const configureGeneratorCommand = (
           const undos = collectUndos(task, {
             resolveExists: hostExistsResolver(),
             onForwardEffect: (effect) => {
-              if (effect._tag === "Exec") unreversible.push(effect);
+              if (isUnreversibleExec(effect)) unreversible.push(effect);
             },
           });
           if (undos.length === 0) {
             console.log("Nothing to undo.");
             return;
           }
-          const plumbing = new Set([
-            "Log",
-            "ReadFile",
-            "Exists",
-            "ReadContext",
-          ]);
-          const planLines = undos
-            .flatMap((undoTask) => dryRun(undoTask).effects)
-            .filter((effect) => !plumbing.has(effect._tag))
-            .map(describeEffect);
+          const planLines = describeUndoSteps(undos).map((effect) =>
+            effect._tag === "Log" ? effect.message : describeEffect(effect),
+          );
           // Diagnostics go to stderr so stdout stays a clean data stream.
           process.stderr.write(
             `Undo will reverse ${undos.length} step${undos.length === 1 ? "" : "s"}:\n${planLines.map((line) => `  - ${line}`).join("\n")}\n`,

--- a/packages/runtime/task/src/lib/undo-interpreter.test.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.test.ts
@@ -22,7 +22,11 @@ import {
 import { $, effect, fail, flatMap, gen, map, pure, recover } from "./task.js";
 import type { Task } from "./types.js";
 import { collectUndos } from "./undo.js";
-import { hostExistsResolver, runUndo } from "./undo-interpreter.js";
+import {
+  hostExistsResolver,
+  runCollectedUndos,
+  runUndo,
+} from "./undo-interpreter.js";
 
 // =============================================================================
 // collectUndos
@@ -739,6 +743,73 @@ describe("collectUndos - fail-backtracking", () => {
     expect(() => collectUndos(task, { resolveExists: () => true })).toThrow(
       TaskExecutionError,
     );
+  });
+});
+
+describe("collectUndos - onForwardEffect", () => {
+  it("reports the successful walk's leaf effects in forward order", () => {
+    const seen: string[] = [];
+    const task = sequence_([
+      writeFile("/a.txt", "a"),
+      exec("bun", ["install"]),
+      info("done"),
+    ]);
+
+    collectUndos(task, { onForwardEffect: (e) => seen.push(e._tag) });
+
+    expect(seen).toEqual(["WriteFile", "Exec", "Log"]);
+  });
+
+  it("never reports effects from failed backtracking attempts", () => {
+    const seen: string[] = [];
+    const task = ifElseM(
+      exists("/page.tsx"),
+      fail({ code: "PAGE_EXISTS", message: "already there" }),
+      writeFile("/page.tsx", "content"),
+    );
+
+    collectUndos(task, {
+      resolveExists: () => true,
+      onForwardEffect: (e) => seen.push(e._tag),
+    });
+
+    // Only the surviving (flipped) walk's effects: the Exists probe and the
+    // write — never the failed attempt's duplicates.
+    expect(seen).toEqual(["Exists", "WriteFile"]);
+  });
+});
+
+describe("runCollectedUndos", () => {
+  it("executes a pre-collected plan in reverse without re-walking the task", async () => {
+    const order: string[] = [];
+    const onEffectComplete = (eff: import("./types.js").Effect) => {
+      if (eff._tag === "WriteContext" && typeof eff.key === "string") {
+        order.push(eff.key);
+      }
+    };
+    const marker = (label: string) =>
+      effect<void>({ _tag: "WriteContext", key: label, value: true });
+
+    const task = sequence_([
+      writeFile("/tmp/a.txt", "a", { undo: marker("a") }),
+      writeFile("/tmp/b.txt", "b", { undo: marker("b") }),
+    ]);
+    const undos = collectUndos(task);
+
+    const result = await runCollectedUndos(undos, {
+      context: new Map(),
+      onEffectComplete,
+    });
+
+    expect(result.undoCount).toBe(2);
+    expect(order).toEqual(["b", "a"]);
+    // The caller's forward-order array is not mutated by the LIFO execution.
+    expect(dryRun(undos[0]).effects[0]).toMatchObject({ key: "a" });
+  });
+
+  it("returns undoCount 0 for an empty plan", async () => {
+    const result = await runCollectedUndos([]);
+    expect(result.undoCount).toBe(0);
   });
 });
 

--- a/packages/runtime/task/src/lib/undo-interpreter.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.ts
@@ -91,13 +91,31 @@ export const runUndo = async <A>(
     resolveExists: hostExistsResolver(options?.cwd),
   });
 
+  // Phase 2: Execute collected undos in reverse (LIFO)
+  return runCollectedUndos(undos, options);
+};
+
+/**
+ * Execute an already-collected undo plan in reverse (LIFO) order.
+ *
+ * Split out of {@link runUndo} for callers that collect first — to preview
+ * the plan or ask for confirmation — and must not walk the task a second
+ * time (collect once, then execute exactly what was shown).
+ *
+ * @param undos - Undo tasks in forward execution order (as `collectUndos`
+ *   returns them); executed here in reverse
+ * @param options - RunTaskOptions passed to each undo execution
+ * @returns The number of undo steps executed
+ */
+export const runCollectedUndos = async (
+  undos: readonly Task<void>[],
+  options?: RunTaskOptions,
+): Promise<UndoResult> => {
   if (undos.length === 0) {
     return { undoCount: 0 };
   }
 
-  // Phase 2: Execute collected undos in reverse (LIFO)
-  // Import sequence_ inline to avoid circular dependency
-  const reversed = undos.reverse();
+  const reversed = [...undos].reverse();
   for (const undoTask of reversed) {
     await runTask(undoTask, options);
   }

--- a/packages/runtime/task/src/lib/undo.ts
+++ b/packages/runtime/task/src/lib/undo.ts
@@ -28,6 +28,14 @@ export interface CollectUndosOptions {
    * content is the contract.
    */
   resolveExists?: (path: string) => boolean;
+  /**
+   * Observe each leaf forward effect of the successful walk (the branch
+   * assignment the collected undos correspond to), in forward order. Lets a
+   * caller report what the plan does NOT reverse — e.g. `Exec` effects, which
+   * have no default undo — without walking the task again. Called only after
+   * the walk settles; failed backtracking attempts are never reported.
+   */
+  onForwardEffect?: (effect: Effect) => void;
 }
 
 /**
@@ -51,6 +59,8 @@ interface WalkState {
   virtualFs: Set<string>;
   /** Undos collected this attempt, in forward order. */
   undos: Task<void>[];
+  /** Leaf forward effects of this attempt, in forward order. */
+  forwardEffects: Effect[];
   /** Free `Exists` decisions in encounter order. */
   decisions: ExistsDecision[];
   /** Values forced for the first N decisions (backtracking overrides). */
@@ -90,6 +100,7 @@ export const collectUndos = <A>(
     const state: WalkState = {
       virtualFs: new Set(),
       undos: [],
+      forwardEffects: [],
       decisions: [],
       overrides,
       resolveExists: options?.resolveExists,
@@ -112,6 +123,11 @@ export const collectUndos = <A>(
     const { state, error } = walk(overrides);
 
     if (error === null) {
+      if (options?.onForwardEffect) {
+        for (const effect of state.forwardEffects) {
+          options.onForwardEffect(effect);
+        }
+      }
       return state.undos;
     }
 
@@ -204,6 +220,8 @@ const collectUndosInto = (task: Task<unknown>, state: WalkState): unknown => {
       }
       return undefined;
     }
+
+    state.forwardEffects.push(effect);
 
     if (effect._tag === "Exists") {
       // A path this walk already created is present regardless of the host.

--- a/packages/runtime/task/src/lib/undo.ts
+++ b/packages/runtime/task/src/lib/undo.ts
@@ -26,6 +26,15 @@ export interface CollectUndosOptions {
    * append-if-absent helper would see the very line the forward run appended
    * and skip collecting its remove-line undo). Real existence + mocked
    * content is the contract.
+   *
+   * Known boundary: post-run host state cannot recover the PRE-run branch
+   * when the forward run itself changed the answer and both branches
+   * succeed at collection time — `ifElseM(exists(p), append, create)` over
+   * an initially missing `p` collects the append branch's undo, not the
+   * create branch's delete. That is the accepted cost of stateless undo (no
+   * journal, by design); generators keep it benign by making the
+   * existing-branch undo subsume the fresh-branch one (a remove-line undo
+   * deletes the file when its removal leaves nothing behind).
    */
   resolveExists?: (path: string) => boolean;
   /**

--- a/packages/runtime/task/src/node.ts
+++ b/packages/runtime/task/src/node.ts
@@ -40,4 +40,8 @@ export { runPreview } from "./lib/preview-interpreter.js";
 // =============================================================================
 
 export type { UndoResult } from "./lib/undo-interpreter.js";
-export { hostExistsResolver, runUndo } from "./lib/undo-interpreter.js";
+export {
+  hostExistsResolver,
+  runCollectedUndos,
+  runUndo,
+} from "./lib/undo-interpreter.js";


### PR DESCRIPTION
> Reworked after review feedback: the feature now lives entirely in the **summon stack** (`@canonical/task` + the summon CLI) — pragma is untouched, since pragma will consume summon fully in the future. Pragma's `--undo` already benefits from the collection fixes in #971 via `runUndo`.

## Done

- **`summon <generator> --undo` now shows its plan and asks before reversing** — in both execution paths, collecting once (host-backed `Exists` resolution from #971) and executing exactly the collected undos, never re-walking the task between preview and run:
  - **Batch (non-TTY):** the plan prints to stderr (stdout stays a clean data stream); `--undo --dry-run` shows the plan without reversing anything — previously that combination executed the undo; `exec` steps that cannot be reversed (installs) are reported instead of leaving silent residue (`node_modules`, `.git`).
  - **Ink (TTY):** undo gets the same confirm gate the forward run has — the plan renders with a `Reverse these steps? (y/N)` prompt, `--yes` skips the gate, `--undo --dry-run` renders the plan only, and completion reports the reversed count plus any unreversible exec steps.
- **`@canonical/task`: `runCollectedUndos` + `collectUndos` forward-effect observer.** Preview-then-confirm must execute exactly the plan it showed — re-walking between preview and execution is unsound for non-re-interpretable tasks. `runUndo` is now collect + `runCollectedUndos(undos)`; the new `onForwardEffect` option reports the successful walk's leaf effects (used to name unreversible `exec` steps) without walking the task again.

## QA

- `bun run check` passes from the repo root; `bun run test` passes for every package except the three svelte app packages (`svelte-ds-app`, `svelte-ds-global`, `svelte-ds-app-wpe`), which fail on this machine at Playwright browser launch over missing system libraries (`libwoff1`, `gstreamer`, …) — an environment-only failure unrelated to this diff (the branch touches only `@canonical/task` and `cli/summon`).
- New task tests: `runCollectedUndos` LIFO execution without mutating the caller's array; `onForwardEffect` ordering and failed-attempt isolation (`packages/runtime/task/src/lib/undo-interpreter.test.ts`).
- Manual end-to-end in a temp dir with the workspace generators (`--generators`): forward `summon component react src/components/Button --yes` next to a pre-existing `ButtonGroup` barrel, then `--undo` — the plan prints, 16 steps reverse, the barrel keeps the sibling export and loses only the appended line, and the component directory is removed.

### PR readiness check

- [x] PR label: `Feature 🎁`
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added (TTY output changes are terminal UI, not Chromatic-covered visuals).

## Screenshots

n/a

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
