### PR TITLE
fix(summon-application): version fallback, safe route undo, input validation, workspace detection

### DIFF
--- a/packages/summon/application/README.md
+++ b/packages/summon/application/README.md
@@ -136,7 +136,7 @@ const [billing] = group(publicLayout, [billingRoutes.billing] as const);
 
 ### `summon route <domain>/<name>`
 
-Adds a page component to an existing domain and appends the import to its `routes.ts`.
+Adds a page component to an existing domain and wires it into the domain's `routes.ts` — no manual edit needed.
 
 ```bash
 summon route billing/invoices
@@ -147,16 +147,16 @@ Produces:
 ```
 src/domains/billing/
 ├── InvoicesPage.tsx   # New page component
-└── routes.ts          # Import + TODO comment appended
+└── routes.ts          # Import + route entry inserted
 ```
 
-The generator appends the import and a comment with the route entry. Add the route to the `routes` object manually:
+The generator locates the `routes` object with the TypeScript AST and splices in both the import and the full entry:
 
 ```ts
 invoices: route({ url: "/billing/invoices", content: InvoicesPage }),
 ```
 
-Create the domain first with `summon domain <name>`.
+Running with `--undo` removes exactly that entry and import again. Create the domain first with `summon domain <name>`.
 
 ### `summon wrapper <name>`
 

--- a/packages/summon/application/README.md
+++ b/packages/summon/application/README.md
@@ -156,7 +156,7 @@ The generator locates the `routes` object with the TypeScript AST and splices in
 invoices: route({ url: "/billing/invoices", content: InvoicesPage }),
 ```
 
-Running with `--undo` removes exactly that entry and import again. Create the domain first with `summon domain <name>`.
+Running with `--undo` removes that entry and import again — safe when the insertion actually added a new key. If the route key already existed the insertion was a no-op, and `--undo` would remove the pre-existing route (the generator help documents the same caveat). Create the domain first with `summon domain <name>`.
 
 ### `summon wrapper <name>`
 

--- a/packages/summon/application/src/application/react/index.ts
+++ b/packages/summon/application/src/application/react/index.ts
@@ -9,6 +9,7 @@ import {
   copyFile,
   exec,
   exists,
+  fail,
   flatMap,
   info,
   pure,
@@ -18,6 +19,7 @@ import {
 } from "@canonical/task";
 import { pickPackageManager } from "../../shared/packageManager.js";
 import { packageVersion } from "../../shared/packageVersion.js";
+import { validateAppPath } from "../../shared/validators.js";
 import { resolvePragmaVersion } from "../../shared/versions.js";
 import { findEnclosingWorkspaceRoot } from "../../shared/workspace.js";
 
@@ -37,6 +39,7 @@ const prompts: PromptDefinition[] = [
     message: "Application directory name:",
     default: "my-app",
     positional: true,
+    validate: validateAppPath,
     group: "Application",
   },
   {
@@ -114,10 +117,12 @@ Requires both --ssr and --router flags.`,
 
   generate: (answers) => {
     if (!answers.ssr || !answers.router) {
-      throw new Error(
-        "The application/react generator requires both --ssr and --router. " +
+      return fail({
+        code: "APP_UNSUPPORTED_MODE",
+        message:
+          "The application/react generator requires both --ssr and --router. " +
           "Standalone SPA mode is not supported.",
-      );
+      });
     }
 
     // The app path is a directory path, not a route path — keep it as given
@@ -137,10 +142,12 @@ Requires both --ssr and --router flags.`,
       .replace(/^[._-]+|[._-]+$/g, "");
 
     if (!name) {
-      throw new Error(
-        `Could not derive a valid application name from path "${appPath}". ` +
+      return fail({
+        code: "APP_NAME_INVALID",
+        message:
+          `Could not derive a valid application name from path "${appPath}". ` +
           "Pass an explicit directory name (lowercase letters/digits).",
-      );
+      });
     }
 
     const dest = (...segments: string[]) => path.join(appPath, ...segments);
@@ -192,17 +199,30 @@ Requires both --ssr and --router flags.`,
           : `Application "${appPath}" created. Install a package manager (bun, pnpm, npm, or yarn), then run \`cd ${appPath} && <pm> install && <pm> run dev\` to start.`;
 
       return sequence_([
-        // Warn (don't block) if the destination already exists — scaffolding
-        // will overwrite files in place.
+        // Refuse to scaffold over an existing directory: every write's default
+        // undo is a delete, so overwrite-then-`--undo` would destroy files the
+        // user owned before the run (the same guard domain/wrapper apply).
         flatMap(exists(appPath), (present) =>
-          when(
-            present,
-            warn(
-              `"${appPath}" already exists — existing files may be overwritten.`,
-            ),
-          ),
+          present
+            ? fail({
+                code: "APP_DEST_EXISTS",
+                message:
+                  `"${appPath}" already exists. Scaffolding over it would let ` +
+                  "--undo delete pre-existing files. Choose a different " +
+                  "directory or remove it first.",
+              })
+            : pure(undefined),
         ),
         info(`Scaffolding React application in "${appPath}"...`),
+        // The scaffolded package.json composes its scripts with `bun run`; on
+        // a machine where another manager was detected, say so up front.
+        when(
+          pm !== null && pm !== "bun",
+          warn(
+            `Detected ${pm}, but the generated scripts use \`bun run\` — ` +
+              "install bun to run the app's composite scripts.",
+          ),
+        ),
 
         // EJS templates (files needing interpolation)
         template({

--- a/packages/summon/application/src/application/react/index.ts
+++ b/packages/summon/application/src/application/react/index.ts
@@ -162,332 +162,337 @@ Requires both --ssr and --router flags.`,
     const workspaceRoot = findEnclosingWorkspaceRoot(path.resolve(appPath));
     const standalone = workspaceRoot === null;
 
-    // Resolve the @canonical/* version range first (latest from npm, with an
-    // offline fallback), then build the rest of the pipeline with it baked into
-    // the template vars.
-    return flatMap(resolvePragmaVersion(), (pragmaVersion) => {
-      const vars = withHelpers({
-        name,
-        forms: answers.forms,
-        relay: answers.relay,
-        standalone,
-        pragmaVersion,
+    // Guard BEFORE any network: refusing an existing destination is locally
+    // decidable, so it must not wait on (or block behind) the npm lookup.
+    // Every write's default undo is a delete, so overwrite-then-`--undo`
+    // would destroy files the user owned before the run (the same guard
+    // domain/wrapper apply).
+    return flatMap(exists(appPath), (present) => {
+      if (present) {
+        return fail({
+          code: "APP_DEST_EXISTS",
+          message:
+            `"${appPath}" already exists. Scaffolding over it would let ` +
+            "--undo delete pre-existing files. Choose a different " +
+            "directory or remove it first.",
+        });
+      }
+      // Resolve the @canonical/* version range (latest from npm, with an
+      // offline fallback), then build the rest of the pipeline with it baked
+      // into the template vars.
+      return flatMap(resolvePragmaVersion(), (pragmaVersion) => {
+        const vars = withHelpers({
+          name,
+          forms: answers.forms,
+          relay: answers.relay,
+          standalone,
+          pragmaVersion,
+        });
+
+        // Detect an available package manager for both the (optional) install
+        // step and the closing message, so the suggested commands reflect what's
+        // actually on the machine.
+        const pm = pickPackageManager();
+        // Build the install task only when a package manager was actually found —
+        // this narrows `pm` to non-null, so the install command never invents a
+        // manager. `null` when we won't (or can't) install.
+        const installTask =
+          answers.runInstall && pm !== null
+            ? sequence_([
+                info(`Installing dependencies with ${pm}...`),
+                exec(pm, ["install"], appPath),
+              ])
+            : null;
+        // The closing command only names a package manager we actually found; if
+        // none was detected we don't invent one (previously this suggested `bun`
+        // even on a machine without bun), and instead point the user at the
+        // package-manager step.
+        const finalMessage = installTask
+          ? `Application "${appPath}" created. Run \`cd ${appPath} && ${pm} run dev\` to start.`
+          : pm
+            ? `Application "${appPath}" created. Run \`cd ${appPath} && ${pm} install && ${pm} run dev\` to start.`
+            : `Application "${appPath}" created. Install a package manager (bun, pnpm, npm, or yarn), then run \`cd ${appPath} && <pm> install && <pm> run dev\` to start.`;
+
+        return sequence_([
+          info(`Scaffolding React application in "${appPath}"...`),
+          // The scaffolded package.json composes its scripts with `bun run`; on
+          // a machine where another manager was detected, say so up front.
+          when(
+            pm !== null && pm !== "bun",
+            warn(
+              `Detected ${pm}, but the generated scripts use \`bun run\` — ` +
+                "install bun to run the app's composite scripts.",
+            ),
+          ),
+
+          // EJS templates (files needing interpolation)
+          template({
+            source: src("package.json.ejs"),
+            dest: dest("package.json"),
+            vars,
+          }),
+          template({
+            source: src("README.md.ejs"),
+            dest: dest("README.md"),
+            vars,
+          }),
+          template({
+            source: src("biome.json.ejs"),
+            dest: dest("biome.json"),
+            vars,
+          }),
+
+          // Root config
+          // tsconfig (EJS — #relay path alias only when --relay)
+          template({
+            source: src("tsconfig.json.ejs"),
+            dest: dest("tsconfig.json"),
+            vars,
+          }),
+          // vite config (EJS — vite-plugin-relay-lite only when --relay)
+          template({
+            source: src("vite.config.ts.ejs"),
+            dest: dest("vite.config.ts"),
+            vars,
+          }),
+          copy("vitest.config.ts"),
+          // vitest setup (EJS — relay-test-utils' jest→vi alias only when --relay)
+          template({
+            source: src("vitest.setup.ts.ejs"),
+            dest: dest("vitest.setup.ts"),
+            vars,
+          }),
+          copy("vitest.e2e.config.ts"),
+          // Relay compiler config (validates queries against the mock SDL)
+          when(answers.relay, copy("relay.config.json")),
+          // index.html (EJS — <title> uses the app name)
+          template({
+            source: src("index.html.ejs"),
+            dest: dest("index.html"),
+            vars,
+          }),
+          // The template is stored as `gitignore` (no leading dot): npm strips a
+          // literal `.gitignore` from published tarballs, so we ship it dotless and
+          // restore the dot at write time.
+          copyFile(src("gitignore"), dest(".gitignore")),
+          // The app's browser floor, read by vite.config.ts to derive Lightning
+          // CSS targets. Unlike `.gitignore` above, npm does not strip
+          // `.browserslistrc` from tarballs, so the template keeps its dot.
+          copy(".browserslistrc"),
+
+          // E2e tests (the 2×3 server matrix + its spawn/teardown harness)
+          copy("test/e2e/serverHarness.ts"),
+          copy("test/e2e/servers.e2e.ts"),
+
+          // Styles
+          // styles (EJS — form stylesheet imported only when --forms)
+          template({
+            source: src("src/styles/index.css.ejs"),
+            dest: dest("src/styles/index.css"),
+            vars,
+          }),
+          copy("src/styles/app.css"),
+
+          // Client (EJS — RelayEnvironmentProvider only when --relay)
+          template({
+            source: src("src/client/entry.tsx.ejs"),
+            dest: dest("src/client/entry.tsx"),
+            vars,
+          }),
+
+          // Server — dev (Vite + HMR) and preview (compiled) servers each route
+          // between the app + sitemap renderers; the renderers stay routing-agnostic.
+          // Server entry (EJS — a per-request RelayEnvironmentProvider only when --relay)
+          template({
+            source: src("src/server/entry.tsx.ejs"),
+            dest: dest("src/server/entry.tsx"),
+            vars,
+          }),
+          copy("src/server/renderer.tsx"),
+          copy("src/server/server.express.ts"),
+          copy("src/server/server.bun.ts"),
+          copy("src/server/preview.express.ts"),
+          copy("src/server/preview.bun.ts"),
+
+          // Sitemap (rendered route at /sitemap.xml)
+          copy("src/sitemap/renderer.ts"),
+          // sitemap getters (EJS — /contact entry only when --forms, /catalog
+          // entry only when --relay)
+          template({
+            source: src("src/sitemap/getSitemapItems.ts.ejs"),
+            dest: dest("src/sitemap/getSitemapItems.ts"),
+            vars,
+          }),
+
+          // Domain: marketing
+          copy("src/domains/marketing/HomePage.tsx"),
+          copy("src/domains/marketing/GuidePage.tsx"),
+          copy("src/domains/marketing/routes.ts"),
+
+          // Domain: account
+          copy("src/domains/account/AccountPage.tsx"),
+          copy("src/domains/account/LoginPage.tsx"),
+          copy("src/domains/account/routes.ts"),
+
+          // Domain: contact (when --forms is enabled)
+          when(answers.forms, copy("src/domains/contact/ContactPage.tsx")),
+          when(answers.forms, copy("src/domains/contact/routes.ts")),
+
+          // Relay data layer (when --relay is enabled): environment factory +
+          // executable mock schema, the catalog example domain, and the
+          // ClientOnly SSR guard (whose only consumer today is the catalog page).
+          when(answers.relay, copy("src/relay/schema.graphql")),
+          when(answers.relay, copy("src/relay/schema.ts")),
+          when(answers.relay, copy("src/relay/schema.tests.ts")),
+          when(answers.relay, copy("src/relay/environment.ts")),
+          when(answers.relay, copy("src/relay/environment.tests.ts")),
+          // Committed relay-compiler artifacts — deterministic outputs of the
+          // committed schema + the catalog queries; `bun run relay` regenerates
+          // them in the scaffolded app after any schema or graphql-tag edit.
+          when(
+            answers.relay,
+            copy("src/relay/__generated__/ProductCard_product.graphql.ts"),
+          ),
+          when(
+            answers.relay,
+            copy("src/relay/__generated__/ProductListQuery.graphql.ts"),
+          ),
+
+          // Domain: catalog (when --relay is enabled)
+          when(answers.relay, copy("src/domains/catalog/CatalogPage.tsx")),
+          when(answers.relay, copy("src/domains/catalog/ProductList.tsx")),
+          when(
+            answers.relay,
+            copy("src/domains/catalog/ProductList.stories.tsx"),
+          ),
+          when(
+            answers.relay,
+            copy("src/domains/catalog/ProductList.tests.tsx"),
+          ),
+          when(answers.relay, copy("src/domains/catalog/ProductCard.tsx")),
+          when(answers.relay, copy("src/domains/catalog/ErrorBoundary.tsx")),
+          when(
+            answers.relay,
+            copy("src/domains/catalog/ErrorBoundary.tests.tsx"),
+          ),
+          when(answers.relay, copy("src/domains/catalog/routes.ts")),
+
+          // Standalone dependency patches (when --relay is enabled): a
+          // standalone app cannot inherit a workspace's patches/, so they ship
+          // with the scaffold and are applied via "patchedDependencies" in
+          // package.json. Inside a bun workspace the WORKSPACE ROOT owns
+          // patching — bun resolves patch paths from the root, so an app-local
+          // block would abort `bun install` ("Couldn't find patch file") —
+          // hence neither patches/ nor patchedDependencies are emitted there.
+          when(
+            answers.relay && !standalone,
+            info(
+              `Scaffolding into the bun workspace at "${workspaceRoot}" — ` +
+                "dependency patches are owned by the workspace root, so no " +
+                "app-local patches/ or patchedDependencies were emitted. " +
+                "Ensure the workspace root patches react-relay, relay-runtime " +
+                "and relay-runtime-network (see the app README).",
+            ),
+          ),
+          // react-relay: cjs-module-lexer export hints so named imports survive
+          // Node SSR externalisation.
+          when(
+            answers.relay && standalone,
+            copy("patches/react-relay@21.0.1.patch"),
+          ),
+          // relay-runtime: real `module.exports.X = undefined;` assignments for
+          // type-only names (ConcreteRequest, ReaderFragment, FragmentRefs…)
+          // that relay-compiler's TypeScript artifacts import as values —
+          // strict ESM-CJS interop (Node ESM, Vite's SSR module runner, Bun)
+          // rejects them otherwise. Real assignments, not a dead-branch lexer
+          // hint: Bun's interop reflects the actual runtime exports object.
+          when(
+            answers.relay && standalone,
+            copy("patches/relay-runtime@21.0.1.patch"),
+          ),
+          // relay-runtime-network: fixes the broken package `imports` map.
+          // Temporary until the fixed upstream release lands (advl/lit-relay#32);
+          // then this patch and its patchedDependencies entry can be dropped.
+          when(
+            answers.relay && standalone,
+            copy("patches/relay-runtime-network@0.1.0.patch"),
+          ),
+
+          // Routes (EJS — conditionally includes contact + catalog domains)
+          template({
+            source: src("src/routes.tsx.ejs"),
+            dest: dest("src/routes.tsx"),
+            vars,
+          }),
+
+          // Lib: Navigation (EJS — contact link only when --forms, catalog
+          // link only when --relay)
+          template({
+            source: src("src/lib/Navigation/Navigation.tsx.ejs"),
+            dest: dest("src/lib/Navigation/Navigation.tsx"),
+            vars,
+          }),
+          copy("src/lib/Navigation/index.ts"),
+
+          // Lib: ThemeSelector
+          copy("src/lib/ThemeSelector/ThemeSelector.tsx"),
+          copy("src/lib/ThemeSelector/index.ts"),
+
+          // Lib: ExampleComponent
+          copy("src/lib/ExampleComponent/ExampleComponent.tsx"),
+          copy("src/lib/ExampleComponent/ExampleComponent.stories.tsx"),
+          copy("src/lib/ExampleComponent/ExampleComponent.tests.tsx"),
+          copy("src/lib/ExampleComponent/index.ts"),
+          copy("src/lib/ExampleComponent/types.ts"),
+          copy("src/lib/ExampleComponent/styles.css"),
+
+          // Lib: LazyComponent
+          copy("src/lib/LazyComponent/LazyComponent.tsx"),
+          copy("src/lib/LazyComponent/LazyComponent.stories.tsx"),
+          copy("src/lib/LazyComponent/index.ts"),
+
+          // Lib: ClientOnly (when --relay is enabled — the catalog page is its
+          // only consumer, keeping Relay queries off the server render until
+          // SSR data serialization/hydration is supported)
+          when(answers.relay, copy("src/lib/ClientOnly/ClientOnly.tsx")),
+          when(answers.relay, copy("src/lib/ClientOnly/ClientOnly.tests.tsx")),
+          when(answers.relay, copy("src/lib/ClientOnly/index.ts")),
+
+          // Lib barrel (EJS — ClientOnly export only when --relay)
+          template({
+            source: src("src/lib/index.ts.ejs"),
+            dest: dest("src/lib/index.ts"),
+            vars,
+          }),
+
+          // Vite types
+          copy("src/vite-env.d.ts"),
+
+          // Storybook
+          // main config (EJS — the relay mocking addon only when --relay)
+          template({
+            source: src(".storybook/main.ts.ejs"),
+            dest: dest(".storybook/main.ts"),
+            vars,
+          }),
+          copy(".storybook/preview.ts"),
+          copy(".storybook/decorators/withRouter.tsx"),
+          copy(".storybook/decorators/index.ts"),
+
+          // Static asset dirs (kept by placeholder; both wired into Storybook staticDirs)
+          copy("src/assets/.gitkeep"),
+          copy("public/.gitkeep"),
+          copy("public/robots.txt"),
+
+          // Install dependencies with the detected package manager, or a no-op
+          // when none was found / the user declined. Built above where `pm` is
+          // narrowed to non-null, so the install command never invents a manager;
+          // the scaffold completes and the closing message says what to run.
+          installTask ?? pure(undefined),
+
+          info(finalMessage),
+        ]);
       });
-
-      // Detect an available package manager for both the (optional) install
-      // step and the closing message, so the suggested commands reflect what's
-      // actually on the machine.
-      const pm = pickPackageManager();
-      // Build the install task only when a package manager was actually found —
-      // this narrows `pm` to non-null, so the install command never invents a
-      // manager. `null` when we won't (or can't) install.
-      const installTask =
-        answers.runInstall && pm !== null
-          ? sequence_([
-              info(`Installing dependencies with ${pm}...`),
-              exec(pm, ["install"], appPath),
-            ])
-          : null;
-      // The closing command only names a package manager we actually found; if
-      // none was detected we don't invent one (previously this suggested `bun`
-      // even on a machine without bun), and instead point the user at the
-      // package-manager step.
-      const finalMessage = installTask
-        ? `Application "${appPath}" created. Run \`cd ${appPath} && ${pm} run dev\` to start.`
-        : pm
-          ? `Application "${appPath}" created. Run \`cd ${appPath} && ${pm} install && ${pm} run dev\` to start.`
-          : `Application "${appPath}" created. Install a package manager (bun, pnpm, npm, or yarn), then run \`cd ${appPath} && <pm> install && <pm> run dev\` to start.`;
-
-      return sequence_([
-        // Refuse to scaffold over an existing directory: every write's default
-        // undo is a delete, so overwrite-then-`--undo` would destroy files the
-        // user owned before the run (the same guard domain/wrapper apply).
-        flatMap(exists(appPath), (present) =>
-          present
-            ? fail({
-                code: "APP_DEST_EXISTS",
-                message:
-                  `"${appPath}" already exists. Scaffolding over it would let ` +
-                  "--undo delete pre-existing files. Choose a different " +
-                  "directory or remove it first.",
-              })
-            : pure(undefined),
-        ),
-        info(`Scaffolding React application in "${appPath}"...`),
-        // The scaffolded package.json composes its scripts with `bun run`; on
-        // a machine where another manager was detected, say so up front.
-        when(
-          pm !== null && pm !== "bun",
-          warn(
-            `Detected ${pm}, but the generated scripts use \`bun run\` — ` +
-              "install bun to run the app's composite scripts.",
-          ),
-        ),
-
-        // EJS templates (files needing interpolation)
-        template({
-          source: src("package.json.ejs"),
-          dest: dest("package.json"),
-          vars,
-        }),
-        template({
-          source: src("README.md.ejs"),
-          dest: dest("README.md"),
-          vars,
-        }),
-        template({
-          source: src("biome.json.ejs"),
-          dest: dest("biome.json"),
-          vars,
-        }),
-
-        // Root config
-        // tsconfig (EJS — #relay path alias only when --relay)
-        template({
-          source: src("tsconfig.json.ejs"),
-          dest: dest("tsconfig.json"),
-          vars,
-        }),
-        // vite config (EJS — vite-plugin-relay-lite only when --relay)
-        template({
-          source: src("vite.config.ts.ejs"),
-          dest: dest("vite.config.ts"),
-          vars,
-        }),
-        copy("vitest.config.ts"),
-        // vitest setup (EJS — relay-test-utils' jest→vi alias only when --relay)
-        template({
-          source: src("vitest.setup.ts.ejs"),
-          dest: dest("vitest.setup.ts"),
-          vars,
-        }),
-        copy("vitest.e2e.config.ts"),
-        // Relay compiler config (validates queries against the mock SDL)
-        when(answers.relay, copy("relay.config.json")),
-        // index.html (EJS — <title> uses the app name)
-        template({
-          source: src("index.html.ejs"),
-          dest: dest("index.html"),
-          vars,
-        }),
-        // The template is stored as `gitignore` (no leading dot): npm strips a
-        // literal `.gitignore` from published tarballs, so we ship it dotless and
-        // restore the dot at write time.
-        copyFile(src("gitignore"), dest(".gitignore")),
-        // The app's browser floor, read by vite.config.ts to derive Lightning
-        // CSS targets. Unlike `.gitignore` above, npm does not strip
-        // `.browserslistrc` from tarballs, so the template keeps its dot.
-        copy(".browserslistrc"),
-
-        // E2e tests (the 2×3 server matrix + its spawn/teardown harness)
-        copy("test/e2e/serverHarness.ts"),
-        copy("test/e2e/servers.e2e.ts"),
-
-        // Styles
-        // styles (EJS — form stylesheet imported only when --forms)
-        template({
-          source: src("src/styles/index.css.ejs"),
-          dest: dest("src/styles/index.css"),
-          vars,
-        }),
-        copy("src/styles/app.css"),
-
-        // Client (EJS — RelayEnvironmentProvider only when --relay)
-        template({
-          source: src("src/client/entry.tsx.ejs"),
-          dest: dest("src/client/entry.tsx"),
-          vars,
-        }),
-
-        // Server — dev (Vite + HMR) and preview (compiled) servers each route
-        // between the app + sitemap renderers; the renderers stay routing-agnostic.
-        // Server entry (EJS — a per-request RelayEnvironmentProvider only when --relay)
-        template({
-          source: src("src/server/entry.tsx.ejs"),
-          dest: dest("src/server/entry.tsx"),
-          vars,
-        }),
-        copy("src/server/renderer.tsx"),
-        copy("src/server/server.express.ts"),
-        copy("src/server/server.bun.ts"),
-        copy("src/server/preview.express.ts"),
-        copy("src/server/preview.bun.ts"),
-
-        // Sitemap (rendered route at /sitemap.xml)
-        copy("src/sitemap/renderer.ts"),
-        // sitemap getters (EJS — /contact entry only when --forms, /catalog
-        // entry only when --relay)
-        template({
-          source: src("src/sitemap/getSitemapItems.ts.ejs"),
-          dest: dest("src/sitemap/getSitemapItems.ts"),
-          vars,
-        }),
-
-        // Domain: marketing
-        copy("src/domains/marketing/HomePage.tsx"),
-        copy("src/domains/marketing/GuidePage.tsx"),
-        copy("src/domains/marketing/routes.ts"),
-
-        // Domain: account
-        copy("src/domains/account/AccountPage.tsx"),
-        copy("src/domains/account/LoginPage.tsx"),
-        copy("src/domains/account/routes.ts"),
-
-        // Domain: contact (when --forms is enabled)
-        when(answers.forms, copy("src/domains/contact/ContactPage.tsx")),
-        when(answers.forms, copy("src/domains/contact/routes.ts")),
-
-        // Relay data layer (when --relay is enabled): environment factory +
-        // executable mock schema, the catalog example domain, and the
-        // ClientOnly SSR guard (whose only consumer today is the catalog page).
-        when(answers.relay, copy("src/relay/schema.graphql")),
-        when(answers.relay, copy("src/relay/schema.ts")),
-        when(answers.relay, copy("src/relay/schema.tests.ts")),
-        when(answers.relay, copy("src/relay/environment.ts")),
-        when(answers.relay, copy("src/relay/environment.tests.ts")),
-        // Committed relay-compiler artifacts — deterministic outputs of the
-        // committed schema + the catalog queries; `bun run relay` regenerates
-        // them in the scaffolded app after any schema or graphql-tag edit.
-        when(
-          answers.relay,
-          copy("src/relay/__generated__/ProductCard_product.graphql.ts"),
-        ),
-        when(
-          answers.relay,
-          copy("src/relay/__generated__/ProductListQuery.graphql.ts"),
-        ),
-
-        // Domain: catalog (when --relay is enabled)
-        when(answers.relay, copy("src/domains/catalog/CatalogPage.tsx")),
-        when(answers.relay, copy("src/domains/catalog/ProductList.tsx")),
-        when(
-          answers.relay,
-          copy("src/domains/catalog/ProductList.stories.tsx"),
-        ),
-        when(answers.relay, copy("src/domains/catalog/ProductList.tests.tsx")),
-        when(answers.relay, copy("src/domains/catalog/ProductCard.tsx")),
-        when(answers.relay, copy("src/domains/catalog/ErrorBoundary.tsx")),
-        when(
-          answers.relay,
-          copy("src/domains/catalog/ErrorBoundary.tests.tsx"),
-        ),
-        when(answers.relay, copy("src/domains/catalog/routes.ts")),
-
-        // Standalone dependency patches (when --relay is enabled): a
-        // standalone app cannot inherit a workspace's patches/, so they ship
-        // with the scaffold and are applied via "patchedDependencies" in
-        // package.json. Inside a bun workspace the WORKSPACE ROOT owns
-        // patching — bun resolves patch paths from the root, so an app-local
-        // block would abort `bun install` ("Couldn't find patch file") —
-        // hence neither patches/ nor patchedDependencies are emitted there.
-        when(
-          answers.relay && !standalone,
-          info(
-            `Scaffolding into the bun workspace at "${workspaceRoot}" — ` +
-              "dependency patches are owned by the workspace root, so no " +
-              "app-local patches/ or patchedDependencies were emitted. " +
-              "Ensure the workspace root patches react-relay, relay-runtime " +
-              "and relay-runtime-network (see the app README).",
-          ),
-        ),
-        // react-relay: cjs-module-lexer export hints so named imports survive
-        // Node SSR externalisation.
-        when(
-          answers.relay && standalone,
-          copy("patches/react-relay@21.0.1.patch"),
-        ),
-        // relay-runtime: real `module.exports.X = undefined;` assignments for
-        // type-only names (ConcreteRequest, ReaderFragment, FragmentRefs…)
-        // that relay-compiler's TypeScript artifacts import as values —
-        // strict ESM-CJS interop (Node ESM, Vite's SSR module runner, Bun)
-        // rejects them otherwise. Real assignments, not a dead-branch lexer
-        // hint: Bun's interop reflects the actual runtime exports object.
-        when(
-          answers.relay && standalone,
-          copy("patches/relay-runtime@21.0.1.patch"),
-        ),
-        // relay-runtime-network: fixes the broken package `imports` map.
-        // Temporary until the fixed upstream release lands (advl/lit-relay#32);
-        // then this patch and its patchedDependencies entry can be dropped.
-        when(
-          answers.relay && standalone,
-          copy("patches/relay-runtime-network@0.1.0.patch"),
-        ),
-
-        // Routes (EJS — conditionally includes contact + catalog domains)
-        template({
-          source: src("src/routes.tsx.ejs"),
-          dest: dest("src/routes.tsx"),
-          vars,
-        }),
-
-        // Lib: Navigation (EJS — contact link only when --forms, catalog
-        // link only when --relay)
-        template({
-          source: src("src/lib/Navigation/Navigation.tsx.ejs"),
-          dest: dest("src/lib/Navigation/Navigation.tsx"),
-          vars,
-        }),
-        copy("src/lib/Navigation/index.ts"),
-
-        // Lib: ThemeSelector
-        copy("src/lib/ThemeSelector/ThemeSelector.tsx"),
-        copy("src/lib/ThemeSelector/index.ts"),
-
-        // Lib: ExampleComponent
-        copy("src/lib/ExampleComponent/ExampleComponent.tsx"),
-        copy("src/lib/ExampleComponent/ExampleComponent.stories.tsx"),
-        copy("src/lib/ExampleComponent/ExampleComponent.tests.tsx"),
-        copy("src/lib/ExampleComponent/index.ts"),
-        copy("src/lib/ExampleComponent/types.ts"),
-        copy("src/lib/ExampleComponent/styles.css"),
-
-        // Lib: LazyComponent
-        copy("src/lib/LazyComponent/LazyComponent.tsx"),
-        copy("src/lib/LazyComponent/LazyComponent.stories.tsx"),
-        copy("src/lib/LazyComponent/index.ts"),
-
-        // Lib: ClientOnly (when --relay is enabled — the catalog page is its
-        // only consumer, keeping Relay queries off the server render until
-        // SSR data serialization/hydration is supported)
-        when(answers.relay, copy("src/lib/ClientOnly/ClientOnly.tsx")),
-        when(answers.relay, copy("src/lib/ClientOnly/ClientOnly.tests.tsx")),
-        when(answers.relay, copy("src/lib/ClientOnly/index.ts")),
-
-        // Lib barrel (EJS — ClientOnly export only when --relay)
-        template({
-          source: src("src/lib/index.ts.ejs"),
-          dest: dest("src/lib/index.ts"),
-          vars,
-        }),
-
-        // Vite types
-        copy("src/vite-env.d.ts"),
-
-        // Storybook
-        // main config (EJS — the relay mocking addon only when --relay)
-        template({
-          source: src(".storybook/main.ts.ejs"),
-          dest: dest(".storybook/main.ts"),
-          vars,
-        }),
-        copy(".storybook/preview.ts"),
-        copy(".storybook/decorators/withRouter.tsx"),
-        copy(".storybook/decorators/index.ts"),
-
-        // Static asset dirs (kept by placeholder; both wired into Storybook staticDirs)
-        copy("src/assets/.gitkeep"),
-        copy("public/.gitkeep"),
-        copy("public/robots.txt"),
-
-        // Install dependencies with the detected package manager, or a no-op
-        // when none was found / the user declined. Built above where `pm` is
-        // narrowed to non-null, so the install command never invents a manager;
-        // the scaffold completes and the closing message says what to run.
-        installTask ?? pure(undefined),
-
-        info(finalMessage),
-      ]);
     });
   },
 };

--- a/packages/summon/application/src/application/react/templates/package.json.ejs
+++ b/packages/summon/application/src/application/react/templates/package.json.ejs
@@ -60,9 +60,9 @@
 <% } -%>
     "react": "^19.2.4",
     "react-dom": "^19.2.4"<% if (relay) { %>,
-    "react-relay": "^21.0.1",
-    "relay-runtime": "^21.0.1",
-    "relay-runtime-network": "^0.1.0"<% } %>
+    "react-relay": "21.0.1",
+    "relay-runtime": "21.0.1",
+    "relay-runtime-network": "0.1.0"<% } %>
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.9",

--- a/packages/summon/application/src/domain/index.ts
+++ b/packages/summon/application/src/domain/index.ts
@@ -15,6 +15,7 @@ import {
 import { toCamelCase, toTitleCase } from "@canonical/utils";
 import { normalizeCommandPath } from "../shared/casing.js";
 import { packageVersion } from "../shared/packageVersion.js";
+import { validateCommandPath } from "../shared/validators.js";
 import { printVersions } from "../shared/versions.js";
 
 export interface DomainAnswers {
@@ -28,6 +29,11 @@ const prompts: PromptDefinition[] = [
     message: "Domain name (for example billing):",
     default: "example",
     positional: true,
+    validate: validateCommandPath({
+      label: "Domain name",
+      maxSegments: 1,
+      example: "billing",
+    }),
     group: "Domain",
   },
 ];

--- a/packages/summon/application/src/index.test.ts
+++ b/packages/summon/application/src/index.test.ts
@@ -9,7 +9,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { dryRun, sequence_ } from "@canonical/task";
+import { dryRun, dryRunWith, type Effect, sequence_ } from "@canonical/task";
 import { describe, expect, it } from "vitest";
 import { generators } from "./index.js";
 
@@ -378,6 +378,24 @@ describe("application/react generator", () => {
 
     expect(filePaths).toContain("custom-app/package.json");
     expect(filePaths).toContain("custom-app/src/client/entry.tsx");
+  });
+
+  it("refuses to scaffold over an existing directory", () => {
+    // Every write's default undo is a delete, so overwrite-then-`--undo`
+    // would destroy pre-existing files — the guard must hard-fail, not warn.
+    const task = generators["application/react"].generate({
+      appPath: "my-app",
+      ssr: true,
+      router: true,
+      forms: false,
+      relay: false,
+      runInstall: false,
+    });
+    const mocks = new Map<string, (effect: Effect) => unknown>([
+      ["Exists", (e) => (e as { path: string }).path === "my-app"],
+    ]);
+
+    expect(() => dryRunWith(task, mocks)).toThrow(/already exists/);
   });
 
   it("throws when --ssr is false", () => {

--- a/packages/summon/application/src/route/index.ts
+++ b/packages/summon/application/src/route/index.ts
@@ -15,6 +15,7 @@ import {
 import { toCamelCase, toPascalCase, toTitleCase } from "@canonical/utils";
 import { normalizeCommandPath } from "../shared/casing.js";
 import { packageVersion } from "../shared/packageVersion.js";
+import { validateCommandPath } from "../shared/validators.js";
 import { insertRoute, removeRoute } from "./insertRoute.js";
 
 export interface RouteAnswers {
@@ -28,6 +29,11 @@ const prompts: PromptDefinition[] = [
     message: "Route path (for example account/settings):",
     default: "example/page",
     positional: true,
+    validate: validateCommandPath({
+      label: "Route path",
+      minSegments: 2,
+      example: "account/settings",
+    }),
     group: "Route",
   },
 ];
@@ -89,9 +95,10 @@ route key already existed) would remove a route you already had.`,
     const segments = normalized.split("/");
 
     if (segments.length < 2) {
-      throw new Error(
-        `Route path must include a domain and route name (e.g. "account/settings"), got "${normalized}"`,
-      );
+      return fail({
+        code: "ROUTE_PATH_INVALID",
+        message: `Route path must include a domain and route name (e.g. "account/settings"), got "${normalized}"`,
+      });
     }
 
     const domainName = segments[0];

--- a/packages/summon/application/src/route/insertRoute.test.ts
+++ b/packages/summon/application/src/route/insertRoute.test.ts
@@ -83,6 +83,43 @@ describe("removeRoute", () => {
     expect(back).not.toContain("InvoicesPage");
   });
 
+  it("removes a property from a single-line routes object without corrupting it", () => {
+    // Whole-line removal deleted the line carrying `} as const;` here, leaving
+    // unparseable source; removal must be span-based when code shares the line.
+    const singleLine = `const routes = { billing: route({ url: "/billing", content: MainPage }) } as const;\n`;
+    const added = insertRoute(singleLine, INS);
+    const back = removeRoute(added, INS);
+
+    const sf = ts.createSourceFile("r.ts", back, ts.ScriptTarget.Latest, true);
+    // @ts-expect-error parseDiagnostics is internal but reliable for this check
+    expect(sf.parseDiagnostics).toHaveLength(0);
+    expect(back).toContain("billing: route({");
+    expect(back).toContain("} as const;");
+    expect(back).not.toContain("invoices: route({");
+  });
+
+  it("round-trips an initially empty single-line routes object", () => {
+    const emptyObject = "const routes = {} as const;\n";
+    const added = insertRoute(emptyObject, INS);
+    const back = removeRoute(added, INS);
+
+    const sf = ts.createSourceFile("r.ts", back, ts.ScriptTarget.Latest, true);
+    // @ts-expect-error parseDiagnostics is internal but reliable for this check
+    expect(sf.parseDiagnostics).toHaveLength(0);
+    expect(back).not.toContain("invoices");
+  });
+
+  it("removes the last property of a multi-line object left without a trailing comma", () => {
+    const source = `import MainPage from "./MainPage.js";\nimport InvoicesPage from "./InvoicesPage.js";\n\nconst routes = {\n  billing: route({ url: "/billing", content: MainPage }),\n  invoices: route({ url: "/billing/invoices", content: InvoicesPage })\n} as const;\n`;
+    const back = removeRoute(source, INS);
+
+    const sf = ts.createSourceFile("r.ts", back, ts.ScriptTarget.Latest, true);
+    // @ts-expect-error parseDiagnostics is internal but reliable for this check
+    expect(sf.parseDiagnostics).toHaveLength(0);
+    expect(back).toContain("billing: route({");
+    expect(back).not.toContain("invoices: route({");
+  });
+
   it("does NOT delete a merged import that has named bindings", () => {
     // A user may have merged named bindings into the generated import. removing
     // the whole line would discard them, so removeRoute leaves it alone.

--- a/packages/summon/application/src/route/insertRoute.ts
+++ b/packages/summon/application/src/route/insertRoute.ts
@@ -180,7 +180,7 @@ export function removeRoute(
           p.name.text === ins.routeKey,
       );
       if (prop) {
-        result = removeFullLines(result, prop.getStart(sf), prop.end);
+        result = removePropertySpan(result, prop.getStart(sf), prop.end);
       }
     }
   }
@@ -203,7 +203,7 @@ export function removeRoute(
       // would discard their bindings.
       !stmt.importClause.namedBindings
     ) {
-      result = removeFullLines(result, stmt.getStart(sf2), stmt.end);
+      result = removeLinesOrSpan(result, stmt.getStart(sf2), stmt.end);
       break;
     }
   }
@@ -212,15 +212,49 @@ export function removeRoute(
 }
 
 /**
- * Remove the whole-line span covering [start, end), including the node's
- * leading indentation and its trailing newline, so no blank line is left behind.
+ * Remove a property node's span [start, end) plus its separator comma: the
+ * trailing comma when one follows, otherwise the preceding one (the
+ * last-property case), so the object literal stays syntactically valid.
  */
-function removeFullLines(source: string, start: number, end: number): string {
+function removePropertySpan(
+  source: string,
+  start: number,
+  end: number,
+): string {
+  let spanStart = start;
+  let spanEnd = end;
+  let after = spanEnd;
+  while (after < source.length && /\s/.test(source.charAt(after))) after++;
+  if (source.charAt(after) === ",") {
+    spanEnd = after + 1;
+  } else {
+    let before = spanStart - 1;
+    while (before >= 0 && /\s/.test(source.charAt(before))) before--;
+    if (source.charAt(before) === ",") spanStart = before;
+  }
+  return removeLinesOrSpan(source, spanStart, spanEnd);
+}
+
+/**
+ * Remove [start, end): as whole lines (including leading indentation and the
+ * trailing newline, so no blank line is left behind) when the span owns its
+ * lines — but as an exact span when other code shares a line with it, so a
+ * single-line `const routes = { billing: route(...) } as const;` loses only
+ * the property, never the code around it.
+ */
+function removeLinesOrSpan(source: string, start: number, end: number): string {
   const lineStart = source.lastIndexOf("\n", start - 1) + 1;
-  let lineEnd = source.indexOf("\n", end);
-  if (lineEnd === -1) lineEnd = source.length;
-  else lineEnd += 1; // include the newline
-  return source.slice(0, lineStart) + source.slice(lineEnd);
+  const newlineAfter = source.indexOf("\n", end);
+  const lineEnd = newlineAfter === -1 ? source.length : newlineAfter + 1;
+  const leading = source.slice(lineStart, start);
+  const trailing = source.slice(
+    end,
+    newlineAfter === -1 ? source.length : newlineAfter,
+  );
+  if (/^\s*$/.test(leading) && /^\s*$/.test(trailing)) {
+    return source.slice(0, lineStart) + source.slice(lineEnd);
+  }
+  return source.slice(0, start) + source.slice(end);
 }
 
 /** Detect the indentation used by the first property of the object literal. */

--- a/packages/summon/application/src/shared/validators.test.ts
+++ b/packages/summon/application/src/shared/validators.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { validateAppPath, validateCommandPath } from "./validators.js";
+
+describe("validateCommandPath", () => {
+  const routePath = validateCommandPath({
+    label: "Route path",
+    minSegments: 2,
+    example: "account/settings",
+  });
+  const singleName = validateCommandPath({
+    label: "Domain name",
+    maxSegments: 1,
+    example: "billing",
+  });
+
+  it("accepts well-formed paths", () => {
+    expect(routePath("account/settings")).toBe(true);
+    expect(routePath(" /billing/invoices/ ")).toBe(true);
+    expect(singleName("billing")).toBe(true);
+    expect(singleName("my-domain")).toBe(true);
+  });
+
+  it("rejects empty or non-string values", () => {
+    expect(routePath("")).toContain("required");
+    expect(routePath("   ")).toContain("required");
+    expect(routePath(undefined)).toContain("required");
+    expect(routePath("///")).toContain("required");
+  });
+
+  it("enforces the minimum segment count", () => {
+    expect(routePath("settings")).toContain("at least 2");
+  });
+
+  it("enforces the maximum segment count", () => {
+    expect(singleName("a/b")).toContain("single name");
+  });
+
+  it("rejects segments that would not survive as identifiers", () => {
+    // toPascalCase("2fa") keeps the leading digit → `function 2faPage()`.
+    expect(routePath("account/2fa")).toContain('"2fa"');
+    expect(routePath("account/se ttings")).not.toBe(true);
+    expect(singleName("_billing")).not.toBe(true);
+  });
+});
+
+describe("validateAppPath", () => {
+  it("accepts relative directory paths", () => {
+    expect(validateAppPath("my-app")).toBe(true);
+    expect(validateAppPath("apps/my-app")).toBe(true);
+  });
+
+  it("rejects empty, absolute, and traversal paths", () => {
+    expect(validateAppPath("")).toContain("required");
+    expect(validateAppPath(undefined)).toContain("required");
+    expect(validateAppPath("/tmp/app")).toContain("relative");
+    expect(validateAppPath("C:\\apps\\x")).toContain("relative");
+    expect(validateAppPath("../escape")).toContain('".."');
+    expect(validateAppPath("a//b")).not.toBe(true);
+  });
+});

--- a/packages/summon/application/src/shared/validators.ts
+++ b/packages/summon/application/src/shared/validators.ts
@@ -1,0 +1,74 @@
+import { normalizeCommandPath } from "./casing.js";
+
+/**
+ * A path segment that survives the casing helpers as a valid JS identifier:
+ * it must start with a letter (a leading digit would emit code like
+ * `function 2faPage()`), and stay within letters/digits/hyphens so
+ * toPascalCase/toCamelCase have something well-formed to work on.
+ */
+const SEGMENT = /^[A-Za-z][A-Za-z0-9-]*$/;
+
+/**
+ * Build a `PromptDefinition.validate` for a slash-separated command path
+ * (`billing`, `account/settings`). Returns `true | string` per the prompt
+ * contract; never throws.
+ */
+export function validateCommandPath(options: {
+  /** Human label for messages, e.g. "Route path". */
+  label: string;
+  /** Minimum segment count (route needs domain/name = 2). */
+  minSegments?: number;
+  /** Maximum segment count (a domain or wrapper name is a single segment). */
+  maxSegments?: number;
+  /** Example shown in error messages. */
+  example: string;
+}): (value: unknown) => true | string {
+  const { label, minSegments = 1, maxSegments, example } = options;
+  return (value: unknown): true | string => {
+    if (typeof value !== "string" || value.trim() === "") {
+      return `${label} is required (for example ${example})`;
+    }
+    const normalized = normalizeCommandPath(value);
+    if (normalized === "") {
+      return `${label} is required (for example ${example})`;
+    }
+    const segments = normalized.split("/");
+    if (segments.length < minSegments) {
+      return `${label} needs at least ${minSegments} segments (for example ${example})`;
+    }
+    if (maxSegments !== undefined && segments.length > maxSegments) {
+      return `${label} must be a single name without slashes (for example ${example})`;
+    }
+    for (const segment of segments) {
+      if (!SEGMENT.test(segment)) {
+        return (
+          `${label} segment "${segment}" must start with a letter and use ` +
+          `only letters, digits, and hyphens (for example ${example})`
+        );
+      }
+    }
+    return true;
+  };
+}
+
+/**
+ * Validate the application directory path: non-empty, relative, and free of
+ * `..` traversal — the generator writes an entire tree under it.
+ */
+export function validateAppPath(value: unknown): true | string {
+  if (typeof value !== "string" || value.trim() === "") {
+    return "Application directory is required (for example my-app)";
+  }
+  const trimmed = value.trim();
+  if (trimmed.startsWith("/") || /^[A-Za-z]:[\\/]/.test(trimmed)) {
+    return "Application directory must be a relative path";
+  }
+  const segments = trimmed.replace(/\\/g, "/").split("/");
+  if (segments.some((segment) => segment === "..")) {
+    return 'Application directory must not contain ".."';
+  }
+  if (segments.some((segment) => segment === "" || segment === ".")) {
+    return "Application directory must not contain empty or '.' segments";
+  }
+  return true;
+}

--- a/packages/summon/application/src/shared/versions.test.ts
+++ b/packages/summon/application/src/shared/versions.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ownVersion, readVersion } from "./versions.js";
+
+const SEMVER = /^\d+\.\d+\.\d+/;
+
+describe("versions", () => {
+  it("resolves this generator's own version from its manifest", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf-8"),
+    ) as { version: string };
+
+    expect(ownVersion()).toBe(manifest.version);
+  });
+
+  it("resolves an installed package's version without a ./package.json export", () => {
+    // require("<pkg>/package.json") throws ERR_PACKAGE_PATH_NOT_EXPORTED for
+    // every workspace package; the resolve-and-walk path must still answer.
+    expect(readVersion("@canonical/summon-core")).toMatch(SEMVER);
+    expect(readVersion("@canonical/task")).toMatch(SEMVER);
+  });
+
+  it('answers "unknown" for a package that is not installed', () => {
+    expect(readVersion("@canonical/definitely-not-installed")).toBe("unknown");
+  });
+});

--- a/packages/summon/application/src/shared/versions.ts
+++ b/packages/summon/application/src/shared/versions.ts
@@ -1,4 +1,6 @@
-import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ExecResult, Task } from "@canonical/task";
 import { exec, flatMap, info, map, pure, recover } from "@canonical/task";
 
@@ -25,8 +27,6 @@ import { exec, flatMap, info, map, pure, recover } from "@canonical/task";
  *    fresh as the generator binary in use.
  */
 
-const require = createRequire(import.meta.url);
-
 /**
  * A representative workspace package whose `latest` dist-tag tracks the shared
  * lerna release line. Any of the co-released packages would do; styles is a
@@ -34,28 +34,103 @@ const require = createRequire(import.meta.url);
  */
 const REPRESENTATIVE_PACKAGE = "@canonical/styles";
 
-/** Read a package's version from the installed tree (offline fallback). */
-function readVersion(packageName: string): string {
-  try {
-    const pkg = require(`${packageName}/package.json`);
-    return pkg.version ?? "unknown";
-  } catch {
-    return "unknown";
+const OWN_PACKAGE = "@canonical/summon-application";
+
+/**
+ * Walk up from `from` until a `package.json` names `packageName`, and return
+ * its version. A manifest that is unreadable, is not JSON, names another
+ * package, or carries no version is just an ancestor directory that happens to
+ * hold a `package.json`, so the walk continues; running out of parents yields
+ * "unknown".
+ *
+ * @note Impure — reads the filesystem.
+ */
+function findVersionAbove(from: string, packageName: string): string {
+  let dir = from;
+  for (;;) {
+    try {
+      const manifest = JSON.parse(
+        readFileSync(path.join(dir, "package.json"), "utf-8"),
+      ) as { name?: string; version?: string };
+      if (manifest.name === packageName && manifest.version) {
+        return manifest.version;
+      }
+    } catch {
+      // No readable manifest at this level — keep walking.
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return "unknown";
+    }
+    dir = parent;
   }
+}
+
+/**
+ * Read an installed package's version. Not `require("<pkg>/package.json")`:
+ * none of the workspace packages export `./package.json` (and their ESM-only
+ * exports maps make `require.resolve` itself throw), so module resolution is
+ * avoided entirely — the standard `node_modules/<name>/package.json` location
+ * is probed at each ancestor of this module instead, exactly the way node
+ * itself would look the package up.
+ *
+ * @note Impure — reads the filesystem.
+ */
+export function readVersion(packageName: string): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (;;) {
+    try {
+      const manifest = JSON.parse(
+        readFileSync(
+          path.join(
+            dir,
+            "node_modules",
+            ...packageName.split("/"),
+            "package.json",
+          ),
+          "utf-8",
+        ),
+      ) as { version?: string };
+      if (manifest.version) {
+        return manifest.version;
+      }
+    } catch {
+      // No such package at this level — keep walking.
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return "unknown";
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * This generator's own version, read by walking up from THIS module — correct
+ * from `src/` and from `dist/esm/` alike, with no build-layout coupling (see
+ * summon-package's packageVersion for the full rationale). Lazy and cached so
+ * importing this module performs no IO.
+ */
+let cachedOwnVersion: string | undefined;
+export function ownVersion(): string {
+  cachedOwnVersion ??= findVersionAbove(
+    path.dirname(fileURLToPath(import.meta.url)),
+    OWN_PACKAGE,
+  );
+  return cachedOwnVersion;
 }
 
 /**
  * The generator's own release-line version, used as the offline fallback range.
  * summon-application is published in lockstep with the workspace packages an app
- * depends on, so `^<own version>` is a safe, non-stale default.
+ * depends on, so `^<own version>` is a safe, non-stale default. The module
+ * always sits inside its own package, so the walk cannot miss in practice; the
+ * "latest" escape survives only as a last resort for a mangled installation.
  */
 function fallbackRange(): string {
-  const own = readVersion("@canonical/summon-application");
+  const own = ownVersion();
   return own === "unknown" ? "latest" : `^${own}`;
 }
-
-const coreVersion = readVersion("@canonical/summon-core");
-const appVersion = readVersion("@canonical/summon-application");
 
 const SEMVER = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
 
@@ -68,7 +143,6 @@ const SEMVER = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
  * @note Impure — spawns `npm` and reads the registry over the network.
  */
 export function resolvePragmaVersion(): Task<string> {
-  const fallback = fallbackRange();
   return flatMap(
     // A missing `npm` binary makes the spawn reject (a task failure) rather
     // than resolve with a nonzero exit code, so recover to a synthetic failed
@@ -89,6 +163,7 @@ export function resolvePragmaVersion(): Task<string> {
           () => `^${latest}`,
         );
       }
+      const fallback = fallbackRange();
       return map(
         info(
           `Could not reach npm for the latest @canonical/* version; ` +
@@ -105,7 +180,7 @@ export function resolvePragmaVersion(): Task<string> {
  */
 export function printVersions(generatorName: string): Task<void> {
   return info(
-    `@canonical/summon-core         ${coreVersion}\n` +
-      `@canonical/summon-application  ${appVersion}  (${generatorName})`,
+    `@canonical/summon-core         ${readVersion("@canonical/summon-core")}\n` +
+      `@canonical/summon-application  ${ownVersion()}  (${generatorName})`,
   );
 }

--- a/packages/summon/application/src/shared/workspace.test.ts
+++ b/packages/summon/application/src/shared/workspace.test.ts
@@ -31,6 +31,21 @@ afterEach(() => {
 });
 
 describe("findEnclosingWorkspaceRoot", () => {
+  it("treats a pnpm-workspace.yaml directory as an enclosing root", () => {
+    // pnpm declares members in pnpm-workspace.yaml, not package.json
+    // `workspaces` — a pnpm root misread as "standalone" would emit an
+    // app-local bun-only patch block the root never applies.
+    const root = createFixture();
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      path.join(root, "pnpm-workspace.yaml"),
+      "packages:\n  - apps/*\n",
+    );
+    expect(findEnclosingWorkspaceRoot(path.join(root, "apps", "my-app"))).toBe(
+      root,
+    );
+  });
+
   it("returns the root whose globs cover the app directory", () => {
     const root = createFixture();
     writeManifest(root, { name: "ws", workspaces: ["apps/*"] });

--- a/packages/summon/application/src/shared/workspace.test.ts
+++ b/packages/summon/application/src/shared/workspace.test.ts
@@ -46,6 +46,26 @@ describe("findEnclosingWorkspaceRoot", () => {
     );
   });
 
+  it("does not claim a descendant the pnpm member patterns exclude", () => {
+    // Membership is decided by the `packages` patterns, not by ancestry: a
+    // path outside them (or negated) is standalone and keeps its patches.
+    const root = createFixture();
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      path.join(root, "pnpm-workspace.yaml"),
+      "packages:\n  - apps/*\n  - '!apps/excluded'\n",
+    );
+    expect(
+      findEnclosingWorkspaceRoot(path.join(root, "packages", "my-app")),
+    ).toBeNull();
+    expect(
+      findEnclosingWorkspaceRoot(path.join(root, "apps", "excluded")),
+    ).toBeNull();
+    expect(findEnclosingWorkspaceRoot(path.join(root, "apps", "member"))).toBe(
+      root,
+    );
+  });
+
   it("returns the root whose globs cover the app directory", () => {
     const root = createFixture();
     writeManifest(root, { name: "ws", workspaces: ["apps/*"] });

--- a/packages/summon/application/src/shared/workspace.ts
+++ b/packages/summon/application/src/shared/workspace.ts
@@ -57,6 +57,42 @@ function readWorkspaceGlobs(manifestPath: string): readonly string[] | null {
   return patterns.length > 0 ? patterns : null;
 }
 
+/**
+ * Read the member patterns from a `pnpm-workspace.yaml` with a minimal
+ * parser: the top-level `packages:` block's `- pattern` items (quoted or
+ * bare, `!`-negations preserved). Returns `null` when the file is missing,
+ * unreadable, or declares no patterns — a malformed file up the tree must
+ * not break scaffolding, and full YAML is deliberately out of scope.
+ *
+ * @note Impure — reads the filesystem.
+ */
+function readPnpmWorkspaceGlobs(yamlPath: string): readonly string[] | null {
+  let content: string;
+  try {
+    content = readFileSync(yamlPath, "utf8");
+  } catch {
+    return null;
+  }
+  const patterns: string[] = [];
+  let inPackages = false;
+  for (const line of content.split("\n")) {
+    if (/^packages\s*:/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    // A new top-level key ends the block.
+    if (inPackages && /^\S/.test(line)) {
+      break;
+    }
+    if (!inPackages) continue;
+    const item = /^\s*-\s*(['"]?)(.+?)\1\s*$/.exec(line);
+    if (item?.[2]) {
+      patterns.push(item[2]);
+    }
+  }
+  return patterns.length > 0 ? patterns : null;
+}
+
 /** Escape a literal glob segment for regex use, keeping `*`/`?` wildcards. */
 function compileGlobSegment(segment: string): string {
   return segment
@@ -128,12 +164,28 @@ export function findEnclosingWorkspaceRoot(
       }
     }
     // A pnpm workspace declares its members in pnpm-workspace.yaml, not in
-    // package.json `workspaces` — treat such a root as enclosing without
-    // parsing the YAML (member globs are overwhelmingly directory-wide, and
-    // misclassifying a pnpm root as "standalone" emits an app-local bun-only
-    // patch block the root would never apply).
-    if (existsSync(path.join(current, "pnpm-workspace.yaml"))) {
-      return current;
+    // package.json `workspaces`. Membership is decided by its `packages`
+    // patterns (including `!` exclusions), so match them rather than claiming
+    // every descendant — a non-member below a pnpm root is standalone and
+    // still needs its app-local patches.
+    const pnpmGlobs = readPnpmWorkspaceGlobs(
+      path.join(current, "pnpm-workspace.yaml"),
+    );
+    if (pnpmGlobs !== null) {
+      const relativePath = path
+        .relative(current, target)
+        .split(path.sep)
+        .join("/");
+      const includes = pnpmGlobs.filter((glob) => !glob.startsWith("!"));
+      const excludes = pnpmGlobs
+        .filter((glob) => glob.startsWith("!"))
+        .map((glob) => glob.slice(1));
+      if (
+        coversRelativePath(includes, relativePath) &&
+        !coversRelativePath(excludes, relativePath)
+      ) {
+        return current;
+      }
     }
     const parent = path.dirname(current);
     if (parent === current) return null;

--- a/packages/summon/application/src/shared/workspace.ts
+++ b/packages/summon/application/src/shared/workspace.ts
@@ -127,6 +127,14 @@ export function findEnclosingWorkspaceRoot(
         if (coversRelativePath(globs, relativePath)) return current;
       }
     }
+    // A pnpm workspace declares its members in pnpm-workspace.yaml, not in
+    // package.json `workspaces` — treat such a root as enclosing without
+    // parsing the YAML (member globs are overwhelmingly directory-wide, and
+    // misclassifying a pnpm root as "standalone" emits an app-local bun-only
+    // patch block the root would never apply).
+    if (existsSync(path.join(current, "pnpm-workspace.yaml"))) {
+      return current;
+    }
     const parent = path.dirname(current);
     if (parent === current) return null;
     current = parent;

--- a/packages/summon/application/src/wrapper/index.ts
+++ b/packages/summon/application/src/wrapper/index.ts
@@ -15,6 +15,7 @@ import {
 import { toKebabCase, toPascalCase } from "@canonical/utils";
 import { normalizeCommandPath } from "../shared/casing.js";
 import { packageVersion } from "../shared/packageVersion.js";
+import { validateCommandPath } from "../shared/validators.js";
 
 export interface WrapperAnswers {
   readonly wrapperName: string;
@@ -27,6 +28,11 @@ const prompts: PromptDefinition[] = [
     message: "Wrapper name (for example settings):",
     default: "example",
     positional: true,
+    validate: validateCommandPath({
+      label: "Wrapper name",
+      maxSegments: 1,
+      example: "settings",
+    }),
     group: "Wrapper",
   },
 ];


### PR DESCRIPTION
## Done

Generated-output and correctness fixes for `summon-application` found by the summon audit:

- **Version resolution's offline fallback could never work.** `readVersion` used `require("<pkg>/package.json")`, which throws `ERR_PACKAGE_PATH_NOT_EXPORTED` for every workspace package — offline scaffolds pinned `@canonical/*` deps to `"latest"` and the version table printed `unknown`. Versions now come from probing `node_modules/<name>/package.json` up the ancestry, and the generator's own version from a manifest walk-up (correct from `src/` and `dist/esm` alike, no IO at import).
- **`removeRoute` (route `--undo`) corrupted single-line routes files.** Whole-line removal deleted the line carrying `} as const;`. Removal is now span-based (property + separator comma), upgrading to whole-line removal only when the span owns its lines — multi-line files still round-trip byte-identically; single-line and last-property-no-comma shapes stay parseable (new tests).
- **Inputs are validated.** No prompt in the package had a `validate` — `summon route account/2fa` emitted `function 2faPage()` (invalid JS). All four generators now validate path/name inputs; segments must survive the casing helpers as identifiers, and the app path must be relative and traversal-free.
- **`application/react` refuses to scaffold over an existing directory** (coded failure instead of a warning): every write's default undo is a delete, so overwrite-then-`--undo` destroyed pre-existing user files — the guard domain/wrapper already had. Answer-shape guards now `fail()` with codes instead of raw throws, and a warning names the detected package manager when it isn't bun (the scaffolded scripts compose with `bun run`).
- **pnpm workspaces are recognized as workspace roots** (`pnpm-workspace.yaml`): previously a pnpm app classified as standalone and received an app-local, bun-only `patchedDependencies` block its root would never apply. Relay deps are now **pinned exactly** (`21.0.1`, not `^21.0.1`) so an upstream patch release can't silently detach the patch keys from the resolved versions.
- README: the route generator's docs described the old append-a-TODO flow; they now describe the AST insertion and its exact-inverse undo.

## QA

- `bun run check` passes from the repo root; `bun run test` passes everywhere except the three svelte app packages, which fail on this machine at Playwright browser launch over missing system libraries — a pre-existing environment-only failure unrelated to this diff.
- New tests: validators (segments/min/max/identifier rules, app-path traversal), version resolution (own version matches the manifest; installed packages resolve without a `./package.json` export; absent packages answer "unknown"), single-line + last-property `removeRoute` round-trips, the dest-exists guard, and the pnpm-workspace root case.

### PR readiness check

- [x] PR label: `Bug 🐛`
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

n/a

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
