### PR TITLE
feat(pragma-cli): detect VS Code by installation, and report a harness inventory

### DIFF
--- a/packages/cli/pragma/docs/getting-started.md
+++ b/packages/cli/pragma/docs/getting-started.md
@@ -15,7 +15,7 @@ The package ships compiled JavaScript and runs on **Node.js 22.18+ or 23.6+** (a
 pragma doctor
 ```
 
-`pragma doctor` prints pass / fail / skip for nine health checks, each failure with the command that fixes it. Nothing needs to pass before your first read — it is there so you know the state of things.
+`pragma doctor` prints pass / fail / skip for every health check, each failure with the command that fixes it. Nothing needs to pass before your first read — it is there so you know the state of things.
 
 ## First read
 

--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -383,7 +383,7 @@ pragma create package --name @canonical/my-tool --no-run-install
 
 Check environment health and every setup target, in both bands.
 
-Reports the environment checks and then one row per setup target in each band, as pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Every banded row is named after the setup target that repairs it. Storeless by default; the store check boots lazily and never fails the run.
+Reports the environment checks and then one row per setup target in each band, as pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Every banded row is named after the setup target that repairs it, except the `harnesses` row: a per-band inventory of the AI harnesses detected on this machine and whether this CLI's MCP server is registered in each — the detected ones only, or every known harness under the verbose global flag. Storeless by default; the store check boots lazily and never fails the run.
 
 ```
 pragma doctor

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -194,7 +194,7 @@ Mutation — plan-first (set `confirm: true` to apply). Non-destructive.
 
 ### doctor
 
-Reports the environment checks and then one row per setup target in each band, as pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Every banded row is named after the setup target that repairs it. Storeless by default; the store check boots lazily and never fails the run.
+Reports the environment checks and then one row per setup target in each band, as pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Every banded row is named after the setup target that repairs it, except the `harnesses` row: a per-band inventory of the AI harnesses detected on this machine and whether this CLI's MCP server is registered in each — the detected ones only, or every known harness under the verbose global flag. Storeless by default; the store check boots lazily and never fails the run.
 
 Read-only.
 

--- a/packages/cli/pragma/docs/setup.md
+++ b/packages/cli/pragma/docs/setup.md
@@ -88,7 +88,7 @@ pragma setup mcp --scope project
 
 ## `pragma doctor`
 
-`pragma doctor` runs nine health checks and prints pass / fail / skip, each failure with the command that fixes it. It is storeless by default — the one store check boots lazily and a broken store never aborts the run — so it works before you have built anything.
+`pragma doctor` runs its health checks and prints pass / fail / skip, each failure with the command that fixes it. It is storeless by default — the one store check boots lazily and a broken store never aborts the run — so it works before you have built anything.
 
 ```console
 $ pragma doctor

--- a/packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.test.ts
@@ -12,10 +12,12 @@ import {
   harnessInventory,
   type InventoryGroup,
   type InventoryHarness,
+  type InventoryMember,
   type InventoryRow,
   inventoryHealth,
   inventoryItems,
   isDetectedState,
+  type WriteState,
 } from "./harnessInventory.js";
 
 const REGISTRY: InventoryHarness[] = [
@@ -23,6 +25,12 @@ const REGISTRY: InventoryHarness[] = [
   { id: "cursor", name: "Cursor", inBand: true },
   { id: "vscode", name: "VS Code", inBand: false },
 ];
+
+/** One harness's share of a file — its OWN write's state, never the file's. */
+const named = (name: string, state: WriteState): InventoryMember => ({
+  name,
+  state,
+});
 
 const roll = (groups: InventoryGroup[]): InventoryRow[] =>
   harnessInventory(REGISTRY, groups, "global");
@@ -32,10 +40,9 @@ describe("harnessInventory — the roll-up", () => {
     const rows = roll([
       {
         path: "~/.claude.json",
-        harnessNames: ["Claude Code"],
-        state: "configured",
+        harnesses: [named("Claude Code", "configured")],
       },
-      { path: "~/.cursor/mcp.json", harnessNames: ["Cursor"], state: "absent" },
+      { path: "~/.cursor/mcp.json", harnesses: [named("Cursor", "absent")] },
     ]);
 
     expect(rows.map((r) => `${r.harnessId}:${r.state}`)).toEqual([
@@ -61,11 +68,7 @@ describe("harnessInventory — the roll-up", () => {
 
   it("reports a drifted group as drifted, not as registered", () => {
     const rows = roll([
-      {
-        path: "~/.claude.json",
-        harnessNames: ["Claude Code"],
-        state: "drifted",
-      },
+      { path: "~/.claude.json", harnesses: [named("Claude Code", "drifted")] },
     ]);
     expect(rows[0]?.state).toBe("drifted");
   });
@@ -74,8 +77,8 @@ describe("harnessInventory — the roll-up", () => {
     const both = harnessInventory(
       REGISTRY,
       [
-        { path: "a.json", harnessNames: ["Cursor"], state: "configured" },
-        { path: "b.json", harnessNames: ["Cursor"], state: "configured" },
+        { path: "a.json", harnesses: [named("Cursor", "configured")] },
+        { path: "b.json", harnesses: [named("Cursor", "configured")] },
       ],
       "global",
     );
@@ -85,19 +88,49 @@ describe("harnessInventory — the roll-up", () => {
     const mixed = harnessInventory(
       REGISTRY,
       [
-        { path: "a.json", harnessNames: ["Cursor"], state: "configured" },
-        { path: "b.json", harnessNames: ["Cursor"], state: "absent" },
+        { path: "a.json", harnesses: [named("Cursor", "configured")] },
+        { path: "b.json", harnesses: [named("Cursor", "absent")] },
       ],
       "global",
     );
     expect(mixed[1]?.state).toBe("drifted");
   });
 
+  it("gives each harness sharing ONE file its own state, not the file's", () => {
+    // The co-detection case, and the reason a group carries per-harness state:
+    // `.vscode/mcp.json` holds VS Code's `servers` and Cline's `mcpServers` as
+    // two independent entries. Register pragma for VS Code alone and the FILE
+    // classifies as drifted — one key current, one absent — but neither
+    // harness is drifted: VS Code is registered and Cline is merely detected.
+    // A fixture with one harness per file cannot see this.
+    const shared: InventoryHarness[] = [
+      { id: "cline", name: "Cline", inBand: true },
+      { id: "vscode", name: "VS Code", inBand: true },
+    ];
+    const rows = harnessInventory(
+      shared,
+      [
+        {
+          path: ".vscode/mcp.json",
+          harnesses: [named("Cline", "absent"), named("VS Code", "configured")],
+        },
+      ],
+      "project",
+    );
+
+    expect(rows.map((r) => `${r.harnessId}:${r.state}`)).toEqual([
+      "cline:detected",
+      "vscode:registered",
+    ]);
+    // Both are located in the same file — the sharing itself is unchanged.
+    for (const row of rows) expect(row.locations).toEqual([".vscode/mcp.json"]);
+  });
+
   it("ignores a group naming a harness the registry does not know", () => {
     // The inventory reports on the REGISTRY; a group is evidence, not a source
     // of rows, so an unknown name adds nothing rather than inventing an entry.
     const rows = roll([
-      { path: "x.json", harnessNames: ["Ghost Editor"], state: "configured" },
+      { path: "x.json", harnesses: [named("Ghost Editor", "configured")] },
     ]);
     expect(rows).toHaveLength(REGISTRY.length);
     expect(rows.map((r) => r.harnessName)).not.toContain("Ghost Editor");
@@ -111,11 +144,7 @@ describe("harnessInventory — the roll-up", () => {
 
 describe("harnessInventory — the listing", () => {
   const rows = roll([
-    {
-      path: "~/.claude.json",
-      harnessNames: ["Claude Code"],
-      state: "configured",
-    },
+    { path: "~/.claude.json", harnesses: [named("Claude Code", "configured")] },
   ]);
 
   it("shows detected harnesses only by default", () => {
@@ -166,11 +195,7 @@ describe("harnessInventory — the listing", () => {
 
   it("counts a drifted harness as detected but not as registered", () => {
     const drifted = roll([
-      {
-        path: "~/.claude.json",
-        harnessNames: ["Claude Code"],
-        state: "drifted",
-      },
+      { path: "~/.claude.json", harnesses: [named("Claude Code", "drifted")] },
     ]);
     expect(inventoryHealth(drifted, false).detail).toBe(
       "1 detected · 0 registered",

--- a/packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The harness inventory roll-up — the pure half, driven by fixtures.
+ *
+ * `doctor.test.ts` covers the wiring (both bands, `--verbose`, the real
+ * registry). What is unit-tested here is the classification itself: the
+ * registry supplies the universe so the NEGATIVE is representable, the groups
+ * supply the state, and no combination of the two may ever produce a `fail`.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  harnessInventory,
+  type InventoryGroup,
+  type InventoryHarness,
+  type InventoryRow,
+  inventoryHealth,
+  inventoryItems,
+  isDetectedState,
+} from "./harnessInventory.js";
+
+const REGISTRY: InventoryHarness[] = [
+  { id: "claude-code", name: "Claude Code", inBand: true },
+  { id: "cursor", name: "Cursor", inBand: true },
+  { id: "vscode", name: "VS Code", inBand: false },
+];
+
+const roll = (groups: InventoryGroup[]): InventoryRow[] =>
+  harnessInventory(REGISTRY, groups, "global");
+
+describe("harnessInventory — the roll-up", () => {
+  it("classifies each registry harness against the band's groups", () => {
+    const rows = roll([
+      {
+        path: "~/.claude.json",
+        harnessNames: ["Claude Code"],
+        state: "configured",
+      },
+      { path: "~/.cursor/mcp.json", harnessNames: ["Cursor"], state: "absent" },
+    ]);
+
+    expect(rows.map((r) => `${r.harnessId}:${r.state}`)).toEqual([
+      "claude-code:registered",
+      "cursor:detected",
+      // Not detected AND has no location in this band at all — the two are
+      // different facts and the row says which one applies.
+      "vscode:unbanded",
+    ]);
+    expect(rows[0]?.locations).toEqual(["~/.claude.json"]);
+    expect(rows[2]?.locations).toEqual([]);
+  });
+
+  it("keeps 'undetected' and 'unbanded' apart", () => {
+    // Same absence, two different reasons: Cursor could be here and is not,
+    // VS Code could never be here at all.
+    const rows = roll([]);
+    expect(rows.find((r) => r.harnessId === "cursor")?.state).toBe(
+      "undetected",
+    );
+    expect(rows.find((r) => r.harnessId === "vscode")?.state).toBe("unbanded");
+  });
+
+  it("reports a drifted group as drifted, not as registered", () => {
+    const rows = roll([
+      {
+        path: "~/.claude.json",
+        harnessNames: ["Claude Code"],
+        state: "drifted",
+      },
+    ]);
+    expect(rows[0]?.state).toBe("drifted");
+  });
+
+  it("a harness sharing two files is registered only when BOTH carry the entry", () => {
+    const both = harnessInventory(
+      REGISTRY,
+      [
+        { path: "a.json", harnessNames: ["Cursor"], state: "configured" },
+        { path: "b.json", harnessNames: ["Cursor"], state: "configured" },
+      ],
+      "global",
+    );
+    expect(both[1]?.state).toBe("registered");
+    expect(both[1]?.locations).toEqual(["a.json", "b.json"]);
+
+    const mixed = harnessInventory(
+      REGISTRY,
+      [
+        { path: "a.json", harnessNames: ["Cursor"], state: "configured" },
+        { path: "b.json", harnessNames: ["Cursor"], state: "absent" },
+      ],
+      "global",
+    );
+    expect(mixed[1]?.state).toBe("drifted");
+  });
+
+  it("ignores a group naming a harness the registry does not know", () => {
+    // The inventory reports on the REGISTRY; a group is evidence, not a source
+    // of rows, so an unknown name adds nothing rather than inventing an entry.
+    const rows = roll([
+      { path: "x.json", harnessNames: ["Ghost Editor"], state: "configured" },
+    ]);
+    expect(rows).toHaveLength(REGISTRY.length);
+    expect(rows.map((r) => r.harnessName)).not.toContain("Ghost Editor");
+  });
+
+  it("names every row with the band it was rolled up for", () => {
+    const rows = harnessInventory(REGISTRY, [], "project");
+    expect(rows.every((r) => r.band === "project")).toBe(true);
+  });
+});
+
+describe("harnessInventory — the listing", () => {
+  const rows = roll([
+    {
+      path: "~/.claude.json",
+      harnessNames: ["Claude Code"],
+      state: "configured",
+    },
+  ]);
+
+  it("shows detected harnesses only by default", () => {
+    const items = inventoryItems(rows, false);
+    expect(items.map((i) => i.label)).toEqual(["Claude Code"]);
+    expect(items[0]?.detail).toBe("registered — ~/.claude.json");
+  });
+
+  it("--verbose widens the same rows to the whole registry", () => {
+    const items = inventoryItems(rows, true);
+    expect(items.map((i) => i.label)).toEqual([
+      "Claude Code",
+      "Cursor",
+      "VS Code",
+    ]);
+    expect(items[1]?.detail).toBe("not detected");
+    // Band-aware, and it uses the ONE band vocabulary (`BAND_LABELS`).
+    expect(items[2]?.detail).toBe("no Global band");
+  });
+
+  it("never renders any state as a failure", () => {
+    for (const item of inventoryItems(rows, true)) {
+      expect(item.status).not.toBe("fail");
+    }
+    const every = harnessInventory(REGISTRY, [], "project");
+    for (const item of inventoryItems(every, true)) {
+      expect(item.status).not.toBe("fail");
+    }
+  });
+
+  it("is a listing, not a verdict: pass when the band holds harnesses, skip when it does not", () => {
+    expect(inventoryHealth(rows, false).status).toBe("pass");
+    expect(inventoryHealth(rows, false).detail).toBe(
+      "1 detected · 1 registered",
+    );
+    expect(inventoryHealth(rows, true).detail).toBe(
+      "1 detected · 1 registered · 3 known",
+    );
+
+    const empty = roll([]);
+    expect(inventoryHealth(empty, false).status).toBe("skip");
+    expect(inventoryHealth(empty, false).detail).toBe("no harnesses detected");
+    expect(inventoryHealth(empty, false).items).toEqual([]);
+    expect(inventoryHealth(empty, true).detail).toBe(
+      "none of 3 known harnesses detected",
+    );
+  });
+
+  it("counts a drifted harness as detected but not as registered", () => {
+    const drifted = roll([
+      {
+        path: "~/.claude.json",
+        harnessNames: ["Claude Code"],
+        state: "drifted",
+      },
+    ]);
+    expect(inventoryHealth(drifted, false).detail).toBe(
+      "1 detected · 0 registered",
+    );
+    expect(inventoryItems(drifted, false)[0]?.status).toBe("available");
+  });
+});
+
+describe("isDetectedState", () => {
+  it("counts every state that means the harness is on the machine", () => {
+    expect(isDetectedState("registered")).toBe(true);
+    expect(isDetectedState("drifted")).toBe(true);
+    expect(isDetectedState("detected")).toBe(true);
+    expect(isDetectedState("undetected")).toBe(false);
+    expect(isDetectedState("unbanded")).toBe(false);
+  });
+});

--- a/packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.ts
@@ -1,0 +1,262 @@
+/**
+ * The harness inventory: one row per harness per band, saying what was detected
+ * and whether pragma is registered in it.
+ *
+ * Every fact this needs was ALREADY COMPUTED and thrown away.
+ * `TargetGroup.harnessNames` carries every harness sharing a config file and
+ * both consumers reduced it to `shortenPath(group.path)`; `McpDetection`
+ * carries the per-file `absent`/`configured`/`drifted` classification keyed by
+ * that same path. The only thing detection could NOT answer is the negative —
+ * `detectHarnesses` filters to hits, so a harness the machine does not have was
+ * unrepresentable — which is why the roll-up takes the REGISTRY alongside the
+ * groups: the registry supplies the universe, the groups supply the state.
+ *
+ * Three deliberate constraints:
+ *
+ * 1. **No `@canonical/harnesses` import, of any kind.** `capabilities/lazy.test`
+ *    forbids one from any file statically reachable from `capabilities/index`,
+ *    and its regex has no `import type` exemption. This module is reached only
+ *    through `runChecks`'s dynamic import today, but it is written so that
+ *    staying legal never depends on that: the inputs are declared here as
+ *    narrow structural records.
+ *
+ * 2. **Narrowed to DATA, so `mutates: false` is enforced rather than asserted.**
+ *    `McpDetection` is write-capable — it carries `writeMcpConfigTargets` and
+ *    `removeMcpConfigFrom` as live function references. Projecting it down to
+ *    {@link InventoryGroup} before it reaches this file means a read-only
+ *    report literally cannot reach a writer.
+ *
+ * 3. **It never invents a failure.** The states an inventory can report map onto
+ *    `pass`/`available`/`skip` and NEVER `fail` (see `../types.ts`): a machine
+ *    that simply does not have Windsurf is not a broken machine, and the `mcp`
+ *    row already owns the actionable finding for the harnesses it does have.
+ *    Reporting it twice is how a failure count becomes noise.
+ *
+ * Placement: this is a doctor helper because doctor is its only consumer today,
+ * and `shared/` is explicitly not a utility drawer (see `shared/index.ts`). It
+ * is written to MOVE there unchanged — pure, no capability imports beyond the
+ * band type — the moment `setup`'s detection summary becomes the second caller.
+ */
+
+import { BAND_LABELS } from "../../shared/index.js";
+import type { CheckItem, CheckStatus, ScopeBand } from "../types.js";
+
+/**
+ * What the inventory says about one harness in one band.
+ *
+ * The vocabulary is deliberately NOT "installed". The codebase carries two
+ * different things under that word — `DetectedHarness.configExists` ("the
+ * harness's own config file exists") and `McpTargetState.configured` ("pragma
+ * is registered in it") — and they are not the same claim. Every state here
+ * names the PRAGMA-ENTRY meaning, and `configExists` is never surfaced.
+ *
+ * - `registered` — detected, and pragma's MCP entry in this band is current.
+ * - `drifted` — detected, and a pragma entry exists but differs from what a
+ *   write would emit. Actionable, but the `mcp` row is where it is actionED;
+ *   here it is reported without inflating the failure count.
+ * - `detected` — the harness is on this machine; pragma is not registered.
+ * - `undetected` — in the registry, has a location in this band, not found.
+ * - `unbanded` — in the registry, but has NO config location in this band at
+ *   all (VS Code is `scope: "project"`, so it can never hold a global entry).
+ *   Stated rather than omitted: a verbose listing that silently dropped a row
+ *   reads as a bug in the listing.
+ */
+export type InventoryState =
+  | "registered"
+  | "drifted"
+  | "detected"
+  | "undetected"
+  | "unbanded";
+
+/** One harness's standing in one band. */
+export interface InventoryRow {
+  readonly harnessId: string;
+  readonly harnessName: string;
+  readonly band: ScopeBand;
+  readonly state: InventoryState;
+  /** The config paths in this band that carry (or would carry) the entry. */
+  readonly locations: readonly string[];
+}
+
+/** A registry entry, narrowed to what the roll-up reads. */
+export interface InventoryHarness {
+  readonly id: string;
+  readonly name: string;
+  /** Whether this harness has a config location in the band being rolled up. */
+  readonly inBand: boolean;
+}
+
+/**
+ * One detected config file, narrowed off {@link McpDetection}: the group's
+ * already-shortened path, the harness names sharing it, and its prior state.
+ */
+export interface InventoryGroup {
+  readonly path: string;
+  readonly harnessNames: readonly string[];
+  readonly state: "absent" | "configured" | "drifted";
+}
+
+/** Whether a state means "this harness is on the machine". */
+export const isDetectedState = (state: InventoryState): boolean =>
+  state === "registered" || state === "drifted" || state === "detected";
+
+/**
+ * Roll one band's detected config groups up against the registry into one row
+ * per harness.
+ *
+ * Groups are keyed by harness NAME because that is the only identity
+ * `TargetGroup` records; the registry is the map back to an id, which is why it
+ * is a parameter rather than a lookup. A harness naming no registry row is
+ * ignored rather than invented — the inventory reports on the registry, not on
+ * whatever a group happened to say.
+ *
+ * @param registry - Every known harness, each flagged for band membership.
+ * @param groups - This band's detected config files (narrowed, path-shortened).
+ * @param band - The band being rolled up.
+ * @returns One row per registry harness, in registry order.
+ * @note Pure — it reads no filesystem and holds no live effect.
+ */
+export function harnessInventory(
+  registry: readonly InventoryHarness[],
+  groups: readonly InventoryGroup[],
+  band: ScopeBand,
+): InventoryRow[] {
+  const states = new Map<string, InventoryGroup["state"]>();
+  const locations = new Map<string, string[]>();
+  for (const group of groups) {
+    for (const name of group.harnessNames) {
+      const paths = locations.get(name) ?? [];
+      paths.push(group.path);
+      locations.set(name, paths);
+      // A harness sharing two files is registered only where EVERY one of them
+      // carries the current entry — the same "all or nothing" rule
+      // `classifyGroup` applies within a single file.
+      const prior = states.get(name);
+      states.set(
+        name,
+        prior === undefined || prior === group.state ? group.state : "drifted",
+      );
+    }
+  }
+
+  return registry.map((harness): InventoryRow => {
+    const detected = states.get(harness.name);
+    const paths = locations.get(harness.name) ?? [];
+    const state: InventoryState =
+      detected === undefined
+        ? harness.inBand
+          ? "undetected"
+          : "unbanded"
+        : detected === "configured"
+          ? "registered"
+          : detected === "drifted"
+            ? "drifted"
+            : "detected";
+    return {
+      harnessId: harness.id,
+      harnessName: harness.name,
+      band,
+      state,
+      locations: paths,
+    };
+  });
+}
+
+/** The per-item status each state renders as. Never `fail` — see the docblock. */
+const STATE_STATUS: Record<InventoryState, CheckStatus> = {
+  registered: "pass",
+  drifted: "available",
+  detected: "available",
+  undetected: "skip",
+  unbanded: "skip",
+};
+
+/** The phrase each state reads as, band-aware for the unbanded case. */
+const stateDetail = (row: InventoryRow): string => {
+  switch (row.state) {
+    case "registered":
+      return "registered";
+    case "drifted":
+      return "registered, entry differs from current";
+    case "detected":
+      return "detected, not registered";
+    case "undetected":
+      return "not detected";
+    case "unbanded":
+      return `no ${BAND_LABELS[row.band]} band`;
+  }
+};
+
+/**
+ * Project inventory rows into doctor sub-items.
+ *
+ * The default listing is DETECTED HARNESSES ONLY — a report that names every
+ * tool the user does not have buries the ones they do. `--verbose` widens it to
+ * the whole registry, which is the only view in which `undetected`/`unbanded`
+ * rows appear at all.
+ *
+ * @param rows - This band's inventory rows.
+ * @param verbose - Whether to list the whole registry rather than the hits.
+ * @returns The sub-items, harness name in the left column.
+ */
+export function inventoryItems(
+  rows: readonly InventoryRow[],
+  verbose: boolean,
+): CheckItem[] {
+  const shown = verbose
+    ? rows
+    : rows.filter((row) => isDetectedState(row.state));
+  return shown.map((row): CheckItem => {
+    const where = row.locations.join(", ");
+    return {
+      label: row.harnessName,
+      status: STATE_STATUS[row.state],
+      detail: where ? `${stateDetail(row)} — ${where}` : stateDetail(row),
+    };
+  });
+}
+
+/** The inventory check's headline, and whether it has anything to show. */
+export interface InventoryHealth {
+  readonly status: CheckStatus;
+  readonly detail: string;
+  readonly items: readonly CheckItem[];
+}
+
+/**
+ * The whole inventory row for one band: a listing, not a verdict.
+ *
+ * Its status is only ever `pass` (this band has harnesses) or `skip` (it has
+ * none). It is the one banded row that is not a setup target, so it derives no
+ * `fix:` line — the `mcp` and `skills` rows beside it own every action a
+ * harness can need, and a second row proposing the same command would be the
+ * "same finding seen twice" the report is built to avoid.
+ *
+ * @param rows - This band's inventory rows.
+ * @param verbose - Whether the listing widens to the whole registry.
+ * @returns The status, headline and sub-items for the band's inventory check.
+ */
+export function inventoryHealth(
+  rows: readonly InventoryRow[],
+  verbose: boolean,
+): InventoryHealth {
+  const detected = rows.filter((row) => isDetectedState(row.state));
+  const registered = rows.filter((row) => row.state === "registered");
+  const items = inventoryItems(rows, verbose);
+  if (detected.length === 0) {
+    return {
+      status: "skip",
+      detail: verbose
+        ? `none of ${rows.length} known harnesses detected`
+        : "no harnesses detected",
+      items,
+    };
+  }
+  return {
+    status: "pass",
+    detail: `${detected.length} detected · ${registered.length} registered${
+      verbose ? ` · ${rows.length} known` : ""
+    }`,
+    items,
+  };
+}

--- a/packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.ts
@@ -5,11 +5,19 @@
  * Every fact this needs was ALREADY COMPUTED and thrown away.
  * `TargetGroup.harnessNames` carries every harness sharing a config file and
  * both consumers reduced it to `shortenPath(group.path)`; `McpDetection`
- * carries the per-file `absent`/`configured`/`drifted` classification keyed by
- * that same path. The only thing detection could NOT answer is the negative —
+ * carries the `absent`/`configured`/`drifted` classification of every WRITE in
+ * that file. The only thing detection could NOT answer is the negative —
  * `detectHarnesses` filters to hits, so a harness the machine does not have was
  * unrepresentable — which is why the roll-up takes the REGISTRY alongside the
  * groups: the registry supplies the universe, the groups supply the state.
+ *
+ * The state arrives PER HARNESS, never per file. A shared `.vscode/mcp.json`
+ * holds VS Code's `servers` and Cline's `mcpServers` as two independent
+ * entries, so the file's aggregate — `drifted`, when one key is current and the
+ * other absent — is the standing of NEITHER harness. Pairing each name with
+ * the write it owns is the caller's job (it holds the registry's `mcpKey`s and
+ * the group's writes); by the time a group reaches this module the association
+ * is resolved and every name carries its own state.
  *
  * Three deliberate constraints:
  *
@@ -86,14 +94,26 @@ export interface InventoryHarness {
   readonly inBand: boolean;
 }
 
+/** The prior state of one harness's own write, as detection classified it. */
+export type WriteState = "absent" | "configured" | "drifted";
+
+/** One harness's share of a config file: the state of the write IT owns. */
+export interface InventoryMember {
+  readonly name: string;
+  readonly state: WriteState;
+}
+
 /**
  * One detected config file, narrowed off {@link McpDetection}: the group's
- * already-shortened path, the harness names sharing it, and its prior state.
+ * already-shortened path, and every harness sharing it WITH ITS OWN state.
+ *
+ * Per harness, not per file — see the module docblock. A file-level state here
+ * would report both harnesses sharing `.vscode/mcp.json` as drifted the moment
+ * either one of them is registered alone.
  */
 export interface InventoryGroup {
   readonly path: string;
-  readonly harnessNames: readonly string[];
-  readonly state: "absent" | "configured" | "drifted";
+  readonly harnesses: readonly InventoryMember[];
 }
 
 /** Whether a state means "this harness is on the machine". */
@@ -111,7 +131,8 @@ export const isDetectedState = (state: InventoryState): boolean =>
  * whatever a group happened to say.
  *
  * @param registry - Every known harness, each flagged for band membership.
- * @param groups - This band's detected config files (narrowed, path-shortened).
+ * @param groups - This band's detected config files (narrowed, path-shortened),
+ *   each naming the harnesses that share it with their own per-write state.
  * @param band - The band being rolled up.
  * @returns One row per registry harness, in registry order.
  * @note Pure — it reads no filesystem and holds no live effect.
@@ -121,20 +142,22 @@ export function harnessInventory(
   groups: readonly InventoryGroup[],
   band: ScopeBand,
 ): InventoryRow[] {
-  const states = new Map<string, InventoryGroup["state"]>();
+  const states = new Map<string, WriteState>();
   const locations = new Map<string, string[]>();
   for (const group of groups) {
-    for (const name of group.harnessNames) {
-      const paths = locations.get(name) ?? [];
+    for (const member of group.harnesses) {
+      const paths = locations.get(member.name) ?? [];
       paths.push(group.path);
-      locations.set(name, paths);
+      locations.set(member.name, paths);
       // A harness sharing two files is registered only where EVERY one of them
       // carries the current entry — the same "all or nothing" rule
-      // `classifyGroup` applies within a single file.
-      const prior = states.get(name);
+      // `aggregateMcpStates` applies across the writes within a single file.
+      const prior = states.get(member.name);
       states.set(
-        name,
-        prior === undefined || prior === group.state ? group.state : "drifted",
+        member.name,
+        prior === undefined || prior === member.state
+          ? member.state
+          : "drifted",
       );
     }
   }

--- a/packages/cli/pragma/src/capabilities/doctor/checks/targetHealth.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/targetHealth.ts
@@ -16,6 +16,13 @@
  * Doctor's UNBANDED environment checks (Node version, the CLI's own version,
  * pack refs, the store) diagnose things setup cannot install and stay outside
  * this list.
+ *
+ * ONE banded row is not a target: `harnesses`, the per-band inventory. It is an
+ * inventory of the machine the targets are measured against, not a target that
+ * can be set up, so it deliberately carries no `fix:` and can never be `fail`
+ * or `available` — see {@link inventoryChecks}. The bijection between the other
+ * rows and the setup table is untouched: `harnesses` is not a `TargetId`, and
+ * nothing derives a command from it.
  */
 
 import { MCP_SERVER_NAME } from "../../../constants.js";
@@ -43,6 +50,12 @@ import {
 import { shortenPath, TARGET_IDS } from "../../setup/plan.js";
 import type { CheckItem, CheckResult, ScopeBand } from "../types.js";
 import { checkShellCompletions } from "./checkShellCompletions.js";
+import {
+  harnessInventory,
+  type InventoryGroup,
+  type InventoryHarness,
+  inventoryHealth,
+} from "./harnessInventory.js";
 import { commandResolves } from "./mcpCommand.js";
 
 /** What a row reports before its name, band and `fix:` line are attached. */
@@ -241,6 +254,89 @@ async function healthOf(
   }
 }
 
+/** The banded inventory row's name — a LISTING, not a setup target id. */
+export const INVENTORY_CHECK = "harnesses";
+
+/**
+ * The `harnesses` row for one band: what this machine has, and where pragma
+ * stands in each.
+ *
+ * It is the one banded row that is NOT a target, and it earns that by never
+ * competing with the ones that are. Its status is only `pass` or `skip`, so it
+ * adds no failure and no `available` to the tally, and it derives no `fix:` —
+ * the `mcp` and `skills` rows beside it already name every command a harness
+ * needs, and repeating them here would be the same finding seen twice.
+ *
+ * The registry is the only thing detection could not supply: `detectHarnesses`
+ * filters to hits, so "Windsurf is not on this machine" was unrepresentable
+ * until the universe came from somewhere. Everything else — which harnesses
+ * share which file, and whether that file already carries pragma's current
+ * entry — is read straight off the `mcp` detection this report already ran.
+ * The projection to {@link InventoryGroup} is deliberate: `McpDetection` holds
+ * `writeMcpConfigTargets`/`removeMcpConfigFrom` as live functions, and a
+ * `mutates: false` command should be unable to reach a writer, not merely
+ * trusted not to.
+ *
+ * @param rt - The per-invocation runtime (read for `--verbose`).
+ * @param rows - Every detected row, both bands, as `bandedChecks` has them.
+ * @param roots - The roots every path renders relative to.
+ * @returns One inventory {@link CheckResult} per band, global then project.
+ * @note Impure — dynamically imports the harness registry.
+ */
+async function inventoryChecks(
+  rt: PragmaRuntime,
+  rows: readonly DetectedRow[],
+  roots: { global: string; project: string },
+): Promise<CheckResult[]> {
+  const { harnesses, isHarnessInBand } = await import("@canonical/harnesses");
+  const verbose = rt.globalFlags.verbose;
+  const bands: readonly ScopeBand[] = ["global", "project"];
+
+  return bands.map((band): CheckResult => {
+    // `isHarnessInBand(scope, band, band)` — the band as its OWN selection — is
+    // exactly "does this harness have a config location here", which is the
+    // question `detectMcp` already answers for that band. Asking it under the
+    // `both` selection would instead answer "who writes here when both bands
+    // run", and report every dual-scope harness as having no global band.
+    const registry: InventoryHarness[] = harnesses.map((harness) => ({
+      id: harness.id,
+      name: harness.name,
+      inBand: isHarnessInBand(harness.scope, band, band),
+    }));
+
+    const mcpRow = rows.find(
+      (row) => row.target.id === "mcp" && row.band === band,
+    );
+    if (mcpRow === undefined || detectionFailure(mcpRow) !== undefined) {
+      return {
+        name: INVENTORY_CHECK,
+        status: "skip",
+        detail: "harness detection did not settle — see the `mcp` row",
+        band,
+      };
+    }
+
+    const detection = mcpRow.detection as McpDetection;
+    const groups: InventoryGroup[] = detection.groups.map((group) => ({
+      path: shortenPath(group.path, roots),
+      harnessNames: group.harnessNames,
+      state: mcpGroupState(detection, group.path),
+    }));
+
+    const health = inventoryHealth(
+      harnessInventory(registry, groups, band),
+      verbose,
+    );
+    return {
+      name: INVENTORY_CHECK,
+      status: health.status,
+      detail: health.detail,
+      band,
+      ...(health.items.length === 0 ? {} : { items: health.items }),
+    };
+  });
+}
+
 /**
  * The command that repairs a row — derived from its id and band, never
  * authored. This is the bijection made mechanical: a row exists because a
@@ -253,11 +349,18 @@ export const fixCommandFor = (
 ): string => `${bin} setup ${id}${band === "project" ? " --local" : ""}`;
 
 /**
- * Run every banded check: the target table, both bands, in table order.
+ * Run every banded check: the target table, both bands, in table order, then
+ * each band's harness inventory.
+ *
+ * The inventory rows come LAST within the array, and the renderer partitions by
+ * band while preserving order, so each band's section ends with the listing of
+ * what that band actually holds — the targets first, then the machine they were
+ * measured against. They ride on the SAME detection pass: no target is probed a
+ * second time to produce them.
  *
  * @param rt - The per-invocation runtime.
  * @param bin - The binary name the `fix:` lines are derived from.
- * @returns One {@link CheckResult} per (target, band) the machine can hold.
+ * @returns One {@link CheckResult} per (target, band), plus one per band.
  * @note Impure — every target's detection reads the real filesystem.
  */
 export async function bandedChecks(
@@ -266,26 +369,30 @@ export async function bandedChecks(
 ): Promise<CheckResult[]> {
   const roots = await resolveRoots(rt);
   const detected = await detectTargets(rt, [...TARGET_IDS], "both");
-  return Promise.all(
-    detected.map(async (row): Promise<CheckResult> => {
-      const health = await healthOf(row, rt, roots);
-      const needsFix =
-        health.status === "fail" || health.status === "available";
-      // A `skip` gets no DERIVED fix — re-running the target's own setup command
-      // would reproduce the skip. But a skip that AUTHORED a remedy has found a
-      // real next step on this machine (fill the band's skill root, say), and
-      // dropping it is what made the skip a dead end on both surfaces.
-      const remedy = needsFix
-        ? (health.remedy ?? fixCommandFor(row.target.id, row.band, bin))
-        : health.remedy;
-      return {
-        name: row.target.id,
-        status: health.status,
-        detail: health.detail,
-        band: row.band,
-        ...(health.items === undefined ? {} : { items: health.items }),
-        ...(remedy === undefined ? {} : { remedy }),
-      };
-    }),
-  );
+  const [targetRows, inventoryRows] = await Promise.all([
+    Promise.all(
+      detected.map(async (row): Promise<CheckResult> => {
+        const health = await healthOf(row, rt, roots);
+        const needsFix =
+          health.status === "fail" || health.status === "available";
+        // A `skip` gets no DERIVED fix — re-running the target's own setup command
+        // would reproduce the skip. But a skip that AUTHORED a remedy has found a
+        // real next step on this machine (fill the band's skill root, say), and
+        // dropping it is what made the skip a dead end on both surfaces.
+        const remedy = needsFix
+          ? (health.remedy ?? fixCommandFor(row.target.id, row.band, bin))
+          : health.remedy;
+        return {
+          name: row.target.id,
+          status: health.status,
+          detail: health.detail,
+          band: row.band,
+          ...(health.items === undefined ? {} : { items: health.items }),
+          ...(remedy === undefined ? {} : { remedy }),
+        };
+      }),
+    ),
+    inventoryChecks(rt, detected, roots),
+  ]);
+  return [...targetRows, ...inventoryRows];
 }

--- a/packages/cli/pragma/src/capabilities/doctor/checks/targetHealth.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/targetHealth.ts
@@ -43,6 +43,7 @@ import {
   lspSkipReason,
   type McpDetection,
   mcpGroupState,
+  mcpWriteState,
   type SkillsDetection,
   skillsSkipReason,
   skillsSkipRemedy,
@@ -270,12 +271,21 @@ export const INVENTORY_CHECK = "harnesses";
  * The registry is the only thing detection could not supply: `detectHarnesses`
  * filters to hits, so "Windsurf is not on this machine" was unrepresentable
  * until the universe came from somewhere. Everything else — which harnesses
- * share which file, and whether that file already carries pragma's current
- * entry — is read straight off the `mcp` detection this report already ran.
- * The projection to {@link InventoryGroup} is deliberate: `McpDetection` holds
+ * share which file, and whether each one's own entry in it is current — is read
+ * straight off the `mcp` detection this report already ran. The projection to
+ * {@link InventoryGroup} is deliberate: `McpDetection` holds
  * `writeMcpConfigTargets`/`removeMcpConfigFrom` as live functions, and a
  * `mutates: false` command should be unable to reach a writer, not merely
  * trusted not to.
+ *
+ * This is also where the harness↔`mcpKey` association is REJOINED, because it
+ * is the one place that holds both halves: `TargetGroup` records the names
+ * sharing a file and, separately, one write per distinct `mcpKey`, and the
+ * registry is what says which key a given harness writes. Without that join the
+ * only state available per harness is the file's aggregate — and a
+ * `.vscode/mcp.json` where VS Code's `servers` entry is current while Cline's
+ * `mcpServers` is absent aggregates to `drifted`, which would report BOTH
+ * harnesses as drifted when neither one is.
  *
  * @param rt - The per-invocation runtime (read for `--verbose`).
  * @param rows - Every detected row, both bands, as `bandedChecks` has them.
@@ -291,6 +301,10 @@ async function inventoryChecks(
   const { harnesses, isHarnessInBand } = await import("@canonical/harnesses");
   const verbose = rt.globalFlags.verbose;
   const bands: readonly ScopeBand[] = ["global", "project"];
+  // The key each harness NAME writes under — the half of the association
+  // `groupConfigTargets` consumed and did not record. Names are the only
+  // identity a group carries, and the registry's are unique.
+  const keyByName = new Map(harnesses.map((h) => [h.name, h.mcpKey]));
 
   return bands.map((band): CheckResult => {
     // `isHarnessInBand(scope, band, band)` — the band as its OWN selection — is
@@ -319,8 +333,22 @@ async function inventoryChecks(
     const detection = mcpRow.detection as McpDetection;
     const groups: InventoryGroup[] = detection.groups.map((group) => ({
       path: shortenPath(group.path, roots),
-      harnessNames: group.harnessNames,
-      state: mcpGroupState(detection, group.path),
+      harnesses: group.harnessNames.map((name) => {
+        // The harness's OWN write in this file. A name the registry does not
+        // know (or a key no write carries — impossible while the group was
+        // built from the same registry) falls back to the file's aggregate:
+        // strictly no worse than the state before this join existed.
+        const write = group.writes.find(
+          (w) => w.mcpKey === keyByName.get(name),
+        );
+        return {
+          name,
+          state:
+            write === undefined
+              ? mcpGroupState(detection, group.path)
+              : mcpWriteState(detection, write),
+        };
+      }),
     }));
 
     const health = inventoryHealth(

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.render.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.render.test.ts
@@ -179,3 +179,68 @@ describe("doctor render — color ON (attended TTY)", () => {
     });
   });
 });
+
+/**
+ * The harness inventory renders through the EXISTING check-with-items
+ * primitive — a listing needs no new machinery, only a check whose `items` are
+ * harnesses. This pins that it reads as an inventory in both formats: named
+ * harnesses under their band, mixed per-item glyphs, and NO `fix:` line (the
+ * `mcp`/`skills` rows own every action a harness can need).
+ */
+const INVENTORY_DATA: DoctorData = {
+  checks: [
+    {
+      name: "harnesses",
+      status: "pass",
+      detail: "1 detected · 1 registered · 3 known",
+      band: "global",
+      items: [
+        {
+          label: "Claude Code",
+          status: "pass",
+          detail: "registered — ~/.claude.json",
+        },
+        { label: "Cursor", status: "skip", detail: "not detected" },
+        { label: "VS Code", status: "skip", detail: "no Global band" },
+      ],
+    },
+  ],
+  passed: 1,
+  failed: 0,
+  available: 0,
+  skipped: 0,
+};
+
+describe("doctor render — the harness inventory", () => {
+  it("renders one aligned sub-item per harness, with no fix line", () => {
+    const out = doctorFormatters.plain(INVENTORY_DATA);
+    expect(out).toContain("Global");
+    expect(out).toContain("harnesses");
+    expect(out).toContain("1 detected · 1 registered · 3 known");
+    expect(out).toContain("· ✓ Claude Code  registered — ~/.claude.json");
+    expect(out).toContain("· ○ Cursor       not detected");
+    expect(out).toContain("· ○ VS Code      no Global band");
+    // A listing proposes nothing — and never renders a failure glyph.
+    expect(out).not.toContain("fix:");
+    expect(out).not.toContain("✗");
+  });
+
+  it("nests the harnesses under the check in the llm format", () => {
+    const out = doctorFormatters.llm(INVENTORY_DATA);
+    expect(out).toContain("### Global");
+    expect(out).toContain(
+      "- ✓ **harnesses**: 1 detected · 1 registered · 3 known",
+    );
+    expect(out).toContain("  - ✓ Claude Code: registered — ~/.claude.json");
+    expect(out).toContain("  - ○ VS Code: no Global band");
+    expect(out).not.toContain("_fix:_");
+  });
+
+  it("round-trips through json with every row intact", () => {
+    const parsed = JSON.parse(
+      doctorFormatters.json(INVENTORY_DATA),
+    ) as DoctorData;
+    expect(parsed).toEqual(INVENTORY_DATA);
+    expect(parsed.checks[0]?.items).toHaveLength(3);
+  });
+});

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
@@ -391,6 +391,59 @@ describe("doctor — the harness inventory", () => {
     expect(vscode?.detail).toContain("registered");
     expect(vscode?.detail).not.toContain("not registered");
   });
+
+  it("reports two harnesses sharing ONE file by their own keys, not by the file", async () => {
+    // The co-detection case. `.vscode/mcp.json` is written under TWO keys —
+    // VS Code's `servers` and Cline's `mcpServers` — and registering pragma
+    // for VS Code alone leaves the FILE half-configured, which `detectMcp`
+    // aggregates to `drifted` (correctly: a write is still owed). That
+    // aggregate is not either harness's standing, and reporting it per harness
+    // said both had a stale entry when one was current and the other had none.
+    const cwd = tmp("pragma-doctor-proj-");
+    mkdirSync(join(cwd, ".vscode"), { recursive: true });
+    // Cline is detected ONLY by its installed extension, in the same directory
+    // that also proves VS Code is installed — so the two co-detect.
+    mkdirSync(
+      join(
+        process.env.HOME as string,
+        ".vscode",
+        "extensions",
+        "saoudrizwan.claude-dev-3.20.0",
+      ),
+      { recursive: true },
+    );
+    writeFileSync(
+      join(
+        process.env.HOME as string,
+        ".vscode",
+        "extensions",
+        "saoudrizwan.claude-dev-3.20.0",
+        "package.json",
+      ),
+      "{}",
+    );
+    // Only VS Code's key is registered; Cline's `mcpServers` is absent.
+    writeFileSync(
+      join(cwd, ".vscode", "mcp.json"),
+      JSON.stringify({
+        servers: { pragma: { command: "pragma", args: ["mcp", "serve"], cwd } },
+      }),
+    );
+
+    const rows = await bandedChecks(bootRuntime(FLAGS, cwd), "pragma");
+    const { project } = inventory(rows);
+    expect(project?.detail).toBe("2 detected · 1 registered");
+
+    const vscode = project?.items?.find((i) => i.label === "VS Code");
+    expect(vscode?.status).toBe("pass");
+    expect(vscode?.detail).toContain("registered — ");
+    expect(vscode?.detail).not.toContain("differs");
+
+    const cline = project?.items?.find((i) => i.label === "Cline");
+    expect(cline?.status).toBe("available");
+    expect(cline?.detail).toContain("detected, not registered");
+    expect(cline?.detail).not.toContain("differs");
+  });
 });
 
 describe("doctor — a blocked skill link path is never reported as current", () => {

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
@@ -120,10 +120,11 @@ const byName = (data: DoctorData, name: string) =>
 describe("doctor — shape & spread", () => {
   it("returns the environment checks plus one row per banded target", async () => {
     const data = await runChecks(bootRuntime(FLAGS, tmp("pragma-proj-")));
-    // Four unbanded environment checks, then the target table in both bands:
-    // all five targets are global, mcp and skills are also project.
-    expect(data.checks).toHaveLength(11);
-    expect(data.passed + data.failed + data.available + data.skipped).toBe(11);
+    // Four unbanded environment checks, then the target table in both bands
+    // (all five targets are global, mcp and skills are also project) = 11,
+    // plus the two `harnesses` inventory rows, one per band = 13.
+    expect(data.checks).toHaveLength(13);
+    expect(data.passed + data.failed + data.available + data.skipped).toBe(13);
     for (const check of data.checks) {
       expect(["pass", "fail", "available", "skip"]).toContain(check.status);
     }
@@ -138,7 +139,9 @@ describe("doctor — shape & spread", () => {
 
     // The banded rows carry the TARGET IDS verbatim — `mcp`, not "MCP
     // configured" — because the row name IS the fix command's argument. The
-    // environment checks stay unbanded.
+    // environment checks stay unbanded. `harnesses` is the ONE banded row that
+    // is not a target: an inventory of the machine, not something to set up, so
+    // it sits last in each band and derives no `fix:`.
     const banded = data.checks.filter((c) => c.band !== undefined);
     expect(banded.map((c) => `${c.band}:${c.name}`)).toEqual([
       "global:config",
@@ -148,6 +151,8 @@ describe("doctor — shape & spread", () => {
       "global:skills",
       "project:mcp",
       "project:skills",
+      "global:harnesses",
+      "project:harnesses",
     ]);
     // Every row that wants action names the exact command that repairs it,
     // band included — the bijection, derived rather than authored.
@@ -155,6 +160,13 @@ describe("doctor — shape & spread", () => {
       if (check.status === "fail" || check.status === "available") {
         expect(check.remedy).toBeDefined();
       }
+    }
+    // The inventory never inflates the failure or the action count: it is only
+    // ever `pass` (this band holds harnesses) or `skip` (it holds none), and it
+    // proposes nothing — the `mcp`/`skills` rows own every harness action.
+    for (const check of banded.filter((c) => c.name === "harnesses")) {
+      expect(["pass", "skip"]).toContain(check.status);
+      expect(check.remedy).toBeUndefined();
     }
     // No harnesses in an empty HOME/cwd, so both mcp rows skip; the project
     // band is opt-in, so its absence is never a fault.
@@ -200,7 +212,7 @@ describe("doctor — the pack-refs check", () => {
 describe("doctor — the store check", () => {
   it("a store that fails to boot is an attributable fail, not a crash", async () => {
     const data = await runChecks(throwingStoreRuntime(tmp("pragma-proj-")));
-    expect(data.checks).toHaveLength(11);
+    expect(data.checks).toHaveLength(13);
     const store = byName(data, "store");
     expect(store?.status).toBe("fail");
     expect(store?.remedy).toBeTruthy();
@@ -242,7 +254,7 @@ describe("doctor — dispatch & MCP", () => {
     const envelope = await mcp.callTool("doctor");
     await mcp.cleanup();
     expect(envelope.ok).toBe(true);
-    expect((envelope.data as DoctorData).checks).toHaveLength(11);
+    expect((envelope.data as DoctorData).checks).toHaveLength(13);
   });
 });
 
@@ -281,6 +293,103 @@ describe("doctor — the banded rows can see the GLOBAL band", () => {
     // ...and the project band stays an opt-in skip, never a fault.
     const project = rows.find((r) => r.name === "mcp" && r.band === "project");
     expect(project?.status).toBe("skip");
+  });
+});
+
+describe("doctor — the harness inventory", () => {
+  const VERBOSE: GlobalFlags = { ...FLAGS, verbose: true };
+  const inventory = (rows: Awaited<ReturnType<typeof bandedChecks>>) => ({
+    global: rows.find((r) => r.name === "harnesses" && r.band === "global"),
+    project: rows.find((r) => r.name === "harnesses" && r.band === "project"),
+  });
+
+  it("lists ONLY detected harnesses by default, by name and with their location", async () => {
+    const cwd = tmp("pragma-doctor-proj-");
+    mkdirSync(join(cwd, ".vscode"), { recursive: true }); // ⇒ VS Code detected
+
+    const rows = await bandedChecks(bootRuntime(FLAGS, cwd), "pragma");
+    const { global, project } = inventory(rows);
+
+    // The project band holds the hit — by NAME, with the file it resolves to.
+    expect(project?.status).toBe("pass");
+    expect(project?.detail).toBe("1 detected · 0 registered");
+    expect(project?.items?.map((i) => i.label)).toEqual(["VS Code"]);
+    expect(project?.items?.[0]?.status).toBe("available");
+    expect(project?.items?.[0]?.detail).toContain("detected, not registered");
+    expect(project?.items?.[0]?.detail).toContain(".vscode/mcp.json");
+
+    // Nothing detected in the global band, and that is a skip — not a fault.
+    expect(global?.status).toBe("skip");
+    expect(global?.detail).toBe("no harnesses detected");
+    expect(global?.items).toBeUndefined();
+  });
+
+  it("--verbose lists every registry harness, undetected ones as a NON-failing skip", async () => {
+    const cwd = tmp("pragma-doctor-proj-");
+    mkdirSync(join(cwd, ".vscode"), { recursive: true });
+
+    const rows = await bandedChecks(bootRuntime(VERBOSE, cwd), "pragma");
+    const { global, project } = inventory(rows);
+
+    // Every harness the registry knows, in both bands.
+    expect(project?.items).toHaveLength(12);
+    expect(global?.items).toHaveLength(12);
+    expect(project?.detail).toBe("1 detected · 0 registered · 12 known");
+
+    // `types.ts` forbids inflating the failure count: a machine that simply
+    // does not have Cursor is not a broken machine.
+    for (const check of [global, project]) {
+      expect(["pass", "skip"]).toContain(check?.status);
+      for (const item of check?.items ?? []) {
+        expect(item.status).not.toBe("fail");
+        expect(["pass", "available", "skip"]).toContain(item.status);
+      }
+    }
+
+    const cursor = project?.items?.find((i) => i.label === "Cursor");
+    expect(cursor?.status).toBe("skip");
+    expect(cursor?.detail).toBe("not detected");
+  });
+
+  it("states 'no <band> band' for a harness that band cannot hold, rather than omitting it", async () => {
+    // `vscode` is `scope: "project"`, so it can NEVER carry a global entry. A
+    // verbose global listing that silently dropped it would read as a bug in
+    // the listing; the row says why instead. The mirror case is Windsurf, which
+    // is `scope: "global"` and so has no project band.
+    const rows = await bandedChecks(
+      bootRuntime(VERBOSE, tmp("pragma-doctor-proj-")),
+      "pragma",
+    );
+    const { global, project } = inventory(rows);
+
+    const vscodeGlobal = global?.items?.find((i) => i.label === "VS Code");
+    expect(vscodeGlobal?.detail).toBe("no Global band");
+    expect(vscodeGlobal?.status).toBe("skip");
+
+    const windsurfProject = project?.items?.find((i) => i.label === "Windsurf");
+    expect(windsurfProject?.detail).toBe("no Project band");
+    expect(windsurfProject?.status).toBe("skip");
+  });
+
+  it("reports a harness whose pragma entry is current as registered", async () => {
+    const cwd = tmp("pragma-doctor-proj-");
+    mkdirSync(join(cwd, ".vscode"), { recursive: true });
+    // Byte-for-byte what a project-band `setup mcp` writes for VS Code: its
+    // `servers` key, and the `cwd` a project registration pins.
+    writeFileSync(
+      join(cwd, ".vscode", "mcp.json"),
+      JSON.stringify({
+        servers: { pragma: { command: "pragma", args: ["mcp", "serve"], cwd } },
+      }),
+    );
+
+    const rows = await bandedChecks(bootRuntime(FLAGS, cwd), "pragma");
+    const { project } = inventory(rows);
+    expect(project?.detail).toBe("1 detected · 1 registered");
+    const vscode = project?.items?.find((i) => i.label === "VS Code");
+    expect(vscode?.status).toBe("pass");
+    expect(vscode?.detail).toContain("registered");
+    expect(vscode?.detail).not.toContain("not registered");
   });
 });
 

--- a/packages/cli/pragma/src/capabilities/doctor/doctor.verb.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.verb.ts
@@ -21,7 +21,11 @@ import type { DoctorData } from "./types.js";
 const doctorVerb: VerbSpec<Record<string, unknown>, DoctorData> = {
   path: ["doctor"],
   summary: "Check environment health and every setup target, in both bands.",
-  doc: "Reports the environment checks and then one row per setup target in each band, as pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Every banded row is named after the setup target that repairs it. Storeless by default; the store check boots lazily and never fails the run.",
+  // Two house rules constrain this string and both are PROTECTED: it may not
+  // name the distribution (`identity.test.ts`) and it may not spell a CLI flag
+  // (`toolDescriptions.test.ts`), so the inventory's widening is described as
+  // "the verbose global flag" rather than by its spelling.
+  doc: "Reports the environment checks and then one row per setup target in each band, as pass, fail, available (an opt-in integration not yet set up), or skip, with inline remedies. Every banded row is named after the setup target that repairs it, except the `harnesses` row: a per-band inventory of the AI harnesses detected on this machine and whether this CLI's MCP server is registered in each — the detected ones only, or every known harness under the verbose global flag. Storeless by default; the store check boots lazily and never fails the run.",
   params: [],
   output: { formatters: doctorFormatters },
   examples: [

--- a/packages/cli/pragma/src/capabilities/doctor/runChecks.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/runChecks.ts
@@ -5,9 +5,12 @@
  * Two kinds of finding live in one report and they are not the same kind. The
  * ENVIRONMENT checks — the Node version, this CLI's own version, pack refs, the
  * store — diagnose things `setup` cannot install; they carry no band and stay
- * their own section. The BANDED rows are exactly the setup targets, in both
- * bands, named with the target ids verbatim and repaired by the target's own
- * command. Adding a target adds its rows here for free.
+ * their own section. The BANDED rows are the setup targets, in both bands,
+ * named with the target ids verbatim and repaired by the target's own command
+ * — plus, per band, the `harnesses` inventory row: a listing of what this
+ * machine holds and where pragma stands in it, which is the thing the targets
+ * are measured against rather than a target itself. Adding a target adds its
+ * rows here for free.
  *
  * Checks are started eagerly (they run concurrently) and collected in
  * declaration order for a deterministic report. Each is guarded so a thrown

--- a/packages/cli/pragma/src/capabilities/setup/operations/index.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/index.ts
@@ -62,6 +62,7 @@ export {
   composeMcpRemoval,
   detectMcp,
   mcpGroupState,
+  mcpWriteState,
   ownedMcpGroups,
   selectedGroups,
 } from "./setupMcp.js";

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
@@ -21,6 +21,7 @@
 
 import { dirname } from "node:path";
 import type {
+  ConfigTarget,
   McpServerConfig,
   PlatformEnv,
   TargetGroup,
@@ -41,15 +42,25 @@ type RemoveMcpConfigFrom =
 /**
  * The detected MCP state: the per-file target groups (already scoped to the
  * requested `--scope`), a by-path map of each group's prior
- * {@link McpTargetState} (read up front), the project root, and the
- * (dynamically imported) target-based writer the pure `composeMcp` needs
- * synchronously. Keeping `groups` a plain {@link TargetGroup}[] leaves every
- * existing `.groups` consumer (path/harnessNames/scope) unchanged; the state
- * rides alongside, keyed by the group's `path`.
+ * {@link McpTargetState} (read up front), the same states at PER-WRITE
+ * resolution, the project root, and the (dynamically imported) target-based
+ * writer the pure `composeMcp` needs synchronously. Keeping `groups` a plain
+ * {@link TargetGroup}[] leaves every existing `.groups` consumer
+ * (path/harnessNames/scope) unchanged; the state rides alongside, keyed by the
+ * group's `path`.
+ *
+ * `stateByPath` is what the WRITE side needs — a file is written unless every
+ * key in it is already current — and it is the aggregate of `stateByWrite`
+ * (see {@link aggregateMcpStates}), so the two can never disagree.
+ * `stateByWrite` is the finer grain a per-HARNESS report needs: two harnesses
+ * sharing one file own two different keys in it, and the file's aggregate is
+ * not either harness's standing.
  */
 export interface McpDetection {
   readonly groups: readonly TargetGroup[];
   readonly stateByPath: ReadonlyMap<string, McpTargetState>;
+  /** Each write's own state, keyed by {@link mcpWriteKey} — see the docblock. */
+  readonly stateByWrite: ReadonlyMap<string, McpTargetState>;
   readonly cwd: string;
   readonly platform: PlatformEnv;
   readonly writeMcpConfigTargets: WriteMcpConfigTargets;
@@ -98,25 +109,30 @@ export function pragmaMcpEntry(cwd: string, band: ScopeBand): McpServerConfig {
 }
 
 /**
- * Classify one target group against its on-disk config: `absent` when no pragma
- * entry exists in ANY of the group's writes, `configured` when EVERY write
- * already carries a matching pragma entry, `drifted` otherwise (present in at
- * least one write but not matching everywhere). Reads each write's file for real
- * via `readMcpConfigFrom`, and matches each raw entry against what THAT write's
+ * Classify ONE write against its on-disk config: `absent` when the file carries
+ * no pragma entry under this write's `mcpKey`, `configured` when the entry
+ * already matches what this write would emit, `drifted` when one is there and
+ * differs. Reads the file for real via `readMcpConfigFrom` (which reads only
+ * this write's key), and matches the raw entry against what THAT write's
  * per-harness serializer would emit for the group's BAND (`mcpEntryMatches`
  * compares the serializer's controlled fields — so a global entry still
  * pinning a `cwd` reads as drifted — and ignores extra keys a harness or user
  * added, so we never churn a file we did not author).
  *
- * @param group - The target group whose writes to inspect.
+ * The write, not the file, is the unit that can be classified honestly: a
+ * shared `.vscode/mcp.json` holds VS Code's `servers` and Cline's `mcpServers`
+ * as two independent entries, and "the file" has no single state when one is
+ * current and the other is missing.
+ *
+ * @param write - The resolved config target to inspect.
  * @param want - The canonical pragma entry for the group's band.
  * @param harnessesApi - The dynamically imported harnesses module.
  * @param runTask - The node Task interpreter.
- * @returns The group's {@link McpTargetState}.
- * @note Impure — reads each write's config file.
+ * @returns This write's {@link McpTargetState}.
+ * @note Impure — reads the write's config file.
  */
-async function classifyGroup(
-  group: TargetGroup,
+async function classifyWrite(
+  write: ConfigTarget,
   want: McpServerConfig,
   harnessesApi: Pick<
     typeof import("@canonical/harnesses"),
@@ -124,21 +140,44 @@ async function classifyGroup(
   >,
   runTask: typeof import("@canonical/task/node").runTask,
 ): Promise<McpTargetState> {
-  let present = 0;
-  let matching = 0;
-  for (const write of group.writes) {
-    const servers = await runTask(harnessesApi.readMcpConfigFrom(write));
-    const existing = servers[MCP_SERVER_NAME];
-    if (existing === undefined) continue;
-    present += 1;
-    if (harnessesApi.mcpEntryMatches(existing, want, write.serializeEntry)) {
-      matching += 1;
-    }
-  }
-  if (present === 0) return "absent";
-  if (matching === group.writes.length) return "configured";
-  return "drifted";
+  const servers = await runTask(harnessesApi.readMcpConfigFrom(write));
+  const existing = servers[MCP_SERVER_NAME];
+  if (existing === undefined) return "absent";
+  return harnessesApi.mcpEntryMatches(existing, want, write.serializeEntry)
+    ? "configured"
+    : "drifted";
 }
+
+/**
+ * The state of a whole FILE, aggregated from its writes: `absent` when no write
+ * carries the entry, `configured` when every write already carries a matching
+ * one, `drifted` otherwise. This is the rule the write side needs — a file is
+ * rewritten unless it is `configured` everywhere — and it is deliberately the
+ * only place the per-write states are collapsed, so nothing else re-derives it.
+ *
+ * @param states - Each write's own state, in the group's write order.
+ * @returns The group's {@link McpTargetState}.
+ */
+const aggregateMcpStates = (
+  states: readonly McpTargetState[],
+): McpTargetState => {
+  if (states.every((state) => state === "absent")) return "absent";
+  if (states.every((state) => state === "configured")) return "configured";
+  return "drifted";
+};
+
+/**
+ * The key one write's state is recorded under: the file it lands in AND the
+ * `mcpKey` it owns there. `(path, mcpKey)` is exactly the write-dedup key
+ * `groupConfigTargets` builds its `writes` from, so the map has one entry per
+ * write and no two harnesses sharing a file can collide. The separator is NUL
+ * because a config path may legally contain everything else.
+ *
+ * @param write - The resolved config target.
+ * @returns Its lookup key in {@link McpDetection.stateByWrite}.
+ */
+const mcpWriteKey = (write: ConfigTarget): string =>
+  `${write.path}\u0000${write.mcpKey}`;
 
 /**
  * Detect the AI harnesses present in the project (real reads, up front),
@@ -180,23 +219,39 @@ export async function detectMcp(
   // and the default selection reflect true prior state — the same discipline
   // `detectSkills` uses for its per-link create/skip/replace decision. The
   // wanted entry is BAND-shaped (a global entry omits `cwd`), so it is built
-  // per group, not once.
+  // per group, not once. Each WRITE is classified and kept; the file's state is
+  // their aggregate, so the coarse view is derived from the fine one rather
+  // than measured separately.
   const stateByPath = new Map<string, McpTargetState>();
+  const stateByWrite = new Map<string, McpTargetState>();
   await Promise.all(
     groups.map(async (group) => {
-      const state = await classifyGroup(
-        group,
-        pragmaMcpEntry(cwd, group.scope),
-        { readMcpConfigFrom, mcpEntryMatches },
-        runTask,
+      const want = pragmaMcpEntry(cwd, group.scope);
+      const classified = await Promise.all(
+        group.writes.map(async (write) => ({
+          write,
+          state: await classifyWrite(
+            write,
+            want,
+            { readMcpConfigFrom, mcpEntryMatches },
+            runTask,
+          ),
+        })),
       );
-      stateByPath.set(group.path, state);
+      for (const { write, state } of classified) {
+        stateByWrite.set(mcpWriteKey(write), state);
+      }
+      stateByPath.set(
+        group.path,
+        aggregateMcpStates(classified.map((c) => c.state)),
+      );
     }),
   );
 
   return {
     groups,
     stateByPath,
+    stateByWrite,
     cwd,
     platform,
     writeMcpConfigTargets,
@@ -210,6 +265,22 @@ export async function detectMcp(
  */
 export function mcpGroupState(d: McpDetection, path: string): McpTargetState {
   return d.stateByPath.get(path) ?? "absent";
+}
+
+/**
+ * The prior state of ONE write — the state of the single harness key it owns,
+ * not of the file it shares. Defaults to `absent` for an unknown write, the
+ * same way {@link mcpGroupState} does for an unknown path.
+ *
+ * @param d - The detection gathered up front.
+ * @param write - One of a group's {@link ConfigTarget} writes.
+ * @returns That write's {@link McpTargetState}.
+ */
+export function mcpWriteState(
+  d: McpDetection,
+  write: ConfigTarget,
+): McpTargetState {
+  return d.stateByWrite.get(mcpWriteKey(write)) ?? "absent";
 }
 
 /** The target groups the user selected (by path), or all when none recorded. */

--- a/packages/runtime/harnesses/README.md
+++ b/packages/runtime/harnesses/README.md
@@ -47,6 +47,8 @@ A `directory`/`file` path is resolved by prefix: `$XDG_CONFIG_HOME/…` against 
 
 A `process` signal is a `PATH` resolution, not a process-table scan: the named binary is tested for existence under every `PATH` directory (and, on win32, every `PATHEXT` suffix — `code.cmd`, not `code.exe`). It never launches anything unless the signal declares a `verify`.
 
+A location that differs by platform is declared as one signal per platform, since any single match detects the harness: VS Code's user directory is `$XDG_CONFIG_HOME/Code/User` on Linux and `~/Library/Application Support/Code/User` on macOS, and the row carries both. (`$XDG_CONFIG_HOME` resolves under `~/.config` on macOS too, by design, so it does *not* cover the second.)
+
 A row should carry both project-relative *and* user-level signals where the harness has them. Project-relative signals alone answer only "does this repo carry a committed config", which misses the common case of an installed editor with the config directory gitignored.
 
 Multiple harnesses can be detected simultaneously — a developer may use both Claude Code and Cursor, and a VS Code install with a Cline extension detects **both** `vscode` and `cline` (they share `.vscode/mcp.json` under two different `mcpKey`s).

--- a/packages/runtime/harnesses/README.md
+++ b/packages/runtime/harnesses/README.md
@@ -37,13 +37,19 @@ Each harness defines detection signals:
 
 | Signal type | Confidence | Example |
 |-------------|------------|---------|
-| `directory` | high | `~/.claude` exists |
+| `directory` | high | `~/.vscode/extensions` exists |
 | `file` | high | `.mcp.json` exists |
 | `extension` | medium | VS Code extension installed |
-| `process` | medium | Running process name |
+| `process` | medium | `code` resolves on `PATH` |
 | `env` | low | Environment variable hint |
 
-Multiple harnesses can be detected simultaneously — a developer may use both Claude Code and Cursor.
+A `directory`/`file` path is resolved by prefix: `$XDG_CONFIG_HOME/…` against the XDG config base, `~/…` against the platform home, **anything else against the project root**. The XDG form is spelled out rather than written `~/.config/…` — a user who sets `$XDG_CONFIG_HOME` keeps nothing under `~/.config`.
+
+A `process` signal is a `PATH` resolution, not a process-table scan: the named binary is tested for existence under every `PATH` directory (and, on win32, every `PATHEXT` suffix — `code.cmd`, not `code.exe`). It never launches anything unless the signal declares a `verify`.
+
+A row should carry both project-relative *and* user-level signals where the harness has them. Project-relative signals alone answer only "does this repo carry a committed config", which misses the common case of an installed editor with the config directory gitignored.
+
+Multiple harnesses can be detected simultaneously — a developer may use both Claude Code and Cursor, and a VS Code install with a Cline extension detects **both** `vscode` and `cline` (they share `.vscode/mcp.json` under two different `mcpKey`s).
 
 ## MCP Configuration
 

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
@@ -271,6 +271,39 @@ describe("detectHarnesses — VS Code installation signals", () => {
     expect(seen).not.toContain("/home/tester/.config/Code/User");
   });
 
+  /**
+   * The macOS host. VS Code keeps its user data under
+   * `~/Library/Application Support` (env-paths' DATA base), which is not where
+   * `$XDG_CONFIG_HOME` resolves on darwin — `xdgConfigHome` falls back to
+   * `~/.config` on every platform, deliberately, because a tool documenting
+   * `~/.config/<tool>` reads that path on macOS too. A default macOS install
+   * also puts no `code` on PATH (the palette's "Install 'code' command in
+   * PATH" is opt-in), and a fresh install has no `~/.vscode/extensions` yet —
+   * so this directory is the only probe that can see such a machine.
+   */
+  const DARWIN: PlatformEnv = {
+    platform: "darwin",
+    env: { PATH: "/usr/bin:/bin" },
+    home: "/Users/tester",
+    isWsl: false,
+  };
+
+  it("detects a macOS install from ~/Library/Application Support alone", () => {
+    const seen: string[] = [];
+    const result = dryRunWith(
+      detectHarnesses("/project", DARWIN),
+      only("/Users/tester/Library/Application Support/Code/User", seen),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["vscode"]);
+    // A config DIRECTORY, so the same `high` tier the linux probe scores.
+    expect(result.value[0]?.confidence).toBe("high");
+    expect(result.value[0]?.configPath).toBe("/project/.vscode/mcp.json");
+    // ...and it is genuinely a SECOND location, not the XDG one under another
+    // name: that probe ran too, and on darwin it looks under `~/.config`.
+    expect(seen).toContain("/Users/tester/.config/Code/User");
+  });
+
   it("detects the extensions directory alone, without Cline", () => {
     const result = dryRunWith(
       detectHarnesses("/project", PLATFORM),

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
@@ -132,7 +132,13 @@ describe("detectHarnesses", () => {
     expect(ids).not.toContain("cline");
   });
 
-  it("detects Cline when its saoudrizwan.claude-dev extension is installed", () => {
+  // AMENDED (was `not.toContain("vscode")`): `~/.vscode/extensions` is now a
+  // VS Code INSTALLATION signal, and it is exactly the directory a Cline
+  // extension lives in — so the two must co-detect. Asserting otherwise
+  // asserted the false negative this pairing exists to rule out. The invariant
+  // that actually matters (a bare `.vscode` PROJECT dir must not detect Cline)
+  // is the test above and is untouched.
+  it("detects BOTH Cline and VS Code from an extension in ~/.vscode/extensions", () => {
     const result = dryRunWith(
       detectHarnesses("/project", PLATFORM),
       new Map<string, (effect: Effect) => unknown>([
@@ -156,8 +162,18 @@ describe("detectHarnesses", () => {
     const cline = result.value.find((d) => d.harness.id === "cline");
     expect(cline).toBeDefined();
     expect(cline?.confidence).toBe("medium");
-    // A bare extension must not drag in VS Code (no `.vscode` dir here).
-    expect(result.value.map((d) => d.harness.id)).not.toContain("vscode");
+
+    const vscode = result.value.find((d) => d.harness.id === "vscode");
+    expect(vscode).toBeDefined();
+    // The extensions DIRECTORY is a `directory` signal, so it scores high.
+    expect(vscode?.confidence).toBe("high");
+
+    // They still group to the ONE file, under their two distinct keys — the
+    // two-level dedup documented on the `cline` row.
+    expect(cline?.configPath).toBe("/project/.vscode/mcp.json");
+    expect(vscode?.configPath).toBe("/project/.vscode/mcp.json");
+    expect(cline?.harness.mcpKey).toBe("mcpServers");
+    expect(vscode?.harness.mcpKey).toBe("servers");
   });
 
   it("reports configExists as false when config file is missing", () => {
@@ -175,5 +191,118 @@ describe("detectHarnesses", () => {
     const result = dryRun(detectHarnesses("/project"));
     expect(result.effects.length).toBeGreaterThan(0);
     expect(Array.isArray(result.value)).toBe(true);
+  });
+});
+
+/**
+ * VS Code installation detection. Each case drives EXACTLY ONE of the row's
+ * five signals so the probes can never be quietly collapsed into an AND: a
+ * machine with the editor installed but no committed `.vscode/` must still be
+ * seen. `dryRunWith` over a `Map` keyed by effect tag is the whole seam — no
+ * colleague's machine required.
+ */
+describe("detectHarnesses — VS Code installation signals", () => {
+  const withPath = (path: string): PlatformEnv => ({
+    ...PLATFORM,
+    env: { ...PLATFORM.env, PATH: path },
+  });
+
+  const only = (
+    wanted: string,
+    seen?: string[],
+  ): Map<string, (effect: Effect) => unknown> =>
+    new Map([
+      [
+        "Exists",
+        (effect: Effect): unknown => {
+          const { path } = effect as Effect & { _tag: "Exists"; path: string };
+          seen?.push(path);
+          return path === wanted;
+        },
+      ],
+    ]);
+
+  it("detects a snap install from /snap/bin/code alone", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", withPath("/usr/bin:/bin:/snap/bin")),
+      only("/snap/bin/code"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["vscode"]);
+    // `code` on PATH means "installed", not "this project uses it".
+    expect(result.value[0]?.confidence).toBe("medium");
+    expect(result.value[0]?.configExists).toBe(false);
+  });
+
+  it("detects a deb install from /usr/bin/code alone", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", PLATFORM),
+      only("/usr/bin/code"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["vscode"]);
+    expect(result.value[0]?.confidence).toBe("medium");
+  });
+
+  it("detects the user config directory alone, at high confidence", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", PLATFORM),
+      only("/home/tester/.config/Code/User"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["vscode"]);
+    expect(result.value[0]?.confidence).toBe("high");
+  });
+
+  it("honours $XDG_CONFIG_HOME and never probes ~/.config for the config dir", () => {
+    const seen: string[] = [];
+    const platform: PlatformEnv = {
+      ...PLATFORM,
+      env: { ...PLATFORM.env, XDG_CONFIG_HOME: "/xdg/config" },
+    };
+    const result = dryRunWith(
+      detectHarnesses("/project", platform),
+      only("/xdg/config/Code/User", seen),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["vscode"]);
+    expect(result.value[0]?.confidence).toBe("high");
+    expect(seen).toContain("/xdg/config/Code/User");
+    expect(seen).not.toContain("/home/tester/.config/Code/User");
+  });
+
+  it("detects the extensions directory alone, without Cline", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", PLATFORM),
+      only("/home/tester/.vscode/extensions"),
+    );
+
+    const ids = result.value.map((d) => d.harness.id);
+    expect(ids).toContain("vscode");
+    // The directory exists but holds no matching extension, so no `Glob` hit.
+    expect(ids).not.toContain("cline");
+    expect(ids).not.toContain("roo-code");
+  });
+
+  /**
+   * The hostile guard. A POPULATED `PATH` and a `Glob` that matches ANY
+   * pattern, but nothing exists on disk ⇒ nothing is detected. This proves the
+   * `process` arm probes the filesystem rather than the PATH string, and that a
+   * permissive glob cannot manufacture an extension hit through the `exists`
+   * gate `checkExtension` puts in front of it.
+   */
+  it("detects nothing from a populated PATH and a permissive glob when nothing exists", () => {
+    const result = dryRunWith(
+      detectHarnesses(
+        "/project",
+        withPath("/usr/bin:/bin:/snap/bin:/usr/local/bin"),
+      ),
+      new Map<string, (effect: Effect) => unknown>([
+        ["Exists", () => false],
+        ["Glob", () => ["anything-1.0.0/package.json"]],
+      ]),
+    );
+
+    expect(result.value).toEqual([]);
   });
 });

--- a/packages/runtime/harnesses/src/lib/harnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.test.ts
@@ -35,6 +35,14 @@ describe("harnesses registry", () => {
     }
   });
 
+  // `TargetGroup` records the sharing harnesses by NAME, not by id, so every
+  // consumer that maps a group back to a registry row (doctor's inventory) is
+  // relying on names being a key. Two rows sharing a name would silently merge.
+  it("ids and display names are both unique", () => {
+    expect(new Set(harnesses.map((h) => h.id)).size).toBe(harnesses.length);
+    expect(new Set(harnesses.map((h) => h.name)).size).toBe(harnesses.length);
+  });
+
   it("declares a valid scope, and global/both harnesses have a home config", () => {
     for (const h of harnesses) {
       expect(h.scope).toMatch(/^(project|global|both)$/);

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -229,9 +229,31 @@ const harnesses: readonly HarnessDefinition[] = [
     name: "VS Code",
     version: "*",
     scope: "project",
+    // The first two signals are PROJECT-relative (`resolveFsPath` resolves an
+    // unprefixed path against `ctx.projectRoot`), so on their own this row can
+    // only see "this repo carries a committed `.vscode/`" — a developer with
+    // VS Code installed and `.vscode/` gitignored, the common case, was
+    // invisible. The three that follow are the user-level and binary probes
+    // every sibling GUI-editor row already has:
+    // - `$XDG_CONFIG_HOME/Code/User` is VS Code's user config dir on Linux. It
+    //   is spelled in XDG form deliberately (see `resolveFsPath`'s docblock): a
+    //   user who sets `$XDG_CONFIG_HOME` keeps nothing under `~/.config`, so a
+    //   `~/.config/Code/User` literal would report the editor absent.
+    // - `~/.vscode/extensions` is present on any install with ≥1 extension, and
+    //   is the same directory `checkExtension` already globs on behalf of Cline
+    //   and Roo Code.
+    // - `code` on PATH covers `/usr/bin/code` (deb), `/snap/bin/code` (the snap
+    //   is CLASSIC confinement, so its home and PATH are the real ones) and
+    //   `code.cmd` on win32 — `executableCandidates` owns those rules.
+    // Tiers fall out of `toSignalTier` correctly: the dirs score `high`, the
+    // process `medium` — right, since `code` on PATH means "installed", not
+    // "this project uses it".
     detect: [
       { type: "directory", path: ".vscode" },
       { type: "file", path: ".vscode/mcp.json" },
+      { type: "directory", path: "$XDG_CONFIG_HOME/Code/User" },
+      { type: "directory", path: "~/.vscode/extensions" },
+      { type: "process", name: "code" },
     ],
     configPath: (root) => `${root}/.vscode/mcp.json`,
     configFormat: "json",

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -233,25 +233,44 @@ const harnesses: readonly HarnessDefinition[] = [
     // unprefixed path against `ctx.projectRoot`), so on their own this row can
     // only see "this repo carries a committed `.vscode/`" — a developer with
     // VS Code installed and `.vscode/` gitignored, the common case, was
-    // invisible. The three that follow are the user-level and binary probes
+    // invisible. The four that follow are the user-level and binary probes
     // every sibling GUI-editor row already has:
     // - `$XDG_CONFIG_HOME/Code/User` is VS Code's user config dir on Linux. It
     //   is spelled in XDG form deliberately (see `resolveFsPath`'s docblock): a
     //   user who sets `$XDG_CONFIG_HOME` keeps nothing under `~/.config`, so a
     //   `~/.config/Code/User` literal would report the editor absent.
-    // - `~/.vscode/extensions` is present on any install with ≥1 extension, and
-    //   is the same directory `checkExtension` already globs on behalf of Cline
-    //   and Roo Code.
+    // - `~/Library/Application Support/Code/User` is the SAME directory on
+    //   macOS, and needs its own row because nothing else here finds it: the
+    //   XDG probe above resolves to `~/.config` on darwin (`xdgConfigHome` is
+    //   platform-independent BY DESIGN — a tool documenting `~/.config/<tool>`
+    //   reads it on macOS too), and a default macOS install puts no `code` on
+    //   PATH until the user runs "Install 'code' command in PATH" from the
+    //   palette. Written as a `~/…` literal rather than through
+    //   `platformPaths`, because VS Code's user dir follows env-paths' DATA
+    //   base on darwin (`~/Library/Application Support`) and the XDG CONFIG
+    //   base on linux — no single helper spans both, and `userConfigBase`'s
+    //   darwin arm (`~/Library/Preferences`) is the wrong one. The literal is
+    //   inert on linux/win32: the path simply never exists there.
+    // - `~/.vscode/extensions` is present on any install with ≥1 extension —
+    //   on macOS as well as linux, it is the same path — and is the directory
+    //   `checkExtension` already globs on behalf of Cline and Roo Code. A
+    //   FRESH install has none, which is exactly the gap the two config-dir
+    //   probes above cover: both are created on first launch.
     // - `code` on PATH covers `/usr/bin/code` (deb), `/snap/bin/code` (the snap
     //   is CLASSIC confinement, so its home and PATH are the real ones) and
     //   `code.cmd` on win32 — `executableCandidates` owns those rules.
     // Tiers fall out of `toSignalTier` correctly: the dirs score `high`, the
     // process `medium` — right, since `code` on PATH means "installed", not
     // "this project uses it".
+    // Win32's user dir (`%APPDATA%\Code\User`) has no row: the signal grammar
+    // expands `~` and `$XDG_CONFIG_HOME` only, so a `~/AppData/Roaming` literal
+    // would silently miss a relocated `%APPDATA%`. It belongs with the rest of
+    // the unvalidated win32 surface in AV-287 (see `platformPaths.ts`).
     detect: [
       { type: "directory", path: ".vscode" },
       { type: "file", path: ".vscode/mcp.json" },
       { type: "directory", path: "$XDG_CONFIG_HOME/Code/User" },
+      { type: "directory", path: "~/Library/Application Support/Code/User" },
       { type: "directory", path: "~/.vscode/extensions" },
       { type: "process", name: "code" },
     ],


### PR DESCRIPTION
## Done

- **`packages/runtime/harnesses/src/lib/harnesses.ts`** — the `vscode` registry row gains user-level and binary signals, so VS Code is detected by *installation* rather than by a committed `.vscode/` directory.
- **New `packages/cli/pragma/src/capabilities/doctor/checks/harnessInventory.ts`** — a harness inventory per band, rolled up from the detection pass `bandedChecks` already runs.
- **Doctor check count: 11 → 13**, updated at the four hard-coded assertions.
- **`detectHarnesses.test.ts` — one test amended, not restored** (it encoded the bug as the expectation); new cases added, each driving exactly one signal, plus a hostile false-positive guard.
- **Drive-bys** — corrected the `process` signal's description in the harnesses README; de-pinned the stale "nine health checks" claim in `docs/setup.md` and `docs/getting-started.md`.

### Why

A colleague on Ubuntu had VS Code installed and `pragma setup mcp` did not offer it. The reported suspicion was snap packaging. It wasn't — it fails identically on deb, flatpak and macOS.

**The `vscode` registry row declared only two signals, both project-relative:** `.vscode` and `.vscode/mcp.json`. Since `resolveFsPath` treats an unprefixed path as relative to the project root, the only question the detector could ever ask about VS Code was *"does this repo carry a committed `.vscode/` directory?"* Any developer who gitignores it is invisible.

It is the only GUI-editor row in the registry with **neither** a binary probe **nor** any user-level probe — every sibling (Claude Code, Cursor, Codex, Gemini, Copilot, Windsurf, …) has at least one. The irony: `checkExtension` already globs `~/.vscode/extensions`, but only on behalf of Cline and Roo Code. VS Code detection was a strict subset of machinery already running for its own extensions.

### What changed

**`harnesses.ts` — one row, data only.** Added `$XDG_CONFIG_HOME/Code/User`, `~/.vscode/extensions`, and `{process "code"}`. No new signal type, no new helper, no shared `code`-on-PATH detector (`detectLsp` untouched — it belongs to another change). Still 12 harnesses. Confidence tiers fall out of the existing `toSignalTier`: directories score high, `process` scores medium, which is right — `code` on PATH means *installed*, not *this project uses it*.

Because `doctor` and `setup` consume the same `detectHarnesses`, this fixes three surfaces with zero CLI code.

**New `doctor/checks/harnessInventory.ts` — a harness inventory per band.** Rolled up from the *same* detection pass `bandedChecks` already runs, against the registry (which supplies the universe `detectHarnesses` cannot, since it filters to hits). Detected-only by default; `--verbose` lists all 12 via the existing `rt.globalFlags.verbose`. Undetected renders as `skip`, never `fail`. Rendering needed nothing new — `formatCheckPlain`'s existing `items` primitive, with llm and json for free.

Band membership uses `isHarnessInBand`, so `vscode` in the Global section reads **"no Global band"** rather than silently vanishing (mirror: Windsurf, "no Project band"). States name the *pragma-entry* meaning — `registered` / `drifted` / `detected` / `undetected` / `unbanded`. `configExists` is deliberately never surfaced under an "installed" heading, because it means "the harness's own config file exists", not "we are registered in it".

**Doctor check count: 11 → 13** (one inventory row per band). Updated deliberately at the four hard-coded assertions.

### ⚠️ One test was amended, not restored

`detectHarnesses.test.ts:135-161` mocked `~/.vscode/extensions` as present and asserted VS Code was **not** detected — the test encoded the bug as the expectation. It now asserts the correct Cline↔VS Code pairing (both detected, one config file, two `mcpKey`s). The invariant it was actually protecting — a bare project `.vscode/` must not detect Cline (`:124-133`) — is byte-identical.

New cases each drive exactly one signal (snap, deb, config dir, `$XDG_CONFIG_HOME` honoured, extensions-dir-without-Cline), plus a **hostile false-positive guard**: populated `PATH`, a `Glob` mock matching anything, `Exists` false everywhere ⇒ empty result. That proves the `process` signal cannot fire on PATH-string presence alone.

### Honest scope limits

- **This does not fix the colleague's default command.** `vscode` is still `scope: "project"`, and setup defaults to the global band, so the row only materialises under `--local`/`--scope both`. Making it visible by default needs `scope: "both"` + a `homeConfigPath`, which starts *writing* to a new location and needs the per-platform user-dir question settled. Deliberately deferred.
- **Setup is not yet wired to the inventory helper.** The classifier is pure and consumer-agnostic, but adopting it lands in `targets.ts` / `plan.render.ts` / `setupGenerator.ts` — files another change owns. Adopting it later is a rename plus a call.
- **Expect a visible delta**: `code` is near-universal on a dev box, so `--scope project` will now propose creating `.vscode/mcp.json` in most repos. Intended, but new.
- The MCP `doctor` tool always gets the detected-only view, since `buildServer.ts` hard-codes `verbose: false`.

### Drive-bys

The harnesses README documented the `process` signal as "Running process name". It resolves against `PATH` and scans no process table; corrected. Both `docs/setup.md` and `docs/getting-started.md` claimed "nine health checks" (already wrong at 11) — de-pinned rather than re-pinned to a number that will drift again.

## QA

Run from the repo root unless stated otherwise.

1. **Harnesses suite** — `cd packages/runtime/harnesses && bun run test`
   Expected: 16 files, **255 passed**, 100% coverage.
2. **CLI suite** — `cd packages/cli/pragma && bun run test`
   Expected: 131 files, **1485 passed**, 0 failed. All four PROTECTED guards green (`lazy`, `reference`, `identity`, `toolDescriptions`).
3. **Reference docs in sync** — `cd packages/cli/pragma && bun run gen:reference`
   Expected: no diff.
4. **Repo-wide check** — `bun run check`
   Expected: green across 62 projects.
5. **Detection, by hand** — on a box with VS Code installed but no committed `.vscode/`, run `pragma doctor --verbose` and confirm `vscode` appears in the harness inventory; in the Global section it should read **"no Global band"** rather than being absent.
6. **Setup surface** — `pragma setup mcp --scope project --dry-run` should now offer `.vscode/mcp.json`. This is the intended new behaviour, not a regression.

**Pre-existing flakiness, verified not a regression:** at default parallelism a few `create` tests time out and `test:perf` blows its budget. Stashing these changes and re-running at `0d76ed87b` reproduces it *worse* (4 failures; `--help` 387ms vs 167ms here). Environmental contention. Note a timed-out `create` test leaves `src/lib/Button/` behind because its `process.chdir` restore never runs, which then breaks the next build.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`. — `Feature 🎁` applied.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`: — verified on this branch for every touched package (`cli/pragma`, `runtime/harnesses`, `runtime/ke-graphql`, `summon/component`, `summon/package`).
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: … — **n/a**, no new package is introduced.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic. — CLI and detection-data only, no rendered component changes; label applied.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
