### PR TITLE
fix(task): repair the fallback glob and implement templateDir's transform option

### DIFF
--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it, vi } from "vitest";
 import { parallel, sequence_ } from "./combinators.js";
 import {
   executeEffect,
+  matchesPattern,
   run,
   runTask,
   TaskExecutionError,
@@ -1914,5 +1915,27 @@ describe("Interpreter - interruption bypasses recovery", () => {
 
     // The interrupt bypassed the recover handler entirely.
     expect(handlerCalls).toBe(0);
+  });
+});
+
+describe("matchesPattern — the fallback glob matcher", () => {
+  it("matches everything under a directory with **/*", () => {
+    // Regression: dots were escaped AFTER the ** → .* substitution, turning
+    // the wildcard into `\.*` (zero-or-more literal dots) — glob("**/*")
+    // matched nothing under plain Node.
+    expect(matchesPattern("a.txt", "**/*")).toBe(true);
+    expect(matchesPattern("dir/a.txt", "**/*")).toBe(true);
+    expect(matchesPattern("dir/sub/b.ts", "**/*")).toBe(true);
+  });
+
+  it("keeps * within one path segment", () => {
+    expect(matchesPattern("x.ts", "*.ts")).toBe(true);
+    expect(matchesPattern("dir/x.ts", "*.ts")).toBe(false);
+    expect(matchesPattern("dir/x.ts", "dir/*.ts")).toBe(true);
+  });
+
+  it("treats dots in the pattern literally", () => {
+    expect(matchesPattern("axts", "a.ts")).toBe(false);
+    expect(matchesPattern("a.ts", "a.ts")).toBe(true);
   });
 });

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -287,6 +287,10 @@ const simpleGlob = async (pattern: string, cwd: string): Promise<string[]> => {
  * `Glob` effect's (otherwise real) matches.
  */
 export const matchesPattern = (filepath: string, pattern: string): boolean => {
+  // Callers hand over relative paths from `path.relative`/readdir walks, which
+  // use `\` on Windows; the pattern language is `/`-separated, so normalize
+  // the platform separator before matching.
+  const normalized = filepath.split(path.sep).join("/");
   // Very simple glob matching - just handles * and **. Dots are escaped FIRST:
   // escaping them after the `**` → `.*` substitution turned the wildcard into
   // `\.*` (zero-or-more literal dots), so `glob("**/*")` matched nothing. A
@@ -299,7 +303,7 @@ export const matchesPattern = (filepath: string, pattern: string): boolean => {
     .replace(/\*/g, "[^/]*")
     .replace(/<<GLOBSTARSLASH>>/g, "(?:.*/)?")
     .replace(/<<GLOBSTAR>>/g, ".*");
-  return new RegExp(`^${regex}$`).test(filepath);
+  return new RegExp(`^${regex}$`).test(normalized);
 };
 
 // =============================================================================

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -287,12 +287,18 @@ const simpleGlob = async (pattern: string, cwd: string): Promise<string[]> => {
  * `Glob` effect's (otherwise real) matches.
  */
 export const matchesPattern = (filepath: string, pattern: string): boolean => {
-  // Very simple glob matching - just handles * and **
+  // Very simple glob matching - just handles * and **. Dots are escaped FIRST:
+  // escaping them after the `**` → `.*` substitution turned the wildcard into
+  // `\.*` (zero-or-more literal dots), so `glob("**/*")` matched nothing. A
+  // `**/` prefix also matches ZERO directories (standard globstar), so
+  // `**/*` covers top-level files too.
   const regex = pattern
+    .replace(/\./g, "\\.")
+    .replace(/\*\*\//g, "<<GLOBSTARSLASH>>")
     .replace(/\*\*/g, "<<GLOBSTAR>>")
     .replace(/\*/g, "[^/]*")
-    .replace(/<<GLOBSTAR>>/g, ".*")
-    .replace(/\./g, "\\.");
+    .replace(/<<GLOBSTARSLASH>>/g, "(?:.*/)?")
+    .replace(/<<GLOBSTAR>>/g, ".*");
   return new RegExp(`^${regex}$`).test(filepath);
 };
 

--- a/packages/summon/core/src/template/tasks/template.ts
+++ b/packages/summon/core/src/template/tasks/template.ts
@@ -36,6 +36,7 @@ export default function template(options: TemplateOptions): Task<void> {
   return task(mkdir(destDir))
     .chain(() => readSource)
     .map((content) => renderString(content, options.vars, engine))
+    .map((rendered) => options.transform?.(rendered) ?? rendered)
     .chain((rendered) => task(writeFile(destPath, rendered)))
     .unwrap();
 }

--- a/packages/summon/core/src/template/tasks/templateDir.test.ts
+++ b/packages/summon/core/src/template/tasks/templateDir.test.ts
@@ -123,4 +123,38 @@ describe("templateDir", () => {
     const writes = filterEffects(effects, "WriteFile");
     expect(writes).toHaveLength(3);
   });
+
+  it("applies the declared transform, extension-keyed", () => {
+    // The transform option was declared in TemplateDirOptions but never read
+    // — a silent no-op for every caller.
+    const t = templateDir({
+      source: "/tpl",
+      dest: "/out",
+      vars: {},
+      transform: { ".ts": (content) => content.toUpperCase() },
+    });
+
+    const { effects } = dryRunWith(t, buildMocks(["a.ts", "note.md"]));
+    const writes = filterEffects(effects, "WriteFile");
+    const byPath = new Map(writes.map((w) => [w.path, w.content]));
+
+    expect(byPath.get("/out/a.ts")).toBe("CONTENT OF /TPL/A.TS");
+    expect(byPath.get("/out/note.md")).toBe("content of /tpl/note.md");
+  });
+
+  it("prefers an exact basename transform over the extension entry", () => {
+    const t = templateDir({
+      source: "/tpl",
+      dest: "/out",
+      vars: {},
+      transform: {
+        ".ts": (content) => content.toUpperCase(),
+        "special.ts": (content) => `${content}!`,
+      },
+    });
+
+    const { effects } = dryRunWith(t, buildMocks(["special.ts"]));
+    const writes = filterEffects(effects, "WriteFile");
+    expect(writes[0]?.content).toBe("content of /tpl/special.ts!");
+  });
 });

--- a/packages/summon/core/src/template/tasks/templateDir.ts
+++ b/packages/summon/core/src/template/tasks/templateDir.ts
@@ -46,11 +46,18 @@ export default function templateDir(options: TemplateDirOptions): Task<void> {
           destFile = renderString(destFile, options.vars, engine);
           const destPath = path.join(options.dest, destFile);
 
+          // Resolve the declared content transformer for this file: an exact
+          // (post-`.ejs`-strip) basename entry wins over an extension entry.
+          const transform =
+            options.transform?.[path.basename(destFile)] ??
+            options.transform?.[path.extname(destFile)];
+
           return template({
             source: sourcePath,
             dest: destPath,
             vars: options.vars,
             engine,
+            transform,
           });
         });
 

--- a/packages/summon/core/src/template/tasks/types.ts
+++ b/packages/summon/core/src/template/tasks/types.ts
@@ -14,6 +14,8 @@ export interface TemplateOptions {
    * Use this when the template is embedded or pre-loaded (e.g. compiled binaries).
    */
   content?: string;
+  /** Applied to the rendered content before it is written. */
+  transform?: (content: string) => string;
 }
 
 export interface TemplateDirOptions {


### PR DESCRIPTION
## Done

Two `templateDir`-class fixes from the summon audit:

- **The non-Bun glob fallback matched nothing.** `matchesPattern` escaped dots *after* substituting `**` → `.*`, yielding `\.*` (zero-or-more literal dots) — so `glob("**/*")` under plain Node returned an empty list and any `templateDir`-based generator wrote nothing there (the Bun.Glob branch masked this for bun users). Dots are now escaped first, and a `**/` prefix matches zero directories (standard globstar), so top-level files match too. The same matcher backs the preview interpreter's overlay membership.
- **`TemplateDirOptions.transform` is implemented.** It was declared in the public options type but never read — a silent no-op for every caller. `template()` now applies an optional transform to rendered content before writing, and `templateDir` resolves the transformer per file (an exact post-`.ejs`-strip basename entry wins over an extension entry).

## QA

- `bun run check` passes from the repo root; `bun run test` passes everywhere except the three svelte app packages (pre-existing environment-only Playwright system-library failure on this machine, unrelated).
- New tests: `matchesPattern` regression pins (`**/*` matches nested *and* top-level files; `*` stays within a segment; literal dots) in the task package; extension-keyed and basename-over-extension transform behavior in `templateDir.test.ts`. Coverage thresholds intact (805 task / 432 core tests).

### PR readiness check

- [x] PR label: `Bug 🐛`
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

n/a

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
