### PR TITLE
feat(pragma-cli): concept read story — ds:Concept documentation on the CLI/MCP surface

### DIFF
--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -114,6 +114,60 @@ pragma colophon  # the toolchain + active domain story
 pragma colophon --format llm  # condensed Markdown for agents
 ```
 
+## concept
+
+### pragma concept list
+
+List design-system concepts.
+
+List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search.
+
+```
+pragma concept list [options]
+```
+
+**Flags**
+
+| Flag | Value | Description |
+| --- | --- | --- |
+| `--type` | `<string>` | Filter by concept type (e.g. Explanation, How-to guide). |
+| `--search` | `<string>` | Search in name and summary. |
+
+- Store: reads the local store (`pragma sources update` builds it).
+- MCP: exposed as the `concept_list` tool.
+
+**Examples**
+
+```bash
+pragma concept list
+pragma concept list --format llm
+```
+
+### pragma concept lookup
+
+Look up a concept's full documentation by name, IRI, or glob.
+
+Get a design-system concept's full Markdown documentation. Address concepts by name, prefixed name (ds:concept.…), absolute IRI, or glob pattern.
+
+```
+pragma concept lookup <name...>
+```
+
+**Arguments**
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<name...>` | yes | Concept names, prefixed names/IRIs, or glob patterns. |
+
+- Store: reads the local store (`pragma sources update` builds it).
+- MCP: exposed as the `concept_lookup` tool.
+
+**Examples**
+
+```bash
+pragma concept lookup <name>
+```
+
 ## config
 
 ### pragma config set

--- a/packages/cli/pragma/docs/reference/index.md
+++ b/packages/cli/pragma/docs/reference/index.md
@@ -4,9 +4,9 @@ Machine-generated reference for the `pragma` CLI and MCP server, projected from 
 
 ## At a glance
 
-- **18** command nouns
-- **41** CLI commands
-- **37** MCP tools
+- **19** command nouns
+- **43** CLI commands
+- **39** MCP tools
 - **1** resource template(s)
 
 ## Pages

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -57,6 +57,32 @@ Read-only.
 
 _No input parameters._
 
+### concept_list
+
+List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search.
+
+Read-only.
+
+**Input**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | no | Filter by concept type (e.g. Explanation, How-to guide). |
+| `search` | string | no | Search in name and summary. |
+
+### concept_lookup
+
+Get a design-system concept's full Markdown documentation. Address concepts by name, prefixed name (ds:concept.…), absolute IRI, or glob pattern.
+
+Read-only.
+
+**Input**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string[] | yes | Concept names, prefixed names/IRIs, or glob patterns. |
+| `detail` | enum(summary, standard, detailed) | no | Progressive-disclosure level (default standard). |
+
 ### config_set
 
 Write a global config field by name — the one-command form of the per-field setters. `key` is one of `tier`, `channel`, or `detail`; the field's own reset rules apply (e.g. `set tier none` clears it). Written to the global layer only — project configs are authored by hand.

--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -404,6 +404,84 @@ const designSystemStories: readonly PackDefinition[] = [
  * `--detail detailed` adds `donts`. `cs:extends` stays the raw IRI in JSON
  * (renderers compact it at display time).
  */
+// The `concept` story: long-form design-system documentation not bound to a
+// single UIBlock (foundations, how-to guides, decision guides) — ds:Concept
+// entries ingested from Coda by the design-system pack. The list stays terse
+// (name/type/summary); the Markdown body is the lookup's payload, served at
+// the `standard` level with knownEdgeCases behind `detailed`.
+const conceptStory: PackDefinition = {
+  noun: "concept",
+  description: "List design-system concepts.",
+  toolDescription:
+    "List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search.",
+  list: {
+    query: [
+      "SELECT ?uri ?name ?type ?summary",
+      "WHERE {",
+      "  ?uri a ds:Concept ;",
+      "       ds:name ?name .",
+      "  OPTIONAL { ?uri ds:conceptType/ds:name ?type . }",
+      "  OPTIONAL { ?uri ds:summary ?summary . }",
+      "}",
+      "ORDER BY ?name",
+    ].join("\n"),
+    columns: [
+      { field: "uri", label: "IRI" },
+      { field: "name", label: "Name" },
+      { field: "type", label: "Type" },
+      { field: "summary", label: "Summary" },
+    ],
+    filters: [
+      {
+        param: "type",
+        variable: "type",
+        description: "Filter by concept type (e.g. Explanation, How-to guide).",
+      },
+    ],
+    search: {
+      variables: ["name", "summary"],
+      description: "Search in name and summary.",
+    },
+    emptyRecovery: {
+      message:
+        "No concepts in the store. The @canonical/design-system pack provides them; refresh the local store.",
+      cli: "sources update",
+    },
+  },
+  lookup: {
+    source: "sparql",
+    by: "ds:name",
+    type: "ds:Concept",
+    description:
+      "Look up a concept's full documentation by name, IRI, or glob.",
+    toolDescription:
+      "Get a design-system concept's full Markdown documentation. Address concepts by name, prefixed name (ds:concept.…), absolute IRI, or glob pattern.",
+    fields: [
+      { name: "type", property: "ds:conceptType/ds:name", label: "Type" },
+      { name: "tier", property: "ds:tier", label: "Tier" },
+      { name: "summary", property: "ds:summary", label: "Summary" },
+    ],
+    sections: [
+      {
+        name: "content",
+        property: "ds:content",
+        label: "Content",
+        level: "standard",
+      },
+      {
+        name: "knownEdgeCases",
+        property: "ds:knownEdgeCases",
+        label: "Known edge cases",
+        level: "detailed",
+      },
+    ],
+    disclosure: {
+      levels: ["summary", "standard", "detailed"],
+      default: "standard",
+    },
+  },
+};
+
 const codeStandardsStories: readonly PackDefinition[] = [
   {
     noun: "standard",
@@ -599,7 +677,7 @@ Made by the Canonical Webteam — https://canonical.com.`,
     {
       name: "@canonical/design-system",
       source: "git+https://github.com/canonical/design-system.git#main",
-      stories: designSystemStories,
+      stories: [...designSystemStories, conceptStory],
     },
     {
       name: "@canonical/anatomy-dsl",

--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -396,19 +396,12 @@ const designSystemStories: readonly PackDefinition[] = [
 ];
 
 /**
- * The read story the code-standards pack supplies — `standard` as declared data.
- *
- * Normalized for the v2 grammar: the old `digest` level is the canonical
- * `standard`, so disclosure gates by the canonical index. The default is
- * `summary` (base fields by name), `--detail standard` adds the `dos` examples,
- * `--detail detailed` adds `donts`. `cs:extends` stays the raw IRI in JSON
- * (renderers compact it at display time).
+ * The `concept` story the design-system pack also supplies: long-form
+ * documentation not bound to a single UIBlock (foundations, how-to guides,
+ * decision guides) — ds:Concept entries ingested from Coda. The list stays
+ * terse (name/type/summary); the Markdown body is the lookup's payload,
+ * served at the `standard` level with knownEdgeCases behind `detailed`.
  */
-// The `concept` story: long-form design-system documentation not bound to a
-// single UIBlock (foundations, how-to guides, decision guides) — ds:Concept
-// entries ingested from Coda by the design-system pack. The list stays terse
-// (name/type/summary); the Markdown body is the lookup's payload, served at
-// the `standard` level with knownEdgeCases behind `detailed`.
 const conceptStory: PackDefinition = {
   noun: "concept",
   description: "List design-system concepts.",
@@ -482,6 +475,15 @@ const conceptStory: PackDefinition = {
   },
 };
 
+/**
+ * The read story the code-standards pack supplies — `standard` as declared data.
+ *
+ * Normalized for the v2 grammar: the old `digest` level is the canonical
+ * `standard`, so disclosure gates by the canonical index. The default is
+ * `summary` (base fields by name), `--detail standard` adds the `dos` examples,
+ * `--detail detailed` adds `donts`. `cs:extends` stays the raw IRI in JSON
+ * (renderers compact it at display time).
+ */
 const codeStandardsStories: readonly PackDefinition[] = [
   {
     noun: "standard",

--- a/packages/cli/pragma/src/capabilities/capabilities/hints.ts
+++ b/packages/cli/pragma/src/capabilities/capabilities/hints.ts
@@ -141,6 +141,15 @@ export const TOOL_HINTS: Record<string, ToolHint> = {
     category: "read",
     use_when: "Discovering which standard categories exist before filtering",
   },
+  concept_list: {
+    category: "read",
+    use_when:
+      "Browsing long-form design-system concepts (foundations, how-to guides, decision guides)",
+  },
+  concept_lookup: {
+    category: "read",
+    use_when: "Reading a concept's full Markdown documentation by name or IRI",
+  },
   standard_sample: {
     category: "read",
     use_when:

--- a/packages/cli/pragma/src/capabilities/distribution.test.ts
+++ b/packages/cli/pragma/src/capabilities/distribution.test.ts
@@ -33,12 +33,13 @@ function declaredShape(verb: VerbSpec): Record<string, unknown> {
 }
 
 describe("the distribution's declared stories (PROTECTED)", () => {
-  it("declares exactly the five domain nouns", () => {
+  it("declares exactly the six domain nouns", () => {
     // Every domain noun is now nothing BUT its story (L-OPEN-9), so a renamed
     // or dropped noun deletes a whole command rather than shrinking one — it
     // must fail HERE.
     expect([...declaredStories.keys()].sort()).toEqual([
       "block",
+      "concept",
       "modifier",
       "standard",
       "tier",

--- a/packages/cli/pragma/src/capabilities/surface.test.ts
+++ b/packages/cli/pragma/src/capabilities/surface.test.ts
@@ -213,14 +213,14 @@ describe("surface COMPLETE — emitted == covenant (PROTECTED)", () => {
   // The CLOSING direction: assertConforms already proves emitted ⊆ covenant;
   // this proves covenant ⊆ emitted, so together the tool sets are EQUAL — the
   // surface-complete milestone. After PR7, every covenant tool is realized.
-  it("emits every covenant tool (all 37) — set equality with the covenant", () => {
+  it("emits every covenant tool (all 39) — set equality with the covenant", () => {
     const emittedTools = new Set(emitted.mcpSurface.tools);
     const missing = golden.mcpSurface.tools.filter((t) => !emittedTools.has(t));
     expect(missing).toEqual([]);
     expect([...emitted.mcpSurface.tools].sort()).toEqual(
       [...golden.mcpSurface.tools].sort(),
     );
-    expect(emitted.mcpSurface.tools).toHaveLength(37);
+    expect(emitted.mcpSurface.tools).toHaveLength(39);
   });
 
   // The covenant edit: the non-tool MCP surface is frozen too.

--- a/packages/cli/pragma/src/kernel/completion/complete.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/complete.test.ts
@@ -16,6 +16,7 @@ describe("runComplete — the __complete pipeline", () => {
   it("resolves against the live capabilities (storeless static matches)", async () => {
     await expect(runComplete(["co"], capabilities)).resolves.toEqual([
       "colophon",
+      "concept",
       "config",
     ]);
     // The live `config` sub-verbs, prefix-filtered and sorted by the resolver.
@@ -38,6 +39,7 @@ describe("runComplete — the __complete pipeline", () => {
   it("strips a leading bin name", async () => {
     await expect(runComplete(["pragma", "co"], capabilities)).resolves.toEqual([
       "colophon",
+      "concept",
       "config",
     ]);
   });
@@ -93,7 +95,7 @@ describe("runComplete — never-throw guard (PROTECTED)", () => {
     await runComplete(["co"], capabilities);
     const lines = write.mock.calls.map((call) => String(call[0]));
     expect(lines.join("")).toMatch(
-      /\[complete\] context=noun partial="co" candidates=2 in \d+(\.\d+)?ms/,
+      /\[complete\] context=noun partial="co" candidates=3 in \d+(\.\d+)?ms/,
     );
   });
 });

--- a/packages/cli/pragma/src/kernel/completion/safety.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/safety.test.ts
@@ -376,7 +376,7 @@ describe("storeless guarantee (PROTECTED)", () => {
       },
     );
     expect(nouns.status).toBe(0);
-    expect(nouns.stdout).toBe("colophon\nconfig\n");
+    expect(nouns.stdout).toBe("colophon\nconcept\nconfig\n");
     expect(nouns.stderr).toBe("");
 
     // The headline guarantee of the embedded pack: a user who has installed

--- a/packages/cli/pragma/src/kernel/completion/shellDrive.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/shellDrive.test.ts
@@ -321,7 +321,7 @@ const STRUCTURE = [
     at: "pragma co",
     words: ["pragma", "co"],
     cword: 1,
-    offers: ["colophon", "config"],
+    offers: ["colophon", "concept", "config"],
   },
   {
     at: "pragma block <TAB>",
@@ -364,6 +364,7 @@ const NOUNS = [
   "block",
   "capabilities",
   "colophon",
+  "concept",
   "config",
   "create",
   "doctor",
@@ -526,7 +527,7 @@ describe.skipIf(!hasShell("fish"))(
     });
 
     it.each([
-      { line: "pragma co", offers: ["colophon", "config"] },
+      { line: "pragma co", offers: ["colophon", "concept", "config"] },
       { line: "pragma block ", offers: ["list", "lookup", "sample"] },
       {
         line: "pragma setup ",

--- a/packages/cli/pragma/src/kernel/config/defaults.test.ts
+++ b/packages/cli/pragma/src/kernel/config/defaults.test.ts
@@ -59,7 +59,7 @@ describe("defaults — the validated distribution config (pragma.conf.ts)", () =
     const storyCounts = defaults.packs?.map((pack) =>
       typeof pack === "string" ? 0 : (pack.stories?.length ?? 0),
     );
-    expect(storyCounts).toEqual([4, 0, 1, 0]);
+    expect(storyCounts).toEqual([5, 0, 1, 0]);
   });
 
   it("declares no removed field — the validator would refuse to load one", () => {

--- a/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
+++ b/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
@@ -221,7 +221,10 @@ function looksLikeIri(query: string): boolean {
   return (
     query.startsWith("http://") ||
     query.startsWith("https://") ||
-    query.includes(":")
+    // Neither an IRI nor a SPARQL prefixed name may contain whitespace, so a
+    // colon in a spaced string is part of a plain entity name — e.g. the
+    // concept "Foundations: Grid" — not a prefix separator.
+    (query.includes(":") && !/\s/.test(query))
   );
 }
 

--- a/packages/cli/pragma/src/kernel/spec/surfaceConformance.test.ts
+++ b/packages/cli/pragma/src/kernel/spec/surfaceConformance.test.ts
@@ -84,8 +84,8 @@ describe("surface conformance (PROTECTED)", () => {
     );
   });
 
-  it("freezes exactly 37 designed MCP tools including info, config_show, config_set, colophon", () => {
-    expect(golden.mcpSurface.tools).toHaveLength(37);
+  it("freezes exactly 39 designed MCP tools including info, config_show, config_set, colophon", () => {
+    expect(golden.mcpSurface.tools).toHaveLength(39);
     expect(golden.mcpSurface.tools).toContain("info");
     expect(golden.mcpSurface.tools).toContain("config_show");
     expect(golden.mcpSurface.tools).toContain("config_set");

--- a/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
+++ b/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
@@ -165,6 +165,43 @@ ds:prompt.scaffold-component a ds:Prompt ;
   ds:promptArgument [ ds:argName "framework" ; rdfs:comment "react | svelte | lit." ; ds:argRequired false ] .
 `;
 
+/** The `ds:Concept` section — long-form documentation entries the `concept`
+ * story reads. Mirrors the real design-system data shape (canonical/design-system#64):
+ * `ds:name`/`ds:summary`/`ds:tier` base, the Markdown body in `ds:content`
+ * (standard disclosure), `ds:knownEdgeCases` (detailed), and `ds:conceptType`
+ * → a named `ds:ConceptType` individual carrying its own `ds:name`. */
+const CONCEPT_TTL = `
+ds:Concept a owl:Class .
+ds:ConceptType a owl:Class .
+ds:content a owl:DatatypeProperty ; rdfs:domain ds:Concept ; rdfs:range xsd:string .
+ds:knownEdgeCases a owl:DatatypeProperty ; rdfs:domain ds:Concept ; rdfs:range xsd:string .
+ds:conceptType a owl:ObjectProperty ; rdfs:domain ds:Concept ; rdfs:range ds:ConceptType .
+
+ds:concepttype.Explanation a ds:ConceptType ;
+  ds:name "Explanation" ;
+  ds:summary "Concept documentation that deepens understanding of a topic." .
+
+ds:concepttype.How-to-guide a ds:ConceptType ;
+  ds:name "How-to guide" ;
+  ds:summary "Concept documentation that walks through solving a problem." .
+
+ds:concept.Foundations-Grid a ds:Concept ;
+  ds:name "Foundations: Grid" ;
+  ds:summary "How the grid system underpins every layout." ;
+  ds:tier ds:global ;
+  ds:conceptType ds:concepttype.Explanation ;
+  ds:content "The grid is the shared spatial contract every block lays out against." ;
+  ds:knownEdgeCases "Nested grids inherit the outer gutter unless re-declared." .
+
+ds:concept.Question-mark-vs-information-icon a ds:Concept ;
+  ds:name "Question mark vs information icon" ;
+  ds:summary "Deciding between the information icon and the question mark icon." ;
+  ds:tier ds:global ;
+  ds:conceptType ds:concepttype.How-to-guide ;
+  ds:content "The information icon offers context proactively; the question mark answers a question the user already has." ;
+  ds:knownEdgeCases "Icon interpretation depends on the user's prior conventions." .
+`;
+
 /** The prefixes the canonical store is built and queried with. */
 export const CANONICAL_PREFIXES: Readonly<Record<string, string>> = {
   ...BLOCK_PREFIXES,
@@ -172,7 +209,7 @@ export const CANONICAL_PREFIXES: Readonly<Record<string, string>> = {
 };
 
 /** The full canonical Turtle: PR3's `BLOCK_TTL` verbatim, plus the sections above. */
-export const CANONICAL_TTL = `${BLOCK_TTL}\n${DS_EXTRA_TTL}\n${CS_TTL}\n${PROMPT_TTL}`;
+export const CANONICAL_TTL = `${BLOCK_TTL}\n${DS_EXTRA_TTL}\n${CS_TTL}\n${PROMPT_TTL}\n${CONCEPT_TTL}`;
 
 /** Default viewing config: no tier set, `normal` channel — drops the beta-only block. */
 export const CANONICAL_CONFIG = { channel: "normal" as const };

--- a/packages/cli/pragma/surface/surface.v2.json
+++ b/packages/cli/pragma/surface/surface.v2.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "FROZEN designed surface (covenant) for pragma v2. Each PR emits only the entries it has built and asserts emitted ⊆ covenant (see kernel/spec/surfaceConformance.ts). PR7 is the surface-completion PR: it emits ALL tools (emitted == covenant); PR9 extended this to 39 tools (added config_set, 38→39) and extends mcpSurface with the non-tool surfaces — resources (the pragma:{+uri} template), prompts (the native prompts/* capability), and instructions (the handshake orientation); PR10 extended it to 40 tools (added the colophon self-verb + its tool, 39→40); AV-228 B1 blesses `ontology_lookup` (the ratified by-name read name) and keeps `ontology_show` as a deprecated alias, 40→41; AV-228 B3 RETIRES the per-field setters `config_tier`/`config_channel`/`config_detail` in favour of `config_set <key> <value>`, 41→38; AV-228 B8 unifies ALL `create application` include-flags on the `--with-X` convention (`--ssr`/`--router`/`--forms`/`--relay` → `--with-ssr`/`--with-router`/`--with-forms`/`--with-relay`; tool count unchanged). L-PR6 (PRA-107 ruling, PROJECT FROM CONFIG) records the WIRE IDENTITY rule as mcpSurface.serverInfo: serverInfo PROJECTS from the distribution — name is the declared distribution name, version the package version — so a fork's server introduces itself under its own name (surface.test.ts pins the covenant text, identity.test.ts pins the wire from a fork's config); the resource template pragma:{+uri}, the pragma:<uri> URIs it mints, and the pragma/box / pragma/instanceCount _meta keys stay FROZEN protocol identity every distribution serves unchanged — clients persist resource URIs, and the measured half-derivation (template renamed, minting sites literal) made all 653 of a fork's resources unreadable; tool count unchanged. L-OPEN-9 removes the non-compliant commands — reads the declared grammar can express become declared content, the rest is removed: `tier_lookup` becomes the tier story's compiled lookup (args `<name>` → `<name...>`, the variadic every pack lookup emits); `block_list` becomes the block story's compiled list (`--all-tiers` retired with the hand-written tier-chain/channel filtering — it lists ALL blocks, experimental included, for everyone, until filtering returns in declared form); `token add-config` is REMOVED rather than made declared — it writes a `tokens.config.mjs` starter file, and the content grammar deliberately has no mutation verb, 38→37. L-OPEN-10 strips the `v2` framing from the `bins.pragma` description string (`pragma v2 CLI and MCP server host (stdio)` -> `pragma CLI and MCP server host (stdio)`) — the tool is the tool, not a successor to something; the FILENAME and the chronological records above keep their `v2` because they are history, not a claim about the product. The --intl port (i18n behind an opt-in flag in application/react) adds `--with-intl` to `create application`; flag list only, tool count unchanged. Prompt NAMES are graph data, guarded by the prompt tests, not frozen here. The fixed sections mirror FIXED_SURFACE in kernel/spec/emitSurface.ts verbatim.",
+  "$comment": "FROZEN designed surface (covenant) for pragma v2. Each PR emits only the entries it has built and asserts emitted ⊆ covenant (see kernel/spec/surfaceConformance.ts). PR7 is the surface-completion PR: it emits ALL tools (emitted == covenant); PR9 extended this to 39 tools (added config_set, 38→39) and extends mcpSurface with the non-tool surfaces — resources (the pragma:{+uri} template), prompts (the native prompts/* capability), and instructions (the handshake orientation); PR10 extended it to 40 tools (added the colophon self-verb + its tool, 39→40); AV-228 B1 blesses `ontology_lookup` (the ratified by-name read name) and keeps `ontology_show` as a deprecated alias, 40→41; AV-228 B3 RETIRES the per-field setters `config_tier`/`config_channel`/`config_detail` in favour of `config_set <key> <value>`, 41→38; AV-228 B8 unifies ALL `create application` include-flags on the `--with-X` convention (`--ssr`/`--router`/`--forms`/`--relay` → `--with-ssr`/`--with-router`/`--with-forms`/`--with-relay`; tool count unchanged). L-PR6 (PRA-107 ruling, PROJECT FROM CONFIG) records the WIRE IDENTITY rule as mcpSurface.serverInfo: serverInfo PROJECTS from the distribution — name is the declared distribution name, version the package version — so a fork's server introduces itself under its own name (surface.test.ts pins the covenant text, identity.test.ts pins the wire from a fork's config); the resource template pragma:{+uri}, the pragma:<uri> URIs it mints, and the pragma/box / pragma/instanceCount _meta keys stay FROZEN protocol identity every distribution serves unchanged — clients persist resource URIs, and the measured half-derivation (template renamed, minting sites literal) made all 653 of a fork's resources unreadable; tool count unchanged. L-OPEN-9 removes the non-compliant commands — reads the declared grammar can express become declared content, the rest is removed: `tier_lookup` becomes the tier story's compiled lookup (args `<name>` → `<name...>`, the variadic every pack lookup emits); `block_list` becomes the block story's compiled list (`--all-tiers` retired with the hand-written tier-chain/channel filtering — it lists ALL blocks, experimental included, for everyone, until filtering returns in declared form); `token add-config` is REMOVED rather than made declared — it writes a `tokens.config.mjs` starter file, and the content grammar deliberately has no mutation verb, 38→37. L-OPEN-10 strips the `v2` framing from the `bins.pragma` description string (`pragma v2 CLI and MCP server host (stdio)` -> `pragma CLI and MCP server host (stdio)`) — the tool is the tool, not a successor to something; the FILENAME and the chronological records above keep their `v2` because they are history, not a claim about the product. The --intl port (i18n behind an opt-in flag in application/react) adds `--with-intl` to `create application`; flag list only, tool count unchanged. Prompt NAMES are graph data, guarded by the prompt tests, not frozen here. The fixed sections mirror FIXED_SURFACE in kernel/spec/emitSurface.ts verbatim. The concept read story (ds:Concept — long-form design-system documentation ingested from Coda, canonical/design-system#64) adds the `concept` noun: a declared list (--type/--search) and a SPARQL lookup serving the Markdown body at `standard` disclosure, 37→39 tools (concept_list, concept_lookup).",
   "nouns": {
     "block": {
       "verbs": [
@@ -72,6 +72,22 @@
           "args": ["<name...>"],
           "needsStore": true,
           "mcp": "tier_lookup"
+        }
+      ]
+    },
+    "concept": {
+      "verbs": [
+        {
+          "v": "list",
+          "flags": ["--type", "--search"],
+          "needsStore": true,
+          "mcp": "concept_list"
+        },
+        {
+          "v": "lookup",
+          "args": ["<name...>"],
+          "needsStore": true,
+          "mcp": "concept_lookup"
         }
       ]
     },
@@ -250,6 +266,8 @@
       "block_sample",
       "capabilities",
       "colophon",
+      "concept_list",
+      "concept_lookup",
       "config_set",
       "config_show",
       "create_application",


### PR DESCRIPTION
> **Stacked on #1012** (which stacks on #1010) — this PR's base is that branch.

## Done

- Declares a `concept` read story on the `@canonical/design-system` pack in `pragma.conf.ts`: `concept list` (`--type`/`--search`) and `concept lookup <name...>` serving the long-form Markdown body (`ds:content`, from canonical/design-system#64) at `standard` disclosure, `knownEdgeCases` behind `detailed`
- Covenant (`surface/surface.v2.json`) extended 37 → 39 tools (`concept_list`, `concept_lookup`) with a `$comment` history entry; surgical 19-line diff
- Updated in step: completion tables (bash/zsh noun tables, `co` → colophon/concept/config), story-count and tool-count pins, `TOOL_HINTS`, and the canonical fixture graph (a `ds:Concept` section mirroring the real data shape, colon-bearing name included)
- **Bug fix**: entity resolution misparsed names containing a colon — `concept lookup "Foundations: Grid"` (real production data) failed with `Invalid prefix "Foundations"`. A colon in a whitespace-bearing string is now part of the plain name (neither an IRI nor a SPARQL prefixed name may contain whitespace); behavior for actual prefixed names and bad prefixes is unchanged

## QA

- Full CLI suite green: 1166 passed (incl. the auto-generated concept behavioral tests — B1 agent session, B5 CLI/MCP parity, B6 disclosure growth — which pin the colon-name fix)
- Live smoke against the real graph (`sources update` with default packs): `pragma concept list` shows the 4 ingested concepts; `pragma concept lookup "Foundations: Grid"` renders the full 17KB Grid doc
- `biome` + `tsc` clean on all changed files (repo has 3 pre-existing lint errors in untouched files: `create.verb.ts`, `copy.test.ts`)

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (no packages added)
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Not relevant (CLI/MCP surface).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)