### PR TITLE
fix(pragma-cli)!: setup steps survive each other, and the harness registry covers its targets

### DIFF
--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkMcpCommands.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkMcpCommands.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `checkMcpCommands` — the doctor check that probes every command-based MCP
+ * entry for a resolvable executable.
+ *
+ * The cases here exist because `command` has TWO schema-legal shapes and the
+ * check must read both: the scalar most harnesses take (`command: "pragma"`)
+ * and the string ARRAY OpenCode's `McpLocalConfig` requires
+ * (`command: ["pragma", "mcp"]`). A reader that understands only the scalar
+ * skips the array entry silently — doctor then reports a clean "nothing to
+ * check" on a machine `setup` has just configured correctly, which is the
+ * failure mode these tests pin shut.
+ *
+ * Everything is driven off a temp project root, a temp HOME, and a temp bin
+ * dir prepended to `PATH` holding a STUB executable — nothing here reads or
+ * writes a real config, and no real binary is installed or spawned.
+ */
+
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { checkMcpCommands } from "./checkMcpCommands.js";
+
+const STUB = "pragma-stub-mcp";
+
+let root: string;
+let bin: string;
+let prevHome: string | undefined;
+let prevPath: string | undefined;
+const roots: string[] = [];
+
+const tmp = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(dir);
+  return dir;
+};
+
+beforeEach(() => {
+  prevHome = process.env.HOME;
+  prevPath = process.env.PATH;
+  root = tmp("pragma-mcp-commands-");
+  bin = tmp("pragma-mcp-bin-");
+  // An isolated HOME keeps the developer's real global harness configs out of
+  // detection, so only what a case writes under `root` is examined.
+  process.env.HOME = tmp("pragma-mcp-home-");
+  writeFileSync(join(bin, STUB), "#!/bin/sh\nexit 0\n");
+  chmodSync(join(bin, STUB), 0o755);
+  process.env.PATH = `${bin}:${prevPath ?? ""}`;
+});
+
+afterEach(() => {
+  process.env.HOME = prevHome;
+  process.env.PATH = prevPath;
+  for (const dir of roots) rmSync(dir, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+/** Write OpenCode's `opencode.json`, whose `mcp` entries take ARRAY commands. */
+const writeOpencode = (command: unknown): void => {
+  writeFileSync(
+    join(root, "opencode.json"),
+    JSON.stringify({ mcp: { pragma: { type: "local", command } } }),
+  );
+};
+
+/** Write Claude Code's `.mcp.json`, whose entries take a SCALAR command. */
+const writeClaudeCode = (command: unknown): void => {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(
+    join(root, ".mcp.json"),
+    JSON.stringify({ mcpServers: { pragma: { command, args: ["mcp"] } } }),
+  );
+};
+
+describe("checkMcpCommands — both command shapes", () => {
+  it("resolves the executable from an array command (first element, rest are arguments)", async () => {
+    writeOpencode([STUB, "mcp", "--verbose"]);
+    const result = await checkMcpCommands(root);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toBe("1 command resolve on PATH");
+  });
+
+  it("resolves the executable from a scalar command", async () => {
+    writeClaudeCode(STUB);
+    const result = await checkMcpCommands(root);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toBe("1 command resolve on PATH");
+  });
+
+  it("gives the array and scalar shapes of the same entry the same verdict", async () => {
+    writeOpencode([STUB, "mcp"]);
+    writeClaudeCode(STUB);
+    const result = await checkMcpCommands(root);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toBe("2 commands resolve on PATH");
+  });
+
+  it("names the executable — not the whole array — when an array command is unresolvable", async () => {
+    writeOpencode(["pragma-stub-absent", "mcp"]);
+    const result = await checkMcpCommands(root);
+    expect(result.status).toBe("fail");
+    expect(result.items?.[0]?.detail).toContain(
+      '"pragma-stub-absent" not found',
+    );
+  });
+
+  it("skips entries with no command at all (HTTP/SSE)", async () => {
+    writeFileSync(
+      join(root, "opencode.json"),
+      JSON.stringify({ mcp: { remote: { type: "remote", url: "https://x" } } }),
+    );
+    const result = await checkMcpCommands(root);
+    expect(result.status).toBe("skip");
+    expect(result.detail).toBe("no command-based MCP servers configured");
+  });
+});

--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkMcpCommands.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkMcpCommands.ts
@@ -9,14 +9,32 @@ import { deriveBand } from "./deriveBand.js";
 const NAME = "MCP commands";
 
 /**
- * Extract the stdio command from an MCP server config entry, if any. HTTP/SSE
- * entries (`{ type: "http", url }`) have no command and are not checked.
+ * Extract the stdio EXECUTABLE from an MCP server config entry, if any.
+ *
+ * `command` arrives in two schema-legal shapes. Most harnesses take the scalar
+ * (`command: "pragma"`, arguments in a sibling `args`), but OpenCode's
+ * `McpLocalConfig` requires an ARRAY that fuses the two
+ * (`command: ["pragma", "mcp"]` — see `opencodeMcpEntry` in
+ * `@canonical/harnesses`). Reading only the scalar made this check step over
+ * the array form entirely: doctor skipped the executable probe on an entry
+ * `setup` had just written correctly, and a machine whose only MCP config is
+ * OpenCode's reported "no command-based MCP servers configured" while being
+ * fully configured. A silently wrong clean answer is worse than a loud wrong
+ * one, so both shapes are read here.
+ *
+ * The executable is the FIRST non-empty string in either shape, so the two
+ * yield the same answer for the same entry; the remaining array elements are
+ * arguments and are not probed. HTTP/SSE entries (`{ type: "http", url }`)
+ * have no command and are not checked.
  */
 function commandOf(entry: unknown): string | undefined {
   if (typeof entry !== "object" || entry === null) return undefined;
   const command = (entry as { command?: unknown }).command;
-  return typeof command === "string" && command.length > 0
-    ? command
+  const executable = Array.isArray(command)
+    ? command.find((part) => typeof part === "string" && part.length > 0)
+    : command;
+  return typeof executable === "string" && executable.length > 0
+    ? executable
     : undefined;
 }
 

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
@@ -30,19 +30,18 @@ import type {
 import { sequence_, type Task, when } from "@canonical/task";
 import { BIN_NAME } from "../../../constants.js";
 import type { PragmaRuntime } from "../../../kernel/runtime/types.js";
-import { guardMissingBinary } from "../../shared/assertExecOk.js";
-import type {
-  LspState,
-  ScopeSelection,
-  SetupMode,
-  SetupResult,
-} from "../types.js";
+import type { ScopeSelection, SetupMode, SetupResult } from "../types.js";
 import {
   type CompletionsDetection,
   composeCompletions,
   detectCompletions,
 } from "./setupCompletions.js";
-import { composeLsp, detectLsp, type LspDetection } from "./setupLsp.js";
+import {
+  composeLsp,
+  detectLsp,
+  type LspDetection,
+  lspEditorNames,
+} from "./setupLsp.js";
 import {
   composeMcp,
   detectMcp,
@@ -99,25 +98,6 @@ const selectChosenGroups = (
   d: McpDetection,
   answers: Record<string, unknown>,
 ) => selectedGroups(d, resolveMcpPaths(d, answers));
-
-/**
- * The LSP-install step, guarded at its use site. An absent `bunx` (no Bun on
- * PATH) REJECTS the exec with ENOENT, which would otherwise collapse to
- * INTERNAL_ERROR ("report this issue") at the CLI/MCP boundary;
- * `guardMissingBinary` names it a UNSUPPORTED "`bunx` not found on PATH" with an
- * actionable install recovery instead. Preview-transparent — a dry-run mocks the
- * exec (no spawn) — and re-runnable (the guard is a `recover`, and `composeLsp`
- * is combinator-built), so it survives `execute`'s double interpretation.
- */
-const composeGuardedLsp = (rt: PragmaRuntime, state: LspState): Task<void> =>
-  guardMissingBinary(
-    "bunx",
-    {
-      message:
-        "Install Bun (https://bun.sh) to provide `bunx`, then run this again.",
-    },
-    composeLsp(rt.cwd, state),
-  );
 
 /** Build a generator's `meta` (no stamping — the version is just header text). */
 const buildMeta = (
@@ -292,7 +272,7 @@ function buildRunAllPlan(
           chosen.includes("completions"),
           composeCompletions(detected.completions),
         ),
-        when(chosen.includes("lsp"), composeGuardedLsp(rt, detected.lsp.state)),
+        when(chosen.includes("lsp"), composeLsp(detected.lsp)),
         when(
           chosen.includes("mcp"),
           composeMcp(detected.mcp, selectChosenGroups(detected.mcp, answers)),
@@ -363,9 +343,13 @@ export async function buildSetupPlan(
       const d = await detectLsp(rt.cwd);
       return {
         generator: buildSingleStep(rt, `${BIN_NAME} setup lsp`, [], () =>
-          composeGuardedLsp(rt, d.state),
+          composeLsp(d),
         ),
-        toResult: () => ({ kind: "lsp", state: d.state }),
+        toResult: () => ({
+          kind: "lsp",
+          state: d.state,
+          editors: lspEditorNames(d),
+        }),
       };
     }
 

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
@@ -27,8 +27,18 @@ import type {
   GeneratorDefinition,
   PromptDefinition,
 } from "@canonical/summon-core";
-import { sequence_, type Task, when } from "@canonical/task";
+import {
+  flatMap,
+  map,
+  pure,
+  recover,
+  sequence,
+  type Task,
+  type TaskError,
+  warn,
+} from "@canonical/task";
 import { BIN_NAME } from "../../../constants.js";
+import { PragmaError } from "../../../kernel/error/PragmaError.js";
 import type { PragmaRuntime } from "../../../kernel/runtime/types.js";
 import type { ScopeSelection, SetupMode, SetupResult } from "../types.js";
 import {
@@ -98,6 +108,82 @@ const selectChosenGroups = (
   d: McpDetection,
   answers: Record<string, unknown>,
 ) => selectedGroups(d, resolveMcpPaths(d, answers));
+
+/** One run-all step's outcome: its id, plus the failure it ended in (if any). */
+interface StepOutcome {
+  readonly id: StepId;
+  readonly error?: TaskError;
+}
+
+/** The {@link PragmaError} a step failure carries, or a wrapper around it. */
+const stepPragmaError = (error: TaskError): PragmaError =>
+  error.cause instanceof PragmaError
+    ? error.cause
+    : new PragmaError({ code: "UNSUPPORTED", message: error.message });
+
+/**
+ * Run the CHOSEN steps with per-step failure isolation (S1-1). The steps are
+ * independent installers, so one unsatisfiable prerequisite must not consume
+ * the others: previously the sequenced composition let a failing LSP step
+ * abort the run before MCP or skills ever executed — on every machine without
+ * a usable editor CLI, the single advertised onboarding command configured
+ * nothing that mattered and exited 1.
+ *
+ * Each step runs under a `recover` frame: a failure is reported inline (a
+ * `warn` right where it happened) and recorded, and the remaining steps still
+ * run. After the last step the recorded failures decide the aggregate
+ * outcome — none: success; one: the ORIGINAL error is rethrown (its code,
+ * message, and recovery intact); several: one UNSUPPORTED error naming every
+ * failed step. The run's exit code therefore reflects the true aggregate
+ * result while every satisfiable step has already applied.
+ *
+ * Only failures travelling the task FAILURE CHANNEL are isolable — a
+ * synchronous throw bypasses the trampoline's recovery frames — which is why
+ * the step bodies raise via `checkExecOk`/`failPragma`/`failWith`, never a
+ * bare throw. Interruption (TASK_INTERRUPTED) bypasses recovery by interpreter
+ * invariant, so Ctrl-C still stops the whole run. Pure and re-runnable: the
+ * outcome array flows through task values, never a captured mutable, so
+ * `execute`'s double interpretation (preview + perform) stays sound.
+ */
+const runStepsIsolated = (
+  steps: readonly { id: StepId; task: Task<void> }[],
+): Task<void> =>
+  flatMap(
+    sequence(
+      steps.map(({ id, task }) =>
+        recover(
+          map(task, (): StepOutcome => ({ id })),
+          (error) =>
+            flatMap(
+              warn(
+                `Step "${id}" failed — continuing with the remaining steps.`,
+              ),
+              () => pure<StepOutcome>({ id, error }),
+            ),
+        ),
+      ),
+    ),
+    (outcomes) => {
+      const failures = outcomes.flatMap((o) =>
+        o.error === undefined ? [] : [{ id: o.id, error: o.error }],
+      );
+      const first = failures[0];
+      if (first === undefined) return pure(undefined);
+      if (failures.length === 1) throw stepPragmaError(first.error);
+      const lines = failures
+        .map((f) => `${f.id}: ${stepPragmaError(f.error).message}`)
+        .join("\n");
+      throw new PragmaError({
+        code: "UNSUPPORTED",
+        message: `${failures.length} of ${outcomes.length} setup steps failed:\n${lines}`,
+        recovery: {
+          message: `The other steps completed. Re-run the failed ones individually: ${failures
+            .map((f) => `\`${BIN_NAME} setup ${f.id}\``)
+            .join(", ")}.`,
+        },
+      });
+    },
+  );
 
 /** Build a generator's `meta` (no stamping — the version is just header text). */
 const buildMeta = (
@@ -258,27 +344,29 @@ function buildRunAllPlan(
   }
 
   // `generate` MUST be pure and re-runnable — `execute` interprets it twice (the
-  // confirm-gate preview + the build) — so it composes with `when`/`sequence_`
-  // (immutable) rather than a single-use `gen`, and does NO detection (all real
-  // reads already happened up front). Composing an unchosen step is harmless:
-  // `when(false, …)` discards the (side-effect-free) task it was handed.
+  // confirm-gate preview + the build) — so it composes with immutable
+  // combinators rather than a single-use `gen`, and does NO detection (all real
+  // reads already happened up front). The chosen steps run through
+  // {@link runStepsIsolated} so one failing step reports and lets the rest
+  // proceed (S1-1) while the run's exit code reflects the aggregate outcome.
   const generator: GeneratorDefinition = {
     meta: buildMeta(rt, `${BIN_NAME} setup`),
     prompts,
     generate: (answers) => {
       const chosen = readSteps(answers);
-      return sequence_([
-        when(
-          chosen.includes("completions"),
-          composeCompletions(detected.completions),
-        ),
-        when(chosen.includes("lsp"), composeLsp(detected.lsp)),
-        when(
-          chosen.includes("mcp"),
-          composeMcp(detected.mcp, selectChosenGroups(detected.mcp, answers)),
-        ),
-        when(chosen.includes("skills"), composeSkills(detected.skills)),
-      ]);
+      const all: { id: StepId; task: Task<void> }[] = [
+        { id: "completions", task: composeCompletions(detected.completions) },
+        { id: "lsp", task: composeLsp(detected.lsp) },
+        {
+          id: "mcp",
+          task: composeMcp(
+            detected.mcp,
+            selectChosenGroups(detected.mcp, answers),
+          ),
+        },
+        { id: "skills", task: composeSkills(detected.skills) },
+      ];
+      return runStepsIsolated(all.filter((s) => chosen.includes(s.id)));
     },
   };
 

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
@@ -183,7 +183,7 @@ export function composeLsp(d: LspDetection): Task<void> {
         (result) =>
           checkExecOk(fetchCommand, result as ExecResult, {
             message:
-              "The extension package could not be fetched — check that this machine can reach registry.npmjs.org, then run " +
+              "The extension package cannot be fetched — this machine cannot reach registry.npmjs.org. Check the connection, then run " +
               `\`${BIN_NAME} setup lsp\` again.`,
           }),
       ),

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
@@ -30,7 +30,7 @@
  */
 
 import { existsSync, readdirSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import { join } from "node:path";
 import type { EditorCliDefinition, PlatformEnv } from "@canonical/harnesses";
 import {
   type ExecResult,
@@ -71,12 +71,23 @@ export interface LspDetection {
   readonly stagingDir: string;
 }
 
-/** Whether `cli` resolves in any PATH dir (same probe doctor's checks use). */
-const cliOnPath = (cli: string, platform: PlatformEnv): boolean =>
-  (platform.env.PATH ?? "")
-    .split(delimiter)
-    .filter((dir) => dir.length > 0)
-    .some((dir) => existsSync(join(dir, cli)));
+/**
+ * Whether an editor CLI resolves on PATH, given the candidate paths the host
+ * would consider for it.
+ *
+ * The candidates come from `@canonical/harnesses`' `executableCandidates` —
+ * the same helper harness detection resolves `process` signals with — rather
+ * than from a local `PATH`-join here. That local version joined the BARE name
+ * onto each PATH directory, which resolves nothing on Windows: `code`,
+ * `codium` and friends install as `.cmd` shims, so every installed editor
+ * went unseen and `setup lsp` took the no-editor path. That path is a named
+ * SKIP, so the run exited 0 reporting a clean answer on a machine that had
+ * the editor — a wrong skip reads as correct, which is worse than a wrong
+ * failure. One implementation of the platform rules means the probe cannot
+ * drift away from detection's.
+ */
+const cliOnPath = (candidates: readonly string[]): boolean =>
+  candidates.some((candidate) => existsSync(candidate));
 
 /** Whether an editor's extensions dir holds a versioned copy of the extension. */
 const extensionInstalled = (
@@ -103,12 +114,11 @@ const extensionInstalled = (
  * @note Impure — reads PATH dirs and editor extension dirs off the real fs.
  */
 export async function detectLsp(_cwd: string): Promise<LspDetection> {
-  const { editorClis, readPlatformEnv, userDataBase } = await import(
-    "@canonical/harnesses"
-  );
+  const { editorClis, executableCandidates, readPlatformEnv, userDataBase } =
+    await import("@canonical/harnesses");
   const platform = readPlatformEnv();
   const editors: DetectedEditor[] = editorClis
-    .filter((editor) => cliOnPath(editor.cli, platform))
+    .filter((editor) => cliOnPath(executableCandidates(editor.cli, platform)))
     .map((editor) => ({
       editor,
       installed: extensionInstalled(editor, platform),

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
@@ -1,105 +1,221 @@
 /**
- * `setup lsp` — ensure the Terrazzo LSP VS Code extension is installed.
+ * `setup lsp` — ensure the Terrazzo LSP extension is installed in every
+ * VS Code-family editor present on this machine.
  *
- * `detectLsp` probes for the extension FOR REAL up front — it runs
- * `code --list-extensions` (via the `exec` seam, over `runTask`) and matches the
- * `terrazzo` extension id — so a re-run of an already-installed extension is a
- * true no-op and the recap says so, rather than always shelling out. When the
- * `code` CLI is absent from PATH the state is `unknown` (we cannot enumerate,
- * so the installer still runs). `composeLsp` holds the sole mutation, mocked
- * under `--dry-run` and skipped when detection already found the extension.
+ * There is no marketplace listing yet: the install is a VSIX SIDELOAD. The
+ * published npm package bundles the VSIX, so the install is two exec steps —
+ * fetch the package into a pragma-owned staging dir (`bun add`, so the VSIX
+ * lands at a DURABLE path a user can retry by hand, not bunx's ephemeral
+ * `/tmp/bunx-…` cache), then `<editor cli> --install-extension <vsix>` for
+ * each detected editor. The package's own `install.mjs` bin is deliberately
+ * NOT used: it hardcodes the `code` CLI, which is precisely what left
+ * VSCodium/Cursor/Windsurf/Antigravity machines unable to install at all.
+ *
+ * `detectLsp` probes FOR REAL up front, and spawns NOTHING: an editor is
+ * "present" when its CLI resolves on PATH (the `editorClis` registry names
+ * them), and "installed" when its extensions dir holds a
+ * `canonical.terrazzo-lsp-extension-<version>/` entry. Running
+ * `--list-extensions` instead would be the natural probe, but Cursor's Linux
+ * launcher OPENS THE EDITOR on that flag — a detection step must never launch
+ * an app, so the fs is the source of truth. The full extension id is matched
+ * (not the old `terrazzo` substring, which any other terrazzo-named extension
+ * could false-positive).
+ *
+ * No editor CLI found is a NAMED SKIP, not an error: the message says what was
+ * looked for and what to do, and the run exits 0 — there is nothing on this
+ * machine the step could honestly fail at. Real failures (fetch, sideload)
+ * travel the task failure channel (`checkExecOk`) with a recovery that names a
+ * command runnable on THIS machine, so the run-all can isolate the step
+ * (S1-1) and a direct `setup lsp` still renders the original error.
  */
 
+import { existsSync, readdirSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import type { EditorCliDefinition, PlatformEnv } from "@canonical/harnesses";
 import {
   type ExecResult,
   exec,
   flatMap,
   info,
-  pure,
+  mkdir,
   sequence_,
   type Task,
 } from "@canonical/task";
-import { assertExecOk } from "../../shared/assertExecOk.js";
+import { BIN_NAME } from "../../../constants.js";
+import { checkExecOk, guardMissingBinary } from "../../shared/assertExecOk.js";
 import type { LspState } from "../types.js";
 
-/** The VS Code CLI queried for the installed-extensions list. */
-const VSCODE_CLI = "code";
+/** The full extension id, as the editor's extensions dir spells it. */
+const EXTENSION_ID = "canonical.terrazzo-lsp-extension";
 
-/** The substring an installed Terrazzo extension id contains (publisher-agnostic). */
-const TERRAZZO_EXTENSION_MATCH = "terrazzo";
+/** The npm package whose tarball bundles the VSIX. */
+const LSP_PACKAGE = "@canonical/terrazzo-lsp-extension";
+
+/** One detected editor: its registry row + whether the extension is present. */
+export interface DetectedEditor {
+  readonly editor: EditorCliDefinition;
+  readonly installed: boolean;
+}
 
 /**
- * The detected LSP state: whether the Terrazzo extension is already `installed`,
- * `absent`, or `unknown` (the `code` CLI is not on PATH, so we cannot enumerate).
+ * The detected LSP state: the editors whose CLI is on PATH (each with its
+ * installed-state), the staging dir the VSIX is fetched into, and the
+ * aggregate {@link LspState} — `unknown` when NO editor CLI was found (the
+ * step becomes a named skip), `installed` when every found editor already has
+ * the extension, `absent` otherwise (the installer runs for the missing ones).
  */
 export interface LspDetection {
   readonly available: true;
   readonly state: LspState;
+  readonly editors: readonly DetectedEditor[];
+  readonly stagingDir: string;
 }
 
-/**
- * Probe VS Code for the Terrazzo extension. Runs `code --list-extensions` and
- * matches the `terrazzo` id; an absent `code` CLI (spawn ENOENT) or a nonzero
- * exit yields `unknown` (we fall through to running the installer).
- *
- * @param cwd - The directory the probe runs in.
- * @returns The detected {@link LspState}.
- * @note Impure — spawns `code --list-extensions`.
- */
-export async function detectLsp(cwd: string): Promise<LspDetection> {
-  const { runTask } = await import("@canonical/task/node");
-  let state: LspState = "unknown";
+/** Whether `cli` resolves in any PATH dir (same probe doctor's checks use). */
+const cliOnPath = (cli: string, platform: PlatformEnv): boolean =>
+  (platform.env.PATH ?? "")
+    .split(delimiter)
+    .filter((dir) => dir.length > 0)
+    .some((dir) => existsSync(join(dir, cli)));
+
+/** Whether an editor's extensions dir holds a versioned copy of the extension. */
+const extensionInstalled = (
+  editor: EditorCliDefinition,
+  platform: PlatformEnv,
+): boolean => {
+  let entries: string[];
   try {
-    const result = (await runTask(
-      exec(VSCODE_CLI, ["--list-extensions"], cwd),
-    )) as ExecResult;
-    if (result.exitCode === 0) {
-      const installed = result.stdout
-        .toLowerCase()
-        .includes(TERRAZZO_EXTENSION_MATCH);
-      state = installed ? "installed" : "absent";
-    }
+    entries = readdirSync(editor.extensionsDir(platform));
   } catch {
-    // `code` absent from PATH (ENOENT) or any spawn failure → we cannot tell;
-    // leave `unknown` so the installer still runs.
-    state = "unknown";
+    return false; // No extensions dir — nothing installed.
   }
-  return { available: true, state };
-}
+  return entries.some((entry) =>
+    entry.toLowerCase().startsWith(`${EXTENSION_ID}-`),
+  );
+};
 
 /**
- * Compose the LSP-install exec.
+ * Probe every registry editor: CLI presence via PATH lookup, installed-state
+ * via the extensions dir — no spawns (see the module docblock for why).
  *
- * Built from re-runnable combinators (NOT a single-use `gen`) because `execute`
- * interprets the task twice (preview + perform). Under the dry-run preview the
- * `exec` is MOCKED to `exitCode 0`, so `assertExecOk` passes there; a real run's
- * nonzero exit still fails loudly. When detection already found the extension
- * `installed`, the install is SKIPPED — a re-run is a true no-op.
- *
- * @param cwd - The directory to run the installer in.
- * @param state - The prior state from {@link detectLsp} (defaults to `unknown`).
- * @returns A Task that execs the installer (or reports already-installed).
+ * @param _cwd - Unused; kept so every `detectX` shares the (cwd) shape.
+ * @returns The detected {@link LspDetection}.
+ * @note Impure — reads PATH dirs and editor extension dirs off the real fs.
  */
-export function composeLsp(
-  cwd: string,
-  state: LspState = "unknown",
-): Task<void> {
-  if (state === "installed") {
-    return info("Terrazzo LSP VS Code extension already installed — skipped.");
+export async function detectLsp(_cwd: string): Promise<LspDetection> {
+  const { editorClis, readPlatformEnv, userDataBase } = await import(
+    "@canonical/harnesses"
+  );
+  const platform = readPlatformEnv();
+  const editors: DetectedEditor[] = editorClis
+    .filter((editor) => cliOnPath(editor.cli, platform))
+    .map((editor) => ({
+      editor,
+      installed: extensionInstalled(editor, platform),
+    }));
+  const state: LspState =
+    editors.length === 0
+      ? "unknown"
+      : editors.every((e) => e.installed)
+        ? "installed"
+        : "absent";
+  return {
+    available: true,
+    state,
+    editors,
+    stagingDir: join(userDataBase(platform), BIN_NAME, "lsp"),
+  };
+}
+
+/** The editor names in a detection (for messages/results). */
+export const lspEditorNames = (d: LspDetection): string[] =>
+  d.editors.map((e) => e.editor.name);
+
+/** The named-skip line for a machine with no VS Code-family CLI on PATH. */
+export const NO_EDITOR_SKIP_MESSAGE =
+  `No VS Code-family editor CLI found on PATH — skipped installing the ` +
+  `Terrazzo LSP extension. Install VS Code, VSCodium, or another fork (or ` +
+  `put its CLI on PATH), then run \`${BIN_NAME} setup lsp\`.`;
+
+/**
+ * Compose the LSP-install effects for a detection.
+ *
+ * Built from re-runnable combinators (NOT a single-use `gen`) because
+ * `execute` interprets the task twice (preview + perform); a dry-run mocks
+ * every exec (exit 0), so the preview shows the fetch + per-editor sideloads
+ * without spawning. Failures travel the task failure channel with
+ * machine-honest recoveries (see module docblock).
+ *
+ * @param d - The detection gathered up front.
+ * @returns A Task installing the extension into each editor missing it.
+ */
+export function composeLsp(d: LspDetection): Task<void> {
+  if (d.state === "unknown") {
+    return info(NO_EDITOR_SKIP_MESSAGE);
   }
-  return sequence_([
-    info("Ensuring the Terrazzo LSP VS Code extension is installed..."),
-    // The interpreter RESOLVES on a nonzero exit — a failed installer must fail
-    // loudly (surfacing its stderr), not report a false success.
-    flatMap(
-      exec("bunx", ["@canonical/terrazzo-lsp-extension"], cwd),
-      (result) => {
-        assertExecOk(
-          "bunx @canonical/terrazzo-lsp-extension",
-          result as ExecResult,
-        );
-        return pure(undefined);
+  if (d.state === "installed") {
+    return info(
+      `Terrazzo LSP extension already installed (${lspEditorNames(d).join(", ")}) — skipped.`,
+    );
+  }
+
+  const pending = d.editors.filter((e) => !e.installed);
+  const vsixPath = join(
+    d.stagingDir,
+    "node_modules",
+    ...LSP_PACKAGE.split("/"),
+    "terrazzo-lsp.vsix",
+  );
+
+  // Fetch the VSIX-bundling package into the pragma-owned staging dir. `bun`
+  // (not bunx) so the unpacked package — and its VSIX — survives at a stable
+  // path the recovery lines below can honestly point at.
+  const fetchCommand = `bun add ${LSP_PACKAGE}@latest`;
+  const fetchVsix = guardMissingBinary(
+    "bun",
+    {
+      message: `Install Bun (https://bun.sh), then run \`${BIN_NAME} setup lsp\` again.`,
+    },
+    sequence_([
+      mkdir(d.stagingDir, true),
+      flatMap(
+        exec("bun", ["add", `${LSP_PACKAGE}@latest`], d.stagingDir),
+        (result) =>
+          checkExecOk(fetchCommand, result as ExecResult, {
+            message:
+              "The extension package could not be fetched — check that this machine can reach registry.npmjs.org, then run " +
+              `\`${BIN_NAME} setup lsp\` again.`,
+          }),
+      ),
+    ]),
+  );
+
+  const sideloads = pending.map(({ editor }) => {
+    const command = `${editor.cli} --install-extension ${vsixPath}`;
+    return guardMissingBinary(
+      editor.cli,
+      {
+        message: `The \`${editor.cli}\` CLI disappeared from PATH mid-run — restore it, then run \`${BIN_NAME} setup lsp\` again.`,
       },
+      flatMap(
+        exec(editor.cli, ["--install-extension", vsixPath], d.stagingDir),
+        (result) =>
+          checkExecOk(command, result as ExecResult, {
+            message:
+              `${editor.name} refused the VSIX (its output is above). The file is kept at ${vsixPath} — retry by hand with ` +
+              `\`${command}\`, or update ${editor.name} first.`,
+          }),
+      ),
+    );
+  });
+
+  return sequence_([
+    info(
+      `Installing the Terrazzo LSP extension (${EXTENSION_ID}) into: ${pending
+        .map((e) => e.editor.name)
+        .join(", ")}...`,
     ),
+    fetchVsix,
+    ...sideloads,
   ]);
 }

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
@@ -30,6 +30,7 @@ import type { PragmaRuntime } from "../../../kernel/runtime/types.js";
 import type {
   ConfiguredTarget,
   McpTargetState,
+  ScopeBand,
   ScopeSelection,
 } from "../types.js";
 
@@ -59,11 +60,25 @@ export interface McpDetection {
  * classifier (does the existing entry match this?) and the writer (`composeMcp`)
  * consume, so "already configured" means byte-for-byte what a write would emit.
  *
- * @param cwd - The project root recorded on the entry.
+ * The entry is BAND-shaped: a project-band entry records the project root as
+ * `cwd` (that binding is the point of a per-repo registration), while a
+ * global-band entry OMITS `cwd` entirely — a per-user server must not be
+ * pinned to whatever directory `setup mcp --global` happened to run from
+ * (observed: a global registration from `~/Downloads` permanently served
+ * `~/Downloads`, and re-running from repo B "repaired" it to repo B,
+ * ping-ponging the machine band between projects). The per-harness
+ * serializers already omit an undefined `cwd`, and the matcher treats an
+ * omitted controlled field as must-be-absent, so a stale global entry still
+ * carrying a `cwd` classifies as `drifted` and converges on the next write.
+ *
+ * @param cwd - The project root (recorded only on project-band entries).
+ * @param band - The config band the entry is written to.
  * @returns The pragma {@link McpServerConfig}.
  */
-export function pragmaMcpEntry(cwd: string): McpServerConfig {
-  return { command: MCP_SERVER_NAME, args: ["mcp"], cwd };
+export function pragmaMcpEntry(cwd: string, band: ScopeBand): McpServerConfig {
+  return band === "project"
+    ? { command: MCP_SERVER_NAME, args: ["mcp"], cwd }
+    : { command: MCP_SERVER_NAME, args: ["mcp"] };
 }
 
 /**
@@ -72,11 +87,13 @@ export function pragmaMcpEntry(cwd: string): McpServerConfig {
  * already carries a matching pragma entry, `drifted` otherwise (present in at
  * least one write but not matching everywhere). Reads each write's file for real
  * via `readMcpConfigFrom`, and matches each raw entry against what THAT write's
- * per-harness serializer would emit (`mcpEntryMatches` ignores extra keys a
- * harness or user added, so we never churn a file we did not author).
+ * per-harness serializer would emit for the group's BAND (`mcpEntryMatches`
+ * compares the serializer's controlled fields — so a global entry still
+ * pinning a `cwd` reads as drifted — and ignores extra keys a harness or user
+ * added, so we never churn a file we did not author).
  *
  * @param group - The target group whose writes to inspect.
- * @param want - The canonical pragma entry a write would serialize.
+ * @param want - The canonical pragma entry for the group's band.
  * @param harnessesApi - The dynamically imported harnesses module.
  * @param runTask - The node Task interpreter.
  * @returns The group's {@link McpTargetState}.
@@ -98,7 +115,7 @@ async function classifyGroup(
     const existing = servers[MCP_SERVER_NAME];
     if (existing === undefined) continue;
     present += 1;
-    if (harnessesApi.mcpEntryMatches(existing, write.serializeEntry(want))) {
+    if (harnessesApi.mcpEntryMatches(existing, want, write.serializeEntry)) {
       matching += 1;
     }
   }
@@ -144,14 +161,15 @@ export async function detectMcp(
 
   // Read each group's existing config (for real, up front) so the recap/preview
   // and the default selection reflect true prior state — the same discipline
-  // `detectSkills` uses for its per-link create/skip/replace decision.
-  const want = pragmaMcpEntry(cwd);
+  // `detectSkills` uses for its per-link create/skip/replace decision. The
+  // wanted entry is BAND-shaped (a global entry omits `cwd`), so it is built
+  // per group, not once.
   const stateByPath = new Map<string, McpTargetState>();
   await Promise.all(
     groups.map(async (group) => {
       const state = await classifyGroup(
         group,
-        want,
+        pragmaMcpEntry(cwd, group.scope),
         { readMcpConfigFrom, mcpEntryMatches },
         runTask,
       );
@@ -199,16 +217,20 @@ export function composeMcp(
   if (groups.length === 0) {
     return warn("No AI harnesses selected — nothing to configure.");
   }
-  const pragmaMcpConfig = pragmaMcpEntry(d.cwd);
   // Re-runnable combinators (NOT a single-use `gen`): `execute` interprets the
   // task twice (preview + perform). One combined write per file keeps a shared
-  // file (VS Code + Cline) a single read-modify-write — dry-run safe.
+  // file (VS Code + Cline) a single read-modify-write — dry-run safe. The
+  // written entry is BAND-shaped per group (a global entry omits `cwd`).
   const tasks: Task<unknown>[] = [];
   for (const group of groups) {
     const state = mcpGroupState(d, group.path);
     const names = group.harnessNames.join(", ");
     tasks.push(
-      d.writeMcpConfigTargets(group.writes, MCP_SERVER_NAME, pragmaMcpConfig),
+      d.writeMcpConfigTargets(
+        group.writes,
+        MCP_SERVER_NAME,
+        pragmaMcpEntry(d.cwd, group.scope),
+      ),
     );
     const verb =
       state === "configured"

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
@@ -67,33 +67,17 @@ export function pragmaMcpEntry(cwd: string): McpServerConfig {
 }
 
 /**
- * Whether an existing MCP entry equals the pragma entry we would write, over the
- * fields we control (`command`/`args`/`cwd`). A shallow structural compare — a
- * harness that carries extra keys (e.g. `env`) still reads as `configured` as
- * long as our three fields match, so we never churn a file we did not author.
- */
-function entryMatches(
-  existing: McpServerConfig,
-  want: McpServerConfig,
-): boolean {
-  const sameArgs =
-    (existing.args ?? []).length === (want.args ?? []).length &&
-    (want.args ?? []).every((a, i) => existing.args?.[i] === a);
-  return (
-    existing.command === want.command && existing.cwd === want.cwd && sameArgs
-  );
-}
-
-/**
  * Classify one target group against its on-disk config: `absent` when no pragma
  * entry exists in ANY of the group's writes, `configured` when EVERY write
  * already carries a matching pragma entry, `drifted` otherwise (present in at
  * least one write but not matching everywhere). Reads each write's file for real
- * via `readMcpConfigFrom`.
+ * via `readMcpConfigFrom`, and matches each raw entry against what THAT write's
+ * per-harness serializer would emit (`mcpEntryMatches` ignores extra keys a
+ * harness or user added, so we never churn a file we did not author).
  *
  * @param group - The target group whose writes to inspect.
- * @param want - The pragma entry a write would emit.
- * @param readMcpConfigFrom - The harness reader (dynamically imported).
+ * @param want - The canonical pragma entry a write would serialize.
+ * @param harnessesApi - The dynamically imported harnesses module.
  * @param runTask - The node Task interpreter.
  * @returns The group's {@link McpTargetState}.
  * @note Impure — reads each write's config file.
@@ -101,17 +85,22 @@ function entryMatches(
 async function classifyGroup(
   group: TargetGroup,
   want: McpServerConfig,
-  readMcpConfigFrom: typeof import("@canonical/harnesses").readMcpConfigFrom,
+  harnessesApi: Pick<
+    typeof import("@canonical/harnesses"),
+    "readMcpConfigFrom" | "mcpEntryMatches"
+  >,
   runTask: typeof import("@canonical/task/node").runTask,
 ): Promise<McpTargetState> {
   let present = 0;
   let matching = 0;
   for (const write of group.writes) {
-    const servers = await runTask(readMcpConfigFrom(write));
+    const servers = await runTask(harnessesApi.readMcpConfigFrom(write));
     const existing = servers[MCP_SERVER_NAME];
     if (existing === undefined) continue;
     present += 1;
-    if (entryMatches(existing, want)) matching += 1;
+    if (harnessesApi.mcpEntryMatches(existing, write.serializeEntry(want))) {
+      matching += 1;
+    }
   }
   if (present === 0) return "absent";
   if (matching === group.writes.length) return "configured";
@@ -139,6 +128,7 @@ export async function detectMcp(
     {
       detectHarnesses,
       groupTargetsForScope,
+      mcpEntryMatches,
       readMcpConfigFrom,
       readPlatformEnv,
       writeMcpConfigTargets,
@@ -162,7 +152,7 @@ export async function detectMcp(
       const state = await classifyGroup(
         group,
         want,
-        readMcpConfigFrom,
+        { readMcpConfigFrom, mcpEntryMatches },
         runTask,
       );
       stateByPath.set(group.path, state);

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
@@ -9,7 +9,7 @@
  * interpreter mocks). Idempotent by construction.
  */
 
-import { existsSync, readlinkSync } from "node:fs";
+import { lstatSync, readlinkSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   deleteFile,
@@ -42,14 +42,36 @@ export interface SkillsDetection {
   readonly warnings: readonly string[];
 }
 
-/** The current target of a symlink, or `null` when absent / not a symlink. */
-function currentLink(linkPath: string): string | null {
-  if (!existsSync(linkPath)) return null;
+/** What currently occupies a candidate link path. */
+type LinkState =
+  | { readonly kind: "absent" }
+  | { readonly kind: "symlink"; readonly target: string }
+  | { readonly kind: "other" };
+
+/**
+ * Classify a link path WITHOUT following it: absent, a symlink (with its raw
+ * target, resolving or not), or a real (non-symlink) entry. `lstat`-based, the
+ * same classification `sources/installSkills.ts`'s `linkState` uses — the two
+ * planners previously disagreed: this one probed with `existsSync`, which
+ * FOLLOWS the link, so a DANGLING symlink read as "absent", the plan said
+ * `created`, and the real `symlink()` crashed EEXIST with a "please report
+ * this issue" label (S1-2) while the dry-run previewed a clean create.
+ */
+function linkState(linkPath: string): LinkState {
+  let stat: ReturnType<typeof lstatSync>;
   try {
-    return readlinkSync(linkPath);
+    stat = lstatSync(linkPath);
   } catch {
-    return "";
+    return { kind: "absent" };
   }
+  if (stat.isSymbolicLink()) {
+    try {
+      return { kind: "symlink", target: readlinkSync(linkPath) };
+    } catch {
+      return { kind: "other" };
+    }
+  }
+  return { kind: "other" };
 }
 
 /**
@@ -102,18 +124,23 @@ export async function detectSkills(
     targets.push({ dir: crossDir, name: CROSS_CLIENT_DIR });
   }
 
-  // Decide each action against REAL fs (so the preview is accurate).
+  // Decide each action against REAL fs (so the preview is accurate). Dangling
+  // or wrong-target symlinks are `replaced` (delete + relink); a real
+  // (non-symlink) file/dir at the path is `skipped` — a hand-placed skill is
+  // never this command's to delete (matching `planSkillInstall`).
   const actions: SymlinkAction[] = [];
   for (const { dir, name } of targets) {
     for (const skill of skills) {
       const linkPath = resolve(dir, skill.folderName);
-      const current = currentLink(linkPath);
+      const state = linkState(linkPath);
       const action: SymlinkAction["action"] =
-        current === null
+        state.kind === "absent"
           ? "created"
-          : current === skill.sourcePath
+          : state.kind === "symlink" && state.target === skill.sourcePath
             ? "skipped"
-            : "replaced";
+            : state.kind === "symlink"
+              ? "replaced"
+              : "skipped";
       actions.push({
         skillName: skill.name,
         target: skill.sourcePath,

--- a/packages/cli/pragma/src/capabilities/setup/setup.render.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.render.test.ts
@@ -107,3 +107,36 @@ describe("setup render — MCP recap banded by Global/Project", () => {
     expect(JSON.parse(setupFormatters.json(BOTH_BANDS))).toEqual(BOTH_BANDS);
   });
 });
+
+describe("setup render — LSP line names editors, never a false 'installed'", () => {
+  it("`unknown` (no editor CLI) renders as the honest named skip", () => {
+    // The old copy said "is installed (up to date)" for every non-installed
+    // state — false on a machine where nothing was installed at all.
+    const none: SetupResult = { kind: "lsp", state: "unknown", editors: [] };
+    expect(setupFormatters.plain(none)).toBe(
+      "No VS Code-family editor CLI found on PATH — Terrazzo LSP extension not installed.",
+    );
+  });
+
+  it("`installed` names the editors it is already present in", () => {
+    const done: SetupResult = {
+      kind: "lsp",
+      state: "installed",
+      editors: ["VS Code", "VSCodium"],
+    };
+    expect(setupFormatters.plain(done)).toBe(
+      "Terrazzo LSP extension already installed (VS Code, VSCodium).",
+    );
+  });
+
+  it("`absent` (installer ran) names the target editors", () => {
+    const ran: SetupResult = {
+      kind: "lsp",
+      state: "absent",
+      editors: ["Cursor"],
+    };
+    expect(setupFormatters.plain(ran)).toBe(
+      "Terrazzo LSP extension installed (Cursor).",
+    );
+  });
+});

--- a/packages/cli/pragma/src/capabilities/setup/setup.render.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.render.ts
@@ -68,10 +68,20 @@ function renderSetupLine(data: SetupResult): string {
           return `Installed ${data.shell} completions at ${data.path}.`;
       }
     }
-    case "lsp":
+    case "lsp": {
+      // `unknown` = no VS Code-family CLI on PATH: an honest named skip — the
+      // old copy claimed "is installed (up to date)" for every non-installed
+      // state, which was false twice over (nothing was installed, and nothing
+      // ever checks a version).
+      if (data.state === "unknown") {
+        return "No VS Code-family editor CLI found on PATH — Terrazzo LSP extension not installed.";
+      }
+      const into =
+        data.editors.length > 0 ? ` (${data.editors.join(", ")})` : "";
       return data.state === "installed"
-        ? "Terrazzo LSP extension already installed (up to date)."
-        : "Terrazzo LSP extension is installed (up to date).";
+        ? `Terrazzo LSP extension already installed${into}.`
+        : `Terrazzo LSP extension installed${into}.`;
+    }
     case "mcp":
       return summarizeMcpTargets(data.targets);
     case "skills":

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -853,6 +853,41 @@ describe("setup (run-all wizard)", () => {
     expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(false);
   });
 
+  it("a failing LSP step no longer aborts the run — MCP and skills still apply, exit reflects the failure (S1-1)", async () => {
+    // The audit's headline break: with an unsatisfiable LSP prerequisite the
+    // single advertised onboarding command configured NOTHING (no MCP write,
+    // no skills link) and exited 1. Steps are independent — one failure must
+    // report, let the rest proceed, and only then fail the run. Here the LSP
+    // step has an editor (`code` stub on PATH) but no `bun`, so its fetch
+    // fails; MCP (.cursor) and skills (a seeded skill) must still apply.
+    const prevData = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = tmp("pragma-s11-data-"); // jail the staging dir
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".cursor"), { recursive: true });
+    const skillDir = join(cwd, ".pragma", "skills", "s");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: s\ndescription: A skill.\n---\n",
+    );
+    let thrown: unknown;
+    try {
+      await executeVerb(setupSelfVerb, {}, YES, bootRuntime(FLAGS, cwd));
+    } catch (error) {
+      thrown = error;
+    } finally {
+      process.env.XDG_DATA_HOME = prevData;
+    }
+    // The satisfiable steps ran to completion...
+    expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(true);
+    expect(existsSync(join(cwd, ".agents", "skills", "s"))).toBe(true);
+    // ...and the run still failed, with the ORIGINAL step error surfaced.
+    expect(thrown).toBeDefined();
+    const err = asPragmaError(thrown);
+    expect(err.code).toBe("UNSUPPORTED");
+    expect(err.message).toContain("bun");
+  });
+
   it("omits skills gracefully when none are discovered (no mid-wizard EMPTY_RESULTS)", async () => {
     // A run-all in a project with no skills must NOT throw — it just doesn't
     // offer the skills step. Reaching a clean plan proves the graceful degrade.

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -319,6 +319,86 @@ describe("setup mcp — scope & dedup", () => {
     ).toBe(true);
     expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(false);
   });
+
+  it("a GLOBAL entry omits cwd — registrations from two directories are byte-identical", async () => {
+    // A per-user server must not be pinned to whatever directory `setup mcp
+    // --global` happened to run from (a registration made from ~/Downloads
+    // used to serve ~/Downloads forever, and re-running from repo B flipped
+    // the machine band to repo B).
+    const home = process.env.HOME ?? "";
+    const configPath = join(home, ".codeium", "windsurf", "mcp_config.json");
+    const register = async (cwd: string): Promise<string> => {
+      mkdirSync(join(cwd, ".windsurf"), { recursive: true });
+      await executeVerb(
+        verbOf("mcp"),
+        { global: true },
+        YES,
+        bootRuntime(FLAGS, cwd),
+      );
+      return readFileSync(configPath, "utf-8");
+    };
+    const fromA = await register(tmp("pragma-setup-projA-"));
+    const fromB = await register(tmp("pragma-setup-projB-"));
+    expect(fromA).toBe(fromB);
+    const entry = JSON.parse(fromA).mcpServers?.pragma;
+    expect(entry).toEqual({ command: "pragma", args: ["mcp"] });
+    expect(entry).not.toHaveProperty("cwd");
+  });
+
+  it("a stale cwd-pinned GLOBAL entry converges: drifted once, configured after", async () => {
+    const home = process.env.HOME ?? "";
+    const configPath = join(home, ".codeium", "windsurf", "mcp_config.json");
+    mkdirSync(join(home, ".codeium", "windsurf"), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          pragma: {
+            command: "pragma",
+            args: ["mcp"],
+            cwd: "/home/u/Downloads",
+          },
+        },
+      }),
+    );
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".windsurf"), { recursive: true });
+    const rt = bootRuntime(FLAGS, cwd);
+    const { detectMcp, mcpGroupState } = await import(
+      "./operations/setupMcp.js"
+    );
+    // The pinned entry reads as drift (the omitted cwd is a controlled field).
+    const before = await detectMcp(rt, "global");
+    expect(mcpGroupState(before, configPath)).toBe("drifted");
+    // One write converges it...
+    await executeVerb(
+      verbOf("mcp"),
+      { global: true },
+      YES,
+      bootRuntime(FLAGS, cwd),
+    );
+    expect(
+      JSON.parse(readFileSync(configPath, "utf-8")).mcpServers.pragma,
+    ).toEqual({ command: "pragma", args: ["mcp"] });
+    // ...and it stays `configured` afterwards (no churn on every run).
+    const after = await detectMcp(bootRuntime(FLAGS, cwd), "global");
+    expect(mcpGroupState(after, configPath)).toBe("configured");
+  });
+
+  it("a PROJECT entry still records the project root as cwd", async () => {
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".cursor"), { recursive: true });
+    await executeVerb(
+      verbOf("mcp"),
+      { local: true },
+      YES,
+      bootRuntime(FLAGS, cwd),
+    );
+    const entry = JSON.parse(
+      readFileSync(join(cwd, ".cursor", "mcp.json"), "utf-8"),
+    ).mcpServers?.pragma;
+    expect(entry.cwd).toBe(cwd);
+  });
 });
 
 describe("setup mcp — customize opt-in gate (Item 6)", () => {

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -18,7 +18,9 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -431,6 +433,71 @@ describe("setup skills", () => {
     expect(symlinkEffect).toBeDefined();
     expect(symlinkEffect?.undo).toBeDefined();
     expect(existsSync(join(cwd, ".agents", "skills", "my-skill"))).toBe(false);
+  });
+
+  it("classifies a DANGLING symlink as replaced and repairs it (S1-2)", async () => {
+    // `existsSync` FOLLOWS a symlink, so a dangling link used to read as
+    // "absent" → plan `created` → the real symlink() crashed EEXIST labeled
+    // INTERNAL_ERROR ("please report this issue"), leaving the broken link in
+    // place — and the dry-run previewed a clean create the run then belied.
+    const cwd = tmp("pragma-setup-proj-");
+    const skillDir = join(cwd, ".pragma", "skills", "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: my-skill\ndescription: A test skill.\n---\n",
+    );
+    const linkDir = join(cwd, ".agents", "skills");
+    mkdirSync(linkDir, { recursive: true });
+    const linkPath = join(linkDir, "my-skill");
+    symlinkSync(join(cwd, "nonexistent-target"), linkPath);
+
+    const detected = await detectSkills(bootRuntime(FLAGS, cwd));
+    const action = detected.actions.find((a) => a.linkPath === linkPath);
+    expect(action?.action).toBe("replaced");
+
+    // The dry-run preview now PREDICTS the repair: a delete before the relink.
+    const { effects } = dryRun(composeSkills(detected));
+    const deletes = effects.filter(
+      (e) =>
+        e._tag === "DeleteFile" && (e as { path?: string }).path === linkPath,
+    );
+    expect(deletes.length).toBe(1);
+
+    // The real run repairs the link instead of crashing EEXIST.
+    await runTask(composeSkills(detected));
+    expect(readlinkSync(linkPath)).toBe(skillDir);
+  });
+
+  it("skips a real (non-symlink) directory at the link path, never deleting it", async () => {
+    // A hand-placed skill directory is not this command's to delete — the
+    // sibling planner (sources/installSkills.ts) already refuses to clobber
+    // it, and the two planners must agree on classification.
+    const cwd = tmp("pragma-setup-proj-");
+    const skillDir = join(cwd, ".pragma", "skills", "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: my-skill\ndescription: A test skill.\n---\n",
+    );
+    const realDir = join(cwd, ".agents", "skills", "my-skill");
+    mkdirSync(realDir, { recursive: true });
+    writeFileSync(join(realDir, "SKILL.md"), "hand-placed\n");
+
+    const detected = await detectSkills(bootRuntime(FLAGS, cwd));
+    const action = detected.actions.find((a) => a.linkPath === realDir);
+    expect(action?.action).toBe("skipped");
+
+    const { effects } = dryRun(composeSkills(detected));
+    expect(
+      effects.some(
+        (e) =>
+          e._tag === "DeleteFile" && (e as { path?: string }).path === realDir,
+      ),
+    ).toBe(false);
+    expect(readFileSync(join(realDir, "SKILL.md"), "utf-8")).toBe(
+      "hand-placed\n",
+    );
   });
 });
 

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -346,14 +346,22 @@ describe("setup mcp — customize opt-in gate (Item 6)", () => {
 describe("setup (run-all wizard) — scope threading", () => {
   // Isolate PATH so an ambient `claude`/`codex` can't inject a harness via a
   // `process` signal — detection is driven only by the dirs each test makes.
+  // A stubbed `code` CLI makes the LSP step's editor detection deterministic.
   let prevPath: string | undefined;
+  let stubPath = "";
   beforeEach(() => {
     prevPath = process.env.PATH;
-    process.env.PATH = tmp("pragma-runall-path-");
+    stubPath = tmp("pragma-runall-path-");
+    process.env.PATH = stubPath;
   });
   afterEach(() => {
     process.env.PATH = prevPath;
   });
+
+  /** Put a stub `code` on the isolated PATH so an LSP install is composable. */
+  const seedEditorCli = (): void => {
+    writeFileSync(join(stubPath, "code"), "");
+  };
 
   /** Seed a discoverable skill so the project-band skills step is offerable. */
   const seedSkill = (cwd: string): void => {
@@ -388,6 +396,7 @@ describe("setup (run-all wizard) — scope threading", () => {
   it("--global omits the project-band skills step, keeping global steps", async () => {
     const cwd = tmp("pragma-setup-proj-");
     seedSkill(cwd); // WOULD be offered under the default `both`
+    seedEditorCli(); // vscode detected ⇒ the LSP install is in the plan
     const outcome = await executeVerb(
       setupSelfVerb,
       { global: true },
@@ -501,14 +510,19 @@ describe("setup skills", () => {
   });
 });
 
-describe("setup lsp — missing-binary guard (bunx absent)", () => {
-  it("surfaces a NAMED UNSUPPORTED (not INTERNAL_ERROR) when bunx is off PATH", async () => {
-    // Drives the REAL composeLsp exec (YES — not a dry-run mock) with `bunx`
-    // removed from PATH, so the spawn REJECTS with ENOENT. The reconciled guard
-    // at composeLsp's use site names it; without the guard the raw reject
-    // collapses to INTERNAL_ERROR ("report this issue") at the boundary.
+describe("setup lsp — prerequisites (bun absent / no editor CLI)", () => {
+  it("surfaces a NAMED UNSUPPORTED (not INTERNAL_ERROR) when bun is off PATH", async () => {
+    // Drives the REAL composeLsp fetch (YES — not a dry-run mock) with a
+    // stubbed `code` CLI on PATH (so the sideload is attempted) but no `bun`,
+    // so the fetch spawn REJECTS with ENOENT. The guard names it; without the
+    // guard the raw reject collapses to INTERNAL_ERROR ("please report this
+    // issue") at the boundary.
     const prevPath = process.env.PATH;
-    process.env.PATH = tmp("pragma-empty-path-"); // empty dir ⇒ bunx unresolvable
+    const prevData = process.env.XDG_DATA_HOME;
+    const stubDir = tmp("pragma-lsp-path-");
+    writeFileSync(join(stubDir, "code"), ""); // present ⇒ vscode is a target
+    process.env.PATH = stubDir;
+    process.env.XDG_DATA_HOME = tmp("pragma-lsp-data-"); // jail the staging dir
     let thrown: unknown;
     try {
       await executeVerb(
@@ -521,15 +535,140 @@ describe("setup lsp — missing-binary guard (bunx absent)", () => {
       thrown = error;
     } finally {
       process.env.PATH = prevPath;
+      process.env.XDG_DATA_HOME = prevData;
     }
     expect(thrown).toBeDefined();
     const err = asPragmaError(thrown);
     expect(err.code).toBe("UNSUPPORTED");
     expect(err.code).not.toBe("INTERNAL_ERROR");
-    expect(err.message).toContain("bunx");
+    expect(err.message).toContain("bun");
     expect(err.message).toMatch(/not found on your PATH/i);
     // The recovery is the actionable install hint, not "report this issue".
     expect(err.recovery?.message ?? "").not.toMatch(/report this issue/i);
+  });
+
+  it("sideloads the bundled VSIX into EACH detected editor missing it (per-editor CLI, not a hardcoded `code`)", async () => {
+    // Two editor CLIs on PATH; VS Code already has the extension (its
+    // extensions dir carries a versioned copy), VSCodium does not — so the
+    // composed plan fetches the package once (bun, into a durable staging dir)
+    // and sideloads ONLY into `codium`. This is the VSCodium fix: the editor
+    // CLI is a registry lookup, no longer the hardcoded `code`.
+    const prevPath = process.env.PATH;
+    const stubDir = tmp("pragma-forks-path-");
+    writeFileSync(join(stubDir, "code"), "");
+    writeFileSync(join(stubDir, "codium"), "");
+    process.env.PATH = stubDir;
+    try {
+      mkdirSync(
+        join(
+          process.env.HOME ?? "",
+          ".vscode",
+          "extensions",
+          "canonical.terrazzo-lsp-extension-1.2.3",
+        ),
+        { recursive: true },
+      );
+      const { detectLsp, composeLsp } = await import(
+        "./operations/setupLsp.js"
+      );
+      const detected = await detectLsp(tmp("pragma-setup-proj-"));
+      expect(detected.state).toBe("absent");
+      expect(detected.editors.map((e) => [e.editor.cli, e.installed])).toEqual([
+        ["code", true],
+        ["codium", false],
+      ]);
+
+      const { effects } = dryRun(composeLsp(detected));
+      const execs = effects.filter((e) => e._tag === "Exec") as (Effect & {
+        _tag: "Exec";
+        command: string;
+        args: string[];
+      })[];
+      // One fetch (bun add, durable staging) + one sideload per PENDING editor.
+      expect(execs.map((e) => e.command)).toEqual(["bun", "codium"]);
+      expect(execs[0].args).toEqual([
+        "add",
+        "@canonical/terrazzo-lsp-extension@latest",
+      ]);
+      expect(execs[1].args[0]).toBe("--install-extension");
+      // The VSIX path is the staging dir's — durable, not a bunx /tmp cache.
+      expect(execs[1].args[1]).toContain(detected.stagingDir);
+      expect(execs[1].args[1]).toContain("terrazzo-lsp.vsix");
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+
+  it("reports already-installed (a true no-op) when every detected editor has the extension", async () => {
+    const prevPath = process.env.PATH;
+    const stubDir = tmp("pragma-installed-path-");
+    writeFileSync(join(stubDir, "code"), "");
+    process.env.PATH = stubDir;
+    try {
+      mkdirSync(
+        join(
+          process.env.HOME ?? "",
+          ".vscode",
+          "extensions",
+          "canonical.terrazzo-lsp-extension-1.2.3",
+        ),
+        { recursive: true },
+      );
+      const { detectLsp, composeLsp } = await import(
+        "./operations/setupLsp.js"
+      );
+      const detected = await detectLsp(tmp("pragma-setup-proj-"));
+      expect(detected.state).toBe("installed");
+      const { effects } = dryRun(composeLsp(detected));
+      expect(effects.some((e) => e._tag === "Exec")).toBe(false);
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+
+  it("matches the FULL extension id, not any terrazzo-named directory", async () => {
+    // The old probe matched the substring "terrazzo", which any other
+    // terrazzo-named extension would false-positive.
+    const prevPath = process.env.PATH;
+    const stubDir = tmp("pragma-substr-path-");
+    writeFileSync(join(stubDir, "code"), "");
+    process.env.PATH = stubDir;
+    try {
+      mkdirSync(
+        join(
+          process.env.HOME ?? "",
+          ".vscode",
+          "extensions",
+          "someoneelse.terrazzo-tools-9.9.9",
+        ),
+        { recursive: true },
+      );
+      const { detectLsp } = await import("./operations/setupLsp.js");
+      const detected = await detectLsp(tmp("pragma-setup-proj-"));
+      expect(detected.state).toBe("absent");
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+
+  it("skips with a NAMED message (exit 0) when no editor CLI exists at all", async () => {
+    // A machine with no VS Code-family CLI cannot be installed into — the
+    // honest outcome is a named skip, not the old UNSUPPORTED with a
+    // "permissions or network" guess and a dead /tmp path (§3, S1-1's trigger).
+    const prevPath = process.env.PATH;
+    process.env.PATH = tmp("pragma-noeditor-path-"); // empty ⇒ no editor CLI
+    try {
+      const outcome = await executeVerb(
+        verbOf("lsp"),
+        {},
+        YES,
+        bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
+      );
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stdout).toContain("No VS Code-family editor CLI");
+    } finally {
+      process.env.PATH = prevPath;
+    }
   });
 });
 
@@ -680,6 +819,20 @@ describe("setup — idempotent detection of already-present config", () => {
 });
 
 describe("setup (run-all wizard)", () => {
+  // Pin PATH to a stub dir carrying only a `code` CLI: the LSP step's editor
+  // detection (and the ambient-harness process signals) must not depend on
+  // what happens to be installed on the host running the tests.
+  let prevPath: string | undefined;
+  beforeEach(() => {
+    prevPath = process.env.PATH;
+    const stubPath = tmp("pragma-wizard-path-");
+    writeFileSync(join(stubPath, "code"), "");
+    process.env.PATH = stubPath;
+  });
+  afterEach(() => {
+    process.env.PATH = prevPath;
+  });
+
   it("--dry-run previews every DETECTED step (completions + lsp + mcp), writing nothing", async () => {
     const cwd = tmp("pragma-setup-proj-");
     mkdirSync(join(cwd, ".cursor"), { recursive: true }); // harness detected

--- a/packages/cli/pragma/src/capabilities/setup/types.ts
+++ b/packages/cli/pragma/src/capabilities/setup/types.ts
@@ -56,10 +56,12 @@ export interface ConfiguredTarget {
 export type CompletionsState = "absent" | "installed" | "stale";
 
 /**
- * The detected state of the Terrazzo LSP VS Code extension, probed up front by
- * `detectLsp`: `installed` (already present — a re-run skips it), `absent` (not
- * present, so the installer runs), or `unknown` (the `code` CLI is not on PATH,
- * so we cannot enumerate and the installer runs regardless).
+ * The detected state of the Terrazzo LSP extension across the VS Code-family
+ * editors on this machine, probed up front by `detectLsp`: `installed` (every
+ * editor whose CLI is on PATH already has it — a re-run skips), `absent` (at
+ * least one detected editor is missing it, so the sideload runs for those), or
+ * `unknown` (NO editor CLI was found on PATH — the step is a named skip, since
+ * there is nothing to install into).
  */
 export type LspState = "installed" | "absent" | "unknown";
 
@@ -89,7 +91,12 @@ export type SetupResult =
       readonly installed: boolean;
       readonly state: CompletionsState;
     }
-  | { readonly kind: "lsp"; readonly state: LspState }
+  | {
+      readonly kind: "lsp";
+      readonly state: LspState;
+      /** The detected editors (CLI on PATH) the state aggregates over. */
+      readonly editors: readonly string[];
+    }
   | {
       readonly kind: "mcp";
       readonly configured: readonly string[];

--- a/packages/cli/pragma/src/capabilities/shared/assertExecOk.ts
+++ b/packages/cli/pragma/src/capabilities/shared/assertExecOk.ts
@@ -17,9 +17,62 @@
  * instead of resolving, so it never reaches here.)
  */
 
-import { type ExecResult, fail, recover, type Task } from "@canonical/task";
+import {
+  type ExecResult,
+  fail,
+  pure,
+  recover,
+  type Task,
+} from "@canonical/task";
 import { PragmaError } from "../../kernel/error/PragmaError.js";
 import type { Recovery } from "../../kernel/error/types.js";
+
+/**
+ * Route a {@link PragmaError} through the Task FAILURE CHANNEL (a `Fail` node
+ * carrying the error as `cause`) instead of a synchronous throw.
+ *
+ * The distinction is load-bearing: a synchronous throw from a bind/recover
+ * continuation ESCAPES the interpreter's trampoline entirely — no enclosing
+ * `recover` can see it — whereas a `Fail` node unwinds to the nearest recovery
+ * frame. Setup's run-all isolates each step with `recover` so one failed step
+ * cannot abort the rest (S1-1); that only works if step failures travel the
+ * failure channel. The boundary (`asPragmaError`) unwraps the carried cause,
+ * so a failure that escapes un-recovered still renders with its own code,
+ * message, and recovery — never the INTERNAL_ERROR catch-all.
+ */
+export function failPragma(error: PragmaError): Task<never> {
+  return fail({ code: error.code, message: error.message, cause: error });
+}
+
+/**
+ * The failure-channel sibling of {@link assertExecOk}: yield `pure(undefined)`
+ * on exit 0, otherwise fail with an UNSUPPORTED {@link PragmaError} carrying
+ * the command, exit code, trimmed stderr, and the CALLER'S recovery — the
+ * recovery must name an action that works on this machine now, not the generic
+ * "permissions or network" guess.
+ *
+ * @param command - Human-readable command, surfaced in the error message.
+ * @param result - The {@link ExecResult} the `exec` effect yielded.
+ * @param recovery - The actionable, site-specific recovery.
+ * @returns A Task that succeeds on exit 0 and fails (recoverably) otherwise.
+ */
+export function checkExecOk(
+  command: string,
+  result: ExecResult,
+  recovery: Recovery,
+): Task<void> {
+  if (result.exitCode === 0) return pure(undefined);
+  const stderr = result.stderr.trim();
+  return failPragma(
+    new PragmaError({
+      code: "UNSUPPORTED",
+      message: `\`${command}\` exited with code ${result.exitCode}.${
+        stderr ? `\n${stderr}` : ""
+      }`,
+      recovery,
+    }),
+  );
+}
 
 /**
  * Raise UNSUPPORTED when an `exec` result carries a nonzero exit code.
@@ -93,11 +146,16 @@ export function guardMissingBinary<A>(
 ): Task<A> {
   return recover(task, (error) => {
     if (isMissingBinaryError(error)) {
-      throw new PragmaError({
-        code: "UNSUPPORTED",
-        message: `\`${bin}\` was not found on your PATH.`,
-        recovery,
-      });
+      // Failure CHANNEL, not a synchronous throw: an enclosing recover (the
+      // run-all's per-step isolation, S1-1) must be able to catch this, and
+      // the boundary unwraps the carried PragmaError when nothing does.
+      return failPragma(
+        new PragmaError({
+          code: "UNSUPPORTED",
+          message: `\`${bin}\` was not found on your PATH.`,
+          recovery,
+        }),
+      );
     }
     // Not a missing binary — re-raise unchanged (the interpreter rethrows it as
     // a TaskExecutionError, exactly as it would with no guard installed).

--- a/packages/cli/pragma/src/identity.test.ts
+++ b/packages/cli/pragma/src/identity.test.ts
@@ -246,10 +246,16 @@ describe("identity projection — a fork changes values, not code (PROTECTED)", 
     const { pragmaMcpEntry } = await import(
       "./capabilities/setup/operations/setupMcp.js"
     );
-    expect(pragmaMcpEntry("/work")).toEqual({
+    expect(pragmaMcpEntry("/work", "project")).toEqual({
       command: "recipes",
       args: ["mcp"],
       cwd: "/work",
+    });
+    // The global band omits `cwd` (a per-user server is not project-pinned)
+    // but still runs the fork's own binary.
+    expect(pragmaMcpEntry("/work", "global")).toEqual({
+      command: "recipes",
+      args: ["mcp"],
     });
   });
 

--- a/packages/cli/pragma/src/kernel/error/fromTaskError.ts
+++ b/packages/cli/pragma/src/kernel/error/fromTaskError.ts
@@ -63,14 +63,36 @@ export function isInterruption(error: unknown): boolean {
 }
 
 /**
+ * The {@link PragmaError} a task failure CARRIES, if any. A task-layer failure
+ * raised through the failure channel (`failPragma` — so an enclosing `recover`
+ * such as setup's per-step isolation can catch it, which a synchronous throw
+ * bypasses) stores the original PragmaError as the TaskError's `cause`;
+ * `runTask` then wraps that TaskError in a `TaskExecutionError` whose
+ * `taskError` carries it. Walk both wrappers (bounded — the shapes nest at
+ * most a few levels) so the boundary recovers the ORIGINAL error with its
+ * code, message, and recovery intact.
+ */
+function carriedPragmaError(error: unknown): PragmaError | undefined {
+  let current: unknown = error;
+  for (let depth = 0; depth < 4 && current !== undefined; depth += 1) {
+    if (current instanceof PragmaError) return current;
+    const record = current as { taskError?: unknown; cause?: unknown } | null;
+    current = record?.taskError ?? record?.cause;
+  }
+  return undefined;
+}
+
+/**
  * Coerce a thrown value into a {@link PragmaError} for the CLI/MCP boundary,
- * bridging summon-core task-error codes: absent/invalid non-interactive answers
- * become INVALID_INPUT (a usage error, exit 2); a `PragmaError` passes through
- * unchanged; everything else stays INTERNAL_ERROR. Cancellation is handled
- * separately by {@link isCancellation} as a clean, non-error outcome.
+ * bridging summon-core task-error codes: a `PragmaError` (direct, or carried
+ * through the task failure channel as a TaskError `cause`) passes through
+ * unchanged; absent/invalid non-interactive answers become INVALID_INPUT (a
+ * usage error, exit 2); everything else stays INTERNAL_ERROR. Cancellation is
+ * handled separately by {@link isCancellation} as a clean, non-error outcome.
  */
 export function asPragmaError(error: unknown): PragmaError {
-  if (error instanceof PragmaError) return error;
+  const carried = carriedPragmaError(error);
+  if (carried !== undefined) return carried;
   const message = error instanceof Error ? error.message : String(error);
   const code = taskErrorCode(error);
   if (code !== undefined && ANSWER_USAGE_CODES.has(code)) {

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -452,8 +452,11 @@ describe("resolveConfigTarget", () => {
   });
 
   it("throws for a global band on a harness with no homeConfigPath", () => {
+    // vscode is a project-only row (its user-profile mcp.json is per-profile,
+    // so no global band is offered) — the assertion's exercising case.
+    const vscode = findHarnessById("vscode") as (typeof harnesses)[number];
     expect(() =>
-      resolveConfigTarget(cursor, "/project", "global", PLATFORM),
+      resolveConfigTarget(vscode, "/project", "global", PLATFORM),
     ).toThrow(/homeConfigPath/);
   });
 });

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -16,6 +16,11 @@ import {
 } from "./config.js";
 import findHarnessById from "./findHarnessById.js";
 import harnesses from "./harnesses.js";
+import {
+  defaultMcpEntry,
+  opencodeMcpEntry,
+  opendesignMcpEntry,
+} from "./mcpEntries.js";
 import type { PlatformEnv } from "./platformPaths.js";
 import type { ConfigTarget } from "./types.js";
 
@@ -524,12 +529,14 @@ describe("writeMcpConfigTargets — shared-file multi-key write", () => {
     configFormat: "json",
     mcpKey: "servers",
     scope: "project",
+    serializeEntry: defaultMcpEntry,
   };
   const clineTarget: ConfigTarget = {
     path: "/project/.vscode/mcp.json",
     configFormat: "json",
     mcpKey: "mcpServers",
     scope: "project",
+    serializeEntry: defaultMcpEntry,
   };
 
   it("creates one file with the server under BOTH keys in a single write", () => {
@@ -579,13 +586,45 @@ describe("writeMcpConfigTargets — shared-file multi-key write", () => {
     ).toThrow(/at least one target/);
   });
 
-  it("forces env to an object for a normalizeEnv (OpenDesign) target (7g)", () => {
+  it("writes OpenCode's own entry shape end-to-end through the registry (S1-3)", () => {
+    const opencode = findHarnessById("opencode") as (typeof harnesses)[number];
+    expect(opencode.mcpEntry).toBe(opencodeMcpEntry);
+    const target = resolveConfigTarget(opencode, "/project", "project", {
+      platform: "linux",
+      env: {},
+      home: "/home/tester",
+      isWsl: false,
+    });
+    const result = dryRunWith(
+      writeMcpConfigTargets([target], "pragma", {
+        command: "pragma",
+        args: ["mcp"],
+        cwd: "/project",
+      }),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    const written = JSON.parse(writeEffects[0].content);
+    // McpLocalConfig: type required, command is command+args as ONE string
+    // array, no `args` key (additionalProperties: false rejects it).
+    expect(written.mcp.pragma).toEqual({
+      type: "local",
+      command: ["pragma", "mcp"],
+      cwd: "/project",
+    });
+  });
+
+  it("forces env to an object for an OpenDesign-shaped target (7g)", () => {
     const odTarget: ConfigTarget = {
       path: "/project/.od/mcp-config.json",
       configFormat: "json",
       mcpKey: "mcpServers",
       scope: "both",
-      normalizeEnv: true,
+      serializeEntry: opendesignMcpEntry,
     };
     const result = dryRunWith(
       // pragma writes no env — normalization must add an empty object, not omit it.

--- a/packages/runtime/harnesses/src/lib/config.ts
+++ b/packages/runtime/harnesses/src/lib/config.ts
@@ -25,6 +25,7 @@ import {
   type Task,
   writeFile,
 } from "@canonical/task";
+import { defaultMcpEntry } from "./mcpEntries.js";
 import parseJsonc from "./parseJsonc.js";
 import { type PlatformEnv, readPlatformEnv } from "./platformPaths.js";
 import {
@@ -116,36 +117,29 @@ export const resolveConfigTarget = (
   configFormat: harness.configFormat,
   mcpKey: harness.mcpKey,
   scope: harness.scope,
-  normalizeEnv: harness.normalizeEnv,
+  serializeEntry: harness.mcpEntry ?? defaultMcpEntry,
 });
 
 /**
- * Coerce a server config's `env` to a JSON object/map — dropping a non-object
- * `env` to `{}` — for harnesses (OpenDesign, 7g) that reject a non-map `env`.
- */
-const normalizeOdEnv = (config: McpServerConfig): McpServerConfig => ({
-  ...config,
-  env: asServerRecord(config.env) as Record<string, string>,
-});
-
-/**
- * Read existing MCP server entries from a resolved config target.
+ * Read existing MCP server entries from a resolved config target. Entries come
+ * back RAW (`unknown` values): each harness stores its own entry shape (see
+ * `mcpEntries.ts`), so no single record type is honest here — a caller
+ * classifies an entry against `target.serializeEntry` via `mcpEntryMatches`.
  *
  * @param target - The resolved config location.
- * @returns The server map (empty when the file is absent/unparseable).
+ * @returns The raw server map (empty when the file is absent/unparseable).
  * @note Impure — reads from the filesystem via Task effects.
  */
 export const readMcpConfigFrom = (
   target: ConfigTarget,
-): Task<Record<string, McpServerConfig>> => {
+): Task<Record<string, unknown>> => {
   if (target.configFormat === "toml") {
     return ifElseM(
       exists(target.path),
-      map(readFile(target.path), (content) => {
-        const sections = parseTomlSection(content, target.mcpKey);
-        return sections as unknown as Record<string, McpServerConfig>;
-      }),
-      pure({} as Record<string, McpServerConfig>),
+      map(readFile(target.path), (content) =>
+        parseTomlSection(content, target.mcpKey),
+      ),
+      pure({} as Record<string, unknown>),
     );
   }
 
@@ -153,22 +147,17 @@ export const readMcpConfigFrom = (
     exists(target.path),
     map(readFile(target.path), (content) => {
       const parsed = parseJsonc(content) ?? {};
-      return asServerRecord(parsed[target.mcpKey]) as Record<
-        string,
-        McpServerConfig
-      >;
+      return asServerRecord(parsed[target.mcpKey]);
     }),
-    pure({} as Record<string, McpServerConfig>),
+    pure({} as Record<string, unknown>),
   );
 };
 
-/** The TOML field record for a server config (command + optional args/cwd). */
-const tomlFields = (config: McpServerConfig): Record<string, unknown> => {
-  const fields: Record<string, unknown> = { command: config.command };
-  if (config.args) fields.args = config.args;
-  if (config.cwd) fields.cwd = config.cwd;
-  return fields;
-};
+/** One key's serialized entry within a shared-file write. */
+interface KeyedEntry {
+  readonly mcpKey: string;
+  readonly entry: Record<string, unknown>;
+}
 
 /**
  * Write or merge one server entry under EVERY `mcpKey` of a shared config file,
@@ -180,9 +169,8 @@ const tomlFields = (config: McpServerConfig): Record<string, unknown> => {
  *
  * @param path - The config file path.
  * @param configFormat - Its serialization format.
- * @param mcpKeys - The server-map keys to write the entry under (≥1).
+ * @param entries - One already-serialized entry per server-map key (≥1).
  * @param serverName - The server entry name.
- * @param config - The server config.
  * @param undoTask - The task that reverses this write.
  * @returns A Task performing the merge/create (with an undo).
  * @note Impure — reads and writes the filesystem via Task effects.
@@ -190,27 +178,25 @@ const tomlFields = (config: McpServerConfig): Record<string, unknown> => {
 const writeServerUnderKeys = (
   path: string,
   configFormat: ConfigTarget["configFormat"],
-  mcpKeys: readonly string[],
+  entries: readonly KeyedEntry[],
   serverName: string,
-  rawConfig: McpServerConfig,
-  normalizeEnv: boolean,
   undoTask: Task<void>,
 ): Task<void> => {
-  const config = normalizeEnv ? normalizeOdEnv(rawConfig) : rawConfig;
   if (configFormat === "toml") {
-    const fields = tomlFields(config);
     return ifElseM(
       exists(path),
       flatMap(readFile(path), (content) => {
         let merged = content;
-        for (const key of mcpKeys) {
-          merged = mergeTomlSection(merged, key, serverName, fields);
+        for (const { mcpKey, entry } of entries) {
+          merged = mergeTomlSection(merged, mcpKey, serverName, entry);
         }
         return writeFile(path, merged, { undo: undoTask });
       }),
       flatMap(mkdir(dirname(path), true), () => {
-        const body = mcpKeys
-          .map((key) => serializeTomlSection(key, { [serverName]: fields }))
+        const body = entries
+          .map(({ mcpKey, entry }) =>
+            serializeTomlSection(mcpKey, { [serverName]: entry }),
+          )
           .join("");
         return writeFile(path, body, { undo: undoTask });
       }),
@@ -224,16 +210,18 @@ const writeServerUnderKeys = (
       if (parsed === undefined) {
         return unparseableConfig(path);
       }
-      for (const key of mcpKeys) {
-        const servers = asServerRecord(parsed[key]);
-        servers[serverName] = config;
-        parsed[key] = servers;
+      for (const { mcpKey, entry } of entries) {
+        const servers = asServerRecord(parsed[mcpKey]);
+        servers[serverName] = entry;
+        parsed[mcpKey] = servers;
       }
       return writeFile(path, formatJson(parsed), { undo: undoTask });
     }),
     flatMap(mkdir(dirname(path), true), () => {
       const initial: Record<string, unknown> = {};
-      for (const key of mcpKeys) initial[key] = { [serverName]: config };
+      for (const { mcpKey, entry } of entries) {
+        initial[mcpKey] = { [serverName]: entry };
+      }
       return writeFile(path, formatJson(initial), { undo: undoTask });
     }),
   );
@@ -261,10 +249,8 @@ export const writeMcpConfigTo = (
   writeServerUnderKeys(
     target.path,
     target.configFormat,
-    [target.mcpKey],
+    [{ mcpKey: target.mcpKey, entry: target.serializeEntry(config) }],
     serverName,
-    config,
-    target.normalizeEnv === true,
     removeMcpConfigFrom(target, serverName),
   );
 
@@ -295,10 +281,11 @@ export const writeMcpConfigTargets = (
   return writeServerUnderKeys(
     first.path,
     first.configFormat,
-    targets.map((t) => t.mcpKey),
+    targets.map((t) => ({
+      mcpKey: t.mcpKey,
+      entry: t.serializeEntry(config),
+    })),
     serverName,
-    config,
-    first.normalizeEnv === true,
     undoTask,
   );
 };
@@ -350,7 +337,7 @@ export const removeMcpConfigFrom = (
  * @param projectRoot - The project root.
  * @param band - The band to read (defaults to the harness's default band).
  * @param platform - The captured host (defaults to the live reader).
- * @returns The server map.
+ * @returns The raw server map (see {@link readMcpConfigFrom}).
  * @note Impure — reads from the filesystem via Task effects.
  */
 export const readMcpConfig = (
@@ -358,7 +345,7 @@ export const readMcpConfig = (
   projectRoot: string,
   band: ScopeBand = defaultBandOf(harness),
   platform: PlatformEnv = readPlatformEnv(),
-): Task<Record<string, McpServerConfig>> =>
+): Task<Record<string, unknown>> =>
   readMcpConfigFrom(resolveConfigTarget(harness, projectRoot, band, platform));
 
 /**

--- a/packages/runtime/harnesses/src/lib/editors.test.ts
+++ b/packages/runtime/harnesses/src/lib/editors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import editorClis from "./editors.js";
+import type { PlatformEnv } from "./platformPaths.js";
+
+const PLATFORM: PlatformEnv = {
+  platform: "linux",
+  env: {},
+  home: "/home/tester",
+  isWsl: false,
+};
+
+describe("editorClis registry", () => {
+  it("contains the five VS Code-family editors, VS Code first", () => {
+    expect(editorClis.map((e) => e.id)).toEqual([
+      "vscode",
+      "vscodium",
+      "cursor",
+      "windsurf",
+      "antigravity",
+    ]);
+  });
+
+  it("maps each editor to its CLI binary name", () => {
+    const byId = Object.fromEntries(editorClis.map((e) => [e.id, e.cli]));
+    expect(byId).toEqual({
+      vscode: "code",
+      vscodium: "codium",
+      cursor: "cursor",
+      windsurf: "windsurf",
+      antigravity: "antigravity",
+    });
+  });
+
+  it("resolves every extensions dir under the user's home", () => {
+    expect(editorClis.map((e) => e.extensionsDir(PLATFORM))).toEqual([
+      "/home/tester/.vscode/extensions",
+      "/home/tester/.vscode-oss/extensions",
+      "/home/tester/.cursor/extensions",
+      "/home/tester/.windsurf/extensions",
+      "/home/tester/.antigravity/extensions",
+    ]);
+  });
+});

--- a/packages/runtime/harnesses/src/lib/editors.ts
+++ b/packages/runtime/harnesses/src/lib/editors.ts
@@ -1,0 +1,89 @@
+/**
+ * Registry of VS Code-family editor CLIs — the table `setup lsp` (and any
+ * future extension work) resolves editors through. Pure data, like
+ * `harnesses.ts`: adding an editor is adding a row.
+ *
+ * Two columns per editor: the CLI binary name (every fork inherits VS Code's
+ * `--install-extension <vsix>` / `--list-extensions` surface) and the user
+ * extensions directory (every fork keeps the identical
+ * `<dir>/<publisher>.<name>-<version>/` layout). The extensions dir — not a
+ * `--list-extensions` spawn — is what detection reads: probing must never be
+ * able to LAUNCH an editor, and Cursor's Linux launcher is known to open the
+ * UI on `--list-extensions` (forum.cursor.com/t/command-line-list-extensions/103565).
+ *
+ * Designed for the registry-per-editor future: when the extension is published
+ * to a marketplace, a `registry` column (`"marketplace" | "open-vsx" |
+ * "sideload"`) is ADDED here — rows, not new code — and the VSIX sideload
+ * stays the universal fallback. Until then sideload is the only install path,
+ * which works identically on every row that has a CLI.
+ *
+ * Row sources (checked 2026-08-27):
+ * - vscode: official CLI + marketplace docs
+ *   (code.visualstudio.com/docs/configure/command-line,
+ *   code.visualstudio.com/docs/editor/extension-marketplace).
+ * - vscodium: binary is `codium` (github.com/VSCodium/vscodium README);
+ *   `--install-extension` used verbatim in vendor-repo issues (#2564, #332);
+ *   `.vscode-oss` is upstream's dataFolderName, kept by VSCodium's
+ *   prepare_vscode.sh for stable builds.
+ * - cursor: `cursor` launcher installed via the palette's "Install 'cursor'
+ *   command"; `--install-extension` and `~/.cursor/extensions` are community
+ *   evidence only — Cursor's own docs cover extensions via GUI.
+ * - windsurf: VERIFY(F1a) — `windsurf` launcher and `~/.windsurf/extensions`
+ *   are community evidence (Exafunction/codeium#295); `--install-extension`
+ *   unconfirmed officially.
+ * - antigravity: VERIFY(F1b) — community reports the `antigravity` launcher
+ *   (with a possible post-2.0 rename to `agy-ide`) and conflicting extension
+ *   dirs (`~/.antigravity` vs `~/.antigravity-ide`); nothing official. The
+ *   row keeps the launch-era names: a wrong CLI name degrades to "editor not
+ *   found", never to a wrong install.
+ */
+
+import type { PlatformEnv } from "./platformPaths.js";
+import { userHome } from "./platformPaths.js";
+
+/** One VS Code-family editor the extension installer can target. */
+export interface EditorCliDefinition {
+  readonly id: string;
+  readonly name: string;
+  /** The CLI binary name probed on PATH and used for the VSIX sideload. */
+  readonly cli: string;
+  /** The user extensions directory (the `<id>-<version>/` layout). */
+  readonly extensionsDir: (platform: PlatformEnv) => string;
+}
+
+const editorClis: readonly EditorCliDefinition[] = [
+  {
+    id: "vscode",
+    name: "VS Code",
+    cli: "code",
+    extensionsDir: (p) => `${userHome(p)}/.vscode/extensions`,
+  },
+  {
+    id: "vscodium",
+    name: "VSCodium",
+    cli: "codium",
+    extensionsDir: (p) => `${userHome(p)}/.vscode-oss/extensions`,
+  },
+  {
+    id: "cursor",
+    name: "Cursor",
+    cli: "cursor",
+    extensionsDir: (p) => `${userHome(p)}/.cursor/extensions`,
+  },
+  {
+    id: "windsurf",
+    name: "Windsurf",
+    cli: "windsurf",
+    // VERIFY(F1a): community-evidenced only (see module docblock).
+    extensionsDir: (p) => `${userHome(p)}/.windsurf/extensions`,
+  },
+  {
+    id: "antigravity",
+    name: "Antigravity",
+    cli: "antigravity",
+    // VERIFY(F1b): community-evidenced only (see module docblock).
+    extensionsDir: (p) => `${userHome(p)}/.antigravity/extensions`,
+  },
+];
+
+export default editorClis;

--- a/packages/runtime/harnesses/src/lib/executablePaths.test.ts
+++ b/packages/runtime/harnesses/src/lib/executablePaths.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `executableCandidates` — the shared PATH/PATHEXT rules.
+ *
+ * These are the rules that decide whether a probe SEES an installed tool, and
+ * every way of getting them wrong is silent: harness detection reports the
+ * harness absent, `setup lsp` reports a clean skip. Both consumers now resolve
+ * through this one function, so the platform matrix is pinned here once —
+ * driven entirely off injected {@link PlatformEnv} fixtures, never the host.
+ */
+
+import { describe, expect, it } from "vitest";
+import { executableCandidates } from "./executablePaths.js";
+import type { PlatformEnv } from "./platformPaths.js";
+
+const platformOf = (
+  platform: PlatformEnv["platform"],
+  env: Record<string, string | undefined>,
+): PlatformEnv => ({ platform, env, home: "/home/u", isWsl: false });
+
+describe("executableCandidates", () => {
+  it("joins the bare name onto each PATH dir on a posix host", () => {
+    const candidates = executableCandidates(
+      "code",
+      platformOf("linux", { PATH: "/usr/bin:/usr/local/bin" }),
+    );
+    expect(candidates).toEqual(["/usr/bin/code", "/usr/local/bin/code"]);
+  });
+
+  it("ignores PATHEXT away from win32 — a posix binary carries no suffix", () => {
+    const candidates = executableCandidates(
+      "code",
+      platformOf("darwin", { PATH: "/usr/bin", PATHEXT: ".EXE;.CMD" }),
+    );
+    expect(candidates).toEqual(["/usr/bin/code"]);
+  });
+
+  it("crosses every PATH dir with every PATHEXT suffix under win32, splitting PATH on ;", () => {
+    const candidates = executableCandidates(
+      "code",
+      platformOf("win32", { PATH: "C:/bin;C:/tools", PATHEXT: ".EXE;.CMD" }),
+    );
+    expect(candidates.map((c) => c.replaceAll("\\", "/"))).toEqual([
+      "C:/bin/code.EXE",
+      "C:/bin/code.CMD",
+      "C:/tools/code.EXE",
+      "C:/tools/code.CMD",
+    ]);
+  });
+
+  it("finds the .cmd shim npm installs an editor CLI as, under the default PATHEXT", () => {
+    const candidates = executableCandidates(
+      "codium",
+      platformOf("win32", { PATH: "C:/bin" }),
+    ).map((c) => c.replaceAll("\\", "/"));
+    expect(candidates).toContain("C:/bin/codium.CMD");
+    expect(candidates).toContain("C:/bin/codium.BAT");
+  });
+
+  it("drops empty PATH segments and yields nothing for an unset PATH", () => {
+    expect(
+      executableCandidates("code", platformOf("linux", { PATH: "/usr/bin::" })),
+    ).toEqual(["/usr/bin/code"]);
+    expect(executableCandidates("code", platformOf("linux", {}))).toEqual([]);
+  });
+
+  it("drops empty PATHEXT segments under win32", () => {
+    expect(
+      executableCandidates(
+        "code",
+        platformOf("win32", { PATH: "C:/bin", PATHEXT: ".EXE;;" }),
+      ).map((c) => c.replaceAll("\\", "/")),
+    ).toEqual(["C:/bin/code.EXE"]);
+  });
+});

--- a/packages/runtime/harnesses/src/lib/executablePaths.ts
+++ b/packages/runtime/harnesses/src/lib/executablePaths.ts
@@ -1,0 +1,58 @@
+/**
+ * The ONE implementation of "where would this host look for that command".
+ *
+ * Two rules differ per platform and both are silent when got wrong. `PATH` is
+ * split on `;` under win32 and `:` everywhere else; and on Windows an
+ * executable is almost never the bare name — npm installs CLI harnesses and
+ * editor CLIs as `.cmd` shims (`code.cmd`, `codium.cmd`, `claude.cmd`), never
+ * as `.exe` — so a probe that joins the bare name onto each `PATH` directory
+ * finds NOTHING on a Windows machine that has the tool installed.
+ *
+ * Harness detection ({@link checkSignal}'s `process` arm) and `setup lsp`'s
+ * editor probe both need this, and the failure mode a second copy would
+ * produce is the dangerous one: not a loud error, but a clean SKIP on a
+ * machine that has the editor. So the rules live here once, take the injected
+ * {@link PlatformEnv} rather than reading `process`, and stay PURE — the
+ * caller decides how to test each candidate (a Task `exists` effect during
+ * detection, `existsSync` during setup).
+ */
+
+import { join } from "node:path";
+import type { PlatformEnv } from "./platformPaths.js";
+
+/**
+ * The executable suffixes probed on win32 when `PATHEXT` is unset — the usual
+ * Windows default. Crucially includes `.CMD`/`.BAT`: npm installs CLI
+ * harnesses (`claude`, `codex`, `od`…) as `.cmd` shims, never `.exe`, so an
+ * `.exe`-only probe would miss every npm-installed harness on Windows.
+ */
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/**
+ * Every filesystem path the host would consider when resolving a bare command
+ * name, in `PATH` order (each directory crossed with each applicable
+ * extension).
+ *
+ * @param name - The bare command name, without an extension.
+ * @param platform - The captured host: its OS family, `PATH`, and `PATHEXT`.
+ * @returns The candidate paths to test for existence; empty when `PATH` is.
+ * @note Pure — it composes strings and tests nothing on the filesystem.
+ */
+export const executableCandidates = (
+  name: string,
+  platform: PlatformEnv,
+): string[] => {
+  const isWindows = platform.platform === "win32";
+  const separator = isWindows ? ";" : ":";
+  // On win32 an executable matches under any PATHEXT suffix; elsewhere the
+  // bare name is the sole candidate (the empty suffix).
+  const suffixes = isWindows
+    ? (platform.env.PATHEXT ?? DEFAULT_PATHEXT)
+        .split(";")
+        .filter((suffix) => suffix.length > 0)
+    : [""];
+  return (platform.env.PATH ?? "")
+    .split(separator)
+    .filter((dir) => dir.length > 0)
+    .flatMap((dir) => suffixes.map((suffix) => join(dir, `${name}${suffix}`)));
+};

--- a/packages/runtime/harnesses/src/lib/harnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import harnesses from "./harnesses.js";
+import { opendesignMcpEntry } from "./mcpEntries.js";
 
 describe("harnesses registry", () => {
   it("contains all known harnesses", () => {
@@ -60,7 +61,7 @@ describe("harnesses registry", () => {
   it("opendesign is dual-scope with project + home config and skills paths (7g)", () => {
     const od = harnesses.find((h) => h.id === "opendesign");
     expect(od?.scope).toBe("both");
-    expect(od?.normalizeEnv).toBe(true);
+    expect(od?.mcpEntry).toBe(opendesignMcpEntry);
     expect(od?.configPath("/project")).toBe("/project/.od/mcp-config.json");
     expect(
       od?.homeConfigPath?.({

--- a/packages/runtime/harnesses/src/lib/harnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.test.ts
@@ -4,7 +4,7 @@ import { opendesignMcpEntry } from "./mcpEntries.js";
 
 describe("harnesses registry", () => {
   it("contains all known harnesses", () => {
-    expect(harnesses).toHaveLength(10);
+    expect(harnesses).toHaveLength(12);
     const ids = harnesses.map((h) => h.id);
     expect(ids).toEqual([
       "claude-code",
@@ -15,6 +15,8 @@ describe("harnesses registry", () => {
       "opencode",
       "gemini-cli",
       "codex",
+      "copilot",
+      "antigravity",
       "vscode",
       "opendesign",
     ]);
@@ -47,6 +49,64 @@ describe("harnesses registry", () => {
     const claude = harnesses.find((h) => h.id === "claude-code");
     expect(windsurf?.scope).toBe("global");
     expect(claude?.scope).toBe("both");
+  });
+
+  const PLATFORM = {
+    platform: "linux" as const,
+    env: {},
+    home: "/home/tester",
+    isWsl: false,
+  };
+
+  it("cursor and gemini-cli are dual-scope with their documented home configs", () => {
+    const cursor = harnesses.find((h) => h.id === "cursor");
+    const gemini = harnesses.find((h) => h.id === "gemini-cli");
+    expect(cursor?.scope).toBe("both");
+    expect(cursor?.homeConfigPath?.(PLATFORM)).toBe(
+      "/home/tester/.cursor/mcp.json",
+    );
+    expect(gemini?.scope).toBe("both");
+    expect(gemini?.homeConfigPath?.(PLATFORM)).toBe(
+      "/home/tester/.gemini/settings.json",
+    );
+  });
+
+  it("codex resolves its home config under $CODEX_HOME, defaulting to ~/.codex", () => {
+    const codex = harnesses.find((h) => h.id === "codex");
+    expect(codex?.scope).toBe("both");
+    expect(codex?.homeConfigPath?.(PLATFORM)).toBe(
+      "/home/tester/.codex/config.toml",
+    );
+    expect(
+      codex?.homeConfigPath?.({ ...PLATFORM, env: { CODEX_HOME: "/custom" } }),
+    ).toBe("/custom/config.toml");
+  });
+
+  it("copilot is global-only at ~/.copilot/mcp-config.json (COPILOT_HOME honoured)", () => {
+    const copilot = harnesses.find((h) => h.id === "copilot");
+    expect(copilot?.scope).toBe("global");
+    expect(copilot?.homeConfigPath?.(PLATFORM)).toBe(
+      "/home/tester/.copilot/mcp-config.json",
+    );
+    expect(
+      copilot?.homeConfigPath?.({
+        ...PLATFORM,
+        env: { COPILOT_HOME: "/custom" },
+      }),
+    ).toBe("/custom/mcp-config.json");
+    expect(copilot?.mcpEntry).toBeDefined();
+  });
+
+  it("antigravity is dual-scope: workspace .agents/mcp_config.json, global under ~/.gemini/config", () => {
+    const antigravity = harnesses.find((h) => h.id === "antigravity");
+    expect(antigravity?.scope).toBe("both");
+    expect(antigravity?.configPath("/project")).toBe(
+      "/project/.agents/mcp_config.json",
+    );
+    expect(antigravity?.homeConfigPath?.(PLATFORM)).toBe(
+      "/home/tester/.gemini/config/mcp_config.json",
+    );
+    expect(antigravity?.mcpKey).toBe("mcpServers");
   });
 
   it("cline shares .vscode/mcp.json with VS Code under a different mcpKey", () => {

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  copilotMcpEntry,
   cursorMcpEntry,
   opencodeMcpEntry,
   opendesignMcpEntry,
@@ -26,7 +27,8 @@ const harnesses: readonly HarnessDefinition[] = [
       { type: "process", name: "claude" },
     ],
     configPath: (root) => `${root}/.mcp.json`,
-    // VERIFY(7b): claude-code reads the user MCP config from ~/.claude.json.
+    // Confirmed (was VERIFY(7b)): "User-scoped servers are stored in
+    // ~/.claude.json" — https://code.claude.com/docs/en/mcp (2026-08-27).
     homeConfigPath: (p) => `${userHome(p)}/.claude.json`,
     configFormat: "json",
     mcpKey: "mcpServers",
@@ -36,9 +38,13 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "cursor",
     name: "Cursor",
     version: "*",
-    scope: "project",
+    scope: "both",
     detect: [{ type: "directory", path: ".cursor" }],
     configPath: (root) => `${root}/.cursor/mcp.json`,
+    // Cursor documents a global band: "~/.cursor/mcp.json" alongside the
+    // project ".cursor/mcp.json" — https://cursor.com/docs/context/mcp
+    // (2026-08-27).
+    homeConfigPath: (p) => `${userHome(p)}/.cursor/mcp.json`,
     configFormat: "json",
     mcpKey: "mcpServers",
     // Cursor's MCP docs (https://cursor.com/docs/context/mcp) type stdio
@@ -119,12 +125,17 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "gemini-cli",
     name: "Gemini CLI",
     version: "*",
-    scope: "project",
+    scope: "both",
     detect: [
       { type: "directory", path: ".gemini" },
       { type: "process", name: "gemini" },
     ],
     configPath: (root) => `${root}/.gemini/settings.json`,
+    // Gemini CLI documents a global band: "~/.gemini/settings.json" alongside
+    // the project ".gemini/settings.json" —
+    // https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md
+    // (2026-08-27; `cwd` is an explicitly documented stdio field there too).
+    homeConfigPath: (p) => `${userHome(p)}/.gemini/settings.json`,
     configFormat: "json",
     mcpKey: "mcpServers",
     skillsPath: (root) => `${root}/.agents/skills`,
@@ -133,14 +144,71 @@ const harnesses: readonly HarnessDefinition[] = [
     id: "codex",
     name: "Codex",
     version: "*",
-    scope: "project",
+    scope: "both",
     detect: [
       { type: "directory", path: ".codex" },
       { type: "process", name: "codex" },
     ],
+    // Codex reads project-scoped overrides from ".codex/config.toml" (loaded
+    // only for trusted projects) and its user config from
+    // "$CODEX_HOME/config.toml" (default ~/.codex) —
+    // https://developers.openai.com/codex/config-reference (2026-08-27).
     configPath: (root) => `${root}/.codex/config.toml`,
+    homeConfigPath: (p) =>
+      `${p.env.CODEX_HOME ?? `${userHome(p)}/.codex`}/config.toml`,
     configFormat: "toml",
     mcpKey: "mcp_servers",
+    skillsPath: (root) => `${root}/.agents/skills`,
+  },
+  {
+    id: "copilot",
+    name: "GitHub Copilot CLI",
+    version: "*",
+    // Global-only ON PURPOSE, although Copilot CLI also reads project files:
+    // its project bands are ".mcp.json" (shared with Claude Code's row, same
+    // `mcpServers` key — one write covers both) and ".github/mcp.json". A
+    // project row here would put a SECOND serializer on the same
+    // (path, mcpKey) write the Claude Code row owns; the home config is the
+    // only location nothing else covers.
+    scope: "global",
+    detect: [
+      { type: "directory", path: "~/.copilot" },
+      { type: "process", name: "copilot" },
+    ],
+    // Never resolved (global-only band), but the type requires one; kept at
+    // the documented project fallback shape for legibility.
+    configPath: (root) => `${root}/.mcp.json`,
+    // "~/.copilot/mcp-config.json", relocatable via COPILOT_HOME —
+    // https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+    // (2026-08-27).
+    homeConfigPath: (p) =>
+      `${p.env.COPILOT_HOME ?? `${userHome(p)}/.copilot`}/mcp-config.json`,
+    configFormat: "json",
+    mcpKey: "mcpServers",
+    // Its documented local-entry shape carries `type: "local"` and a `tools`
+    // grant — see `copilotMcpEntry`.
+    mcpEntry: copilotMcpEntry,
+    skillsPath: (root) => `${root}/.agents/skills`,
+  },
+  {
+    id: "antigravity",
+    name: "Antigravity",
+    version: "*",
+    scope: "both",
+    detect: [
+      { type: "file", path: ".agents/mcp_config.json" },
+      { type: "file", path: "~/.gemini/config/mcp_config.json" },
+      { type: "process", name: "antigravity" },
+    ],
+    // Antigravity documents a workspace band at ".agents/mcp_config.json" and
+    // a global band at "~/.gemini/config/mcp_config.json", both under
+    // `mcpServers` — https://antigravity.google/docs/ide/mcp/ (2026-08-27).
+    // (The Nov-2025 launch path "~/.gemini/antigravity/mcp_config.json" is
+    // legacy; the docs' current path is the one written here.)
+    configPath: (root) => `${root}/.agents/mcp_config.json`,
+    homeConfigPath: (p) => `${userHome(p)}/.gemini/config/mcp_config.json`,
+    configFormat: "json",
+    mcpKey: "mcpServers",
     skillsPath: (root) => `${root}/.agents/skills`,
   },
   {
@@ -182,5 +250,18 @@ const harnesses: readonly HarnessDefinition[] = [
     skillsPath: (root) => `${root}/.od/skills`,
   },
 ];
+
+// Deliberately ABSENT from the registry (product calls, not oversights):
+//
+// - `pi` (github.com/earendil-works/pi): no first-party MCP client exists —
+//   the README states "No MCP" outright; MCP reaches pi only through the
+//   third-party pi-mcp-adapter extension a user installs themselves. A row
+//   here would write config pi itself never reads. pi IS served on the skills
+//   side without a row: it reads `.agents/skills`, the cross-client directory
+//   `setup skills` always links into.
+//
+// - `vscodium` as an MCP CLIENT: VSCodium has no first-party MCP surface (no
+//   Copilot agent mode), so there is nothing to configure. As an extension
+//   HOST it is fully supported via the editor-CLI registry (`editors.ts`).
 
 export default harnesses;

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -6,6 +6,11 @@
  * ranges to handle config format changes across versions.
  */
 
+import {
+  cursorMcpEntry,
+  opencodeMcpEntry,
+  opendesignMcpEntry,
+} from "./mcpEntries.js";
 import { userHome } from "./platformPaths.js";
 import type { HarnessDefinition } from "./types.js";
 
@@ -36,6 +41,9 @@ const harnesses: readonly HarnessDefinition[] = [
     configPath: (root) => `${root}/.cursor/mcp.json`,
     configFormat: "json",
     mcpKey: "mcpServers",
+    // Cursor's MCP docs (https://cursor.com/docs/context/mcp) type stdio
+    // entries with `type: "stdio"`.
+    mcpEntry: cursorMcpEntry,
     skillsPath: (root) => `${root}/.cursor/skills`,
   },
   {
@@ -100,6 +108,11 @@ const harnesses: readonly HarnessDefinition[] = [
     configPath: (root) => `${root}/opencode.json`,
     configFormat: "json",
     mcpKey: "mcp",
+    // OpenCode's schema (https://opencode.ai/config.json, $defs.McpLocalConfig)
+    // requires `type: "local"` + `command` as a string array and rejects
+    // unknown keys — the default `{command, args, cwd}` shape fails its
+    // validation three ways (S1-3).
+    mcpEntry: opencodeMcpEntry,
     skillsPath: (root) => `${root}/.agents/skills`,
   },
   {
@@ -150,7 +163,7 @@ const harnesses: readonly HarnessDefinition[] = [
     version: "*",
     scope: "both",
     // VERIFY(7g): OpenDesign requires the MCP server `env` to be a JSON map.
-    normalizeEnv: true,
+    mcpEntry: opendesignMcpEntry,
     detect: [
       { type: "directory", path: ".od" },
       {

--- a/packages/runtime/harnesses/src/lib/index.ts
+++ b/packages/runtime/harnesses/src/lib/index.ts
@@ -19,6 +19,7 @@ export {
   type TargetGroup,
 } from "./configTargets.js";
 export { default as detectHarnesses } from "./detectHarnesses.js";
+export { default as editorClis, type EditorCliDefinition } from "./editors.js";
 export { default as findHarnessById } from "./findHarnessById.js";
 export { default as harnesses } from "./harnesses.js";
 export {

--- a/packages/runtime/harnesses/src/lib/index.ts
+++ b/packages/runtime/harnesses/src/lib/index.ts
@@ -22,6 +22,15 @@ export { default as detectHarnesses } from "./detectHarnesses.js";
 export { default as findHarnessById } from "./findHarnessById.js";
 export { default as harnesses } from "./harnesses.js";
 export {
+  copilotMcpEntry,
+  cursorMcpEntry,
+  defaultMcpEntry,
+  type McpEntrySerializer,
+  mcpEntryMatches,
+  opencodeMcpEntry,
+  opendesignMcpEntry,
+} from "./mcpEntries.js";
+export {
   type PlatformEnv,
   type PlatformId,
   readPlatformEnv,

--- a/packages/runtime/harnesses/src/lib/index.ts
+++ b/packages/runtime/harnesses/src/lib/index.ts
@@ -20,6 +20,7 @@ export {
 } from "./configTargets.js";
 export { default as detectHarnesses } from "./detectHarnesses.js";
 export { default as editorClis, type EditorCliDefinition } from "./editors.js";
+export { executableCandidates } from "./executablePaths.js";
 export { default as findHarnessById } from "./findHarnessById.js";
 export { default as harnesses } from "./harnesses.js";
 export {

--- a/packages/runtime/harnesses/src/lib/mcpEntries.test.ts
+++ b/packages/runtime/harnesses/src/lib/mcpEntries.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  copilotMcpEntry,
+  cursorMcpEntry,
+  defaultMcpEntry,
+  mcpEntryMatches,
+  opencodeMcpEntry,
+  opendesignMcpEntry,
+} from "./mcpEntries.js";
+
+describe("defaultMcpEntry", () => {
+  it("emits the canonical shape with every optional field present", () => {
+    expect(
+      defaultMcpEntry({
+        command: "pragma",
+        args: ["mcp"],
+        cwd: "/project",
+        env: { KEY: "value" },
+      }),
+    ).toEqual({
+      command: "pragma",
+      args: ["mcp"],
+      cwd: "/project",
+      env: { KEY: "value" },
+    });
+  });
+
+  it("omits absent optional fields instead of writing undefined", () => {
+    expect(defaultMcpEntry({ command: "pragma" })).toEqual({
+      command: "pragma",
+    });
+  });
+});
+
+describe("opencodeMcpEntry", () => {
+  it("emits type local with command+args combined into ONE string array (S1-3)", () => {
+    expect(
+      opencodeMcpEntry({ command: "pragma", args: ["mcp"], cwd: "/project" }),
+    ).toEqual({
+      type: "local",
+      command: ["pragma", "mcp"],
+      cwd: "/project",
+    });
+  });
+
+  it("spells the env map `environment` and tolerates absent args/cwd", () => {
+    expect(
+      opencodeMcpEntry({ command: "pragma", env: { KEY: "value" } }),
+    ).toEqual({
+      type: "local",
+      command: ["pragma"],
+      environment: { KEY: "value" },
+    });
+  });
+
+  it("never emits the schema-rejected `args`/`env` keys", () => {
+    const entry = opencodeMcpEntry({
+      command: "pragma",
+      args: ["mcp"],
+      env: { KEY: "value" },
+    });
+    expect(entry).not.toHaveProperty("args");
+    expect(entry).not.toHaveProperty("env");
+  });
+});
+
+describe("cursorMcpEntry", () => {
+  it("adds the documented stdio discriminator over the default shape", () => {
+    expect(cursorMcpEntry({ command: "pragma", args: ["mcp"] })).toEqual({
+      type: "stdio",
+      command: "pragma",
+      args: ["mcp"],
+    });
+  });
+});
+
+describe("copilotMcpEntry", () => {
+  it("adds type local + the documented full-tool grant", () => {
+    expect(copilotMcpEntry({ command: "pragma", args: ["mcp"] })).toEqual({
+      type: "local",
+      command: "pragma",
+      args: ["mcp"],
+      tools: ["*"],
+    });
+  });
+});
+
+describe("opendesignMcpEntry", () => {
+  it("forces env to a (possibly empty) map — the old normalizeEnv column (7g)", () => {
+    expect(opendesignMcpEntry({ command: "pragma" })).toEqual({
+      command: "pragma",
+      env: {},
+    });
+  });
+
+  it("keeps an authored env map", () => {
+    expect(
+      opendesignMcpEntry({ command: "pragma", env: { KEY: "value" } }),
+    ).toEqual({ command: "pragma", env: { KEY: "value" } });
+  });
+});
+
+describe("mcpEntryMatches", () => {
+  const want = defaultMcpEntry({
+    command: "pragma",
+    args: ["mcp"],
+    cwd: "/project",
+  });
+
+  it("matches an identical entry", () => {
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", args: ["mcp"], cwd: "/project" },
+        want,
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores EXTRA keys on the existing entry (no churn on decorated files)", () => {
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", args: ["mcp"], cwd: "/project", timeout: 5000 },
+        want,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a drifted scalar field", () => {
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", args: ["mcp"], cwd: "/elsewhere" },
+        want,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a drifted array (length and element-wise)", () => {
+    expect(
+      mcpEntryMatches({ command: "pragma", args: [], cwd: "/project" }, want),
+    ).toBe(false);
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", args: ["serve"], cwd: "/project" },
+        want,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a missing field and non-object entries", () => {
+    expect(mcpEntryMatches({ command: "pragma" }, want)).toBe(false);
+    expect(mcpEntryMatches("pragma", want)).toBe(false);
+    expect(mcpEntryMatches(null, want)).toBe(false);
+  });
+
+  it("matches the opencode shape it would write, per its own serializer", () => {
+    const opencodeWant = opencodeMcpEntry({
+      command: "pragma",
+      args: ["mcp"],
+      cwd: "/project",
+    });
+    expect(
+      mcpEntryMatches(
+        { type: "local", command: ["pragma", "mcp"], cwd: "/project" },
+        opencodeWant,
+      ),
+    ).toBe(true);
+    // The legacy default-shaped entry (S1-3's corrupt output) reads as drift.
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", args: ["mcp"], cwd: "/project" },
+        opencodeWant,
+      ),
+    ).toBe(false);
+  });
+
+  it("compares nested env maps structurally (exact keys, both ways)", () => {
+    const withEnv = defaultMcpEntry({
+      command: "pragma",
+      env: { A: "1", B: "2" },
+    });
+    expect(
+      mcpEntryMatches({ command: "pragma", env: { B: "2", A: "1" } }, withEnv),
+    ).toBe(true);
+    expect(
+      mcpEntryMatches({ command: "pragma", env: { A: "1" } }, withEnv),
+    ).toBe(false);
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", env: { A: "1", B: "2", C: "3" } },
+        withEnv,
+      ),
+    ).toBe(false);
+    expect(mcpEntryMatches({ command: "pragma", env: ["A"] }, withEnv)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/runtime/harnesses/src/lib/mcpEntries.test.ts
+++ b/packages/runtime/harnesses/src/lib/mcpEntries.test.ts
@@ -7,6 +7,7 @@ import {
   opencodeMcpEntry,
   opendesignMcpEntry,
 } from "./mcpEntries.js";
+import type { McpServerConfig } from "./types.js";
 
 describe("defaultMcpEntry", () => {
   it("emits the canonical shape with every optional field present", () => {
@@ -101,26 +102,28 @@ describe("opendesignMcpEntry", () => {
 });
 
 describe("mcpEntryMatches", () => {
-  const want = defaultMcpEntry({
+  const want: McpServerConfig = {
     command: "pragma",
     args: ["mcp"],
     cwd: "/project",
-  });
+  };
 
   it("matches an identical entry", () => {
     expect(
       mcpEntryMatches(
         { command: "pragma", args: ["mcp"], cwd: "/project" },
         want,
+        defaultMcpEntry,
       ),
     ).toBe(true);
   });
 
-  it("ignores EXTRA keys on the existing entry (no churn on decorated files)", () => {
+  it("ignores UNCONTROLLED extra keys (no churn on decorated files)", () => {
     expect(
       mcpEntryMatches(
         { command: "pragma", args: ["mcp"], cwd: "/project", timeout: 5000 },
         want,
+        defaultMcpEntry,
       ),
     ).toBe(true);
   });
@@ -130,68 +133,107 @@ describe("mcpEntryMatches", () => {
       mcpEntryMatches(
         { command: "pragma", args: ["mcp"], cwd: "/elsewhere" },
         want,
+        defaultMcpEntry,
       ),
     ).toBe(false);
   });
 
   it("rejects a drifted array (length and element-wise)", () => {
     expect(
-      mcpEntryMatches({ command: "pragma", args: [], cwd: "/project" }, want),
+      mcpEntryMatches(
+        { command: "pragma", args: [], cwd: "/project" },
+        want,
+        defaultMcpEntry,
+      ),
     ).toBe(false);
     expect(
       mcpEntryMatches(
         { command: "pragma", args: ["serve"], cwd: "/project" },
         want,
+        defaultMcpEntry,
       ),
     ).toBe(false);
   });
 
   it("rejects a missing field and non-object entries", () => {
-    expect(mcpEntryMatches({ command: "pragma" }, want)).toBe(false);
-    expect(mcpEntryMatches("pragma", want)).toBe(false);
-    expect(mcpEntryMatches(null, want)).toBe(false);
+    expect(mcpEntryMatches({ command: "pragma" }, want, defaultMcpEntry)).toBe(
+      false,
+    );
+    expect(mcpEntryMatches("pragma", want, defaultMcpEntry)).toBe(false);
+    expect(mcpEntryMatches(null, want, defaultMcpEntry)).toBe(false);
+  });
+
+  it("a CONTROLLED field the want omits must be ABSENT (global-band cwd)", () => {
+    // A global-band registration omits `cwd` — a per-user server must not be
+    // pinned to the directory setup happened to run from. A stale entry still
+    // carrying one is drift to converge, not decoration to ignore.
+    const globalWant: McpServerConfig = { command: "pragma", args: ["mcp"] };
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", args: ["mcp"], cwd: "/home/u/Downloads" },
+        globalWant,
+        defaultMcpEntry,
+      ),
+    ).toBe(false);
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", args: ["mcp"] },
+        globalWant,
+        defaultMcpEntry,
+      ),
+    ).toBe(true);
   });
 
   it("matches the opencode shape it would write, per its own serializer", () => {
-    const opencodeWant = opencodeMcpEntry({
-      command: "pragma",
-      args: ["mcp"],
-      cwd: "/project",
-    });
     expect(
       mcpEntryMatches(
         { type: "local", command: ["pragma", "mcp"], cwd: "/project" },
-        opencodeWant,
+        want,
+        opencodeMcpEntry,
       ),
     ).toBe(true);
     // The legacy default-shaped entry (S1-3's corrupt output) reads as drift.
     expect(
       mcpEntryMatches(
         { command: "pragma", args: ["mcp"], cwd: "/project" },
-        opencodeWant,
+        want,
+        opencodeMcpEntry,
       ),
     ).toBe(false);
   });
 
   it("compares nested env maps structurally (exact keys, both ways)", () => {
-    const withEnv = defaultMcpEntry({
+    const withEnv: McpServerConfig = {
       command: "pragma",
       env: { A: "1", B: "2" },
-    });
+    };
     expect(
-      mcpEntryMatches({ command: "pragma", env: { B: "2", A: "1" } }, withEnv),
+      mcpEntryMatches(
+        { command: "pragma", env: { B: "2", A: "1" } },
+        withEnv,
+        defaultMcpEntry,
+      ),
     ).toBe(true);
     expect(
-      mcpEntryMatches({ command: "pragma", env: { A: "1" } }, withEnv),
+      mcpEntryMatches(
+        { command: "pragma", env: { A: "1" } },
+        withEnv,
+        defaultMcpEntry,
+      ),
     ).toBe(false);
     expect(
       mcpEntryMatches(
         { command: "pragma", env: { A: "1", B: "2", C: "3" } },
         withEnv,
+        defaultMcpEntry,
       ),
     ).toBe(false);
-    expect(mcpEntryMatches({ command: "pragma", env: ["A"] }, withEnv)).toBe(
-      false,
-    );
+    expect(
+      mcpEntryMatches(
+        { command: "pragma", env: ["A"] },
+        withEnv,
+        defaultMcpEntry,
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/runtime/harnesses/src/lib/mcpEntries.ts
+++ b/packages/runtime/harnesses/src/lib/mcpEntries.ts
@@ -1,0 +1,155 @@
+/**
+ * Per-harness MCP entry SHAPES — the registry column that turns "what does a
+ * pragma server entry look like in THIS harness's config file" into data.
+ *
+ * One hardcoded `{command, args, cwd}` shape used to be written for every
+ * harness, which was wrong wherever a harness's own schema demands a different
+ * shape: OpenCode's `McpLocalConfig` requires `type: "local"`, takes `command`
+ * as a STRING ARRAY (command + args combined), spells its env map
+ * `environment`, and declares `additionalProperties: false` — so the shared
+ * shape was rejected three ways over (S1-3). A serializer per harness fixes
+ * the CLASS of bug, not the one symptom: both the writer and the read-back
+ * classifier consume the same serialized shape, so "already configured" stays
+ * byte-for-byte what a write would emit and idempotence holds per harness.
+ *
+ * Shapes verified against each tool's own documentation (fetched 2026-08-27):
+ * - OpenCode: https://opencode.ai/config.json (`$defs.McpLocalConfig` —
+ *   required `["type","command"]`, `command: string[]`, optional `cwd`,
+ *   `environment`, `enabled`; `additionalProperties: false`).
+ * - Cursor: https://cursor.com/docs/context/mcp (stdio entries carry
+ *   `type: "stdio"` + `command` + optional `args`/`env`).
+ * - Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+ *   (local entries: `type: "local"`, `command`, `args`, `env`, `tools`).
+ */
+
+import type { McpServerConfig } from "./types.js";
+
+/**
+ * Serialize the canonical pragma {@link McpServerConfig} into the JSON/TOML
+ * entry a specific harness's config schema requires. The registry's
+ * `mcpEntry` column; resolved onto every {@link ConfigTarget} so writer and
+ * classifier can never disagree about a harness's shape.
+ */
+export type McpEntrySerializer = (
+  config: McpServerConfig,
+) => Record<string, unknown>;
+
+/**
+ * The canonical `{command, args?, cwd?, env?}` shape most harnesses accept
+ * (Claude Code `.mcp.json`, Gemini CLI, Codex TOML, VS Code `servers`,
+ * Windsurf/Antigravity `mcp_config.json`). Optional fields are omitted, not
+ * written as `undefined`/empty, so a minimal entry stays minimal.
+ */
+export const defaultMcpEntry: McpEntrySerializer = (config) => {
+  const entry: Record<string, unknown> = { command: config.command };
+  if (config.args !== undefined) entry.args = [...config.args];
+  if (config.cwd !== undefined) entry.cwd = config.cwd;
+  if (config.env !== undefined) entry.env = { ...config.env };
+  return entry;
+};
+
+/**
+ * OpenCode's `McpLocalConfig`: `type: "local"` (required), `command` as ONE
+ * string array (command + args combined), env under `environment` (not
+ * `env`), optional `cwd`. `additionalProperties: false` in the live schema —
+ * an `args` or `env` key fails validation, which is exactly what the shared
+ * default shape used to write (S1-3).
+ */
+export const opencodeMcpEntry: McpEntrySerializer = (config) => {
+  const entry: Record<string, unknown> = {
+    type: "local",
+    command: [config.command, ...(config.args ?? [])],
+  };
+  if (config.cwd !== undefined) entry.cwd = config.cwd;
+  if (config.env !== undefined) entry.environment = { ...config.env };
+  return entry;
+};
+
+/**
+ * Cursor's stdio entry: the default shape plus the documented `type: "stdio"`
+ * discriminator. `cwd` is NOT in Cursor's documented field set but is kept:
+ * Cursor has no strict (additionalProperties-style) validation on `mcp.json`,
+ * and dropping it would silently change where the pragma server resolves the
+ * project — the machine-band `cwd` question is S3-11's product call, not this
+ * column's.
+ */
+export const cursorMcpEntry: McpEntrySerializer = (config) => ({
+  type: "stdio",
+  ...defaultMcpEntry(config),
+});
+
+/**
+ * Copilot CLI's `~/.copilot/mcp-config.json` local entry: `type: "local"`
+ * plus the default fields, and `tools: ["*"]` (the documented example grants
+ * the server's full tool surface; without the key the docs do not define
+ * which tools are enabled).
+ */
+export const copilotMcpEntry: McpEntrySerializer = (config) => ({
+  type: "local",
+  ...defaultMcpEntry(config),
+  tools: ["*"],
+});
+
+/**
+ * OpenDesign requires the entry's `env` to be present as a JSON object/map —
+ * VERIFY(7g): internal tool, contract unconfirmed against public docs. The
+ * previous `normalizeEnv` boolean column expressed exactly this one tweak;
+ * it is now just another entry shape.
+ */
+export const opendesignMcpEntry: McpEntrySerializer = (config) => ({
+  ...defaultMcpEntry(config),
+  env: { ...(config.env ?? {}) },
+});
+
+/** Deep structural equality over JSON-shaped values (the matcher's helper). */
+const deepEquals = (a: unknown, b: unknown): boolean => {
+  if (Object.is(a, b)) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return (
+      a.length === b.length && a.every((item, i) => deepEquals(item, b[i]))
+    );
+  }
+  if (
+    typeof a === "object" &&
+    a !== null &&
+    !Array.isArray(a) &&
+    typeof b === "object" &&
+    b !== null &&
+    !Array.isArray(b)
+  ) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return (
+      aKeys.length === bKeys.length &&
+      aKeys.every((key) =>
+        deepEquals(
+          (a as Record<string, unknown>)[key],
+          (b as Record<string, unknown>)[key],
+        ),
+      )
+    );
+  }
+  return false;
+};
+
+/**
+ * Whether an existing on-disk entry already matches what a serializer would
+ * write: every serialized field must be present and deep-equal, while EXTRA
+ * keys on the existing entry are ignored — a harness (or user) that decorates
+ * the entry (e.g. `timeout`, `enabled`) still reads as `configured`, so a
+ * re-run never churns a file it did not author.
+ *
+ * @param existing - The raw entry read back from a harness config.
+ * @param want - The serialized entry a write would emit.
+ * @returns Whether the existing entry matches over the serialized fields.
+ */
+export const mcpEntryMatches = (
+  existing: unknown,
+  want: Record<string, unknown>,
+): boolean => {
+  if (typeof existing !== "object" || existing === null) return false;
+  const record = existing as Record<string, unknown>;
+  return Object.entries(want).every(([key, value]) =>
+    deepEquals(record[key], value),
+  );
+};

--- a/packages/runtime/harnesses/src/lib/mcpEntries.ts
+++ b/packages/runtime/harnesses/src/lib/mcpEntries.ts
@@ -133,23 +133,46 @@ const deepEquals = (a: unknown, b: unknown): boolean => {
 };
 
 /**
- * Whether an existing on-disk entry already matches what a serializer would
- * write: every serialized field must be present and deep-equal, while EXTRA
- * keys on the existing entry are ignored — a harness (or user) that decorates
- * the entry (e.g. `timeout`, `enabled`) still reads as `configured`, so a
- * re-run never churns a file it did not author.
+ * A fully-populated probe config: serializing it reveals a serializer's FULL
+ * field surface — every key it could ever emit, i.e. every key pragma
+ * CONTROLS in that harness's entry shape (see {@link mcpEntryMatches}).
+ */
+const PROBE_CONFIG: McpServerConfig = {
+  command: "probe",
+  args: ["probe"],
+  cwd: "/probe",
+  env: { PROBE: "probe" },
+};
+
+/**
+ * Whether an existing on-disk entry already matches what a write would emit
+ * for `config` under `serialize`. The comparison runs over the serializer's
+ * CONTROLLED keys (its full field surface, revealed by serializing a
+ * fully-populated probe), in both directions:
+ *
+ * - a controlled key the want carries must be present and deep-equal;
+ * - a controlled key the want OMITS must be absent — a global-band entry
+ *   deliberately omits `cwd` (a per-user server must not be pinned to
+ *   whatever directory registration happened to run from), so a stale entry
+ *   still carrying one reads as `drifted` and converges on the next write;
+ * - keys OUTSIDE the controlled surface are ignored — a harness (or user)
+ *   that decorates the entry (e.g. `timeout`, `enabled`) still reads as
+ *   `configured`, so a re-run never churns a file it did not author.
  *
  * @param existing - The raw entry read back from a harness config.
- * @param want - The serialized entry a write would emit.
- * @returns Whether the existing entry matches over the serialized fields.
+ * @param config - The canonical pragma config a write would serialize.
+ * @param serialize - The target's entry serializer.
+ * @returns Whether the existing entry matches over the controlled fields.
  */
 export const mcpEntryMatches = (
   existing: unknown,
-  want: Record<string, unknown>,
+  config: McpServerConfig,
+  serialize: McpEntrySerializer,
 ): boolean => {
   if (typeof existing !== "object" || existing === null) return false;
   const record = existing as Record<string, unknown>;
-  return Object.entries(want).every(([key, value]) =>
-    deepEquals(record[key], value),
+  const want = serialize(config);
+  return Object.keys(serialize(PROBE_CONFIG)).every((key) =>
+    deepEquals(record[key], want[key]),
   );
 };

--- a/packages/runtime/harnesses/src/lib/signals.test.ts
+++ b/packages/runtime/harnesses/src/lib/signals.test.ts
@@ -158,11 +158,14 @@ describe("checkSignal — extension", () => {
     expect(result).toBe(false);
     // A missing dir is never globbed (globbing an absent dir throws).
     expect(globbed).toBe(false);
+    // One dir per row of the editor-CLI registry — the single source of truth
+    // for the VS Code family (Antigravity included).
     expect(probed).toEqual([
       "/home/tester/.vscode/extensions",
-      "/home/tester/.cursor/extensions",
       "/home/tester/.vscode-oss/extensions",
+      "/home/tester/.cursor/extensions",
       "/home/tester/.windsurf/extensions",
+      "/home/tester/.antigravity/extensions",
     ]);
   });
 });

--- a/packages/runtime/harnesses/src/lib/signals.ts
+++ b/packages/runtime/harnesses/src/lib/signals.ts
@@ -20,6 +20,7 @@ import {
   type Task,
   traverse,
 } from "@canonical/task";
+import editorClis from "./editors.js";
 import { type PlatformEnv, userHome } from "./platformPaths.js";
 import type { DetectionSignal } from "./types.js";
 
@@ -103,26 +104,13 @@ const checkProcess = (
 };
 
 /**
- * The VS Code-family extension roots probed for an `extension` signal, relative
- * to home. VS Code and its forks each keep their own extensions directory in the
- * identical `<id>-<version>` layout, so an extension installed under ANY of them
- * counts: stock VS Code (`~/.vscode`), Cursor (`~/.cursor`), VSCodium
- * (`~/.vscode-oss`), and Windsurf (`~/.windsurf`).
- */
-const VSCODE_FAMILY_EXTENSION_ROOTS = [
-  ".vscode",
-  ".cursor",
-  ".vscode-oss",
-  ".windsurf",
-] as const;
-
-/**
  * Check an `extension` signal: whether any installed VS Code-family extension
- * directory `<id>-<version>/` is present. VS Code and its forks (Cursor,
- * VSCodium, Windsurf) keep extensions under the same `<root>/extensions` layout,
- * so every known family root ({@link VSCODE_FAMILY_EXTENSION_ROOTS}) is probed
- * and ANY match counts. Each directory is confirmed to exist before it is
- * globbed, since globbing a missing directory throws.
+ * directory `<id>-<version>/` is present. VS Code and its forks keep
+ * extensions under the same `<dir>/<id>-<version>` layout, so every editor in
+ * the {@link editorClis} registry is probed (one source of truth for the
+ * family — previously a local root list here that had drifted, e.g. it lacked
+ * Antigravity) and ANY match counts. Each directory is confirmed to exist
+ * before it is globbed, since globbing a missing directory throws.
  *
  * The pattern targets the `package.json` MANIFEST inside each versioned
  * extension directory, not the directory itself: the `glob` effect lists files
@@ -134,9 +122,8 @@ const checkExtension = (
   signal: Extract<DetectionSignal, { type: "extension" }>,
   ctx: DetectContext,
 ): Task<boolean> => {
-  const home = userHome(ctx.platform);
-  const extensionDirs = VSCODE_FAMILY_EXTENSION_ROOTS.map((root) =>
-    join(home, root, "extensions"),
+  const extensionDirs = editorClis.map((editor) =>
+    editor.extensionsDir(ctx.platform),
   );
   return map(
     traverse(extensionDirs, (extensionsDir) =>

--- a/packages/runtime/harnesses/src/lib/signals.ts
+++ b/packages/runtime/harnesses/src/lib/signals.ts
@@ -21,6 +21,7 @@ import {
   traverse,
 } from "@canonical/task";
 import editorClis from "./editors.js";
+import { executableCandidates } from "./executablePaths.js";
 import { type PlatformEnv, userHome } from "./platformPaths.js";
 import type { DetectionSignal } from "./types.js";
 
@@ -50,14 +51,6 @@ const resolveFsPath = (path: string, ctx: DetectContext): string =>
     : join(ctx.projectRoot, path);
 
 /**
- * The executable suffixes probed on win32 when `PATHEXT` is unset — the usual
- * Windows default. Crucially includes `.CMD`/`.BAT`: npm installs CLI harnesses
- * (`claude`, `codex`, `od`…) as `.cmd` shims, never `.exe`, so an `.exe`-only
- * probe would miss every npm-installed harness on Windows.
- */
-const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
-
-/**
  * Check a `process` signal: whether `name` resolves on the platform `PATH` (on
  * win32, under any `PATHEXT` suffix — not just `.exe`) and, when a `verify` is
  * given, whether running it produces stdout matching `verify.match`.
@@ -71,21 +64,9 @@ const checkProcess = (
   signal: Extract<DetectionSignal, { type: "process" }>,
   ctx: DetectContext,
 ): Task<boolean> => {
-  const isWindows = ctx.platform.platform === "win32";
-  const separator = isWindows ? ";" : ":";
-  // On win32 an executable matches under any PATHEXT suffix; elsewhere the bare
-  // name is the sole candidate (the empty suffix).
-  const suffixes = isWindows
-    ? (ctx.platform.env.PATHEXT ?? DEFAULT_PATHEXT)
-        .split(";")
-        .filter((suffix) => suffix.length > 0)
-    : [""];
-  const candidates = (ctx.platform.env.PATH ?? "")
-    .split(separator)
-    .filter((dir) => dir.length > 0)
-    .flatMap((dir) =>
-      suffixes.map((suffix) => join(dir, `${signal.name}${suffix}`)),
-    );
+  // The PATH/PATHEXT rules live in one shared helper (`setup lsp`'s editor
+  // probe resolves the same way) — see `executablePaths.ts` for why.
+  const candidates = executableCandidates(signal.name, ctx.platform);
 
   return flatMap(
     traverse(candidates, (candidate) => exists(candidate)),

--- a/packages/runtime/harnesses/src/lib/toml/parseTomlSection.test.ts
+++ b/packages/runtime/harnesses/src/lib/toml/parseTomlSection.test.ts
@@ -72,4 +72,40 @@ describe("parseTomlSection", () => {
     const result = parseTomlSection(toml, "mcp_servers");
     expect(result.test.path).toBe('some"quoted"path');
   });
+
+  it("parses a string array back as an ARRAY, not raw bracket text (S1-4)", () => {
+    const toml = '[mcp_servers.pragma]\nargs = ["mcp"]';
+    const result = parseTomlSection(toml, "mcp_servers");
+    expect(result.pragma.args).toEqual(["mcp"]);
+  });
+
+  it("parses multi-element and mixed-type arrays element-wise", () => {
+    const toml = '[mcp_servers.test]\nvalues = ["a", "b", 3, true]';
+    const result = parseTomlSection(toml, "mcp_servers");
+    expect(result.test.values).toEqual(["a", "b", 3, true]);
+  });
+
+  it("keeps a comma INSIDE a quoted array element as data", () => {
+    const toml = '[mcp_servers.test]\nargs = ["a,b", "c"]';
+    const result = parseTomlSection(toml, "mcp_servers");
+    expect(result.test.args).toEqual(["a,b", "c"]);
+  });
+
+  it("parses an empty array", () => {
+    const toml = "[mcp_servers.test]\nargs = []";
+    const result = parseTomlSection(toml, "mcp_servers");
+    expect(result.test.args).toEqual([]);
+  });
+
+  it("keeps an ESCAPED quote inside an array element as data", () => {
+    const toml = '[mcp_servers.test]\nargs = ["say \\"hi,there\\"", "b"]';
+    const result = parseTomlSection(toml, "mcp_servers");
+    expect(result.test.args).toEqual(['say "hi,there"', "b"]);
+  });
+
+  it("parses a nested array without splitting on its inner commas", () => {
+    const toml = '[mcp_servers.test]\nmatrix = [["a", "b"], ["c"]]';
+    const result = parseTomlSection(toml, "mcp_servers");
+    expect(result.test.matrix).toEqual([["a", "b"], ["c"]]);
+  });
 });

--- a/packages/runtime/harnesses/src/lib/toml/serializeTomlSection.test.ts
+++ b/packages/runtime/harnesses/src/lib/toml/serializeTomlSection.test.ts
@@ -52,4 +52,26 @@ describe("serializeTomlSection", () => {
     });
     expect(result).toContain("disabled = false");
   });
+
+  it("serializes a string array as a TOML inline array (S1-4)", () => {
+    const result = serializeTomlSection("mcp_servers", {
+      pragma: { command: "pragma", args: ["mcp"] },
+    });
+    expect(result).toContain('args = ["mcp"]');
+  });
+
+  it("serializes a multi-element array element-wise, never comma-joined", () => {
+    const result = serializeTomlSection("mcp_servers", {
+      pragma: { args: ["a", "b"] },
+    });
+    expect(result).toContain('args = ["a", "b"]');
+    expect(result).not.toContain('"a,b"');
+  });
+
+  it("escapes quotes inside array string elements", () => {
+    const result = serializeTomlSection("mcp_servers", {
+      pragma: { args: ['say "hi"'] },
+    });
+    expect(result).toContain('args = ["say \\"hi\\""]');
+  });
 });

--- a/packages/runtime/harnesses/src/lib/toml/toml-values.test.ts
+++ b/packages/runtime/harnesses/src/lib/toml/toml-values.test.ts
@@ -1,0 +1,106 @@
+/**
+ * TOML basic-string escaping — the round trip that makes a second `setup` run
+ * a no-op.
+ *
+ * The read-back classifier compares a config's parsed values against what a
+ * write WOULD emit, so a value that does not survive serialize→parse reports
+ * "updated" on every run forever. Escaping and decoding therefore have to
+ * cover the same set of characters, and the cases here pin the ones that
+ * previously did not: the backslash (a Windows path went out with bare
+ * backslashes, which TOML reads as escape sequences, so Codex saw a different
+ * string than we wrote), the control characters (a literal newline in a value
+ * would have split the line and corrupted the file), and a correctly escaped
+ * PRE-EXISTING value written by hand.
+ */
+
+import { describe, expect, it } from "vitest";
+import parseTomlSection from "./parseTomlSection.js";
+import serializeTomlSection from "./serializeTomlSection.js";
+import { formatTomlValue, parseTomlValue } from "./toml-values.js";
+
+/** Serialize a value and read it straight back. */
+const roundTrip = (value: unknown): unknown =>
+  parseTomlValue(formatTomlValue(value));
+
+describe("formatTomlValue / parseTomlValue — string round trip", () => {
+  it("round-trips a Windows path carrying backslashes and an embedded quote", () => {
+    const value = 'C:\\Users\\me\\bin\\the "good" one\\';
+    const written = formatTomlValue(value);
+    // The backslash is escaped BEFORE the quote, so the quote's own escape is
+    // not doubled: the escaped quote stays two characters.
+    expect(written).toBe(
+      '"C:\\\\Users\\\\me\\\\bin\\\\the \\"good\\" one\\\\"',
+    );
+    expect(parseTomlValue(written)).toBe(value);
+  });
+
+  it("round-trips the control characters TOML basic strings forbid literally", () => {
+    expect(formatTomlValue("a\nb\tc\rd\be\ff")).toBe('"a\\nb\\tc\\rd\\be\\ff"');
+    expect(roundTrip("a\nb\tc\rd\be\ff")).toBe("a\nb\tc\rd\be\ff");
+    // No short escape exists for these, so they take the \uXXXX form.
+    expect(formatTomlValue("bell\u0007 del\u007f")).toBe(
+      '"bell\\u0007 del\\u007f"',
+    );
+    expect(roundTrip("bell\u0007 del\u007f")).toBe("bell\u0007 del\u007f");
+  });
+
+  it("leaves an ordinary string untouched", () => {
+    expect(formatTomlValue("pragma")).toBe('"pragma"');
+    expect(roundTrip("pragma")).toBe("pragma");
+  });
+
+  it("decodes an already-correctly-escaped pre-existing value unchanged", () => {
+    // What a hand-written (or previously written) config holds on disk.
+    const onDisk = String.raw`"C:\\Users\\me\\bin"`;
+    const parsed = parseTomlValue(onDisk);
+    expect(parsed).toBe(String.raw`C:\Users\me\bin`);
+    // Re-emitting it reproduces the file bytes — this is what makes a second
+    // run a no-op instead of a perpetual "updated".
+    expect(formatTomlValue(parsed)).toBe(onDisk);
+  });
+
+  it("decodes the \\uXXXX and \\UXXXXXXXX forms a hand-written config may use", () => {
+    expect(parseTomlValue('"caf\\u00e9 \\U0001F600"')).toBe("café \u{1F600}");
+  });
+
+  it("leaves an unrecognised escape sequence verbatim rather than dropping it", () => {
+    expect(parseTomlValue('"a\\qb"')).toBe("a\\qb");
+  });
+
+  it("round-trips escaped strings nested in an inline array", () => {
+    const value = [String.raw`C:\bin`, 'say "hi"'];
+    expect(roundTrip(value)).toEqual(value);
+  });
+});
+
+describe("serializeTomlSection / parseTomlSection — end to end", () => {
+  it("round-trips a Windows command path with a quote and a control character", () => {
+    const entry = {
+      command: String.raw`C:\Program Files\pragma\pragma.cmd`,
+      args: ["mcp", 'the "odd" one', "line\nbreak"],
+      enabled: true,
+    };
+    const written = serializeTomlSection("mcp_servers", { pragma: entry });
+    // The escaped newline keeps the value on ONE line — a literal one would
+    // have split the record and corrupted every entry after it.
+    expect(
+      written.split("\n").filter((l) => l.startsWith("args")),
+    ).toHaveLength(1);
+    expect(parseTomlSection(written, "mcp_servers").pragma).toEqual(entry);
+  });
+
+  it("re-serializes its own output byte for byte (idempotence)", () => {
+    const entries = {
+      pragma: {
+        command: String.raw`C:\bin\pragma.cmd`,
+        args: ['a "b"', String.raw`c\d`],
+      },
+    };
+    const once = serializeTomlSection("mcp_servers", entries);
+    const twice = serializeTomlSection(
+      "mcp_servers",
+      parseTomlSection(once, "mcp_servers"),
+    );
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/runtime/harnesses/src/lib/toml/toml-values.ts
+++ b/packages/runtime/harnesses/src/lib/toml/toml-values.ts
@@ -45,11 +45,94 @@ const splitTomlArrayItems = (body: string): string[] => {
   return items.map((item) => item.trim()).filter((item) => item.length > 0);
 };
 
+/**
+ * The TOML basic-string escape table, both directions.
+ *
+ * A basic string may not carry a literal backslash, a literal quote, or a
+ * control character; TOML spells each as one of these sequences. Writing only
+ * the quote (and decoding only the quote) was asymmetric AND lossy: a Windows
+ * path like `C:\\Users\\me\\bin` went out with bare backslashes, which TOML
+ * reads back as escape sequences — so Codex saw a different string than we
+ * wrote — and a correctly escaped PRE-EXISTING value did not survive a
+ * read/write cycle, which breaks TOML idempotence: the read-back classifier
+ * compares against what a write would emit, so a value it cannot round-trip
+ * reports "updated" on every single run.
+ */
+const TOML_ESCAPES: Readonly<Record<string, string>> = {
+  "\\": "\\\\",
+  '"': '\\"',
+  "\b": "\\b",
+  "\t": "\\t",
+  "\n": "\\n",
+  "\f": "\\f",
+  "\r": "\\r",
+};
+
+/** The reverse table, for decoding a single-character escape sequence. */
+const TOML_UNESCAPES: Readonly<Record<string, string>> = {
+  "\\": "\\",
+  '"': '"',
+  b: "\b",
+  t: "\t",
+  n: "\n",
+  f: "\f",
+  r: "\r",
+};
+
+/**
+ * Escape one character for a TOML basic string: its short escape when the
+ * spec gives it one, the `\\uXXXX` form for the remaining control characters
+ * (and DEL, which a basic string may not carry literally either), otherwise
+ * the character itself.
+ */
+const escapeTomlChar = (char: string): string => {
+  const shortEscape = TOML_ESCAPES[char];
+  if (shortEscape !== undefined) return shortEscape;
+  const code = char.charCodeAt(0);
+  if (code < 0x20 || code === 0x7f) {
+    return `\\u${code.toString(16).padStart(4, "0")}`;
+  }
+  return char;
+};
+
+/**
+ * Escape a string for a TOML basic string (the body, without the quotes).
+ *
+ * ONE pass over the SOURCE characters, not a chain of `.replace` calls: a
+ * chain has to escape the backslash strictly first, or the later steps escape
+ * the backslashes it just wrote and every quote comes out doubled. That
+ * ordering hazard is invisible until one value carries both characters — a
+ * Windows path with an embedded quote is exactly that value. A pass that
+ * never re-reads its own output cannot have the hazard at all.
+ */
+const escapeTomlString = (value: string): string =>
+  [...value].map(escapeTomlChar).join("");
+
+/**
+ * Decode a TOML basic-string body — the exact inverse of
+ * {@link escapeTomlString}, plus the `\uXXXX`/`\UXXXXXXXX` forms a
+ * hand-written config may already use. An unrecognised sequence is left
+ * verbatim rather than silently dropping its backslash, so a value this
+ * grammar does not model survives the round trip untouched.
+ */
+const unescapeTomlString = (body: string): string =>
+  body.replace(
+    /\\(u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|.)/g,
+    (match, sequence: string) => {
+      const simple = TOML_UNESCAPES[sequence];
+      if (simple !== undefined) return simple;
+      if (sequence[0] === "u" || sequence[0] === "U") {
+        return String.fromCodePoint(Number.parseInt(sequence.slice(1), 16));
+      }
+      return match;
+    },
+  );
+
 export const parseTomlValue = (raw: string): unknown => {
   if (raw === "true") return true;
   if (raw === "false") return false;
   if (raw.startsWith('"') && raw.endsWith('"')) {
-    return raw.slice(1, -1).replace(/\\"/g, '"');
+    return unescapeTomlString(raw.slice(1, -1));
   }
   // Inline arrays (`["a", "b"]`) parse element-wise so a written string array
   // (e.g. Codex `args = ["mcp"]`) round-trips as an ARRAY — without this
@@ -65,7 +148,7 @@ export const parseTomlValue = (raw: string): unknown => {
 };
 
 export const formatTomlValue = (value: unknown): string => {
-  if (typeof value === "string") return `"${value.replace(/"/g, '\\"')}"`;
+  if (typeof value === "string") return `"${escapeTomlString(value)}"`;
   if (typeof value === "boolean") return value ? "true" : "false";
   if (typeof value === "number") return String(value);
   // Arrays serialize element-wise (`["mcp"]`) — the missing branch here let an

--- a/packages/runtime/harnesses/src/lib/toml/toml-values.ts
+++ b/packages/runtime/harnesses/src/lib/toml/toml-values.ts
@@ -6,11 +6,58 @@
 export const escapeRegex = (s: string): string =>
   s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+/**
+ * Split a TOML inline-array body on its TOP-LEVEL commas, respecting quoted
+ * strings (a comma inside `"a,b"` is data, not a separator) and nested arrays.
+ * A helper for {@link parseTomlValue}'s array branch — like the rest of this
+ * module it covers only the flat value grammar Codex-style MCP tables use.
+ */
+const splitTomlArrayItems = (body: string): string[] => {
+  const items: string[] = [];
+  let current = "";
+  let depth = 0;
+  let inString = false;
+  for (let i = 0; i < body.length; i += 1) {
+    const char = body[i];
+    if (inString) {
+      current += char;
+      if (char === "\\") {
+        // `slice` is empty past the end, so a (malformed) trailing backslash
+        // needs no special branch.
+        current += body.slice(i + 1, i + 2);
+        i += 1;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "[") depth += 1;
+    else if (char === "]") depth -= 1;
+    else if (char === "," && depth === 0) {
+      items.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim().length > 0) items.push(current);
+  return items.map((item) => item.trim()).filter((item) => item.length > 0);
+};
+
 export const parseTomlValue = (raw: string): unknown => {
   if (raw === "true") return true;
   if (raw === "false") return false;
   if (raw.startsWith('"') && raw.endsWith('"')) {
     return raw.slice(1, -1).replace(/\\"/g, '"');
+  }
+  // Inline arrays (`["a", "b"]`) parse element-wise so a written string array
+  // (e.g. Codex `args = ["mcp"]`) round-trips as an ARRAY — without this
+  // branch the raw bracket text came back as a plain string, so the read-back
+  // classifier could never match the entry it had just written and every
+  // re-run reported "updated" (idempotence structurally broken for TOML).
+  if (raw.startsWith("[") && raw.endsWith("]")) {
+    return splitTomlArrayItems(raw.slice(1, -1)).map(parseTomlValue);
   }
   if (/^-?\d+$/.test(raw)) return Number.parseInt(raw, 10);
   if (/^-?\d+\.\d+$/.test(raw)) return Number.parseFloat(raw);
@@ -21,5 +68,12 @@ export const formatTomlValue = (value: unknown): string => {
   if (typeof value === "string") return `"${value.replace(/"/g, '\\"')}"`;
   if (typeof value === "boolean") return value ? "true" : "false";
   if (typeof value === "number") return String(value);
+  // Arrays serialize element-wise (`["mcp"]`) — the missing branch here let an
+  // array fall through to the quoted-`String(value)` fallback below, which
+  // corrupted every Codex `args` to `args = "mcp"` (or `"a,b"`), a value the
+  // TOML schema rejects (S1-4).
+  if (Array.isArray(value)) {
+    return `[${value.map(formatTomlValue).join(", ")}]`;
+  }
   return `"${String(value)}"`;
 };

--- a/packages/runtime/harnesses/src/lib/types.ts
+++ b/packages/runtime/harnesses/src/lib/types.ts
@@ -2,6 +2,7 @@
  * Core types for AI harness detection and MCP configuration.
  */
 
+import type { McpEntrySerializer } from "./mcpEntries.js";
 import type { PlatformEnv } from "./platformPaths.js";
 
 /**
@@ -70,11 +71,15 @@ export interface HarnessDefinition {
   readonly mcpKey: string;
   readonly skillsPath: (projectRoot: string) => string;
   /**
-   * When true, a written server entry's `env` is forced to a JSON object/map
-   * (OpenDesign requires it — see VERIFY(7g)). Omitted (falsy) for harnesses
-   * that leave `env` as authored.
+   * How a server entry is SHAPED in this harness's config — its
+   * {@link McpEntrySerializer}. Omitted for harnesses that accept the
+   * canonical `{command, args?, cwd?, env?}` shape (`defaultMcpEntry`);
+   * declared wherever the harness's own schema demands a different one
+   * (OpenCode's `McpLocalConfig`, Cursor's typed stdio entry, …). Both the
+   * writer and the read-back classifier consume the resolved serializer, so
+   * idempotence holds per shape.
    */
-  readonly normalizeEnv?: boolean;
+  readonly mcpEntry?: McpEntrySerializer;
 }
 
 /**
@@ -87,8 +92,12 @@ export interface ConfigTarget {
   readonly configFormat: "json" | "jsonc" | "toml";
   readonly mcpKey: string;
   readonly scope: HarnessScope;
-  /** Force a written entry's `env` to a JSON object/map (OpenDesign — 7g). */
-  readonly normalizeEnv?: boolean;
+  /**
+   * The RESOLVED entry serializer (the harness's `mcpEntry`, defaulted to
+   * `defaultMcpEntry`) — always concrete here so read/write bodies never
+   * re-consult the harness definition.
+   */
+  readonly serializeEntry: McpEntrySerializer;
 }
 
 /**


### PR DESCRIPTION
## Done

**`setup` configured almost nothing on a machine without VS Code.** Reproduced on a scratch environment before the fix:

```
pragma setup --yes   →  exit 1
  completions: YES     mcp: NO     skills: NO
```

The LSP step aborted the whole run, so MCP and skills never executed — every VSCodium-only machine, every headless server, every CI box. Since the extension is unpublished, that is currently everyone without VS Code installed.

- **Run-all steps are isolated** — one unsatisfiable prerequisite reports and the rest proceed; the exit code reflects the true aggregate outcome.
- **Per-harness MCP entry serializers.** The OpenCode entry was schema-invalid (`type` required, `command` must be a string array, `additionalProperties:false`) and the TOML serializer corrupted arrays, so Codex got `args = "mcp"` and reported "updated" on every re-run. Both were one entry shape written for every harness; the shape is now per-harness, so idempotence holds for TOML too.
- **Global MCP entries no longer pin the invoking directory.** `pragmaMcpEntry` recorded `cwd` on every entry including global ones, so a user-level registration made from `~/Downloads` pointed there permanently. Global entries omit it; project entries keep it, where recording the root is the point. An existing global entry carrying a `cwd` classifies as drifted and is rewritten once, then converges.
- **Skill links are classified with `lstat`**, so a dangling symlink repairs instead of crashing with an internal error, and the dry-run preview matches the run. This agrees with the `planStaleLinkPrunes` behaviour already on `main`.
- **An editor-CLI registry** replaces the hard-coded `code` binary, with per-editor Terrazzo LSP sideload. The VSIX now lands at a durable path a user can retry by hand rather than bunx's ephemeral `/tmp/bunx-…` cache, and the missing-binary guards name the actual missing binary — including a missing editor CLI.
- **The harness registry is completed** against its target set.

## QA

Use a scratch `HOME` and `XDG_*` so nothing real is touched.

1. With no `code`/`codium` on `PATH`: `pragma setup --yes` — LSP reports a named skip, **MCP and skills still run**, and the exit code reflects the aggregate.
2. `pragma setup mcp --global` from two different directories — the resulting config is byte-identical, and neither records a `cwd`.
3. `pragma setup mcp --global` on a machine with an older entry that carries a `cwd` — reports a drifted rewrite once, then reports configured on every subsequent run.
4. Validate the OpenCode entry against `opencode.ai/config.json`; run `pragma setup mcp` twice for a TOML harness and confirm the second run is a no-op with an intact `args` array.
5. Point a skill link at a deleted target, then `pragma setup skills` — repairs rather than crashing, and `--dry-run` previewed the same action.

### PR readiness check

- [x] PR should have one of the following labels: `Bug 🐛`
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — no package boundaries changed.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

n/a — CLI behaviour, covered by the QA steps above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)