### PR TITLE
fix(summon-monorepo): working publish auth, honest metadata, resolvable root deps

### DIFF
--- a/packages/summon/monorepo/README.md
+++ b/packages/summon/monorepo/README.md
@@ -52,7 +52,7 @@ summon monorepo --name=my-project --description="My awesome project"
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `name` | string | _(required)_ | Monorepo name (kebab-case) |
+| `name` | string | `my-monorepo` | Monorepo name (kebab-case), used as-is |
 | `description` | string | `""` | Description |
 | `license` | `LGPL-3.0` \| `GPL-3.0` | `LGPL-3.0` | Root license |
 | `typescriptConfig` | string | `@canonical/typescript-config-base` | Shared TypeScript config |
@@ -69,20 +69,20 @@ summon monorepo --name=my-project --description="My awesome project"
 | Module system | ESM (`"type": "module"`) |
 | Build output | `dist/esm/` + `dist/types/` |
 | Test runner | Vitest with v8 coverage |
-| Test file pattern | `*.tests.ts` (plural) |
+| Test file pattern | `*.test.ts` |
 | Linter/formatter | Biome via `@canonical/biome-config` |
 | Versioning | Lerna fixed mode |
 | Orchestration | Lerna + Nx caching |
 | CI | Two parallel jobs (check + build-and-test) |
 | PR lint | Conventional commits (`amannn/action-semantic-pull-request@v6`) |
 | Merge strategy | Squash merge with PR title |
-| Release | `tag.yml` workflow_dispatch with `NPM_AUTH_TOKEN` |
+| Release | `tag.yml` workflow_dispatch, npm OIDC trusted publishing |
 
 ## Post-Setup Actions
 
 After running the generator:
 
-1. **Configure `NPM_AUTH_TOKEN` secret** in GitHub repo settings
+1. **Configure npm trusted publishers** for each package (repo + `tag.yml`) after its first manual publish
 2. **Configure squash merge** as the default (or only) merge strategy
 3. **Set "Default commit message"** to "Pull request title"
 4. **Generate initial changelogs** (optional): `bun run lerna version --conventional-commits --no-git-tag-version --no-push --yes`

--- a/packages/summon/monorepo/README.md
+++ b/packages/summon/monorepo/README.md
@@ -55,7 +55,7 @@ summon monorepo --name=my-project --description="My awesome project"
 | `name` | string | `my-monorepo` | Monorepo name (kebab-case), used as-is |
 | `description` | string | `""` | Description |
 | `license` | `LGPL-3.0` \| `GPL-3.0` | `LGPL-3.0` | Root license |
-| `typescriptConfig` | string | `@canonical/typescript-config-base` | Shared TypeScript config |
+| `typescriptConfig` | string | `@canonical/typescript-config` | Shared TypeScript config |
 | `repository` | string | `""` | GitHub repository URL |
 | `bunVersion` | string | `1.3.9` | Pinned Bun version for CI |
 | `initGit` | boolean | `true` | Initialize git repository |

--- a/packages/summon/monorepo/src/generators.test.ts
+++ b/packages/summon/monorepo/src/generators.test.ts
@@ -97,7 +97,9 @@ describe("monorepo generator", () => {
       expect(pkgFile).toBeDefined();
 
       const pkg = JSON.parse(pkgFile?.content ?? "");
-      expect(pkg.name).toBe("test-monorepo-monorepo");
+      // The name is used as-is: appending a suffix turned the default
+      // "my-monorepo" into "my-monorepo-monorepo".
+      expect(pkg.name).toBe("test-monorepo");
       expect(pkg.private).toBe(true);
       expect(pkg.version).toBe("0.0.0");
       expect(pkg.description).toBe("A test monorepo");
@@ -112,6 +114,16 @@ describe("monorepo generator", () => {
       expect(pkg.devDependencies.lerna).toBeDefined();
       expect(pkg.devDependencies.nx).toBeDefined();
       expect(pkg.devDependencies["@vitest/coverage-v8"]).toBeDefined();
+      // The root configs extend these packages, so the root manifest must
+      // declare them (a fresh install previously could not resolve them),
+      // and coverage-v8 needs its vitest peer alongside.
+      expect(pkg.devDependencies.vitest).toBeDefined();
+      expect(pkg.devDependencies["@biomejs/biome"]).toBeDefined();
+      expect(pkg.devDependencies["@canonical/biome-config"]).toMatch(/^\^\d/);
+      expect(pkg.devDependencies["@canonical/typescript-config-base"]).toMatch(
+        /^\^\d/,
+      );
+      expect(pkg.devDependencies.typescript).toBeDefined();
     });
 
     it("generates lerna.json with fixed versioning", () => {
@@ -165,15 +177,34 @@ describe("monorepo generator", () => {
       expect(biome.extends).toEqual(["@canonical/biome-config"]);
     });
 
-    it("generates tag.yml with NPM_AUTH_TOKEN", () => {
+    it("generates tag.yml publishing via OIDC trusted publishing", () => {
       const result = dryRun(generator.generate(defaultAnswers));
 
       const tagFile = getFiles(result).find(
         (f) => f.path === "test-monorepo/.github/workflows/tag.yml",
       );
       expect(tagFile).toBeDefined();
-      expect(tagFile?.content).toContain("NPM_AUTH_TOKEN");
-      expect(tagFile?.content).not.toContain("NODE_AUTH_TOKEN");
+      // The old pattern set NPM_AUTH_TOKEN step-scoped on setup-node — a
+      // variable setup-node never reads (it reads NODE_AUTH_TOKEN), scoped to
+      // a step the publish never runs in. OIDC needs neither secret.
+      expect(tagFile?.content).toContain("id-token: write");
+      expect(tagFile?.content).not.toContain("NPM_AUTH_TOKEN");
+    });
+
+    it("omits repository metadata when no repository was given", () => {
+      const result = dryRun(
+        generator.generate({ ...defaultAnswers, repository: "" }),
+      );
+
+      const pkgFile = getFiles(result).find(
+        (f) => f.path === "test-monorepo/package.json",
+      );
+      const pkg = JSON.parse(pkgFile?.content ?? "");
+      // Previously this emitted "url": "", "bugs": {"url": "/issues"},
+      // "homepage": "#readme" — malformed metadata.
+      expect(pkg.repository).toBeUndefined();
+      expect(pkg.bugs).toBeUndefined();
+      expect(pkg.homepage).toBeUndefined();
     });
 
     it("generates setup-env with pinned bun version", () => {

--- a/packages/summon/monorepo/src/generators.test.ts
+++ b/packages/summon/monorepo/src/generators.test.ts
@@ -31,7 +31,7 @@ const defaultAnswers = {
   name: "test-monorepo",
   description: "A test monorepo",
   license: "LGPL-3.0" as const,
-  typescriptConfig: "@canonical/typescript-config-base",
+  typescriptConfig: "@canonical/typescript-config",
   repository: "https://github.com/test/test-monorepo",
   bunVersion: "1.3.9",
   runInstall: false,
@@ -120,7 +120,7 @@ describe("monorepo generator", () => {
       expect(pkg.devDependencies.vitest).toBeDefined();
       expect(pkg.devDependencies["@biomejs/biome"]).toBeDefined();
       expect(pkg.devDependencies["@canonical/biome-config"]).toMatch(/^\^\d/);
-      expect(pkg.devDependencies["@canonical/typescript-config-base"]).toMatch(
+      expect(pkg.devDependencies["@canonical/typescript-config"]).toMatch(
         /^\^\d/,
       );
       expect(pkg.devDependencies.typescript).toBeDefined();
@@ -147,7 +147,7 @@ describe("monorepo generator", () => {
       expect(tsconfigFile).toBeDefined();
 
       const tsconfig = JSON.parse(tsconfigFile?.content ?? "");
-      expect(tsconfig.extends).toBe("@canonical/typescript-config-base");
+      expect(tsconfig.extends).toBe("@canonical/typescript-config");
     });
 
     it("generates tsconfig with lit config when selected", () => {
@@ -189,6 +189,25 @@ describe("monorepo generator", () => {
       // a step the publish never runs in. OIDC needs neither secret.
       expect(tagFile?.content).toContain("id-token: write");
       expect(tagFile?.content).not.toContain("NPM_AUTH_TOKEN");
+    });
+
+    it("canonicalizes a noncanonical repository URL in the metadata", () => {
+      // Validation accepts trailing "/" and ".git"; emitting them verbatim
+      // produced ".../repo//issues" and ".../repo.git#readme".
+      const result = dryRun(
+        generator.generate({
+          ...defaultAnswers,
+          repository: " https://github.com/test/test-monorepo.git ",
+        }),
+      );
+
+      const pkgFile = getFiles(result).find(
+        (f) => f.path === "test-monorepo/package.json",
+      );
+      const pkg = JSON.parse(pkgFile?.content ?? "");
+      expect(pkg.repository.url).toBe("https://github.com/test/test-monorepo");
+      expect(pkg.bugs.url).toBe("https://github.com/test/test-monorepo/issues");
+      expect(pkg.homepage).toBe("https://github.com/test/test-monorepo#readme");
     });
 
     it("omits repository metadata when no repository was given", () => {

--- a/packages/summon/monorepo/src/monorepo/index.ts
+++ b/packages/summon/monorepo/src/monorepo/index.ts
@@ -90,8 +90,8 @@ const prompts: PromptDefinition[] = [
     message: "TypeScript config package:",
     choices: [
       {
-        label: "@canonical/typescript-config-base - Standard (no DOM)",
-        value: "@canonical/typescript-config-base",
+        label: "@canonical/typescript-config - Standard (no DOM)",
+        value: "@canonical/typescript-config",
       },
       {
         label:
@@ -99,7 +99,7 @@ const prompts: PromptDefinition[] = [
         value: "@canonical/typescript-config-lit",
       },
     ],
-    default: "@canonical/typescript-config-base",
+    default: "@canonical/typescript-config",
     group: "Monorepo",
   },
   {

--- a/packages/summon/monorepo/src/monorepo/index.ts
+++ b/packages/summon/monorepo/src/monorepo/index.ts
@@ -153,7 +153,7 @@ WHAT'S INCLUDED:
   - Bun + Lerna + Nx orchestration
   - GitHub Actions CI (check + build-and-test)
   - PR lint (conventional commits)
-  - Release workflow (tag.yml with NPM_AUTH_TOKEN)
+  - Release workflow (tag.yml, npm OIDC trusted publishing)
   - Shared config (@canonical/biome-config, TypeScript config)
   - Coverage testing setup
   - Organized .gitignore
@@ -162,7 +162,7 @@ WHAT'S INCLUDED:
   - Renovate config with batching families
 
 POST-SETUP:
-  1. Configure GitHub repo secret NPM_AUTH_TOKEN
+  1. Configure each package's npm trusted publisher (repo + tag.yml)
   2. Configure GitHub repo: squash merge only, PR title as commit message
   3. Enable Renovate GitHub App on the repository
   4. Use summon-package to add the first package`,
@@ -382,7 +382,9 @@ POST-SETUP:
       info(""),
       info("Next steps:"),
       info(`  cd ${repoDir}`),
-      info("  # Add NPM_AUTH_TOKEN secret to GitHub repo"),
+      info(
+        "  # Configure npm trusted publishers for the repo (workflow tag.yml)",
+      ),
       info("  # Configure squash merge in GitHub repo settings"),
       info("  # Enable Renovate GitHub App on the repository"),
       info("  # Use summon-package to add the first package"),

--- a/packages/summon/monorepo/src/shared/createTemplateContext.ts
+++ b/packages/summon/monorepo/src/shared/createTemplateContext.ts
@@ -1,5 +1,6 @@
 import { packageVersion } from "./packageVersion.js";
 import type { MonorepoAnswers, TemplateContext } from "./types.js";
+import { normalizeRepositoryUrl } from "./validateRepository.js";
 
 /**
  * Create template context from answers.
@@ -17,7 +18,7 @@ export default function createTemplateContext(
       null,
       4,
     ),
-    repository: answers.repository,
+    repository: normalizeRepositoryUrl(answers.repository),
     bunVersion: answers.bunVersion,
     // The @canonical/* config packages release on the same fixed-version
     // train as this generator, so its own version is the correct range line.

--- a/packages/summon/monorepo/src/shared/createTemplateContext.ts
+++ b/packages/summon/monorepo/src/shared/createTemplateContext.ts
@@ -1,3 +1,4 @@
+import { packageVersion } from "./packageVersion.js";
 import type { MonorepoAnswers, TemplateContext } from "./types.js";
 
 /**
@@ -18,5 +19,8 @@ export default function createTemplateContext(
     ),
     repository: answers.repository,
     bunVersion: answers.bunVersion,
+    // The @canonical/* config packages release on the same fixed-version
+    // train as this generator, so its own version is the correct range line.
+    canonicalVersion: packageVersion(),
   };
 }

--- a/packages/summon/monorepo/src/shared/types.ts
+++ b/packages/summon/monorepo/src/shared/types.ts
@@ -32,6 +32,8 @@ export interface TemplateContext {
   repository: string;
   /** Bun version for CI */
   bunVersion: string;
+  /** Version line for the @canonical/* config dependencies */
+  canonicalVersion: string;
   /** Index signature for EJS compatibility */
   [key: string]: unknown;
 }

--- a/packages/summon/monorepo/src/shared/validateRepository.test.ts
+++ b/packages/summon/monorepo/src/shared/validateRepository.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import validateRepository from "./validateRepository.js";
+import validateRepository, {
+  normalizeRepositoryUrl,
+} from "./validateRepository.js";
 
 describe("validateRepository", () => {
   it("accepts valid GitHub URLs", () => {
@@ -26,5 +28,22 @@ describe("validateRepository", () => {
     expect(validateRepository(42)).not.toBe(true);
     expect(validateRepository(true)).not.toBe(true);
     expect(validateRepository(["https://github.com/a/b"])).not.toBe(true);
+  });
+});
+
+describe("normalizeRepositoryUrl", () => {
+  it("canonicalizes accepted noncanonical forms", () => {
+    expect(normalizeRepositoryUrl(" https://github.com/org/repo ")).toBe(
+      "https://github.com/org/repo",
+    );
+    expect(normalizeRepositoryUrl("https://github.com/org/repo/")).toBe(
+      "https://github.com/org/repo",
+    );
+    expect(normalizeRepositoryUrl("https://github.com/org/repo.git")).toBe(
+      "https://github.com/org/repo",
+    );
+    expect(normalizeRepositoryUrl("https://github.com/org/repo")).toBe(
+      "https://github.com/org/repo",
+    );
   });
 });

--- a/packages/summon/monorepo/src/shared/validateRepository.test.ts
+++ b/packages/summon/monorepo/src/shared/validateRepository.test.ts
@@ -4,13 +4,27 @@ import validateRepository from "./validateRepository.js";
 describe("validateRepository", () => {
   it("accepts valid GitHub URLs", () => {
     expect(validateRepository("https://github.com/org/repo")).toBe(true);
+    expect(validateRepository("https://github.com/org/repo/")).toBe(true);
+    expect(validateRepository("https://github.com/org/repo.git")).toBe(true);
   });
 
   it("accepts empty values (optional field)", () => {
     expect(validateRepository("")).toBe(true);
+    expect(validateRepository(undefined)).toBe(true);
   });
 
   it("rejects non-GitHub URLs", () => {
     expect(validateRepository("not-a-url")).not.toBe(true);
+  });
+
+  it("rejects a GitHub URL without an org/repo path", () => {
+    expect(validateRepository("https://github.com/")).not.toBe(true);
+    expect(validateRepository("https://github.com/only-org")).not.toBe(true);
+  });
+
+  it("rejects truthy non-string values instead of skipping validation", () => {
+    expect(validateRepository(42)).not.toBe(true);
+    expect(validateRepository(true)).not.toBe(true);
+    expect(validateRepository(["https://github.com/a/b"])).not.toBe(true);
   });
 });

--- a/packages/summon/monorepo/src/shared/validateRepository.ts
+++ b/packages/summon/monorepo/src/shared/validateRepository.ts
@@ -1,13 +1,23 @@
 /**
- * Validate repository URL.
+ * A full GitHub repository URL: org and repo segments, optional trailing
+ * slash or `.git` suffix.
+ */
+const GITHUB_REPO =
+  /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?\/?$/;
+
+/**
+ * Validate the repository URL. The field is optional — only an absent or
+ * empty value is the optional escape; any other value (including a truthy
+ * non-string) must be a full GitHub repository URL, since it flows verbatim
+ * into the scaffolded package.json repository/bugs/homepage fields.
  */
 export default function validateRepository(value: unknown): true | string {
-  if (!value || typeof value !== "string") {
+  if (value === undefined || value === null || value === "") {
     return true; // Optional field
   }
 
-  if (!value.startsWith("https://github.com/")) {
-    return "Repository URL must start with https://github.com/";
+  if (typeof value !== "string" || !GITHUB_REPO.test(value.trim())) {
+    return "Repository must be a GitHub repository URL like https://github.com/org/repo";
   }
 
   return true;

--- a/packages/summon/monorepo/src/shared/validateRepository.ts
+++ b/packages/summon/monorepo/src/shared/validateRepository.ts
@@ -22,3 +22,16 @@ export default function validateRepository(value: unknown): true | string {
 
   return true;
 }
+
+/**
+ * Canonicalize an accepted repository URL for template emission: trimmed,
+ * without a trailing slash or `.git` suffix — validation accepts those
+ * forms, but emitting them verbatim produces `.../repo//issues` or
+ * `.../repo.git#readme` in the scaffolded metadata.
+ */
+export function normalizeRepositoryUrl(value: string): string {
+  return value
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/\.git$/, "");
+}

--- a/packages/summon/monorepo/src/templates/lerna-version-action.yml.ejs
+++ b/packages/summon/monorepo/src/templates/lerna-version-action.yml.ejs
@@ -32,6 +32,7 @@ runs:
       uses: ./.github/actions/setup-git
       with:
         name: ${{ github.actor }}
+        email: ${{ github.actor }}@users.noreply.github.com
 
     - name: Commit and tag v${{ steps.lerna_version.outputs.VERSION }}
       shell: bash

--- a/packages/summon/monorepo/src/templates/package.json.ejs
+++ b/packages/summon/monorepo/src/templates/package.json.ejs
@@ -1,18 +1,22 @@
 {
-  "name": "<%= name %>-monorepo",
+  "name": "<%= name %>",
   "private": true,
   "version": "0.0.0",
   "description": "<%= description %>",
   "author": <%- author %>,
+<% if (repository) { -%>
   "repository": {
     "type": "git",
     "url": "<%= repository %>"
   },
+<% } -%>
   "license": "<%= license %>",
+<% if (repository) { -%>
   "bugs": {
     "url": "<%= repository %>/issues"
   },
   "homepage": "<%= repository %>#readme",
+<% } -%>
   "workspaces": ["packages/*"],
   "scripts": {
     "build": "lerna run build",
@@ -27,8 +31,13 @@
     "publish:status": "bun scripts/publish-status.ts"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.6",
+    "@canonical/biome-config": "^<%= canonicalVersion %>",
+    "<%= typescriptConfig %>": "^<%= canonicalVersion %>",
     "@vitest/coverage-v8": "^4.0.0",
     "lerna": "^9.0.3",
-    "nx": "^22.5.0"
+    "nx": "^22.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.0"
   }
 }

--- a/packages/summon/monorepo/src/templates/renovate.json.ejs
+++ b/packages/summon/monorepo/src/templates/renovate.json.ejs
@@ -12,28 +12,27 @@
     },
     {
       "description": "Group TypeScript toolchain",
-      "matchPackageNames": ["typescript"],
-      "matchPackagePrefixes": ["@canonical/typescript-config-"],
+      "matchPackageNames": ["typescript", "@canonical/typescript-config-**"],
       "groupName": "typescript"
     },
     {
       "description": "Group Vitest ecosystem",
-      "matchPackageNames": ["vitest"],
-      "matchPackagePrefixes": ["@vitest/"],
+      "matchPackageNames": ["vitest", "@vitest/**"],
       "groupName": "vitest"
     },
     {
       "description": "Group Lerna + Nx orchestration",
-      "matchPackageNames": ["lerna", "nx"],
-      "matchPackagePrefixes": ["@nx/"],
+      "matchPackageNames": ["lerna", "nx", "@nx/**"],
       "groupName": "lerna-nx"
     },
     {
       "description": "Group Canonical internal packages",
-      "matchPackagePrefixes": ["@canonical/"],
-      "groupName": "canonical",
-      "excludePackageNames": ["@canonical/biome-config"],
-      "excludePackagePrefixes": ["@canonical/typescript-config-"]
+      "matchPackageNames": [
+        "@canonical/**",
+        "!@canonical/biome-config",
+        "!@canonical/typescript-config-**"
+      ],
+      "groupName": "canonical"
     },
     {
       "description": "Automerge patch/minor devDependencies",

--- a/packages/summon/monorepo/src/templates/setup-git.yml.ejs
+++ b/packages/summon/monorepo/src/templates/setup-git.yml.ejs
@@ -7,7 +7,6 @@ inputs:
   email:
     required: true
     description: Git email
-    default: "webteam@canonical.com"
 
 runs:
   using: composite

--- a/packages/summon/monorepo/src/templates/tag.yml.ejs
+++ b/packages/summon/monorepo/src/templates/tag.yml.ejs
@@ -68,6 +68,13 @@ jobs:
     name: Publish packages
     runs-on: ubuntu-latest
     needs: version
+    # OIDC trusted publishing: GitHub mints a short-lived npm token at publish
+    # time instead of using a long-lived repository secret. Configure each
+    # package's trusted publisher on npmjs.com (this repo, workflow tag.yml)
+    # after its first manual publish.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -83,8 +90,6 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Publish packages
         run: lerna publish --yes --no-private from-package


### PR DESCRIPTION
## Done

Generated-output fixes for `summon monorepo` found by the summon audit:

- **Generated release workflows could never authenticate with npm.** The scaffolded `tag.yml` set `NPM_AUTH_TOKEN` as a step-scoped env on the *setup-node* step — a variable setup-node never reads (its generated `.npmrc` reads `NODE_AUTH_TOKEN`), scoped to a step the publish never runs in. The template now uses **npm OIDC trusted publishing** (`permissions: id-token: write`), the pattern pragma's own `tag.yml` already moved to. The unit test that pinned the broken variable now pins the OIDC permissions; help text and README updated.
- **Default answers no longer emit malformed metadata.** `repository` defaults to empty and previously rendered `"url": ""`, `"bugs": {"url": "/issues"}`, `"homepage": "#readme"` unconditionally — those fields are now emitted only when a repository was given, and `validateRepository` requires a full `https://github.com/org/repo` URL (truthy non-strings no longer skip validation).
- **The scaffold name is used as-is** — the template appended `-monorepo`, so the default name produced `my-monorepo-monorepo`.
- **A fresh scaffold can actually run `check` and `test`.** The root `biome.json`/`tsconfig.json` extend `@canonical/biome-config` and the chosen `@canonical/typescript-config-*`, but no scaffolded manifest declared them (nor `@biomejs/biome`, `typescript`, or `vitest` alongside `@vitest/coverage-v8`). They're now declared, ranged on the generator's own release-line version via a new `packageVersion` walk-up (the summon-package pattern).
- `renovate.json.ejs` migrates off options Renovate removed (`matchPackagePrefixes`, `excludePackageNames`, `excludePackagePrefixes`) to glob `matchPackageNames`; the `setup-git` action's `email` input drops its contradictory `required: true` + hardcoded-default combination, with the caller passing the actor's noreply address.

Known-and-left: the generated `LICENSE` remains a pointer stub rather than the full license text (GitHub/npm license detection won't recognize it) — flagged in the audit, left as a policy decision.

## QA

- `bun run check` passes from the repo root; `bun run test` passes everywhere except the three svelte app packages (pre-existing environment-only Playwright system-library failure on this machine, unrelated).
- New/updated tests: OIDC pin (replacing the broken-auth pin), empty-repository metadata omission, name-as-is, root devDependency declarations, tightened `validateRepository` cases, `packageVersion` walk-up. 100% coverage thresholds intact.

### PR readiness check

- [x] PR label: `Bug 🐛`
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

n/a

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
