### PR TITLE
fix(pragma-cli): make the code standards reachable in one call

### DIFF
--- a/packages/cli/pragma/docs/design-system.md
+++ b/packages/cli/pragma/docs/design-system.md
@@ -223,21 +223,28 @@ A **standard** is one do/don't coding rule, categorized by stack and linked to t
 pragma standard categories
 ```
 
-List a category, search across all of them, or list everything:
+Categories are a hierarchy, and a parent answers for its whole branch — `--category testing` returns all 8 testing standards, not only the one filed directly on `testing`:
 
 ```bash
 pragma standard list
-pragma standard list --category react
+pragma standard list --category testing
 pragma standard list --search naming
 ```
+
+A slug the graph does not carry is refused, with the ones it does carry named — so a typo is a corrected call, not a silent empty list.
 
 Each row carries the standard's full rule text, so `list` is often all you need. `lookup` adds the worked code examples, gated by detail level — the default is a summary, `--detail standard` adds the **Do** examples, `--detail detailed` adds the **Don't**:
 
 ```bash
-pragma standard lookup 'Local Name Casing Convention' --detail detailed
+pragma standard lookup 'react/component/tsdoc' --detail detailed
 ```
 
-Lookups address a standard by its display name (globs work: `'Local*'`). Not every standard in this distribution carries one yet — for those, `standard list` and `standard sample` are the reliable paths to the same content.
+**The name `list` prints is the name `lookup` answers to.** Take a row's `Name` column verbatim; most standards carry no separate display title (the canonical identifier is the IRI), so that name is derived from the IRI — `cs:react.component.tsdoc` prints, and resolves, as `react/component/tsdoc`. The prefixed IRI works too, and globs work over either spelling:
+
+```bash
+pragma standard lookup 'react/component/*' --detail detailed
+pragma standard lookup 'cs:react.*' --detail detailed
+```
 
 ## Tokens
 

--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -924,9 +924,9 @@ pragma sources update --skip-invalid  # build from the parseable sources, warnin
 
 ### pragma standard categories
 
-List all standard categories with counts.
+List all standard categories with counts (a parent counts its whole branch).
 
-List all code standard categories.
+List all code standard categories with the number of standards each covers. Categories are a hierarchy: a parent's count includes every descendant, and `standard_list { category }` answers for the same set. Use this to pick a valid slug before filtering. Example: standard_categories {}.
 
 ```
 pragma standard categories
@@ -956,7 +956,7 @@ pragma standard list [options]
 
 | Flag | Value | Description |
 | --- | --- | --- |
-| `--category` | `<string>` | Filter by category name. |
+| `--category` | `<string>` | Filter by category slug. A parent category answers for its whole branch. |
 | `--search` | `<string>` | Search in name and description. |
 
 - Store: reads the local store (`pragma sources update` builds it).

--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -55,7 +55,7 @@ pragma block lookup <name>
 
 Return randomly selected complete block entries as exemplars.
 
-Return randomly selected complete design-system blocks as exemplars. Use BEFORE writing queries to see actual data shapes, anatomy, and property names.
+Return randomly selected complete design-system blocks as exemplars. Use BEFORE writing queries to see actual data shapes, anatomy, and property names. Example: block_sample {}.
 
 ```
 pragma block sample
@@ -120,7 +120,7 @@ pragma colophon --format llm  # condensed Markdown for agents
 
 List design-system concepts.
 
-List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search.
+List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search. Example: concept_list { type: "Explanation" }.
 
 ```
 pragma concept list [options]
@@ -147,7 +147,7 @@ pragma concept list --format llm
 
 Look up a concept's full documentation by name, IRI, or glob.
 
-Get a design-system concept's full Markdown documentation. Address concepts by name, prefixed name (ds:concept.…), absolute IRI, or glob pattern.
+Get a design-system concept's full Markdown documentation. Address concepts by the name concept_list publishes, by prefixed name (ds:concept.…), by absolute IRI, or by a glob. Example: concept_lookup { name: ["Foundations: Grid"] }.
 
 ```
 pragma concept lookup <name...>
@@ -589,7 +589,7 @@ pragma modifier lookup <name>
 
 Return randomly selected complete modifier entries as exemplars.
 
-Return randomly selected complete modifier families (with value lists) as exemplars. Use BEFORE writing queries to see actual data shapes.
+Return randomly selected complete modifier families (with value lists) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: modifier_sample {}.
 
 ```
 pragma modifier sample
@@ -946,7 +946,7 @@ pragma standard categories --format llm
 
 List all code standards.
 
-List code standards. Optionally filter by category or search term.
+List code standards: one ROW per standard — its IRI, name, category and description — not the standards themselves. Take a row's `name` VERBATIM to standard_lookup for the dos and donts. Optionally filter by category slug (a parent slug answers for its whole branch; standard_categories lists them) or by search term. Example: standard_list { category: "react" }.
 
 ```
 pragma standard list [options]
@@ -971,9 +971,9 @@ pragma standard list --format llm
 
 ### pragma standard lookup
 
-Look up detailed information for a standard by name, IRI, or glob.
+Look up one or more standards by name, IRI, or glob. --detail standard adds the dos, --detail detailed adds the don'ts.
 
-Get detailed information about one or more code standards including dos and donts with code examples. Address standards by name, prefixed name (cs:…), absolute IRI, or glob pattern (react/component/*).
+Get one or more code standards in full, with dos and don'ts as code examples. `detail` DEFAULTS to "summary", which returns neither: pass detail: "standard" for the dos and detail: "detailed" for dos AND don'ts. Address a standard by the name standard_list publishes (`react/component/tsdoc`), by prefixed name (`cs:react.component.tsdoc`), by absolute IRI, or by a glob over any of those. Example: standard_lookup { name: ["react/component/tsdoc"], detail: "detailed" }.
 
 ```
 pragma standard lookup <name...>
@@ -998,7 +998,7 @@ pragma standard lookup <name>
 
 Return randomly selected complete standard instances as exemplars for shape discovery.
 
-Return 1–5 randomly selected complete code standard instances as exemplars. Use BEFORE writing queries to see actual data shapes, property names, and value formats. Each call returns different instances.
+Return 1–5 randomly selected complete code standard instances as exemplars. Use BEFORE writing queries to see actual data shapes, property names, and value formats. Each call returns different instances. Example: standard_sample { count: 2 }.
 
 ```
 pragma standard sample [count]
@@ -1118,7 +1118,7 @@ pragma token lookup <name>
 
 Return randomly selected complete token entries as exemplars.
 
-Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes.
+Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.
 
 ```
 pragma token sample

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -405,7 +405,7 @@ Mutation — plan-first (set `confirm: true` to apply).
 
 ### standard_categories
 
-List all code standard categories.
+List all code standard categories with the number of standards each covers. Categories are a hierarchy: a parent's count includes every descendant, and `standard_list { category }` answers for the same set. Use this to pick a valid slug before filtering. Example: standard_categories {}.
 
 Read-only.
 
@@ -423,7 +423,7 @@ Read-only.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `category` | string | no | Filter by category name. |
+| `category` | string | no | Filter by category slug. A parent category answers for its whole branch. |
 | `search` | string | no | Search in name and description. |
 
 ### standard_lookup

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -29,7 +29,7 @@ Read-only.
 
 ### block_sample
 
-Return randomly selected complete design-system blocks as exemplars. Use BEFORE writing queries to see actual data shapes, anatomy, and property names.
+Return randomly selected complete design-system blocks as exemplars. Use BEFORE writing queries to see actual data shapes, anatomy, and property names. Example: block_sample {}.
 
 Read-only.
 
@@ -59,7 +59,7 @@ _No input parameters._
 
 ### concept_list
 
-List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search.
+List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search. Example: concept_list { type: "Explanation" }.
 
 Read-only.
 
@@ -72,7 +72,7 @@ Read-only.
 
 ### concept_lookup
 
-Get a design-system concept's full Markdown documentation. Address concepts by name, prefixed name (ds:concept.…), absolute IRI, or glob pattern.
+Get a design-system concept's full Markdown documentation. Address concepts by the name concept_list publishes, by prefixed name (ds:concept.…), by absolute IRI, or by a glob. Example: concept_lookup { name: ["Foundations: Grid"] }.
 
 Read-only.
 
@@ -285,7 +285,7 @@ Read-only.
 
 ### modifier_sample
 
-Return randomly selected complete modifier families (with value lists) as exemplars. Use BEFORE writing queries to see actual data shapes.
+Return randomly selected complete modifier families (with value lists) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: modifier_sample {}.
 
 Read-only.
 
@@ -415,7 +415,7 @@ _No input parameters._
 
 ### standard_list
 
-List code standards. Optionally filter by category or search term.
+List code standards: one ROW per standard — its IRI, name, category and description — not the standards themselves. Take a row's `name` VERBATIM to standard_lookup for the dos and donts. Optionally filter by category slug (a parent slug answers for its whole branch; standard_categories lists them) or by search term. Example: standard_list { category: "react" }.
 
 Read-only.
 
@@ -428,7 +428,7 @@ Read-only.
 
 ### standard_lookup
 
-Get detailed information about one or more code standards including dos and donts with code examples. Address standards by name, prefixed name (cs:…), absolute IRI, or glob pattern (react/component/*).
+Get one or more code standards in full, with dos and don'ts as code examples. `detail` DEFAULTS to "summary", which returns neither: pass detail: "standard" for the dos and detail: "detailed" for dos AND don'ts. Address a standard by the name standard_list publishes (`react/component/tsdoc`), by prefixed name (`cs:react.component.tsdoc`), by absolute IRI, or by a glob over any of those. Example: standard_lookup { name: ["react/component/tsdoc"], detail: "detailed" }.
 
 Read-only.
 
@@ -441,7 +441,7 @@ Read-only.
 
 ### standard_sample
 
-Return 1–5 randomly selected complete code standard instances as exemplars. Use BEFORE writing queries to see actual data shapes, property names, and value formats. Each call returns different instances.
+Return 1–5 randomly selected complete code standard instances as exemplars. Use BEFORE writing queries to see actual data shapes, property names, and value formats. Each call returns different instances. Example: standard_sample { count: 2 }.
 
 Read-only.
 
@@ -497,7 +497,7 @@ Read-only.
 
 ### token_sample
 
-Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes.
+Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.
 
 Read-only.
 

--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -443,6 +443,20 @@ const conceptStory: PackDefinition = {
       {
         param: "type",
         variable: "type",
+        // `ds:ConceptType` is the vocabulary; the concepts are the population.
+        // The shipped graph declares six types and uses two, so validating
+        // against the rows rejected "Decision guide" — a type the ontology
+        // declares — as an invalid argument instead of answering with the
+        // empty list it actually has.
+        vocabulary: {
+          query: [
+            "SELECT DISTINCT ?name WHERE {",
+            "  ?conceptType a ds:ConceptType ;",
+            "               ds:name ?name .",
+            "}",
+          ].join("\n"),
+          variable: "name",
+        },
         description: "Filter by concept type (e.g. Explanation, How-to guide).",
       },
     ],
@@ -544,14 +558,34 @@ const implementationStory: PackDefinition = {
       { field: "uri", label: "IRI" },
     ],
     filters: [
+      // Both vocabularies are read off `ds:ImplementationLibrary`, the subject
+      // that carries them — the same terms `implementation libraries`
+      // enumerates. A library that implements nothing yet still exists, and
+      // asking for it is an empty answer rather than a bad argument.
       {
         param: "platform",
         variable: "platform",
+        vocabulary: {
+          query: [
+            "SELECT DISTINCT ?platform WHERE {",
+            "  ?lib a ds:ImplementationLibrary ;",
+            "       ds:platform ?platform .",
+            "}",
+          ].join("\n"),
+        },
         description: "Filter by platform (e.g. react, svelte, typescript).",
       },
       {
         param: "library",
         variable: "library",
+        vocabulary: {
+          query: [
+            "SELECT DISTINCT ?library WHERE {",
+            "  ?lib a ds:ImplementationLibrary ;",
+            "       ds:libraryName ?library .",
+            "}",
+          ].join("\n"),
+        },
         description: "Filter by implementation library name.",
       },
     ],
@@ -661,6 +695,22 @@ const codeStandardsStories: readonly PackDefinition[] = [
           param: "category",
           variable: "categories",
           match: "set",
+          // The SAME terms `standard categories` enumerates (`cs:Category` /
+          // `cs:slug`), so the slugs that surface hands out are exactly the
+          // slugs this filter accepts. Read from the graph rather than the
+          // returned ROWS: a category the graph declares with no standards
+          // filed under it is reported by `standard categories` with count 0,
+          // and asking for it must be the documented calm empty list, not
+          // INVALID_INPUT.
+          vocabulary: {
+            query: [
+              "SELECT DISTINCT ?slug WHERE {",
+              "  ?cat a cs:Category ;",
+              "       cs:slug ?slug .",
+              "}",
+            ].join("\n"),
+            variable: "slug",
+          },
           description:
             "Filter by category slug. A parent category answers for its whole branch.",
         },
@@ -723,6 +773,16 @@ const codeStandardsStories: readonly PackDefinition[] = [
     lookup: {
       source: "sparql",
       by: "cs:name",
+      // The one story whose `list` PUBLISHES a synthesized name: `cs:name` is
+      // an optional display title (22 of 156 standards carry one), so the row
+      // name for the other ~87% is derived from the IRI local name. Declaring
+      // the fallback here is what keeps the two halves of the two-step grammar
+      // over one population — the same derivation, read from the other side.
+      // It is deliberately NOT declared on `block`/`token`/`tier`/`concept`:
+      // each of those lists REQUIRES its `by` property, so an entity without
+      // one is a row they never publish, and making it addressable (or
+      // sampleable) here would be the mirror of the defect this repairs.
+      nameFallback: "iri",
       type: "cs:CodeStandard",
       description:
         "Look up one or more standards by name, IRI, or glob. --detail standard adds the dos, --detail detailed adds the don'ts.",

--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -621,7 +621,13 @@ const codeStandardsStories: readonly PackDefinition[] = [
       "List code standards. Optionally filter by category or search term.",
     list: {
       query: [
+        // `?category` is the LEAF a standard is filed under — what a row
+        // displays. `?categories` is that leaf plus every ancestor, which is
+        // what `--category` matches against, so asking for a parent answers for
+        // the whole branch. The traversal is written ONCE, here, rather than
+        // repeated by each consumer.
         "SELECT ?uri ?name ?category ?description",
+        '       (GROUP_CONCAT(DISTINCT ?ancestorSlug; SEPARATOR=" ") AS ?categories)',
         "WHERE {",
         "  ?uri a cs:CodeStandard ;",
         "       cs:description ?description .",
@@ -630,8 +636,18 @@ const codeStandardsStories: readonly PackDefinition[] = [
         "  OPTIONAL {",
         "    ?uri cs:hasCategory ?cat .",
         "    ?cat cs:slug ?category .",
+        // `skos:broader` is deliberately NOT transitive, and this store
+        // (oxigraph) has no reasoner — so `skos:broaderTransitive` returns zero
+        // rows and hand-asserting it would be materialisation wearing a
+        // standards badge. `broader*` is the only thing that works.
+        // The `*` is REFLEXIVE and that is load-bearing: `+` would silently
+        // drop every standard filed DIRECTLY on the category being asked for
+        // (one of the 8 under `testing` today). Do not "correct" it.
+        "    ?cat skos:broader* ?ancestor .",
+        "    ?ancestor cs:slug ?ancestorSlug .",
         "  }",
         "}",
+        "GROUP BY ?uri ?name ?category ?description",
         "ORDER BY ?name",
       ].join("\n"),
       columns: [
@@ -643,8 +659,10 @@ const codeStandardsStories: readonly PackDefinition[] = [
       filters: [
         {
           param: "category",
-          variable: "category",
-          description: "Filter by category name.",
+          variable: "categories",
+          match: "set",
+          description:
+            "Filter by category slug. A parent category answers for its whole branch.",
         },
       ],
       search: {
@@ -655,16 +673,24 @@ const codeStandardsStories: readonly PackDefinition[] = [
     verbs: [
       {
         verb: "categories",
-        description: "List all standard categories with counts.",
-        toolDescription: "List all code standard categories.",
+        description:
+          "List all standard categories with counts (a parent counts its whole branch).",
+        toolDescription:
+          "List all code standard categories with the number of standards each covers. Categories are a hierarchy: a parent's count includes every descendant, and `standard_list { category }` answers for the same set. Use this to pick a valid slug before filtering. Example: standard_categories {}.",
         query: [
-          "SELECT ?name (COUNT(?standard) AS ?count)",
+          // The same reflexive roll-up `list` filters with — written the other
+          // way round (every category whose broader-chain reaches ?cat), so the
+          // count a category reports and the rows `--category` returns are the
+          // same set. `COUNT(DISTINCT ?standard)`: a standard reachable by two
+          // paths is still one standard.
+          "SELECT ?name (COUNT(DISTINCT ?standard) AS ?count)",
           "WHERE {",
           "  ?cat a cs:Category ;",
           "       cs:slug ?name .",
           "  OPTIONAL {",
+          "    ?descendant skos:broader* ?cat .",
           "    ?standard a cs:CodeStandard ;",
-          "              cs:hasCategory ?cat .",
+          "              cs:hasCategory ?descendant .",
           "  }",
           "}",
           "GROUP BY ?name",

--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -246,7 +246,7 @@ const designSystemStories: readonly PackDefinition[] = [
       sample: {
         fixedCount: true,
         toolDescription:
-          "Return randomly selected complete design-system blocks as exemplars. Use BEFORE writing queries to see actual data shapes, anatomy, and property names.",
+          "Return randomly selected complete design-system blocks as exemplars. Use BEFORE writing queries to see actual data shapes, anatomy, and property names. Example: block_sample {}.",
       },
     },
   },
@@ -303,7 +303,7 @@ const designSystemStories: readonly PackDefinition[] = [
       sample: {
         fixedCount: true,
         toolDescription:
-          "Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes.",
+          "Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.",
       },
     },
   },
@@ -361,7 +361,7 @@ const designSystemStories: readonly PackDefinition[] = [
       sample: {
         fixedCount: true,
         toolDescription:
-          "Return randomly selected complete modifier families (with value lists) as exemplars. Use BEFORE writing queries to see actual data shapes.",
+          "Return randomly selected complete modifier families (with value lists) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: modifier_sample {}.",
       },
     },
   },
@@ -421,7 +421,7 @@ const conceptStory: PackDefinition = {
   noun: "concept",
   description: "List design-system concepts.",
   toolDescription:
-    "List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search.",
+    'List design-system concepts — long-form foundations, how-to guides, and decision guides not bound to a single UI block. Optionally filter by type or search. Example: concept_list { type: "Explanation" }.',
   list: {
     query: [
       "SELECT ?uri ?name ?type ?summary",
@@ -463,7 +463,7 @@ const conceptStory: PackDefinition = {
     description:
       "Look up a concept's full documentation by name, IRI, or glob.",
     toolDescription:
-      "Get a design-system concept's full Markdown documentation. Address concepts by name, prefixed name (ds:concept.…), absolute IRI, or glob pattern.",
+      'Get a design-system concept\'s full Markdown documentation. Address concepts by the name concept_list publishes, by prefixed name (ds:concept.…), by absolute IRI, or by a glob. Example: concept_lookup { name: ["Foundations: Grid"] }.',
     fields: [
       { name: "type", property: "ds:conceptType/ds:name", label: "Type" },
       { name: "tier", property: "ds:tier", label: "Tier" },
@@ -618,7 +618,7 @@ const codeStandardsStories: readonly PackDefinition[] = [
     noun: "standard",
     description: "List all code standards.",
     toolDescription:
-      "List code standards. Optionally filter by category or search term.",
+      'List code standards: one ROW per standard — its IRI, name, category and description — not the standards themselves. Take a row\'s `name` VERBATIM to standard_lookup for the dos and donts. Optionally filter by category slug (a parent slug answers for its whole branch; standard_categories lists them) or by search term. Example: standard_list { category: "react" }.',
     list: {
       query: [
         // `?category` is the LEAF a standard is filed under — what a row
@@ -669,6 +669,16 @@ const codeStandardsStories: readonly PackDefinition[] = [
         variables: ["name", "description"],
         description: "Search in name and description.",
       },
+      // Deliberately NOT `sources update`: the code standards ship in the
+      // embedded snapshot and answer with no update at all, so the generic
+      // build hint is actively wrong here. An empty result on this noun means
+      // the filter, and the vocabulary it must be drawn from lives in the graph
+      // — which is what `standard categories` reads out.
+      emptyRecovery: {
+        message:
+          "Category slugs come from the graph, and a parent slug answers for its whole branch — read them out rather than guessing.",
+        cli: "standard categories",
+      },
     },
     verbs: [
       {
@@ -700,6 +710,14 @@ const codeStandardsStories: readonly PackDefinition[] = [
           { field: "name", label: "Category" },
           { field: "count", label: "Standards" },
         ],
+        // Also not `sources update`. The categories ride the same embedded
+        // snapshot, so zero rows means the store did not load — a health
+        // question, not a staleness one.
+        emptyRecovery: {
+          message:
+            "The code standards ship in the embedded snapshot, so no categories at all means the store did not load rather than that it is out of date.",
+          cli: "doctor",
+        },
       },
     ],
     lookup: {
@@ -707,9 +725,9 @@ const codeStandardsStories: readonly PackDefinition[] = [
       by: "cs:name",
       type: "cs:CodeStandard",
       description:
-        "Look up detailed information for a standard by name, IRI, or glob.",
+        "Look up one or more standards by name, IRI, or glob. --detail standard adds the dos, --detail detailed adds the don'ts.",
       toolDescription:
-        "Get detailed information about one or more code standards including dos and donts with code examples. Address standards by name, prefixed name (cs:…), absolute IRI, or glob pattern (react/component/*).",
+        'Get one or more code standards in full, with dos and don\'ts as code examples. `detail` DEFAULTS to "summary", which returns neither: pass detail: "standard" for the dos and detail: "detailed" for dos AND don\'ts. Address a standard by the name standard_list publishes (`react/component/tsdoc`), by prefixed name (`cs:react.component.tsdoc`), by absolute IRI, or by a glob over any of those. Example: standard_lookup { name: ["react/component/tsdoc"], detail: "detailed" }.',
       fields: [
         {
           name: "category",
@@ -755,7 +773,7 @@ const codeStandardsStories: readonly PackDefinition[] = [
         description:
           "Return randomly selected complete standard instances as exemplars for shape discovery.",
         toolDescription:
-          "Return 1–5 randomly selected complete code standard instances as exemplars. Use BEFORE writing queries to see actual data shapes, property names, and value formats. Each call returns different instances.",
+          "Return 1–5 randomly selected complete code standard instances as exemplars. Use BEFORE writing queries to see actual data shapes, property names, and value formats. Each call returns different instances. Example: standard_sample { count: 2 }.",
       },
     },
   },

--- a/packages/cli/pragma/src/capabilities/distribution.parity.test.ts
+++ b/packages/cli/pragma/src/capabilities/distribution.parity.test.ts
@@ -30,6 +30,10 @@ if (!standardPack) {
 const CS = "http://pragma.canonical.com/codestandards#";
 const PREFIXES = {
   cs: CS,
+  // The store the fixture builds is queried with the story queries verbatim,
+  // and the category roll-up names `skos:broader` — a CORE prefix on the real
+  // build path (`buildPackPrefixes`), which this in-memory helper does not use.
+  skos: "http://www.w3.org/2004/02/skos/core#",
   owl: "http://www.w3.org/2002/07/owl#",
   rdfs: "http://www.w3.org/2000/01/rdf-schema#",
   xsd: "http://www.w3.org/2001/XMLSchema#",

--- a/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
+++ b/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
@@ -35,6 +35,9 @@ function storyFor(noun: string): PackDefinition {
 const PREFIXES = {
   ds: "https://ds.canonical.com/",
   cs: "https://ds.canonical.com/code-standards/",
+  // The `standard` list query names `skos:broader` for its category roll-up —
+  // a CORE prefix on the real build path, which this in-memory helper bypasses.
+  skos: "http://www.w3.org/2004/02/skos/core#",
   owl: "http://www.w3.org/2002/07/owl#",
   rdfs: "http://www.w3.org/2000/01/rdf-schema#",
   xsd: "http://www.w3.org/2001/XMLSchema#",

--- a/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
+++ b/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
@@ -88,7 +88,12 @@ const listVerb = (pack: PackDefinition): VerbSpec =>
 const PACK_LISTS: readonly { pack: PackDefinition; hint: RegExp }[] = [
   { pack: storyFor("modifier"), hint: /pragma sources update/ },
   { pack: storyFor("token"), hint: /pragma sources update/ },
-  { pack: storyFor("standard"), hint: /broaden the filter/ },
+  // CHANGED DELIBERATELY. `standard` used to fall through to the generic
+  // build/broaden hint, and the build half of it is actively WRONG for this
+  // noun: the code standards ride the embedded snapshot and answer with no
+  // `sources update` at all. It now authors its own, pointing at the one
+  // surface that reads the category vocabulary out of the graph.
+  { pack: storyFor("standard"), hint: /pragma standard categories/ },
 ];
 
 const REAL = { dryRun: false, undo: false, yes: false };

--- a/packages/cli/pragma/src/kernel/packs/compile.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/compile.test.ts
@@ -485,6 +485,98 @@ describe("weights validation (a weight that can never apply is rejected)", () =>
   });
 });
 
+describe("nameFallback validation (a derived name needs a class to vouch for it)", () => {
+  it("accepts the fallback beside a class constraint", () => {
+    const definition = {
+      noun: "gadget",
+      lookup: { by: "ex:name", nameFallback: "iri", type: "ex:Widget" },
+    };
+    expect(parsePackDefinition(definition, "t")).toEqual(definition);
+  });
+
+  it("REJECTS the fallback with no class constraint", () => {
+    // Without one there is no triple bounding `?uri`, so the derived-name
+    // population would be scanned over the whole graph — and a derived name is
+    // only as trustworthy as the class vouching for the entity it came from.
+    expect(() =>
+      parsePackDefinition(
+        { noun: "gadget", lookup: { by: "ex:name", nameFallback: "iri" } },
+        "t",
+      ),
+    ).toThrow(/nameFallback/);
+  });
+});
+
+describe("filter vocabulary validation (where a value-free filter's values live)", () => {
+  const listShape = {
+    query: "SELECT ?uri ?kind WHERE { ?uri a ex:Widget ; ex:kind ?kind }",
+    columns: [{ field: "uri" }],
+  };
+
+  it("accepts a vocabulary SELECT on a value-free filter", () => {
+    const definition = {
+      noun: "widget",
+      list: {
+        ...listShape,
+        filters: [
+          {
+            param: "kind",
+            variable: "kind",
+            vocabulary: { query: "SELECT ?kind WHERE { ?k a ex:Kind }" },
+          },
+        ],
+      },
+    };
+    expect(parsePackDefinition(definition, "t")).toEqual(definition);
+  });
+
+  it("REJECTS a vocabulary beside a declared `values` set", () => {
+    // A declared set IS the vocabulary — the filter projects it as an enum and
+    // canonicalizes against it. A second, graph-read one alongside is a silent
+    // no-op at best and a disagreement at worst.
+    expect(() =>
+      parsePackDefinition(
+        {
+          noun: "widget",
+          list: {
+            ...listShape,
+            filters: [
+              {
+                param: "kind",
+                variable: "kind",
+                values: ["a", "b"],
+                vocabulary: { query: "SELECT ?kind WHERE { ?k a ex:Kind }" },
+              },
+            ],
+          },
+        },
+        "t",
+      ),
+    ).toThrow(/mutually exclusive/);
+  });
+
+  it("REJECTS a vocabulary query that is not a SELECT", () => {
+    expect(() =>
+      parsePackDefinition(
+        {
+          noun: "widget",
+          list: {
+            ...listShape,
+            filters: [
+              {
+                param: "kind",
+                variable: "kind",
+                vocabulary: { query: "ASK { ?k a ex:Kind }" },
+              },
+            ],
+          },
+        },
+        "t",
+      ),
+    ).toThrow(/SELECT/);
+  });
+});
+
 describe("compileListable — absolute IRIs reach the prefixed contract", () => {
   it("compacts an absolute lookup type, and its weight key with it", () => {
     // `PackLookup.type`/`types` accept a prefixed name OR an absolute IRI, but

--- a/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
+++ b/packages/cli/pragma/src/kernel/packs/resolveEntity.ts
@@ -80,6 +80,9 @@ export async function resolveLookup(
     throw PragmaError.invalidInput("names", "(empty)", {
       recovery: cliRecovery(`${noun} list`, `List available ${noun} entries.`, {
         tool: `${noun}_list`,
+        // A concrete, valid argument bag rather than a bare tool name: an
+        // agent can call the recovery as written instead of guessing one.
+        params: {},
       }),
     });
   }
@@ -209,6 +212,9 @@ async function lookupOne(
       suggestions: suggestNames(query, candidates),
       recovery: cliRecovery(`${noun} list`, `List available ${noun} entries.`, {
         tool: `${noun}_list`,
+        // A concrete, valid argument bag rather than a bare tool name: an
+        // agent can call the recovery as written instead of guessing one.
+        params: {},
       }),
     });
   }

--- a/packages/cli/pragma/src/kernel/packs/runBodies.ts
+++ b/packages/cli/pragma/src/kernel/packs/runBodies.ts
@@ -19,10 +19,19 @@ import {
   resolveLookup,
 } from "./resolveEntity.js";
 import { parseSampleCount, pickRandom } from "./sample.js";
-import { applyPackFilters } from "./sparql/applyFilters.js";
+import {
+  applyPackFilters,
+  type FilterVocabularies,
+} from "./sparql/applyFilters.js";
 import { applyPackSearch } from "./sparql/applySearch.js";
 import { runSelect } from "./sparql/runSelect.js";
-import type { PackList, PackLookup, PackRow, StorySource } from "./types.js";
+import type {
+  PackFilter,
+  PackList,
+  PackLookup,
+  PackRow,
+  StorySource,
+} from "./types.js";
 
 /** The highest canonical level — sample fetches everything for shape discovery. */
 const HIGHEST_LEVEL = "detailed";
@@ -61,16 +70,64 @@ export function makeListRun(
   shape: PackList,
   meta: ListRunMeta,
 ): (params: Record<string, unknown>, rt: PragmaRuntime) => Promise<PackRow[]> {
-  return async (params, rt) =>
-    applyPackSearch(
-      applyPackFilters(
-        await runSelect(rt, shape.query, meta.source),
-        shape.filters,
-        params,
-      ),
+  return async (params, rt) => {
+    const rows = await runSelect(rt, shape.query, meta.source);
+    const vocabularies = await readFilterVocabularies(
+      rt,
+      shape.filters,
+      params,
+      meta.source,
+    );
+    return applyPackSearch(
+      applyPackFilters(rows, shape.filters, params, vocabularies),
       shape.search,
       params,
     );
+  };
+}
+
+/**
+ * Read the declared vocabulary of each value-free filter the caller actually
+ * used.
+ *
+ * WHY a second query rather than the rows already in hand: the rows are a
+ * population, not a vocabulary. A category the graph declares with no standards
+ * filed under it, or a `ds:ConceptType` no concept uses yet, is a REAL value
+ * that appears in no row — and rejecting it as `INVALID_INPUT` contradicts both
+ * `standard categories` (which lists it, with count 0) and the documented calm
+ * empty list. The query reads the same terms the enumerating surface reads, so
+ * "the graph is the vocabulary" stays true of the graph rather than of whatever
+ * the list happened to return.
+ *
+ * Only for a filter that is DECLARED with a vocabulary, carries no `values`
+ * (a declared set is already the vocabulary), and was actually PROVIDED — an
+ * unfiltered `list` runs exactly the one query it always did.
+ */
+async function readFilterVocabularies(
+  rt: PragmaRuntime,
+  filters: readonly PackFilter[] | undefined,
+  params: Record<string, unknown>,
+  source: StorySource,
+): Promise<FilterVocabularies | undefined> {
+  const needed = (filters ?? []).filter(
+    (filter) =>
+      filter.vocabulary !== undefined &&
+      filter.values === undefined &&
+      params[filter.param] !== undefined,
+  );
+  if (needed.length === 0) return undefined;
+  const resolved = new Map<string, readonly string[]>();
+  for (const filter of needed) {
+    const vocabulary = filter.vocabulary;
+    if (!vocabulary) continue;
+    const variable = vocabulary.variable ?? filter.variable;
+    const rows = await runSelect(rt, vocabulary.query, source);
+    resolved.set(
+      filter.param,
+      rows.map((row) => row[variable] ?? "").filter((value) => value !== ""),
+    );
+  }
+  return resolved;
 }
 
 /** Build the run body for a lookup verb (variadic names → resolved entities). */

--- a/packages/cli/pragma/src/kernel/packs/runBodies.ts
+++ b/packages/cli/pragma/src/kernel/packs/runBodies.ts
@@ -27,6 +27,22 @@ import type { PackList, PackLookup, PackRow, StorySource } from "./types.js";
 /** The highest canonical level — sample fetches everything for shape discovery. */
 const HIGHEST_LEVEL = "detailed";
 
+/**
+ * The recovery every lookup-shaped miss carries: browse the noun's list.
+ *
+ * `mcp.params` is populated rather than left off. A bare tool NAME is only half
+ * an instruction to an agent — it still has to guess an argument bag, and a
+ * guess that misses returns `-32602 Invalid arguments`, which reads like the
+ * recovery itself was wrong. `{}` is the concrete, valid call: every compiled
+ * list verb's params are optional, so the recovery is now copy-pasteable.
+ */
+function listRecovery(noun: string) {
+  return cliRecovery(`${noun} list`, `List available ${noun} entries.`, {
+    tool: `${noun}_list`,
+    params: {},
+  });
+}
+
 /** Facts a list-shaped run body needs beyond its `shape`. */
 export interface ListRunMeta {
   readonly source: StorySource;
@@ -88,11 +104,7 @@ export function makeLookupRun(
           code: first.code as PragmaError["code"],
           message: first.message,
           suggestions: first.suggestions ? [...first.suggestions] : undefined,
-          recovery: cliRecovery(
-            `${noun} list`,
-            `List available ${noun} entries.`,
-            { tool: `${noun}_list` },
-          ),
+          recovery: listRecovery(noun),
         });
       }
     }
@@ -119,11 +131,7 @@ export function makeSampleRun(
     if (names.length === 0) {
       throw PragmaError.emptyResults(noun, {
         message: `No ${noun} entries to sample.`,
-        recovery: cliRecovery(
-          `${noun} list`,
-          `List available ${noun} entries.`,
-          { tool: `${noun}_list` },
-        ),
+        recovery: listRecovery(noun),
       });
     }
     const selected = pickRandom(names, count);

--- a/packages/cli/pragma/src/kernel/packs/schema.ts
+++ b/packages/cli/pragma/src/kernel/packs/schema.ts
@@ -41,6 +41,16 @@ const TERM_PATTERN =
 /** Params a filter/verb may not claim (they are the shared read vocabulary). */
 const RESERVED_PARAMS = new Set(["search", "detail", "name", "count"]);
 
+/**
+ * Whether an author-supplied query is a SELECT (optionally preceded by its own
+ * PREFIX lines). Every author query a story declares runs through `runSelect`,
+ * which reads `result.bindings` — so a non-SELECT is a shape mismatch caught
+ * here rather than downstream.
+ */
+function isSelectQuery(query: string): boolean {
+  return /^\s*(?:PREFIX\s+[^\n]*\n\s*)*SELECT\s/i.test(query);
+}
+
 const term = z.string().regex(TERM_PATTERN, "must be a prefixed name or IRI");
 const graphqlName = z.string().regex(GRAPHQL_NAME_PATTERN);
 const fieldName = z.string().regex(FIELD_PATTERN);
@@ -49,17 +59,35 @@ const columnSchema = z
   .object({ field: fieldName, label: z.string().optional() })
   .strict();
 
+const vocabularySchema = z
+  .object({
+    query: z.string().min(1),
+    variable: fieldName.optional(),
+  })
+  .strict();
+
 const filterSchema = z
   .object({
     param: z.string().regex(FILTER_PARAM_PATTERN),
     variable: fieldName,
     values: z.array(z.string()).min(1).optional(),
     match: z.enum(["exact", "set"]).optional(),
+    vocabulary: vocabularySchema.optional(),
     description: z.string().optional(),
   })
   .strict()
   .refine((f) => !RESERVED_PARAMS.has(f.param), {
     message: "filter param is a reserved name",
+  })
+  // A declared `values` set IS the vocabulary — the filter projects it as an
+  // enum and canonicalizes against it. A second, graph-read one alongside would
+  // be a silent no-op at best and a disagreement at worst.
+  .refine((f) => !(f.values && f.vocabulary), {
+    message:
+      '"values" and "vocabulary" are mutually exclusive — a declared value set is already the vocabulary',
+  })
+  .refine((f) => !f.vocabulary || isSelectQuery(f.vocabulary.query), {
+    message: '"vocabulary.query" must be a SPARQL SELECT query',
   });
 
 const searchSchema = z
@@ -209,6 +237,7 @@ const lookupSchema = z
   .object({
     source: z.enum(["sparql", "graphql"]).optional(),
     by: term,
+    nameFallback: z.enum(["iri"]).optional(),
     type: term.optional(),
     description: z.string().optional(),
     toolDescription: z.string().optional(),
@@ -242,10 +271,7 @@ const definitionSchema = z
         message: 'a pack must declare at least one of "list" or "lookup".',
       });
     }
-    if (
-      def.list &&
-      !/^\s*(?:PREFIX\s+[^\n]*\n\s*)*SELECT\s/i.test(def.list.query)
-    ) {
+    if (def.list && !isSelectQuery(def.list.query)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: '"list.query" must be a SPARQL SELECT query.',
@@ -331,6 +357,20 @@ function refineLookup(
       code: z.ZodIssueCode.custom,
       message: '"lookup.type" and "lookup.types" are mutually exclusive.',
       path: ["lookup"],
+    });
+  }
+
+  // An IRI-derived name is only as trustworthy as the class vouching for the
+  // entity it came from, and without a class constraint nothing bounds the scan
+  // the derived-name population would run. Rejected rather than ignored, for the
+  // same reason a stale weight is: a silent no-op is how a declaration that
+  // never applied survives review.
+  if (lookup.nameFallback !== undefined && !lookup.type && !lookup.types) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        '"lookup.nameFallback" requires a class constraint ("lookup.type" or "lookup.types") to vouch for the entities it names.',
+      path: ["lookup", "nameFallback"],
     });
   }
 

--- a/packages/cli/pragma/src/kernel/packs/schema.ts
+++ b/packages/cli/pragma/src/kernel/packs/schema.ts
@@ -54,6 +54,7 @@ const filterSchema = z
     param: z.string().regex(FILTER_PARAM_PATTERN),
     variable: fieldName,
     values: z.array(z.string()).min(1).optional(),
+    match: z.enum(["exact", "set"]).optional(),
     description: z.string().optional(),
   })
   .strict()

--- a/packages/cli/pragma/src/kernel/packs/sparql/applyFilters.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/applyFilters.ts
@@ -8,6 +8,12 @@
  * the input is a free term matched the same way. A row lacking the variable never
  * matches. Several filters combine conjunctively; several values for one
  * filter (a repeated flag) combine as a union.
+ *
+ * A filter declaring `match: "set"` reads its cell as a space-separated SET and
+ * matches any member — the shape a query produces for a dimension a row belongs
+ * to several values of at once (a category and its ancestors, say). The
+ * comparison is otherwise identical, so exactly one code path decides what a
+ * match is.
  */
 
 import { PragmaError } from "../../error/index.js";
@@ -41,12 +47,25 @@ export function applyPackFilters(
         ? requireStringValue(occurrence, filter).toLowerCase()
         : canonicalizeFilterValue(occurrence, filter, values).toLowerCase(),
     );
-    result = result.filter((row) => {
-      const cell = row[filter.variable]?.normalize("NFC").toLowerCase();
-      return cell !== undefined && terms.includes(cell);
-    });
+    result = result.filter((row) =>
+      cellValues(row, filter).some((value) => terms.includes(value)),
+    );
   }
   return result;
+}
+
+/**
+ * The comparable values a row offers for one filter, lowercased.
+ *
+ * One value for an ordinary filter; every space-separated member for a `"set"`
+ * one. A row lacking the variable offers none, so it never matches.
+ */
+function cellValues(row: PackRow, filter: PackFilter): string[] {
+  const cell = row[filter.variable];
+  if (cell === undefined) return [];
+  const normalized = cell.normalize("NFC").toLowerCase();
+  if (filter.match !== "set") return [normalized];
+  return normalized.split(/\s+/).filter((value) => value !== "");
 }
 
 /** @throws PragmaError INVALID_INPUT when a value-free filter value is not a string. */

--- a/packages/cli/pragma/src/kernel/packs/sparql/applyFilters.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/applyFilters.ts
@@ -14,6 +14,15 @@
  * to several values of at once (a category and its ancestors, say). The
  * comparison is otherwise identical, so exactly one code path decides what a
  * match is.
+ *
+ * A value-free filter still REJECTS a value the data does not carry, with the
+ * observed values as `validOptions` — the same courtesy a declared-`values`
+ * filter has always extended, without copying the vocabulary into the consumer.
+ * The vocabulary is read from the rows the graph just answered with, because the
+ * graph IS the vocabulary; a story that hard-coded the slugs would go stale the
+ * first time the data grew a category. Before this, a typo'd `--category`
+ * returned `{"ok":true,"data":[],"meta":{}}` — indistinguishable, over MCP, from
+ * a genuinely empty category.
  */
 
 import { PragmaError } from "../../error/index.js";
@@ -47,24 +56,71 @@ export function applyPackFilters(
         ? requireStringValue(occurrence, filter).toLowerCase()
         : canonicalizeFilterValue(occurrence, filter, values).toLowerCase(),
     );
+    // Compared against the UNFILTERED rows: a value that exists but is excluded
+    // by a conjunction is a legitimately empty answer, not a bad argument.
+    if (values === undefined)
+      rejectUnobserved(rows, filter, occurrences, terms);
     result = result.filter((row) =>
-      cellValues(row, filter).some((value) => terms.includes(value)),
+      cellValues(row, filter).some((value) =>
+        terms.includes(value.toLowerCase()),
+      ),
     );
   }
   return result;
 }
 
 /**
- * The comparable values a row offers for one filter, lowercased.
+ * Reject a value-free filter value the data does not carry, naming the ones it
+ * does.
+ *
+ * Silent when the dimension is empty across every row: an unbuilt or
+ * genuinely-empty store is not the caller's mistake, and the list's own
+ * `emptyRecovery` is the right voice for it.
+ *
+ * @throws PragmaError INVALID_INPUT when a term matches none of the observed
+ *   values, carrying them as `validOptions`.
+ */
+function rejectUnobserved(
+  rows: readonly PackRow[],
+  filter: PackFilter,
+  occurrences: readonly unknown[],
+  terms: readonly string[],
+): void {
+  const observed = new Map<string, string>();
+  for (const row of rows) {
+    for (const value of cellValues(row, filter)) {
+      const key = value.toLowerCase();
+      if (!observed.has(key)) observed.set(key, value);
+    }
+  }
+  if (observed.size === 0) return;
+  const index = terms.findIndex((term) => !observed.has(term));
+  if (index === -1) return;
+  const validOptions = [...observed.values()].sort();
+  throw PragmaError.invalidInput(filter.param, String(occurrences[index]), {
+    validOptions,
+    recovery: {
+      message: `Values present for --${filter.param}: ${validOptions.join(", ")}.`,
+    },
+  });
+}
+
+/**
+ * The values a row offers for one filter, in their DISPLAY spelling (NFC).
  *
  * One value for an ordinary filter; every space-separated member for a `"set"`
- * one. A row lacking the variable offers none, so it never matches.
+ * one. A row lacking the variable offers none, so it never matches. Kept in the
+ * data's own casing because these are also what an INVALID_INPUT lists back as
+ * `validOptions` — lowercasing here would hand the caller a value the graph does
+ * not spell that way. Comparison lowercases at the point of comparison instead.
  */
 function cellValues(row: PackRow, filter: PackFilter): string[] {
   const cell = row[filter.variable];
   if (cell === undefined) return [];
-  const normalized = cell.normalize("NFC").toLowerCase();
-  if (filter.match !== "set") return [normalized];
+  const normalized = cell.normalize("NFC");
+  if (filter.match !== "set") {
+    return normalized === "" ? [] : [normalized];
+  }
   return normalized.split(/\s+/).filter((value) => value !== "");
 }
 

--- a/packages/cli/pragma/src/kernel/packs/sparql/applyFilters.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/applyFilters.ts
@@ -16,22 +16,40 @@
  * match is.
  *
  * A value-free filter still REJECTS a value the data does not carry, with the
- * observed values as `validOptions` — the same courtesy a declared-`values`
+ * admissible values as `validOptions` — the same courtesy a declared-`values`
  * filter has always extended, without copying the vocabulary into the consumer.
- * The vocabulary is read from the rows the graph just answered with, because the
- * graph IS the vocabulary; a story that hard-coded the slugs would go stale the
- * first time the data grew a category. Before this, a typo'd `--category`
- * returned `{"ok":true,"data":[],"meta":{}}` — indistinguishable, over MCP, from
- * a genuinely empty category.
+ * The vocabulary is read from the graph, because the graph IS the vocabulary; a
+ * story that hard-coded the slugs would go stale the first time the data grew a
+ * category. Before this, a typo'd `--category` returned
+ * `{"ok":true,"data":[],"meta":{}}` — indistinguishable, over MCP, from a
+ * genuinely empty category.
+ *
+ * WHICH part of the graph is the vocabulary matters, and it is NOT the rows.
+ * Rows are a population: a value can be perfectly real while no row carries it —
+ * `standard categories` lists a category with count 0, `ds:ConceptType` declares
+ * "Decision guide" before any concept uses it. Validating against rows called
+ * those `INVALID_INPUT`, when the documented answer is a calm empty list. So a
+ * filter DECLARES where its vocabulary lives ({@link PackFilter.vocabulary},
+ * resolved by the caller and handed in here), and the observed rows are the
+ * fallback for a filter that declares none — the only evidence there is, and
+ * knowingly narrower than the truth.
  */
 
 import { PragmaError } from "../../error/index.js";
 import type { PackFilter, PackRow } from "../types.js";
 
 /**
+ * Authoritative values per filter `param`, read from each filter's declared
+ * `vocabulary`. A param absent from the map falls back to the observed rows.
+ */
+export type FilterVocabularies = ReadonlyMap<string, readonly string[]>;
+
+/**
  * @param rows - Rows produced by the pack's list query.
  * @param filters - Declared filters (absent means no filtering).
  * @param params - Story parameters as provided by the surface.
+ * @param vocabularies - Authoritative values per filter param, resolved from
+ *   each filter's declared `vocabulary` (see {@link FilterVocabularies}).
  * @returns Rows matching every provided filter.
  * @throws PragmaError INVALID_INPUT when a value is not in a filter's declared
  *   set, or when a value-free filter receives a non-string value.
@@ -40,6 +58,7 @@ export function applyPackFilters(
   rows: PackRow[],
   filters: readonly PackFilter[] | undefined,
   params: Record<string, unknown>,
+  vocabularies?: FilterVocabularies,
 ): PackRow[] {
   let result = rows;
   for (const filter of filters ?? []) {
@@ -56,10 +75,16 @@ export function applyPackFilters(
         ? requireStringValue(occurrence, filter).toLowerCase()
         : canonicalizeFilterValue(occurrence, filter, values).toLowerCase(),
     );
-    // Compared against the UNFILTERED rows: a value that exists but is excluded
-    // by a conjunction is a legitimately empty answer, not a bad argument.
+    // The fallback vocabulary is read from the UNFILTERED rows: a value that
+    // exists but is excluded by a conjunction is a legitimately empty answer,
+    // not a bad argument.
     if (values === undefined)
-      rejectUnobserved(rows, filter, occurrences, terms);
+      rejectUnknownValue(
+        vocabularies?.get(filter.param) ?? observedValues(rows, filter),
+        filter,
+        occurrences,
+        terms,
+      );
     result = result.filter((row) =>
       cellValues(row, filter).some((value) =>
         terms.includes(value.toLowerCase()),
@@ -70,22 +95,13 @@ export function applyPackFilters(
 }
 
 /**
- * Reject a value-free filter value the data does not carry, naming the ones it
- * does.
- *
- * Silent when the dimension is empty across every row: an unbuilt or
- * genuinely-empty store is not the caller's mistake, and the list's own
- * `emptyRecovery` is the right voice for it.
- *
- * @throws PragmaError INVALID_INPUT when a term matches none of the observed
- *   values, carrying them as `validOptions`.
+ * The values the rows themselves carry — the fallback vocabulary for a filter
+ * that declares no authoritative one, in the data's own DISPLAY spelling.
  */
-function rejectUnobserved(
+function observedValues(
   rows: readonly PackRow[],
   filter: PackFilter,
-  occurrences: readonly unknown[],
-  terms: readonly string[],
-): void {
+): string[] {
   const observed = new Map<string, string>();
   for (const row of rows) {
     for (const value of cellValues(row, filter)) {
@@ -93,14 +109,44 @@ function rejectUnobserved(
       if (!observed.has(key)) observed.set(key, value);
     }
   }
-  if (observed.size === 0) return;
-  const index = terms.findIndex((term) => !observed.has(term));
+  return [...observed.values()];
+}
+
+/**
+ * Reject a value-free filter value the vocabulary does not admit, naming the
+ * ones it does.
+ *
+ * Silent when the vocabulary is EMPTY: an unbuilt or genuinely-empty store is
+ * not the caller's mistake, and the list's own `emptyRecovery` is the right
+ * voice for it.
+ *
+ * A value the vocabulary admits is never rejected here even when no row carries
+ * it — a real slug with zero standards is a calm empty list, which is what the
+ * tool descriptions document and what `standard categories` reporting count 0
+ * promises.
+ *
+ * @throws PragmaError INVALID_INPUT when a term matches none of the admissible
+ *   values, carrying them as `validOptions`.
+ */
+function rejectUnknownValue(
+  vocabulary: readonly string[],
+  filter: PackFilter,
+  occurrences: readonly unknown[],
+  terms: readonly string[],
+): void {
+  const admissible = new Map<string, string>();
+  for (const value of vocabulary) {
+    const key = value.normalize("NFC").toLowerCase();
+    if (!admissible.has(key)) admissible.set(key, value.normalize("NFC"));
+  }
+  if (admissible.size === 0) return;
+  const index = terms.findIndex((term) => !admissible.has(term));
   if (index === -1) return;
-  const validOptions = [...observed.values()].sort();
+  const validOptions = [...admissible.values()].sort();
   throw PragmaError.invalidInput(filter.param, String(occurrences[index]), {
     validOptions,
     recovery: {
-      message: `Values present for --${filter.param}: ${validOptions.join(", ")}.`,
+      message: `Values allowed for --${filter.param}: ${validOptions.join(", ")}.`,
     },
   });
 }

--- a/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.test.ts
@@ -7,6 +7,13 @@
  * `react/component/tsdoc` and `standard lookup react/component/tsdoc` answered
  * ENTITY_NOT_FOUND — the two halves of the declared two-step grammar
  * disagreeing about the same entity.
+ *
+ * The agreement runs in BOTH directions, which is why the fallback is a
+ * DECLARATION (`nameFallback: "iri"`) and not an inference from the presence of
+ * a class constraint. A story whose list REQUIRES its `by` property publishes no
+ * derived name, so deriving one for its lookup would make entities addressable
+ * — and sampleable — under names the list never handed out. Both directions are
+ * pinned below.
  */
 
 import { describe, expect, it } from "vitest";
@@ -17,19 +24,31 @@ import {
   buildLookupQuery,
 } from "./buildLookupQuery.js";
 
-/** A class-constrained lookup — the shape every bundled story declares. */
-const CONSTRAINED: PackLookup = {
+/** The one story that declares the fallback: `standard`, whose list derives names. */
+const DERIVED: PackLookup = {
   source: "sparql",
   by: "cs:name",
+  nameFallback: "iri",
   type: "cs:CodeStandard",
 };
 
-/** The one shape that keeps the strict binding: no class to vouch for `?uri`. */
+/**
+ * A class-constrained lookup that does NOT declare the fallback — the shape
+ * `block`/`token`/`tier`/`concept` declare, whose lists require the `by`
+ * property.
+ */
+const CONSTRAINED: PackLookup = {
+  source: "sparql",
+  by: "ds:tokenId",
+  type: "ds:Token",
+};
+
+/** No class to vouch for `?uri`: the strictest binding of the three. */
 const UNCONSTRAINED: PackLookup = { source: "sparql", by: "ds:name" };
 
 describe("the shared ?name binding", () => {
-  it("makes the `by` triple OPTIONAL and derives a name when a class vouches", () => {
-    const query = buildLookupQuery(CONSTRAINED, "react/component/props");
+  it("makes the `by` triple OPTIONAL and derives a name when the story declares it", () => {
+    const query = buildLookupQuery(DERIVED, "react/component/props");
     expect(query).toContain("?uri a cs:CodeStandard .");
     expect(query).toContain("OPTIONAL { ?uri cs:name ?byName . }");
     expect(query).toContain("BIND(COALESCE(?byName,");
@@ -39,9 +58,20 @@ describe("the shared ?name binding", () => {
     // `cs:react.component.props` → `react/component/props`. Pinned because the
     // list story performs the SAME derivation to publish a row's name; a change
     // on one side without the other re-opens the unaddressable-name defect.
-    expect(buildLookupQuery(CONSTRAINED, "x")).toContain(
+    expect(buildLookupQuery(DERIVED, "x")).toContain(
       'REPLACE(REPLACE(STR(?uri), "^.*[#/]", ""), "\\\\.", "/")',
     );
+  });
+
+  it("REQUIRES the `by` triple for a class-constrained story that declares no fallback", () => {
+    // The narrowing this option exists for. `token list` requires `ds:tokenId`,
+    // so a `ds:Token` without one is a row the list never publishes — inferring
+    // a derived name from the class constraint alone made it addressable under
+    // a name no surface ever handed out.
+    const query = buildLookupQuery(CONSTRAINED, "spacing.medium");
+    expect(query).toContain("?uri a ds:Token .");
+    expect(query).toContain("?uri ds:tokenId ?name .");
+    expect(query).not.toContain("COALESCE");
   });
 
   it("still REQUIRES the `by` triple when the lookup constrains no class", () => {
@@ -51,15 +81,42 @@ describe("the shared ?name binding", () => {
     expect(query).not.toContain("COALESCE");
   });
 
+  it("ignores a fallback declared without a class to vouch for it", () => {
+    // The schema rejects the pairing outright; this is the builders' own guard,
+    // because a derived name with no class constraint leaves `?uri` bound by
+    // nothing and scans the whole graph.
+    const query = buildLookupQuery(
+      { ...UNCONSTRAINED, nameFallback: "iri" },
+      "Button",
+    );
+    expect(query).toContain("?uri ds:name ?name .");
+    expect(query).not.toContain("COALESCE");
+  });
+
   it("binds `?uri` before the BIND that reads it (SPARQL scoping)", () => {
-    const query = buildLookupQuery(CONSTRAINED, "x");
+    const query = buildLookupQuery(DERIVED, "x");
     expect(query.indexOf("?uri a cs:CodeStandard .")).toBeLessThan(
       query.indexOf("BIND(COALESCE("),
     );
-    const byIri = buildLookupByIriQuery(CONSTRAINED, "https://example.test/a");
+    const byIri = buildLookupByIriQuery(DERIVED, "https://example.test/a");
     expect(
       byIri.indexOf("BIND(<https://example.test/a> AS ?uri)"),
     ).toBeLessThan(byIri.indexOf("BIND(COALESCE("));
+  });
+
+  it("keeps the `by` value a LABEL on the IRI-addressed form", () => {
+    // An IRI names the entity by itself, so a class constraint is already a
+    // sufficient existence check and the `by` triple is a label to project.
+    // Unchanged by the fallback option: a `ds:Token` reached by its IRI still
+    // resolves whether or not it carries a `ds:tokenId`.
+    const byIri = buildLookupByIriQuery(CONSTRAINED, "https://example.test/a");
+    expect(byIri).toContain("OPTIONAL { ?uri ds:tokenId ?name . }");
+    expect(byIri).not.toContain("COALESCE");
+    // With no class to vouch for it, the triple is the only existence check
+    // between a typo'd IRI and an empty entity, so it stays required.
+    expect(
+      buildLookupByIriQuery(UNCONSTRAINED, "https://example.test/a"),
+    ).toContain("  ?uri ds:name ?name .");
   });
 
   it("uses the SAME binding for the addressable population as for the resolve", () => {
@@ -67,9 +124,15 @@ describe("the shared ?name binding", () => {
     // query. A population wider or narrower than the resolve's is how a
     // suggested name could itself miss, and how the advertised
     // `react/component/*` glob expanded over a pool that contained no slashes.
-    const names = buildLookupNamesQuery(CONSTRAINED);
+    const names = buildLookupNamesQuery(DERIVED);
     expect(names).toContain("OPTIONAL { ?uri cs:name ?byName . }");
     expect(names).toContain("BIND(COALESCE(?byName,");
+    // And the narrowing reaches the draw pool too: an unnamed `ds:Token` is not
+    // a candidate `token sample` can draw.
+    expect(buildLookupNamesQuery(CONSTRAINED)).toContain(
+      "?uri ds:tokenId ?name .",
+    );
+    expect(buildLookupNamesQuery(CONSTRAINED)).not.toContain("COALESCE");
     expect(buildLookupNamesQuery(UNCONSTRAINED)).toContain(
       "?uri ds:name ?name .",
     );

--- a/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The `?name` binding every generated lookup query shares.
+ *
+ * The unit under test is narrow but load-bearing: WHAT an entity's name is
+ * decides which entities a `lookup` can address at all, and it must agree with
+ * what the `list` story publishes. When it did not, `standard list` handed out
+ * `react/component/tsdoc` and `standard lookup react/component/tsdoc` answered
+ * ENTITY_NOT_FOUND — the two halves of the declared two-step grammar
+ * disagreeing about the same entity.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { PackLookup } from "../types.js";
+import {
+  buildLookupByIriQuery,
+  buildLookupNamesQuery,
+  buildLookupQuery,
+} from "./buildLookupQuery.js";
+
+/** A class-constrained lookup — the shape every bundled story declares. */
+const CONSTRAINED: PackLookup = {
+  source: "sparql",
+  by: "cs:name",
+  type: "cs:CodeStandard",
+};
+
+/** The one shape that keeps the strict binding: no class to vouch for `?uri`. */
+const UNCONSTRAINED: PackLookup = { source: "sparql", by: "ds:name" };
+
+describe("the shared ?name binding", () => {
+  it("makes the `by` triple OPTIONAL and derives a name when a class vouches", () => {
+    const query = buildLookupQuery(CONSTRAINED, "react/component/props");
+    expect(query).toContain("?uri a cs:CodeStandard .");
+    expect(query).toContain("OPTIONAL { ?uri cs:name ?byName . }");
+    expect(query).toContain("BIND(COALESCE(?byName,");
+  });
+
+  it("derives dot-separated local names with slashes — the spelling `list` publishes", () => {
+    // `cs:react.component.props` → `react/component/props`. Pinned because the
+    // list story performs the SAME derivation to publish a row's name; a change
+    // on one side without the other re-opens the unaddressable-name defect.
+    expect(buildLookupQuery(CONSTRAINED, "x")).toContain(
+      'REPLACE(REPLACE(STR(?uri), "^.*[#/]", ""), "\\\\.", "/")',
+    );
+  });
+
+  it("still REQUIRES the `by` triple when the lookup constrains no class", () => {
+    const query = buildLookupQuery(UNCONSTRAINED, "Button");
+    expect(query).toContain("?uri ds:name ?name .");
+    expect(query).not.toContain("OPTIONAL { ?uri ds:name");
+    expect(query).not.toContain("COALESCE");
+  });
+
+  it("binds `?uri` before the BIND that reads it (SPARQL scoping)", () => {
+    const query = buildLookupQuery(CONSTRAINED, "x");
+    expect(query.indexOf("?uri a cs:CodeStandard .")).toBeLessThan(
+      query.indexOf("BIND(COALESCE("),
+    );
+    const byIri = buildLookupByIriQuery(CONSTRAINED, "https://example.test/a");
+    expect(
+      byIri.indexOf("BIND(<https://example.test/a> AS ?uri)"),
+    ).toBeLessThan(byIri.indexOf("BIND(COALESCE("));
+  });
+
+  it("uses the SAME binding for the addressable population as for the resolve", () => {
+    // Miss-suggestions, glob expansion and `sample`'s draw pool all read this
+    // query. A population wider or narrower than the resolve's is how a
+    // suggested name could itself miss, and how the advertised
+    // `react/component/*` glob expanded over a pool that contained no slashes.
+    const names = buildLookupNamesQuery(CONSTRAINED);
+    expect(names).toContain("OPTIONAL { ?uri cs:name ?byName . }");
+    expect(names).toContain("BIND(COALESCE(?byName,");
+    expect(buildLookupNamesQuery(UNCONSTRAINED)).toContain(
+      "?uri ds:name ?name .",
+    );
+  });
+});

--- a/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.ts
@@ -5,15 +5,22 @@
  * and which properties to read; the query text is generated here so
  * user-supplied names are always escaped SPARQL string literals, and level-gated
  * fields below the active level are excluded from the projection (fetch-gating).
- * Matching on the `by` property is exact and case-insensitive.
+ * Matching on the name is exact and case-insensitive.
+ *
+ * WHAT an entity's name IS lives in one place — {@link nameBinding} — and every
+ * form here uses it: the asserted `by` value when the entity carries one, and
+ * otherwise the IRI-derived name a class-constrained lookup can vouch for. That
+ * single binding is what makes the population a `list` publishes and the
+ * population a `lookup` answers to the same population.
  *
  * Every name-addressed resolve is TOTALLY ORDERED before its `LIMIT 1`. A name
  * can recur across tiers, and an unordered `LIMIT 1` hands the tie to the
  * store's enumeration order — a different answer on a different machine, or
  * after a repack. `ORDER BY STR(?uri)` is a total, engine-independent order over
- * a variable that is always bound (`?uri` carries the `by` triple), so it needs
- * no unbound-value sentinel. It fixes WHICH answer is arbitrary, not WHETHER:
- * declaring a precedence between tiers is an ontology change, tracked separately.
+ * a variable that is always bound (`?uri` carries the class constraint, or the
+ * `by` triple when there is none), so it needs no unbound-value sentinel. It
+ * fixes WHICH answer is arbitrary, not WHETHER: declaring a precedence between
+ * tiers is an ontology change, tracked separately.
  */
 
 import { activeExpands, activeFields } from "../disclosure.js";
@@ -43,11 +50,15 @@ function buildTypeConstraint(lookup: PackLookup): string {
  * differ ONLY in how `?uri` is bound (a `FILTER` on the escaped name vs a `BIND`
  * of the resolved IRI), so both thread the active level through here and gate
  * identically — an IRI-addressed lookup honours `--detail` just like a name one.
+ *
+ * `constraint` and `optionals` are handed back SEPARATELY because the `?name`
+ * binding has to sit between them: it reads `?uri`, which the class constraint
+ * binds, and a SPARQL `BIND` may only name variables already in scope.
  */
 function lookupProjection(
   lookup: PackLookup,
   level: string | undefined,
-): { header: string; body: string } {
+): { header: string; constraint: string; optionals: string } {
   const fields = activeFields(lookup, level);
   const vars = fields.map((field) => `?${field.name}`).join(" ");
   const optionals = fields
@@ -58,8 +69,54 @@ function lookupProjection(
     .join("\n");
   return {
     header: `SELECT ?uri ?name${vars.length > 0 ? ` ${vars}` : ""} WHERE {`,
-    body: buildTypeConstraint(lookup) + optionals,
+    constraint: buildTypeConstraint(lookup).trimEnd(),
+    optionals,
   };
+}
+
+/**
+ * The IRI-derived display name, in ONE spelling every relaxed form shares.
+ *
+ * The local name is everything after the last `#` or `/`, and its dot-separated
+ * hierarchy segments are published with slashes — `cs:react.component.props` →
+ * `react/component/props`. That is not an invention here: it is the derivation
+ * the `standard` list story already performs to PUBLISH a row's name, so this is
+ * the same rule read from the other side. Written once, so the name a list hands
+ * out and the name a lookup answers to cannot drift apart.
+ */
+const DERIVED_NAME = 'REPLACE(REPLACE(STR(?uri), "^.*[#/]", ""), "\\\\.", "/")';
+
+/**
+ * The `?name` binding shared by every lookup form.
+ *
+ * Requiring the `by` triple made every entity that carries no name unaddressable
+ * by any means at all: 22 of the 156 live code standards have a `cs:name`, and
+ * the code-standards ontology says so deliberately — `cs:name` is "an optional
+ * human-readable display title" that "never participates in identity". Their
+ * displayed name is synthesized from the IRI by the list story, and shell
+ * completion offers their IRIs.
+ *
+ * So wherever a class constraint can vouch for the entity, the `by` triple is
+ * OPTIONAL and the name falls back to {@link DERIVED_NAME}. It stays REQUIRED
+ * for a lookup that declares no `type`/`types` — there it is the one thing
+ * standing between a typo'd IRI and an empty entity, and there is no class to
+ * bound a derived-name scan with either.
+ *
+ * The relaxation used to apply to the IRI-addressed form ALONE, which is what
+ * left the two-step grammar broken in the middle: `standard list` published
+ * `react/component/tsdoc` and `standard lookup react/component/tsdoc` answered
+ * ENTITY_NOT_FOUND with empty suggestions, because the only addressable
+ * population was the ~13% carrying an asserted name. Applied here, one binding
+ * serves the name resolve, the IRI resolve, the miss-suggestion pool, glob
+ * expansion and `sample`'s draw pool alike.
+ */
+function nameBinding(lookup: PackLookup): string {
+  const constrained = Boolean(lookup.type ?? lookup.types?.length);
+  if (!constrained) return `  ?uri ${formatTerm(lookup.by)} ?name .`;
+  return [
+    `  OPTIONAL { ?uri ${formatTerm(lookup.by)} ?byName . }`,
+    `  BIND(COALESCE(?byName, ${DERIVED_NAME}) AS ?name)`,
+  ].join("\n");
 }
 
 /**
@@ -75,11 +132,12 @@ export function buildLookupQuery(
   name: string,
   level?: string,
 ): string {
-  const { header, body } = lookupProjection(lookup, level);
+  const { header, constraint, optionals } = lookupProjection(lookup, level);
   return [
     header,
-    `  ?uri ${formatTerm(lookup.by)} ?name .`,
-    body,
+    constraint,
+    nameBinding(lookup),
+    optionals,
     `  FILTER (LCASE(STR(?name)) = LCASE("${escapeSparqlString(name)}"))`,
     "}",
     "ORDER BY STR(?uri)",
@@ -87,25 +145,6 @@ export function buildLookupQuery(
   ]
     .filter((line) => line !== "")
     .join("\n");
-}
-
-/**
- * The `?name` clause for an IRI-addressed form.
- *
- * An IRI names the entity by itself, so the `by` value is a LABEL to project,
- * not the thing that identifies it — and a class constraint is already a
- * sufficient existence check. Requiring the `by` triple here made every entity
- * that carries no name unaddressable by any means at all: 131 of the 144 live
- * code standards have no `cs:name` (their displayed name is synthesized from the
- * IRI by the list story), and shell completion offers their IRIs. So the triple
- * is OPTIONAL wherever a class constraint can vouch for the entity, and
- * REQUIRED only for a lookup that declares no `type`/`types` — where it is the
- * one thing standing between a typo'd IRI and an empty entity.
- */
-function iriNameClause(lookup: PackLookup): string {
-  const named = `?uri ${formatTerm(lookup.by)} ?name .`;
-  const constrained = Boolean(lookup.type ?? lookup.types?.length);
-  return constrained ? `  OPTIONAL { ${named} }` : `  ${named}`;
 }
 
 /**
@@ -126,12 +165,13 @@ export function buildLookupByIriQuery(
   iri: string,
   level?: string,
 ): string {
-  const { header, body } = lookupProjection(lookup, level);
+  const { header, constraint, optionals } = lookupProjection(lookup, level);
   return [
     header,
     `  BIND(<${iri}> AS ?uri)`,
-    iriNameClause(lookup),
-    body,
+    constraint,
+    nameBinding(lookup),
+    optionals,
     "}",
     "LIMIT 1",
   ]
@@ -151,8 +191,8 @@ export function buildNameResolveQuery(
 ): string {
   return [
     "SELECT ?uri ?name WHERE {",
-    `  ?uri ${formatTerm(lookup.by)} ?name .`,
     buildTypeConstraint(lookup).trimEnd(),
+    nameBinding(lookup),
     `  FILTER (LCASE(STR(?name)) = LCASE("${escapeSparqlString(name)}"))`,
     "}",
     "ORDER BY STR(?uri)",
@@ -175,8 +215,8 @@ export function buildIriResolveQuery(lookup: PackLookup, iri: string): string {
   return [
     "SELECT ?uri ?name WHERE {",
     `  BIND(<${iri}> AS ?uri)`,
-    iriNameClause(lookup),
     buildTypeConstraint(lookup).trimEnd(),
+    nameBinding(lookup),
     "}",
     "LIMIT 1",
   ]
@@ -239,8 +279,12 @@ export function buildLookupNamesQuery(lookup: PackLookup): string {
     // `block lookup 'Butt*'` listed one Button twice while the other Button
     // never appeared at all.
     "SELECT DISTINCT ?name WHERE {",
-    `  ?uri ${formatTerm(lookup.by)} ?name .`,
     buildTypeConstraint(lookup).trimEnd(),
+    // Same {@link nameBinding} the resolves use, so the addressable population
+    // and the resolvable population are the same population. When they were
+    // not, a name a miss-suggestion offered could itself miss, and a glob
+    // expanded over a pool the resolve could not answer from.
+    nameBinding(lookup),
     "}",
   ]
     .filter((line) => line !== "")

--- a/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.ts
+++ b/packages/cli/pragma/src/kernel/packs/sparql/buildLookupQuery.ts
@@ -8,19 +8,19 @@
  * Matching on the name is exact and case-insensitive.
  *
  * WHAT an entity's name IS lives in one place — {@link nameBinding} — and every
- * form here uses it: the asserted `by` value when the entity carries one, and
- * otherwise the IRI-derived name a class-constrained lookup can vouch for. That
- * single binding is what makes the population a `list` publishes and the
- * population a `lookup` answers to the same population.
+ * form here uses it: the asserted `by` value, plus, for a lookup that DECLARES
+ * `nameFallback: "iri"`, the IRI-derived name its class constraint can vouch
+ * for. That single binding is what makes the population a `list` publishes and
+ * the population a `lookup` answers to the same population.
  *
  * Every name-addressed resolve is TOTALLY ORDERED before its `LIMIT 1`. A name
  * can recur across tiers, and an unordered `LIMIT 1` hands the tie to the
  * store's enumeration order — a different answer on a different machine, or
  * after a repack. `ORDER BY STR(?uri)` is a total, engine-independent order over
  * a variable that is always bound (`?uri` carries the class constraint, or the
- * `by` triple when there is none), so it needs no unbound-value sentinel. It
- * fixes WHICH answer is arbitrary, not WHETHER: declaring a precedence between
- * tiers is an ontology change, tracked separately.
+ * `by` triple when the name is not derived), so it needs no unbound-value
+ * sentinel. It fixes WHICH answer is arbitrary, not WHETHER: declaring a
+ * precedence between tiers is an ontology change, tracked separately.
  */
 
 import { activeExpands, activeFields } from "../disclosure.js";
@@ -89,34 +89,81 @@ const DERIVED_NAME = 'REPLACE(REPLACE(STR(?uri), "^.*[#/]", ""), "\\\\.", "/")';
 /**
  * The `?name` binding shared by every lookup form.
  *
- * Requiring the `by` triple made every entity that carries no name unaddressable
- * by any means at all: 22 of the 156 live code standards have a `cs:name`, and
- * the code-standards ontology says so deliberately — `cs:name` is "an optional
- * human-readable display title" that "never participates in identity". Their
- * displayed name is synthesized from the IRI by the list story, and shell
- * completion offers their IRIs.
+ * By DEFAULT the `by` triple is required, and that is the honest default: `by`
+ * is documented as "the property whose value names the entity", so an entity
+ * without one has no name, is not addressable, and is not drawn by `sample`.
+ * It is also the one thing standing between a typo'd IRI and an empty entity.
  *
- * So wherever a class constraint can vouch for the entity, the `by` triple is
- * OPTIONAL and the name falls back to {@link DERIVED_NAME}. It stays REQUIRED
- * for a lookup that declares no `type`/`types` — there it is the one thing
- * standing between a typo'd IRI and an empty entity, and there is no class to
- * bound a derived-name scan with either.
+ * A story whose `list` SYNTHESIZES a name instead of reading one declares
+ * `nameFallback: "iri"`, and then the triple becomes OPTIONAL with
+ * {@link DERIVED_NAME} behind it. `standard` is the case that exists: 22 of the
+ * 156 live code standards carry a `cs:name`, and the code-standards ontology
+ * says so deliberately — it is "an optional human-readable display title" that
+ * "never participates in identity". `standard list` published
+ * `react/component/tsdoc` while `standard lookup react/component/tsdoc`
+ * answered ENTITY_NOT_FOUND with empty suggestions, because the only
+ * addressable population was the ~13% carrying an asserted name.
  *
- * The relaxation used to apply to the IRI-addressed form ALONE, which is what
- * left the two-step grammar broken in the middle: `standard list` published
- * `react/component/tsdoc` and `standard lookup react/component/tsdoc` answered
- * ENTITY_NOT_FOUND with empty suggestions, because the only addressable
- * population was the ~13% carrying an asserted name. Applied here, one binding
- * serves the name resolve, the IRI resolve, the miss-suggestion pool, glob
- * expansion and `sample`'s draw pool alike.
+ * INFERRING the fallback from the mere PRESENCE of a class constraint is what
+ * this option replaced, and it was over-reach in both directions of the same
+ * defect: `token list` requires `ds:tokenId`, so an inferred fallback made a
+ * `ds:Token` without one addressable and sampleable under a name `token list`
+ * never publishes. The declaration is per story because the list/lookup
+ * agreement is per story.
+ *
+ * The class constraint is still required for the fallback (the schema rejects
+ * the pairing, and this guard keeps a statically-compiled story from generating
+ * a query with nothing bounding `?uri`): a derived name is only as trustworthy
+ * as the class vouching for the entity it came from.
+ *
+ * One binding then serves the name resolve, the miss-suggestion pool, glob
+ * expansion and `sample`'s draw pool alike — every form that decides WHICH
+ * entities a name can reach. (The IRI-addressed forms reach an entity without
+ * going through a name at all: see {@link iriNameBinding}.)
  */
 function nameBinding(lookup: PackLookup): string {
-  const constrained = Boolean(lookup.type ?? lookup.types?.length);
-  if (!constrained) return `  ?uri ${formatTerm(lookup.by)} ?name .`;
+  if (!derivesNames(lookup)) return `  ?uri ${formatTerm(lookup.by)} ?name .`;
   return [
     `  OPTIONAL { ?uri ${formatTerm(lookup.by)} ?byName . }`,
     `  BIND(COALESCE(?byName, ${DERIVED_NAME}) AS ?name)`,
   ].join("\n");
+}
+
+/**
+ * Whether this lookup names an entity that carries no `by` value.
+ *
+ * The class constraint is part of the condition, not merely a schema rule the
+ * builders trust: without one there is no triple bounding `?uri`, so a derived
+ * name would be scanned over the whole graph. The schema rejects the pairing
+ * for declared packs; this keeps a statically-compiled story from generating
+ * that query.
+ */
+function derivesNames(lookup: PackLookup): boolean {
+  return (
+    lookup.nameFallback === "iri" &&
+    Boolean(lookup.type ?? lookup.types?.length)
+  );
+}
+
+/**
+ * The `?name` binding for an IRI-ADDRESSED form.
+ *
+ * An IRI names the entity by itself, so here the `by` value is a LABEL to
+ * project, not the thing that identifies it — and the class constraint is
+ * already a sufficient existence check. So the triple is OPTIONAL wherever a
+ * class vouches for the entity, and `?name` is simply left unbound when there is
+ * no label; it is REQUIRED only for a lookup constraining no class, where it is
+ * the one thing standing between a typo'd IRI and an empty entity.
+ *
+ * A story that {@link derivesNames} gets the same COALESCE the name forms use,
+ * so an entity reached by IRI reports the name `list` published for it rather
+ * than a blank.
+ */
+function iriNameBinding(lookup: PackLookup): string {
+  if (derivesNames(lookup)) return nameBinding(lookup);
+  const named = `?uri ${formatTerm(lookup.by)} ?name .`;
+  const constrained = Boolean(lookup.type ?? lookup.types?.length);
+  return constrained ? `  OPTIONAL { ${named} }` : `  ${named}`;
 }
 
 /**
@@ -170,7 +217,7 @@ export function buildLookupByIriQuery(
     header,
     `  BIND(<${iri}> AS ?uri)`,
     constraint,
-    nameBinding(lookup),
+    iriNameBinding(lookup),
     optionals,
     "}",
     "LIMIT 1",
@@ -216,7 +263,7 @@ export function buildIriResolveQuery(lookup: PackLookup, iri: string): string {
     "SELECT ?uri ?name WHERE {",
     `  BIND(<${iri}> AS ?uri)`,
     buildTypeConstraint(lookup).trimEnd(),
-    nameBinding(lookup),
+    iriNameBinding(lookup),
     "}",
     "LIMIT 1",
   ]

--- a/packages/cli/pragma/src/kernel/packs/toolDescription.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/toolDescription.test.ts
@@ -130,3 +130,33 @@ describe("a tool-call example names a parameter the tool ACCEPTS (PROTECTED)", (
     }
   });
 });
+
+describe("every story tool CARRIES a call example (PROTECTED)", () => {
+  // The check above only polices examples that exist. `standard` authored NONE,
+  // and the auto-generated one fires only for a filter declaring `values` —
+  // which the category filter deliberately does not, because the graph is the
+  // vocabulary. So the four `standard_*` tools shipped with no worked call at
+  // all, and the model that could not form one had nothing to copy.
+  //
+  // This asserts the gap cannot reappear on a future story: a compiled story
+  // tool must show an agent one call it can make, spelled with its OWN name so
+  // the example cannot be copied from a sibling tool and left stale.
+  it("names its own tool in an `Example: <tool_name> {…}` fragment", async () => {
+    const mcp = await projectMcp([...storyModules.values()]);
+    try {
+      const tools = await mcp.listTools();
+      expect(tools.length).toBeGreaterThan(0);
+      const missing = tools
+        .filter(
+          (tool) =>
+            !new RegExp(`Example:\\s*${tool.name}\\s*\\{`).test(
+              tool.description ?? "",
+            ),
+        )
+        .map((tool) => tool.name);
+      expect(missing).toEqual([]);
+    } finally {
+      await mcp.cleanup();
+    }
+  });
+});

--- a/packages/cli/pragma/src/kernel/packs/toolDescription.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/toolDescription.test.ts
@@ -68,7 +68,11 @@ describe("pack toolDescription wiring (PROTECTED)", () => {
       (t) => t.name === "standard_categories",
     )?.description;
     await mcp.cleanup();
-    expect(desc).toBe("List all code standard categories.");
+    // The authored prose reaches the extra verb's tool, whole. Asserted by
+    // fragment rather than by exact string: the wiring is what this pins, and
+    // tool descriptions are explicitly not frozen (`registerVerb.ts:324-326`).
+    expect(desc).toContain("List all code standard categories");
+    expect(desc).toContain("Example: standard_categories {}");
   });
 
   it("CLI --help shows the rich prose but NEVER the MCP tool-call syntax", () => {

--- a/packages/cli/pragma/src/kernel/packs/types.ts
+++ b/packages/cli/pragma/src/kernel/packs/types.ts
@@ -150,6 +150,19 @@ export interface PackFilter {
    * string matched case-insensitively against the variable).
    */
   readonly values?: readonly string[];
+  /**
+   * How a provided value is compared to the row's cell.
+   *
+   * `"exact"` (the default) compares the whole cell. `"set"` reads the cell as
+   * a SPACE-SEPARATED set and matches when ANY member equals the provided
+   * value — the shape a `GROUP_CONCAT` produces, for a dimension where one row
+   * legitimately belongs to several values at once. The standing case is a
+   * hierarchy: a standard filed under `testing-unit` is, by the definition of
+   * the hierarchy, also a `testing` standard, and a filter that compared only
+   * the leaf answered `--category testing` with 1 of 8 — a silently wrong
+   * answer, exit 0.
+   */
+  readonly match?: "exact" | "set";
   /** Help text (defaults to a generated description). */
   readonly description?: string;
 }

--- a/packages/cli/pragma/src/kernel/packs/types.ts
+++ b/packages/cli/pragma/src/kernel/packs/types.ts
@@ -163,8 +163,41 @@ export interface PackFilter {
    * answer, exit 0.
    */
   readonly match?: "exact" | "set";
+  /**
+   * Where the dimension's VOCABULARY lives in the graph, for a filter with no
+   * declared {@link values}.
+   *
+   * A value-free filter rejects a value the data does not carry. The question is
+   * what "the data" means. The rows a list just returned are the wrong answer:
+   * they are a POPULATION, and a value can be real while no row carries it — a
+   * category the graph declares with zero standards filed under it, a
+   * `ds:ConceptType` no concept uses yet. Validating against rows turns those
+   * into `INVALID_INPUT`, when the honest answer is a calm empty list.
+   *
+   * So the vocabulary is read from the graph directly, from the same terms the
+   * surface that ENUMERATES it reads (`standard categories` reads `cs:Category`
+   * / `cs:slug`; so does the `category` filter's vocabulary query). The ruling
+   * this honours is "the graph is the vocabulary, don't hard-code the slugs" —
+   * rows were never the graph, just the part of it that answered.
+   *
+   * Without it a value-free filter falls back to the observed rows, which is the
+   * only evidence available; that is a NARROWER vocabulary than the truth, and a
+   * story whose dimension has an authoritative source should declare it.
+   */
+  readonly vocabulary?: PackFilterVocabulary;
   /** Help text (defaults to a generated description). */
   readonly description?: string;
+}
+
+/** The authoritative value set for a value-free {@link PackFilter}. */
+export interface PackFilterVocabulary {
+  /** SPARQL SELECT producing one row per admissible value. */
+  readonly query: string;
+  /**
+   * SELECT variable carrying the value (without `?`). Defaults to the filter's
+   * own {@link PackFilter.variable}.
+   */
+  readonly variable?: string;
 }
 
 /**
@@ -269,6 +302,29 @@ export interface PackLookup {
   readonly source?: "sparql" | "graphql";
   /** Property whose value names the entity — prefixed name or IRI. */
   readonly by: string;
+  /**
+   * What names an entity that carries no {@link by} value. Absent (the default)
+   * means NOTHING does: the `by` triple is required, and an entity without one
+   * is not addressable by name and never drawn by `sample`.
+   *
+   * `"iri"` opts the family into an IRI-DERIVED name — the local name after the
+   * last `#`/`/`, with dot-separated hierarchy segments published as slashes
+   * (`cs:react.component.props` → `react/component/props`).
+   *
+   * DECLARE IT ONLY WHEN THE STORY'S `list` PUBLISHES THE SAME DERIVED NAME.
+   * The option exists to keep the two halves of the two-step grammar over ONE
+   * population: `standard list` synthesizes a name for the ~87% of code
+   * standards carrying no `cs:name`, so `standard lookup` must answer to it.
+   * Turning it on where the list does NOT publish such a name is the mirror
+   * defect — `token list` requires `ds:tokenId`, so a `ds:Token` without one
+   * would become addressable and sampleable under a name the list never
+   * published.
+   *
+   * Requires a class constraint ({@link type}/{@link types}): the derived name
+   * is only as trustworthy as the class that vouches for the entity, and
+   * without one there is nothing to bound the scan with either.
+   */
+  readonly nameFallback?: "iri";
   /** Optional single class constraint — prefixed name or IRI. */
   readonly type?: string;
   /** CLI description for the lookup command (defaults to a generated one). */

--- a/packages/cli/pragma/src/kernel/project/cli/dispatch.ts
+++ b/packages/cli/pragma/src/kernel/project/cli/dispatch.ts
@@ -181,8 +181,16 @@ function renderData(
 ): DispatchOutcome {
   if (flags.format === "json") {
     const projection = JSON.parse(verb.output.formatters.json(data));
+    // The calm zero-record notice rides `meta` on the machine surfaces, so an
+    // empty result is distinguishable from an unbuilt store or a mistyped
+    // filter. `data` keeps its uniform empty shape, and MCP builds the same key
+    // from the same seam (`mcp/registerVerb.ts#emptyMeta`) — the two machine
+    // surfaces stay byte-equal.
+    const notice = verb.output.formatters.emptyNotice?.(data);
     return {
-      stdout: `${JSON.stringify(successEnvelope(projection, meta))}\n`,
+      stdout: `${JSON.stringify(
+        successEnvelope(projection, notice ? { ...meta, notice } : meta),
+      )}\n`,
       exitCode: 0,
     };
   }

--- a/packages/cli/pragma/src/kernel/project/mcp/registerVerb.ts
+++ b/packages/cli/pragma/src/kernel/project/mcp/registerVerb.ts
@@ -143,6 +143,21 @@ function withDetail(
   };
 }
 
+/**
+ * The empty-state seam, projected into the envelope's `meta`.
+ *
+ * `emptyNotice` existed with exactly ONE consumer: the CLI dispatcher, which
+ * writes it to stderr. An agent therefore could not tell an unbuilt store, a
+ * mistyped filter and a genuinely empty result apart — all three were
+ * `{"ok":true,"data":[],"meta":{}}`. Riding in `meta` keeps `data` the uniform
+ * empty shape (`[]` stays `[]`) while making empty ≠ silence, and the CLI's
+ * `--format json` carries the same key so the two surfaces stay byte-equal.
+ */
+function emptyMeta(verb: VerbSpec, data: unknown): Record<string, unknown> {
+  const notice = verb.output.formatters.emptyNotice?.(data as never);
+  return notice ? { notice } : {};
+}
+
 /** The tool handler for a read verb: run, project, envelope. */
 function readHandler(verb: VerbSpec, runtime: PragmaRuntime) {
   return async (args: Record<string, unknown>): Promise<CallToolResult> => {
@@ -152,7 +167,10 @@ function readHandler(verb: VerbSpec, runtime: PragmaRuntime) {
       const result = await Promise.resolve(
         verb.run(params, withDetail(verb, runtime, args)) as Promise<unknown>,
       );
-      return toolSuccess(JSON.parse(verb.output.formatters.json(result)));
+      return toolSuccess(
+        JSON.parse(verb.output.formatters.json(result)),
+        emptyMeta(verb, result),
+      );
     } catch (error) {
       return toolError(asPragmaError(error));
     }

--- a/packages/cli/pragma/src/kernel/spec/types.ts
+++ b/packages/cli/pragma/src/kernel/spec/types.ts
@@ -150,10 +150,26 @@ export type ParamSpec =
  * `json` (the envelope) never see it.
  *
  * `emptyNotice` is the empty-state seam: when the data amounts to zero
- * records, return the calm notice — the dispatcher routes it to STDERR with
- * exit 0, keeping the stdout data stream free of human sentences a pipe
- * would read as records. Return `undefined` (or omit the member) for data
- * that has content; only the plain mode routes it.
+ * records, return the calm notice. Return `undefined` (or omit the member) for
+ * data that has content.
+ *
+ * Three surfaces route it, each in its own register — it is one seam, not a
+ * plain-mode courtesy:
+ * - `plain`: the dispatcher writes it to STDERR with exit 0, keeping the stdout
+ *   data stream free of human sentences a pipe would read as records. `--quiet`
+ *   mutes it (success-path guidance).
+ * - `--format json` AND the MCP tool result: it rides the envelope as
+ *   `meta.notice` (`project/cli/dispatch.ts#renderData`,
+ *   `project/mcp/registerVerb.ts#emptyMeta` — the same key from the same seam,
+ *   so the two MACHINE surfaces stay byte-equal). `data` keeps its uniform empty
+ *   shape; `[]` stays `[]`. Without it an agent could not tell an unbuilt store,
+ *   a mistyped filter and a genuinely empty result apart — all three were
+ *   `{"ok":true,"data":[],"meta":{}}`.
+ * - `llm` (the byte-frozen agent contract) is the ONE mode that still ignores
+ *   it: it renders one stream and its bytes are frozen.
+ *
+ * The formatters themselves never see the notice: `json(d)` renders the data
+ * alone, and the ENVELOPE layer carries the notice beside it.
  */
 export interface Formatters<T> {
   readonly plain: (

--- a/packages/cli/pragma/src/testing/PARITY_GAPS.ts
+++ b/packages/cli/pragma/src/testing/PARITY_GAPS.ts
@@ -42,13 +42,13 @@ export const PARITY_GAPS: readonly ParityGapEntry[] = [
     id: "read-meta-always-empty",
     area: "envelope",
     description:
-      "`dispatch.ts#executeVerb`'s read branch always renders with `meta: {}` — there is no `meta.count`/`meta.total` field on a list/lookup envelope (verified empirically). An empty (possibly filtered) list is `{ok:true, data:[], meta:{}}`; the only way to know it's empty is `data.length === 0`, not a meta field.",
+      "NARROWED: a read envelope still carries no `meta.count`/`meta.total` — the only way to know a list is empty is `data.length === 0`, not a count field. But `meta` is no longer ALWAYS `{}` on a read. A zero-record read now carries the verb's own `emptyNotice` as `meta.notice` on BOTH machine surfaces (`project/cli/dispatch.ts#renderData` for `--format json`, `project/mcp/registerVerb.ts#emptyMeta` for MCP — one seam, the same key, so the two stay byte-equal). `data` keeps its uniform empty shape; `[]` is still `[]`. The divergence this entry records is the ABSENCE of counts, not the emptiness of `meta`: without the notice an agent could not tell an unbuilt store, a mistyped filter and a genuinely empty result apart, all three being `{ok:true,data:[],meta:{}}`.",
   },
   {
     id: "no-empty-hook-on-free-filter",
     area: "pack list / empty-state",
     description:
-      "A zero-row pack list — whether narrowed by a declared filter, an unmatched `--search`, or unconditionally empty — returns `ok:true, data:[], meta:{}` at exit 0 with a calm `emptyMessage`/`emptyHint`; pragma v2 never raises a typed EMPTY_RESULTS error for an empty list. (U5 removed the former enum-filter-only `buildListEmptyError` hook, making the empty-state uniform across every list verb.)",
+      "STILL TRUE OF EMPTINESS, NARROWED ON BAD ARGUMENTS. A zero-row pack list — narrowed by a declared filter, by an unmatched `--search`, or unconditionally empty — is a SUCCESS: `ok:true, data:[]` at exit 0 with a calm notice (stderr in plain mode, `meta.notice` on the machine surfaces). pragma v2 still never raises EMPTY_RESULTS for an empty list, and U5's removal of the enum-filter-only `buildListEmptyError` hook stands. What is no longer true is that an UNMATCHED free-filter value stays successful: a value-free filter now rejects a value its vocabulary does not admit with INVALID_INPUT and the admissible values as `validOptions`, the same courtesy a declared-`values` filter always extended (`packs/sparql/applyFilters.ts`). The vocabulary is the graph's, not the returned rows' — a filter declares where it lives (`PackFilter.vocabulary`), so a real value that happens to match no row (a category with zero standards, a `ds:ConceptType` no concept uses) is a calm empty list, and only a value the graph does not know is an error.",
   },
   {
     id: "raw-iri-in-data",

--- a/packages/cli/pragma/src/testing/behavioral/docExamples.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/docExamples.test.ts
@@ -164,9 +164,11 @@ const READ_CASES: readonly ReadCase[] = [
   },
   { command: "pragma standard list", key: "standard list", params: {} },
   {
-    command: "pragma standard list --category react",
+    // The doc's headline example, and the one the roll-up is about: a parent
+    // category answering for its whole branch.
+    command: "pragma standard list --category testing",
     key: "standard list",
-    params: { category: ["react"] },
+    params: { category: ["testing"] },
   },
   {
     command: "pragma standard categories",

--- a/packages/cli/pragma/src/testing/behavioral/errorMatrix.mcp.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/errorMatrix.mcp.test.ts
@@ -12,10 +12,15 @@
  *    `ok:true` (that shape is B1's job, `agentSession.mcp.test.ts`). See
  *    PARITY_GAPS `single-lookup-miss-fails-batch-partial-reports`.
  * 2. A filtered list narrowed to zero rows is `{ok:true, data:[]}` — there is
- *    still no `meta.count` field on any read envelope. `meta` is no longer
- *    always `{}` on a read, though: a zero-record read carries the list's own
- *    `emptyNotice` as `meta.notice`, on BOTH machine surfaces. See PARITY_GAPS
- *    `read-meta-always-empty`.
+ *    still no `meta.count` field on any read envelope, which is the divergence
+ *    `read-meta-always-empty` now records (it no longer claims `meta` is always
+ *    `{}`: a zero-record read carries the list's own `emptyNotice` as
+ *    `meta.notice` on both machine surfaces, asserted below).
+ * 3. A value-free filter given a value its vocabulary does not admit is
+ *    INVALID_INPUT, not a successful empty list — the narrowing recorded in
+ *    PARITY_GAPS `no-empty-hook-on-free-filter`. Emptiness itself is still a
+ *    success: a value the GRAPH admits but no row carries (a category with zero
+ *    standards) is a calm empty list, asserted below.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -97,11 +102,12 @@ describe("lookup miss — total miss fails the call (B3, adapted)", () => {
  * `--category`, an unbuilt store and a genuinely empty category byte-identical —
  * the silence a model has no way to recover from.
  *
- * A value the data does not carry is now INVALID_INPUT with the observed values
- * as `validOptions`, exactly as a filter declaring `values` has always behaved;
- * the difference is that the vocabulary is READ FROM THE GRAPH rather than
- * copied into the story. Zero rows for a value that DOES exist stays a calm
- * empty list — that is a real answer, not a bad argument.
+ * A value the graph does not know is now INVALID_INPUT with the admissible
+ * values as `validOptions`, exactly as a filter declaring `values` has always
+ * behaved; the difference is that the vocabulary is READ FROM THE GRAPH rather
+ * than copied into the story. Zero rows for a value that DOES exist stays a calm
+ * empty list — that is a real answer, not a bad argument — and "exists" means
+ * the graph declares it, not that some returned row happened to carry it.
  */
 describe("list — a filter value the graph does not carry is INVALID_INPUT (B3, adapted)", () => {
   it("has at least one filtered list verb to sweep", () => {
@@ -128,16 +134,65 @@ describe("list — a filter value the graph does not carry is INVALID_INPUT (B3,
 
   it.each(
     filteredListVerbs,
-  )("$tool: a value the graph DOES carry still narrows to a calm list", async ({
+  )("$tool: every value the graph DOES carry narrows to a calm list", async ({
     tool,
     param,
   }) => {
     const rejected = await mcp.callTool(tool, { [param]: "zzz-nope" });
-    const observed = (rejected.error as { validOptions: string[] })
-      .validOptions[0] as string;
-    const result = await mcp.callTool(tool, { [param]: observed });
-    expect(result.ok).toBe(true);
-    expect((result.data as unknown[]).length).toBeGreaterThan(0);
+    const admissible = (rejected.error as { validOptions: string[] })
+      .validOptions;
+    expect(admissible.length).toBeGreaterThan(0);
+    // EVERY admissible value is accepted, and at least one is populated. Not
+    // "the first one returns rows": the vocabulary is the graph's, so it can
+    // legitimately contain a value no row carries (a category with zero
+    // standards) — that value is a calm empty list, not a rejection, and the
+    // sweep would otherwise read a real answer as a failure.
+    let populated = 0;
+    for (const value of admissible) {
+      const result = await mcp.callTool(tool, { [param]: value });
+      expect(result.ok).toBe(true);
+      if ((result.data as unknown[]).length > 0) populated += 1;
+    }
+    expect(populated).toBeGreaterThan(0);
+  });
+
+  it("standard_list: a declared category with NO standards is a calm empty list", async () => {
+    // The case that separates "the graph is the vocabulary" from "the returned
+    // rows are the vocabulary". `standard_categories` publishes every declared
+    // slug with its count, zeros included, and tells the agent to pick one —
+    // so rejecting a zero-count slug as INVALID_INPUT tells it the slug the
+    // tool just handed it was a typo. Validity read off the rows did exactly
+    // that, because a category with no standards appears in no row.
+    const categories = await mcp.callTool("standard_categories");
+    const zero = (categories.data as { name: string; count: string }[]).filter(
+      (row) => Number(row.count) === 0,
+    );
+    expect(zero.length).toBeGreaterThan(0);
+    for (const row of zero) {
+      const result = await mcp.callTool("standard_list", {
+        category: row.name,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.data).toEqual([]);
+      // And it is a real empty answer, so it carries the calm notice rather
+      // than passing in silence.
+      expect((result.meta as { notice?: string }).notice ?? "").not.toBe("");
+    }
+  });
+
+  it("standard_list: the rejection names the declared slugs, not just the used ones", async () => {
+    const result = await mcp.callTool("standard_list", {
+      category: "zzz-definitely-not-a-slug",
+    });
+    expect(result.ok).toBe(false);
+    const error = result.error as { code: string; validOptions: string[] };
+    expect(error.code).toBe("INVALID_INPUT");
+    const categories = await mcp.callTool("standard_categories");
+    const declared = (categories.data as { name: string }[]).map((r) => r.name);
+    // Same vocabulary, both surfaces: whatever `standard_categories` lists is
+    // what `--category` accepts. Read from `cs:Category`/`cs:slug` on both
+    // sides, so the two cannot drift.
+    expect([...error.validOptions].sort()).toEqual([...declared].sort());
   });
 });
 

--- a/packages/cli/pragma/src/testing/behavioral/errorMatrix.mcp.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/errorMatrix.mcp.test.ts
@@ -11,9 +11,10 @@
  *    a total miss; only a PARTIAL batch reports the miss while staying
  *    `ok:true` (that shape is B1's job, `agentSession.mcp.test.ts`). See
  *    PARITY_GAPS `single-lookup-miss-fails-batch-partial-reports`.
- * 2. A filtered list narrowed to zero rows is `{ok:true, data:[], meta:{}}` —
- *    there is no `meta.count` field on any read envelope (`dispatch.ts`
- *    always renders reads with `meta:{}`). See PARITY_GAPS
+ * 2. A filtered list narrowed to zero rows is `{ok:true, data:[]}` — there is
+ *    still no `meta.count` field on any read envelope. `meta` is no longer
+ *    always `{}` on a read, though: a zero-record read carries the list's own
+ *    `emptyNotice` as `meta.notice`, on BOTH machine surfaces. See PARITY_GAPS
  *    `read-meta-always-empty`.
  */
 
@@ -88,7 +89,21 @@ describe("lookup miss — total miss fails the call (B3, adapted)", () => {
   });
 });
 
-describe("list — a narrowing filter to zero rows is a plain empty list (B3, adapted)", () => {
+/**
+ * CHANGED DELIBERATELY. This used to assert that ANY filter value narrowed to a
+ * plain `{"ok":true,"data":[],"meta":{}}`, which was written when no value-free
+ * filter could tell a typo from an empty answer. It could: the rows it is
+ * filtering carry the vocabulary. Over MCP the old shape made a mistyped
+ * `--category`, an unbuilt store and a genuinely empty category byte-identical —
+ * the silence a model has no way to recover from.
+ *
+ * A value the data does not carry is now INVALID_INPUT with the observed values
+ * as `validOptions`, exactly as a filter declaring `values` has always behaved;
+ * the difference is that the vocabulary is READ FROM THE GRAPH rather than
+ * copied into the story. Zero rows for a value that DOES exist stays a calm
+ * empty list — that is a real answer, not a bad argument.
+ */
+describe("list — a filter value the graph does not carry is INVALID_INPUT (B3, adapted)", () => {
   it("has at least one filtered list verb to sweep", () => {
     // A guard, not a no-op: if this ever goes empty the sweep below silently
     // covers nothing, which would be a silent coverage loss worth noticing.
@@ -97,16 +112,49 @@ describe("list — a narrowing filter to zero rows is a plain empty list (B3, ad
 
   it.each(
     filteredListVerbs,
-  )("$tool: an unmatched filter value narrows to [] (no EMPTY_RESULTS)", async ({
+  )("$tool: an unobserved filter value is rejected, naming the observed ones", async ({
     tool,
     param,
   }) => {
     const result = await mcp.callTool(tool, {
       [param]: "zzz-definitely-not-a-real-value",
     });
+    expect(result.ok).toBe(false);
+    const error = result.error as { code: string; validOptions?: string[] };
+    expect(error.code).toBe("INVALID_INPUT");
+    expect(error.validOptions?.length).toBeGreaterThan(0);
+    expect(error.validOptions).not.toContain("zzz-definitely-not-a-real-value");
+  });
+
+  it.each(
+    filteredListVerbs,
+  )("$tool: a value the graph DOES carry still narrows to a calm list", async ({
+    tool,
+    param,
+  }) => {
+    const rejected = await mcp.callTool(tool, { [param]: "zzz-nope" });
+    const observed = (rejected.error as { validOptions: string[] })
+      .validOptions[0] as string;
+    const result = await mcp.callTool(tool, { [param]: observed });
+    expect(result.ok).toBe(true);
+    expect((result.data as unknown[]).length).toBeGreaterThan(0);
+  });
+});
+
+describe("empty ≠ silence on the machine surfaces", () => {
+  it("carries the list's empty-state guidance in the envelope meta", async () => {
+    // `emptyNotice` had exactly one consumer — the CLI dispatcher's stderr — so
+    // an agent received `{"ok":true,"data":[],"meta":{}}` and nothing else. The
+    // search path is the honest way to reach an empty list without a bad
+    // argument.
+    const result = await mcp.callTool("standard_list", {
+      search: "zzz-nothing-matches-this",
+    });
     expect(result.ok).toBe(true);
     expect(result.data).toEqual([]);
-    expect(result.meta).toEqual({});
+    const notice = (result.meta as { notice?: string }).notice ?? "";
+    expect(notice).toContain("No standard entries found.");
+    expect(notice).toContain("pragma standard categories");
   });
 });
 

--- a/packages/cli/pragma/src/testing/eval/__snapshots__/eval.test.ts.snap
+++ b/packages/cli/pragma/src/testing/eval/__snapshots__/eval.test.ts.snap
@@ -63,7 +63,12 @@ exports[`eval harness — seed gate > runs the full seed (stable + read-noun) ca
     "passed": true,
   },
   {
-    "id": "content-standard-list-length-equals-category-count-sum",
+    "id": "content-standard-category-counts-match-filtered-list",
+    "kind": "content",
+    "passed": true,
+  },
+  {
+    "id": "content-standard-category-rollup-keeps-the-direct-member",
     "kind": "content",
     "passed": true,
   },

--- a/packages/cli/pragma/src/testing/eval/__snapshots__/eval.test.ts.snap
+++ b/packages/cli/pragma/src/testing/eval/__snapshots__/eval.test.ts.snap
@@ -178,6 +178,11 @@ exports[`eval harness — seed gate > runs the full seed (stable + read-noun) ca
     "passed": true,
   },
   {
+    "id": "tool-standard-list-empty-category-is-a-calm-empty-list",
+    "kind": "tool",
+    "passed": true,
+  },
+  {
     "id": "tool-standard-list-names-are-addressable-by-lookup",
     "kind": "tool",
     "passed": true,
@@ -194,6 +199,11 @@ exports[`eval harness — seed gate > runs the full seed (stable + read-noun) ca
   },
   {
     "id": "tool-tier-lookup-lists-scoped-blocks",
+    "kind": "tool",
+    "passed": true,
+  },
+  {
+    "id": "tool-token-lookup-addresses-only-what-list-publishes",
     "kind": "tool",
     "passed": true,
   },

--- a/packages/cli/pragma/src/testing/eval/__snapshots__/eval.test.ts.snap
+++ b/packages/cli/pragma/src/testing/eval/__snapshots__/eval.test.ts.snap
@@ -173,6 +173,16 @@ exports[`eval harness — seed gate > runs the full seed (stable + read-noun) ca
     "passed": true,
   },
   {
+    "id": "tool-standard-list-names-are-addressable-by-lookup",
+    "kind": "tool",
+    "passed": true,
+  },
+  {
+    "id": "tool-standard-lookup-advertised-glob-matches",
+    "kind": "tool",
+    "passed": true,
+  },
+  {
     "id": "tool-standard-lookup-has-dos-and-donts",
     "kind": "tool",
     "passed": true,

--- a/packages/cli/pragma/src/testing/eval/cases/readNouns.ts
+++ b/packages/cli/pragma/src/testing/eval/cases/readNouns.ts
@@ -154,6 +154,114 @@ export const readNounEvalCases: readonly EvalCase[] = [
     },
   },
   {
+    // The MIRROR of the addressability case above, and the reason the IRI-name
+    // fallback is DECLARED per story rather than inferred from a class
+    // constraint. `token list` requires `ds:tokenId`, so a `ds:Token` without
+    // one is a row it never publishes — and it must therefore be reachable by
+    // no name at all, and drawn by no sample. Inferring the fallback from the
+    // presence of `type: ds:Token` made it addressable and sampleable under an
+    // IRI-derived name the list never handed out: the same list/lookup
+    // disagreement as the standards defect, pointing the other way.
+    id: "tool-token-lookup-addresses-only-what-list-publishes",
+    kind: "tool",
+    input:
+      "a ds:Token carrying no ds:tokenId appears in no token_list row, resolves through no token_lookup name, and is drawn by no token_sample.",
+    async expect() {
+      await withCanonicalFixture(ALL_VISIBLE_CONFIG, async (mcp) => {
+        const list = await mcp.callTool("token_list");
+        assert.equal(list.ok, true);
+        const published = new Set(
+          (list.data as { name: string }[]).map((row) => row.name),
+        );
+        assert.ok(published.size > 0, "expected token_list to publish rows");
+        // The IRI-derived spellings the fallback would have minted for
+        // `ds:token.legacy.borderRadius` (local name, dots as slashes).
+        for (const derived of [
+          "token.legacy.borderRadius",
+          "token/legacy/borderRadius",
+        ]) {
+          assert.ok(
+            !published.has(derived),
+            `token_list must not publish ${derived}`,
+          );
+          const result = await mcp.callTool("token_lookup", {
+            name: [derived],
+          });
+          assert.equal(
+            result.ok,
+            false,
+            `token_lookup addressed ${derived}, a name token_list never published`,
+          );
+          assert.equal(
+            (result.error as { code: string }).code,
+            "ENTITY_NOT_FOUND",
+          );
+        }
+        // `sample`'s draw pool is the same population, so its reported total is
+        // the published population — not one entity wider.
+        const sample = await mcp.callTool("token_sample", {});
+        assert.equal(sample.ok, true);
+        assert.equal(
+          (sample.data as { totalCount: number }).totalCount,
+          published.size,
+        );
+      });
+    },
+  },
+  {
+    // A slug the graph declares with no standards filed under it. `standard
+    // categories` lists it at count 0 and the tool descriptions document a
+    // filtered list as a plain list, so asking for it is a calm empty answer —
+    // an INVALID_INPUT here tells an agent its own valid slug was a typo.
+    // Validity read off the RETURNED ROWS produced exactly that, because a
+    // category with no standards appears in no row.
+    id: "tool-standard-list-empty-category-is-a-calm-empty-list",
+    kind: "tool",
+    input:
+      "standard_list {category} for a real slug that no standard uses is ok:true with an empty list, not INVALID_INPUT.",
+    async expect() {
+      await withCanonicalFixture(CANONICAL_CONFIG, async (mcp) => {
+        const categories = await mcp.callTool("standard_categories");
+        assert.equal(categories.ok, true);
+        const empty = (categories.data as { name: string; count: string }[])
+          .filter((row) => Number(row.count) === 0)
+          .map((row) => row.name);
+        assert.ok(
+          empty.length > 0,
+          "expected standard_categories to report a zero-count category",
+        );
+        for (const slug of empty) {
+          const result = await mcp.callTool("standard_list", {
+            category: slug,
+          });
+          assert.equal(
+            result.ok,
+            true,
+            `standard_list rejected ${slug}, a slug standard_categories publishes`,
+          );
+          assert.deepEqual(result.data, []);
+        }
+        // The rejection itself still works, and still names the graph's whole
+        // vocabulary — including the categories no standard uses.
+        const rejected = await mcp.callTool("standard_list", {
+          category: "zzz-not-a-slug",
+        });
+        assert.equal(rejected.ok, false);
+        const error = rejected.error as {
+          code: string;
+          validOptions: string[];
+        };
+        assert.equal(error.code, "INVALID_INPUT");
+        for (const slug of empty) {
+          assert.ok(
+            error.validOptions.includes(slug),
+            `validOptions omitted the declared category ${slug}`,
+          );
+        }
+      });
+    },
+  },
+  {
     id: "content-canonical-graph-has-4-components",
     kind: "content",
     input:

--- a/packages/cli/pragma/src/testing/eval/cases/readNouns.ts
+++ b/packages/cli/pragma/src/testing/eval/cases/readNouns.ts
@@ -87,6 +87,73 @@ export const readNounEvalCases: readonly EvalCase[] = [
     },
   },
   {
+    // The journey the reported failure actually walked: browse a category, take
+    // a published `name` VERBATIM, and ask for its content. Every row `list`
+    // publishes must be addressable by `lookup` — otherwise the two-step
+    // grammar the whole read surface is built on has a hole in it, and an agent
+    // that follows the tools' own output gets ENTITY_NOT_FOUND with empty
+    // suggestions and a recovery pointing back at the list it just read.
+    id: "tool-standard-list-names-are-addressable-by-lookup",
+    kind: "tool",
+    input:
+      "every name standard_list {category:react} publishes resolves through standard_lookup {name:[…], detail:detailed}, dos/donts included.",
+    async expect() {
+      await withCanonicalFixture(CANONICAL_CONFIG, async (mcp) => {
+        const list = await mcp.callTool("standard_list", { category: "react" });
+        assert.equal(list.ok, true);
+        const names = (list.data as { name: string }[]).map((row) => row.name);
+        assert.ok(names.length > 0, "expected standard_list to publish rows");
+        let withExamples = 0;
+        for (const name of names) {
+          const result = await mcp.callTool("standard_lookup", {
+            name: [name],
+            detail: "detailed",
+          });
+          assert.equal(
+            result.ok,
+            true,
+            `standard_lookup rejected the name standard_list published: ${name}`,
+          );
+          const entity = (result.data as { results: Record<string, unknown>[] })
+            .results[0];
+          assert.equal(entity?.name, name);
+          if (
+            (entity?.dos as unknown[] | undefined)?.length &&
+            (entity?.donts as unknown[] | undefined)?.length
+          ) {
+            withExamples += 1;
+          }
+        }
+        assert.ok(
+          withExamples > 0,
+          "expected at least one resolved standard to carry both dos and donts",
+        );
+      });
+    },
+  },
+  {
+    // The glob the lookup tool's own description advertises. It matched nothing
+    // on the shipped graph, because the candidate pool was the `cs:name`
+    // population and no asserted name contains a slash.
+    id: "tool-standard-lookup-advertised-glob-matches",
+    kind: "tool",
+    input:
+      'standard_lookup {name:["react/component/*"]} — the glob the tool description advertises — resolves at least one standard.',
+    async expect() {
+      await withCanonicalFixture(CANONICAL_CONFIG, async (mcp) => {
+        const result = await mcp.callTool("standard_lookup", {
+          name: ["react/component/*"],
+        });
+        assert.equal(result.ok, true);
+        const results = (result.data as { results: unknown[] }).results;
+        assert.ok(
+          results.length > 0,
+          "the advertised glob must match at least one standard",
+        );
+      });
+    },
+  },
+  {
     id: "content-canonical-graph-has-4-components",
     kind: "content",
     input:

--- a/packages/cli/pragma/src/testing/eval/cases/readNouns.ts
+++ b/packages/cli/pragma/src/testing/eval/cases/readNouns.ts
@@ -213,24 +213,85 @@ export const readNounEvalCases: readonly EvalCase[] = [
     },
   },
   {
-    id: "content-standard-list-length-equals-category-count-sum",
+    // The cross-surface count-parity invariant, stated for a HIERARCHY. Summing
+    // the category counts stopped being the right arithmetic the moment a
+    // parent counted its branch (a standard under `testing-unit` is counted by
+    // both `testing-unit` and `testing`); what must hold — and what actually
+    // catches the reported defect — is that each category's count and the rows
+    // `--category` returns for it are the same set. Before the roll-up,
+    // `testing` reported 1 and `standard list --category testing` returned 1 of
+    // the 8 standards in the branch: a silently wrong answer, exit 0.
+    id: "content-standard-category-counts-match-filtered-list",
     kind: "content",
     input:
-      "standard_list length equals the sum of standard_categories counts (the cross-surface count-parity invariant).",
+      "every standard_categories count equals the length of standard_list {category: <slug>}, and a parent category answers for its whole branch.",
     async expect() {
       await withCanonicalFixture(CANONICAL_CONFIG, async (mcp) => {
         const list = await mcp.callTool("standard_list");
         const categories = await mcp.callTool("standard_categories");
-        const listLength = (list.data as unknown[]).length;
-        const categorySum = (categories.data as { count: string }[]).reduce(
-          (sum, row) => sum + Number(row.count),
-          0,
+        const rows = categories.data as { name: string; count: string }[];
+        assert.ok(
+          (list.data as unknown[]).length > 0 && rows.length > 0,
+          "both surfaces must be non-empty for the parity invariant to bite",
+        );
+        let rolledUp = 0;
+        for (const row of rows) {
+          const filtered = await mcp.callTool("standard_list", {
+            category: row.name,
+          });
+          assert.equal(
+            (filtered.data as unknown[]).length,
+            Number(row.count),
+            `standard_list --category ${row.name} disagrees with its count`,
+          );
+          // A parent whose branch is bigger than its own direct membership:
+          // the roll-up is doing something, so this case cannot pass vacuously.
+          const direct = (list.data as { category?: string }[]).filter(
+            (r) => r.category === row.name,
+          ).length;
+          if (Number(row.count) > direct) rolledUp += 1;
+        }
+        assert.ok(
+          rolledUp > 0,
+          "expected at least one parent category to answer for its descendants",
+        );
+      });
+    },
+  },
+  {
+    // The reflexive half of `skos:broader*`. `broader+` looks equivalent and
+    // silently drops every standard filed DIRECTLY on the category asked for —
+    // one of the 8 under `testing` in the shipped graph.
+    id: "content-standard-category-rollup-keeps-the-direct-member",
+    kind: "content",
+    input:
+      "standard_list {category: <parent>} includes both the standard filed directly on the parent and those filed on its child.",
+    async expect() {
+      await withCanonicalFixture(CANONICAL_CONFIG, async (mcp) => {
+        const parent = await mcp.callTool("standard_list", {
+          category: "testing",
+        });
+        const child = await mcp.callTool("standard_list", {
+          category: "testing-unit",
+        });
+        const parentRows = parent.data as { name: string; category: string }[];
+        const childNames = new Set(
+          (child.data as { name: string }[]).map((r) => r.name),
         );
         assert.ok(
-          listLength > 0,
-          "standard_list must be non-empty for the count-parity invariant to be meaningful",
+          childNames.size > 0,
+          "expected the child category to be used",
         );
-        assert.equal(listLength, categorySum);
+        for (const name of childNames) {
+          assert.ok(
+            parentRows.some((r) => r.name === name),
+            `the parent category dropped its descendant ${name}`,
+          );
+        }
+        assert.ok(
+          parentRows.some((r) => r.category === "testing"),
+          "the parent category dropped the standard filed directly on it",
+        );
       });
     },
   },

--- a/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
+++ b/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
@@ -78,11 +78,33 @@ ds:token.spacing.medium a ds:Token ;
   ds:valueDark "16px" .
 `;
 
-/** The `cs:` (code standards) section — reused verbatim from `standard/parity.test.ts`'s
- * fixture shape so `code/function/purity`/`react/component/*` are stable, shared
- * anchor names rather than a second invented set. */
+/**
+ * The `cs:` (code standards) section — shaped like the SHIPPED code-standards
+ * graph, not like a convenience fixture.
+ *
+ * Two facts about the real data are reproduced here on purpose, because the
+ * eval harness was blind to both while every fixture standard carried a
+ * `cs:name`:
+ *
+ * 1. **Most standards carry NO `cs:name`.** The shipped graph asserts it on 22
+ *    of 156 (~13%); one of the eight standards below carries one (~13%). The
+ *    ontology says so deliberately — `cs:name` is "an optional human-readable
+ *    display title" that "never participates in identity", the canonical
+ *    identifier being the compact IRI. So the name `standard list` publishes for
+ *    the other seven is SYNTHESIZED from the IRI local name
+ *    (`cs:react.component.props` → `react/component/props`), and a lookup that
+ *    cannot resolve a synthesized name cannot resolve the graph.
+ * 2. **Categories are a two-level SKOS tree.** `cs:testing.unit skos:broader
+ *    cs:testing`, exactly as the shipped graph declares for `testing.*` and
+ *    `ui_blocks.nojs`, and one standard sits DIRECTLY on the parent — the case a
+ *    non-reflexive roll-up (`skos:broader+`) silently drops.
+ *
+ * Anchor names (`code/function/purity`, `react/component/*`) are unchanged; they
+ * are simply reached the way the real graph reaches them.
+ */
 const CS_TTL = `
 @prefix cs: <http://pragma.canonical.com/codestandards#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 cs:CodeStandard a owl:Class .
 cs:Category a owl:Class .
@@ -97,27 +119,57 @@ cs:dont a owl:ObjectProperty ; rdfs:domain cs:CodeStandard ; rdfs:range cs:Examp
 cs:language a owl:DatatypeProperty ; rdfs:domain cs:Example ; rdfs:range xsd:string .
 cs:code a owl:DatatypeProperty ; rdfs:domain cs:Example ; rdfs:range xsd:string .
 
-cs:cat.react a cs:Category ; cs:slug "react" .
-cs:cat.code a cs:Category ; cs:slug "code" .
+# ---- Categories: flat roots, plus one two-level branch (testing) ----
+cs:react a cs:Category ; rdfs:label "React" ; cs:slug "react" .
+cs:code a cs:Category ; rdfs:label "Code" ; cs:slug "code" .
+cs:turtle a cs:Category ; rdfs:label "Turtle" ; cs:slug "turtle" .
+cs:testing a cs:Category ; rdfs:label "Testing" ; cs:slug "testing" .
+cs:testing.unit a cs:Category ;
+  rdfs:label "Unit testing" ;
+  cs:slug "testing-unit" ;
+  skos:broader cs:testing .
 
+# ---- Standards. Seven of eight carry NO cs:name (the shipped ~13% split). ----
 cs:react.component.props a cs:CodeStandard ;
-  cs:name "react/component/props" ;
   cs:description "Type component props explicitly." ;
-  cs:hasCategory cs:cat.react ;
+  cs:hasCategory cs:react ;
   cs:do [ a cs:Example ; cs:description "Do type props" ; cs:language "tsx" ; cs:code "interface P {}" ] ;
   cs:dont [ a cs:Example ; cs:description "Avoid any" ; cs:language "tsx" ; cs:code "props: any" ] .
 
 cs:react.component.structure a cs:CodeStandard ;
-  cs:name "react/component/structure" ;
   cs:description "Keep folder structure flat." ;
-  cs:hasCategory cs:cat.react ;
+  cs:hasCategory cs:react ;
   cs:extends cs:react.component.props ;
   cs:do [ a cs:Example ; cs:description "Do flatten" ; cs:language "text" ; cs:code "src/Button.tsx" ] .
 
 cs:code.function.purity a cs:CodeStandard ;
-  cs:name "code/function/purity" ;
   cs:description "Prefer pure functions." ;
-  cs:hasCategory cs:cat.code .
+  cs:hasCategory cs:code .
+
+# The standard sitting DIRECTLY on the parent category: a skos:broader+
+# roll-up loses it, a reflexive skos:broader* keeps it.
+cs:testing.smoke a cs:CodeStandard ;
+  cs:description "Keep one end-to-end smoke path green." ;
+  cs:hasCategory cs:testing .
+
+cs:testing.unit.isolation a cs:CodeStandard ;
+  cs:description "Isolate the unit under test." ;
+  cs:hasCategory cs:testing.unit .
+
+cs:testing.unit.naming a cs:CodeStandard ;
+  cs:description "Name a unit test for the behaviour it pins." ;
+  cs:hasCategory cs:testing.unit ;
+  cs:do [ a cs:Example ; cs:description "Do name the behaviour" ; cs:language "ts" ; cs:code "it(\\"rejects an empty batch\\")" ] .
+
+cs:testing.unit.fixtures a cs:CodeStandard ;
+  cs:description "Share one fixture per behavioural claim." ;
+  cs:hasCategory cs:testing.unit .
+
+# The ~13%: a display title that adds something the IRI does not.
+cs:turtle.naming.local_name_casing a cs:CodeStandard ;
+  cs:name "Turtle local-name casing" ;
+  cs:description "Use snake_case for multi-word local-name segments." ;
+  cs:hasCategory cs:turtle .
 `;
 
 /** The `ds:Prompt` workflow templates — the ONE source both the `prompt_list`/
@@ -255,6 +307,7 @@ ds:implementation.svelte-ds-global.button a ds:ImplementationObject ;
 export const CANONICAL_PREFIXES: Readonly<Record<string, string>> = {
   ...BLOCK_PREFIXES,
   cs: "http://pragma.canonical.com/codestandards#",
+  skos: "http://www.w3.org/2004/02/skos/core#",
 };
 
 /** The full canonical Turtle: PR3's `BLOCK_TTL` verbatim, plus the sections above. */

--- a/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
+++ b/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
@@ -26,6 +26,16 @@
  * ours to pin): 4 `ds:Component` (Button, Modal, LXD Panel, Beta Widget),
  * `importance` family with value `primary`, code standard
  * `code/function/purity`.
+ *
+ * Two of those anchors exist to pin an ABSENCE, and are load-bearing for the
+ * "declared, not inferred" halves of the read grammar:
+ * - `ds:token.legacy.borderRadius` — a `ds:Token` with no `ds:tokenId`, which
+ *   `token list` therefore never publishes and `token lookup`/`token sample`
+ *   must never reach (`PackLookup.nameFallback` is declared by `standard`
+ *   alone).
+ * - `cs:archive` — a `cs:Category` with no standards, which `standard
+ *   categories` reports at count 0 and `standard list --category archive` must
+ *   answer with a calm empty list rather than INVALID_INPUT.
  */
 
 import { BLOCK_PREFIXES, BLOCK_TTL } from "../blockGraph.js";
@@ -76,6 +86,17 @@ ds:token.spacing.medium a ds:Token ;
   ds:tokenType ds:type.spacing ;
   ds:valueLight "16px" ;
   ds:valueDark "16px" .
+
+# A ds:Token carrying NO ds:tokenId — the entity "token list" does not publish,
+# because its query REQUIRES the id. It is here to pin what a lookup may NOT
+# reach: "token lookup" addresses by ds:tokenId, and a story whose list requires
+# its "by" property must not become addressable (or sampleable) under a name
+# derived from its IRI. See PackLookup.nameFallback, declared by the "standard"
+# story alone — the one story whose list DOES publish such a name.
+ds:token.legacy.borderRadius a ds:Token ;
+  ds:tokenType ds:type.spacing ;
+  ds:valueLight "4px" ;
+  ds:valueDark "4px" .
 `;
 
 /**
@@ -128,6 +149,15 @@ cs:testing.unit a cs:Category ;
   rdfs:label "Unit testing" ;
   cs:slug "testing-unit" ;
   skos:broader cs:testing .
+
+# A category the graph DECLARES with no standards filed under it. The
+# "standard categories" verb lists it with count 0, so
+# "standard list --category archive" must be the documented calm empty list — a
+# real slug, an empty answer. Validity read off the returned ROWS instead of the
+# graph called it INVALID_INPUT.
+cs:archive a cs:Category ;
+  rdfs:label "Archive" ;
+  cs:slug "archive" .
 
 # ---- Standards. Seven of eight carry NO cs:name (the shipped ~13% split). ----
 cs:react.component.props a cs:CodeStandard ;


### PR DESCRIPTION
## Done

Five commits, in dependency order:

- **`test(eval)`** — make the harness able to see the bug, before fixing it.
- **`fix(packs)`** — make published names addressable.
- **`fix(standard)`** — the category roll-up.
- **`feat(standard)`** — make the surface formable.
- **`docs`** — replace the advice that produced the `/tmp` dump.
- **Drive-by carried by the last two commits:** the v0.35.0 peer-range fix, without which `main` and every PR against it fails to build.

### Why

An AI agent was asked for the Canonical code standards. It tried repeatedly, failed to form a working call, and finally **extracted the entire corpus into a `/tmp` folder**. That looked absurd. It was rational.

**The error recovery was a closed loop:**

| Call | Result |
|---|---|
| `standard_list {category:"react"}` | rows named `react/component/tsdoc` — **no dos/donts** |
| `standard_lookup {name:["react/component/tsdoc"]}` | `ENTITY_NOT_FOUND`, **empty suggestions**, recovery says *"call `standard_list`"* |
| `standard_lookup {name:["react/component/*"]}` — **the tool description's own example** | `EMPTY_RESULTS`, no recovery |
| `standard_lookup {name:["cs:react.component.tsdoc"]}` | **works — never advertised** |

List publishes a name synthesised from the IRI; lookup required an *asserted* `cs:name` that **~86% of standards do not carry**. The recovery pointed back at the tool that produced the unusable name. Meanwhile the only call that returned the requested content was the unfiltered dump.

And `--category testing` silently returned **1 standard of 8**, because categories are a two-level SKOS tree and the filter matched only the leaf — while the data repo's own `docs/index.md` says 8. Same graph, two answers.

### What changed, commit by commit

**`test(eval)` — make the harness able to see the bug, before fixing it**
The eval cases passed only because the fixture asserted `cs:name` on *every* standard while the shipped graph asserts it on ~14%. The fixture now mirrors production: 7 of 8 standards carry no `cs:name`, and the categories form the same two-level tree — including one standard filed *directly* on the parent, the row a non-reflexive roll-up drops.

**This commit makes existing tests fail.** At step 0, `tool-standard-lookup-has-dos-and-donts` and `content-code-function-purity-description-mentions-pure` go red alongside the two new cases. At HEAD, all pass.

**`fix(packs)` — make published names addressable**
One shared `nameBinding(lookup)` replaces the hard `?uri <by> ?name` triple across the name resolve, IRI resolve, both graphql resolves and `buildLookupNamesQuery`. Where a class constraint vouches for the entity, the triple is OPTIONAL and the name falls back to the **exact derivation the list story uses to publish it**. Unconstrained lookups keep the strict triple.

Note this is more than the "make it OPTIONAL" the plan called for: optional alone is enough for the IRI branch (the IRI *is* identity) but not the name branch, whose `FILTER` compares against `?name` — without the `COALESCE` fallback the relaxed query matches nothing.

**`fix(standard)` — the category roll-up**
The list projects `?category` (leaf, displayed) plus `?categories` (leaf + every `skos:broader*` ancestor); `--category` matches any member via a new `PackFilter.match: "set"`. `standard categories` counts the same way.

Comments record both load-bearing facts: the store has **no reasoner**, so `skos:broaderTransitive` returns zero rows and `broader*` is the only thing that works; and **the `*` is reflexive on purpose** — `+` would silently drop the standard sitting directly on `cs:testing`.

**`feat(standard)` — make the surface formable**
Worked `Example:` on all four `standard_*` tools (and five other story tools that had none); `detail` named in the lookup prose; authored `emptyRecovery` on `list` (→ `standard categories`) and `categories` (→ `doctor`) — **not** `sources update`, which is actively wrong advice since standards ship in the embedded snapshot; `recovery.mcp.params` populated at the three lookup-miss sites; `emptyNotice` surfaced as `meta.notice` on both MCP and `--format json`, so **empty ≠ silence**.

A value-free filter now rejects an unobserved value with the **observed** values as `validOptions`, read from the rows the graph just returned. **No slugs are hard-coded** — the graph is the vocabulary.

**`docs`** — `docs/design-system.md` said *"`standard list` and `standard sample` are the reliable paths"*. That advice is what produced the `/tmp` dump. Replaced with the working form, including the previously-secret `cs:react.*`.

### Two tests changed deliberately, and why

- **`errorMatrix.mcp.test.ts`** pinned `ok:true, data:[], meta:{}` for an unmatched filter — encoding *both* the silent zero this change replaces and the empty `meta` that `notice` now fills.
- **`content-standard-list-length-equals-category-count-sum`** is arithmetically false for a hierarchy (a parent double-counts its branch). Replaced with a stronger per-category invariant — each `standard_categories` count equals `standard_list {category}`'s length — plus a non-vacuity guard that some parent exceeds its direct membership.

### Not in scope

The `web-code-standards` modelling migration (`rdfs:label` backfill, retiring `cs:name`, SHACL shapes, `skos:ConceptScheme`) — a different repository, separate PR. `disclosure.default` stays `summary`; the prose now names `detail` rather than changing the default under existing callers.

## QA

1. **Full suite with coverage** — from `packages/cli/pragma`:
   ```
   bunx vitest run --coverage --maxWorkers=3
     Test Files  131 passed | 2 skipped (133)
          Tests  1476 passed | 13 skipped | 5 todo (1494)
   ```
2. **Reference docs in sync** — `cd packages/cli/pragma && bun run gen:reference` → 0 changed pages.
3. **Repo-wide check** — `bun run check` → 62 projects green.
4. **Surface parity** — `surface.v2.json` untouched; no tool added or removed.
5. **Against the real shipped graph, not fixtures** — run each of these and compare with the before/after table under Screenshots:
   ```
   pragma standard list --category testing        # expect 8 rows
   pragma standard list --category ui-blocks      # expect 9 rows
   pragma standard lookup 'react/component/tsdoc' # expect a hit, not ENTITY_NOT_FOUND
   pragma standard lookup 'react/component/*'     # expect hits, not EMPTY_RESULTS
   pragma standard list --category nope           # expect INVALID_INPUT listing all 21 slugs
   ```
   The 8 and 9 match the data repo's own `docs/index.md`.
6. **Empty is never silent** — any call that legitimately returns no rows should now carry `meta.notice` in both the MCP response and `--format json`.

## Screenshots

Measured against the real shipped graph, not fixtures:

```
                                            before          after
standard list --category testing            1               8
standard list --category ui-blocks          3               9
standard sample draw pool                   ~22 named       147
standard lookup 'react/component/tsdoc'     not found       ok
standard lookup 'react/component/*'         empty           ok
standard list --category nope               ok:true,data:[] INVALID_INPUT + all 21 slugs
```

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`. — `Bug 🐛` applied (a closed error-recovery loop and a silently wrong category filter).
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`: — verified on this branch for every touched package (`cli/pragma`, `runtime/ke-graphql`, `summon/component`, `summon/package`).
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [ ] If this PR introduces a **new package**: … — **n/a**, no new package is introduced.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic. — CLI, query and data-shape changes only, no rendered component changes. Label applied.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
