### PR TITLE
feat(pragma-cli): the colophon leads with the design system, not the toolchain

### DIFF
--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -45,6 +45,12 @@ over GraphQL or raw SPARQL.
 - **Tokens** — the themeable design values, resolved per theme.
 - **Standards** — the do / don't coding guidance, categorized and linked to the
   blocks they govern.
+- **Concepts** — the long-form documentation that belongs to no single block:
+  foundations, decision guides, and how-to guides, each typed by a
+  \`ds:ConceptType\`.
+- **Implementations** — which library implements which block, in which
+  framework, with a source link pinned to the release that shipped it: the
+  spec and the code realizing it are edges in one graph.
 
 ## How it fits together
 
@@ -57,8 +63,10 @@ over GraphQL or raw SPARQL.
 ## Why RDF
 
 One graph makes every relationship first-class and queryable: \`block lookup\`
-follows edges to modifiers and subcomponents, \`graph query\` runs arbitrary
-SPARQL, and \`ontology show\` reads the schema itself. The store is built once
+follows edges to modifiers and subcomponents, \`concept lookup\` reads the
+long-form documentation, \`graph query\` runs arbitrary SPARQL, and
+\`ontology lookup\` reads the schema itself. Which React components implement
+a global-tier block is one query, not an afternoon. The store is built once
 by \`sources update\` and addressed by content hash, so the domain you query is
 exactly the domain that was published.`;
 
@@ -617,60 +625,12 @@ export default {
   // form. Both are BODIES with no leading H1 (the renderer supplies the
   // heading), grounded in this tree's real architecture.
   colophon: {
-    markdown: `pragma is a **domain-based toolchain**: one CLI and one MCP server projected
-from a single grammar, serving a knowledge-graph domain that reads as data.
-
-## The effect monad
-
-Reads are plain \`async\` functions; a mutation instead *describes* its effects
-as a \`Task\` (\`@canonical/task\`) that is interpreted — under the real node
-interpreter, a \`--dry-run\` planner, or an \`--undo\` reverser. Describe-then-
-interpret means dry-run and undo come for free, and the dispatcher tells the two
-worlds apart on one bit: \`capability.mutates\`.
-
-## One grammar, many projections
-
-Every capability is a \`VerbSpec\` — a noun, its params, its effect profile, its
-formatters. The CLI commands, the MCP tools, shell completion, and the
-surface/docs are all *projections* of that one shape, so they cannot drift. The
-projected surface is frozen in a covenant (\`surface/surface.v2.json\`): a single
-source of truth a test asserts the live grammar still emits, tool for tool.
-
-## LLM-optimized output
-
-Each verb renders three ways — \`plain\` for a terminal, \`json\` for the machine
-envelope, and \`llm\` for condensed Markdown. \`--format llm\` (or a non-interactive
-stdout) selects the agent form: the same data, shaped for a model to read. This
-colophon is itself a showcase of that render model.
-
-## Modular, storeless by construction
-
-Capabilities ship as **modules** — named bundles of verbs with optional
-boot / resource / prompt hooks. A verb declares whether it \`needsStore\`, and
-the dispatcher boots the triple store *only* for those; a storeless verb
-(\`info\`, \`config\`, \`capabilities\`, \`colophon\`) never pays for the graph.
-
-## Scaffolding
-
-\`pragma create\` scaffolds components, packages, and applications through the
-\`@canonical/summon-*\` generators, reusing summon's rich Ink wizard when it runs
-interactively.
-
-## The domain reads as data
-
-A domain is a **pack**: a declarative \`PackDefinition\` (its list / lookup
-queries) compiled into verbs, backed by a content-addressed graphpack that
-\`sources update\` builds once. Swap the pack and the same pragma serves a
-different domain — including the domain colophon printed below this one.
+    markdown: `pragma is a **domain-based toolchain** — one CLI and one MCP server
+projected from a single grammar. That machinery is documented in
+\`docs/architecture.md\`; what follows is the domain it serves.
 
 Made by the Canonical Webteam — https://canonical.com.`,
-    summary: `pragma is a domain-based toolchain: one CLI + MCP server projected from a single \`VerbSpec\` grammar.
-
-- **Effect monad** (\`@canonical/task\`): reads are async; a mutation returns an interpreted \`Task\`, so \`--dry-run\` and \`--undo\` are free. The dispatcher branches on \`capability.mutates\`.
-- **One grammar, many projections**: CLI, MCP tools, completion, and docs all project one \`VerbSpec\`; the emitted surface is frozen in a covenant so the projections never drift.
-- **LLM-optimized output**: every verb renders \`plain\` / \`json\` / \`llm\`; \`--format llm\` (or a piped stdout) emits condensed Markdown for agents.
-- **Modular + storeless**: capability modules; the triple store boots only for \`needsStore\` verbs.
-- **Domain as data**: a pack is a declarative \`PackDefinition\` compiled to verbs over a content-addressed graph built by \`sources update\`.
+    summary: `pragma is a domain-based toolchain: one CLI + MCP server projected from a single grammar (see \`docs/architecture.md\`). The domain it serves follows.
 
 Made by the Canonical Webteam — https://canonical.com.`,
   },

--- a/packages/cli/pragma/src/kernel/config/defaults.test.ts
+++ b/packages/cli/pragma/src/kernel/config/defaults.test.ts
@@ -15,6 +15,13 @@ describe("defaults — the validated distribution config (pragma.conf.ts)", () =
     // `collectColophon` reads exactly this object. Pin the shape and the two
     // stable fragments — the story's own subject and the maker line the old
     // one-line `colophon` string carried (folded in when the field went live).
+    //
+    // DOMAIN FIRST: this section is deliberately a one-liner that hands off to
+    // `docs/architecture.md`. `pragma colophon` renders it ABOVE the active
+    // pack's domain colophon, and a reader reaching for the colophon wants the
+    // design system, not the toolchain that serves it. The length pin is the
+    // ruling: architecture prose belongs in the docs, not in front of the
+    // domain every reader came for.
     expect(defaults.colophon?.markdown).toContain("domain-based toolchain");
     expect(defaults.colophon?.markdown).toContain(
       "Made by the Canonical Webteam — https://canonical.com.",
@@ -23,6 +30,10 @@ describe("defaults — the validated distribution config (pragma.conf.ts)", () =
     // Bodies, not documents: the renderer supplies the H1 from the name.
     expect(defaults.colophon?.markdown.startsWith("#")).toBe(false);
     expect(defaults.colophon?.summary?.startsWith("#")).toBe(false);
+    // The handoff, and the brevity that makes it honest (see the note above).
+    expect(defaults.colophon?.markdown).toContain("docs/architecture.md");
+    expect(defaults.colophon?.markdown.length).toBeLessThan(400);
+    expect(defaults.colophon?.summary?.length).toBeLessThan(400);
   });
 
   it("ships the four canonical default packs (git+https sources)", () => {


### PR DESCRIPTION
> **Stacked on #1013** (→ #1012 → #1010). Small and self-contained — squash it into #1013 at merge time if you prefer a shorter train.

## Done

- **The distribution colophon becomes three lines.** `pragma colophon` opened with six sections of toolchain architecture — the effect monad, the projection model, capability modules, scaffolding — before reaching the design system. Someone running `colophon` wants the domain, not the machinery that serves it. That prose is already in `docs/architecture.md` (Layers, The effect seam), so the declaration now hands off to it and gets out of the way.
- **The domain colophon carries the story**, and gains what the graph learned since it was written:
  - **Concepts** — the long-form documentation belonging to no single block, typed by `ds:ConceptType` (#1013)
  - **Implementations** — which library implements which block, in which framework, with a source link pinned to the release that shipped it (#1010/#1012)
- **Drive-by**: `ontology show` → `ontology lookup` (the ratified name; `show` is a deprecated alias per the covenant).
- `defaults.test.ts` pins the ruling — the handoff plus a length bound — so the toolchain section cannot creep back in front of the domain.

Net: −54 / +14 lines in `pragma.conf.ts`.

## QA

- `pragma colophon` rendered against the real store: three lines of toolchain, then the full design-system narrative (verified end to end)
- Full CLI suite green: 1166 passed
- `biome` + `tsc` clean on both changed files

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (no packages added)
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Not relevant (CLI output).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)