### PR TITLE
feat(pragma-cli): CLI standards conformance

### DIFF
--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -276,7 +276,7 @@ pragma create package --name @canonical/my-tool --no-run-install
 
 Check environment health — Node, config, store, MCP, and skills.
 
-Runs nine diagnostic checks and reports pass/fail/skip with inline remedies. Storeless by default; the store check boots lazily and never fails the run.
+Runs nine diagnostic checks and reports pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Storeless by default; the store check boots lazily and never fails the run.
 
 ```
 pragma doctor

--- a/packages/cli/pragma/docs/reference/errors.md
+++ b/packages/cli/pragma/docs/reference/errors.md
@@ -45,7 +45,7 @@ Every `error.code` in a failure envelope is one of the following:
 | `INVALID_INPUT` | An argument was malformed, out of range, or the wrong shape. |
 | `AMBIGUOUS_INPUT` | A name resolved to several entities (reserved; not yet raised). |
 | `UNKNOWN_VERB` | The command noun or verb is not recognized. |
-| `STORE_UNAVAILABLE` | The local store could not be reached or is not built. |
-| `CONFIG_ERROR` | The layered configuration could not be resolved. |
-| `INTERNAL_ERROR` | An unexpected failure — please report it. |
+| `STORE_UNAVAILABLE` | The local store cannot be reached or is not built. |
+| `CONFIG_ERROR` | The layered configuration cannot be resolved. |
+| `INTERNAL_ERROR` | An unexpected failure — report it as a bug. |
 | `UNSUPPORTED` | A capability is unavailable in this build or environment. |

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -142,7 +142,7 @@ Mutation — plan-first (set `confirm: true` to apply). Non-destructive.
 
 ### doctor
 
-Runs nine diagnostic checks and reports pass/fail/skip with inline remedies. Storeless by default; the store check boots lazily and never fails the run.
+Runs nine diagnostic checks and reports pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Storeless by default; the store check boots lazily and never fails the run.
 
 Read-only.
 

--- a/packages/cli/pragma/src/capabilities/capabilities/hints.ts
+++ b/packages/cli/pragma/src/capabilities/capabilities/hints.ts
@@ -115,7 +115,7 @@ export const TOOL_HINTS: Record<string, ToolHint> = {
   },
   skill_list: {
     category: "read",
-    use_when: "Discovering agent skills provided by installed packages",
+    use_when: "Discovering agent skills provided by installed packs",
   },
   skill_lookup: {
     category: "read",

--- a/packages/cli/pragma/src/capabilities/create/create.verb.ts
+++ b/packages/cli/pragma/src/capabilities/create/create.verb.ts
@@ -201,9 +201,9 @@ async function loadCreateRuntime() {
       throw new PragmaError({
         code: "UNSUPPORTED",
         message:
-          "`create` cannot load its generator runtime — the `@canonical/summon-*` packages it depends on could not be resolved.",
+          "`create` cannot load its generator runtime — the `@canonical/summon-*` packages it depends on are missing from this install.",
         recovery: {
-          message: `Reinstall ${BIN_NAME}; its generator dependencies look missing.`,
+          message: `Reinstall ${BIN_NAME} to restore its generator dependencies.`,
         },
       });
     }

--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkKeStore.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkKeStore.ts
@@ -4,7 +4,9 @@ import type { PragmaRuntime } from "../../../kernel/runtime/types.js";
 import type { CheckResult } from "../types.js";
 
 /**
- * Check that the ke store boots, reporting the entity total and boot time.
+ * Check that the local store boots, reporting the entity total and boot time.
+ * The check is NAMED "store" in the report — the same word every other surface
+ * uses for it; the ke library it boots through is an implementation detail.
  *
  * This is the ONE check that touches the store — it boots the shared lazy store
  * inside a try/catch, so doctor stays storeless-by-default at the dispatch level
@@ -24,15 +26,15 @@ export async function checkKeStore(rt: PragmaRuntime): Promise<CheckResult> {
     const total = entityTotal(session.index);
     const elapsed = Math.round(performance.now() - start);
     return {
-      name: "ke store",
+      name: "store",
       status: "pass",
       detail: `${total.toLocaleString()} entities in ${elapsed}ms`,
     };
   } catch {
     return {
-      name: "ke store",
+      name: "store",
       status: "fail",
-      detail: "failed to boot",
+      detail: "cannot boot",
       remedy: `Ensure design-system packs are configured and run \`${BIN_NAME} sources update\`.`,
     };
   }

--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkMcpConfigured.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkMcpConfigured.ts
@@ -11,8 +11,15 @@ import { deriveBand } from "./deriveBand.js";
  * Cursor ⇒ project), not the check name — so a global-scope harness is not
  * mislabeled PROJECT.
  *
+ * MCP registration is OPT-IN, so its tiers are honest about fault: harnesses
+ * detected with nothing configured is `available` (nothing is broken — the
+ * setup command is the remedy), no harnesses at all is `skip` (nothing to
+ * configure, same as the skills check), and only a broken detection is a
+ * `fail`.
+ *
  * @param cwd - The project root to detect harnesses against.
- * @returns A CheckResult listing configured harnesses, or fail with a remedy.
+ * @returns A CheckResult listing configured harnesses, available with the
+ *   setup remedy when none is, or skip when no harness is present.
  * @note Impure — detects harnesses and reads their MCP configs.
  */
 export async function checkMcpConfigured(cwd: string): Promise<CheckResult> {
@@ -31,9 +38,8 @@ export async function checkMcpConfigured(cwd: string): Promise<CheckResult> {
   if (detected.length === 0) {
     return {
       name: "MCP configured",
-      status: "fail",
+      status: "skip",
       detail: "no AI harnesses detected",
-      remedy: `${BIN_NAME} setup mcp`,
     };
   }
 
@@ -60,8 +66,8 @@ export async function checkMcpConfigured(cwd: string): Promise<CheckResult> {
   const names = detected.map((d) => d.harness.name).join(", ");
   return {
     name: "MCP configured",
-    status: "fail",
-    detail: `detected ${names} but ${MCP_SERVER_NAME} not configured`,
+    status: "available",
+    detail: `not set up for ${names}`,
     remedy: `${BIN_NAME} setup mcp`,
     band: deriveBand(detected),
   };

--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkShellCompletions.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkShellCompletions.test.ts
@@ -79,10 +79,10 @@ describe("checkShellCompletions — effect test (gate 1)", () => {
 });
 
 describe("checkShellCompletions — install probe (gate 2)", () => {
-  it("fails when $SHELL is set but no script is installed", async () => {
+  it("a never-installed script is available (opt-in, not a fault) with the setup command", async () => {
     process.env.SHELL = "/usr/bin/bash";
     const result = await checkShellCompletions(tmp());
-    expect(result.status).toBe("fail");
+    expect(result.status).toBe("available");
     expect(result.detail).toMatch(/not installed/);
     expect(result.remedy).toBe("pragma setup completions");
   });

--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkShellCompletions.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkShellCompletions.ts
@@ -97,10 +97,16 @@ async function completeProbe(cwd: string): Promise<number> {
  * 3. For zsh, `~/.zfunc` is on `$fpath` — the activation step setup can only
  *    hint. Installed-but-unwired reports a distinct remedy.
  *
+ * Fault tiers: a broken resolver, a stale installed script, or an unwired zsh
+ * install are `fail` — something that exists does not work. A script that was
+ * never installed is `available`: completions are opt-in and a fresh install
+ * is healthy without them.
+ *
  * @param cwd - The project directory (the resolver's entity seam, and the
  *   `completion` config gate 2 renders this project's body from).
- * @returns A CheckResult: pass (up to date + wired + answering), fail (with the
- *   attributable remedy), or skip (shell undetected).
+ * @returns A CheckResult: pass (up to date + wired + answering), available
+ *   (never installed, with the setup remedy), fail (with the attributable
+ *   remedy), or skip (shell undetected).
  * @note Impure — reads `$SHELL`, the install path, the config layers, `.zshrc`,
  *   and drives the storeless resolver.
  */
@@ -137,9 +143,13 @@ export async function checkShellCompletions(cwd: string): Promise<CheckResult> {
     };
   }
   if (state === "absent") {
+    // Never installed is `available`, not a fault: completions are opt-in and
+    // a fresh install is healthy without them. An INSTALLED script that is
+    // out of date or unwired (below) is the real failure — something the user
+    // set up no longer works.
     return {
       name: NAME,
-      status: "fail",
+      status: "available",
       detail: `resolver OK; ${shell} script not installed`,
       remedy: INSTALL_REMEDY,
     };

--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkSkillsSymlinked.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkSkillsSymlinked.ts
@@ -9,8 +9,13 @@ import type { CheckResult } from "../types.js";
  * Check that a skills directory exists for each detected AI harness. Skipped
  * when no harnesses are detected.
  *
+ * Skills symlinks are OPT-IN: a harness with no skills directory is
+ * `available` (the setup command is the remedy), not a fault — a fresh
+ * install has none and is healthy. Only a broken detection is a `fail`.
+ *
  * @param cwd - The project root to detect harnesses against.
- * @returns A CheckResult indicating pass, fail (with a remedy), or skip.
+ * @returns A CheckResult indicating pass, available (with the setup remedy),
+ *   fail, or skip.
  * @note Impure — detects harnesses and probes the filesystem.
  */
 export async function checkSkillsSymlinked(cwd: string): Promise<CheckResult> {
@@ -54,8 +59,8 @@ export async function checkSkillsSymlinked(cwd: string): Promise<CheckResult> {
 
   return {
     name: "Skills symlinked",
-    status: "fail",
-    detail: `missing for ${missing.join(", ")}`,
+    status: "available",
+    detail: `not set up for ${missing.join(", ")}`,
     remedy: `${BIN_NAME} setup skills`,
   };
 }

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.render.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.render.test.ts
@@ -29,8 +29,8 @@ const BANDED_DATA: DoctorData = {
     },
     {
       name: "MCP configured",
-      status: "fail",
-      detail: "detected Windsurf but pragma not configured",
+      status: "available",
+      detail: "not set up for Windsurf",
       remedy: "pragma setup mcp",
       band: "global",
     },
@@ -42,11 +42,12 @@ const BANDED_DATA: DoctorData = {
     },
   ],
   passed: 2,
-  failed: 1,
+  failed: 0,
+  available: 1,
   skipped: 1,
 };
 
-/** A fixture spanning pass/fail/skip, sub-items, and a remedy — every color path. */
+/** A fixture spanning every status tier, sub-items, and remedies — every color path. */
 const COLOR_DATA: DoctorData = {
   checks: [
     { name: "Node version", status: "pass", detail: "v24" },
@@ -60,10 +61,17 @@ const COLOR_DATA: DoctorData = {
       ],
       remedy: "pragma sources update",
     },
+    {
+      name: "Shell completions",
+      status: "available",
+      detail: "resolver OK; zsh script not installed",
+      remedy: "pragma setup completions",
+    },
     { name: "Skills symlinked", status: "skip", detail: "no harness" },
   ],
   passed: 1,
   failed: 1,
+  available: 1,
   skipped: 1,
 };
 
@@ -112,7 +120,7 @@ describe("doctor render — banded plain report", () => {
     expect(at("Global")).toBeLessThan(at("Shell completions"));
     expect(at("MCP configured")).toBeLessThan(at("Project"));
     expect(at("Project")).toBeLessThan(at("Skills symlinked"));
-    // A failing banded check keeps its inline remedy under its band.
+    // An available banded check keeps its inline setup command under its band.
     expect(out).toContain("fix: pragma setup mcp");
     // The tally closes the report.
     expect(out).toContain("2 passed");
@@ -131,7 +139,7 @@ describe("doctor render — banded llm report", () => {
     expect(at("### Global")).toBeLessThan(at("Shell completions"));
     expect(at("Shell completions")).toBeLessThan(at("### Project"));
     expect(at("### Project")).toBeLessThan(at("Skills symlinked"));
-    expect(out).toContain("_2 passed, 1 failed, 1 skipped_");
+    expect(out).toContain("_2 passed, 0 failed, 1 available, 1 skipped_");
   });
 });
 
@@ -152,9 +160,12 @@ describe("doctor render — piped output is ANSI-free (F1)", () => {
       expect(out).toContain("pragma doctor");
       expect(out).toContain("✓  Node version");
       expect(out).toContain("✗  pack refs");
+      expect(out).toContain("◇  Shell completions");
       expect(out).toContain("○  Skills symlinked");
       expect(out).toContain("↳ fix: pragma sources update");
-      expect(out).toContain("  1 passed · 1 failed · 1 skipped");
+      // The available tier keeps its setup command inline, like a fail's fix.
+      expect(out).toContain("↳ fix: pragma setup completions");
+      expect(out).toContain("  1 passed · 1 failed · 1 available · 1 skipped");
     });
   });
 });

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.render.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.render.ts
@@ -17,10 +17,17 @@ import type { Formatters } from "../../kernel/spec/types.js";
 import { BAND_LABELS } from "../shared/bands.js";
 import type { CheckResult, CheckStatus, DoctorData } from "./types.js";
 
-/** Uncolored status glyphs — tinted at render time (never baked at module load). */
+/**
+ * Uncolored status glyphs — tinted at render time (never baked at module load).
+ * `available` gets its own glyph, distinct from ✗: an opt-in integration that
+ * is not set up is not a fault, and rendering it as one would train users to
+ * ignore the failure count. The glyph pairs with the word in the tally, so the
+ * distinction survives with color stripped.
+ */
 const STATUS_GLYPHS: Record<CheckStatus, string> = {
   pass: "✓",
   fail: "✗",
+  available: "◇",
   skip: "○",
 };
 
@@ -48,11 +55,16 @@ function doctorStyle(): DoctorStyle {
   };
 }
 
-/** Tint a status glyph by meaning — green pass, red fail, yellow skip. */
+/**
+ * Tint a status glyph by meaning — green pass, red fail, cyan available
+ * (actionable-but-optional, the same tint as the `fix:` arrow it points at),
+ * yellow skip.
+ */
 function paintGlyph(status: CheckStatus, style: DoctorStyle): string {
   const glyph = STATUS_GLYPHS[status];
   if (status === "pass") return style.green(glyph);
   if (status === "fail") return style.red(glyph);
+  if (status === "available") return style.cyan(glyph);
   return style.yellow(glyph);
 }
 
@@ -89,7 +101,12 @@ function formatCheckPlain(
     }
   }
 
-  if (check.status === "fail" && check.remedy) {
+  // Both actionable tiers keep their inline instruction: a fail's remedy is
+  // the repair, an available's remedy is the setup command that enables it.
+  if (
+    (check.status === "fail" || check.status === "available") &&
+    check.remedy
+  ) {
     lines.push(
       `${INDENT}${style.cyan(FIX_ARROW)} ${style.cyan("fix:")} ${check.remedy}`,
     );
@@ -98,13 +115,22 @@ function formatCheckPlain(
   return lines;
 }
 
-/** Render the pass/fail/skip tally, coloring non-zero fail/skip. */
+/**
+ * Render the pass/fail/available/skip tally, coloring the non-zero counts.
+ * `available` is counted apart from `failed` so a healthy install with
+ * integrations left to opt into never reports failures it does not have.
+ */
 function formatSummary(data: DoctorData, style: DoctorStyle): string {
   const parts = [style.green(`${data.passed} passed`)];
   parts.push(
     data.failed > 0
       ? style.red(`${data.failed} failed`)
       : style.dim(`${data.failed} failed`),
+  );
+  parts.push(
+    data.available > 0
+      ? style.cyan(`${data.available} available`)
+      : style.dim(`${data.available} available`),
   );
   parts.push(
     data.skipped > 0
@@ -155,22 +181,20 @@ export const doctorFormatters: Formatters<DoctorData> = {
 
   llm(data) {
     const renderCheck = (check: CheckResult): string[] => {
-      const icon =
-        check.status === "pass" ? "✓" : check.status === "fail" ? "✗" : "○";
-      const out = [`- ${icon} **${check.name}**: ${check.detail}`];
+      const out = [
+        `- ${STATUS_GLYPHS[check.status]} **${check.name}**: ${check.detail}`,
+      ];
       for (const item of check.items ?? []) {
-        const itemIcon =
-          item.status === "pass"
-            ? "✓ "
-            : item.status === "fail"
-              ? "✗ "
-              : item.status === "skip"
-                ? "○ "
-                : "";
+        const itemIcon = item.status ? `${STATUS_GLYPHS[item.status]} ` : "";
         const detail = item.detail ? `: ${item.detail}` : "";
         out.push(`  - ${itemIcon}${item.label}${detail}`);
       }
-      if (check.status === "fail" && check.remedy) {
+      // Same rule as the plain path: fail and available both carry their
+      // inline instruction (the repair, or the setup command).
+      if (
+        (check.status === "fail" || check.status === "available") &&
+        check.remedy
+      ) {
         out.push(`  - _fix:_ \`${check.remedy}\``);
       }
       return out;
@@ -188,7 +212,7 @@ export const doctorFormatters: Formatters<DoctorData> = {
     section(BAND_LABELS.project, project);
     lines.push(
       "",
-      `_${data.passed} passed, ${data.failed} failed, ${data.skipped} skipped_`,
+      `_${data.passed} passed, ${data.failed} failed, ${data.available} available, ${data.skipped} skipped_`,
     );
     return lines.join("\n");
   },

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
@@ -3,9 +3,9 @@
  *
  * Runs against isolated HOME/cwd/XDG so the harness/config/completion checks are
  * deterministic (no harnesses, no config, no rc files). Covers the shape, a
- * representative pass/fail/skip spread, the store check (down via an injected
- * throwing store; up via the canonical fixture), exit 0 despite failures, and
- * the MCP read-only envelope.
+ * representative pass/fail/available/skip spread, the store check (down via an
+ * injected throwing store; up via the canonical fixture), exit 0 despite
+ * failures, and the MCP read-only envelope.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -115,9 +115,9 @@ describe("doctor — shape & spread", () => {
   it("returns 9 checks whose tallies sum, each with a valid status", async () => {
     const data = await runChecks(bootRuntime(FLAGS, tmp("pragma-proj-")));
     expect(data.checks).toHaveLength(9);
-    expect(data.passed + data.failed + data.skipped).toBe(9);
+    expect(data.passed + data.failed + data.available + data.skipped).toBe(9);
     for (const check of data.checks) {
-      expect(["pass", "fail", "skip"]).toContain(check.status);
+      expect(["pass", "fail", "available", "skip"]).toContain(check.status);
     }
     // Deterministic under the isolated env.
     expect(byName(data, "Node version")?.status).toBe("pass");
@@ -127,8 +127,9 @@ describe("doctor — shape & spread", () => {
     expect(pkgRefs?.status).toBe("pass");
     expect(pkgRefs?.detail).toContain("embedded snapshot @ ");
     expect(pkgRefs?.remedy).toBeUndefined();
-    // No harnesses in an empty HOME/cwd — attributable fail + skips.
-    expect(byName(data, "MCP configured")?.status).toBe("fail");
+    // No harnesses in an empty HOME/cwd — nothing to check, so all three
+    // harness checks skip (none of this is a fault).
+    expect(byName(data, "MCP configured")?.status).toBe("skip");
     expect(byName(data, "Skills symlinked")?.status).toBe("skip");
     expect(byName(data, "MCP commands")?.status).toBe("skip");
     // No project/global config in the isolated XDG.
@@ -234,5 +235,22 @@ describe("doctor — MCP checks band by detected harness scope, not check name",
     expect(check.status).toBe("pass");
     expect(check.detail).toContain("Windsurf");
     expect(check.band).toBe("global"); // NOT the old static "project"
+  });
+});
+
+describe("doctor — an unconfigured opt-in integration is available, not a fault", () => {
+  it("a detected harness with no MCP entry reports available with the setup command", async () => {
+    // Windsurf is detected (project signal) but nothing is configured. A fresh
+    // install lands exactly here, and a fresh install is healthy — so this is
+    // the `available` tier, keeping its actionable setup command, and it must
+    // never inflate the failure count.
+    const cwd = tmp("pragma-doctor-proj-");
+    mkdirSync(join(cwd, ".windsurf"), { recursive: true }); // ⇒ Windsurf detected
+
+    const check = await checkMcpConfigured(cwd);
+    expect(check.status).toBe("available");
+    expect(check.detail).toContain("not set up for");
+    expect(check.detail).toContain("Windsurf");
+    expect(check.remedy).toBe("pragma setup mcp");
   });
 });

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
@@ -170,9 +170,9 @@ describe("doctor — the store check", () => {
   it("a store that fails to boot is an attributable fail, not a crash", async () => {
     const data = await runChecks(throwingStoreRuntime(tmp("pragma-proj-")));
     expect(data.checks).toHaveLength(9);
-    const keStore = byName(data, "ke store");
-    expect(keStore?.status).toBe("fail");
-    expect(keStore?.remedy).toBeTruthy();
+    const store = byName(data, "store");
+    expect(store?.status).toBe("fail");
+    expect(store?.remedy).toBeTruthy();
   });
 
   it("a booted store passes with an entity total", async () => {
@@ -181,9 +181,9 @@ describe("doctor — the store check", () => {
       config: ALL_VISIBLE_CONFIG,
     });
     const data = await runChecks(fixture.runtime);
-    const keStore = byName(data, "ke store");
-    expect(keStore?.status).toBe("pass");
-    expect(keStore?.detail).toMatch(/entities/);
+    const store = byName(data, "store");
+    expect(store?.status).toBe("pass");
+    expect(store?.detail).toMatch(/entities/);
     await fixture.dispose();
   });
 });

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.verb.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.verb.ts
@@ -21,7 +21,7 @@ import type { DoctorData } from "./types.js";
 const doctorVerb: VerbSpec<Record<string, unknown>, DoctorData> = {
   path: ["doctor"],
   summary: "Check environment health — Node, config, store, MCP, and skills.",
-  doc: "Runs nine diagnostic checks and reports pass/fail/skip with inline remedies. Storeless by default; the store check boots lazily and never fails the run.",
+  doc: "Runs nine diagnostic checks and reports pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Storeless by default; the store check boots lazily and never fails the run.",
   params: [],
   output: { formatters: doctorFormatters },
   examples: [

--- a/packages/cli/pragma/src/capabilities/doctor/runChecks.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/runChecks.ts
@@ -59,7 +59,7 @@ function buildChecks(
     [`${BIN_NAME} version`, checkPragmaVersion(rt)],
     [`${BIN_NAME} config`, checkConfigFile(rt)],
     ["pack refs", checkPackageRefs(rt)],
-    ["ke store", checkKeStore(rt)],
+    ["store", checkKeStore(rt)],
     ["Shell completions", checkShellCompletions(rt.cwd)],
     ["MCP configured", checkMcpConfigured(rt.cwd)],
     ["MCP commands", checkMcpCommands(rt.cwd)],

--- a/packages/cli/pragma/src/capabilities/doctor/runChecks.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/runChecks.ts
@@ -95,6 +95,7 @@ export async function runChecks(rt: PragmaRuntime): Promise<DoctorData> {
     checks,
     passed: checks.filter((c) => c.status === "pass").length,
     failed: checks.filter((c) => c.status === "fail").length,
+    available: checks.filter((c) => c.status === "available").length,
     skipped: checks.filter((c) => c.status === "skip").length,
   };
 }

--- a/packages/cli/pragma/src/capabilities/doctor/types.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/types.ts
@@ -9,8 +9,19 @@
  */
 export type ScopeBand = "project" | "global";
 
-/** Status of a doctor check or one of its sub-items. */
-export type CheckStatus = "pass" | "fail" | "skip";
+/**
+ * Status of a doctor check or one of its sub-items.
+ *
+ * `available` is the tier between fail and skip that keeps the report honest:
+ * an opt-in integration (MCP registration, skills symlinks, a completion
+ * script) that is detected and installable but that the user has not set up.
+ * Nothing is broken — a fresh install is HEALTHY with several availables — so
+ * reporting these as `fail` would teach users that the failure count is noise.
+ * `fail` stays reserved for a real fault: something set up that no longer
+ * works, or an environment the CLI cannot run correctly in. `skip` remains
+ * "nothing to check here" (no shell detected, no harnesses present).
+ */
+export type CheckStatus = "pass" | "fail" | "available" | "skip";
 
 /**
  * A structured sub-item under a check — e.g. one resolved package under
@@ -35,7 +46,10 @@ export interface CheckResult {
   readonly detail: string;
   /** Optional structured breakdown, rendered as indented sub-items. */
   readonly items?: readonly CheckItem[];
-  /** Remedial instruction shown inline under a failing check. */
+  /**
+   * Remedial instruction shown inline under the check: for `fail` the fix,
+   * for `available` the setup command that enables the integration.
+   */
   readonly remedy?: string;
   /**
    * Which config band the check concerns, if any: `global` for the user/home
@@ -47,10 +61,12 @@ export interface CheckResult {
   readonly band?: ScopeBand;
 }
 
-/** Aggregated results from all doctor checks. */
+/** Aggregated results from all doctor checks — one count per status tier. */
 export interface DoctorData {
   readonly checks: readonly CheckResult[];
   readonly passed: number;
   readonly failed: number;
+  /** Opt-in integrations detected but not set up — counted apart from failures. */
+  readonly available: number;
   readonly skipped: number;
 }

--- a/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
+++ b/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
@@ -85,7 +85,7 @@ const listVerb = (pack: PackDefinition): VerbSpec =>
 const PACK_LISTS: readonly { pack: PackDefinition; hint: RegExp }[] = [
   { pack: storyFor("modifier"), hint: /pragma sources update/ },
   { pack: storyFor("token"), hint: /pragma sources update/ },
-  { pack: storyFor("standard"), hint: /broaden your filter/ },
+  { pack: storyFor("standard"), hint: /broaden the filter/ },
 ];
 
 const REAL = { dryRun: false, undo: false, yes: false };

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupCompletions.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupCompletions.ts
@@ -123,9 +123,7 @@ export async function detectCompletions(
  */
 export function composeCompletions(d: CompletionsDetection): Task<void> {
   if (d.shell === null || d.path === null || d.script === null) {
-    return warn(
-      "Could not detect your shell — set $SHELL to zsh, bash, or fish.",
-    );
+    return warn("Cannot detect your shell — set $SHELL to zsh, bash, or fish.");
   }
   const { path, script, shell, state } = d;
   const opening =

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
@@ -103,7 +103,7 @@ const selectChosenGroups = (
 /**
  * The LSP-install step, guarded at its use site. An absent `bunx` (no Bun on
  * PATH) REJECTS the exec with ENOENT, which would otherwise collapse to
- * INTERNAL_ERROR ("please report this issue") at the CLI/MCP boundary;
+ * INTERNAL_ERROR ("report this issue") at the CLI/MCP boundary;
  * `guardMissingBinary` names it a UNSUPPORTED "`bunx` not found on PATH" with an
  * actionable install recovery instead. Preview-transparent — a dry-run mocks the
  * exec (no spawn) — and re-runnable (the guard is a `recover`, and `composeLsp`

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
@@ -199,7 +199,7 @@ export function skillsEmptyError(): PragmaError {
     message: "No skills found to link.",
     recovery: cliRecovery(
       "sources update",
-      `Add a design-system package that ships skills to your config, then run \`${BIN_NAME} sources update\` to install them.`,
+      `Add a design-system pack that ships skills to your config, then run \`${BIN_NAME} sources update\` to install them.`,
     ),
   });
 }

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -439,7 +439,7 @@ describe("setup lsp — missing-binary guard (bunx absent)", () => {
     // Drives the REAL composeLsp exec (YES — not a dry-run mock) with `bunx`
     // removed from PATH, so the spawn REJECTS with ENOENT. The reconciled guard
     // at composeLsp's use site names it; without the guard the raw reject
-    // collapses to INTERNAL_ERROR ("please report this issue") at the boundary.
+    // collapses to INTERNAL_ERROR ("report this issue") at the boundary.
     const prevPath = process.env.PATH;
     process.env.PATH = tmp("pragma-empty-path-"); // empty dir ⇒ bunx unresolvable
     let thrown: unknown;

--- a/packages/cli/pragma/src/capabilities/shared/assertExecOk.ts
+++ b/packages/cli/pragma/src/capabilities/shared/assertExecOk.ts
@@ -13,7 +13,7 @@
  * A denied `npm i -g` (EACCES), a registry/network failure, or any other
  * nonzero exit is a fixable ENVIRONMENT condition — NOT a pragma bug — so it is
  * classified UNSUPPORTED with an actionable recovery, never INTERNAL_ERROR's
- * "please report this issue". (A spawn error like ENOENT REJECTS the effect
+ * "report this issue". (A spawn error like ENOENT REJECTS the effect
  * instead of resolving, so it never reaches here.)
  */
 
@@ -40,7 +40,7 @@ export function assertExecOk(command: string, result: ExecResult): void {
     }`,
     recovery: {
       message:
-        "The command failed — often a permissions or network issue. Check the output above and retry (for a global install, try elevated privileges).",
+        "Check the command's output above; a global install may need elevated privileges.",
     },
   });
 }

--- a/packages/cli/pragma/src/capabilities/sources/runUpdate.ts
+++ b/packages/cli/pragma/src/capabilities/sources/runUpdate.ts
@@ -209,17 +209,17 @@ export async function buildUpdateTask(
   // prefix. Display-only, so a warning (not a hard failure) is the right call.
   for (const clash of detectPrefixClashes(inputs)) {
     report?.(
-      `Prefix "${clash.label}:" is declared with conflicting IRIs across packages (${clash.iris.join(" vs ")}); last wins, so some entities may compact to the wrong prefix.`,
+      `Prefix "${clash.label}:" is declared with conflicting IRIs across packs (${clash.iris.join(" vs ")}); last wins, so some entities may compact to the wrong prefix.`,
     );
   }
 
   report?.(`Building store from ${inputs.length} source(s)`);
   if (verbose) for (const input of inputs) report?.(`  parse ${input.path}`);
   if (stories.length > 0)
-    report?.(`Carrying ${stories.length} package read story file(s)`);
+    report?.(`Carrying ${stories.length} pack read story file(s)`);
 
   // Build the pack. On a parse/build failure, classify it as a NAMED data error
-  // (U6) — not INTERNAL_ERROR's "please report this issue" — identifying the
+  // (U6) — not INTERNAL_ERROR's "report this issue" — identifying the
   // offending package source, since ke's parser error carries only line/column.
   // With `--skip-invalid`, drop the unparseable sources (warning LOUDLY about
   // each — never a silent partial graph) and build from the rest instead of
@@ -262,7 +262,7 @@ export async function buildUpdateTask(
     );
     if (usableInputs.length === 0)
       throw PragmaError.configError(
-        `All ${inputs.length} configured source(s) failed to parse — nothing to build.`,
+        `None of the ${inputs.length} configured source(s) can be parsed — nothing to build.`,
         {
           recovery: cliRecovery(
             "sources update --verbose",
@@ -299,7 +299,7 @@ export async function buildUpdateTask(
       {
         recovery: cliRecovery(
           "sources update --verbose",
-          "Check that the package sources actually contain RDF triples, then re-run.",
+          "Check that the pack sources actually contain RDF triples, then re-run.",
         ),
       },
     );
@@ -415,12 +415,12 @@ export async function classifySourceBuildError(
   const culprit = await isolateBadSource(inputs);
   const detail = culprit?.message ?? parserMessage;
   const where = culprit
-    ? `Package source "${culprit.path}" could not be parsed`
-    : "The configured package sources could not be built into a store";
+    ? `Pack source "${culprit.path}" cannot be parsed`
+    : "The configured packs cannot be built into a store";
   return PragmaError.configError(`${where}: ${detail}`, {
     recovery: cliRecovery(
       "sources update --verbose",
-      "Re-run with --verbose to see each file as it parses. If a package ships malformed RDF, report it to that package's maintainer.",
+      "Re-run with --verbose to see each file as it parses. If a pack ships malformed RDF, report it to that pack's maintainer.",
     ),
   });
 }

--- a/packages/cli/pragma/src/capabilities/sources/sources.test.ts
+++ b/packages/cli/pragma/src/capabilities/sources/sources.test.ts
@@ -203,7 +203,7 @@ describe("sources update round-trip (PROTECTED)", () => {
   it("does not recurse into a symlinked directory cycle (L6 safety)", async () => {
     // The L6 fix follows symlinked FILES but must NOT recurse into a symlinked
     // DIRECTORY: a link to an ancestor dir is a cycle that, if walked, recurses
-    // without bound → a stack-overflow RangeError (an INTERNAL "please report").
+    // without bound → a stack-overflow RangeError (an INTERNAL "report").
     // The real `.ttl` is still ingested and the build completes.
     const pkg = tmp("pragma-symlink-cycle-");
     mkdirSync(join(pkg, "definitions"), { recursive: true });
@@ -502,7 +502,7 @@ describe("sources update — data-failure classification (U6)", () => {
     expect(err.message).toContain("bad-pkg/definitions/broken.ttl");
     // … carries the parser's own detail …
     expect(err.message.toLowerCase()).toContain("parser error");
-    // … and is NOT the internal-bug "please report this issue" path.
+    // … and is NOT the internal-bug "report this issue" path.
     expect(err.message).not.toContain("Internal error");
     expect(err.recovery?.message ?? "").not.toContain("report this issue");
     // The recovery points the user at a runnable, useful next step.

--- a/packages/cli/pragma/src/capabilities/upgrade/runUpgrade.ts
+++ b/packages/cli/pragma/src/capabilities/upgrade/runUpgrade.ts
@@ -61,9 +61,7 @@ export async function runUpgrade(
       executed: false,
     };
     return gen(function* () {
-      yield* $(
-        warn("Could not reach the registry — skipped the update check."),
-      );
+      yield* $(warn("Cannot reach the registry — skipped the update check."));
       return data;
     });
   }
@@ -97,7 +95,7 @@ export async function runUpgrade(
   const bin = parts[0] ?? "npm";
   const args = parts.slice(1);
   // Guard the spawn: an absent package manager (`bin` not on PATH) REJECTS the
-  // exec with ENOENT, which would collapse to INTERNAL_ERROR ("please report
+  // exec with ENOENT, which would collapse to INTERNAL_ERROR ("report
   // this issue"). Surface it as a named "`<pm>` not found on PATH" instead.
   return guardMissingBinary(
     bin,

--- a/packages/cli/pragma/src/capabilities/upgrade/upgrade.render.ts
+++ b/packages/cli/pragma/src/capabilities/upgrade/upgrade.render.ts
@@ -15,7 +15,7 @@ export const upgradeFormatters: Formatters<UpgradeData> = {
   plain(data) {
     const lines = [`Installed via: ${data.pm}`];
     if (data.offline) {
-      lines.push("Could not reach the registry — try again later.");
+      lines.push("Cannot reach the registry — try again later.");
       return lines.join("\n");
     }
     if (data.alreadyLatest) {
@@ -40,8 +40,7 @@ export const upgradeFormatters: Formatters<UpgradeData> = {
   },
 
   llm(data) {
-    if (data.offline)
-      return "Upgrade check failed: could not reach the registry.";
+    if (data.offline) return "Upgrade check failed: cannot reach the registry.";
     if (data.alreadyLatest) {
       return `Already at the latest version (${data.current}).`;
     }

--- a/packages/cli/pragma/src/capabilities/upgrade/upgrade.test.ts
+++ b/packages/cli/pragma/src/capabilities/upgrade/upgrade.test.ts
@@ -199,10 +199,10 @@ describe("assertExecOk — the exec-exitCode guard", () => {
     }
     const err = asPragmaError(thrown);
     // A denied `npm i -g` is user-fixable, NOT a bug — so it must not tell the
-    // user to "please report this issue" (that is INTERNAL_ERROR's recovery).
+    // user to "report this issue" (that is INTERNAL_ERROR's recovery).
     expect(err.code).toBe("UNSUPPORTED");
     expect(err.recovery?.message).not.toContain("report this issue");
-    expect(err.recovery?.message).toMatch(/permissions or network/i);
+    expect(err.recovery?.message).toMatch(/elevated privileges/i);
     // Surfaces the command + exit code + the captured stderr (trimmed).
     expect(err.message).toContain("npm i -g @canonical/pragma-cli");
     expect(err.message).toContain("code 13");
@@ -276,7 +276,7 @@ describe("upgrade — a failed exec maps to an actionable runtime error (exit 1)
 
   it("a missing-binary spawn (ENOENT) at a guarded site is a named UNSUPPORTED, not INTERNAL_ERROR", async () => {
     // The same wrapper `runUpgrade`/`setupLsp` apply: a spawn ENOENT REJECTS the
-    // exec, which used to collapse to INTERNAL_ERROR ("please report this issue").
+    // exec, which used to collapse to INTERNAL_ERROR ("report this issue").
     // `guardMissingBinary` names it instead.
     const thrown = await runToError(
       failVerbWith((_p, rt) =>

--- a/packages/cli/pragma/src/kernel/config/__snapshots__/firstRun.test.ts.snap
+++ b/packages/cli/pragma/src/kernel/config/__snapshots__/firstRun.test.ts.snap
@@ -2,9 +2,8 @@
 
 exports[`first run > greets on stderr and seeds the global config 1`] = `
 [
-  "Hello! Thanks for taking the time to try the pre-release pragma CLI.",
-  "Please file issues and feedback at https://github.com/canonical/pragma/issues.",
-  "pragma stores its configuration in <CONFIG> (just created with defaults).",
+  "pragma is pre-release — report issues at https://github.com/canonical/pragma/issues.",
+  "Configuration created with defaults at <CONFIG>.",
   "A \`pragma.config.ts\` in this directory or above it overrides it per project.",
   "",
 ]

--- a/packages/cli/pragma/src/kernel/config/evaluateProjectConfig.ts
+++ b/packages/cli/pragma/src/kernel/config/evaluateProjectConfig.ts
@@ -102,7 +102,7 @@ export async function evaluateProjectConfig(path: string): Promise<RawConfig> {
   const url = `${pathToFileURL(path).href}?v=${key}`;
   // Evaluating real TypeScript can throw for reasons `parseRawConfig` never sees:
   // a syntax error, a bad import, or a top-level throw in the config module. Left
-  // unwrapped, that raw throw collapses to INTERNAL_ERROR ("please report this
+  // unwrapped, that raw throw collapses to INTERNAL_ERROR ("report this
   // issue") on EVERY command that reads config. Name it: a CONFIG_ERROR that
   // identifies the offending file and the underlying reason.
   let module: { default?: unknown };
@@ -127,7 +127,7 @@ export async function evaluateProjectConfig(path: string): Promise<RawConfig> {
       );
     }
     throw PragmaError.configError(
-      `Could not load project config ${path}: ${reason}`,
+      `Cannot load project config ${path}: ${reason}`,
       {
         recovery: {
           message: `Fix the error in your ${PROJECT_CONFIG_FILENAME} (it must evaluate to a default export), then try again.`,

--- a/packages/cli/pragma/src/kernel/config/firstRun.test.ts
+++ b/packages/cli/pragma/src/kernel/config/firstRun.test.ts
@@ -25,7 +25,7 @@ describe("first run", () => {
 
     expect(existsSync(path)).toBe(true);
     expect(readFileSync(path, "utf-8")).toBe("{}\n");
-    expect(lines[0]).toContain("Hello!");
+    expect(lines[0]).toContain("pre-release");
     expect(lines.some((line) => line.includes(path))).toBe(true);
     // Snapshot the note with the volatile path masked.
     expect(
@@ -55,6 +55,6 @@ describe("first run", () => {
       ensureFirstRun((line) => lines.push(line)),
     ).resolves.toBeUndefined();
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain("Warning: could not create");
+    expect(lines[0]).toContain("Warning: cannot create");
   });
 });

--- a/packages/cli/pragma/src/kernel/config/firstRun.ts
+++ b/packages/cli/pragma/src/kernel/config/firstRun.ts
@@ -1,8 +1,8 @@
 /**
- * First-run onboarding — welcome note + global config creation.
+ * First-run onboarding — pre-release note + global config creation.
  *
  * On the first invocation (detected by the absence of the global config file),
- * greet on STDERR and seed `$XDG_CONFIG_HOME/pragma/config.json` with `{}` so
+ * print a terse note on STDERR and seed `$XDG_CONFIG_HOME/pragma/config.json` with `{}` so
  * every field keeps its built-in default and `config show` reports honest
  * provenance. Modeled as a {@link Task} so the effects stay declarative and
  * testable. The banner goes to stderr — stdout belongs to command output
@@ -31,12 +31,11 @@ import { globalConfigPath } from "./paths.js";
 /** Seed content: an empty object, so nothing is pinned the user did not choose. */
 const SEED_CONFIG = "{}\n";
 
-/** Build the welcome note; the resolved path is shown so it is copyable. */
+/** Build the first-run note; the resolved path is shown so it is copyable. */
 function welcomeLines(path: string): string[] {
   return [
-    `Hello! Thanks for taking the time to try the pre-release ${BIN_NAME} CLI.`,
-    `Please file issues and feedback at ${ISSUES_URL}.`,
-    `${BIN_NAME} stores its configuration in ${path} (just created with defaults).`,
+    `${BIN_NAME} is pre-release — report issues at ${ISSUES_URL}.`,
+    `Configuration created with defaults at ${path}.`,
     `A \`${PROJECT_CONFIG_FILENAME}\` in this directory or above it overrides it per project.`,
     "",
   ];
@@ -56,7 +55,7 @@ export function firstRunTask(): Task<{ created: boolean; path: string }> {
       return { created: false, path };
     }
 
-    // Create first, then greet: if creation fails the effects throw before any
+    // Create first, then announce: if creation fails the effects throw before any
     // line is emitted, so onboarding degrades to the single stderr warning
     // rather than a "just created" banner alongside a failure.
     yield* $(mkdir(dirname(path), true));
@@ -86,13 +85,11 @@ export async function ensureFirstRun(
   try {
     await runTask(firstRunTask(), {
       // Route log effects to stderr without the interpreter's [INFO] prefix —
-      // this is a greeting, not diagnostics.
+      // this is onboarding copy, not diagnostics.
       onLog: (_level, message) => write(message),
     });
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    write(
-      `Warning: could not create the global ${BIN_NAME} config — ${reason}`,
-    );
+    write(`Warning: cannot create the global ${BIN_NAME} config — ${reason}`);
   }
 }

--- a/packages/cli/pragma/src/kernel/config/readConfig.test.ts
+++ b/packages/cli/pragma/src/kernel/config/readConfig.test.ts
@@ -461,7 +461,7 @@ describe("evaluateProjectConfig — mtime+VERSION cache", () => {
     freshXdg();
     // A malformed project config: references an undefined symbol → the module
     // throws at evaluation. Left unwrapped this collapsed to INTERNAL_ERROR
-    // ("please report this issue") on EVERY command that reads config.
+    // ("report this issue") on EVERY command that reads config.
     const dir = projectWith("export default { tier: definitelyNotDefined };");
     const path = join(dir, "pragma.config.ts");
 

--- a/packages/cli/pragma/src/kernel/copy.test.ts
+++ b/packages/cli/pragma/src/kernel/copy.test.ts
@@ -28,6 +28,11 @@
  * in a capability source — became content the config declares
  * (`pragma.conf.ts#colophon`), which is what made removing it checkable.
  *
+ * Beside the naming rules, the same scanner enforces the HOUSE VOICE rules for
+ * user-facing copy ({@link COPY_RULES}, authored as data in `copy.ts`) over
+ * both file sets — the kernel set above and `src/capabilities/**` — in the
+ * last describe of this file. See `copy.ts` for what each rule bans and why.
+ *
  * NOTE for a reader of an older revision: this docblock used to say the
  * `examples[].cmd` sweep and the `docs/reference/*.md` regen "have to move
  * together". They must be CONSISTENT, not simultaneous — the whole sweep was
@@ -41,6 +46,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import conf from "../../pragma.conf.js";
 import { BIN_NAME } from "../constants.js";
+import { COPY_RULES } from "./copy.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
@@ -250,13 +256,17 @@ function pushCopy(copy: string[], literal: string): void {
  * `file: literal` for every authored literal matching `pattern`, so a failure
  * names its offenders instead of only counting them.
  *
- * @param pattern - What kernel copy may not contain.
+ * @param pattern - What the copy may not contain.
+ * @param sources - The files to read; the kernel set by default.
  * @returns One entry per offending literal.
- * @note Impure — reads every kernel source.
+ * @note Impure — reads every listed source.
  */
-function findOffenders(pattern: RegExp): string[] {
+function findOffenders(
+  pattern: RegExp,
+  sources: readonly string[] = files,
+): string[] {
   const found: string[] = [];
-  for (const file of files) {
+  for (const file of sources) {
     for (const literal of readCopy(readFileSync(file, "utf-8"))) {
       if (pattern.test(literal)) {
         found.push(`${relative(root, file)}: ${literal}`);
@@ -450,4 +460,24 @@ describe("capability commands (PROTECTED)", () => {
     }
     expect(offenders).toEqual([]);
   });
+});
+
+describe("user-facing copy house style (PROTECTED)", () => {
+  // The voice rules ({@link COPY_RULES}) run over BOTH file sets the naming
+  // rules above read — the kernel set and the capability set — because voice,
+  // unlike the distribution's name, is not content anywhere: a capability's
+  // error is the same product speaking as a kernel diagnostic. `readCopy`
+  // keeps comments, regexes, specifiers and test files out of scope, so a
+  // rule fires only on a string a user can actually be shown.
+  //
+  // One `it` per rule, NAMED by the rule, so a red run states the rule that
+  // fired; the assertion message carries the fix. What a failure prints is the
+  // offender list plus those two strings — everything needed to correct the
+  // copy lives in this repo.
+  const allSources = [...files, ...capabilitySources];
+  for (const { pattern, rule, fix } of COPY_RULES) {
+    it(rule, () => {
+      expect(findOffenders(pattern, allSources), fix).toEqual([]);
+    });
+  }
 });

--- a/packages/cli/pragma/src/kernel/copy.ts
+++ b/packages/cli/pragma/src/kernel/copy.ts
@@ -1,0 +1,54 @@
+/**
+ * The house rules for user-facing copy, as data.
+ *
+ * Every string this CLI prints is one product speaking, and a product with one
+ * voice phrases one meaning one way. These descriptors name the phrasings that
+ * are out of that voice, why, and what to write instead; `copy.test.ts` runs
+ * them over every authored string literal in the tree — the same scanner and
+ * file sets as the naming rules there, so comments, regexes, module specifiers
+ * and test fixtures are never in scope. A failure quotes the offending literal,
+ * the rule, and the fix, and nothing else: everything a maintainer needs to
+ * correct the string lives in this file.
+ *
+ * Rules are DATA rather than assertions so the set can grow (or move into a
+ * shared standards package) without rewriting the guard, and so each rule's
+ * pattern, statement and fix are reviewed together as one unit. Precision is
+ * the set's credibility: a pattern that fires on domain vocabulary gets
+ * disabled in practice, so a carve-out is encoded in the pattern itself — with
+ * its reason — never in an exemption list beside it.
+ */
+
+/** One banned phrasing: what copy may not contain, why, and the rewrite. */
+export interface CopyRule {
+  /** What the copy must not contain. */
+  readonly pattern: RegExp;
+  /** The house rule, stated for a reader of THIS codebase. */
+  readonly rule: string;
+  /** How to fix an offending string. */
+  readonly fix: string;
+}
+
+/** The banned phrasings for user-facing copy. Enforced by `copy.test.ts`. */
+export const COPY_RULES: readonly CopyRule[] = [
+  {
+    pattern: /\b(?:could not|failed to|unable to)\b/i,
+    rule: "User-facing copy says `cannot` — one phrasing for one meaning, so the CLI reads as one voice.",
+    fix: "Rewrite with `cannot` (present tense, no hedging), naming what is wrong rather than what was attempted.",
+  },
+  {
+    // `\w+n't` covers every negated contraction in one arm; the lookbehind
+    // carves out `do/don't`, which is domain vocabulary — the name of the
+    // paired good/bad example a coding standard ships — not conversational
+    // tone. The second arm lists the pronoun contractions, which have no
+    // shared suffix shape.
+    pattern:
+      /\b(?<!do\/)\w+n't\b|\b(?:you|we|they|it|that|there|here|what|let)'(?:re|ve|ll|s|d)\b|\bi'm\b/i,
+    rule: "No contractions in user-facing copy — instructions read as statements, not conversation.",
+    fix: "Spell the words out, or restructure the sentence to drop the second person.",
+  },
+  {
+    pattern: /\b(?:please|sorry|oops)\b/i,
+    rule: "The CLI does not apologise or plead; it states the fact and the action.",
+    fix: "Drop the pleading word and instruct directly: `Report this issue at <url>.`",
+  },
+];

--- a/packages/cli/pragma/src/kernel/error/PragmaError.test.ts
+++ b/packages/cli/pragma/src/kernel/error/PragmaError.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { ISSUES_URL } from "../../constants.js";
 import { errorEnvelope, successEnvelope } from "../render/envelope.js";
 import { PragmaError } from "./PragmaError.js";
 import { cliRecovery } from "./recovery.js";
@@ -56,7 +57,9 @@ describe("PragmaError factories", () => {
   it("internalError attaches a report hint", () => {
     const error = PragmaError.internalError("boom");
     expect(error.code).toBe("INTERNAL_ERROR");
-    expect(error.recovery).toEqual({ message: "Please report this issue." });
+    expect(error.recovery).toEqual({
+      message: `Report this issue at ${ISSUES_URL}.`,
+    });
   });
 });
 
@@ -66,7 +69,7 @@ describe("serializeError", () => {
     expect(serializeError(error)).toEqual({
       code: "INTERNAL_ERROR",
       message: "Internal error: boom",
-      recovery: { message: "Please report this issue." },
+      recovery: { message: `Report this issue at ${ISSUES_URL}.` },
     });
   });
 

--- a/packages/cli/pragma/src/kernel/error/PragmaError.ts
+++ b/packages/cli/pragma/src/kernel/error/PragmaError.ts
@@ -1,3 +1,4 @@
+import { ISSUES_URL } from "../../constants.js";
 import type { ErrorCode, PragmaErrorData, Recovery } from "./types.js";
 
 /**
@@ -168,13 +169,14 @@ class PragmaError extends Error {
    * Factory: unexpected internal failure (a bug).
    *
    * @param reason - Description of the internal error.
-   * @returns PragmaError with code `INTERNAL_ERROR` and a "please report" hint.
+   * @returns PragmaError with code `INTERNAL_ERROR` and a report-this hint
+   *   naming the issue tracker.
    */
   static internalError(reason: string): PragmaError {
     return new PragmaError({
       code: "INTERNAL_ERROR",
       message: `Internal error: ${reason}`,
-      recovery: { message: "Please report this issue." },
+      recovery: { message: `Report this issue at ${ISSUES_URL}.` },
     });
   }
 }

--- a/packages/cli/pragma/src/kernel/error/constants.ts
+++ b/packages/cli/pragma/src/kernel/error/constants.ts
@@ -25,7 +25,7 @@ const ERROR_CODES = [
   "CONFIG_ERROR",
   "INTERNAL_ERROR",
   // A runtime condition that is NOT a bug and NOT a usage mistake, so it must
-  // NOT collapse to INTERNAL_ERROR's "please report this issue": a capability
+  // NOT collapse to INTERNAL_ERROR's "report this issue": a capability
   // genuinely unavailable in this environment (`create` refusing when its
   // lazily-imported generator runtime cannot be loaded at all — the
   // module-not-found backstop in `capabilities/create/create.verb.ts`, which

--- a/packages/cli/pragma/src/kernel/error/fromTaskError.ts
+++ b/packages/cli/pragma/src/kernel/error/fromTaskError.ts
@@ -6,7 +6,7 @@
  * `MISSING_REQUIRED_ANSWER` / `GENERATOR_INVALID_ANSWER` for absent or invalid
  * non-interactive answers. `runTask` rethrows these as a `TaskExecutionError`
  * carrying `.code`. Without a bridge the CLI/MCP boundary collapses every
- * non-`PragmaError` to INTERNAL_ERROR + "please report this issue" — telling a
+ * non-`PragmaError` to INTERNAL_ERROR + "report this issue" — telling a
  * user to file a bug for cancelling their own scaffold.
  *
  * The codes are matched as STRING LITERALS, never imported from summon-core, so

--- a/packages/cli/pragma/src/kernel/packs/graphql/fetchGraphqlLookup.ts
+++ b/packages/cli/pragma/src/kernel/packs/graphql/fetchGraphqlLookup.ts
@@ -72,7 +72,7 @@ export async function fetchGraphqlLookup(
     // ontology). That is a runtime not-found, not an unavailable store (exit 3).
     throw new PragmaError({
       code: "ENTITY_NOT_FOUND",
-      message: `Could not resolve <${entityUri}> — its rdf:type may be missing from the ontology.`,
+      message: `Cannot resolve <${entityUri}> — its rdf:type may be missing from the ontology.`,
       recovery: cliRecovery(
         `graph inspect ${entityUri}`,
         "Inspect the entity's triples to check its rdf:type.",

--- a/packages/cli/pragma/src/kernel/packs/renderPack.ts
+++ b/packages/cli/pragma/src/kernel/packs/renderPack.ts
@@ -53,7 +53,7 @@ export interface RenderMeta {
  * list on a BUILT store (a cold store would have failed with STORE_UNAVAILABLE
  * first) means "nothing matched", so point at both possible fixes.
  */
-const DEFAULT_EMPTY_HINT = `If you haven't built the store yet, run \`${BIN_NAME} sources update\`; otherwise broaden your filter or channel.`;
+const DEFAULT_EMPTY_HINT = `Build the store with \`${BIN_NAME} sources update\`, or broaden the filter or channel.`;
 
 /** Build the list formatters for a list-shaped verb (list or an extra verb). */
 export function listFormatters(

--- a/packages/cli/pragma/src/kernel/packs/sparql/runSelect.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/runSelect.test.ts
@@ -4,7 +4,7 @@
  * Pins the remap: a generated query is composed from declared and pack-authored
  * terms, never from user input, so a "Prefix not found" from the facade means
  * the store cannot answer this read — an actionable error, NOT a raw one
- * collapsing to INTERNAL_ERROR ("please report this issue").
+ * collapsing to INTERNAL_ERROR ("report this issue").
  *
  * WHICH actionable error is the story's provenance to decide, which is the
  * second thing pinned here. A DISTRIBUTION story keeps STORE_UNAVAILABLE and its

--- a/packages/cli/pragma/src/kernel/packs/sparql/runSelect.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/runSelect.ts
@@ -79,7 +79,7 @@ function unboundPrefixError(source: StorySource): PragmaError {
  * Run the facade query, remapping a store that cannot answer it. A generated
  * query hitting an unknown prefix surfaces an actionable error — chosen by the
  * story's provenance, see {@link unboundPrefixError} — instead of a raw SPARQL
- * "Prefix not found" wrapped as INTERNAL_ERROR ("please report this issue").
+ * "Prefix not found" wrapped as INTERNAL_ERROR ("report this issue").
  * Returns the inferred facade result type, so this module stays clear of a
  * static `@canonical/ke` import (the lazy-dispatch guard).
  */

--- a/packages/cli/pragma/src/kernel/project/cli/dispatch.test.ts
+++ b/packages/cli/pragma/src/kernel/project/cli/dispatch.test.ts
@@ -190,7 +190,7 @@ describe("dispatch — errors", () => {
   it("renders a declined confirm gate as a clean cancellation, not a bug report", async () => {
     // A TTY user declining execute()'s "Proceed?" gate fails the task with
     // GENERATOR_CANCELLED; the boundary must treat it as a clean cancel, never
-    // the scary INTERNAL_ERROR "please report this issue" / exit 1.
+    // the scary INTERNAL_ERROR "report this issue" / exit 1.
     const cancelling: VerbSpec = {
       ...make,
       run: () => fail({ code: "GENERATOR_CANCELLED", message: "Cancelled." }),

--- a/packages/cli/pragma/src/kernel/runtime/graphpack/manifest.ts
+++ b/packages/cli/pragma/src/kernel/runtime/graphpack/manifest.ts
@@ -104,7 +104,7 @@ export function readManifest(dir: string): Manifest | undefined {
  * would silently drop every package-declared noun. Requiring all four present +
  * non-empty makes `buildPack` rebuild a torn pack and makes the boot decision
  * surface STORE_UNAVAILABLE (the ordinary "not built" recovery) instead of a
- * "please report this" crash. `stories.json` is additionally gated on its SHAPE
+ * "report this" crash. `stories.json` is additionally gated on its SHAPE
  * — see {@link storiesAreReadable} for why it, and only it, is parsed here. */
 export function packIsComplete(dir: string): boolean {
   if (readManifest(dir) === undefined) return false;

--- a/packages/cli/pragma/src/kernel/runtime/refs/resolve.ts
+++ b/packages/cli/pragma/src/kernel/runtime/refs/resolve.ts
@@ -95,7 +95,7 @@ function walkTtl(
     // symlinked `.ttl` was silently skipped (L6). Follow the link to recover a
     // symlinked FILE, but NEVER recurse into a symlinked DIRECTORY: a symlink
     // cycle (a link to an ancestor dir) would recurse without bound — a
-    // stack-overflow RangeError surfacing as an INTERNAL "please report" — and a
+    // stack-overflow RangeError surfacing as an INTERNAL "report" — and a
     // linked directory could pull `.ttl` from OUTSIDE the package root. Linking
     // individual source files (all L6 needs) stays supported; a dangling link is
     // skipped, not fatal.
@@ -343,7 +343,7 @@ export async function resolvePackage(
           "0.0.0";
       } catch (error) {
         // A malformed `package.json` for an otherwise-installed package: name it
-        // as a data error, not an INTERNAL_ERROR "please report this issue".
+        // as a data error, not an INTERNAL_ERROR "report this issue".
         throw PragmaError.configError(
           `Package "${ref.pkg}" has an invalid package.json (${pkgJsonPath}): ${errorDetail(error)}`,
         );

--- a/packages/cli/pragma/src/kernel/spec/emitReference.ts
+++ b/packages/cli/pragma/src/kernel/spec/emitReference.ts
@@ -50,9 +50,9 @@ const ERROR_CODE_DESCRIPTIONS: Record<(typeof ERROR_CODES)[number], string> = {
   AMBIGUOUS_INPUT:
     "A name resolved to several entities (reserved; not yet raised).",
   UNKNOWN_VERB: "The command noun or verb is not recognized.",
-  STORE_UNAVAILABLE: "The local store could not be reached or is not built.",
-  CONFIG_ERROR: "The layered configuration could not be resolved.",
-  INTERNAL_ERROR: "An unexpected failure — please report it.",
+  STORE_UNAVAILABLE: "The local store cannot be reached or is not built.",
+  CONFIG_ERROR: "The layered configuration cannot be resolved.",
+  INTERNAL_ERROR: "An unexpected failure — report it as a bug.",
   UNSUPPORTED: "A capability is unavailable in this build or environment.",
 };
 

--- a/packages/cli/pragma/src/testing/behavioral/firstRun.e2e.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/firstRun.e2e.test.ts
@@ -21,11 +21,10 @@ describe("first-run onboarding (A1, e2e)", () => {
       env: { ...env, PRAGMA_NO_AUTO_LLM: "1" },
     });
     expect(first.exitCode).toBe(0);
-    expect(first.stderr).toContain("Hello!");
     expect(first.stderr).toContain("pre-release");
     expect(first.stderr).toContain(configPath);
-    // Command output stays on stdout, untouched by the greeting.
-    expect(first.stdout).not.toContain("Hello!");
+    // Command output stays on stdout, untouched by the first-run note.
+    expect(first.stdout).not.toContain("pre-release");
     expect(first.stdout).toContain("pragma v");
 
     expect(existsSync(configPath)).toBe(true);

--- a/packages/cli/pragma/src/testing/behavioral/journeys.defaultPack.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/journeys.defaultPack.test.ts
@@ -447,7 +447,7 @@ describe("default-pack journey — real-data shapes the clean fixture masked (E1
   // `schema.json` currently surfaces UNCLASSIFIED. `packIsComplete` only checks
   // size > 0, so torn-but-nonempty garbage bypasses the completeness guard and
   // `compileFromExtraction` throws a raw `SyntaxError` (renders as INTERNAL
-  // "please report") instead of a classified error. It SHOULD degrade to
+  // "report") instead of a classified error. It SHOULD degrade to
   // STORE_UNAVAILABLE like the emptied case does — the fix belongs in
   // `kernel/runtime/graphpack/read.ts` (guard the `schema.json` read/compile).
   // No lane in this wave owns that, so rather than a false `it.fails` hand-off

--- a/packages/cli/pragma/src/testing/eval/cases/effectful.ts
+++ b/packages/cli/pragma/src/testing/eval/cases/effectful.ts
@@ -88,7 +88,7 @@ export const effectfulEvalCases: readonly EvalCase[] = [
     id: "tool-doctor-reports-check-tallies",
     kind: "tool",
     input:
-      "doctor returns a { checks, passed, failed, skipped } diagnostic report where the tallies sum to the checks.",
+      "doctor returns a { checks, passed, failed, available, skipped } diagnostic report where the tallies sum to the checks.",
     async expect({ mcp }) {
       const result = await mcp.callTool("doctor");
       assert.equal(result.ok, true);
@@ -96,11 +96,12 @@ export const effectfulEvalCases: readonly EvalCase[] = [
         checks: unknown[];
         passed: number;
         failed: number;
+        available: number;
         skipped: number;
       };
       assert.ok(Array.isArray(data.checks), "expected a checks array");
       assert.equal(
-        data.passed + data.failed + data.skipped,
+        data.passed + data.failed + data.available + data.skipped,
         data.checks.length,
       );
     },

--- a/packages/cli/pragma/src/testing/fixtures/graph/defaultPack.ts
+++ b/packages/cli/pragma/src/testing/fixtures/graph/defaultPack.ts
@@ -171,7 +171,7 @@ ex:beta ex:name "Beta" .
 /**
  * A malformed Turtle source — a subject/predicate with no object — drives the
  * `sources update` data-error classification path (a NAMED `CONFIG_ERROR`, not
- * an INTERNAL "please report this issue").
+ * an INTERNAL "report this issue").
  */
 export const MALFORMED_TTL = `@prefix ex: <https://ex.test/#> .
 ex:One a ex:Widget .


### PR DESCRIPTION
> Replaces #1008, which was merged into `feat/pragma-create-is-summon` after that branch had already landed on `main` — so its content never reached `main`. Same commits, rebased onto `main` now that #1005 is in. **This PR will grow**: it carries the CLI-standards batch as one change, added unit by unit. Currently landed: the copy gate and its sweep.

## Done

**A copy gate.** Voice rules live as data in `kernel/copy.ts` — each rule is `{pattern, rule, fix}` stated as a house rule in its own terms. `kernel/copy.test.ts` runs them through the existing hardened scanner over authored string literals only, never comments, regexes, module specifiers, or test bodies. One test per rule, named for the rule; a failure prints the offending `file: literal` plus the fix to apply.

Three rules to start: no hedging (`could not` / `failed to` / `unable to` → `cannot`), no contractions, and no apologising or pleading.

RED-proven against the pre-sweep tree — **14 + 1 + 3 real offenders**, two more than the audit had counted.

**The sweep**, grouped rather than enumerated:
- hedging rewritten across 10 files
- every `INTERNAL_ERROR` now says `Report this issue at <issues-url>`, derived from the identity seam rather than hard-coded
- the first-run banner reduced to its terse pre-release + issues form
- "packs" and "packages" unified on **pack**
- doctor's `ke store` check renamed `store`
- `assertExecOk`'s recovery drops speculation about the cause
- `docs/reference/errors.md` regenerated; ~20 docblocks quoting the old hint updated

**Drive-by:** `doctor` gains an "available" tier so opt-in integrations that were never set up (MCP, skills, completions) stop counting as failures — a fresh install reporting "3 failed" teaches users the check is noise, which makes this an honesty-of-copy fix that travels with this PR.

All nine checks were audited for correct tier, not just the two that prompted it. Completions **never installed** is available; stale, unwired, or a broken resolver stay failures. Config, pack-refs, store and node keep their failure modes — a missing config is a genuine anomaly, since first run seeds it.

```
before:  5 passed, 3 failed, 1 skipped
after:   5 passed, 1 failed, 2 available, 1 skipped
```

The real failure — a stale completions script — still reports as `✗`, with its fix line intact.

## QA

1. `bun install && bun run build` from the root.
2. `pragma doctor` on a machine with no MCP config: MCP and skills render `◇` and count as *available*, not failed; any genuine fault still renders `✗`; every row keeps its `fix:` line.
3. `pragma doctor` after `pragma setup mcp`: the MCP row moves to `✓`.
4. Introduce a hedging phrase into any user-facing string and run `bun run test` in `packages/cli/pragma` — the copy gate fails, naming the file, the literal, and the fix.
5. `pragma --help`, an error path (`pragma nosuchverb`), and an empty list all read in one voice, with no contractions or apologies.

### PR readiness check

- [x] PR should have one of the following labels: `Maintenance 🔨`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — no package boundaries changed.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

n/a — CLI behaviour, covered by the QA steps above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)