### PR TITLE
refactor(svelte-ds-app-wpe): conflate the dso: prefix into ds:

### DIFF
--- a/packages/svelte/ds-app-wpe/src/lib/components/KeyboardKey/KeyboardKey.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/components/KeyboardKey/KeyboardKey.svelte
@@ -37,5 +37,5 @@ non-interactive and purely informational.
 <KeyboardKey keyValue="enter" />
 ```
 
-@implements dso:global.component.keyboard_key
+@implements ds:global.component.keyboard_key
 -->

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/Cards.svelte
@@ -43,5 +43,5 @@ master columns. Outside a grid it degrades to a plain block.
 </div>
 ```
 
-@implements dso:global.group.cards
+@implements ds:global.group.cards
 -->

--- a/packages/svelte/ds-app-wpe/src/lib/group/Cards/styles.css
+++ b/packages/svelte/ds-app-wpe/src/lib/group/Cards/styles.css
@@ -1,6 +1,6 @@
 /**
  * Cards styles
- * @implements dso:global.group.cards
+ * @implements ds:global.group.cards
  *
  * A two-level subgrid: the parent `.grid` supplies columns; `Cards` inherits
  * them and defines four shared section row tracks (image / header / content /

--- a/packages/svelte/ds-app-wpe/src/lib/group/KeyboardKeys/KeyboardKeys.svelte
+++ b/packages/svelte/ds-app-wpe/src/lib/group/KeyboardKeys/KeyboardKeys.svelte
@@ -34,5 +34,5 @@ elements (e.g., individual keys) as children, forming a single grouped keystroke
 </KeyboardKeys>
 ```
 
-@implements dso:global.group.keyboard_keys
+@implements ds:global.group.keyboard_keys
 -->

--- a/packages/svelte/ds-app-wpe/src/lib/subcomponent/Spinner/styles.css
+++ b/packages/svelte/ds-app-wpe/src/lib/subcomponent/Spinner/styles.css
@@ -1,6 +1,6 @@
 /**
  * Spinner styles
- * @implements dso:global.subcomponent.spinner
+ * @implements ds:global.subcomponent.spinner
  *
  * The Spinner renders the `spinner` glyph and rotates it continuously. The
  * rotation is a linear, infinite animation so the motion reads as steady


### PR DESCRIPTION
## Done

Split out of #1029 so it can get your review on its own rather than dragging
`@canonical/workplace-engineering-ui` onto a 100-file integration PR.

The design system declared its ontology terms under two prefixes for the same
namespace — `ds:` and `dso:`. `dso:` is retired. It matters here because the
implementation collector only recognises `ds:`: a `dso:` annotation is silently
invisible to the knowledge graph, so whole component families were being dropped
without any error.

- Five `@implements` annotations renamed `dso:` → `ds:` (three `.svelte`, two `.css`).
- **Comment-only.** No behaviour change, no export change, no rendered output change.
- `ds-app-wpe` declares no `design-system.json`, so it is not collected today —
  this is preparation, not a graph change. Adding the package to the collector
  would be a separate, opt-in change for you to decide on.

Fixes nothing; unblocks #1029.

## QA

```bash
git diff main...refactor/dso-prefix-ds-app-wpe   # 5 files, 5 insertions, 5 deletions
grep -rn "@implements dso:" packages/svelte/ds-app-wpe/   # no matches
cd packages/svelte/ds-app-wpe && bun run check && bun run test
```

### PR readiness check

- [x] PR should have one of the following labels
- [x] PR title follows the Conventional Commits format
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json`
- [x] No new package in this PR
- [x] If this PR does not require visual testing, add the `no visual change` label

🤖 Posted by Claude Code
