### PR TITLE
fix(pragma-cli): teach the parameter the tool actually takes, and count a name once

### DIFF
--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -30,7 +30,7 @@ pragma block list --format llm
 
 Look up block details by name, IRI, or glob.
 
-Get detailed information about one or more design system blocks including anatomy, modifiers, and properties. Use when you need the full spec of specific blocks by name — detail: "summary" trims to the base view. Example: block_lookup { names: ["Button"] }.
+Get detailed information about one or more design system blocks including anatomy, modifiers, and properties. Use when you need the full spec of specific blocks by name — detail: "summary" trims to the base view. Example: block_lookup { name: ["Button"] }.
 
 ```
 pragma block lookup <name...>
@@ -564,7 +564,7 @@ pragma modifier list --format llm
 
 Look up modifier details by name, IRI, or glob.
 
-Get values and usage details for one or more modifier families by name. Use when you need the allowed values of specific families. Example: modifier_lookup { names: ["importance"] }.
+Get values and usage details for one or more modifier families by name. Use when you need the allowed values of specific families. Example: modifier_lookup { name: ["importance"] }.
 
 ```
 pragma modifier lookup <name...>
@@ -1046,7 +1046,7 @@ pragma tier list --format llm
 
 Show tiers by name, with the blocks scoped to each.
 
-Get one or more tiers by name, with the blocks scoped directly to each. Use when you need which blocks a specific tier carries. Example: tier_lookup { names: ["apps/lxd"] }.
+Get one or more tiers by name, with the blocks scoped directly to each. Use when you need which blocks a specific tier carries. Example: tier_lookup { name: ["apps/lxd"] }.
 
 ```
 pragma tier lookup <name...>
@@ -1093,7 +1093,7 @@ pragma token list --format llm
 
 Look up token details by name, IRI, or glob.
 
-Get type and theme values for one or more design tokens by name. Use when resolving specific tokens' light/dark values. Example: token_lookup { names: ["color.primary"] }.
+Get type and theme values for one or more design tokens by name. Use when resolving specific tokens' light/dark values. Example: token_lookup { name: ["color.primary"] }.
 
 ```
 pragma token lookup <name...>

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -16,7 +16,7 @@ _No input parameters._
 
 ### block_lookup
 
-Get detailed information about one or more design system blocks including anatomy, modifiers, and properties. Use when you need the full spec of specific blocks by name — detail: "summary" trims to the base view. Example: block_lookup { names: ["Button"] }.
+Get detailed information about one or more design system blocks including anatomy, modifiers, and properties. Use when you need the full spec of specific blocks by name — detail: "summary" trims to the base view. Example: block_lookup { name: ["Button"] }.
 
 Read-only.
 
@@ -273,7 +273,7 @@ _No input parameters._
 
 ### modifier_lookup
 
-Get values and usage details for one or more modifier families by name. Use when you need the allowed values of specific families. Example: modifier_lookup { names: ["importance"] }.
+Get values and usage details for one or more modifier families by name. Use when you need the allowed values of specific families. Example: modifier_lookup { name: ["importance"] }.
 
 Read-only.
 
@@ -463,7 +463,7 @@ _No input parameters._
 
 ### tier_lookup
 
-Get one or more tiers by name, with the blocks scoped directly to each. Use when you need which blocks a specific tier carries. Example: tier_lookup { names: ["apps/lxd"] }.
+Get one or more tiers by name, with the blocks scoped directly to each. Use when you need which blocks a specific tier carries. Example: tier_lookup { name: ["apps/lxd"] }.
 
 Read-only.
 
@@ -485,7 +485,7 @@ _No input parameters._
 
 ### token_lookup
 
-Get type and theme values for one or more design tokens by name. Use when resolving specific tokens' light/dark values. Example: token_lookup { names: ["color.primary"] }.
+Get type and theme values for one or more design tokens by name. Use when resolving specific tokens' light/dark values. Example: token_lookup { name: ["color.primary"] }.
 
 Read-only.
 

--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -146,7 +146,7 @@ const designSystemStories: readonly PackDefinition[] = [
     lookup: {
       source: "graphql",
       toolDescription:
-        'Get detailed information about one or more design system blocks including anatomy, modifiers, and properties. Use when you need the full spec of specific blocks by name — detail: "summary" trims to the base view. Example: block_lookup { names: ["Button"] }.',
+        'Get detailed information about one or more design system blocks including anatomy, modifiers, and properties. Use when you need the full spec of specific blocks by name — detail: "summary" trims to the base view. Example: block_lookup { name: ["Button"] }.',
       by: "ds:name",
       types: ["ds:Component", "ds:Pattern", "ds:Layout", "ds:Subcomponent"],
       // A subcomponent is a PART of a block, never the block someone means:
@@ -290,7 +290,7 @@ const designSystemStories: readonly PackDefinition[] = [
       by: "ds:tokenId",
       type: "ds:Token",
       toolDescription:
-        'Get type and theme values for one or more design tokens by name. Use when resolving specific tokens\' light/dark values. Example: token_lookup { names: ["color.primary"] }.',
+        'Get type and theme values for one or more design tokens by name. Use when resolving specific tokens\' light/dark values. Example: token_lookup { name: ["color.primary"] }.',
       fields: [
         {
           name: "category",
@@ -349,7 +349,7 @@ const designSystemStories: readonly PackDefinition[] = [
       by: "ds:name",
       type: "ds:ModifierFamily",
       toolDescription:
-        'Get values and usage details for one or more modifier families by name. Use when you need the allowed values of specific families. Example: modifier_lookup { names: ["importance"] }.',
+        'Get values and usage details for one or more modifier families by name. Use when you need the allowed values of specific families. Example: modifier_lookup { name: ["importance"] }.',
       expand: [
         {
           name: "values",
@@ -397,7 +397,7 @@ const designSystemStories: readonly PackDefinition[] = [
       type: "ds:Tier",
       description: "Show tiers by name, with the blocks scoped to each.",
       toolDescription:
-        'Get one or more tiers by name, with the blocks scoped directly to each. Use when you need which blocks a specific tier carries. Example: tier_lookup { names: ["apps/lxd"] }.',
+        'Get one or more tiers by name, with the blocks scoped directly to each. Use when you need which blocks a specific tier carries. Example: tier_lookup { name: ["apps/lxd"] }.',
       expand: [
         {
           name: "blocks",

--- a/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.ts
@@ -232,7 +232,13 @@ export function buildExpandQuery(
 /** Build the SELECT listing all entity names — lookup-miss suggestions. */
 export function buildLookupNamesQuery(lookup: PackLookup): string {
   return [
-    "SELECT ?name WHERE {",
+    // DISTINCT: this population feeds miss-suggestions and glob expansion, and
+    // a name that several entities share is one CANDIDATE, not several. Without
+    // it a glob matching such a name expanded to it once per entity carrying
+    // it, and `lookup` then resolved each copy to the same winner — so
+    // `block lookup 'Butt*'` listed one Button twice while the other Button
+    // never appeared at all.
+    "SELECT DISTINCT ?name WHERE {",
     `  ?uri ${formatTerm(lookup.by)} ?name .`,
     buildTypeConstraint(lookup).trimEnd(),
     "}",

--- a/packages/cli/pragma/src/kernel/packs/toolDescription.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/toolDescription.test.ts
@@ -47,9 +47,7 @@ describe("pack toolDescription wiring (PROTECTED)", () => {
       "Get type and theme values for one or more design tokens by name.",
     );
     // The authored MCP tool-call example survives on the MCP surface.
-    expect(desc).toContain(
-      'Example: token_lookup { names: ["color.primary"] }',
-    );
+    expect(desc).toContain('Example: token_lookup { name: ["color.primary"] }');
   });
 
   it("routes the definition-level toolDescription to the MCP list tool", async () => {
@@ -85,5 +83,46 @@ describe("pack toolDescription wiring (PROTECTED)", () => {
     const listHelp = formatVerbHelp("pragma", verb(tokenModule, "list"));
     expect(listHelp).toContain("List all design tokens with their type.");
     expect(listHelp).not.toContain("token_list {");
+  });
+});
+
+describe("a tool-call example names a parameter the tool ACCEPTS (PROTECTED)", () => {
+  // Four `*_lookup` descriptions taught agents `{ names: [...] }` while every
+  // schema required `name`. An agent copying the example — which is what an
+  // example is for — got `-32602 Invalid arguments`, and the description is
+  // the only instruction it has. Prose that contradicts the schema beside it
+  // is worse than no prose: it is a documented wrong answer.
+  it("every `Example: tool { key: … }` uses a declared property", async () => {
+    const mcp = await projectMcp([...storyModules.values()]);
+    try {
+      const tools = await mcp.listTools();
+      const offenders: string[] = [];
+
+      for (const tool of tools) {
+        const example = /Example:\s*\w+\s*\{\s*([A-Za-z_$][\w$]*)\s*:/.exec(
+          tool.description ?? "",
+        );
+        const key = example?.[1];
+        if (key === undefined) continue; // No call example to check.
+        const properties = Object.keys(
+          (tool.inputSchema as { properties?: Record<string, unknown> })
+            ?.properties ?? {},
+        );
+        if (!properties.includes(key)) {
+          offenders.push(
+            `${tool.name}: example says \`${key}\`, schema declares ${properties.join(", ")}`,
+          );
+        }
+      }
+
+      expect(offenders).toEqual([]);
+      // Guard against a vacuous pass: some tool must actually carry an example.
+      expect(
+        tools.filter((t) => /Example:\s*\w+\s*\{/.test(t.description ?? ""))
+          .length,
+      ).toBeGreaterThan(0);
+    } finally {
+      await mcp.cleanup();
+    }
   });
 });


### PR DESCRIPTION
## Done

Two small defects on the lookup surface, both of which made a correct request look wrong.

### Four tool descriptions taught a parameter that does not exist

`block_lookup`, `token_lookup`, `modifier_lookup` and `tier_lookup` all carried `Example: … { names: [...] }` while every schema requires `name`:

```json
"required": ["name"],
"properties": { "name": { "type": "array", "items": { "type": "string" } }, … }
```

An agent copying the example — which is the entire purpose of an example — gets `-32602 Invalid arguments`, and the description is the only instruction it has. Prose contradicting the schema beside it is worse than no prose: it is a documented wrong answer.

**Pinned so it cannot come back.** A PROTECTED case parses `Example: tool { key:` out of every registered tool's description and asserts the key is a property that tool declares — with a guard against passing vacuously if the examples ever disappear.

### A shared name counted once

`buildLookupNamesQuery` had no `DISTINCT`, and it feeds both miss-suggestions and glob expansion. A name several entities share is one *candidate*, not several — without that, a glob matching such a name expanded to it once per entity carrying it, and each copy then resolved to the same winner:

```
before   block lookup 'Butt*' → [apps_launchpad…button, apps_launchpad…button, global…button_link]
after    block lookup 'Butt*' → [apps_launchpad…button, global…button_link]
```

## Deliberately NOT fixed here

`global.component.button` still does not appear for `Button` or `Butt*`. That is the `LIMIT 1` on name resolution — **one entity per name** — and lifting it changes the lookup contract, the renderer and the surface covenant. It gets its own PR.

## QA

```
NX_SKIP_NX_CACHE=true bun run check    # 62 projects, green
@canonical/pragma-cli                  # 1464 passed | 13 skipped | 5 todo
```

RED-proved — restoring one `names:` fails the new guard with the offender named:

```
+   "token_lookup: example says `names`, schema declares name"
× every `Example: tool { key: … }` uses a declared property
```

`docs/reference/tools.md` regenerated from the emitter, not hand-edited.

### PR readiness check

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged.
- [x] No new package.
- [x] Not visual — `no visual change` applied.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
