### PR TITLE
fix(pragma): retire skill links a package no longer provides

### DIFF
--- a/packages/cli/pragma/src/capabilities/sources/installSkills.ts
+++ b/packages/cli/pragma/src/capabilities/sources/installSkills.ts
@@ -10,6 +10,18 @@
  * first), and the update Task stays reversible (each created link carries an
  * unlink undo).
  *
+ * Installing alone leaks, because planning walks the PACKAGES and so only ever
+ * visits a skill that still exists. When a package DROPS one (a `0.1.2` that
+ * shipped `component-specifier` upgrading to a `0.2.0` that does not), the link
+ * the previous update installed is never revisited and is left dangling at a
+ * target that no longer exists — which reads as a broken install rather than the
+ * intentional removal it is, and which `skill` commands can still list or try to
+ * open. So planning ALSO walks the installed root and prunes those, under a
+ * deliberately narrow rule: an entry is removed only when this run did not plan
+ * it AND it is a symlink whose target is gone. A real directory is a
+ * manually-installed skill and a still-resolving symlink is someone's own link;
+ * neither is this update's to delete.
+ *
  * Decisions run against REAL fs here so the update's `--dry-run` plan is
  * accurate; the composed Task performs only the symlink/delete effects.
  */
@@ -21,16 +33,28 @@ import { installedSkillsDir } from "../skill/discover.js";
 
 /** One planned skill symlink into the installed-skills root. */
 export interface SkillLinkAction {
-  /** The package's skill folder — the symlink target. */
+  /**
+   * The symlink target: the package's skill folder for an install, or — on a
+   * `pruned` entry — the missing target the stale link still points at, kept so
+   * the prune's undo can put the link back exactly as it was.
+   */
   readonly target: string;
   /** `<installedSkillsDir>/<folderName>` — where the symlink is created. */
   readonly linkPath: string;
-  /** created (absent), skipped (already correct / a real dir), or replaced. */
-  readonly action: "created" | "skipped" | "replaced";
+  /**
+   * created (absent), skipped (already correct / a real dir), replaced, or
+   * pruned (an unplanned link whose target is gone — deleted, not re-created).
+   */
+  readonly action: "created" | "skipped" | "replaced" | "pruned";
   /** The skill folder name (the discovery key). */
   readonly folderName: string;
-  /** The package the skill came from. */
-  readonly packageName: string;
+  /**
+   * The package the skill came from. Absent on a `pruned` entry: a stale link
+   * records only a target path, and the package that installed it is precisely
+   * the one that no longer provides the skill — there is nothing honest left to
+   * attribute it to.
+   */
+  readonly packageName?: string;
 }
 
 /** What currently occupies a candidate link path. */
@@ -81,8 +105,57 @@ function packageSkillDirs(root: string): string[] {
 }
 
 /**
+ * Plan the removal of the links a package has since dropped.
+ *
+ * The install pass walks the packages, so it can only ever visit a skill that
+ * still exists; this pass walks the installed root, which is the ONLY place a
+ * dropped skill still shows up. An entry is pruned only when both hold: this run
+ * did not plan it, and it is a symlink whose target is gone. Both halves matter —
+ *
+ * - a real (non-symlink) entry is a manually-installed skill, which the install
+ *   pass already refuses to clobber (`skipped`) and which this pass must refuse
+ *   just as firmly: "unplanned" is exactly what a hand-placed skill looks like;
+ * - a symlink whose target still resolves is someone's own link into a checkout
+ *   this command knows nothing about. Unplanned does not make it garbage, and an
+ *   update that silently ate it would be a worse bug than the dangling link.
+ *
+ * A broken target, by contrast, cannot be anything but debris: nothing can read
+ * it, and re-creating it is a matter of re-running the update that installed it
+ * (which is also what this prune's undo does).
+ *
+ * @param dest - The installed-skills root.
+ * @param planned - Every folder name the install pass planned, whatever action.
+ * @returns One `pruned` action per stale link, for the plan and its preview.
+ * @note Impure — reads the installed root and stats each entry's target.
+ */
+function planStaleLinkPrunes(
+  dest: string,
+  planned: ReadonlySet<string>,
+): SkillLinkAction[] {
+  let names: string[];
+  try {
+    names = readdirSync(dest);
+  } catch {
+    return []; // No installed root — nothing was ever installed to go stale.
+  }
+  const out: SkillLinkAction[] = [];
+  for (const folderName of names) {
+    if (planned.has(folderName)) continue;
+    const linkPath = resolve(dest, folderName);
+    const state = linkState(linkPath);
+    if (state.kind !== "symlink") continue;
+    // A relative target is stored relative to the link's OWN directory, which
+    // for an entry of the installed root is that root itself.
+    if (existsSync(resolve(dest, state.target))) continue;
+    out.push({ target: state.target, linkPath, action: "pruned", folderName });
+  }
+  return out;
+}
+
+/**
  * Plan the symlink actions that install each resolved package's `skills/*` into
- * the installed-skills discovery root. First-seen wins on a folder-name clash
+ * the installed-skills discovery root, then the removals that retire the links
+ * a package has since dropped. First-seen wins on a folder-name clash
  * across packages. A real (non-symlink) entry at the link path is left untouched
  * (`skipped`) so a manually-installed skill is never clobbered.
  *
@@ -120,5 +193,9 @@ export function planSkillInstall(
       });
     }
   }
+  // `seen` is every folder name this run planned — the `skipped` ones included,
+  // so a name a package still provides is never a prune candidate even when the
+  // install pass decided to leave its entry alone.
+  actions.push(...planStaleLinkPrunes(dest, seen));
   return actions;
 }

--- a/packages/cli/pragma/src/capabilities/sources/runUpdate.ts
+++ b/packages/cli/pragma/src/capabilities/sources/runUpdate.ts
@@ -322,13 +322,24 @@ export async function buildUpdateTask(
 
   // Install package-provided skills (U10): symlink each resolved package's
   // `skills/*` into the installed-skills root, so `skill list` / `setup skills`
-  // see them after an update. Kept in this Task (reversible: created links carry
-  // an unlink undo) so `sources update --undo` also removes them.
-  const skillLinks = planSkillInstall(resolved).filter(
-    (link) => link.action !== "skipped",
+  // see them after an update — and RETIRE the links of skills those packages
+  // have since dropped, which the same plan reports as `pruned`. Kept in this
+  // Task (reversible: a created link carries an unlink undo, a pruned one a
+  // re-link undo) so `sources update --undo` restores the root as it was.
+  //
+  // The two are split, not counted together: a prune is a deletion, so folding
+  // it into "Installing N skill(s)" would report a removal as an install.
+  const skillPlan = planSkillInstall(resolved);
+  const skillLinks = skillPlan.filter(
+    (link) => link.action === "created" || link.action === "replaced",
   );
+  const staleLinks = skillPlan.filter((link) => link.action === "pruned");
   if (skillLinks.length > 0)
     report?.(`Installing ${skillLinks.length} skill(s)`);
+  if (staleLinks.length > 0)
+    report?.(
+      `Removing ${staleLinks.length} skill link(s) no longer provided by any package`,
+    );
 
   report?.(`Pointing ${runtime.cwd} at pack ${built.contentHash.slice(0, 12)}`);
   return gen(function* () {
@@ -343,6 +354,25 @@ export async function buildUpdateTask(
           }),
         );
       }
+    }
+    // No `mkdir` guard here: a stale link can only have been enumerated FROM
+    // the installed root, so the root necessarily exists.
+    //
+    // The undo re-creates the link exactly as found — dangling target and all —
+    // because undo's job is to restore the prior state, not to improve on it. It
+    // clears the path first because the undo interpreter MOCKS forward effects
+    // when collecting: the delete above may never have run, and `fs.symlink`
+    // refuses a path that already exists. Same delete-then-link shape the
+    // `replaced` branch above uses, for the same reason.
+    for (const stale of staleLinks) {
+      yield* $(
+        deleteFile(stale.linkPath, {
+          undo: gen(function* () {
+            yield* $(deleteFile(stale.linkPath));
+            yield* $(symlink(stale.target, stale.linkPath));
+          }),
+        }),
+      );
     }
     return data;
   });

--- a/packages/cli/pragma/src/capabilities/sources/sources.test.ts
+++ b/packages/cli/pragma/src/capabilities/sources/sources.test.ts
@@ -1,9 +1,12 @@
 import { execFileSync } from "node:child_process";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -767,6 +770,155 @@ describe("sources update — installs package skills (U10)", () => {
     await runUndo(await buildUpdateTask(runtime));
 
     expect(existsSync(join(dataHome, "pragma", "skills", "bar"))).toBe(false);
+  });
+
+  /** The installed-skills root, created so a prior install can be seeded into it. */
+  function installedRoot(): string {
+    const root = join(dataHome, "pragma", "skills");
+    mkdirSync(root, { recursive: true });
+    return root;
+  }
+
+  /** A symlink at `<installedRoot>/<name>` whose target does not exist. */
+  function danglingLink(root: string, name: string): string {
+    const target = join(tmp("pragma-uninstalled-"), "skills", name);
+    symlinkSync(target, join(root, name));
+    return target;
+  }
+
+  // The `@canonical/design-system` 0.2.0 regression: 0.1.2 shipped
+  // `component-specifier`, 0.2.0 deleted it in favour of `specify-component`,
+  // and every machine that had updated against 0.1.2 kept a symlink into a
+  // package directory that no longer exists.
+  it("prunes a link whose package dropped the skill", async () => {
+    const pkg = skillPackage("specify-component"); // the 0.2.0 shape
+    const root = installedRoot();
+    danglingLink(root, "component-specifier"); // what 0.1.2 left behind
+
+    const cwd = tmp("pragma-proj-");
+    const runtime = runtimeFor(cwd, [
+      { name: "design-system", source: `file://${pkg}` },
+    ]);
+    await runTask(await buildUpdateTask(runtime));
+
+    expect(readdirSync(root)).toEqual(["specify-component"]);
+    expect(discoverSkills(cwd).map((s) => s.name)).not.toContain(
+      "component-specifier",
+    );
+  });
+
+  it("spares a manually-installed skill and a foreign link that still resolves", async () => {
+    const pkg = skillPackage("specify-component");
+    const root = installedRoot();
+    danglingLink(root, "component-specifier");
+
+    // A hand-installed skill: a REAL directory, belonging to no package. The
+    // install pass already refuses to clobber these; so must the prune pass.
+    const manual = join(root, "hand-written");
+    mkdirSync(manual, { recursive: true });
+    writeFileSync(
+      join(manual, "SKILL.md"),
+      "---\nname: hand-written\ndescription: Mine.\n---\n",
+    );
+    // Someone's own link into a checkout this update knows nothing about, and
+    // which still resolves. Deliberately RELATIVE: a relative target is stored
+    // relative to the LINK's directory, so resolving it against anything else
+    // (the cwd, say) would read as broken and eat a perfectly live link.
+    const foreign = join(dataHome, "elsewhere", "my-own");
+    mkdirSync(foreign, { recursive: true });
+    writeFileSync(
+      join(foreign, "SKILL.md"),
+      "---\nname: my-own\ndescription: Theirs.\n---\n",
+    );
+    symlinkSync(join("..", "..", "elsewhere", "my-own"), join(root, "my-own"));
+
+    const cwd = tmp("pragma-proj-");
+    const runtime = runtimeFor(cwd, [
+      { name: "design-system", source: `file://${pkg}` },
+    ]);
+    await runTask(await buildUpdateTask(runtime));
+
+    // Only the dangling link went.
+    expect(readdirSync(root).sort()).toEqual([
+      "hand-written",
+      "my-own",
+      "specify-component",
+    ]);
+    expect(lstatSync(manual).isDirectory()).toBe(true);
+    expect(existsSync(join(manual, "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(root, "my-own")).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(root, "my-own"))).toBe(true); // still resolves
+    const found = discoverSkills(cwd).map((s) => s.name);
+    expect(found).toEqual(
+      expect.arrayContaining(["hand-written", "my-own", "specify-component"]),
+    );
+  });
+
+  it("re-points, rather than prunes, a dangling link the package still provides", async () => {
+    const pkg = skillPackage("foo");
+    const root = installedRoot();
+    danglingLink(root, "foo"); // e.g. the package moved to a new cache dir
+
+    const cwd = tmp("pragma-proj-");
+    const runtime = runtimeFor(cwd, [
+      { name: "pkg-a", source: `file://${pkg}` },
+    ]);
+    await runTask(await buildUpdateTask(runtime));
+
+    // `replaced`, never `pruned`: the prune pass skips every name this run
+    // planned, or it would delete the link the install pass just created.
+    expect(readlinkSync(join(root, "foo"))).toBe(join(pkg, "skills", "foo"));
+    expect(discoverSkills(cwd).map((s) => s.name)).toContain("foo");
+  });
+
+  it("is reversible — undo restores a pruned link, dangling target and all", async () => {
+    const pkg = skillPackage("specify-component");
+    const root = installedRoot();
+    const staleTarget = danglingLink(root, "component-specifier");
+    const link = join(root, "component-specifier");
+
+    const cwd = tmp("pragma-proj-");
+    const runtime = runtimeFor(cwd, [
+      { name: "design-system", source: `file://${pkg}` },
+    ]);
+    // The plan is made while the stale link is still there; `runUndo` MOCKS the
+    // forward effects, so stand in for the delete it would have performed.
+    const task = await buildUpdateTask(runtime);
+    rmSync(link);
+
+    const { runUndo } = await import("@canonical/task/node");
+    await runUndo(task);
+
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link)).toBe(staleTarget); // the target it always had
+  });
+
+  it("undoes a prune whose forward delete never ran, rather than failing EEXIST", async () => {
+    const pkg = skillPackage("specify-component");
+    const root = installedRoot();
+    const staleTarget = danglingLink(root, "component-specifier");
+
+    const cwd = tmp("pragma-proj-");
+    const runtime = runtimeFor(cwd, [
+      { name: "design-system", source: `file://${pkg}` },
+    ]);
+    // No `rmSync` this time: the link is still in place when the undo re-links,
+    // and `fs.symlink` refuses an existing path — so the undo must clear it.
+    const { runUndo } = await import("@canonical/task/node");
+    await expect(runUndo(await buildUpdateTask(runtime))).resolves.toBeTruthy();
+
+    expect(readlinkSync(join(root, "component-specifier"))).toBe(staleTarget);
+  });
+
+  it("plans no prunes when nothing was ever installed", async () => {
+    const pkg = skillPackage("foo"); // $XDG_DATA_HOME/pragma/skills absent
+    const cwd = tmp("pragma-proj-");
+    const runtime = runtimeFor(cwd, [
+      { name: "pkg-a", source: `file://${pkg}` },
+    ]);
+    await runTask(await buildUpdateTask(runtime));
+
+    expect(readdirSync(join(dataHome, "pragma", "skills"))).toEqual(["foo"]);
   });
 });
 


### PR DESCRIPTION
## Done

- `planSkillInstall` gains a second pass, `planStaleLinkPrunes`, that walks the installed-skills root — the only place a dropped skill still appears, since the install pass walks *packages* and can only ever visit a skill that still exists.
- Adds a fourth action, `pruned`, to the same returned plan, so `--dry-run` previews removals and the composed Task still performs only symlink/delete effects.
- `runUpdate` reports installs and prunes separately; folding a deletion into `Installing N skill(s)` would report a removal as an install.
- Each prune carries a re-link undo that clears the path first — the undo interpreter mocks forward effects and `fs.symlink` refuses an existing path. Same delete-then-link shape the `replaced` branch already uses.

**Why now:** `@canonical/design-system@0.2.0` was published today and **deleted** the `component-specifier` skill (replaced by `specify-component` + `specify-pattern`). Every machine that ran `sources update` against `0.1.2` retains a dangling symlink to a directory that no longer exists — it reads as a broken install rather than an intentional removal. This is a live regression.

**The prune rule is narrow by construction.** An entry goes only if this run did not plan it, **and** it is a symlink, **and** its target no longer resolves:

```ts
if (planned.has(folderName)) continue;
if (state.kind !== "symlink") continue;
if (existsSync(resolve(dest, state.target))) continue;
```

- a **manually-installed skill** (real directory) is skipped, as the install pass already skips it
- a **still-valid foreign symlink** survives — targets resolve against the link's own directory, so a live *relative* link isn't mistaken for debris (dedicated test; getting this wrong would eat live links)
- a **name the package still provides** is guarded by the `seen` set, which includes `skipped` entries — otherwise a dangling link the package still ships would be planned `replaced` *and* pruned, deleting the link just created

## QA

1. Point `XDG_DATA_HOME` at a scratch directory.
2. `pragma sources update` against a source tree providing a skill, e.g. `component-specifier`.
3. Remove that skill from the source tree (or update to a package version that dropped it).
4. `pragma sources update --dry-run` — the plan reports `Removing 1 skill link(s) no longer provided by any package`.
5. `pragma sources update` — the dangling link is gone; a hand-made directory and any still-resolving symlink in that root are untouched.

Automated equivalent: 6 new cases in `sources.test.ts` drive the real update path against a scratch `XDG_DATA_HOME`. Verified they catch the bug — with the two source files reverted to `main`, **3 fail**; with the fix, all 36 pass.

### PR readiness check

- [x] PR should have one of the following labels: `Bug 🐛`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — no package boundaries changed.
- [x] If this PR introduces a **new package** — n/a, no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

n/a — CLI behaviour, covered by the QA steps above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)