### PR TITLE
feat(task): mark carried writes verbatim so seam transforms skip them

### DIFF
--- a/packages/runtime/task/src/lib/effect.test.ts
+++ b/packages/runtime/task/src/lib/effect.test.ts
@@ -80,6 +80,22 @@ describe("Effect Constructors - File System", () => {
       expect((effect as { content: string }).content).toBe(content);
     });
 
+    it("carries the verbatim marker when opted in", () => {
+      const effect = writeFileEffect("/copied.txt", "bytes", {
+        verbatim: true,
+      });
+      expect((effect as { verbatim?: boolean }).verbatim).toBe(true);
+      // The marker is inert for undo: the default delete-undo still resolves.
+      expect((effect as { undo?: unknown }).undo).toBeDefined();
+    });
+
+    it("omits the verbatim field entirely by default", () => {
+      const effect = writeFileEffect("/plain.txt", "bytes");
+      expect("verbatim" in effect).toBe(false);
+      const withUndo = writeFileEffect("/plain.txt", "bytes", { undo: null });
+      expect("verbatim" in withUndo).toBe(false);
+    });
+
     it("handles large content", () => {
       const content = "x".repeat(100000);
       const effect = writeFileEffect("/large.txt", content);

--- a/packages/runtime/task/src/lib/effect.ts
+++ b/packages/runtime/task/src/lib/effect.ts
@@ -59,11 +59,12 @@ export const readFileEffect = (path: string): Effect => ({
 export const writeFileEffect = (
   path: string,
   content: string,
-  opts?: UndoOptions,
+  opts?: UndoOptions & { verbatim?: boolean },
 ): Effect => ({
   _tag: "WriteFile",
   path,
   content,
+  ...(opts?.verbatim !== undefined ? { verbatim: opts.verbatim } : {}),
   undo: resolveUndo(opts?.undo, bareTask({ _tag: "DeleteFile", path })),
 });
 

--- a/packages/runtime/task/src/lib/primitives.test.ts
+++ b/packages/runtime/task/src/lib/primitives.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { dryRun, dryRunWith } from "./dry-run.js";
+import { describeEffect } from "./effect.js";
 import {
   appendFile,
   copyDirectory,
@@ -100,6 +101,22 @@ describe("Primitives - File System", () => {
       const task = writeFile("/multiline.txt", content);
       const { effects } = dryRun(task);
       expect((effects[0] as { content: string }).content).toBe(content);
+    });
+
+    it("passes the verbatim marker through, leaving undo and describe as-is", () => {
+      const task = writeFile("/copied.txt", "bytes", { verbatim: true });
+      const { effects } = dryRun(task);
+      const effect = effects[0] as {
+        verbatim?: boolean;
+        undo?: unknown;
+      };
+      expect(effect.verbatim).toBe(true);
+      // Inert for the interpreters: default undo still attached, description
+      // unchanged — only content transforms on the effect seam read it.
+      expect(effect.undo).toBeDefined();
+      expect(describeEffect(effects[0] as never)).toBe(
+        "Write file: /copied.txt (5 bytes)",
+      );
     });
 
     it("handles content with special characters", () => {

--- a/packages/runtime/task/src/lib/primitives.ts
+++ b/packages/runtime/task/src/lib/primitives.ts
@@ -41,11 +41,13 @@ export const readFile = (path: string): Task<string> =>
 /**
  * Write content to a file.
  * Default undo: delete the file.
+ * `verbatim: true` marks a carried copy — content transforms on the effect
+ * seam (e.g. generated-file stamping) skip it, so the bytes land unchanged.
  */
 export const writeFile = (
   path: string,
   content: string,
-  opts?: UndoOptions,
+  opts?: UndoOptions & { verbatim?: boolean },
 ): Task<void> => effect(writeFileEffect(path, content, opts));
 
 /**

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -102,8 +102,19 @@ export type PromptQuestion =
 export type Effect =
   /** Read file contents as UTF-8 string */
   | { _tag: "ReadFile"; path: string }
-  /** Write content to file, creating parent directories */
-  | { _tag: "WriteFile"; path: string; content: string; undo?: Task<void> }
+  /**
+   * Write content to file, creating parent directories. `verbatim` marks the
+   * content as a carried copy that must land byte-for-byte: interpreters treat
+   * it identically, but content transforms hooked on the effect seam (e.g. a
+   * generated-file stamp) skip it.
+   */
+  | {
+      _tag: "WriteFile";
+      path: string;
+      content: string;
+      verbatim?: boolean;
+      undo?: Task<void>;
+    }
   /** Append content to file */
   | {
       _tag: "AppendFile";


### PR DESCRIPTION
`writeFile` gains an optional `verbatim` flag that rides on the `WriteFile` effect. Interpreters treat a verbatim write identically — the flag changes no execution semantics — but content transforms hooked on the effect seam read it and pass the bytes through untouched.

The motivating case is a generator that carries a file into the output tree as an exact copy. A generated-file stamp applied at the seam would otherwise rewrite those bytes, breaking checksums and byte-for-byte fixtures. Marking the write is the only way the seam can tell a carried copy from generated content — by the time the effect is interpreted, both are just strings.

**Additive and optional.** Existing `writeFile` calls are unchanged, and an interpreter that ignores the field behaves exactly as before.

+51 / −4 across 5 files. Independently mergeable — nothing else in flight depends on it landing first.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)