### PR TITLE
feat(boilerplate-vite): align the reference app and overhaul the router docs (re-land of #979)

### DIFF
--- a/apps/react/boilerplate-vite/src/client/entry.tsx
+++ b/apps/react/boilerplate-vite/src/client/entry.tsx
@@ -2,23 +2,33 @@ import { isSupportedLocale, negotiateLocale } from "@canonical/i18n-core";
 import { I18nProvider } from "@canonical/i18n-react";
 import { HeadProvider } from "@canonical/react-head";
 import { createBrowserAdapter, createRouter } from "@canonical/router-core";
-import { Outlet, RouterProvider } from "@canonical/router-react";
+import {
+  Outlet,
+  RouterProvider,
+  readDehydratedState,
+} from "@canonical/router-react";
 import { hydrateRoot } from "react-dom/client";
 import { RelayEnvironmentProvider } from "react-relay";
 import { catalogs, i18nConfig } from "#i18n/index.js";
-import { createEnvironment } from "#relay/environment.js";
+import { getBrowserEnvironment } from "#relay/environment.js";
 import { appRoutes, middleware, notFoundRoute } from "../routes.js";
 import "#styles/index.css";
 
+// On SSR pages __INITIAL_DATA__ carries the flat dehydrated router state
+// (href/kind/routeId/status); hydrating from it resumes the server-rendered
+// match and skips the duplicate initial load. In the SPA cells there is no
+// payload (or no router fields) and readDehydratedState() returns null, so
+// the router performs a normal initial load.
 const router = createRouter(appRoutes, {
   adapter: createBrowserAdapter(),
   middleware: [...middleware],
   notFound: notFoundRoute,
+  hydratedState: readDehydratedState() ?? undefined,
 });
 
 // One Relay environment (network + normalized store) for the whole browser
 // session — module scope, so client-side navigations share the cache.
-const relayEnvironment = createEnvironment();
+const relayEnvironment = getBrowserEnvironment();
 
 /**
  * Resolve the locale for the first client render.

--- a/apps/react/boilerplate-vite/src/domains/account/routes.ts
+++ b/apps/react/boilerplate-vite/src/domains/account/routes.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from "@canonical/router-core";
 import { route } from "@canonical/router-core";
 import AccountPage from "./AccountPage.js";
 import LoginPage from "./LoginPage.js";
@@ -6,24 +7,36 @@ function readString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-const accountSearchSchema = {
+/**
+ * Standard Schema v1 search validators — the same interface Zod, Valibot,
+ * and ArkType implement, so any of them can be dropped in here directly.
+ */
+const accountSearchSchema: StandardSchemaV1<
+  Record<string, unknown>,
+  { readonly auth?: string }
+> = {
   "~standard": {
-    output: {} as { readonly auth?: string },
-    validate(value: unknown): { readonly auth?: string } {
+    version: 1,
+    vendor: "boilerplate",
+    validate(value) {
       const record = value as Record<string, unknown>;
 
-      return { auth: readString(record.auth) };
+      return { value: { auth: readString(record.auth) } };
     },
   },
 };
 
-const loginSearchSchema = {
+const loginSearchSchema: StandardSchemaV1<
+  Record<string, unknown>,
+  { readonly from?: string }
+> = {
   "~standard": {
-    output: {} as { readonly from?: string },
-    validate(value: unknown): { readonly from?: string } {
+    version: 1,
+    vendor: "boilerplate",
+    validate(value) {
       const record = value as Record<string, unknown>;
 
-      return { from: readString(record.from) };
+      return { value: { from: readString(record.from) } };
     },
   },
 };

--- a/apps/react/boilerplate-vite/src/domains/catalog/ProductList.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/ProductList.tsx
@@ -5,9 +5,9 @@ import type { ProductListQuery } from "#relay/__generated__/ProductListQuery.gra
 import ProductCard from "./ProductCard.js";
 
 /** How many products the list requests from the connection. */
-const PAGE_SIZE = 4;
+export const PAGE_SIZE = 4;
 
-const productListQuery = graphql`
+export const productListQuery = graphql`
   query ProductListQuery($count: Int!, $cursor: String) {
     viewer {
       name

--- a/apps/react/boilerplate-vite/src/domains/catalog/routes.ts
+++ b/apps/react/boilerplate-vite/src/domains/catalog/routes.ts
@@ -1,9 +1,32 @@
 import { route } from "@canonical/router-core";
+import { fetchQuery } from "react-relay";
+import { getBrowserEnvironment } from "#relay/environment.js";
 import CatalogPage from "./CatalogPage.js";
+import { PAGE_SIZE, productListQuery } from "./ProductList.js";
 
 const routes = {
   catalog: route({
     url: "/catalog",
+    // Navigation-time cache warm: fetch the first catalog page into the
+    // browser session's Relay store so `useLazyLoadQuery` (store-or-network)
+    // reads it without a second request. Fire-and-forget by design — the
+    // route never blocks on it and no data is passed to the component; a
+    // failed warm just falls back to the component's own fetch. `fetchQuery`
+    // rather than `loadQuery`: the latter returns a reference that must be
+    // disposed, which has no owner in a fire-and-forget hook (unretained data
+    // sits in the store's release buffer and may eventually be GC'd —
+    // harmless, it re-fetches).
+    warm: () => {
+      if (typeof document === "undefined") {
+        return; // SSR: catalog content is ClientOnly; nothing to warm.
+      }
+
+      void fetchQuery(getBrowserEnvironment(), productListQuery, {
+        count: PAGE_SIZE,
+      })
+        .toPromise()
+        .catch(() => {});
+    },
     content: CatalogPage,
   }),
 } as const;

--- a/apps/react/boilerplate-vite/src/relay/environment.ts
+++ b/apps/react/boilerplate-vite/src/relay/environment.ts
@@ -117,3 +117,19 @@ export const createEnvironment = (
     store: new Store(new RecordSource()),
   });
 };
+
+let browserEnvironment: Environment | null = null;
+
+/**
+ * The browser-session Relay environment, created lazily on first use.
+ *
+ * Module scope so the client entry's provider and route-level `warm` hooks
+ * share one normalized store — a navigation-time cache warm lands in the same
+ * store `useLazyLoadQuery` reads from. Server code must keep using
+ * `createEnvironment()` (fresh per request).
+ */
+export const getBrowserEnvironment = (): Environment => {
+  browserEnvironment ??= createEnvironment();
+
+  return browserEnvironment;
+};

--- a/apps/react/boilerplate-vite/src/routes.tsx
+++ b/apps/react/boilerplate-vite/src/routes.tsx
@@ -24,50 +24,54 @@ function hasDemoAuth(search: unknown): boolean {
   return authValue === "1";
 }
 
-export function getAuthRedirectHref(input: string | URL): string | null {
-  const url =
-    input instanceof URL
-      ? input
-      : new URL(
-          input.startsWith("http") ? input : input,
-          "https://router.local",
-        );
-
-  if (
-    !protectedPaths.has(url.pathname) ||
-    hasDemoAuth({ auth: url.searchParams.get("auth") })
-  ) {
+/**
+ * Auth decision for an already-matched route, from the router's own data —
+ * the matched pattern and the schema-validated search. Deriving it from the
+ * raw URL would normalize differently from the router (trailing slashes,
+ * duplicate search values) and let a protected page render unauthenticated.
+ */
+export function getAuthRedirectForMatch(match: {
+  readonly route: AnyRoute;
+  readonly search: unknown;
+  readonly pathname: string;
+}): string | null {
+  if (!protectedPaths.has(match.route.url) || hasDemoAuth(match.search)) {
     return null;
   }
 
-  return `/login?from=${encodeURIComponent(url.pathname)}`;
+  return `/login?from=${encodeURIComponent(match.pathname)}`;
 }
 
 export function withAuth(loginPath: string): RouteMiddleware {
-  return ((currentRoute: AnyRoute) => {
+  return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
     if (!protectedPaths.has(currentRoute.url)) {
       return currentRoute;
     }
 
     const currentWarm = currentRoute.warm;
+    const guardedWarm = (
+      params: unknown,
+      search: unknown,
+      context: NavigationContext,
+    ) => {
+      if (!hasDemoAuth(search)) {
+        const from = currentRoute.render(
+          (params ?? {}) as RouteParamValues | Record<string, never>,
+        );
 
-    return {
-      ...currentRoute,
-      warm: (params: unknown, search: unknown, context: NavigationContext) => {
-        if (!hasDemoAuth(search)) {
-          const from = currentRoute.render(
-            (params ?? {}) as RouteParamValues | Record<string, never>,
-          );
+        redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);
+      }
 
-          redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);
-        }
-
-        if (currentWarm) {
-          return currentWarm(params, search, context);
-        }
-      },
+      if (currentWarm) {
+        return currentWarm(params, search, context);
+      }
     };
-  }) as RouteMiddleware;
+
+    // Overriding `warm` widens the property's type, so the object needs a
+    // local assertion back to TRoute; the middleware's signature itself is
+    // now the real generic contract.
+    return { ...currentRoute, warm: guardedWarm } as TRoute;
+  };
 }
 
 const publicLayout = wrapper<ReactElement>({
@@ -112,9 +116,19 @@ const [contact] = group(publicLayout, [contactRoutes.contact] as const);
 
 const [catalog] = group(publicLayout, [catalogRoutes.catalog] as const);
 
+// Static redirect route: matched entirely from the URL, no content — the
+// router (and the SSR disposition helper) answers with a real 301. Static
+// redirects accept 301 or 308 only; runtime redirect() covers the 302 family.
+const legacyHome = route({
+  url: "/home",
+  redirect: "/",
+  status: 301,
+});
+
 const appRoutes = {
   guide,
   home,
+  legacyHome,
   account,
   login,
   contact,

--- a/apps/react/boilerplate-vite/src/server/entry.tsx
+++ b/apps/react/boilerplate-vite/src/server/entry.tsx
@@ -2,20 +2,115 @@ import { documentAttrs, isSupportedLocale } from "@canonical/i18n-core";
 import { I18nProvider } from "@canonical/i18n-react";
 import { HeadProvider } from "@canonical/react-head";
 import type { ServerEntrypointProps } from "@canonical/react-ssr/renderer";
-import { createRouter, createServerAdapter } from "@canonical/router-core";
+import {
+  createRouter,
+  createServerAdapter,
+  StatusResponse,
+} from "@canonical/router-core";
 import { Outlet, RouterProvider } from "@canonical/router-react";
 import { RelayEnvironmentProvider } from "react-relay";
 import { catalogs, i18nConfig } from "#i18n/index.js";
 import { createEnvironment } from "#relay/environment.js";
-import { appRoutes, middleware, notFoundRoute } from "../routes.js";
+import {
+  appRoutes,
+  getAuthRedirectForMatch,
+  middleware,
+  notFoundRoute,
+} from "../routes.js";
 import "#styles/app.css";
 
 interface InitialData extends Record<string, unknown> {
   readonly url?: string;
   /** Colour-scheme preference resolved from the request cookie, if any. */
   readonly theme?: "light" | "dark";
+  /**
+   * Flat dehydrated router state (from resolveRouteDisposition), read back by
+   * router-react's readDehydratedState() on the client. Absent in SPA cells.
+   */
+  readonly href?: string;
+  readonly kind?: "route" | "not-found";
+  readonly routeId?: string | null;
+  readonly status?: number;
   /** Locale negotiated from the request cookie / Accept-Language, if any. */
   readonly locale?: string;
+}
+
+/** How the server should answer a request for this URL. */
+export type RouteDisposition =
+  | {
+      readonly kind: "render";
+      readonly status: number;
+      readonly dehydratedState: {
+        readonly href: string;
+        readonly kind: "route" | "not-found";
+        readonly routeId: string | null;
+        readonly status: number;
+      } | null;
+    }
+  | {
+      readonly kind: "redirect";
+      readonly status: number;
+      readonly location: string;
+    };
+
+// A module-scope adapterless router is a pure matcher: without an adapter,
+// construction fires no load and no warm hooks, and match() runs no hooks at
+// all. Never use a server-adapter router here — it warms at construction.
+const dispositionMatcher = createRouter(appRoutes, {
+  middleware: [...middleware],
+  notFound: notFoundRoute,
+});
+
+/**
+ * Resolve a request URL to the HTTP answer the router implies: a redirect
+ * (auth guard or a static redirect route) or a render with the matched
+ * document's real status — a matched not-found page is a 404 response, not a
+ * soft 200.
+ */
+export function resolveRouteDisposition(url: string): RouteDisposition {
+  let matchResult: ReturnType<typeof dispositionMatcher.match>;
+
+  try {
+    matchResult = dispositionMatcher.match(url);
+  } catch (error) {
+    // A rejected search schema is a client error; render the shell with the
+    // error status and let the client router re-derive the same state.
+    return {
+      kind: "render",
+      status: error instanceof StatusResponse ? error.status : 500,
+      dehydratedState: null,
+    };
+  }
+
+  if (matchResult?.kind === "redirect") {
+    return {
+      kind: "redirect",
+      status: matchResult.status,
+      location: matchResult.redirectTo,
+    };
+  }
+
+  // Auth is decided from the router's own match (pattern + validated search),
+  // never from the raw URL — the two normalize differently.
+  const authRedirect =
+    matchResult?.kind === "route" ? getAuthRedirectForMatch(matchResult) : null;
+
+  if (authRedirect) {
+    return { kind: "redirect", status: 302, location: authRedirect };
+  }
+
+  const status = matchResult?.status ?? 404;
+
+  return {
+    kind: "render",
+    status,
+    dehydratedState: {
+      href: url,
+      kind: matchResult?.kind === "route" ? "route" : "not-found",
+      routeId: matchResult?.kind === "route" ? String(matchResult.name) : null,
+      status,
+    },
+  };
 }
 
 export default function EntryServer(props: ServerEntrypointProps<InitialData>) {

--- a/apps/react/boilerplate-vite/src/server/entry.tsx
+++ b/apps/react/boilerplate-vite/src/server/entry.tsx
@@ -121,7 +121,18 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
     notFound: notFoundRoute,
     adapter: createServerAdapter(url),
   });
-  const serverMatch = router.match(url);
+  // A rejected search schema throws from match(); resolveRouteDisposition
+  // already turned that into the response status (400-class), so render the
+  // shell unhydrated instead of letting the throw reach React — a shell
+  // error would override the supplied status with 500. The client router
+  // re-derives the same error state on load.
+  let serverMatch: ReturnType<typeof router.match>;
+
+  try {
+    serverMatch = router.match(url);
+  } catch {
+    serverMatch = null;
+  }
 
   // Hydrate the store synchronously so render() works without awaiting
   // load(). Redirects and unmatched URLs are the server's concern before

--- a/apps/react/boilerplate-vite/src/server/preview.bun.ts
+++ b/apps/react/boilerplate-vite/src/server/preview.bun.ts
@@ -63,15 +63,30 @@ Bun.serve({
       }
     }
 
-    const renderer =
-      url.pathname === "/sitemap.xml"
-        ? (createSitemapRenderer as CreateSitemapRenderer)()
-        : (createAppRenderer as CreateAppRenderer)(req);
-    const stream = await renderer.renderToReadableStream(req.signal);
+    if (url.pathname === "/sitemap.xml") {
+      const renderer = (createSitemapRenderer as CreateSitemapRenderer)();
+      const stream = await renderer.renderToReadableStream(req.signal);
+
+      return new Response(stream, {
+        status: renderer.statusCode,
+        headers: { "Content-Type": renderer.contentType },
+      });
+    }
+
+    const appResult = (createAppRenderer as CreateAppRenderer)(req);
+
+    if (appResult.kind === "redirect") {
+      return new Response(null, {
+        status: appResult.status,
+        headers: { location: appResult.location },
+      });
+    }
+
+    const stream = await appResult.renderer.renderToReadableStream(req.signal);
 
     return new Response(stream, {
-      status: renderer.statusCode,
-      headers: { "Content-Type": renderer.contentType },
+      status: appResult.renderer.statusCode,
+      headers: { "Content-Type": appResult.renderer.contentType },
     });
   },
 });

--- a/apps/react/boilerplate-vite/src/server/preview.express.ts
+++ b/apps/react/boilerplate-vite/src/server/preview.express.ts
@@ -49,10 +49,25 @@ app.use(express.static("dist/client", { index: false }));
 
 app.use(async (req, res, next) => {
   try {
-    const renderer =
-      req.path === "/sitemap.xml"
-        ? (createSitemapRenderer as CreateSitemapRenderer)()
-        : (createAppRenderer as CreateAppRenderer)(req);
+    if (req.path === "/sitemap.xml") {
+      const renderer = (createSitemapRenderer as CreateSitemapRenderer)();
+      const result = renderer.renderToPipeableStream();
+
+      await renderer.statusReady;
+      res.status(renderer.statusCode);
+      res.setHeader("content-type", renderer.contentType);
+      result.pipe(res);
+      return;
+    }
+
+    const appResult = (createAppRenderer as CreateAppRenderer)(req);
+
+    if (appResult.kind === "redirect") {
+      res.redirect(appResult.status, appResult.location);
+      return;
+    }
+
+    const renderer = appResult.renderer;
     const result = renderer.renderToPipeableStream();
 
     await renderer.statusReady;

--- a/apps/react/boilerplate-vite/src/server/renderer.tsx
+++ b/apps/react/boilerplate-vite/src/server/renderer.tsx
@@ -22,7 +22,11 @@ import { extractPreferences } from "@canonical/react-hooks";
 import { JSXRenderer } from "@canonical/react-ssr/renderer";
 import { getRequestUrl } from "@canonical/react-ssr/server";
 import { i18nConfig } from "#i18n/config.js";
-import EntryServer, { type InitialData } from "./entry.js";
+import EntryServer, {
+  type InitialData,
+  type RouteDisposition,
+  resolveRouteDisposition,
+} from "./entry.js";
 
 const htmlString = fs.readFileSync(
   path.join(process.cwd(), "dist", "client", "index.html"),
@@ -55,7 +59,17 @@ function acceptLanguageHeader(
  * URL for routing and the cookie-backed theme so the first paint matches the
  * user's preference, passing both as the renderer's initial data.
  */
-export default function createAppRenderer(request: Request | IncomingMessage) {
+/** The app renderer's answer: a stream renderer, or an HTTP redirect. */
+export type AppRendererResult =
+  | {
+      readonly kind: "render";
+      readonly renderer: JSXRenderer<typeof EntryServer, InitialData>;
+    }
+  | Extract<RouteDisposition, { kind: "redirect" }>;
+
+export default function createAppRenderer(
+  request: Request | IncomingMessage,
+): AppRendererResult {
   const cookie = cookieHeader(request);
   const { theme } = extractPreferences(cookie);
   const locale = negotiateLocale(i18nConfig, {
@@ -67,8 +81,22 @@ export default function createAppRenderer(request: Request | IncomingMessage) {
     theme: theme === "light" || theme === "dark" ? theme : undefined,
     locale,
   };
-  return new JSXRenderer(EntryServer, initialData, {
-    htmlString,
-    defaultLocale: locale,
-  });
+  const disposition = resolveRouteDisposition(initialData.url ?? "/");
+
+  if (disposition.kind === "redirect") {
+    return disposition;
+  }
+
+  // Flat-spread the dehydrated router state into the page payload; the client
+  // reads it back with readDehydratedState() and resumes the server match.
+  Object.assign(initialData, disposition.dehydratedState ?? {});
+
+  return {
+    kind: "render",
+    renderer: new JSXRenderer(EntryServer, initialData, {
+      htmlString,
+      defaultLocale: locale,
+      statusCode: disposition.status,
+    }),
+  };
 }

--- a/apps/react/boilerplate-vite/src/server/server.bun.ts
+++ b/apps/react/boilerplate-vite/src/server/server.bun.ts
@@ -65,9 +65,17 @@ Bun.serve({
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(requestUrl, template);
 
-      const { default: EntryServer } = await vite.ssrLoadModule(
-        "/src/server/entry.tsx",
-      );
+      const { default: EntryServer, resolveRouteDisposition } =
+        await vite.ssrLoadModule("/src/server/entry.tsx");
+
+      const disposition = resolveRouteDisposition(requestUrl);
+
+      if (disposition.kind === "redirect") {
+        return new Response(null, {
+          status: disposition.status,
+          headers: { location: disposition.location },
+        });
+      }
       const { JSXRenderer } = await vite.ssrLoadModule(
         "@canonical/react-ssr/renderer",
       );
@@ -94,8 +102,13 @@ Bun.serve({
           url: requestUrl,
           theme: theme === "light" || theme === "dark" ? theme : undefined,
           locale,
+          ...(disposition.dehydratedState ?? {}),
         },
-        { htmlString: html, defaultLocale: locale },
+        {
+          htmlString: html,
+          defaultLocale: locale,
+          statusCode: disposition.status,
+        },
       );
       const stream = await renderer.renderToReadableStream(req.signal);
 

--- a/apps/react/boilerplate-vite/src/server/server.express.ts
+++ b/apps/react/boilerplate-vite/src/server/server.express.ts
@@ -60,9 +60,15 @@ async function start() {
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(url, template);
 
-      const { default: EntryServer } = await vite.ssrLoadModule(
-        "/src/server/entry.tsx",
-      );
+      const { default: EntryServer, resolveRouteDisposition } =
+        await vite.ssrLoadModule("/src/server/entry.tsx");
+
+      const disposition = resolveRouteDisposition(url);
+
+      if (disposition.kind === "redirect") {
+        res.redirect(disposition.status, disposition.location);
+        return;
+      }
       const { JSXRenderer } = await vite.ssrLoadModule(
         "@canonical/react-ssr/renderer",
       );
@@ -91,8 +97,13 @@ async function start() {
           url,
           theme: theme === "light" || theme === "dark" ? theme : undefined,
           locale,
+          ...(disposition.dehydratedState ?? {}),
         },
-        { htmlString: html, defaultLocale: locale },
+        {
+          htmlString: html,
+          defaultLocale: locale,
+          statusCode: disposition.status,
+        },
       );
       const result = renderer.renderToPipeableStream();
 

--- a/apps/react/boilerplate-vite/test/e2e/servers.e2e.ts
+++ b/apps/react/boilerplate-vite/test/e2e/servers.e2e.ts
@@ -111,6 +111,62 @@ describe("server matrix (2×3) serves correctly", () => {
             expect(arabicHtml).toContain('dir="rtl"');
             expect(arabicHtml).toContain("الرئيسية");
           }
+
+          // SSR cells answer with the router's disposition: a matched
+          // not-found page is a real 404, static redirect routes and the
+          // auth guard are real HTTP redirects, and an authorized request
+          // renders 200. (The SPA cells stay 200-only: Vite's static
+          // fallback serves index.html for every route and cannot express
+          // router statuses.)
+          if (cell.ssr) {
+            const notFound = await fetch(
+              `${server.base}/definitely-not-a-page`,
+            );
+            expect(notFound.status).toBe(404);
+            const notFoundHtml = await notFound.text();
+            expect(notFoundHtml).toContain('id="root"');
+
+            const legacy = await fetch(`${server.base}/home`, {
+              redirect: "manual",
+            });
+            expect(legacy.status).toBe(301);
+            const legacyLocation = legacy.headers.get("location");
+            expect(legacyLocation, "301 must carry a Location").toBeTruthy();
+            expect(
+              new URL(legacyLocation as string, server.base).pathname,
+            ).toBe("/");
+
+            const guarded = await fetch(`${server.base}/account`, {
+              redirect: "manual",
+            });
+            expect(guarded.status).toBe(302);
+            const guardedHeader = guarded.headers.get("location");
+            expect(guardedHeader, "302 must carry a Location").toBeTruthy();
+            const guardedLocation = new URL(
+              guardedHeader as string,
+              server.base,
+            );
+            expect(guardedLocation.pathname).toBe("/login");
+            expect(guardedLocation.searchParams.get("from")).toBe("/account");
+
+            // The auth decision comes from the router's own match, so URL
+            // shapes the router normalizes differently from a raw-URL check
+            // must still redirect: a trailing slash, and duplicate auth
+            // values where the router keeps the last one.
+            const trailing = await fetch(`${server.base}/account/`, {
+              redirect: "manual",
+            });
+            expect(trailing.status).toBe(302);
+
+            const duplicated = await fetch(
+              `${server.base}/account?auth=1&auth=0`,
+              { redirect: "manual" },
+            );
+            expect(duplicated.status).toBe(302);
+
+            const authorized = await fetch(`${server.base}/account?auth=1`);
+            expect(authorized.status).toBe(200);
+          }
         } finally {
           await server.stop();
         }

--- a/docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md
+++ b/docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md
@@ -6,6 +6,8 @@ Migration guide for apps currently using React Router (v5, v6, v7) or TanStack R
 
 Before diving into version-specific translations, understand the pragma router's model:
 
+**One constructor, adapters as the axis.** `createRouter(routes, { adapter, ... })` is the only way to build a router. The adapter picks the platform: `createBrowserAdapter()` (Navigation API with a History fallback), `createHashAdapter()`, `createMemoryAdapter(url)` for tests, `createServerAdapter(url)` for SSR. There are no preset factories.
+
 **Flat routes, not nested trees.** Every route is a top-level entry in a route map object. There is no route tree or hierarchy. Shared layout and data live in wrappers, not parent routes.
 
 **Wrappers for layout.** Where other routers use nested routes for shared layout, pragma uses `wrapper()` + `group()`. A wrapper provides a layout shell; `group()` applies it to a set of routes.
@@ -16,7 +18,7 @@ Before diving into version-specific translations, understand the pragma router's
 
 **Data is not a routing concern.** The router does not own data fetching. `warm()` is a fire-and-forget navigation-time hook for warming caches or preloading assets. Components fetch their own data from their cache library (Relay, TanStack Query, SWR, etc.).
 
-**React error boundaries for errors.** No router-specific error UI. Errors from `warm()` throw into the React tree and are caught by standard React error boundaries. Use `StatusResponse` to signal HTTP-like errors.
+**Errors are state, not exceptions.** Data errors never throw into React. A thrown `StatusResponse` (or an unmatched URL) becomes the committed location's `status`; read `useRoute().status` and conditionally render error UI. A `redirect()` thrown from `warm()` — synchronously or from an async hook — is honored by the router (async ones apply late, after the route committed; render never blocks). Ordinary React error boundaries remain responsible for **render** errors only.
 
 ---
 
@@ -26,17 +28,18 @@ React Router v5 uses class-based patterns, `<Switch>`, render props, and the `wi
 
 | React Router v5 | Pragma |
 |---|---|
-| `<BrowserRouter>` | `createBrowserRouter(routes)` + `<RouterProvider>` |
+| `<BrowserRouter>` | `createRouter(routes, { adapter: createBrowserAdapter() })` + `<RouterProvider>` |
 | `<Switch>` / `<Route path="/foo">` | `route({ url: "/foo", content: FooPage })` in a flat route map |
 | `<Route component={Foo}>` | `content: FooPage` on the route definition |
 | `<Route render={() => <Foo />}>` | `content: FooPage` (pass component directly) |
 | `withRouter(Component)` | `useRouter()` hook |
-| `this.props.match.params` | `useRoute().params` or `({ params }) => ...` in content |
+| `this.props.match.params` | `({ params }) => ...` in `content`, or `useRouterState((s) => s.match?.params)` |
 | `this.props.history.push("/bar")` | `router.navigate("bar")` (by route name, not path) |
-| `this.props.location` | `useRoute()` returns pathname, search, hash |
+| `this.props.location` | `useRoute()` returns `pathname`, `searchParams`, `hash`, `status` |
 | `<Redirect to="/login">` | `redirect("/login", 302)` in `warm()`, or a static redirect route |
 | `<Link to="/foo">` | `<Link to="foo">` (route name, typed) |
 | `<NavLink activeClassName="on">` | `<Link to="foo">` sets `aria-current="page"` when active |
+| `<Prompt when={dirty}>` | `useBlocker(dirty)` — render your own dialog from its `state` |
 | Nested `<Route>` for layout | `wrapper()` + `group()` |
 
 ### Key differences
@@ -53,25 +56,27 @@ React Router v6 is hooks-based and closer to pragma's model. The main difference
 
 | React Router v6 | Pragma |
 |---|---|
-| `<BrowserRouter>` | `createBrowserRouter(routes)` + `<RouterProvider>` |
+| `<BrowserRouter>` | `createRouter(routes, { adapter: createBrowserAdapter() })` + `<RouterProvider>` |
 | `<Routes>` / `<Route path="/foo" element={<Foo />}>` | `route({ url: "/foo", content: FooPage })` |
 | Nested `<Route>` for layout | `wrapper()` + `group()` |
 | `<Outlet />` | `<Outlet />` (same concept, different implementation) |
 | `useNavigate()` | `useRouter().navigate("routeName")` |
-| `useParams()` | `useRoute().params` |
+| `useParams()` | `({ params }) => ...` in `content`, or `useRouterState((s) => s.match?.params)` |
 | `useSearchParams()` | `useSearchParams()` (similar API) |
-| `useLocation()` | `useRoute()` returns pathname, hash, searchParams |
+| `useLocation()` | `useRoute()` returns `pathname`, `hash`, `searchParams`, `status` |
 | `<Link to="/foo">` | `<Link to="foo">` (route name, not path) |
 | `<Link to="../sibling">` | Not supported — use absolute route names |
 | `Navigate` component | `redirect()` in `warm()` |
+| `useBlocker()` / `unstable_usePrompt` | `useBlocker(isDirty)` |
 | `loader` (v6.4+) | `warm()` (fire-and-forget, not data provider) |
 | `useLoaderData()` | Use your cache library: `useQuery()`, `useLazyLoadQuery()` |
-| Error boundaries via `errorElement` | React `<ErrorBoundary>` with `StatusResponse` |
+| `errorElement` | `useRoute().status` conditional render (data errors are state); React `<ErrorBoundary>` for render errors |
 
 ### Key differences
 
 - **No relative paths.** Pragma routes are flat — there's no hierarchy to navigate relative to. All navigation uses route names.
 - **No `loader` data return.** `warm()` warms caches but doesn't return data to the component. Components own their data.
+- **No throwing into `errorElement`.** In v6.4+ a loader throw renders the `errorElement`. In pragma a `StatusResponse` thrown from `warm()` commits the location with that `status` — the page decides what to render by reading `useRoute().status`. Nothing throws into React for data errors.
 - **Wrappers instead of layout routes.** Instead of nesting `<Route>` inside a layout route with `<Outlet>`, use `wrapper()` to define the layout and `group()` to apply it.
 
 ### Example: nested layout migration
@@ -113,7 +118,7 @@ React Router v7 merges Remix's data model (loaders, actions, forms) into the rou
 | `useFetcher()` | Cache library's `useMutation()` or `useQuery()` |
 | `useNavigation()` | `useNavigationState()` for loading state |
 | `redirect()` in loader | `redirect()` in `warm()` |
-| `ErrorBoundary` in route | React `<ErrorBoundary>` wrapping `<Outlet>` |
+| `ErrorBoundary` in route | `useRoute().status` for data errors; React `<ErrorBoundary>` for render errors |
 | File-based routing (optional) | Code-based only — no file conventions |
 | Framework mode | Library only — no server functions |
 
@@ -141,18 +146,19 @@ TanStack Router's type-safe tree model is the closest competitor to pragma's typ
 |---|---|
 | `createRootRoute()` + `createRoute()` | `route()` in a flat map |
 | Nested route tree | Flat routes + `wrapper()` + `group()` |
-| `createRouter()` | `createBrowserRouter(routes)` |
+| `createRouter()` | `createRouter(routes, { adapter: createBrowserAdapter() })` |
 | `RouterProvider` | `RouterProvider` (same concept) |
 | `<Outlet />` | `<Outlet />` |
 | `<Link to="/foo" params={...}>` | `<Link to="foo" params={...}>` |
 | `useSearch()` | `useSearchParams()` |
-| `useParams()` | `useRoute().params` |
+| `useParams()` | `({ params }) => ...` in `content`, or `useRouterState((s) => s.match?.params)` |
 | `useNavigate()` | `useRouter().navigate("routeName")` |
-| `beforeLoad` | Middleware via `applyMiddleware()` |
+| `useBlocker()` | `useBlocker(isDirty)` |
+| `beforeLoad` | Middleware via the `middleware` option |
 | `loader` | `warm()` (fire-and-forget) |
 | `useLoaderData()` | Cache library hooks |
 | `zodSearchValidator()` | Standard Schema on route: `search: schema` |
-| Route-level `errorComponent` | React `<ErrorBoundary>` |
+| Route-level `errorComponent` | `useRoute().status` conditional render; React `<ErrorBoundary>` for render errors |
 | `Pending` component | `<Outlet fallback={...}>` |
 | File-based routing (optional) | Code-based only |
 
@@ -166,9 +172,9 @@ TanStack Router's type-safe tree model is the closest competitor to pragma's typ
 
 ## Incremental adoption
 
-Most migrations are incremental. Pragma supports two coexistence patterns for running alongside an existing router during transition.
+Most migrations are incremental. Pragma supports one honest coexistence pattern for running alongside an existing router during transition.
 
-### DOM-subtree partitioning (recommended)
+### DOM-subtree partitioning
 
 The existing router manages the outer app. Pragma is mounted inside it for new sections:
 
@@ -191,23 +197,13 @@ The existing router manages the outer app. Pragma is mounted inside it for new s
 
 Navigation within `/new/*` stays inside pragma. Navigation to `/legacy/*` goes through React Router. Migrate sections one at a time.
 
-### URL-prefix partitioning
-
-Each router handles a distinct URL prefix. No nesting required:
-
-```tsx
-const pragmaRouter = createBrowserRouter(newRoutes, {
-  // Only handle routes under /new
-});
-```
-
-The existing router handles everything outside pragma's route definitions. Clear URL-level boundary.
+Note that pragma has **no basename/prefix option**: the pragma router will attempt to match any URL its adapter reports, so the routes you give it must be defined with their full paths (`/new/...`), and its `notFound` handling should stay out of the legacy router's territory (mounting it under a partitioned subtree, as above, is what scopes it). If you need a hard URL boundary instead, split at the server: serve the two apps from distinct prefixes and let each page load boot only its own router.
 
 ### Limitations
 
 - Navigation between the two routers may cause a full page load (the target router doesn't intercept the other's navigations).
 - Scroll restoration may not work across router boundaries.
-- Browser back/forward may behave unexpectedly if both routers listen to the same history events. The Navigation API adapter (default in modern browsers) mitigates this via `event.intercept()`.
+- Browser back/forward may behave unexpectedly if both routers listen to the same history events. The Navigation API adapter (the default in `createBrowserAdapter()` on modern browsers) mitigates this via `event.intercept()`.
 
 ---
 

--- a/docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md
+++ b/docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md
@@ -127,38 +127,38 @@ What makes this correct against the current API:
 - **`warm` returns `void | Promise<void>`.** The redirect is a side effect on the control flow, not a value the hook hands back. Never try to model the redirect as a return value or a resolved promise.
 - **Status `302` is the runtime default.** The runtime `redirect()` helper accepts `301 | 302 | 307 | 308` and defaults to `302`. The boilerplate passes `302` explicitly. Do not confuse this with static redirect routes (`route({ url, redirect, status })`), whose `status` is narrower: `301 | 308` only.
 
-### The pure-decision companion: `getAuthRedirectHref`
+### The pure-decision companion: `getAuthRedirectForMatch`
 
-The middleware decides at navigation time, inside `warm`. But a server (sitemap generation, an SSR pre-flight, an edge function) often needs the **same** decision *without* a router and without throwing. Factor the decision into a pure helper and call it from both places:
+The middleware decides at navigation time, inside `warm`. But a server (an SSR pre-flight, an edge function) needs the **same** decision without throwing. Factor it into a pure helper — and hand it the router's **match**, never the raw URL. A raw-URL check disagrees with router matching on exactly the inputs an attacker would try: matching ignores trailing empty path segments (`/account/` matches `/account`) and validated search keeps the **last** duplicate value (`?auth=1&auth=0` means `auth=0`), while `url.pathname` compares raw and `URLSearchParams.get()` reads the first value — so a raw-URL guard can SSR a protected page unauthenticated:
 
 ```ts
-export function getAuthRedirectHref(input: string | URL): string | null {
-  const url =
-    input instanceof URL ? input : new URL(input, "https://router.local");
-
-  if (
-    !protectedPaths.has(url.pathname) ||
-    hasDemoAuth({ auth: url.searchParams.get("auth") })
-  ) {
+export function getAuthRedirectForMatch(match: {
+  readonly route: AnyRoute;
+  readonly search: unknown;
+  readonly pathname: string;
+}): string | null {
+  if (!protectedPaths.has(match.route.url) || hasDemoAuth(match.search)) {
     return null;
   }
 
-  return `/login?from=${encodeURIComponent(url.pathname)}`;
+  return `/login?from=${encodeURIComponent(match.pathname)}`;
 }
 ```
 
-`getAuthRedirectHref` returns the redirect target as a string, or `null` when no redirect is needed. It never throws and never touches the router, so a server can branch on it before rendering:
+The helper never throws; the server **matches first** (with an adapterless pure-matcher router), then asks:
 
 ```ts
-const redirectHref = getAuthRedirectHref(requestUrl);
+const matchResult = matcher.match(requestUrl); // adapterless createRouter — a pure matcher
+const redirectHref =
+  matchResult?.kind === "route" ? getAuthRedirectForMatch(matchResult) : null;
 if (redirectHref) {
   return Response.redirect(redirectHref, 302);
 }
-// otherwise fall through to matching + rendering — see the boilerplate's
+// otherwise fall through to rendering — see the boilerplate's
 // resolveRouteDisposition in apps/react/boilerplate-vite/src/server/entry.tsx
 ```
 
-This is the corrected shape of the auth recipe: the **throwing** path lives inside `warm` (client navigation), the **pure** path is a reusable function (server pre-flight), and both share `protectedPaths` and `hasDemoAuth` so the policy cannot drift between them.
+This is the corrected shape of the auth recipe: the **throwing** path lives inside `warm` (client navigation), the **pure** path is a reusable function fed by the router's own match (server pre-flight), and both share `protectedPaths` and `hasDemoAuth` so the policy cannot drift between them.
 
 ### Rationale
 
@@ -349,13 +349,13 @@ export const middleware = [withAuth("/login")] as const;
 - capture and delegate to `currentRoute.warm` — never assume it exists, and never replace it with a hook the route never had
 - there is no `fetch` field; `warm(params, search, context)` is the only route data hook
 - `redirect()` throws (`never`) — call it for its side effect inside `warm`, never `return` it; thrown sync it applies before commit, thrown from an async hook it applies late (render never blocks)
-- factor any decision a server also needs into a pure helper (the `getAuthRedirectHref` pattern) so client and server share one policy
+- factor any decision a server also needs into a pure helper fed by the router's match (the `getAuthRedirectForMatch` pattern) so client and server share one policy
 - prefer middleware for cross-cutting policy, wrappers (`wrapper()` + `group()`) for layout and shared UI
 - document any redirect or URL-shape change clearly for consumers — middleware rewrites routes out from under the call site
 
 ## See a working example
 
-The live auth middleware — `withAuth` and the pure `getAuthRedirectHref` companion — is in [apps/react/boilerplate-vite/src/routes.tsx](../../apps/react/boilerplate-vite/src/routes.tsx). The routes it transforms, including the Standard Schema v1 search schemas, are in [apps/react/boilerplate-vite/src/domains/account/routes.ts](../../apps/react/boilerplate-vite/src/domains/account/routes.ts) and [apps/react/boilerplate-vite/src/domains/marketing/routes.ts](../../apps/react/boilerplate-vite/src/domains/marketing/routes.ts). The client and server entries that apply the middleware are [src/client/entry.tsx](../../apps/react/boilerplate-vite/src/client/entry.tsx) and [src/server/entry.tsx](../../apps/react/boilerplate-vite/src/server/entry.tsx).
+The live auth middleware — `withAuth` and the pure `getAuthRedirectForMatch` companion — is in [apps/react/boilerplate-vite/src/routes.tsx](../../apps/react/boilerplate-vite/src/routes.tsx). The routes it transforms, including the Standard Schema v1 search schemas, are in [apps/react/boilerplate-vite/src/domains/account/routes.ts](../../apps/react/boilerplate-vite/src/domains/account/routes.ts) and [apps/react/boilerplate-vite/src/domains/marketing/routes.ts](../../apps/react/boilerplate-vite/src/domains/marketing/routes.ts). The client and server entries that apply the middleware are [src/client/entry.tsx](../../apps/react/boilerplate-vite/src/client/entry.tsx) and [src/server/entry.tsx](../../apps/react/boilerplate-vite/src/server/entry.tsx).
 
 ## Reference
 

--- a/docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md
+++ b/docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md
@@ -31,27 +31,28 @@ const passthrough: RouteMiddleware = <TRoute extends AnyRoute>(
 
 The `<TRoute extends AnyRoute>` generic is what keeps middleware type-preserving: the route you return is the same shape (and same named-route type) as the one you received. Returning the route unchanged is always valid — that is the correct response when a rule does not apply.
 
-A middleware **factory** is a function that captures configuration and returns a `RouteMiddleware`:
+A middleware **factory** is a function that captures configuration and returns a `RouteMiddleware`. Write the inner function with the real generic signature — no `as RouteMiddleware` cast on the whole function:
 
 ```ts
 function withSomething(config: string): RouteMiddleware {
-  return ((currentRoute: AnyRoute) => {
+  return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
     // inspect currentRoute.url, currentRoute.meta, etc.
     return currentRoute;
-  }) as RouteMiddleware;
+  };
 }
 ```
 
-The cast on the inner arrow (`as RouteMiddleware`) is the practical idiom: the body works with `AnyRoute`, but the exported value advertises the type-preserving generic signature. This mirrors the real `withAuth` factory in the boilerplate.
+One narrow assertion remains when you *replace a property*: overriding `warm` (or `url`) on the spread object widens that property's type, and TypeScript cannot prove the result is still `TRoute`. Assert the constructed object back — `return { ...currentRoute, warm: guardedWarm } as TRoute;` — and keep the function signature itself honest. This mirrors the real `withAuth` factory in the boilerplate.
 
 ## How middleware is applied
 
-`applyMiddleware(routes, middleware)` runs the middleware over an array of routes and rebuilds each route's `parse`/`render` codec from the (possibly changed) `url`. You rarely call it directly — `createBrowserRouter`, `createStaticRouter`, and `createMemoryRouter` all accept a `middleware` option and apply it for you.
+`applyMiddleware(routes, middleware)` takes an **array** of routes and the middleware array, transforms each route through the chain, and rebuilds each route's `parse`/`render` codec from the (possibly changed) `url`. You rarely call it directly — `createRouter` accepts a `middleware` option and applies the chain to the whole route map for you:
 
 ```ts
-import { createBrowserRouter } from "@canonical/router-core";
+import { createBrowserAdapter, createRouter } from "@canonical/router-core";
 
-const router = createBrowserRouter(appRoutes, {
+const router = createRouter(appRoutes, {
+  adapter: createBrowserAdapter(),
   middleware: [withAuth("/login")],
   notFound: notFoundRoute,
 });
@@ -60,7 +61,11 @@ const router = createBrowserRouter(appRoutes, {
 Two facts about `applyMiddleware` worth internalising:
 
 1. **It rebuilds the codec from `url`.** After the middleware chain runs, `parse(url)` and `render(params)` are regenerated from `transformed.url`. So a middleware that rewrites `url` (for example, a locale prefix) gets coherent matching and link-building for free — you do not rebuild the codec yourself.
-2. **Outermost-first array semantics.** The middleware array is reversed and folded, so the **first** entry in the array is the **outermost** transform: it sees the route last on the way in and its effect wraps everything after it. Order your array from broadest policy to narrowest. See [Composition order](#composition-order).
+2. **First entry = outermost.** The array is reversed and folded (`[...middleware].reverse().reduce(...)`), so with `[A, B, C]` the routes pass through **C first, then B, then A**. Two consequences, one per direction:
+   - *Build time:* the **last** entry sees the original route; the **first** entry sees everything the others already produced. A URL rewrite by the first entry happens after the later entries already ran — they never see it.
+   - *Runtime:* each middleware that wraps `warm` nests around the wrappers applied before it, so the **first** entry's hook code runs outermost (first on the way in), and the **last** entry's runs innermost, closest to the original hook.
+
+   See [Composition order](#composition-order) for a worked example.
 
 ## Recipe: `withAuth(loginPath)`
 
@@ -82,34 +87,35 @@ function hasDemoAuth(search: unknown): boolean {
 }
 
 export function withAuth(loginPath: string): RouteMiddleware {
-  return ((currentRoute: AnyRoute) => {
+  return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
     if (!protectedPaths.has(currentRoute.url)) {
       return currentRoute;
     }
 
     const currentWarm = currentRoute.warm;
+    const guardedWarm = (
+      params: unknown,
+      search: unknown,
+      context: NavigationContext,
+    ) => {
+      if (!hasDemoAuth(search)) {
+        const from = currentRoute.render(
+          (params ?? {}) as RouteParamValues | Record<string, never>,
+        );
 
-    return {
-      ...currentRoute,
-      warm: (
-        params: unknown,
-        search: unknown,
-        context: NavigationContext,
-      ) => {
-        if (!hasDemoAuth(search)) {
-          const from = currentRoute.render(
-            (params ?? {}) as RouteParamValues | Record<string, never>,
-          );
+        redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);
+      }
 
-          redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);
-        }
-
-        if (currentWarm) {
-          return currentWarm(params, search, context);
-        }
-      },
+      if (currentWarm) {
+        return currentWarm(params, search, context);
+      }
     };
-  }) as RouteMiddleware;
+
+    // Overriding `warm` widens the property's type, so the object needs a
+    // local assertion back to TRoute; the middleware's signature itself is
+    // the real generic contract.
+    return { ...currentRoute, warm: guardedWarm } as TRoute;
+  };
 }
 ```
 
@@ -117,6 +123,7 @@ What makes this correct against the current API:
 
 - **The data hook is `warm`, not `fetch`.** The route's only data hook is `warm(params, search, context)`. The middleware captures the original (`const currentWarm = currentRoute.warm;`) and delegates to it once the auth check passes.
 - **`redirect()` does not return — it throws.** `redirect(to, status)` constructs a `RouteRedirect` (exported as `Redirect`) and throws it; its return type is `never`. You do not `return redirect(...)`. The throw unwinds out of the void-returning `warm`, and the router catches it and performs the navigation. Because the redirect throws, the `currentWarm(...)` call below it is unreachable for unauthenticated visitors — exactly the intent.
+- **The throw is honored from async hooks too.** A synchronous throw is applied before the navigation commits. If the guard is `async` (say, a session fetch precedes the check), the rejection carrying the `RouteRedirect` arrives after the route has already committed and rendered — the router then applies it late: the page shows briefly, then the redirect lands (as a history *replace*, so Back does not return to the guarded page). A superseded or abandoned navigation drops the late redirect. Fire-and-forget means render is never blocked; the flash is the honest price.
 - **`warm` returns `void | Promise<void>`.** The redirect is a side effect on the control flow, not a value the hook hands back. Never try to model the redirect as a return value or a resolved promise.
 - **Status `302` is the runtime default.** The runtime `redirect()` helper accepts `301 | 302 | 307 | 308` and defaults to `302`. The boilerplate passes `302` explicitly. Do not confuse this with static redirect routes (`route({ url, redirect, status })`), whose `status` is narrower: `301 | 308` only.
 
@@ -127,9 +134,7 @@ The middleware decides at navigation time, inside `warm`. But a server (sitemap 
 ```ts
 export function getAuthRedirectHref(input: string | URL): string | null {
   const url =
-    input instanceof URL
-      ? input
-      : new URL(input, "https://router.local");
+    input instanceof URL ? input : new URL(input, "https://router.local");
 
   if (
     !protectedPaths.has(url.pathname) ||
@@ -149,7 +154,8 @@ const redirectHref = getAuthRedirectHref(requestUrl);
 if (redirectHref) {
   return Response.redirect(redirectHref, 302);
 }
-// otherwise fall through to createStaticRouter(...) + render
+// otherwise fall through to matching + rendering — see the boilerplate's
+// resolveRouteDisposition in apps/react/boilerplate-vite/src/server/entry.tsx
 ```
 
 This is the corrected shape of the auth recipe: the **throwing** path lives inside `warm` (client navigation), the **pure** path is a reusable function (server pre-flight), and both share `protectedPaths` and `hasDemoAuth` so the policy cannot drift between them.
@@ -172,7 +178,7 @@ import {
 } from "@canonical/router-core";
 
 export function withI18n(defaultLocale: string): RouteMiddleware {
-  return ((currentRoute: AnyRoute) => {
+  return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
     const currentWarm = currentRoute.warm;
 
     return {
@@ -186,11 +192,15 @@ export function withI18n(defaultLocale: string): RouteMiddleware {
           ) => {
             const locale = params.locale ?? defaultLocale;
 
-            return currentWarm(params, { ...(search as object), locale }, context);
+            return currentWarm(
+              params,
+              { ...(search as object), locale },
+              context,
+            );
           }
         : undefined,
-    };
-  }) as RouteMiddleware;
+    } as TRoute;
+  };
 }
 ```
 
@@ -220,40 +230,40 @@ import {
 export function withTiming(
   report: (event: { route: string; durationMs: number }) => void,
 ): RouteMiddleware {
-  return ((currentRoute: AnyRoute) => {
+  return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
     const currentWarm = currentRoute.warm;
 
     if (!currentWarm) {
       return currentRoute;
     }
 
-    return {
-      ...currentRoute,
-      warm: async (
-        params: unknown,
-        search: unknown,
-        context: NavigationContext,
-      ) => {
-        const startedAt = performance.now();
+    const timedWarm = async (
+      params: unknown,
+      search: unknown,
+      context: NavigationContext,
+    ) => {
+      const startedAt = performance.now();
 
-        try {
-          return await currentWarm(params, search, context);
-        } finally {
-          report({
-            durationMs: performance.now() - startedAt,
-            route: currentRoute.url,
-          });
-        }
-      },
+      try {
+        return await currentWarm(params, search, context);
+      } finally {
+        report({
+          durationMs: performance.now() - startedAt,
+          route: currentRoute.url,
+        });
+      }
     };
-  }) as RouteMiddleware;
+
+    return { ...currentRoute, warm: timedWarm } as TRoute;
+  };
 }
 ```
 
 Notes:
 
 - Return the route untouched when there is no `warm` to time.
-- `warm` may return `void` or `Promise<void>`; `await` handles both, and the `finally` reports even if the hook throws (including a `redirect()` thrown by an inner auth middleware) — instrumentation should not swallow that throw.
+- `warm` may return `void` or `Promise<void>`; `await` handles both.
+- **Wrapping the hook in `async` does not break redirects or statuses.** A `redirect()` or `StatusResponse` thrown by an inner hook rejects the timing wrapper's promise, and the router honors async control-flow rejections: the redirect or status is applied late, after the navigation has committed (a brief render of the target, then the redirect, as a history replace). The `finally` still reports the duration in that case. What instrumentation must **not** do is swallow the rejection — re-throw (or, as here, simply do not catch), so the control flow reaches the router.
 
 ### Rationale
 
@@ -270,9 +280,9 @@ import {
   type AnyRoute,
   type RouteMiddleware,
   type WrapperDefinition,
+  wrapper,
 } from "@canonical/router-core";
 import type { ReactElement } from "react";
-import { wrapper } from "@canonical/router-core";
 
 const shellBoundary = wrapper<ReactElement>({
   id: "shell:error-boundary",
@@ -282,12 +292,12 @@ const shellBoundary = wrapper<ReactElement>({
 export function withErrorBoundary(
   boundary: WrapperDefinition<ReactElement> = shellBoundary,
 ): RouteMiddleware {
-  return ((currentRoute: AnyRoute) => {
+  return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
     return {
       ...currentRoute,
       wrappers: [boundary, ...currentRoute.wrappers],
-    };
-  }) as RouteMiddleware;
+    } as TRoute;
+  };
 }
 ```
 
@@ -295,7 +305,7 @@ Notes:
 
 - `wrappers` is always present on a `RouteDefinition` (it defaults to `[]`), so `[boundary, ...currentRoute.wrappers]` is safe without a guard.
 - `wrapper()` takes a single type parameter, `wrapper<TRendered>` (here `ReactElement`). A wrapper's own optional `warm` is `(params, context)` — two arguments, no `search` — distinct from a route's three-argument `warm`.
-- The error experience itself is a React `<ErrorBoundary>` inside the wrapper component. The router has no error-UI field; render errors propagate past `<Outlet>`, so the boundary belongs in the wrapper's JSX. Use `StatusResponse` from a `warm` to signal an HTTP-like status to that boundary.
+- The boundary in the wrapper's JSX catches **render errors** only. Data errors never throw into React: a `StatusResponse` thrown from a `warm` becomes the committed location's `status`, so the wrapper (or any component) reads `useRoute().status` and conditionally renders error UI. Router handles data errors as state; React handles render errors — two channels, two mechanisms.
 
 ### Rationale
 
@@ -305,32 +315,32 @@ Notes:
 
 ## Composition order
 
-Middleware runs with outermost-first array semantics: the first array entry is the outermost transform. Order from broadest URL policy to narrowest concern.
+The array is applied **last entry first**: with `[A, B, C]`, routes pass through C, then B, then A. At runtime the nesting is the mirror image — the first entry's hook wrapper is outermost. Order the array deliberately.
 
 ```ts
-import { createBrowserRouter } from "@canonical/router-core";
+import { createBrowserAdapter, createRouter } from "@canonical/router-core";
 
-const router = createBrowserRouter(appRoutes, {
+const router = createRouter(appRoutes, {
+  adapter: createBrowserAdapter(),
   middleware: [withI18n("en"), withAuth("/login"), withTiming(report)],
   notFound: notFoundRoute,
 });
 ```
 
-Reading the array left to right:
+What actually happens with `[withI18n("en"), withAuth("/login"), withTiming(report)]`:
 
-1. `withI18n("en")` rewrites the URL first, so `withAuth` and `withTiming` see the locale-prefixed route and the locale-aware `warm`.
-2. `withAuth("/login")` wraps the (now locale-aware) `warm` with its redirect guard.
-3. `withTiming(report)` wraps last, so its timer is the innermost wrapper around whatever the chain produced — it measures the full composed `warm`, redirect throw included.
+1. **Build time runs right-to-left.** `withTiming` is applied first and wraps the route's original `warm`. `withAuth` is applied next — it checks `protectedPaths.has(currentRoute.url)` against the **un-prefixed** URL, which is exactly why its plain-path lookup works. `withI18n` is applied last: it rewrites the URL to `/:locale/...` after the other two already ran, so neither of them ever sees the prefixed URL.
+2. **Runtime nests left-to-right.** On navigation, `withI18n`'s locale injection runs outermost, then `withAuth`'s guard, then — only if the auth check passes — `withTiming`'s timer around the original hook. For an unauthenticated visitor the redirect throws in the auth layer **before the timer ever starts**: the timer measures the route's own data work, not the guard.
 
-If you reverse the order, `withAuth` would inspect the unprefixed URL and the timer would sit outside the redirect logic. Order is meaningful; choose it deliberately.
+If you moved `withI18n` to the **end** of the array, it would be applied first — `withAuth` would then see `/:locale/account` and its `protectedPaths` lookup would silently stop matching. If you moved `withTiming` to the **front**, its timer would wrap the guard and count redirects as "data time". The given order is the deliberate one: URL policy first in the array (outermost), instrumentation last (innermost, closest to the real work).
 
 The boilerplate exports its chain as a `const` tuple and spreads it into both entries so client and server apply identical policy:
 
 ```ts
 export const middleware = [withAuth("/login")] as const;
 
-// client: createBrowserRouter(appRoutes, { middleware: [...middleware], notFound: notFoundRoute })
-// server: createStaticRouter(appRoutes, url, { middleware: [...middleware], notFound: notFoundRoute })
+// client: createRouter(appRoutes, { adapter: createBrowserAdapter(), middleware: [...middleware], notFound: notFoundRoute })
+// server: createRouter(appRoutes, { adapter: createServerAdapter(url), middleware: [...middleware], notFound: notFoundRoute })
 ```
 
 ## Rules of thumb
@@ -338,14 +348,14 @@ export const middleware = [withAuth("/login")] as const;
 - return the original route unchanged when the rule does not apply
 - capture and delegate to `currentRoute.warm` — never assume it exists, and never replace it with a hook the route never had
 - there is no `fetch` field; `warm(params, search, context)` is the only route data hook
-- `redirect()` throws (`never`) — call it for its side effect inside `warm`, never `return` it
+- `redirect()` throws (`never`) — call it for its side effect inside `warm`, never `return` it; thrown sync it applies before commit, thrown from an async hook it applies late (render never blocks)
 - factor any decision a server also needs into a pure helper (the `getAuthRedirectHref` pattern) so client and server share one policy
 - prefer middleware for cross-cutting policy, wrappers (`wrapper()` + `group()`) for layout and shared UI
 - document any redirect or URL-shape change clearly for consumers — middleware rewrites routes out from under the call site
 
 ## See a working example
 
-The live auth middleware — `withAuth` and the pure `getAuthRedirectHref` companion — is in [apps/react/boilerplate-vite/src/routes.tsx](../../apps/react/boilerplate-vite/src/routes.tsx). The routes it transforms, including the `~standard` search schemas, are in [apps/react/boilerplate-vite/src/domains/account/routes.ts](../../apps/react/boilerplate-vite/src/domains/account/routes.ts) and [apps/react/boilerplate-vite/src/domains/marketing/routes.ts](../../apps/react/boilerplate-vite/src/domains/marketing/routes.ts). The client and server entries that apply the middleware are [src/client/entry.tsx](../../apps/react/boilerplate-vite/src/client/entry.tsx) and [src/server/entry.tsx](../../apps/react/boilerplate-vite/src/server/entry.tsx).
+The live auth middleware — `withAuth` and the pure `getAuthRedirectHref` companion — is in [apps/react/boilerplate-vite/src/routes.tsx](../../apps/react/boilerplate-vite/src/routes.tsx). The routes it transforms, including the Standard Schema v1 search schemas, are in [apps/react/boilerplate-vite/src/domains/account/routes.ts](../../apps/react/boilerplate-vite/src/domains/account/routes.ts) and [apps/react/boilerplate-vite/src/domains/marketing/routes.ts](../../apps/react/boilerplate-vite/src/domains/marketing/routes.ts). The client and server entries that apply the middleware are [src/client/entry.tsx](../../apps/react/boilerplate-vite/src/client/entry.tsx) and [src/server/entry.tsx](../../apps/react/boilerplate-vite/src/server/entry.tsx).
 
 ## Reference
 

--- a/docs/references/ROUTER_API.md
+++ b/docs/references/ROUTER_API.md
@@ -2,8 +2,10 @@
 
 Complete public API for the pragma router. Two packages:
 
-- **`@canonical/router-core`** (`packages/runtime/router`) — framework-agnostic routing engine: factories, route/wrapper/group/middleware primitives, adapters, types.
+- **`@canonical/router-core`** (`packages/runtime/router`) — framework-agnostic routing engine: the `createRouter` constructor, route/wrapper/group/middleware primitives, platform adapters, accessibility managers, types.
 - **`@canonical/router-react`** (`packages/react/router`) — React binding: provider, `Link`, `Outlet`, hooks, SSR and hydration helpers.
+
+> **Stability: pre-1.0.** The API can change between minor versions. The design principles behind the surface — minimal API, low sugar, fire-and-forget `warm`, errors-as-state — and what is likely to change are documented in the [Design rationale](../../packages/runtime/router/README.md#design-rationale) section of the core README.
 
 Every signature below is transcribed from source. Type parameters are elided to their load-bearing form where the full constraint adds no information; defaults are preserved.
 
@@ -17,18 +19,7 @@ Conventions used throughout:
 
 ## @canonical/router-core
 
-### Router factories
-
-All four return a [`Router`](#router). `createBrowserRouter`, `createMemoryRouter`, and `createStaticRouter` wrap `createRouter` with a preset adapter. Pick by environment.
-
-| Factory | Adapter | Use when |
-|---|---|---|
-| `createBrowserRouter` | `createBrowserAdapter()` (Navigation API → History API fallback) | Client, non-SSR app entry |
-| `createStaticRouter` | `createServerAdapter(url)` | Server-side render of one request |
-| `createMemoryRouter` | `createMemoryAdapter(initialUrl)` | Tests and non-DOM environments |
-| `createRouter` | none unless you pass `adapter` | Custom adapter / low-level control |
-
-#### `createRouter`
+### `createRouter` — the one constructor
 
 ```ts
 function createRouter<
@@ -40,82 +31,27 @@ function createRouter<
 ): Router<TRoutes, TNotFound>;
 ```
 
-Base factory. Applies `options.middleware` to the route map, asserts unique wrapper ids, wires accessibility managers, and constructs the store. Every other factory delegates here.
+The only router constructor. Applies `options.middleware` to the route map, asserts unique wrapper ids (construction **throws** on a duplicate), wires accessibility managers, constructs the store, and — when an adapter is present — performs the initial load (or resumes from `options.hydratedState`).
+
+**The adapter is the environment axis.** Pick one:
 
 ```ts
-const router = createRouter(appRoutes, { adapter: myAdapter, notFound: notFoundRoute });
-```
-
-#### `createBrowserRouter`
-
-```ts
-function createBrowserRouter<
-  const TRoutes extends RouteMap,
-  const TNotFound extends AnyRoute | undefined = undefined,
->(
-  routes: TRoutes,
-  options?: Omit<RouterOptions<TNotFound>, "adapter">,
-): Router<TRoutes, TNotFound>;
-```
-
-Client router. Injects `createBrowserAdapter()` (Navigation API where available, History API otherwise). `options` omits `adapter`.
-
-```ts
-const router = createBrowserRouter(appRoutes, {
+const router = createRouter(appRoutes, {
+  adapter: createBrowserAdapter(),   // client entry
   middleware: [...middleware],
   notFound: notFoundRoute,
 });
 ```
 
-#### `createStaticRouter`
+| Environment | Adapter |
+|---|---|
+| Browser (SSR or SPA client entry) | `createBrowserAdapter()` — Navigation API where available, History API otherwise |
+| Browser, fragment-only routing (Storybook, static hosts) | `createHashAdapter()` |
+| Server-side render of one request | `createServerAdapter(url)` |
+| Tests / non-DOM environments | `createMemoryAdapter(initialUrl)` |
+| Explicit History / Navigation API choice | `createHistoryAdapter()` / `createNavigationAdapter()` |
 
-```ts
-function createStaticRouter<
-  const TRoutes extends RouteMap,
-  const TNotFound extends AnyRoute | undefined = undefined,
->(
-  routes: TRoutes,
-  url: string | URL,
-  options?: Omit<RouterOptions<TNotFound>, "adapter" | "initialUrl">,
-): Router<TRoutes, TNotFound> & {
-  readonly match: RouterMatch<TRoutes, TNotFound> | null;
-};
-```
-
-SSR router. Matches `url` synchronously and hydrates the store so `render()`/`<Outlet>` work without awaiting `load()`; warm fires in the background. The returned object adds a `match` field for status-code and redirect decisions before rendering. `options` omits `adapter` and `initialUrl`.
-
-```ts
-const router = createStaticRouter(appRoutes, req.url, {
-  middleware: [...middleware],
-  notFound: notFoundRoute,
-});
-
-if (!router.match) {
-  res.status(404);
-} else if (router.match.kind === "redirect") {
-  return res.redirect(router.match.status, router.match.redirectTo);
-}
-```
-
-#### `createMemoryRouter`
-
-```ts
-function createMemoryRouter<
-  const TRoutes extends RouteMap,
-  const TNotFound extends AnyRoute | undefined = undefined,
->(
-  routes: TRoutes,
-  initialUrl: string | URL = "/",
-  options?: Omit<RouterOptions<TNotFound>, "adapter">,
-): Router<TRoutes, TNotFound>;
-```
-
-In-memory router for tests. Injects `createMemoryAdapter(initialUrl)`, whose adapter additionally exposes `back()` / `forward()`. `initialUrl` defaults to `"/"`.
-
-```ts
-const router = createMemoryRouter(appRoutes, "/account?auth=1");
-await router.load(router.getState().location.url);
-```
+**Without an adapter, the router is a pure matcher.** Construction fires no initial load and no `warm` hooks; `match()`, `buildPath()`, and `load()` work; `navigate()` and `setSearchParams()` **throw** a descriptive error. Use an adapterless router server-side to compute statuses and redirects for a URL without side effects (see [Entry wiring](#entry-wiring-reference)).
 
 ### `RouterOptions`
 
@@ -130,18 +66,20 @@ interface RouterOptions<TNotFound extends AnyRoute | undefined = undefined> {
 }
 ```
 
-`accessibility` configures focus, route announcement, scroll restoration, and view transitions (each `false` to disable); see `RouterAccessibilityOptions` in `types.ts`. `hydratedState` resumes from a dehydrated SSR snapshot.
+- **`adapter`** — the platform adapter; see the table above. Omit for a pure matcher.
+- **`accessibility`** — configures focus, route announcement, scroll restoration, and view transitions (each `false` to disable); see [`RouterAccessibilityOptions`](#accessibility).
+- **`hydratedState`** — resumes from a dehydrated SSR snapshot instead of running the initial load. `hydrate()` (and therefore construction with a stale snapshot) **throws** when the snapshot doesn't match the route map — e.g. a `routeId` that no longer exists or a `kind: "route"` href that no longer matches that route. On the client, feed it from [`readDehydratedState()`](#readdehydratedstate), which returns `null` for payloads that carry no router state.
+- **`initialUrl`** — the starting location **for adapterless routers only**; when an adapter is present, the adapter's `getLocation()` wins and `initialUrl` is ignored.
+- **`middleware`** — applied to the route map before construction; see [Middleware](#middleware--applymiddleware).
+- **`notFound`** — the route rendered for unmatched URLs (committed with status 404).
 
 ### `Router`
-
-The router instance. Selected members (full surface in `types.ts`, lines 586–636):
 
 ```ts
 interface Router<TRoutes extends RouteMap, TNotFound extends AnyRoute | undefined = undefined> {
   readonly routes: TRoutes;
   readonly notFound: TNotFound;
   readonly adapter: PlatformAdapter | null;
-  readonly store: RouterStore<TRoutes, TNotFound>;
   getRoute<TName extends RouteName<TRoutes>>(name: TName): RouteOf<TRoutes, TName>;
   getState(): RouterState<TRoutes, TNotFound>;
   getTrackedLocation(onAccess: (key: RouterLocationKey) => void): TrackedLocation<RouterLocationState>;
@@ -152,12 +90,8 @@ interface Router<TRoutes extends RouteMap, TNotFound extends AnyRoute | undefine
   load(url: string | URL): Promise<RouterLoadResult<TRoutes, TNotFound>>;
   match(url: string | URL): RouterMatch<TRoutes, TNotFound> | null;
   navigate: NavigateFn<TRoutes>;                         // (name, options?) => NavigationIntent
-  warm: WarmFn<TRoutes>;                         // (name, options?) => Promise<void>
-  registerBlocker(blocker: RouterBlocker): void;
-  unregisterBlocker(id: string): void;
-  readonly blockerState: "idle" | "blocked";
-  proceedNavigation(): void;
-  cancelNavigation(): void;
+  warm: WarmFn<TRoutes>;                                 // (name, options?) => Promise<void>
+  block(isActive: () => boolean): RouterBlockerHandle;
   render(result?: RouterLoadResult<TRoutes, TNotFound> | null): unknown;
   setSearchParams(
     params:
@@ -171,10 +105,13 @@ interface Router<TRoutes extends RouteMap, TNotFound extends AnyRoute | undefine
 }
 ```
 
-- **`navigate(name, options?)`** and **`buildPath(name, options?)`** take a route name and `PathBuildOptions`. `params` is required at the type level iff the route's `url` contains `:params`; `search`, `hash`, and `replace` are optional. `navigate` returns a `NavigationIntent` (`{ name, href, params, search, hash? }`); `buildPath` returns the built path string.
-- **`warm(name, options?)`** returns `Promise<void>` — warms the route's `warm` hook ahead of navigation.
-- **`render(result?)`** returns `unknown` (framework-agnostic); the React layer consumes it via `<Outlet>`.
-- **`render()` returns `unknown`**, not a React element — typing is supplied by `TRendered` on `content`/`wrapper.component`.
+- **`navigate(name, options?)`** and **`buildPath(name, options?)`** take a route name and `PathBuildOptions`. `params` is required at the type level iff the route's `url` contains `:params`; `search`, `hash`, and `replace` are optional. `navigate` returns a `NavigationIntent` (`{ name, href, params, search, hash? }`); `buildPath` returns the built path string. **Both `navigate` and `setSearchParams` throw on an adapterless router** — an adapterless router only matches and builds URLs.
+- **`warm(name, options?)`** returns `Promise<void>` — runs the route's `warm` hook ahead of navigation and caches the resolved load per href. **The cached entry is consumed by the next navigation to that href, and the `warm` hooks do not run again for it**; the cache is cleared on every committed navigation. `Link` calls this on hover.
+- **`match(url)`** is pure — it runs no hooks — but **can throw** a 400 `StatusResponse` when the matched route's [search schema](#search-validation) rejects the query string. `load()` catches that and commits it as an error result; call sites that use `match()` directly (e.g. a server disposition helper) must catch it themselves.
+- **`block(isActive)`** — see [Blocking navigation](#blocking-navigation--block).
+- **`render(result?)`** returns `unknown` (framework-agnostic); the React layer consumes it via `<Outlet>`. Typing is supplied by `TRendered` on `content`/`wrapper.component`.
+- **`dispose()`** aborts the in-flight load and unsubscribes from the adapter.
+- **`content.preload`**, when a route declares it, is **awaited during the load** — unlike `warm`, it gates navigation completion (it exists for code-splitting, where rendering without the module is impossible).
 
 ```ts
 router.navigate("account", { search: { auth: "1" } });
@@ -182,10 +119,24 @@ const href = router.buildPath("guide", { params: { slug: "intro" } });
 await router.warm("home");
 ```
 
+### URL patterns and matching
+
+Route paths are segment patterns:
+
+- **Static segments** (`/account`) match exactly.
+- **`:param` segments** match any single non-empty segment; the value is `decodeURIComponent`-decoded into `params`. Modifier suffixes on a param name — `?`, `*`, `+`, or a `(regex)` group — are **stripped for naming only and never evaluated**: `:id(\d+)` matches `abc` just like `:id` does, and `:section?` does **not** make the segment optional. Segment counts must match exactly (use a params schema for syntactic constraints, or a wildcard for variable depth).
+- **A trailing `*` wildcard** (`/docs/*`) matches zero or more remaining segments. Wildcard segments are not captured as params and are omitted when rendering the pattern back to a path.
+
+**Route priority** is purely structural, computed per pattern: more static segments win, then more param segments, then fewer wildcards; ties keep definition order. Redirect routes compete on the same specificity rules as data routes — a redirect route has no special precedence at match time (the `redirect` property only selects the `route()` **overload** at the type level).
+
+**Path rendering** (`buildPath`, a route's `render`) substitutes params into the pattern, serializes non-string schema outputs with `String()`, and `encodeURIComponent`s every substituted segment; `match` decodes on the way back in. A param value containing `/` or `?` therefore round-trips as one encoded segment rather than splitting the path.
+
+**Relative URLs get a synthetic origin.** The router resolves relative inputs against the internal base `https://router.local`, and `location.url` is that absolute `URL` object. Compare `pathname`/`search`/`hash`, not `origin` or `href`-with-origin.
+
 ### Route definition — `route`
 
 ```ts
-// Redirect overload (matched first; presence of `redirect` selects it):
+// Redirect overload (selected by the presence of `redirect`):
 function route<
   const TPath extends string,
   TTarget extends string,
@@ -226,8 +177,8 @@ interface DataRouteInput<TPath, TSearchSchema, TRendered, TWrappers, TParamsSche
 }
 ```
 
-- **`url`** — path pattern. `:param` segments become typed params; modifiers (`?`, `*`, `+`, `(regex)`) are stripped for naming. `RouteParams<TPath>` infers `{ readonly [name]: string }`, or `Record<string, never>` when the path has none.
-- **`content`** — the component, called with `RouteContentProps`. Carries an optional `preload?: () => Promise<RouteModule>` for code-splitting.
+- **`url`** — path pattern; see [URL patterns and matching](#url-patterns-and-matching).
+- **`content`** — the component, called with `RouteContentProps`. Carries an optional `preload?: () => Promise<RouteModule>` for code-splitting; `preload` is awaited during the load and its module is cached per route.
 - **`warm`** — see [the warm hook](#the-warm-hook).
 - **`params`** — a [Standard Schema](#params-validation) validator for the path params; its output type replaces `RouteParams<TPath>` everywhere (`content`, `warm`, `Link`, `navigate`, `buildPath`). A failed validation makes the URL a **non-match** (404), not an error.
 - **`search`** — a [Standard Schema](#search-validation) validator; its output type flows to `content`'s `search` prop and the route's `SearchOf`. A failed validation throws a 400 `StatusResponse`.
@@ -264,7 +215,7 @@ function AccountPage({ params, search }: RouteContentProps<{ readonly id: string
 
 #### The `warm` hook
 
-`warm` is the **only** data hook — there is no `fetch` field anywhere. It is fire-and-forget: the router does **not** block render on it or feed its result to the component. Use it to warm an external cache (Relay, TanStack Query, SWR) or preload assets at navigation time; components own their own data.
+`warm` is the **only** data hook — there is no loader anywhere. It is fire-and-forget: the router never blocks render on it and never feeds its result to the component. Use it to warm an external cache (Relay, TanStack Query, SWR) or preload assets at navigation time; components own their own data.
 
 ```ts
 readonly warm?: (
@@ -282,8 +233,6 @@ interface NavigationContext {
 }
 ```
 
-Throwing inside `warm` is meaningful: throw a [`StatusResponse`](#statusresponse) for an HTTP-like error, or call [`redirect()`](#runtime-redirects--redirect-redirect-routeredirect) to short-circuit navigation. Both propagate to standard React error boundaries on the client and to the server handler under SSR.
-
 ```ts
 warm: (params, search, context) => {
   void queryClient.prefetchQuery({
@@ -293,6 +242,15 @@ warm: (params, search, context) => {
   });
 },
 ```
+
+**Control flow from `warm`.** Throwing (or rejecting with) a [`StatusResponse`](#statusresponse), a `Response`, or the [`redirect()`](#runtime-redirects--redirect-redirect-routeredirect) throwable is meaningful — it becomes a redirect or a status **on the committed location**, never a React exception:
+
+- A **synchronous** throw lands before the navigation commits: a `redirect()` re-routes the load, a `StatusResponse` commits its status on the location (`location.status`).
+- An **async** rejection is honored by guarded late application. The load has already committed (fire-and-forget never blocks render), so the page may render briefly before the redirect or error status lands — that flash is by design, the price of never blocking on data. A rejection arriving while the load is still in flight is held and applied at commit; one arriving after the user has navigated elsewhere (or after the load was superseded) is dropped. The **first** control-flow rejection of a load wins; late redirects re-sync the adapter with replace semantics, so Back does not return to the bounced page.
+- On the hover-warm path (`router.warm()` / `Link` hover), a late redirect warms the redirect **target** instead; a late status is folded into the cached entry so the eventual navigation observes it — and applied live if that navigation already consumed the entry.
+- **Any other rejection is deliberately ignored** — a failed cache warm must never break navigation.
+
+Errors never reach React error boundaries from `warm`; read `useRoute().status` for error UI. See [Error model](#error-model-errors-are-state) and the [react README's error-handling recipe](../../packages/react/router/README.md#error-handling).
 
 #### `RedirectRouteInput` — static redirect routes
 
@@ -309,10 +267,10 @@ interface RedirectRouteInput<TPath, TTarget, TWrappers, TParamsSchema> {
 }
 ```
 
-A route with no `content`. The `status` is restricted to permanent redirects (`301 | 308`) — distinct from the runtime [`redirect()`](#runtime-redirects--redirect-redirect-routeredirect) helper's wider union. Matched ahead of data routes by the presence of `redirect`.
+A route with no `content`. The `status` is restricted to permanent redirects (`301 | 308`) — distinct from the runtime [`redirect()`](#runtime-redirects--redirect-redirect-routeredirect) helper's wider union. The presence of `redirect` selects the redirect **overload of `route()`** at the type level; at match time a redirect route competes on ordinary path specificity (see [route priority](#url-patterns-and-matching)) and yields a `RedirectRouteMatch` (`kind: "redirect"`, `redirectTo`, `status`) for the server or the loader to follow.
 
 ```ts
-const legacy = route({ url: "/old", redirect: "/new", status: 308 });
+const legacyHome = route({ url: "/home", redirect: "/", status: 301 });
 ```
 
 #### Definition shapes and codec
@@ -326,7 +284,7 @@ interface RouteCodec<TPath extends string = string, TParams = RouteParams<TPath>
 }
 ```
 
-`TParams` is `InferParams<TPath, TParamsSchema>` — the [params schema](#params-validation)'s output when one is declared, otherwise the raw string params inferred from the path. `parse` applies the params schema: a rejected URL returns `null`, exactly like a pattern mismatch. `render` accepts the schema's output values and serializes non-string values (numbers, booleans) with `String()`.
+`TParams` is `InferParams<TPath, TParamsSchema>` — the [params schema](#params-validation)'s output when one is declared, otherwise the raw string params inferred from the path. `parse` applies the params schema: a rejected URL returns `null`, exactly like a pattern mismatch. `render` accepts the schema's output values, serializes non-string values with `String()`, and percent-encodes each substituted segment (see [path rendering](#url-patterns-and-matching)).
 
 The definition is the input shape with `wrappers` made required (defaulted to `[]`) plus `parse`/`render`. `DataRouteDefinition` keeps the same three-arg `warm` signature as the input.
 
@@ -356,7 +314,9 @@ interface WrapperComponentProps<TRendered = unknown> {
 }
 ```
 
-Note the wrapper `warm` takes **two** args `(params, context)` — no `search`, unlike route `warm`. Wrapper warms are fire-and-forget and not cached. Wrappers are shared across routes, so `params` is always the **raw string params** extracted from the URL (`RouteParamValues`) — a route's [params schema](#params-validation) only transforms what the route's own hooks receive.
+`id` uniqueness is enforced: `createRouter` **throws at construction** when the same id is attached to two different wrapper definitions (sharing one definition across routes is fine — that is the point).
+
+Note the wrapper `warm` takes **two** args `(params, context)` — no `search`, unlike route `warm`. Wrapper warms run for every wrapper on the matched route, are fire-and-forget within a load, and follow the same [control-flow semantics](#the-warm-hook) as route warms. Wrappers are shared across routes, so `params` is always the **raw string params** extracted from the URL (`RouteParamValues`) — a route's [params schema](#params-validation) only transforms what the route's own hooks receive.
 
 ```ts
 const publicLayout = wrapper<ReactElement>({
@@ -417,44 +377,47 @@ function applyMiddleware<TRoutes extends readonly AnyRoute[]>(
 ): TRoutes;
 ```
 
-Applies each middleware to each route with **outermost-first** array semantics (the first entry runs last, wrapping the rest), then rebuilds `parse`/`render` from the possibly-changed `url`. `createRouter` runs this internally over `options.middleware`, so passing `middleware` to a factory is equivalent; call `applyMiddleware` directly only when manipulating a route array outside a router.
+Applies each middleware to each route, then rebuilds `parse`/`render` from the possibly-changed `url`. **Composition order: the array is reversed and folded, so the first entry is applied last — it is the outermost wrapper.** With `[withI18n, withAuth, withTiming]`, `withTiming` transforms the raw route first (innermost), then `withAuth` wraps that, then `withI18n` wraps everything. Consequently the outermost middleware sees the innermost ones' output, and a hook wrapped by an inner middleware runs inside the outer ones' hooks.
+
+`createRouter` runs this internally over `options.middleware`, so passing `middleware` to the constructor is equivalent; call `applyMiddleware` directly only when manipulating a route array outside a router.
 
 #### Middleware contract (the `withAuth` pattern)
 
-A middleware that guards protected paths wraps the route's existing `warm`, preserving it for the authorised case:
+A middleware that guards protected paths wraps the route's existing `warm`, preserving it for the authorized case. Written generically, no cast on the middleware itself is needed:
 
 ```ts
 export function withAuth(loginPath: string): RouteMiddleware {
-  return ((currentRoute: AnyRoute) => {
+  return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
     if (!protectedPaths.has(currentRoute.url)) {
       return currentRoute;                          // leave unprotected routes untouched
     }
 
-    const currentWarm = currentRoute.warm;  // preserve the original
-
-    return {
-      ...currentRoute,
-      warm: (params: unknown, search: unknown, context: NavigationContext) => {
-        if (!hasDemoAuth(search)) {
-          const from = currentRoute.render((params ?? {}) as RouteParamValues | Record<string, never>);
-          redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);  // throws RouteRedirect
-        }
-        if (currentWarm) {
-          return currentWarm(params, search, context);
-        }
-      },
+    const currentWarm = currentRoute.warm;          // preserve the original
+    const guardedWarm = (params: unknown, search: unknown, context: NavigationContext) => {
+      if (!hasDemoAuth(search)) {
+        const from = currentRoute.render((params ?? {}) as RouteParamValues | Record<string, never>);
+        redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);  // throws RouteRedirect
+      }
+      if (currentWarm) {
+        return currentWarm(params, search, context);
+      }
     };
-  }) as RouteMiddleware;
+
+    // Overriding `warm` widens the property's type; assert the object back to TRoute.
+    return { ...currentRoute, warm: guardedWarm } as TRoute;
+  };
 }
 
 export const middleware = [withAuth("/login")] as const;
 ```
 
+Because the guard throws **synchronously** before delegating, the redirect applies before the guarded page commits. A guard that must await something (a session check) still works — the rejection is applied late per the [warm control-flow semantics](#the-warm-hook) — but the page may flash first; when the server can decide, prefer deciding there (see [Entry wiring](#entry-wiring-reference)).
+
 Wire it into both entries:
 
 ```ts
-createBrowserRouter(appRoutes, { middleware: [...middleware], notFound: notFoundRoute });   // client
-createStaticRouter(appRoutes, url, { middleware: [...middleware], notFound: notFoundRoute }); // server
+createRouter(appRoutes, { adapter: createBrowserAdapter(), middleware: [...middleware], notFound: notFoundRoute });  // client
+createRouter(appRoutes, { adapter: createServerAdapter(url), middleware: [...middleware], notFound: notFoundRoute }); // server
 ```
 
 For a server-side pre-render decision that must not throw, mirror the same logic in a pure helper that returns the redirect href or `null`:
@@ -469,9 +432,18 @@ function getAuthRedirectHref(input: string | URL): string | null {
 }
 ```
 
+### Error model: errors are state
+
+The router has two error channels, and neither goes through React error boundaries:
+
+1. **Data errors are state.** Every load commits a result: an unmatched URL commits the `notFound` route with `location.status === 404`; a rejected search schema commits 400; a `StatusResponse`/`Response` thrown from `warm` commits its status; any other throw commits 500. Nothing is thrown into the render tree — read `location.status` (in React: the tracked [`useRoute().status`](#useroute)) and render error UI conditionally.
+2. **Render errors belong to React.** A component that throws while rendering is caught by an ordinary React error boundary you place yourself — the router deliberately does not own error UI.
+
+The complete worked recipe (status-driven pages plus a render-error boundary) lives in the [react README](../../packages/react/router/README.md#error-handling).
+
 ### Runtime redirects — `redirect`, `Redirect`, `RouteRedirect`
 
-> **`Redirect` is not a React component.** It is the `RouteRedirect` class, re-exported from `@canonical/router-core` under the name `Redirect`. There is no `<Redirect>` element. Use these as the throwable redirect primitives inside a `warm`/`fetch`-time hook.
+> **`Redirect` is not a React component.** It is the `RouteRedirect` class, re-exported from `@canonical/router-core` under the name `Redirect`. There is no `<Redirect>` element. These are the throwable redirect primitives for `warm`-time control flow.
 
 #### `redirect`
 
@@ -479,7 +451,7 @@ function getAuthRedirectHref(input: string | URL): string | null {
 function redirect(to: string, status: 301 | 302 | 307 | 308 = 302): never;
 ```
 
-Throws a `RouteRedirect` to short-circuit navigation from inside a route or wrapper `warm` (or middleware). Status union is **wider** than static redirect routes (which only allow `301 | 308`); default is `302`.
+Throws a `RouteRedirect` to short-circuit navigation from inside a route or wrapper `warm` (or middleware wrapping one). Status union is **wider** than static redirect routes (which only allow `301 | 308`); default is `302`.
 
 ```ts
 redirect(`/login?from=${encodeURIComponent(from)}`, 302);
@@ -495,7 +467,7 @@ class RouteRedirect {        // export { default as Redirect } from "./RouteRedi
 }
 ```
 
-The throwable value `redirect()` constructs. Catch it (or read `router.match` / `RedirectRouteMatch`) on the server to emit a real HTTP redirect.
+The throwable value `redirect()` constructs. The router follows it internally (up to a redirect depth of 10); on the server, prefer matching first and answering redirects at the HTTP layer (see [Entry wiring](#entry-wiring-reference)).
 
 ### `StatusResponse`
 
@@ -503,16 +475,17 @@ The throwable value `redirect()` constructs. Catch it (or read `router.match` / 
 class StatusResponse<TData = unknown> {
   readonly status: number;
   readonly data: TData;
-  constructor(status: number, data: TData);
+  constructor(status: number, data?: TData);
 }
 ```
 
-A typed non-success status thrown from a `warm`. Surfaces to React error boundaries (client) or the SSR handler (server) for HTTP-like error UI.
+A typed non-success status thrown from `warm` (the `data` payload is optional — `new StatusResponse(401)` works). The router commits it as `location.status` per the [error model](#error-model-errors-are-state); it never reaches a React error boundary.
 
 ```ts
-warm: async (params) => {
-  const user = await fetchUser(params.id);
-  if (!user) throw new StatusResponse(404, { id: params.id });
+warm: (params) => {
+  if (!canView(params.id)) {
+    throw new StatusResponse(403, { id: params.id });
+  }
 },
 ```
 
@@ -583,51 +556,62 @@ const product = route({
   content: ProductPage,          // ({ params }) — params.id is a number
 });
 
-router.buildPath("product", { params: { id: 42 } });   // "/products/42" — typed, serialized with String()
+const routes = { product } as const;
+const matcher = createRouter(routes);
+
+matcher.buildPath("product", { params: { id: 42 } });   // "/products/42" — typed, serialized with String()
 ```
 
-For *semantic* validation (does the record exist?), keep using `warm` + [`StatusResponse`](#statusresponse). For simple syntactic constraints, a `(regex)` modifier in the pattern (`/products/:id(\\d+)`) also works — `params` adds typed coercion on top.
+This is the mechanism for syntactic constraints — a `(regex)` modifier in the pattern is **not** (it is stripped, never evaluated; see [URL patterns](#url-patterns-and-matching)). For *semantic* validation (does the record exist?), keep using `warm` + [`StatusResponse`](#statusresponse).
 
 #### Search validation
 
 `search` validates the query string. Its output type flows to `content`'s `search` prop and to `SearchOf<TRoute>`.
 
-**Failure semantics: a rejected query string throws `StatusResponse(400, { issues, message })`.** During `load()`/navigation the router catches it and commits an error result (`result.status === 400`, `result.error instanceof StatusResponse`); under SSR that surfaces as a real 400, and on the client it reaches your error boundary. A shared URL with a garbage query is a *bad request*, not a crash — and for that reason, prefer **normalizing** schemas that supply defaults over rejecting ones (`z.coerce.number().catch(1)` rather than `.int()` alone), reserving hard failure for genuinely unrenderable input.
+**Failure semantics: a rejected query string throws `StatusResponse(400, { issues, message })`** (the payload shape is the `SearchValidationFailure` interface). During `load()`/navigation the router catches it and commits an error result — `location.status === 400`, `result.error instanceof StatusResponse` — per the [error model](#error-model-errors-are-state); a server disposition helper that calls `match()` directly must catch it and answer 400. A shared URL with a garbage query is a *bad request*, not a crash — and for that reason, prefer **normalizing** schemas that supply defaults over rejecting ones (`z.coerce.number().catch(1)` rather than `.int()` alone), reserving hard failure for genuinely unrenderable input.
 
 ```ts
-const accountSearchSchema = {
+const accountSearchSchema: StandardSchemaV1<
+  Record<string, unknown>,
+  { readonly auth?: string }
+> = {
   "~standard": {
-    output: {} as { readonly auth?: string },
-    validate(value: unknown): { readonly auth?: string } {
+    version: 1,
+    vendor: "app",
+    validate(value) {
       const record = value as Record<string, unknown>;
-      return { auth: typeof record.auth === "string" ? record.auth : undefined };
+      return { value: { auth: typeof record.auth === "string" ? record.auth : undefined } };
     },
   },
 };
 ```
 
-This hand-rolled legacy shape never fails (it normalizes), which makes it a good dependency-free default. A type-only schema (`output` phantom, no `validate`) passes the raw string record through unvalidated.
+This schema never fails (it normalizes), which makes it a good dependency-free default. A type-only legacy schema (`output` phantom, no `validate`) passes the raw string record through unvalidated.
 
-### Adapters and low-level helpers
-
-Also exported from `@canonical/router-core`:
+### Blocking navigation — `block`
 
 ```ts
-function createBrowserAdapter(): PlatformAdapter;                          // Navigation API → History API
-function createHistoryAdapter(browserWindow?): PlatformAdapter;           // History API
-function createNavigationAdapter(navigationWindow?): PlatformAdapter;     // Navigation API
-function createServerAdapter(initialUrl: string | URL): PlatformAdapter;
-function createMemoryAdapter(initialUrl: string | URL = "/"): MemoryAdapter;
-function createRouterStore<TRoutes, TNotFound>(
-  resolveMatch: (input: string | URL) => RouterMatch<TRoutes, TNotFound> | null,
-  initialUrl: string | URL = "/",
-): RouterStore<TRoutes, TNotFound>;
-function createSubject<TValue>(): Subject<TValue>;
-function createTrackedLocation<TLocation extends object>(
-  location: TLocation,
-  onAccess: (key: Extract<keyof TLocation, RouterLocationKey>) => void,
-): TrackedLocation<TLocation>;
+interface RouterBlockerHandle {
+  readonly state: "idle" | "blocked";
+  proceed(): void;     // continue the blocked navigation
+  cancel(): void;      // discard it and stay
+  subscribe(listener: (state: "idle" | "blocked") => void): () => void;
+  dispose(): void;     // remove the blocker; a navigation blocked on it is discarded, not resumed
+}
+
+router.block(isActive: () => boolean): RouterBlockerHandle;
 ```
+
+While `isActive()` returns true, `navigate()` is intercepted: the navigation is held, the handle's `state` becomes `"blocked"`, and subscribers are notified. `proceed()` performs the held navigation; `cancel()` discards it. **Scope:** blockers intercept `router.navigate()` only — `setSearchParams()` and adapter-driven back/forward are not intercepted. Disposing while blocked discards the pending navigation.
+
+React consumers use [`useBlocker`](#useblocker), which wraps this handle.
+
+```ts
+const blocker = router.block(() => form.isDirty);
+const unsubscribe = blocker.subscribe((state) => updateDialog(state));
+```
+
+### Platform adapters
 
 ```ts
 interface PlatformAdapter {
@@ -635,11 +619,127 @@ interface PlatformAdapter {
   navigate(url: string, options?: PlatformNavigateOptions): void;
   subscribe(callback: (location: string | URL) => void): () => void;
 }
-interface MemoryAdapter extends PlatformAdapter {
-  back(): void;
-  forward(): void;
+
+interface PlatformNavigateOptions {
+  readonly replace?: boolean;
+  readonly state?: unknown;
 }
 ```
+
+| Adapter | Signature | Notes |
+|---|---|---|
+| `createBrowserAdapter` | `(): PlatformAdapter` | Navigation API (`window.navigation`) when available, History API otherwise. The default client choice. |
+| `createNavigationAdapter` | `(navigationWindow?): PlatformAdapter` | Navigation API only; throws without one. Intercepts same-origin navigations; transition-promise rejections from superseded navigations are absorbed. |
+| `createHistoryAdapter` | `(browserWindow?): PlatformAdapter` | History API (`pushState`/`popstate`). |
+| `createHashAdapter` | `(browserWindow?): PlatformAdapter` | Stores the route in `location.hash` (`#/path`). For Storybook, static file hosts, and anywhere the real path is fixed. Throws without a window-like object. |
+| `createMemoryAdapter` | `(initialUrl?: string \| URL, options?: MemoryAdapterOptions): MemoryAdapter` | In-memory location for tests; adds `back()`/`forward()`. |
+| `createServerAdapter` | `(initialUrl: string \| URL): PlatformAdapter` | Pins one request URL. **Its `navigate()` throws** — a server render never client-navigates — so `router.navigate()`/`setSearchParams()` on a server-adapter router throw too. |
+
+The optional-parameter adapters accept an injectable window-like object for testing.
+
+#### `MemoryAdapterOptions` — delegating location ownership
+
+```ts
+interface MemoryAdapterOptions {
+  readonly history?: MemoryHistoryDelegate;
+}
+
+interface MemoryHistoryDelegate {
+  getLocation(): string | URL;                                        // single source of the current location
+  onNavigate(url: string, options?: PlatformNavigateOptions): void;   // receives every navigation
+  subscribe(listener: (location: string | URL) => void): () => void;  // host announces location changes
+  onBack?(): void;                                                    // optional; omitted → back() is a no-op
+  onForward?(): void;                                                 // optional; omitted → forward() is a no-op
+}
+```
+
+With a `history` delegate the adapter owns no location state: the host is the source of truth. The host must apply a forwarded navigation and notify `subscribe` listeners **synchronously inside `onNavigate`** — the router suppresses the echo of its own navigations with a single-slot guard that only holds for a synchronous notification; batched (microtask-later) notifications make router-initiated navigations resolve twice.
+
+```ts
+const adapter = createMemoryAdapter("/", { history: hostHistoryDelegate });
+```
+
+### Store primitive — `createRouterStore`
+
+The router's reactive state container, exported standalone for hosts that need a router-shaped store without a router. **It is not exposed on `Router`** — subscribe through the router's own `subscribe`/`subscribeToNavigation`/`subscribeToSearchParam`, and read through `getState()`/`getTrackedLocation()`.
+
+```ts
+function createRouterStore<TRoutes extends RouteMap, TNotFound extends AnyRoute | undefined = undefined>(
+  resolveMatch: (input: string | URL) => RouterMatch<TRoutes, TNotFound> | null,
+  initialUrl: string | URL = "/",
+): RouterStore<TRoutes, TNotFound>;
+
+interface RouterStore<TRoutes, TNotFound> {
+  commit(input: string | URL, match: RouterMatch<TRoutes, TNotFound> | null, status?: number): RouterState<TRoutes, TNotFound>;
+  getSnapshot(): RouterSnapshot<TRoutes, TNotFound>;
+  getState(): RouterState<TRoutes, TNotFound>;
+  getTrackedLocation(onAccess: (key: RouterLocationKey) => void): TrackedLocation<RouterLocationState>;
+  setLocation(input: string | URL): RouterState<TRoutes, TNotFound>;
+  setNavigationState(state: RouterNavigationState): RouterState<TRoutes, TNotFound>;
+  subscribe(listener: (snapshot: RouterSnapshot<TRoutes, TNotFound>) => void): () => void;
+  subscribeToNavigation(listener: (state, previousState) => void): () => void;
+  subscribeToSearchParam(key: string, listener: (value, previousValue) => void): () => void;
+}
+```
+
+Subscribers are notified with a changed-key diff over the location (`hash`, `href`, `pathname`, `searchParams`, `status`, `url`), which is what makes the tracked-location proxies re-render only on the fields they read.
+
+### Accessibility
+
+Construction wires four managers (each defaulting on when a `document`/`window` is available, each disableable with `false`):
+
+```ts
+interface RouterAccessibilityOptions {
+  readonly document?: RouterAccessibilityDocumentLike;
+  readonly focusManager?: FocusManagerLike | false;
+  readonly getTitle?: (context: RouterAccessibilityContext) => string | null;
+  readonly routeAnnouncer?: RouteAnnouncerLike | false;
+  readonly scrollManager?: ScrollManagerLike | false;
+  readonly viewTransition?: ViewTransitionManagerLike | false;
+}
+
+interface RouterAccessibilityContext {
+  readonly location: RouterLocationState;
+  readonly match: RouterMatch<RouteMap, AnyRoute | undefined> | null;
+  readonly status: number;
+}
+```
+
+The default implementations are exported classes, constructible standalone (each takes a document/window-like object, injectable for tests):
+
+```ts
+class FocusManager {           // moves focus after navigation
+  constructor(documentLike, options?: { fallbackSelector?: string });  // default "[data-router-outlet]"
+  focus(): boolean;
+}
+class RouteAnnouncer {         // aria-live announcement of the new route
+  constructor(documentLike);
+  announce(message: string): Promise<void>;
+}
+class ScrollManager {          // save/restore scroll positions per location
+  constructor(windowLike, options?: { document?; sessionStorage?; storageKey?: string });
+  save(location: string | URL): void;
+  restore(location: string | URL, navigationType: "pop" | "push"): void;
+}
+class ViewTransitionManager {  // wraps committed updates in document.startViewTransition
+  constructor(documentLike);
+  run(update: () => void | Promise<void>): Promise<void>;
+}
+```
+
+`getTitle` sets `document.title` after push/pop navigations from the accessibility context.
+
+### Low-level helpers
+
+```ts
+function createSubject<TValue>(): Subject<TValue>;   // { next(value); subscribe(subscriber) → unsubscribe }
+function createTrackedLocation<TLocation extends object>(
+  location: TLocation,
+  onAccess: (key: Extract<keyof TLocation, RouterLocationKey>) => void,
+): TrackedLocation<TLocation>;
+```
+
+`createTrackedLocation` tracks with property getters defined at construction time, so it only tracks keys present on the given object; the React `useRoute` hook uses a `Proxy` internally instead to also catch dynamic keys.
 
 ### Supporting types
 
@@ -647,15 +747,17 @@ interface MemoryAdapter extends PlatformAdapter {
 |---|---|
 | `RouteMap` | `Record<string, AnyRoute>` |
 | `RouterState` | `{ location: RouterLocationState; match: RouterMatch \| null; navigation: { state } }` |
-| `RouterLocationState` | `{ hash; href; pathname; searchParams: URLSearchParams; status; url: URL }` |
+| `RouterLocationState` | `{ hash; href; pathname; searchParams: URLSearchParams; status: number; url: URL }` — `url` is absolute against the synthetic `https://router.local` origin for relative inputs |
 | `RouterNavigationState` | `"idle" \| "loading"` |
 | `RouterMatch` | union of `DataRouteMatch` (`kind: "route"`, `status: 200`), `RedirectRouteMatch` (`kind: "redirect"`, `redirectTo`, `status`), `NotFoundRouteMatch` (`kind: "not-found"`, `status: 404`) |
 | `RouterDehydratedState` | `{ href; kind: "route" \| "not-found" \| "unmatched"; routeId; status }` |
 | `RouterLoadResult` | `{ dehydrate(); error; location; match; status }` (returned by `load`/`hydrate`) |
+| `RouterBlockerHandle` | the handle returned by [`router.block()`](#blocking-navigation--block) |
 | `PathBuildOptions<TRoute>` | `{ params?; search?; hash?; replace? }` — `params` required iff the path has params |
 | `NavigationIntent` | `{ name; href; params; search; hash? }` (returned by `navigate`) |
-| `TrackedLocation<T>` | proxy over a location; reading a field subscribes to just that field |
+| `TrackedLocation<T>` | a location whose field reads subscribe the reader to just that field |
 | `Subject<T>` | `{ next(value); subscribe(subscriber) → unsubscribe }` |
+| `PlatformAdapter` / `MemoryAdapter` / `MemoryAdapterOptions` / `MemoryHistoryDelegate` | see [Platform adapters](#platform-adapters) |
 | `SchemaLike<TOutput>` | `StandardSchemaV1<unknown, TOutput> \| StandardSchemaLike<TOutput>` — what `params`/`search` accept |
 | `InferOutput<TSchema>` | a schema's output type (`types.output` phantom, or legacy `output`) |
 | `InferParams<TPath, TParamsSchema>` | params schema output when declared, else `RouteParams<TPath>` |
@@ -697,7 +799,9 @@ function Link<
 >(props: LinkProps<TRoutes, TName>): ReactElement;
 ```
 
-A `forwardRef` anchor that builds `href` from a **typed route name**. Intercepts primary-button clicks → `router.navigate()`, hover (`onMouseEnter`) → `router.warm()`, and sets `aria-current="page"` when its target matches the current pathname. Modified clicks, `download`, and `target` fall through to native anchor behaviour.
+A `forwardRef` anchor that builds `href` from a **typed route name**. A primary-button click is intercepted into `router.navigate()`; hover (`onMouseEnter`) calls `router.warm()`; `aria-current="page"` is set when the target matches the current pathname.
+
+**Native fall-through happens only when:** the click was already `defaultPrevented`, the button is not the primary one, a modifier key is held (`ctrl`/`meta`/`shift`/`alt`), `target="_blank"` is set, or `download` is set. **Any other `target` value** (`_self`, `_top`, `_parent`, a named frame) is still intercepted and routed through `router.navigate()` — use a plain `<a>` when you need those to behave natively.
 
 ```ts
 type LinkProps<TRoutes, TName> =
@@ -725,6 +829,8 @@ type LinkBuildOptions<TRoute> = {
 <Link to="guide" params={{ slug: "intro" }} replace>Guide</Link>
 ```
 
+The hover warm is fire-and-forget and cached per href; see [`router.warm`](#router) for the cache semantics.
+
 ### `Outlet`
 
 ```ts
@@ -735,7 +841,7 @@ interface OutletProps {
 function Outlet({ fallback = null }: OutletProps): ReactElement;
 ```
 
-Renders the matched route subtree (route content wrapped by its wrappers). Rerenders only when the location `href` or `match` changes — not on `idle → loading` transitions. Output is wrapped in `<Suspense key={routeName} fallback={fallback}>`. Render errors from route content propagate **past** `Outlet`; wrap it in an error boundary to catch them.
+Renders the matched route subtree (route content wrapped by its wrappers). Rerenders only when the location `href` or `match` changes — not on `idle → loading` transitions. Output is wrapped in `<Suspense key={routeName} fallback={fallback}>`. Render errors from route content propagate **past** `Outlet`; wrap it in an error boundary to catch them (data errors never throw — see the [error model](#error-model-errors-are-state)).
 
 ```tsx
 <Outlet fallback={<p>Loading…</p>} />
@@ -751,7 +857,7 @@ All default their generics to `RegisteredRouteMap` / `RegisteredNotFound` (see [
 function useRouter<TRoutes = RegisteredRouteMap, TNotFound = RegisteredNotFound>(): Router<TRoutes, TNotFound>;
 ```
 
-The raw router from the nearest provider. Throws if no provider is present. Use for imperative `navigate`/`buildPath`/`warm`.
+The raw router from the nearest provider. Throws if no provider is present. Use for imperative `navigate`/`buildPath`/`warm`/`setSearchParams`/`block`.
 
 ```ts
 const router = useRouter();
@@ -764,7 +870,16 @@ router.navigate("home");
 function useRoute<TRoutes = RegisteredRouteMap, TNotFound = RegisteredNotFound>(): TrackedLocation<RouterLocationState>;
 ```
 
-The current location as a tracked proxy. Reading a field (e.g. `pathname`) subscribes the component to **only** that field.
+The current location as a tracked proxy over `RouterLocationState` — the keys are `hash`, `href`, `pathname`, `searchParams`, `status`, and `url`. Reading a field subscribes the component to **only** that field.
+
+`useRoute().status` is the data-error bridge: the router commits every load's HTTP-like status onto the location (200, 404 for not-found, 400 for a rejected search schema, whatever a `warm` hook threw), so status-driven error UI is a conditional render, not an error boundary:
+
+```tsx
+const { status } = useRoute();
+if (status >= 400) {
+  return <ErrorPage status={status} />;
+}
+```
 
 ```ts
 const { pathname, searchParams } = useRoute();
@@ -783,7 +898,9 @@ function useRouterState<TRoutes, TNotFound, TSelected>(
 Power-user state subscription. Without a selector, returns the whole `RouterState`. With one, returns the narrowed slice and rerenders only when it changes (compared with `isEqual`, default `Object.is`).
 
 ```ts
-const status = useRouterState((state) => state.match?.status ?? 200);
+const routeName = useRouterState((state) =>
+  state.match?.kind === "route" ? state.match.name : null,
+);
 ```
 
 #### `useNavigationState`
@@ -841,7 +958,7 @@ interface BlockerState {
 function useBlocker(isActive: boolean): BlockerState;
 ```
 
-Registers a navigation blocker while `isActive` is true. When a navigation is attempted, `state` becomes `"blocked"`; call `proceed()` to continue or `cancel()` to stay.
+Registers a navigation blocker via [`router.block()`](#blocking-navigation--block) while mounted. When a navigation is attempted with `isActive` true, `state` becomes `"blocked"` (the hook re-renders on the block itself); call `proceed()` to continue or `cancel()` to stay. Unmounting while blocked disposes the blocker and **discards** the pending navigation. Blockers cover `navigate()` only — not `setSearchParams()` or browser back/forward.
 
 ```tsx
 const blocker = useBlocker(form.isDirty);
@@ -853,28 +970,24 @@ return blocker.state === "blocked" ? (
 ) : null;
 ```
 
-### `createHydratedRouter`
+### `readDehydratedState`
 
 ```ts
-interface CreateHydratedRouterOptions<TNotFound extends AnyRoute | undefined>
-  extends Omit<RouterOptions<TNotFound>, "adapter"> {
-  readonly browserWindow?: HydrationWindow;
-}
-
-function createHydratedRouter<
-  const TRoutes extends RouteMap,
-  const TNotFound extends AnyRoute | undefined = undefined,
->(
-  routes: TRoutes,
-  options?: CreateHydratedRouterOptions<TNotFound>,
-): Router<TRoutes, TNotFound>;
+function readDehydratedState<TRoutes extends RouteMap = RouteMap>(
+  browserWindow?: HydrationWindow,   // defaults to window
+): RouterDehydratedState<TRoutes> | null;
 ```
 
-Browser router that resumes from dehydrated SSR state read off `window` (key `INITIAL_DATA_KEY`). Injects `createHistoryAdapter` and passes the read state as `hydratedState`. Use as the client entry of an SSR app instead of `createBrowserRouter`. `browserWindow` overrides the source of the hydration payload (defaults to `window`).
+Reads the router's dehydrated SSR state from the page's initial-data payload (`window` key `INITIAL_DATA_KEY` from `@canonical/react-ssr` — the `__INITIAL_DATA__` global). The server flat-spreads `dehydrate()`'s fields (`href`, `kind`, `routeId`, `status`) into that payload; this reader validates their presence and returns `null` when the payload is absent or carries no router fields — so an SPA page (or a payload holding only app data) falls back to a normal initial load instead of a hydration crash.
 
 ```ts
-const router = createHydratedRouter(appRoutes, { middleware: [...middleware], notFound: notFoundRoute });
+const router = createRouter(appRoutes, {
+  adapter: createBrowserAdapter(),
+  hydratedState: readDehydratedState() ?? undefined,
+});
 ```
+
+This is the client half of SSR hydration; the server half is `renderToStream`'s `bootstrapScriptContent` or the manual flat-spread shown in [Entry wiring](#entry-wiring-reference). There is exactly one payload channel — `INITIAL_DATA_KEY` — shared with the rest of the app's initial data.
 
 ### `renderToStream`
 
@@ -896,10 +1009,10 @@ function renderToStream<TRoutes extends RouteMap, TNotFound extends AnyRoute | u
 ): Promise<RenderToStreamResult<TRoutes, TNotFound>>;
 ```
 
-SSR helper. Calls `router.load(url)`, then `renderToReadableStream` of `<RouterProvider><Outlet/></RouterProvider>`. Returns the stream plus dehydrated state and a bootstrap script for client hydration (pairs with `createHydratedRouter`).
+SSR helper. Calls `router.load(url)`, then `renderToReadableStream` of `<RouterProvider><Outlet/></RouterProvider>`. Returns the stream plus dehydrated state and a bootstrap script for client hydration (pairs with [`readDehydratedState`](#readdehydratedstate)).
 
 ```ts
-const { stream, bootstrapScriptContent, loadResult } = await renderToStream(router, req.url);
+const { stream, bootstrapScriptContent, loadResult } = await renderToStream(router, requestUrl);
 if (loadResult.status >= 400) res.status(loadResult.status);
 ```
 
@@ -930,10 +1043,89 @@ useRouter().navigate("home");
 
 ## Entry wiring (reference)
 
-**Client** (`createBrowserRouter` or `createHydratedRouter`):
+The reference app (`apps/react/boilerplate-vite`) wires the full pattern; the summon templates scaffold the same shape.
+
+**Server — answer with the router's disposition first.** A module-scope **adapterless** router is a pure matcher (construction runs no load and no `warm` hooks; never use a server-adapter router here — it warms at construction). Resolve every request to a redirect or a render + status before touching React:
+
+```ts
+const dispositionMatcher = createRouter(appRoutes, {
+  middleware: [...middleware],
+  notFound: notFoundRoute,
+});
+
+export function resolveRouteDisposition(url: string): RouteDisposition {
+  const authRedirect = getAuthRedirectHref(url);
+  if (authRedirect) {
+    return { kind: "redirect", status: 302, location: authRedirect };
+  }
+
+  let matchResult: ReturnType<typeof dispositionMatcher.match>;
+  try {
+    matchResult = dispositionMatcher.match(url);
+  } catch (error) {
+    // A rejected search schema is a client error, not a crash.
+    return {
+      kind: "render",
+      status: error instanceof StatusResponse ? error.status : 500,
+      dehydratedState: null,
+    };
+  }
+
+  if (matchResult?.kind === "redirect") {
+    return { kind: "redirect", status: matchResult.status, location: matchResult.redirectTo };
+  }
+
+  const status = matchResult?.status ?? 404;
+  return {
+    kind: "render",
+    status,
+    dehydratedState: {
+      href: url,
+      kind: matchResult?.kind === "route" ? "route" : "not-found",
+      routeId: matchResult?.kind === "route" ? String(matchResult.name) : null,
+      status,
+    },
+  };
+}
+```
+
+The HTTP layer answers `redirect` dispositions directly (a 301 for a static redirect route, the auth guard's 302) and passes a `render` disposition's `status` to the response (via `@canonical/react-ssr`'s `RendererOptions.statusCode`) — a matched not-found page is a real 404, never a soft 200. The `dehydratedState` fields are flat-spread into the page's `__INITIAL_DATA__` payload next to the app's own initial data.
+
+**Server — render the request.** The server entry builds a per-request router pinned to the URL and hydrates it synchronously so `render()`/`<Outlet>` work without awaiting `load()`:
 
 ```tsx
-const router = createBrowserRouter(appRoutes, { middleware: [...middleware], notFound: notFoundRoute });
+const router = createRouter(appRoutes, {
+  middleware: [...middleware],
+  notFound: notFoundRoute,
+  adapter: createServerAdapter(url),
+});
+const serverMatch = router.match(url);
+
+if (serverMatch?.kind === "route" || serverMatch?.kind === "not-found") {
+  router.hydrate({
+    href: url,
+    kind: serverMatch.kind,
+    routeId: serverMatch.kind === "route" ? serverMatch.name : null,
+    status: serverMatch.status,
+  });
+}
+
+<RouterProvider router={router}>
+  <Outlet fallback={<p>Loading…</p>} />
+</RouterProvider>;
+```
+
+(Alternatively, `renderToStream(router, url)` performs load + stream + payload in one call.)
+
+**Client — resume from the payload:**
+
+```tsx
+const router = createRouter(appRoutes, {
+  adapter: createBrowserAdapter(),
+  middleware: [...middleware],
+  notFound: notFoundRoute,
+  hydratedState: readDehydratedState() ?? undefined,   // null on SPA pages → normal initial load
+});
 
 hydrateRoot(
   document.getElementById("root")!,
@@ -943,21 +1135,15 @@ hydrateRoot(
 );
 ```
 
-**Server** (`createStaticRouter`, render inside the full HTML document):
-
-```tsx
-const router = createStaticRouter(appRoutes, url, { middleware: [...middleware], notFound: notFoundRoute });
-// inspect router.match for status / redirect, then:
-<RouterProvider router={router}>
-  <Outlet fallback={<p>Loading…</p>} />
-</RouterProvider>;
-```
+On SSR pages the router resumes the server-rendered match and skips the duplicate initial load; in SPA cells `readDehydratedState()` returns `null` and a normal load runs.
 
 ---
 
 ## See also
 
 - [Migrating to the pragma router](../how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md)
+- [Router middleware cookbook](../how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md)
+- Design rationale and stability: [core README](../../packages/runtime/router/README.md), [react README](../../packages/react/router/README.md)
 - Router core package: `packages/runtime/router`
 - Router React package: `packages/react/router`
 - Reference app: `apps/react/boilerplate-vite`

--- a/docs/references/ROUTER_API.md
+++ b/docs/references/ROUTER_API.md
@@ -420,17 +420,22 @@ createRouter(appRoutes, { adapter: createBrowserAdapter(), middleware: [...middl
 createRouter(appRoutes, { adapter: createServerAdapter(url), middleware: [...middleware], notFound: notFoundRoute }); // server
 ```
 
-For a server-side pre-render decision that must not throw, mirror the same logic in a pure helper that returns the redirect href or `null`:
+For a server-side pre-render decision that must not throw, mirror the same logic in a pure helper — and hand it the router's **match**, never the raw URL. A raw-URL check normalizes differently from the router (trailing slashes are ignored by matching, and the last duplicate search value wins), so it could let a protected page render unauthenticated:
 
 ```ts
-function getAuthRedirectHref(input: string | URL): string | null {
-  const url = input instanceof URL ? input : new URL(input, "https://router.local");
-  if (!protectedPaths.has(url.pathname) || hasDemoAuth({ auth: url.searchParams.get("auth") })) {
+function getAuthRedirectForMatch(match: {
+  readonly route: AnyRoute;
+  readonly search: unknown;
+  readonly pathname: string;
+}): string | null {
+  if (!protectedPaths.has(match.route.url) || hasDemoAuth(match.search)) {
     return null;
   }
-  return `/login?from=${encodeURIComponent(url.pathname)}`;
+  return `/login?from=${encodeURIComponent(match.pathname)}`;
 }
 ```
+
+The server matches first, then asks (see [Entry wiring](#entry-wiring-reference)).
 
 ### Error model: errors are state
 
@@ -1054,11 +1059,6 @@ const dispositionMatcher = createRouter(appRoutes, {
 });
 
 export function resolveRouteDisposition(url: string): RouteDisposition {
-  const authRedirect = getAuthRedirectHref(url);
-  if (authRedirect) {
-    return { kind: "redirect", status: 302, location: authRedirect };
-  }
-
   let matchResult: ReturnType<typeof dispositionMatcher.match>;
   try {
     matchResult = dispositionMatcher.match(url);
@@ -1073,6 +1073,15 @@ export function resolveRouteDisposition(url: string): RouteDisposition {
 
   if (matchResult?.kind === "redirect") {
     return { kind: "redirect", status: matchResult.status, location: matchResult.redirectTo };
+  }
+
+  // Auth is decided AFTER matching, from the router's own data — the matched
+  // pattern and the schema-validated search — so the server can never
+  // normalize differently from the router.
+  const authRedirect =
+    matchResult?.kind === "route" ? getAuthRedirectForMatch(matchResult) : null;
+  if (authRedirect) {
+    return { kind: "redirect", status: 302, location: authRedirect };
   }
 
   const status = matchResult?.status ?? 404;

--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -2,6 +2,8 @@
 
 React bindings for `@canonical/router-core`. `@canonical/router-react` turns a core router into React context, hooks, links, outlets, and SSR helpers while preserving the flat-route model from the core package.
 
+> **Stability: pre-1.0 / experimental.** The API is still consolidating and breaking changes may land between minor versions; the CHANGELOG and conventional-commit history are the migration record. The design positions behind the API are documented in the core package's [Design rationale](../../runtime/router/README.md#design-rationale).
+
 ## Installation
 
 ```bash
@@ -12,10 +14,14 @@ Requires `react` and `react-dom`.
 
 ## Quick start
 
-### 1. Define routes in core
+### 1. Define routes and a router in core
 
 ```tsx
-import { createRouter, route } from "@canonical/router-core";
+import {
+  createBrowserAdapter,
+  createRouter,
+  route,
+} from "@canonical/router-core";
 
 export const routes = {
   home: route({
@@ -28,7 +34,9 @@ export const routes = {
   }),
 } as const;
 
-export const router = createRouter(routes);
+export const router = createRouter(routes, {
+  adapter: createBrowserAdapter(),
+});
 ```
 
 `@canonical/router-core` owns route definitions, matching, and typed navigation. `@canonical/router-react` layers React rendering and subscriptions on top.
@@ -38,7 +46,7 @@ Route authoring story, in short:
 - define every route with `route()`
 - give it a `url` pattern such as `/docs/:slug`
 - optionally add `warm`, `content`, and `wrappers`
-- create one router from the full flat route map
+- create one router from the full flat route map, with an adapter
 - let the router match incoming URLs — React renders the result
 
 ### 2. Provide the router and render the current match
@@ -64,7 +72,6 @@ import {
   Link,
   useNavigationState,
   useRoute,
-  useRouterState,
   useSearchParam,
   useSearchParams,
 } from "@canonical/router-react";
@@ -72,7 +79,6 @@ import {
 function Navigation() {
   const navigationState = useNavigationState();
   const location = useRoute();
-  const status = useRouterState((state) => state.match?.status ?? 404);
   const tab = useSearchParam("tab");
   const search = useSearchParams();
 
@@ -83,7 +89,7 @@ function Navigation() {
         Docs
       </Link>
       <span>{navigationState}</span>
-      <span>{status}</span>
+      <span>{location.status}</span>
       <span>{location.pathname}</span>
       <span>{tab ?? "overview"}</span>
       <span>{search.toString()}</span>
@@ -97,7 +103,7 @@ All hooks and `Link` default to `RegisteredRouteMap`. Register your route map on
 ```ts
 declare module "@canonical/router-react" {
   interface RouterRegister {
-    routes: typeof appRoutes;
+    routes: typeof routes;
   }
 }
 ```
@@ -117,7 +123,7 @@ Important distinction:
 
 The router does not own data. `content()` receives `params` and `search` — not data. Components fetch their own data from their cache library (Relay, TanStack Query, SWR, etc.).
 
-The optional `warm()` on routes is a fire-and-forget navigation-time hook. Use it to warm caches, preload assets, or run side effects before the component renders. It does not pass data to `content()`.
+The optional `warm()` on routes is a fire-and-forget navigation-time hook. Use it to warm caches, preload assets, or run side effects before the component renders. It does not pass data to `content()` — the component's cache hook finds the data already warm. (Why this is the design, and why loader-data-as-props is rejected, is spelled out in the core [Design rationale](../../runtime/router/README.md#design-rationale).)
 
 ```tsx
 const userRoute = route({
@@ -136,34 +142,80 @@ function UserProfile({ id }: { id: string }) {
 
 ## Error handling
 
-The router does not ship an error boundary component. When `warm()` throws, the error propagates into the React render tree and is caught by the nearest React error boundary.
+Errors travel through two separate channels. Knowing which one you are in tells you which tool to reach for.
 
-Use `StatusResponse` from `@canonical/router-core` to signal HTTP-like errors:
+### Channel 1 — data errors are state, not exceptions
+
+The router commits every data failure as a status on the location: an unmatched URL is a 404, a rejected search schema is a 400, a `StatusResponse`/`Response` thrown from `warm()` carries its own status, and any other throw during a load becomes a 500. **None of these are thrown into React** — a `StatusResponse` thrown during a load never reaches an error boundary; it becomes `location.status`.
+
+The bridge into React is one property read: `useRoute().status`. The location object is tracked, so a component reading `status` re-renders only when the status changes:
 
 ```tsx
-import { StatusResponse } from "@canonical/router-core";
+import { useRoute } from "@canonical/router-react";
 
-function ErrorFallback({ error }: { error: unknown }) {
-  const status = error instanceof StatusResponse ? error.status : 500;
+function RouteStatusGate({ children }: { children: React.ReactNode }) {
+  const { status } = useRoute();
 
-  if (status === 404) return <NotFound />;
-  if (status === 401) return <LoginRedirect />;
-  return <ErrorPage status={status} />;
+  if (status === 404) return <NotFoundPage />;
+  if (status === 401) return <LoginPrompt />;
+  if (status >= 400) return <ErrorPage status={status} />;
+
+  return <>{children}</>;
 }
 
-function DashboardLayout({ children }: { children: React.ReactNode }) {
+// Wrap the outlet once, near the top of the tree:
+// <RouterProvider router={router}>
+//   <RouteStatusGate>
+//     <Outlet />
+//   </RouteStatusGate>
+// </RouterProvider>
+```
+
+### Channel 2 — render errors belong to React
+
+A component that throws while rendering (including a suspense cache read that rejects) is React's concern, handled by an ordinary error boundary. The router deliberately does not ship one — error UI is application-specific. A complete boundary, inline:
+
+```tsx
+import { useRoute } from "@canonical/router-react";
+import { Component, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  readonly children: ReactNode;
+  readonly fallback: (error: unknown) => ReactNode;
+}
+
+interface ErrorBoundaryState {
+  readonly error: unknown | null;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    return { error };
+  }
+
+  render(): ReactNode {
+    return this.state.error !== null
+      ? this.props.fallback(this.state.error)
+      : this.props.children;
+  }
+}
+
+// A plain boundary sticks in its error state after the user navigates away.
+// Key it by the location so navigation remounts it fresh:
+function RouteErrorGate({ children }: { children: ReactNode }) {
+  const { href } = useRoute();
+
   return (
-    <div>
-      <Sidebar />
-      <ErrorBoundary fallbackRender={({ error }) => <ErrorFallback error={error} />}>
-        {children}
-      </ErrorBoundary>
-    </div>
+    <ErrorBoundary key={href} fallback={(error) => <CrashPage error={error} />}>
+      {children}
+    </ErrorBoundary>
   );
 }
 ```
 
-The boilerplate reference app provides a complete `RouteErrorBoundary` implementation to copy and adapt.
+Compose the two channels in one place — status gate outside, render boundary inside — and every route gets both behaviors for free.
 
 ## Search param mutation
 
@@ -192,7 +244,7 @@ function FilterBar() {
 
 ## Navigation blocking
 
-`useBlocker()` prevents navigation when the component has unsaved state. The hook returns a state object — the consumer controls the confirmation UI:
+`useBlocker()` prevents navigation when the component has unsaved state. The hook returns a state object — the consumer controls the confirmation UI, and the hook re-renders the moment a navigation is blocked:
 
 ```tsx
 import { useBlocker } from "@canonical/router-react";
@@ -254,7 +306,7 @@ function QuickEditForm() {
 }
 ```
 
-The blocker registers on mount and unregisters on unmount — when the form is submitted or the component is removed, blocking stops automatically.
+The blocker registers on mount and disposes on unmount. Unmounting while a navigation is blocked **discards** that navigation (it is not resumed). Blockers intercept `router.navigate()` only — `setSearchParams()` and browser back/forward are not intercepted.
 
 ## Creating routes and matching URLs
 
@@ -263,7 +315,11 @@ The blocker registers on mount and unregisters on unmount — when the form is s
 Each entry in the route map is a named call to `route()`.
 
 ```tsx
-import { createRouter, route } from "@canonical/router-core";
+import {
+  createBrowserAdapter,
+  createRouter,
+  route,
+} from "@canonical/router-core";
 
 const routes = {
   home: route({
@@ -283,7 +339,7 @@ const routes = {
   }),
 } as const;
 
-const router = createRouter(routes);
+const router = createRouter(routes, { adapter: createBrowserAdapter() });
 ```
 
 Important parts:
@@ -296,96 +352,75 @@ Important parts:
 
 Routes stay flat even when the UI is nested. Shared layout lives in wrappers from the core package, not in a nested route tree.
 
-## SSR
+## SSR and hydration
+
+There is one SSR story: the server serializes the router's dehydrated state into the page's `__INITIAL_DATA__` payload (the `INITIAL_DATA_KEY` contract shared with `@canonical/react-ssr`), and the client reads it back with `readDehydratedState()`.
 
 ### Server side
 
-Wire your own render tree using standard React SSR primitives. Use `createStaticRouter` for server rendering — it matches on construction and fires `warm()` eagerly so caches start warming before React renders:
+`renderToStream(router, url)` loads the URL into a server-adapter router, streams the matched React output, and hands back everything the response needs:
 
 ```tsx
-import { createStaticRouter } from "@canonical/router-core";
-import { createHeadCollector, HeadProvider } from "@canonical/react-head";
-import { Outlet, RouterProvider } from "@canonical/router-react";
-import { renderToPipeableStream } from "react-dom/server";
+import { createRouter, createServerAdapter } from "@canonical/router-core";
+import { renderToStream } from "@canonical/router-react";
 
-app.get("*", (req, res) => {
-  const router = createStaticRouter(routes, req.url);
-  const headCollector = createHeadCollector();
+app.get("*", async (req, res) => {
+  const router = createRouter(routes, {
+    adapter: createServerAdapter(req.url),
+    notFound: notFoundRoute,
+  });
 
-  // Check match for status code before rendering
-  if (!router.match) {
-    res.status(404);
-  } else if (router.match.kind === "redirect") {
-    return res.redirect(router.match.status, router.match.redirectTo);
-  }
-
-  const { pipe } = renderToPipeableStream(
-    <HeadProvider collector={headCollector}>
-      <RouterProvider router={router}>
-        <Shell>
-          <Outlet />
-        </Shell>
-      </RouterProvider>
-    </HeadProvider>,
-    {
-      onShellReady() {
-        const headHtml = headCollector.toHtml();
-        res.setHeader("content-type", "text/html");
-        res.write(`<!doctype html><html><head>${headHtml}</head><body>`);
-        pipe(res);
-      },
-    },
+  const { stream, loadResult, bootstrapScriptContent } = await renderToStream(
+    router,
+    req.url,
   );
+
+  res.status(loadResult.status); // 200, 404 for not-found, error statuses
+  // Inject `bootstrapScriptContent` into the HTML (an inline <script> that
+  // sets window.__INITIAL_DATA__), then send the stream.
 });
 ```
 
-The router dehydrates navigation state only. Data dehydration is the cache library's responsibility (dual dehydration):
+When you integrate with `@canonical/react-ssr`'s `JSXRenderer` instead (as the reference app does), spread the dehydrated fields — `{ href, kind, routeId, status }` from `router.dehydrate()` — flat into the initial-data object next to your own fields, and pass the document's status through the renderer's `statusCode` option.
 
-```tsx
-// In onShellReady or after render:
-const routerState = router.dehydrate();
-const cacheState = queryClient.dehydrate(); // TanStack Query, Relay, etc.
-
-// Inject both into the HTML template
-res.write(`<script>
-  window.__ROUTER_STATE__ = ${JSON.stringify(routerState)};
-  window.__QUERY_DATA__ = ${JSON.stringify(cacheState)};
-</script>`);
-```
+The router dehydrates **navigation state only**. Data dehydration is the cache library's responsibility.
 
 ### Client side
 
-```tsx
-import { createBrowserRouter } from "@canonical/router-core";
-import { HeadProvider } from "@canonical/react-head";
-import { Outlet, RouterProvider } from "@canonical/router-react";
+`readDehydratedState()` reads `window.__INITIAL_DATA__`, validates that it actually carries router fields, and returns `null` otherwise — so the same entry works on server-rendered pages (resume the server match, skip the duplicate initial load) and in SPA builds (normal initial load):
 
-const router = createBrowserRouter(routes, {
-  hydratedState: window.__ROUTER_STATE__,
+```tsx
+import { createBrowserAdapter, createRouter } from "@canonical/router-core";
+import {
+  Outlet,
+  readDehydratedState,
+  RouterProvider,
+} from "@canonical/router-react";
+import { hydrateRoot } from "react-dom/client";
+
+const router = createRouter(routes, {
+  adapter: createBrowserAdapter(),
+  hydratedState: readDehydratedState() ?? undefined,
 });
 
 hydrateRoot(
-  document,
-  <HeadProvider>
-    <RouterProvider router={router}>
-      <Shell>
-        <Outlet />
-      </Shell>
-    </RouterProvider>
-  </HeadProvider>,
+  document.getElementById("root")!,
+  <RouterProvider router={router}>
+    <Outlet />
+  </RouterProvider>,
 );
 ```
 
-`createBrowserRouter` uses the Navigation API when available (Baseline Newly Available since January 2026), falling back to the History API.
+`createBrowserAdapter` uses the Navigation API when available (Baseline Newly Available since January 2026), falling back to the History API.
 
 ## Progressive disclosure
 
 ### `Link`
 
-`Link` builds typed hrefs from route names and optional route params, search data, and hash values. Primary-button clicks are intercepted and routed through the core router. Hover warms the destination.
+`Link` builds typed hrefs from route names and optional route params, search data, and hash values. A plain primary-button click is intercepted and routed through `router.navigate()`; the click falls through to native anchor behaviour when it has a modifier key, a non-primary button, `target="_blank"`, a `download` attribute, or was `preventDefault()`ed. Hovering warms the destination through `router.warm()`.
 
 ```tsx
-<Link<typeof routes> params={{ slug: "api" }} to="docs">
+<Link params={{ slug: "api" }} to="docs">
   API docs
 </Link>
 ```
@@ -402,7 +437,7 @@ hydrateRoot(
 
 - `useBlocker(isActive)` blocks navigation when `isActive` is `true`. Returns `{ state, proceed, cancel }`.
 - `useNavigationState()` subscribes to the router loading state.
-- `useRoute()` returns a tracked location proxy and rerenders only when an accessed location key changes.
+- `useRoute()` returns a tracked location proxy and rerenders only when an accessed location key changes — including `status`.
 - `useRouter()` returns the router instance from context. Use `useRouter().setSearchParams()` for search param mutation.
 - `useRouterState()` is the power-user hook for subscribing to selected slices of `router.getState()`.
 - `useSearchParam()` subscribes to one query-string key.
@@ -414,7 +449,7 @@ Typical selection strategy:
 - reach for `useNavigationState()` when you only need loading lifecycle
 - reach for `useSearchParam()` for one query-string key
 - reach for `useSearchParams()` for a fixed key set or the full query string
-- reach for `useRoute()` for pathname, hash, or full URL reads
+- reach for `useRoute()` for pathname, hash, status, or full URL reads
 - reach for `useRouter()` for search param mutation or direct router access
 - reach for `useRouterState()` when you need `match`, `navigation`, or other advanced state in one selector
 
@@ -422,21 +457,23 @@ Typical selection strategy:
 
 The reference integration lives in [apps/react/boilerplate-vite](../../../apps/react/boilerplate-vite). It shows:
 
-- domain-colocated route modules
-- a shell-as-route-provider layout
-- SSR + hydration
-- hover warm
-- auth middleware redirect flow
-- error handling with `StatusResponse` and React error boundaries
+- domain-colocated route modules assembled into one flat map
+- a shell-as-layout wrapper applied with `group()`
+- SSR with real HTTP statuses and redirects (`resolveRouteDisposition` in its server entry) and hydration via `readDehydratedState()`
+- a route-level `warm` hook priming the Relay store, read by the component's own query hook
+- an auth middleware redirect flow
+- a static redirect route answering 301
 
 ## Public API
 
 ### Components and helpers
 
-- `createHydratedRouter()` — create a browser-backed router that resumes from dehydrated state.
 - `Link` — render a typed anchor that navigates and warms through the router.
 - `Outlet` — render the current matched subtree.
 - `RouterProvider` — place a router instance into React context.
+- `readDehydratedState()` — read (and validate) dehydrated router state from the page's initial-data payload.
+- `renderToStream()` — load a URL into a router and stream the matched React output with dehydrated state and a bootstrap script.
+- `RouterRegister` / `RegisteredRouteMap` / `RegisteredNotFound` — module-augmentation hooks for generics-free typing.
 - `useBlocker()` — block navigation when the component has unsaved state.
 - `useNavigationState()` — subscribe to the navigation lifecycle state.
 - `useRoute()` — subscribe to a tracked location object.
@@ -447,4 +484,6 @@ The reference integration lives in [apps/react/boilerplate-vite](../../../apps/r
 
 ### Reference docs
 
+- API reference: [docs/references/ROUTER_API.md](../../../docs/references/ROUTER_API.md)
 - Migration guide: [docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md](../../../docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md)
+- Design rationale: [packages/runtime/router/README.md](../../runtime/router/README.md#design-rationale)

--- a/packages/runtime/router/README.md
+++ b/packages/runtime/router/README.md
@@ -2,6 +2,8 @@
 
 Framework-agnostic routing primitives for Canonical apps. `@canonical/router-core` gives you flat route definitions, wrapper composition, typed navigation helpers, SSR dehydration, middleware hooks, and accessibility orchestration without locking you into a specific view layer.
 
+> **Stability: pre-1.0 / experimental.** The API is still consolidating and breaking changes may land between minor versions. Every breaking change ships with a conventional-commit subject and a CHANGELOG entry — those are the migration record. Pin a minor version if you need stability today.
+
 ## Installation
 
 ```bash
@@ -13,7 +15,7 @@ bun add @canonical/router-core
 ### 1. Define routes
 
 ```tsx
-import { createRouter, route } from "@canonical/router-core";
+import { route } from "@canonical/router-core";
 
 const routes = {
   home: route({
@@ -27,11 +29,17 @@ const routes = {
 } as const;
 ```
 
-### 2. Create a router
+### 2. Create a router with an adapter
+
+The adapter is the one construction axis — it decides where the location lives (browser URL, hash fragment, memory, a fixed server URL):
 
 ```ts
-const router = createRouter(routes);
+import { createBrowserAdapter, createRouter } from "@canonical/router-core";
+
+const router = createRouter(routes, { adapter: createBrowserAdapter() });
 ```
+
+A router created **without** an adapter is a pure matcher: `match()`, `buildPath()`, and `load()` work, while `navigate()` and `setSearchParams()` throw — there is no location for them to change.
 
 ### 3. Use typed helpers
 
@@ -52,9 +60,35 @@ The core package intentionally stops at route matching, state, dehydration, and 
 - **Routes are flat.** Every route is declared with `route()`.
 - **Wrappers are annotations.** Reuse layout with `wrapper()` and `group()`.
 - **Middleware is route-to-route transformation.** Use it to add auth, i18n, metrics, or shared wrapper policy. Middleware runs once, before the router is created.
+- **The adapter is the construction axis.** `createRouter(routes, { adapter })` is the only constructor; pick `createBrowserAdapter()`, `createHashAdapter()`, `createMemoryAdapter()`, `createServerAdapter()`, or bring your own `PlatformAdapter`.
 - **`warm()` is fire-and-forget.** It warms caches, preloads assets, or runs side effects at navigation time. It does not provide data to `content()` — components own their data via their cache library.
+- **Errors are state, not exceptions.** Every load commits a `status` onto the location (404 for no match, 400 for a rejected query string, the status of a thrown `StatusResponse`, 500 otherwise). Nothing is thrown at the view layer.
 - **URL params are validated by schemas.** Give a route a `params` or `search` [Standard Schema](https://standardschema.dev) validator (Zod, Valibot, ArkType, or hand-rolled) and the validated, typed output flows to `content()`, `warm()`, and the typed navigation helpers.
 - **SSR is built in.** `dehydrate()` preserves navigation state across the server/client boundary.
+
+## Design rationale
+
+These are deliberate positions, not gaps. If the router feels smaller than others you have used, that is the design.
+
+### The router does not own data
+
+`warm()` is the only data-adjacent hook and it is fire-and-forget on purpose. It never blocks rendering and never passes data to `content()`. The supported pattern is **cache population**: the hook warms the cache your components already read from — `fetchQuery` into a Relay store, `queryClient.prefetchQuery` for TanStack Query — and the component's own hook finds the data already there.
+
+Handing loader data to components as props (the loader model other routers use) is rejected as an antipattern here:
+
+- it couples data lifetime to route lifetime — leaving the route drops data the cache could have kept;
+- it blocks navigation on the slowest fetch instead of letting the page stream in;
+- on a cache-aware app it double-fetches: the loader fetches, then the component's cache hook fetches again or needs bridging glue.
+
+One consequence to know: because the hook never blocks, a redirect or status thrown from an **async** `warm()` is applied *late* — the destination may render briefly before the redirect lands (applied with replace semantics, so Back does not return to it). That flash is the honest price of never blocking render.
+
+### Errors are state, not exceptions
+
+HTTP-shaped failures are facts about the location, so they live on the location: `getState().location.status`. The router owns data errors (no match → 404, rejected query → 400, thrown `StatusResponse`/`Response` → its status, anything else → 500) and commits them as state; the view layer owns render errors with its native mechanism (an error boundary, in React). Nothing the router does throws into your component tree. See the two-channel guide in [`@canonical/router-react`'s README](../../react/router/README.md#error-handling).
+
+### Minimal API, low sugar
+
+One orthogonal way per capability. There are no preset router factories — the adapter is the whole axis, so `createRouter(routes, { adapter })` is the entire construction story. Blocking is one method (`router.block()`) returning one handle. Convenience layers must earn their place; the surface we stabilize at 1.0 should be the smallest one that composes.
 
 ## Progressive disclosure
 
@@ -87,6 +121,8 @@ const userRoute = route({
 });
 ```
 
+Throwing from `warm()` is meaningful control flow: `redirect(to, status)` redirects, `throw new StatusResponse(404)` sets the location status. Both work from sync and async hooks — an async throw is applied late (after the route rendered) and only while the navigation is still current; any other async rejection is deliberately ignored, because a failed cache warm must never break navigation.
+
 ### Schema validation for URL params
 
 Routes accept [Standard Schema](https://standardschema.dev) validators for both kinds of URL parameters. Any spec-compliant library schema (Zod ≥3.24, Valibot, ArkType) can be passed directly; raw values always arrive as strings, so use coercion.
@@ -94,7 +130,7 @@ Routes accept [Standard Schema](https://standardschema.dev) validators for both 
 **Path params** — the `params` field validates and coerces `:param` segments. A rejected URL is a **non-match**: matching falls through to the next route and ultimately the not-found route (404), exactly like a pattern mismatch.
 
 ```tsx
-import { route } from "@canonical/router-core";
+import { createBrowserAdapter, createRouter, route } from "@canonical/router-core";
 import { z } from "zod";
 
 const productRoute = route({
@@ -104,10 +140,15 @@ const productRoute = route({
   content: ({ params }) => `Product #${params.id}`,
 });
 
+const router = createRouter(
+  { product: productRoute },
+  { adapter: createBrowserAdapter() },
+);
+
 router.buildPath("product", { params: { id: 42 } }); // "/products/42" — fully typed
 ```
 
-**Search params** — the `search` field validates the query string. A rejected query throws `StatusResponse(400, { issues, message })`: `load()` commits it as a 400 error result (a real 400 under SSR, an error-boundary render on the client). Prefer normalizing schemas that supply defaults over rejecting ones — a shared URL with a stale query should not crash the page:
+**Search params** — the `search` field validates the query string. A rejected query throws `StatusResponse(400, { issues, message })`, which `load()` commits as a 400 **error result on the location** — a real 400 under SSR, `location.status === 400` on the client. It does not reach an error boundary. Prefer normalizing schemas that supply defaults over rejecting ones — a shared URL with a stale query should not error the page:
 
 ```tsx
 const listRoute = route({
@@ -120,7 +161,7 @@ const listRoute = route({
 });
 ```
 
-No dependency? Hand-roll the schema — either the Standard Schema v1 shape (`{ "~standard": { version: 1, vendor, validate } }`, annotate with `StandardSchemaV1<In, Out>` for inference) or the legacy type-only shape (`{ "~standard": { output, validate } }`). See the [Router API reference](../../../docs/references/ROUTER_API.md#schema-validation) for both.
+No dependency? Hand-roll the Standard Schema v1 shape (`{ "~standard": { version: 1, vendor, validate } }`, annotated with `StandardSchemaV1<In, Out>` for inference). See the [Router API reference](../../../docs/references/ROUTER_API.md#schema-validation).
 
 Validation runs at match time and is **synchronous** — async validators (e.g. Zod async refinements) throw with an explanatory error. For semantic checks (does the record exist?) use `warm` + `StatusResponse`.
 
@@ -140,16 +181,16 @@ const [dashboardRoute, reportsRoute] = group(appShell, [
 ] as const);
 ```
 
-### Error handling
+### Error signalling
 
-The router does not ship an error boundary component. Errors from `warm()` are thrown into the React render tree and caught by standard React error boundaries. Use `StatusResponse` to signal HTTP-like errors:
+Use `StatusResponse` to give a failure an HTTP status. Thrown from `warm()`, it becomes the location's status — read it as state (`getState().location.status`, or `useRoute().status` in React), never from an error boundary:
 
 ```tsx
-import { StatusResponse, route } from "@canonical/router-core";
+import { route, StatusResponse } from "@canonical/router-core";
 
-const protectedRoute = route({
+const adminRoute = route({
   url: "/admin",
-  warm: async () => {
+  warm: () => {
     if (!isAuthenticated()) {
       throw new StatusResponse(401);
     }
@@ -158,34 +199,39 @@ const protectedRoute = route({
 });
 ```
 
-In your React tree, catch these with any error boundary:
-
-```tsx
-import { StatusResponse } from "@canonical/router-core";
-
-function ErrorFallback({ error }) {
-  const status = error instanceof StatusResponse ? error.status : 500;
-  return <ErrorPage status={status} />;
-}
-```
+The `data` argument is optional; pass one to carry a typed payload (`new StatusResponse(503, { retryAfter: "5m" })`).
 
 ### Redirects
+
+Runtime redirects — thrown from `warm()`, sync or async:
 
 ```ts
 import { redirect, route } from "@canonical/router-core";
 
-const loginRequired = route({
+const privateRoute = route({
   url: "/private",
-  warm: async () => {
-    redirect("/login", 302);
+  warm: () => {
+    if (!isAuthenticated()) {
+      redirect("/login", 302);
+    }
   },
   content: () => "private",
 });
 ```
 
+Static redirect routes — declared entirely in the route map, no content; they answer with 301 or 308 (the permanent family; `redirect()` covers the temporary one):
+
+```ts
+const legacyHome = route({
+  url: "/home",
+  redirect: "/",
+  status: 301,
+});
+```
+
 ## Search param mutation
 
-`setSearchParams()` patches the current URL's search params without requiring the route name:
+`setSearchParams()` patches the current URL's search params without requiring the route name (adapter required — it changes the location):
 
 ```ts
 // Merge into current search params
@@ -206,37 +252,38 @@ router.setSearchParams({ page: "2" }, { replace: true });
 
 ## Navigation blocking
 
-Register blockers to prevent navigation when there is unsaved state. Blockers are checked before any navigation proceeds:
+`router.block(isActive)` registers a blocker and returns a handle. While `isActive()` returns true, `navigate()` is intercepted and held until the handle decides it:
 
 ```ts
-const blockerId = "edit-form";
+const blocker = router.block(() => formHasUnsavedChanges);
 
-// Register a blocker that checks whether to block
-router.registerBlocker({
-  id: blockerId,
-  isActive: () => formHasUnsavedChanges,
+// When a navigation is attempted while the blocker is active:
+blocker.state; // "blocked"
+
+blocker.subscribe((state) => {
+  // "blocked" → show your confirmation UI; "idle" → hide it
 });
 
-// When navigation is attempted while a blocker is active:
-router.blockerState; // "blocked"
+blocker.proceed(); // continue the blocked navigation
+blocker.cancel(); // stay on the current page
 
-// The consumer decides whether to proceed or cancel
-router.proceedNavigation(); // continue the blocked navigation
-router.cancelNavigation();  // stay on the current page
-
-// Remove the blocker when the form is submitted or discarded
-router.unregisterBlocker(blockerId);
+// Remove the blocker; a navigation blocked on it is discarded, not resumed
+blocker.dispose();
 ```
 
-For React, use the `useBlocker()` hook from `@canonical/router-react` instead of these core primitives.
+Blockers intercept `router.navigate()` only — `setSearchParams()` and adapter-driven back/forward are not intercepted. For React, use `useBlocker()` from `@canonical/router-react`.
 
 ## Middleware
 
-Middleware runs once, before the router is created. Apply it to route definitions with `applyMiddleware()`:
+Middleware is a route-to-route transformation (`<TRoute extends AnyRoute>(route: TRoute) => TRoute`), applied once before the router exists. Pass it through `RouterOptions.middleware` — the first entry in the array is the outermost transformation (applied last):
 
 ```ts
-import { applyMiddleware, createRouter } from "@canonical/router-core";
-import type { AnyRoute } from "@canonical/router-core";
+import {
+  type AnyRoute,
+  createBrowserAdapter,
+  createRouter,
+  route,
+} from "@canonical/router-core";
 
 function withBasePath(basePath: string) {
   return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
@@ -247,69 +294,33 @@ function withBasePath(basePath: string) {
   };
 }
 
-const routes = applyMiddleware([withBasePath("/app")], rawRoutes);
-const router = createRouter(routes);
-```
+const routes = {
+  home: route({ url: "/", content: () => "Home" }),
+} as const;
 
-See the [migration guide](../../../docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md) for middleware patterns and migration from other routers.
-
-## Router factories
-
-Convenience functions that create a router with a pre-configured platform adapter:
-
-```ts
-import {
-  createBrowserRouter,
-  createStaticRouter,
-  createMemoryRouter,
-} from "@canonical/router-core";
-
-// Client — auto-detects Navigation API with History fallback
-const router = createBrowserRouter(routes);
-
-// Server — matches URL on construction, exposes router.match for status codes
-const serverRouter = createStaticRouter(routes, req.url);
-
-if (!serverRouter.match) { res.status(404); }
-else if (serverRouter.match.kind === "redirect") {
-  return res.redirect(serverRouter.match.status, serverRouter.match.redirectTo);
-}
-
-// Testing — in-memory adapter, supports navigation
-const testRouter = createMemoryRouter(routes, "/users/42");
-```
-
-`createStaticRouter` fires `warm()` eagerly on construction, so caches start warming before React renders.
-
-The low-level `createRouter(routes, { adapter })` is still available for cases that need explicit adapter control.
-
-## SSR and hydration
-
-The router dehydrates navigation state only (matched route, params, search, URL). Data dehydration is the cache library's responsibility.
-
-```ts
-const serverRouter = createStaticRouter(routes, "/users/42");
-const navigationState = serverRouter.dehydrate();
-
-const clientRouter = createBrowserRouter(routes, {
-  hydratedState: navigationState ?? undefined,
+const router = createRouter(routes, {
+  adapter: createBrowserAdapter(),
+  middleware: [withBasePath("/app")],
 });
 ```
 
-For a full React SSR flow, see [packages/react/router/README.md](../../react/router/README.md) and [apps/react/boilerplate-vite](../../../apps/react/boilerplate-vite).
+The standalone `applyMiddleware(routes, middleware)` export is the lower-level array primitive (`readonly AnyRoute[]` in, same out) the option is built on; reach for it only when transforming route arrays outside a router.
+
+See the [middleware cookbook](../../../docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md) for auth, i18n, and instrumentation patterns.
 
 ## Platform adapters
 
-The router factories use platform adapters internally. You can also use them directly with `createRouter()`:
+The adapter decides where the location lives; everything else about the router is identical across them:
 
 - `createBrowserAdapter()` — auto-detects the best API: uses the Navigation API (`window.navigation`) when available, falls back to the History API (`pushState` / `popstate`) for older browsers.
 - `createNavigationAdapter()` — explicitly use the Navigation API. Baseline Newly Available since January 2026.
 - `createHistoryAdapter()` — explicitly use the History API.
-- `createMemoryAdapter()` — in-memory adapter for testing.
-- `createServerAdapter()` — static URL for server-side rendering.
+- `createHashAdapter()` — store the route in `window.location.hash`; useful where the path is fixed (Storybook, static file hosts).
+- `createMemoryAdapter(initialUrl?, options?)` — in-memory adapter for testing.
+- `createServerAdapter(url)` — a fixed URL for server-side rendering; its `navigate()` throws.
 
 ```ts
-import { createRouter, createMemoryAdapter } from "@canonical/router-core";
+import { createMemoryAdapter, createRouter } from "@canonical/router-core";
 
 const testRouter = createRouter(routes, {
   adapter: createMemoryAdapter("/users/42"),
@@ -338,7 +349,46 @@ Host values are normalized at the boundary: `getLocation` reads and subscription
 
 **The host must notify synchronously.** When the router navigates, it suppresses the echo of its own navigation through a guard that only holds for a notification fired synchronously within `onNavigate`. A host that batches change notifications (microtask, animation frame, or later) will miss the guard and every router-initiated navigation will resolve twice. If your store batches, notify the adapter's listener directly and synchronously inside `onNavigate`.
 
-`createMemoryRouter(routes, initialUrl, { history })` forwards the delegate to its internal adapter, so the convenience factory supports externally owned location too.
+## SSR and hydration
+
+On the server, create the router with a server adapter, match the URL for the response status, and hydrate the store synchronously so rendering works without awaiting `load()`:
+
+```ts
+import { createRouter, createServerAdapter } from "@canonical/router-core";
+
+const router = createRouter(routes, {
+  adapter: createServerAdapter(url),
+  notFound: notFoundRoute,
+});
+const serverMatch = router.match(url);
+
+if (serverMatch?.kind === "redirect") {
+  // Answer with a real HTTP redirect before rendering anything.
+  return respondRedirect(serverMatch.status, serverMatch.redirectTo);
+}
+
+if (serverMatch?.kind === "route" || serverMatch?.kind === "not-found") {
+  router.hydrate({
+    href: url,
+    kind: serverMatch.kind,
+    routeId: serverMatch.kind === "route" ? serverMatch.name : null,
+    status: serverMatch.status, // 200, or 404 for the matched not-found route
+  });
+}
+```
+
+The router dehydrates navigation state only (`router.dehydrate()` → `{ href, kind, routeId, status }`). Data dehydration is the cache library's responsibility. On the client, pass the serialized state back as `hydratedState`:
+
+```ts
+import { createBrowserAdapter, createRouter } from "@canonical/router-core";
+
+const clientRouter = createRouter(routes, {
+  adapter: createBrowserAdapter(),
+  hydratedState: serializedState ?? undefined,
+});
+```
+
+For the full React flow — `renderToStream`, `readDehydratedState`, and the `__INITIAL_DATA__` contract — see [packages/react/router/README.md](../../react/router/README.md) and the reference app in [apps/react/boilerplate-vite](../../../apps/react/boilerplate-vite).
 
 ## Accessibility
 
@@ -357,15 +407,13 @@ Override or disable them through `RouterOptions.accessibility`.
 
 - `applyMiddleware()`
 - `createBrowserAdapter()`
-- `createBrowserRouter()`
+- `createHashAdapter()`
 - `createHistoryAdapter()`
 - `createMemoryAdapter()`
-- `createMemoryRouter()`
 - `createNavigationAdapter()`
 - `createRouter()`
 - `createRouterStore()`
 - `createServerAdapter()`
-- `createStaticRouter()`
 - `createSubject()`
 - `createTrackedLocation()`
 - `group()`
@@ -379,6 +427,10 @@ Override or disable them through `RouterOptions.accessibility`.
 - `Redirect`
 - `StatusResponse`
 
+All supporting types (`Router`, `RouterOptions`, `RouterBlockerHandle`, `PlatformAdapter`, `MemoryAdapterOptions`, `StandardSchemaV1`, …) are exported from the package root.
+
 ### Reference docs
 
+- API reference: [docs/references/ROUTER_API.md](../../../docs/references/ROUTER_API.md)
 - Migration guide: [docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md](../../../docs/how-to-guides/MIGRATE_TO_PRAGMA_ROUTER.md)
+- Middleware cookbook: [docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md](../../../docs/how-to-guides/ROUTER_MIDDLEWARE_COOKBOOK.md)

--- a/packages/runtime/router/src/lib/index.ts
+++ b/packages/runtime/router/src/lib/index.ts
@@ -4,6 +4,7 @@ export { default as createHashAdapter } from "./createHashAdapter.js";
 export { default as createHistoryAdapter } from "./createHistoryAdapter.js";
 export { default as createMemoryAdapter } from "./createMemoryAdapter.js";
 export { default as createNavigationAdapter } from "./createNavigationAdapter.js";
+export type { SearchValidationFailure } from "./createRouter.js";
 export { default as createRouter } from "./createRouter.js";
 export { default as createRouterStore } from "./createRouterStore.js";
 export { default as createServerAdapter } from "./createServerAdapter.js";

--- a/packages/summon/application/src/application/react/templates/src/client/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/client/entry.tsx.ejs
@@ -1,24 +1,34 @@
 import { HeadProvider } from "@canonical/react-head";
 import { createBrowserAdapter, createRouter } from "@canonical/router-core";
-import { Outlet, RouterProvider } from "@canonical/router-react";
+import {
+  Outlet,
+  readDehydratedState,
+  RouterProvider,
+} from "@canonical/router-react";
 import { hydrateRoot } from "react-dom/client";
 <% if (relay) { -%>
 import { RelayEnvironmentProvider } from "react-relay";
-import { createEnvironment } from "#relay/environment.js";
+import { getBrowserEnvironment } from "#relay/environment.js";
 <% } -%>
 import { appRoutes, middleware, notFoundRoute } from "../routes.js";
 import "#styles/index.css";
 
+// On SSR pages __INITIAL_DATA__ carries the flat dehydrated router state
+// (href/kind/routeId/status); hydrating from it resumes the server-rendered
+// match and skips the duplicate initial load. In the SPA cells there is no
+// payload (or no router fields) and readDehydratedState() returns null, so
+// the router performs a normal initial load.
 const router = createRouter(appRoutes, {
   adapter: createBrowserAdapter(),
   middleware: [...middleware],
   notFound: notFoundRoute,
+  hydratedState: readDehydratedState() ?? undefined,
 });
 <% if (relay) { -%>
 
 // One Relay environment (network + normalized store) for the whole browser
 // session — module scope, so client-side navigations share the cache.
-const relayEnvironment = createEnvironment();
+const relayEnvironment = getBrowserEnvironment();
 <% } -%>
 
 const root = document.getElementById("root");

--- a/packages/summon/application/src/application/react/templates/src/domains/account/routes.ts
+++ b/packages/summon/application/src/application/react/templates/src/domains/account/routes.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from "@canonical/router-core";
 import { route } from "@canonical/router-core";
 import AccountPage from "./AccountPage.js";
 import LoginPage from "./LoginPage.js";
@@ -6,24 +7,36 @@ function readString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-const accountSearchSchema = {
+/**
+ * Standard Schema v1 search validators — the same interface Zod, Valibot,
+ * and ArkType implement, so any of them can be dropped in here directly.
+ */
+const accountSearchSchema: StandardSchemaV1<
+  Record<string, unknown>,
+  { readonly auth?: string }
+> = {
   "~standard": {
-    output: {} as { readonly auth?: string },
-    validate(value: unknown): { readonly auth?: string } {
+    version: 1,
+    vendor: "boilerplate",
+    validate(value) {
       const record = value as Record<string, unknown>;
 
-      return { auth: readString(record.auth) };
+      return { value: { auth: readString(record.auth) } };
     },
   },
 };
 
-const loginSearchSchema = {
+const loginSearchSchema: StandardSchemaV1<
+  Record<string, unknown>,
+  { readonly from?: string }
+> = {
   "~standard": {
-    output: {} as { readonly from?: string },
-    validate(value: unknown): { readonly from?: string } {
+    version: 1,
+    vendor: "boilerplate",
+    validate(value) {
       const record = value as Record<string, unknown>;
 
-      return { from: readString(record.from) };
+      return { value: { from: readString(record.from) } };
     },
   },
 };

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductList.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/ProductList.tsx
@@ -4,9 +4,9 @@ import type { ProductListQuery } from "#relay/__generated__/ProductListQuery.gra
 import ProductCard from "./ProductCard.js";
 
 /** How many products the list requests from the connection. */
-const PAGE_SIZE = 4;
+export const PAGE_SIZE = 4;
 
-const productListQuery = graphql`
+export const productListQuery = graphql`
   query ProductListQuery($count: Int!, $cursor: String) {
     viewer {
       name

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/routes.ts
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/routes.ts
@@ -1,9 +1,32 @@
 import { route } from "@canonical/router-core";
+import { fetchQuery } from "react-relay";
+import { getBrowserEnvironment } from "#relay/environment.js";
 import CatalogPage from "./CatalogPage.js";
+import { PAGE_SIZE, productListQuery } from "./ProductList.js";
 
 const routes = {
   catalog: route({
     url: "/catalog",
+    // Navigation-time cache warm: fetch the first catalog page into the
+    // browser session's Relay store so `useLazyLoadQuery` (store-or-network)
+    // reads it without a second request. Fire-and-forget by design — the
+    // route never blocks on it and no data is passed to the component; a
+    // failed warm just falls back to the component's own fetch. `fetchQuery`
+    // rather than `loadQuery`: the latter returns a reference that must be
+    // disposed, which has no owner in a fire-and-forget hook (unretained data
+    // sits in the store's release buffer and may eventually be GC'd —
+    // harmless, it re-fetches).
+    warm: () => {
+      if (typeof document === "undefined") {
+        return; // SSR: catalog content is ClientOnly; nothing to warm.
+      }
+
+      void fetchQuery(getBrowserEnvironment(), productListQuery, {
+        count: PAGE_SIZE,
+      })
+        .toPromise()
+        .catch(() => {});
+    },
     content: CatalogPage,
   }),
 } as const;

--- a/packages/summon/application/src/application/react/templates/src/domains/marketing/routes.ts
+++ b/packages/summon/application/src/application/react/templates/src/domains/marketing/routes.ts
@@ -1,6 +1,30 @@
+import type { StandardSchemaV1 } from "@canonical/router-core";
 import { route } from "@canonical/router-core";
 import GuidePage from "./GuidePage.js";
 import HomePage from "./HomePage.js";
+
+/**
+ * Standard Schema v1 params validator — the same interface Zod, Valibot, and
+ * ArkType schemas implement, so any of them can be dropped in here directly.
+ * A slug that is not lowercase kebab-case makes the URL a non-match: the
+ * router falls through to the not-found route (404) instead of rendering.
+ */
+const guideParamsSchema: StandardSchemaV1<
+  { readonly slug: string },
+  { readonly slug: string }
+> = {
+  "~standard": {
+    version: 1,
+    vendor: "boilerplate",
+    validate(value) {
+      const record = value as { slug?: string };
+
+      return record.slug && /^[a-z0-9]+(-[a-z0-9]+)*$/.test(record.slug)
+        ? { value: { slug: record.slug } }
+        : { issues: [{ message: "slug must be lowercase kebab-case" }] };
+    },
+  },
+};
 
 const routes = {
   home: route({
@@ -9,6 +33,7 @@ const routes = {
   }),
   guide: route({
     url: "/guides/:slug",
+    params: guideParamsSchema,
     content: GuidePage,
   }),
 } as const;

--- a/packages/summon/application/src/application/react/templates/src/relay/environment.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/environment.ts
@@ -117,3 +117,19 @@ export const createEnvironment = (
     store: new Store(new RecordSource()),
   });
 };
+
+let browserEnvironment: Environment | null = null;
+
+/**
+ * The browser-session Relay environment, created lazily on first use.
+ *
+ * Module scope so the client entry's provider and route-level `warm` hooks
+ * share one normalized store — a navigation-time cache warm lands in the same
+ * store `useLazyLoadQuery` reads from. Server code must keep using
+ * `createEnvironment()` (fresh per request).
+ */
+export const getBrowserEnvironment = (): Environment => {
+  browserEnvironment ??= createEnvironment();
+
+  return browserEnvironment;
+};

--- a/packages/summon/application/src/application/react/templates/src/routes.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/routes.tsx.ejs
@@ -27,50 +27,54 @@ function hasDemoAuth(search: unknown): boolean {
   return authValue === "1";
 }
 
-export function getAuthRedirectHref(input: string | URL): string | null {
-  // Absolute URLs are used as-is; relative paths resolve against a dummy base.
-  const url =
-    input instanceof URL ? input : new URL(input, "https://router.local");
-
-  if (
-    !protectedPaths.has(url.pathname) ||
-    hasDemoAuth({ auth: url.searchParams.get("auth") })
-  ) {
+/**
+ * Auth decision for an already-matched route, from the router's own data —
+ * the matched pattern and the schema-validated search. Deriving it from the
+ * raw URL would normalize differently from the router (trailing slashes,
+ * duplicate search values) and let a protected page render unauthenticated.
+ */
+export function getAuthRedirectForMatch(match: {
+  readonly route: AnyRoute;
+  readonly search: unknown;
+  readonly pathname: string;
+}): string | null {
+  if (!protectedPaths.has(match.route.url) || hasDemoAuth(match.search)) {
     return null;
   }
 
-  return `/login?from=${encodeURIComponent(url.pathname)}`;
+  return `/login?from=${encodeURIComponent(match.pathname)}`;
 }
 
 export function withAuth(loginPath: string): RouteMiddleware {
-  return ((currentRoute: AnyRoute) => {
+  return <TRoute extends AnyRoute>(currentRoute: TRoute): TRoute => {
     if (!protectedPaths.has(currentRoute.url)) {
       return currentRoute;
     }
 
     const currentWarm = currentRoute.warm;
+    const guardedWarm = (
+      params: unknown,
+      search: unknown,
+      context: NavigationContext,
+    ) => {
+      if (!hasDemoAuth(search)) {
+        const from = currentRoute.render(
+          (params ?? {}) as RouteParamValues | Record<string, never>,
+        );
 
-    return {
-      ...currentRoute,
-      warm: (
-        params: unknown,
-        search: unknown,
-        context: NavigationContext,
-      ) => {
-        if (!hasDemoAuth(search)) {
-          const from = currentRoute.render(
-            (params ?? {}) as RouteParamValues | Record<string, never>,
-          );
+        redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);
+      }
 
-          redirect(`${loginPath}?from=${encodeURIComponent(from)}`, 302);
-        }
-
-        if (currentWarm) {
-          return currentWarm(params, search, context);
-        }
-      },
+      if (currentWarm) {
+        return currentWarm(params, search, context);
+      }
     };
-  }) as RouteMiddleware;
+
+    // Overriding `warm` widens the property's type, so the object needs a
+    // local assertion back to TRoute; the middleware's signature itself is
+    // now the real generic contract.
+    return { ...currentRoute, warm: guardedWarm } as TRoute;
+  };
 }
 
 const publicLayout = wrapper<ReactElement>({
@@ -113,9 +117,19 @@ const [contact] = group(publicLayout, [contactRoutes.contact] as const);
 const [catalog] = group(publicLayout, [catalogRoutes.catalog] as const);
 
 <% } -%>
+// Static redirect route: matched entirely from the URL, no content — the
+// router (and the SSR disposition helper) answers with a real 301. Static
+// redirects accept 301 or 308 only; runtime redirect() covers the 302 family.
+const legacyHome = route({
+  url: "/home",
+  redirect: "/",
+  status: 301,
+});
+
 const appRoutes = {
   guide,
   home,
+  legacyHome,
   account,
   login,
 <% if (forms) { -%>

--- a/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
@@ -118,7 +118,18 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
     notFound: notFoundRoute,
     adapter: createServerAdapter(url),
   });
-  const serverMatch = router.match(url);
+  // A rejected search schema throws from match(); resolveRouteDisposition
+  // already turned that into the response status (400-class), so render the
+  // shell unhydrated instead of letting the throw reach React — a shell
+  // error would override the supplied status with 500. The client router
+  // re-derives the same error state on load.
+  let serverMatch: ReturnType<typeof router.match>;
+
+  try {
+    serverMatch = router.match(url);
+  } catch {
+    serverMatch = null;
+  }
 
   // Hydrate the store synchronously so render() works without awaiting
   // load(). Redirects and unmatched URLs are the server's concern before

--- a/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
@@ -1,18 +1,113 @@
 import { HeadProvider } from "@canonical/react-head";
 import type { ServerEntrypointProps } from "@canonical/react-ssr/renderer";
-import { createRouter, createServerAdapter } from "@canonical/router-core";
+import {
+  createRouter,
+  createServerAdapter,
+  StatusResponse,
+} from "@canonical/router-core";
 import { Outlet, RouterProvider } from "@canonical/router-react";
 <% if (relay) { -%>
 import { RelayEnvironmentProvider } from "react-relay";
 import { createEnvironment } from "#relay/environment.js";
 <% } -%>
-import { appRoutes, middleware, notFoundRoute } from "../routes.js";
+import {
+  appRoutes,
+  getAuthRedirectForMatch,
+  middleware,
+  notFoundRoute,
+} from "../routes.js";
 import "#styles/app.css";
 
 interface InitialData extends Record<string, unknown> {
   readonly url?: string;
   /** Colour-scheme preference resolved from the request cookie, if any. */
   readonly theme?: "light" | "dark";
+  /**
+   * Flat dehydrated router state (from resolveRouteDisposition), read back by
+   * router-react's readDehydratedState() on the client. Absent in SPA cells.
+   */
+  readonly href?: string;
+  readonly kind?: "route" | "not-found";
+  readonly routeId?: string | null;
+  readonly status?: number;
+}
+
+/** How the server should answer a request for this URL. */
+export type RouteDisposition =
+  | {
+      readonly kind: "render";
+      readonly status: number;
+      readonly dehydratedState: {
+        readonly href: string;
+        readonly kind: "route" | "not-found";
+        readonly routeId: string | null;
+        readonly status: number;
+      } | null;
+    }
+  | {
+      readonly kind: "redirect";
+      readonly status: number;
+      readonly location: string;
+    };
+
+// A module-scope adapterless router is a pure matcher: without an adapter,
+// construction fires no load and no warm hooks, and match() runs no hooks at
+// all. Never use a server-adapter router here — it warms at construction.
+const dispositionMatcher = createRouter(appRoutes, {
+  middleware: [...middleware],
+  notFound: notFoundRoute,
+});
+
+/**
+ * Resolve a request URL to the HTTP answer the router implies: a redirect
+ * (auth guard or a static redirect route) or a render with the matched
+ * document's real status — a matched not-found page is a 404 response, not a
+ * soft 200.
+ */
+export function resolveRouteDisposition(url: string): RouteDisposition {
+  let matchResult: ReturnType<typeof dispositionMatcher.match>;
+
+  try {
+    matchResult = dispositionMatcher.match(url);
+  } catch (error) {
+    // A rejected search schema is a client error; render the shell with the
+    // error status and let the client router re-derive the same state.
+    return {
+      kind: "render",
+      status: error instanceof StatusResponse ? error.status : 500,
+      dehydratedState: null,
+    };
+  }
+
+  if (matchResult?.kind === "redirect") {
+    return {
+      kind: "redirect",
+      status: matchResult.status,
+      location: matchResult.redirectTo,
+    };
+  }
+
+  // Auth is decided from the router's own match (pattern + validated search),
+  // never from the raw URL — the two normalize differently.
+  const authRedirect =
+    matchResult?.kind === "route" ? getAuthRedirectForMatch(matchResult) : null;
+
+  if (authRedirect) {
+    return { kind: "redirect", status: 302, location: authRedirect };
+  }
+
+  const status = matchResult?.status ?? 404;
+
+  return {
+    kind: "render",
+    status,
+    dehydratedState: {
+      href: url,
+      kind: matchResult?.kind === "route" ? "route" : "not-found",
+      routeId: matchResult?.kind === "route" ? String(matchResult.name) : null,
+      status,
+    },
+  };
 }
 
 export default function EntryServer(props: ServerEntrypointProps<InitialData>) {

--- a/packages/summon/application/src/application/react/templates/src/server/preview.bun.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/preview.bun.ts
@@ -63,15 +63,30 @@ Bun.serve({
       }
     }
 
-    const renderer =
-      url.pathname === "/sitemap.xml"
-        ? (createSitemapRenderer as CreateSitemapRenderer)()
-        : (createAppRenderer as CreateAppRenderer)(req);
-    const stream = await renderer.renderToReadableStream(req.signal);
+    if (url.pathname === "/sitemap.xml") {
+      const renderer = (createSitemapRenderer as CreateSitemapRenderer)();
+      const stream = await renderer.renderToReadableStream(req.signal);
+
+      return new Response(stream, {
+        status: renderer.statusCode,
+        headers: { "Content-Type": renderer.contentType },
+      });
+    }
+
+    const appResult = (createAppRenderer as CreateAppRenderer)(req);
+
+    if (appResult.kind === "redirect") {
+      return new Response(null, {
+        status: appResult.status,
+        headers: { location: appResult.location },
+      });
+    }
+
+    const stream = await appResult.renderer.renderToReadableStream(req.signal);
 
     return new Response(stream, {
-      status: renderer.statusCode,
-      headers: { "Content-Type": renderer.contentType },
+      status: appResult.renderer.statusCode,
+      headers: { "Content-Type": appResult.renderer.contentType },
     });
   },
 });

--- a/packages/summon/application/src/application/react/templates/src/server/preview.express.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/preview.express.ts
@@ -49,10 +49,25 @@ app.use(express.static("dist/client", { index: false }));
 
 app.use(async (req, res, next) => {
   try {
-    const renderer =
-      req.path === "/sitemap.xml"
-        ? (createSitemapRenderer as CreateSitemapRenderer)()
-        : (createAppRenderer as CreateAppRenderer)(req);
+    if (req.path === "/sitemap.xml") {
+      const renderer = (createSitemapRenderer as CreateSitemapRenderer)();
+      const result = renderer.renderToPipeableStream();
+
+      await renderer.statusReady;
+      res.status(renderer.statusCode);
+      res.setHeader("content-type", renderer.contentType);
+      result.pipe(res);
+      return;
+    }
+
+    const appResult = (createAppRenderer as CreateAppRenderer)(req);
+
+    if (appResult.kind === "redirect") {
+      res.redirect(appResult.status, appResult.location);
+      return;
+    }
+
+    const renderer = appResult.renderer;
     const result = renderer.renderToPipeableStream();
 
     await renderer.statusReady;

--- a/packages/summon/application/src/application/react/templates/src/server/renderer.tsx
+++ b/packages/summon/application/src/application/react/templates/src/server/renderer.tsx
@@ -20,7 +20,11 @@ import path from "node:path";
 import { extractPreferences } from "@canonical/react-hooks";
 import { JSXRenderer } from "@canonical/react-ssr/renderer";
 import { getRequestUrl } from "@canonical/react-ssr/server";
-import EntryServer, { type InitialData } from "./entry.js";
+import EntryServer, {
+  type InitialData,
+  type RouteDisposition,
+  resolveRouteDisposition,
+} from "./entry.js";
 
 const htmlString = fs.readFileSync(
   path.join(process.cwd(), "dist", "client", "index.html"),
@@ -40,11 +44,37 @@ function cookieHeader(request: Request | IncomingMessage): string | null {
  * URL for routing and the cookie-backed theme so the first paint matches the
  * user's preference, passing both as the renderer's initial data.
  */
-export default function createAppRenderer(request: Request | IncomingMessage) {
+/** The app renderer's answer: a stream renderer, or an HTTP redirect. */
+export type AppRendererResult =
+  | {
+      readonly kind: "render";
+      readonly renderer: JSXRenderer<typeof EntryServer, InitialData>;
+    }
+  | Extract<RouteDisposition, { kind: "redirect" }>;
+
+export default function createAppRenderer(
+  request: Request | IncomingMessage,
+): AppRendererResult {
   const { theme } = extractPreferences(cookieHeader(request));
   const initialData: InitialData = {
     url: getRequestUrl(request),
     theme: theme === "light" || theme === "dark" ? theme : undefined,
   };
-  return new JSXRenderer(EntryServer, initialData, { htmlString });
+  const disposition = resolveRouteDisposition(initialData.url ?? "/");
+
+  if (disposition.kind === "redirect") {
+    return disposition;
+  }
+
+  // Flat-spread the dehydrated router state into the page payload; the client
+  // reads it back with readDehydratedState() and resumes the server match.
+  Object.assign(initialData, disposition.dehydratedState ?? {});
+
+  return {
+    kind: "render",
+    renderer: new JSXRenderer(EntryServer, initialData, {
+      htmlString,
+      statusCode: disposition.status,
+    }),
+  };
 }

--- a/packages/summon/application/src/application/react/templates/src/server/server.bun.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/server.bun.ts
@@ -65,9 +65,17 @@ Bun.serve({
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(requestUrl, template);
 
-      const { default: EntryServer } = await vite.ssrLoadModule(
-        "/src/server/entry.tsx",
-      );
+      const { default: EntryServer, resolveRouteDisposition } =
+        await vite.ssrLoadModule("/src/server/entry.tsx");
+
+      const disposition = resolveRouteDisposition(requestUrl);
+
+      if (disposition.kind === "redirect") {
+        return new Response(null, {
+          status: disposition.status,
+          headers: { location: disposition.location },
+        });
+      }
       const { JSXRenderer } = await vite.ssrLoadModule(
         "@canonical/react-ssr/renderer",
       );
@@ -84,8 +92,9 @@ Bun.serve({
         {
           url: requestUrl,
           theme: theme === "light" || theme === "dark" ? theme : undefined,
+          ...(disposition.dehydratedState ?? {}),
         },
-        { htmlString: html },
+        { htmlString: html, statusCode: disposition.status },
       );
       const stream = await renderer.renderToReadableStream(req.signal);
 

--- a/packages/summon/application/src/application/react/templates/src/server/server.express.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/server.express.ts
@@ -60,9 +60,15 @@ async function start() {
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(url, template);
 
-      const { default: EntryServer } = await vite.ssrLoadModule(
-        "/src/server/entry.tsx",
-      );
+      const { default: EntryServer, resolveRouteDisposition } =
+        await vite.ssrLoadModule("/src/server/entry.tsx");
+
+      const disposition = resolveRouteDisposition(url);
+
+      if (disposition.kind === "redirect") {
+        res.redirect(disposition.status, disposition.location);
+        return;
+      }
       const { JSXRenderer } = await vite.ssrLoadModule(
         "@canonical/react-ssr/renderer",
       );
@@ -79,8 +85,9 @@ async function start() {
         {
           url,
           theme: theme === "light" || theme === "dark" ? theme : undefined,
+          ...(disposition.dehydratedState ?? {}),
         },
-        { htmlString: html },
+        { htmlString: html, statusCode: disposition.status },
       );
       const result = renderer.renderToPipeableStream();
 

--- a/packages/summon/application/src/application/react/templates/test/e2e/servers.e2e.ts
+++ b/packages/summon/application/src/application/react/templates/test/e2e/servers.e2e.ts
@@ -89,6 +89,62 @@ describe("server matrix (2×3) serves correctly", () => {
             expect(xml).toContain("<urlset");
             expect(xml).toContain("<loc>");
           }
+
+          // SSR cells answer with the router's disposition: a matched
+          // not-found page is a real 404, static redirect routes and the
+          // auth guard are real HTTP redirects, and an authorized request
+          // renders 200. (The SPA cells stay 200-only: Vite's static
+          // fallback serves index.html for every route and cannot express
+          // router statuses.)
+          if (cell.ssr) {
+            const notFound = await fetch(
+              `${server.base}/definitely-not-a-page`,
+            );
+            expect(notFound.status).toBe(404);
+            const notFoundHtml = await notFound.text();
+            expect(notFoundHtml).toContain('id="root"');
+
+            const legacy = await fetch(`${server.base}/home`, {
+              redirect: "manual",
+            });
+            expect(legacy.status).toBe(301);
+            const legacyLocation = legacy.headers.get("location");
+            expect(legacyLocation, "301 must carry a Location").toBeTruthy();
+            expect(
+              new URL(legacyLocation as string, server.base).pathname,
+            ).toBe("/");
+
+            const guarded = await fetch(`${server.base}/account`, {
+              redirect: "manual",
+            });
+            expect(guarded.status).toBe(302);
+            const guardedHeader = guarded.headers.get("location");
+            expect(guardedHeader, "302 must carry a Location").toBeTruthy();
+            const guardedLocation = new URL(
+              guardedHeader as string,
+              server.base,
+            );
+            expect(guardedLocation.pathname).toBe("/login");
+            expect(guardedLocation.searchParams.get("from")).toBe("/account");
+
+            // The auth decision comes from the router's own match, so URL
+            // shapes the router normalizes differently from a raw-URL check
+            // must still redirect: a trailing slash, and duplicate auth
+            // values where the router keeps the last one.
+            const trailing = await fetch(`${server.base}/account/`, {
+              redirect: "manual",
+            });
+            expect(trailing.status).toBe(302);
+
+            const duplicated = await fetch(
+              `${server.base}/account?auth=1&auth=0`,
+              { redirect: "manual" },
+            );
+            expect(duplicated.status).toBe(302);
+
+            const authorized = await fetch(`${server.base}/account?auth=1`);
+            expect(authorized.status).toBe(200);
+          }
         } finally {
           await server.stop();
         }

--- a/packages/summon/application/src/shared/versions.ts
+++ b/packages/summon/application/src/shared/versions.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ExecResult, Task } from "@canonical/task";
-import { exec, flatMap, info, map, pure, recover } from "@canonical/task";
+import type { Task } from "@canonical/task";
+import { info, map } from "@canonical/task";
 
 /**
  * Resolve the pragma workspace version range that a generated app should pin
@@ -16,23 +16,13 @@ import { exec, flatMap, info, map, pure, recover } from "@canonical/task";
  * - `@canonical/design-tokens` is versioned SEPARATELY and is NOT pinned here —
  *   it reaches the app transitively via `@canonical/styles`, which owns its range.
  *
- * Resolution strategy (in order):
- * 1. At summon time, query the npm registry for the latest published version of
- *    a representative workspace package and pin `^<latest>`. This keeps freshly
- *    scaffolded apps on the newest release without a manual bump here.
- * 2. If the query fails (offline, registry down, npm missing), fall back to the
- *    version of the generator itself — because summon-application is released in
- *    lockstep with the rest of the workspace, its own version is the correct
- *    release line for the app it just generated. This is always at least as
- *    fresh as the generator binary in use.
+ * Resolution is fully offline, by design: `pragma create` performs no network
+ * calls. The generator pins the version of the release line it belongs to —
+ * summon-application is published in lockstep with the workspace packages an
+ * app depends on, so `^<own version>` is always release-correct, and two
+ * scaffolds of the same generator are byte-identical (a registry lookup here
+ * once made concurrent scaffolds race the network and diverge).
  */
-
-/**
- * A representative workspace package whose `latest` dist-tag tracks the shared
- * lerna release line. Any of the co-released packages would do; styles is a
- * root dependency of every generated app.
- */
-const REPRESENTATIVE_PACKAGE = "@canonical/styles";
 
 const OWN_PACKAGE = "@canonical/summon-application";
 
@@ -121,57 +111,29 @@ export function ownVersion(): string {
 }
 
 /**
- * The generator's own release-line version, used as the offline fallback range.
+ * The generator's own release-line version, used as the pinned range.
  * summon-application is published in lockstep with the workspace packages an app
  * depends on, so `^<own version>` is a safe, non-stale default. The module
  * always sits inside its own package, so the walk cannot miss in practice; the
  * "latest" escape survives only as a last resort for a mangled installation.
  */
-function fallbackRange(): string {
+function pinnedRange(): string {
   const own = ownVersion();
   return own === "unknown" ? "latest" : `^${own}`;
 }
 
-const SEMVER = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
-
 /**
- * Resolve the version range as a Task, so the npm query participates in the
- * generator pipeline (dry-run visible, cancellable) instead of firing on module
- * import. Runs `npm view <pkg> version`; on any failure or unparseable output it
- * yields the offline fallback range.
- *
- * @note Impure — spawns `npm` and reads the registry over the network.
+ * Resolve the version range as a Task so the decision is visible in the
+ * generator pipeline (dry-run included). Deterministic and offline: the range
+ * comes from the installed generator's own release line.
  */
 export function resolvePragmaVersion(): Task<string> {
-  return flatMap(
-    // A missing `npm` binary makes the spawn reject (a task failure) rather
-    // than resolve with a nonzero exit code, so recover to a synthetic failed
-    // ExecResult. Both spawn errors and nonzero exits then flow through the
-    // single fallback branch below.
-    recover(
-      exec("npm", ["view", REPRESENTATIVE_PACKAGE, "version"], undefined, {
-        // Best-effort lookup — never let a registry miss undo prior file writes.
-        undo: null,
-      }),
-      () => pure<ExecResult>({ stdout: "", stderr: "", exitCode: 1 }),
+  const pinned = pinnedRange();
+  return map(
+    info(
+      `Pinning @canonical/* packages to ${pinned} (the installed generator's release line).`,
     ),
-    (result) => {
-      const latest = result.stdout.trim();
-      if (result.exitCode === 0 && SEMVER.test(latest)) {
-        return map(
-          info(`Pinning @canonical/* packages to ^${latest} (latest on npm).`),
-          () => `^${latest}`,
-        );
-      }
-      const fallback = fallbackRange();
-      return map(
-        info(
-          `Could not reach npm for the latest @canonical/* version; ` +
-            `pinning ${fallback} (from the installed generator).`,
-        ),
-        () => fallback,
-      );
-    },
+    () => pinned,
   );
 }
 


### PR DESCRIPTION
## Done

**Re-land of #979** (reference-app alignment + router docs overhaul — reviewed and approved there; all review threads addressed). The stacked-merge mishap happened a second time: #981 was squash-merged to `main` at 09:20, and #979 was then merged at 10:09 **into that already-merged branch**, so its content never reached `main`. This PR is #979's squash commit cherry-picked cleanly onto current `main` (33 files; root `check` and all affected-package tests green).

> ⚠️ **This PR's base is `main` and it is the last of the train — please merge it directly.** For future stacked trains: merge top-down into the child branch first, or land the bottom PR only after all stacked PRs above it have been folded in.

Content (full discussion in #979): SSR answers with the router's real statuses and redirects (`resolveRouteDisposition`, auth decided from the router's own match), client hydration from dehydrated state via `readDehydratedState()`, a route-level `warm` hook priming the shared Relay store, a static 301 redirect route, Standard Schema v1 unification, generic `withAuth`, hardened e2e status matrix — plus the docs overhaul: `ROUTER_API.md` rewritten against the runtime, **Design rationale** + pre-1.0 stability notes + two-channel error handling in the READMEs, corrected middleware cookbook and migration guide, and the `SearchValidationFailure` barrel export. Templates mirrored throughout.

Together with #965 and #981 this closes out all five externally reported router issues. Follow-ups: #966 #967 #968 #969 #970.

## QA

- Cherry-pick applied with zero conflicts onto `main`; root `bun run check` green (61 projects); router-core, router-react, boilerplate-vite, and summon-application tests green.

### PR readiness check

- [x] PR label: `Documentation 📝` (+ feat aspects noted above)
- [x] PR title follows Conventional Commits
- [x] Code follows the code standards
- [x] All packages define required scripts (no new packages)
- [x] No new package
- [x] `no visual change` label

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
