### PR TITLE
fix(pragma-cli): three argument-parsing defects that answered wrongly in silence

### DIFF
--- a/packages/cli/pragma/src/bin.ts
+++ b/packages/cli/pragma/src/bin.ts
@@ -16,6 +16,13 @@
 import type { Command } from "commander";
 import { BIN_NAME, PROGRAM_DESCRIPTION, VERSION } from "./constants.js";
 
+/**
+ * The flags a bare invocation answers itself. `--version` returns earlier; the
+ * help forms fall through to the front door, which IS their answer — so the
+ * unknown-flag guard must not mistake them for typos.
+ */
+const ROOT_FLAGS = new Set(["--help", "-h", "--version", "-v"]);
+
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
 
@@ -119,6 +126,43 @@ async function main(): Promise<void> {
   //    prints the curated front door instead of exiting silently. Uses the
   //    static capabilities — the front door never reads config or stories.
   if (!args.some((arg) => !arg.startsWith("-"))) {
+    // `args` is argv with the global flags already stripped, so a token still
+    // starting with `-` here is a flag this program does not have — EXCEPT the
+    // two the front door itself answers, which reach this branch by design.
+    // Commander rejects unknown flags below the root; without this the ROOT
+    // answered a typo with the front door and exit 0, so `pragma --detial
+    // standard` read as success.
+    const unknownFlag = args.find(
+      (arg) => arg.startsWith("-") && !ROOT_FLAGS.has(arg),
+    );
+    if (unknownFlag !== undefined) {
+      const [
+        { PragmaError },
+        { renderErrorPlain, renderErrorJson },
+        { mapExitCode },
+      ] = await Promise.all([
+        import("./kernel/error/PragmaError.js"),
+        import("./kernel/error/renderError.js"),
+        import("./kernel/project/cli/exitCodes.js"),
+      ]);
+      const error = new PragmaError({
+        code: "INVALID_INPUT",
+        message: `Unknown option "${unknownFlag}".`,
+        recovery: {
+          message: "Run with `--help` to see the available options.",
+        },
+      });
+      process.stderr.write(
+        `${
+          globalFlags.format === "json"
+            ? renderErrorJson(error)
+            : renderErrorPlain(error)
+        }\n`,
+      );
+      process.exitCode = mapExitCode(error.code);
+      return;
+    }
+
     const { formatRootHelp } = await import("./kernel/project/cli/rootHelp.js");
     const live = capabilities
       .flatMap((module) => [...module.verbs])

--- a/packages/cli/pragma/src/kernel/project/cli/globalFlags.test.ts
+++ b/packages/cli/pragma/src/kernel/project/cli/globalFlags.test.ts
@@ -105,3 +105,68 @@ describe("readRawFormat", () => {
     expect(readRawFormat(["block", "list"])).toBeUndefined();
   });
 });
+
+describe("the option terminator bounds every scan (PROTECTED)", () => {
+  // `--` means the rest is the user's data. A scanner that ignored it would
+  // both misread a flag and STRIP it, so a lookup for a block literally named
+  // `--format` would lose its own argument and change how the error rendered.
+  it("does not read a flag that appears after `--`", () => {
+    expect(readRawFormat(["block", "lookup", "--", "--format", "json"])).toBe(
+      undefined,
+    );
+    expect(
+      parseGlobalFlags(["block", "lookup", "--", "--verbose"], TTY).verbose,
+    ).toBe(false);
+    expect(
+      parseGlobalFlags(["block", "lookup", "--", "--detail", "detailed"], TTY)
+        .detail,
+    ).toBe(undefined);
+  });
+
+  it("hands everything from `--` onward through untouched", () => {
+    expect(
+      stripGlobalFlags(["block", "lookup", "--", "--format", "json"]),
+    ).toEqual(["block", "lookup", "--", "--format", "json"]);
+  });
+
+  it("still reads a flag that appears before `--`", () => {
+    expect(
+      readRawFormat(["--format", "json", "block", "lookup", "--", "x"]),
+    ).toBe("json");
+    expect(
+      stripGlobalFlags(["--format", "json", "block", "lookup", "--", "x"]),
+    ).toEqual(["block", "lookup", "--", "x"]);
+  });
+});
+
+describe("a flag's value is never another flag (PROTECTED)", () => {
+  // The defect this pins: a valueless `--detail` consumed the NEXT flag as its
+  // value and stripped it, so `--detail --category css` silently answered over
+  // the whole set instead of the filtered one — a wrong answer, no diagnostic.
+  it("leaves a following flag standing when the value is absent", () => {
+    expect(
+      stripGlobalFlags(["standard", "list", "--detail", "--category", "css"]),
+    ).toEqual(["standard", "list", "--category", "css"]);
+  });
+
+  it("reports no detail for a valueless --detail", () => {
+    expect(
+      parseGlobalFlags(["standard", "list", "--detail", "--category"], TTY)
+        .detail,
+    ).toBe(undefined);
+  });
+
+  it("still consumes a real value", () => {
+    expect(
+      stripGlobalFlags(["standard", "list", "--detail", "summary"]),
+    ).toEqual(["standard", "list"]);
+    expect(
+      parseGlobalFlags(["standard", "list", "--detail", "summary"], TTY).detail,
+    ).toBe("summary");
+  });
+
+  it("reports a valueless --format as empty so the caller rejects it", () => {
+    // `""`, not `undefined` — `undefined` would fall through to the default.
+    expect(readRawFormat(["--format", "--verbose"])).toBe("");
+  });
+});

--- a/packages/cli/pragma/src/kernel/project/cli/globalFlags.ts
+++ b/packages/cli/pragma/src/kernel/project/cli/globalFlags.ts
@@ -4,6 +4,18 @@
  * `--format`, `--verbose`, and `--detail` may appear anywhere on the line, so
  * they are scanned and stripped before Commander sees argv — otherwise
  * `enablePositionalOptions()` scoping would reject a flag placed after a verb.
+ *
+ * ANYWHERE STOPS AT `--`. Everything after the option terminator is the user's
+ * data, not this program's flags: `block lookup -- --format` looks up a block
+ * literally named `--format`. Commander honours the terminator on its own, so
+ * a scan here that ignored it would parse — and strip — tokens Commander was
+ * about to hand through verbatim.
+ *
+ * A FLAG'S VALUE IS NEVER ANOTHER FLAG. `--detail --category css` supplies no
+ * detail; it is a valueless `--detail` followed by a separate flag. Reading the
+ * next token unconditionally would consume `--category` as the value and strip
+ * it, so the filter would vanish and the command would answer over the whole
+ * set instead — a wrong answer with no diagnostic.
  * Ported from the v1 `parseGlobalFlags`, with two v2 changes: a new `--detail`
  * flag and the `--format text` value renamed to `plain` (the kernel's
  * {@link OutputFormat}). The dedicated `--llm` flag was folded into
@@ -13,6 +25,35 @@
 
 import { DETAIL_LEVELS, type DetailLevel } from "../../../constants.js";
 import type { GlobalFlags } from "../../runtime/types.js";
+
+/** The end-of-options separator: nothing after it is a flag of this program. */
+const OPTION_TERMINATOR = "--";
+
+/**
+ * The span of argv this program's flags may occupy — everything before the
+ * option terminator, or all of argv when there is none.
+ *
+ * @param argv - The user's arguments.
+ * @returns The scannable span; the same array when no terminator is present.
+ */
+function selectScanSpan(argv: readonly string[]): readonly string[] {
+  const terminator = argv.indexOf(OPTION_TERMINATOR);
+  return terminator === -1 ? argv : argv.slice(0, terminator);
+}
+
+/**
+ * Whether a token can serve as a flag's value.
+ *
+ * A token starting with `-` is the next flag, not this one's value. Shared by
+ * every reader below so the space form cannot swallow a sibling flag at one
+ * call site while guarding against it at another.
+ *
+ * @param token - The token following a flag, if any.
+ * @returns True when the token is a value rather than another flag.
+ */
+function isFlagValue(token: string | undefined): token is string {
+  return token !== undefined && !token.startsWith("-");
+}
 
 /**
  * Read a `--flag`'s value, accepting both `--flag value` and `--flag=value`.
@@ -25,13 +66,16 @@ function readFlagValue(
   argv: readonly string[],
   flag: string,
 ): string | undefined {
+  const span = selectScanSpan(argv);
   const equalsPrefix = `${flag}=`;
-  const equalsArg = argv.find((arg) => arg.startsWith(equalsPrefix));
+  const equalsArg = span.find((arg) => arg.startsWith(equalsPrefix));
   if (equalsArg !== undefined) {
     return equalsArg.slice(equalsPrefix.length);
   }
-  const spaceIndex = argv.indexOf(flag);
-  return spaceIndex === -1 ? undefined : argv[spaceIndex + 1];
+  const spaceIndex = span.indexOf(flag);
+  if (spaceIndex === -1) return undefined;
+  const value = span.at(spaceIndex + 1);
+  return isFlagValue(value) ? value : undefined;
 }
 
 /**
@@ -46,14 +90,17 @@ function readFlagValue(
  * @returns The raw value, `""` for a valueless `--format`, or `undefined`.
  */
 export function readRawFormat(argv: readonly string[]): string | undefined {
-  const equalsArg = argv.find((arg) => arg.startsWith("--format="));
+  const span = selectScanSpan(argv);
+  const equalsArg = span.find((arg) => arg.startsWith("--format="));
   if (equalsArg !== undefined) return equalsArg.slice("--format=".length);
 
-  const spaceIndex = argv.indexOf("--format");
+  const spaceIndex = span.indexOf("--format");
   if (spaceIndex === -1) return undefined;
 
-  const value = argv[spaceIndex + 1];
-  return value !== undefined && !value.startsWith("-") ? value : "";
+  // `""` rather than `undefined`: a valueless `--format` must be REJECTED by the
+  // caller, not fall through to the default.
+  const value = span.at(spaceIndex + 1);
+  return isFlagValue(value) ? value : "";
 }
 
 /**
@@ -112,7 +159,7 @@ export function parseGlobalFlags(
     llm: format === "llm" || autoLlm,
     autoLlm,
     format,
-    verbose: argv.includes("--verbose"),
+    verbose: selectScanSpan(argv).includes("--verbose"),
     ...(detail !== undefined ? { detail } : {}),
   };
 }
@@ -122,7 +169,8 @@ export function parseGlobalFlags(
  *
  * Since {@link parseGlobalFlags} pre-parses these, they are dropped so they do
  * not collide with Commander's positional scoping, letting the user place them
- * anywhere on the line.
+ * anywhere on the line — anywhere before the option terminator, which this
+ * stops at and hands through whole.
  *
  * @param argv - The user's arguments.
  * @returns A new array with global flags stripped.
@@ -130,20 +178,31 @@ export function parseGlobalFlags(
 export function stripGlobalFlags(argv: readonly string[]): string[] {
   const result: string[] = [];
   for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
+    const arg = argv.at(i);
+    if (arg === undefined) continue;
+
+    // Past the terminator nothing is ours: hand the remainder over untouched,
+    // terminator included, so Commander still sees where options end.
+    if (arg === OPTION_TERMINATOR) {
+      result.push(...argv.slice(i));
+      return result;
+    }
+
     if (arg === "--verbose") continue;
     if (
-      arg?.startsWith("--format=") ||
-      arg?.startsWith("--verbose=") ||
-      arg?.startsWith("--detail=")
+      arg.startsWith("--format=") ||
+      arg.startsWith("--verbose=") ||
+      arg.startsWith("--detail=")
     ) {
       continue;
     }
     if (arg === "--format" || arg === "--detail") {
-      i += 1; // skip the space-form value too
+      // Skip the value ONLY when the next token is one. A valueless flag before
+      // another flag must leave that flag standing.
+      if (isFlagValue(argv.at(i + 1))) i += 1;
       continue;
     }
-    result.push(arg as string);
+    result.push(arg);
   }
   return result;
 }


### PR DESCRIPTION
## Done

Three defects in the global-flag pre-parser. All three answered **wrongly, in silence** — none of them errored, so nothing surfaced them.

- **A flag's value could be another flag.** `readFlagValue` took the next token unconditionally and `stripGlobalFlags` skipped it to match, so `standard list --detail --category css` consumed `--category` as the detail value and stripped it. The command then answered over **every** standard instead of the css ones — wrong data, exit 0, no diagnostic. `readRawFormat` already had the doesn't-start-with-`-` guard this needed; it is now one shared predicate, so the space form cannot guard at one call site while swallowing a sibling flag at another.

- **`--` did not stop the scan.** Everything after the option terminator is the user's data, and Commander honours that — but the pre-parse ran over the whole array first, so `block lookup -- --format json` parsed and stripped `--format json`, losing the argument *and* switching how the error rendered. Every reader is now bounded at the terminator, and the stripper hands the remainder through whole, terminator included.

- **The root accepted unknown flags.** `pragma --bogus` printed the front door and exited **0**, while `pragma standard categories --bogus` exited 2. A typo'd global flag read as success. The bare-invocation path now rejects any leftover dash token — except the help forms, which reach that branch by design because the front door is their answer.

## QA

```bash
# the filter survives
pragma standard list --detail --category css --format json   # css entries, as without --detail

# -- is honoured
pragma block lookup -- --format json    # looks up a block named "--format", renders plain

# unknown flags are rejected, real ones are not
pragma --bogus     # Error: Unknown option "--bogus".   exit 2
pragma            # front door,  exit 0
pragma --help     # front door,  exit 0
```

The two parser invariants are pinned by colocated tests, **RED-proven**: 3 fail at the pre-fix revision.

One regression was caught by the gate during this work and is worth naming: the first cut of the root check rejected `--help`, because `--help` reaches the bare-invocation branch *by design*. Two e2e suites went red immediately; they remain the pin.

Gates: check 3/3 · 1130 tests (up 7) · perf budgets unchanged.

### PR readiness check

- [x] Label: `Bug 🐛`
- [x] Conventional Commits title
- [x] Follows the [code standards](https://github.com/canonical/web-code-standards) — `.at()` over bracket indexing (`cs:code.array.safe_access`, and the argv scan is exactly where that bites), the `as string` cast removed for a real `undefined` check (`cs:code.assertion.non_null`), and the fixes **fail loudly rather than default** (`cs:code.fallback.defensive`), which is the class all three belonged to
- [x] Package scripts unchanged
- [x] N/A — not a new package
- [x] `no visual change`


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)