### PR TITLE
test(pragma-cli): make two never-executed test suites actually run

### DIFF
--- a/.github/actions/setup-env/install-shells.sh
+++ b/.github/actions/setup-env/install-shells.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Installs the shells whose GENERATED completion scripts the suite executes.
+#
+# `shellDrive.test.ts` drives the emitted bash, zsh and fish scripts in the
+# real shell. Its bash describes are ungated (the runner always has bash), but
+# the zsh and fish describes are `describe.skipIf(!hasShell(...))` — so on a
+# runner without those two interpreters they assert NOTHING and the suite still
+# reports green. That is what CI did from the day the file was written: the
+# only execution proof for the zsh and fish scripts ran nowhere. zsh is the
+# default shell on macOS, and the static tier (`safety.test.ts`) only pins what
+# characters a script may not contain, never that it parses or answers.
+#
+# So the install is verified rather than assumed. `apt-get install` failing —
+# a transient mirror, a renamed package, universe not enabled — would put the
+# suite straight back to silently skipping, which is the exact defect this step
+# exists to close. Failing HERE names the cause; a green suite that ran nothing
+# names nothing.
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends zsh fish
+
+# `hasShell` in the suite probes exactly this: the interpreter is on PATH and
+# runs a `-c` script. Probe it the same way, so a shell that installs but is
+# not invocable fails the step instead of silently skipping a describe.
+missing=0
+for sh in zsh fish; do
+  if [ "$("$sh" -c 'printf ok' 2>/dev/null)" = "ok" ]; then
+    echo "$sh: $("$sh" --version)"
+  else
+    echo "::error::${sh} is not on PATH or cannot run a -c script — shellDrive.test.ts would skip its ${sh} describes and assert nothing"
+    missing=1
+  fi
+done
+exit "$missing"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,6 +68,14 @@ jobs:
           INSTALL_PLAYWRIGHT: ${{ steps.pw.outputs.required }}
         run: bash .github/actions/setup-env/install-playwright.sh
 
+      # `shellDrive.test.ts` executes the GENERATED zsh and fish completion
+      # scripts in the real interpreter, but `skipIf`s those describes when the
+      # shell is absent — so without this step the only execution proof for
+      # those two script families runs nowhere and the suite still reports
+      # green. The script verifies the install rather than assuming it.
+      - name: Install completion shells (zsh, fish)
+        run: bash .github/actions/setup-env/install-shells.sh
+
       - name: Test
         run: bunx nx affected -t test --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,5 +59,13 @@ jobs:
           INSTALL_PLAYWRIGHT: 'true'
         run: bash .github/actions/setup-env/install-playwright.sh
 
+      # `shellDrive.test.ts` executes the GENERATED zsh and fish completion
+      # scripts in the real interpreter, but `skipIf`s those describes when the
+      # shell is absent — so without this step the only execution proof for
+      # those two script families runs nowhere and the suite still reports
+      # green. The script verifies the install rather than assuming it.
+      - name: Install completion shells (zsh, fish)
+        run: bash .github/actions/setup-env/install-shells.sh
+
       - name: Test
         run: bun run test

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -78,6 +78,14 @@ jobs:
           INSTALL_PLAYWRIGHT: 'true'
         run: bash .github/actions/setup-env/install-playwright.sh
 
+      # `shellDrive.test.ts` executes the GENERATED zsh and fish completion
+      # scripts in the real interpreter, but `skipIf`s those describes when the
+      # shell is absent — so without this step the only execution proof for
+      # those two script families runs nowhere and the suite still reports
+      # green. The script verifies the install rather than assuming it.
+      - name: Install completion shells (zsh, fish)
+        run: bash .github/actions/setup-env/install-shells.sh
+
       - name: Test
         run: bun run test
 

--- a/packages/cli/pragma/src/kernel/completion/shellDrive.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/shellDrive.test.ts
@@ -56,13 +56,14 @@ import { emitScripts } from "./emitScripts.js";
  *   `os: ["linux"]`; run on a bash-3.2 macOS box this fails loudly, which is
  *   the intended signal — see `templates/bash.ts` on the mapfile floor.)
  * - **By execution only where the shell is installed:** the same guarantees
- *   for zsh and fish. Those describes `skipIf` the shell is absent, which
- *   includes this development box and, today, CI — so on those machines they
- *   assert NOTHING, and say so by skipping visibly. Every assertion in them
- *   was executed during development against zsh 5.9 and fish 3.7.0 (obtained
- *   with `apt-get download zsh zsh-common fish fish-common` + `dpkg-deb -x`
- *   into a scratch prefix, leaving the box itself untouched). Adding
- *   `zsh fish` to CI's apt step is what would make them continuous.
+ *   for zsh and fish. Those describes `skipIf` the shell is absent, so a
+ *   development box without them asserts NOTHING and says so by skipping
+ *   visibly. CI is no longer such a box: the test jobs in `pr.yml`,
+ *   `push.yml` and `tag.yml` run `install-shells.sh`, which installs zsh and
+ *   fish and then PROBES each one exactly as `hasShell` does, failing the job
+ *   if either is missing — a silently failed install can never again reduce
+ *   these describes to a green no-op. Measured green against zsh 5.9/5.9.1 and
+ *   fish 3.7.0/4.7.1, which brackets what Ubuntu runners ship.
  * - **By static assertion only, everywhere:** that the zsh and fish scripts
  *   contain no `eval`, no backticks, guarded `compadd`, inert value lists and
  *   the exact delegation form — `safety.test.ts`'s script-safety describe. A

--- a/packages/cli/pragma/src/testing/behavioral/journeys.livePack.e2e.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/journeys.livePack.e2e.test.ts
@@ -1,12 +1,25 @@
 /**
- * E3 (AV-231, Backlog E) — real-oxigraph ordering, label choice and build
- * re-entrancy, against the VENDORED default pack.
+ * E3 (AV-231, Backlog E) — real-oxigraph ordering, multilingual label
+ * RESOLUTION and build re-entrancy, against the VENDORED default pack.
  *
- * A handful of behaviours can only be confirmed against a REAL oxigraph store:
- * result ordering (A3/A9), which language a multilingual label resolves to
- * under real store order (A7), ke truncation of long literals, and
- * `buildIndex`'s `Promise.all` re-entrancy when the same pack is built
- * concurrently. Nothing else in the tree asserts any of them.
+ * WHAT IS ACTUALLY UNIQUE HERE. This docblock used to claim "nothing else in
+ * the tree asserts any of them". That was false, and review caught it — with
+ * some irony, since the argument for un-gating this file was that a suite which
+ * never runs hides what it fails to do. `journeys.defaultPack.test.ts:188-210`
+ * already boots {@link DEFAULT_PACK_TTL} through the real store and asserts the
+ * same `ORDER BY` result, and its A7 test already asserts both raw `rdfs:label`
+ * literals and that the indexed label is tag-stripped. The honest accounting:
+ *
+ *  - CONCURRENT `buildPack` re-entrancy — covered nowhere else.
+ *  - A 20k literal surviving the build round-trip — covered nowhere else.
+ *  - WHICH multilingual label the built index resolves to — pinned to the exact
+ *    value here; the E1 journey only asserts the winner is one of the two
+ *    declared forms.
+ *  - `ORDER BY` determinism — DUPLICATED with E1 deliberately: this asserts a
+ *    query repeats identically within one session, E1 asserts one evaluation
+ *    through the `graph query` verb envelope. A second, differently-shaped
+ *    assertion of the same behaviour is cheap; only the exclusivity claim was
+ *    wrong, not the test.
  *
  * WHY THERE IS NO LONGER A GATE. This suite spent its whole life behind
  * `process.env.PRAGMA_LIVE_PACK`, whose docblock promised "a dedicated,
@@ -32,8 +45,12 @@
  * already run — not a precondition for running them.
  */
 
+import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
+import { readPackIndex } from "../../kernel/completion/entitySource.js";
 import { buildPack } from "../../kernel/runtime/graphpack/build.js";
+import { packIsComplete } from "../../kernel/runtime/graphpack/manifest.js";
+import { resolveSources } from "../../kernel/runtime/resolveSources.js";
 import {
   DEFAULT_PACK_PREFIXES,
   DEFAULT_PACK_TTL,
@@ -42,6 +59,30 @@ import {
   bootFixtureRuntime,
   type FixtureGraph,
 } from "../helpers/fixtureGraph.js";
+
+/**
+ * A source set no pack cache can already hold: the default-pack TTL under a
+ * nonced path and with a nonced comment line, so its content hash is NEW on
+ * every call and every run.
+ *
+ * The build tests are about the BUILD path, and `buildPack` short-circuits on a
+ * complete cached directory. Nonced inputs make a cache hit impossible by
+ * construction rather than leaving it to whatever the ambient cache happens to
+ * hold — the per-file `$XDG_CACHE_HOME` isolation stays a hygiene measure, not
+ * a load-bearing precondition of these assertions.
+ *
+ * @returns One `BuildPackInput`, unique to this call.
+ * @note Impure — draws a random nonce.
+ */
+function freshInputs(): { path: string; content: string }[] {
+  const nonce = randomUUID();
+  return [
+    {
+      path: `concurrent/${nonce}/pack.ttl`,
+      content: `# re-entrancy run ${nonce}\n${DEFAULT_PACK_TTL}`,
+    },
+  ];
+}
 
 describe("live-pack journey — real oxigraph ordering + build re-entrancy (E3)", () => {
   it("a SELECT ... ORDER BY returns a STABLE, deterministic ordering (A3/A9)", async () => {
@@ -63,30 +104,92 @@ describe("live-pack journey — real oxigraph ordering + build re-entrancy (E3)"
     }
   });
 
-  it("a multilingual label resolves to a SINGLE, tag-stripped value under real store order (A7)", async () => {
-    // TODO(AV-231/E3): against the live pack, pin the EXACT language the store
-    // yields first, so the index-label choice is a confirmed contract rather than
-    // the store-order accident it is today (see the A7 note in the E1 journey).
+  it("a multilingual label resolves to EXACTLY the @en value in the BUILT index (A7)", async () => {
     const fixture = await bootFixtureRuntime({ ttl: DEFAULT_PACK_TTL });
     try {
-      const result = await fixture.runtime.query.sparql(
+      // PRECONDITION, not the claim: both candidate literals really are in the
+      // store, so the selection below has something to select BETWEEN. Asserting
+      // only this (as this test once did) proves the store round-trips two
+      // literals and says nothing about which one the index carries — the E1
+      // journey already pins the pair.
+      const raw = await fixture.runtime.query.sparql(
         "SELECT ?l WHERE { ds:button rdfs:label ?l } ORDER BY ?l",
       );
       const labels =
-        result.type === "select"
-          ? result.bindings.map((binding) => String(binding.l))
+        raw.type === "select"
+          ? raw.bindings.map((binding) => String(binding.l))
           : [];
       expect(labels).toEqual(["Bouton", "Button"]);
+      // THE CLAIM: `buildIndex` carries ONE label per subject, and which one is
+      // a contract, not a store-order accident — `preferredBySubject` ranks
+      // untagged < `@en` < any other tag, so `"Button"@en` beats `"Bouton"@fr`
+      // every time, tag-stripped. The E1 journey only asserts the winner is one
+      // of the two; this is where the exact value is pinned.
+      const index = await readPackIndex(
+        resolveSources(await fixture.runtime.loadConfig(), fixture.cwd),
+      );
+      const button = index?.entities.find(
+        (entity) => entity.name === "ds:button",
+      );
+      expect(button?.label).toBe("Button");
     } finally {
       await fixture.dispose();
     }
   });
 
-  it("building the same sources CONCURRENTLY is re-entrant — one hash, no torn pack (buildIndex Promise.all)", async () => {
-    // buildIndex fans out four bulk SPARQL queries under Promise.all, and buildPack
-    // publishes atomically; N concurrent builds of identical sources must converge
-    // on ONE content hash with every pack complete (no half-written cache).
-    const inputs = [{ path: "concurrent/pack.ttl", content: DEFAULT_PACK_TTL }];
+  it("N concurrent builds of DISTINCT sources each publish their OWN complete pack (buildIndex Promise.all)", async () => {
+    // `buildIndex` fans out four bulk SPARQL queries under `Promise.all`, and
+    // `buildPack` writes to a temp directory it renames in atomically. This is
+    // the shape that provably OVERLAPS: five distinct source sets can never
+    // cache-hit one another, so all five necessarily take the build path — the
+    // `reused: false` below is a guarantee, not a hope.
+    const options = {
+      name: "pragma",
+      version: "0.0.0-e3",
+      sourceRef: "e3-reentrancy",
+      prefixes: DEFAULT_PACK_PREFIXES,
+    };
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => buildPack(freshInputs(), options)),
+    );
+    for (const result of results) {
+      // Not a cache hit: this call ran the store, the compile and the index.
+      expect(result.reused).toBe(false);
+      expect(result.contentHash).toMatch(/^[0-9a-f]{64}$/);
+      // Complete: manifest plus four non-empty artifacts, so the atomic publish
+      // left nothing torn behind.
+      expect(packIsComplete(result.dir)).toBe(true);
+      // A build that produced an EMPTY pack would satisfy every hash check.
+      expect(result.manifest.tripleCount ?? 0).toBeGreaterThan(0);
+    }
+    // Distinct sources, distinct content-addressed directories — no clobbering.
+    expect(new Set(results.map((result) => result.dir)).size).toBe(5);
+  });
+
+  it("N concurrent builds of IDENTICAL sources converge on ONE complete pack, built at least once", async () => {
+    // TWO THINGS THIS TEST HAS TO EARN, both of which an earlier version faked.
+    //
+    // 1. IT MUST ACTUALLY BUILD. `buildPack` returns at its top for a hash whose
+    //    directory is already complete (build.ts's `packIsComplete`
+    //    short-circuit), so fixed inputs can decay into pure cache hits that
+    //    exercise nothing. `setupXdgIsolation.ts` gives every test FILE a fresh
+    //    `$XDG_CACHE_HOME`, so the cache does not survive a run today — but the
+    //    test must not DEPEND on ambient isolation for its meaning. A nonce in
+    //    the sources makes the content hash new on every run, so a stale hit is
+    //    impossible by construction, and `reused: false` is then ASSERTED.
+    // 2. THE ASSERTION MUST BE FALSIFIABLE. Comparing the five content hashes
+    //    proves nothing: the hash is computed FROM the inputs before any work
+    //    happens, so identical inputs give identical hashes even if every build
+    //    produced nothing at all. What concurrency actually risks is a TORN or
+    //    clobbered directory, so that is what is checked — `packIsComplete` on
+    //    the converged directory, a non-empty triple count, and a reuse after.
+    //
+    // HOW MANY of the five build is deliberately NOT pinned. The pack build is
+    // synchronous WASM work that blocks the event loop, so whether the other
+    // four get past their cache check before the winner publishes depends on
+    // whether the store module is already warm: cold, all five build; warm, one
+    // builds and four reuse. Both are correct, and both must converge here.
+    const inputs = freshInputs();
     const options = {
       name: "pragma",
       version: "0.0.0-e3",
@@ -96,11 +199,24 @@ describe("live-pack journey — real oxigraph ordering + build re-entrancy (E3)"
     const results = await Promise.all(
       Array.from({ length: 5 }, () => buildPack(inputs, options)),
     );
-    const hashes = new Set(results.map((result) => result.contentHash));
-    expect(hashes.size).toBe(1);
+    // The build path RAN — these are not five no-op cache hits.
+    expect(results.some((result) => !result.reused)).toBe(true);
+    // One directory, and it is complete: reusers were handed a whole pack, not
+    // a half-written one.
+    const dirs = new Set(results.map((result) => result.dir));
+    expect(dirs.size).toBe(1);
+    const dir = results[0]?.dir ?? "";
+    expect(packIsComplete(dir)).toBe(true);
     for (const result of results) {
       expect(result.contentHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(result.manifest.tripleCount ?? 0).toBeGreaterThan(0);
     }
+    // The published pack is genuinely REUSABLE, which is also what proves
+    // `reused` is a real distinction above rather than a constant `false`.
+    const after = await buildPack(inputs, options);
+    expect(after.reused).toBe(true);
+    expect(after.dir).toBe(dir);
+    expect(after.contentHash).toBe(results[0]?.contentHash);
   });
 
   it("a long literal survives the build round-trip without silent ke truncation", async () => {

--- a/packages/cli/pragma/src/testing/behavioral/journeys.livePack.e2e.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/journeys.livePack.e2e.test.ts
@@ -1,23 +1,35 @@
 /**
- * E3 (AV-231, Backlog E) — the network-gated, NON-BLOCKING live-pack job.
+ * E3 (AV-231, Backlog E) — real-oxigraph ordering, label choice and build
+ * re-entrancy, against the VENDORED default pack.
  *
- * A handful of behaviours can only be confirmed against a REAL oxigraph store
- * built from the REAL default pack: result ordering (A3/A9), which language a
- * multilingual label resolves to under real store order (A7), ke truncation of
- * long literals, and `buildIndex`'s `Promise.all` re-entrancy when the same pack
- * is built concurrently. Those depend on the network (fetching the shipped pack)
- * and on real build cost, so this suite is GATED OFF by default — it never runs
- * (or flakes) in the ordinary `bun test` pass. Set `PRAGMA_LIVE_PACK=1` to run
- * it (a dedicated, non-required CI job).
+ * A handful of behaviours can only be confirmed against a REAL oxigraph store:
+ * result ordering (A3/A9), which language a multilingual label resolves to
+ * under real store order (A7), ke truncation of long literals, and
+ * `buildIndex`'s `Promise.all` re-entrancy when the same pack is built
+ * concurrently. Nothing else in the tree asserts any of them.
  *
- * The assertions here run against the VENDORED default pack as a faithful local
- * proxy for the shipped one, so a maintainer who flips the gate gets real signal
- * today. Each carries a TODO for wiring the ACTUAL network pack fetch — the one
- * piece this environment cannot provide.
+ * WHY THERE IS NO LONGER A GATE. This suite spent its whole life behind
+ * `process.env.PRAGMA_LIVE_PACK`, whose docblock promised "a dedicated,
+ * non-required CI job". That job never existed — the variable appeared in this
+ * one file and nowhere else in the repo — so the suite had never executed
+ * anywhere, and the first run of it found a broken fixture (the ke-truncation
+ * TTL below referenced `rdfs:` without declaring the prefix, so the build threw
+ * before the assertion was ever reached).
+ *
+ * The gate's premise was false in any case. It claimed these tests "depend on
+ * the network (fetching the shipped pack) and on real build cost", but as
+ * written they fetch nothing: they boot {@link DEFAULT_PACK_TTL}, an in-tree
+ * string, which `journeys.defaultPack.test.ts` already boots ~20 times UNGATED
+ * in the same pass. There is nothing here to be flaky, slow, or non-required
+ * about, and no separate e2e runner to hang a dedicated job on — this file is
+ * matched by `vitest.config.ts`'s ordinary include, exactly like its
+ * ungated `.e2e.` siblings (`rootCli`, `exitCodes`, `firstRun`, `mcpServe`).
+ * So it simply runs, and a regression in it turns CI red like any other.
  *
  * TODO(AV-231/E3): resolve the real shipped default pack (git/npm source) here
  * instead of the vendored TTL, so ordering/truncation are asserted against the
- * bytes agents actually receive.
+ * bytes agents actually receive. That is a STRENGTHENING of assertions that
+ * already run — not a precondition for running them.
  */
 
 import { describe, expect, it } from "vitest";
@@ -31,99 +43,96 @@ import {
   type FixtureGraph,
 } from "../helpers/fixtureGraph.js";
 
-/** Non-blocking gate: skipped unless a maintainer opts in (or CI's live job). */
-const liveGate = process.env.PRAGMA_LIVE_PACK ? describe : describe.skip;
+describe("live-pack journey — real oxigraph ordering + build re-entrancy (E3)", () => {
+  it("a SELECT ... ORDER BY returns a STABLE, deterministic ordering (A3/A9)", async () => {
+    const fixture = await bootFixtureRuntime({ ttl: DEFAULT_PACK_TTL });
+    try {
+      const query =
+        "SELECT ?name WHERE { ?c a ds:Component ; ds:name ?name } ORDER BY ?name";
+      const first = await fixture.runtime.query.sparql(query);
+      const second = await fixture.runtime.query.sparql(query);
+      const names = (result: typeof first): string[] =>
+        result.type === "select"
+          ? result.bindings.map((binding) => String(binding.name))
+          : [];
+      // Repeated evaluation is identical, and ORDER BY is honoured.
+      expect(names(first)).toEqual(names(second));
+      expect(names(first)).toEqual(["Beta Badge", "Button", "Orphan Widget"]);
+    } finally {
+      await fixture.dispose();
+    }
+  });
 
-liveGate(
-  "live-pack journey — real oxigraph ordering + build re-entrancy (E3)",
-  () => {
-    it("a SELECT ... ORDER BY returns a STABLE, deterministic ordering (A3/A9)", async () => {
-      const fixture = await bootFixtureRuntime({ ttl: DEFAULT_PACK_TTL });
-      try {
-        const query =
-          "SELECT ?name WHERE { ?c a ds:Component ; ds:name ?name } ORDER BY ?name";
-        const first = await fixture.runtime.query.sparql(query);
-        const second = await fixture.runtime.query.sparql(query);
-        const names = (result: typeof first): string[] =>
-          result.type === "select"
-            ? result.bindings.map((binding) => String(binding.name))
-            : [];
-        // Repeated evaluation is identical, and ORDER BY is honoured.
-        expect(names(first)).toEqual(names(second));
-        expect(names(first)).toEqual(["Beta Badge", "Button", "Orphan Widget"]);
-      } finally {
-        await fixture.dispose();
-      }
-    });
-
-    it("a multilingual label resolves to a SINGLE, tag-stripped value under real store order (A7)", async () => {
-      // TODO(AV-231/E3): against the live pack, pin the EXACT language the store
-      // yields first, so the index-label choice is a confirmed contract rather than
-      // the store-order accident it is today (see the A7 note in the E1 journey).
-      const fixture = await bootFixtureRuntime({ ttl: DEFAULT_PACK_TTL });
-      try {
-        const result = await fixture.runtime.query.sparql(
-          "SELECT ?l WHERE { ds:button rdfs:label ?l } ORDER BY ?l",
-        );
-        const labels =
-          result.type === "select"
-            ? result.bindings.map((binding) => String(binding.l))
-            : [];
-        expect(labels).toEqual(["Bouton", "Button"]);
-      } finally {
-        await fixture.dispose();
-      }
-    });
-
-    it("building the same sources CONCURRENTLY is re-entrant — one hash, no torn pack (buildIndex Promise.all)", async () => {
-      // buildIndex fans out four bulk SPARQL queries under Promise.all, and buildPack
-      // publishes atomically; N concurrent builds of identical sources must converge
-      // on ONE content hash with every pack complete (no half-written cache).
-      const inputs = [
-        { path: "concurrent/pack.ttl", content: DEFAULT_PACK_TTL },
-      ];
-      const options = {
-        name: "pragma",
-        version: "0.0.0-e3",
-        sourceRef: "e3-reentrancy",
-        prefixes: DEFAULT_PACK_PREFIXES,
-      };
-      const results = await Promise.all(
-        Array.from({ length: 5 }, () => buildPack(inputs, options)),
+  it("a multilingual label resolves to a SINGLE, tag-stripped value under real store order (A7)", async () => {
+    // TODO(AV-231/E3): against the live pack, pin the EXACT language the store
+    // yields first, so the index-label choice is a confirmed contract rather than
+    // the store-order accident it is today (see the A7 note in the E1 journey).
+    const fixture = await bootFixtureRuntime({ ttl: DEFAULT_PACK_TTL });
+    try {
+      const result = await fixture.runtime.query.sparql(
+        "SELECT ?l WHERE { ds:button rdfs:label ?l } ORDER BY ?l",
       );
-      const hashes = new Set(results.map((result) => result.contentHash));
-      expect(hashes.size).toBe(1);
-      for (const result of results) {
-        expect(result.contentHash).toMatch(/^[0-9a-f]{64}$/);
-      }
-    });
+      const labels =
+        result.type === "select"
+          ? result.bindings.map((binding) => String(binding.l))
+          : [];
+      expect(labels).toEqual(["Bouton", "Button"]);
+    } finally {
+      await fixture.dispose();
+    }
+  });
 
-    it("a long literal survives the build round-trip without silent ke truncation", async () => {
-      // TODO(AV-231/E3): confirm against the live pack, whose real summaries/guidelines
-      // are long enough to trip any downstream ke truncation (A7/A9 tail).
-      const longText = "x".repeat(20_000);
-      const ttl = `@prefix ds: <https://ds.canonical.com/> .
+  it("building the same sources CONCURRENTLY is re-entrant — one hash, no torn pack (buildIndex Promise.all)", async () => {
+    // buildIndex fans out four bulk SPARQL queries under Promise.all, and buildPack
+    // publishes atomically; N concurrent builds of identical sources must converge
+    // on ONE content hash with every pack complete (no half-written cache).
+    const inputs = [{ path: "concurrent/pack.ttl", content: DEFAULT_PACK_TTL }];
+    const options = {
+      name: "pragma",
+      version: "0.0.0-e3",
+      sourceRef: "e3-reentrancy",
+      prefixes: DEFAULT_PACK_PREFIXES,
+    };
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => buildPack(inputs, options)),
+    );
+    const hashes = new Set(results.map((result) => result.contentHash));
+    expect(hashes.size).toBe(1);
+    for (const result of results) {
+      expect(result.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it("a long literal survives the build round-trip without silent ke truncation", async () => {
+    // TODO(AV-231/E3): confirm against the live pack, whose real summaries/guidelines
+    // are long enough to trip any downstream ke truncation (A7/A9 tail).
+    const longText = "x".repeat(20_000);
+    // `rdfs:` MUST be declared: the property below is typed with
+    // `rdfs:range`, and an undeclared prefix makes oxigraph reject the whole
+    // document at parse time — which is what this fixture did, unnoticed, for
+    // as long as the gate kept the suite from ever running.
+    const ttl = `@prefix ds: <https://ds.canonical.com/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 ds:Component a owl:Class .
 ds:summary a owl:DatatypeProperty ; rdfs:range xsd:string .
 ds:big a ds:Component ; ds:summary "${longText}" .`;
-      let fixture: FixtureGraph | undefined;
-      try {
-        fixture = await bootFixtureRuntime({ ttl });
-        const result = await fixture.runtime.query.sparql(
-          "SELECT ?s WHERE { ds:big ds:summary ?s }",
-        );
-        const value =
-          result.type === "select"
-            ? String(
-                (result.bindings.at(0) as { s?: string } | undefined)?.s ?? "",
-              )
-            : "";
-        expect(value.length).toBe(longText.length);
-      } finally {
-        await fixture?.dispose();
-      }
-    });
-  },
-);
+    let fixture: FixtureGraph | undefined;
+    try {
+      fixture = await bootFixtureRuntime({ ttl });
+      const result = await fixture.runtime.query.sparql(
+        "SELECT ?s WHERE { ds:big ds:summary ?s }",
+      );
+      const value =
+        result.type === "select"
+          ? String(
+              (result.bindings.at(0) as { s?: string } | undefined)?.s ?? "",
+            )
+          : "";
+      expect(value.length).toBe(longText.length);
+    } finally {
+      await fixture?.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Done

Two test suites had never executed anywhere. This makes both run — and then makes one of them assert what it claims to. The three commits are independent; the first two can be dropped on their own.

- **`ci: install zsh and fish so the completion drive suite actually runs`** — `shellDrive.test.ts` is the only test that *executes* the generated completion scripts. Its bash describes are ungated; the zsh and fish ones are `describe.skipIf(!hasShell(...))`, and **no workflow ever installed either shell**. The file's own header names "adding `zsh fish` to CI's apt step" as the fix — but there is no apt step anywhere in `.github/`. Added `install-shells.sh` beside the existing `install-playwright.sh`, wired into the test jobs of `pr.yml` / `push.yml` / `tag.yml`.

  It **probes each shell exactly as the suite's own `hasShell` does, and fails the job if either is missing.** Otherwise a silently-failed install returns the suite to asserting nothing — which is the defect being closed, not a new one to introduce.

- **`test(cli): un-gate the live-pack E2E suite and fix the fixture it hid`** — `journeys.livePack.e2e.test.ts` was gated on `PRAGMA_LIVE_PACK`, and its docblock promised "a dedicated, non-required CI job". **No such job or variable exists.** The suite had never run since it was written.

  **Its first-ever execution found a real bug.** The ke-truncation test's inline TTL uses `rdfs:range` while declaring only `ds:`, `owl:` and `xsd:`:

  ```
  Parser error at line 5 between columns 37 and 47: The prefix rdfs: has not been declared
  ```

  oxigraph rejected the document and the build threw before the assertion was reached. Production code was correct — the fixture was malformed, and had been since it was written, invisible because the gate never opened.

- **`test(pragma-cli): make the live-pack suite assert what it claims to cover`** — added after review, which found that **the un-gated suite over-claimed.** That is the same defect this PR is about, one level up: the argument was "a suite that never runs hides what it fails to do", and what it hid included its own coverage claims. See "Corrections from review" below.

### Corrections from review

Three claims in the first version did not survive checking. All three are fixed in the third commit; none of the tests were deleted.

1. **The exclusivity claim was false.** `journeys.defaultPack.test.ts:188-210` already boots `DEFAULT_PACK_TTL` through the real store and asserts the identical `ORDER BY` result, and `:389-413` already asserts both raw `rdfs:label` literals and the tag-stripped index label. The docblock now accounts honestly rather than claiming "nothing else in the tree asserts any of them". The overlapping `ORDER BY` test **stays** — it asserts a differently-shaped property (repeat-identical within one session, versus E1's single evaluation through the `graph query` envelope), it costs ~1s, and it now runs. Only the claim was wrong, not the test.

2. **The multilingual test asserted the wrong thing.** `['Bouton', 'Button']` is both *raw* bindings: it proves the store round-trips two literals and says nothing about which one `buildIndex` picks — the behaviour its name advertised — and E1 already pins that pair. A stale `TODO` here (and a matching stale `NOTE(A7)` in E1) called the index-label choice "store-order-arbitrary"; `buildIndex.ts`'s `preferredBySubject` in fact ranks untagged < `@en` < any other tag, so `"Button"@en` wins deterministically. There was a contract nobody was asserting. The test now keeps the raw `SELECT` as a labelled **precondition** (there really are two candidates to choose between) and asserts the built index's one `ds:button` label is exactly `"Button"`.

3. **The concurrency test asserted nothing falsifiable, and was not concurrent.** `expect(hashes.size).toBe(1)` is tautological — the hash is computed *from the inputs* before any work happens, so five identical inputs give five identical hashes even if every build produced nothing; it would have passed with the build path deleted. Instrumenting it showed `reused` as `[false, true, true, true, true]` on every run: one build and four `packIsComplete` short-circuits, because the pack build is synchronous WASM work that blocks the event loop until the winner publishes. (The reviewer's *cross-run* cache premise does not hold — `setupXdgIsolation.ts` gives every test file a fresh `$XDG_CACHE_HOME` — but the hits were happening inside a single run instead.) Replaced with two tests over **nonced** inputs, so a cache hit is impossible by construction rather than dependent on ambient isolation: five **distinct** source sets built concurrently, each asserted `reused: false` + `packIsComplete` + non-empty `tripleCount` + distinct directories; and five **identical** source sets that must converge on one complete directory, built at least once, with a sixth sequential call asserted to reuse it. How many of the five build is deliberately unpinned — cold, all five do; warm, one does and four reuse — since pinning either would be a flake.

### Why the gate was deleted rather than the promised job built

The gate's stated premise is false for the code as written. These tests need neither network nor real build cost:

- **No network** — they boot `DEFAULT_PACK_TTL`, an in-tree string; `fixtureGraph.ts` contains no fetch or http at all.
- **No cost** — `journeys.defaultPack.test.ts` already boots that same fixture ~20× **ungated** in the same pass. The whole file runs in ~3s.
- **No separate runner to hang a job on** — it is matched by `vitest.config.ts`'s ordinary include, exactly like its `.e2e.` siblings (`rootCli`, `exitCodes`, `firstRun`, `mcpServe`, `autoLlm`), all of which are ungated. `.e2e.` is a naming convention here, not a separate pass.
- **A non-required job would be strictly weaker** — a red one blocks nothing. What it would be guarding, stated precisely (see "Corrections from review"): concurrent `buildPack` re-entrancy and the 20k-literal build round-trip, which nothing else covers; the exact multilingual label the index resolves to, which nothing else pins; and real-oxigraph `ORDER BY` determinism, which E1 also covers in a different shape.

Inventing a job plus an env var to run five hermetic 3-second tests the default pass already collects is CI surface for zero isolation benefit. The TODO about fetching the real shipped pack stays, reworded as a *strengthening of assertions that now run* rather than a precondition for running them at all.

## QA

1. `bunx vitest run src/kernel/completion/shellDrive.test.ts` → **33/33 pass**, including the 9 previously-dark zsh and fish cases. No bug in the generated scripts.
2. `bunx vitest run src/testing/behavioral/journeys.livePack.e2e.test.ts` → **5/5 pass**, over consecutive runs. Fails before the fixture fix with the parser error above. The build tests prove they *build* rather than cache-hit by asserting `reused: false`, so a cache hit fails the test rather than passing it silently.
3. `bunx vitest run src/testing/behavioral/journeys.defaultPack.test.ts` → **20/20 pass** (unchanged by this PR; re-run because the corrections above are stated relative to it).
4. `bun run check` at repo root → passes across 62 projects. Re-run after rebasing onto `main` at `fff26ef0`.
5. Confirm the shell install fails loudly: remove `fish` from PATH and re-run the workflow step — it must fail the job, not skip the suite.

**Honest caveat:** both suites have been observed running **locally only, never yet on an Ubuntu runner.** This box is NixOS, so there was no apt; zsh 5.9.1 was already present and fish 4.7.1 was built via `nix build nixpkgs#fish`. Together with the zsh 5.9 / fish 3.7.0 the docblock records from development, that brackets what Ubuntu 24.04 runners ship — but the install step's real-world behaviour is unconfirmed until CI goes green.

Scattered 5s vitest timeouts appear locally on a different file set each run, each passing in isolation; `origin/main` fails the same way. That is box load (several concurrent agents), not this change. This suite's first test (the fixture boot, untouched by this PR) is one of them under load — checked directly by restoring the file to its pre-change state and re-running: it times out at the same rate with and without these changes. The baseline's `2 skipped` files versus this branch's `1` is the live-pack suite going from never-running to running.

### PR readiness check

- [x] PR has a label: `Bug 🐛`, plus `no visual change`.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts in `package.json` — no package manifests are touched by this PR.
- [x] New package: **n/a** — none introduced.
- [x] Does not require visual testing — CI configuration and test files only, no rendered component changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC

