### PR TITLE
fix(pragma-cli): read ds:usage in block lookup, the vocabulary the graph has

### DIFF
--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -97,8 +97,22 @@ const designSystemStories: readonly PackDefinition[] = [
   // Base level mirrors the old summary view (name/tier/summary); the default is
   // `detailed`, matching the old CLI which rendered anatomy and modifiers
   // without a flag. A derived name that maps onto no schema field is omitted
-  // (OPTIONAL parity), so a graph lacking whenToUse/whenNotToUse degrades
-  // gracefully.
+  // (OPTIONAL parity), so a graph missing one of these properties degrades
+  // gracefully rather than erroring.
+  //
+  // That graceful degradation is also how this story went silent: it used to
+  // read `ds:whenToUse`/`ds:whenNotToUse`, which the ontology RETIRED in favour
+  // of a single `ds:usage` — "Subsumes the former whenToUse/whenNotToUse" is
+  // that property's own skos:definition. The shipped pack asserts `ds:usage` on
+  // all 264 blocks and neither retired term on any of them, so every
+  // `block lookup` on every install rendered no usage narrative at all —
+  // silently, because a name that maps onto no schema field is exactly the case
+  // OPTIONAL parity swallows. The retired terms are NOT kept as a fallback:
+  // `ds:usage` subsumes them, so a pack carrying both would print the same
+  // guidance twice, and a declaration no shipped graph can satisfy is
+  // untestable by construction — which is what let the silence ship.
+  // `block.shipped.exec.test.ts` now holds every property declared here to
+  // being asserted in the SHIPPED graph.
   //
   // Disclosure declares the FULL canonical ladder `[summary, standard,
   // detailed]` — the same set `standard` declares — so a config
@@ -168,16 +182,19 @@ const designSystemStories: readonly PackDefinition[] = [
       ],
       sections: [
         { name: "summary", property: "ds:summary", label: "Summary" },
+        // ONE section, because `ds:usage` is ONE property: its literal is
+        // free-text Markdown carrying its own `### When to use` / `### When not
+        // to use` sub-sections (78 and 71 of the 126 non-empty ones do), so
+        // splitting it back into two headings here would mean parsing prose the
+        // graph deliberately keeps whole. The renderer demotes a body's own ATX
+        // headings below the section heading, so those sub-sections nest UNDER
+        // `### Usage` instead of colliding with it. Half the blocks assert an
+        // EMPTY `ds:usage` (138 of 264); the renderer skips empty sections, so
+        // those print no heading rather than an empty one.
         {
-          name: "whenToUse",
-          property: "ds:whenToUse",
-          label: "When to use",
-          level: "detailed",
-        },
-        {
-          name: "whenNotToUse",
-          property: "ds:whenNotToUse",
-          label: "When not to use",
+          name: "usage",
+          property: "ds:usage",
+          label: "Usage",
           level: "detailed",
         },
         {

--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -111,8 +111,16 @@ const designSystemStories: readonly PackDefinition[] = [
   // `ds:usage` subsumes them, so a pack carrying both would print the same
   // guidance twice, and a declaration no shipped graph can satisfy is
   // untestable by construction — which is what let the silence ship.
-  // `block.shipped.exec.test.ts` now holds every property declared here to
-  // being asserted in the SHIPPED graph.
+  // `block.shipped.exec.test.ts` now holds every graph term declared here — the
+  // identity property, fields, sections, expand relations, and every term
+  // selected beneath them, walked recursively — to being DEFINED as a property
+  // by the SHIPPED ontology. Defined, not asserted, and the difference is the
+  // whole point: a term the ontology never defines is a story bug that can
+  // never render, on any block, on any install — this defect. A term it defines
+  // that no instance asserts yet (`ds:figmaLink` today) is a content gap
+  // upstream, which the OPTIONAL parity above degrades over gracefully and
+  // which this pack has no business failing on. `ds:usage` alone is ALSO held
+  // to being asserted, on every block, because its absence is what shipped.
   //
   // Disclosure declares the FULL canonical ladder `[summary, standard,
   // detailed]` — the same set `standard` declares — so a config

--- a/packages/cli/pragma/src/capabilities/block.parity.test.ts
+++ b/packages/cli/pragma/src/capabilities/block.parity.test.ts
@@ -17,8 +17,11 @@
  *   deleted `capabilities/block/parity.test.ts`. Button and Modal resolve with
  *   the same content a direct SPARQL oracle returns (summary, guidance,
  *   anatomy, tier, modifier families with values, properties, subcomponents).
- *   The fixture DECLARES whenToUse/whenNotToUse (which the live graph superseded
- *   with ds:usage), so those sections are exercised here.
+ *   The fixture declares the usage narrative the way the live graph does — one
+ *   `ds:usage` literal — so what is exercised here is the path a real install
+ *   takes. It formerly declared the retired whenToUse/whenNotToUse pair, and
+ *   that divergence is exactly why this suite could assert a "### When to use"
+ *   heading no install had rendered in months.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -159,10 +162,7 @@ describe("block lookup — Button content parity (GraphQL, detailed)", () => {
 
     // Guidance + anatomy sections — each cross-checked against the graph.
     expect(button.summary).toBe(await oracle(`${DS}button`, "ds:summary"));
-    expect(button.whenToUse).toBe(await oracle(`${DS}button`, "ds:whenToUse"));
-    expect(button.whenNotToUse).toBe(
-      await oracle(`${DS}button`, "ds:whenNotToUse"),
-    );
+    expect(button.usage).toBe(await oracle(`${DS}button`, "ds:usage"));
     expect(button.guidelines).toBe(
       await oracle(`${DS}button`, "ds:guidelines"),
     );
@@ -200,7 +200,13 @@ describe("block lookup — Button content parity (GraphQL, detailed)", () => {
     const out = (await verb("lookup").run({ name: ["Button"] }, rt)) as never;
     const llm = verb("lookup").output.formatters.llm(out);
     expect(llm).toContain("## Button");
-    expect(llm).toContain("### When to use");
+    expect(llm).toContain("### Usage");
+    // The usage literal's OWN headings are demoted below the section heading
+    // they now live under, so `### When to use` renders as a CHILD of Usage
+    // rather than a sibling that reads as an empty section.
+    expect(llm).toContain("#### When to use");
+    expect(llm).toContain("#### When not to use");
+    expect(llm).not.toContain("\n### When to use\n");
     expect(llm).toContain("### Anatomy (DSL)");
     expect(llm).toContain("### Modifier Families");
     expect(llm).toContain("primary");
@@ -213,7 +219,15 @@ describe("block lookup — Modal content parity (GraphQL, detailed)", () => {
     expect(modal.uri).toBe(`${DS}modal`);
     expect(modal.name).toBe("Modal");
     expect(modal.summary).toBe(await oracle(`${DS}modal`, "ds:summary"));
-    expect(modal.whenToUse).toBe(await oracle(`${DS}modal`, "ds:whenToUse"));
+    // Modal asserts an EMPTY `ds:usage` — the shape 138 of the 264 live blocks
+    // have. It resolves (parity with the oracle) and renders NOTHING: an empty
+    // literal must not print a bare "### Usage" heading with no body under it.
+    expect(modal.usage).toBe(await oracle(`${DS}modal`, "ds:usage"));
+    expect(modal.usage).toBe("");
+    const modalLlm = verb("lookup").output.formatters.llm(
+      (await verb("lookup").run({ name: ["Modal"] }, rt)) as never,
+    );
+    expect(modalLlm).not.toContain("### Usage");
     const families = modal.modifierFamilies as {
       name: string;
       values?: string[];
@@ -237,7 +251,7 @@ describe("block lookup — disclosure trims to the base view at summary", () => 
     const button = out.results.at(0) as Record<string, unknown>;
     expect(button.name).toBe("Button");
     expect(button.summary).toBeDefined();
-    expect(button.whenToUse).toBeUndefined();
+    expect(button.usage).toBeUndefined();
     expect(button.anatomyDsl).toBeUndefined();
     expect(button.modifierFamilies).toBeUndefined();
     expect(button.figmaLink).toBeUndefined();

--- a/packages/cli/pragma/src/capabilities/block.shipped.exec.test.ts
+++ b/packages/cli/pragma/src/capabilities/block.shipped.exec.test.ts
@@ -1,0 +1,233 @@
+/**
+ * The `block` story's declared vocabulary, EXECUTED against the shipped pack
+ * (PROTECTED).
+ *
+ * `block.parity.test.ts` asserts the story's semantics over a FIXTURE graph the
+ * repository writes. That is a real check, but it can only ever prove the story
+ * agrees with the fixture — and when the two drifted apart, that is exactly
+ * what happened: the story read `ds:whenToUse`/`ds:whenNotToUse`, the fixture
+ * obligingly declared them, the suite stayed green, and every real install
+ * rendered `block lookup` with no usage narrative at all, because the ontology
+ * had long since retired both terms in favour of a single `ds:usage`. Nothing
+ * in the pipeline treats that as an error: the GraphQL projection omits a name
+ * it cannot express the way OPTIONAL omits an unbound variable, and the
+ * renderer skips a section with no value. Silence all the way down.
+ *
+ * So this file boots the SHIPPED graph and asserts what a fixture structurally
+ * cannot. It distinguishes two failures that look identical in the output but
+ * are not the same defect:
+ *
+ * - a declared property the ontology does not define is a STORY bug — the CLI
+ *   is asking for a name the schema can never answer, and no upstream content
+ *   edit can ever make it render. That is this defect, and it is forbidden here.
+ * - a declared property the ontology defines but no instance asserts yet is a
+ *   CONTENT gap upstream (`ds:figmaLink` is one today). The story is correct and
+ *   degrades gracefully; that is not this suite's business.
+ *
+ * The `graph/examples.exec.test.ts` precedent: an example is a promise to a
+ * stranger, and only running it against what actually ships reads it as one. A
+ * declared property is the same kind of promise.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { verbKey } from "../kernel/packs/uniqueness.js";
+import { bootRuntime } from "../kernel/runtime/boot.js";
+import type { PragmaRuntime } from "../kernel/runtime/types.js";
+import type { VerbSpec } from "../kernel/spec/types.js";
+import { TEST_FLAGS } from "../testing/helpers/projectCli.js";
+import { declaredStories, storyModules } from "./distribution.js";
+
+const story = declaredStories.get("block");
+if (!story?.lookup) {
+  throw new Error('pragma.conf.ts declares no "block" lookup');
+}
+const blockLookup = story.lookup;
+
+const blockModule = storyModules.get("block");
+if (!blockModule) {
+  throw new Error('pragma.conf.ts declares no story for "block"');
+}
+
+const lookupVerb = blockModule.verbs.find(
+  (v) => verbKey(v.path) === "block lookup",
+) as VerbSpec;
+
+/**
+ * The block classes the lookup addresses, read from the story rather than
+ * retyped — a class added there widens these checks with it.
+ */
+const TYPE_VALUES = (blockLookup.types ?? []).join(" ");
+
+/**
+ * Every property the story names in the graph, read from the declaration.
+ *
+ * Fields, sections and expand relations all name graph vocabulary and all fail
+ * the same silent way, so all three are held to the same standard.
+ */
+const DECLARED_PROPERTIES: readonly {
+  readonly what: string;
+  readonly property: string;
+}[] = [
+  ...(blockLookup.fields ?? []).map((f) => ({
+    what: `field "${f.name}"`,
+    property: f.property,
+  })),
+  ...(blockLookup.sections ?? []).map((s) => ({
+    what: `section "${s.name}"`,
+    property: s.property,
+  })),
+  ...(blockLookup.expand ?? []).map((e) => ({
+    what: `expand "${e.name}"`,
+    property: e.relation,
+  })),
+];
+
+/** The IRI of the block whose usage narrative is asserted on below. */
+const BUTTON = "https://ds.canonical.com/global.component.button";
+
+// ONE store for the file — booting the shipped pack is the expensive part, and
+// this package already contends under parallel runs.
+let rt: PragmaRuntime;
+beforeAll(async () => {
+  rt = bootRuntime(TEST_FLAGS);
+  // Load the shipped store HERE, once. `it.each` splits the vocabulary check
+  // into one small case per declared property, and whichever ran first would
+  // otherwise pay the whole lazy-load cost and time out under contention.
+  await rt.store.get();
+}, 60_000);
+afterAll(async () => {
+  (await rt.store.get()).store.dispose();
+});
+
+/** One scalar from the shipped graph, queried directly. */
+async function scalar(query: string): Promise<string | undefined> {
+  const result = await rt.query.sparql(query);
+  if (result.type !== "select") return undefined;
+  const row = result.bindings[0];
+  return row === undefined ? undefined : Object.values(row)[0];
+}
+
+/** The `llm` rendering of `block lookup <value>`. */
+async function renderLookup(value: string): Promise<string> {
+  const out = (await lookupVerb.run({ name: [value] }, rt)) as never;
+  return lookupVerb.output.formatters.llm(out);
+}
+
+describe("the `block` story declares vocabulary the shipped ontology defines (PROTECTED)", () => {
+  it("declares at least one property to check", () => {
+    expect(DECLARED_PROPERTIES.length).toBeGreaterThan(0);
+  });
+
+  it.each(
+    DECLARED_PROPERTIES,
+  )("$what reads $property, which the shipped ontology defines", async ({
+    what,
+    property,
+  }) => {
+    const result = await rt.query.sparql(
+      [
+        "ASK {",
+        `  ${property} a ?kind .`,
+        "  VALUES ?kind { owl:DatatypeProperty owl:ObjectProperty }",
+        "}",
+      ].join("\n"),
+    );
+    expect(result.type).toBe("ask");
+    expect(
+      result.type === "ask" ? result.result : false,
+      `${what} reads ${property}, which the shipped ontology does not define — it can never render, for any block, on any install`,
+    ).toBe(true);
+  });
+});
+
+describe("the shipped graph carries the usage narrative on every block (PROTECTED)", () => {
+  it("asserts ds:usage on every block, and neither retired term on any", async () => {
+    const blocks = await scalar(
+      [
+        "SELECT (COUNT(DISTINCT ?b) AS ?n) WHERE {",
+        `  VALUES ?class { ${TYPE_VALUES} }`,
+        "  ?b a ?class .",
+        "}",
+      ].join("\n"),
+    );
+    const withUsage = await scalar(
+      [
+        "SELECT (COUNT(DISTINCT ?b) AS ?n) WHERE {",
+        `  VALUES ?class { ${TYPE_VALUES} }`,
+        "  ?b a ?class ; ds:usage ?u .",
+        "}",
+      ].join("\n"),
+    );
+    expect(Number(blocks)).toBeGreaterThan(0);
+    expect(withUsage).toBe(blocks);
+
+    // The retirement itself, pinned: reading these again would reintroduce the
+    // defect, silently, exactly as before.
+    for (const retired of ["ds:whenToUse", "ds:whenNotToUse"]) {
+      const result = await rt.query.sparql(`ASK { ?s ${retired} ?o }`);
+      expect(
+        result.type === "ask" ? result.result : true,
+        `${retired} is asserted somewhere in the shipped graph`,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("block lookup renders the usage narrative from the shipped graph (PROTECTED)", () => {
+  it("renders a Usage section carrying the graph's own literal", async () => {
+    const usage = await scalar(`SELECT ?u WHERE { <${BUTTON}> ds:usage ?u }`);
+    expect(usage?.trim().length ?? 0).toBeGreaterThan(0);
+
+    const llm = await renderLookup(BUTTON);
+    expect(llm).toContain("### Usage");
+    // The narrative itself, not just its heading: the first prose line of the
+    // literal is read FROM the graph rather than retyped here, so editing the
+    // content upstream cannot leave this asserting yesterday's copy.
+    const firstProseLine = (usage ?? "")
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.length > 0 && !line.startsWith("#")) as string;
+    expect(llm).toContain(firstProseLine);
+  });
+
+  it("nests the literal's own headings UNDER the Usage heading", async () => {
+    // The live literals carry their own `### When to use` / `### When not to
+    // use` sub-sections. Left at `###` they would be siblings of the section
+    // heading, which reads as an empty Usage section; the renderer demotes them.
+    const heading = await scalar(
+      [
+        "SELECT ?h WHERE {",
+        `  <${BUTTON}> ds:usage ?u .`,
+        '  BIND(REPLACE(STR(?u), "(?s)^.*?\\\\n### ([^\\\\n]+)\\\\n.*$", "$1") AS ?h)',
+        "}",
+      ].join("\n"),
+    );
+    expect(
+      heading,
+      "the Button usage literal carries no `### ` heading",
+    ).toBeDefined();
+
+    const llm = await renderLookup(BUTTON);
+    expect(llm).toContain(`#### ${heading}`);
+    expect(llm).not.toContain(`\n### ${heading}\n`);
+  });
+
+  it("prints no Usage heading for a block whose usage literal is empty", async () => {
+    // Roughly half the shipped blocks assert `ds:usage ""`. An empty literal
+    // must render as no section at all, never as a heading with nothing below.
+    const uri = await scalar(
+      [
+        "SELECT ?b WHERE {",
+        `  VALUES ?class { ${TYPE_VALUES} }`,
+        "  ?b a ?class ; ds:usage ?u .",
+        '  FILTER(STR(?u) = "")',
+        "}",
+        "ORDER BY ?b",
+        "LIMIT 1",
+      ].join("\n"),
+    );
+    expect(uri, "no shipped block carries an empty ds:usage").toBeDefined();
+
+    expect(await renderLookup(uri as string)).not.toContain("### Usage");
+  });
+});

--- a/packages/cli/pragma/src/capabilities/block.shipped.exec.test.ts
+++ b/packages/cli/pragma/src/capabilities/block.shipped.exec.test.ts
@@ -30,6 +30,10 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  isNestedExpand,
+  type PackExpandSelect,
+} from "../kernel/packs/types.js";
 import { verbKey } from "../kernel/packs/uniqueness.js";
 import { bootRuntime } from "../kernel/runtime/boot.js";
 import type { PragmaRuntime } from "../kernel/runtime/types.js";
@@ -58,16 +62,61 @@ const lookupVerb = blockModule.verbs.find(
  */
 const TYPE_VALUES = (blockLookup.types ?? []).join(" ");
 
+/** One graph term the story names, paired with the site that declares it. */
+interface DeclaredTerm {
+  readonly what: string;
+  readonly property: string;
+}
+
+/**
+ * Every term an `expand.select` names, to whatever depth it nests.
+ *
+ * WALKED, not listed. A hand-maintained enumeration would carry this file's own
+ * defect one level down: `ds:hasModifier`, `ds:propertyType` and `ds:optional`
+ * could be retired exactly the way `ds:whenToUse` was, and `block lookup` would
+ * quietly lose its modifier values and its property table while a list nobody
+ * thought to update stayed green. Recursing over the declaration instead means
+ * a term added to any `select` is covered the moment it is declared, by the
+ * author who declares it and without their help.
+ */
+function selectedTerms(
+  site: string,
+  select: readonly PackExpandSelect[],
+): readonly DeclaredTerm[] {
+  return select.flatMap((entry) =>
+    isNestedExpand(entry)
+      ? [
+          {
+            what: `${site} → nested expand "${entry.name}"`,
+            property: entry.relation,
+          },
+          ...selectedTerms(`${site} → "${entry.name}"`, entry.select),
+        ]
+      : [
+          {
+            what: `${site} → field "${entry.name}"`,
+            property: entry.property,
+          },
+        ],
+  );
+}
+
 /**
  * Every property the story names in the graph, read from the declaration.
  *
- * Fields, sections and expand relations all name graph vocabulary and all fail
- * the same silent way, so all three are held to the same standard.
+ * The identity property, fields, sections, expand relations and everything
+ * selected beneath them all name graph vocabulary and all fail the same silent
+ * way, so all of them are held to the same standard. `by` is included because a
+ * lookup whose identity property the ontology has retired resolves NOTHING —
+ * the loudest form of the same defect, and the one no rendering test would
+ * reach, since there would be no entity to render.
+ *
+ * One case per declaration SITE rather than per distinct term: `ds:name` is
+ * named at six of them, and a failure that names the site it was declared at
+ * is the one a reader can act on.
  */
-const DECLARED_PROPERTIES: readonly {
-  readonly what: string;
-  readonly property: string;
-}[] = [
+const DECLARED_PROPERTIES: readonly DeclaredTerm[] = [
+  { what: "lookup `by`", property: blockLookup.by },
   ...(blockLookup.fields ?? []).map((f) => ({
     what: `field "${f.name}"`,
     property: f.property,
@@ -76,10 +125,10 @@ const DECLARED_PROPERTIES: readonly {
     what: `section "${s.name}"`,
     property: s.property,
   })),
-  ...(blockLookup.expand ?? []).map((e) => ({
-    what: `expand "${e.name}"`,
-    property: e.relation,
-  })),
+  ...(blockLookup.expand ?? []).flatMap((e) => [
+    { what: `expand "${e.name}"`, property: e.relation },
+    ...selectedTerms(`expand "${e.name}"`, e.select),
+  ]),
 ];
 
 /** The IRI of the block whose usage narrative is asserted on below. */

--- a/packages/cli/pragma/src/testing/fixtures/blockGraph.ts
+++ b/packages/cli/pragma/src/testing/fixtures/blockGraph.ts
@@ -4,13 +4,26 @@
  *
  * Models the live ontology's shape faithfully but compactly: a `ds:UIBlock`
  * interface with `Component`/`Pattern`/`Subcomponent` subclasses, the block
- * detail properties (summary, whenToUse/whenNotToUse, guidelines, anatomy,
- * figmaLink), modifier families with values asserted ONLY in the reverse
+ * detail properties (summary, usage, guidelines, anatomy, figmaLink),
+ * modifier families with values asserted ONLY in the reverse
  * `ds:modifierFamily` direction (so the compiled inverse-union resolver is
  * exercised), block properties, and `ds:hasSubcomponent` scoped to `ds:Component`
  * (reached via a subtype-scoped fragment). Two blocks — Button and Modal —
- * carry the full spec so block content-parity asserts on a graph that DECLARES
- * whenToUse/whenNotToUse (which the live graph superseded with ds:usage).
+ * carry the full spec so block content-parity asserts on a graph shaped like
+ * the live one.
+ *
+ * The usage narrative is modelled as the live graph models it: ONE `ds:usage`
+ * literal per block, free-text Markdown carrying its own `### When to use` /
+ * `### When not to use` sub-sections. It used to declare the retired
+ * `ds:whenToUse`/`ds:whenNotToUse` pair instead, which is why the block parity
+ * suite went on asserting a "### When to use" heading that no real install had
+ * rendered since the ontology conflated the two into `ds:usage`.
+ *
+ * Both shapes the live pack has are here on purpose: Button carries a
+ * non-empty literal (126 of the 264 live blocks) and Modal an EMPTY one (the
+ * other 138), so the fixture proves the renderer both nests a body's own
+ * headings under the section heading AND prints no heading at all for an empty
+ * literal. A fixture that only ever carried prose could not tell those apart.
  */
 
 /** The prefixes the fixture store is built and queried with. */
@@ -56,8 +69,7 @@ ds:name a owl:DatatypeProperty ;
 ds:tier a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:domain ds:UIBlock ; rdfs:range ds:Tier .
 ds:summary a owl:DatatypeProperty ; rdfs:domain ds:UIBlock ; rdfs:range xsd:string .
-ds:whenToUse a owl:DatatypeProperty ; rdfs:domain ds:UIBlock ; rdfs:range xsd:string .
-ds:whenNotToUse a owl:DatatypeProperty ; rdfs:domain ds:UIBlock ; rdfs:range xsd:string .
+ds:usage a owl:DatatypeProperty ; rdfs:domain ds:UIBlock ; rdfs:range xsd:string .
 ds:guidelines a owl:DatatypeProperty ; rdfs:domain ds:UIBlock ; rdfs:range xsd:string .
 ds:anatomyDsl a owl:DatatypeProperty ; rdfs:domain ds:UIBlock ; rdfs:range xsd:string .
 ds:anatomyClassic a owl:DatatypeProperty ; rdfs:domain ds:UIBlock ; rdfs:range xsd:string .
@@ -82,8 +94,7 @@ ds:button a ds:Component ;
   ds:name "Button" ;
   ds:tier ds:global ;
   ds:summary "Primary action trigger with optional icon and label." ;
-  ds:whenToUse "Use for the primary action on a view." ;
-  ds:whenNotToUse "Do not use for navigation between pages." ;
+  ds:usage "Buttons trigger actions; links go places.\\n\\n### When to use\\n\\n- For the primary action on a view.\\n\\n### When not to use\\n\\n- For navigation between pages." ;
   ds:guidelines "Keep labels short and action-oriented." ;
   ds:anatomyDsl "root: button; children: label, icon" ;
   ds:anatomyClassic "Button > Label, Icon" ;
@@ -96,8 +107,7 @@ ds:modal a ds:Component ;
   ds:name "Modal" ;
   ds:tier ds:global ;
   ds:summary "Focused overlay dialog for a single task." ;
-  ds:whenToUse "Use to interrupt for a critical confirmation." ;
-  ds:whenNotToUse "Do not use for non-blocking notifications." ;
+  ds:usage "" ;
   ds:guidelines "Always provide an explicit close affordance." ;
   ds:anatomyDsl "root: dialog; children: header, body, footer" ;
   ds:hasModifierFamily ds:family.size ;


### PR DESCRIPTION
## Done

**`block lookup` — the flagship read — has been silently omitting its usage narrative for every block on every install.**

The story reads `ds:whenToUse` and `ds:whenNotToUse`. The shipped graph contains **zero** of either. `ds:usage` — which the embedded ontology's own `skos:definition` says *"Subsumes the former whenToUse/whenNotToUse"* — is asserted on **264 of 264 blocks**. A comment in `pragma.conf.ts` rationalised this as *"a graph lacking whenToUse/whenNotToUse degrades gracefully"*; it was describing 100% of production as an edge case.

No test caught it because `blockGraph.ts` still authored the retired vocabulary, and said so in its own docblock. The fixture spoke a dialect production had already left.

- **`pragma.conf.ts`** — the two retired sections replaced by one `usage` / `ds:usage` / "Usage" section at `detailed`. The "degrades gracefully" comment replaced with the actual history.
- **`testing/fixtures/blockGraph.ts`** — authors `ds:usage`. Button carries a non-empty literal with its own sub-headings; **Modal carries `ds:usage ""`** so the fixture covers both shapes that exist in production. Only this property changed; nothing else reshaped.
- **`capabilities/block.parity.test.ts`** — asserts `### Usage`, the demoted `#### When to use`, and that Modal's empty literal renders no heading.
- **New `capabilities/block.shipped.exec.test.ts`** (PROTECTED) — boots the *shipped* pack, per the `examples.exec.test.ts` precedent, so this class of drift is caught against real data rather than a fixture.

### Two facts from the census that changed the design

Measured by parsing the 9,068-quad literal out of `pack.generated.ts`, not assumed:

- **138 of the 264 `ds:usage` literals are empty strings** — only 126 carry prose. An unconditional section would have printed a bare heading for over half of production.
- The non-empty literals **already contain their own `### When to use` / `### When not to use` sub-headings** (78 and 71 of 126).

Both are handled by renderer behaviour that already existed and was verified rather than added: `nestHeadings` demotes the body's own ATX headings under `### Usage`, and `isEmptyValue` skips empty sections.

Also: `ds:usage` is on **seven** block classes, not the four in the original report — Component 110, Subcomponent 86, Pattern 42, Layout 14, plus Group 9, View 2, Variant 1.

### The retired properties are dropped, not kept as a fallback

Justified in `pragma.conf.ts` itself. (1) `ds:usage` subsumes them by definition, so a pack carrying both would print the same guidance twice. (2) No fixture would author them, so they would be two more never-exercised declarations behind the same comment that hid the first two — untestable config is exactly what let this ship. (3) The new guard would need an exemption for them, i.e. the guard disbelieving its own rule.

## QA

1. Built CLI against the **shipped** pack, `global.component.button`:
   - **before** — `### Summary` straight to `### Guidelines`
   - **after** — a full `### Usage` section with the real narrative, and `#### When to use` / `#### When not to use` / `#### Call to actions` nested one level below it
2. `bunx vitest run src/capabilities/block.parity.test.ts src/capabilities/block.shipped.exec.test.ts` → green, including the empty-literal case.
3. `bun run gen:reference` → **no diff**.
4. `bun run check` → clean at package and repo root; block, reference, surface and distribution suites 64/64.

Full-suite failures are confined to `create/*` and other subprocess-spawning tests hitting the default 5,000 ms timeout; they vary run to run, pass in isolation (136/136 for `create`), and touch nothing here. **Worth knowing:** when those tests time out mid-run they leak scaffolded files into `packages/cli/pragma/src/lib/`, which then breaks the *next* run's `tsc` gate with a confusing `Cannot find module './Button.svelte'`. `rm -rf packages/cli/pragma/src/lib` clears it.

### Found, deliberately not fixed

**`ds:figmaLink` is declared on `ds:UIBlock` but asserted on zero blocks** in the shipped pack. The guard checks the ontology *definition* rather than instance data precisely to separate the two cases: a property the ontology never defines is a story bug that can never render (this defect), while one it defines that no instance asserts is an upstream content gap that genuinely does degrade gracefully.

### PR readiness check

- [x] PR has a label: `Bug 🐛`, plus `no visual change`.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards).
- [x] All packages define the required scripts in `package.json` — no manifests are touched.
- [x] New package: **n/a** — none introduced.
- [x] Does not require visual testing — CLI story configuration, fixtures and tests only.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
