### PR TITLE
fix(pragma-cli): address lookups by the shape given, and nest a section's own headings

### DIFF
--- a/packages/cli/pragma/src/kernel/packs/renderPack.ts
+++ b/packages/cli/pragma/src/kernel/packs/renderPack.ts
@@ -10,6 +10,7 @@
  */
 
 import { BIN_NAME, RECOVERY_CLI_PREFIX } from "../../constants.js";
+import { compactUri } from "../render/compactUri.js";
 import type {
   ColumnDef,
   LookupField,
@@ -120,7 +121,11 @@ export function lookupOptions(
     }),
   );
   return {
-    title: (entity) => scalar(entity.name) ?? scalar(entity.uri) ?? "(unnamed)",
+    // An entity reached by IRI need not carry a `by` value, so the IRI is a
+    // real title, not a fallback nobody hits — and it is titled in the form the
+    // user addressed it with, not the expanded one they never typed.
+    title: (entity) =>
+      scalar(entity.name) ?? compactScalar(entity.uri, prefixes) ?? "(unnamed)",
     fields,
     sections: [...flatSections, ...expandSections],
     prefixes,
@@ -196,6 +201,15 @@ function scalar(
   value: string | readonly PackChildRow[] | undefined,
 ): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+/** A scalar URI in its prefixed display form, or undefined when it is neither. */
+function compactScalar(
+  value: string | readonly PackChildRow[] | undefined,
+  prefixes: Readonly<Record<string, string>>,
+): string | undefined {
+  const uri = scalar(value);
+  return uri === undefined ? undefined : compactUri(uri, prefixes);
 }
 
 function capitalize(value: string): string {

--- a/packages/cli/pragma/src/kernel/packs/resolveEntity.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/resolveEntity.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Lookup ADDRESSING (PROTECTED): which argument shapes a pack lookup accepts,
+ * and whether the answer is the same twice.
+ *
+ * A lookup's `<name...>` positional is documented — in the generated reference,
+ * in the MCP tool schema, and by shell completion, which offers prefixed IRIs
+ * and nothing else — as accepting a name, a prefixed name, an absolute IRI, or
+ * a glob. These assert that the resolver honours the shape it is handed rather
+ * than the source its pack declares, that an entity is addressable by IRI even
+ * when it carries no `by` value, and that an ambiguous name resolves to the
+ * same entity on every store and every machine.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  AMBIGUOUS_TTL,
+  BLOCK_PREFIXES,
+  BLOCK_TTL,
+} from "../../testing/fixtures/blockGraph.js";
+import { buildFixtureRuntime } from "../../testing/helpers/packRuntime.js";
+import type { PragmaRuntime } from "../runtime/types.js";
+import { compilePack } from "./compile.js";
+import type { LookupOutput } from "./resolveEntity.js";
+import type { PackDefinition } from "./types.js";
+import { distributionSource } from "./types.js";
+import { verbKey } from "./uniqueness.js";
+
+const DS = "https://ds.canonical.com/";
+
+/** A graphql-sourced pack — the shape `block` and `modifier` declare. */
+const GQL: PackDefinition = {
+  noun: "gblock",
+  lookup: {
+    source: "graphql",
+    by: "ds:name",
+    types: ["ds:Component", "ds:Pattern", "ds:Subcomponent"],
+    graphqlType: "UIBlock",
+    fields: [{ name: "summary", property: "ds:summary" }],
+  },
+};
+
+/** A sparql-sourced pack — the shape `tier`, `token` and `standard` declare. */
+const SPQ: PackDefinition = {
+  noun: "sblock",
+  lookup: {
+    source: "sparql",
+    by: "ds:name",
+    type: "ds:Component",
+    fields: [{ name: "summary", property: "ds:summary" }],
+  },
+};
+
+describe("pack lookup addressing (PROTECTED)", () => {
+  let rt: PragmaRuntime;
+
+  beforeAll(async () => {
+    ({ rt } = await buildFixtureRuntime({
+      ttl: BLOCK_TTL + AMBIGUOUS_TTL,
+      prefixes: BLOCK_PREFIXES,
+      detail: "detailed",
+    }));
+  });
+
+  afterAll(async () => {
+    (await rt.store.get()).store.dispose();
+  });
+
+  const lookupVia = (
+    definition: PackDefinition,
+    ...name: string[]
+  ): Promise<LookupOutput> => {
+    const verb = compilePack(
+      definition,
+      distributionSource("t"),
+      BLOCK_PREFIXES,
+    ).find((v) => verbKey(v.path) === `${definition.noun} lookup`);
+    if (!verb) throw new Error("no lookup verb");
+    return verb.run({ name }, rt) as Promise<LookupOutput>;
+  };
+
+  const uris = (out: LookupOutput): string[] =>
+    out.results.map((entity) => String(entity.uri));
+
+  describe("an IRI addresses an entity on EVERY pack, not just sparql ones", () => {
+    it("resolves a prefixed name on a graphql-sourced pack", async () => {
+      const out = await lookupVia(GQL, "ds:button");
+      expect(out.errors).toEqual([]);
+      expect(uris(out)).toEqual([`${DS}button`]);
+    });
+
+    it("resolves an absolute IRI on a graphql-sourced pack", async () => {
+      const out = await lookupVia(GQL, `${DS}modal`);
+      expect(out.errors).toEqual([]);
+      expect(uris(out)).toEqual([`${DS}modal`]);
+    });
+
+    it("still resolves a plain name on a graphql-sourced pack", async () => {
+      const out = await lookupVia(GQL, "Modal");
+      expect(uris(out)).toEqual([`${DS}modal`]);
+    });
+
+    it("reports an IRI that names nothing as a clean miss", async () => {
+      await expect(lookupVia(GQL, "ds:nosuchblock")).rejects.toMatchObject({
+        code: "ENTITY_NOT_FOUND",
+      });
+    });
+  });
+
+  describe("an IRI addresses an entity that carries no `by` value", () => {
+    it("resolves it on the sparql path", async () => {
+      const out = await lookupVia(SPQ, "ds:nameless.widget");
+      expect(out.errors).toEqual([]);
+      expect(uris(out)).toEqual([`${DS}nameless.widget`]);
+      expect(out.results.at(0)?.summary).toBe(
+        "Carries no ds:name; addressable only by IRI.",
+      );
+    });
+
+    it("resolves it on the graphql path", async () => {
+      const out = await lookupVia(GQL, "ds:nameless.widget");
+      expect(out.errors).toEqual([]);
+      expect(uris(out)).toEqual([`${DS}nameless.widget`]);
+    });
+  });
+
+  describe("a glob expands over the population its own shape addresses", () => {
+    it("expands an IRI-shaped glob on a sparql-sourced pack", async () => {
+      const out = await lookupVia(SPQ, "ds:*.chip");
+      expect(out.errors).toEqual([]);
+      expect(uris(out).sort()).toEqual([`${DS}alpha.chip`, `${DS}zeta.chip`]);
+    });
+
+    it("expands an IRI-shaped glob on a graphql-sourced pack", async () => {
+      const out = await lookupVia(GQL, "ds:button*");
+      expect(out.errors).toEqual([]);
+      expect(uris(out).sort()).toEqual([`${DS}button`, `${DS}button.icon`]);
+    });
+
+    it("reaches an entity with no `by` value through an IRI glob", async () => {
+      const out = await lookupVia(SPQ, "ds:nameless.*");
+      expect(uris(out)).toEqual([`${DS}nameless.widget`]);
+    });
+
+    it("still expands a name-shaped glob over names", async () => {
+      const out = await lookupVia(SPQ, "Mod*");
+      expect(uris(out)).toEqual([`${DS}modal`]);
+    });
+
+    it("reports an IRI-shaped glob that matches nothing", async () => {
+      await expect(lookupVia(SPQ, "ds:nosuch*")).rejects.toMatchObject({
+        code: "EMPTY_RESULTS",
+      });
+    });
+  });
+
+  describe("an ambiguous name resolves to the SAME entity every time", () => {
+    // `ds:zeta.chip` is declared BEFORE `ds:alpha.chip` in the fixture, so the
+    // store enumerates it first while IRI order puts `alpha` first. Without an
+    // explicit ORDER BY the winner is whichever the store happens to yield —
+    // exactly the cross-tier `Button` ambiguity in the live graph.
+    it("picks the lowest IRI on the sparql path", async () => {
+      const out = await lookupVia(SPQ, "Chip");
+      expect(uris(out)).toEqual([`${DS}alpha.chip`]);
+    });
+
+    it("picks the lowest IRI on the graphql path", async () => {
+      const out = await lookupVia(GQL, "Chip");
+      expect(uris(out)).toEqual([`${DS}alpha.chip`]);
+    });
+
+    it("agrees with itself across repeated resolves", async () => {
+      const runs = await Promise.all([
+        lookupVia(SPQ, "Chip"),
+        lookupVia(SPQ, "chip"),
+        lookupVia(GQL, "CHIP"),
+      ]);
+      expect(runs.map(uris)).toEqual([
+        [`${DS}alpha.chip`],
+        [`${DS}alpha.chip`],
+        [`${DS}alpha.chip`],
+      ]);
+    });
+  });
+});

--- a/packages/cli/pragma/src/kernel/packs/resolveEntity.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/resolveEntity.test.ts
@@ -154,6 +154,27 @@ describe("pack lookup addressing (PROTECTED)", () => {
       expect(uris(out)).toEqual([`${DS}modal`]);
     });
 
+    it("expands an ABSOLUTE-IRI glob, not only the compact spelling", async () => {
+      // An entity under a registered prefix has two legal spellings, and a
+      // literal lookup honours both — so a glob that generalises one of them
+      // must too. Expanding over the compact form alone made
+      // `https://ds.canonical.com/but*` an EMPTY_RESULTS while the exact IRI
+      // it generalises resolved fine.
+      const out = await lookupVia(GQL, `${DS}button*`);
+      expect(out.errors).toEqual([]);
+      expect(uris(out).sort()).toEqual([`${DS}button`, `${DS}button.icon`]);
+    });
+
+    it("yields an entity ONCE when both its spellings match", async () => {
+      // Reachable, not defensive: a glob counts as IRI-shaped if it contains
+      // a colon, so `*:*chip` matches BOTH `ds:alpha.chip` and its absolute
+      // twin. That is why the population is a spelling→entity map rather than
+      // a flat list of both forms — a match under either spelling must render
+      // one row, not two.
+      const out = await lookupVia(SPQ, "*:*chip");
+      expect(uris(out).sort()).toEqual([`${DS}alpha.chip`, `${DS}zeta.chip`]);
+    });
+
     it("reports an IRI-shaped glob that matches nothing", async () => {
       await expect(lookupVia(SPQ, "ds:nosuch*")).rejects.toMatchObject({
         code: "EMPTY_RESULTS",

--- a/packages/cli/pragma/src/kernel/packs/resolveEntity.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/resolveEntity.test.ts
@@ -20,8 +20,9 @@ import {
 import { buildFixtureRuntime } from "../../testing/helpers/packRuntime.js";
 import type { PragmaRuntime } from "../runtime/types.js";
 import { compilePack } from "./compile.js";
+import { lookupOptions } from "./renderPack.js";
 import type { LookupOutput } from "./resolveEntity.js";
-import type { PackDefinition } from "./types.js";
+import type { PackDefinition, PackLookup } from "./types.js";
 import { distributionSource } from "./types.js";
 import { verbKey } from "./uniqueness.js";
 
@@ -120,6 +121,13 @@ describe("pack lookup addressing (PROTECTED)", () => {
       const out = await lookupVia(GQL, "ds:nameless.widget");
       expect(out.errors).toEqual([]);
       expect(uris(out)).toEqual([`${DS}nameless.widget`]);
+    });
+
+    it("titles it with the prefixed IRI it was addressed by", () => {
+      const options = lookupOptions(SPQ.lookup as PackLookup, BLOCK_PREFIXES);
+      expect(options.title({ uri: `${DS}nameless.widget` })).toBe(
+        "ds:nameless.widget",
+      );
     });
   });
 

--- a/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
+++ b/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
@@ -151,8 +151,8 @@ async function expandQueries(
     return { names: [...queries], globErrors: [] };
   const globs = queries.filter(isGlobPattern);
   const byIri = globs.some(looksLikeIri)
-    ? await listEntityIris(rt, lookup, source, prefixes)
-    : [];
+    ? await listEntityIriSpellings(rt, lookup, source, prefixes)
+    : new Map<string, string>();
   const byName = globs.some((glob) => !looksLikeIri(glob))
     ? await listEntityNames(rt, lookup, source)
     : [];
@@ -163,7 +163,17 @@ async function expandQueries(
       names.push(query);
       continue;
     }
-    const matches = expandGlob(query, looksLikeIri(query) ? byIri : byName);
+    // An IRI glob expands over every spelling, then collapses to the entity:
+    // matching `ds:button` and its absolute twin must not list it twice.
+    const matches = looksLikeIri(query)
+      ? [
+          ...new Set(
+            expandGlob(query, [...byIri.keys()]).map(
+              (spelling) => byIri.get(spelling) ?? spelling,
+            ),
+          ),
+        ]
+      : expandGlob(query, byName);
     if (matches.length === 0) {
       globErrors.push({
         query,
@@ -274,25 +284,37 @@ function looksLikeIri(query: string): boolean {
 }
 
 /**
- * List every entity IRI the lookup can address, in the prefixed form shell
- * completion offers and the absolute form a user may paste — the population an
- * IRI-shaped glob expands over.
+ * Every SPELLING an IRI-shaped glob may be written against, mapped to the one
+ * entity it addresses.
  *
- * An entity contributes ONE candidate: its prefixed form when a registered
- * prefix covers it, its absolute IRI otherwise. Offering both would let a
- * pattern match the same entity twice and render it twice.
+ * An entity under a registered prefix has two legal spellings — the compact
+ * `ds:button` shell completion offers, and the absolute
+ * `https://ds.canonical.com/button` a user pastes from a browser. Both resolve
+ * to the same entity in a literal lookup, so a glob must expand over both;
+ * offering only the compact form made `https://ds.canonical.com/but*` return
+ * EMPTY_RESULTS while the literal IRI it generalises succeeded.
+ *
+ * The map is spelling → CANONICAL IRI precisely so a pattern that matches an
+ * entity under both spellings still yields it once. Matching over a flat list
+ * of both would render the entity twice, which is why the previous shape
+ * offered only one.
  */
-async function listEntityIris(
+async function listEntityIriSpellings(
   rt: LookupRuntime,
   lookup: PackLookup,
   source: StorySource,
   prefixes: Readonly<Record<string, string>>,
-): Promise<string[]> {
+): Promise<Map<string, string>> {
   const rows = await runSelect(rt, buildLookupIrisQuery(lookup), source);
-  return rows
-    .map((row) => row.uri ?? "")
-    .filter((uri) => uri !== "")
-    .map((uri) => compactUri(uri, prefixes));
+  const spellings = new Map<string, string>();
+  for (const row of rows) {
+    const uri = row.uri ?? "";
+    if (uri === "") continue;
+    spellings.set(uri, uri);
+    const compact = compactUri(uri, prefixes);
+    if (compact !== uri) spellings.set(compact, uri);
+  }
+  return spellings;
 }
 
 /** List every entity name the lookup can address (miss suggestions + sample/glob). */

--- a/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
+++ b/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
@@ -2,11 +2,19 @@
  * Look up one or more pack entities by name, prefixed name, absolute IRI, or
  * glob, via the fetch strategy the pack declares.
  *
- * The name→URI resolve is ALWAYS generated SPARQL (an escaped literal or a
- * validated `<iri>` BIND) regardless of `source`; from the resolved IRI, values
- * are fetched either through more generated SELECTs (`sparql`) or one generated
+ * The resolve is ALWAYS generated SPARQL (an escaped literal or a validated
+ * `<iri>` BIND) regardless of `source`; from the resolved IRI, values are
+ * fetched either through more generated SELECTs (`sparql`) or one generated
  * GraphQL document (`graphql`). One poisoned query never discards the batch —
  * per-query failures are collected as structured error entries.
+ *
+ * WHICH query is chosen is decided by the ARGUMENT'S SHAPE first and the pack's
+ * `source` second, and both dispatches live here. Getting that order wrong is
+ * not a style question: it is what made an IRI reach a name FILTER on every
+ * graphql-sourced pack, and what left an IRI-shaped glob expanding against a
+ * population of names. The shape a user typed is a fact about the argument; the
+ * fetch strategy is a fact about the pack, and it cannot change what the
+ * argument means.
  *
  * Reached only behind a dynamic import from the lookup run body, so its imports
  * (including the GraphQL path) stay off the storeless fast path.
@@ -15,6 +23,7 @@
 import { PragmaError } from "../error/PragmaError.js";
 import { cliRecovery } from "../error/recovery.js";
 import { suggestNames } from "../project/cli/suggestNames.js";
+import { compactUri } from "../render/compactUri.js";
 import type { PragmaRuntime } from "../runtime/types.js";
 import { activeExpands } from "./disclosure.js";
 import { expandGlob, isGlobPattern } from "./glob.js";
@@ -22,7 +31,9 @@ import { fetchGraphqlLookup } from "./graphql/fetchGraphqlLookup.js";
 import { isEmbeddableIri, resolveUri } from "./iri.js";
 import {
   buildExpandQuery,
+  buildIriResolveQuery,
   buildLookupByIriQuery,
+  buildLookupIrisQuery,
   buildLookupNamesQuery,
   buildLookupQuery,
   buildNameResolveQuery,
@@ -74,7 +85,14 @@ export async function resolveLookup(
     });
   }
 
-  const expanded = await expandQueries(rt, lookup, noun, source, queries);
+  const expanded = await expandQueries(
+    rt,
+    lookup,
+    noun,
+    source,
+    queries,
+    prefixes,
+  );
   const results: PackEntity[] = [];
   const errors: LookupError[] = [...expanded.globErrors];
   const settled = await Promise.allSettled(
@@ -110,17 +128,34 @@ export async function resolveLookup(
   return { results, errors };
 }
 
-/** Expand glob queries against the entity name list; literals pass through. */
+/**
+ * Expand glob queries against the population their own shape addresses;
+ * literals pass through.
+ *
+ * A name glob expands over the `by` values, an IRI glob over the entity IRIs —
+ * the same split {@link buildResolveQuery} makes, because a glob is just a
+ * lookup argument with a `*` in it. Expanding an IRI pattern over names was why
+ * `ds:global.component.but*` matched nothing on any pack while shell completion
+ * offered nothing BUT those IRIs. Each population is fetched at most once, and
+ * only when a glob of that shape is actually present.
+ */
 async function expandQueries(
   rt: LookupRuntime,
   lookup: PackLookup,
   noun: string,
   source: StorySource,
   queries: readonly string[],
+  prefixes: Readonly<Record<string, string>>,
 ): Promise<{ names: string[]; globErrors: LookupError[] }> {
   if (!queries.some(isGlobPattern))
     return { names: [...queries], globErrors: [] };
-  const allNames = await listEntityNames(rt, lookup, source);
+  const globs = queries.filter(isGlobPattern);
+  const byIri = globs.some(looksLikeIri)
+    ? await listEntityIris(rt, lookup, source, prefixes)
+    : [];
+  const byName = globs.some((glob) => !looksLikeIri(glob))
+    ? await listEntityNames(rt, lookup, source)
+    : [];
   const names: string[] = [];
   const globErrors: LookupError[] = [];
   for (const query of queries) {
@@ -128,7 +163,7 @@ async function expandQueries(
       names.push(query);
       continue;
     }
-    const matches = expandGlob(query, allNames);
+    const matches = expandGlob(query, looksLikeIri(query) ? byIri : byName);
     if (matches.length === 0) {
       globErrors.push({
         query,
@@ -155,9 +190,7 @@ async function lookupOne(
   const graphqlSourced = lookup.source === "graphql";
   const rows = await runSelect(
     rt,
-    graphqlSourced
-      ? buildNameResolveQuery(lookup, query)
-      : buildEntityQuery(lookup, query, prefixes, level),
+    buildResolveQuery(lookup, query, prefixes, level),
     source,
   );
   const base = rows.at(0);
@@ -196,14 +229,27 @@ async function lookupOne(
   return entity;
 }
 
-/** Build the base entity SELECT for the SPARQL path (name or IRI form). */
-function buildEntityQuery(
+/**
+ * Build the resolve SELECT for one lookup argument: shape first, source second.
+ *
+ * The four cells of that 2×2 are the whole dispatch. A graphql-sourced pack
+ * resolves to an IRI and fetches everything else through its document, so both
+ * of its queries are the minimal `?uri ?name` pair; a sparql-sourced pack reads
+ * its fields in the same SELECT, so both of its queries carry the level-gated
+ * projection.
+ */
+function buildResolveQuery(
   lookup: PackLookup,
   query: string,
   prefixes: Readonly<Record<string, string>>,
   level: string | undefined,
 ): string {
-  if (!looksLikeIri(query)) return buildLookupQuery(lookup, query, level);
+  const graphqlSourced = lookup.source === "graphql";
+  if (!looksLikeIri(query)) {
+    return graphqlSourced
+      ? buildNameResolveQuery(lookup, query)
+      : buildLookupQuery(lookup, query, level);
+  }
   const resolved = resolveUri(query, prefixes);
   if (!isEmbeddableIri(resolved)) {
     throw PragmaError.invalidInput("name", query, {
@@ -213,7 +259,9 @@ function buildEntityQuery(
       },
     });
   }
-  return buildLookupByIriQuery(lookup, resolved, level);
+  return graphqlSourced
+    ? buildIriResolveQuery(lookup, resolved)
+    : buildLookupByIriQuery(lookup, resolved, level);
 }
 
 /** Whether a lookup query addresses an entity by IRI or prefixed name. */
@@ -223,6 +271,28 @@ function looksLikeIri(query: string): boolean {
     query.startsWith("https://") ||
     query.includes(":")
   );
+}
+
+/**
+ * List every entity IRI the lookup can address, in the prefixed form shell
+ * completion offers and the absolute form a user may paste — the population an
+ * IRI-shaped glob expands over.
+ *
+ * An entity contributes ONE candidate: its prefixed form when a registered
+ * prefix covers it, its absolute IRI otherwise. Offering both would let a
+ * pattern match the same entity twice and render it twice.
+ */
+async function listEntityIris(
+  rt: LookupRuntime,
+  lookup: PackLookup,
+  source: StorySource,
+  prefixes: Readonly<Record<string, string>>,
+): Promise<string[]> {
+  const rows = await runSelect(rt, buildLookupIrisQuery(lookup), source);
+  return rows
+    .map((row) => row.uri ?? "")
+    .filter((uri) => uri !== "")
+    .map((uri) => compactUri(uri, prefixes));
 }
 
 /** List every entity name the lookup can address (miss suggestions + sample/glob). */

--- a/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.ts
@@ -6,6 +6,14 @@
  * user-supplied names are always escaped SPARQL string literals, and level-gated
  * fields below the active level are excluded from the projection (fetch-gating).
  * Matching on the `by` property is exact and case-insensitive.
+ *
+ * Every name-addressed resolve is TOTALLY ORDERED before its `LIMIT 1`. A name
+ * can recur across tiers, and an unordered `LIMIT 1` hands the tie to the
+ * store's enumeration order — a different answer on a different machine, or
+ * after a repack. `ORDER BY STR(?uri)` is a total, engine-independent order over
+ * a variable that is always bound (`?uri` carries the `by` triple), so it needs
+ * no unbound-value sentinel. It fixes WHICH answer is arbitrary, not WHETHER:
+ * declaring a precedence between tiers is an ontology change, tracked separately.
  */
 
 import { activeExpands, activeFields } from "../disclosure.js";
@@ -74,10 +82,30 @@ export function buildLookupQuery(
     body,
     `  FILTER (LCASE(STR(?name)) = LCASE("${escapeSparqlString(name)}"))`,
     "}",
+    "ORDER BY STR(?uri)",
     "LIMIT 1",
   ]
     .filter((line) => line !== "")
     .join("\n");
+}
+
+/**
+ * The `?name` clause for an IRI-addressed form.
+ *
+ * An IRI names the entity by itself, so the `by` value is a LABEL to project,
+ * not the thing that identifies it — and a class constraint is already a
+ * sufficient existence check. Requiring the `by` triple here made every entity
+ * that carries no name unaddressable by any means at all: 131 of the 144 live
+ * code standards have no `cs:name` (their displayed name is synthesized from the
+ * IRI by the list story), and shell completion offers their IRIs. So the triple
+ * is OPTIONAL wherever a class constraint can vouch for the entity, and
+ * REQUIRED only for a lookup that declares no `type`/`types` — where it is the
+ * one thing standing between a typo'd IRI and an empty entity.
+ */
+function iriNameClause(lookup: PackLookup): string {
+  const named = `?uri ${formatTerm(lookup.by)} ?name .`;
+  const constrained = Boolean(lookup.type ?? lookup.types?.length);
+  return constrained ? `  OPTIONAL { ${named} }` : `  ${named}`;
 }
 
 /**
@@ -102,7 +130,7 @@ export function buildLookupByIriQuery(
   return [
     header,
     `  BIND(<${iri}> AS ?uri)`,
-    `  ?uri ${formatTerm(lookup.by)} ?name .`,
+    iriNameClause(lookup),
     body,
     "}",
     "LIMIT 1",
@@ -127,8 +155,46 @@ export function buildNameResolveQuery(
     buildTypeConstraint(lookup).trimEnd(),
     `  FILTER (LCASE(STR(?name)) = LCASE("${escapeSparqlString(name)}"))`,
     "}",
-    // Names can recur across tiers; LIMIT 1 takes the store's first match.
+    "ORDER BY STR(?uri)",
     "LIMIT 1",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+/**
+ * Build the minimal IRI→entity resolve for a graphql-sourced lookup: the mirror
+ * of {@link buildNameResolveQuery} for the other argument shape.
+ *
+ * The GraphQL lane fetches by IRI, so this exists to ANSWER ONE QUESTION — does
+ * the pack's class constraint vouch for this entity? — and to pick up a display
+ * name if there is one. Injection-safe by construction: `iri` is already
+ * resolved and validated against the embeddable-IRI shape by the caller.
+ */
+export function buildIriResolveQuery(lookup: PackLookup, iri: string): string {
+  return [
+    "SELECT ?uri ?name WHERE {",
+    `  BIND(<${iri}> AS ?uri)`,
+    iriNameClause(lookup),
+    buildTypeConstraint(lookup).trimEnd(),
+    "}",
+    "LIMIT 1",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+/** Build the SELECT listing every entity IRI a lookup can address (IRI globs). */
+export function buildLookupIrisQuery(lookup: PackLookup): string {
+  const constraint = buildTypeConstraint(lookup).trimEnd();
+  return [
+    "SELECT DISTINCT ?uri WHERE {",
+    // A pack that constrains by class is asking about its class; one that does
+    // not has only the `by` triple to bound the scan, so it keeps that bound
+    // (and, like the name population, addresses only entities that carry one).
+    constraint !== "" ? constraint : `  ?uri ${formatTerm(lookup.by)} ?name .`,
+    "}",
+    "ORDER BY STR(?uri)",
   ]
     .filter((line) => line !== "")
     .join("\n");

--- a/packages/cli/pragma/src/kernel/render/renderers.test.ts
+++ b/packages/cli/pragma/src/kernel/render/renderers.test.ts
@@ -321,11 +321,14 @@ describe("section-body headings nest under the heading the renderer gives them",
   }
 
   const render = (guidelines: string): string =>
-    renderLookupLlm<Doc>({ guidelines }, {
-      title: () => "Button",
-      fields: [],
-      sections: [{ key: "guidelines", heading: "Guidelines", kind: "field" }],
-    });
+    renderLookupLlm<Doc>(
+      { guidelines },
+      {
+        title: () => "Button",
+        fields: [],
+        sections: [{ key: "guidelines", heading: "Guidelines", kind: "field" }],
+      },
+    );
 
   it("demotes authored headings that collide with the section heading", () => {
     const out = render(
@@ -367,11 +370,14 @@ describe("section-body headings nest under the heading the renderer gives them",
   });
 
   it("does not rewrite the plain body, where `###` is literal text", () => {
-    const out = renderLookupPlain<Doc>({ guidelines: "### Accessibility" }, {
-      title: () => "Button",
-      fields: [],
-      sections: [{ key: "guidelines", heading: "Guidelines", kind: "field" }],
-    });
+    const out = renderLookupPlain<Doc>(
+      { guidelines: "### Accessibility" },
+      {
+        title: () => "Button",
+        fields: [],
+        sections: [{ key: "guidelines", heading: "Guidelines", kind: "field" }],
+      },
+    );
     expect(out).toContain("Guidelines:");
     expect(out).toContain("  ### Accessibility");
   });

--- a/packages/cli/pragma/src/kernel/render/renderers.test.ts
+++ b/packages/cli/pragma/src/kernel/render/renderers.test.ts
@@ -314,3 +314,65 @@ describe("error render matrix (× plain/llm/json)", () => {
     }).toMatchSnapshot();
   });
 });
+
+describe("section-body headings nest under the heading the renderer gives them", () => {
+  interface Doc {
+    readonly guidelines: string;
+  }
+
+  const render = (guidelines: string): string =>
+    renderLookupLlm<Doc>({ guidelines }, {
+      title: () => "Button",
+      fields: [],
+      sections: [{ key: "guidelines", heading: "Guidelines", kind: "field" }],
+    });
+
+  it("demotes authored headings that collide with the section heading", () => {
+    const out = render(
+      "### Accessibility\n\n- Label the button.\n\n### Content\n\n- Verb first.",
+    );
+    expect(out).toContain("### Guidelines");
+    expect(out).toContain("#### Accessibility");
+    expect(out).toContain("#### Content");
+    expect(out).not.toMatch(/^### Accessibility$/m);
+  });
+
+  it("preserves the content's own hierarchy while shifting it as a block", () => {
+    const out = render("## Overview\n\ntext\n\n### Detail\n\nmore");
+    expect(out).toContain("#### Overview");
+    expect(out).toContain("##### Detail");
+  });
+
+  it("leaves content already nested below the section alone", () => {
+    const out = render("#### Already nested\n\ntext");
+    expect(out).toContain("#### Already nested");
+    expect(out).not.toContain("##### Already nested");
+  });
+
+  it("never emits a heading deeper than markdown's floor", () => {
+    const out = render("###### Deep\n\ntext");
+    expect(out).toContain("###### Deep");
+  });
+
+  it("leaves `#` inside a fenced code block exactly as authored", () => {
+    const out = render("### Setup\n\n```sh\n# not a heading\nbun install\n```");
+    expect(out).toContain("#### Setup");
+    expect(out).toContain("# not a heading");
+    expect(out).not.toContain("## not a heading");
+  });
+
+  it("leaves a body with no headings untouched", () => {
+    const out = render("Plain prose with a # hash mid-line.");
+    expect(out).toContain("Plain prose with a # hash mid-line.");
+  });
+
+  it("does not rewrite the plain body, where `###` is literal text", () => {
+    const out = renderLookupPlain<Doc>({ guidelines: "### Accessibility" }, {
+      title: () => "Button",
+      fields: [],
+      sections: [{ key: "guidelines", heading: "Guidelines", kind: "field" }],
+    });
+    expect(out).toContain("Guidelines:");
+    expect(out).toContain("  ### Accessibility");
+  });
+});

--- a/packages/cli/pragma/src/kernel/render/renderers.test.ts
+++ b/packages/cli/pragma/src/kernel/render/renderers.test.ts
@@ -382,3 +382,61 @@ describe("section-body headings nest under the heading the renderer gives them",
     expect(out).toContain("  ### Accessibility");
   });
 });
+
+describe("section-body nesting follows CommonMark, not a near-enough reading", () => {
+  interface Doc {
+    readonly guidelines: string;
+  }
+
+  const render = (guidelines: string): string =>
+    renderLookupLlm<Doc>(
+      { guidelines },
+      {
+        title: () => "Button",
+        fields: [],
+        sections: [{ key: "guidelines", heading: "Guidelines", kind: "field" }],
+      },
+    );
+
+  it("nests a heading indented up to three spaces, keeping its indent", () => {
+    // Four spaces would make the line an indented code block; three or fewer
+    // leave it a heading. Missing that left an indented heading at the
+    // section's own level while its unindented twin was demoted — one body
+    // rendered with two conflicting hierarchies.
+    expect(render("  ### Accessibility\n\ntext")).toMatch(
+      /^ {2}#### Accessibility$/m,
+    );
+  });
+
+  it("does not close a four-backtick fence on a three-backtick sample", () => {
+    // A closing fence must be AT LEAST as long as the opener. Toggling on any
+    // same-character run let the inner sample read as the close, after which
+    // every `#` line in that code block was rewritten — the renderer silently
+    // editing the user's sample code.
+    const out = render(
+      [
+        "````md",
+        "```",
+        "### Sample text, not a heading",
+        "```",
+        "````",
+        "",
+        "### A real heading",
+      ].join("\n"),
+    );
+    // Anchored: `#### x` CONTAINS `### x`, so a substring check would pass
+    // against the very rewrite this pins against.
+    expect(out).toMatch(/^### Sample text, not a heading$/m);
+    expect(out).toMatch(/^#### A real heading$/m);
+  });
+
+  it("does not close a fence on a run that carries an info string", () => {
+    // An opener may carry an info string; a CLOSER may not. A ```js line
+    // inside a block opens nothing and closes nothing.
+    const out = render(
+      ["```", "### inside", "```js", "### also inside", "```"].join("\n"),
+    );
+    expect(out).toMatch(/^### inside$/m);
+    expect(out).toMatch(/^### also inside$/m);
+  });
+});

--- a/packages/cli/pragma/src/kernel/render/renderers.ts
+++ b/packages/cli/pragma/src/kernel/render/renderers.ts
@@ -50,11 +50,25 @@ const SECTION_HEADING_LEVEL = 3;
 /** Markdown's deepest heading. Demotion clamps here rather than overflowing. */
 const MAX_HEADING_LEVEL = 6;
 
-/** An ATX heading: 1–6 `#` then whitespace then text (a bare `#` line is not one). */
-const ATX_HEADING = /^(#{1,6})(\s+\S.*)$/;
+/**
+ * An ATX heading: up to three spaces of indent, 1–6 `#`, whitespace, text.
+ *
+ * The indent is CommonMark's — four spaces would make the line an indented
+ * code block, three or fewer leave it a heading. Missing it left
+ * `  ### Accessibility` un-nested while its unindented twin was demoted, so
+ * one body could come out with two conflicting hierarchies. The indent is
+ * captured so a rewrite preserves it.
+ */
+const ATX_HEADING = /^( {0,3})(#{1,6})(\s+\S.*)$/;
 
-/** A fenced code-block delimiter, indentable by up to three spaces. */
-const CODE_FENCE = /^ {0,3}(`{3,}|~{3,})/;
+/**
+ * A fenced code-block delimiter: up to three spaces of indent, then the run of
+ * markers, then whatever follows on the line (the info string).
+ *
+ * The RUN LENGTH and the info string both matter for closing, which is why
+ * they are captured rather than just recognised — see {@link nestHeadings}.
+ */
+const CODE_FENCE = /^ {0,3}((`{3,})|(~{3,}))([^`]*)$/;
 
 /**
  * The empty-state body — the message plus its optional hint on a second line,
@@ -382,16 +396,34 @@ function renderFieldValue(
 function nestHeadings(text: string, parentLevel: number): string {
   const lines = text.split("\n");
   const headings = new Map<number, number>();
-  let fence: string | undefined;
+  // A fence CLOSES only on the same marker character, a run at least as long
+  // as the opener's, and no info string — CommonMark's rule, and the reason
+  // the opener's length is remembered rather than just its character. Toggling
+  // on any same-character run let a ``` sample inside a ```` block read as the
+  // close, after which every `#` line in that code block was rewritten as a
+  // heading: the renderer editing someone's sample code.
+  let fence: { marker: string; length: number } | undefined;
   for (const [index, line] of lines.entries()) {
-    const marker = CODE_FENCE.exec(line)?.[1]?.charAt(0);
-    if (marker !== undefined) {
-      fence =
-        fence === undefined ? marker : fence === marker ? undefined : fence;
+    const delimiter = CODE_FENCE.exec(line);
+    const run = delimiter?.[1];
+    if (run !== undefined) {
+      const marker = run.charAt(0);
+      const info = (delimiter?.[4] ?? "").trim();
+      if (fence === undefined) {
+        fence = { marker, length: run.length };
+        continue;
+      }
+      if (
+        marker === fence.marker &&
+        run.length >= fence.length &&
+        info === ""
+      ) {
+        fence = undefined;
+      }
       continue;
     }
     if (fence !== undefined) continue;
-    const level = ATX_HEADING.exec(line)?.[1]?.length;
+    const level = ATX_HEADING.exec(line)?.[2]?.length;
     if (level !== undefined) headings.set(index, level);
   }
 
@@ -404,7 +436,9 @@ function nestHeadings(text: string, parentLevel: number): string {
       const level = headings.get(index);
       if (level === undefined) return line;
       const hashes = "#".repeat(Math.min(level + shift, MAX_HEADING_LEVEL));
-      return line.replace(ATX_HEADING, `${hashes}$2`);
+      // `$1` keeps the line's own indent: rewriting it away would turn a
+      // legally indented heading into an unindented one.
+      return line.replace(ATX_HEADING, `$1${hashes}$3`);
     })
     .join("\n");
 }

--- a/packages/cli/pragma/src/kernel/render/renderers.ts
+++ b/packages/cli/pragma/src/kernel/render/renderers.ts
@@ -40,6 +40,23 @@ const EMPTY_CELL = "-";
 const DEFAULT_CONTEXT: RenderContext = { headers: true, stdoutIsTty: true };
 
 /**
+ * The markdown heading level `renderLookupSections` gives a section in llm mode
+ * — the lookup title is `##`, so a section is `###`. Read, not re-typed, by
+ * {@link nestHeadings}: the renderer is the only party that knows its own
+ * nesting depth, and it must stay the only party that encodes it.
+ */
+const SECTION_HEADING_LEVEL = 3;
+
+/** Markdown's deepest heading. Demotion clamps here rather than overflowing. */
+const MAX_HEADING_LEVEL = 6;
+
+/** An ATX heading: 1–6 `#` then whitespace then text (a bare `#` line is not one). */
+const ATX_HEADING = /^(#{1,6})(\s+\S.*)$/;
+
+/** A fenced code-block delimiter, indentable by up to three spaces. */
+const CODE_FENCE = /^ {0,3}(`{3,}|~{3,})/;
+
+/**
  * The empty-state body — the message plus its optional hint on a second line,
  * or "" when the caller declared no message (bare-empty behavior preserved).
  */
@@ -291,7 +308,9 @@ function renderLookupSections<T>(
 
     sections.push("");
     sections.push(
-      mode === "llm" ? `### ${section.heading}` : `${section.heading}:`,
+      mode === "llm"
+        ? `${"#".repeat(SECTION_HEADING_LEVEL)} ${section.heading}`
+        : `${section.heading}:`,
     );
     sections.push(body);
   }
@@ -333,7 +352,61 @@ function renderFieldValue(
   }
 
   const text = formatScalarValue(value, prefixes);
-  return mode === "llm" ? text : indentBlock(text);
+  // Plain mode is not markdown — a `###` there is literal text, and rewriting
+  // it would corrupt the value. Only the llm mode's markdown has a hierarchy to
+  // collide with, so only it nests.
+  return mode === "llm"
+    ? nestHeadings(text, SECTION_HEADING_LEVEL)
+    : indentBlock(text);
+}
+
+/**
+ * Demote a section body's own ATX headings so they nest UNDER the heading the
+ * renderer gave the section.
+ *
+ * Authored markdown cannot know what level it will be rendered at; the renderer
+ * can, and so the renderer is the side that moves. A block whose shallowest
+ * heading is at or above `parentLevel` is shifted down as a whole — `###
+ * Accessibility` inside a `### Guidelines` section becomes `#### Accessibility`
+ * — which fixes the collision (a section heading immediately followed by a
+ * same-level heading reads as an empty section) while preserving the content's
+ * internal hierarchy exactly. Content already nested deeper is left alone.
+ *
+ * Headings inside a fenced code block are content, not structure — a `# ` in a
+ * shell sample is a comment — so fenced regions pass through untouched.
+ *
+ * @param text - The section body as authored.
+ * @param parentLevel - The heading level the section itself was rendered at.
+ * @returns The body with its headings nested below `parentLevel`.
+ */
+function nestHeadings(text: string, parentLevel: number): string {
+  const lines = text.split("\n");
+  const headings = new Map<number, number>();
+  let fence: string | undefined;
+  for (const [index, line] of lines.entries()) {
+    const marker = CODE_FENCE.exec(line)?.[1]?.charAt(0);
+    if (marker !== undefined) {
+      fence =
+        fence === undefined ? marker : fence === marker ? undefined : fence;
+      continue;
+    }
+    if (fence !== undefined) continue;
+    const level = ATX_HEADING.exec(line)?.[1]?.length;
+    if (level !== undefined) headings.set(index, level);
+  }
+
+  if (headings.size === 0) return text;
+  const shift = parentLevel + 1 - Math.min(...headings.values());
+  if (shift <= 0) return text;
+
+  return lines
+    .map((line, index) => {
+      const level = headings.get(index);
+      if (level === undefined) return line;
+      const hashes = "#".repeat(Math.min(level + shift, MAX_HEADING_LEVEL));
+      return line.replace(ATX_HEADING, `${hashes}$2`);
+    })
+    .join("\n");
 }
 
 function renderCodeValue<T>(

--- a/packages/cli/pragma/src/testing/fixtures/blockGraph.ts
+++ b/packages/cli/pragma/src/testing/fixtures/blockGraph.ts
@@ -110,3 +110,33 @@ ds:mod.density.compact a ds:Modifier ; ds:name "compact" ; ds:modifierFamily ds:
 ds:mod.size.small a ds:Modifier ; ds:name "small" ; ds:modifierFamily ds:family.size .
 ds:mod.size.large a ds:Modifier ; ds:name "large" ; ds:modifierFamily ds:family.size .
 `;
+
+/**
+ * An OPT-IN overlay for the lookup-addressing suite, appended to
+ * {@link BLOCK_TTL} by the tests that need it and by nothing else — the block
+ * parity, ontology and GraphQL-engine suites assert over the base graph and
+ * must keep seeing exactly two components.
+ *
+ * It models the three shapes the addressing path gets wrong: two components
+ * sharing one `ds:name` (declared zeta-first so the store's enumeration order
+ * and IRI order DISAGREE — an unordered `LIMIT 1` picks the zeta one), and a
+ * component carrying no `ds:name` at all (reachable only by IRI, the way 131 of
+ * the 144 live code standards are).
+ */
+export const AMBIGUOUS_TTL = `
+ds:apps a ds:Tier ; ds:name "apps" .
+
+ds:zeta.chip a ds:Component ;
+  ds:name "Chip" ;
+  ds:tier ds:global ;
+  ds:summary "The zeta chip — declared first, sorts last." .
+
+ds:alpha.chip a ds:Component ;
+  ds:name "Chip" ;
+  ds:tier ds:apps ;
+  ds:summary "The alpha chip — declared last, sorts first." .
+
+ds:nameless.widget a ds:Component ;
+  ds:tier ds:global ;
+  ds:summary "Carries no ds:name; addressable only by IRI." .
+`;


### PR DESCRIPTION
## Done

Four user-visible defects found while validating the documentation in #1027. All four were reproduced on `main` and each is pinned by a test that fails on the base commit and passes here.

**1 · An IRI or prefixed name did not address a `block` or a `modifier`.**
`lookupOne` dispatched on the pack's `source` before the argument's shape, so on a `graphql`-sourced pack an IRI was escaped into the *name* `FILTER` and matched nothing — `block lookup ds:global.component.button` was `ENTITY_NOT_FOUND` while `tier lookup ds:global` worked. The parameter doc, the MCP schema, the generated reference and shell completion all hand the user exactly those IRIs, and they failed on the only two nouns where names collide. The dispatch is now shape-first, source-second, both for lookups and for globs.

**2 · A glob returned nothing on `standard lookup` — and it is two defects, only one of them ours.**
- *Ours:* a glob only ever expanded over the `by` values, so an **IRI-shaped glob matched nothing on any pack** — `ds:global.component.but*`, `cs:react.component.*` — though completion offers nothing but those IRIs. And an IRI-addressed lookup **required** the entity to carry a `by` value, which made an unnamed entity unreachable by any means at all. Both fixed: a glob expands over the population its own shape addresses, and where a pack declares a class constraint that constraint is the existence check while the name is projected rather than required.
- *Not ours:* `react/component/*` cannot match, because **131 of the 144 code standards in the published pack carry no `cs:name`**. The `standard` list story synthesises the displayed name from the IRI (`COALESCE(?n, REPLACE(STRAFTER(STR(?uri), "#"), "\.", "/"))`); the lookup story cannot. This repo's own fixtures (`testing/fixtures/graph/canonical.ts`, `distribution.parity.test.ts`) declare `cs:name "react/component/props"` — the pack declaration, the documented glob example and the test graph are all mutually consistent and correct, and the **published `@canonical/code-standards` pack is what regressed**. That is why it went undetected. It needs an upstream fix in `canonical/web-code-standards`, not a CLI change; inventing a derived-name lookup grammar to paper over it was declined as out of scope. In the meantime every standard is now reachable by the IRI form completion already offers.

**3 · An ambiguous name resolved arbitrarily. Determinism only.**
`buildLookupQuery` and `buildNameResolveQuery` ended in an unordered `LIMIT 1`, so a name shared by two entities resolved to whichever the store enumerated first — a different answer on a different machine or after a repack. Both now `ORDER BY STR(?uri)` before the `LIMIT`.

`?uri` is bound by the `by` triple in the same BGP and by the class constraint, so **the ordering clause touches no optional variable** and needs no `COALESCE` sentinel — SPARQL's rule that unbound sorts *first* cannot fire here, and no entity can win by lacking something.

This fixes *which* answer is arbitrary, not *whether*: `block lookup Button` still returns the Launchpad entry, now reliably, because `apps_launchpad…` precedes `global…` by IRI. **No tier precedence is added and no tier list is hardcoded.** Making `global` win needs a rank the ontology does not declare — all 15 `ds:Tier` individuals carry exactly `a ds:Tier` and `ds:name` — and a precedence only the CLI knew would be one the MCP surface got wrong. That work is parked upstream. Defect 1's fix is meanwhile the escape hatch: `block lookup ds:global.component.button` now names either entity exactly.

**4 · A block's `Guidelines` rendered as a bare heading.**
The renderer emitted `### Guidelines` and the field's own markdown opened with `### Accessibility` — same level, so the label read as an empty section and its content sat beside the heading instead of inside it. The renderer is the side that moved: it knows its own nesting depth and the content cannot, so a section body's ATX headings are shifted down as a block until the shallowest sits one level below the section. Relative hierarchy is preserved, depth clamps at `######`, content already nested deeper is untouched, fenced code (where `#` is a comment) passes through verbatim, and the plain mode — where `###` is literal text, not markup — is unchanged. Nothing an author writes has to know the renderer's heading level.

Drive-by, inseparable from 2: an entity reached by IRI and carrying no name is now titled by its **prefixed** IRI (`cs:react.component.barrel_exports`) rather than the expanded one, i.e. the form the user typed. That render path was unreachable before this PR.

Found while validating #1027.

## QA

Against the embedded pack (`@canonical/design-system@git:41c31b34`, `@canonical/code-standards@git:85dd71af`):

```bash
# 1 — was ENTITY_NOT_FOUND on both graphql-sourced nouns
pragma block lookup ds:global.component.button          # → the GLOBAL Button
pragma block lookup https://ds.canonical.com/global.component.button
pragma modifier lookup ds:global.modifier_family._color_luminosity

# 2 — IRI globs matched nothing on ANY pack; nameless entities were unreachable
pragma standard lookup 'cs:react.component.*'           # → 14 standards
pragma standard lookup cs:react.component.barrel_exports # → titled cs:react.component.barrel_exports
pragma block lookup 'ds:global.component.but*'
pragma standard lookup 'react/component/*'              # → still EMPTY_RESULTS; upstream data, see above

# 3 — same answer every time, on every machine
for i in 1 2 3; do pragma block lookup Button | sed -n 3p; done

# 4 — `### Guidelines` is now followed by `#### Button hierarchy`
pragma block lookup ds:global.component.button --detail detailed
```

**RED proof.** The first commit is tests only. On its own tree (`origin/main` + tests, no fixes) **13 assertions fail**: 10 in `kernel/packs/resolveEntity.test.ts` (IRI on graphql packs ×2, IRI lookup of a `by`-less entity ×2, IRI globs ×3, deterministic resolution ×3) and 3 in `kernel/render/renderers.test.ts` (collision, hierarchy preservation, fenced code). The controls in both files — a plain name, a name glob, the two miss paths, an already-nested body, a body with no headings, the plain mode — pass on the base, so the suites are not merely asserting the new code back to itself. All 37 pass with the fixes.

**Gate.** Rebased onto `origin/main@5004baa06`, `bun install`, then from the repo root with the nx cache off:

```
NX_SKIP_NX_CACHE=true bunx lerna run check --no-bail --concurrency 2   # 62 projects, green
NX_SKIP_NX_CACHE=true bunx lerna run test  --no-bail --concurrency 1
```

Four projects fail in the root test run and **none of them are this PR**, each confirmed by running the identical command on a clean `origin/main` checkout in the same worktree:

- `@canonical/svelte-ds-global`, `@canonical/svelte-ds-app`, `@canonical/svelte-ds-app-wpe` — Playwright's Firefox/WebKit are not installed on this box.
- `@canonical/pragma-cli` — `src/identity.test.ts > owns its own on-disk skills namespace`, plus three `capabilities/create` tests (`byteEquality`, `create.mcp`, `cwdJail`) that leak fixtures under the coverage-instrumented run. `bun run test` on clean `origin/main` produces **exactly these same four failures** (`4 failed | 1369 passed`); this branch produces the same four (`4 failed | 1391 passed`, +22 new tests). Standalone `vitest run` on both trees leaves only `identity.test.ts`.

### PR readiness check

- [x] PR should have one of the following labels: `Bug 🐛`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` and `build:all`.
- [x] No new package.
- [x] `no visual change` added — CLI/graph only, no rendered UI.

## Screenshots

Not applicable — terminal and MCP output only; the `Guidelines` before/after is in the QA block above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
