### PR TITLE
fix(ci): guard against workspace sibling ranges the sibling has outgrown

### DIFF
--- a/.github/actions/lerna-version/action.yml
+++ b/.github/actions/lerna-version/action.yml
@@ -62,6 +62,26 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/refresh-pack.sh "${{ inputs.packs_token }}"
 
+      # LAST GATE BEFORE THE BUMP BECOMES PERMANENT. Everything above has
+      # rewritten versions and ranges in the working tree; nothing has been
+      # committed, tagged, pushed or published yet. This is the only moment at
+      # which a bad bump can still be stopped for free.
+      #
+      # The v0.35.0 bump (5198c5399) moved every package to 0.35.0 and rewrote
+      # sibling ranges in `dependencies` and `devDependencies` but not in
+      # `peerDependencies`, leaving `^0.34.0` ranges that 0.35.0 cannot satisfy
+      # — for a 0.x version the caret pins the MINOR. Bun then stopped linking
+      # those workspace siblings and silently substituted published copies, and
+      # main was red from the moment the bump landed.
+      #
+      # The `check` and `test` jobs in tag.yml cannot catch this: they run
+      # BEFORE this action, on the pre-bump tree, where every range is still
+      # correct. Nor can pr.yml — this commit is pushed straight to main by
+      # git-commit.sh below and never sees a pull request.
+    - name: Verify the bump left every workspace sibling range satisfiable
+      shell: bash
+      run: bun run check:ranges
+
     - name: Setup Git CLI
       uses: ./.github/actions/setup-git
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -91,6 +91,43 @@ jobs:
       - name: Check implementation graph data is up to date
         run: bun run collect:check
 
+    # A workspace package must never declare a range on a workspace sibling
+    # that the sibling's current version cannot satisfy: Bun then declines to
+    # link the in-tree copy and silently substitutes a published one from the
+    # registry, and the build dies far from the cause (v0.35.0 bump, 5198c5399).
+    #
+    # This is a sibling of `implementation-data` rather than a step inside it,
+    # for two reasons. It reads package.json manifests and nothing else — no
+    # install, no node_modules, no build — so bolting it onto a job that first
+    # spends ~60-90s in `bun install` would delay the repo's cheapest signal
+    # and make it contingent on the very dependency resolution this class of
+    # bug corrupts. And a failure needs to surface under a check named for what
+    # actually broke; reporting a stale range under "Implementation graph
+    # freshness" is exactly the 2am misdirection the guard exists to avoid.
+    # No new workflow file: it shares pr.yml with the job it is modelled on.
+  workspace-ranges:
+    name: Workspace sibling version ranges
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: '1.3.9'
+
+        # Runs first: a guard whose failing case no longer fails is worse than
+        # no guard, and this suite constructs the exact ^0.34.0-vs-0.35.0 case
+        # and asserts it is reported.
+      - name: Test the guard
+        run: bun run check:ranges:test
+
+      - name: Check workspace sibling version ranges
+        run: bun run check:ranges
+
   build-gate:
     runs-on: ubuntu-latest
     needs: build-matrix

--- a/bun.lock
+++ b/bun.lock
@@ -792,15 +792,15 @@
       "name": "@canonical/i18n-react",
       "version": "0.35.0",
       "dependencies": {
-        "@canonical/i18n-core": "^0.34.0",
+        "@canonical/i18n-core": "^0.35.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/typescript-config-react": "^0.34.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.35.0",
+        "@canonical/typescript-config-react": "^0.35.0",
+        "@canonical/webarchitect": "^0.35.0",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26.0.0",
@@ -986,8 +986,8 @@
       "version": "0.35.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.9",
-        "@canonical/biome-config": "^0.27.1-experimental.0",
-        "@canonical/webarchitect": "^0.27.1-experimental.0",
+        "@canonical/biome-config": "^0.35.0",
+        "@canonical/webarchitect": "^0.35.0",
         "@types/node": "^26.0.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
@@ -4625,14 +4625,6 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@bundled-es-modules/glob/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
-    "@canonical/i18n-core/@canonical/biome-config": ["@canonical/biome-config@0.27.1-experimental.0", "", { "peerDependencies": { "@biomejs/biome": "2.4.9" } }, "sha512-r52b1lLhfqYU39azYqnIVI0eNgWSTUloQq4INoIokIPXQbh/qypSP5fDXGb5CSF/1789M4c6F1AGdr7SFlunog=="],
-
-    "@canonical/i18n-core/@canonical/webarchitect": ["@canonical/webarchitect@0.27.1-experimental.0", "", { "dependencies": { "ajv": "^8.18.0", "chalk": "^5.6.2", "commander": "^14.0.3" }, "bin": { "webarchitect": "src/cli.ts" } }, "sha512-WLJZMrGzfURGRvTbUGkGf/sBlQL9W23EAuIMxuYe4AkH5oJ8yonmFEeC9UwrAELwAcdFsdq1PFHdt8ocSsXw5Q=="],
-
-    "@canonical/i18n-react/@canonical/biome-config": ["@canonical/biome-config@0.27.1-experimental.0", "", { "peerDependencies": { "@biomejs/biome": "2.4.9" } }, "sha512-r52b1lLhfqYU39azYqnIVI0eNgWSTUloQq4INoIokIPXQbh/qypSP5fDXGb5CSF/1789M4c6F1AGdr7SFlunog=="],
-
-    "@canonical/i18n-react/@canonical/webarchitect": ["@canonical/webarchitect@0.27.1-experimental.0", "", { "dependencies": { "ajv": "^8.18.0", "chalk": "^5.6.2", "commander": "^14.0.3" }, "bin": { "webarchitect": "src/cli.ts" } }, "sha512-WLJZMrGzfURGRvTbUGkGf/sBlQL9W23EAuIMxuYe4AkH5oJ8yonmFEeC9UwrAELwAcdFsdq1PFHdt8ocSsXw5Q=="],
 
     "@canonical/react-boilerplate-vite/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "scripts": {
     "collect": "bun scripts/collect-implementations.ts",
     "collect:check": "bun run collect && git diff --exit-code -- data/",
+    "check:ranges": "bun scripts/check-workspace-ranges.ts",
+    "check:ranges:test": "bun test scripts/check-workspace-ranges.test.ts",
     "build": "lerna run build",
     "prepare": "bun run build",
     "lerna": "lerna",

--- a/packages/react/i18n/package.json
+++ b/packages/react/i18n/package.json
@@ -51,9 +51,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.9",
-    "@canonical/biome-config": "^0.27.1-experimental.0",
+    "@canonical/biome-config": "^0.35.0",
     "@canonical/typescript-config-react": "^0.35.0",
-    "@canonical/webarchitect": "^0.27.1-experimental.0",
+    "@canonical/webarchitect": "^0.35.0",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.0.0",

--- a/packages/runtime/i18n/package.json
+++ b/packages/runtime/i18n/package.json
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.9",
-    "@canonical/biome-config": "^0.27.1-experimental.0",
-    "@canonical/webarchitect": "^0.27.1-experimental.0",
+    "@canonical/biome-config": "^0.35.0",
+    "@canonical/webarchitect": "^0.35.0",
     "@types/node": "^26.0.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"

--- a/scripts/check-workspace-ranges.test.ts
+++ b/scripts/check-workspace-ranges.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	DEPENDENCY_FIELDS,
+	type DependencyField,
+	type WorkspacePackage,
+	findViolations,
+	loadWorkspacePackages,
+	satisfies,
+} from "./check-workspace-ranges";
+
+/** Build a minimal workspace package manifest for the pure core. */
+function pkg(
+	name: string,
+	version: string,
+	deps: Partial<Record<DependencyField, Record<string, string>>> = {},
+): WorkspacePackage {
+	return { file: `packages/${name}/package.json`, name, version, deps };
+}
+
+describe("the regression that broke main", () => {
+	// This is the exact shape of packages/summon/component/package.json after
+	// commit 5198c5399: the package moved to 0.35.0, the sibling moved to
+	// 0.35.0, and the peerDependencies range stayed at ^0.34.0.
+	const workspace = [
+		pkg("@canonical/summon-component", "0.35.0", {
+			dependencies: { "@canonical/utils": "^0.35.0" },
+			peerDependencies: { "@canonical/summon-core": "^0.34.0" },
+		}),
+		pkg("@canonical/summon-core", "0.35.0"),
+		pkg("@canonical/utils", "0.35.0"),
+	];
+
+	test("^0.34.0 against a 0.35.0 sibling is reported", () => {
+		const violations = findViolations(workspace);
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0]).toMatchObject({
+			file: "packages/@canonical/summon-component/package.json",
+			field: "peerDependencies",
+			from: "@canonical/summon-component",
+			sibling: "@canonical/summon-core",
+			range: "^0.34.0",
+			actual: "0.35.0",
+		});
+	});
+
+	test("bumping the range to ^0.35.0 clears it", () => {
+		const fixed = structuredClone(workspace);
+		// biome-ignore lint/style/noNonNullAssertion: constructed above
+		fixed[0].deps.peerDependencies!["@canonical/summon-core"] = "^0.35.0";
+
+		expect(findViolations(fixed)).toEqual([]);
+	});
+
+	test("0.35.0 really does not satisfy ^0.34.0 (the 0.x caret trap)", () => {
+		// Below 1.0.0 the caret pins the MINOR, not the major. This single fact
+		// is the whole bug: at ^1.34.0 the same bump would have been harmless.
+		expect(satisfies("0.35.0", "^0.34.0")).toBe(false);
+		expect(satisfies("1.35.0", "^1.34.0")).toBe(true);
+	});
+});
+
+describe("field-agnosticism", () => {
+	// The bump forgot peerDependencies. The next tool will forget a different
+	// field, so the guard must not privilege any of them.
+	for (const field of DEPENDENCY_FIELDS) {
+		test(`a stale range in ${field} is caught`, () => {
+			const violations = findViolations([
+				pkg("a", "1.0.0", { [field]: { b: "^0.34.0" } }),
+				pkg("b", "0.35.0"),
+			]);
+
+			expect(violations).toHaveLength(1);
+			expect(violations[0].field).toBe(field);
+		});
+	}
+});
+
+describe("scope", () => {
+	test("external dependencies are ignored, however stale they look", () => {
+		expect(
+			findViolations([pkg("a", "1.0.0", { dependencies: { typescript: "^4.0.0" } })]),
+		).toEqual([]);
+	});
+
+	test("a satisfied range is not reported, whatever its form", () => {
+		const workspace = [
+			pkg("a", "1.0.0", {
+				dependencies: {
+					caret: "^0.35.0",
+					tilde: "~0.35.0",
+					compound: ">=0.34.0 <1.0.0",
+					open: ">=0.18.0",
+					exact: "0.35.0",
+					star: "*",
+					alternation: "^0.30.0 || ^0.35.0",
+				},
+			}),
+			pkg("caret", "0.35.0"),
+			pkg("tilde", "0.35.1"),
+			pkg("compound", "0.35.0"),
+			pkg("open", "0.35.0"),
+			pkg("exact", "0.35.0"),
+			pkg("star", "0.35.0"),
+			pkg("alternation", "0.35.0"),
+		];
+
+		expect(findViolations(workspace)).toEqual([]);
+	});
+
+	test("workspace: protocol is satisfied by construction", () => {
+		expect(
+			findViolations([
+				pkg("a", "1.0.0", { dependencies: { b: "workspace:*" } }),
+				pkg("b", "0.35.0"),
+			]),
+		).toEqual([]);
+	});
+
+	test("but workspace: with a real range is still checked", () => {
+		// `workspace:^0.34.0` carries a range that can go stale exactly like a
+		// bare one, so the prefix must not be a free pass.
+		const violations = findViolations([
+			pkg("a", "1.0.0", { dependencies: { b: "workspace:^0.34.0" } }),
+			pkg("b", "0.35.0"),
+		]);
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0].range).toBe("workspace:^0.34.0");
+	});
+
+	test("an exact pin that has drifted is caught", () => {
+		const violations = findViolations([
+			pkg("a", "1.0.0", { dependencies: { b: "0.34.0" } }),
+			pkg("b", "0.35.0"),
+		]);
+
+		expect(violations).toHaveLength(1);
+	});
+});
+
+describe("prerelease handling", () => {
+	test("a prerelease caret does not float to a later release", () => {
+		// ^0.27.1-experimental.0 is >=0.27.1-experimental.0 <0.28.0.
+		expect(satisfies("0.35.0", "^0.27.1-experimental.0")).toBe(false);
+		expect(satisfies("0.27.1", "^0.27.1-experimental.0")).toBe(true);
+	});
+
+	test("a prerelease sibling version only satisfies an opted-in range", () => {
+		expect(satisfies("0.36.0-alpha.1", "^0.35.0")).toBe(false);
+		expect(satisfies("0.35.1-alpha.1", "^0.35.1-alpha.0")).toBe(true);
+	});
+});
+
+describe("failing loudly instead of silently", () => {
+	test("an unmodelled range form is reported, not waved through", () => {
+		// A guard that quietly passes what it cannot parse is the green-that-
+		// proves-nothing this exists to prevent.
+		const violations = findViolations([
+			pkg("a", "1.0.0", { dependencies: { b: "1.2.3 - 2.3.4" } }),
+			pkg("b", "0.35.0"),
+		]);
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0].unparseable).toBe(true);
+	});
+});
+
+describe("against the real repository", () => {
+	test("enumerates packages from the root workspace globs", async () => {
+		const packages = await loadWorkspacePackages(`${import.meta.dir}/..`);
+
+		// Guards against the enumeration silently resolving an empty set and
+		// vacuously passing — the exact shape of the #901 incident.
+		expect(packages.length).toBeGreaterThan(20);
+		expect(packages.map((p) => p.name)).toContain("@canonical/summon-component");
+		for (const p of packages) expect(p.file).not.toContain("node_modules");
+	});
+
+	test("every workspace sibling range in this tree is satisfiable", async () => {
+		const packages = await loadWorkspacePackages(`${import.meta.dir}/..`);
+		const violations = findViolations(packages);
+
+		expect(
+			violations.map((v) => `${v.file} ${v.field}.${v.sibling} = ${v.range} (actual ${v.actual})`),
+		).toEqual([]);
+	});
+});

--- a/scripts/check-workspace-ranges.test.ts
+++ b/scripts/check-workspace-ranges.test.ts
@@ -61,6 +61,30 @@ describe("the regression that broke main", () => {
 	});
 });
 
+describe("caret semantics from 1.0.0 up", () => {
+	// The 0.x trap above is one half of the caret; this is the other. Getting
+	// this half wrong would make the guard reject legitimate 1.x sibling
+	// ranges, and it runs inside lerna-version — a false positive here blocks
+	// the release rather than letting a bad one through.
+	test("^1.2.3 is >=1.2.3 <2.0.0", () => {
+		expect(satisfies("1.2.3", "^1.2.3")).toBe(true);
+		expect(satisfies("1.2.2", "^1.2.3")).toBe(false);
+		expect(satisfies("1.99.99", "^1.2.3")).toBe(true);
+		expect(satisfies("2.0.0", "^1.2.3")).toBe(false);
+	});
+
+	test("a 1.x sibling a minor ahead of its caret range is not a violation", () => {
+		// The exact shape of the 5198c5399 bump, had the packages been at 1.x:
+		// everything moves to 1.35.0 and the stale ^1.34.0 still admits it.
+		expect(
+			findViolations([
+				pkg("a", "1.35.0", { peerDependencies: { b: "^1.34.0" } }),
+				pkg("b", "1.35.0"),
+			]),
+		).toEqual([]);
+	});
+});
+
 describe("field-agnosticism", () => {
 	// The bump forgot peerDependencies. The next tool will forget a different
 	// field, so the guard must not privilege any of them.

--- a/scripts/check-workspace-ranges.test.ts
+++ b/scripts/check-workspace-ranges.test.ts
@@ -151,6 +151,33 @@ describe("prerelease handling", () => {
 		expect(satisfies("0.36.0-alpha.1", "^0.35.0")).toBe(false);
 		expect(satisfies("0.35.1-alpha.1", "^0.35.1-alpha.0")).toBe(true);
 	});
+
+	test("does not false-positive on the experimental release flow", () => {
+		// tag.yml defaults release_type to "experimental", and the guard now
+		// gates that release before it commits. A false positive here would
+		// block every pre-release, so pin the shapes lerna actually produces.
+		expect(satisfies("0.36.0-experimental.0", "^0.36.0-experimental.0")).toBe(true);
+		expect(satisfies("0.36.0-experimental.1", "^0.36.0-experimental.0")).toBe(true);
+		expect(satisfies("0.36.0", "^0.36.0-experimental.0")).toBe(true);
+		expect(satisfies("0.36.0-rc.1", "^0.36.0-rc.0")).toBe(true);
+		// ...but a different pre-release line is still out of range.
+		expect(satisfies("0.36.0-alpha.0", "^0.36.0-experimental.0")).toBe(false);
+	});
+
+	test("a whole-workspace experimental bump is clean", () => {
+		// The shape of a `release_type: experimental` bump: every package and
+		// every sibling range moves together.
+		expect(
+			findViolations([
+				pkg("a", "0.36.0-experimental.0", {
+					peerDependencies: { b: "^0.36.0-experimental.0" },
+					dependencies: { c: "^0.36.0-experimental.0" },
+				}),
+				pkg("b", "0.36.0-experimental.0"),
+				pkg("c", "0.36.0-experimental.0"),
+			]),
+		).toEqual([]);
+	});
 });
 
 describe("failing loudly instead of silently", () => {

--- a/scripts/check-workspace-ranges.ts
+++ b/scripts/check-workspace-ranges.ts
@@ -1,0 +1,504 @@
+#!/usr/bin/env bun
+/**
+ * Workspace sibling range guard
+ *
+ * Fails when any workspace package declares a dependency range on another
+ * workspace package that the sibling's CURRENT in-tree version does not
+ * satisfy.
+ *
+ * Why this exists
+ * ---------------
+ * The v0.35.0 version bump (5198c5399) moved every package to 0.35.0 and
+ * rewrote every `dependencies` / `devDependencies` range from ^0.34.0 to
+ * ^0.35.0 — but left `peerDependencies` untouched. For a 0.x version
+ * `^0.34.0` means `>=0.34.0 <0.35.0`, so 0.35.0 no longer satisfied it. Bun
+ * then declined to link the workspace sibling and silently installed a
+ * *published* copy from the registry into a nested node_modules instead. The
+ * build died on `Cannot find module '@canonical/summon-core'` and main stayed
+ * red.
+ *
+ * The class is "a manifest points at a sibling by a range the sibling has
+ * outgrown". It is not specific to peerDependencies, and not specific to
+ * Lerna: a hand edit or a different release tool produces the identical
+ * breakage. So this guard is field-agnostic (all four dependency fields) and
+ * tool-agnostic (it reads the manifests, not the tool's configuration), and
+ * it enumerates packages from the root workspace globs rather than a list —
+ * a hardcoded list of packages would be the same omission one level up.
+ *
+ * What it deliberately does NOT do
+ * --------------------------------
+ * - It says nothing about external (non-workspace) dependencies.
+ * - It does not police WHICH range you use — `*`, `>=0.18.0` and `^0.35.0`
+ *   are all fine as long as the sibling's version satisfies them.
+ * - It does not read bun.lock or node_modules; it is a pure function of the
+ *   manifests, so it needs no install and cannot be confused by a stale one.
+ *
+ * Usage:
+ *   bun scripts/check-workspace-ranges.ts            # check the repo, exit 1 on violations
+ *   bun scripts/check-workspace-ranges.ts --help
+ */
+
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+// -------------------------------------------------------------------
+// Types
+// -------------------------------------------------------------------
+
+/** The four manifest fields that can carry a range pointing at a sibling. */
+export const DEPENDENCY_FIELDS = [
+	"dependencies",
+	"devDependencies",
+	"peerDependencies",
+	"optionalDependencies",
+] as const;
+
+export type DependencyField = (typeof DEPENDENCY_FIELDS)[number];
+
+export interface WorkspacePackage {
+	/** Repo-relative path to the package.json, for error messages. */
+	file: string;
+	name: string;
+	version: string;
+	deps: Partial<Record<DependencyField, Record<string, string>>>;
+}
+
+export interface Violation {
+	file: string;
+	field: DependencyField;
+	/** The package declaring the range. */
+	from: string;
+	/** The workspace sibling being pointed at. */
+	sibling: string;
+	range: string;
+	/** The sibling's actual in-tree version. */
+	actual: string;
+	/** Set when the range form itself could not be understood. */
+	unparseable?: boolean;
+}
+
+// -------------------------------------------------------------------
+// Semver: a deliberately small comparator
+// -------------------------------------------------------------------
+//
+// `semver` is only available here transitively, and pulling a direct
+// dependency into the root of a monorepo to answer "does 0.35.0 satisfy
+// ^0.34.0" is a worse trade than fifty commented lines. The subset below
+// covers every range form in use in this repo (surveyed across all 62
+// workspace packages): `^x.y.z`, `~x.y.z`, `>=x.y.z <a.b.c`, `>=x.y.z`,
+// exact pins, `*`, prerelease-tagged carets such as `^0.27.1-experimental.0`,
+// and `||` alternation. Anything outside that subset is reported rather than
+// waved through — see `parseRange`.
+
+interface SemVer {
+	major: number;
+	minor: number;
+	patch: number;
+	/** Dot-separated prerelease identifiers; empty for a release version. */
+	pre: string[];
+}
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function parseVersion(input: string): SemVer | null {
+	const m = VERSION_RE.exec(input.trim());
+	if (!m) return null;
+	return {
+		major: Number(m[1]),
+		minor: Number(m[2]),
+		patch: Number(m[3]),
+		pre: m[4] ? m[4].split(".") : [],
+	};
+}
+
+/** Standard semver precedence, prerelease identifiers included. */
+export function compareVersions(a: SemVer, b: SemVer): number {
+	if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+	if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+	if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+
+	// A version with a prerelease has LOWER precedence than one without.
+	if (a.pre.length === 0 && b.pre.length === 0) return 0;
+	if (a.pre.length === 0) return 1;
+	if (b.pre.length === 0) return -1;
+
+	for (let i = 0; i < Math.max(a.pre.length, b.pre.length); i++) {
+		const x = a.pre[i];
+		const y = b.pre[i];
+		// A shorter set of identifiers sorts lower when all preceding are equal.
+		if (x === undefined) return -1;
+		if (y === undefined) return 1;
+		if (x === y) continue;
+		const xn = /^\d+$/.test(x);
+		const yn = /^\d+$/.test(y);
+		// Numeric identifiers always compare lower than alphanumeric ones.
+		if (xn && yn) return Number(x) < Number(y) ? -1 : 1;
+		if (xn) return -1;
+		if (yn) return 1;
+		return x < y ? -1 : 1;
+	}
+	return 0;
+}
+
+type Op = "<" | "<=" | ">" | ">=" | "=";
+
+interface Comparator {
+	op: Op;
+	version: SemVer;
+}
+
+const COMPARATOR_RE = /^(<=|>=|<|>|=|)\s*v?(.+)$/;
+
+/**
+ * Expand `^` / `~` into an explicit `>= <` pair.
+ *
+ * Caret is the one that bit us: below 1.0.0 the caret does NOT float the
+ * minor, so `^0.34.0` is `>=0.34.0 <0.35.0` and a 0.35.0 sibling falls
+ * outside it. Above 1.0.0 it would have been `>=0.34.0 <1.0.0` and nobody
+ * would have noticed.
+ */
+function expandRangeOperator(prefix: "^" | "~", v: SemVer): Comparator[] {
+	const lower: Comparator = { op: ">=", version: v };
+	let upper: SemVer;
+	if (prefix === "~") {
+		// ~1.2.3 -> <1.3.0 ; ~0.2.3 -> <0.3.0
+		upper = { major: v.major, minor: v.minor + 1, patch: 0, pre: [] };
+	} else if (v.major > 0) {
+		// ^1.2.3 -> <2.0.0
+		upper = { major: v.major + 1, minor: 0, patch: 0, pre: [] };
+	} else if (v.minor > 0) {
+		// ^0.2.3 -> <0.3.0   (the 0.x case that broke main)
+		upper = { major: 0, minor: v.minor + 1, patch: 0, pre: [] };
+	} else {
+		// ^0.0.3 -> <0.0.4
+		upper = { major: 0, minor: 0, patch: v.patch + 1, pre: [] };
+	}
+	return [lower, { op: "<", version: upper }];
+}
+
+/**
+ * Parse a range into a disjunction (`||`) of conjunctions (space-separated).
+ * Returns null when any part is a form this guard does not model — the caller
+ * reports that rather than assuming it passes.
+ */
+export function parseRange(range: string): Comparator[][] | null {
+	const alternatives: Comparator[][] = [];
+	for (const alt of range.split("||")) {
+		const set: Comparator[] = [];
+		const parts = alt.trim().split(/\s+/).filter(Boolean);
+		// A bare `*` / `x` / empty range matches anything: an empty conjunction.
+		if (parts.length === 0 || (parts.length === 1 && /^[*xX]$/.test(parts[0]))) {
+			alternatives.push([]);
+			continue;
+		}
+		for (const part of parts) {
+			if (part === "-") return null; // hyphen ranges: not modelled
+			if (part.startsWith("^") || part.startsWith("~")) {
+				const v = parseVersion(part.slice(1));
+				if (!v) return null;
+				set.push(...expandRangeOperator(part[0] as "^" | "~", v));
+				continue;
+			}
+			const m = COMPARATOR_RE.exec(part);
+			if (!m) return null;
+			const v = parseVersion(m[2]);
+			if (!v) return null;
+			set.push({ op: (m[1] || "=") as Op, version: v });
+		}
+		alternatives.push(set);
+	}
+	return alternatives;
+}
+
+function satisfiesComparator(v: SemVer, c: Comparator): boolean {
+	const cmp = compareVersions(v, c.version);
+	switch (c.op) {
+		case "<":
+			return cmp < 0;
+		case "<=":
+			return cmp <= 0;
+		case ">":
+			return cmp > 0;
+		case ">=":
+			return cmp >= 0;
+		default:
+			return cmp === 0;
+	}
+}
+
+/**
+ * Does `version` satisfy `range`?
+ *
+ * Returns null when the range form is not modelled, so callers can report
+ * "I do not understand this" instead of silently passing it.
+ */
+export function satisfies(version: string, range: string): boolean | null {
+	const v = parseVersion(version);
+	if (!v) return null;
+	const alternatives = parseRange(range);
+	if (!alternatives) return null;
+
+	for (const set of alternatives) {
+		if (!set.every((c) => satisfiesComparator(v, c))) continue;
+		// npm rule: a prerelease version only satisfies a comparator set that
+		// mentions a prerelease at the same [major, minor, patch]. Otherwise
+		// `>=0.1.0` would quietly match `0.2.0-alpha.1`.
+		if (v.pre.length > 0) {
+			const opted = set.some(
+				(c) =>
+					c.version.pre.length > 0 &&
+					c.version.major === v.major &&
+					c.version.minor === v.minor &&
+					c.version.patch === v.patch,
+			);
+			if (!opted) continue;
+		}
+		return true;
+	}
+	return false;
+}
+
+// -------------------------------------------------------------------
+// Range specifiers that are satisfied by construction
+// -------------------------------------------------------------------
+
+/**
+ * Protocol specifiers that resolve to the in-tree sibling directly rather
+ * than by version, so there is no range to outgrow. `workspace:*` is the
+ * canonical one; `file:` / `link:` / `portal:` behave the same way.
+ *
+ * `workspace:^0.34.0` is NOT in this set: the version part is still a range
+ * and can still be stale, so it is unwrapped and checked below.
+ */
+const LINK_PROTOCOLS = ["file:", "link:", "portal:"];
+
+/** Strip a `workspace:` prefix, returning null if the spec links by path. */
+function unwrapWorkspaceProtocol(range: string): string | null {
+	const rest = range.slice("workspace:".length);
+	// `workspace:*`, `workspace:^`, `workspace:~` and `workspace:` all mean
+	// "whatever the sibling currently is" — satisfied by construction.
+	if (rest === "" || rest === "*" || rest === "^" || rest === "~") return null;
+	return rest;
+}
+
+// -------------------------------------------------------------------
+// Workspace enumeration
+// -------------------------------------------------------------------
+
+/**
+ * Read every workspace package's manifest, driven by the globs in the root
+ * package.json `workspaces` field. Nothing is hardcoded: a package added to a
+ * new directory is covered the moment the root glob covers it.
+ */
+export async function loadWorkspacePackages(rootDir: string): Promise<WorkspacePackage[]> {
+	const rootManifest = JSON.parse(await readFile(join(rootDir, "package.json"), "utf8"));
+	const globs: string[] = Array.isArray(rootManifest.workspaces)
+		? rootManifest.workspaces
+		: (rootManifest.workspaces?.packages ?? []);
+	if (globs.length === 0) {
+		throw new Error(
+			`No workspace globs found in ${join(rootDir, "package.json")}. ` +
+				"This guard enumerates packages from that field; with no globs it would " +
+				"vacuously pass, which is worse than failing.",
+		);
+	}
+
+	const files = new Set<string>();
+	for (const pattern of globs) {
+		const glob = new Bun.Glob(`${pattern}/package.json`);
+		for await (const match of glob.scan({ cwd: rootDir })) {
+			if (match.includes("node_modules")) continue;
+			files.add(match);
+		}
+	}
+
+	const packages: WorkspacePackage[] = [];
+	for (const file of [...files].sort()) {
+		const manifest = JSON.parse(await readFile(join(rootDir, file), "utf8"));
+		if (!manifest.name || !manifest.version) continue;
+		const deps: WorkspacePackage["deps"] = {};
+		for (const field of DEPENDENCY_FIELDS) {
+			if (manifest[field]) deps[field] = manifest[field];
+		}
+		packages.push({ file, name: manifest.name, version: manifest.version, deps });
+	}
+	return packages;
+}
+
+// -------------------------------------------------------------------
+// The check itself
+// -------------------------------------------------------------------
+
+/**
+ * Pure core: given the workspace manifests, return every sibling range the
+ * sibling's own version does not satisfy. Exported so the test can build the
+ * exact `^0.34.0` vs `0.35.0` case without touching the filesystem.
+ */
+export function findViolations(packages: WorkspacePackage[]): Violation[] {
+	const versions = new Map<string, string>();
+	for (const pkg of packages) versions.set(pkg.name, pkg.version);
+
+	const violations: Violation[] = [];
+	for (const pkg of packages) {
+		for (const field of DEPENDENCY_FIELDS) {
+			for (const [sibling, rawRange] of Object.entries(pkg.deps[field] ?? {})) {
+				const actual = versions.get(sibling);
+				// External dependency: none of this guard's business.
+				if (actual === undefined) continue;
+
+				let range = rawRange;
+				if (LINK_PROTOCOLS.some((p) => range.startsWith(p))) continue;
+				if (range.startsWith("npm:")) continue; // aliased to a different package
+				if (range.startsWith("workspace:")) {
+					const unwrapped = unwrapWorkspaceProtocol(range);
+					if (unwrapped === null) continue; // linked by construction
+					range = unwrapped;
+				}
+
+				const ok = satisfies(actual, range);
+				if (ok === null) {
+					violations.push({
+						file: pkg.file,
+						field,
+						from: pkg.name,
+						sibling,
+						range: rawRange,
+						actual,
+						unparseable: true,
+					});
+				} else if (!ok) {
+					violations.push({
+						file: pkg.file,
+						field,
+						from: pkg.name,
+						sibling,
+						range: rawRange,
+						actual,
+					});
+				}
+			}
+		}
+	}
+	return violations;
+}
+
+/**
+ * Human-readable report. Written for someone who hits this in CI at 2am and
+ * will not read this file: it names the manifest, the field, the range, the
+ * sibling's real version, and the edit to make.
+ */
+export function formatViolations(violations: Violation[]): string {
+	const lines: string[] = [];
+	lines.push(
+		`✗ ${violations.length} workspace sibling range${violations.length === 1 ? "" : "s"} ` +
+			"cannot be satisfied by the sibling's current version.",
+	);
+	lines.push("");
+
+	for (const v of violations) {
+		lines.push(`  ${v.file}`);
+		lines.push(`    ${v.field}."${v.sibling}": "${v.range}"`);
+		if (v.unparseable) {
+			lines.push(
+				`    ${v.sibling} is at ${v.actual}, but this guard does not understand the range ` +
+					`form "${v.range}", so it cannot prove the range is still valid.`,
+			);
+			lines.push(
+				"    Fix: use a range form the guard models (^x.y.z, ~x.y.z, >=x.y.z, <x.y.z, " +
+					"an exact version, *, workspace:*, or these joined by spaces / ||), or teach " +
+					"scripts/check-workspace-ranges.ts the new form.",
+			);
+		} else {
+			lines.push(
+				`    ${v.sibling} is at ${v.actual} in this repo, which does NOT satisfy "${v.range}".`,
+			);
+			lines.push(
+				`    Fix: in ${v.file}, set ${v.field}."${v.sibling}" to a range that admits ` +
+					`${v.actual} — usually "^${v.actual}". Then re-run \`bun install\`.`,
+			);
+		}
+		lines.push("");
+	}
+
+	lines.push("Why this matters:");
+	lines.push(
+		"  Bun only links the in-tree workspace copy of a sibling when the declared range",
+	);
+	lines.push(
+		"  admits the sibling's version. When it does not, Bun silently installs a PUBLISHED",
+	);
+	lines.push(
+		"  copy from the registry into a nested node_modules instead. Nothing errors at",
+	);
+	lines.push(
+		"  install time; the build fails later with \"Cannot find module\" or, worse, succeeds",
+	);
+	lines.push("  against a stale published package.");
+	lines.push("");
+	lines.push(
+		"  A version bump must rewrite sibling ranges in ALL of dependencies,",
+	);
+	lines.push(
+		"  devDependencies, peerDependencies and optionalDependencies. The v0.35.0 bump",
+	);
+	lines.push("  (5198c5399) rewrote the first two only, and main went red.");
+
+	return lines.join("\n");
+}
+
+// -------------------------------------------------------------------
+// CLI
+// -------------------------------------------------------------------
+
+/** Walk up from `start` until a directory holds a package.json with workspaces. */
+async function findRepoRoot(start: string): Promise<string> {
+	let dir = start;
+	for (;;) {
+		try {
+			const manifest = JSON.parse(await readFile(join(dir, "package.json"), "utf8"));
+			if (manifest.workspaces) return dir;
+		} catch {
+			// keep walking
+		}
+		const parent = resolve(dir, "..");
+		if (parent === dir) throw new Error(`No workspace root found above ${start}`);
+		dir = parent;
+	}
+}
+
+async function main(): Promise<number> {
+	if (process.argv.includes("--help") || process.argv.includes("-h")) {
+		console.log(
+			[
+				"Usage: bun scripts/check-workspace-ranges.ts",
+				"",
+				"Fails when a workspace package declares a dependency range on a workspace",
+				"sibling that the sibling's current version does not satisfy, across",
+				`${DEPENDENCY_FIELDS.join(", ")}.`,
+				"",
+				"Exit codes: 0 = every sibling range is satisfiable, 1 = at least one is not.",
+			].join("\n"),
+		);
+		return 0;
+	}
+
+	const rootDir = await findRepoRoot(resolve(import.meta.dir, ".."));
+	const packages = await loadWorkspacePackages(rootDir);
+	const violations = findViolations(packages);
+
+	if (violations.length === 0) {
+		console.log(
+			`✓ ${packages.length} workspace packages: every sibling range is satisfied by the ` +
+				"sibling's current version.",
+		);
+		return 0;
+	}
+
+	console.error(formatViolations(violations));
+	return 1;
+}
+
+// Only run the CLI when invoked directly, so the test can import the module.
+if (import.meta.main) {
+	process.exit(await main());
+}

--- a/scripts/check-workspace-ranges.ts
+++ b/scripts/check-workspace-ranges.ts
@@ -152,10 +152,13 @@ const COMPARATOR_RE = /^(<=|>=|<|>|=|)\s*v?(.+)$/;
 /**
  * Expand `^` / `~` into an explicit `>= <` pair.
  *
- * Caret is the one that bit us: below 1.0.0 the caret does NOT float the
- * minor, so `^0.34.0` is `>=0.34.0 <0.35.0` and a 0.35.0 sibling falls
- * outside it. Above 1.0.0 it would have been `>=0.34.0 <1.0.0` and nobody
- * would have noticed.
+ * Caret is the one that bit us, because its upper bound moves with the
+ * leading zero. From 1.0.0 up, the caret pins the major and floats the
+ * minor: `^1.2.3` is `>=1.2.3 <2.0.0`. Below 1.0.0 the minor IS the
+ * breaking position, so the caret pins that instead: `^0.34.0` is
+ * `>=0.34.0 <0.35.0`, and a 0.35.0 sibling falls outside it. Had these
+ * packages been at 1.x, `^1.34.0` would have been `>=1.34.0 <2.0.0`, the
+ * 1.35.0 bump would have stayed inside it, and nobody would have noticed.
  */
 function expandRangeOperator(prefix: "^" | "~", v: SemVer): Comparator[] {
 	const lower: Comparator = { op: ">=", version: v };


### PR DESCRIPTION
## Done

A release bump broke `main`, and every PR opened against it, in packages they did not touch. #1044 has since carried the range corrections to `main`; **what remains here is the guard that stops it recurring**, plus four older instances of the same class that never broke a build.

- **`feat(ci)`: `scripts/check-workspace-ranges.ts`** — fails when any workspace package declares a range on a workspace sibling that the sibling's current version does not satisfy. Field-agnostic across **all four** dependency fields, so it catches this no matter which one a future release tool forgets. Packages come from the root `workspaces` globs, because a hardcoded list would be the same failure mode one level up. Zero new dependencies: an in-file comparator covering `^ ~ >= <= > <`, exact, `*`, prereleases, space-conjunction and `||`. Range forms it does not model are **reported**, never waved through.

- **`fix(build)`: four stale ranges in `packages/react/i18n` and `packages/runtime/i18n`** — `@canonical/biome-config` and `@canonical/webarchitect` pinned at `^0.27.1-experimental.0`. These had been linting against *published* 0.27 copies for eight minor versions, with real directories in `node_modules` where symlinks belonged. Neither package is in pragma-cli's or summon's graph, which is why nothing ever went red.

### What the release tooling actually did

The v0.35.0 bump moved every `version` and every `dependencies` / `devDependencies` range, and **skipped `peerDependencies` unconditionally**. For a `0.x` version `^0.34.0` means `>=0.34.0 <0.35.0`, so `0.35.0` does not satisfy it — bun cannot link the sibling and `tsc` reports `Cannot find module '@canonical/summon-core'`.

The field is the variable, **not** whether the sibling appears elsewhere: `summon/package` and `ke-graphql` already carried those siblings in `devDependencies`, those entries *were* bumped correctly, and their `peerDependencies` were left stale anyway. That is why mirroring peers into `devDependencies` was considered and rejected — it would not have prevented one of the five, and it puts the same range in two places able to disagree.

### Why two gates, and why not a PR-only one

**The bump has no pull request.** `tag.yml`'s version job runs the `lerna-version` composite and pushes straight to `main`; its `check` / `test` jobs run *before* that, on the pre-bump tree where every range is still correct. A PR-only guard would have watched this outage happen again. So:

1. **In `.github/actions/lerna-version/action.yml`** — after lerna rewrites versions and ranges, **before** anything is committed, tagged, pushed or published. This is the one that matters.
2. **A `workspace-ranges` job in `pr.yml`** — a sibling of `implementation-data`, not a step inside it. The guard reads only `package.json`, so attaching it there would put the repo's cheapest signal behind a ~90s install *and* make it contingent on the dependency resolution this bug corrupts. It reports in **7s**.

`push.yml` deliberately gets nothing — a third check would only report that main is already broken.

## QA

1. `bun run check:ranges` → `✓ 62 workspace packages`.
2. `bun run check:ranges:test` → **21 tests pass**. Note this suite is `bun:test`, run via `bun test` as `check:ranges:test`, **not vitest** — vitest would not pick up the `bun:test` imports at all.
3. Guard against an untouched pre-fix tree → **exit 1, 9 violations**. On this branch → exit 0. One range hand-reverted → exit 1 naming that range. A simulated 0.36.0 bump that forgets `peerDependencies` → exit 1.
4. `bunx lerna run build:all` → exit 0. `bun run check` at repo root → exit 0 across 101 tasks. `bun install` leaves `bun.lock` byte-identical.
5. Comparator differential-tested against real `semver` 7.8.5 over **304 version/range pairs across 16 ranges — zero mismatches**, covering all three caret tiers, tilde, compound, open, exact, star, alternation and prereleases. `semver` was a throwaway oracle; it is **not** a dependency of the guard.

**CI green after rebase:** `build-matrix (1.3.9, 22)` and `(1.3.9, 24)` both pass, `Workspace sibling version ranges` 7s, build-gate, graph freshness and metadata all pass.

### One earlier red, diagnosed and not ours

An earlier commit hit `crossCli.subprocess.test.ts › package: an invalid explicit --name under --yes` with `expected 1 to be 2`. **Not caused by this PR**, and the evidence is in [this comment](https://github.com/canonical/pragma/pull/1045#issuecomment-5458683153): the commit carrying the *entire* range fix was green on both node versions; the commit that went red changed only a docblock and four `bun:test` assertions, neither reachable from vitest nor affecting resolution; node 24 passed on the identical commit, and the `summon` bin is spawned with **bun**, so its resolution cannot vary by matrix leg. 136 hand-run spawns all exited 2. A sweep of 162 failed jobs across 86 runs found one prior failure in this file, on `renovate/renovate-44.x`, same node-22-red / node-24-green shape, fault inside the spawned child.

**Follow-up worth its own PR:** in that matrix `expect(summon.status).toBe(2)` runs *before* every stderr assertion, file-wide — so an exit-code divergence prints nothing about why, which is exactly why the log could not name the exit-1 path. Asserting the pair together would make the next occurrence self-diagnosing. It changes a PROTECTED matrix's diagnostics, so it does not belong here.

### PR readiness check

- [x] PR has a label: `Bug 🐛`, plus `no visual change`.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts in `package.json` — this PR corrects dependency ranges and adds a root script; no package scripts change.
- [x] New package: **n/a** — none introduced. `check-workspace-ranges.ts` is a root script, not a package, so it needs no version or publish of its own.
- [x] Does not require visual testing — dependency ranges, a script and CI wiring only.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
