### PR TITLE
fix(summon-core): align the CLI seams — one flag name, safe replays, honest validation

### DIFF
--- a/packages/cli/pragma/src/capabilities/create/create.verb.ts
+++ b/packages/cli/pragma/src/capabilities/create/create.verb.ts
@@ -373,6 +373,9 @@ async function runCreate(
       signal,
       onCancel: abort,
       cwd: rt.cwd,
+      // Flag-provided answers reach the wizard too: without the seed the
+      // confirm gate previews with them missing (undefined paths, wrong plan).
+      initialAnswers: answers,
     });
     // Thread the per-call write root: the interpreter resolves the generator's
     // relative output paths against `rt.cwd` — the SAME dir the SEC-2 jail

--- a/packages/summon/core/src/execute/collectAnswers.ts
+++ b/packages/summon/core/src/execute/collectAnswers.ts
@@ -130,7 +130,7 @@ export default function collectAnswers(
     }
     const definition = prompts[index];
     if (
-      definition.name in answers ||
+      Object.hasOwn(answers, definition.name) ||
       (definition.when && definition.when(answers) !== true)
     ) {
       return step(index + 1, answers);

--- a/packages/summon/core/src/execute/validateAnswers.test.ts
+++ b/packages/summon/core/src/execute/validateAnswers.test.ts
@@ -79,6 +79,12 @@ describe("validateAnswers — multiselect and hostile names", () => {
       '"zzz"',
     );
     expect(validateAnswers(prompts, { features: ["a", "b"] })).toBeNull();
+    // Strict entries: no coercion (1 is not the declared "1"-style string
+    // value "a"/"b"), and an undefined entry is still reported.
+    expect(validateAnswers(prompts, { features: [1] })).toContain('"1"');
+    expect(validateAnswers(prompts, { features: [undefined] })).toContain(
+      '"undefined"',
+    );
   });
 
   it("names the offending flag with the CLI's own kebab form", () => {

--- a/packages/summon/core/src/execute/validateAnswers.test.ts
+++ b/packages/summon/core/src/execute/validateAnswers.test.ts
@@ -60,3 +60,52 @@ describe("validateAnswers", () => {
     expect(validateAnswers(prompts, {})).toBeNull();
   });
 });
+
+describe("validateAnswers — multiselect and hostile names", () => {
+  it("rejects a multiselect value outside the declared choices", () => {
+    const prompts = [
+      {
+        name: "features",
+        message: "?",
+        type: "multiselect" as const,
+        choices: [
+          { label: "A", value: "a" },
+          { label: "B", value: "b" },
+        ],
+      },
+    ];
+    // select membership was checked; multiselect flowed through unvalidated.
+    expect(validateAnswers(prompts, { features: ["a", "zzz"] })).toContain(
+      '"zzz"',
+    );
+    expect(validateAnswers(prompts, { features: ["a", "b"] })).toBeNull();
+  });
+
+  it("names the offending flag with the CLI's own kebab form", () => {
+    const prompts = [
+      {
+        name: "componentURL",
+        message: "?",
+        type: "text" as const,
+        validate: () => "nope",
+      },
+    ];
+    const message = validateAnswers(prompts, { componentURL: "x" });
+    expect(message).toContain("--component-url");
+    expect(message).not.toContain("--component-u-r-l");
+  });
+
+  it("does not treat prototype properties as provided answers", () => {
+    const prompts = [
+      {
+        name: "toString",
+        message: "?",
+        type: "text" as const,
+        validate: () => "invalid",
+      },
+    ];
+    // `"toString" in answers` is true for any object; Object.hasOwn is not.
+    expect(validateAnswers(prompts, {})).toBeNull();
+    expect(validateAnswers(prompts, { toString: "x" })).toContain("invalid");
+  });
+});

--- a/packages/summon/core/src/execute/validateAnswers.ts
+++ b/packages/summon/core/src/execute/validateAnswers.ts
@@ -47,11 +47,17 @@ export default function validateAnswers(
       prompt.choices.length > 0 &&
       Array.isArray(value)
     ) {
-      const allowed = new Set(prompt.choices.map((choice) => choice.value));
-      const unknown = value.find((entry) => !allowed.has(String(entry)));
-      if (unknown !== undefined) {
+      const allowed = new Set<unknown>(
+        prompt.choices.map((choice) => choice.value),
+      );
+      // Strict membership with an index, not a find() sentinel: `[1]` must
+      // not pass for a declared "1", and `[undefined]` must still be caught.
+      const badIndex = value.findIndex(
+        (entry) => typeof entry !== "string" || !allowed.has(entry),
+      );
+      if (badIndex !== -1) {
         const valid = prompt.choices.map((choice) => choice.value).join(", ");
-        return `Invalid --${flagName(prompt.name)} "${String(unknown)}". Valid values: ${valid}.`;
+        return `Invalid --${flagName(prompt.name)} "${String(value[badIndex])}". Valid values: ${valid}.`;
       }
     }
 

--- a/packages/summon/core/src/execute/validateAnswers.ts
+++ b/packages/summon/core/src/execute/validateAnswers.ts
@@ -12,7 +12,7 @@
  * {@link execute} so both interactive and non-interactive paths share it.
  */
 
-import flagName from "../format/flagName.js";
+import formatFlagName from "../format/formatFlagName.js";
 import type PromptDefinition from "../types/PromptDefinition.js";
 
 /**
@@ -38,7 +38,7 @@ export default function validateAnswers(
       !prompt.choices.some((choice) => choice.value === value)
     ) {
       const valid = prompt.choices.map((choice) => choice.value).join(", ");
-      return `Invalid --${flagName(prompt.name)} "${String(value)}". Valid values: ${valid}.`;
+      return `Invalid --${formatFlagName(prompt.name)} "${String(value)}". Valid values: ${valid}.`;
     }
 
     if (
@@ -57,7 +57,7 @@ export default function validateAnswers(
       );
       if (badIndex !== -1) {
         const valid = prompt.choices.map((choice) => choice.value).join(", ");
-        return `Invalid --${flagName(prompt.name)} "${String(value[badIndex])}". Valid values: ${valid}.`;
+        return `Invalid --${formatFlagName(prompt.name)} "${String(value[badIndex])}". Valid values: ${valid}.`;
       }
     }
 
@@ -65,7 +65,7 @@ export default function validateAnswers(
       const verdict = prompt.validate(value);
       if (verdict !== true) {
         const detail = typeof verdict === "string" ? verdict : "invalid value";
-        return `Invalid --${flagName(prompt.name)}: ${detail}`;
+        return `Invalid --${formatFlagName(prompt.name)}: ${detail}`;
       }
     }
   }

--- a/packages/summon/core/src/execute/validateAnswers.ts
+++ b/packages/summon/core/src/execute/validateAnswers.ts
@@ -12,11 +12,8 @@
  * {@link execute} so both interactive and non-interactive paths share it.
  */
 
+import flagName from "../format/flagName.js";
 import type PromptDefinition from "../types/PromptDefinition.js";
-
-/** Convert a camelCase prompt name to its kebab-case CLI flag form. */
-const toKebab = (name: string): string =>
-  name.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 
 /**
  * Find the first answer that violates its prompt's constraints.
@@ -31,7 +28,7 @@ export default function validateAnswers(
 ): string | null {
   for (const prompt of prompts) {
     if (prompt.when && prompt.when(answers) !== true) continue;
-    if (!(prompt.name in answers)) continue;
+    if (!Object.hasOwn(answers, prompt.name)) continue;
     const value = answers[prompt.name];
 
     if (
@@ -41,14 +38,28 @@ export default function validateAnswers(
       !prompt.choices.some((choice) => choice.value === value)
     ) {
       const valid = prompt.choices.map((choice) => choice.value).join(", ");
-      return `Invalid --${toKebab(prompt.name)} "${String(value)}". Valid values: ${valid}.`;
+      return `Invalid --${flagName(prompt.name)} "${String(value)}". Valid values: ${valid}.`;
+    }
+
+    if (
+      prompt.type === "multiselect" &&
+      prompt.choices &&
+      prompt.choices.length > 0 &&
+      Array.isArray(value)
+    ) {
+      const allowed = new Set(prompt.choices.map((choice) => choice.value));
+      const unknown = value.find((entry) => !allowed.has(String(entry)));
+      if (unknown !== undefined) {
+        const valid = prompt.choices.map((choice) => choice.value).join(", ");
+        return `Invalid --${flagName(prompt.name)} "${String(unknown)}". Valid values: ${valid}.`;
+      }
     }
 
     if (prompt.validate) {
       const verdict = prompt.validate(value);
       if (verdict !== true) {
         const detail = typeof verdict === "string" ? verdict : "invalid value";
-        return `Invalid --${toKebab(prompt.name)}: ${detail}`;
+        return `Invalid --${flagName(prompt.name)}: ${detail}`;
       }
     }
   }

--- a/packages/summon/core/src/format/effects.test.ts
+++ b/packages/summon/core/src/format/effects.test.ts
@@ -689,3 +689,59 @@ describe("formatLlmHelp", () => {
     expect(result).toContain("## Optional Options");
   });
 });
+
+describe("buildReplayCommand — shell safety and flag naming", () => {
+  it("quotes values a POSIX shell would split or interpret", () => {
+    const prompts = [
+      { name: "description", message: "?", type: "text" as const },
+    ];
+    const result = buildReplayCommand(
+      "test-gen",
+      { description: "A demo project" },
+      prompts,
+    );
+    expect(result).toContain("--description 'A demo project'");
+  });
+
+  it("leaves plain values unquoted", () => {
+    const prompts = [{ name: "name", message: "?", type: "text" as const }];
+    expect(
+      buildReplayCommand("test-gen", { name: "my-app" }, prompts),
+    ).toContain("--name my-app");
+  });
+
+  it("names flags with the same algorithm help and Commander use", () => {
+    // /[A-Z]/g-style splitting produced --component-u-r-l for componentURL.
+    const prompts = [
+      { name: "componentURL", message: "?", type: "text" as const },
+    ];
+    const result = buildReplayCommand(
+      "test-gen",
+      { componentURL: "x" },
+      prompts,
+    );
+    expect(result).toContain("--component-url x");
+    expect(result).not.toContain("--component-u-r-l");
+  });
+});
+
+describe("formatLlmHelp — select without choices", () => {
+  it("renders a generic value hint instead of crashing", () => {
+    const generator = {
+      meta: {
+        name: "g",
+        displayName: "g",
+        description: "d",
+        version: "1.0.0",
+      },
+      prompts: [{ name: "mode", message: "Mode?", type: "select" as const }],
+      generate: () => {
+        throw new Error("unused");
+      },
+    };
+    // choices is optional on PromptDefinition; this previously threw a
+    // TypeError on --help --llm.
+    const output = formatLlmHelp(generator, "g");
+    expect(output).toContain("`<value>`");
+  });
+});

--- a/packages/summon/core/src/format/effects.ts
+++ b/packages/summon/core/src/format/effects.ts
@@ -13,7 +13,7 @@ import type { Effect } from "@canonical/task";
 import chalk from "chalk";
 import type GeneratorDefinition from "../types/GeneratorDefinition.js";
 import type PromptDefinition from "../types/PromptDefinition.js";
-import flagName from "./flagName.js";
+import formatFlagName from "./formatFlagName.js";
 
 // Fixed width for action label column
 const ACTION_LABEL_WIDTH = 14;
@@ -371,7 +371,7 @@ export const getLlmEffectPath = (effect: Effect): string => {
  * with spaces or shell metacharacters previously produced a broken command in
  * every `--llm` "To execute" line.
  */
-const shellQuote = (value: string): string =>
+const quoteShellValue = (value: string): string =>
   /^[A-Za-z0-9_@%+=:,./-]+$/.test(value)
     ? value
     : `'${value.replaceAll("'", `'\\''`)}'`;
@@ -387,7 +387,7 @@ export const buildReplayCommand = (
     const value = answers[prompt.name];
     if (value === undefined) continue;
 
-    const kebabName = flagName(prompt.name);
+    const kebabName = formatFlagName(prompt.name);
 
     if (prompt.type === "confirm") {
       if (value === true && prompt.default !== true) {
@@ -397,10 +397,10 @@ export const buildReplayCommand = (
       }
     } else if (prompt.type === "multiselect" && Array.isArray(value)) {
       if (value.length > 0) {
-        parts.push(`--${kebabName}`, shellQuote(value.join(",")));
+        parts.push(`--${kebabName}`, quoteShellValue(value.join(",")));
       }
     } else {
-      parts.push(`--${kebabName}`, shellQuote(String(value)));
+      parts.push(`--${kebabName}`, quoteShellValue(String(value)));
     }
   }
 
@@ -626,7 +626,7 @@ export const formatLlmHelp = (
     lines.push("|------|------|-------------|");
     for (const p of requiredPrompts) {
       lines.push(
-        `| --${flagName(p.name)} | ${formatTypeHint(p)} | ${p.message} |`,
+        `| --${formatFlagName(p.name)} | ${formatTypeHint(p)} | ${p.message} |`,
       );
     }
     lines.push("");
@@ -641,7 +641,7 @@ export const formatLlmHelp = (
       const def =
         p.default !== undefined ? `\`${JSON.stringify(p.default)}\`` : "";
       lines.push(
-        `| --${flagName(p.name)} | ${formatTypeHint(p)} | ${def} | ${p.message} |`,
+        `| --${formatFlagName(p.name)} | ${formatTypeHint(p)} | ${def} | ${p.message} |`,
       );
     }
     lines.push("");
@@ -672,7 +672,7 @@ export const formatLlmHelp = (
   lines.push("");
 
   const exampleFlags = requiredPrompts
-    .map((p) => `--${flagName(p.name)} <value>`)
+    .map((p) => `--${formatFlagName(p.name)} <value>`)
     .join(" ");
   const flagStr = exampleFlags ? ` ${exampleFlags}` : "";
 

--- a/packages/summon/core/src/format/effects.ts
+++ b/packages/summon/core/src/format/effects.ts
@@ -13,6 +13,7 @@ import type { Effect } from "@canonical/task";
 import chalk from "chalk";
 import type GeneratorDefinition from "../types/GeneratorDefinition.js";
 import type PromptDefinition from "../types/PromptDefinition.js";
+import flagName from "./flagName.js";
 
 // Fixed width for action label column
 const ACTION_LABEL_WIDTH = 14;
@@ -365,6 +366,16 @@ export const getLlmEffectPath = (effect: Effect): string => {
 /**
  * Build the replay command string from generator name and answers.
  */
+/**
+ * Quote a replay-command value for a POSIX shell when it needs it — a value
+ * with spaces or shell metacharacters previously produced a broken command in
+ * every `--llm` "To execute" line.
+ */
+const shellQuote = (value: string): string =>
+  /^[A-Za-z0-9_@%+=:,./-]+$/.test(value)
+    ? value
+    : `'${value.replaceAll("'", `'\\''`)}'`;
+
 export const buildReplayCommand = (
   generatorName: string,
   answers: Record<string, unknown>,
@@ -376,9 +387,7 @@ export const buildReplayCommand = (
     const value = answers[prompt.name];
     if (value === undefined) continue;
 
-    const kebabName = prompt.name
-      .replace(/([a-z])([A-Z])/g, "$1-$2")
-      .toLowerCase();
+    const kebabName = flagName(prompt.name);
 
     if (prompt.type === "confirm") {
       if (value === true && prompt.default !== true) {
@@ -388,10 +397,10 @@ export const buildReplayCommand = (
       }
     } else if (prompt.type === "multiselect" && Array.isArray(value)) {
       if (value.length > 0) {
-        parts.push(`--${kebabName}`, value.join(","));
+        parts.push(`--${kebabName}`, shellQuote(value.join(",")));
       }
     } else {
-      parts.push(`--${kebabName}`, String(value));
+      parts.push(`--${kebabName}`, shellQuote(String(value)));
     }
   }
 
@@ -598,17 +607,17 @@ export const formatLlmHelp = (
     switch (prompt.type) {
       case "confirm":
         return "`[boolean]`";
-      case "select":
-        return `\`${(prompt.choices as Array<{ value: string }>).map((c) => c.value).join("\\|")}\``;
+      case "select": {
+        const choices = prompt.choices ?? [];
+        if (choices.length === 0) return "`<value>`";
+        return `\`${choices.map((c) => c.value).join("\\|")}\``;
+      }
       case "multiselect":
         return "`[value,value,...]`";
       default:
         return "`<value>`";
     }
   };
-
-  const toKebab = (s: string): string =>
-    s.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
 
   if (requiredPrompts.length > 0) {
     lines.push("## Required Options");
@@ -617,7 +626,7 @@ export const formatLlmHelp = (
     lines.push("|------|------|-------------|");
     for (const p of requiredPrompts) {
       lines.push(
-        `| --${toKebab(p.name)} | ${formatTypeHint(p)} | ${p.message} |`,
+        `| --${flagName(p.name)} | ${formatTypeHint(p)} | ${p.message} |`,
       );
     }
     lines.push("");
@@ -632,7 +641,7 @@ export const formatLlmHelp = (
       const def =
         p.default !== undefined ? `\`${JSON.stringify(p.default)}\`` : "";
       lines.push(
-        `| --${toKebab(p.name)} | ${formatTypeHint(p)} | ${def} | ${p.message} |`,
+        `| --${flagName(p.name)} | ${formatTypeHint(p)} | ${def} | ${p.message} |`,
       );
     }
     lines.push("");
@@ -663,7 +672,7 @@ export const formatLlmHelp = (
   lines.push("");
 
   const exampleFlags = requiredPrompts
-    .map((p) => `--${toKebab(p.name)} <value>`)
+    .map((p) => `--${flagName(p.name)} <value>`)
     .join(" ");
   const flagStr = exampleFlags ? ` ${exampleFlags}` : "";
 

--- a/packages/summon/core/src/format/flagName.ts
+++ b/packages/summon/core/src/format/flagName.ts
@@ -1,0 +1,12 @@
+/**
+ * The kebab-case CLI flag form of a camelCase prompt name — the SINGLE
+ * algorithm every user-facing surface uses. Error messages, `--llm` help,
+ * and replay commands must all name the same flag the CLI actually
+ * registers (`registerFromBarrel` uses this same case-boundary split), or
+ * an error tells the user to pass a flag that does not exist: the old
+ * per-capital split turned `componentURL` into `--component-u-r-l` while
+ * help and Commander said `--component-url`.
+ */
+export default function flagName(promptName: string): string {
+  return promptName.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+}

--- a/packages/summon/core/src/format/formatFlagName.ts
+++ b/packages/summon/core/src/format/formatFlagName.ts
@@ -7,6 +7,6 @@
  * per-capital split turned `componentURL` into `--component-u-r-l` while
  * help and Commander said `--component-url`.
  */
-export default function flagName(promptName: string): string {
+export default function formatFlagName(promptName: string): string {
   return promptName.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
 }

--- a/packages/summon/core/src/format/index.ts
+++ b/packages/summon/core/src/format/index.ts
@@ -14,3 +14,4 @@ export {
   getLlmEffectPath,
   isVisibleEffect,
 } from "./effects.js";
+export { default as flagName } from "./flagName.js";

--- a/packages/summon/core/src/format/index.ts
+++ b/packages/summon/core/src/format/index.ts
@@ -14,4 +14,4 @@ export {
   getLlmEffectPath,
   isVisibleEffect,
 } from "./effects.js";
-export { default as flagName } from "./flagName.js";
+export { default as formatFlagName } from "./formatFlagName.js";

--- a/packages/summon/core/src/prompt/answerPromptWithDefaults.test.ts
+++ b/packages/summon/core/src/prompt/answerPromptWithDefaults.test.ts
@@ -16,12 +16,15 @@ describe("answerPromptWithDefaults", () => {
     ).toBe(false);
   });
 
-  it("defaults a confirm to true when unset", async () => {
+  it("defaults a confirm to false when unset — aligned with the dry-run mock", async () => {
+    // The three non-interactive resolutions previously disagreed (dry-run
+    // false, defaults true, autoPrompt reject): a --dry-run plan could take a
+    // different branch than the identical defaults-driven run.
     expect(
       await answerPromptWithDefaults(
         prompt({ type: "confirm", name: "ok", message: "?" }),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("resolves a select to its default", async () => {
@@ -52,6 +55,16 @@ describe("answerPromptWithDefaults", () => {
         }),
       ),
     ).toBe("bash");
+  });
+
+  it("resolves a select with no default and no choices to an empty string", async () => {
+    // Aligned with the dry-run mock's `?? ""` — previously this injected
+    // `undefined` into the answers.
+    expect(
+      await answerPromptWithDefaults(
+        prompt({ type: "select", name: "mode", message: "?", choices: [] }),
+      ),
+    ).toBe("");
   });
 
   it("resolves a multiselect to its default", async () => {

--- a/packages/summon/core/src/prompt/answerPromptWithDefaults.ts
+++ b/packages/summon/core/src/prompt/answerPromptWithDefaults.ts
@@ -5,9 +5,11 @@ import type { Effect } from "@canonical/task";
  * defaults-only handler the summon Ink progress view drives, and the base the
  * seam's {@link autoPrompt} strategy layers required-missing detection on.
  *
- * Each prompt type yields the value a non-interactive run should assume: a
- * confirm's default (or `true`), a select's default (or its first choice), an
- * empty multiselect, or a text default (or `""`).
+ * Each prompt type yields the value a non-interactive run should assume,
+ * ALIGNED with the dry-run interpreter's mock so a plan and a defaults-driven
+ * run take the same branches: a confirm's default (or `false`), a select's
+ * default (or its first choice, or `""`), an empty multiselect, or a text
+ * default (or `""`).
  *
  * @param effect - A `Prompt` effect to resolve.
  * @returns The default answer for the prompt's type.
@@ -18,9 +20,11 @@ export default function answerPromptWithDefaults(
   const question = effect.question;
   switch (question.type) {
     case "confirm":
-      return Promise.resolve(question.default ?? true);
+      return Promise.resolve(question.default ?? false);
     case "select":
-      return Promise.resolve(question.default ?? question.choices[0]?.value);
+      return Promise.resolve(
+        question.default ?? question.choices[0]?.value ?? "",
+      );
     case "multiselect":
       return Promise.resolve(question.default ?? []);
     default:

--- a/packages/summon/core/src/prompt/autoPrompt.ts
+++ b/packages/summon/core/src/prompt/autoPrompt.ts
@@ -17,7 +17,7 @@ import type { PromptEffect, PromptHandler } from "./types.js";
 /** The task-error code raised when a required answer is neither provided nor defaulted. */
 export const MISSING_REQUIRED_ANSWER = "MISSING_REQUIRED_ANSWER";
 
-import flagName from "../format/flagName.js";
+import formatFlagName from "../format/formatFlagName.js";
 
 /**
  * Build the structured error for a required, unprovided answer.
@@ -33,7 +33,7 @@ export function missingRequiredError(
   const { name, message } = effect.question;
   return new TaskExecutionError({
     code: MISSING_REQUIRED_ANSWER,
-    message: `Missing required ${noun} --${flagName(name)} (${message}). Provide it non-interactively, or run interactively to be prompted.`,
+    message: `Missing required ${noun} --${formatFlagName(name)} (${message}). Provide it non-interactively, or run interactively to be prompted.`,
     context: { answer: name },
   });
 }

--- a/packages/summon/core/src/prompt/autoPrompt.ts
+++ b/packages/summon/core/src/prompt/autoPrompt.ts
@@ -17,9 +17,7 @@ import type { PromptEffect, PromptHandler } from "./types.js";
 /** The task-error code raised when a required answer is neither provided nor defaulted. */
 export const MISSING_REQUIRED_ANSWER = "MISSING_REQUIRED_ANSWER";
 
-/** Convert a camelCase answer key to its kebab-case CLI flag form. */
-const toKebab = (name: string): string =>
-  name.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+import flagName from "../format/flagName.js";
 
 /**
  * Build the structured error for a required, unprovided answer.
@@ -35,7 +33,7 @@ export function missingRequiredError(
   const { name, message } = effect.question;
   return new TaskExecutionError({
     code: MISSING_REQUIRED_ANSWER,
-    message: `Missing required ${noun} --${toKebab(name)} (${message}). Provide it non-interactively, or run interactively to be prompted.`,
+    message: `Missing required ${noun} --${flagName(name)} (${message}). Provide it non-interactively, or run interactively to be prompted.`,
     context: { answer: name },
   });
 }

--- a/packages/summon/core/src/prompt/ink/mount.tsx
+++ b/packages/summon/core/src/prompt/ink/mount.tsx
@@ -45,6 +45,7 @@ export function mountPromptSession(
     generator,
     options.onCancel,
     options.cwd,
+    options.initialAnswers,
   );
   const instance = render(<Wizard controller={controller} />, {
     stdout: process.stderr as unknown as NodeJS.WriteStream,

--- a/packages/summon/core/src/prompt/ink/session.ts
+++ b/packages/summon/core/src/prompt/ink/session.ts
@@ -103,13 +103,17 @@ export class SessionController {
     generator: GeneratorDefinition,
     private readonly onUserCancel?: () => void,
     private readonly cwd?: string,
+    initialAnswers: Readonly<Record<string, unknown>> = {},
   ) {
+    // Seed flag/MCP-provided answers: collectAnswers never asks for them, so
+    // without the seed the confirm gate's preview and the step counter run
+    // against an answer set with those values missing.
     this.current = {
       phase: "idle",
       generator,
-      answers: {},
+      answers: { ...initialAnswers },
       step: 0,
-      total: countApplicable(generator, {}),
+      total: countApplicable(generator, { ...initialAnswers }),
       previewEffects: [],
       progress: [],
     };

--- a/packages/summon/core/src/prompt/ink/session.ts
+++ b/packages/summon/core/src/prompt/ink/session.ts
@@ -61,7 +61,7 @@ export interface WizardState {
 }
 
 /** The prompts that apply given the answers so far (respecting `when`). */
-function applicablePrompts(
+function listApplicablePrompts(
   generator: GeneratorDefinition,
   answers: Record<string, unknown>,
 ): readonly GeneratorDefinition["prompts"][number][] {
@@ -73,7 +73,7 @@ function countApplicable(
   generator: GeneratorDefinition,
   answers: Record<string, unknown>,
 ): number {
-  return applicablePrompts(generator, answers).length;
+  return listApplicablePrompts(generator, answers).length;
 }
 
 /**
@@ -86,7 +86,7 @@ function countAnswered(
   generator: GeneratorDefinition,
   answers: Record<string, unknown>,
 ): number {
-  return applicablePrompts(generator, answers).filter((p) =>
+  return listApplicablePrompts(generator, answers).filter((p) =>
     Object.hasOwn(answers, p.name),
   ).length;
 }

--- a/packages/summon/core/src/prompt/ink/session.ts
+++ b/packages/summon/core/src/prompt/ink/session.ts
@@ -60,13 +60,35 @@ export interface WizardState {
   readonly error?: TaskError;
 }
 
+/** The prompts that apply given the answers so far (respecting `when`). */
+function applicablePrompts(
+  generator: GeneratorDefinition,
+  answers: Record<string, unknown>,
+): readonly GeneratorDefinition["prompts"][number][] {
+  return generator.prompts.filter((p) => !p.when || p.when(answers) === true);
+}
+
 /** Count the prompts that apply given the answers so far (respecting `when`). */
 function countApplicable(
   generator: GeneratorDefinition,
   answers: Record<string, unknown>,
 ): number {
-  return generator.prompts.filter((p) => !p.when || p.when(answers) === true)
-    .length;
+  return applicablePrompts(generator, answers).length;
+}
+
+/**
+ * Count the APPLICABLE prompts already answered. The answer bag can carry
+ * keys that are not generator prompts at all (pragma's `framework` param) or
+ * answers to prompts a `when` currently excludes — counting raw keys let the
+ * step counter exceed the total.
+ */
+function countAnswered(
+  generator: GeneratorDefinition,
+  answers: Record<string, unknown>,
+): number {
+  return applicablePrompts(generator, answers).filter((p) =>
+    Object.hasOwn(answers, p.name),
+  ).length;
 }
 
 /**
@@ -152,7 +174,10 @@ export class SessionController {
         this.set({ phase: "confirming", previewEffects: [] });
         this.previewInFlight = this.loadPreview();
       } else {
-        const answered = Object.keys(this.current.answers).length;
+        const answered = countAnswered(
+          this.current.generator,
+          this.current.answers,
+        );
         this.set({
           phase: "prompting",
           activeQuestion: effect,

--- a/packages/summon/core/src/prompt/inkPrompt.ts
+++ b/packages/summon/core/src/prompt/inkPrompt.ts
@@ -95,19 +95,19 @@ export default function inkPrompt(
   let mounted: MountedSession | undefined;
 
   const ensure = (): Promise<MountedSession> => {
-    mountP ??= import("./ink/mount.js").then(
-      (mod) => {
+    mountP ??= import("./ink/mount.js")
+      .then((mod) => {
         mounted = mod.mountPromptSession(generator, options);
         return mounted;
-      },
-      (error) => {
-        // Do not cache a failed mount: a transient import failure would
-        // otherwise reject every later prompt in the session with the same
-        // stale error.
+      })
+      .catch((error) => {
+        // Do not cache a failure — a trailing catch, so BOTH a failed dynamic
+        // import and a throw from mountPromptSession itself (e.g. Ink render)
+        // reset the memo; otherwise every later prompt in the session would
+        // reuse the same stale rejection.
         mountP = undefined;
         throw error;
-      },
-    );
+      });
     return mountP;
   };
 

--- a/packages/summon/core/src/prompt/inkPrompt.ts
+++ b/packages/summon/core/src/prompt/inkPrompt.ts
@@ -40,6 +40,13 @@ export interface InkPromptOptions {
    * back to the process cwd, matching a run given no `cwd` of its own.
    */
   readonly cwd?: string;
+  /**
+   * Answers already provided outside the wizard (CLI flags / MCP args).
+   * Seeded into the session so the confirm gate's preview and step counter
+   * see the full answer set — without this a partially-flagged run previews
+   * with those answers missing (`undefined` paths, wrong plan).
+   */
+  readonly initialAnswers?: Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -88,10 +95,19 @@ export default function inkPrompt(
   let mounted: MountedSession | undefined;
 
   const ensure = (): Promise<MountedSession> => {
-    mountP ??= import("./ink/mount.js").then((mod) => {
-      mounted = mod.mountPromptSession(generator, options);
-      return mounted;
-    });
+    mountP ??= import("./ink/mount.js").then(
+      (mod) => {
+        mounted = mod.mountPromptSession(generator, options);
+        return mounted;
+      },
+      (error) => {
+        // Do not cache a failed mount: a transient import failure would
+        // otherwise reject every later prompt in the session with the same
+        // stale error.
+        mountP = undefined;
+        throw error;
+      },
+    );
     return mountP;
   };
 

--- a/packages/summon/core/src/prompt/mcpPrompt.ts
+++ b/packages/summon/core/src/prompt/mcpPrompt.ts
@@ -24,7 +24,7 @@ export default function mcpPrompt(
 ): PromptHandler {
   return (effect: PromptEffect) => {
     const q = effect.question;
-    if (q.name in params) return Promise.resolve(params[q.name]);
+    if (Object.hasOwn(params, q.name)) return Promise.resolve(params[q.name]);
     if (q.default !== undefined) return Promise.resolve(q.default);
     return Promise.reject(missingRequiredError(effect, "argument"));
   };

--- a/packages/summon/core/src/types/ReservedOption.ts
+++ b/packages/summon/core/src/types/ReservedOption.ts
@@ -18,6 +18,7 @@ type ReservedOption =
   | "showFiles"
   | "show-files"
   | "verbose"
-  | "generatedStamp";
+  | "generatedStamp"
+  | "generated-stamp";
 
 export type { ReservedOption as default };


### PR DESCRIPTION
## Done

CLI-seam fixes for `summon-core` from the summon audit (one commit; the pieces are one story — the seams between prompts, validation, and output must agree with each other):

- **One flag-name algorithm** (new `formatFlagName` helper) across error messages, `--llm` help, and replay commands: the per-capital split told users to pass `--component-u-r-l` while help and Commander registered `--component-url`.
- **Replay commands are shell-safe**: values with spaces/metacharacters are quoted, so a description like `A demo project` no longer renders a broken "To execute" line in every `--llm` output.
- **`--help --llm` no longer crashes** on a select prompt without `choices` (the field is optional on `PromptDefinition`).
- **`validateAnswers` checks multiselect membership** the way it already checked select membership, and answer-presence checks use `Object.hasOwn` — a prompt named `toString` was treated as already answered via the prototype chain (same fix in `collectAnswers` and `mcpPrompt`).
- **The non-interactive default policies agree**: `answerPromptWithDefaults` aligns with the dry-run mock (confirm → default-or-`false`, select → default-or-first-choice-or-`""`), so a `--dry-run` plan and the identical defaults-driven run take the same branches. The `execute` confirm gate declares `default: true` explicitly and is unaffected.
- `ReservedOption` also reserves `generated-stamp` (the kebab twin of `generatedStamp`, matching `dry-run`/`show-files`).
- **The Ink confirm-gate preview sees flag-provided answers**: new `initialAnswers` option on `inkPrompt`, seeded into the session's answer set and step counter — previously a partially-flagged interactive `pragma create` previewed with those answers missing (`undefined` paths, wrong plan). Pragma's create verb passes its params through (one-line wiring). A failed Ink mount is also no longer cached forever; the next prompt retries the import.

Known-and-left (flagged in the audit, deferred): `template()` renders via the sync EJS path without `filename`, so EJS `include()` works in `renderFile()` but not in `template()`/`templateDir()` — fixing it means extending the `TemplatingEngine` interface.

## QA

- `bun run check` passes from the repo root; `bun run test` passes everywhere except the three svelte app packages (pre-existing environment-only Playwright system-library failure on this machine, unrelated).
- 433 core tests pass (100% coverage thresholds intact); new pins: flag-name consistency in errors and replays, replay quoting, select-without-choices help, multiselect membership, prototype-chain answer names, and the aligned defaults (including the empty-choices select).

### PR readiness check

- [x] PR label: `Bug 🐛`
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added.

## Screenshots

n/a

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

