### PR TITLE
fix(summon-package): make every generated flag combination installable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1381,8 +1381,8 @@
         "vitest": "^4.0.18",
       },
       "peerDependencies": {
-        "@canonical/summon-core": "^0.18.0 || ^0.20.0",
-        "@canonical/task": "^0.18.0 || ^0.20.0",
+        "@canonical/summon-core": "^0.34.0",
+        "@canonical/task": "^0.34.0",
       },
     },
     "packages/svelte/ds-app": {

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -39,14 +39,24 @@ const gen: GeneratorDefinition = {
     writeFile(`${String(a.componentPath)}/index.ts`, "export {};\n"),
 };
 
-/** Poll a predicate until true (robust to render timing under coverage/load). */
-async function waitFor(check: () => boolean, timeout = 30000): Promise<void> {
+/**
+ * Poll a predicate until true (robust to render timing under coverage/load).
+ * `describe` is appended to the timeout error so a CI-only failure shows the
+ * state the wizard was actually wedged in, not just that it timed out.
+ */
+async function waitFor(
+  check: () => boolean,
+  timeout = 30000,
+  describe?: () => string,
+): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeout) {
     if (check()) return;
     await new Promise((r) => setTimeout(r, 15));
   }
-  throw new Error("waitFor: condition not met within timeout");
+  throw new Error(
+    `waitFor: condition not met within timeout${describe ? `\n${describe()}` : ""}`,
+  );
 }
 
 /**
@@ -61,6 +71,7 @@ async function pressUntil(
   key: string,
   done: () => boolean,
   timeout = 30000,
+  describe?: () => string,
 ): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeout) {
@@ -71,7 +82,9 @@ async function pressUntil(
     }
   }
   if (done()) return;
-  throw new Error("pressUntil: key did not take effect within timeout");
+  throw new Error(
+    `pressUntil(${JSON.stringify(key)}): key did not take effect within timeout${describe ? `\n${describe()}` : ""}`,
+  );
 }
 
 /**
@@ -87,8 +100,9 @@ async function typeExactly(
   stdin: { write: (data: string) => void },
   frame: () => string,
   value: string,
+  describe?: () => string,
 ): Promise<void> {
-  await pressUntil(stdin, "@", () => frame().includes("@"));
+  await pressUntil(stdin, "@", () => frame().includes("@"), 30000, describe);
   // Clear however many sentinels landed. Control keys must go one write per
   // keystroke — ink parses key flags per chunk, so a chunk of backspaces is
   // not N backspaces.
@@ -96,9 +110,9 @@ async function typeExactly(
     stdin.write("\x7f");
     await new Promise((r) => setTimeout(r, 5));
   }
-  await waitFor(() => !frame().includes("@"));
+  await waitFor(() => !frame().includes("@"), 30000, describe);
   stdin.write(value);
-  await waitFor(() => frame().includes(value));
+  await waitFor(() => frame().includes(value), 30000, describe);
 }
 
 const text = (name: string, message: string): PromptEffect =>
@@ -135,8 +149,15 @@ describe("create wizard (PROTECTED)", () => {
     const c = new SessionController(gen);
     const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
     const frame = (): string => lastFrame() ?? "";
+    // On a timeout, show the state the wizard was wedged in — this failure
+    // has only ever reproduced on loaded CI runners, so the error text is the
+    // one diagnostic that comes back from there.
+    const wedged = (): string => {
+      const s = c.getSnapshot();
+      return `phase=${s.phase} answers=${JSON.stringify(s.answers)} frame:\n${frame()}`;
+    };
     try {
-      await waitFor(() => frame().includes("component/react"));
+      await waitFor(() => frame().includes("component/react"), 30000, wedged);
 
       // 1. Text prompt with a step counter.
       void c.request(text("componentPath", "Component path:"));
@@ -144,33 +165,47 @@ describe("create wizard (PROTECTED)", () => {
         () =>
           frame().includes("Component path:") &&
           frame().includes("Step 1 of 2"),
+        30000,
+        wedged,
       );
       // Type the value with the sentinel-probe helper — the text write races
       // the useInput subscription just like the keystrokes, and a partial
       // drop plus re-send would submit a garbled value. Then re-send Enter
       // until the answer lands.
-      await typeExactly(stdin, frame, "src/components/Button");
+      await typeExactly(stdin, frame, "src/components/Button", wedged);
       await pressUntil(
         stdin,
         "\r",
         () => c.getSnapshot().answers.componentPath === "src/components/Button",
+        30000,
+        wedged,
       );
 
       // 2. Confirm prompt (submits immediately on "y").
       void c.request(confirm("withStyles", "Include styles?"));
-      await waitFor(() => frame().includes("Step 2 of 2"));
+      await waitFor(() => frame().includes("Step 2 of 2"), 30000, wedged);
       await pressUntil(
         stdin,
         "y",
         () => c.getSnapshot().answers.withStyles === true,
+        30000,
+        wedged,
       );
 
       // 3. The confirm GATE — the wizard shows the preview + "Proceed?".
       void c.request(gate());
       await waitFor(
         () => frame().includes("Proceed?") && /File.*to create/.test(frame()),
+        30000,
+        wedged,
       );
-      await pressUntil(stdin, "y", () => c.getSnapshot().phase === "executing");
+      await pressUntil(
+        stdin,
+        "y",
+        () => c.getSnapshot().phase === "executing",
+        30000,
+        wedged,
+      );
 
       // 4. Progress + completion.
       c.reportEffectComplete(

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -39,24 +39,14 @@ const gen: GeneratorDefinition = {
     writeFile(`${String(a.componentPath)}/index.ts`, "export {};\n"),
 };
 
-/**
- * Poll a predicate until true (robust to render timing under coverage/load).
- * `describe` is appended to the timeout error so a CI-only failure shows the
- * state the wizard was actually wedged in, not just that it timed out.
- */
-async function waitFor(
-  check: () => boolean,
-  timeout = 30000,
-  describe?: () => string,
-): Promise<void> {
+/** Poll a predicate until true (robust to render timing under coverage/load). */
+async function waitFor(check: () => boolean, timeout = 30000): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeout) {
     if (check()) return;
     await new Promise((r) => setTimeout(r, 15));
   }
-  throw new Error(
-    `waitFor: condition not met within timeout${describe ? `\n${describe()}` : ""}`,
-  );
+  throw new Error("waitFor: condition not met within timeout");
 }
 
 /**
@@ -71,7 +61,6 @@ async function pressUntil(
   key: string,
   done: () => boolean,
   timeout = 30000,
-  describe?: () => string,
 ): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeout) {
@@ -82,37 +71,7 @@ async function pressUntil(
     }
   }
   if (done()) return;
-  throw new Error(
-    `pressUntil(${JSON.stringify(key)}): key did not take effect within timeout${describe ? `\n${describe()}` : ""}`,
-  );
-}
-
-/**
- * Type a text value deterministically. Re-sending a multi-character value
- * (the pressUntil strategy) is not safe for text: a partially-dropped first
- * write followed by a full re-send still satisfies an `includes` check but
- * leaves the field garbled, and the later submit wait then hangs to its
- * ceiling. Instead: prove the input subscription is live with a sentinel
- * keystroke, clear it, then send the whole value as one atomic chunk —
- * reliable once the subscription is known to be up.
- */
-async function typeExactly(
-  stdin: { write: (data: string) => void },
-  frame: () => string,
-  value: string,
-  describe?: () => string,
-): Promise<void> {
-  await pressUntil(stdin, "@", () => frame().includes("@"), 30000, describe);
-  // Clear however many sentinels landed. Control keys must go one write per
-  // keystroke — ink parses key flags per chunk, so a chunk of backspaces is
-  // not N backspaces.
-  for (let i = 0; i < 40 && frame().includes("@"); i++) {
-    stdin.write("\x7f");
-    await new Promise((r) => setTimeout(r, 5));
-  }
-  await waitFor(() => !frame().includes("@"), 30000, describe);
-  stdin.write(value);
-  await waitFor(() => frame().includes(value), 30000, describe);
+  throw new Error("pressUntil: key did not take effect within timeout");
 }
 
 const text = (name: string, message: string): PromptEffect =>
@@ -149,15 +108,8 @@ describe("create wizard (PROTECTED)", () => {
     const c = new SessionController(gen);
     const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
     const frame = (): string => lastFrame() ?? "";
-    // On a timeout, show the state the wizard was wedged in — this failure
-    // has only ever reproduced on loaded CI runners, so the error text is the
-    // one diagnostic that comes back from there.
-    const wedged = (): string => {
-      const s = c.getSnapshot();
-      return `phase=${s.phase} answers=${JSON.stringify(s.answers)} frame:\n${frame()}`;
-    };
     try {
-      await waitFor(() => frame().includes("component/react"), 30000, wedged);
+      await waitFor(() => frame().includes("component/react"));
 
       // 1. Text prompt with a step counter.
       void c.request(text("componentPath", "Component path:"));
@@ -165,47 +117,35 @@ describe("create wizard (PROTECTED)", () => {
         () =>
           frame().includes("Component path:") &&
           frame().includes("Step 1 of 2"),
-        30000,
-        wedged,
       );
-      // Type the value with the sentinel-probe helper — the text write races
-      // the useInput subscription just like the keystrokes, and a partial
-      // drop plus re-send would submit a garbled value. Then re-send Enter
-      // until the answer lands.
-      await typeExactly(stdin, frame, "src/components/Button", wedged);
+      // Type the value, re-sending until the frame reflects it — the text write
+      // races the useInput subscription just like the keystrokes (a dropped
+      // write left the field empty and hung the frame wait under CI load). Then
+      // re-send Enter until the answer lands.
+      await pressUntil(stdin, "src/components/Button", () =>
+        frame().includes("src/components/Button"),
+      );
       await pressUntil(
         stdin,
         "\r",
         () => c.getSnapshot().answers.componentPath === "src/components/Button",
-        30000,
-        wedged,
       );
 
       // 2. Confirm prompt (submits immediately on "y").
       void c.request(confirm("withStyles", "Include styles?"));
-      await waitFor(() => frame().includes("Step 2 of 2"), 30000, wedged);
+      await waitFor(() => frame().includes("Step 2 of 2"));
       await pressUntil(
         stdin,
         "y",
         () => c.getSnapshot().answers.withStyles === true,
-        30000,
-        wedged,
       );
 
       // 3. The confirm GATE — the wizard shows the preview + "Proceed?".
       void c.request(gate());
       await waitFor(
         () => frame().includes("Proceed?") && /File.*to create/.test(frame()),
-        30000,
-        wedged,
       );
-      await pressUntil(
-        stdin,
-        "y",
-        () => c.getSnapshot().phase === "executing",
-        30000,
-        wedged,
-      );
+      await pressUntil(stdin, "y", () => c.getSnapshot().phase === "executing");
 
       // 4. Progress + completion.
       c.reportEffectComplete(

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -74,6 +74,33 @@ async function pressUntil(
   throw new Error("pressUntil: key did not take effect within timeout");
 }
 
+/**
+ * Type a text value deterministically. Re-sending a multi-character value
+ * (the pressUntil strategy) is not safe for text: a partially-dropped first
+ * write followed by a full re-send still satisfies an `includes` check but
+ * leaves the field garbled, and the later submit wait then hangs to its
+ * ceiling. Instead: prove the input subscription is live with a sentinel
+ * keystroke, clear it, then send the whole value as one atomic chunk —
+ * reliable once the subscription is known to be up.
+ */
+async function typeExactly(
+  stdin: { write: (data: string) => void },
+  frame: () => string,
+  value: string,
+): Promise<void> {
+  await pressUntil(stdin, "@", () => frame().includes("@"));
+  // Clear however many sentinels landed. Control keys must go one write per
+  // keystroke — ink parses key flags per chunk, so a chunk of backspaces is
+  // not N backspaces.
+  for (let i = 0; i < 40 && frame().includes("@"); i++) {
+    stdin.write("\x7f");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  await waitFor(() => !frame().includes("@"));
+  stdin.write(value);
+  await waitFor(() => frame().includes(value));
+}
+
 const text = (name: string, message: string): PromptEffect =>
   promptEffect({ type: "text", name, message }) as PromptEffect;
 const confirm = (name: string, message: string): PromptEffect =>
@@ -118,13 +145,11 @@ describe("create wizard (PROTECTED)", () => {
           frame().includes("Component path:") &&
           frame().includes("Step 1 of 2"),
       );
-      // Type the value, re-sending until the frame reflects it — the text write
-      // races the useInput subscription just like the keystrokes (a dropped
-      // write left the field empty and hung the frame wait under CI load). Then
-      // re-send Enter until the answer lands.
-      await pressUntil(stdin, "src/components/Button", () =>
-        frame().includes("src/components/Button"),
-      );
+      // Type the value with the sentinel-probe helper — the text write races
+      // the useInput subscription just like the keystrokes, and a partial
+      // drop plus re-send would submit a garbled value. Then re-send Enter
+      // until the answer lands.
+      await typeExactly(stdin, frame, "src/components/Button");
       await pressUntil(
         stdin,
         "\r",

--- a/packages/summon/package/README.md
+++ b/packages/summon/package/README.md
@@ -290,7 +290,12 @@ The generator automatically detects:
 
 ### Monorepo Version
 
-When running in the pragma monorepo, the version is read from `lerna.json`:
+The generator walks up from the current directory to the nearest monorepo
+root — a `lerna.json`, a `pnpm-workspace.yaml`, or a `package.json` with a
+`workspaces` field — and reads the version from it (for pnpm workspaces, from
+the adjacent `package.json`). A malformed `lerna.json` is treated as "not a
+monorepo" instead of aborting the run. In the pragma monorepo that means
+`lerna.json`:
 
 ```json
 {
@@ -302,12 +307,16 @@ New packages inherit this version.
 
 ### Package Manager
 
-Detects which package manager to use for the install step:
+Detects which package manager to use for the install step by walking up from
+the current directory: the nearest directory holding a lockfile wins, and
+within a directory the priority is:
 
-1. If `bun.lockb` or `bun.lock` exists → `bun install`
-2. If `pnpm-lock.yaml` exists → `pnpm install`
-3. If `yarn.lock` exists → `yarn install`
-4. Otherwise → `npm install`
+1. `bun.lockb` / `bun.lock` → `bun install`
+2. `pnpm-lock.yaml` → `pnpm install`
+3. `yarn.lock` → `yarn install`
+4. `package-lock.json` → `npm install`
+
+With no lockfile anywhere, the fallback is `bun install`.
 
 ---
 

--- a/packages/summon/package/package.json
+++ b/packages/summon/package/package.json
@@ -60,7 +60,7 @@
     "@canonical/utils": "^0.34.0"
   },
   "peerDependencies": {
-    "@canonical/summon-core": "^0.18.0 || ^0.20.0",
-    "@canonical/task": "^0.18.0 || ^0.20.0"
+    "@canonical/summon-core": "^0.34.0",
+    "@canonical/task": "^0.34.0"
   }
 }

--- a/packages/summon/package/src/generators.test.ts
+++ b/packages/summon/package/src/generators.test.ts
@@ -19,8 +19,11 @@ interface Manifest {
   module?: string;
   types?: string;
   exports?: unknown;
+  bin?: Record<string, string>;
+  files: string[];
   scripts: Record<string, string>;
   devDependencies: Record<string, string>;
+  dependencies?: Record<string, string>;
 }
 
 /** Render the package.json template the way the generator does, and parse it. */
@@ -221,6 +224,15 @@ describe("generated manifest", () => {
     );
   });
 
+  it("declares webarchitect wherever check:webarchitect is emitted", () => {
+    const manifest = renderManifest(libraryAnswers);
+
+    expect(manifest.scripts["check:webarchitect"]).toBeDefined();
+    expect(manifest.devDependencies["@canonical/webarchitect"]).toBe(
+      `^${pkg.version}`,
+    );
+  });
+
   it("ranges @canonical/* dependencies on the generator's own version", () => {
     // The host repository's version says nothing about which versions of
     // @canonical/* exist on npm, so it must not leak into the ranges.
@@ -235,5 +247,78 @@ describe("generated manifest", () => {
     expect(manifest.devDependencies["@canonical/typescript-config"]).toBe(
       `^${pkg.version}`,
     );
+  });
+});
+
+describe("generated manifest — validity matrix", () => {
+  // Every supported flag combination must render parseable JSON whose
+  // scripts, dependencies, and published files agree with each other. This is
+  // the class of breakage effect-count assertions can never catch (a trailing
+  // comma, a script referencing an undeclared binary, a dangling bin path).
+  const base = {
+    name: "@canonical/my-pkg",
+    description: "A package",
+    withPrTemplate: false,
+    runInstall: false,
+  } as const;
+  const types = ["tool-ts", "library", "css"] as const;
+  const bools = [false, true] as const;
+
+  const combos = types.flatMap((type) =>
+    bools.flatMap((withReact) =>
+      bools.flatMap((withStorybook) =>
+        bools.map((withCli) => ({ type, withReact, withStorybook, withCli })),
+      ),
+    ),
+  );
+
+  it.each(combos)("renders a consistent manifest for %j", ({
+    type,
+    withReact,
+    withStorybook,
+    withCli,
+  }) => {
+    // renderManifest JSON.parses — an unparseable render fails here.
+    const manifest = renderManifest({
+      ...base,
+      type,
+      withReact,
+      withStorybook,
+      withCli,
+    });
+    const devDependencies = manifest.devDependencies ?? {};
+    const allDependencies = {
+      ...devDependencies,
+      ...(manifest.dependencies ?? {}),
+    };
+
+    // Scripts must not reference binaries the manifest does not declare.
+    if (manifest.scripts["check:webarchitect"] !== undefined) {
+      expect(allDependencies["@canonical/webarchitect"]).toBeDefined();
+    }
+    expect(manifest.scripts.storybook !== undefined).toBe(withStorybook);
+    if (withStorybook) {
+      expect(manifest.scripts["build:storybook"]).toBeDefined();
+      expect(allDependencies.storybook).toBeDefined();
+      expect(allDependencies["@storybook/addon-themes"]).toBeDefined();
+      expect(allDependencies["@storybook/react-vite"]).toBeDefined();
+      expect(allDependencies["@canonical/storybook-config"]).toBeDefined();
+      expect(allDependencies["@canonical/styles-debug"]).toBeDefined();
+      // The react renderer needs react even when the package itself is not
+      // a react package.
+      expect(allDependencies.react).toBeDefined();
+      expect(allDependencies["react-dom"]).toBeDefined();
+    }
+
+    // A bin entry must point inside the published file set.
+    if (withCli && type !== "css") {
+      const binPath = Object.values(manifest.bin ?? {})[0];
+      expect(binPath).toBeDefined();
+      expect(
+        manifest.files.some((dir) => (binPath as string).startsWith(`${dir}/`)),
+      ).toBe(true);
+    } else {
+      expect(manifest.bin).toBeUndefined();
+    }
   });
 });

--- a/packages/summon/package/src/package/index.ts
+++ b/packages/summon/package/src/package/index.ts
@@ -158,8 +158,10 @@ OPTIONS:
                       repos; monorepos read only the root template)
 
 The generator auto-detects:
-  - Monorepo: Uses lerna.json version when in pragma monorepo
-  - Package manager: Detects bun/yarn/pnpm (defaults to bun)`,
+  - Monorepo: walks up to the nearest lerna.json, pnpm-workspace.yaml, or
+    package.json "workspaces" root and uses its version
+  - Package manager: nearest lockfile wins, walking up from the current
+    directory (bun > pnpm > yarn > npm within a directory; defaults to bun)`,
     examples: [
       "summon package --name=@canonical/my-tool --type=tool-ts",
       "summon package --name=@canonical/my-lib --type=library --with-react",

--- a/packages/summon/package/src/shared/detection/ancestorDirs.test.ts
+++ b/packages/summon/package/src/shared/detection/ancestorDirs.test.ts
@@ -1,0 +1,23 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import ancestorDirs from "./ancestorDirs.js";
+
+// Build inputs from the platform's real root so the assertions hold under
+// POSIX and Windows path semantics alike.
+const ROOT = path.parse(path.resolve("/")).root;
+
+describe("ancestorDirs", () => {
+  it("lists every directory from start to the filesystem root, nearest first", () => {
+    const start = path.join(ROOT, "a", "b", "c");
+    expect(ancestorDirs(start)).toEqual([
+      start,
+      path.join(ROOT, "a", "b"),
+      path.join(ROOT, "a"),
+      ROOT,
+    ]);
+  });
+
+  it("handles the root itself", () => {
+    expect(ancestorDirs(ROOT)).toEqual([ROOT]);
+  });
+});

--- a/packages/summon/package/src/shared/detection/ancestorDirs.ts
+++ b/packages/summon/package/src/shared/detection/ancestorDirs.ts
@@ -1,0 +1,17 @@
+import * as path from "node:path";
+
+/**
+ * Every directory from `start` up to the filesystem root, nearest first.
+ */
+export default function ancestorDirs(start: string): string[] {
+  const dirs: string[] = [];
+  let current = path.resolve(start);
+  for (;;) {
+    dirs.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return dirs;
+    }
+    current = parent;
+  }
+}

--- a/packages/summon/package/src/shared/detection/detectMonorepo.test.ts
+++ b/packages/summon/package/src/shared/detection/detectMonorepo.test.ts
@@ -3,6 +3,11 @@ import { dryRunWith, type Effect } from "@canonical/task";
 import { describe, expect, it } from "vitest";
 import detectMonorepo from "./detectMonorepo.js";
 
+// All paths are built with node:path from the platform's real root, so the
+// expectations track the same path semantics the production walk uses.
+const ROOT = path.parse(path.resolve("/")).root;
+const at = (...segments: string[]) => path.join(ROOT, ...segments);
+
 const lernaJson = JSON.stringify({ version: "0.22.0" });
 
 const buildMocks = (
@@ -16,7 +21,7 @@ const buildMocks = (
 
 describe("detectMonorepo", () => {
   it("detects lerna.json in cwd", () => {
-    const cwd = "/a/b/c";
+    const cwd = at("a", "b", "c");
     const lernaPath = path.join(cwd, "lerna.json");
 
     const result = dryRunWith(
@@ -28,7 +33,7 @@ describe("detectMonorepo", () => {
   });
 
   it("detects lerna.json in parent directory", () => {
-    const cwd = "/a/b/c";
+    const cwd = at("a", "b", "c");
     const parentLernaPath = path.join(cwd, "..", "lerna.json");
 
     const result = dryRunWith(
@@ -40,7 +45,7 @@ describe("detectMonorepo", () => {
   });
 
   it("detects lerna.json in grandparent directory", () => {
-    const cwd = "/a/b/c";
+    const cwd = at("a", "b", "c");
     const grandparentLernaPath = path.join(cwd, "..", "..", "lerna.json");
 
     const result = dryRunWith(
@@ -53,7 +58,7 @@ describe("detectMonorepo", () => {
 
   it("returns not monorepo when no lerna.json found", () => {
     const result = dryRunWith(
-      detectMonorepo("/standalone"),
+      detectMonorepo(at("standalone")),
       buildMocks(() => false),
     );
 
@@ -62,8 +67,8 @@ describe("detectMonorepo", () => {
 
   it("detects lerna.json in a distant ancestor (deeper than two levels)", () => {
     const result = dryRunWith(
-      detectMonorepo("/repo/packages/summon/package"),
-      buildMocks((p) => p === "/repo/lerna.json"),
+      detectMonorepo(at("repo", "packages", "summon", "package")),
+      buildMocks((p) => p === at("repo", "lerna.json")),
     );
 
     expect(result.value).toEqual({ isMonorepo: true, version: "0.22.0" });
@@ -71,8 +76,8 @@ describe("detectMonorepo", () => {
 
   it("degrades a malformed lerna.json to not-monorepo instead of crashing", () => {
     const result = dryRunWith(
-      detectMonorepo("/a/b/c"),
-      buildMocks((p) => p === "/a/b/c/lerna.json", "{not json"),
+      detectMonorepo(at("a", "b", "c")),
+      buildMocks((p) => p === at("a", "b", "c", "lerna.json"), "{not json"),
     );
 
     expect(result.value).toEqual({ isMonorepo: false });
@@ -85,28 +90,35 @@ describe("detectMonorepo", () => {
         (e) => {
           const p = (e as { path: string }).path;
           return (
-            p === "/repo/pnpm-workspace.yaml" || p === "/repo/package.json"
+            p === at("repo", "pnpm-workspace.yaml") ||
+            p === at("repo", "package.json")
           );
         },
       ],
       ["ReadFile", () => JSON.stringify({ version: "2.0.0" })],
     ]);
 
-    const result = dryRunWith(detectMonorepo("/repo/packages/x"), mocks);
+    const result = dryRunWith(
+      detectMonorepo(at("repo", "packages", "x")),
+      mocks,
+    );
 
     expect(result.value).toEqual({ isMonorepo: true, version: "2.0.0" });
   });
 
   it("detects a package.json workspaces root", () => {
     const mocks = new Map<string, (effect: Effect) => unknown>([
-      ["Exists", (e) => (e as { path: string }).path === "/repo/package.json"],
+      [
+        "Exists",
+        (e) => (e as { path: string }).path === at("repo", "package.json"),
+      ],
       [
         "ReadFile",
         () => JSON.stringify({ version: "3.1.0", workspaces: ["packages/*"] }),
       ],
     ]);
 
-    const result = dryRunWith(detectMonorepo("/repo/apps"), mocks);
+    const result = dryRunWith(detectMonorepo(at("repo", "apps")), mocks);
 
     expect(result.value).toEqual({ isMonorepo: true, version: "3.1.0" });
   });
@@ -117,19 +129,22 @@ describe("detectMonorepo", () => {
         "Exists",
         (e) => {
           const p = (e as { path: string }).path;
-          return p === "/repo/app/package.json" || p === "/repo/lerna.json";
+          return (
+            p === at("repo", "app", "package.json") ||
+            p === at("repo", "lerna.json")
+          );
         },
       ],
       [
         "ReadFile",
         (e) =>
-          (e as { path: string }).path === "/repo/lerna.json"
+          (e as { path: string }).path === at("repo", "lerna.json")
             ? lernaJson
             : JSON.stringify({ name: "app" }),
       ],
     ]);
 
-    const result = dryRunWith(detectMonorepo("/repo/app"), mocks);
+    const result = dryRunWith(detectMonorepo(at("repo", "app")), mocks);
 
     expect(result.value).toEqual({ isMonorepo: true, version: "0.22.0" });
   });
@@ -138,12 +153,16 @@ describe("detectMonorepo", () => {
     const mocks = new Map<string, (effect: Effect) => unknown>([
       [
         "Exists",
-        (e) => (e as { path: string }).path === "/repo/pnpm-workspace.yaml",
+        (e) =>
+          (e as { path: string }).path === at("repo", "pnpm-workspace.yaml"),
       ],
       ["ReadFile", () => ""],
     ]);
 
-    const result = dryRunWith(detectMonorepo("/repo/packages/x"), mocks);
+    const result = dryRunWith(
+      detectMonorepo(at("repo", "packages", "x")),
+      mocks,
+    );
 
     expect(result.value).toEqual({ isMonorepo: true });
   });
@@ -155,23 +174,27 @@ describe("detectMonorepo", () => {
         (e) => {
           const p = (e as { path: string }).path;
           return (
-            p === "/repo/pnpm-workspace.yaml" || p === "/repo/package.json"
+            p === at("repo", "pnpm-workspace.yaml") ||
+            p === at("repo", "package.json")
           );
         },
       ],
       ["ReadFile", () => "{ not json"],
     ]);
 
-    const result = dryRunWith(detectMonorepo("/repo/packages/x"), mocks);
+    const result = dryRunWith(
+      detectMonorepo(at("repo", "packages", "x")),
+      mocks,
+    );
 
     expect(result.value).toEqual({ isMonorepo: true, version: undefined });
   });
 
   it("reports no version when the marker's version field is not a string", () => {
     const result = dryRunWith(
-      detectMonorepo("/a/b"),
+      detectMonorepo(at("a", "b")),
       buildMocks(
-        (p) => p === "/a/b/lerna.json",
+        (p) => p === at("a", "b", "lerna.json"),
         JSON.stringify({ version: 22 }),
       ),
     );
@@ -185,12 +208,13 @@ describe("detectMonorepo", () => {
     const mocks = new Map<string, (effect: Effect) => unknown>([
       [
         "Exists",
-        (e) => (e as { path: string }).path === "/repo/app/package.json",
+        (e) =>
+          (e as { path: string }).path === at("repo", "app", "package.json"),
       ],
       ["ReadFile", () => "42"],
     ]);
 
-    const result = dryRunWith(detectMonorepo("/repo/app"), mocks);
+    const result = dryRunWith(detectMonorepo(at("repo", "app")), mocks);
 
     expect(result.value).toEqual({ isMonorepo: false });
   });

--- a/packages/summon/package/src/shared/detection/detectMonorepo.test.ts
+++ b/packages/summon/package/src/shared/detection/detectMonorepo.test.ts
@@ -59,4 +59,78 @@ describe("detectMonorepo", () => {
 
     expect(result.value).toEqual({ isMonorepo: false });
   });
+
+  it("detects lerna.json in a distant ancestor (deeper than two levels)", () => {
+    const result = dryRunWith(
+      detectMonorepo("/repo/packages/summon/package"),
+      buildMocks((p) => p === "/repo/lerna.json"),
+    );
+
+    expect(result.value).toEqual({ isMonorepo: true, version: "0.22.0" });
+  });
+
+  it("degrades a malformed lerna.json to not-monorepo instead of crashing", () => {
+    const result = dryRunWith(
+      detectMonorepo("/a/b/c"),
+      buildMocks((p) => p === "/a/b/c/lerna.json", "{not json"),
+    );
+
+    expect(result.value).toEqual({ isMonorepo: false });
+  });
+
+  it("detects a pnpm workspace root and reads its manifest version", () => {
+    const mocks = new Map<string, (effect: Effect) => unknown>([
+      [
+        "Exists",
+        (e) => {
+          const p = (e as { path: string }).path;
+          return (
+            p === "/repo/pnpm-workspace.yaml" || p === "/repo/package.json"
+          );
+        },
+      ],
+      ["ReadFile", () => JSON.stringify({ version: "2.0.0" })],
+    ]);
+
+    const result = dryRunWith(detectMonorepo("/repo/packages/x"), mocks);
+
+    expect(result.value).toEqual({ isMonorepo: true, version: "2.0.0" });
+  });
+
+  it("detects a package.json workspaces root", () => {
+    const mocks = new Map<string, (effect: Effect) => unknown>([
+      ["Exists", (e) => (e as { path: string }).path === "/repo/package.json"],
+      [
+        "ReadFile",
+        () => JSON.stringify({ version: "3.1.0", workspaces: ["packages/*"] }),
+      ],
+    ]);
+
+    const result = dryRunWith(detectMonorepo("/repo/apps"), mocks);
+
+    expect(result.value).toEqual({ isMonorepo: true, version: "3.1.0" });
+  });
+
+  it("skips a plain package.json without workspaces and keeps walking up", () => {
+    const mocks = new Map<string, (effect: Effect) => unknown>([
+      [
+        "Exists",
+        (e) => {
+          const p = (e as { path: string }).path;
+          return p === "/repo/app/package.json" || p === "/repo/lerna.json";
+        },
+      ],
+      [
+        "ReadFile",
+        (e) =>
+          (e as { path: string }).path === "/repo/lerna.json"
+            ? lernaJson
+            : JSON.stringify({ name: "app" }),
+      ],
+    ]);
+
+    const result = dryRunWith(detectMonorepo("/repo/app"), mocks);
+
+    expect(result.value).toEqual({ isMonorepo: true, version: "0.22.0" });
+  });
 });

--- a/packages/summon/package/src/shared/detection/detectMonorepo.test.ts
+++ b/packages/summon/package/src/shared/detection/detectMonorepo.test.ts
@@ -133,4 +133,65 @@ describe("detectMonorepo", () => {
 
     expect(result.value).toEqual({ isMonorepo: true, version: "0.22.0" });
   });
+
+  it("detects a pnpm workspace root that has no adjacent package.json", () => {
+    const mocks = new Map<string, (effect: Effect) => unknown>([
+      [
+        "Exists",
+        (e) => (e as { path: string }).path === "/repo/pnpm-workspace.yaml",
+      ],
+      ["ReadFile", () => ""],
+    ]);
+
+    const result = dryRunWith(detectMonorepo("/repo/packages/x"), mocks);
+
+    expect(result.value).toEqual({ isMonorepo: true });
+  });
+
+  it("detects a pnpm workspace root with a malformed manifest, sans version", () => {
+    const mocks = new Map<string, (effect: Effect) => unknown>([
+      [
+        "Exists",
+        (e) => {
+          const p = (e as { path: string }).path;
+          return (
+            p === "/repo/pnpm-workspace.yaml" || p === "/repo/package.json"
+          );
+        },
+      ],
+      ["ReadFile", () => "{ not json"],
+    ]);
+
+    const result = dryRunWith(detectMonorepo("/repo/packages/x"), mocks);
+
+    expect(result.value).toEqual({ isMonorepo: true, version: undefined });
+  });
+
+  it("reports no version when the marker's version field is not a string", () => {
+    const result = dryRunWith(
+      detectMonorepo("/a/b"),
+      buildMocks(
+        (p) => p === "/a/b/lerna.json",
+        JSON.stringify({ version: 22 }),
+      ),
+    );
+
+    expect(result.value).toEqual({ isMonorepo: true, version: undefined });
+  });
+
+  it("treats a manifest holding valid non-object JSON as no data", () => {
+    // safeParse: JSON.parse succeeds ("42" is valid JSON) but yields no
+    // object — the walk must fall through, not crash or false-positive.
+    const mocks = new Map<string, (effect: Effect) => unknown>([
+      [
+        "Exists",
+        (e) => (e as { path: string }).path === "/repo/app/package.json",
+      ],
+      ["ReadFile", () => "42"],
+    ]);
+
+    const result = dryRunWith(detectMonorepo("/repo/app"), mocks);
+
+    expect(result.value).toEqual({ isMonorepo: false });
+  });
 });

--- a/packages/summon/package/src/shared/detection/detectMonorepo.ts
+++ b/packages/summon/package/src/shared/detection/detectMonorepo.ts
@@ -1,44 +1,99 @@
 import * as path from "node:path";
 import { exists, flatMap, pure, readFile, type Task } from "@canonical/task";
 import type { MonorepoInfo } from "../types.js";
+import { ancestorDirs } from "./detectPackageManager.js";
+
+const notMonorepo: MonorepoInfo = { isMonorepo: false };
+
+/** Parse JSON without throwing; a malformed file reads as no data. */
+const safeParse = (content: string): Record<string, unknown> | null => {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+/** The version field of a parsed manifest, when it is a string. */
+const versionOf = (data: Record<string, unknown>): string | undefined =>
+  typeof data.version === "string" ? data.version : undefined;
 
 /**
- * Detect if running in a monorepo and get the version.
- *
- * @note Impure — reads lerna.json from the filesystem.
+ * Probe one directory for a monorepo marker: `lerna.json` (version from it),
+ * `pnpm-workspace.yaml` (version from the adjacent `package.json`), or a
+ * `package.json` with a `workspaces` field. Falls through to `next` when the
+ * directory carries no marker (or only a malformed one).
  */
-export default function detectMonorepo(cwd: string): Task<MonorepoInfo> {
-  const lernaPath = path.join(cwd, "lerna.json");
-  const parentLernaPath = path.join(cwd, "..", "lerna.json");
-  const grandparentLernaPath = path.join(cwd, "..", "..", "lerna.json");
+function detectAt(dir: string, next: Task<MonorepoInfo>): Task<MonorepoInfo> {
+  const lernaPath = path.join(dir, "lerna.json");
+  const pnpmWorkspacePath = path.join(dir, "pnpm-workspace.yaml");
+  const packageJsonPath = path.join(dir, "package.json");
 
-  const parseLerna = (content: string): MonorepoInfo => {
-    const lerna = JSON.parse(content);
-    return { isMonorepo: true, version: lerna.version };
-  };
-
-  const notMonorepo: MonorepoInfo = { isMonorepo: false };
+  const versionFromPackageJson: Task<MonorepoInfo> = flatMap(
+    exists(packageJsonPath),
+    (hasManifest) =>
+      hasManifest
+        ? flatMap(readFile(packageJsonPath), (content) => {
+            const manifest = safeParse(content);
+            return pure<MonorepoInfo>({
+              isMonorepo: true,
+              version: manifest === null ? undefined : versionOf(manifest),
+            });
+          })
+        : pure<MonorepoInfo>({ isMonorepo: true }),
+  );
 
   return flatMap(exists(lernaPath), (hasLerna) => {
     if (hasLerna) {
-      return flatMap(readFile(lernaPath), (content) =>
-        pure(parseLerna(content)),
-      );
-    }
-    return flatMap(exists(parentLernaPath), (hasParent) => {
-      if (hasParent) {
-        return flatMap(readFile(parentLernaPath), (content) =>
-          pure(parseLerna(content)),
-        );
-      }
-      return flatMap(exists(grandparentLernaPath), (hasGrandparent) => {
-        if (hasGrandparent) {
-          return flatMap(readFile(grandparentLernaPath), (content) =>
-            pure(parseLerna(content)),
-          );
+      return flatMap(readFile(lernaPath), (content) => {
+        const lerna = safeParse(content);
+        // Malformed lerna.json: not proof of a monorepo — keep looking upward
+        // instead of crashing the whole generation.
+        if (lerna === null) {
+          return next;
         }
-        return pure(notMonorepo);
+        return pure<MonorepoInfo>({
+          isMonorepo: true,
+          version: versionOf(lerna),
+        });
+      });
+    }
+    return flatMap(exists(pnpmWorkspacePath), (hasPnpmWorkspace) => {
+      if (hasPnpmWorkspace) {
+        return versionFromPackageJson;
+      }
+      return flatMap(exists(packageJsonPath), (hasManifest) => {
+        if (!hasManifest) {
+          return next;
+        }
+        return flatMap(readFile(packageJsonPath), (content) => {
+          const manifest = safeParse(content);
+          if (manifest !== null && "workspaces" in manifest) {
+            return pure<MonorepoInfo>({
+              isMonorepo: true,
+              version: versionOf(manifest),
+            });
+          }
+          return next;
+        });
       });
     });
   });
+}
+
+/**
+ * Detect if running in a monorepo and get its version. Walks from `cwd` up
+ * to the filesystem root, nearest directory first, recognising lerna, pnpm,
+ * and package.json-`workspaces` (npm/yarn/bun) roots.
+ *
+ * @note Impure — probes the filesystem for workspace markers.
+ */
+export default function detectMonorepo(cwd: string): Task<MonorepoInfo> {
+  return ancestorDirs(cwd).reduceRight<Task<MonorepoInfo>>(
+    (fallback, dir) => detectAt(dir, fallback),
+    pure(notMonorepo),
+  );
 }

--- a/packages/summon/package/src/shared/detection/detectMonorepo.ts
+++ b/packages/summon/package/src/shared/detection/detectMonorepo.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { exists, flatMap, pure, readFile, type Task } from "@canonical/task";
 import type { MonorepoInfo } from "../types.js";
-import { ancestorDirs } from "./detectPackageManager.js";
+import ancestorDirs from "./ancestorDirs.js";
 
 const notMonorepo: MonorepoInfo = { isMonorepo: false };
 

--- a/packages/summon/package/src/shared/detection/detectPackageManager.test.ts
+++ b/packages/summon/package/src/shared/detection/detectPackageManager.test.ts
@@ -1,0 +1,64 @@
+import { dryRunWith, type Effect } from "@canonical/task";
+import { describe, expect, it } from "vitest";
+import detectPackageManager, { ancestorDirs } from "./detectPackageManager.js";
+
+const withLockfiles = (...present: string[]) =>
+  new Map<string, (effect: Effect) => unknown>([
+    ["Exists", (e) => present.includes((e as { path: string }).path)],
+  ]);
+
+const detect = (cwd: string, ...present: string[]) =>
+  dryRunWith(detectPackageManager(cwd), withLockfiles(...present)).value;
+
+describe("ancestorDirs", () => {
+  it("lists every directory from start to the filesystem root, nearest first", () => {
+    expect(ancestorDirs("/a/b/c")).toEqual(["/a/b/c", "/a/b", "/a", "/"]);
+  });
+
+  it("handles the root itself", () => {
+    expect(ancestorDirs("/")).toEqual(["/"]);
+  });
+});
+
+describe("detectPackageManager", () => {
+  it("detects each manager from its lockfile in cwd", () => {
+    expect(detect("/p", "/p/bun.lockb")).toBe("bun");
+    expect(detect("/p", "/p/bun.lock")).toBe("bun");
+    expect(detect("/p", "/p/pnpm-lock.yaml")).toBe("pnpm");
+    expect(detect("/p", "/p/yarn.lock")).toBe("yarn");
+    expect(detect("/p", "/p/package-lock.json")).toBe("npm");
+  });
+
+  it("prefers the nearest lockfile over any ancestor's", () => {
+    // A local yarn workspace must not be outranked by a bun lockfile higher up.
+    expect(detect("/repo/pkg", "/repo/pkg/yarn.lock", "/bun.lockb")).toBe(
+      "yarn",
+    );
+    expect(
+      detect("/repo/pkg", "/repo/pkg/pnpm-lock.yaml", "/repo/bun.lockb"),
+    ).toBe("pnpm");
+  });
+
+  it("finds a lockfile in a distant ancestor", () => {
+    expect(detect("/repo/packages/deep/pkg", "/repo/pnpm-lock.yaml")).toBe(
+      "pnpm",
+    );
+    expect(detect("/repo/packages/deep/pkg", "/package-lock.json")).toBe("npm");
+  });
+
+  it("prefers bun over the other managers within one directory", () => {
+    expect(detect("/p", "/p/bun.lockb", "/p/yarn.lock")).toBe("bun");
+    expect(detect("/p", "/p/bun.lock", "/p/pnpm-lock.yaml")).toBe("bun");
+  });
+
+  it("prefers pnpm over yarn over npm within one directory", () => {
+    expect(
+      detect("/p", "/p/pnpm-lock.yaml", "/p/yarn.lock", "/p/package-lock.json"),
+    ).toBe("pnpm");
+    expect(detect("/p", "/p/yarn.lock", "/p/package-lock.json")).toBe("yarn");
+  });
+
+  it("falls back to bun when no lockfile exists anywhere", () => {
+    expect(detect("/p")).toBe("bun");
+  });
+});

--- a/packages/summon/package/src/shared/detection/detectPackageManager.test.ts
+++ b/packages/summon/package/src/shared/detection/detectPackageManager.test.ts
@@ -1,6 +1,12 @@
+import * as path from "node:path";
 import { dryRunWith, type Effect } from "@canonical/task";
 import { describe, expect, it } from "vitest";
-import detectPackageManager, { ancestorDirs } from "./detectPackageManager.js";
+import detectPackageManager from "./detectPackageManager.js";
+
+// All paths are built with node:path from the platform's real root, so the
+// expectations track the same path semantics the production walk uses.
+const ROOT = path.parse(path.resolve("/")).root;
+const at = (...segments: string[]) => path.join(ROOT, ...segments);
 
 const withLockfiles = (...present: string[]) =>
   new Map<string, (effect: Effect) => unknown>([
@@ -10,55 +16,69 @@ const withLockfiles = (...present: string[]) =>
 const detect = (cwd: string, ...present: string[]) =>
   dryRunWith(detectPackageManager(cwd), withLockfiles(...present)).value;
 
-describe("ancestorDirs", () => {
-  it("lists every directory from start to the filesystem root, nearest first", () => {
-    expect(ancestorDirs("/a/b/c")).toEqual(["/a/b/c", "/a/b", "/a", "/"]);
-  });
-
-  it("handles the root itself", () => {
-    expect(ancestorDirs("/")).toEqual(["/"]);
-  });
-});
-
 describe("detectPackageManager", () => {
   it("detects each manager from its lockfile in cwd", () => {
-    expect(detect("/p", "/p/bun.lockb")).toBe("bun");
-    expect(detect("/p", "/p/bun.lock")).toBe("bun");
-    expect(detect("/p", "/p/pnpm-lock.yaml")).toBe("pnpm");
-    expect(detect("/p", "/p/yarn.lock")).toBe("yarn");
-    expect(detect("/p", "/p/package-lock.json")).toBe("npm");
+    expect(detect(at("p"), at("p", "bun.lockb"))).toBe("bun");
+    expect(detect(at("p"), at("p", "bun.lock"))).toBe("bun");
+    expect(detect(at("p"), at("p", "pnpm-lock.yaml"))).toBe("pnpm");
+    expect(detect(at("p"), at("p", "yarn.lock"))).toBe("yarn");
+    expect(detect(at("p"), at("p", "package-lock.json"))).toBe("npm");
   });
 
   it("prefers the nearest lockfile over any ancestor's", () => {
     // A local yarn workspace must not be outranked by a bun lockfile higher up.
-    expect(detect("/repo/pkg", "/repo/pkg/yarn.lock", "/bun.lockb")).toBe(
-      "yarn",
-    );
     expect(
-      detect("/repo/pkg", "/repo/pkg/pnpm-lock.yaml", "/repo/bun.lockb"),
+      detect(
+        at("repo", "pkg"),
+        at("repo", "pkg", "yarn.lock"),
+        at("bun.lockb"),
+      ),
+    ).toBe("yarn");
+    expect(
+      detect(
+        at("repo", "pkg"),
+        at("repo", "pkg", "pnpm-lock.yaml"),
+        at("repo", "bun.lockb"),
+      ),
     ).toBe("pnpm");
   });
 
   it("finds a lockfile in a distant ancestor", () => {
-    expect(detect("/repo/packages/deep/pkg", "/repo/pnpm-lock.yaml")).toBe(
-      "pnpm",
-    );
-    expect(detect("/repo/packages/deep/pkg", "/package-lock.json")).toBe("npm");
+    expect(
+      detect(
+        at("repo", "packages", "deep", "pkg"),
+        at("repo", "pnpm-lock.yaml"),
+      ),
+    ).toBe("pnpm");
+    expect(
+      detect(at("repo", "packages", "deep", "pkg"), at("package-lock.json")),
+    ).toBe("npm");
   });
 
   it("prefers bun over the other managers within one directory", () => {
-    expect(detect("/p", "/p/bun.lockb", "/p/yarn.lock")).toBe("bun");
-    expect(detect("/p", "/p/bun.lock", "/p/pnpm-lock.yaml")).toBe("bun");
+    expect(detect(at("p"), at("p", "bun.lockb"), at("p", "yarn.lock"))).toBe(
+      "bun",
+    );
+    expect(
+      detect(at("p"), at("p", "bun.lock"), at("p", "pnpm-lock.yaml")),
+    ).toBe("bun");
   });
 
   it("prefers pnpm over yarn over npm within one directory", () => {
     expect(
-      detect("/p", "/p/pnpm-lock.yaml", "/p/yarn.lock", "/p/package-lock.json"),
+      detect(
+        at("p"),
+        at("p", "pnpm-lock.yaml"),
+        at("p", "yarn.lock"),
+        at("p", "package-lock.json"),
+      ),
     ).toBe("pnpm");
-    expect(detect("/p", "/p/yarn.lock", "/p/package-lock.json")).toBe("yarn");
+    expect(
+      detect(at("p"), at("p", "yarn.lock"), at("p", "package-lock.json")),
+    ).toBe("yarn");
   });
 
   it("falls back to bun when no lockfile exists anywhere", () => {
-    expect(detect("/p")).toBe("bun");
+    expect(detect(at("p"))).toBe("bun");
   });
 });

--- a/packages/summon/package/src/shared/detection/detectPackageManager.ts
+++ b/packages/summon/package/src/shared/detection/detectPackageManager.ts
@@ -3,44 +3,54 @@ import { exists, ifElseM, pure, type Task } from "@canonical/task";
 import type { PackageManager } from "../types.js";
 
 /**
- * Detect the package manager in use.
+ * Lockfiles in detection-priority order within one directory. Both bun
+ * lockfile generations are probed; the remaining managers follow the
+ * documented preference order.
+ */
+const LOCKFILES: ReadonlyArray<readonly [string, PackageManager]> = [
+  ["bun.lockb", "bun"],
+  ["bun.lock", "bun"],
+  ["pnpm-lock.yaml", "pnpm"],
+  ["yarn.lock", "yarn"],
+  ["package-lock.json", "npm"],
+];
+
+/**
+ * Every directory from `start` up to the filesystem root, nearest first.
+ */
+export function ancestorDirs(start: string): string[] {
+  const dirs: string[] = [];
+  let current = path.resolve(start);
+  for (;;) {
+    dirs.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return dirs;
+    }
+    current = parent;
+  }
+}
+
+/**
+ * Detect the package manager in use: the nearest directory (walking from
+ * `cwd` up to the filesystem root) that holds a lockfile wins, and within a
+ * directory the priority is bun → pnpm → yarn → npm. Falls back to bun when
+ * no lockfile is found anywhere.
  *
  * @note Impure — probes the filesystem for lock files.
  */
 export default function detectPackageManager(
   cwd: string,
 ): Task<PackageManager> {
-  const bunLock = path.join(cwd, "bun.lockb");
-  const bunLock2 = path.join(cwd, "bun.lock");
-  const yarnLock = path.join(cwd, "yarn.lock");
-  const pnpmLock = path.join(cwd, "pnpm-lock.yaml");
-
-  const parentBunLock = path.join(cwd, "..", "..", "bun.lockb");
-  const parentBunLock2 = path.join(cwd, "..", "..", "bun.lock");
-
-  return ifElseM(
-    exists(bunLock),
-    pure("bun" as const),
-    ifElseM(
-      exists(bunLock2),
-      pure("bun" as const),
-      ifElseM(
-        exists(parentBunLock),
-        pure("bun" as const),
-        ifElseM(
-          exists(parentBunLock2),
-          pure("bun" as const),
-          ifElseM(
-            exists(yarnLock),
-            pure("yarn" as const),
-            ifElseM(
-              exists(pnpmLock),
-              pure("pnpm" as const),
-              pure("bun" as const),
-            ),
-          ),
-        ),
-      ),
+  const probes = ancestorDirs(cwd).flatMap((dir) =>
+    LOCKFILES.map(
+      ([file, manager]) => [path.join(dir, file), manager] as const,
     ),
+  );
+
+  return probes.reduceRight<Task<PackageManager>>(
+    (fallback, [lockPath, manager]) =>
+      ifElseM(exists(lockPath), pure(manager), fallback),
+    pure("bun"),
   );
 }

--- a/packages/summon/package/src/shared/detection/detectPackageManager.ts
+++ b/packages/summon/package/src/shared/detection/detectPackageManager.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import { exists, ifElseM, pure, type Task } from "@canonical/task";
 import type { PackageManager } from "../types.js";
+import ancestorDirs from "./ancestorDirs.js";
 
 /**
  * Lockfiles in detection-priority order within one directory. Both bun
@@ -14,22 +15,6 @@ const LOCKFILES: ReadonlyArray<readonly [string, PackageManager]> = [
   ["yarn.lock", "yarn"],
   ["package-lock.json", "npm"],
 ];
-
-/**
- * Every directory from `start` up to the filesystem root, nearest first.
- */
-export function ancestorDirs(start: string): string[] {
-  const dirs: string[] = [];
-  let current = path.resolve(start);
-  for (;;) {
-    dirs.push(current);
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return dirs;
-    }
-    current = parent;
-  }
-}
 
 /**
  * Detect the package manager in use: the nearest directory (walking from

--- a/packages/summon/package/src/shared/validatePackageName.test.ts
+++ b/packages/summon/package/src/shared/validatePackageName.test.ts
@@ -22,6 +22,19 @@ describe("validatePackageName", () => {
     expect(validatePackageName("@canonical/my-package")).toBe(true);
   });
 
+  it("validates the scope segment of scoped names", () => {
+    expect(validatePackageName("@my-scope/pkg")).toBe(true);
+    expect(validatePackageName("@Canonical/pkg")).toContain("scope");
+    expect(validatePackageName("@scope!/pkg")).toContain("scope");
+    expect(validatePackageName("@-scope/pkg")).toContain("scope");
+    expect(validatePackageName("@ /pkg")).toContain("scope");
+  });
+
+  it("rejects a scoped name with an empty or missing short name", () => {
+    expect(validatePackageName("@/pkg")).toContain("scope");
+    expect(validatePackageName("@scope")).toContain("@scope/name");
+  });
+
   it("rejects names longer than 214 characters", () => {
     const longName = `a${"b".repeat(214)}`;
     expect(validatePackageName(longName)).not.toBe(true);

--- a/packages/summon/package/src/shared/validatePackageName.ts
+++ b/packages/summon/package/src/shared/validatePackageName.ts
@@ -5,14 +5,28 @@ import getPackageShortName from "./getPackageShortName.js";
  * Supports scoped packages (@scope/name) and unscoped packages.
  * Rules: lowercase, can contain hyphens, can't start/end with hyphen.
  */
+const KEBAB = /^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$/;
+
 export default function validatePackageName(value: unknown): true | string {
   if (!value || typeof value !== "string") {
     return "Package name is required";
   }
 
+  if (value.startsWith("@")) {
+    // npm rejects scopes that are not lowercase URL-safe strings; hold the
+    // scope to the same kebab-case rule as the short name.
+    const scope = /^@([^/]*)\//.exec(value)?.[1];
+    if (scope === undefined) {
+      return "Scoped package name must look like @scope/name";
+    }
+    if (!KEBAB.test(scope)) {
+      return "Package scope must be lowercase, can contain hyphens, but cannot start or end with a hyphen";
+    }
+  }
+
   const name = getPackageShortName(value);
 
-  if (!/^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$/.test(name)) {
+  if (!KEBAB.test(name)) {
     return "Package name must be lowercase, can contain hyphens, but cannot start or end with a hyphen";
   }
 

--- a/packages/summon/package/src/templates/cli.ts.ejs
+++ b/packages/summon/package/src/templates/cli.ts.ejs
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env <%= needsBuild ? 'node' : 'bun' %>
 /**
  * <%= name %> CLI
  *

--- a/packages/summon/package/src/templates/package.json.ejs
+++ b/packages/summon/package/src/templates/package.json.ejs
@@ -21,7 +21,7 @@
 <% } -%>
 <% if (withCli && type !== 'css') { -%>
   "bin": {
-    "<%= shortName %>": "src/cli.ts"
+    "<%= shortName %>": "<%= needsBuild ? 'dist/esm/cli.js' : 'src/cli.ts' %>"
   },
 <% } -%>
   "files": [
@@ -82,19 +82,29 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@canonical/biome-config": "^<%= canonicalVersion %>",
+<% if (withStorybook) { -%>
+    "@canonical/styles-debug": "^<%= canonicalVersion %>",
+<% } -%>
 <% if (withReact) { -%>
     "@canonical/typescript-config-react": "^<%= canonicalVersion %>",
 <% } else { -%>
     "@canonical/typescript-config": "^<%= canonicalVersion %>",
 <% } -%>
+    "@canonical/webarchitect": "^<%= canonicalVersion %>",
 <% if (withStorybook) { -%>
     "@chromatic-com/storybook": "^5.0.0",
+    "@storybook/addon-themes": "^10.1.11",
+    "@storybook/react-vite": "^10.1.11",
 <% } -%>
 <% if (withReact) { -%>
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
 <% } -%>
     "bun-types": "^1.0.0",
+<% if (withStorybook && !withReact) { -%>
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+<% } -%>
 <% if (withStorybook) { -%>
     "storybook": "^10.1.11",
 <% } -%>
@@ -103,7 +113,7 @@
   },
   "dependencies": {
 <% if (withStorybook) { -%>
-    "@canonical/storybook-config": "^<%= canonicalVersion %>",
+    "@canonical/storybook-config": "^<%= canonicalVersion %>"<%= withReact ? "," : "" %>
 <% } -%>
 <% if (withReact) { -%>
     "react": "^19.0.0",
@@ -113,7 +123,18 @@
 <% } else { -%>
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
-    "@canonical/biome-config": "^<%= canonicalVersion %>"
+    "@canonical/biome-config": "^<%= canonicalVersion %>",
+<% if (withStorybook) { -%>
+    "@canonical/storybook-config": "^<%= canonicalVersion %>",
+    "@canonical/styles-debug": "^<%= canonicalVersion %>",
+    "@chromatic-com/storybook": "^5.0.0",
+    "@storybook/addon-themes": "^10.1.11",
+    "@storybook/react-vite": "^10.1.11",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "storybook": "^10.1.11",
+<% } -%>
+    "@canonical/webarchitect": "^<%= canonicalVersion %>"
   }
 <% } -%>
 }

--- a/packages/summon/package/src/templates/storybook-preview.ts.ejs
+++ b/packages/summon/package/src/templates/storybook-preview.ts.ejs
@@ -1,7 +1,9 @@
 import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview, ReactRenderer } from "@storybook/react-vite";
 
-import "index.css";
+<% if (type === 'css') { -%>
+import "../src/index.css";
+<% } -%>
 import "@canonical/styles-debug/baseline-grid";
 
 const preview: Preview = {


### PR DESCRIPTION
## Done

Comparative audit of the summon generators found `summon package` producing broken-on-arrival output for several supported flag combinations. This PR makes every combination installable and startable, and fixes validation/detection defects around it:

- **Generated manifests repaired** (`src/templates/package.json.ejs`, `storybook-preview.ts.ejs`, `cli.ts.ejs`):
  - `--with-storybook` without `--with-react` emitted a trailing comma → **invalid JSON**; every tooling command in the generated package failed.
  - The generated `.storybook/preview.ts` imported `@storybook/addon-themes`, `@storybook/react-vite`, `@canonical/styles-debug`, and a bare `index.css` — none declared or resolvable. The renderer stack is now declared (react added as a devDependency when the package itself isn't a react package), and the stylesheet import is emitted only for `css` packages as `../src/index.css`.
  - `css`-type packages got storybook scripts with zero storybook dependencies; they now get the full set.
  - Every package ran `check:webarchitect` (wired into `check`, and printed as the post-create "Next step") without depending on `@canonical/webarchitect` — command-not-found outside the pragma monorepo. Now declared everywhere the script is emitted.
  - A `library`'s `bin` pointed at `src/cli.ts` while only `dist/` is published (dangling bin in the tarball, bun shebang for node consumers). Library bins now point at `dist/esm/cli.js` with a node shebang; `tool-ts` keeps `src/cli.ts` + bun.
- **Scope validation** (`src/shared/validatePackageName.ts`): the scope of scoped names was stripped and never validated — `@Canonical/x`, `@scope!/x` passed and produced manifests npm rejects. The scope is now held to the same kebab-case rule as the short name.
- **Detection rewritten to walk ancestors** (`src/shared/detection/`):
  - `detectPackageManager`: nearest lockfile wins walking cwd → root; `bun > pnpm > yarn > npm` within a directory; npm (`package-lock.json`) is now actually detectable; a grandparent bun lockfile no longer outranks a local `yarn.lock`. First test file for this module.
  - `detectMonorepo`: recognizes `lerna.json`, `pnpm-workspace.yaml`, and `package.json` `workspaces` roots at any depth (this repo's own `packages/summon/<pkg>` layout defeated the old fixed 3-level lerna-only probe), and a malformed `lerna.json` degrades to "not a monorepo" instead of crashing the run.
  - README/help updated to match (they documented an npm fallback the code never had).
- **Stale peers**: `peerDependencies` on `@canonical/summon-core`/`@canonical/task` were `^0.18.0 || ^0.20.0` — unsatisfiable against the 0.34.x packages that ship alongside. Now `^0.34.0`.

## QA

- `bun run check` and `bun run test` pass from the repo root.
- New **validity-matrix test**: all 24 type×react×storybook×cli combinations render, `JSON.parse`, and cross-check scripts↔dependencies and bin↔published files (`src/generators.test.ts`). This is the test dimension that would have caught every manifest bug above — effect-count assertions cannot.
- New unit tests: scope validation cases; `detectPackageManager` (nearest-first, per-dir priority, npm, fallback); `detectMonorepo` (deep ancestor, malformed lerna, pnpm workspace, workspaces field, plain-manifest passthrough).
- Verification is at the render level (the matrix test parses and cross-checks every combination's manifest); a live `bun install && bun run storybook` smoke test of a generated package was **not** run here — worth doing once as release QA.

### PR readiness check

- [x] PR label: `Bug 🐛`
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

n/a


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
