### PR TITLE
fix(boilerplate,summon-application): declare the root surface classes

### DIFF
--- a/apps/react/boilerplate-vite/index.html
+++ b/apps/react/boilerplate-vite/index.html
@@ -7,7 +7,8 @@
     <link rel="icon" type="image/png" sizes="32x32" href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png">
     <title>Pragma Boilerplate</title>
   </head>
-  <body>
+  <!-- Surface declaration: context (app) + density (comfortable) — roots the design system's --density-* channel -->
+  <body class="app comfortable">
     <div id="root"></div>
     <script type="module" src="/src/client/entry.tsx"></script>
   </body>

--- a/apps/react/boilerplate-vite/src/server/entry.tsx
+++ b/apps/react/boilerplate-vite/src/server/entry.tsx
@@ -263,7 +263,8 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
         {props.scriptElements}
         {props.linkElements}
       </head>
-      <body>
+      {/* Surface declaration: context (app) + density (comfortable) — roots the design system's --density-* channel */}
+      <body className="app comfortable">
         <div id="root">
           <I18nProvider config={i18nConfig} catalogs={catalogs} locale={locale}>
             <HeadProvider>

--- a/packages/summon/application/src/application/react/templates/index.html.ejs
+++ b/packages/summon/application/src/application/react/templates/index.html.ejs
@@ -7,7 +7,8 @@
     <link rel="icon" type="image/png" sizes="32x32" href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png">
     <title><%= name %></title>
   </head>
-  <body>
+  <!-- Surface declaration: context (app) + density (comfortable) — roots the design system's --density-* channel -->
+  <body class="app comfortable">
     <div id="root"></div>
     <script type="module" src="/src/client/entry.tsx"></script>
   </body>

--- a/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
+++ b/packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs
@@ -297,7 +297,8 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
         {props.scriptElements}
         {props.linkElements}
       </head>
-      <body>
+      {/* Surface declaration: context (app) + density (comfortable) — roots the design system's --density-* channel */}
+      <body className="app comfortable">
         <div id="root">
 <% if (intl) { -%>
           <I18nProvider config={i18nConfig} catalogs={catalogs} locale={locale}>
@@ -334,7 +335,8 @@ export default function EntryServer(props: ServerEntrypointProps<InitialData>) {
         {props.scriptElements}
         {props.linkElements}
       </head>
-      <body>
+      {/* Surface declaration: context (app) + density (comfortable) — roots the design system's --density-* channel */}
+      <body className="app comfortable">
         <div id="root">
 <% if (intl) { -%>
           <I18nProvider config={i18nConfig} catalogs={catalogs} locale={locale}>


### PR DESCRIPTION
## What

The density system in `@canonical/styles` (`packages/styles/main/src/modifiers.density.css`) is class-driven from the app root: a **context** class (`app`/`site`/`docs`) sets the comfortable/dense pair, and a **density** class (`comfortable`/`dense`) picks within it. Neither the boilerplate nor any summon-generated application declared them — every shell shipped a bare `<body>`.

The omission is silent, which is why it went unnoticed: the density primitives carry fallbacks to app-comfortable values, so applications looked right by accident, while any `dense` region or non-app surface quietly rendered with the wrong control heights and spacing.

This adds `class="app comfortable"` (the correct default for generated *applications*) to:

- `apps/react/boilerplate-vite/index.html`
- `apps/react/boilerplate-vite/src/server/entry.tsx` (SSR shell)
- `packages/summon/application/src/application/react/templates/index.html.ejs`
- `packages/summon/application/src/application/react/templates/src/server/entry.tsx.ejs` (both the relay and non-relay branches)

each with a one-line comment naming the constraint so the classes are not dropped again.

Companion PR on the skills side (adoption track now documents the requirement): canonical/design-system#67

## Verify

- `bun run check` in `apps/react/boilerplate-vite`: biome clean; the four pre-existing `tsc` errors (`readDehydratedState`, `warm`, `statusCode` against `@canonical/router-react` types) are unrelated to this change and present without it.
- No snapshot tests assert the `<body>` markup.

## Follow-up candidate

Making the density choice a summon prompt (`--dense`, or site/docs contexts for non-app generators) is left as a separate discussion — `app comfortable` is the right unconditional default for the application generator today.