### PR TITLE
feat(boilerplate-vite): serialize Relay data across the SSR boundary

### DIFF
--- a/apps/react/boilerplate-vite/src/client/entry.tsx
+++ b/apps/react/boilerplate-vite/src/client/entry.tsx
@@ -11,8 +11,31 @@ import { hydrateRoot } from "react-dom/client";
 import { RelayEnvironmentProvider } from "react-relay";
 import { catalogs, i18nConfig } from "#i18n/index.js";
 import { getBrowserEnvironment } from "#relay/environment.js";
-import { appRoutes, middleware, notFoundRoute } from "../routes.js";
+import {
+  appRoutes,
+  middleware,
+  notFoundRoute,
+  resolveRelayPayloads,
+  type SerializedRelayPayload,
+} from "../routes.js";
 import "#styles/index.css";
+
+// Seed the browser-session Relay environment FIRST — before the router exists
+// — from the server-captured payloads riding __INITIAL_DATA__ (SSR pages) so
+// the first `useLazyLoadQuery` reads the store instead of refetching. In the
+// SPA cells there is no payload and the environment starts empty. Order
+// matters: the first getBrowserEnvironment() caller wins, and router
+// construction below can fire warm hooks that reach for the environment.
+const embeddedRelayPayloads = (
+  window as {
+    __INITIAL_DATA__?: {
+      relayPayloads?: readonly SerializedRelayPayload[];
+    };
+  }
+).__INITIAL_DATA__?.relayPayloads;
+const relayEnvironment = getBrowserEnvironment({
+  payloads: resolveRelayPayloads(embeddedRelayPayloads),
+});
 
 // On SSR pages __INITIAL_DATA__ carries the flat dehydrated router state
 // (href/kind/routeId/status); hydrating from it resumes the server-rendered
@@ -25,10 +48,6 @@ const router = createRouter(appRoutes, {
   notFound: notFoundRoute,
   hydratedState: readDehydratedState() ?? undefined,
 });
-
-// One Relay environment (network + normalized store) for the whole browser
-// session — module scope, so client-side navigations share the cache.
-const relayEnvironment = getBrowserEnvironment();
 
 /**
  * Resolve the locale for the first client render.

--- a/apps/react/boilerplate-vite/src/domains/catalog/CatalogPage.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/CatalogPage.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "@canonical/i18n-react";
 import { useHead } from "@canonical/react-head";
 import { type ReactElement, Suspense } from "react";
-import { ClientOnly } from "#lib/index.js";
 import ErrorBoundary from "./ErrorBoundary.js";
 import ProductList from "./ProductList.js";
 
@@ -25,11 +24,13 @@ export default function CatalogPage(): ReactElement {
         point it at a real endpoint instead.
       </p>
       {/*
-        SSR guard: `useLazyLoadQuery` fetches (and suspends) while rendering,
-        and the server has no way to serialize the fetched store for the
-        client yet — that lands in the follow-up SSR data-hydration PR. Until
-        then `ClientOnly` keeps the query off the server render path: the
-        server streams the fallback and the browser fetches after hydration.
+        SSR: the server prefetches this route's declared query (see
+        `serverQueries` in src/routes.tsx) and seeds both render environments
+        from the captured payloads, so `useLazyLoadQuery` (store-or-network)
+        renders synchronously on the server and on first client render — the
+        product list is real server-rendered HTML and the client issues no
+        second fetch. If the prefetch failed, the query suspends and fetches
+        through the active environment instead.
       */}
       {/*
         The canonical Relay pairing: Suspense renders the pending state while
@@ -38,13 +39,11 @@ export default function CatalogPage(): ReactElement {
         `VITE_GRAPHQL_URL` mode) — without it a thrown query error would
         unmount the whole tree to a blank page.
       */}
-      <ClientOnly fallback={<p>{t("catalog.loading")}</p>}>
-        <ErrorBoundary fallback={<p role="alert">{t("catalog.error")}</p>}>
-          <Suspense fallback={<p>{t("catalog.loading")}</p>}>
-            <ProductList />
-          </Suspense>
-        </ErrorBoundary>
-      </ClientOnly>
+      <ErrorBoundary fallback={<p role="alert">{t("catalog.error")}</p>}>
+        <Suspense fallback={<p>{t("catalog.loading")}</p>}>
+          <ProductList />
+        </Suspense>
+      </ErrorBoundary>
     </section>
   );
 }

--- a/apps/react/boilerplate-vite/src/domains/catalog/CatalogPage.tsx
+++ b/apps/react/boilerplate-vite/src/domains/catalog/CatalogPage.tsx
@@ -1,12 +1,23 @@
 import { useTranslation } from "@canonical/i18n-react";
 import { useHead } from "@canonical/react-head";
 import { type ReactElement, Suspense } from "react";
+import { useRelayEnvironment } from "react-relay";
+import { createOperationDescriptor, getRequest } from "relay-runtime";
 import ErrorBoundary from "./ErrorBoundary.js";
-import ProductList from "./ProductList.js";
+import ProductList, { PAGE_SIZE, productListQuery } from "./ProductList.js";
 
 export default function CatalogPage(): ReactElement {
   const { t } = useTranslation();
   useHead({ title: t("catalog.title") });
+
+  const environment = useRelayEnvironment();
+  const canRenderQuery =
+    typeof document !== "undefined" ||
+    environment.check(
+      createOperationDescriptor(getRequest(productListQuery), {
+        count: PAGE_SIZE,
+      }),
+    ).status === "available";
 
   return (
     <section aria-labelledby="catalog-title">
@@ -39,11 +50,23 @@ export default function CatalogPage(): ReactElement {
         `VITE_GRAPHQL_URL` mode) — without it a thrown query error would
         unmount the whole tree to a blank page.
       */}
-      <ErrorBoundary fallback={<p role="alert">{t("catalog.error")}</p>}>
-        <Suspense fallback={<p>{t("catalog.loading")}</p>}>
-          <ProductList />
-        </Suspense>
-      </ErrorBoundary>
+      {/*
+        On the server, the query renders only when the SSR prefetch already
+        seeded the store — after a failed or timed-out prefetch, querying here
+        would re-issue the same doomed request mid-stream. The loading
+        fallback is rendered instead and the client fetches after hydration;
+        markup matches, since a client without payloads paints the same
+        fallback via Suspense first.
+      */}
+      {canRenderQuery ? (
+        <ErrorBoundary fallback={<p role="alert">{t("catalog.error")}</p>}>
+          <Suspense fallback={<p>{t("catalog.loading")}</p>}>
+            <ProductList />
+          </Suspense>
+        </ErrorBoundary>
+      ) : (
+        <p>{t("catalog.loading")}</p>
+      )}
     </section>
   );
 }

--- a/apps/react/boilerplate-vite/src/domains/catalog/routes.ts
+++ b/apps/react/boilerplate-vite/src/domains/catalog/routes.ts
@@ -18,7 +18,9 @@ const routes = {
     // harmless, it re-fetches).
     warm: () => {
       if (typeof document === "undefined") {
-        return; // SSR: catalog content is ClientOnly; nothing to warm.
+        // SSR data comes from the renderer's awaited prefetch of the same
+        // query this route declares in `serverQueries` — nothing to warm.
+        return;
       }
 
       void fetchQuery(getBrowserEnvironment(), productListQuery, {

--- a/apps/react/boilerplate-vite/src/relay/environment.ts
+++ b/apps/react/boilerplate-vite/src/relay/environment.ts
@@ -13,10 +13,14 @@
  */
 
 import {
+  createOperationDescriptor,
   Environment,
   type FetchFunction,
   type GraphQLResponse,
+  type GraphQLTaggedNode,
+  getRequest,
   Network,
+  type PayloadData,
   RecordSource,
   Store,
 } from "relay-runtime";
@@ -29,6 +33,23 @@ import {
   urlMiddleware,
 } from "relay-runtime-network";
 
+/**
+ * A server-captured operation ready to replay: the resolved query node plus
+ * the variables and raw response `data` captured when the server executed it.
+ */
+export interface RelaySeedPayload {
+  readonly query: GraphQLTaggedNode;
+  readonly variables: Record<string, unknown>;
+  readonly data: Record<string, unknown>;
+}
+
+/** A response observed by the network, in the serializable wire shape. */
+export interface CapturedResponse {
+  readonly id: string;
+  readonly variables: Record<string, unknown>;
+  readonly data: Record<string, unknown>;
+}
+
 /** Options for {@link createEnvironment}. */
 export interface CreateEnvironmentOptions {
   /**
@@ -36,6 +57,20 @@ export interface CreateEnvironmentOptions {
    * neither is set the environment executes against the local mock schema.
    */
   readonly graphqlUrl?: string;
+  /**
+   * Server-captured operations replayed into the store at construction via
+   * Relay's public `commitPayload` — only these operations' data ever crosses
+   * the SSR boundary (no whole-store serialization, nothing to scrub). Each
+   * replayed operation is retained, so the seeded data cannot be GC'd before
+   * its first reader mounts.
+   */
+  readonly payloads?: readonly RelaySeedPayload[];
+  /**
+   * Observe each successful single response the environment's network
+   * returns. The SSR prefetch uses this to tee responses into the
+   * serializable payload list while `fetchQuery` normalizes them as usual.
+   */
+  readonly captureResponse?: (captured: CapturedResponse) => void;
 }
 
 /** Reads the endpoint URL from Vite's env, treating the empty string as unset. */
@@ -112,10 +147,58 @@ export const createEnvironment = (
     ? createHttpNetwork(graphqlUrl)
     : createLocalNetwork();
 
-  return new Environment({
-    network: Network.create(toFetchFunction(network.fetch)),
+  // toFetchFunction always yields a promise (see its cast); the narrower
+  // alias lets the capture wrapper await it without widening back into
+  // FetchFunction's observable-bearing return union.
+  const baseFetch = toFetchFunction(network.fetch) as (
+    ...args: Parameters<FetchFunction>
+  ) => Promise<GraphQLResponse>;
+  const capture = options.captureResponse;
+  const fetchFn: FetchFunction = capture
+    ? async (params, variables, cacheConfig, uploadables) => {
+        const response = await baseFetch(
+          params,
+          variables,
+          cacheConfig,
+          uploadables,
+        );
+        // Batched responses are never produced by either executor; capture
+        // only well-formed single responses that carry data and a name.
+        if (
+          !Array.isArray(response) &&
+          "data" in response &&
+          response.data &&
+          params.name
+        ) {
+          capture({
+            id: params.name,
+            variables,
+            data: response.data as unknown as Record<string, unknown>,
+          });
+        }
+
+        return response;
+      }
+    : baseFetch;
+
+  const environment = new Environment({
+    network: Network.create(fetchFn),
     store: new Store(new RecordSource()),
   });
+
+  for (const seed of options.payloads ?? []) {
+    const operation = createOperationDescriptor(
+      getRequest(seed.query),
+      seed.variables,
+    );
+
+    environment.commitPayload(operation, seed.data as PayloadData);
+    // Explicit retention — seeded data must survive until its first reader
+    // mounts and takes over the retain; no reliance on GC timing.
+    environment.retain(operation);
+  }
+
+  return environment;
 };
 
 let browserEnvironment: Environment | null = null;
@@ -125,11 +208,15 @@ let browserEnvironment: Environment | null = null;
  *
  * Module scope so the client entry's provider and route-level `warm` hooks
  * share one normalized store — a navigation-time cache warm lands in the same
- * store `useLazyLoadQuery` reads from. Server code must keep using
+ * store `useLazyLoadQuery` reads from. The FIRST caller's options win (the
+ * client entry seeds SSR payloads before anything else runs); later calls
+ * reuse the existing environment. Server code must keep using
  * `createEnvironment()` (fresh per request).
  */
-export const getBrowserEnvironment = (): Environment => {
-  browserEnvironment ??= createEnvironment();
+export const getBrowserEnvironment = (
+  options?: CreateEnvironmentOptions,
+): Environment => {
+  browserEnvironment ??= createEnvironment(options);
 
   return browserEnvironment;
 };

--- a/apps/react/boilerplate-vite/src/relay/environment.ts
+++ b/apps/react/boilerplate-vite/src/relay/environment.ts
@@ -29,6 +29,7 @@ import {
   httpExecutor,
   localGraphExecutor,
   type RelayFetchContext,
+  type RelayFetchExecutor,
   type RelayRuntimeFetch,
   urlMiddleware,
 } from "relay-runtime-network";
@@ -110,11 +111,46 @@ const createLocalNetwork = () =>
     },
   });
 
+/**
+ * Wraps an executor so a transport failure resolves as a well-formed GraphQL
+ * error payload instead of a thrown exception. The pipeline's fetch context
+ * creates an internal incremental-payload promise that no non-incremental
+ * consumer ever awaits; an executor throw rejects it unhandled (fatal under
+ * Bun). Converting the failure at the source means nothing in the pipeline
+ * ever rejects, while Relay still surfaces it as an operation error.
+ */
+const safeExecutor = (executor: RelayFetchExecutor): RelayFetchExecutor =>
+  Object.assign(
+    async (context: RelayFetchContext) => {
+      try {
+        return await executor(context);
+      } catch (error) {
+        console.warn(
+          "[relay] transport failure converted to error payload:",
+          error,
+        );
+
+        return {
+          payload: {
+            errors: [
+              {
+                message: error instanceof Error ? error.message : String(error),
+              },
+            ],
+          },
+          response: null,
+          status: null,
+        };
+      }
+    },
+    { descriptor: executor.descriptor },
+  );
+
 /** Builds the HTTP network that posts operations to `graphqlUrl`. */
 const createHttpNetwork = (graphqlUrl: string) =>
   createRelayRuntimeNetwork({
     fetch: {
-      executor: httpExecutor(),
+      executor: safeExecutor(httpExecutor()),
       middlewares: [urlMiddleware({ url: graphqlUrl })],
     },
   });
@@ -128,10 +164,19 @@ const createHttpNetwork = (graphqlUrl: string) =>
  */
 const toFetchFunction =
   (fetchGraphQL: RelayRuntimeFetch): FetchFunction =>
-  (params, variables, cacheConfig) =>
-    fetchGraphQL(params, variables, {
+  (params, variables, cacheConfig) => {
+    const response = fetchGraphQL(params, variables, {
       ...cacheConfig,
     }) as Promise<GraphQLResponse>;
+
+    // The pipeline starts the request at call time, before Relay's observable
+    // attaches its handlers — guard the raw promise so a rejection that beats
+    // (or never gains) a subscriber cannot crash the process. Consumers still
+    // observe the same rejection through the returned promise.
+    response.catch(() => {});
+
+    return response;
+  };
 
 /**
  * Creates a Relay `Environment` for the app.

--- a/apps/react/boilerplate-vite/src/routes.tsx
+++ b/apps/react/boilerplate-vite/src/routes.tsx
@@ -10,11 +10,14 @@ import {
   wrapper,
 } from "@canonical/router-core";
 import type { ReactElement, ReactNode } from "react";
+import { getRequest } from "relay-runtime";
 import accountRoutes from "#domains/account/routes.js";
+import { PAGE_SIZE, productListQuery } from "#domains/catalog/ProductList.js";
 import catalogRoutes from "#domains/catalog/routes.js";
 import contactRoutes from "#domains/contact/routes.js";
 import marketingRoutes from "#domains/marketing/routes.js";
 import Navigation from "#lib/Navigation/index.js";
+import type { RelaySeedPayload } from "#relay/environment.js";
 
 const protectedPaths = new Set(["/account"]);
 
@@ -141,6 +144,65 @@ declare module "@canonical/router-react" {
   interface RouterRegister {
     routes: AppRoutes;
   }
+}
+
+/**
+ * A GraphQL operation captured on the server and replayed on the client:
+ * the operation name identifies the query, `variables` rebuilds the operation
+ * descriptor, and `data` is the raw response payload. Pure JSON — this is the
+ * wire shape that rides `__INITIAL_DATA__.relayPayloads`.
+ */
+export interface SerializedRelayPayload {
+  readonly id: string;
+  readonly variables: Record<string, unknown>;
+  readonly data: Record<string, unknown>;
+}
+
+/**
+ * Per-route server queries: what the SSR layer fetches (and serializes) for a
+ * matched route before rendering it. Keyed by the route ids that
+ * `resolveRouteDisposition` computes; the declaration reuses the exact query
+ * the route's client-side `warm` hook fires, so navigation warming and SSR
+ * prefetch can never drift apart.
+ */
+export const serverQueries: Partial<
+  Record<
+    keyof AppRoutes,
+    {
+      readonly query: typeof productListQuery;
+      readonly variables: Record<string, unknown>;
+    }
+  >
+> = {
+  catalog: { query: productListQuery, variables: { count: PAGE_SIZE } },
+};
+
+/**
+ * Resolve serialized payloads back to replayable operations by matching each
+ * entry's operation name against the declared server queries. Unknown or
+ * malformed entries are dropped — a stale payload must never crash boot.
+ */
+export function resolveRelayPayloads(
+  serialized: readonly SerializedRelayPayload[] | undefined,
+): readonly RelaySeedPayload[] {
+  if (!serialized || serialized.length === 0) {
+    return [];
+  }
+
+  const byName = new Map(
+    Object.values(serverQueries).map((serverQuery) => [
+      getRequest(serverQuery.query).params.name,
+      serverQuery.query,
+    ]),
+  );
+
+  return serialized.flatMap((entry) => {
+    const query = byName.get(entry.id);
+
+    return query
+      ? [{ query, variables: entry.variables, data: entry.data }]
+      : [];
+  });
 }
 
 export const middleware = [withAuth("/login")] as const;

--- a/apps/react/boilerplate-vite/src/routes.tsx
+++ b/apps/react/boilerplate-vite/src/routes.tsx
@@ -185,7 +185,9 @@ export const serverQueries: Partial<
 export function resolveRelayPayloads(
   serialized: readonly SerializedRelayPayload[] | undefined,
 ): readonly RelaySeedPayload[] {
-  if (!serialized || serialized.length === 0) {
+  // The payload rides window state, so a stale or foreign value can be any
+  // shape — only a real array is iterable here.
+  if (!Array.isArray(serialized) || serialized.length === 0) {
     return [];
   }
 

--- a/apps/react/boilerplate-vite/src/server/entry.tsx
+++ b/apps/react/boilerplate-vite/src/server/entry.tsx
@@ -131,6 +131,8 @@ export function resolveRouteDisposition(url: string): RouteDisposition {
  * today's behavior — render without payloads, the client fetches after
  * hydration — a data hiccup must never take the page down.
  */
+const SSR_PREFETCH_TIMEOUT_MS = 5_000;
+
 export async function prefetchRouteData(
   disposition: RouteDisposition,
 ): Promise<readonly SerializedRelayPayload[] | undefined> {
@@ -158,9 +160,32 @@ export async function prefetchRouteData(
       },
     });
 
-    await fetchQuery(environment, serverQuery.query, serverQuery.variables, {
-      fetchPolicy: "network-only",
-    }).toPromise();
+    // Bound the prefetch: an endpoint that never settles must not hold the
+    // whole SSR response hostage. On timeout the subscription is cancelled
+    // and rendering proceeds without payloads.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        subscription.unsubscribe();
+        reject(
+          new Error(`SSR data prefetch exceeded ${SSR_PREFETCH_TIMEOUT_MS}ms`),
+        );
+      }, SSR_PREFETCH_TIMEOUT_MS);
+      const subscription = fetchQuery(
+        environment,
+        serverQuery.query,
+        serverQuery.variables,
+        { fetchPolicy: "network-only" },
+      ).subscribe({
+        complete: () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        error: (error: unknown) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+    });
   } catch (error) {
     console.warn(
       "SSR data prefetch failed; rendering without payloads (the client will fetch).",

--- a/apps/react/boilerplate-vite/src/server/entry.tsx
+++ b/apps/react/boilerplate-vite/src/server/entry.tsx
@@ -8,7 +8,7 @@ import {
   StatusResponse,
 } from "@canonical/router-core";
 import { Outlet, RouterProvider } from "@canonical/router-react";
-import { RelayEnvironmentProvider } from "react-relay";
+import { fetchQuery, RelayEnvironmentProvider } from "react-relay";
 import { catalogs, i18nConfig } from "#i18n/index.js";
 import { createEnvironment } from "#relay/environment.js";
 import {
@@ -16,6 +16,9 @@ import {
   getAuthRedirectForMatch,
   middleware,
   notFoundRoute,
+  resolveRelayPayloads,
+  type SerializedRelayPayload,
+  serverQueries,
 } from "../routes.js";
 import "#styles/app.css";
 
@@ -33,6 +36,13 @@ interface InitialData extends Record<string, unknown> {
   readonly status?: number;
   /** Locale negotiated from the request cookie / Accept-Language, if any. */
   readonly locale?: string;
+  /**
+   * Server-captured GraphQL responses for the matched route (see
+   * `prefetchRouteData`), replayed into the Relay store on both the server
+   * render and the client. A dedicated nested key — the router state is
+   * flat-spread into this same object, so nesting avoids any collision.
+   */
+  readonly relayPayloads?: readonly SerializedRelayPayload[];
 }
 
 /** How the server should answer a request for this URL. */
@@ -113,6 +123,56 @@ export function resolveRouteDisposition(url: string): RouteDisposition {
   };
 }
 
+/**
+ * Execute the matched route's declared server query (if any) and return the
+ * captured responses in serializable form. Fetch-then-render: the payloads
+ * exist before the renderer is constructed, so they ride the fixed
+ * `__INITIAL_DATA__` bootstrap script. On any failure the request degrades to
+ * today's behavior — render without payloads, the client fetches after
+ * hydration — a data hiccup must never take the page down.
+ */
+export async function prefetchRouteData(
+  disposition: RouteDisposition,
+): Promise<readonly SerializedRelayPayload[] | undefined> {
+  if (disposition.kind !== "render") {
+    return undefined;
+  }
+
+  const routeId = disposition.dehydratedState?.routeId;
+  const serverQuery = routeId
+    ? serverQueries[routeId as keyof typeof serverQueries]
+    : undefined;
+
+  if (!serverQuery) {
+    return undefined;
+  }
+
+  const captured: SerializedRelayPayload[] = [];
+
+  try {
+    // A fresh, request-scoped environment: nothing leaks across requests,
+    // and the capture tee records exactly the responses this route needs.
+    const environment = createEnvironment({
+      captureResponse: (entry) => {
+        captured.push(entry);
+      },
+    });
+
+    await fetchQuery(environment, serverQuery.query, serverQuery.variables, {
+      fetchPolicy: "network-only",
+    }).toPromise();
+  } catch (error) {
+    console.warn(
+      "SSR data prefetch failed; rendering without payloads (the client will fetch).",
+      error,
+    );
+
+    return undefined;
+  }
+
+  return captured.length > 0 ? captured : undefined;
+}
+
 export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
   const initialData = props.initialData ?? {};
   const url = initialData.url ?? "/";
@@ -147,11 +207,14 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
   }
 
   // A fresh Relay environment per server render, so no store state leaks
-  // between requests. Nothing fetches through it yet: components that issue
-  // queries are wrapped in `ClientOnly` (see CatalogPage) until the follow-up
-  // SSR PR adds data serialization/hydration; the provider is here so any
-  // component touching Relay context renders without branching on runtime.
-  const relayEnvironment = createEnvironment();
+  // between requests — seeded with the same serialized payloads the client
+  // will replay, so server markup and first client render read identical
+  // data. Without payloads (no server query, or the prefetch failed) a
+  // querying component suspends and fetches through this request's own
+  // environment instead.
+  const relayEnvironment = createEnvironment({
+    payloads: resolveRelayPayloads(initialData.relayPayloads),
+  });
 
   // The servers negotiate the locale (cookie > Accept-Language > default,
   // via i18n-core's negotiateLocale) and pass it through initialData; the

--- a/apps/react/boilerplate-vite/src/server/preview.bun.ts
+++ b/apps/react/boilerplate-vite/src/server/preview.bun.ts
@@ -39,6 +39,14 @@ import createSitemapRenderer from "../../dist/server/sitemap.js";
 type CreateAppRenderer = typeof import("./renderer.js").default;
 type CreateSitemapRenderer = typeof import("../sitemap/renderer.js").default;
 
+// Match Node's semantics for unhandled rejections: warn, don't die. Bun
+// kills the process by default, and a data-layer library's internal floating
+// promise (e.g. a failed GraphQL fetch teed inside its pipeline) must take
+// down a request, never the server.
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled rejection (server kept alive):", reason);
+});
+
 const PORT = Number(process.env.PORT) || 5174;
 const staticMount = parseStaticPair(":dist/client");
 

--- a/apps/react/boilerplate-vite/src/server/preview.bun.ts
+++ b/apps/react/boilerplate-vite/src/server/preview.bun.ts
@@ -73,7 +73,7 @@ Bun.serve({
       });
     }
 
-    const appResult = (createAppRenderer as CreateAppRenderer)(req);
+    const appResult = await (createAppRenderer as CreateAppRenderer)(req);
 
     if (appResult.kind === "redirect") {
       return new Response(null, {

--- a/apps/react/boilerplate-vite/src/server/preview.express.ts
+++ b/apps/react/boilerplate-vite/src/server/preview.express.ts
@@ -60,7 +60,7 @@ app.use(async (req, res, next) => {
       return;
     }
 
-    const appResult = (createAppRenderer as CreateAppRenderer)(req);
+    const appResult = await (createAppRenderer as CreateAppRenderer)(req);
 
     if (appResult.kind === "redirect") {
       res.redirect(appResult.status, appResult.location);

--- a/apps/react/boilerplate-vite/src/server/renderer.tsx
+++ b/apps/react/boilerplate-vite/src/server/renderer.tsx
@@ -24,6 +24,7 @@ import { getRequestUrl } from "@canonical/react-ssr/server";
 import { i18nConfig } from "#i18n/config.js";
 import EntryServer, {
   type InitialData,
+  prefetchRouteData,
   type RouteDisposition,
   resolveRouteDisposition,
 } from "./entry.js";
@@ -67,25 +68,33 @@ export type AppRendererResult =
     }
   | Extract<RouteDisposition, { kind: "redirect" }>;
 
-export default function createAppRenderer(
+export default async function createAppRenderer(
   request: Request | IncomingMessage,
-): AppRendererResult {
+): Promise<AppRendererResult> {
   const cookie = cookieHeader(request);
   const { theme } = extractPreferences(cookie);
   const locale = negotiateLocale(i18nConfig, {
     cookieHeader: cookie,
     acceptLanguage: acceptLanguageHeader(request),
   });
-  const initialData: InitialData = {
-    url: getRequestUrl(request),
-    theme: theme === "light" || theme === "dark" ? theme : undefined,
-    locale,
-  };
-  const disposition = resolveRouteDisposition(initialData.url ?? "/");
+  const url = getRequestUrl(request);
+  const disposition = resolveRouteDisposition(url ?? "/");
 
   if (disposition.kind === "redirect") {
     return disposition;
   }
+
+  // Fetch-then-render: the matched route's declared server query runs now so
+  // its captured responses can ride the bootstrap script (which is fixed at
+  // stream start). Absent or failed, the page renders and the client fetches.
+  const relayPayloads = await prefetchRouteData(disposition);
+
+  const initialData: InitialData = {
+    url,
+    theme: theme === "light" || theme === "dark" ? theme : undefined,
+    locale,
+    ...(relayPayloads ? { relayPayloads } : {}),
+  };
 
   // Flat-spread the dehydrated router state into the page payload; the client
   // reads it back with readDehydratedState() and resumes the server match.

--- a/apps/react/boilerplate-vite/src/server/server.bun.ts
+++ b/apps/react/boilerplate-vite/src/server/server.bun.ts
@@ -29,6 +29,14 @@ import * as process from "node:process";
 import { viteFetchMiddleware } from "@canonical/react-ssr/server";
 import { createServer as createViteServer } from "vite";
 
+// Match Node's semantics for unhandled rejections: warn, don't die. Bun
+// kills the process by default, and a data-layer library's internal floating
+// promise (e.g. a failed GraphQL fetch teed inside its pipeline) must take
+// down a request, never the server.
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled rejection (server kept alive):", reason);
+});
+
 const PORT = Number(process.env.PORT) || 5174;
 
 const vite = await createViteServer({

--- a/apps/react/boilerplate-vite/src/server/server.bun.ts
+++ b/apps/react/boilerplate-vite/src/server/server.bun.ts
@@ -65,8 +65,11 @@ Bun.serve({
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(requestUrl, template);
 
-      const { default: EntryServer, resolveRouteDisposition } =
-        await vite.ssrLoadModule("/src/server/entry.tsx");
+      const {
+        default: EntryServer,
+        prefetchRouteData,
+        resolveRouteDisposition,
+      } = await vite.ssrLoadModule("/src/server/entry.tsx");
 
       const disposition = resolveRouteDisposition(requestUrl);
 
@@ -76,6 +79,11 @@ Bun.serve({
           headers: { location: disposition.location },
         });
       }
+
+      // Fetch-then-render: run the matched route's declared server query so
+      // its captured responses ride the bootstrap script (fixed at stream
+      // start); absent or failed, the client fetches after hydration.
+      const relayPayloads = await prefetchRouteData(disposition);
       const { JSXRenderer } = await vite.ssrLoadModule(
         "@canonical/react-ssr/renderer",
       );
@@ -102,6 +110,7 @@ Bun.serve({
           url: requestUrl,
           theme: theme === "light" || theme === "dark" ? theme : undefined,
           locale,
+          ...(relayPayloads ? { relayPayloads } : {}),
           ...(disposition.dehydratedState ?? {}),
         },
         {

--- a/apps/react/boilerplate-vite/src/server/server.express.ts
+++ b/apps/react/boilerplate-vite/src/server/server.express.ts
@@ -60,8 +60,11 @@ async function start() {
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(url, template);
 
-      const { default: EntryServer, resolveRouteDisposition } =
-        await vite.ssrLoadModule("/src/server/entry.tsx");
+      const {
+        default: EntryServer,
+        prefetchRouteData,
+        resolveRouteDisposition,
+      } = await vite.ssrLoadModule("/src/server/entry.tsx");
 
       const disposition = resolveRouteDisposition(url);
 
@@ -69,6 +72,11 @@ async function start() {
         res.redirect(disposition.status, disposition.location);
         return;
       }
+
+      // Fetch-then-render: run the matched route's declared server query so
+      // its captured responses ride the bootstrap script (fixed at stream
+      // start); absent or failed, the client fetches after hydration.
+      const relayPayloads = await prefetchRouteData(disposition);
       const { JSXRenderer } = await vite.ssrLoadModule(
         "@canonical/react-ssr/renderer",
       );
@@ -97,6 +105,7 @@ async function start() {
           url,
           theme: theme === "light" || theme === "dark" ? theme : undefined,
           locale,
+          ...(relayPayloads ? { relayPayloads } : {}),
           ...(disposition.dehydratedState ?? {}),
         },
         {

--- a/apps/react/boilerplate-vite/test/e2e/servers.e2e.ts
+++ b/apps/react/boilerplate-vite/test/e2e/servers.e2e.ts
@@ -167,6 +167,21 @@ describe("server matrix (2×3) serves correctly", () => {
             const authorized = await fetch(`${server.base}/account?auth=1`);
             expect(authorized.status).toBe(200);
           }
+
+          // SSR cells serialize Relay data across the boundary: the catalog
+          // page arrives with server-rendered product markup (a name only
+          // real data produces) and carries the captured operation payloads
+          // for the client to replay — while data-less pages carry none.
+          if (cell.ssr) {
+            const catalog = await fetch(`${server.base}/catalog`);
+            expect(catalog.status).toBe(200);
+            const catalogHtml = await catalog.text();
+            expect(catalogHtml).toContain("Vanguard Workstation");
+            expect(catalogHtml).toContain("relayPayloads");
+
+            const home = await fetch(`${server.base}/`);
+            expect(await home.text()).not.toContain("relayPayloads");
+          }
         } finally {
           await server.stop();
         }

--- a/packages/summon/application/src/application/react/templates/src/client/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/client/entry.tsx.ejs
@@ -10,8 +10,35 @@ import { hydrateRoot } from "react-dom/client";
 import { RelayEnvironmentProvider } from "react-relay";
 import { getBrowserEnvironment } from "#relay/environment.js";
 <% } -%>
-import { appRoutes, middleware, notFoundRoute } from "../routes.js";
+import {
+  appRoutes,
+  middleware,
+  notFoundRoute,
+<% if (relay) { -%>
+  resolveRelayPayloads,
+  type SerializedRelayPayload,
+<% } -%>
+} from "../routes.js";
 import "#styles/index.css";
+<% if (relay) { -%>
+
+// Seed the browser-session Relay environment FIRST — before the router exists
+// — from the server-captured payloads riding __INITIAL_DATA__ (SSR pages) so
+// the first `useLazyLoadQuery` reads the store instead of refetching. In the
+// SPA cells there is no payload and the environment starts empty. Order
+// matters: the first getBrowserEnvironment() caller wins, and router
+// construction below can fire warm hooks that reach for the environment.
+const embeddedRelayPayloads = (
+  window as {
+    __INITIAL_DATA__?: {
+      relayPayloads?: readonly SerializedRelayPayload[];
+    };
+  }
+).__INITIAL_DATA__?.relayPayloads;
+const relayEnvironment = getBrowserEnvironment({
+  payloads: resolveRelayPayloads(embeddedRelayPayloads),
+});
+<% } -%>
 
 // On SSR pages __INITIAL_DATA__ carries the flat dehydrated router state
 // (href/kind/routeId/status); hydrating from it resumes the server-rendered
@@ -24,12 +51,6 @@ const router = createRouter(appRoutes, {
   notFound: notFoundRoute,
   hydratedState: readDehydratedState() ?? undefined,
 });
-<% if (relay) { -%>
-
-// One Relay environment (network + normalized store) for the whole browser
-// session — module scope, so client-side navigations share the cache.
-const relayEnvironment = getBrowserEnvironment();
-<% } -%>
 
 const root = document.getElementById("root");
 if (!root) {

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/CatalogPage.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/CatalogPage.tsx
@@ -1,10 +1,21 @@
 import { useHead } from "@canonical/react-head";
 import { type ReactElement, Suspense } from "react";
+import { useRelayEnvironment } from "react-relay";
+import { createOperationDescriptor, getRequest } from "relay-runtime";
 import ErrorBoundary from "./ErrorBoundary.js";
-import ProductList from "./ProductList.js";
+import ProductList, { PAGE_SIZE, productListQuery } from "./ProductList.js";
 
 export default function CatalogPage(): ReactElement {
   useHead({ title: "Catalog — Boilerplate" });
+
+  const environment = useRelayEnvironment();
+  const canRenderQuery =
+    typeof document !== "undefined" ||
+    environment.check(
+      createOperationDescriptor(getRequest(productListQuery), {
+        count: PAGE_SIZE,
+      }),
+    ).status === "available";
 
   return (
     <section aria-labelledby="catalog-title">
@@ -33,17 +44,29 @@ export default function CatalogPage(): ReactElement {
         `VITE_GRAPHQL_URL` mode) — without it a thrown query error would
         unmount the whole tree to a blank page.
       */}
-      <ErrorBoundary
-        fallback={
-          <p role="alert">
-            The catalog failed to load. Reload the page to try again.
-          </p>
-        }
-      >
-        <Suspense fallback={<p>Loading catalog…</p>}>
-          <ProductList />
-        </Suspense>
-      </ErrorBoundary>
+      {/*
+        On the server, the query renders only when the SSR prefetch already
+        seeded the store — after a failed or timed-out prefetch, querying here
+        would re-issue the same doomed request mid-stream. The loading
+        fallback is rendered instead and the client fetches after hydration;
+        markup matches, since a client without payloads paints the same
+        fallback via Suspense first.
+      */}
+      {canRenderQuery ? (
+        <ErrorBoundary
+          fallback={
+            <p role="alert">
+              The catalog failed to load. Reload the page to try again.
+            </p>
+          }
+        >
+          <Suspense fallback={<p>Loading catalog…</p>}>
+            <ProductList />
+          </Suspense>
+        </ErrorBoundary>
+      ) : (
+        <p>Loading catalog…</p>
+      )}
     </section>
   );
 }

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/CatalogPage.tsx
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/CatalogPage.tsx
@@ -1,6 +1,5 @@
 import { useHead } from "@canonical/react-head";
 import { type ReactElement, Suspense } from "react";
-import { ClientOnly } from "#lib/index.js";
 import ErrorBoundary from "./ErrorBoundary.js";
 import ProductList from "./ProductList.js";
 
@@ -19,11 +18,13 @@ export default function CatalogPage(): ReactElement {
         point it at a real endpoint instead.
       </p>
       {/*
-        SSR guard: `useLazyLoadQuery` fetches (and suspends) while rendering,
-        and the server has no way to serialize the fetched store for the
-        client yet — that lands in the follow-up SSR data-hydration PR. Until
-        then `ClientOnly` keeps the query off the server render path: the
-        server streams the fallback and the browser fetches after hydration.
+        SSR: the server prefetches this route's declared query (see
+        `serverQueries` in src/routes.tsx) and seeds both render environments
+        from the captured payloads, so `useLazyLoadQuery` (store-or-network)
+        renders synchronously on the server and on first client render — the
+        product list is real server-rendered HTML and the client issues no
+        second fetch. If the prefetch failed, the query suspends and fetches
+        through the active environment instead.
       */}
       {/*
         The canonical Relay pairing: Suspense renders the pending state while
@@ -32,19 +33,17 @@ export default function CatalogPage(): ReactElement {
         `VITE_GRAPHQL_URL` mode) — without it a thrown query error would
         unmount the whole tree to a blank page.
       */}
-      <ClientOnly fallback={<p>Loading catalog…</p>}>
-        <ErrorBoundary
-          fallback={
-            <p role="alert">
-              The catalog failed to load. Reload the page to try again.
-            </p>
-          }
-        >
-          <Suspense fallback={<p>Loading catalog…</p>}>
-            <ProductList />
-          </Suspense>
-        </ErrorBoundary>
-      </ClientOnly>
+      <ErrorBoundary
+        fallback={
+          <p role="alert">
+            The catalog failed to load. Reload the page to try again.
+          </p>
+        }
+      >
+        <Suspense fallback={<p>Loading catalog…</p>}>
+          <ProductList />
+        </Suspense>
+      </ErrorBoundary>
     </section>
   );
 }

--- a/packages/summon/application/src/application/react/templates/src/domains/catalog/routes.ts
+++ b/packages/summon/application/src/application/react/templates/src/domains/catalog/routes.ts
@@ -18,7 +18,9 @@ const routes = {
     // harmless, it re-fetches).
     warm: () => {
       if (typeof document === "undefined") {
-        return; // SSR: catalog content is ClientOnly; nothing to warm.
+        // SSR data comes from the renderer's awaited prefetch of the same
+        // query this route declares in `serverQueries` — nothing to warm.
+        return;
       }
 
       void fetchQuery(getBrowserEnvironment(), productListQuery, {

--- a/packages/summon/application/src/application/react/templates/src/relay/environment.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/environment.ts
@@ -13,10 +13,14 @@
  */
 
 import {
+  createOperationDescriptor,
   Environment,
   type FetchFunction,
   type GraphQLResponse,
+  type GraphQLTaggedNode,
+  getRequest,
   Network,
+  type PayloadData,
   RecordSource,
   Store,
 } from "relay-runtime";
@@ -29,6 +33,23 @@ import {
   urlMiddleware,
 } from "relay-runtime-network";
 
+/**
+ * A server-captured operation ready to replay: the resolved query node plus
+ * the variables and raw response `data` captured when the server executed it.
+ */
+export interface RelaySeedPayload {
+  readonly query: GraphQLTaggedNode;
+  readonly variables: Record<string, unknown>;
+  readonly data: Record<string, unknown>;
+}
+
+/** A response observed by the network, in the serializable wire shape. */
+export interface CapturedResponse {
+  readonly id: string;
+  readonly variables: Record<string, unknown>;
+  readonly data: Record<string, unknown>;
+}
+
 /** Options for {@link createEnvironment}. */
 export interface CreateEnvironmentOptions {
   /**
@@ -36,6 +57,20 @@ export interface CreateEnvironmentOptions {
    * neither is set the environment executes against the local mock schema.
    */
   readonly graphqlUrl?: string;
+  /**
+   * Server-captured operations replayed into the store at construction via
+   * Relay's public `commitPayload` — only these operations' data ever crosses
+   * the SSR boundary (no whole-store serialization, nothing to scrub). Each
+   * replayed operation is retained, so the seeded data cannot be GC'd before
+   * its first reader mounts.
+   */
+  readonly payloads?: readonly RelaySeedPayload[];
+  /**
+   * Observe each successful single response the environment's network
+   * returns. The SSR prefetch uses this to tee responses into the
+   * serializable payload list while `fetchQuery` normalizes them as usual.
+   */
+  readonly captureResponse?: (captured: CapturedResponse) => void;
 }
 
 /** Reads the endpoint URL from Vite's env, treating the empty string as unset. */
@@ -112,10 +147,58 @@ export const createEnvironment = (
     ? createHttpNetwork(graphqlUrl)
     : createLocalNetwork();
 
-  return new Environment({
-    network: Network.create(toFetchFunction(network.fetch)),
+  // toFetchFunction always yields a promise (see its cast); the narrower
+  // alias lets the capture wrapper await it without widening back into
+  // FetchFunction's observable-bearing return union.
+  const baseFetch = toFetchFunction(network.fetch) as (
+    ...args: Parameters<FetchFunction>
+  ) => Promise<GraphQLResponse>;
+  const capture = options.captureResponse;
+  const fetchFn: FetchFunction = capture
+    ? async (params, variables, cacheConfig, uploadables) => {
+        const response = await baseFetch(
+          params,
+          variables,
+          cacheConfig,
+          uploadables,
+        );
+        // Batched responses are never produced by either executor; capture
+        // only well-formed single responses that carry data and a name.
+        if (
+          !Array.isArray(response) &&
+          "data" in response &&
+          response.data &&
+          params.name
+        ) {
+          capture({
+            id: params.name,
+            variables,
+            data: response.data as unknown as Record<string, unknown>,
+          });
+        }
+
+        return response;
+      }
+    : baseFetch;
+
+  const environment = new Environment({
+    network: Network.create(fetchFn),
     store: new Store(new RecordSource()),
   });
+
+  for (const seed of options.payloads ?? []) {
+    const operation = createOperationDescriptor(
+      getRequest(seed.query),
+      seed.variables,
+    );
+
+    environment.commitPayload(operation, seed.data as PayloadData);
+    // Explicit retention — seeded data must survive until its first reader
+    // mounts and takes over the retain; no reliance on GC timing.
+    environment.retain(operation);
+  }
+
+  return environment;
 };
 
 let browserEnvironment: Environment | null = null;
@@ -125,11 +208,15 @@ let browserEnvironment: Environment | null = null;
  *
  * Module scope so the client entry's provider and route-level `warm` hooks
  * share one normalized store — a navigation-time cache warm lands in the same
- * store `useLazyLoadQuery` reads from. Server code must keep using
+ * store `useLazyLoadQuery` reads from. The FIRST caller's options win (the
+ * client entry seeds SSR payloads before anything else runs); later calls
+ * reuse the existing environment. Server code must keep using
  * `createEnvironment()` (fresh per request).
  */
-export const getBrowserEnvironment = (): Environment => {
-  browserEnvironment ??= createEnvironment();
+export const getBrowserEnvironment = (
+  options?: CreateEnvironmentOptions,
+): Environment => {
+  browserEnvironment ??= createEnvironment(options);
 
   return browserEnvironment;
 };

--- a/packages/summon/application/src/application/react/templates/src/relay/environment.ts
+++ b/packages/summon/application/src/application/react/templates/src/relay/environment.ts
@@ -29,6 +29,7 @@ import {
   httpExecutor,
   localGraphExecutor,
   type RelayFetchContext,
+  type RelayFetchExecutor,
   type RelayRuntimeFetch,
   urlMiddleware,
 } from "relay-runtime-network";
@@ -110,11 +111,46 @@ const createLocalNetwork = () =>
     },
   });
 
+/**
+ * Wraps an executor so a transport failure resolves as a well-formed GraphQL
+ * error payload instead of a thrown exception. The pipeline's fetch context
+ * creates an internal incremental-payload promise that no non-incremental
+ * consumer ever awaits; an executor throw rejects it unhandled (fatal under
+ * Bun). Converting the failure at the source means nothing in the pipeline
+ * ever rejects, while Relay still surfaces it as an operation error.
+ */
+const safeExecutor = (executor: RelayFetchExecutor): RelayFetchExecutor =>
+  Object.assign(
+    async (context: RelayFetchContext) => {
+      try {
+        return await executor(context);
+      } catch (error) {
+        console.warn(
+          "[relay] transport failure converted to error payload:",
+          error,
+        );
+
+        return {
+          payload: {
+            errors: [
+              {
+                message: error instanceof Error ? error.message : String(error),
+              },
+            ],
+          },
+          response: null,
+          status: null,
+        };
+      }
+    },
+    { descriptor: executor.descriptor },
+  );
+
 /** Builds the HTTP network that posts operations to `graphqlUrl`. */
 const createHttpNetwork = (graphqlUrl: string) =>
   createRelayRuntimeNetwork({
     fetch: {
-      executor: httpExecutor(),
+      executor: safeExecutor(httpExecutor()),
       middlewares: [urlMiddleware({ url: graphqlUrl })],
     },
   });
@@ -128,10 +164,19 @@ const createHttpNetwork = (graphqlUrl: string) =>
  */
 const toFetchFunction =
   (fetchGraphQL: RelayRuntimeFetch): FetchFunction =>
-  (params, variables, cacheConfig) =>
-    fetchGraphQL(params, variables, {
+  (params, variables, cacheConfig) => {
+    const response = fetchGraphQL(params, variables, {
       ...cacheConfig,
     }) as Promise<GraphQLResponse>;
+
+    // The pipeline starts the request at call time, before Relay's observable
+    // attaches its handlers — guard the raw promise so a rejection that beats
+    // (or never gains) a subscriber cannot crash the process. Consumers still
+    // observe the same rejection through the returned promise.
+    response.catch(() => {});
+
+    return response;
+  };
 
 /**
  * Creates a Relay `Environment` for the app.

--- a/packages/summon/application/src/application/react/templates/src/routes.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/routes.tsx.ejs
@@ -11,6 +11,8 @@ import {
 import type { ReactElement, ReactNode } from "react";
 import accountRoutes from "#domains/account/routes.js";
 <% if (relay) { -%>
+import { getRequest } from "relay-runtime";
+import { PAGE_SIZE, productListQuery } from "#domains/catalog/ProductList.js";
 import catalogRoutes from "#domains/catalog/routes.js";
 <% } -%>
 <% if (forms) { -%>
@@ -18,6 +20,9 @@ import contactRoutes from "#domains/contact/routes.js";
 <% } -%>
 import marketingRoutes from "#domains/marketing/routes.js";
 import Navigation from "#lib/Navigation/index.js";
+<% if (relay) { -%>
+import type { RelaySeedPayload } from "#relay/environment.js";
+<% } -%>
 
 const protectedPaths = new Set(["/account"]);
 
@@ -148,6 +153,69 @@ declare module "@canonical/router-react" {
   }
 }
 
+/**
+ * A GraphQL operation captured on the server and replayed on the client:
+ * the operation name identifies the query, `variables` rebuilds the operation
+ * descriptor, and `data` is the raw response payload. Pure JSON — this is the
+ * wire shape that rides `__INITIAL_DATA__.relayPayloads`. (Declared for every
+ * flag combination so the server layer's signatures stay uniform; without
+ * --relay nothing produces or consumes one.)
+ */
+export interface SerializedRelayPayload {
+  readonly id: string;
+  readonly variables: Record<string, unknown>;
+  readonly data: Record<string, unknown>;
+}
+
+<% if (relay) { -%>
+/**
+ * Per-route server queries: what the SSR layer fetches (and serializes) for a
+ * matched route before rendering it. Keyed by the route ids that
+ * `resolveRouteDisposition` computes; the declaration reuses the exact query
+ * the route's client-side `warm` hook fires, so navigation warming and SSR
+ * prefetch can never drift apart.
+ */
+export const serverQueries: Partial<
+  Record<
+    keyof AppRoutes,
+    {
+      readonly query: typeof productListQuery;
+      readonly variables: Record<string, unknown>;
+    }
+  >
+> = {
+  catalog: { query: productListQuery, variables: { count: PAGE_SIZE } },
+};
+
+/**
+ * Resolve serialized payloads back to replayable operations by matching each
+ * entry's operation name against the declared server queries. Unknown or
+ * malformed entries are dropped — a stale payload must never crash boot.
+ */
+export function resolveRelayPayloads(
+  serialized: readonly SerializedRelayPayload[] | undefined,
+): readonly RelaySeedPayload[] {
+  if (!serialized || serialized.length === 0) {
+    return [];
+  }
+
+  const byName = new Map(
+    Object.values(serverQueries).map((serverQuery) => [
+      getRequest(serverQuery.query).params.name,
+      serverQuery.query,
+    ]),
+  );
+
+  return serialized.flatMap((entry) => {
+    const query = byName.get(entry.id);
+
+    return query
+      ? [{ query, variables: entry.variables, data: entry.data }]
+      : [];
+  });
+}
+
+<% } -%>
 export const middleware = [withAuth("/login")] as const;
 
 export { appRoutes, notFoundRoute };

--- a/packages/summon/application/src/application/react/templates/src/routes.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/routes.tsx.ejs
@@ -195,7 +195,9 @@ export const serverQueries: Partial<
 export function resolveRelayPayloads(
   serialized: readonly SerializedRelayPayload[] | undefined,
 ): readonly RelaySeedPayload[] {
-  if (!serialized || serialized.length === 0) {
+  // The payload rides window state, so a stale or foreign value can be any
+  // shape — only a real array is iterable here.
+  if (!Array.isArray(serialized) || serialized.length === 0) {
     return [];
   }
 

--- a/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
@@ -132,6 +132,8 @@ export function resolveRouteDisposition(url: string): RouteDisposition {
  * render without payloads, the client fetches after hydration — a data
  * hiccup must never take the page down.
  */
+const SSR_PREFETCH_TIMEOUT_MS = 5_000;
+
 export async function prefetchRouteData(
   disposition: RouteDisposition,
 ): Promise<readonly SerializedRelayPayload[] | undefined> {
@@ -160,9 +162,34 @@ export async function prefetchRouteData(
       },
     });
 
-    await fetchQuery(environment, serverQuery.query, serverQuery.variables, {
-      fetchPolicy: "network-only",
-    }).toPromise();
+    // Bound the prefetch: an endpoint that never settles must not hold the
+    // whole SSR response hostage. On timeout the subscription is cancelled
+    // and rendering proceeds without payloads.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        subscription.unsubscribe();
+        reject(
+          new Error(
+            `SSR data prefetch exceeded ${SSR_PREFETCH_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, SSR_PREFETCH_TIMEOUT_MS);
+      const subscription = fetchQuery(
+        environment,
+        serverQuery.query,
+        serverQuery.variables,
+        { fetchPolicy: "network-only" },
+      ).subscribe({
+        complete: () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        error: (error: unknown) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+    });
   } catch (error) {
     console.warn(
       "SSR data prefetch failed; rendering without payloads (the client will fetch).",

--- a/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
@@ -7,7 +7,7 @@ import {
 } from "@canonical/router-core";
 import { Outlet, RouterProvider } from "@canonical/router-react";
 <% if (relay) { -%>
-import { RelayEnvironmentProvider } from "react-relay";
+import { fetchQuery, RelayEnvironmentProvider } from "react-relay";
 import { createEnvironment } from "#relay/environment.js";
 <% } -%>
 import {
@@ -15,6 +15,13 @@ import {
   getAuthRedirectForMatch,
   middleware,
   notFoundRoute,
+<% if (relay) { -%>
+  resolveRelayPayloads,
+<% } -%>
+  type SerializedRelayPayload,
+<% if (relay) { -%>
+  serverQueries,
+<% } -%>
 } from "../routes.js";
 import "#styles/app.css";
 
@@ -30,6 +37,13 @@ interface InitialData extends Record<string, unknown> {
   readonly kind?: "route" | "not-found";
   readonly routeId?: string | null;
   readonly status?: number;
+  /**
+   * Server-captured GraphQL responses for the matched route (see
+   * `prefetchRouteData`), replayed into the Relay store on both the server
+   * render and the client. A dedicated nested key — the router state is
+   * flat-spread into this same object, so nesting avoids any collision.
+   */
+  readonly relayPayloads?: readonly SerializedRelayPayload[];
 }
 
 /** How the server should answer a request for this URL. */
@@ -110,6 +124,65 @@ export function resolveRouteDisposition(url: string): RouteDisposition {
   };
 }
 
+/**
+ * Execute the matched route's declared server query (if any) and return the
+ * captured responses in serializable form. Fetch-then-render: the payloads
+ * exist before the renderer is constructed, so they ride the fixed
+ * `__INITIAL_DATA__` bootstrap script. On any failure the request degrades —
+ * render without payloads, the client fetches after hydration — a data
+ * hiccup must never take the page down.
+ */
+export async function prefetchRouteData(
+  disposition: RouteDisposition,
+): Promise<readonly SerializedRelayPayload[] | undefined> {
+<% if (relay) { -%>
+  if (disposition.kind !== "render") {
+    return undefined;
+  }
+
+  const routeId = disposition.dehydratedState?.routeId;
+  const serverQuery = routeId
+    ? serverQueries[routeId as keyof typeof serverQueries]
+    : undefined;
+
+  if (!serverQuery) {
+    return undefined;
+  }
+
+  const captured: SerializedRelayPayload[] = [];
+
+  try {
+    // A fresh, request-scoped environment: nothing leaks across requests,
+    // and the capture tee records exactly the responses this route needs.
+    const environment = createEnvironment({
+      captureResponse: (entry) => {
+        captured.push(entry);
+      },
+    });
+
+    await fetchQuery(environment, serverQuery.query, serverQuery.variables, {
+      fetchPolicy: "network-only",
+    }).toPromise();
+  } catch (error) {
+    console.warn(
+      "SSR data prefetch failed; rendering without payloads (the client will fetch).",
+      error,
+    );
+
+    return undefined;
+  }
+
+  return captured.length > 0 ? captured : undefined;
+<% } else { -%>
+  // No data layer scaffolded: nothing to prefetch, every route renders
+  // without payloads. The uniform signature keeps the server files (plain
+  // copies shared by all flag combinations) unconditional.
+  void disposition;
+
+  return undefined;
+<% } -%>
+}
+
 export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
   const initialData = props.initialData ?? {};
   const url = initialData.url ?? "/";
@@ -145,11 +218,14 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
 <% if (relay) { -%>
 
   // A fresh Relay environment per server render, so no store state leaks
-  // between requests. Nothing fetches through it yet: components that issue
-  // queries are wrapped in `ClientOnly` (see CatalogPage) until data
-  // serialization/hydration is supported; the provider is here so any
-  // component touching Relay context renders without branching on runtime.
-  const relayEnvironment = createEnvironment();
+  // between requests — seeded with the same serialized payloads the client
+  // will replay, so server markup and first client render read identical
+  // data. Without payloads (no server query, or the prefetch failed) a
+  // querying component suspends and fetches through this request's own
+  // environment instead.
+  const relayEnvironment = createEnvironment({
+    payloads: resolveRelayPayloads(initialData.relayPayloads),
+  });
 <% } -%>
 
   // Paint the cookie-resolved theme on <html> for a flash-free first render —

--- a/packages/summon/application/src/application/react/templates/src/server/preview.bun.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/preview.bun.ts
@@ -39,6 +39,14 @@ import createSitemapRenderer from "../../dist/server/sitemap.js";
 type CreateAppRenderer = typeof import("./renderer.js").default;
 type CreateSitemapRenderer = typeof import("../sitemap/renderer.js").default;
 
+// Match Node's semantics for unhandled rejections: warn, don't die. Bun
+// kills the process by default, and a data-layer library's internal floating
+// promise (e.g. a failed GraphQL fetch teed inside its pipeline) must take
+// down a request, never the server.
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled rejection (server kept alive):", reason);
+});
+
 const PORT = Number(process.env.PORT) || 5174;
 const staticMount = parseStaticPair(":dist/client");
 

--- a/packages/summon/application/src/application/react/templates/src/server/preview.bun.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/preview.bun.ts
@@ -73,7 +73,7 @@ Bun.serve({
       });
     }
 
-    const appResult = (createAppRenderer as CreateAppRenderer)(req);
+    const appResult = await (createAppRenderer as CreateAppRenderer)(req);
 
     if (appResult.kind === "redirect") {
       return new Response(null, {

--- a/packages/summon/application/src/application/react/templates/src/server/preview.express.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/preview.express.ts
@@ -60,7 +60,7 @@ app.use(async (req, res, next) => {
       return;
     }
 
-    const appResult = (createAppRenderer as CreateAppRenderer)(req);
+    const appResult = await (createAppRenderer as CreateAppRenderer)(req);
 
     if (appResult.kind === "redirect") {
       res.redirect(appResult.status, appResult.location);

--- a/packages/summon/application/src/application/react/templates/src/server/renderer.tsx
+++ b/packages/summon/application/src/application/react/templates/src/server/renderer.tsx
@@ -22,6 +22,7 @@ import { JSXRenderer } from "@canonical/react-ssr/renderer";
 import { getRequestUrl } from "@canonical/react-ssr/server";
 import EntryServer, {
   type InitialData,
+  prefetchRouteData,
   type RouteDisposition,
   resolveRouteDisposition,
 } from "./entry.js";
@@ -52,19 +53,27 @@ export type AppRendererResult =
     }
   | Extract<RouteDisposition, { kind: "redirect" }>;
 
-export default function createAppRenderer(
+export default async function createAppRenderer(
   request: Request | IncomingMessage,
-): AppRendererResult {
+): Promise<AppRendererResult> {
   const { theme } = extractPreferences(cookieHeader(request));
-  const initialData: InitialData = {
-    url: getRequestUrl(request),
-    theme: theme === "light" || theme === "dark" ? theme : undefined,
-  };
-  const disposition = resolveRouteDisposition(initialData.url ?? "/");
+  const url = getRequestUrl(request);
+  const disposition = resolveRouteDisposition(url ?? "/");
 
   if (disposition.kind === "redirect") {
     return disposition;
   }
+
+  // Fetch-then-render: the matched route's declared server query runs now so
+  // its captured responses can ride the bootstrap script (which is fixed at
+  // stream start). Absent or failed, the page renders and the client fetches.
+  const relayPayloads = await prefetchRouteData(disposition);
+
+  const initialData: InitialData = {
+    url,
+    theme: theme === "light" || theme === "dark" ? theme : undefined,
+    ...(relayPayloads ? { relayPayloads } : {}),
+  };
 
   // Flat-spread the dehydrated router state into the page payload; the client
   // reads it back with readDehydratedState() and resumes the server match.

--- a/packages/summon/application/src/application/react/templates/src/server/server.bun.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/server.bun.ts
@@ -29,6 +29,14 @@ import * as process from "node:process";
 import { viteFetchMiddleware } from "@canonical/react-ssr/server";
 import { createServer as createViteServer } from "vite";
 
+// Match Node's semantics for unhandled rejections: warn, don't die. Bun
+// kills the process by default, and a data-layer library's internal floating
+// promise (e.g. a failed GraphQL fetch teed inside its pipeline) must take
+// down a request, never the server.
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled rejection (server kept alive):", reason);
+});
+
 const PORT = Number(process.env.PORT) || 5174;
 
 const vite = await createViteServer({

--- a/packages/summon/application/src/application/react/templates/src/server/server.bun.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/server.bun.ts
@@ -65,8 +65,11 @@ Bun.serve({
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(requestUrl, template);
 
-      const { default: EntryServer, resolveRouteDisposition } =
-        await vite.ssrLoadModule("/src/server/entry.tsx");
+      const {
+        default: EntryServer,
+        prefetchRouteData,
+        resolveRouteDisposition,
+      } = await vite.ssrLoadModule("/src/server/entry.tsx");
 
       const disposition = resolveRouteDisposition(requestUrl);
 
@@ -76,6 +79,11 @@ Bun.serve({
           headers: { location: disposition.location },
         });
       }
+
+      // Fetch-then-render: run the matched route's declared server query so
+      // its captured responses ride the bootstrap script (fixed at stream
+      // start); absent or failed, the client fetches after hydration.
+      const relayPayloads = await prefetchRouteData(disposition);
       const { JSXRenderer } = await vite.ssrLoadModule(
         "@canonical/react-ssr/renderer",
       );
@@ -92,6 +100,7 @@ Bun.serve({
         {
           url: requestUrl,
           theme: theme === "light" || theme === "dark" ? theme : undefined,
+          ...(relayPayloads ? { relayPayloads } : {}),
           ...(disposition.dehydratedState ?? {}),
         },
         { htmlString: html, statusCode: disposition.status },

--- a/packages/summon/application/src/application/react/templates/src/server/server.express.ts
+++ b/packages/summon/application/src/application/react/templates/src/server/server.express.ts
@@ -60,8 +60,11 @@ async function start() {
       const template = fs.readFileSync("index.html", "utf-8");
       const html = await vite.transformIndexHtml(url, template);
 
-      const { default: EntryServer, resolveRouteDisposition } =
-        await vite.ssrLoadModule("/src/server/entry.tsx");
+      const {
+        default: EntryServer,
+        prefetchRouteData,
+        resolveRouteDisposition,
+      } = await vite.ssrLoadModule("/src/server/entry.tsx");
 
       const disposition = resolveRouteDisposition(url);
 
@@ -69,6 +72,11 @@ async function start() {
         res.redirect(disposition.status, disposition.location);
         return;
       }
+
+      // Fetch-then-render: run the matched route's declared server query so
+      // its captured responses ride the bootstrap script (fixed at stream
+      // start); absent or failed, the client fetches after hydration.
+      const relayPayloads = await prefetchRouteData(disposition);
       const { JSXRenderer } = await vite.ssrLoadModule(
         "@canonical/react-ssr/renderer",
       );
@@ -85,6 +93,7 @@ async function start() {
         {
           url,
           theme: theme === "light" || theme === "dark" ? theme : undefined,
+          ...(relayPayloads ? { relayPayloads } : {}),
           ...(disposition.dehydratedState ?? {}),
         },
         { htmlString: html, statusCode: disposition.status },

--- a/packages/summon/application/src/application/react/templates/test/e2e/servers.e2e.ts
+++ b/packages/summon/application/src/application/react/templates/test/e2e/servers.e2e.ts
@@ -145,6 +145,24 @@ describe("server matrix (2×3) serves correctly", () => {
             const authorized = await fetch(`${server.base}/account?auth=1`);
             expect(authorized.status).toBe(200);
           }
+
+          // SSR cells serialize Relay data across the boundary (when the app
+          // was scaffolded with --relay): the catalog page arrives with
+          // server-rendered product markup and carries the captured operation
+          // payloads for the client to replay. Without --relay there is no
+          // /catalog route (404), so the assertions self-disable — this file
+          // is a plain copy shared by every flag combination.
+          if (cell.ssr) {
+            const catalog = await fetch(`${server.base}/catalog`);
+            if (catalog.status === 200) {
+              const catalogHtml = await catalog.text();
+              expect(catalogHtml).toContain("Vanguard Workstation");
+              expect(catalogHtml).toContain("relayPayloads");
+            }
+
+            const home = await fetch(`${server.base}/`);
+            expect(await home.text()).not.toContain("relayPayloads");
+          }
         } finally {
           await server.stop();
         }


### PR DESCRIPTION
## Done

Implements #968 — Relay data now crosses the SSR boundary in the reference app, replacing the `ClientOnly` gate on the catalog page. Design (an updated take on an older render-then-dehydrate pattern, modernized for the streaming architecture):

- **Per-operation payload replay, not whole-store serialization.** The server captures the raw GraphQL response per executed operation (name + variables + data) and both sides replay it with Relay's public `commitPayload`. Only prefetched data ever reaches the HTML — no internal record format, nothing to scrub, no cross-request store.
- **Fetch-then-render.** `__INITIAL_DATA__`'s bootstrap script is fixed at stream start, so the matched route's declared query runs before the renderer is constructed; the payloads ride the existing escaped channel under a dedicated nested `relayPayloads` key (the router state is flat-spread into the same object — nesting avoids collisions, and `readDehydratedState` is untouched).
- **One declaration, two consumers.** A per-route `serverQueries` registry (app layer, next to the routes) reuses the exact query the route's `warm` hook fires — SSR prefetch and client-side navigation warming cannot drift apart. Zero router-package changes, zero `@canonical/react-ssr` changes.
- **Both environments seeded identically** — the per-request server render environment and the browser-session environment replay the same payloads, so markup matches; the client `retain`s each replayed operation (no GC gamble). `useLazyLoadQuery` (store-or-network) renders synchronously server-side and issues **no second fetch** on first client render.
- **Degrade, never down.** A failed prefetch logs a warning and renders without payloads — the client fetches after hydration, today's behavior.

Boilerplate and summon templates both land it: relay-gated in the EJS files; the shared plain-copy server files stay flag-agnostic through a uniform `prefetchRouteData` (stub body without `--relay`).

## QA

- Live-verified on the bun dev server: `/catalog` HTML contains the synchronously resolved Suspense boundary with the full server-rendered product list, plus `relayPayloads` (operation `ProductListQuery`, captured data) in `__INITIAL_DATA__`; `/` carries no payload key.
- e2e matrix (6 cells incl. compiled previews): every SSR cell now asserts server-rendered product markup + payload presence, and that data-less pages carry none — 6/6 green. Template e2e mirrors it, self-disabling for non-relay scaffolds.
- Gates: boilerplate check + 34 unit tests; summon-application check + 57; pragma-cli conformance suite solo (1138 + 8 — the goldens consume these templates); root `bun run check` green across 61 projects.

### PR readiness check

- [x] PR label: `Feature 🎁`
- [x] PR title follows Conventional Commits
- [x] Code follows the code standards
- [x] All packages define required scripts (no new packages)
- [x] No new package
- [x] `no visual change` label

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
