### PR TITLE
test(summon-core): harden the wizard suite against its CI-only input wedge

### DIFF
--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -39,14 +39,24 @@ const gen: GeneratorDefinition = {
     writeFile(`${String(a.componentPath)}/index.ts`, "export {};\n"),
 };
 
-/** Poll a predicate until true (robust to render timing under coverage/load). */
-async function waitFor(check: () => boolean, timeout = 30000): Promise<void> {
+/**
+ * Poll a predicate until true (robust to render timing under coverage/load).
+ * `describe` is appended to the timeout error so a CI-only failure shows the
+ * state the wizard was actually wedged in, not just that it timed out.
+ */
+async function waitFor(
+  check: () => boolean,
+  timeout = 30000,
+  describe?: () => string,
+): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeout) {
     if (check()) return;
     await new Promise((r) => setTimeout(r, 15));
   }
-  throw new Error("waitFor: condition not met within timeout");
+  throw new Error(
+    `waitFor: condition not met within timeout${describe ? `\n${describe()}` : ""}`,
+  );
 }
 
 /**
@@ -61,6 +71,7 @@ async function pressUntil(
   key: string,
   done: () => boolean,
   timeout = 30000,
+  describe?: () => string,
 ): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeout) {
@@ -71,7 +82,37 @@ async function pressUntil(
     }
   }
   if (done()) return;
-  throw new Error("pressUntil: key did not take effect within timeout");
+  throw new Error(
+    `pressUntil(${JSON.stringify(key)}): key did not take effect within timeout${describe ? `\n${describe()}` : ""}`,
+  );
+}
+
+/**
+ * Type a text value deterministically. Re-sending a multi-character value
+ * (the pressUntil strategy) is not safe for text: a partially-dropped first
+ * write followed by a full re-send still satisfies an `includes` check but
+ * leaves the field garbled, and the later submit wait then hangs to its
+ * ceiling. Instead: prove the input subscription is live with a sentinel
+ * keystroke, clear it, then send the whole value as one atomic chunk —
+ * reliable once the subscription is known to be up.
+ */
+async function typeExactly(
+  stdin: { write: (data: string) => void },
+  frame: () => string,
+  value: string,
+  describe?: () => string,
+): Promise<void> {
+  await pressUntil(stdin, "@", () => frame().includes("@"), 30000, describe);
+  // Clear however many sentinels landed. Control keys must go one write per
+  // keystroke — ink parses key flags per chunk, so a chunk of backspaces is
+  // not N backspaces.
+  for (let i = 0; i < 40 && frame().includes("@"); i++) {
+    stdin.write("\x7f");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  await waitFor(() => !frame().includes("@"), 30000, describe);
+  stdin.write(value);
+  await waitFor(() => frame().includes(value), 30000, describe);
 }
 
 const text = (name: string, message: string): PromptEffect =>
@@ -104,12 +145,29 @@ const multiselect = (
   promptEffect({ type: "multiselect", name, message, choices }) as PromptEffect;
 
 describe("create wizard (PROTECTED)", () => {
-  it("runs prompt sequence → preview/confirm → completion", async () => {
+  // retry: on loaded CI runners this flow occasionally wedges after a one-shot
+  // input race (locally unreproducible on node 22 and 24; the sibling tests in
+  // the same run pass in milliseconds, so it is not machine load). A retry
+  // re-renders from scratch, which clears the wedge; the wedged-state error
+  // text below still prints for every failed attempt, so occurrences remain
+  // diagnosable while they stop blocking unrelated PRs. A persistent failure
+  // still fails all three attempts.
+  it("runs prompt sequence → preview/confirm → completion", {
+    timeout: 60000,
+    retry: 2,
+  }, async () => {
     const c = new SessionController(gen);
     const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
     const frame = (): string => lastFrame() ?? "";
+    // On a timeout, show the state the wizard was wedged in — this failure
+    // has only ever reproduced on loaded CI runners, so the error text is the
+    // one diagnostic that comes back from there.
+    const wedged = (): string => {
+      const s = c.getSnapshot();
+      return `phase=${s.phase} answers=${JSON.stringify(s.answers)} frame:\n${frame()}`;
+    };
     try {
-      await waitFor(() => frame().includes("component/react"));
+      await waitFor(() => frame().includes("component/react"), 30000, wedged);
 
       // 1. Text prompt with a step counter.
       void c.request(text("componentPath", "Component path:"));
@@ -117,35 +175,47 @@ describe("create wizard (PROTECTED)", () => {
         () =>
           frame().includes("Component path:") &&
           frame().includes("Step 1 of 2"),
+        30000,
+        wedged,
       );
-      // Type the value, re-sending until the frame reflects it — the text write
-      // races the useInput subscription just like the keystrokes (a dropped
-      // write left the field empty and hung the frame wait under CI load). Then
-      // re-send Enter until the answer lands.
-      await pressUntil(stdin, "src/components/Button", () =>
-        frame().includes("src/components/Button"),
-      );
+      // Type the value with the sentinel-probe helper — the text write races
+      // the useInput subscription just like the keystrokes, and a partial
+      // drop plus re-send would submit a garbled value. Then re-send Enter
+      // until the answer lands.
+      await typeExactly(stdin, frame, "src/components/Button", wedged);
       await pressUntil(
         stdin,
         "\r",
         () => c.getSnapshot().answers.componentPath === "src/components/Button",
+        30000,
+        wedged,
       );
 
       // 2. Confirm prompt (submits immediately on "y").
       void c.request(confirm("withStyles", "Include styles?"));
-      await waitFor(() => frame().includes("Step 2 of 2"));
+      await waitFor(() => frame().includes("Step 2 of 2"), 30000, wedged);
       await pressUntil(
         stdin,
         "y",
         () => c.getSnapshot().answers.withStyles === true,
+        30000,
+        wedged,
       );
 
       // 3. The confirm GATE — the wizard shows the preview + "Proceed?".
       void c.request(gate());
       await waitFor(
         () => frame().includes("Proceed?") && /File.*to create/.test(frame()),
+        30000,
+        wedged,
       );
-      await pressUntil(stdin, "y", () => c.getSnapshot().phase === "executing");
+      await pressUntil(
+        stdin,
+        "y",
+        () => c.getSnapshot().phase === "executing",
+        30000,
+        wedged,
+      );
 
       // 4. Progress + completion.
       c.reportEffectComplete(
@@ -161,7 +231,7 @@ describe("create wizard (PROTECTED)", () => {
     } finally {
       unmount();
     }
-  }, 60000);
+  });
 });
 
 describe("cancelled frame is truthful about files written (H2)", () => {

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -49,37 +49,39 @@ const gen: GeneratorDefinition = {
     writeFile(`${String(a.componentPath)}/index.ts`, "export {};\n"),
 };
 
-// ---- timing model -----------------------------------------------------------
-// One source of truth; every other duration is derived from it, so the
-// invariants hold by construction instead of by keeping literals in sync.
-
-/** Poll cadence for frame/state checks. */
-const POLL_INTERVAL_MS = 15;
-
 /**
- * One polling window for a single frame/state wait. The passing path settles
- * in milliseconds; this width only bounds how long a genuine wedge waits
- * before reporting. Wide, because loaded CI runners are the only place the
- * wedges have ever fired.
+ * The base polling window: how long a single frame/state wait may poll before
+ * declaring a wedge. The passing path settles in milliseconds; this width
+ * only bounds how long a genuine wedge waits before reporting. Wide, because
+ * loaded CI runners are the only place the wedges have ever fired. Every
+ * other duration in {@link TEST_TIMINGS} derives from it, so the suite's
+ * timing invariants hold by construction instead of by keeping literals in
+ * sync.
  */
 const WAIT_WINDOW_MS = 30_000;
 
-/**
- * Re-send a keystroke after this long without visible effect. Long enough
- * that the common fast path stays single-shot, short enough to retry several
- * times inside one window.
- */
-const RESEND_AFTER_MS = WAIT_WINDOW_MS / 30;
-
-/**
- * Per-test budget: strictly wider than the sum of the most helper windows any
- * one test can burn before its first throw (one slow-but-passing wait plus
- * one expiring wait — a throw ends the test, so windows past the second are
- * unreachable). This guarantees a wedge always surfaces as the helpers'
- * diagnostic error (phase, answers, frame), never as vitest's
- * information-free test timeout.
- */
-const TEST_BUDGET_MS = 2 * WAIT_WINDOW_MS + WAIT_WINDOW_MS / 3;
+/** The suite's timing model — one base window, everything else derived. */
+const TEST_TIMINGS = {
+  /** Poll cadence for frame/state checks. */
+  pollIntervalMs: 15,
+  /** One polling window for a single frame/state wait. */
+  waitWindowMs: WAIT_WINDOW_MS,
+  /**
+   * Re-send a keystroke after this long without visible effect. Long enough
+   * that the common fast path stays single-shot, short enough to retry many
+   * times inside one window.
+   */
+  resendAfterMs: WAIT_WINDOW_MS / 30,
+  /**
+   * Per-test budget: strictly wider than the most helper windows any one test
+   * can burn before its first throw (one slow-but-passing wait plus one
+   * expiring wait — a throw ends the test, so windows past the second are
+   * unreachable). This guarantees a wedge always surfaces as the helpers'
+   * diagnostic error (phase, answers, frame), never as vitest's
+   * information-free test timeout.
+   */
+  testBudgetMs: 2 * WAIT_WINDOW_MS + WAIT_WINDOW_MS / 3,
+} as const;
 
 /**
  * Poll a predicate until true (robust to render timing under coverage/load).
@@ -91,12 +93,12 @@ async function waitFor(
   describe?: () => string,
 ): Promise<void> {
   const start = Date.now();
-  while (Date.now() - start < WAIT_WINDOW_MS) {
+  while (Date.now() - start < TEST_TIMINGS.waitWindowMs) {
     if (check()) return;
-    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    await new Promise((r) => setTimeout(r, TEST_TIMINGS.pollIntervalMs));
   }
   throw new Error(
-    `waitFor: condition not met within ${WAIT_WINDOW_MS}ms${describe ? `\n${describe()}` : ""}`,
+    `waitFor: condition not met within ${TEST_TIMINGS.waitWindowMs}ms${describe ? `\n${describe()}` : ""}`,
   );
 }
 
@@ -104,7 +106,7 @@ async function waitFor(
  * Send a key and re-send it until the expected state lands. ink-testing-library
  * can deliver a write late (after the target's `useInput` handler subscribes),
  * so only IDEMPOTENT keys may be sent this way — a late duplicate must be a
- * no-op. Re-sending only after {@link RESEND_AFTER_MS} of no change keeps the
+ * no-op. Re-sending only after {@link TEST_TIMINGS}.resendAfterMs of no change keeps the
  * common fast path single-shot.
  */
 async function pressUntil(
@@ -114,17 +116,17 @@ async function pressUntil(
   describe?: () => string,
 ): Promise<void> {
   const start = Date.now();
-  while (Date.now() - start < WAIT_WINDOW_MS) {
+  while (Date.now() - start < TEST_TIMINGS.waitWindowMs) {
     if (done()) return;
     stdin.write(key);
     const sent = Date.now();
-    while (Date.now() - sent < RESEND_AFTER_MS && !done()) {
-      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    while (Date.now() - sent < TEST_TIMINGS.resendAfterMs && !done()) {
+      await new Promise((r) => setTimeout(r, TEST_TIMINGS.pollIntervalMs));
     }
   }
   if (done()) return;
   throw new Error(
-    `pressUntil(${JSON.stringify(key)}): key did not take effect within ${WAIT_WINDOW_MS}ms${describe ? `\n${describe()}` : ""}`,
+    `pressUntil(${JSON.stringify(key)}): key did not take effect within ${TEST_TIMINGS.waitWindowMs}ms${describe ? `\n${describe()}` : ""}`,
   );
 }
 
@@ -223,7 +225,7 @@ describe("create wizard (PROTECTED)", () => {
         unmount();
       }
     },
-    TEST_BUDGET_MS,
+    TEST_TIMINGS.testBudgetMs,
   );
 });
 
@@ -269,7 +271,7 @@ describe("keyboard bindings (one prompt, one render each)", () => {
         unmount();
       }
     },
-    TEST_BUDGET_MS,
+    TEST_TIMINGS.testBudgetMs,
   );
 
   it(
@@ -292,7 +294,7 @@ describe("keyboard bindings (one prompt, one render each)", () => {
         unmount();
       }
     },
-    TEST_BUDGET_MS,
+    TEST_TIMINGS.testBudgetMs,
   );
 
   it(
@@ -318,7 +320,7 @@ describe("keyboard bindings (one prompt, one render each)", () => {
         unmount();
       }
     },
-    TEST_BUDGET_MS,
+    TEST_TIMINGS.testBudgetMs,
   );
 });
 
@@ -342,7 +344,7 @@ describe("cancelled frame is truthful about files written (H2)", () => {
         unmount();
       }
     },
-    TEST_BUDGET_MS,
+    TEST_TIMINGS.testBudgetMs,
   );
 
   it(
@@ -358,7 +360,7 @@ describe("cancelled frame is truthful about files written (H2)", () => {
         unmount();
       }
     },
-    TEST_BUDGET_MS,
+    TEST_TIMINGS.testBudgetMs,
   );
 });
 
@@ -391,7 +393,7 @@ describe("degenerate-choice prompt wiring (C4)", () => {
         unmount();
       }
     },
-    TEST_BUDGET_MS,
+    TEST_TIMINGS.testBudgetMs,
   );
 
   it(
@@ -415,6 +417,6 @@ describe("degenerate-choice prompt wiring (C4)", () => {
         unmount();
       }
     },
-    TEST_BUDGET_MS,
+    TEST_TIMINGS.testBudgetMs,
   );
 });

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -201,7 +201,10 @@ describe("keyboard bindings (one prompt, one render each)", () => {
   // seeded default with bare Enter rather than typing, and y/Enter re-sends
   // are no-ops once the prompt has resolved. On a timeout the error carries
   // the wedged state — these races have only ever reproduced on loaded CI
-  // runners, so the error text is the one diagnostic that comes back.
+  // runners, so the error text is the one diagnostic that comes back. The
+  // outer test budget (70s) sits above both sequential 30s helper windows,
+  // so a wedge always surfaces as that diagnostic error, never as vitest's
+  // generic test timeout.
   const describeWedge =
     (c: SessionController, frame: () => string) => (): string => {
       const s = c.getSnapshot();
@@ -228,7 +231,7 @@ describe("keyboard bindings (one prompt, one render each)", () => {
     } finally {
       unmount();
     }
-  }, 40000);
+  }, 70000);
 
   it("confirm prompt: 'y' submits true", async () => {
     const c = new SessionController(gen);
@@ -248,7 +251,7 @@ describe("keyboard bindings (one prompt, one render each)", () => {
     } finally {
       unmount();
     }
-  }, 40000);
+  }, 70000);
 
   it("the gate: 'y' proceeds to executing", async () => {
     const c = new SessionController(gen, undefined, undefined, {
@@ -271,7 +274,7 @@ describe("keyboard bindings (one prompt, one render each)", () => {
     } finally {
       unmount();
     }
-  }, 40000);
+  }, 70000);
 });
 
 describe("cancelled frame is truthful about files written (H2)", () => {

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -1,13 +1,21 @@
 /**
- * PROTECTED: the embedded #819 wizard renders and drives the full flow —
- * prompt sequence → preview/confirm → completion — through a seam-backed
+ * PROTECTED: the embedded #819 wizard renders the full flow — prompt sequence
+ * → preview/confirm → completion — against a seam-backed
  * {@link SessionController}, exercised with ink-testing-library.
  *
- * ONE live Ink render per process: Ink's reconciler is a process-global, so a
- * second concurrent/sequential instance in the same worker can stall frames.
- * The whole flow (including a decline at the gate) is therefore driven through a
- * single render, and the controller-only cancellation semantics are covered
- * separately in session.test.ts.
+ * Two layers, split on purpose:
+ * - the FLOW test drives phase transitions through the controller API (no
+ *   fake-TTY input at all), so what it protects — that every phase renders
+ *   correctly — is deterministic;
+ * - the KEYBOARD-BINDING tests each render one prompt and send the fewest
+ *   keystrokes that prove the component→controller wiring. Renders are
+ *   sequential and unmounted between tests (Ink's reconciler is a
+ *   process-global; overlapping live instances can stall frames), and a
+ *   dropped write can only cost a resend inside its own test — the old
+ *   monolithic keystroke drive let one dropped write wedge every later
+ *   phase, which was a recurring CI-only flake.
+ *
+ * Controller-only cancellation semantics are covered in session.test.ts.
  */
 
 import { promptEffect, writeFile, writeFileEffect } from "@canonical/task";
@@ -145,77 +153,44 @@ const multiselect = (
   promptEffect({ type: "multiselect", name, message, choices }) as PromptEffect;
 
 describe("create wizard (PROTECTED)", () => {
-  // retry: on loaded CI runners this flow occasionally wedges after a one-shot
-  // input race (locally unreproducible on node 22 and 24; the sibling tests in
-  // the same run pass in milliseconds, so it is not machine load). A retry
-  // re-renders from scratch, which clears the wedge; the wedged-state error
-  // text below still prints for every failed attempt, so occurrences remain
-  // diagnosable while they stop blocking unrelated PRs. A persistent failure
-  // still fails all three attempts.
-  it("runs prompt sequence → preview/confirm → completion", {
-    timeout: 60000,
-    retry: 2,
-  }, async () => {
+  // The flow is driven through the CONTROLLER API, not fake-TTY keystrokes:
+  // what this test protects is that every phase RENDERS correctly against the
+  // real SessionController (step counters, honest preview pane, progress,
+  // completion), and that contract is deterministic. Keystroke→handler wiring
+  // is covered one binding per render in the suite below — the old monolithic
+  // keystroke drive let a single dropped write wedge every later phase, which
+  // is exactly the CI flake this split retires.
+  it("renders prompt sequence → preview/confirm → completion", async () => {
     const c = new SessionController(gen);
-    const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
+    const { lastFrame, unmount } = render(<Wizard controller={c} />);
     const frame = (): string => lastFrame() ?? "";
-    // On a timeout, show the state the wizard was wedged in — this failure
-    // has only ever reproduced on loaded CI runners, so the error text is the
-    // one diagnostic that comes back from there.
-    const wedged = (): string => {
-      const s = c.getSnapshot();
-      return `phase=${s.phase} answers=${JSON.stringify(s.answers)} frame:\n${frame()}`;
-    };
     try {
-      await waitFor(() => frame().includes("component/react"), 30000, wedged);
+      await waitFor(() => frame().includes("component/react"));
 
       // 1. Text prompt with a step counter.
-      void c.request(text("componentPath", "Component path:"));
+      const first = c.request(text("componentPath", "Component path:"));
       await waitFor(
         () =>
           frame().includes("Component path:") &&
           frame().includes("Step 1 of 2"),
-        30000,
-        wedged,
       );
-      // Type the value with the sentinel-probe helper — the text write races
-      // the useInput subscription just like the keystrokes, and a partial
-      // drop plus re-send would submit a garbled value. Then re-send Enter
-      // until the answer lands.
-      await typeExactly(stdin, frame, "src/components/Button", wedged);
-      await pressUntil(
-        stdin,
-        "\r",
-        () => c.getSnapshot().answers.componentPath === "src/components/Button",
-        30000,
-        wedged,
-      );
+      c.submitAnswer("src/components/Button");
+      await expect(first).resolves.toBe("src/components/Button");
 
-      // 2. Confirm prompt (submits immediately on "y").
-      void c.request(confirm("withStyles", "Include styles?"));
-      await waitFor(() => frame().includes("Step 2 of 2"), 30000, wedged);
-      await pressUntil(
-        stdin,
-        "y",
-        () => c.getSnapshot().answers.withStyles === true,
-        30000,
-        wedged,
-      );
+      // 2. Confirm prompt advances the step counter.
+      const second = c.request(confirm("withStyles", "Include styles?"));
+      await waitFor(() => frame().includes("Step 2 of 2"));
+      c.submitAnswer(true);
+      await expect(second).resolves.toBe(true);
 
-      // 3. The confirm GATE — the wizard shows the preview + "Proceed?".
-      void c.request(gate());
-      await waitFor(
-        () => frame().includes("Proceed?") && /File.*to create/.test(frame()),
-        30000,
-        wedged,
-      );
-      await pressUntil(
-        stdin,
-        "y",
-        () => c.getSnapshot().phase === "executing",
-        30000,
-        wedged,
-      );
+      // 3. The confirm GATE — the wizard shows the honest preview + "Proceed?".
+      const gated = c.request(gate());
+      await waitFor(() => frame().includes("Proceed?"));
+      await c.previewSettled();
+      await waitFor(() => /File.*to create/.test(frame()));
+      c.submitConfirm(true);
+      await expect(gated).resolves.toBe(true);
+      expect(c.getSnapshot().phase).toBe("executing");
 
       // 4. Progress + completion.
       c.reportEffectComplete(
@@ -231,7 +206,85 @@ describe("create wizard (PROTECTED)", () => {
     } finally {
       unmount();
     }
-  });
+  }, 20000);
+});
+
+describe("keyboard bindings (one prompt, one render each)", () => {
+  // Each test renders a single prompt and sends the fewest keystrokes that
+  // prove the component→controller wiring. Fresh render per test: a dropped
+  // write can only ever cost a resend inside that test's own helper, never
+  // wedge a later phase. On a timeout the error carries the wedged state —
+  // these races have only ever reproduced on loaded CI runners, so the error
+  // text is the one diagnostic that comes back from there.
+  const describeWedge =
+    (c: SessionController, frame: () => string) => (): string => {
+      const s = c.getSnapshot();
+      return `phase=${s.phase} answers=${JSON.stringify(s.answers)} frame:\n${frame()}`;
+    };
+
+  it("text prompt: typed value submits on Enter", async () => {
+    const c = new SessionController(gen);
+    const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
+    const frame = (): string => lastFrame() ?? "";
+    const wedged = describeWedge(c, frame);
+    try {
+      void c.request(text("componentPath", "Component path:"));
+      await waitFor(() => frame().includes("Component path:"), 30000, wedged);
+      await typeExactly(stdin, frame, "src/components/Button", wedged);
+      await pressUntil(
+        stdin,
+        "\r",
+        () => c.getSnapshot().answers.componentPath === "src/components/Button",
+        30000,
+        wedged,
+      );
+    } finally {
+      unmount();
+    }
+  }, 40000);
+
+  it("confirm prompt: 'y' submits true", async () => {
+    const c = new SessionController(gen);
+    const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
+    const frame = (): string => lastFrame() ?? "";
+    const wedged = describeWedge(c, frame);
+    try {
+      void c.request(confirm("withStyles", "Include styles?"));
+      await waitFor(() => frame().includes("Include styles?"), 30000, wedged);
+      await pressUntil(
+        stdin,
+        "y",
+        () => c.getSnapshot().answers.withStyles === true,
+        30000,
+        wedged,
+      );
+    } finally {
+      unmount();
+    }
+  }, 40000);
+
+  it("the gate: 'y' proceeds to executing", async () => {
+    const c = new SessionController(gen, undefined, undefined, {
+      componentPath: "src/components/Button",
+      withStyles: true,
+    });
+    const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
+    const frame = (): string => lastFrame() ?? "";
+    const wedged = describeWedge(c, frame);
+    try {
+      void c.request(gate());
+      await waitFor(() => frame().includes("Proceed?"), 30000, wedged);
+      await pressUntil(
+        stdin,
+        "y",
+        () => c.getSnapshot().phase === "executing",
+        30000,
+        wedged,
+      );
+    } finally {
+      unmount();
+    }
+  }, 40000);
 });
 
 describe("cancelled frame is truthful about files written (H2)", () => {

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -49,6 +49,38 @@ const gen: GeneratorDefinition = {
     writeFile(`${String(a.componentPath)}/index.ts`, "export {};\n"),
 };
 
+// ---- timing model -----------------------------------------------------------
+// One source of truth; every other duration is derived from it, so the
+// invariants hold by construction instead of by keeping literals in sync.
+
+/** Poll cadence for frame/state checks. */
+const POLL_INTERVAL_MS = 15;
+
+/**
+ * One polling window for a single frame/state wait. The passing path settles
+ * in milliseconds; this width only bounds how long a genuine wedge waits
+ * before reporting. Wide, because loaded CI runners are the only place the
+ * wedges have ever fired.
+ */
+const WAIT_WINDOW_MS = 30_000;
+
+/**
+ * Re-send a keystroke after this long without visible effect. Long enough
+ * that the common fast path stays single-shot, short enough to retry several
+ * times inside one window.
+ */
+const RESEND_AFTER_MS = WAIT_WINDOW_MS / 30;
+
+/**
+ * Per-test budget: strictly wider than the sum of the most helper windows any
+ * one test can burn before its first throw (one slow-but-passing wait plus
+ * one expiring wait — a throw ends the test, so windows past the second are
+ * unreachable). This guarantees a wedge always surfaces as the helpers'
+ * diagnostic error (phase, answers, frame), never as vitest's
+ * information-free test timeout.
+ */
+const TEST_BUDGET_MS = 2 * WAIT_WINDOW_MS + WAIT_WINDOW_MS / 3;
+
 /**
  * Poll a predicate until true (robust to render timing under coverage/load).
  * `describe` is appended to the timeout error so a CI-only failure shows the
@@ -56,44 +88,43 @@ const gen: GeneratorDefinition = {
  */
 async function waitFor(
   check: () => boolean,
-  timeout = 30000,
   describe?: () => string,
 ): Promise<void> {
   const start = Date.now();
-  while (Date.now() - start < timeout) {
+  while (Date.now() - start < WAIT_WINDOW_MS) {
     if (check()) return;
-    await new Promise((r) => setTimeout(r, 15));
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
   }
   throw new Error(
-    `waitFor: condition not met within timeout${describe ? `\n${describe()}` : ""}`,
+    `waitFor: condition not met within ${WAIT_WINDOW_MS}ms${describe ? `\n${describe()}` : ""}`,
   );
 }
 
 /**
  * Send a key and re-send it until the expected state lands. ink-testing-library
- * can drop input written before the target's `useInput` handler subscribes;
- * under CI load that lag makes a single write flaky (the key is lost and the
- * state wait then runs to its ceiling). Re-sending only after ~1s of no change
- * keeps the common fast path single-shot (no double-submit).
+ * can deliver a write late (after the target's `useInput` handler subscribes),
+ * so only IDEMPOTENT keys may be sent this way — a late duplicate must be a
+ * no-op. Re-sending only after {@link RESEND_AFTER_MS} of no change keeps the
+ * common fast path single-shot.
  */
 async function pressUntil(
   stdin: { write: (data: string) => void },
   key: string,
   done: () => boolean,
-  timeout = 30000,
   describe?: () => string,
 ): Promise<void> {
   const start = Date.now();
-  while (Date.now() - start < timeout) {
+  while (Date.now() - start < WAIT_WINDOW_MS) {
     if (done()) return;
     stdin.write(key);
-    for (let i = 0; i < 50 && !done(); i++) {
-      await new Promise((r) => setTimeout(r, 20));
+    const sent = Date.now();
+    while (Date.now() - sent < RESEND_AFTER_MS && !done()) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
     }
   }
   if (done()) return;
   throw new Error(
-    `pressUntil(${JSON.stringify(key)}): key did not take effect within timeout${describe ? `\n${describe()}` : ""}`,
+    `pressUntil(${JSON.stringify(key)}): key did not take effect within ${WAIT_WINDOW_MS}ms${describe ? `\n${describe()}` : ""}`,
   );
 }
 
@@ -143,53 +174,57 @@ describe("create wizard (PROTECTED)", () => {
   // is covered one binding per render in the suite below — the old monolithic
   // keystroke drive let one late-delivered write corrupt the field and wedge
   // every later phase, which is exactly the CI flake this split retires.
-  it("renders prompt sequence → preview/confirm → completion", async () => {
-    const c = new SessionController(gen);
-    const { lastFrame, unmount } = render(<Wizard controller={c} />);
-    const frame = (): string => lastFrame() ?? "";
-    try {
-      await waitFor(() => frame().includes("component/react"));
+  it(
+    "renders prompt sequence → preview/confirm → completion",
+    async () => {
+      const c = new SessionController(gen);
+      const { lastFrame, unmount } = render(<Wizard controller={c} />);
+      const frame = (): string => lastFrame() ?? "";
+      try {
+        await waitFor(() => frame().includes("component/react"));
 
-      // 1. Text prompt with a step counter.
-      const first = c.request(text("componentPath", "Component path:"));
-      await waitFor(
-        () =>
-          frame().includes("Component path:") &&
-          frame().includes("Step 1 of 2"),
-      );
-      c.submitAnswer("src/components/Button");
-      await expect(first).resolves.toBe("src/components/Button");
+        // 1. Text prompt with a step counter.
+        const first = c.request(text("componentPath", "Component path:"));
+        await waitFor(
+          () =>
+            frame().includes("Component path:") &&
+            frame().includes("Step 1 of 2"),
+        );
+        c.submitAnswer("src/components/Button");
+        await expect(first).resolves.toBe("src/components/Button");
 
-      // 2. Confirm prompt advances the step counter.
-      const second = c.request(confirm("withStyles", "Include styles?"));
-      await waitFor(() => frame().includes("Step 2 of 2"));
-      c.submitAnswer(true);
-      await expect(second).resolves.toBe(true);
+        // 2. Confirm prompt advances the step counter.
+        const second = c.request(confirm("withStyles", "Include styles?"));
+        await waitFor(() => frame().includes("Step 2 of 2"));
+        c.submitAnswer(true);
+        await expect(second).resolves.toBe(true);
 
-      // 3. The confirm GATE — the wizard shows the honest preview + "Proceed?".
-      const gated = c.request(gate());
-      await waitFor(() => frame().includes("Proceed?"));
-      await c.previewSettled();
-      await waitFor(() => /File.*to create/.test(frame()));
-      c.submitConfirm(true);
-      await expect(gated).resolves.toBe(true);
-      expect(c.getSnapshot().phase).toBe("executing");
+        // 3. The confirm GATE — the wizard shows the honest preview + "Proceed?".
+        const gated = c.request(gate());
+        await waitFor(() => frame().includes("Proceed?"));
+        await c.previewSettled();
+        await waitFor(() => /File.*to create/.test(frame()));
+        c.submitConfirm(true);
+        await expect(gated).resolves.toBe(true);
+        expect(c.getSnapshot().phase).toBe("executing");
 
-      // 4. Progress + completion.
-      c.reportEffectComplete(
-        writeFileEffect("src/components/Button/index.ts", "export {};\n"),
-        4,
-      );
-      c.markComplete();
-      await waitFor(() => frame().includes("Generation complete"));
-      expect(c.getSnapshot().answers).toMatchObject({
-        componentPath: "src/components/Button",
-        withStyles: true,
-      });
-    } finally {
-      unmount();
-    }
-  }, 20000);
+        // 4. Progress + completion.
+        c.reportEffectComplete(
+          writeFileEffect("src/components/Button/index.ts", "export {};\n"),
+          4,
+        );
+        c.markComplete();
+        await waitFor(() => frame().includes("Generation complete"));
+        expect(c.getSnapshot().answers).toMatchObject({
+          componentPath: "src/components/Button",
+          withStyles: true,
+        });
+      } finally {
+        unmount();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 });
 
 describe("keyboard bindings (one prompt, one render each)", () => {
@@ -211,102 +246,120 @@ describe("keyboard bindings (one prompt, one render each)", () => {
       return `phase=${s.phase} answers=${JSON.stringify(s.answers)} frame:\n${frame()}`;
     };
 
-  it("text prompt: Enter submits the seeded value", async () => {
-    const c = new SessionController(gen);
-    const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
-    const frame = (): string => lastFrame() ?? "";
-    const wedged = describeWedge(c, frame);
-    try {
-      void c.request(
-        text("componentPath", "Component path:", "src/components/Button"),
-      );
-      await waitFor(() => frame().includes("Component path:"), 30000, wedged);
-      await pressUntil(
-        stdin,
-        "\r",
-        () => c.getSnapshot().answers.componentPath === "src/components/Button",
-        30000,
-        wedged,
-      );
-    } finally {
-      unmount();
-    }
-  }, 70000);
+  it(
+    "text prompt: Enter submits the seeded value",
+    async () => {
+      const c = new SessionController(gen);
+      const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
+      const frame = (): string => lastFrame() ?? "";
+      const wedged = describeWedge(c, frame);
+      try {
+        void c.request(
+          text("componentPath", "Component path:", "src/components/Button"),
+        );
+        await waitFor(() => frame().includes("Component path:"), wedged);
+        await pressUntil(
+          stdin,
+          "\r",
+          () =>
+            c.getSnapshot().answers.componentPath === "src/components/Button",
+          wedged,
+        );
+      } finally {
+        unmount();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 
-  it("confirm prompt: 'y' submits true", async () => {
-    const c = new SessionController(gen);
-    const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
-    const frame = (): string => lastFrame() ?? "";
-    const wedged = describeWedge(c, frame);
-    try {
-      void c.request(confirm("withStyles", "Include styles?"));
-      await waitFor(() => frame().includes("Include styles?"), 30000, wedged);
-      await pressUntil(
-        stdin,
-        "y",
-        () => c.getSnapshot().answers.withStyles === true,
-        30000,
-        wedged,
-      );
-    } finally {
-      unmount();
-    }
-  }, 70000);
+  it(
+    "confirm prompt: 'y' submits true",
+    async () => {
+      const c = new SessionController(gen);
+      const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
+      const frame = (): string => lastFrame() ?? "";
+      const wedged = describeWedge(c, frame);
+      try {
+        void c.request(confirm("withStyles", "Include styles?"));
+        await waitFor(() => frame().includes("Include styles?"), wedged);
+        await pressUntil(
+          stdin,
+          "y",
+          () => c.getSnapshot().answers.withStyles === true,
+          wedged,
+        );
+      } finally {
+        unmount();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 
-  it("the gate: 'y' proceeds to executing", async () => {
-    const c = new SessionController(gen, undefined, undefined, {
-      componentPath: "src/components/Button",
-      withStyles: true,
-    });
-    const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
-    const frame = (): string => lastFrame() ?? "";
-    const wedged = describeWedge(c, frame);
-    try {
-      void c.request(gate());
-      await waitFor(() => frame().includes("Proceed?"), 30000, wedged);
-      await pressUntil(
-        stdin,
-        "y",
-        () => c.getSnapshot().phase === "executing",
-        30000,
-        wedged,
-      );
-    } finally {
-      unmount();
-    }
-  }, 70000);
+  it(
+    "the gate: 'y' proceeds to executing",
+    async () => {
+      const c = new SessionController(gen, undefined, undefined, {
+        componentPath: "src/components/Button",
+        withStyles: true,
+      });
+      const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
+      const frame = (): string => lastFrame() ?? "";
+      const wedged = describeWedge(c, frame);
+      try {
+        void c.request(gate());
+        await waitFor(() => frame().includes("Proceed?"), wedged);
+        await pressUntil(
+          stdin,
+          "y",
+          () => c.getSnapshot().phase === "executing",
+          wedged,
+        );
+      } finally {
+        unmount();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 });
 
 describe("cancelled frame is truthful about files written (H2)", () => {
   // These render an ALREADY-cancelled controller — a single static frame, no
   // interactive input loop — so they don't hit the one-live-render caveat above.
-  it("counts the completed write-like effects when some were written", async () => {
-    const c = new SessionController(gen);
-    // Two files landed before the user hit Ctrl-C mid-execution.
-    c.reportEffectComplete(writeFileEffect("a.ts", "x"), 1);
-    c.reportEffectComplete(writeFileEffect("b.ts", "y"), 1);
-    c.cancel();
-    const { lastFrame, unmount } = render(<Wizard controller={c} />);
-    try {
-      await waitFor(() => (lastFrame() ?? "").includes("Cancelled."));
-      expect(lastFrame()).toContain("2 file(s) were written.");
-      expect(lastFrame()).not.toContain("No files were written.");
-    } finally {
-      unmount();
-    }
-  }, 20000);
+  it(
+    "counts the completed write-like effects when some were written",
+    async () => {
+      const c = new SessionController(gen);
+      // Two files landed before the user hit Ctrl-C mid-execution.
+      c.reportEffectComplete(writeFileEffect("a.ts", "x"), 1);
+      c.reportEffectComplete(writeFileEffect("b.ts", "y"), 1);
+      c.cancel();
+      const { lastFrame, unmount } = render(<Wizard controller={c} />);
+      try {
+        await waitFor(() => (lastFrame() ?? "").includes("Cancelled."));
+        expect(lastFrame()).toContain("2 file(s) were written.");
+        expect(lastFrame()).not.toContain("No files were written.");
+      } finally {
+        unmount();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 
-  it("says no files were written when the cancel landed before any write", async () => {
-    const c = new SessionController(gen);
-    c.cancel();
-    const { lastFrame, unmount } = render(<Wizard controller={c} />);
-    try {
-      await waitFor(() => (lastFrame() ?? "").includes("Cancelled."));
-      expect(lastFrame()).toContain("No files were written.");
-    } finally {
-      unmount();
-    }
-  }, 20000);
+  it(
+    "says no files were written when the cancel landed before any write",
+    async () => {
+      const c = new SessionController(gen);
+      c.cancel();
+      const { lastFrame, unmount } = render(<Wizard controller={c} />);
+      try {
+        await waitFor(() => (lastFrame() ?? "").includes("Cancelled."));
+        expect(lastFrame()).toContain("No files were written.");
+      } finally {
+        unmount();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 });
 
 describe("degenerate-choice prompt wiring (C4)", () => {
@@ -314,44 +367,54 @@ describe("degenerate-choice prompt wiring (C4)", () => {
   // effect, and the empty multiselect is a static error frame. Both therefore
   // stay clear of the one-live-INTERACTIVE-render caveat above (like the
   // cancelled-frame renders), so they can each stand up their own render.
-  it("auto-resolves a forced single-choice select exactly once, with no keystroke and no loop", async () => {
-    const c = new SessionController(gen);
-    const submitSpy = vi.spyOn(c, "submitAnswer");
-    const { lastFrame, unmount } = render(<Wizard controller={c} />);
-    const frame = (): string => lastFrame() ?? "";
-    try {
-      await waitFor(() => frame().includes("component/react"));
-      void c.request(
-        select("framework", "Framework:", [{ label: "React", value: "react" }]),
-      );
-      await waitFor(() => c.getSnapshot().answers.framework === "react");
-      // Let any stray effect re-fire settle — it must be a no-op, not a loop.
-      await new Promise((r) => setTimeout(r, 60));
-      expect(c.getSnapshot().answers.framework).toBe("react");
-      expect(submitSpy).toHaveBeenCalledTimes(1);
-    } finally {
-      submitSpy.mockRestore();
-      unmount();
-    }
-  }, 20000);
+  it(
+    "auto-resolves a forced single-choice select exactly once, with no keystroke and no loop",
+    async () => {
+      const c = new SessionController(gen);
+      const submitSpy = vi.spyOn(c, "submitAnswer");
+      const { lastFrame, unmount } = render(<Wizard controller={c} />);
+      const frame = (): string => lastFrame() ?? "";
+      try {
+        await waitFor(() => frame().includes("component/react"));
+        void c.request(
+          select("framework", "Framework:", [
+            { label: "React", value: "react" },
+          ]),
+        );
+        await waitFor(() => c.getSnapshot().answers.framework === "react");
+        // Let any stray effect re-fire settle — it must be a no-op, not a loop.
+        await new Promise((r) => setTimeout(r, 60));
+        expect(c.getSnapshot().answers.framework).toBe("react");
+        expect(submitSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        submitSpy.mockRestore();
+        unmount();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 
-  it("renders a clear error for a zero-choice multiselect instead of a silent dead-end", async () => {
-    const c = new SessionController(gen);
-    const submitSpy = vi.spyOn(c, "submitAnswer");
-    const { lastFrame, unmount } = render(<Wizard controller={c} />);
-    const frame = (): string => lastFrame() ?? "";
-    try {
-      await waitFor(() => frame().includes("component/react"));
-      void c.request(multiselect("features", "Features:", []));
-      await waitFor(() => frame().includes("No options are available"));
-      expect(frame()).toContain("Press Escape or Ctrl-C to");
-      // The dead-end must not auto-submit an empty answer; only Escape/Ctrl-C
-      // may leave it.
-      expect(c.getSnapshot().answers.features).toBeUndefined();
-      expect(submitSpy).not.toHaveBeenCalled();
-    } finally {
-      submitSpy.mockRestore();
-      unmount();
-    }
-  }, 20000);
+  it(
+    "renders a clear error for a zero-choice multiselect instead of a silent dead-end",
+    async () => {
+      const c = new SessionController(gen);
+      const submitSpy = vi.spyOn(c, "submitAnswer");
+      const { lastFrame, unmount } = render(<Wizard controller={c} />);
+      const frame = (): string => lastFrame() ?? "";
+      try {
+        await waitFor(() => frame().includes("component/react"));
+        void c.request(multiselect("features", "Features:", []));
+        await waitFor(() => frame().includes("No options are available"));
+        expect(frame()).toContain("Press Escape or Ctrl-C to");
+        // The dead-end must not auto-submit an empty answer; only Escape/Ctrl-C
+        // may leave it.
+        expect(c.getSnapshot().answers.features).toBeUndefined();
+        expect(submitSpy).not.toHaveBeenCalled();
+      } finally {
+        submitSpy.mockRestore();
+        unmount();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
 });

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -7,13 +7,15 @@
  * - the FLOW test drives phase transitions through the controller API (no
  *   fake-TTY input at all), so what it protects — that every phase renders
  *   correctly — is deterministic;
- * - the KEYBOARD-BINDING tests each render one prompt and send the fewest
- *   keystrokes that prove the component→controller wiring. Renders are
- *   sequential and unmounted between tests (Ink's reconciler is a
- *   process-global; overlapping live instances can stall frames), and a
- *   dropped write can only cost a resend inside its own test — the old
- *   monolithic keystroke drive let one dropped write wedge every later
- *   phase, which was a recurring CI-only flake.
+ * - the KEYBOARD-BINDING tests each render one prompt and drive it with one
+ *   idempotent keystroke, proving the component→controller wiring. Renders
+ *   are sequential and unmounted between tests (Ink's reconciler is a
+ *   process-global; overlapping live instances can stall frames). The fake
+ *   stdin can deliver writes LATE under load, so no test sends input whose
+ *   duplicate or delayed arrival changes state — the old monolithic
+ *   keystroke drive typed multi-character values, and one late-arriving
+ *   duplicate garbled the field and wedged every later phase, which was a
+ *   recurring CI-only flake.
  *
  * Controller-only cancellation semantics are covered in session.test.ts.
  */
@@ -95,36 +97,17 @@ async function pressUntil(
   );
 }
 
-/**
- * Type a text value deterministically. Re-sending a multi-character value
- * (the pressUntil strategy) is not safe for text: a partially-dropped first
- * write followed by a full re-send still satisfies an `includes` check but
- * leaves the field garbled, and the later submit wait then hangs to its
- * ceiling. Instead: prove the input subscription is live with a sentinel
- * keystroke, clear it, then send the whole value as one atomic chunk —
- * reliable once the subscription is known to be up.
- */
-async function typeExactly(
-  stdin: { write: (data: string) => void },
-  frame: () => string,
-  value: string,
-  describe?: () => string,
-): Promise<void> {
-  await pressUntil(stdin, "@", () => frame().includes("@"), 30000, describe);
-  // Clear however many sentinels landed. Control keys must go one write per
-  // keystroke — ink parses key flags per chunk, so a chunk of backspaces is
-  // not N backspaces.
-  for (let i = 0; i < 40 && frame().includes("@"); i++) {
-    stdin.write("\x7f");
-    await new Promise((r) => setTimeout(r, 5));
-  }
-  await waitFor(() => !frame().includes("@"), 30000, describe);
-  stdin.write(value);
-  await waitFor(() => frame().includes(value), 30000, describe);
-}
-
-const text = (name: string, message: string): PromptEffect =>
-  promptEffect({ type: "text", name, message }) as PromptEffect;
+const text = (
+  name: string,
+  message: string,
+  defaultValue?: string,
+): PromptEffect =>
+  promptEffect({
+    type: "text",
+    name,
+    message,
+    default: defaultValue,
+  }) as PromptEffect;
 const confirm = (name: string, message: string): PromptEffect =>
   promptEffect({
     type: "confirm",
@@ -158,8 +141,8 @@ describe("create wizard (PROTECTED)", () => {
   // real SessionController (step counters, honest preview pane, progress,
   // completion), and that contract is deterministic. Keystroke→handler wiring
   // is covered one binding per render in the suite below — the old monolithic
-  // keystroke drive let a single dropped write wedge every later phase, which
-  // is exactly the CI flake this split retires.
+  // keystroke drive let one late-delivered write corrupt the field and wedge
+  // every later phase, which is exactly the CI flake this split retires.
   it("renders prompt sequence → preview/confirm → completion", async () => {
     const c = new SessionController(gen);
     const { lastFrame, unmount } = render(<Wizard controller={c} />);
@@ -210,27 +193,31 @@ describe("create wizard (PROTECTED)", () => {
 });
 
 describe("keyboard bindings (one prompt, one render each)", () => {
-  // Each test renders a single prompt and sends the fewest keystrokes that
-  // prove the component→controller wiring. Fresh render per test: a dropped
-  // write can only ever cost a resend inside that test's own helper, never
-  // wedge a later phase. On a timeout the error carries the wedged state —
-  // these races have only ever reproduced on loaded CI runners, so the error
-  // text is the one diagnostic that comes back from there.
+  // Each test renders a single prompt and drives it with ONE IDEMPOTENT
+  // keystroke. The fake stdin does not lose writes — it can deliver them LATE
+  // (a CI diagnostic caught a probe character landing after its verification
+  // window and corrupting the field), so no test may send input whose
+  // duplicate or late arrival changes state: the text prompt submits its
+  // seeded default with bare Enter rather than typing, and y/Enter re-sends
+  // are no-ops once the prompt has resolved. On a timeout the error carries
+  // the wedged state — these races have only ever reproduced on loaded CI
+  // runners, so the error text is the one diagnostic that comes back.
   const describeWedge =
     (c: SessionController, frame: () => string) => (): string => {
       const s = c.getSnapshot();
       return `phase=${s.phase} answers=${JSON.stringify(s.answers)} frame:\n${frame()}`;
     };
 
-  it("text prompt: typed value submits on Enter", async () => {
+  it("text prompt: Enter submits the seeded value", async () => {
     const c = new SessionController(gen);
     const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
     const frame = (): string => lastFrame() ?? "";
     const wedged = describeWedge(c, frame);
     try {
-      void c.request(text("componentPath", "Component path:"));
+      void c.request(
+        text("componentPath", "Component path:", "src/components/Button"),
+      );
       await waitFor(() => frame().includes("Component path:"), 30000, wedged);
-      await typeExactly(stdin, frame, "src/components/Button", wedged);
       await pressUntil(
         stdin,
         "\r",


### PR DESCRIPTION
## Done

The protected wizard end-to-end test flaked repeatedly on loaded CI runners and its bare `timeout` error made every occurrence undiagnosable. Test-only restructure, no production code touched, **no retries** — and the first CI run of the instrumented version caught the actual mechanism.

**Root cause (from the wedged-state diagnostic on this PR's own CI run):** the submitted answer was `"@src/components/Button"`. Writes to ink-testing-library's fake stdin are not *lost* — they can be **delivered late** under load, landing after whatever verification window a polling protocol closes. The old monolithic test re-sent a multi-character value, so one late duplicate garbled the field, the submit produced a wrong answer, and every later phase hung to its 30s ceiling. No poll-check-act protocol can close that race.

**The structure that makes it impossible:**

- **The PROTECTED flow test is deterministic**: it drives phase transitions through the controller API (`submitAnswer` / `submitConfirm` / `previewSettled`) with no fake-TTY input at all. What it protects — that every phase renders correctly against the real `SessionController` (step counters, honest preview pane, progress, completion) — never depended on keystroke plumbing.
- **Keyboard bindings get one test per prompt, one render each, one *idempotent* keystroke each**: the text prompt submits its seeded default with bare Enter (no typing — a late duplicate Enter after resolution is a no-op), confirm submits on `y`, the gate proceeds on `y`. No test sends input whose duplicate or delayed arrival can change state.
- **Wedged-state diagnostics stay**: binding-test timeouts append the controller phase, the answers, and the last frame to the error — this is the channel that identified the root cause, and CI remains the only place these races fire.

Extracted from #975 where it started as a drive-by — it pulled summon-core into that PR's blast radius, and the flake conversation belongs on its own change.

## QA

- `bun run check` and `bun run test` pass in `packages/summon/core` (447 + 8 tests).
- The wizard suite (8 tests, up from 5) completes in ~280ms; repeated consecutive runs green on node 24 and a node 22.19 binary.

### PR readiness check

- [x] PR label: `Maintenance 🔨`
- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] `no visual change`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
