### PR TITLE
feat(router-core): tie the Navigation API intercept handler to the router load

### DIFF
--- a/docs/references/ROUTER_API.md
+++ b/docs/references/ROUTER_API.md
@@ -623,6 +623,7 @@ interface PlatformAdapter {
   getLocation(): string | URL;
   navigate(url: string, options?: PlatformNavigateOptions): void;
   subscribe(callback: (location: string | URL) => void): () => void;
+  trackLoad?(load: Promise<void>): void; // optional — see below
 }
 
 interface PlatformNavigateOptions {
@@ -631,10 +632,12 @@ interface PlatformNavigateOptions {
 }
 ```
 
+**`trackLoad` (optional).** For every adapter-visible navigation (`navigate()`, `setSearchParams()`, and adapter-driven back/forward), the router hands the adapter a promise for the load it just scheduled. The promise settles when the load settles — success or failure — and **never rejects**. Adapters that don't implement it are unaffected; the Navigation API adapter uses it to pass the router's work to `event.intercept({ handler })`, so the browser's native loading UI (spinner, stop button) reflects the in-flight router navigation. The intercept handler never rejects either — a failed load still commits router state (as an error status on the location) and must not mark the browser navigation as failed.
+
 | Adapter | Signature | Notes |
 |---|---|---|
 | `createBrowserAdapter` | `(): PlatformAdapter` | Navigation API (`window.navigation`) when available, History API otherwise. The default client choice. |
-| `createNavigationAdapter` | `(navigationWindow?): PlatformAdapter` | Navigation API only; throws without one. Intercepts same-origin navigations; transition-promise rejections from superseded navigations are absorbed. |
+| `createNavigationAdapter` | `(navigationWindow?): PlatformAdapter` | Navigation API only; throws without one. Intercepts same-origin navigations and ties `intercept()`'s handler to the router's tracked load (`trackLoad`), so native loading UI reflects the navigation; transition-promise rejections from superseded navigations are absorbed. |
 | `createHistoryAdapter` | `(browserWindow?): PlatformAdapter` | History API (`pushState`/`popstate`). |
 | `createHashAdapter` | `(browserWindow?): PlatformAdapter` | Stores the route in `location.hash` (`#/path`). For Storybook, static file hosts, and anywhere the real path is fixed. Throws without a window-like object. |
 | `createMemoryAdapter` | `(initialUrl?: string \| URL, options?: MemoryAdapterOptions): MemoryAdapter` | In-memory location for tests; adds `back()`/`forward()`. |

--- a/packages/runtime/router/src/lib/createNavigationAdapter.test.ts
+++ b/packages/runtime/router/src/lib/createNavigationAdapter.test.ts
@@ -42,6 +42,9 @@ function createFakeNavigationWindow(initialHref = "https://example.com/") {
         }
       },
     },
+    lastInterceptOptions: undefined as
+      | { handler?: () => void | Promise<void> }
+      | undefined,
     dispatchNavigate(nextHref: string, navigationType: string = "traverse") {
       navigationWindow.location.href = nextHref;
       navigateListener?.({
@@ -49,7 +52,9 @@ function createFakeNavigationWindow(initialHref = "https://example.com/") {
         destination: { url: nextHref },
         canIntercept: true,
         hashChange: false,
-        intercept: vi.fn(),
+        intercept: (options?: { handler?: () => void | Promise<void> }) => {
+          navigationWindow.lastInterceptOptions = options;
+        },
       });
     },
     dispatchNavigateRaw(
@@ -199,5 +204,75 @@ describe("createNavigationAdapter (Navigation API)", () => {
     } finally {
       process.off("unhandledRejection", onUnhandled);
     }
+  });
+
+  it("hands the tracked router load to the intercept handler", async () => {
+    const navigationWindow = createFakeNavigationWindow();
+    const adapter = createNavigationAdapter(navigationWindow);
+
+    adapter.subscribe(() => {});
+
+    let releaseLoad!: () => void;
+    const load = new Promise<void>((resolve) => {
+      releaseLoad = resolve;
+    });
+
+    adapter.trackLoad?.(load);
+    navigationWindow.dispatchNavigate("https://example.com/docs", "push");
+
+    const handler = navigationWindow.lastInterceptOptions?.handler;
+
+    expect(handler).toBeTypeOf("function");
+
+    let settled = false;
+    const handled = Promise.resolve(handler?.()).then(() => {
+      settled = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(settled).toBe(false);
+
+    releaseLoad();
+    await handled;
+    expect(settled).toBe(true);
+  });
+
+  it("resolves the intercept handler even when the tracked load rejects", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const navigationWindow = createFakeNavigationWindow();
+      const adapter = createNavigationAdapter(navigationWindow);
+
+      adapter.subscribe(() => {});
+      adapter.trackLoad?.(Promise.reject(new Error("load failed")));
+      navigationWindow.dispatchNavigate("https://example.com/docs", "push");
+
+      const handler = navigationWindow.lastInterceptOptions?.handler;
+
+      await expect(Promise.resolve(handler?.())).resolves.toBeUndefined();
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  it("resolves the intercept handler when no load was tracked", async () => {
+    const navigationWindow = createFakeNavigationWindow();
+    const adapter = createNavigationAdapter(navigationWindow);
+
+    adapter.subscribe(() => {});
+    navigationWindow.dispatchNavigate("https://example.com/docs", "push");
+
+    const handler = navigationWindow.lastInterceptOptions?.handler;
+
+    await expect(Promise.resolve(handler?.())).resolves.toBeUndefined();
   });
 });

--- a/packages/runtime/router/src/lib/createNavigationAdapter.ts
+++ b/packages/runtime/router/src/lib/createNavigationAdapter.ts
@@ -65,6 +65,7 @@ export default function createNavigationAdapter(
 ): PlatformAdapter {
   const subscribers = new Set<(location: string | URL) => void>();
   const navigation = navigationWindow.navigation;
+  let trackedLoad: Promise<void> | null = null;
 
   function getLocation(): URL {
     return new URL(navigationWindow.location.href);
@@ -84,8 +85,22 @@ export default function createNavigationAdapter(
     }
 
     // Intercept all same-origin navigations to prevent full page reloads.
-    // The router handles the URL update and re-render internally.
-    event.intercept();
+    // The router handles the URL update and re-render internally.  The
+    // handler hands the browser the router's in-flight load (tracked via
+    // trackLoad below), so native loading UI reflects the navigation.  It
+    // reads trackedLoad at call time — the router tracks the load
+    // synchronously during the navigate event (via notify() here, or right
+    // after its own navigation.navigate() call), and intercept handlers run
+    // on a later microtask.  A failed load still commits router state, so
+    // the handler never rejects — it must not mark the browser navigation
+    // as failed.
+    event.intercept({
+      handler: () =>
+        Promise.resolve(trackedLoad).then(
+          () => undefined,
+          ignoreNavigationTransitionError,
+        ),
+    });
 
     if (
       event.navigationType === "traverse" ||
@@ -108,6 +123,9 @@ export default function createNavigationAdapter(
       result?.finished?.catch(ignoreNavigationTransitionError);
 
       notify();
+    },
+    trackLoad(load) {
+      trackedLoad = load;
     },
     subscribe(callback) {
       const shouldAttachListener = subscribers.size === 0;

--- a/packages/runtime/router/src/lib/createRouter.test.ts
+++ b/packages/runtime/router/src/lib/createRouter.test.ts
@@ -2540,4 +2540,67 @@ describe("createRouter", () => {
       expect(result.status).toBe(200);
     });
   });
+
+  describe("adapter load tracking", () => {
+    it("hands a settle-only load promise to trackLoad for adapter-visible navigations", async () => {
+      let popCallback: ((location: string | URL) => void) | null = null;
+      const trackedLoads: Array<Promise<void>> = [];
+      const adapter = {
+        getLocation: () => "/",
+        navigate: vi.fn(),
+        subscribe(callback: (location: string | URL) => void) {
+          popCallback = callback;
+          return () => {
+            popCallback = null;
+          };
+        },
+        trackLoad(load: Promise<void>) {
+          trackedLoads.push(load);
+        },
+      };
+
+      const router = createRouter(
+        {
+          home: route({ url: "/", content: () => "home" }),
+          about: route({ url: "/about", content: () => "about" }),
+        },
+        { adapter },
+      );
+
+      await router.load("/");
+
+      router.navigate("about");
+      expect(trackedLoads).toHaveLength(1);
+
+      router.setSearchParams({ page: "2" });
+      expect(trackedLoads).toHaveLength(2);
+
+      popCallback?.("/");
+      expect(trackedLoads).toHaveLength(3);
+
+      // Every tracked promise settles by resolving — never rejecting.
+      await expect(Promise.all(trackedLoads)).resolves.toBeDefined();
+
+      await vi.waitFor(() => {
+        expect(router.getState().location.pathname).toBe("/");
+      });
+    });
+
+    it("works unchanged with adapters that do not implement trackLoad", async () => {
+      const router = createRouter(
+        {
+          home: route({ url: "/", content: () => "home" }),
+          about: route({ url: "/about", content: () => "about" }),
+        },
+        { adapter: createMemoryAdapter("/") },
+      );
+
+      await router.load("/");
+      router.navigate("about");
+
+      await vi.waitFor(() => {
+        expect(router.getState().location.pathname).toBe("/about");
+      });
+    });
+  });
 });

--- a/packages/runtime/router/src/lib/createRouter.ts
+++ b/packages/runtime/router/src/lib/createRouter.ts
@@ -891,6 +891,27 @@ export default function createRouter<
   }
 
   /**
+   * Schedule an adapter-visible load and hand the adapter a settle-only view
+   * of it, so platform loading UI (e.g. the Navigation API's intercept
+   * handler) can await the router's work.  The tracked promise resolves when
+   * the load settles — success or failure — and never rejects.
+   */
+  function scheduleAdapterLoad(
+    input: string | URL,
+    mode: NavigationMode,
+  ): void {
+    const load = performLoad(input, 0, true, mode);
+
+    adapter?.trackLoad?.(
+      load.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    void load.catch(ignoreScheduledLoadError);
+  }
+
+  /**
    * Apply a control-flow rejection (redirect / status) that arrived from an
    * async warm hook after its navigation already committed.  Warm is
    * fire-and-forget, so a late arrival is expected: the page may render
@@ -1119,12 +1140,7 @@ export default function createRouter<
             intent.href,
             replace ? { replace: true } : undefined,
           );
-          void performLoad(
-            intent.href,
-            0,
-            true,
-            replace ? "pop" : "push",
-          ).catch(ignoreScheduledLoadError);
+          scheduleAdapterLoad(intent.href, replace ? "pop" : "push");
         },
       };
       notifyBlockerState();
@@ -1134,9 +1150,7 @@ export default function createRouter<
 
     saveScrollPosition();
     syncAdapterLocation(intent.href, replace ? { replace: true } : undefined);
-    void performLoad(intent.href, 0, true, replace ? "pop" : "push").catch(
-      ignoreScheduledLoadError,
-    );
+    scheduleAdapterLoad(intent.href, replace ? "pop" : "push");
 
     return intent;
   }) as NavigateFn<TRoutes>;
@@ -1203,9 +1217,7 @@ export default function createRouter<
     }
 
     syncAdapterLocation(href, replace ? { replace: true } : undefined);
-    void performLoad(href, 0, true, replace ? "pop" : "push").catch(
-      ignoreScheduledLoadError,
-    );
+    scheduleAdapterLoad(href, replace ? "pop" : "push");
   }
 
   const warm: WarmFn<TRoutes> = ((
@@ -1541,9 +1553,7 @@ export default function createRouter<
       }
 
       saveScrollPosition();
-      void performLoad(location, 0, true, "pop").catch(
-        ignoreScheduledLoadError,
-      );
+      scheduleAdapterLoad(location, "pop");
     });
   }
 

--- a/packages/runtime/router/src/lib/types.ts
+++ b/packages/runtime/router/src/lib/types.ts
@@ -648,6 +648,13 @@ export interface PlatformAdapter {
   getLocation(): string | URL;
   navigate(url: string, options?: PlatformNavigateOptions): void;
   subscribe(callback: (location: string | URL) => void): () => void;
+  /**
+   * Optional: receive the in-flight load the router scheduled for the most
+   * recent adapter-visible navigation, so platform loading UI can await it
+   * (the Navigation API adapter passes it to `event.intercept()`). The
+   * promise settles when the load settles and never rejects.
+   */
+  trackLoad?(load: Promise<void>): void;
 }
 
 export interface MemoryAdapter extends PlatformAdapter {


### PR DESCRIPTION
## Done

Implements #966: the Navigation API adapter called `event.intercept()` with no handler, so the browser had no signal for when the router's navigation finished — native loading UI (spinner, stop button) never reflected in-flight router loads.

- **`PlatformAdapter.trackLoad?(load)`** (optional, additive): for every adapter-visible navigation (`navigate()`, `setSearchParams()`, adapter-driven back/forward) the router hands the adapter a settle-only view of the load it just scheduled — it resolves when the load settles, success or failure, and **never rejects**. Adapters that don't implement it are untouched.
- **`createNavigationAdapter`** stores the tracked load and passes it to `event.intercept({ handler })`. The handler reads the tracked load at call time — the router tracks synchronously during the navigate event, and intercept handlers run a microtask later — and **never rejects**: a failed load still commits router state (as an error status on the location) and must not mark the browser navigation as failed. The existing synchronous `notify()` placement and the `committed`/`finished` no-op catches are untouched.
- `docs/references/ROUTER_API.md`: `PlatformAdapter` and the adapter table document the new member and both never-rejects contracts.

Originally planned as stacked on #990; #990 merged while this was in flight, so this PR is based directly on `main` — no stacking, merge normally.

## QA

- `packages/runtime/router`: 192 tests green (5 new — handler resolves only after the tracked load settles; a rejecting load resolves the handler with zero unhandled rejections; no tracked load resolves immediately; core `trackLoad` invoked for navigate/setSearchParams/pop with all tracked promises resolving; memory-adapter path unchanged without `trackLoad`).
- `packages/react/router`: 38 tests green.
- Root `bun run check` green (61 projects).

### PR readiness check

- [x] PR label: `Feature 🎁`
- [x] PR title follows Conventional Commits
- [x] Code follows the code standards
- [x] All packages define required scripts (no new packages)
- [x] No new package
- [x] `no visual change` label

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
