### PR TITLE
fix(summon-component): test naming, exists guard, honest lit answers, portable template keys

### DIFF
--- a/packages/summon/component/README.md
+++ b/packages/summon/component/README.md
@@ -471,7 +471,7 @@ export const generators = {
 
 ### Modify Templates
 
-Fork the package and edit templates in `src/templates/react/`, `src/templates/svelte/`, or `src/templates/lit/`. Templates use [EJS syntax](https://ejs.co/).
+Fork the package and edit templates in `src/templates/react/`, `src/templates/svelte/`, or `src/templates/lit/` — plus `src/templates/shared/`, which holds the framework-agnostic templates (currently `styles.css.ejs`, the generated stylesheet rendered by the React and Svelte generators; Lit ships its own). Templates use [EJS syntax](https://ejs.co/).
 
 ---
 

--- a/packages/summon/component/README.md
+++ b/packages/summon/component/README.md
@@ -91,7 +91,7 @@ src/components/Button/
 And appends to `src/components/index.ts`:
 
 ```typescript
-export * from "./Button";
+export * from "./Button/index.js";
 ```
 
 #### Generated Component
@@ -198,7 +198,7 @@ src/lib/Button/
 ├── Button.ts            # Lit element implementation
 ├── types.ts             # Props interface
 ├── index.ts             # Barrel export
-├── Button.tests.ts      # Unit tests (Vitest + shadow DOM)
+├── Button.test.ts      # Unit tests (Vitest + shadow DOM)
 ├── Button.stories.ts    # Storybook stories (optional)
 └── styles.css           # Component styles as CSSResult (optional)
 ```
@@ -271,7 +271,7 @@ export interface ButtonProps {
 #### Generated Test
 
 ```typescript
-// Button.tests.ts
+// Button.test.ts
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "./Button.js";
 import type Button from "./Button.js";
@@ -344,7 +344,7 @@ export const Default: Story = {
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--component-path` | Full path for the component (e.g., `src/lib/components/Card`) | Interactive prompt |
-| `--with-styles` | Include inline `<style>` block | `true` |
+| `--with-styles` | Import an external `styles.css` | `true` |
 | `--no-with-styles` | Skip styles | — |
 | `--with-stories` | Include Storybook stories | `true` |
 | `--no-with-stories` | Skip stories | — |
@@ -403,7 +403,7 @@ summon component react --component-path=src/components/Button
 Appends to `src/components/index.ts`:
 
 ```typescript
-export * from "./Button";
+export * from "./Button/index.js";
 ```
 
 If the barrel file doesn't exist, it's created.
@@ -471,7 +471,7 @@ export const generators = {
 
 ### Modify Templates
 
-Fork the package and edit templates in `src/react/templates/` or `src/svelte/templates/`. Templates use [EJS syntax](https://ejs.co/).
+Fork the package and edit templates in `src/templates/react/`, `src/templates/svelte/`, or `src/templates/lit/`. Templates use [EJS syntax](https://ejs.co/).
 
 ---
 

--- a/packages/summon/component/src/index.test.ts
+++ b/packages/summon/component/src/index.test.ts
@@ -10,6 +10,7 @@ import { dryRun, dryRunWith, type Effect, type Task } from "@canonical/task";
 import { describe, expect, it } from "vitest";
 import pkg from "../package.json" with { type: "json" };
 import { generators } from "./index.js";
+import dryRunWithFileState from "./shared/file-operations/dryRunWithFileState.js";
 
 /**
  * Helper: dry-run with actual file reading for templates.
@@ -28,6 +29,9 @@ const dryRunWithTemplates = <A>(task: Task<A>) => {
         return `[mock content of ${e.path}]`;
       },
     ],
+    // Blank filesystem: the default mock answers Exists with true, which
+    // would trip the component-exists guard.
+    ["Exists", () => false],
   ]);
   return dryRunWith(task, mocks);
 };
@@ -123,8 +127,8 @@ describe("component/react generator", () => {
       expect(paths).toContain("src/components/Button/Button.tsx");
       expect(paths).toContain("src/components/Button/types.ts");
       expect(paths).toContain("src/components/Button/index.ts");
-      expect(paths).toContain("src/components/Button/Button.tests.tsx");
-      expect(paths).toContain("src/components/Button/Button.ssr.tests.tsx");
+      expect(paths).toContain("src/components/Button/Button.test.tsx");
+      expect(paths).toContain("src/components/Button/Button.ssr.test.tsx");
       expect(paths).toContain("src/components/Button/Button.stories.tsx");
       expect(paths).toContain("src/components/Button/styles.css");
     });
@@ -145,8 +149,8 @@ describe("component/react generator", () => {
       expect(paths).toContain("src/components/Icon/Icon.tsx");
       expect(paths).toContain("src/components/Icon/types.ts");
       expect(paths).toContain("src/components/Icon/index.ts");
-      expect(paths).toContain("src/components/Icon/Icon.tests.tsx");
-      expect(paths).not.toContain("src/components/Icon/Icon.ssr.tests.tsx");
+      expect(paths).toContain("src/components/Icon/Icon.test.tsx");
+      expect(paths).not.toContain("src/components/Icon/Icon.ssr.test.tsx");
       expect(paths).not.toContain("src/components/Icon/Icon.stories.tsx");
       expect(paths).not.toContain("src/components/Icon/styles.css");
     });
@@ -416,7 +420,6 @@ describe("component/lit generator", () => {
         componentPath: "src/lib/components/Button",
         withStyles: true,
         withStories: true,
-        withSsrTests: false,
       });
 
       const result = dryRun(task);
@@ -427,7 +430,7 @@ describe("component/lit generator", () => {
       expect(paths).toContain("src/lib/components/Button/Button.ts");
       expect(paths).toContain("src/lib/components/Button/index.ts");
       expect(paths).toContain("src/lib/components/Button/types.ts");
-      expect(paths).toContain("src/lib/components/Button/Button.tests.ts");
+      expect(paths).toContain("src/lib/components/Button/Button.test.ts");
       expect(paths).toContain("src/lib/components/Button/Button.stories.ts");
       expect(paths).toContain("src/lib/components/Button/styles.css");
     });
@@ -437,7 +440,6 @@ describe("component/lit generator", () => {
         componentPath: "src/lib/components/Icon",
         withStyles: false,
         withStories: false,
-        withSsrTests: false,
       });
 
       const result = dryRun(task);
@@ -448,7 +450,7 @@ describe("component/lit generator", () => {
       expect(paths).toContain("src/lib/components/Icon/Icon.ts");
       expect(paths).toContain("src/lib/components/Icon/index.ts");
       expect(paths).toContain("src/lib/components/Icon/types.ts");
-      expect(paths).toContain("src/lib/components/Icon/Icon.tests.ts");
+      expect(paths).toContain("src/lib/components/Icon/Icon.test.ts");
       expect(paths).not.toContain("src/lib/components/Icon/Icon.stories.ts");
       expect(paths).not.toContain("src/lib/components/Icon/styles.css");
     });
@@ -458,7 +460,6 @@ describe("component/lit generator", () => {
         componentPath: "src/lib/components/MyButton",
         withStyles: false,
         withStories: false,
-        withSsrTests: false,
       });
 
       const result = dryRunWithTemplates(task);
@@ -478,7 +479,6 @@ describe("component/lit generator", () => {
         componentPath: "src/lib/components/MyButton",
         withStyles: false,
         withStories: false,
-        withSsrTests: false,
       });
 
       const result = dryRunWithTemplates(task);
@@ -497,7 +497,6 @@ describe("component/lit generator", () => {
         componentPath: "src/lib/components/Card",
         withStyles: false,
         withStories: false,
-        withSsrTests: false,
       });
 
       const result = dryRun(task);
@@ -511,5 +510,46 @@ describe("component/lit generator", () => {
       const content = (parentIndex as { content: string }).content;
       expect(content).toContain('export * from "./Card/index.js"');
     });
+  });
+});
+
+describe("component-exists guard", () => {
+  it("react refuses to scaffold over an existing component directory", () => {
+    const task = generators["component/react"].generate({
+      componentPath: "src/components/Button",
+      withStyles: false,
+      withStories: false,
+      withSsrTests: false,
+    });
+
+    expect(() =>
+      dryRunWithFileState(task, { "src/components/Button": "" }),
+    ).toThrow(/already exists/);
+  });
+
+  it("svelte refuses to scaffold over an existing component directory", () => {
+    const task = generators["component/svelte"].generate({
+      componentPath: "src/lib/components/Button",
+      withStyles: false,
+      withStories: false,
+      useTsStories: false,
+      withSsrTests: false,
+    });
+
+    expect(() =>
+      dryRunWithFileState(task, { "src/lib/components/Button": "" }),
+    ).toThrow(/already exists/);
+  });
+
+  it("lit refuses to scaffold over an existing component directory", () => {
+    const task = generators["component/lit"].generate({
+      componentPath: "src/lib/components/Button",
+      withStyles: false,
+      withStories: false,
+    });
+
+    expect(() =>
+      dryRunWithFileState(task, { "src/lib/components/Button": "" }),
+    ).toThrow(/already exists/);
   });
 });

--- a/packages/summon/component/src/lit/generator.ts
+++ b/packages/summon/component/src/lit/generator.ts
@@ -4,7 +4,7 @@
  * Generates a Lit web component with a consistent file structure:
  * - `ComponentName.ts` - Main component file (Lit element)
  * - `index.ts` - Barrel export
- * - `ComponentName.tests.ts` - Unit tests with Vitest
+ * - `ComponentName.test.ts` - Unit tests with Vitest
  * - `ComponentName.stories.ts` - Storybook stories (optional)
  * - `styles.css` - CSS styles (optional)
  *
@@ -26,10 +26,12 @@ import {
   appendExportToParentIndex,
   createComponentPathPrompt,
   createTemplateContext,
+  failIfComponentExists,
   getComponentName,
   getParentDir,
   PACKAGE_NAME,
   packageVersion,
+  sharedPrompts,
 } from "../shared/index.js";
 import { loadTemplateSync } from "../shared/loadTemplate.js";
 import type { LitAnswers } from "./types.js";
@@ -71,22 +73,11 @@ function litTemplates(): ReturnType<typeof loadLitTemplates> {
 // Custom Prompts (without SSR tests)
 // =============================================================================
 
-const litPrompts = [
-  {
-    name: "withStyles",
-    type: "confirm",
-    message: "Include styles?",
-    default: true,
-    group: "Options",
-  },
-  {
-    name: "withStories",
-    type: "confirm",
-    message: "Include Storybook stories?",
-    default: true,
-    group: "Options",
-  },
-] as const;
+// Reuse the shared prompt definitions rather than duplicating them; lit only
+// drops the SSR-tests flag it never acts on.
+const litPrompts = sharedPrompts.filter(
+  (prompt) => prompt.name !== "withSsrTests",
+);
 
 // =============================================================================
 // Generator Definition
@@ -118,7 +109,7 @@ FEATURES:
 
 The component name is extracted from the path and must be PascalCase.
 For example, 'src/lib/components/Button' creates a 'Button' component
-with the custom element tag 'button'.`,
+with the custom element tag 'ds-button'.`,
     examples: [
       "summon component lit --component-path=src/lib/components/Button",
       "summon component lit --component-path=src/lib/components/Card --with-styles --with-stories",
@@ -138,6 +129,10 @@ with the custom element tag 'button'.`,
 
     return sequence_([
       info(`Generating Lit web component: ${componentName}`),
+
+      // Refuse to scaffold over an existing component: the writes' delete
+      // undos would otherwise let --undo destroy pre-existing files.
+      failIfComponentExists(componentDir),
 
       debug("Creating component directory"),
       mkdir(componentDir),
@@ -170,7 +165,7 @@ with the custom element tag 'button'.`,
       template({
         source: t.tests.source,
         content: t.tests.content,
-        dest: path.join(componentDir, `${componentName}.tests.ts`),
+        dest: path.join(componentDir, `${componentName}.test.ts`),
         vars: ctx,
       }),
 

--- a/packages/summon/component/src/lit/types.ts
+++ b/packages/summon/component/src/lit/types.ts
@@ -4,5 +4,9 @@
 
 import type { BaseComponentAnswers } from "../shared/index.js";
 
-/** Lit web component generator answers - uses base answers only */
-export type LitAnswers = BaseComponentAnswers;
+/**
+ * Lit web component generator answers — the base answers minus SSR tests,
+ * which the lit generator does not offer (its prompts never collect the flag,
+ * so the type must not promise it).
+ */
+export type LitAnswers = Omit<BaseComponentAnswers, "withSsrTests">;

--- a/packages/summon/component/src/react/generator.ts
+++ b/packages/summon/component/src/react/generator.ts
@@ -22,6 +22,7 @@ import {
   appendExportToParentIndex,
   createComponentPathPrompt,
   createTemplateContext,
+  failIfComponentExists,
   getComponentName,
   getParentDir,
   PACKAGE_NAME,
@@ -115,6 +116,10 @@ For example, 'src/components/Button' creates a 'Button' component.`,
     return sequence_([
       info(`Generating React component: ${componentName}`),
 
+      // Refuse to scaffold over an existing component: the writes' delete
+      // undos would otherwise let --undo destroy pre-existing files.
+      failIfComponentExists(componentDir),
+
       debug("Creating component directory"),
       mkdir(componentDir),
 
@@ -146,7 +151,7 @@ For example, 'src/components/Button' creates a 'Button' component.`,
       template({
         source: t.test.source,
         content: t.test.content,
-        dest: path.join(componentDir, `${componentName}.tests.tsx`),
+        dest: path.join(componentDir, `${componentName}.test.tsx`),
         vars: ctx,
       }),
 
@@ -156,7 +161,7 @@ For example, 'src/components/Button' creates a 'Button' component.`,
         template({
           source: t.ssrTest.source,
           content: t.ssrTest.content,
-          dest: path.join(componentDir, `${componentName}.ssr.tests.tsx`),
+          dest: path.join(componentDir, `${componentName}.ssr.test.tsx`),
           vars: ctx,
         }),
       ),

--- a/packages/summon/component/src/shared/createTemplateContext.ts
+++ b/packages/summon/component/src/shared/createTemplateContext.ts
@@ -6,10 +6,13 @@ import { getComponentName, kebabCase } from "./string-helpers/index.js";
 import type { BaseComponentAnswers, TemplateContext } from "./types.js";
 
 /**
- * Create template context from answers
+ * Create template context from answers. `withSsrTests` is optional so
+ * generators that do not offer SSR tests (lit) can pass their honest answer
+ * shape; the context defaults it to false.
  */
 export default function createTemplateContext(
-  answers: BaseComponentAnswers,
+  answers: Omit<BaseComponentAnswers, "withSsrTests"> &
+    Partial<Pick<BaseComponentAnswers, "withSsrTests">>,
 ): TemplateContext {
   const name = getComponentName(answers.componentPath);
   return {
@@ -17,6 +20,6 @@ export default function createTemplateContext(
     kebabName: kebabCase(name),
     withStyles: answers.withStyles,
     withStories: answers.withStories,
-    withSsrTests: answers.withSsrTests,
+    withSsrTests: answers.withSsrTests ?? false,
   };
 }

--- a/packages/summon/component/src/shared/failIfComponentExists.ts
+++ b/packages/summon/component/src/shared/failIfComponentExists.ts
@@ -1,0 +1,25 @@
+import { exists, fail, flatMap, pure, type Task } from "@canonical/task";
+
+/**
+ * Refuse to scaffold over an existing component directory.
+ *
+ * Every generated write carries a delete as its default undo, so scaffolding
+ * over an existing directory and then running `--undo` would destroy files
+ * the user owned before the run. The domain/wrapper generators in
+ * summon-application guard the same way for the same reason.
+ */
+export default function failIfComponentExists(
+  componentDir: string,
+): Task<void> {
+  return flatMap(exists(componentDir), (present) =>
+    present
+      ? fail({
+          code: "COMPONENT_EXISTS",
+          message:
+            `"${componentDir}" already exists. Scaffolding over it would let ` +
+            "--undo delete pre-existing files. Choose a different path or " +
+            "remove the directory first.",
+        })
+      : pure(undefined),
+  );
+}

--- a/packages/summon/component/src/shared/file-operations/appendExportToParentIndex.test.ts
+++ b/packages/summon/component/src/shared/file-operations/appendExportToParentIndex.test.ts
@@ -33,6 +33,26 @@ describe("appendExportToParentIndex", () => {
     expect(writeEffects).toHaveLength(0);
   });
 
+  it("recognizes an equivalent hand-written export (single quotes, no semicolon)", () => {
+    // Exact string equality would miss these and append a duplicate — the
+    // check compares the parsed module path, not the serialization.
+    for (const existing of [
+      "export * from './Button/index.js';\n",
+      'export * from "./Button/index.js"\n',
+      "export  *  from   './Button/index.js'\n",
+    ]) {
+      const result = dryRunWithFileState(
+        appendExportToParentIndex("src/components", "Button"),
+        { "src/components/index.ts": existing },
+      );
+
+      const writeEffects = result.effects.filter(
+        (e) => e._tag === "AppendFile" || e._tag === "WriteFile",
+      );
+      expect(writeEffects).toHaveLength(0);
+    }
+  });
+
   it("appends when an existing export is a prefix-named sibling", () => {
     // Substring matching would treat ./ButtonGroup as covering ./Button and
     // silently skip the append — the whole-line check must not.

--- a/packages/summon/component/src/shared/file-operations/appendExportToParentIndex.ts
+++ b/packages/summon/component/src/shared/file-operations/appendExportToParentIndex.ts
@@ -12,6 +12,12 @@ import {
 import removeLineFromFile from "./removeLineFromFile.js";
 
 /**
+ * A whole star-export line, capturing its module path: either quote style,
+ * flexible inner whitespace, optional semicolon.
+ */
+const STAR_EXPORT_LINE = /^export\s*\*\s*from\s*(["'])(.+)\1\s*;?$/;
+
+/**
  * Append export to parent index.ts file (or create if not exists).
  * Carries undo metadata: removes the export line (or deletes the index
  * if it was created from scratch).
@@ -21,18 +27,22 @@ export default function appendExportToParentIndex(
   componentName: string,
 ): Task<void> {
   const indexPath = path.join(parentDir, "index.ts");
-  const exportLine = `export * from "./${componentName}/index.js";\n`;
+  const modulePath = `./${componentName}/index.js`;
+  const exportLine = `export * from "${modulePath}";\n`;
 
   return ifElseM(
     exists(indexPath),
     // If exists, append (if not already exported)
     flatMap(readFile(indexPath), (content) => {
-      // Whole-line match — a substring check on `./${componentName}` would
-      // false-positive on prefix-named siblings (adding Button next to an
-      // existing ButtonGroup export) and silently skip the append.
-      const alreadyExported = content
-        .split("\n")
-        .some((existingLine) => existingLine.trim() === exportLine.trim());
+      // Whole-line match on the parsed module path — a substring check on
+      // `./${componentName}` would false-positive on prefix-named siblings
+      // (adding Button next to an existing ButtonGroup export), while exact
+      // string equality would miss a hand-written equivalent in the other
+      // quote style or without the semicolon and append a duplicate.
+      const alreadyExported = content.split("\n").some((existingLine) => {
+        const match = existingLine.trim().match(STAR_EXPORT_LINE);
+        return match !== null && match[2] === modulePath;
+      });
       if (alreadyExported) {
         return pure(undefined); // Already exported
       }

--- a/packages/summon/component/src/shared/index.ts
+++ b/packages/summon/component/src/shared/index.ts
@@ -4,6 +4,7 @@
 
 export { default as createComponentPathPrompt } from "./createComponentPathPrompt.js";
 export { default as createTemplateContext } from "./createTemplateContext.js";
+export { default as failIfComponentExists } from "./failIfComponentExists.js";
 export * from "./file-operations/index.js";
 export { PACKAGE_NAME } from "./packageName.js";
 export { packageVersion } from "./packageVersion.js";

--- a/packages/summon/component/src/shared/loadTemplate.test.ts
+++ b/packages/summon/component/src/shared/loadTemplate.test.ts
@@ -47,6 +47,20 @@ describe("loadTemplate", () => {
     expect(result.source).toBe(missingPath);
   });
 
+  it("resolves a Windows-style backslash source against the manifest", async () => {
+    // path.join yields backslashes on win32; the manifest keys are always
+    // forward-slash, so the lookup must normalize before matching.
+    setEmbeddedTemplates({
+      "component/react/types.ts.ejs": "EMBEDDED CONTENT",
+    });
+
+    const result = await loadTemplate(
+      "C:\\pkg\\dist\\esm\\templates\\react\\types.ts.ejs",
+    );
+
+    expect(result.content).toBe("EMBEDDED CONTENT");
+  });
+
   it("resolves the shared/ styles template by its qualified key", async () => {
     // react pulls its stylesheet from templates/shared/, not templates/react/.
     const missingPath = join(dir, "templates", "shared", "styles.css.ejs");

--- a/packages/summon/component/src/shared/loadTemplate.ts
+++ b/packages/summon/component/src/shared/loadTemplate.ts
@@ -61,10 +61,14 @@ export function setEmbeddedTemplates(
  * `template()` and read from disk, so no manifest entry could serve them.
  */
 function qualifiedKey(source: string): string | undefined {
+  // Manifest keys are always forward-slash; sources are built with path.join,
+  // which yields backslashes on Windows — normalize before matching so a
+  // compiled binary resolves its templates there too.
+  const normalized = source.replaceAll("\\", "/");
   const marker = "/templates/";
-  const at = source.lastIndexOf(marker);
+  const at = normalized.lastIndexOf(marker);
   if (at === -1) return undefined;
-  return `component/${source.slice(at + marker.length)}`;
+  return `component/${normalized.slice(at + marker.length)}`;
 }
 
 /**

--- a/packages/summon/component/src/svelte/generator.ts
+++ b/packages/summon/component/src/svelte/generator.ts
@@ -30,6 +30,7 @@ import {
   appendExportToParentIndex,
   createComponentPathPrompt,
   createTemplateContext,
+  failIfComponentExists,
   getComponentName,
   getParentDir,
   PACKAGE_NAME,
@@ -144,6 +145,10 @@ For example, 'src/lib/components/Button' creates a 'Button' component.`,
 
     return sequence_([
       info(`Generating Svelte component: ${componentName}`),
+
+      // Refuse to scaffold over an existing component: the writes' delete
+      // undos would otherwise let --undo destroy pre-existing files.
+      failIfComponentExists(componentDir),
 
       debug("Creating component directory"),
       mkdir(componentDir),

--- a/packages/summon/component/src/testing/integration/generators-undo.test.ts
+++ b/packages/summon/component/src/testing/integration/generators-undo.test.ts
@@ -208,7 +208,6 @@ describe("component/lit undo plan", () => {
       componentPath: "src/lib/components/Button",
       withStyles: true,
       withStories: true,
-      withSsrTests: false,
     });
     const undos = collectUndos(task);
 
@@ -222,7 +221,6 @@ describe("component/lit undo plan", () => {
       componentPath: "src/lib/components/Button",
       withStyles: false,
       withStories: false,
-      withSsrTests: false,
     });
     const minUndos = collectUndos(minTask);
 
@@ -235,7 +233,6 @@ describe("component/lit undo plan", () => {
       componentPath: "src/lib/components/Widget",
       withStyles: true,
       withStories: true,
-      withSsrTests: false,
     });
     const undos = collectUndos(task);
     const tags = getUndoEffectTags(undos);


### PR DESCRIPTION
> Depends on #971 (merged) — rebased onto main.

## Done

Generated-output fixes for `summon component` found by the summon audit (one commit; the pieces share files, and the PR squash-merges as one story):

- **Generated tests are now named `*.test.*`.** React emitted `Name.tests.tsx` / `Name.ssr.tests.tsx` and lit `Name.tests.ts` (plural) — invisible to vitest's default include pattern, so generated tests silently never ran in consumer projects. All flavors now match CONVENTIONS C7.2, the README, and the svelte flavor.
- **All three flavors refuse to scaffold over an existing component directory** (new shared `failIfComponentExists`). Generated writes carry deletes as their default undos, so overwrite-then-`--undo` would destroy files the user owned before the run. Mirrors the domain/wrapper guards in summon-application. (Depends on #971: undo collection backtracks past forward-only guards.)
- **`LitAnswers` stops promising `withSsrTests`** (a flag lit's prompts never collect) via `Omit<>`, and lit reuses the shared prompt definitions instead of duplicating them verbatim. `createTemplateContext` accepts the honest shape and defaults the flag.
- **Embedded-template manifest keys normalize path separators**, so a compiled binary resolves its templates on Windows (`path.join` backslashes never matched the forward-slash `/templates/` marker).
- Docs/help drift corrected: the actual appended export line (`./Button/index.js`), actual template locations (`src/templates/<flavor>/`), svelte's external-stylesheet behavior, and the lit custom-element tag (`ds-button`).

## QA

- `bun run check` and `bun run test` pass from the repo root (102 component tests, 100% coverage thresholds intact).
- New tests: the exists-guard for each flavor, the Windows-style backslash manifest lookup, and the naming pins updated to the singular forms.

### PR readiness check

- [x] PR label: `Bug 🐛`
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

n/a

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
