### PR TITLE
fix(pragma-cli): name the typed URI in resolution errors, accept encoded ones

### DIFF
--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -351,7 +351,7 @@ pragma doctor --format json  # machine-readable checks
 
 Show every triple where a URI is the subject, grouped by predicate.
 
-Inspect one entity: all predicate/object pairs asserted on the subject. Address it by prefixed name (ds:button) or absolute IRI.
+Inspect one entity: all predicate/object pairs asserted on the subject. Address it by prefixed name (ds:global.component.button) or absolute IRI.
 
 ```
 pragma graph inspect <uri>
@@ -369,8 +369,8 @@ pragma graph inspect <uri>
 **Examples**
 
 ```bash
-pragma graph inspect ds:button
-pragma graph inspect https://ds.canonical.com/button
+pragma graph inspect ds:global.component.button
+pragma graph inspect https://ds.canonical.com/global.component.button
 ```
 
 ### pragma graph query
@@ -396,7 +396,7 @@ pragma graph query <sparql>
 
 ```bash
 pragma graph query "SELECT ?s WHERE { ?s a ds:Component }"  # list every component subject
-pragma graph query "ASK { ds:button a ds:Component }" --format json
+pragma graph query "ASK { <https://ds.canonical.com/global.component.button> a ds:Component }" --format json
 ```
 
 ## info

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -178,7 +178,7 @@ _No input parameters._
 
 ### graph_inspect
 
-Inspect one entity: all predicate/object pairs asserted on the subject. Address it by prefixed name (ds:button) or absolute IRI.
+Inspect one entity: all predicate/object pairs asserted on the subject. Address it by prefixed name (ds:global.component.button) or absolute IRI.
 
 Read-only.
 

--- a/packages/cli/pragma/src/capabilities/graph/examples.exec.test.ts
+++ b/packages/cli/pragma/src/capabilities/graph/examples.exec.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The documented examples, EXECUTED against the shipped pack (PROTECTED).
+ *
+ * The existing documentation suite validates example GRAMMAR — that a `cmd`
+ * parses as a command this CLI declares. Grammar is not truth: the previous
+ * `graph inspect ds:button` examples passed that check for as long as they
+ * existed while 404ing for every user who copied them, and the `graph query`
+ * ASK example passed while quietly answering `false`.
+ *
+ * So these run the examples as WRITTEN, against the embedded graph, and assert
+ * they answer. An example is a promise to a stranger; this is the only check
+ * that reads it as one.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { verbKey } from "../../kernel/packs/uniqueness.js";
+import { bootRuntime } from "../../kernel/runtime/boot.js";
+import type { InspectResult } from "../../kernel/runtime/readEntity.js";
+import type { PragmaRuntime } from "../../kernel/runtime/types.js";
+import type { VerbSpec } from "../../kernel/spec/types.js";
+import { TEST_FLAGS } from "../../testing/helpers/projectCli.js";
+import { graphModule } from "./index.js";
+
+const verb = (name: string): VerbSpec =>
+  graphModule.verbs.find((v) => verbKey(v.path) === name) as VerbSpec;
+
+/**
+ * The name of a verb's single positional, read from the verb rather than
+ * retyped — the point of this file is that documentation and code agree, so it
+ * should not itself hardcode a name that could drift.
+ */
+const positionalOf = (spec: VerbSpec): string =>
+  spec.params.find((p) => p.positional)?.name ?? "";
+
+/**
+ * The argument an example passes, recovered from the example's own `cmd`.
+ *
+ * Read from the declaration rather than retyped, so editing an example without
+ * editing this file cannot leave the test asserting the old one.
+ */
+function exampleArg(spec: VerbSpec, index: number): string {
+  const cmd = spec.examples?.[index]?.cmd ?? "";
+  const quoted = cmd.match(/"([^"]*)"/);
+  if (quoted?.[1]) return quoted[1];
+  return cmd.trim().split(/\s+/).slice(3).join(" ");
+}
+
+// ONE store for the file. Booting per case tripled this suite's cost against
+// the shipped pack for no extra coverage, and the whole package already flakes
+// under parallel contention — a test that need not add load should not.
+let rt: PragmaRuntime;
+beforeAll(() => {
+  rt = bootRuntime(TEST_FLAGS);
+});
+afterAll(async () => {
+  (await rt.store.get()).store.dispose();
+});
+
+describe("documented examples resolve against the shipped graph (PROTECTED)", () => {
+  it("runs every `graph inspect` example as written", async () => {
+    const inspect = verb("graph inspect");
+    expect(inspect.examples?.length).toBeGreaterThan(0);
+
+    for (const [index] of (inspect.examples ?? []).entries()) {
+      const uri = exampleArg(inspect, index);
+      const result = (await inspect.run(
+        { [positionalOf(inspect)]: uri },
+        rt,
+      )) as InspectResult;
+      // The prefixed and absolute forms are two spellings of one subject.
+      expect(
+        result.uri,
+        `example ${index} (${uri}) did not resolve to the documented entity`,
+      ).toBe("https://ds.canonical.com/global.component.button");
+      expect(result.groups.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("runs the `graph query` ASK example and gets a true answer", async () => {
+    // The old example returned `false` — syntactically fine, semantically a lie
+    // about the graph. Asserting the ANSWER is what catches that.
+    const query = verb("graph query");
+    const ask = (query.examples ?? []).findIndex((e) => e.cmd.includes("ASK"));
+    expect(ask, "no ASK example to execute").toBeGreaterThanOrEqual(0);
+
+    const result = (await query.run(
+      { [positionalOf(query)]: exampleArg(query, ask) },
+      rt,
+    )) as { type: string; result?: boolean };
+
+    expect(result.type).toBe("ask");
+    expect(result.result, "the documented ASK example answers false").toBe(
+      true,
+    );
+  });
+
+  it("runs the `graph query` SELECT example and gets rows", async () => {
+    const query = verb("graph query");
+    const result = (await query.run(
+      { [positionalOf(query)]: exampleArg(query, 0) },
+      rt,
+    )) as { type: string; bindings?: unknown[] };
+
+    expect(result.type).toBe("select");
+    expect(result.bindings?.length ?? 0).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/pragma/src/capabilities/graph/inspect.verb.ts
+++ b/packages/cli/pragma/src/capabilities/graph/inspect.verb.ts
@@ -20,7 +20,7 @@ const inspectVerb: VerbSpec<Record<string, unknown>, InspectResult> = {
   path: ["graph", "inspect"],
   summary:
     "Show every triple where a URI is the subject, grouped by predicate.",
-  doc: "Inspect one entity: all predicate/object pairs asserted on the subject. Address it by prefixed name (ds:button) or absolute IRI.",
+  doc: "Inspect one entity: all predicate/object pairs asserted on the subject. Address it by prefixed name (ds:global.component.button) or absolute IRI.",
   params: [
     {
       kind: "string",
@@ -33,8 +33,10 @@ const inspectVerb: VerbSpec<Record<string, unknown>, InspectResult> = {
   ],
   output: { formatters: inspectFormatters },
   examples: [
-    { cmd: `${BIN_NAME} graph inspect ds:button` },
-    { cmd: `${BIN_NAME} graph inspect https://ds.canonical.com/button` },
+    { cmd: `${BIN_NAME} graph inspect ds:global.component.button` },
+    {
+      cmd: `${BIN_NAME} graph inspect https://ds.canonical.com/global.component.button`,
+    },
   ],
   capability: {
     needsStore: true,

--- a/packages/cli/pragma/src/capabilities/graph/query.verb.ts
+++ b/packages/cli/pragma/src/capabilities/graph/query.verb.ts
@@ -40,7 +40,7 @@ const queryVerb: VerbSpec<Record<string, unknown>, QueryResult> = {
       note: "list every component subject",
     },
     {
-      cmd: `${BIN_NAME} graph query "ASK { ds:button a ds:Component }" --format json`,
+      cmd: `${BIN_NAME} graph query "ASK { <https://ds.canonical.com/global.component.button> a ds:Component }" --format json`,
     },
   ],
   capability: {

--- a/packages/cli/pragma/src/capabilities/resources/resources.test.ts
+++ b/packages/cli/pragma/src/capabilities/resources/resources.test.ts
@@ -267,3 +267,34 @@ describe("resource read — cold-store failure surfaces isError + recovery (D3)"
     expect(data?.recovery?.mcp?.tool).toBe("sources_update");
   });
 });
+
+describe("a percent-encoded resource URI reads (PROTECTED)", () => {
+  let harness: Awaited<ReturnType<typeof projectMcp>>;
+  beforeAll(async () => {
+    harness = await projectMcp([graphModule]);
+  });
+  afterAll(async () => {
+    await harness.cleanup();
+  });
+
+  it("resolves the encoded form to the same entity as the plain one", async () => {
+    // A client that percent-encodes the URI it puts in a `pragma:{+uri}` read is
+    // not doing anything wrong, and the surface was rejecting its own advertised
+    // identifiers. Asserted THROUGH the server, since that is where a client
+    // meets it — the unit test on `resolveUri` cannot see the template.
+    const plain = await harness.readResource("pragma:ds:Component");
+    const encoded = await harness.readResource("pragma:ds%3AComponent");
+    expect(encoded.text).toBe(plain.text);
+  });
+
+  it("still refuses a malformed escape as InvalidParams", async () => {
+    const error = await harness.readResource("pragma:%E0%A4%A").then(
+      () => undefined,
+      (caught: unknown) => caught,
+    );
+    expect(error, "a malformed escape must not read as success").toBeDefined();
+    expect((error as { data?: { code?: string } }).data?.code).toBe(
+      "INVALID_INPUT",
+    );
+  });
+});

--- a/packages/cli/pragma/src/kernel/packs/iri.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/iri.test.ts
@@ -1,0 +1,73 @@
+/**
+ * URI resolution — what it accepts, and what it says when it refuses.
+ *
+ * Both halves matter and only one was covered. `resolveUri` is reached by every
+ * read (`graph inspect`, every pack lookup, the `pragma:{+uri}` resource), so
+ * its diagnostic is the sentence a user or an agent actually has to act on.
+ * Nothing asserted that sentence, which is how it came to quote a string the
+ * caller never typed.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveUri } from "./iri.js";
+
+const DS = "https://ds.canonical.com/";
+const PREFIXES: Readonly<Record<string, string>> = { ds: DS };
+
+/** Run `resolveUri` and hand back whatever it threw, for assertion. */
+function refusal(uri: string): { code?: string; message?: string } {
+  try {
+    resolveUri(uri, PREFIXES);
+    throw new Error(`expected "${uri}" to be refused`);
+  } catch (error) {
+    return error as { code?: string; message?: string };
+  }
+}
+
+describe("resolveUri", () => {
+  it("resolves the plain forms", () => {
+    expect(resolveUri("ds:Component", PREFIXES)).toBe(`${DS}Component`);
+    expect(resolveUri(`${DS}Component`, PREFIXES)).toBe(`${DS}Component`);
+  });
+
+  it("accepts a percent-encoded prefixed name", () => {
+    // A client that encodes the URI it puts in a `pragma:{+uri}` read is not
+    // doing anything wrong; refusing it made the resource surface reject its
+    // own advertised identifiers.
+    expect(resolveUri("ds%3AComponent", PREFIXES)).toBe(`${DS}Component`);
+  });
+
+  it("names the URI the CALLER typed, not the expansion", () => {
+    // The safety check runs on the expanded IRI — it has to — but the message
+    // is for whoever typed the input, and they never typed the expansion.
+    const error = refusal("ds:my component");
+    expect(error.code).toBe("INVALID_INPUT");
+    expect(error.message).toContain("ds:my component");
+    expect(error.message).not.toContain(DS);
+  });
+
+  it("refuses malformed percent input as INVALID_INPUT, not a URIError", () => {
+    // `decodeURIComponent` throws `URIError` on a truncated escape. Escaping as
+    // a raw TypeError would surface as an internal fault rather than the
+    // caller's bad input.
+    const error = refusal("%E0%A4%A");
+    expect(error.code).toBe("INVALID_INPUT");
+    expect(error).not.toBeInstanceOf(URIError);
+    expect(error.message).toContain("%E0%A4%A");
+  });
+
+  it("refuses an unknown prefix and offers the ones it knows", () => {
+    const error = refusal("nope:Thing") as {
+      code?: string;
+      validOptions?: string[];
+    };
+    expect(error.code).toBe("INVALID_INPUT");
+    expect(error.validOptions).toContain("ds");
+  });
+
+  it("refuses a payload that would break out of the <iri> token", () => {
+    // The injection guard, asserted here rather than only through a verb.
+    const error = refusal('ds:x> } INSERT { ?s ?p "y" } #');
+    expect(error.code).toBe("INVALID_INPUT");
+  });
+});

--- a/packages/cli/pragma/src/kernel/packs/iri.ts
+++ b/packages/cli/pragma/src/kernel/packs/iri.ts
@@ -27,6 +27,11 @@ export function isEmbeddableIri(value: string): boolean {
 /**
  * Resolve a prefixed or absolute URI to its full form.
  *
+ * A value that fails to resolve and carries a `%` is retried once decoded, so a
+ * client that percent-encodes the URI it addresses (`ds%3AComponent`) is served
+ * rather than rejected. Every diagnostic names the value the CALLER supplied —
+ * the safety check runs on the expansion, but nobody typed the expansion.
+ *
  * @param uri - A full or prefixed URI string.
  * @param prefixes - The store's merged prefix→namespace map.
  * @returns The fully expanded URI.
@@ -36,9 +41,33 @@ export function resolveUri(
   uri: string,
   prefixes: Readonly<Record<string, string>>,
 ): string {
+  const direct = tryResolveUri(uri, prefixes);
+  if (typeof direct === "string") return direct;
+
+  const decoded = uri.includes("%") ? decodeOnce(uri) : undefined;
+  if (decoded !== undefined && decoded !== uri) {
+    const viaDecoded = tryResolveUri(decoded, prefixes);
+    if (typeof viaDecoded === "string") return viaDecoded;
+  }
+
+  // Report the input as given, never the decoded or expanded form.
+  throw direct;
+}
+
+/**
+ * One resolution attempt: the expanded IRI, or the error describing `uri`.
+ *
+ * @param uri - The candidate URI, as the caller wrote it.
+ * @param prefixes - The store's merged prefix→namespace map.
+ * @returns The expanded IRI on success, else the PragmaError to report.
+ */
+function tryResolveUri(
+  uri: string,
+  prefixes: Readonly<Record<string, string>>,
+): string | PragmaError {
   const colonIdx = uri.indexOf(":");
   if (colonIdx === -1) {
-    throw PragmaError.invalidInput("uri", uri, {
+    return PragmaError.invalidInput("uri", uri, {
       recovery: {
         message: 'Use a prefixed URI (e.g. "prefix:name") or a full URI.',
       },
@@ -49,16 +78,14 @@ export function resolveUri(
   const namespace = prefixes[prefix];
   if (namespace !== undefined) {
     const resolved = `${namespace}${uri.slice(colonIdx + 1)}`;
-    assertSafeIri(resolved);
-    return resolved;
+    return unsafeIriError(uri, resolved) ?? resolved;
   }
 
   if (ABSOLUTE_IRI_PATTERN.test(uri)) {
-    assertSafeIri(uri);
-    return uri;
+    return unsafeIriError(uri, uri) ?? uri;
   }
 
-  throw PragmaError.invalidInput("prefix", prefix, {
+  return PragmaError.invalidInput("prefix", prefix, {
     validOptions: Object.keys(prefixes),
     recovery: cliRecovery("ontology list", "List known ontology prefixes.", {
       tool: "ontology_list",
@@ -66,11 +93,37 @@ export function resolveUri(
   });
 }
 
-/** @throws PragmaError INVALID_INPUT when the URI contains IRI-breaking characters. */
-function assertSafeIri(uri: string): void {
-  if (UNSAFE_IRI_PATTERN.test(uri)) {
-    throw PragmaError.invalidInput("uri", uri, {
-      recovery: { message: "URI contains characters not allowed in IRIs." },
-    });
+/**
+ * Guard the EXPANSION, name the INPUT: the check is on the IRI that would reach
+ * a query, the message is about the value the caller actually typed.
+ *
+ * @param input - The URI as the caller wrote it.
+ * @param resolved - The expanded IRI the check runs against.
+ * @returns The error when `resolved` carries IRI-breaking characters, else undefined.
+ */
+function unsafeIriError(
+  input: string,
+  resolved: string,
+): PragmaError | undefined {
+  if (!UNSAFE_IRI_PATTERN.test(resolved)) return undefined;
+  return PragmaError.invalidInput("uri", input, {
+    recovery: { message: "URI contains characters not allowed in IRIs." },
+  });
+}
+
+/**
+ * Percent-decode a value, tolerating malformed encodings.
+ *
+ * `decodeURIComponent` throws `URIError` on a stray `%` — a decode ATTEMPT must
+ * never turn a reportable input error into a crash.
+ *
+ * @param value - The possibly percent-encoded value.
+ * @returns The decoded value, or undefined when it cannot be decoded.
+ */
+function decodeOnce(value: string): string | undefined {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return undefined;
   }
 }


### PR DESCRIPTION
## Done

Three fixes to URI resolution in the CLI's pack kernel, all reachable from `graph inspect` and the `pragma:{+uri}` MCP resource read.

1. **Errors now echo what the caller typed, not the expansion.** `resolveUri` expanded a prefixed name and then validated the result, so the diagnostic quoted a string the user never wrote. The safety check still runs on the expanded IRI — only the *message* changed to name the input.

   ```
   $ pragma graph inspect 'ds:my component'

   # before
   ## Error: INVALID_INPUT
   Invalid uri "https://ds.canonical.com/my component".
   Recovery: URI contains characters not allowed in IRIs.

   # after
   ## Error: INVALID_INPUT
   Invalid uri "ds:my component".
   Recovery: URI contains characters not allowed in IRIs.
   ```

2. **Percent-encoded URIs resolve instead of failing.** A client that percent-encodes the value it puts in a `pragma:{+uri}` resource read got a hard failure. Resolution now retries once with the value decoded; if the decoded form resolves it is used, otherwise the original input is reported per (1). `decodeURIComponent` throws `URIError` on malformed input, so the decode attempt is guarded — a stray `%` stays a reportable input error rather than becoming a crash.

   ```
   $ pragma graph inspect 'ds%3AComponent'      # = MCP resource pragma:ds%3AComponent

   # before
   ## Error: INVALID_INPUT
   Invalid uri "ds%3AComponent".
   Recovery: Use a prefixed URI (e.g. "prefix:name") or a full URI.

   # after
   ## ds:Component — Component
   - **rdfs:label**: Component
   - **rdfs:subClassOf**: ds:UIBlock
   …
   ```

   Malformed encodings still report cleanly, with no `URIError` escaping:

   ```
   $ pragma graph inspect '%E0%A4%A'
   ## Error: INVALID_INPUT
   Invalid uri "%E0%A4%A".
   Recovery: Use a prefixed URI (e.g. "prefix:name") or a full URI.
   ```

3. **Documented examples that 404 against the shipped graph.** `ds:button` is not in the shipped pack index — the real entity is `ds:global.component.button`. A copy-pasteable example that fails is the first thing an agent or a new user tries. Retargeted on `graph inspect` (both examples plus the verb's `doc` line, which named `ds:button` as the addressing example) and, as a drive-by, on `graph query`'s ASK example, which silently answered `false`. `docs/reference/*.md` regenerated with `bun run gen:reference` rather than hand-edited.

   The `graph query` example had to move to the absolute-IRI form — **surprise:** the store's SPARQL parser rejects a prefixed local name containing more than one dot, so `ASK { ds:global.component.button a ds:Component }` is a parse error at the second `.` while `ASK { <https://ds.canonical.com/global.component.button> a ds:Component }` answers `true`. `graph inspect` is unaffected because it expands the prefix itself and embeds an `<iri>` token.

Deliberately **not** touched: `resources/provider.ts`'s `TEMPLATE_DESCRIPTION` still advertises `pragma:ds:button`, and its index reads are still unmemoised. Both are known and deferred to concurrent work on that file.

## QA

```bash
# fix 1 — the message names the input
pragma graph inspect 'ds:my component'

# fix 2 — a percent-encoded URI resolves; a malformed one reports cleanly
pragma graph inspect 'ds%3AComponent'
pragma graph inspect '%E0%A4%A'

# fix 3 — every documented example resolves
pragma graph inspect ds:global.component.button
pragma graph inspect https://ds.canonical.com/global.component.button
pragma graph query "ASK { <https://ds.canonical.com/global.component.button> a ds:Component }" --format json
```

Gate from the repo root: `bun run check` passes across all 62 projects. `bun run test` — `@canonical/pragma-cli` passes 1358 vitest + 22 perf tests (no assertion changes were needed; the new message shape broke nothing). Nx classified `pragma-cli:test` and `react-ds-app-launchpad:test` as flaky under parallel load — both pass solo, failing only with 5000 ms timeouts under contention. `svelte-ds-*` fail on missing Playwright browser binaries in a fresh worktree (environment-only, discountable per AGENTS.md). The known scaffolded-fixture leak into `packages/cli/pragma/src/lib/` reproduced and was cleaned; it is not committed.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: n/a — no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

n/a — CLI/MCP diagnostics only, no visual surface. The before/after strings are quoted verbatim above.

🤖 Opened with [Claude Code](https://claude.com/claude-code)
