### PR TITLE
refactor(pragma-cli): add barrels to the ten domains that lacked one

### DIFF
--- a/packages/cli/pragma/src/capabilities/doctor/checks/index.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/index.ts
@@ -1,0 +1,27 @@
+/**
+ * The doctor check catalogue — the diagnoses `doctor` composes into a report.
+ *
+ * A check is the whole shape of this domain: it inspects ONE thing, decides
+ * pass or fail, and hands back a `CheckResult` carrying the remedy. Keeping
+ * them apart from the report body is what lets `runChecks` stay a composition
+ * — it orders and awaits, and knows nothing about what any check looks at.
+ *
+ * Two kinds live here, and the barrel exposes them differently. The UNBANDED
+ * checks diagnose what `setup` cannot install — the Node floor, the CLI's own
+ * version and install source, the pack answering this project's reads, and the
+ * store — so each is its own named entry point. The BANDED rows are derived
+ * per target, per band, from the setup target table rather than authored here,
+ * so they surface as the one generator that derives them, never as a list of
+ * row names this file would then have to keep in step with `setup`.
+ *
+ * The per-target probes (the completions script check, the MCP command
+ * resolution helpers) stay internal on purpose: `bandedChecks` is the only way
+ * they are meant to be reached, and a row reachable past its band is a row
+ * `doctor` can report and `setup` cannot fix.
+ */
+
+export { checkKeStore } from "./checkKeStore.js";
+export { checkNodeVersion } from "./checkNodeVersion.js";
+export { checkPackageRefs } from "./checkPackageRefs.js";
+export { checkPragmaVersion } from "./checkPragmaVersion.js";
+export { bandedChecks } from "./targetHealth.js";

--- a/packages/cli/pragma/src/capabilities/setup/operations/index.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/index.ts
@@ -1,0 +1,74 @@
+/**
+ * The setup operations — one module per installable target, each answering the
+ * same three questions about it.
+ *
+ * `setup` and `doctor` are two projections of ONE target table, and this is
+ * where that table's cells live. Every target module exports the same trio: a
+ * `detect*` that reads the machine and returns that target's detection record,
+ * a `compose*` that turns a detection into the Task which installs it, and a
+ * `compose*Removal` that turns the same detection into the Task which undoes
+ * it. Nothing here decides WHICH targets run or in what order — `targets.ts`
+ * owns that — so a new target is a new module plus a row, and neither surface
+ * has to learn about it twice.
+ *
+ * The detection types are part of the surface, not an implementation leak: a
+ * detection is the value passed from the read half to the compose half and on
+ * to the plan rows, so `doctor`'s banded checks name the same records `setup`
+ * acts on. The presentation helpers travel with them for the same reason — a
+ * skip reason or an uninstall remedy is derived from one detection, and
+ * deriving it twice is how the two surfaces start disagreeing about the same
+ * machine.
+ *
+ * `buildSetupRun` sits apart: it is the run assembler that drives every
+ * selected target's detection and projects the result into a plan and a summon
+ * generator. It is reached through a DYNAMIC import from `setup.verb.ts` so
+ * the wizard's React/Ink dependency stays off the `--help`/`__complete` fast
+ * path — a consumer that routes it through this barrel statically would undo
+ * that, and the setup guard test would say so.
+ *
+ * Deliberately internal: the config seed literal, the per-target message
+ * builders, and the MCP entry writer. They are inputs to the composers above,
+ * not operations a caller performs.
+ */
+
+export type { CompletionsDetection } from "./setupCompletions.js";
+export {
+  composeCompletions,
+  composeCompletionsRemoval,
+  detectCompletions,
+} from "./setupCompletions.js";
+export type { ConfigDetection } from "./setupConfig.js";
+export {
+  composeConfigFile,
+  composeConfigRemoval,
+  detectConfigFile,
+} from "./setupConfig.js";
+export type { SetupRun } from "./setupGenerator.js";
+export { buildSetupRun } from "./setupGenerator.js";
+export type { LspDetection } from "./setupLsp.js";
+export {
+  composeLsp,
+  composeLspRemoval,
+  detectLsp,
+  LSP_SKIP_REMEDY,
+  lspEditorNames,
+  lspSkipReason,
+  lspUninstallRemedy,
+} from "./setupLsp.js";
+export type { McpDetection } from "./setupMcp.js";
+export {
+  composeMcp,
+  composeMcpRemoval,
+  detectMcp,
+  mcpGroupState,
+  ownedMcpGroups,
+  selectedGroups,
+} from "./setupMcp.js";
+export type { SkillsDetection, SymlinkAction } from "./setupSkills.js";
+export {
+  composeSkills,
+  composeSkillsRemoval,
+  detectSkills,
+  ownedSkillLinks,
+  skillsSkipReason,
+} from "./setupSkills.js";

--- a/packages/cli/pragma/src/capabilities/shared/index.ts
+++ b/packages/cli/pragma/src/capabilities/shared/index.ts
@@ -1,0 +1,32 @@
+/**
+ * The cross-capability shared surface — the few facts more than one capability
+ * needs and none of them owns.
+ *
+ * Everything here earned its place by being needed in two capabilities at
+ * once, and the cohesion principle is that shortness of the list. `shared/` is
+ * not a utility drawer: a helper used by exactly one capability belongs in
+ * that capability, and the moment something here has a single consumer again
+ * it should move back. What survives is the environment the CLI reports on but
+ * does not own — how it was installed, what the registry says about it,
+ * whether a subprocess it ran actually succeeded — plus the one piece of
+ * vocabulary (`BAND_LABELS`) that keeps `setup` and `doctor` calling the two
+ * config bands by the same names users meet in the flags.
+ *
+ * The exec guard is exported as the pair a caller needs together: `checkExecOk`
+ * to classify a result inside a Task and `assertExecOk` to throw on one
+ * outside, with `guardMissingBinary` wrapping the absent-binary case that
+ * neither should report as a pragma bug. The predicates they are built from
+ * stay internal — a caller reaching for the predicate instead of the guard is
+ * a caller about to reimplement the classification.
+ */
+
+export {
+  assertExecOk,
+  checkExecOk,
+  guardMissingBinary,
+} from "./assertExecOk.js";
+export { BAND_LABELS } from "./bands.js";
+export type { InstallSource } from "./packageManager.js";
+export { detectInstallSource, pmUpdateCommand } from "./packageManager.js";
+export type { RegistryCheckResult } from "./registry.js";
+export { checkRegistryVersion, PRAGMA_PACKAGE } from "./registry.js";

--- a/packages/cli/pragma/src/kernel/completion/templates/index.ts
+++ b/packages/cli/pragma/src/kernel/completion/templates/index.ts
@@ -1,0 +1,23 @@
+/**
+ * The static shell-completion templates — one emitter per shell, all fed by
+ * the same completion model.
+ *
+ * The three exports are the domain: each takes the model and returns the text
+ * of a script `setup completions` writes to disk. They are grouped because
+ * they are interchangeable answers to one question — which shell is this — and
+ * because they must stay in step: a fact the model carries has to be
+ * expressible in all three, so a change to one is a change to all three.
+ *
+ * What the barrel does NOT expose is the rendering layer underneath
+ * (`shared.ts`): the per-verb views, the token allowlist re-assertion, the
+ * name/flag list derivations. Those exist so the scripts cannot disagree about
+ * structure, and they are safe only in the emit context they were built for —
+ * every token they return has been re-checked against the safety allowlist on
+ * its way into script text. Offering them across the domain boundary would
+ * offer a way to compose that text without that check, which is the one thing
+ * this domain exists to make impossible.
+ */
+
+export { bashScript } from "./bash.js";
+export { fishScript } from "./fish.js";
+export { zshScript } from "./zsh.js";

--- a/packages/cli/pragma/src/kernel/index.ts
+++ b/packages/cli/pragma/src/kernel/index.ts
@@ -1,0 +1,26 @@
+/**
+ * The kernel's own top-level declarations — the small set of facts that belong
+ * to no sub-domain because every sub-domain may need them.
+ *
+ * This is NOT a facade over the kernel. `kernel/` is a namespace of domains,
+ * each of which keeps its own barrel (`config/`, `render/`, `runtime/`,
+ * `packs/`, `error/`, `spec/`, `completion/`, `project/…`); a consumer wanting
+ * one of those imports that domain's barrel, not this one. What lives here is
+ * only what sits directly in `kernel/`, and the bar for putting a file there
+ * is high: it must be a declaration the kernel makes about itself rather than
+ * a step in any one pipeline.
+ *
+ * Today that is the declared vocabulary — the distribution's mapping from the
+ * roles the CLI knows (a prompt, a resource) onto the RDF terms that actually
+ * carry them in the active graph. It is parsed once at module load and read
+ * from the prompt capability, the MCP prompt source, and the pack index
+ * builder, none of which owns it and any of which would otherwise hardcode
+ * someone else's IRIs.
+ *
+ * The copy-gate rule table (`copy.ts`) deliberately stays off this barrel. It
+ * is reviewed data consumed by its own test and by nothing else at runtime;
+ * exporting it here would advertise a runtime API the gate does not have.
+ */
+
+export type { DeclaredVocabulary } from "./vocabulary.js";
+export { VOCABULARY } from "./vocabulary.js";

--- a/packages/cli/pragma/src/kernel/packs/graphql/index.ts
+++ b/packages/cli/pragma/src/kernel/packs/graphql/index.ts
@@ -1,0 +1,20 @@
+/**
+ * The GraphQL lookup path — what a `source: "graphql"` pack story executes
+ * once SPARQL has resolved its name to an entity IRI.
+ *
+ * The three files here are one function split for testability, not three
+ * services: the naming rules derive schema field names from the RDF properties
+ * a pack declares, the document generator turns a lookup declaration plus
+ * those names into the single query to run, and the fetcher executes it and
+ * unwraps the Relay envelope into the same flat entity shape the SPARQL path
+ * produces. Only the last of those is something a caller does.
+ *
+ * So the barrel is one export, and the narrowness is the point. The document
+ * generator's contract is that the entity IRI travels as a query VARIABLE and
+ * never as interpolated text, and that a document is composed only from
+ * validated pack terms and compiled schema names. Handing out the generator on
+ * its own would hand out a way to build a document and execute it by some
+ * other route; handing out the fetcher hands out the guarantee with it.
+ */
+
+export { fetchGraphqlLookup } from "./fetchGraphqlLookup.js";

--- a/packages/cli/pragma/src/kernel/packs/index.ts
+++ b/packages/cli/pragma/src/kernel/packs/index.ts
@@ -1,0 +1,40 @@
+/**
+ * The packs domain — declared stories become runnable verbs.
+ *
+ * One pipeline runs end to end inside this folder: a JSON pack declaration is
+ * parsed and validated, compiled into `VerbSpec`s, and given run bodies that
+ * resolve entities out of the graph and formatters that render them. The
+ * intermediate stages — the schema parser, the query/render/run-body builders,
+ * the entity resolver, the sampler, the glob expander — are steps in that
+ * pipeline, not services, and they stay off this barrel: a caller reaching for
+ * one of them is a caller reassembling the pipeline by hand, and the whole
+ * point of compiling a pack once is that nobody has to.
+ *
+ * What crosses the boundary is the pipeline's ends and the contracts naming
+ * them. `compilePack` is the entry the distribution and the config-story path
+ * both take. `validateStories` and `loadEffectiveModules` are the two ways
+ * third-party stories are admitted — the first screens records and reports
+ * every problem (which is how `doctor` reports a story the CLI drops rather
+ * than letting it vanish), the second is the full load the MCP server and the
+ * `capabilities` verb take. `resolvePackDetail` and `resolveUri` are the two
+ * decisions a pack's own reads defer to the runtime, and `verbKey` is the
+ * identity function every surface keys a verb by.
+ *
+ * `loadEffectiveModules` reads config and the answering pack behind DYNAMIC
+ * imports so a bare `--help` never pays for either; consumers reach it lazily
+ * today for exactly that reason, and routing it through this barrel statically
+ * would put the config reader back on the fast path.
+ */
+
+export type { StoryProblem } from "./collect.js";
+export { loadEffectiveModules, validateStories } from "./collect.js";
+export { compilePack } from "./compile.js";
+export { resolvePackDetail } from "./disclosure.js";
+export { resolveUri } from "./iri.js";
+export type {
+  PackDefinition,
+  PackRow,
+  StorySource,
+} from "./types.js";
+export { distributionSource } from "./types.js";
+export { verbKey } from "./uniqueness.js";

--- a/packages/cli/pragma/src/kernel/packs/sparql/index.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/index.ts
@@ -1,0 +1,37 @@
+/**
+ * The SPARQL path — every generated read a pack story performs, and the two
+ * row operations that must NOT be generated.
+ *
+ * The domain is organised around one invariant: user input never reaches query
+ * text. The query builders compose only from validated pack terms and escaped
+ * literals, so a name a user typed becomes a SPARQL string literal or nothing;
+ * `runSelect` is the single choke point every one of those trusted queries
+ * goes through, which is what makes "a generated query failed" distinguishable
+ * from "the user's own `graph query` failed". Filtering and search then run as
+ * predicates over the resolved ROWS rather than as clauses in the query —
+ * which is why they live in this domain despite touching no SPARQL at all:
+ * they are the operations that would otherwise be tempting to express as query
+ * text, and keeping them here keeps the temptation answered.
+ *
+ * The escaping primitives stay internal. They are how the builders keep that
+ * invariant, not a service for composing query text elsewhere — a caller with
+ * the escaper is a caller who can build an unvalidated query, which is exactly
+ * the shape this domain exists to prevent.
+ *
+ * Two names re-exported by `buildLookupQuery.ts` for its own callers'
+ * convenience — the disclosure-level field and expand selectors — are also
+ * omitted. They belong to `kernel/packs/disclosure.ts`; laundering them
+ * through here would make this domain look like their owner and freeze a
+ * pass-through that has no reason to be permanent.
+ */
+
+export { applyPackFilters } from "./applyFilters.js";
+export { applyPackSearch } from "./applySearch.js";
+export {
+  buildExpandQuery,
+  buildLookupByIriQuery,
+  buildLookupNamesQuery,
+  buildLookupQuery,
+  buildNameResolveQuery,
+} from "./buildLookupQuery.js";
+export { runSelect } from "./runSelect.js";

--- a/packages/cli/pragma/src/kernel/project/mcp/prompts/index.ts
+++ b/packages/cli/pragma/src/kernel/project/mcp/prompts/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Prompt entities, read two ways from one graph type.
+ *
+ * A prompt lives in the graph as an entity the distribution's vocabulary
+ * declares, and two surfaces offer it: the native MCP `prompts/list` +
+ * `prompts/get` handlers, and the `prompt list` / `prompt lookup` verbs behind
+ * the covenant tools. The pair is the cohesion principle — the reader here is
+ * the ONE place either surface learns what a prompt is, so the two can never
+ * report a different set of prompts or a different template body for one.
+ *
+ * The barrel carries both halves. `promptProvider` is the MCP module hook,
+ * registered by the prompt capability; `readPrompts` and `readPrompt` are the
+ * reads the CLI verbs take. Their laziness is deliberate and survives the
+ * barrel only if callers keep it: listing is STORELESS over the pack index,
+ * a get is store-backed, and both the SDK request schemas and this module
+ * itself are reached through DYNAMIC imports so neither the MCP SDK nor a
+ * store boot lands on the `--help`/`__complete` fast path. A consumer that
+ * imports this barrel statically from the capability graph would put them
+ * there.
+ *
+ * `listPromptSummaries` — the storeless index projection both readers build on
+ * — stays internal: it is the shared half of the two reads above, and a caller
+ * choosing it directly is choosing a partial prompt without the store-backed
+ * body that makes it usable.
+ */
+
+export { promptProvider } from "./provider.js";
+export type { PromptArgument, PromptEntry } from "./source.js";
+export { readPrompt, readPrompts } from "./source.js";

--- a/packages/cli/pragma/src/kernel/project/mcp/prompts/index.ts
+++ b/packages/cli/pragma/src/kernel/project/mcp/prompts/index.ts
@@ -8,20 +8,28 @@
  * the ONE place either surface learns what a prompt is, so the two can never
  * report a different set of prompts or a different template body for one.
  *
- * The barrel carries both halves. `promptProvider` is the MCP module hook,
- * registered by the prompt capability; `readPrompts` and `readPrompt` are the
- * reads the CLI verbs take. Their laziness is deliberate and survives the
- * barrel only if callers keep it: listing is STORELESS over the pack index,
- * a get is store-backed, and both the SDK request schemas and this module
- * itself are reached through DYNAMIC imports so neither the MCP SDK nor a
- * store boot lands on the `--help`/`__complete` fast path. A consumer that
- * imports this barrel statically from the capability graph would put them
- * there.
+ * The barrel carries both halves, and they READ DIFFERENTLY — the distinction
+ * matters to anyone rerouting imports through here, so it is stated rather
+ * than implied.
  *
- * `listPromptSummaries` — the storeless index projection both readers build on
- * — stays internal: it is the shared half of the two reads above, and a caller
- * choosing it directly is choosing a partial prompt without the store-backed
- * body that makes it usable.
+ * `promptProvider` is the MCP module hook. Its `prompts/list` is STORELESS:
+ * it projects the pack index through `listPromptSummaries`, returning `[]`
+ * when no index is reachable and never booting the store. Its `prompts/get`
+ * is store-backed. The provider is imported STATICALLY by the prompt
+ * capability (`capabilities/prompt/index.ts`) — what it defers is the MCP SDK
+ * itself, whose request schemas it reaches through a dynamic import so the SDK
+ * stays off the `--help`/`__complete` fast path.
+ *
+ * `readPrompts` and `readPrompt` are the reads the CLI verbs take, and BOTH
+ * are store-backed: they query through `runSelect` directly, not through the
+ * index projection. A caller that expects a listing here to be as cheap as the
+ * MCP one is mistaken, and a reroute that makes either reachable statically
+ * from the capability graph puts a store boot on the fast path.
+ *
+ * `listPromptSummaries` stays internal. It is the MCP list path's projection,
+ * not a shared foundation under the two exported reads, and a caller choosing
+ * it directly is choosing a partial prompt without the store-backed body that
+ * makes it usable.
  */
 
 export { promptProvider } from "./provider.js";

--- a/packages/cli/pragma/src/kernel/runtime/refs/index.ts
+++ b/packages/cli/pragma/src/kernel/runtime/refs/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Package refs — turning what a project DECLARED into pinned, on-disk RDF.
+ *
+ * `sources update` is the only caller, and this domain is its whole
+ * resolution: parse a `packs` entry into a typed reference, resolve that
+ * reference to a revision and the TTL/story files it carries, and report what
+ * the resulting set of sources says about itself. Three declaration kinds
+ * (`npm`, `file`, `git`) resolve three different ways but converge on one
+ * `ResolvedPackage`, so callers pin, hash, and build from a single shape.
+ *
+ * The prefix inspectors belong here rather than with the pack builder because
+ * they answer a question about the RESOLVED SET, not about any one package: a
+ * label two packages bind to different IRIs is a conflict nobody can see from
+ * inside either one, and it must be caught before the sources are built rather
+ * than after, when it would surface as a query that silently reads the wrong
+ * namespace.
+ *
+ * `redactUrl` is on the surface because every one of these paths ends in a
+ * message: a git URL may carry a token, and the caller that reports what it
+ * resolved needs the redactor as much as it needs the result.
+ *
+ * The git operations underneath — clone, fetch, head — stay internal. They are
+ * how `git` refs resolve, and they are safe because refs and URLs reach them
+ * as argv and never as shell text; exposing them would offer the operations
+ * without the parsing that validated their arguments.
+ */
+
+export type { PackageRef } from "./parseRef.js";
+export { parsePackDeclaration, redactUrl } from "./parseRef.js";
+export type {
+  PrefixClash,
+  ResolvedPackage,
+  ResolveOptions,
+} from "./resolve.js";
+export {
+  detectPrefixClashes,
+  harvestPrefixes,
+  resolvePackage,
+} from "./resolve.js";


### PR DESCRIPTION
## Done

Brings `packages/cli/pragma` into compliance with **one** code standard: domain
barrels — `cs:packaging.application.structure` and `cs:packaging.export.barrel`,
which require every domain folder in an application package to carry an
`index.ts` naming the API its sibling domains reach it through.

**Purely additive.** No file is renamed, no export form changes, and **no import
is rerouted through the new barrels in this PR.** Rerouting the ~443 existing
cross-domain file-reaches is a separate, larger wave that lands on top of these
barrels; doing it here would touch half the CLI and collide with everything in
flight. Nothing else in the module-shape backlog (single-export file names,
atomic export form, mixed-shape splits, constants/types purity) is touched.

### Ten barrels, one per domain that lacked one

| Domain | Files | Surface exported |
|---|---:|---|
| `capabilities/doctor/checks` | 7 | the 4 unbanded checks + `bandedChecks` |
| `capabilities/setup/operations` | 6 | per-target `detect`/`compose`/`composeRemoval` trios, their detection types, the presentation helpers, `buildSetupRun` |
| `capabilities/shared` | 4 | install-source, registry check, exec guard, `BAND_LABELS` |
| `kernel` | 2 | the declared vocabulary |
| `kernel/completion/templates` | 4 | `bashScript`, `fishScript`, `zshScript` |
| `kernel/packs` | 12 | `compilePack`, the two story-admission reads, `resolvePackDetail`, `resolveUri`, `verbKey`, the pack contracts |
| `kernel/packs/graphql` | 3 | `fetchGraphqlLookup` |
| `kernel/packs/sparql` | 5 | the query builders, `runSelect`, the two row operations |
| `kernel/project/mcp/prompts` | 2 | `promptProvider`, `readPrompt`, `readPrompts` |
| `kernel/runtime/refs` | 3 | ref parsing, resolution, prefix inspection, `redactUrl` |

Each barrel exports the surface its consumers **actually use today**, not every
symbol in the directory. A barrel that re-exports internals is worse than none:
it makes the domain unreadable and freezes implementation details as public
API. Held back deliberately, each with the reason stated in the barrel's own
docblock: the packs pipeline's intermediate stages, the SPARQL escaping
primitives, the completion templates' emit-time rendering layer, the git
plumbing under ref resolution, the per-target doctor probes, and the
`shared/` exec predicates. Where a symbol is a pass-through re-export owned by
another domain (`activeFields`/`activeExpands` via `buildLookupQuery.ts`) it is
omitted rather than laundered through a second owner.

Three barrels carry an explicit **laziness note**: `buildSetupRun`,
`loadEffectiveModules`, and the MCP prompt source are reached through *dynamic*
imports today so the wizard's Ink/React dependency, the config reader, and the
MCP SDK stay off the `--help` / `__complete` fast path. A follow-up that routes
those statically through a barrel would put them back on it — the docblocks say
so, so the reroute wave does not have to rediscover it.

### Scope decisions (what is *not* a domain folder)

At `origin/main@f4b4f90db`, **20** directories under `packages/cli/pragma/src`
hold source `.ts` files and no `index.ts`. Ten got a barrel; ten are out of
scope under the standard's own definition:

- **`src/testing/**` — 9 directories, excluded.** `cs:packaging.application.structure`
  defines domain folders as *execution domains* ("commands, routes, tools,
  operations") — the package's internal code organised around what it executes.
  Test infrastructure executes nothing in the product. `cs:testing.file.structure`
  independently places shared test infra in a **package-root** `testing/`
  directory, outside `src/` and therefore outside the application's domain tree
  entirely; this package's `src/testing/` is already a recorded deviation
  pending relocation, and barrelling it would cement the layout the standards
  say should move. It is also coverage-excluded in `vitest.config.ts`.
- **`kernel/runtime/graphpack/embedded` — 1 directory, excluded.** Three
  `*.generated.ts` files stamped *"AUTO-GENERATED by scripts/bundle.ts — do not
  edit by hand"*, holding serialised data blobs (~1.9 MB of N-Quads), not an
  API. Its domain-facing facade already exists as
  `kernel/runtime/graphpack/embedded.ts` and is exported from the graphpack
  barrel. A hand-written barrel in a generated directory would also be a perf
  trap: it would make the 1.8 MB `dataNq` literal reachable behind one
  specifier.

`kernel/project/` holds no `.ts` files at all — it is a namespace over `cli/`
and `mcp/`, both of which already have barrels — so there is nothing to expose.

`kernel/index.ts` is the one judgement call worth flagging: it is **not** a
facade over the kernel. It carries only what sits directly in `kernel/` (the
declared vocabulary), and its docblock says so explicitly, because each kernel
sub-domain keeps its own barrel. The copy-gate rule table stays off it — that is
reviewed data for its own test, not a runtime API.

## QA

Root gate, with the nx cache disabled so no stale per-project pass is served:

```bash
NX_SKIP_NX_CACHE=true bun run check --concurrency 2
NX_SKIP_NX_CACHE=true npx lerna run test --no-bail --concurrency 2
NX_SKIP_NX_CACHE=true npx lerna run test --scope @canonical/pragma-cli
```

- **`check`: green across all 62 projects** (biome + `tsc --noEmit` + webarchitect).
- **`@canonical/pragma-cli:test`: green** — 1358 passed / 13 skipped / 5 todo,
  coverage 88.41% statements against the package's 50% thresholds, **plus all 22
  PERF budget tests** (`src/testing/perf/budgets.test.ts`, the separate serial
  `test:perf` pass). **No budget was changed.**

### On the perf budgets, since they did fail once

A first run failed `BUDGET_COMPLETE_MS` (174 vs 150) and `BUDGET_WARM_STORE_MS`
(614 vs 500). That was the build box, not this diff — established rather than
assumed:

1. The box was at **load average 47 on 24 CPUs** (the whole monorepo suite was
   running concurrently). `budgets.ts` documents this path's sensitivity
   directly: *"this box's process start swings 60–287 ms with page-cache state
   alone."*
2. `BUDGET_HELP_MS` — the budget most sensitive to a module landing on a fast
   path, and the one a bad barrel would break first — **passed throughout**.
3. **Paired A/B on the same box, same conditions**, the method `budgets.ts`
   itself prescribes: `origin/main` and this branch each `rm -rf dist`, rebuilt
   and run alternately once load settled. **Both arms: 22/22 passing.**
4. Mechanically, the barrels cannot reach a fast path in this PR: nothing
   imports them. They are emitted to `dist` (the build is per-file, not
   entry-bundled) but no module resolves them, so the runtime import graph of
   `dist/src/bin.js` is byte-for-byte the same work as before.

One unrelated **environment** failure in the full root run:
`@canonical/svelte-ds-global:test` (and the two svelte apps depending on it)
cannot launch Playwright's Firefox — `browserType.launch: Executable doesn't
exist at …/ms-playwright/firefox-1532/…` — because the browser binaries are not
installed in this checkout. Browser-mode svelte packages, untouched here;
`--no-bail` is used above so they do not mask the rest of the run.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` and `build:all`.
- [x] This PR introduces no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

Not applicable — no user-visible change. Ten new `index.ts` files, nothing else.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
