### PR TITLE
chore(labels): improvements to the repo labels

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -33,4 +33,4 @@ settings:
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
   # If label on the issue is not in specified list, this issue will be created as a Bug
   label_mapping:
-    enhancement: Story
+    feat: Story

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,15 +10,15 @@ Fixes [list issues/bugs if needed]
 
 ### PR readiness check
 
-- [ ] PR should have one of the following labels:
-  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
-- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
+- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
+  - The matching type label is applied automatically from the title — there is no type label to add by hand.
+  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
 - [ ] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
 - [ ] All packages define the required scripts in `package.json`:
   - [ ] All packages: `check`, `check:fix`, and `test`.
   - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
 - [ ] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions.
-- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.
+- [ ] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic.
 
 ## Screenshots
 

--- a/.github/workflows/chromatic._template.yml
+++ b/.github/workflows/chromatic._template.yml
@@ -23,6 +23,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       (!github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'Chromatic: skip') &&
       !contains(github.event.pull_request.labels.*.name, 'no visual change'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -21,3 +21,84 @@ jobs:
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # The closed type vocabulary. Every entry has a label of the same name,
+          # applied by `apply-type-label` below — keep the two lists in step.
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            chore
+            test
+            ci
+            revert
+
+  apply-type-label:
+    name: Apply type label
+    needs: validate-pr-metadata
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      # Creating a managed label that does not exist yet goes through the issues API.
+      issues: write
+    steps:
+      # The title is the source of truth. It has just been validated, so the type
+      # label is derived from it rather than applied by hand: `feat(x): …` gets
+      # `feat`, and a `!` marker gets `breaking` alongside it. Labels this job
+      # manages are also removed when the title stops implying them, so an edited
+      # title never leaves a stale type behind.
+      - name: Derive the type label from the PR title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const TYPES = ["feat", "fix", "docs", "refactor", "chore", "test", "ci", "revert"];
+            const BREAKING = "breaking";
+            // Only consulted when a label is missing from the repository, so a
+            // freshly generated repo labels its first PR correctly.
+            const COLORS = Object.fromEntries(TYPES.map((type) => [type, "b3c5d7"]));
+            COLORS[BREAKING] = "b60205";
+
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            // A fork PR gets a read-only token, so labelling would fail the run.
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.warning("PR is from a fork; skipping labelling (the token is read-only).");
+              return;
+            }
+
+            const match = /^([a-z]+)(\([^)]*\))?(!)?:\s/.exec(pr.title);
+            if (!match) {
+              core.setFailed(`PR title is not a conventional commit: ${pr.title}`);
+              return;
+            }
+            const [, type, , breaking] = match;
+            if (!TYPES.includes(type)) {
+              core.setFailed(`"${type}" is not one of the allowed types: ${TYPES.join(", ")}`);
+              return;
+            }
+
+            const managed = new Set([...TYPES, BREAKING]);
+            const desired = new Set([type, ...(breaking ? [BREAKING] : [])]);
+            const current = new Set(pr.labels.map((label) => label.name).filter((name) => managed.has(name)));
+
+            const add = [...desired].filter((name) => !current.has(name));
+            const remove = [...current].filter((name) => !desired.has(name));
+
+            for (const name of add) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({ owner, repo, name, color: COLORS[name] });
+                core.info(`Created missing label "${name}"`);
+              }
+            }
+            if (add.length > 0) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: add });
+            }
+            for (const name of remove) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+            }
+            core.info(`${pr.title}\n  added:   ${add.join(", ") || "—"}\n  removed: ${remove.join(", ") || "—"}`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,11 @@ file is the PR workflow contract.
 - **Keep commits atomic.** One logical change per commit; the diff should be reviewable
   on its own and tell a single story. Bundling unrelated items into one commit/PR is
   allowed but should be **rare** and called out in the PR body (a "drive-by" line).
-- The PR also needs one of these **labels**: `Feature 🎁`, `Breaking Change 💣`,
-  `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
+- The allowed types are `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci` and
+  `revert`; the **type label** is derived from the title by CI, so never add one by hand.
+  A breaking change is marked with `!` in the title (`feat(router)!: …`), which is what
+  applies the `breaking` label. Every other label is a human judgement — see
+  [docs/references/LABELS.md](docs/references/LABELS.md).
 - The release CHANGELOG is Lerna-generated from commit history — write commit subjects
   for the changelog reader, not just yourself.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ precedent.
   itself. The same goes for commit subjects, which Lerna puts in the CHANGELOG.
   Internal sequencing stays in the planning repo; when merge order matters, name
   the PR that must land first **by number** and say why in one line.
-- Add `no visual change` to skip Chromatic when there's no visual diff.
+- Add `Chromatic: skip` to skip Chromatic when there's no visual diff.
 - New package? First-time publish is manual (`npm publish --access public` from the
   package dir); verify with `bun run publish:status` from the root.
 - **New packages need OIDC trusted-publisher setup — a manual human step, agents cannot

--- a/configs/renovate/README.md
+++ b/configs/renovate/README.md
@@ -32,7 +32,8 @@ Or if published to npm:
   - `lerna-nx` — `lerna`, `nx`, `@nx/*`
   - `canonical` — `@canonical/*` (catch-all for internal packages)
 - **DevDep automerge** — patch and minor updates for devDependencies
-- **Labels** — `Maintenance 🔨` on all Renovate PRs
+- **Labels** — none applied directly; the `chore` type label is derived from the
+  `chore(deps): ...` title by the `pr-lint` workflow
 - **Semantic commits** — `chore(deps): ...` format
 
 ## Adding domain-specific groups

--- a/configs/renovate/default.json
+++ b/configs/renovate/default.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "schedule": ["before 9am on monday"],
-  "labels": ["Maintenance 🔨"],
   "semanticCommits": "enabled",
   "packageRules": [
     {
@@ -67,7 +66,7 @@
         "@vitest/{/,}**",
         "renovate"
       ],
-      "addLabels": ["no visual change"]
+      "addLabels": ["Chromatic: skip"]
     },
     {
       "description": "Majors carry an impact review: the generated body is often truncated, and PR CI rarely exercises the release path, so the breaking surface has to be triaged by hand",

--- a/docs/references/LABELS.md
+++ b/docs/references/LABELS.md
@@ -1,0 +1,82 @@
+# Labels
+
+One rule decides how a label is named and who owns it:
+
+> **A bare lowercase label is derived from the PR title. A `Namespace: value` label is a human judgement.**
+
+Everything below follows from that. The type of a change is already stated in the
+title — `pr-lint.yml` validates it against a closed vocabulary — so restating it as a
+label by hand is a step that can only be forgotten, and was: **a third of merged PRs
+carried no type label at all**. The `pr-lint` workflow now derives it instead.
+
+## Derived from the title
+
+Applied and removed automatically by `.github/workflows/pr-lint.yml`. Never add these
+by hand on a PR; fix the title instead. All share one colour (`#b3c5d7`) because they
+are an index for filtering, not a signal that needs attention.
+
+| Label | Comes from |
+| --- | --- |
+| `feat` | `feat(scope): …` |
+| `fix` | `fix(scope): …` |
+| `docs` | `docs(scope): …` |
+| `refactor` | `refactor(scope): …` |
+| `chore` | `chore(scope): …` |
+| `test` | `test(scope): …` |
+| `ci` | `ci(scope): …` |
+| `revert` | `revert(scope): …` |
+| `breaking` | the `!` marker, e.g. `feat(router)!: …` — sits alongside the type |
+
+This list is the same one pinned as the `types:` input of
+`amannn/action-semantic-pull-request`. **The two must be kept in step**: a type the
+lint accepts but the label set does not know is exactly the gap this replaces.
+
+Issues have no conventional-commit title, so on an **issue** the same vocabulary is
+applied by hand as a triage act. `.github/.jira_sync_config.yaml` maps `feat` to a Jira
+Story.
+
+## Human judgements
+
+| Label | Colour | Meaning |
+| --- | --- | --- |
+| `Chromatic: skip` | `#bfdadc` | CI directive: this PR cannot change rendered UI, so `chromatic._template.yml` skips the build. Renamed from `no visual change`. |
+| `Review: code needed` … | `#cdcdcd` | A named discipline still owes this PR a look: `code`, `QA`, `design`, `a11y`, `UX`, `Chromatic`. |
+| `Review: code +1` … | `#0e8a16` | That discipline has signed off. Same six disciplines. |
+| `Status: blocked` | `#b60205` | Waiting on something outside this PR. |
+| `Status: do not merge` | `#b60205` | Deliberately not for merging yet. |
+| `Status: question` | `#cdcdcd` | Needs more information before it can move. |
+| `Priority: low` / `medium` / `high` | sand → amber → orange | Triage order. |
+| `Topic: design tokens` | `#8250df` | Part of a migration train that spans many PRs. Add a sibling `Topic:` label per train rather than a bespoke label each time. |
+| `good first issue` | `#7057ff` | **Deliberate exception to the naming rule** — GitHub treats this exact name specially for repository discovery, so it is not namespaced. |
+
+Values are lowercase, except acronyms and proper nouns (`QA`, `UX`, `a11y`,
+`Chromatic`).
+
+## Colour means something
+
+| Colour | Meaning |
+| --- | --- |
+| slate `#b3c5d7` | derived from the title — informational |
+| grey `#cdcdcd` | waiting on a human |
+| green `#0e8a16` | approved |
+| red `#b60205` | stop: breaking, blocked, do not merge |
+| amber ramp | priority |
+| purple `#8250df` | migration train |
+| pale teal `#bfdadc` | CI directive |
+
+## What was removed, and why
+
+| Removed | Replaced by | Evidence |
+| --- | --- | --- |
+| `Feature 🎁` `Bug 🐛` `Documentation 📝` | `feat` `fix` `docs` | Renamed to match the vocabulary already enforced on titles. |
+| `Maintenance 🔨` | `chore` `refactor` `test` `ci` | One bucket held four types (23% of all merged work). `refactor` in particular had no home: of 32 merged refactors, 10 were unlabelled and 7 carried only `Breaking Change 💣`. |
+| `Breaking Change 💣` | `breaking` | Was used *instead of* a type rather than alongside it, so a breaking PR lost its type. It is a modifier, exactly like `!`. |
+| `Review: * -1` (all six) | GitHub's "Request changes" | Zero uses across ~800 PRs and issues. |
+| `Review: Code +1 (with changes)` | — | Zero uses; the only label of its shape on one axis. |
+| `Don't merge` | `Status: do not merge` | Zero uses; a duplicate of `do not merge` with a different colour. |
+| `Dependencies` | `chore` | Zero uses; Renovate titles its PRs `chore(deps): …`. |
+| `enhancement` | `feat` | A GitHub default that duplicated `Feature 🎁`. |
+| `question` | `Status: question` | Namespaced. |
+
+Renaming a label preserves it on every PR and issue that already carries it, so
+history stays intact.

--- a/packages/summon/monorepo/src/templates/PULL_REQUEST_TEMPLATE.md.ejs
+++ b/packages/summon/monorepo/src/templates/PULL_REQUEST_TEMPLATE.md.ejs
@@ -10,9 +10,9 @@ Fixes [list issues/bugs if needed]
 
 ### PR readiness check
 
-- [ ] PR should have one of the following labels:
-  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
-- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
+- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
+  - The matching type label is applied automatically from the title — there is no type label to add by hand.
+  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
 - [ ] All packages define the required scripts in `package.json`:
   - [ ] All packages: `check`, `check:fix`, and `test`.
   - [ ] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.

--- a/packages/summon/monorepo/src/templates/pr-lint.yml.ejs
+++ b/packages/summon/monorepo/src/templates/pr-lint.yml.ejs
@@ -21,3 +21,84 @@ jobs:
         uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # The closed type vocabulary. Every entry has a label of the same name,
+          # applied by `apply-type-label` below — keep the two lists in step.
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            chore
+            test
+            ci
+            revert
+
+  apply-type-label:
+    name: Apply type label
+    needs: validate-pr-metadata
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      # Creating a managed label that does not exist yet goes through the issues API.
+      issues: write
+    steps:
+      # The title is the source of truth. It has just been validated, so the type
+      # label is derived from it rather than applied by hand: `feat(x): …` gets
+      # `feat`, and a `!` marker gets `breaking` alongside it. Labels this job
+      # manages are also removed when the title stops implying them, so an edited
+      # title never leaves a stale type behind.
+      - name: Derive the type label from the PR title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const TYPES = ["feat", "fix", "docs", "refactor", "chore", "test", "ci", "revert"];
+            const BREAKING = "breaking";
+            // Only consulted when a label is missing from the repository, so a
+            // freshly generated repo labels its first PR correctly.
+            const COLORS = Object.fromEntries(TYPES.map((type) => [type, "b3c5d7"]));
+            COLORS[BREAKING] = "b60205";
+
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            // A fork PR gets a read-only token, so labelling would fail the run.
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.warning("PR is from a fork; skipping labelling (the token is read-only).");
+              return;
+            }
+
+            const match = /^([a-z]+)(\([^)]*\))?(!)?:\s/.exec(pr.title);
+            if (!match) {
+              core.setFailed(`PR title is not a conventional commit: ${pr.title}`);
+              return;
+            }
+            const [, type, , breaking] = match;
+            if (!TYPES.includes(type)) {
+              core.setFailed(`"${type}" is not one of the allowed types: ${TYPES.join(", ")}`);
+              return;
+            }
+
+            const managed = new Set([...TYPES, BREAKING]);
+            const desired = new Set([type, ...(breaking ? [BREAKING] : [])]);
+            const current = new Set(pr.labels.map((label) => label.name).filter((name) => managed.has(name)));
+
+            const add = [...desired].filter((name) => !current.has(name));
+            const remove = [...current].filter((name) => !desired.has(name));
+
+            for (const name of add) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({ owner, repo, name, color: COLORS[name] });
+                core.info(`Created missing label "${name}"`);
+              }
+            }
+            if (add.length > 0) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: add });
+            }
+            for (const name of remove) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+            }
+            core.info(`${pr.title}\n  added:   ${add.join(", ") || "—"}\n  removed: ${remove.join(", ") || "—"}`);

--- a/packages/summon/monorepo/src/templates/renovate.json.ejs
+++ b/packages/summon/monorepo/src/templates/renovate.json.ejs
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["before 9am on monday"],
-  "labels": ["Maintenance 🔨"],
   "semanticCommits": "enabled",
   "packageRules": [
     {

--- a/scripts/one-time-only/migrate-labels.sh
+++ b/scripts/one-time-only/migrate-labels.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Migrates the repository label set to the taxonomy in docs/references/LABELS.md.
+# Run once, after the PR that lands the taxonomy is merged. Safe to re-run: every
+# step is idempotent and skips work that is already done.
+#
+# `gh label edit --name` RENAMES in place, so a rename keeps the label on every PR
+# and issue that already carries it — history is preserved, not rewritten.
+#
+# Requires: gh, authenticated with write access to the repository.
+set -euo pipefail
+
+DERIVED_COLOR="b3c5d7"
+
+rename() { # rename <old> <new> [color]
+  if gh label list --limit 200 --json name --jq '.[].name' | grep -qxF "$1"; then
+    echo "rename: $1 -> $2"
+    gh label edit "$1" --name "$2" ${3:+--color "$3"}
+  else
+    echo "rename: $1 not present, skipping"
+  fi
+}
+
+create() { # create <name> <color> [description]
+  echo "create: $1"
+  gh label create "$1" --color "$2" ${3:+--description "$3"} --force
+}
+
+remove() { # remove <name>
+  if gh label list --limit 200 --json name --jq '.[].name' | grep -qxF "$1"; then
+    echo "delete: $1"
+    gh label delete "$1" --yes
+  else
+    echo "delete: $1 not present, skipping"
+  fi
+}
+
+echo "== Types: renamed to the conventional-commit vocabulary =="
+# Renamed rather than recreated so the ~240 PRs carrying them keep their label.
+rename "Feature 🎁"          "feat"      "$DERIVED_COLOR"
+rename "Bug 🐛"              "fix"       "$DERIVED_COLOR"
+rename "Documentation 📝"    "docs"      "$DERIVED_COLOR"
+rename "Maintenance 🔨"      "chore"     "$DERIVED_COLOR"
+rename "Breaking Change 💣"  "breaking"  "b60205"
+# `refactor`, `test` and `ci` split out of the old `Maintenance 🔨` bucket, and
+# `revert` is new — no existing label maps onto them.
+create "refactor" "$DERIVED_COLOR" "Derived from the PR title"
+create "test"     "$DERIVED_COLOR" "Derived from the PR title"
+create "ci"       "$DERIVED_COLOR" "Derived from the PR title"
+create "revert"   "$DERIVED_COLOR" "Derived from the PR title"
+
+echo "== Chromatic gate: renamed, keeping it on the 145 PRs that use it =="
+rename "no visual change" "Chromatic: skip" "bfdadc"
+
+echo "== Review: consistent casing, unused polarities dropped =="
+rename "Review: Code needed"      "Review: code needed"
+rename "Review: A11y needed"      "Review: a11y needed"
+rename "Review: Design needed"    "Review: design needed"
+rename "Review: Chromatic Needed" "Review: Chromatic needed"
+rename "Review: Code +1"          "Review: code +1"
+rename "Review: A11y +1"          "Review: a11y +1"
+rename "Review: Design +1"        "Review: design +1"
+# Zero uses across ~800 PRs and issues; GitHub's "Request changes" covers rejection.
+for discipline in "Code" "QA" "A11y" "UX" "Design" "Chromatic"; do
+  remove "Review: ${discipline} -1"
+done
+remove "Review: Code +1 (with changes)"
+
+echo "== Status and priority: namespaced =="
+rename "Blocked"      "Status: blocked"
+rename "do not merge" "Status: do not merge"
+rename "question"     "Status: question" "cdcdcd"
+remove "Don't merge"  # zero uses; duplicate of `do not merge`
+rename "Priority: Low"      "Priority: low"
+rename "Priority: Moderate" "Priority: medium"
+rename "Priority: High"     "Priority: high"
+
+echo "== Topic: migration trains =="
+create "Topic: design tokens" "8250df" "Part of the design-token migration"
+
+echo "== Superseded =="
+remove "Dependencies"  # zero uses; Renovate titles its PRs chore(deps): …
+# `feat` exists by now, so `enhancement` cannot be renamed onto it — move the items
+# that carry it across first, then drop the duplicate.
+gh issue list --state all --limit 200 --label "enhancement" --json number --jq '.[].number' |
+  while read -r number; do
+    echo "  issue #$number: enhancement -> feat"
+    gh issue edit "$number" --add-label "feat" --remove-label "enhancement"
+  done
+remove "enhancement"
+
+echo "== Backfill: derive the type label for every open PR =="
+# New PRs get this from pr-lint.yml; open PRs predate it.
+gh pr list --state open --limit 200 --json number,title --jq '.[] | "\(.number)\t\(.title)"' |
+  while IFS=$'\t' read -r number title; do
+    type="$(sed -nE 's/^([a-z]+)(\([^)]*\))?(!)?:[[:space:]].*/\1/p' <<<"$title")"
+    [[ -z "$type" ]] && { echo "  #$number: title is not conventional, skipping"; continue; }
+    labels="$type"
+    [[ "$title" =~ ^[a-z]+(\([^\)]*\))?! ]] && labels="$labels,breaking"
+    echo "  #$number: $labels"
+    gh pr edit "$number" --add-label "$labels"
+  done
+
+echo "== Backfill: the design-token migration train =="
+for pr in 940 941 942 943 944 945 946 947 948 950 954 \
+          888 890 892 920 922 925 927 929 938 949; do
+  gh pr edit "$pr" --add-label "Topic: design tokens"
+done
+
+echo "Done. Verify with: gh label list --limit 100"


### PR DESCRIPTION
## Done

Written by Opus 5 under @advl 's instructions

**This is a proposal, opened for discussion — let's not merge it before we've agreed on the taxonomy.** The code is complete and working, so it's easier to argue about something concrete than about a doc.

### The problem

PR titles in this repo are already strict: `pr-lint.yml` validates every one against Conventional Commits, and **300/300 of the last merged PRs comply**. Labels are the opposite — a checkbox in the PR template that nobody is reminded about:

- **50 of the last 150 merged PRs (33%) carry no type label at all.**
- **78 of 300 have a title prefix that disagrees with their labels** — `feat(…)` merged with no `Feature 🎁`, `refactor(cli)!:` labelled only `Breaking Change 💣`.
- `refactor` has no label at all. Of 32 merged refactors: 14 got `Maintenance 🔨`, 10 got nothing, 7 got only `Breaking Change 💣`.
- `Maintenance 🔨` is a bucket for four different types — `refactor`, `chore`, `test`, `ci` — which together are **23% of all merged work**.
- `Breaking Change 💣` is used *instead of* a type rather than alongside it, so a breaking PR loses its type entirely.
- The lint passes no `types:` input, so it accepts commitlint's full default list. `build`, `perf`, `style` and `revert` are legal titles today with no label to match.
- 13 labels have **zero uses** across ~800 PRs and issues (every `Review: … -1`, `Review: Code +1 (with changes)`, `Don't merge`, `Dependencies`).

The pattern behind all of it: the only label that gets applied reliably is `no visual change` (145 uses), because it's the only one that *does* something — it gates Chromatic. Labels people can't feel don't get applied.

### The proposal

One rule decides everything:

> **A bare lowercase label is derived from the PR title. A `Namespace: value` label is a human judgement.**

The type is already in the title, so CI derives it instead of asking a human to restate it. `feat(router)!: …` gets `feat` + `breaking`; edit the title and the labels follow. The full set, the colour system and the rationale are in **[`docs/references/LABELS.md`](docs/references/LABELS.md)**.

| | |
| --- | --- |
| **Derived** (slate, machine-owned) | `feat` `fix` `docs` `refactor` `chore` `test` `ci` `revert` `breaking` |
| **CI directive** | `Chromatic: skip` (was `no visual change`) |
| **Review** | `Review: {code,QA,design,a11y,UX,Chromatic} {needed,+1}` |
| **Status** | `Status: blocked` `Status: do not merge` `Status: question` |
| **Priority** | `Priority: {low,medium,high}` |
| **Topic** | `Topic: design tokens` — for migration trains that span many PRs |
| **Exception** | `good first issue`, kept verbatim because GitHub treats that exact name specially |

36 labels → 30, and every survivor has either usage evidence or a functional role.

### What's in the diff

- **`.github/workflows/pr-lint.yml`** — pins `types:` to the closed vocabulary, then derives the label from the title in a second job. Adds *and removes* the labels it manages, so an edited title never leaves a stale type behind. Creates a label that doesn't exist yet, so a freshly generated repo labels its first PR correctly. Skips fork PRs, whose token is read-only.
- **`chromatic._template.yml`** — the gate accepts `Chromatic: skip` *and* `no visual change`, so the rename needs no atomic cutover in either merge order. The 16 chromatic workflows inherit this from the one reusable template.
- **`scripts/one-time-only/migrate-labels.sh`** — the whole migration, idempotent. Uses `gh label edit --name`, which **renames in place**: every PR and issue keeps its label and history stays intact. Backfills the type label on all open PRs, and `Topic: design tokens` on the 21 PRs of that train.
- **`docs/references/LABELS.md`** — the taxonomy, the colour system, and a table of what was removed with the evidence for each.
- **PR template, `AGENTS.md`, Renovate config** — the type label is no longer a human step, so it stops being asked for. Renovate drops its hard-coded `Maintenance 🔨`; `chore(deps): …` derives `chore` on its own.
- **`packages/summon/monorepo/`** — the same workflow and PR template ship to every generated monorepo, so new repos start consistent instead of inheriting the drift. (`summon/package` has no `pr-lint`, so it's untouched.)
- **`.jira_sync_config.yaml`** — `enhancement` was a duplicate of `Feature 🎁`; the mapping moves to `feat: Story`.

### Worth arguing about

1. **One colour for all derived types, or a colour each?** They're slate here on the argument that a derived label is an index for filtering, not a signal that needs attention — colour is reserved for human judgements. This is the change most likely to feel like a downgrade, and it's one line in the script.
2. **Deleting the six `Review: … -1` labels.** Zero uses ever; GitHub's "Request changes" is the native mechanism. But it is a process change, so it's the team's call, not mine.
3. **`revert` is in the allowed types** with zero historical uses, because being blocked by the title lint mid-incident is a bad trade. `perf`, `build` and `style` are deliberately left out — `chore` covers them.
4. **Renaming `no visual change`** is the most-used label (145). The gate accepts both names so nothing breaks, but muscle memory is a real cost — happy to drop this one item and keep the name.

## QA

- `pr-lint.yml` and `chromatic._template.yml` parse as valid YAML; both Renovate configs still parse as JSON.
- `packages/summon/monorepo` tests pass (22/22) — the generator asserts the template file list, which is unchanged.
- **The label derivation itself is unverified until this PR runs it.** The first real check is this PR's own CI: the title is `chore(labels): …`, so `apply-type-label` should put `chore` on it and nothing else.

### Merge checklist

- [ ] Team agrees on the taxonomy (points 1–4 above)
- [ ] Merge
- [ ] Run `scripts/one-time-only/migrate-labels.sh` once — until it runs, the old label names simply stay in place and CI creates the new ones as PRs land
- [ ] Follow-up PR drops the `no visual change` clause from the Chromatic gate once the rename is done

---
🤖 Drafted with [Claude Code](https://claude.com/claude-code)
