### PR TITLE
docs(pragma-cli): show what a working LSP install logs

### DIFF
--- a/packages/cli/pragma/README.md
+++ b/packages/cli/pragma/README.md
@@ -149,6 +149,19 @@ pragma doctor
 
 `pragma setup` is one wizard for the whole environment: MCP registration, shell completions, agent skills, and the LSP extension. Each installer can target your project's configuration, your user-level (global) configuration, or both — `--scope project|global|both`, with `--global`/`--local` as shorthands. Preview everything it would write with `pragma setup --dry-run`, or run one installer directly: `pragma setup mcp`, `setup completions`, `setup skills`, `setup lsp`.
 
+The LSP step installs the Terrazzo extension, and the extension's own log is the fastest way to confirm it took. Open your editor's Output panel, select the `terrazzo-lsp` channel, and look for a startup block like this (timestamps dropped, paths shortened):
+
+```console
+[info] Config loaded from <project>/packages/react/ds-global/terrazzo-lsp.config.json
+[info] Root: <project>/packages/react/ds-global
+[info] Artifacts: <project>/packages/react/ds-global/node_modules/@canonical/design-tokens/dist/tokens.json
+[info] Loaded 781 tokens from 1 artifact
+[info] Global stylesheets: 1 file, 0 declarations
+[info] terrazzo-lsp ready
+```
+
+The token count is the line to read: `terrazzo-lsp ready` says the server started, but a run that loaded 0 tokens resolved its artifact path to nothing and will complete nothing. With tokens loaded, type `color: var(--` in a stylesheet — the design tokens should appear as completions.
+
 `pragma doctor` checks the environment (Node version, store health, registrations) and says what to fix. `pragma info` shows the version, the configuration in effect, and update status; `pragma upgrade` updates the CLI itself.
 
 ## Point it at your own design system


### PR DESCRIPTION
`pragma setup lsp` reports that it installed the extension, and then the trail goes cold — nothing tells you whether the language server actually came up, or came up empty. This adds the missing half to the README's setup section: where to look, what a healthy start looks like, and how to confirm it live.

The sample is a real capture, with timestamps dropped and paths shortened — the convention [docs/setup.md](../packages/cli/pragma/docs/setup.md) already uses for captured output:

```console
[info] Config loaded from <project>/packages/react/ds-global/terrazzo-lsp.config.json
[info] Root: <project>/packages/react/ds-global
[info] Artifacts: <project>/packages/react/ds-global/node_modules/@canonical/design-tokens/dist/tokens.json
[info] Loaded 781 tokens from 1 artifact
[info] Global stylesheets: 1 file, 0 declarations
[info] terrazzo-lsp ready
```

The text points at the token count rather than the last line, because that is where the failure actually shows: `terrazzo-lsp ready` prints whether or not the artifact path resolved, so a server that loaded 0 tokens looks healthy in the log and completes nothing in the editor. Then the cheapest live check — type `color: var(--` in a stylesheet and see whether the tokens appear.

README only, one section.