### PR TITLE
chore(deps): consume @canonical/design-system 0.2.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "ds25",
       "devDependencies": {
-        "@canonical/design-system": "^0.2.2",
+        "@canonical/design-system": "^0.2.3",
         "@vitest/coverage-v8": "^4.0.18",
         "lerna": "^9.0.5",
         "nx": "^22.5.4",
@@ -1770,7 +1770,7 @@
 
     "@canonical/biome-config": ["@canonical/biome-config@workspace:configs/biome"],
 
-    "@canonical/design-system": ["@canonical/design-system@0.2.2", "", { "dependencies": { "ajv": "^8.17.1", "jsonld": "^9.0.0", "n3": "^2.0.1", "tinyglobby": "^0.2.14" }, "bin": { "collect-implementations": "src/collect-implementations.ts" } }, "sha512-per6gSdBdOWLxgqYjQ3e2BMRgD6Ad02Qz3xBCu4cGUGwPMMB6FTp9pE+WePNgDv7Xz6IfyIQMlUKYTiB7FK7Pw=="],
+    "@canonical/design-system": ["@canonical/design-system@0.2.3", "", { "dependencies": { "ajv": "^8.17.1", "jsonld": "^9.0.0", "n3": "^2.0.1", "tinyglobby": "^0.2.14" }, "bin": { "collect-implementations": "src/collect-implementations.ts" } }, "sha512-4l9v19xSkM4/gbsR4ny+VDnCuJ2uknTOA/JBkPJHca6DCsf9HtcmZwPMFnOt3HaFeD9b+G29fM0Uj53aYvLo6Q=="],
 
     "@canonical/design-tokens": ["@canonical/design-tokens@0.8.1", "", { "dependencies": { "@canonical/terrazzo-lsp": "^0.8.1" } }, "sha512-5EQj2ZpYl3Jqg8rmbckovp+FAEzTPFsAnD8GrCLMCscIpHdumrIHeVzD8hM1Vx1hKchJ8S8IpW91fPyE26onDg=="],
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "special:clean": "bun run nx reset && lerna clean --yes && rm -rf node_modules **/dist **/node_modules"
   },
   "devDependencies": {
-    "@canonical/design-system": "^0.2.2",
+    "@canonical/design-system": "^0.2.3",
     "@vitest/coverage-v8": "^4.0.18",
     "lerna": "^9.0.5",
     "nx": "^22.5.4",


### PR DESCRIPTION
Bumps the root devDependency `@canonical/design-system` from `^0.2.2` to `^0.2.3` and pins the lockfile to it (it was resolving to `0.2.2`).

`0.2.3` publishes the skills change from canonical/design-system#71: every skill now opens by asking the person for the starting point — as a suggestion carrying an example rather than an interrogation — and offers, in the same breath, to run the flow as a guided tutorial on a worked example. Each skill's `description` gained a matching clause so a "teach me how this works" ask routes to it.

Two things worth being precise about, since they are easy to conflate:

- **This dependency is the collect script's.** `scripts/collect-implementations.ts` imports `@canonical/design-system/src/collect`; nothing else in the tree imports the package. The bump keeps that import on the published version.
- **The skills themselves do not arrive through this bump.** `pragma.conf.ts` declares the pack as `git+https://github.com/canonical/design-system.git#main`, so `sources update` resolves the git ref and symlinks its `skills/` — the new text is already reaching users who update. Verified locally against a build of this branch: `pragma sources update` moved the pack to `f8fb157`, and `pragma skill list` / `skill lookup specify-component` show the new descriptions and the `Opening move` section.

The embedded snapshot is untouched on purpose: `scripts/bundle.ts` writes nothing when the resolved TTL inputs are unchanged, and a skills-only change alters no triples. The release's `lerna-version` job refreshes it into the tagged commit as usual.

Two files, three lines.