### PR TITLE
feat(pragma-cli): ship the packs' skills with the release

### DIFF
--- a/packages/cli/pragma/biome.json
+++ b/packages/cli/pragma/biome.json
@@ -5,7 +5,8 @@
       "**/src/**",
       "**/*.json",
       "pragma.conf.ts",
-      "!**/*.generated.ts"
+      "!**/*.generated.ts",
+      "!bundled-skills"
     ]
   }
 }

--- a/packages/cli/pragma/bundled-skills/add-standard/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/add-standard/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: add-standard
+description: Create and add a new code standard to the code-standards package
+---
+
+# Add Standard
+
+Create and add a new code standard to the code-standards package.
+
+## When to Use
+
+Use this skill when:
+- "Add a standard for..."
+- "Create a coding standard..."
+- "Document a new convention..."
+- "Add guidance for..."
+
+## Workflow
+
+### 1. Check for Existing Standards
+
+Before creating a new standard, always check if one already exists:
+
+```sparql
+PREFIX cs: <http://pragma.canonical.com/codestandards#>
+
+SELECT ?standard ?description WHERE {
+  ?standard a cs:CodeStandard ;
+            cs:description ?description .
+  FILTER(CONTAINS(LCASE(STR(?standard)), "your-topic"))
+}
+```
+
+Or use lookup:
+```
+sem_lookup(type: "cs:CodeStandard", filters: {"@id": {"$contains": "your-topic"}})
+```
+
+### 2. Determine the Category
+
+List existing categories to find the right fit:
+
+```sparql
+PREFIX cs: <http://pragma.canonical.com/codestandards#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?category ?label ?slug WHERE {
+  ?category a cs:Category ;
+            rdfs:label ?label ;
+            cs:slug ?slug .
+}
+```
+
+**Available Categories:**
+
+| Category | Slug | Description |
+|----------|------|-------------|
+| React | `react` | React component development |
+| CSS | `css` | CSS technical implementation |
+| Styling | `styling` | Design system styling patterns |
+| Code | `code` | General TypeScript standards |
+| Storybook | `storybook` | Storybook documentation |
+| Icons | `icons` | Icon implementation |
+| Packaging | `packaging` | Package structure and exports |
+| Rust | `rust` | Idiomatic Rust development |
+| Git | `git` | Git workflow conventions |
+| TSDoc | `tsdoc` | Documentation conventions |
+| Turtle | `turtle` | RDF/Turtle authoring |
+| UI Blocks | `ui-blocks` | Framework-agnostic capabilities and patterns for UI blocks |
+
+If no existing category fits, create a new one (see Section 5).
+
+### 3. Design the Standard Identifier
+
+Standard identifiers follow a hierarchical compact IRI pattern: `cs:{category}.{domain}.{topic}`
+
+**Pattern:** `^cs:[a-z]+(\.[a-z0-9_]+){2,}$`
+
+**Examples:**
+- `cs:react.component.structure.folder`
+- `cs:css.selectors.namespace`
+- `cs:styling.tokens.creation`
+- `cs:react.hooks.naming`
+
+**Guidelines:**
+- Use lowercase with underscores for multi-word segments
+- Category is always the first segment after `cs:`
+- Be specific but not overly verbose
+- Follow existing naming patterns in the same category
+- Treat the subject IRI as the only canonical identifier
+- Use `cs:name` only for an optional human-readable display title
+
+### 4. Write the Standard
+
+Create a new standard instance in the appropriate data file under `data/`.
+
+**Template:**
+
+```turtle
+cs:category.domain.topic a cs:CodeStandard ;
+    cs:name "Human Readable Title" ;
+    cs:hasCategory cs:category ;
+    cs:description "Clear, concise description of what this standard covers and why it matters." ;
+    cs:do [
+        cs:description "First recommended practice." ;
+        cs:language "typescript" ;
+        cs:code """
+// Example showing the correct approach
+const good = true;
+    """
+    ] ;
+    cs:do [
+        cs:description "Second recommended practice." ;
+        cs:language "typescript" ;
+        cs:code """
+// Another correct example
+const alsoGood = true;
+    """
+    ] ;
+    cs:dont [
+        cs:description "First anti-pattern to avoid." ;
+        cs:language "typescript" ;
+        cs:code """
+// Example showing what NOT to do
+const bad = true;
+    """
+    ] ;
+    cs:dont [
+        cs:description "Second anti-pattern." ;
+        cs:language "typescript" ;
+        cs:code """
+// Another bad example
+const alsoBad = true;
+    """
+    ] .
+```
+
+Each `cs:do` and `cs:dont` is a blank node (`cs:Example`) with structured fields:
+- `cs:description` — What the example demonstrates (required)
+- `cs:language` — Language of the code block, e.g. `"typescript"`, `"rust"`, `"css"`, `"bash"`, `"svg"` (optional, omit when no code)
+- `cs:code` — The code content (optional, omit for description-only examples)
+
+**Required Properties:**
+- subject IRI - Canonical compact identifier
+- `cs:hasCategory` - Reference to a Category instance
+- `cs:description` - What and why (plain text or markdown)
+- `cs:do` - One or more positive examples (blank nodes)
+- `cs:dont` - One or more negative examples (blank nodes)
+
+**Optional Properties:**
+- `cs:name` - Human-readable display title
+- `cs:extends` - Reference to a parent standard this builds upon
+
+### 5. Create a New Category (if needed)
+
+If your standard doesn't fit existing categories:
+
+```turtle
+cs:new_category a cs:Category ;
+    rdfs:label "Category Name"@en ;
+    rdfs:comment "Description of what this category covers"@en ;
+    cs:slug "slug-name" .
+```
+
+### 6. Extending Existing Standards
+
+When your standard builds on another:
+
+```turtle
+cs:react.component.props.special_case a cs:CodeStandard ;
+    cs:name "React Props Special Case" ;
+    cs:extends cs:react.component.props ;
+    cs:hasCategory cs:react ;
+    cs:description "Specific guidance that builds on the general props standard." ;
+    cs:do [
+        cs:description "Example of the specific pattern." ;
+        cs:language "typescript" ;
+        cs:code """
+// ...
+    """
+    ] ;
+    cs:dont [
+        cs:description "Anti-pattern to avoid." ;
+        cs:language "typescript" ;
+        cs:code """
+// ...
+    """
+    ] .
+```
+
+Query to find potential parent standards:
+```sparql
+PREFIX cs: <http://pragma.canonical.com/codestandards#>
+
+SELECT ?standard WHERE {
+  ?standard a cs:CodeStandard .
+  FILTER(STRSTARTS(STR(?standard), STR(cs:react.component.props)))
+}
+```
+
+### 7. Validate Before Committing
+
+After writing the standard, validate the Turtle syntax:
+
+```bash
+sem check code-standards
+```
+
+Then verify the standard loads correctly:
+```
+sem_lookup(type: "cs:CodeStandard", filters: {"@id": "cs:category.domain.topic"})
+```
+
+The `@id` must always use the canonical compact IRI. Do not look up standards by `cs:name`.
+
+## File Organization
+
+Standards are organized by category in `data/`:
+
+```
+code-standards/
+├── definitions/
+│   └── CodeStandard.ttl    # Ontology schema
+├── data/
+│   ├── react.ttl           # React standards
+│   ├── css.ttl             # CSS standards
+│   ├── styling.ttl         # Styling standards
+│   ├── code.ttl            # General code standards
+│   ├── storybook.ttl       # Storybook standards
+│   └── icons.ttl           # Icon standards
+└── skills/
+    └── standards-guide/
+        └── SKILL.md
+```
+
+Add new standards to the file matching their category.
+
+## Writing Quality Standards
+
+### Description Guidelines
+- Start with WHAT the standard covers
+- Explain WHY it matters
+- Keep it concise but complete
+- Use markdown for complex descriptions
+
+### Do Examples Guidelines
+- Each `cs:do` blank node is one discrete positive example
+- `cs:description` explains what the example demonstrates
+- `cs:language` must match the code block language (e.g. `"typescript"`, `"css"`, `"rust"`)
+- `cs:code` contains the actual code — no markdown fences needed
+- Provide concrete, runnable examples
+- Show the COMPLETE correct pattern
+
+### Don't Examples Guidelines
+- Each `cs:dont` blank node is one discrete negative example
+- Show realistic mistakes developers make
+- `cs:description` should explain WHY it's problematic
+- Mirror the structure of the do examples where possible
+
+### Example Quality Checklist
+- [ ] Examples are syntactically correct
+- [ ] Examples are self-contained (can be understood without context)
+- [ ] Examples use realistic code, not `foo`/`bar`
+- [ ] Examples include comments explaining key points
+- [ ] Both do's and don'ts cover the same scenarios
+
+## Complete Example
+
+Adding a new standard for React error boundaries:
+
+```turtle
+# In data/react.ttl
+
+cs:react.component.error_boundaries a cs:CodeStandard ;
+    cs:name "React Error Boundaries" ;
+    cs:hasCategory cs:react ;
+    cs:description "Error boundaries must be used to catch JavaScript errors in component trees and display fallback UI. They should be placed strategically to isolate failures without breaking the entire application." ;
+    cs:do [
+        cs:description "Wrap feature sections with error boundaries to isolate failures." ;
+        cs:language "tsx" ;
+        cs:code """
+const Dashboard = () => (
+  <div className="ds dashboard">
+    <ErrorBoundary fallback={<WidgetError />}>
+      <AnalyticsWidget />
+    </ErrorBoundary>
+    <ErrorBoundary fallback={<WidgetError />}>
+      <ActivityWidget />
+    </ErrorBoundary>
+  </div>
+);
+    """
+    ] ;
+    cs:do [
+        cs:description "Provide meaningful fallback UI that helps users understand and recover." ;
+        cs:language "tsx" ;
+        cs:code """
+const WidgetError = () => (
+  <div className="ds widget-error">
+    <p>This section couldn't load.</p>
+    <button onClick={() => window.location.reload()}>
+      Refresh page
+    </button>
+  </div>
+);
+    """
+    ] ;
+    cs:dont [
+        cs:description "Wrap the entire application in a single error boundary." ;
+        cs:language "tsx" ;
+        cs:code """
+// Bad: One error anywhere crashes everything
+const App = () => (
+  <ErrorBoundary>
+    <Header />
+    <Main />
+    <Footer />
+  </ErrorBoundary>
+);
+    """
+    ] ;
+    cs:dont [
+        cs:description "Use generic or unhelpful fallback messages." ;
+        cs:language "tsx" ;
+        cs:code """
+// Bad: Doesn't help the user
+const fallback = <div>Something went wrong</div>;
+    """
+    ] .
+```
+
+## Tips
+
+1. **Check before creating**: Always search for existing standards first - you might need to extend rather than create new
+2. **Follow patterns**: Look at existing standards in the same category for style guidance
+3. **Be specific**: Vague standards are hard to follow - include concrete examples
+4. **Test your examples**: Make sure code examples actually work
+5. **Consider hierarchy**: Use `cs:extends` when your standard builds on another

--- a/packages/cli/pragma/bundled-skills/adoption-a1-styles/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/adoption-a1-styles/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: adoption-a1-styles
+description: Adopt Canonical design-system styles, fonts, and icons in an application (adoption track A1); also runs as a guided tutorial on a worked example
+---
+
+# Adoption A1 — Styles, fonts, icons
+
+The first track of adopting the design system: the visual foundation — reset,
+typography, tokens, fonts, icons — before any component swap. Complete this track and
+the app looks and reads like the design system even while it still renders its old
+components.
+
+## When to Use
+
+- Starting design-system adoption in an application — this is the first track
+- The app needs the visual foundation (reset, typography, tokens, fonts, icons) before
+  any component swap
+
+## When NOT to Use
+
+- The foundation is already installed and verified — continue with
+  `adoption-a2-components`
+- Authoring design-system content rather than adopting it — see `specify-component`
+  and its sibling skills
+
+## Opening move: ask, or offer the tutorial
+
+Activation is an opening, not a starting gun. Unless the first message already names
+the work, ask for the starting point — as a suggestion carrying an example, not as a
+form to fill in:
+
+> To get started, point me at the app — the repo or directory — and say whether it
+> already pulls in any Canonical styles.
+
+"I don't know what's in there" is a fine answer: the install and verify steps
+establish it. Ask again only for what the next step genuinely blocks on.
+
+If the activation message already carries the starting point, do not re-ask — say what
+you took it to be, and go.
+
+Offer the tutorial in the same breath, because this track doubles as one:
+
+> Or if you'd rather see what this track changes before touching your app, I can run
+> it as a tutorial: I'll take a plausible example — a small Vite React app — and walk
+> you through the track on it.
+
+Tutorial mode is the step narration below, turned up: the same outcome-path-conclusion
+frame, with the reasoning behind each change made explicit. It runs on a scratch
+example, not on the person's app — nothing in their repo changes unless they ask.
+
+## Every step is narrated: outcome, path, conclusion
+
+Every step is addressed to the person — once before it runs, once when it ends. This is
+not tutorial manner. It holds in the ordinary flow too: the person is the design
+authority, and they can only steer a step they saw coming. A decision gate met cold is
+a decision they cannot really make.
+
+**Open** the step with what it is FOR — the outcome it should leave behind — and how
+you are about to get there. **Close** it with a sentence saying what it established and
+what that means for the step after. One sentence each is enough; the failure mode is
+silence, not length, and a step whose outcome looks obvious still gets its sentence
+rather than a shrug.
+
+Do:
+
+> **Fonts, then styles.** The outcome is an app whose type and tokens come from the
+> design system, with the fonts loaded before the styles that expect them. The path is
+> the two `@import` lines below, in the root stylesheet, fonts first.
+>
+> …
+>
+> So: type and tokens are live and Ubuntu Sans is self-hosted — which leaves the
+> surface classes as the step that decides whether the density channel emits real
+> values at all.
+
+Don't:
+
+> Added the two imports. Fonts load.
+
+Both carry the same facts. Only the first says what the step was trying to achieve and
+what it settled — and only the first lets the person cut in with the thing they know
+and the graph does not, which is the whole reason they are here.
+
+## Asked about the skill: methodology and outcomes first
+
+A question about what this skill does — what it covers, what its steps are, how it
+works — is answered in that order: the METHOD it applies and the OUTCOMES it leaves
+the person holding come first, the step-by-step breakdown comes after.
+
+Two or three sentences of method is enough: what the skill treats as its object, the
+discipline that makes it work, and what exists at the end that did not exist before.
+The enumeration then reads as steps in service of something, rather than as a list to
+be got through.
+
+What this prevents is a table of contents standing in for an answer. A reply opening
+with the step names tells someone who already knows the skill nothing new, and someone
+who does not, nothing at all.
+
+So, asked what this skill is:
+
+> It installs the visual foundation — reset, typography, tokens, fonts, icons — before
+> any component is swapped, under the live code standards. Complete it and the app
+> looks and reads like the design system while it still renders its old components,
+> which is what makes every later track land on the right ground.
+
+Then, and only then, the breakdown.
+
+## Install
+
+```bash
+bun add @canonical/styles @canonical/ds-assets
+```
+
+One import of `@canonical/styles` aggregates the normalize/reset, typography, and design
+tokens. Two things come with it:
+
+- Cascade layers `@layer normalize, ds.reset, ds.modifiers, ds.components` — component
+  styles beat modifiers beat reset regardless of import order, so adopting apps do not
+  fight specificity.
+- `color-scheme: light dark` on `:root` — the foundation is theme-aware out of the box.
+
+## Code standards are the gate
+
+Styling work in this track falls under the live code standards — the `styling`, `css`,
+and `icons` categories at minimum (take the actual set from the live output, not from
+this list). Pull them BEFORE touching a stylesheet and hold the Do/Don't pairs open
+while editing, so they shape the change as it is written, not only in review:
+
+```bash
+pragma standard categories                 # the live category set — never from memory
+pragma standard list --category styling    # repeat per applicable category
+pragma standard lookup <name> --detail detailed
+```
+
+Apps follow the code standards as closely as the work allows. Where a change has to
+deviate from a pulled standard, record the deviation in the PR next to the standard's
+name — and ideally file it as an issue, either to bring the app into line later or to
+propose a change to the standard itself. The standards apply even when the app has no
+pragma dependency, and they are open to contribution: a missing or wrong standard is
+something to propose a change for, not to silently work around.
+
+## Fonts before styles
+
+Fonts are opt-in and must be imported FIRST. The canonical form, in the root stylesheet:
+
+```css
+@import url("@canonical/styles/fonts");
+@import url("@canonical/styles");
+```
+
+(Equivalent JS-side: import the fonts CSS, then `import "@canonical/styles"`.) The
+fonts entry loads Ubuntu Sans as variable fonts, self-hosted from
+`@canonical/ds-assets` via its `@font-face` rules — no external font host.
+
+## Declare the surface: context and density classes
+
+The density system is class-driven, and it starts at the root. The app's root element
+(`<body>`, or the app's root container) must carry TWO classes:
+
+```html
+<body class="app comfortable">
+```
+
+- **Context** — `app`, `site`, or `docs`: which surface this is. Applications take
+  `app`; marketing/brochure surfaces take `site`; documentation surfaces take `docs`
+  (`docs` shares `site`'s values).
+- **Density** — `comfortable` or `dense`: picks within the context's pair.
+  `comfortable` is the default choice unless the product's design calls for `dense`.
+
+The requirement, stated as a rule: the root carries EXACTLY ONE class from each
+family — a context (`app` | `site` | `docs`) AND a density (`comfortable` | `dense`).
+That makes six valid combinations (`app comfortable`, `app dense`, `site comfortable`,
+`site dense`, `docs comfortable`, `docs dense`) and nothing else: a single class, a
+value outside either set, or two values from the same family is an invalid surface
+declaration. `app comfortable` is the default for applications; adoption is not done
+until the root carries a valid pair.
+
+Components never read these classes directly — they read the `--density-*` custom
+properties the classes emit (control heights, inline padding, vertical spacing rungs,
+baseline seating). A section can locally tighten by carrying its own `dense` class on
+an ancestor of just that region.
+
+**Failure mode: missing root classes fail SILENTLY.** The primitives fall back to
+app-comfortable values, so an application looks right by accident — while a site or
+docs surface, or any intended `dense` region, quietly renders with the wrong control
+heights and spacing. This step has historically been forgotten precisely because
+nothing errors. If control heights or spacing look subtly off, check the root classes
+before debugging component CSS.
+
+## The /icons serving contract (and its silent failure)
+
+Icons are per-file SVGs in `@canonical/ds-assets` (`icons/<name>.svg`, 16x16 viewBox,
+`currentColor` fill, a single `<g id="<name>">`), referenced at RUNTIME: the React
+`Icon` component renders
+
+```html
+<use href="/icons/<name>.svg#<name>" />
+```
+
+with `rootPath="/icons"` as the default, overridable via the `rootPath` prop.
+
+**The app must expose `@canonical/ds-assets`' `icons/` directory at `/icons`** — copy or
+symlink it into the static dir, or add a static mount in the server/bundler config — or
+pass `rootPath` to point where the app does serve them.
+
+**Failure mode: an unserved icon renders EMPTY, silently.** No error, no broken-image
+glyph — an external `<use>` reference that 404s resolves to nothing. If icons "don't
+show up", check the network tab for `/icons/<name>.svg` before debugging anything else.
+
+For TypeScript apps, the valid icon names ship as data:
+
+```ts
+import { ICON_NAMES, type IconName } from "@canonical/ds-assets";
+```
+
+## Storybook freebies
+
+```bash
+bun add -d @canonical/storybook-config
+```
+
+```ts
+// .storybook/main.ts
+import { createConfig } from "@canonical/storybook-config";
+
+export default createConfig("react"); // or "svelte" | "sveltekit" | "lit"
+```
+
+This single call:
+
+- serves the whole `@canonical/ds-assets` package via `staticDirs`, so `/icons/*` just
+  works in Storybook — do not mistake that for your APP serving them;
+- ships the shared addons and shell theme;
+- fixes the full-height preview chain.
+
+One caveat: declare `tags: ["autodocs"]` inline in your own `.storybook/preview.ts` —
+Storybook statically parses that file and does not reliably pick up tags spread from an
+imported preview.
+
+## Verify
+
+- [ ] Computed `font-family` on body text shows Ubuntu Sans.
+- [ ] The root element carries one context class (`app`/`site`/`docs`) and one
+      density class (`comfortable`/`dense`).
+- [ ] Computed `--density-line-height` on a control matches the intended cell
+      (e.g. `32px` for app-comfortable, `36px` for site-comfortable) — a fallback
+      value on a class-less root passes visual inspection and still fails this check
+      on non-app surfaces.
+- [ ] `/icons/<name>.svg` returns 200 with SVG content, and an icon visibly renders.
+- [ ] The `@layer normalize, ds.reset, ds.modifiers, ds.components` rule is present in
+      the served CSS.
+- [ ] Typography baseline behaves. Note: the baseline grid is computed with the CSS
+      `mod()` function and cannot be downleveled — check the support table in the
+      `@canonical/styles-typography` README against the browsers you target.
+
+## Next
+
+Foundation in place — continue with `adoption-a2-components`.
+
+## Support
+
+If this skill leads somewhere broken — a command that errors, guidance that
+contradicts what the live system answers, a gap the flow cannot cover — you are not
+stuck:
+
+- Raise an issue in the pragma repo: https://github.com/canonical/pragma/issues —
+  include the skill name, what was run, and expected vs. actual outcome.
+- Or contact the design-system team owners directly through your organization's
+  professional messaging channels for assistance.

--- a/packages/cli/pragma/bundled-skills/adoption-a2-components/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/adoption-a2-components/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: adoption-a2-components
+description: Swap an application's UI to Canonical design-system components one component type per PR (adoption track A2); also runs as a guided tutorial on a worked example
+---
+
+# Adoption A2 — Components
+
+The second adoption track: replace the app's existing UI elements with design-system
+components. Prerequisite: track A1 is done — styles, fonts, and icons are live, so
+swapped components land on the right foundation. That includes the root context and
+density classes (`class="app comfortable"` — A1's "Declare the surface" section):
+component geometry reads the `--density-*` channel those classes emit, and a swap onto
+a class-less root looks subtly wrong rather than broken.
+
+## When to Use
+
+- Track A1 is done and the app's UI elements should become design-system components
+- Planning or executing a component swap PR
+
+## When NOT to Use
+
+- The visual foundation is not in place — run `adoption-a1-styles` first
+- Migrating forms — a different programming model: `adoption-a3-forms`
+
+(An uncovered component TYPE is not a reason to skip the track — it is a per-type
+finding: see "The covered set is queried live" below.)
+
+## Opening move: ask, or offer the tutorial
+
+Activation is an opening, not a starting gun. Unless the first message already names
+the work, ask for the starting point — as a suggestion carrying an example, not as a
+form to fill in:
+
+> To get started, point me at the app and say which component type you'd like swapped
+> first — buttons, say — or let me inventory the app and suggest one.
+
+The inventory is cheap, so no preference is a fine answer. Ask again only for what the
+next step genuinely blocks on.
+
+If the activation message already carries the starting point, do not re-ask — say what
+you took it to be, and go.
+
+Offer the tutorial in the same breath, because this track doubles as one:
+
+> Or if you'd rather see what a swap looks like before touching your app, I can run it
+> as a tutorial: I'll take a plausible example — buttons in a small React app — and
+> walk you through one type from inventory to a finished PR.
+
+Tutorial mode is the step narration below, turned up: the same outcome-path-conclusion
+frame, with the reasoning behind each change made explicit. It runs on a scratch
+example, not on the person's app — nothing in their repo changes unless they ask.
+
+## Every step is narrated: outcome, path, conclusion
+
+Every step is addressed to the person — once before it runs, once when it ends. This is
+not tutorial manner. It holds in the ordinary flow too: the person is the design
+authority, and they can only steer a step they saw coming. A decision gate met cold is
+a decision they cannot really make.
+
+**Open** the step with what it is FOR — the outcome it should leave behind — and how
+you are about to get there. **Close** it with a sentence saying what it established and
+what that means for the step after. One sentence each is enough; the failure mode is
+silence, not length, and a step whose outcome looks obvious still gets its sentence
+rather than a shrug.
+
+Do:
+
+> **Inventory first.** The outcome is a real count of what the app uses, per component
+> type, so the first swap PR is chosen from evidence rather than instinct. The path is
+> the greps below over `src/`, deduped with counts.
+>
+> …
+>
+> So: 43 button call sites against 6 cards — buttons are the widest swap and the
+> obvious first PR, and two of those call sites use a variant the system has no
+> modifier for, which is a finding to report rather than a blocker.
+
+Don't:
+
+> Inventory: 43 buttons, 6 cards, 3 tooltips.
+
+Both carry the same facts. Only the first says what the step was trying to achieve and
+what it settled — and only the first lets the person cut in with the thing they know
+and the graph does not, which is the whole reason they are here.
+
+## Asked about the skill: methodology and outcomes first
+
+A question about what this skill does — what it covers, what its steps are, how it
+works — is answered in that order: the METHOD it applies and the OUTCOMES it leaves
+the person holding come first, the step-by-step breakdown comes after.
+
+Two or three sentences of method is enough: what the skill treats as its object, the
+discipline that makes it work, and what exists at the end that did not exist before.
+The enumeration then reads as steps in service of something, rather than as a list to
+be got through.
+
+What this prevents is a table of contents standing in for an answer. A reply opening
+with the step names tells someone who already knows the skill nothing new, and someone
+who does not, nothing at all.
+
+So, asked what this skill is:
+
+> It replaces the app's UI elements with design-system components, one component type
+> per PR, with the order chosen from a real inventory rather than instinct. You end
+> with each swapped type sitting on A1's foundation, accessibility warnings treated as
+> contract, and any type the system does not cover reported as a finding rather than
+> treated as a blocker.
+
+Then, and only then, the breakdown.
+
+## Install
+
+```bash
+bun add @canonical/react-ds-global
+```
+
+That is the universal (global) tier package. App-tier siblings, where they exist,
+follow a naming convention — the mapping is convention, not a graph field:
+`@canonical/<framework>-ds-global` for the `global` tier, `-ds-app` for the shared
+`apps` tier, and `-ds-app-<app>` for an app-specific tier (so the `apps_lxd` tier
+installs `@canonical/react-ds-app-lxd`). The `<app>` segment is the package's own
+short name, not always the tier suffix (the `apps_workplaceengineering` tier's
+package is `@canonical/svelte-ds-app-wpe`) — `pragma tier list` shows which tiers
+exist, and the derived package name must resolve before you install it. Tiers
+outside `global`/`apps*` have no package convention today: there the target package
+is a decision to raise, not to derive.
+
+```tsx
+import { Button, Badge, Card, Tooltip } from "@canonical/react-ds-global";
+```
+
+Named imports; components accept the underlying element's native HTML attributes, so
+existing `onClick`/`aria-*`/`data-*` plumbing carries over.
+
+## Code standards are the gate
+
+Every swap writes component code, and that code falls under the live code standards —
+the target framework's category (`react`, `svelte`, `lit`), plus `testing` and
+`storybook` where the swap touches those (take the actual set from the live output,
+not from this list). Pull them BEFORE the first swap of a PR and hold the Do/Don't
+pairs open while writing:
+
+```bash
+pragma standard categories                 # the live category set — never from memory
+pragma standard list --category react      # swap react for the target framework
+pragma standard lookup <name> --detail detailed
+```
+
+Apps follow the code standards as closely as the swap allows. Where swapped code has
+to deviate from a pulled standard, record the deviation in the PR next to the
+standard's name — "the old code did it this way" is a deviation to record, not a
+reason to stay silent — and ideally file it as an issue, either to bring the app into
+line later or to propose a change to the standard itself. The standards apply even
+when the app has no pragma dependency, and they are open to contribution: a missing
+or wrong standard is something to propose a change for, not to silently work around.
+
+## Inventory first (grep, don't guess)
+
+Build the swap list from the code, not from memory:
+
+```bash
+grep -rhoE '\bp-[a-z0-9-]+' src/ | sort | uniq -c | sort -rn   # Vanilla class inventory, deduped with counts
+grep -rn 'from "@canonical/react-components"' src/             # or your current component library's import
+```
+
+Group the hits by component TYPE — all buttons, all cards, all tooltips — because the
+type is the unit of work below. When you get to one type, locate its call sites with an
+anchored grep:
+
+```bash
+grep -rnE '\bp-button\b' src/   # swap p-button for the type at hand
+```
+
+Anchor on the class TOKEN, not on the attribute — a `class(Name)?="…"` pattern
+under-collects, missing template-literal (`` className={`p-button …`} ``), `clsx(…)`,
+and single-quoted call sites.
+
+## The covered set is queried live
+
+Before swapping a type, confirm the design system covers it TODAY:
+
+```bash
+pragma block list            # what exists, with tiers
+pragma block lookup <Name>   # anatomy, modifiers, properties (MCP: block_lookup)
+```
+
+A bare name can match blocks in several tiers, and `block lookup` silently picks
+one — it resolves `ds:name` globally and cannot be steered to a tier.
+Confirm the tier the lookup picked from its own `- Tier:` line; the name query below lists every tier that carries the name.
+The name query
+`pragma graph query "SELECT ?b WHERE { ?b ds:name ?n . FILTER(LCASE(?n) = LCASE('<Name>')) }"`
+prints every tier's IRI for `pragma graph inspect <IRI>`. If the lookup picked the wrong
+tier's block, read the one you want with `pragma graph inspect <IRI from that row>`
+instead.
+
+**A block being in the graph does not mean the package exports it.** The graph
+records what the design system has DOCUMENTED; the package ships what has been
+BUILT, and the two run ahead of each other in both directions. So before you
+swap a type, confirm the named export in the package you installed:
+
+```bash
+node -e "console.log(Object.keys(require('@canonical/react-ds-global')))" | tr ',' '\n' | grep -i '<Name>'
+```
+
+If the export is absent, the block is documented but not available — file the
+gap and leave the existing markup in place. Do not infer availability from a
+Storybook story either: a story can exist for a block that ships no
+implementation and no export, so a story CORROBORATES an export you have
+already confirmed, and never substitutes for it.
+
+If the name has no row and the lookup errors, the block may be a Group — `block list`/`block lookup` cover no groups; the name query above returns its IRI for `pragma graph inspect <IRI>`.
+Run it before calling a type uncovered: `Cards` and `KeyboardKeys` are groups, and both
+ship from the `@canonical/react-ds-global` this track installs. The export check above
+applies to them exactly as it does to any other block.
+
+Then check the component in a running Storybook — your app's own (track A1 set it up
+via `@canonical/storybook-config`), your team's hosted hub, or `bun run storybook`
+inside the component's package in the pragma monorepo (e.g. `packages/react/ds-global`
+— the monorepo root has no such script).
+
+> The covered set is whatever the graph answers today. Query it live — never copy its
+> output into documentation, PRs, or this skill.
+
+A gap found is a FINDING to report (and a `specify-component` candidate) — skip that
+type and keep swapping the types the system does cover; never hand-roll a lookalike
+silently.
+
+## One component type per PR
+
+The swap unit is a component TYPE across the app — all buttons in one PR — not a page.
+
+- Diffs stay reviewable: one decision, applied everywhere.
+- Accessibility regressions stay attributable to the one swap that caused them.
+- One PR reverts one decision, cleanly.
+
+## Names and boundaries changed vs Vanilla
+
+Do NOT assume a 1:1 mapping from Vanilla names and `p-*` classes. Boundaries moved:
+what was one blob may now be a component plus subcomponents (e.g. `Accordion` with
+`Accordion.Item`), and icon semantics changed to `currentColor`. The block's `ds:usage`
+When-to-use / When-not-to-use guidance decides what replaces what — read it with
+`pragma graph inspect <block IRI>` (the IRI from the block's `pragma block list` row;
+`block lookup` does not render the usage field today) — often the honest swap is a
+DIFFERENT component than the old name suggests.
+
+## Accessibility warnings are contract
+
+The components warn in dev mode when misused — for example, an icon-only `Button`
+without `aria-label`/`aria-labelledby` logs a console warning, and icons are
+decorative/aria-hidden unless labelled. Treat every such warning as a FAILED acceptance
+criterion of the swap PR: fix the usage, never silence the warning.
+
+Modifier props (e.g. `anticipation="constructive"` on `Button`) take their values from
+modifier families — read them live, list first:
+
+```bash
+pragma modifier list             # every family with its values
+pragma modifier lookup <Family>  # one family in full — take the name from the list output
+```
+
+The families a block draws from print as the last column of its `pragma block list`
+row, and in full on the block itself via `pragma graph inspect <IRI from that row>`
+(the `ds:hasModifierFamily` triples). Mapping a family to code follows two rules: the
+React prop IS the family name lowercased (`Anticipation` → `anticipation`), and the
+prop's values are the family's values lowercased with spaces as underscores
+(`In Progress` → `in_progress`) — the lookups print display casing; the code takes
+the lowercase form. A family listed on the block may have no prop on the component
+yet — check the component's types before writing it.
+
+## Verify per PR
+
+- [ ] Root context and density classes present (track A1) — swapped components size
+      from the `--density-*` channel, not from luck.
+- [ ] Zero dev-console warnings from the swapped components.
+- [ ] Keyboard pass on each swapped instance (focus, activation, escape where relevant).
+- [ ] Visual pass against the component's Storybook stories.
+
+## Next
+
+Forms are their own programming model — continue with `adoption-a3-forms`.
+
+## Support
+
+If this skill leads somewhere broken — a command that errors, guidance that
+contradicts what the live system answers, a gap the flow cannot cover — you are not
+stuck:
+
+- Raise an issue in the pragma repo: https://github.com/canonical/pragma/issues —
+  include the skill name, what was run, and expected vs. actual outcome.
+- Or contact the design-system team owners directly through your organization's
+  professional messaging channels for assistance.

--- a/packages/cli/pragma/bundled-skills/adoption-a3-forms/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/adoption-a3-forms/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: adoption-a3-forms
+description: Migrate application forms to the Canonical form system built on react-hook-form (adoption track A3); also runs as a guided tutorial on a worked example
+---
+
+# Adoption A3 — Forms
+
+The third adoption track: move the app's forms onto the design-system form package.
+Prerequisite: track A1 (A2 recommended). Understand what this track is before starting:
+the form system is a DIFFERENT PROGRAMMING MODEL built on react-hook-form, not a restyle
+of your existing inputs.
+
+## When to Use
+
+- Track A1 is done and the app's forms should move onto the design-system form package
+- A form is being built or rewritten and should use the `Form`/`Field` model from the
+  start
+- A form contains an input type the system does not cover — the `custom` escape hatch
+  below keeps it inside the `Form` (and the gap is a finding to report)
+
+## When NOT to Use
+
+- The visual foundation is not in place yet — run `adoption-a1-styles` first
+- Swapping non-form components — that is `adoption-a2-components`
+
+## Opening move: ask, or offer the tutorial
+
+Activation is an opening, not a starting gun. Unless the first message already names
+the work, ask for the starting point — as a suggestion carrying an example, not as a
+form to fill in:
+
+> To get started, point me at the app and say which form you'd like moved first — or
+> let me find the forms and suggest a starting one.
+
+The smallest real form is usually the best first move: the programming-model switch is
+easier to see on a short one. Ask again only for what the next step genuinely blocks
+on.
+
+If the activation message already carries the starting point, do not re-ask — say what
+you took it to be, and go.
+
+Offer the tutorial in the same breath, because this track doubles as one:
+
+> Or if you'd rather see the model before touching your forms, I can run it as a
+> tutorial: I'll take a plausible example — a couple of text fields and a select — and
+> walk you through the migration on it.
+
+Tutorial mode is the step narration below, turned up: the same outcome-path-conclusion
+frame, with the reasoning behind each change made explicit. It runs on a scratch
+example, not on the person's app — nothing in their repo changes unless they ask.
+
+## Every step is narrated: outcome, path, conclusion
+
+Every step is addressed to the person — once before it runs, once when it ends. This is
+not tutorial manner. It holds in the ordinary flow too: the person is the design
+authority, and they can only steer a step they saw coming. A decision gate met cold is
+a decision they cannot really make.
+
+**Open** the step with what it is FOR — the outcome it should leave behind — and how
+you are about to get there. **Close** it with a sentence saying what it established and
+what that means for the step after. One sentence each is enough; the failure mode is
+silence, not length, and a step whose outcome looks obvious still gets its sentence
+rather than a shrug.
+
+Do:
+
+> **The first field conversion.** The outcome is one field moved onto the `Form`/`Field`
+> model, proving the wiring end to end before the rest follow. The path is to replace
+> the input with a `<Field>` and let `Form` own the state `useState` was holding.
+>
+> …
+>
+> So: the field validates and submits through react-hook-form and the local `useState`
+> is gone — every remaining field is the same move, except the file upload, which needs
+> the `custom` escape hatch.
+
+Don't:
+
+> Converted the email field. Works.
+
+Both carry the same facts. Only the first says what the step was trying to achieve and
+what it settled — and only the first lets the person cut in with the thing they know
+and the graph does not, which is the whole reason they are here.
+
+## Asked about the skill: methodology and outcomes first
+
+A question about what this skill does — what it covers, what its steps are, how it
+works — is answered in that order: the METHOD it applies and the OUTCOMES it leaves
+the person holding come first, the step-by-step breakdown comes after.
+
+Two or three sentences of method is enough: what the skill treats as its object, the
+discipline that makes it work, and what exists at the end that did not exist before.
+The enumeration then reads as steps in service of something, rather than as a list to
+be got through.
+
+What this prevents is a table of contents standing in for an answer. A reply opening
+with the step names tells someone who already knows the skill nothing new, and someone
+who does not, nothing at all.
+
+So, asked what this skill is:
+
+> It moves forms onto the design-system form package, and the thing to understand
+> before starting is that this is a DIFFERENT PROGRAMMING MODEL built on
+> react-hook-form — fields as data, `Form` owning the state — not a restyle of the
+> existing inputs. You end with forms on the `Form`/`Field` model, and anything the
+> system does not cover kept inside the `Form` through the `custom` escape hatch.
+
+Then, and only then, the breakdown.
+
+## Install + the forms styles import
+
+```bash
+bun add @canonical/react-ds-global-form @canonical/styles
+```
+
+Then BOTH stylesheets in the root stylesheet:
+
+```css
+@import url("@canonical/styles");
+@import url("@canonical/react-ds-global-form/dist/esm/index.css");
+```
+
+The first brings the global reset and tokens; the second the input chrome and field
+layout. The package builds on top of `@canonical/react-ds-global`.
+
+Forms are the heaviest consumer of the density system: control heights, field spacing,
+and baseline seating all read the `--density-*` channel, which only emits real values
+when the app root carries its context and density classes
+(`class="app comfortable"` — track A1's "Declare the surface" section). Confirm those
+classes before judging any form layout: without them the primitives silently fall back
+to app-comfortable values, and a `dense` or site-surface form renders with the wrong
+geometry.
+
+## Code standards are the gate
+
+Form migration is component code, and it falls under the live code standards — the
+`react` category at minimum, plus `testing` where the migration touches tests (take
+the actual set from the live output, not from this list). Pull them BEFORE the first
+field conversion and hold the Do/Don't pairs open while writing:
+
+```bash
+pragma standard categories                 # the live category set — never from memory
+pragma standard list --category react
+pragma standard lookup <name> --detail detailed
+```
+
+Apps follow the code standards as closely as the migration allows. Where a
+conversion has to deviate from a pulled standard, record the deviation in the PR next
+to the standard's name — and ideally file it as an issue, either to bring the app
+into line later or to propose a change to the standard itself. The standards apply
+even when the app has no pragma dependency, and they are open to contribution: a
+missing or wrong standard is something to propose a change for, not to silently work
+around.
+
+## The react-hook-form switch
+
+Form state moves INTO the form system:
+
+- `<Form onSubmit={…}>` wraps a react-hook-form `FormProvider`. Pass your own `useForm`
+  return via the `methods` prop when you need external control; otherwise `defaultValues`
+  and `mode` are enough and the Form calls `useForm` internally.
+- `Field` reads the form context via `useFormContext` — **a `Field` outside a `Form` is
+  a bug**, not a styling choice.
+- Migrating a form means DELETING its `useState`/`onChange` handler plumbing, not
+  wrapping it. If the old state code survives the migration, the migration is not done.
+
+## Fields as data
+
+Each field is a declaration, not an assembly of label + input + error markup:
+
+```tsx
+<Form onSubmit={handleSubmit}>
+  <Field name="email" inputType="email" label="Email address" description="Work address preferred" />
+</Form>
+```
+
+`inputType` is a discriminated union selecting the input subcomponent — text, textarea,
+select, checkbox, radio-style choices, date/time, phone, combobox, and more — and the
+label, description, and error wiring come with the frame.
+
+> The covered set is whatever the graph answers today. Query it live — never copy its
+> output into documentation, PRs, or this skill.
+
+Enumerate the input types that exist TODAY from the package's `Field` types and its
+Storybook stories — not from this skill.
+
+## The custom escape hatch
+
+A one-off input stays INSIDE the system:
+
+```tsx
+<Field name="tags" inputType="custom" CustomComponent={TagPicker} label="Tags" />
+```
+
+`CustomComponent` is a `React.ComponentType<InputProps>`: it keeps react-hook-form
+registration, the label/description/error framing, and validation. The escape hatch is
+for the INPUT, never for leaving the `Form`.
+
+## WIP-stage warnings
+
+Input maturity is graph data, not folklore. Before building on an input type, read its
+documentation stage — the stage lives on the block's graph entity:
+
+```bash
+pragma block list                 # find the input's row — it carries the block's IRI
+pragma graph inspect <block IRI>  # every triple, including ds:documentationStage
+```
+
+Look the row up under the PACKAGE COMPONENT's name, not the `inputType` token — the
+union maps several tokens onto one component (`"text"`, `"email"`, `"tel"` and `"url"`
+all render `TextField`/`TextInput`; `"file"` renders `FileUploadField`; `"choices"`
+renders `ChoicesField`). Read the component a token selects from the package's `Field`
+types above, then find THAT name's row.
+
+An input name can be declared at more than one tier, so the list can carry a row per
+tier — names resolve globally, not within one tier. To list every tier that declares
+the name, the name query
+`pragma graph query "SELECT ?b WHERE { ?b ds:name ?n . FILTER(LCASE(?n) = LCASE('<Name>')) }"`
+prints every tier's IRI. Inspect the one whose tier matches the package you
+installed — `global` for `@canonical/react-ds-global-form`'s inputs; the stage
+below is per-block, so another tier's row answers about a different block.
+
+Read whatever `ds:documentationStage` tag comes back — the tag vocabulary is the
+graph's, not this skill's, so do not expect a fixed value list; if the predicate is
+absent, no stage is recorded for that block. The tag's MEANING is graph data too —
+inspect the tag entity itself:
+
+```bash
+pragma graph inspect ds:tag.<name>   # the tag the stage read returned; ds:whenToApply says what it means
+```
+
+Split the action on what `ds:whenToApply` says. A tag meaning the block was rejected
+or triaged out, or that it is only PROPOSED or postponed — not yet accepted into the
+system: do NOT build on that input — raise it as a gap (the `custom` escape hatch
+covers the form meanwhile). A tag meaning the documentation is unfinished: the block
+may change under you — SAY SO in the migration PR rather than discovering it in
+production. A tag whose `ds:whenToApply` comes back blank: the stage's meaning is
+unrecorded — treat it as unknown, and say so in the PR.
+
+Debug aid: `@canonical/storybook-addon-form-state` adds a Storybook panel showing the
+live react-hook-form state while you exercise a story.
+
+## Verify
+
+- [ ] Root context and density classes present (track A1) — field spacing and control
+      seating read the `--density-*` channel.
+- [ ] Submit round-trip works, with validation errors surfaced per field.
+- [ ] The whole form is completable keyboard-only.
+- [ ] Zero dev-console warnings from the form components.
+
+## Support
+
+If this skill leads somewhere broken — a command that errors, guidance that
+contradicts what the live system answers, a gap the flow cannot cover — you are not
+stuck:
+
+- Raise an issue in the pragma repo: https://github.com/canonical/pragma/issues —
+  include the skill name, what was run, and expected vs. actual outcome.
+- Or contact the design-system team owners directly through your organization's
+  professional messaging channels for assistance.

--- a/packages/cli/pragma/bundled-skills/anatomy-author/ANATOMY_DSL_SPEC.md
+++ b/packages/cli/pragma/bundled-skills/anatomy-author/ANATOMY_DSL_SPEC.md
@@ -1,0 +1,406 @@
+# Anatomy DSL Specification
+
+This specification presents a DSL to represent design system anatomies, providing an accurate platform-agnostic markup primitive to precede implementation.
+
+## Rationale
+
+Design systems need a formal way to describe component structure that:
+- Precedes and guides implementation
+- Is platform-agnostic (works for React, SwiftUI, Flutter, etc.)
+- Supports discussion and review
+- Enables automated tooling (auditing, code generation)
+
+## Intended Usage
+
+1. **Documentation**: Implementation primitive for markup and style bindings
+2. **Specification**: Using the tree-based DSL to identify entities to implement and/or reuse
+3. **Discussion**: Using the DSL to discuss across conversations related to DS (e.g., "I believe these nodes should be siblings, not parents of one another")
+4. **Inference**: Supporting automated inference to audit a codebase against its specifications or to support code generation
+
+## Requirements
+
+### General DSL Requirements
+
+- The DSL MUST optimize for readability
+- The DSL MUST be easy to get started with and use a familiar language
+- The scope of the DSL MUST be minimized to cover only the strict necessary - additional specification information being covered in the schema
+
+### Modelling Requirements
+
+- The children of a node MUST be modelled through a reified relation for annotation purposes
+- The DSL MUST support anonymous nodes (nodes that are not named components, for instance an unnamed "div"). In this case, the DSL should support role annotations
+- The DSL MUST support reified annotations of cardinality
+- The DSL MUST support all classes of UI Blocks identified in the ontology (Layout, Pattern, Component, Subcomponent, Group)
+
+## Type System
+
+We structure the children one-to-many relation following inspiration by [the Relay connection pattern](https://relay.dev/graphql/connections.htm) and propose the following typings.
+
+```typescript
+/* Reusable types */
+
+/**
+ * Styles use a CTI (Category-Type-Item) inspired flat key structure for
+ * platform-agnostic UI properties. This allows to avoid using language
+ * specific keys such as CSS.
+ *
+ * KEY NAMING CONVENTION:
+ * Properties follow a dot-notation pattern: "category.type[.item]"
+ * - Category: Primary concern (layout, spacing, appearance, typography, size, etc.)
+ * - Type: Specific aspect within that category
+ * - Item: Optional further specification
+ *
+ * INVARIANT VS THEMEABLE:
+ * Whether a property is invariant (structural) or themeable depends on its
+ * semantic meaning and value type, rather than strict rules:
+ *
+ * Typically invariant (structural decisions):
+ * - layout.type: "stack" | "flow" | "grid"  // Component structure
+ * - layout.direction: "horizontal" | "vertical"
+ * - size.width: "fill" | "hug" | "100%"  // Structural sizing
+ *
+ * Typically themeable (brand/theme variations):
+ * - appearance.*: Color, shadow, radius values via tokens
+ * - spacing.*: When referencing design tokens
+ * - typography.*: Font properties via tokens
+ *
+ * Context-dependent:
+ * - size.width: "320px" or "size/card/width"  // Token = themeable
+ * - size.width: "fill" or "100%"  // Structural = invariant
+ * - spacing.internal: "16"  // Fixed value = invariant
+ * - spacing.internal: "spacing/medium"  // Token = themeable
+ *
+ * The distinction is semantic: does this property define structure or appearance?
+ */
+type Styles = Record<string, TokenPath | TokenPath[] | PrimitiveValue>;
+
+/**
+ * TokenPath represents a forward-slash delimited path to a design token.
+ * Follows design token naming conventions referenced by the W3C Design Token Format.
+ *
+ * Examples:
+ * - "spacing/medium"
+ * - "color/surface/primary"
+ * - "font/size/heading/1"
+ * - "border/width/thin"
+ * - "shadow/elevated/medium"
+ * - "radius/button/default"
+ *
+ * Token paths are resolved at runtime against the active theme.
+ */
+type TokenPath = string;
+
+/**
+ * PrimitiveValue represents direct values not resolved from tokens.
+ * Used for structural decisions and fixed values.
+ *
+ * Examples:
+ * - string: "stack", "flow", "center", "fill", "100%", "1fr"
+ * - number: 1.5 (aspect ratio), 2 (column count), -1 (z-index)
+ * - boolean: true/false (for wrap, reverse, etc.)
+ */
+type PrimitiveValue = string | number | boolean;
+
+/* Main types */
+
+interface Relation {
+  /**
+   * Cardinality represents the number of allowed instances of the related node.
+   * See https://en.wikipedia.org/wiki/Cardinality_(data_modeling) for reference.
+   *
+   * Examples:
+   * - "1"     : Exactly one (required)
+   * - "0..1"  : Zero or one (optional)
+   * - "0..*"  : Zero or more
+   * - "1..*"  : One or more
+   * - "2..5"  : Between 2 and 5
+   */
+  cardinality: string;
+
+  /**
+   * Maps content to a specific slot in the parent component.
+   *
+   * Common values:
+   * - "default" : Main content (React children)
+   * - "header"  : Header slot
+   * - "footer"  : Footer slot
+   * - "icon"    : Icon placement
+   * - "label"   : Text label
+   * - Custom slots as needed
+   */
+  slotName?: string;
+}
+
+/**
+ * Base interface for all nodes in the anatomy tree.
+ */
+interface BaseNode {
+  /**
+   * Style properties using CTI-inspired keys.
+   *
+   * Common patterns and their platform mappings:
+   *
+   * LAYOUT:
+   * - "layout.type": "stack" | "flow" | "grid"
+   *   -> CSS: display + flexDirection | SwiftUI: VStack/HStack | Flutter: Column/Row
+   * - "layout.align": "center" | "start" | "end"
+   *   -> CSS: align-items | SwiftUI: alignment | Flutter: crossAxisAlignment
+   *
+   * SPACING:
+   * - "spacing.internal": "spacing/medium"
+   *   -> CSS: padding | SwiftUI: .padding() | Flutter: EdgeInsets
+   * - "spacing.external": "spacing/large"
+   *   -> CSS: margin | SwiftUI: frame modifiers | Flutter: Container margin
+   * - "spacing.gap": "spacing/small"
+   *   -> CSS: gap | SwiftUI: spacing parameter | Flutter: SizedBox between
+   *
+   * APPEARANCE:
+   * - "appearance.background": "color/surface/primary"
+   *   -> CSS: background | SwiftUI: .background() | Flutter: Container color
+   * - "appearance.radius": "radius/medium"
+   *   -> CSS: border-radius | SwiftUI: .cornerRadius() | Flutter: BorderRadius
+   *
+   * SIZE:
+   * - "size.width": "fill" | "hug" | "size/card/width"
+   *   -> CSS: width: 100% | auto | var() | SwiftUI: .frame() | Flutter: constraints
+   *
+   * Examples showing invariant vs themeable:
+   * {
+   *   "layout.type": "grid",                    // Invariant: structural
+   *   "layout.columns": "1fr 300px 1fr",        // Invariant: grid structure
+   *   "spacing.gap": "spacing/grid/gap",        // Themeable: token reference
+   *   "appearance.background": "color/surface", // Themeable: always
+   *   "size.width": "fill",                     // Invariant: structural behavior
+   *   "size.max.width": "size/container/max",   // Themeable: token reference
+   *   "typography.align": "center",             // Invariant: structural
+   *   "typography.size": "font/size/body",      // Themeable: token reference
+   * }
+   */
+  styles?: Styles;
+
+  /**
+   * Child nodes and their relationships.
+   * Enables recursive component composition.
+   */
+  edges?: Edge[];
+}
+
+/**
+ * Named nodes represent identifiable components in the design system.
+ */
+interface NamedNode extends BaseNode {
+  /**
+   * Unique identifier following "tier.type.name" pattern.
+   * Maps to URI field on UI Block in the ontology.
+   *
+   * Examples:
+   * - "global.component.button"
+   * - "global.component.card"
+   * - "apps.layout.application_layout"
+   */
+  uri: string;
+}
+
+/**
+ * Anonymous nodes represent structural elements without DS identity.
+ */
+interface AnonymousNode extends BaseNode {
+  /**
+   * Human-readable description of the node's purpose.
+   *
+   * Examples:
+   * - "content wrapper"
+   * - "spacer element"
+   * - "icon container"
+   * - "layout grid cell"
+   */
+  role: string;
+}
+
+/**
+ * Union type for all possible nodes.
+ */
+type Node = NamedNode | AnonymousNode;
+
+/**
+ * A switch fills one position with ONE of several alternatives,
+ * making polymorphism explicit at the edge level.
+ * The discriminator says who chooses:
+ * - "props"    : the consumer chooses via component props
+ * - "internal" : the component chooses from its own state
+ * - "override" : the consumer may replace the default with a custom component
+ */
+interface Switch {
+  on: "props" | "internal" | "override";
+  cases: SwitchCase[];
+}
+
+/**
+ * One switch alternative — exactly one of `uri` or `node`.
+ * `uri` is the shorthand for `node: { uri }`; use the full `node` form
+ * when the case carries styles or edges. The reserved URI `$custom`
+ * marks a case filled by a user-provided component.
+ */
+interface SwitchCase {
+  uri?: string;
+  node?: Node;
+
+  /** Marks the default case. */
+  default?: boolean;
+}
+
+/**
+ * Represents a parent-child relationship in the anatomy tree.
+ */
+interface Edge {
+  /** The child node (Named or Anonymous) — exactly one of `node` or `switch` */
+  node?: Node;
+
+  /** A polymorphic position (mutually exclusive with node) */
+  switch?: Switch;
+
+  /** Relationship metadata (cardinality, slot) */
+  relation: Relation;
+}
+
+/**
+ * Root specification for a component anatomy.
+ * The top-level node must always be Named.
+ */
+interface AnatomySpec {
+  node: NamedNode;
+}
+```
+
+## Language Choice
+
+We propose the use of YAML, a mature indentation-based configuration syntax based on scalars, maps and lists. The main contender we have considered aside from YAML was JSON, rejected for its verbosity. We have also rejected TOML (maps with difficulty deeply nested nodes), SDLang and KDL (promising markup syntaxes without wide adoption at present).
+
+## Examples
+
+### Accordion
+
+```yaml
+node:
+  uri: global.component.accordion
+  styles:
+    # Structural (implicitly invariant)
+    layout.type: stack
+    layout.direction: vertical
+
+    # Themeable
+    appearance.border: border/style/accordion
+
+  edges:
+    # The repeating child is NAMED — reference its URI only; its subtree
+    # lives in its own anatomy. The live Accordion does the same.
+    - node:
+        uri: global.subcomponent.accordion-item
+      relation:
+        cardinality: "1..*"
+        slotName: default
+```
+
+The child's own anatomy — a separate spec on `global.subcomponent.accordion-item`
+(transcribed from the live block) — carries the subtree as anonymous roles:
+
+```yaml
+node:
+  uri: global.subcomponent.accordion-item
+  styles:
+    layout.type: stack
+    layout.direction: vertical
+  edges:
+    - node:
+        role: header tab
+        styles:
+          layout.type: flow
+          layout.direction: horizontal
+          layout.align: center
+          interaction.cursor: pointer
+        edges:
+          - node:
+              role: control
+              styles:
+                size.width: size/icon/small
+                size.height: size/icon/small
+            relation:
+              cardinality: "1"
+          - node:
+              role: heading
+            relation:
+              cardinality: "1"
+              slotName: default
+      relation:
+        cardinality: "1"
+        slotName: header
+
+    - node:
+        role: content panel
+        styles:
+          layout.overflow: hidden
+      relation:
+        cardinality: "1"
+        slotName: default
+```
+
+### Card
+
+```yaml
+node:
+  uri: global.component.card
+  styles:
+    # Structural (implicitly invariant)
+    layout.type: stack
+    layout.direction: vertical
+
+    # Themeable
+    appearance.background: color/surface/card
+    appearance.shadow: shadow/card
+    appearance.radius: shape/rounded/full
+    spacing.gap: spacing/small
+
+  edges:
+    # Named children reference their URI only (each carries its own styles
+    # in its own anatomy); anonymous nodes carry their styles inline. A
+    # named child may carry contextual style overrides — never a copy of
+    # its subtree. The live Card models it the same way.
+    - node:
+        uri: global.subcomponent.card-header
+      relation:
+        cardinality: "0..1"
+        slotName: header
+
+    - node:
+        uri: global.subcomponent.card-image
+      relation:
+        cardinality: "0..1"
+        slotName: media
+
+    - node:
+        uri: global.subcomponent.card-content
+      relation:
+        cardinality: "1..1"
+        slotName: default
+
+    - node:
+        uri: global.subcomponent.card-footer
+      relation:
+        cardinality: "0..1"
+        slotName: footer
+```
+
+## Further Work
+
+The following features would require additional work to this specification:
+
+- Representation of related nodes displayed in portals
+- Representation of conditional display
+- Inheritance reference for styles (e.g., "NetworkCard" inherits the styles from "Card")
+
+## References
+
+Two main references have supported our reflection:
+
+1. The work of the [Open UI W3C Working Group](https://open-ui.org/), which takes interest in a code-based anatomy for their specifications ([Example](https://open-ui.org/components/accordion.explainer/))
+2. The work of Nathan Curtis, exploring a similar syntax in his article "[Components as Data](https://medium.com/@nathanacurtis/components-as-data-2be178777f21)"

--- a/packages/cli/pragma/bundled-skills/anatomy-author/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/anatomy-author/SKILL.md
@@ -1,0 +1,1226 @@
+---
+name: anatomy-author
+description: Write component anatomy specifications using the Design System Anatomy DSL; also runs as a guided tutorial on a worked example
+---
+
+# Anatomy Author
+
+Write component anatomy specifications using the Design System Anatomy DSL. This skill combines semantic discovery (understanding existing components) with procedural authoring (creating well-formed YAML specifications).
+
+## When to Use
+
+- Writing anatomy specifications for new or existing components
+- Documenting component structure before implementation
+- Discussing component composition with the team ("these nodes should be siblings, not parent-child")
+- Auditing a codebase against its specifications
+- Supporting code generation from specifications
+- Serving as step 7 of the `specify-component` flow (and of `specify-pattern`)
+
+## Description
+
+The Anatomy DSL represents design system components as YAML trees with:
+- **Named nodes**: Components with URIs (`global.component.button`)
+- **Anonymous nodes**: Structural elements with roles (`content wrapper`)
+- **Edges**: Parent-child relationships with cardinality and slot names
+- **Styles**: Platform-agnostic properties using CTI-inspired keys
+
+This skill helps you author these specifications correctly and consistently.
+
+## Working mode: assistant to a design authority
+
+Most of the time this skill runs in collaboration with a senior designer or engineer —
+they are the design authority, you are the assistant whose job is to make them
+successful. Default to that mode: lay out where the flow stands, do the legwork
+(discovery queries, template drafting, validation) and return digestible findings, and
+bring structural decisions to the person as a recommendation plus a question rather
+than a fait accompli. An anatomy encodes opinions the graph cannot settle alone —
+draw the person's knowledge out and use it.
+
+Full autonomy is the exception, not the default: run the whole flow alone only when
+explicitly asked to. Even then, list every judgment call made unilaterally in the
+final report so a human can revisit them.
+
+Decision gates — in collaboration, pause at each and resolve it WITH the person:
+
+1. Node boundaries: what is a named subcomponent vs. an anonymous structural role.
+2. Slot names — they become API surface.
+3. Cardinality choices, especially optional vs. required parts.
+4. What the anatomy fixes vs. what is deliberately left free.
+
+The full specification ships beside this file as `ANATOMY_DSL_SPEC.md` in the
+installed skill folder — `pragma skill lookup anatomy-author` renders only this
+SKILL.md, so open the sibling file directly when you need the complete spec (the
+appendix below carries its type system).
+
+## Opening move: ask, or offer the tutorial
+
+Activation is an opening, not a starting gun. Unless the first message already names
+the work, ask for the starting point — as a suggestion carrying an example, not as a
+form to fill in:
+
+> To get started, tell me the component whose anatomy we're writing — a name if it is
+> already in the graph, or just a sketch of its parts, like "a card with an image, a
+> title and a row of actions".
+
+A sketch is enough to begin: discovery turns it into the real node set, and the sketch
+is what you check that set against. Ask again only for what the next step genuinely
+blocks on.
+
+If the activation message already carries the starting point, do not re-ask — say what
+you took it to be, and go.
+
+Offer the tutorial in the same breath, because this skill doubles as one:
+
+> Or if you'd rather see the flow first, I can run it as a tutorial: I'll take a
+> plausible example — a card, say — and walk you through it from discovery to the
+> emitted anatomy.
+
+Tutorial mode is the step narration below, turned up: the same outcome-path-conclusion
+frame, with the reasoning at each decision gate made fully explicit and a check that
+the person is with you before the next step. Stop short of anything that lands — no
+anatomy written into the graph, no file committed — unless they ask to keep what you
+built.
+
+## Every step is narrated: outcome, path, conclusion
+
+Every step is addressed to the person — once before it runs, once when it ends. This is
+not tutorial manner. It holds in the ordinary flow too: the person is the design
+authority, and they can only steer a step they saw coming. A decision gate met cold is
+a decision they cannot really make.
+
+**Open** the step with what it is FOR — the outcome it should leave behind — and how
+you are about to get there. **Close** it with a sentence saying what it established and
+what that means for the step after. One sentence each is enough; the failure mode is
+silence, not length, and a step whose outcome looks obvious still gets its sentence
+rather than a shrug.
+
+Do:
+
+> **Discovery, before any DSL.** The outcome is the component's real context — what it
+> is composed of, and what already names its parts — so the anatomy describes the
+> system instead of inventing beside it. The path is `pragma block lookup Card`, then
+> the subcomponent query below.
+>
+> …
+>
+> So: Card already carries a named `Card-Header` subcomponent and no named body — the
+> anatomy inherits the first and has to decide the second, which is the first
+> structural gate.
+
+Don't:
+
+> Discovery
+>
+> Card exists. Has Card-Header. No body node.
+
+Both carry the same facts. Only the first says what the step was trying to achieve and
+what it settled — and only the first lets the person cut in with the thing they know
+and the graph does not, which is the whole reason they are here.
+
+## Asked about the skill: methodology and outcomes first
+
+A question about what this skill does — what it covers, what its steps are, how it
+works — is answered in that order: the METHOD it applies and the OUTCOMES it leaves
+the person holding come first, the step-by-step breakdown comes after.
+
+Two or three sentences of method is enough: what the skill treats as its object, the
+discipline that makes it work, and what exists at the end that did not exist before.
+The enumeration then reads as steps in service of something, rather than as a list to
+be got through.
+
+What this prevents is a table of contents standing in for an answer. A reply opening
+with the step names tells someone who already knows the skill nothing new, and someone
+who does not, nothing at all.
+
+So, asked what this skill is:
+
+> It writes component anatomies in the Anatomy DSL, combining semantic discovery —
+> understanding what the graph already names — with procedural authoring. The
+> structural choices are the substance: node boundaries, cardinality, and slot names,
+> which become API surface. You end holding a well-formed anatomy whose every
+> deliberate decision is one someone can revisit.
+
+Then, and only then, the breakdown.
+
+## Anatomy falls under standards too
+
+Emitted anatomy is Turtle, and Turtle has standards — the `turtle` category, with
+`ui-blocks` governing block modelling (take the actual set from
+`pragma standard categories`, not from this list). Pull them before authoring and hold
+the Do/Don't pairs open while writing the DSL and its emitted TTL; a deviation from a
+pulled standard is RECORDED next to the anatomy, ideally also filed as an issue. The
+standards apply independent of any package dependency and are open to contribution:
+a missing or wrong modelling rule is something to propose a change for, not to
+silently work around.
+
+## Discovery Flow
+
+Before writing an anatomy, understand the component's context:
+
+```bash
+pragma block list                               # every component, pattern, layout and subcomponent, with its type and tier
+pragma block lookup Card                        # full spec: anatomy, modifiers, properties (MCP: block_lookup)
+pragma graph inspect ds:global.component.card   # every triple on the entity
+```
+
+A bare name can match blocks in several tiers, and `block lookup` silently picks one —
+it resolves `ds:name` globally and cannot be steered to a tier.
+Confirm the tier the lookup picked from its own `- Tier:` line; the name query below lists every tier that carries the name.
+The name query in Workflow §1 is the one that lists them, with each block's IRI. If the
+lookup picked the wrong tier's block, read the block you want with
+`pragma graph inspect <IRI from that row>`, so the lookup step and the inspect step
+describe the same block. If the name has no row at all, the block may be a Group —
+`block list` covers no groups; the group pre-step in Workflow §1 lists them.
+
+### Discovery Queries
+
+Common prefixes (`ds:`, `cs:`) are applied automatically — no PREFIX preamble needed.
+
+**Find components by tier:**
+```bash
+pragma graph query "SELECT ?component ?name WHERE {
+  ?component a ds:Component ;
+             ds:name ?name ;
+             ds:tier ds:global .
+}"
+```
+
+**Find subcomponents of a component:**
+```bash
+pragma graph query "SELECT ?sub ?name WHERE {
+  ?sub a ds:Subcomponent ;
+       ds:name ?name ;
+       ds:parentComponent <https://ds.canonical.com/global.component.card> .
+}"
+```
+
+Inside a SPARQL body, a local name with MORE THAN ONE dot (`ds:global.component.card`)
+does not parse — use the full IRI there: join `https://ds.canonical.com/` with the
+dotted local name (giving `<https://ds.canonical.com/global.component.card>`), or copy
+one from `pragma graph query` output, which prints absolute IRIs. Prefixed names with
+no dot (`ds:global`, `ds:Component`) or a single dot (`ds:tag.needsdefinition`) work
+as-is.
+
+### The empty-anatomy worklist
+
+The Coda sync emits `ds:anatomyDsl` as an empty string for blocks whose anatomy is not
+yet written — this query IS the to-do list; pick from it, never from a copied table:
+
+```bash
+pragma graph query "SELECT ?b ?name WHERE { ?b ds:anatomyDsl ?a ; ds:name ?name . FILTER(STR(?a) = '') }"
+```
+
+The worklist rows point at blocks whose data lives under `data/` — never hand-edit
+that tree: it is regenerated destructively from Coda by CI, and hand edits are
+overwritten by the next sync. An authored DSL lands in the block's spec draft under
+`specs/` (see `specs/README.md`) or is pasted into Coda by a human.
+
+## DSL Reference
+
+### YAML Format
+
+All anatomy files must start with `---` (YAML document start marker):
+
+```yaml
+---
+node:
+  uri: global.component.button
+  # ...
+```
+
+### Type System Overview
+
+```
+AnatomySpec
+  -> node: NamedNode (root must be named)
+
+NamedNode
+  -> uri: string ("tier.type.name")
+  -> styles?: Record<string, TokenPath | TokenPath[] | PrimitiveValue>
+  -> edges?: Edge[]
+
+AnonymousNode
+  -> role: string ("content wrapper")
+  -> styles?: Record<string, TokenPath | TokenPath[] | PrimitiveValue>
+  -> edges?: Edge[]
+
+Edge
+  -> node?: NamedNode | AnonymousNode
+  -> switch?: Switch (mutually exclusive with node)
+  -> relation: Relation
+
+Switch
+  -> on: "props" | "internal" | "override"
+  -> cases: SwitchCase[]
+
+SwitchCase
+  -> uri?: string (shorthand)
+  -> node?: Node (full form)
+  -> default?: boolean (marks the default case)
+
+Relation
+  -> cardinality: string ("1", "0..1", "0..*", "1..*")
+  -> slotName?: string ("default", "header", "icon")
+```
+
+### URI Encoding Convention
+
+URIs follow turtle conventions with dot-separated paths: `tier.type.name`
+
+| Symbol | Meaning | Example |
+|--------|---------|---------|
+| `.` | Path hierarchy | `global.component.button` |
+| `_` | Word boundary from PascalCase | `ChartLegend` → `chart_legend` |
+| `-` | Dot in compound names | `Card.Header` → `card-header` |
+
+**Examples:**
+
+| Component | URI |
+|-----------|-----|
+| `Button` | `global.component.button` |
+| `Accordion.Item` | `global.subcomponent.accordion-item` |
+| `ChartLegend` | `global.subcomponent.chart_legend` |
+| `Card.Header` | `global.subcomponent.card-header` |
+
+**Tiers and Types:**
+
+The tier segment comes from the live tier set — run `pragma tier list` for the tiers
+that exist today; never assign a tier from a remembered list. The type segment is one
+of the ontology's UIBlock classes:
+
+| Type | Use Case |
+|------|----------|
+| `component` | Standalone components |
+| `subcomponent` | Parts of components (user-instantiable) |
+| `pattern` | UX solutions combining components |
+| `layout` | Space-dividing containers |
+| `group` | Repeating series of ONE sibling block (the plural of a Component) |
+
+(`pragma block list` omits groups — read them from the graph:
+`pragma graph query "SELECT ?b ?name WHERE { ?b a ds:Group ; ds:name ?name }"`.)
+
+**Parent Reference in Subcomponents:**
+
+Subcomponents must reference their parent in the name:
+
+| Labelled Name | Turtle URI |
+|---------------|------------|
+| `Timeline.Event` | `global.subcomponent.timeline-event` |
+| `Timeline.ExpansionIndicator` | `global.subcomponent.timeline-expansion_indicator` |
+
+### Named vs Anonymous
+
+| Type | Identifier | Use Case |
+|------|------------|----------|
+| Named | `uri` | User-instantiable components (things users compose in their code) |
+| Anonymous | `role` | Internal structural elements not directly instantiated by users |
+
+**Rule of thumb:** Ask "Can/should a user write `<ComponentName>` in their code?" If yes, use `uri`. If no, use `role`.
+
+### DRY Principle
+
+When a node has a URI (is not anonymous), it references its own DSL file. Do not inline the full tree—reference the URI only. A named child MAY carry `styles:` that override its own anatomy in this context — live, `apps_landscape.component.password_constraints` sizes down its `global.component.icon` child — but never a copy of its subtree.
+
+```yaml
+# Correct: reference only
+edges:
+  - node:
+      uri: global.component.button
+    relation:
+      cardinality: "1"
+
+# Incorrect: copying the child's own definition
+edges:
+  - node:
+      uri: global.component.button
+      styles:
+        # ... full button styles duplicated here
+    relation:
+      cardinality: "1"
+
+# Permitted: contextual style overrides (the live password_constraints → icon pair)
+edges:
+  - node:
+      uri: global.component.icon
+      styles:
+        size.width: size/icon/small
+        size.height: size/icon/small
+    relation:
+      cardinality: "1"
+```
+
+### Cardinality Notation
+
+| Notation | Meaning | Example Use |
+|----------|---------|-------------|
+| `"1"` or `"1..1"` | Exactly one (required) | Card body |
+| `"0..1"` | Zero or one (optional) | Card header, Card footer |
+| `"0..*"` | Zero or more | List items |
+| `"1..*"` | One or more | Accordion items (need at least one) |
+| `"2..5"` | Between 2 and 5 | Bounded repeats — live: KeyboardKeys' `"2..*"` (see the Group template below) |
+
+### Switch Construct
+
+The `switch` construct models positions in the anatomy tree that can be filled by one of several alternatives. It operates at the edge level, parallel to `node`, making polymorphism explicit.
+
+#### Syntax
+
+```yaml
+edges:
+  - switch:
+      on: <discriminator>
+      cases:
+        - uri: <component-uri>
+          default: true  # optional, marks default case
+        - uri: <component-uri>
+        - uri: $custom   # reserved URI for user-provided components
+    relation:
+      cardinality: <cardinality>
+      slotName: <slot>
+```
+
+#### Discriminator Vocabulary
+
+| Value | Meaning | Use Case |
+|-------|---------|----------|
+| `props` | Consumer chooses via component props | `<Field type="checkbox">` renders Checkbox vs Radio |
+| `internal` | Component manages choice internally | AsyncButton shows Loading/Success/Error based on state (hypothetical — see the labelled example below) |
+| `override` | Consumer can replace with custom component | Timeline accepts custom Event component via slot |
+
+This enum is NORMATIVE. Live anatomies that predate it may carry qualified
+discriminators (`props/<prop>`) or a `with:` map in exploratory drafts — do not
+copy those into new anatomies.
+
+#### Shorthand Expansion
+
+The shorthand `- uri: X` expands to `- node: { uri: X }`. This allows cases to be expressed concisely when no additional metadata is needed:
+
+```yaml
+# Shorthand (common case)
+cases:
+  - uri: global.subcomponent.checkbox_input
+
+# Expands to full form
+cases:
+  - node:
+      uri: global.subcomponent.checkbox_input
+```
+
+When a case requires additional properties (styles, nested edges), use the full node form:
+
+```yaml
+cases:
+  - node:
+      uri: global.subcomponent.textarea_input
+      styles:
+        size.height: hug
+        size.min.height: size/input/multiline
+```
+
+#### Reserved URI: `$custom`
+
+The `$custom` URI indicates that the position accepts a user-provided component:
+
+```yaml
+cases:
+  - uri: global.subcomponent.timeline-event
+  - uri: $custom  # consumer can provide custom component
+```
+
+#### Examples
+
+**Field with prop-based switch:**
+
+```yaml
+---
+node:
+  uri: global.pattern.field
+  edges:
+    - switch:
+        on: props
+        cases:
+          - uri: global.subcomponent.checkbox_input
+          - uri: global.subcomponent.radio_input
+          - uri: global.subcomponent.text_input
+      relation:
+        cardinality: "1"
+        slotName: input
+```
+
+**Async button with internal state switch** (the `async_button` family is hypothetical —
+an illustration of the `internal` discriminator, not a live block):
+
+```yaml
+---
+node:
+  uri: global.component.async_button
+  edges:
+    - switch:
+        on: internal
+        cases:
+          - uri: global.subcomponent.async_button-idle
+          - uri: global.subcomponent.async_button-loading
+          - uri: global.subcomponent.async_button-success
+          - uri: global.subcomponent.async_button-error
+      relation:
+        cardinality: "1"
+```
+
+**Timeline with override-capable slot:**
+
+```yaml
+---
+node:
+  uri: global.pattern.timeline
+  edges:
+    - switch:
+        on: override
+        cases:
+          - uri: global.subcomponent.timeline-event
+          - uri: $custom
+      relation:
+        cardinality: "1..*"
+```
+
+### Slot Names
+
+Common slot conventions:
+
+| Slot | Purpose |
+|------|---------|
+| `default` | Main content area (React children, Vue default slot) |
+| `header` | Header content |
+| `footer` | Footer content |
+| `icon` | Icon placement |
+| `label` | Text label |
+| `media` | Image/video content |
+| `actions` | Action buttons |
+
+**Convention:** `slotName: default` implies the main children slot (`children` in React, default slot in Vue).
+
+### Style Key Categories
+
+Styles use CTI-inspired dot-notation: `category.type[.item]`
+
+#### Layout (typically invariant)
+```yaml
+layout.type: stack | flow | grid
+layout.direction: horizontal | vertical
+layout.align: start | center | end | stretch
+layout.justify: start | center | end | space-between | space-around
+layout.wrap: true | false
+layout.display: block | flex | grid | none
+layout.flex: 1 | auto
+layout.overflow: hidden | scroll | visible
+```
+
+#### Spacing (invariant if literal, themeable if token)
+```yaml
+spacing.internal: spacing/medium          # padding (themeable)
+spacing.external: spacing/large           # margin (themeable)
+spacing.gap: spacing/small                # gap between children (themeable)
+spacing.margin.bottom: spacing/small      # specific margin
+```
+
+#### Appearance (typically themeable)
+```yaml
+appearance.background: color/surface/card
+appearance.border: border/style/default
+appearance.border.top: border/style/divider
+appearance.shadow: shadow/elevated/medium
+appearance.radius: shape/rounded/full
+```
+
+#### Size (invariant if structural, themeable if token)
+```yaml
+size.width: fill | hug | 100%             # invariant
+size.width: size/card/width               # themeable
+size.max.width: size/container/max
+size.max.height: size/media/max
+size.min.height: 48px
+```
+
+#### Typography (typically themeable)
+```yaml
+typography.size: font/size/body
+typography.weight: font/weight/bold
+typography.color: color/text/primary
+typography.align: center | left | right    # can be invariant
+typography.line.height: 1.5
+```
+
+#### Interaction (typically invariant)
+```yaml
+interaction.cursor: pointer | default
+interaction.transition.property: background
+interaction.transition.duration: transition/duration   # token = themeable
+interaction.transition.timing: ease
+```
+
+#### Object (for media)
+```yaml
+object.fit: cover | contain | fill
+object.position: center | top
+```
+
+## Templates
+
+### Basic Component Template
+
+```yaml
+node:
+  uri: {tier}.component.{name}
+  styles:
+    # Structural (invariant)
+    layout.type: stack
+    layout.direction: vertical
+
+    # Themeable
+    appearance.background: color/surface/{name}
+    spacing.internal: spacing/medium
+
+  edges:
+    - node:
+        uri: {tier}.subcomponent.{name}-content
+      relation:
+        cardinality: "1..1"
+        slotName: default
+```
+
+### Component with Optional Parts
+
+```yaml
+node:
+  uri: global.component.card
+  styles:
+    layout.type: stack
+    layout.direction: vertical
+    appearance.background: color/surface/card
+    appearance.shadow: shadow/card
+    appearance.radius: shape/rounded/full
+
+  edges:
+    # Named children reference their URI only (DRY Principle above) — each
+    # carries its own styles in its own anatomy; the live Card does the same.
+    - node:
+        uri: global.subcomponent.card-header
+      relation:
+        cardinality: "0..1"        # optional
+        slotName: header
+
+    - node:
+        uri: global.subcomponent.card-content
+      relation:
+        cardinality: "1..1"        # required
+        slotName: default
+
+    - node:
+        uri: global.subcomponent.card-footer
+      relation:
+        cardinality: "0..1"        # optional
+        slotName: footer
+```
+
+### Nested Components (Repeating)
+
+```yaml
+node:
+  uri: global.component.accordion
+  styles:
+    layout.type: stack
+    layout.direction: vertical
+    appearance.border: border/style/accordion
+
+  edges:
+    # The repeating child is NAMED — reference its URI only (DRY Principle
+    # above); its subtree lives in its own anatomy. The live Accordion does
+    # the same.
+    - node:
+        uri: global.subcomponent.accordion-item
+      relation:
+        cardinality: "1..*"       # one or more items
+        slotName: default
+```
+
+The child's own anatomy — a separate spec on `global.subcomponent.accordion-item`
+(transcribed from the live block) — is where the subtree lives; its parts are
+anonymous roles:
+
+```yaml
+node:
+  uri: global.subcomponent.accordion-item
+  styles:
+    layout.type: stack
+    layout.direction: vertical
+  edges:
+    - node:
+        role: header tab
+        styles:
+          layout.type: flow
+          layout.direction: horizontal
+          layout.align: center
+          interaction.cursor: pointer
+        edges:
+          - node:
+              role: control
+              styles:
+                size.width: size/icon/small
+                size.height: size/icon/small
+            relation:
+              cardinality: "1"
+          - node:
+              role: heading
+            relation:
+              cardinality: "1"
+              slotName: default
+      relation:
+        cardinality: "1"
+        slotName: header
+
+    - node:
+        role: content panel
+        styles:
+          layout.overflow: hidden
+      relation:
+        cardinality: "1"
+        slotName: default
+```
+
+### Group (repeating siblings)
+
+A Group is the plural of ONE sibling block: a named root carrying only layout and
+spacing styles, and a single URI-only edge whose cardinality bounds the repetition.
+Transcribed from the live `global.group.keyboard_keys`:
+
+```yaml
+node:
+  uri: global.group.keyboard_keys
+  styles:
+    layout.display: inline-flex
+    layout.align: center
+    spacing.gap: spacing/horizontal/xsmall
+  edges:
+    - node:
+        uri: global.component.keyboard_key
+      relation:
+        cardinality: "2..*"       # a group needs at least two keys
+        slotName: default
+```
+
+### Anonymous Wrapper Node
+
+Use when you need a structural element without design system identity:
+
+```yaml
+node:
+  uri: global.pattern.modal
+  styles:
+    layout.type: stack
+    appearance.background: color/surface/modal
+
+  edges:
+    - node:
+        role: backdrop overlay    # anonymous - no uri
+        styles:
+          layout.display: block
+          appearance.background: color/overlay/dark
+          interaction.cursor: pointer
+      relation:
+        cardinality: "1..1"
+
+    - node:
+        role: content container   # anonymous wrapper
+        styles:
+          layout.type: stack
+          size.max.width: size/modal/max
+          spacing.internal: spacing/large
+        edges:
+          - node:
+              uri: global.subcomponent.modal-header
+            relation:
+              cardinality: "0..1"
+              slotName: header
+          - node:
+              uri: global.subcomponent.modal-content
+            relation:
+              cardinality: "1..1"
+              slotName: default
+      relation:
+        cardinality: "1..1"
+```
+
+### Simple Button Example
+
+The live Button models its icon and label as ANONYMOUS roles — a user writes `<Button>`
+with props and children, never a `Button.Icon` — so the children carry `role`, not `uri`
+(the Named vs Anonymous rule above):
+
+```yaml
+node:
+  uri: global.component.button
+  styles:
+    # Structural
+    layout.type: flow
+    layout.direction: horizontal
+    layout.align: center
+    layout.justify: center
+
+    # Themeable
+    spacing.internal: spacing/button
+    spacing.gap: spacing/small
+    appearance.background: color/action/primary
+    appearance.radius: shape/rounded/button
+    typography.weight: font/weight/medium
+
+    # Interaction
+    interaction.cursor: pointer
+    interaction.transition.property: background, transform
+    interaction.transition.duration: transition/fast
+
+  edges:
+    - node:
+        role: icon
+        styles:
+          size.width: size/icon/small
+          size.height: size/icon/small
+      relation:
+        cardinality: "0..1"
+        slotName: icon
+
+    - node:
+        role: label
+        styles:
+          typography.size: font/size/button
+          typography.color: color/text/on-action
+      relation:
+        cardinality: "0..1"
+        slotName: default
+```
+
+## Workflow
+
+### 1. Identify the Component
+
+First, a pre-step: could the name be a Group? Run the group query before the
+lookup — neither `pragma block lookup` nor `pragma block list` covers groups, and
+a name can be BOTH a Group and another tier's block (`BlogCards` is the Group
+`sites.group.blog_cards` AND the Component
+`sites_webcomponentsprototype.component.blog_cards`; the lookup answers with the
+component and never mentions the group):
+
+```bash
+pragma graph query "SELECT ?b ?name WHERE { ?b a ds:Group ; ds:name ?name }"
+```
+
+If the name is in the answer and the Group is the block you were asked to write,
+it is an existing block: take the URI from that query row (no §3 derivation),
+gather its context with `pragma graph inspect <IRI>`, and continue from §2.
+
+Otherwise, determine if the component exists in the design system:
+
+```bash
+pragma block lookup Card
+```
+
+Two branches:
+
+- **Not found** (`ENTITY_NOT_FOUND`) — this is a NEW block: derive its URI in §3
+  below, then continue from §2.
+- **Found** — this is a draft for an existing block (the empty-anatomy worklist path):
+  take the URI from the block's `pragma block list` row and skip §3. The list carries a
+  row per block it covers, not per tier declaring the name, and the lookup above
+  resolved it globally — the name query
+  `pragma graph query "SELECT ?b WHERE { ?b ds:name ?n . FILTER(LCASE(?n) = LCASE('<Name>')) }"`
+  lists every tier's IRI, so you take the one you meant.
+  Gather the full context — anatomy, modifiers, properties come with the lookup (a
+  bare name can match several tiers: see the multi-tier note in the Discovery Flow
+  above); every raw triple with:
+
+  ```bash
+  pragma graph inspect ds:global.component.card
+  ```
+
+### 2. Gather Structural Requirements
+
+Ask:
+- What are the main parts? (header, body, footer, icon, label)
+- Which parts are required vs optional?
+- Can any parts repeat?
+- Are there anonymous structural wrappers needed?
+
+### 3. Determine Tier and Type
+
+The URI is `{tier}.{type}.{snake_name}` (see URI Encoding Convention above). The tier
+segment comes from the live tier set — run `pragma tier list` and pick from what it
+answers, never from a remembered list; the type segment is one of the ontology's
+UIBlock classes:
+
+| Question | Answer | Result |
+|----------|--------|--------|
+| Is it universal? | Yes | `global.component.{name}` |
+| Is it app-specific? | Yes | `{apps_tier}.component.{name}` — the app's own tier from `pragma tier list` (e.g. `apps_lxd`) |
+| Is it a subpart? | Yes | `{tier}.subcomponent.{parent}-{part}` |
+| Is it a UX solution? | Yes | `{tier}.pattern.{name}` |
+| Does it divide space? | Yes | `{tier}.layout.{name}` |
+| Is it many instances of ONE sibling block laid out together? | Yes | `{tier}.group.{name}` |
+
+### 4. Define Edges
+
+For each child:
+1. Is it named (in DS) or anonymous (structural wrapper)?
+2. What is its cardinality?
+3. Does it map to a slot?
+
+### 5. Apply Styles
+
+For each node, consider:
+- **Layout**: How is content arranged?
+- **Spacing**: Internal padding, gaps between children
+- **Appearance**: Background, borders, shadows, radius
+- **Size**: Width/height constraints
+- **Typography**: Text styling (for text-containing nodes)
+- **Interaction**: Cursor, transitions (for interactive nodes)
+
+**Rule of thumb**:
+- Structural values (stack, center, fill) = invariant
+- Token references (spacing/medium) = themeable
+
+### 6. Validate
+
+Check your anatomy against:
+- [ ] Root node is named (has `uri`)
+- [ ] All cardinalities are valid notation
+- [ ] Style keys follow CTI convention
+- [ ] Token paths use `/` delimiter
+- [ ] Anonymous nodes have `role`, not `uri`
+- [ ] Multi-word names encode word boundaries with `_`; `-` appears only where the name carries a dot (per the URI Encoding Convention table)
+- [ ] Every non-root `uri:` either resolves (`pragma graph inspect ds:<uri>`) or is `$custom`, a template placeholder, or a new block or child this same spec introduces (§3)
+- [ ] Named (`uri:`) children carry no copy of their own subtree — contextual style overrides only
+- [ ] Nested components make semantic sense
+
+## Response Format
+
+When creating an anatomy, respond with:
+
+```markdown
+## Anatomy: {ComponentName}
+
+**URI:** `{tier}.{type}.{snake_name}`
+**Tier:** {tier} - {rationale}
+
+### Structure Overview
+- {Part 1} (required/optional)
+- {Part 2} (required/optional)
+- ...
+
+### Specification
+
+\`\`\`yaml
+{yaml content}
+\`\`\`
+
+### Notes
+- {Design decision 1}
+- {Design decision 2}
+
+### Next Steps
+1. Land the DSL in the block's spec draft under `specs/` (see `specs/README.md`) —
+   as step 7 of a specify flow that is the step-6 spec file; never under `data/`
+2. A human enters the content into Coda, the database of record
+```
+
+## Tips
+
+1. **Start simple**: Begin with just structure, add styles incrementally
+2. **Use discovery**: Query existing components for patterns and consistency
+3. **Name thoughtfully**: URIs are identifiers - choose clear, consistent names
+   (see the URI Encoding Convention table above)
+4. **Annotate decisions**: Use YAML comments for non-obvious choices
+5. **Validate cardinality**: Think through edge cases (empty states, maximums)
+6. **Separate concerns**: Structural styles vs themeable styles
+7. **Anonymous nodes are OK**: Don't force DS identity on pure wrappers
+
+## Limitations
+
+- Does not handle conditional rendering (show/hide based on state)
+- Does not represent portal content (elements rendered elsewhere in DOM)
+- Style inheritance is not yet supported (e.g., "inherits from Card")
+- No runtime behavior specification (only static structure)
+
+## References
+
+- [Open UI W3C Working Group](https://open-ui.org/) - Inspiration for code-based anatomy
+- [Components as Data](https://medium.com/@nathanacurtis/components-as-data-2be178777f21) - Nathan Curtis's exploration
+- [W3C Design Token Format](https://design-tokens.github.io/community-group/format/) - Token path conventions
+
+---
+
+## Appendix: Anatomy DSL Specification
+
+The complete type system for the Anatomy DSL. This specification defines the formal structure for representing component anatomies.
+
+### Abstract
+
+This specification presents a DSL to represent design system anatomies, providing an accurate platform-agnostic markup primitive to precede implementation.
+
+### Intended Usage
+
+1. **Documentation**: Implementation primitive for markup and style bindings
+2. **Specification**: Using the tree-based DSL to identify entities to implement and/or reuse
+3. **Discussion**: Using the DSL to discuss across conversations related to DS (e.g., "I believe these nodes should be siblings, not parents of one another")
+4. **Inference**: Supporting automated inference to audit a codebase against its specifications or to support code generation
+
+### Requirements
+
+**General DSL Requirements:**
+- The DSL MUST optimize for readability
+- The DSL MUST be easy to get started with and use a familiar language
+- The scope of the DSL MUST be minimized to cover only the strict necessary - additional specification information being covered in the schema
+
+**Modelling Requirements:**
+- The children of a node MUST be modelled through a reified relation for annotation purposes
+- The DSL MUST support anonymous nodes (nodes that are not named components). In this case, the DSL should support role annotations
+- The DSL MUST support reified annotations of cardinality
+- The DSL MUST support all classes of UI Blocks identified in the ontology (Layout, Pattern, Component, Subcomponent, Group)
+
+### Type System
+
+The children one-to-many relation follows inspiration from the [Relay connection pattern](https://relay.dev/graphql/connections.htm).
+
+```typescript
+/* Reusable types */
+
+/**
+ * Styles use a CTI (Category-Type-Item) inspired flat key structure
+ * for platform-agnostic UI properties.
+ *
+ * KEY NAMING CONVENTION:
+ * Properties follow dot-notation: "category.type[.item]"
+ * - Category: Primary concern (layout, spacing, appearance, typography, size)
+ * - Type: Specific aspect within that category
+ * - Item: Optional further specification
+ *
+ * INVARIANT VS THEMEABLE:
+ * - Invariant (structural): layout.type, layout.direction, size.width: "fill"
+ * - Themeable (brand/theme): appearance.*, spacing.* (when using tokens)
+ */
+type Styles = Record<string, TokenPath | TokenPath[] | PrimitiveValue>;
+
+/**
+ * TokenPath: Forward-slash delimited path to a design token.
+ * Examples: "spacing/medium", "color/surface/primary", "font/size/heading/1"
+ */
+type TokenPath = string;
+
+/**
+ * PrimitiveValue: Direct values not resolved from tokens.
+ * Examples: "stack", "center", "fill", 1.5, true
+ */
+type PrimitiveValue = string | number | boolean;
+
+/* Main types */
+
+interface Relation {
+  /**
+   * Cardinality: Number of allowed instances.
+   * - "1"     : Exactly one (required)
+   * - "0..1"  : Zero or one (optional)
+   * - "0..*"  : Zero or more
+   * - "1..*"  : One or more
+   * - "2..5"  : Between 2 and 5
+   */
+  cardinality: string;
+
+  /**
+   * Maps content to a specific slot in the parent component.
+   * Common values: "default", "header", "footer", "icon", "label"
+   */
+  slotName?: string;
+}
+
+/**
+ * Base interface for all nodes in the anatomy tree.
+ */
+interface BaseNode {
+  /**
+   * Style properties using CTI-inspired keys.
+   *
+   * Categories:
+   * - layout.*   : type, direction, align, justify, wrap, display, flex, overflow
+   * - spacing.*  : internal, external, gap, margin.*, padding.*
+   * - appearance.*: background, border, shadow, radius
+   * - size.*     : width, height, max.*, min.*
+   * - typography.*: size, weight, color, align, line.height
+   * - interaction.*: cursor, transition.*
+   * - object.*   : fit, position
+   */
+  styles?: Styles;
+
+  /** Child nodes and their relationships. */
+  edges?: Edge[];
+}
+
+/**
+ * Named nodes represent identifiable components in the design system.
+ */
+interface NamedNode extends BaseNode {
+  /**
+   * Unique identifier following "tier.type.name" pattern.
+   * Examples: "global.component.button", "apps.layout.application_layout"
+   */
+  uri: string;
+}
+
+/**
+ * Anonymous nodes represent structural elements without DS identity.
+ */
+interface AnonymousNode extends BaseNode {
+  /**
+   * Human-readable description of the node's purpose.
+   * Examples: "content wrapper", "spacer element", "icon container"
+   */
+  role: string;
+}
+
+type Node = NamedNode | AnonymousNode;
+
+/**
+ * A switch fills one position with ONE of several alternatives.
+ * The discriminator says who chooses: "props" (consumer chooses via
+ * component props), "internal" (the component chooses from its own
+ * state), "override" (the consumer may replace the default with a
+ * custom component).
+ */
+interface Switch {
+  on: "props" | "internal" | "override";
+  cases: SwitchCase[];
+}
+
+/**
+ * One switch alternative — exactly one of `uri` or `node`.
+ * `uri` is the shorthand for `node: { uri }`; use the full `node` form
+ * when the case carries styles or edges. The reserved URI `$custom`
+ * marks a case filled by a user-provided component.
+ */
+interface SwitchCase {
+  uri?: string;
+  node?: Node;
+
+  /** Marks the default case. */
+  default?: boolean;
+}
+
+interface Edge {
+  /** The child node — exactly one of `node` or `switch`. */
+  node?: Node;
+
+  /** A polymorphic position (mutually exclusive with node). */
+  switch?: Switch;
+
+  relation: Relation;
+}
+
+/**
+ * Root specification for a component anatomy.
+ * The top-level node must always be Named.
+ */
+interface AnatomySpec {
+  node: NamedNode;
+}
+```
+
+### Language Choice
+
+YAML is chosen as the markup language for its:
+- Indentation-based structure matching tree hierarchies
+- Readability over JSON's verbosity
+- Wide adoption and tooling support
+
+Alternatives considered and rejected:
+- JSON: Too verbose for deep nesting
+- TOML: Difficulty with deeply nested maps
+- SDLang/KDL: Promising but lacking wide adoption
+
+### Complete Example: Accordion
+
+```yaml
+node:
+  uri: global.component.accordion
+  styles:
+    # Structural (invariant)
+    layout.type: stack
+    layout.direction: vertical
+
+    # Themeable
+    appearance.border: border/style/accordion
+
+  edges:
+    # The repeating child is NAMED — reference its URI only (DRY Principle);
+    # its subtree lives in its own anatomy. The live Accordion does the same.
+    - node:
+        uri: global.subcomponent.accordion-item
+      relation:
+        cardinality: "1..*"
+        slotName: default
+```
+
+The child's own anatomy — a separate spec on `global.subcomponent.accordion-item`
+(transcribed from the live block) — carries the subtree as anonymous roles:
+
+```yaml
+node:
+  uri: global.subcomponent.accordion-item
+  styles:
+    layout.type: stack
+    layout.direction: vertical
+  edges:
+    - node:
+        role: header tab
+        styles:
+          layout.type: flow
+          layout.direction: horizontal
+          layout.align: center
+          interaction.cursor: pointer
+        edges:
+          - node:
+              role: control
+              styles:
+                size.width: size/icon/small
+                size.height: size/icon/small
+            relation:
+              cardinality: "1"
+          - node:
+              role: heading
+            relation:
+              cardinality: "1"
+              slotName: default
+      relation:
+        cardinality: "1"
+        slotName: header
+
+    - node:
+        role: content panel
+        styles:
+          layout.overflow: hidden
+      relation:
+        cardinality: "1"
+        slotName: default
+```
+
+### Future Work
+
+The following features would require additional work:
+- Representation of related nodes displayed in portals
+- Representation of conditional display
+- Inheritance reference for styles (e.g., "NetworkCard inherits from Card")
+
+## Support
+
+If this skill leads somewhere broken — a command that errors, guidance that
+contradicts what the live system answers, a gap the flow cannot cover — you are not
+stuck:
+
+- Raise an issue in the pragma repo: https://github.com/canonical/pragma/issues —
+  include the skill name, what was run, and expected vs. actual outcome.
+- Or contact the design-system team owners directly through your organization's
+  professional messaging channels for assistance.

--- a/packages/cli/pragma/bundled-skills/design-auditor/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/design-auditor/SKILL.md
@@ -1,0 +1,455 @@
+---
+name: design-auditor
+description: Audit design system coverage, consistency, and quality; also runs as a guided tutorial on a worked example
+---
+
+# Design Auditor
+
+Audit design system coverage, consistency, and quality. This semantic skill analyzes
+the knowledge graph to find gaps, inconsistencies, and opportunities for improvement
+across components, patterns, layouts, and documentation.
+
+In a fresh session, orient first:
+
+```bash
+pragma capabilities
+```
+
+## Working mode: assistant to a design authority
+
+An audit produces judgments, and most of the time those judgments belong to a senior
+designer or engineer — you are the assistant whose job is to make them successful.
+Default to that mode: lay out the audit direction, run the queries and return
+digestible findings, and bring each judgment to the person as a recommendation plus a
+question rather than a verdict. They know which gaps are deliberate, which components
+are on the way out, and which numbers actually worry the team — the graph does not.
+
+Full autonomy is the exception, not the default: run a whole audit alone only when
+explicitly asked to. Even then, list every judgment call made unilaterally in the
+final report so a human can revisit them.
+
+Decision gates — in collaboration, pause at each and resolve it WITH the person:
+
+1. Scope: which audit dimensions matter right now, and which tiers are in scope.
+2. What counts as concerning: agree the thresholds with the team instead of importing
+   folklore numbers — a "low" pattern count may be a young catalog, not a problem.
+3. Prioritization of the recommendations.
+4. Any promote/demote/deprecate suggestion — these are roadmap calls, not data calls.
+
+## When to Use
+
+- Reviewing design system health and completeness
+- Finding components missing documentation or guidelines
+- Identifying inconsistent modifier family usage
+- Discovering orphaned or underutilized elements
+- Preparing for design system roadmap planning
+- Auditing before a major release
+
+## When NOT to Use
+
+- Auditing an APP's adoption of the design system — that is the
+  `adoption-a1-styles`/`a2`/`a3` tracks
+- Fixing what the audit finds — route gaps to `specify-component`/`specify-pattern`,
+  missing anatomies to `anatomy-author`
+
+## Opening move: ask, or offer the tutorial
+
+Activation is an opening, not a starting gun. Unless the first message already names
+the work, ask for the starting point — as a suggestion carrying an example, not as a
+form to fill in:
+
+> To get started, tell me what you'd like audited — the whole system, one tier, or
+> just the worry, like "I think our modifier families have drifted".
+
+The worry is the most useful of the three: it says which dimensions to run and which
+numbers actually matter to the team. Ask again only for what the next step genuinely
+blocks on.
+
+If the activation message already carries the starting point, do not re-ask — say what
+you took it to be, and go.
+
+Offer the tutorial in the same breath, because this skill doubles as one:
+
+> Or if you'd rather see how an audit works first, I can run it as a tutorial: I'll
+> take one dimension — documentation coverage, say — and walk you through it end to
+> end on the live graph.
+
+Tutorial mode is the step narration below, turned up: the same outcome-path-conclusion
+frame, with the reasoning at each decision gate made fully explicit and a check that
+the person is with you before the next step. Stop short of anything that lands — no
+report filed, no issues opened — unless they ask to keep what you built.
+
+## Every step is narrated: outcome, path, conclusion
+
+Every step is addressed to the person — once before it runs, once when it ends. This is
+not tutorial manner. It holds in the ordinary flow too: the person is the design
+authority, and they can only steer a step they saw coming. A decision gate met cold is
+a decision they cannot really make.
+
+**Open** the step with what it is FOR — the outcome it should leave behind — and how
+you are about to get there. **Close** it with a sentence saying what it established and
+what that means for the step after. One sentence each is enough; the failure mode is
+silence, not length, and a step whose outcome looks obvious still gets its sentence
+rather than a shrug.
+
+Do:
+
+> **Documentation coverage, the first dimension.** The outcome is a count you can act
+> on: which blocks carry a summary, usage and anatomy, and which are entries in name
+> only. The path is the coverage query below, run per tier so a young tier is not
+> scored against a mature one.
+>
+> …
+>
+> So: 12 of 87 blocks are undocumented and 9 of those sit in one tier — a tier-shaped
+> problem rather than a system-wide one, which changes what the recommendation should
+> say.
+
+Don't:
+
+> Coverage: 75/87 documented (86%). 12 missing.
+
+Both carry the same facts. Only the first says what the step was trying to achieve and
+what it settled — and only the first lets the person cut in with the thing they know
+and the graph does not, which is the whole reason they are here.
+
+## Asked about the skill: methodology and outcomes first
+
+A question about what this skill does — what it covers, what its steps are, how it
+works — is answered in that order: the METHOD it applies and the OUTCOMES it leaves
+the person holding come first, the step-by-step breakdown comes after.
+
+Two or three sentences of method is enough: what the skill treats as its object, the
+discipline that makes it work, and what exists at the end that did not exist before.
+The enumeration then reads as steps in service of something, rather than as a list to
+be got through.
+
+What this prevents is a table of contents standing in for an answer. A reply opening
+with the step names tells someone who already knows the skill nothing new, and someone
+who does not, nothing at all.
+
+So, asked what this skill is:
+
+> It audits the design system by querying the graph along chosen dimensions and
+> turning counts into judgments — against thresholds agreed with the team, not
+> folklore numbers, because a low count can be a young catalog rather than a problem.
+> You end holding prioritised findings, each routed to the skill that fixes it, with
+> the promote/demote/deprecate calls left where they belong: with the person.
+
+Then, and only then, the breakdown.
+
+## Discovery Flow
+
+Start with a broad inventory, then drill into specific concerns:
+
+```bash
+pragma block list      # every component, pattern, layout and subcomponent, with type and tier
+pragma modifier list   # every modifier family with its values
+pragma tier list       # the tiers blocks can live in
+pragma graph query "…" # the audit queries below
+pragma graph inspect <IRI-or-ds:name>  # every triple on one entity
+```
+
+Two graph-query mechanics to know (shared with the sibling skills):
+
+- Common prefixes (`ds:`, `cs:`) are applied automatically — no PREFIX preamble.
+- Inside a SPARQL body, a local name with more than one dot
+  (`ds:global.component.button`) does not parse — use the full IRI there
+  (`<https://ds.canonical.com/global.component.button>`). Single-dot and dot-free
+  prefixed names (`ds:global`, `ds:Component`) work as-is.
+
+Note that `block list` deliberately omits the `ds:Group` class — an audit that counts
+only the list under-counts. The queries below go to the graph directly, so they see
+groups too.
+
+> The covered set is whatever the graph answers today. Query it live — never copy its
+> output (counts, names, ratios) into documentation, PRs, or this skill.
+
+One more live-data rule: before trusting any query, confirm its predicates against the
+current ontology (`pragma ontology lookup ds`). The vocabulary evolves — for example,
+`ds:usage` subsumed the former `whenToUse`/`whenNotToUse` predicates, and queries
+against retired names return empty tables, not errors. An empty result must be
+distinguished from a wrong query before it becomes a finding.
+
+## Audit Dimensions
+
+### 1. Coverage Audit
+What's documented vs. what's missing?
+
+### 2. Consistency Audit
+Are similar components structured similarly?
+
+### 3. Quality Audit
+How complete is the documentation?
+
+### 4. Usage Audit
+What's connected vs. orphaned?
+
+### 5. Standards Audit
+Do the implementations conform to the live code standards?
+
+An audit that stops at the graph misses the code. For each audited implementation,
+pull the applicable categories (`pragma standard categories`, then
+`pragma standard list --category <framework>`) and read the Do/Don't pairs against
+the source the implementation links to (`ds:headLink`). A violation is a finding with
+the standard's name attached — as first-class as a missing anatomy. The standards
+apply even where the audited app has no pragma dependency. Findings cut both ways:
+where the team's practice is right and the standard is not, the finding becomes a
+proposed change to the standard — the standards are open to contribution, and audits
+are where their gaps surface.
+
+## Key Queries
+
+Documentation-completeness queries must catch BOTH the absent predicate and the empty
+string — many entries carry a field that is present but blank, and a
+`FILTER NOT EXISTS` alone misses them.
+
+### Coverage: Components by Tier
+
+```bash
+pragma graph query "SELECT ?tierName (COUNT(?c) as ?componentCount) WHERE {
+  ?c a ds:Component ;
+     ds:tier ?tier .
+  ?tier ds:name ?tierName .
+} GROUP BY ?tierName
+ORDER BY DESC(?componentCount)"
+```
+
+**What it asks**: where the catalog's weight sits. A tier with few components can be a
+gap, a young tier, or a deliberate scope — which one is a question for the team.
+
+### Coverage: UIBlock Types Distribution
+
+```bash
+pragma graph query "SELECT ?type (COUNT(?block) as ?count) WHERE {
+  VALUES ?type { ds:Component ds:Pattern ds:Layout ds:Subcomponent ds:Group }
+  ?block a ?type .
+} GROUP BY ?type"
+```
+
+**What it asks**: the shape of the catalog. There is no universally healthy ratio —
+compare against the previous audit's numbers and let the team judge the trend.
+
+### Quality: Blocks Missing or Blank Summary
+
+```bash
+pragma graph query "SELECT ?block ?name WHERE {
+  ?block a ?type ;
+         ds:name ?name .
+  VALUES ?type { ds:Component ds:Pattern ds:Layout ds:Subcomponent ds:Group }
+  FILTER NOT EXISTS { ?block ds:summary ?s . FILTER(STR(?s) != '') }
+}"
+```
+
+**What it asks**: which blocks have no base definition at all. These rows are also
+what `implement-component` treats as "no spec here to implement".
+
+### Quality: Components Missing or Blank Usage
+
+```bash
+pragma graph query "SELECT ?component ?name WHERE {
+  ?component a ds:Component ;
+             ds:name ?name .
+  FILTER NOT EXISTS { ?component ds:usage ?u . FILTER(STR(?u) != '') }
+}"
+```
+
+**What it asks**: where When-to-use / When-not-to-use guidance is missing (`ds:usage`
+subsumes both). Without it, adopters cannot tell what replaces what — these gaps
+directly hurt the adoption tracks.
+
+### Quality: Components Missing or Blank Guidelines
+
+```bash
+pragma graph query "SELECT ?component ?name WHERE {
+  ?component a ds:Component ;
+             ds:name ?name .
+  FILTER NOT EXISTS { ?component ds:guidelines ?g . FILTER(STR(?g) != '') }
+}"
+```
+
+**What it asks**: where accessibility and best-practice material is missing —
+`ds:guidelines` is its conventional home.
+
+### Quality: Blocks Missing or Blank Anatomy
+
+```bash
+pragma graph query "SELECT ?block ?name WHERE {
+  ?block a ?type ;
+         ds:name ?name .
+  VALUES ?type { ds:Component ds:Pattern }
+  FILTER NOT EXISTS { ?block ds:anatomyDsl ?a . FILTER(STR(?a) != '') }
+}"
+```
+
+**What it asks**: `anatomy-author` candidates.
+
+### Consistency: Modifier Family Usage
+
+```bash
+pragma graph query "SELECT ?family ?familyName (COUNT(?component) as ?usage) WHERE {
+  ?family a ds:ModifierFamily ;
+          ds:name ?familyName .
+  OPTIONAL {
+    ?component a ds:Component ;
+               ds:hasModifierFamily ?family .
+  }
+} GROUP BY ?family ?familyName
+ORDER BY DESC(?usage)"
+```
+
+**What it asks**: which families are core and which are unused. A zero-usage family is
+a question — premature abstraction, or adoption that has not landed yet?
+
+### Consistency: Components Without Modifier Families
+
+```bash
+pragma graph query "SELECT ?component ?name WHERE {
+  ?component a ds:Component ;
+             ds:name ?name .
+  FILTER NOT EXISTS { ?component ds:hasModifierFamily ?mf }
+}"
+```
+
+**What it asks**: candidates to review — not every component needs modifiers, but
+many do.
+
+### Usage: Orphaned Subcomponents
+
+```bash
+pragma graph query "SELECT ?sub ?name WHERE {
+  ?sub a ds:Subcomponent ;
+       ds:name ?name .
+  FILTER NOT EXISTS { ?sub ds:parentComponent ?parent }
+}"
+```
+
+**What it asks**: subcomponents without parents — either the relationship is missing,
+or the block should be promoted to Component. Which one is a team call.
+
+### Usage: Components With Subcomponents
+
+```bash
+pragma graph query "SELECT ?component ?componentName (COUNT(?sub) as ?subCount) WHERE {
+  ?component a ds:Component ;
+             ds:name ?componentName .
+  ?sub ds:parentComponent ?component .
+} GROUP BY ?component ?componentName
+ORDER BY DESC(?subCount)"
+```
+
+**What it asks**: where composition complexity concentrates. A very high count is a
+prompt to ask whether the decomposition still serves its users.
+
+### Cross-Tier: Potential Promotion Candidates
+
+```bash
+pragma graph query "SELECT ?component ?name ?tierName WHERE {
+  ?component a ds:Component ;
+             ds:name ?name ;
+             ds:tier ?tier .
+  ?tier ds:name ?tierName .
+  FILTER(?tier != ds:global)
+  FILTER EXISTS { ?component ds:hasModifierFamily ?mf }
+  FILTER EXISTS { ?component ds:summary ?d . FILTER(STR(?d) != '') }
+  FILTER EXISTS { ?component ds:usage ?u . FILTER(STR(?u) != '') }
+}"
+```
+
+**What it asks**: well-documented tier-specific components that MIGHT be universal.
+Promotion is a roadmap decision — present these as candidates, never as conclusions.
+
+## Audit Report
+
+Build the report from the live query results, structured as:
+
+```markdown
+## Design System Audit Report
+
+**Generated:** {date}   **Scope:** {tiers/dimensions agreed at the scope gate}
+
+### Executive Summary
+Counts per UIBlock type and per tier, documentation coverage percentages, and the
+headline findings — with each "concern" label traced to a threshold the team agreed,
+not an imported one.
+
+### Findings per dimension
+Coverage / Quality / Consistency / Usage — for each: the numbers, the specific blocks
+affected, and the open question or recommendation. Route each actionable gap to its
+skill: missing spec → specify-component / specify-pattern; missing anatomy →
+anatomy-author.
+
+### Recommendations
+Prioritized WITH the person (decision gate 3). Mark which items are data-driven
+(e.g. "12 components have a blank summary") and which are judgment
+(e.g. "consider promoting X to global").
+
+### Appendix
+The raw query results the findings rest on, in collapsible sections.
+```
+
+## Workflow
+
+### Quick Health Check
+
+```text
+1. pragma block list + pragma modifier list — the big picture
+2. Run the three Quality queries (summary, usage, guidelines)
+3. Run Modifier Family Usage
+4. Report the counts and the specific blocks; agree with the person what, if
+   anything, is alarming
+```
+
+### Full Audit
+
+```text
+1. Scope gate: agree dimensions and tiers with the person
+2. Inventory: block list, tier list, modifier list, types-distribution query
+3. Coverage queries, Quality queries, Consistency queries, Usage queries
+4. Compare against the previous audit's report where one exists
+5. Draft the report; resolve interpretation and priorities with the person
+```
+
+### Targeted Audit
+
+| Concern | Queries to Run |
+|---------|----------------|
+| "Are we missing patterns?" | Coverage by tier, types distribution |
+| "Is documentation complete?" | All Quality queries |
+| "Are modifiers consistent?" | Modifier Family Usage, Components Without Modifiers |
+| "Any orphaned elements?" | Orphaned Subcomponents |
+| "What needs promotion?" | Promotion Candidates |
+
+## Interpreting Results
+
+Interpretation is where the working mode matters most. The queries return facts; what
+they MEAN is judged against the team's intent:
+
+- Prefer trends over absolutes: compare with the previous audit rather than against a
+  fixed "healthy" number.
+- A gap can be deliberate (out-of-scope tier, deprecation in progress) — ask before
+  flagging.
+- Distinguish data findings (a blank field IS blank) from judgment findings (a ratio
+  "looks" off) and label them differently in the report.
+- Follow up drill-downs with `pragma graph inspect <IRI>` on the specific blocks a
+  query surfaced, and `pragma block lookup <Name>` for the human-readable view.
+
+## Limitations
+
+- Cannot assess visual design quality (only metadata)
+- Cannot verify Figma link validity (only presence)
+- Pattern quality is subjective (coverage is objective)
+- Does not analyze implementation packages — the graph records what is DOCUMENTED,
+  and packages ship what is BUILT; the two run ahead of each other in both directions
+  (see `adoption-a2-components` for the export check)
+
+## Support
+
+If this skill leads somewhere broken — a command that errors, guidance that
+contradicts what the live system answers, a gap the flow cannot cover — you are not
+stuck:
+
+- Raise an issue in the pragma repo: https://github.com/canonical/pragma/issues —
+  include the skill name, what was run, and expected vs. actual outcome.
+- Or contact the design-system team owners directly through your organization's
+  professional messaging channels for assistance.

--- a/packages/cli/pragma/bundled-skills/implement-component/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/implement-component/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: implement-component
+description: Implement a specified design-system component with pragma create, following the live code standards; also runs as a guided tutorial on a worked example
+---
+
+# Implement Component
+
+Take an APPROVED spec — from `specify-component`, or an existing documented block — to
+working code. The defining discipline: the applicable code standards are pulled and held
+open DURING implementation, so they shape the code as it is written, not only in review.
+
+## Working mode
+
+This skill often runs alongside a senior engineer or designer. When it does, work as
+their assistant: lay out where the flow stands, do the legwork (spec reads, standard
+pulls, scaffolding), and surface decisions rather than absorbing them silently. The
+points to raise with the person rather than decide alone: a thin or ambiguous spec
+field, any deviation from a pulled standard, the target package for a tier outside the
+naming convention, and API naming the spec does not fix. When running fully
+autonomously (only on explicit request), list those judgment calls in the PR.
+
+## When to Use
+
+- An approved spec — from `specify-component`, or an existing documented block — needs
+  working code
+- A scaffolded component needs to be implemented against the live code standards
+
+## When NOT to Use
+
+- No approved spec yet — run `specify-component` first (`specify-pattern` for a pattern)
+- Only the anatomy is missing — that is `anatomy-author`
+- Adopting existing components into an app — the `adoption-a1-styles` /
+  `adoption-a2-components` / `adoption-a3-forms` tracks, not this skill
+
+## Opening move: ask, or offer the tutorial
+
+Activation is an opening, not a starting gun. Unless the first message already names
+the work, ask for the starting point — as a suggestion carrying an example, not as a
+form to fill in:
+
+> To get started, tell me which block to implement — a name like "Badge", or point me
+> at the spec it came out of. If the target framework or package isn't obvious, say
+> that too.
+
+If you are unsure whether the thing is specified at all, take the name anyway:
+pre-flight is what decides, and it routes to `specify-component` when the spec turns
+out not to be there. Ask again only for what the next step genuinely blocks on.
+
+If the activation message already carries the starting point, do not re-ask — say what
+you took it to be, and go.
+
+Offer the tutorial in the same breath, because this skill doubles as one:
+
+> Or if you'd rather see the flow first, I can run it as a tutorial: I'll pick a small
+> documented block from the graph and walk you through it from pre-flight to review.
+
+Tutorial mode is the step narration below, turned up: the same outcome-path-conclusion
+frame, with the reasoning at each decision gate made fully explicit and a check that
+the person is with you before the next step. Stop short of anything that lands — no
+commit, no PR — unless they ask to keep what you built.
+
+## Every step is narrated: outcome, path, conclusion
+
+Every step is addressed to the person — once before it runs, once when it ends. This is
+not tutorial manner. It holds in the ordinary flow too: the person is the design
+authority, and they can only steer a step they saw coming. A decision gate met cold is
+a decision they cannot really make.
+
+**Open** the step with what it is FOR — the outcome it should leave behind — and how
+you are about to get there. **Close** it with a sentence saying what it established and
+what that means for the step after. One sentence each is enough; the failure mode is
+silence, not length, and a step whose outcome looks obvious still gets its sentence
+rather than a shrug.
+
+Do:
+
+> **Pulling the standards, before any code.** The outcome is a shortlist held open
+> while the Badge is written, so the code is shaped by the standards as it is written
+> rather than corrected in review. The path is `pragma standard categories` for the
+> live set, then `standard list --category <name>` for each one that applies.
+>
+> …
+>
+> So: `react`, `storybook` and `testing-unit` are the live shortlist and nothing in
+> them contradicts the spec — implementation can proceed against them, with `css` and
+> `styling` held back for the token work.
+
+Don't:
+
+> Step 3 — Pull the standards NOW
+>
+> Categories exist for: react (16), testing (+coverage/integration/regression/unit),
+> storybook (11), css (15), styling (4).
+
+Both carry the same facts. Only the first says what the step was trying to achieve and
+what it settled — and only the first lets the person cut in with the thing they know
+and the graph does not, which is the whole reason they are here.
+
+## Asked about the skill: methodology and outcomes first
+
+A question about what this skill does — what it covers, what its steps are, how it
+works — is answered in that order: the METHOD it applies and the OUTCOMES it leaves
+the person holding come first, the step-by-step breakdown comes after.
+
+Two or three sentences of method is enough: what the skill treats as its object, the
+discipline that makes it work, and what exists at the end that did not exist before.
+The enumeration then reads as steps in service of something, rather than as a list to
+be got through.
+
+What this prevents is a table of contents standing in for an answer. A reply opening
+with the step names tells someone who already knows the skill nothing new, and someone
+who does not, nothing at all.
+
+So, asked what this skill is:
+
+> It takes an approved spec to working code, and the discipline that defines it is
+> that the applicable code standards are pulled and held open DURING implementation —
+> so they shape the code as it is written, not only in review. You end holding a
+> scaffolded and implemented component, any deviation from a standard recorded next to
+> that standard's name, and an independent review of the result.
+
+Then, and only then, the breakdown.
+
+## Pre-flight
+
+1. **Read the spec.**
+   - Documented block: `pragma block lookup <Name>` — anatomy, modifiers, properties in
+     one read (MCP: block_lookup); `pragma graph inspect <uri>` for the full triple view.
+     A bare name can match blocks in several tiers, and `block lookup` silently picks
+     one — it resolves `ds:name` globally and cannot be steered to a tier. Take the
+     picked block's tier from the lookup's own `- Tier:` line, and check for other
+     tiers carrying the name with the name query below, then address the tier you
+     want by its IRI.
+
+     ```bash
+     pragma graph query "SELECT ?b WHERE { ?b ds:name ?n . FILTER(LCASE(?n) = LCASE('<Name>')) }"   # every tier carrying the name
+     ```
+
+     If the lookup picked the wrong tier's block, read the one you want with
+     `pragma graph inspect <IRI from that row>` instead — step 2 derives the package
+     from the tier of the block confirmed HERE.
+
+     **Check the entry is a spec before building on it — whatever class it is.**
+     A row resolving is not the same as a block being documented: many entries
+     across every class carry an empty `ds:summary`, `ds:usage` and `ds:anatomyDsl`,
+     and `block lookup <Name>` still answers for them with a heading, a blank line
+     and a `- Tier:` row. Judge the BASE DEFINITION: if `ds:summary`, `ds:usage` and
+     `ds:anatomyDsl` all came back filled, the block is documented — implement it,
+     and raise any single thin field (empty guidelines, say) as a gap rather than a
+     blocker. If all three came back empty, there is no spec here to implement: route
+     it to `specify-component`, per the When NOT to Use rules above.
+
+     Then read whatever `ds:documentationStage` tag came back. The tag vocabulary is
+     the graph's, not this skill's, so do not expect a fixed value list; **if the
+     predicate is absent, no stage is recorded for that block** — say so and carry on
+     with what the fields told you. The tag's MEANING is graph data too:
+
+     ```bash
+     pragma graph inspect ds:tag.<name>   # the tag the stage read returned; ds:whenToApply says what it means
+     ```
+
+     Split the action on what `ds:whenToApply` says. A tag meaning the block was
+     rejected or triaged out, or that it is only PROPOSED or postponed — not yet
+     accepted into the system: this is not an approved spec, route it to
+     `specify-component`. A tag meaning the documentation is UNFINISHED: proceed, and
+     say so in the PR — route to `anatomy-author` only the fields that actually came
+     back empty, not the whole block. A tag whose `ds:whenToApply` comes back blank:
+     the meaning is unrecorded — treat it as unknown, and say so.
+
+     If the name has no row and the lookup errors, the block may be a Group — `block list`/`block lookup` cover no groups; the name query above returns its IRI for `pragma graph inspect <IRI>`.
+     Groups are the one UIBlock class `block list` deliberately omits, so the graph
+     entry is their only documentation surface — but the check above is the same
+     check: read the base definition, then the stage.
+
+     The inspect renders `ds:hasProperty` only as opaque blank-node labels; for the
+     property content use the lookup's Properties section — only when the lookup
+     resolved the block you want — or bind the property query to the block confirmed
+     above. (A `block list` row prints the `ds:` form — `graph inspect` takes it
+     as-is, but a SPARQL body needs the full IRI: join `https://ds.canonical.com/`
+     with the row's dotted name, e.g. for the global Button,
+     `<https://ds.canonical.com/global.component.button>`; the name query above
+     prints that full form directly. The bracketed prefixed form `<ds:…>` silently
+     returns an EMPTY table, not an error.)
+
+     ```bash
+     pragma graph query "SELECT ?p ?v WHERE { <https://ds.canonical.com/<dotted name from that row>> ds:hasProperty ?x . ?x ?p ?v }"
+     ```
+   - New block: the `specs/…` file its specify flow produced.
+2. **Confirm the target package and tier.** The spec names its tier; `pragma tier list`
+   shows what exists. Where a package exists for the tier, its name follows a
+   convention — the graph carries no package field: `@canonical/<framework>-ds-global`
+   for the `global` tier, `@canonical/<framework>-ds-app` for the shared `apps` tier,
+   and `@canonical/<framework>-ds-app-<app>` for an app-specific tier
+   (`apps_lxd` → `@canonical/react-ds-app-lxd`). The `<app>` segment is the package's
+   own short name, not always the tier suffix (the `apps_workplaceengineering` tier's
+   package is `@canonical/svelte-ds-app-wpe`) — confirm the derived package actually
+   resolves in the workspace before installing or scaffolding into it. Tiers outside
+   `global`/`apps*` have no package convention today: there the target package is a
+   decision to raise, not to derive.
+3. **Pull the applicable standards NOW.**
+
+   ```bash
+   pragma standard categories                 # what categories exist today
+   pragma standard list --category react      # swap react for the target framework category
+   ```
+
+   > The covered set is whatever the graph answers today. Query it live — never copy its
+   > output into documentation, PRs, or this skill.
+
+   Repeat the `--category` listing for the testing, storybook, css, and styling
+   categories that apply to this component — take the category names from the
+   `standard categories` output, not from memory.
+
+   Then read the shortlisted standards' Do/Don't pairs — few-shot material to keep
+   open in the working context while writing. The pairs live in the graph; pull them
+   per category:
+
+   ```bash
+   pragma graph query "SELECT ?s ?kind ?caption ?code WHERE { ?s cs:hasCategory cs:react . { ?s cs:do ?x . BIND('do' AS ?kind) } UNION { ?s cs:dont ?x . BIND('dont' AS ?kind) } ?x cs:description ?caption . OPTIONAL { ?x cs:code ?code } }"
+   ```
+
+   Keep `cs:code` OPTIONAL as written — some pairs carry a caption and no code
+   snippet, and requiring the code triple silently drops those standards from the
+   result.
+
+   For ONE standard, bind the same query to its IRI. (`pragma graph inspect cs:<id>`
+   shows which predicates a standard carries, but renders `cs:do`/`cs:dont` only as
+   opaque blank-node labels — the pairs come back through the query, not the
+   inspect):
+
+   ```bash
+   pragma graph query "SELECT ?kind ?caption ?code WHERE { BIND(<http://pragma.canonical.com/codestandards#react.component.barrel_exports> AS ?s) { ?s cs:do ?x . BIND('do' AS ?kind) } UNION { ?s cs:dont ?x . BIND('dont' AS ?kind) } ?x cs:description ?caption . OPTIONAL { ?x cs:code ?code } }"
+   ```
+
+   Swap `cs:react` for each shortlisted category, using the category's GRAPH ID — not
+   its display name. `standard categories` prints display names (`testing-coverage`);
+   the graph ids differ (`testing.coverage`), and a display name pasted into the
+   query returns an empty table, not an error. List the exact IRIs with
+   `pragma graph query "SELECT DISTINCT ?c WHERE { ?s cs:hasCategory ?c }"` and paste
+   one in full `<…>` form, e.g.:
+
+   ```bash
+   pragma graph query "SELECT ?s ?kind ?caption ?code WHERE { ?s cs:hasCategory <http://pragma.canonical.com/codestandards#testing.coverage> . { ?s cs:do ?x . BIND('do' AS ?kind) } UNION { ?s cs:dont ?x . BIND('dont' AS ?kind) } ?x cs:description ?caption . OPTIONAL { ?x cs:code ?code } }"
+   ```
+
+   (Inside a SPARQL body a local name with more than one dot does not parse; a
+   single dot — `cs:testing.unit` — is fine.) `pragma standard lookup <name>` and
+   `pragma standard sample` resolve only the standards that carry a `cs:name`
+   title — today only a few do — so for the rest the graph query above is the read
+   path. (MCP: standard_categories / standard_list / graph_query / graph_inspect.)
+
+## Scaffold
+
+```bash
+pragma create component react src/components/Button
+```
+
+- The framework is a tree segment — `pragma create component <framework> <path>` with
+  `react`, `svelte`, or `lit` as the segment; the path's final segment is the
+  PascalCase component name.
+- Run it from inside the target package confirmed in pre-flight step 2 — the path is
+  package-relative (in the ds packages, components live at `src/lib/component/<Name>`,
+  so the path there is `src/lib/component/Button`, not the generic example above).
+- Plan-first: preview with `--dry-run`, apply non-interactively with `--yes`, reverse
+  with `--undo`. Run without `--yes` to answer the generator's prompts interactively.
+- The scaffold's include options (styles, stories, SSR tests) are prompt-derived and
+  discoverable — read them from the leaf's own help, never from a copied table:
+
+  ```bash
+  pragma create component react --help
+  ```
+
+- MCP: the `create_component` tool ({framework, componentPath, …}); it returns a plan
+  unless `confirm: true`.
+
+The same generator is available as `summon component react src/components/Button` —
+`pragma create <args…>` and `summon <args…>` are one machine in two binaries, identical
+grammar. Teach and use the pragma spelling.
+
+## Implement following the pulled standards
+
+Write the component against the open Do/Don't pairs from pre-flight. When a case comes
+up that the shortlist does not cover, widen before improvising: re-run
+`pragma standard categories`, list the further categories that could apply
+(`pragma standard list --category <c>`), and pull their Do/Don't pairs with the same
+graph query as pre-flight. Each surface takes its own spelling: `--category` takes the
+DISPLAY name `standard categories` prints (`testing-coverage`); the SPARQL body takes
+the category's graph id from the `SELECT DISTINCT ?c` read there (`testing.coverage`) —
+never the other way around. An empty pair table has two causes: a display name pasted
+into the query, or a category that records standards but no Do/Don't pairs at all —
+`pragma standard list --category <c>` distinguishes them (it lists the category's
+standards either way; when no pairs exist, work from those standards' descriptions).
+
+A standard you disagree with is feedback for the standards repo, not a license to
+deviate silently.
+
+## Post-flight
+
+- Fill in the stories and tests the scaffold stubbed — the spec's properties, modifiers,
+  and states each get exercised.
+- Register the component per the package's convention (barrel/export registration).
+- Run the package's own `bun run check` and `bun run test` (the repo-standard script
+  names) until green.
+
+## Close: independent review
+
+Finish by invoking the `standards-review` skill as the independent quality gate over the
+diff:
+
+```bash
+pragma skill lookup standards-review
+```
+
+It ships from canonical/web-code-standards once that skill lands; until then the
+lookup will not resolve. Fall back to re-reading the pre-flight Do/Don't material
+against the diff yourself, and say in the PR that the independent gate was
+unavailable.
+
+## Related skills
+
+- `specify-component` — upstream: produces the spec this skill implements
+- `anatomy-author` — the structure contract the implementation must honor
+
+## Support
+
+If this skill leads somewhere broken — a command that errors, guidance that
+contradicts what the live system answers, a gap the flow cannot cover — you are not
+stuck:
+
+- Raise an issue in the pragma repo: https://github.com/canonical/pragma/issues —
+  include the skill name, what was run, and expected vs. actual outcome.
+- Or contact the design-system team owners directly through your organization's
+  professional messaging channels for assistance.

--- a/packages/cli/pragma/bundled-skills/specify-component/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/specify-component/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: specify-component
+description: Specify a new design-system component with the knowledge graph, from graph search to a sync-safe spec file; also runs as a guided tutorial on a worked example
+---
+
+# Specify Component
+
+Create a NEW component on the design/spec side, using the full power of the knowledge
+graph. This skill supersedes the retired component-specifier skill (a name that no
+longer resolves) with an eight-step flow: nothing is invented before the graph has been
+searched, the entry shape comes from the ontology, and the output is a standalone spec
+file the data sync cannot destroy.
+
+In a fresh session, orient first:
+
+```bash
+pragma capabilities
+```
+
+## Working mode: assistant to a design authority
+
+Most of the time this skill runs in collaboration with a senior designer or engineer —
+they are the design authority, you are the assistant whose job is to make them
+successful. Default to that mode:
+
+- Lay out the workflow direction: say which step comes next and why, so the person
+  always knows where the flow stands.
+- Do the legwork yourself — graph searches, ontology reads, benchmark research — and
+  bring back digestible findings, not raw dumps.
+- Bring each decision to the person as a recommendation plus a question, never as a
+  fait accompli. They hold context the graph does not — history, intent, naming
+  precedent, roadmap — so ask the questions that draw that knowledge out, and use it.
+
+Full autonomy is the exception, not the default: run the whole flow alone only when
+explicitly asked to. Even then, list every judgment call made unilaterally in the
+final report so a human can revisit them.
+
+Decision gates — in collaboration, pause at each and resolve it WITH the person:
+
+1. The step-1 verdict: exists/extend vs. a named gap.
+2. The step-2 category choice (which `ds:UIBlock` subclass the entry is).
+3. The step-3 boundary: how the definition disambiguates from its neighbors.
+4. The step-4 adopt/reject decisions from the benchmark.
+5. Whether the step-5 state gate fires, and the state model when it does.
+
+## When to Use
+
+- A component is proposed that the design system may not cover yet
+- An existing component needs a formally specified sibling or replacement
+- A gap found during adoption or implementation needs to become a real spec
+
+## When NOT to Use
+
+- Implementing an already-specified component — use `implement-component`
+- Specifying a pattern (a recurring arrangement of components) — use `specify-pattern`
+- Writing only the anatomy for an existing block — use `anatomy-author`
+
+## Opening move: ask, or offer the tutorial
+
+Activation is an opening, not a starting gun. Unless the first message already names
+the work, ask for the starting point — as a suggestion carrying an example, not as a
+form to fill in:
+
+> To get started, tell me the component you'd like to work on — a name if it has one,
+> or just the idea, like "it should let someone pick a date".
+
+Rough is fine, and often better: step 1 turns an idea into a graph search, and the
+search regularly renames the thing. Ask again only for what the next step genuinely
+blocks on.
+
+If the activation message already carries the starting point, do not re-ask — say what
+you took it to be, and go.
+
+Offer the tutorial in the same breath, because this skill doubles as one:
+
+> Or if you'd rather see the flow first, I can run it as a tutorial: I'll take a
+> plausible example — a date picker, say — and walk you through the eight steps on it.
+
+Tutorial mode is the step narration below, turned up: the same outcome-path-conclusion
+frame, with the reasoning at each decision gate made fully explicit and a check that
+the person is with you before the next step. Stop short of anything that lands — no spec
+file written, no proposal filed — unless they ask to keep what you built.
+
+## Every step is narrated: outcome, path, conclusion
+
+Every step is addressed to the person — once before it runs, once when it ends. This is
+not tutorial manner. It holds in the ordinary flow too: the person is the design
+authority, and they can only steer a step they saw coming. A decision gate met cold is
+a decision they cannot really make.
+
+**Open** the step with what it is FOR — the outcome it should leave behind — and how
+you are about to get there. **Close** it with a sentence saying what it established and
+what that means for the step after. One sentence each is enough; the failure mode is
+silence, not length, and a step whose outcome looks obvious still gets its sentence
+rather than a shrug.
+
+Do:
+
+> **Step 1 — search the graph.** The outcome is a verdict: the thing already exists,
+> an existing block should be extended, or there is a named gap worth specifying. The
+> path is `pragma block list` for the catalog, then `block lookup` on the closest
+> candidates.
+>
+> …
+>
+> So: nothing covers date entry, and the nearest neighbour (`Input`) stops at free
+> text — a real gap, and one that step 2 has to place as a component rather than a
+> pattern.
+
+Don't:
+
+> Step 1 — Search the graph
+>
+> 87 blocks. No date picker. Closest: Input, Select.
+
+Both carry the same facts. Only the first says what the step was trying to achieve and
+what it settled — and only the first lets the person cut in with the thing they know
+and the graph does not, which is the whole reason they are here.
+
+## Asked about the skill: methodology and outcomes first
+
+A question about what this skill does — what it covers, what its steps are, how it
+works — is answered in that order: the METHOD it applies and the OUTCOMES it leaves
+the person holding come first, the step-by-step breakdown comes after.
+
+Two or three sentences of method is enough: what the skill treats as its object, the
+discipline that makes it work, and what exists at the end that did not exist before.
+The enumeration then reads as steps in service of something, rather than as a list to
+be got through.
+
+What this prevents is a table of contents standing in for an answer. A reply opening
+with the step names tells someone who already knows the skill nothing new, and someone
+who does not, nothing at all.
+
+So, asked what this skill is:
+
+> It specifies a component against the knowledge graph, and the discipline is that
+> nothing is invented before the graph has been searched: the entry's category comes
+> from the ontology rather than from taste, the boundary is drawn against its real
+> neighbours, and a benchmark decides what is adopted and what is refused. You end
+> holding a standalone spec file the data sync cannot destroy, plus a record of every
+> judgment call it took to get there.
+
+Then, and only then, the breakdown.
+
+## The spec falls under standards too
+
+A spec is Turtle, and Turtle has standards — the `turtle` category, with `ui-blocks`
+governing how blocks are modelled (take the actual set from
+`pragma standard categories`, not from this list). Pull them before writing and hold
+the Do/Don't pairs open; a spec that contradicts a pulled standard carries a DECLARED
+deviation in the proposal, ideally also filed as an issue. The standards apply
+independent of any package dependency and are open to contribution: a missing or
+wrong modelling rule is something to propose a change for, not to silently work
+around.
+
+## The eight steps
+
+### 1. Search the graph
+
+Before anything is invented, find what already exists:
+
+```bash
+pragma block list                  # every component, pattern, layout and subcomponent, with its type and tier
+pragma block lookup <Name-or-glob> # full spec of candidates: anatomy, modifiers, properties (MCP: block_lookup); a glob repeats a multi-tier name once per IRI and every repeat is the SAME block — the fragment query below lists the tiers
+pragma block sample                # real entry shapes — read these BEFORE writing queries
+pragma modifier list               # the modifier families blocks draw from
+pragma tier list                   # the tiers a block can live in
+```
+
+Search by name fragment when the naming is uncertain:
+
+```bash
+pragma graph query "SELECT ?b ?name WHERE { ?b ds:name ?name . FILTER(CONTAINS(LCASE(?name), 'crumb')) }"
+```
+
+> The covered set is whatever the graph answers today. Query it live — never copy its
+> output into documentation, PRs, or this skill.
+
+Outcome gate: **either "exists — stop or extend it" or a NAMED gap.** No spec is written
+without one of those two sentences, naming the blocks that were checked.
+
+### 2. Understand the ontology
+
+Read the shape the entry must satisfy:
+
+```bash
+pragma ontology lookup ds                    # the design-system vocabulary
+pragma ontology lookup ds --class UIBlock    # the block-level properties every entry carries
+pragma ontology lookup ds --class Component  # what Component itself declares
+```
+
+`--class` shows only what a class declares itself — usage, guidelines, properties,
+and tier are declared on `ds:UIBlock` and inherited by its subclasses; `summary` and
+`name` sit further up the chain on `ds:Entity`
+(`pragma ontology lookup ds --class Entity`).
+
+The documented conventions the entry follows:
+
+- `ds:summary` — what the component is, in one or two sentences
+- `ds:usage` — markdown with `### When to use` and `### When not to use` sections
+- `ds:guidelines` — markdown; Accessibility material lives here by convention
+  (contrast, alternative text, keyboard and focus behavior)
+- `ds:hasProperty` — one entry per property: name, type, summary, optional, default,
+  constraints
+- Modifier families the component participates in
+- The tier it belongs to
+- The category definitions — `pragma ontology lookup ds` above lists every `ds:UIBlock` subclass; read what each one means with `pragma graph inspect ds:<Subclass>`
+  (each prints its `skos:definition`; `--class` prints declared properties, not
+  definitions), and state which category the entry belongs to BEFORE writing
+
+Each field's acceptance criteria live on the property itself —
+`pragma graph inspect ds:usage` / `ds:guidelines` print the `ds:acceptanceCriteria`
+the content must satisfy; read them before writing the field.
+
+Do not trust this list over the data: run `pragma block sample` and mirror what real
+entries carry today. The draw is RANDOM and many blocks are near-empty, so a sample can come back content-free and teach you nothing: re-run it until it lands on a filled entry, or inspect a block you already know is documented.
+
+### 3. Define the principles
+
+Write the component's main definition — and write it to DISAMBIGUATE. Name the closest
+existing blocks found in step 1 and state the boundary explicitly: "unlike X, this …".
+A definition that could equally describe a step-1 neighbor is not done.
+
+### 4. Research & benchmark
+
+Study the same affordance or role in other design systems — React Aria, Carbon,
+Material, shadcn (list extensible). Compare:
+
+- API shape
+- Accessibility pattern
+- Naming
+- State model
+- Composition
+
+Output: a short comparison table plus an explicit statement of what pragma adopts, what
+it rejects, and why.
+
+### 5. State-complexity gate
+
+Decide whether the component carries complex, state-machine-like state: many interacting
+modes, async transitions, orchestration across parts.
+
+Calibration: a Button — hover, active, disabled visual states — does NOT fire this
+gate; a Combobox — open/closed, filtering, async loading, selection moving between
+input and list — does.
+
+If YES, write a **"States & interaction"** section INSIDE the guidelines content of the
+spec (the v0 home for the state spec), covering:
+
+- The states
+- Events and transitions between them
+- The initial state
+- Error states
+- Keyboard interactions per state
+
+If NO, say so in the spec and move on.
+
+### 6. Write the documentation (without the anatomy)
+
+Write the spec in markdown or Turtle following the step-2 structure: definition, usage,
+guidelines (including the step-5 section when it fired), properties. The anatomy is
+step 7, not here.
+
+**Output location (hard rule)**: a standalone spec file the sync cannot destroy.
+
+- In canonical/design-system: `specs/<tier>.<type>.<snake_name>.{md,ttl}`
+  (e.g. `specs/global.component.carousel.md` — step 1 must have shown the name to be
+  a genuine gap first)
+- In any other repo: that repo's design-docs location
+
+NEVER write into design-system `data/` — it is regenerated destructively from Coda by
+CI, and hand edits are overwritten by the next sync. Database entry is a separate,
+currently-human step: a person pastes the spec content into Coda.
+
+### 7. Write the anatomy DSL
+
+Delegate to the `anatomy-author` skill:
+
+```bash
+pragma skill lookup anatomy-author
+```
+
+The skill covers named and anonymous nodes, edges with cardinality, slot names, and
+CTI-inspired style keys; the full ANATOMY_DSL_SPEC ships beside it as
+`ANATOMY_DSL_SPEC.md` in the installed `anatomy-author` skill folder (the lookup
+renders SKILL.md only — open that file directly for the complete spec). The produced
+DSL lands in the step-6 spec file
+under `specs/` — in a `.md` spec as its anatomy section, in a `.ttl` spec as the
+block's `ds:anatomyDsl` string literal — never under `data/`; entry into Coda stays
+the human step.
+
+### 8. Pair with tokens — placeholder
+
+**Left blank for now** — token pairing content lands with the token work. Do not invent
+token guidance.
+
+## Response format
+
+Report the spec-file path, then the eight step outcomes as a checklist (the reported
+path ends in `.ttl` instead when step 6 took the Turtle branch):
+
+```markdown
+Spec: specs/<tier>.<type>.<snake_name>.md
+
+- [ ] 1. Graph searched — verdict: exists/extend OR named gap (blocks checked: …)
+- [ ] 2. Ontology shape read (classes and conventions applied)
+- [ ] 3. Principles defined, disambiguated from: …
+- [ ] 4. Benchmarked against: … (adopt/reject decisions stated)
+- [ ] 5. State gate: fired/not fired (States & interaction section: yes/no)
+- [ ] 6. Documentation written to the sync-safe location
+- [ ] 7. Anatomy DSL written via anatomy-author
+- [ ] 8. Token pairing: placeholder (deferred)
+```
+
+## Related skills
+
+- `anatomy-author` — the step-7 engine
+- `specify-pattern` — the same skeleton, context-first, for recurring arrangements
+- `implement-component` — what happens after the spec is approved
+
+## Support
+
+If this skill leads somewhere broken — a command that errors, guidance that
+contradicts what the live system answers, a gap the flow cannot cover — you are not
+stuck:
+
+- Raise an issue in the pragma repo: https://github.com/canonical/pragma/issues —
+  include the skill name, what was run, and expected vs. actual outcome.
+- Or contact the design-system team owners directly through your organization's
+  professional messaging channels for assistance.

--- a/packages/cli/pragma/bundled-skills/specify-pattern/SKILL.md
+++ b/packages/cli/pragma/bundled-skills/specify-pattern/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: specify-pattern
+description: Specify a new design-system pattern from the repeatable user context it serves; also runs as a guided tutorial on a worked example
+---
+
+# Specify Pattern
+
+Create a NEW pattern on the design/spec side. The skeleton is the same eight steps as
+`specify-component`, with the emphasis inverted by the defining principle:
+
+**A pattern is defined by the repeatable USER CONTEXT it serves — the situation, the
+job, the flow it recurs in — more than by the atomicity of the element itself.**
+
+A component earns its place by being a distinct element; a pattern earns its place by a
+situation that keeps coming back and an arrangement that keeps answering it. Every step
+below is aimed at that context.
+
+In a fresh session, orient first:
+
+```bash
+pragma capabilities
+```
+
+## Working mode: assistant to a design authority
+
+Most of the time this skill runs in collaboration with a senior designer or engineer —
+they are the design authority, you are the assistant whose job is to make them
+successful. Default to that mode: lay out the workflow direction step by step, do the
+legwork (graph searches, ontology reads, benchmark research) and return digestible
+findings, and bring each decision to the person as a recommendation plus a question
+rather than a fait accompli. They hold context the graph does not — which situations
+actually recur across products, history, naming precedent — so ask the questions that
+draw that knowledge out; for patterns especially, the recurring CONTEXT often lives in
+the person's experience before it lives in any data.
+
+Full autonomy is the exception, not the default: run the whole flow alone only when
+explicitly asked to. Even then, list every judgment call made unilaterally in the
+final report so a human can revisit them.
+
+Decision gates — in collaboration, pause at each and resolve it WITH the person:
+
+1. The step-1 verdicts: for the pattern AND for each composed component.
+2. Whether the entry IS a pattern (a recurring arrangement, not a component or layout).
+3. The step-3 context definition and composition rule — what is fixed, what varies.
+4. The step-4 adopt/reject decisions from the benchmark.
+5. The step-5 state model spanning the composed components.
+
+## When to Use
+
+- A recurring arrangement of components (a flow, a page region, a repeated pairing)
+  needs a formal specification
+- The same ad-hoc composition keeps being rebuilt across apps and should be named
+
+## When NOT to Use
+
+- Specifying a single element — use `specify-component`
+- Implementing an already-specified block — use `implement-component`
+- Writing only the anatomy — use `anatomy-author`
+
+## Opening move: ask, or offer the tutorial
+
+Activation is an opening, not a starting gun. Unless the first message already names
+the work, ask for the starting point — as a suggestion carrying an example, not as a
+form to fill in:
+
+> To get started, tell me the pattern you'd like to work on — a name if it has one, or
+> just the situation behind it, like "people keep having to confirm before something
+> destructive happens".
+
+The situation is the better of the two starts: this skill defines a pattern by the
+context it serves, so what recurs matters more than what it is called. Ask again only
+for what the next step genuinely blocks on.
+
+If the activation message already carries the starting point, do not re-ask — say what
+you took it to be, and go.
+
+Offer the tutorial in the same breath, because this skill doubles as one:
+
+> Or if you'd rather see the flow first, I can run it as a tutorial: I'll take a
+> plausible example — confirming a destructive action, say — and walk you through the
+> eight steps on it.
+
+Tutorial mode is the step narration below, turned up: the same outcome-path-conclusion
+frame, with the reasoning at each decision gate made fully explicit and a check that
+the person is with you before the next step. Stop short of anything that lands — no spec
+file written, no proposal filed — unless they ask to keep what you built.
+
+## Every step is narrated: outcome, path, conclusion
+
+Every step is addressed to the person — once before it runs, once when it ends. This is
+not tutorial manner. It holds in the ordinary flow too: the person is the design
+authority, and they can only steer a step they saw coming. A decision gate met cold is
+a decision they cannot really make.
+
+**Open** the step with what it is FOR — the outcome it should leave behind — and how
+you are about to get there. **Close** it with a sentence saying what it established and
+what that means for the step after. One sentence each is enough; the failure mode is
+silence, not length, and a step whose outcome looks obvious still gets its sentence
+rather than a shrug.
+
+Do:
+
+> **Step 1 — search the graph, twice.** The outcome is two verdicts: whether a pattern
+> already answers this situation, and whether the components it would compose exist.
+> The path is `pragma block list`, then `block lookup` on the near patterns and on each
+> part.
+>
+> …
+>
+> So: no pattern covers destructive confirmation, and both parts it would compose
+> (`Modal`, `Button`) already exist — the gap is the arrangement, not the pieces, which
+> is exactly what step 2 has to defend.
+
+Don't:
+
+> Step 1 — Search
+>
+> No confirmation pattern. Modal and Button exist.
+
+Both carry the same facts. Only the first says what the step was trying to achieve and
+what it settled — and only the first lets the person cut in with the thing they know
+and the graph does not, which is the whole reason they are here.
+
+## Asked about the skill: methodology and outcomes first
+
+A question about what this skill does — what it covers, what its steps are, how it
+works — is answered in that order: the METHOD it applies and the OUTCOMES it leaves
+the person holding come first, the step-by-step breakdown comes after.
+
+Two or three sentences of method is enough: what the skill treats as its object, the
+discipline that makes it work, and what exists at the end that did not exist before.
+The enumeration then reads as steps in service of something, rather than as a list to
+be got through.
+
+What this prevents is a table of contents standing in for an answer. A reply opening
+with the step names tells someone who already knows the skill nothing new, and someone
+who does not, nothing at all.
+
+So, asked what this skill is:
+
+> It specifies a pattern, and the defining move is that a pattern is defined by the
+> repeatable USER CONTEXT it serves — the situation, the job, the flow it recurs in —
+> more than by the atomicity of the element. Every step is aimed at that context. You
+> end holding a spec that names the situation, fixes what the arrangement holds
+> constant and what it lets vary, and records the judgment calls behind both.
+
+Then, and only then, the breakdown.
+
+## The spec falls under standards too
+
+A pattern spec is Turtle, and Turtle has standards — the `turtle` category, with
+`ui-blocks` governing how blocks and their parts are modelled (take the actual set
+from `pragma standard categories`, not from this list). Pull them before writing and
+hold the Do/Don't pairs open; a spec that contradicts a pulled standard carries a
+RECORDED deviation in the proposal, ideally also filed as an issue. The standards
+apply independent of any package dependency and are open to contribution: a missing
+or wrong modelling rule is something to propose a change for, not to silently work
+around.
+
+## The eight steps
+
+### 1. Search the graph — patterns AND their parts
+
+Search twice: for existing patterns near the candidate, and for the components the
+candidate pattern composes.
+
+```bash
+pragma block list                  # patterns are blocks — the list covers them, with tiers
+pragma block lookup <Name-or-glob> # the closest existing patterns, in full (MCP: block_lookup); a glob repeats a multi-tier name once per IRI and every repeat is the SAME block — the fragment query below lists the tiers
+pragma block sample                # real entry shapes before writing queries
+pragma modifier list               # the modifier families blocks draw from
+pragma tier list                   # the tiers a block can live in
+```
+
+Search by name fragment when the naming is uncertain:
+
+```bash
+pragma graph query "SELECT ?b ?name WHERE { ?b ds:name ?name . FILTER(CONTAINS(LCASE(?name), 'nav')) }"
+```
+
+Then look up EACH component the candidate arrangement composes
+(`pragma block lookup <Name>` per component) — a pattern spec over parts the system does
+not cover is really a component gap plus a pattern gap; name both.
+
+> The covered set is whatever the graph answers today. Query it live — never copy its
+> output into documentation, PRs, or this skill.
+
+Outcome gate: **either "exists — stop or extend it" or a NAMED gap**, for the pattern
+and for each composed component.
+
+### 2. Understand the ontology
+
+Same read as specify-component:
+
+```bash
+pragma ontology lookup ds
+pragma ontology lookup ds --class UIBlock    # the block-level properties every entry carries
+pragma ontology lookup ds --class Pattern    # what Pattern itself declares
+```
+
+`--class` shows only what a class declares itself — Pattern declares nothing of its
+own today; usage, guidelines, properties, and tier come from `ds:UIBlock`, and
+`summary`/`name` from `ds:Entity`, further up the chain (`--class Entity`).
+
+The entry follows the documented conventions — `ds:summary`; `ds:usage` with
+`### When to use` / `### When not to use`; `ds:guidelines` with Accessibility as a
+convention; `ds:hasProperty`; modifier families; tier — and `pragma block sample`
+overrules this list wherever real entries differ. The draw is RANDOM and many blocks are near-empty, so a sample can come back content-free and teach you nothing: re-run it until it lands on a filled entry, or inspect a block you already know is documented. Each field's acceptance criteria
+are on the property itself: `pragma graph inspect ds:usage` / `ds:guidelines` print
+the `ds:acceptanceCriteria` the content must satisfy. Read the category definitions
+too — `pragma ontology lookup ds` above lists every `ds:UIBlock` subclass; read what each one means with `pragma graph inspect ds:<Subclass>`
+(each prints its `skos:definition`) — and confirm the entry IS a pattern — a recurring
+arrangement, not a single element or a space-dividing layout — BEFORE writing.
+
+### 3. Define the context and the composition rule
+
+The main definition names the RECURRING CONTEXT, not just the shape:
+
+- When does this arrangement apply — the situation, the job, the flow it recurs in
+- Which components does it orchestrate
+- What varies per use, and what is fixed (the composition rule)
+
+Disambiguate from the step-1 neighbors explicitly ("unlike X, this …") — for a pattern
+that includes naming the contexts the neighbors serve.
+
+### 4. Research & benchmark pattern catalogs
+
+Benchmark against the pattern sections of other systems — React Aria, Carbon, Material,
+shadcn (list extensible): how they frame the same context, what they compose, the
+accessibility pattern, the naming, the state model. Output: a short comparison table
+plus what pragma adopts, what it rejects, and why.
+
+### 5. State-complexity gate — expect it to fire
+
+Patterns orchestrate state ACROSS components, so this gate fires more often than for a
+single component: selection flowing between parts, async steps, wizard-like progressions.
+
+When it fires, write the **"States & interaction"** section inside the guidelines
+content of the spec, same as specify-component: states, events and transitions, initial
+state, error states, keyboard interactions per state — here spanning the composed
+components, not just one.
+
+### 6. Write the documentation (without the anatomy)
+
+Markdown or Turtle following the step-2 structure; category = pattern.
+
+**Output location (hard rule)**: a standalone spec file the sync cannot destroy.
+
+- In canonical/design-system: `specs/<tier>.pattern.<snake_name>.{md,ttl}`
+- In any other repo: that repo's design-docs location
+
+NEVER write into design-system `data/` — it is regenerated destructively from Coda by
+CI, and hand edits are overwritten by the next sync. Database entry is a separate,
+currently-human step: a person pastes the spec content into Coda.
+
+### 7. Write the anatomy DSL — where the skeleton is stable
+
+Where the pattern has a stable structural skeleton, write its anatomy via the
+`anatomy-author` skill (`pragma skill lookup anatomy-author`). A pattern whose whole
+point is a varying arrangement may carry only the invariant frame; say which parts are
+anatomy and which are composition rule. The produced DSL lands in the step-6 spec file
+under `specs/` — in a `.md` spec as its anatomy section, in a `.ttl` spec as the
+block's `ds:anatomyDsl` string literal — never under `data/`; entry into Coda stays
+the human step.
+
+### 8. Pair with tokens — placeholder
+
+**Left blank for now** — token pairing content lands with the token work. Do not invent
+token guidance.
+
+## Response format
+
+Report the spec-file path, then the eight step outcomes as a checklist (pattern AND
+composed components named in step 1; the composition rule stated in step 3).
+
+## Related skills
+
+- `specify-component` — the sibling flow for single elements (and for component gaps
+  step 1 uncovers)
+- `anatomy-author` — the step-7 engine
+- `implement-component` — after the spec is approved
+
+## Support
+
+If this skill leads somewhere broken — a command that errors, guidance that
+contradicts what the live system answers, a gap the flow cannot cover — you are not
+stuck:
+
+- Raise an issue in the pragma repo: https://github.com/canonical/pragma/issues —
+  include the skill name, what was run, and expected vs. actual outcome.
+- Or contact the design-system team owners directly through your organization's
+  professional messaging channels for assistance.

--- a/packages/cli/pragma/package.json
+++ b/packages/cli/pragma/package.json
@@ -11,7 +11,8 @@
   "files": [
     "src",
     "dist",
-    "pragma.conf.ts"
+    "pragma.conf.ts",
+    "bundled-skills"
   ],
   "author": {
     "email": "webteam@canonical.com",

--- a/packages/cli/pragma/scripts/bundle.ts
+++ b/packages/cli/pragma/scripts/bundle.ts
@@ -1,5 +1,5 @@
 /**
- * Compile the embedded pack from `pragma.conf.ts`.
+ * Compile the embedded pack — and the bundled skills — from `pragma.conf.ts`.
  *
  * Resolves the distribution's own declared packs through the PRODUCT's pipeline
  * (`parsePackDeclaration` → `resolvePackage` → `buildPack`, with `sources
@@ -21,6 +21,19 @@
  * on every test run), and deleting `pack.generated.ts` forces a full
  * regeneration.
  *
+ * THE SAME RESOLUTION ALSO SHIPS THE PACKS' SKILLS. Every pack this script
+ * clones has its `skills/<name>/SKILL.md` on disk at the moment the graph is
+ * read out of it, and until now that was thrown away with the throwaway cache:
+ * a fresh install answered `block lookup` offline and listed ZERO skills.
+ * {@link writeBundledSkills} copies them into the committed `bundled-skills/`
+ * directory at the package root — the skills half of the snapshot the graph
+ * already had. It runs OUTSIDE the unchanged-skip below, for two reasons: a
+ * directory copy IS byte-reproducible (unlike the n-quads), so re-running
+ * against unchanged upstream still produces a zero diff without a skip; and the
+ * manifest's `contentHash` covers the resolved TTL inputs ONLY, so a pack that
+ * edits a SKILL.md and no `.ttl` is invisible to it — skipping on that hash
+ * would silently ship the previous release's skills forever.
+ *
  * Needs the network (a shallow clone per git pack), so it is NOT part of
  * `build` / `build:all`: a PR build must not clone three repositories, and the
  * artifacts are committed. It runs in exactly two places — a maintainer's
@@ -32,14 +45,17 @@
  */
 
 import {
+  cpSync,
   existsSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildPackPrefixes } from "../src/capabilities/sources/runUpdate.js";
 import { VERSION } from "../src/constants.js";
@@ -106,9 +122,121 @@ const indexOutPath = join(embeddedDir, "pack.index.generated.ts");
 // putting them in `pack.generated.ts` would load its ~1.9 MB of n-quads with
 // them (a measured +28 ms on every invocation).
 const storiesOutPath = join(embeddedDir, "pack.stories.generated.ts");
+/**
+ * The committed skills snapshot, at the PACKAGE ROOT (not `dist/`, not `src/`).
+ *
+ * `dist/` is wrong because nothing committed produces it: `bundle` is a
+ * release-time step deliberately outside `build`, so an artifact only `bundle`
+ * writes has to live where git holds it — exactly as `pack.generated.ts` does.
+ * `src/` is wrong because `tsc` copies no non-TS file into `dist/`, and because
+ * biome's include list covers everything under `src`, which would start linting
+ * whatever JSON an upstream skill happens to ship. The package root is the same place a design-system
+ * pack puts its own `skills/`, which is the layout this is a snapshot OF.
+ * `package.json`'s `files` allowlists the directory by name.
+ */
+const skillsOutDir = join(packageRoot, "bundled-skills");
 
 const entryName = (entry: PackDeclaration): string =>
   typeof entry === "string" ? entry : entry.name;
+
+/**
+ * A package's skill folders: immediate children of `<root>/skills` that hold a
+ * `SKILL.md`, sorted so the copy order is deterministic.
+ *
+ * `statSync`, not `lstatSync`, and it is the same call
+ * `capabilities/sources/installSkills.ts` makes for the same reason: a package
+ * that ships `skills/<name>` as a SYMLINK (the ordinary pnpm / monorepo /
+ * `file:` layout) contributed nothing at all, silently, under `lstat`.
+ */
+function packageSkillDirs(root: string): string[] {
+  const skillsDir = join(root, "skills");
+  let names: string[];
+  try {
+    names = readdirSync(skillsDir);
+  } catch {
+    return []; // No `skills/` dir — a pack that ships none.
+  }
+  return names
+    .sort()
+    .map((name) => join(skillsDir, name))
+    .filter((dir) => {
+      try {
+        return statSync(dir).isDirectory() && existsSync(join(dir, "SKILL.md"));
+      } catch {
+        return false; // Unreadable entry — skip, as discovery does.
+      }
+    });
+}
+
+/** Total bytes of a directory tree, for the packaging figure this logs. */
+function treeBytes(dir: string): number {
+  let total = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    total += entry.isDirectory() ? treeBytes(path) : statSync(path).size;
+  }
+  return total;
+}
+
+/**
+ * Copy every resolved pack's `skills/*` into the committed `bundled-skills/`
+ * root, replacing whatever was there.
+ *
+ * ALL FOUR DECLARED PACKS contribute, for the same reason the graph snapshot
+ * takes all four: the packs are the distribution's declared content, and a
+ * subset would mean the shipped skills and the shipped graph disagreed about
+ * which packs this release is. (`@canonical/anatomy-dsl` resolves through
+ * {@link SOURCE_OVERRIDES} from `node_modules` here, so its skills — if it ever
+ * ships any — come from the npm tarball rather than the git ref, the identical
+ * caveat the manifest's `sourceRef` already records for its triples.)
+ *
+ * COPIED, not linked: the artifact is committed and published in a tarball, and
+ * neither git nor npm can carry a link into a build machine's ref cache.
+ *
+ * The whole directory is REMOVED first, which is what retires a skill a pack has
+ * since dropped — the copy pass walks the packages and so can only ever visit a
+ * skill that still exists, the same blind spot `planStaleLinkPrunes` exists to
+ * cover at run time. Rewriting rather than patching is safe here precisely
+ * because a file copy is byte-reproducible: unchanged upstream ⇒ zero git diff.
+ *
+ * @param packs - The resolved packages, in declaration order.
+ * @returns The folder names copied, and the total bytes written.
+ * @throws When the packs yielded no skills at all — shipping none is the defect
+ *   this artifact exists to fix, so it fails loudly rather than committing an
+ *   empty directory that would look like a working snapshot.
+ * @note Impure — deletes and rewrites `bundled-skills/`.
+ */
+function writeBundledSkills(packs: readonly { name: string; root: string }[]): {
+  folders: string[];
+  bytes: number;
+} {
+  rmSync(skillsOutDir, { recursive: true, force: true });
+  const seen = new Set<string>();
+  for (const pkg of packs) {
+    for (const dir of packageSkillDirs(pkg.root)) {
+      const folder = basename(dir);
+      // First-seen wins on a folder-name clash across packs — the SAME rule
+      // `planSkillInstall` applies when installing them for real, so the
+      // snapshot cannot disagree with what a `sources update` would produce.
+      if (seen.has(folder)) continue;
+      seen.add(folder);
+      // `dereference`: a pack whose `skills/<name>` (or a file beneath it) is a
+      // symlink must contribute its CONTENT, never a link that resolves only on
+      // the build machine.
+      cpSync(dir, join(skillsOutDir, folder), {
+        recursive: true,
+        dereference: true,
+      });
+    }
+  }
+  const folders = [...seen].sort();
+  if (folders.length === 0) {
+    throw new Error(
+      `The ${packs.length} resolved pack(s) provided 0 skills — refusing to commit an empty bundled-skills/ snapshot.`,
+    );
+  }
+  return { folders, bytes: treeBytes(skillsOutDir) };
+}
 
 /** The committed embed's manifest JSON, or `undefined` when there is none. */
 async function readCommittedManifest(): Promise<string | undefined> {
@@ -238,6 +366,14 @@ export const manifestJson = ${JSON.stringify(read(MANIFEST_FILE))};
       body: `export const storiesJson = ${JSON.stringify(read(STORIES_FILE))};\n`,
     },
   ];
+
+  // Unconditional, and deliberately ahead of the unchanged-skip: see the module
+  // docblock — the manifest hash cannot see a skills-only upstream change, and a
+  // file copy needs no skip to stay diff-free.
+  const skills = writeBundledSkills(resolved);
+  console.log(
+    `Bundled ${skills.folders.length} skill(s) → bundled-skills/ (${(skills.bytes / 1024).toFixed(1)} KiB): ${skills.folders.join(", ")}`,
+  );
 
   const committed = await readCommittedManifest();
   const unchanged =

--- a/packages/cli/pragma/scripts/bundle.ts
+++ b/packages/cli/pragma/scripts/bundle.ts
@@ -50,12 +50,13 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, isAbsolute, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildPackPrefixes } from "../src/capabilities/sources/runUpdate.js";
 import { VERSION } from "../src/constants.js";
@@ -206,6 +207,55 @@ function treeBytes(dir: string): number {
  *   empty directory that would look like a working snapshot.
  * @note Impure — deletes and rewrites `bundled-skills/`.
  */
+/**
+ * Fail unless every symlink beneath `dir` resolves inside the pack.
+ *
+ * Walked with `lstat` so the check sees links rather than their targets, and
+ * compared on REAL paths so neither a symlinked pack root nor `..` in a target
+ * can walk out unnoticed. A broken link fails too — it cannot be shown to be
+ * contained, and `cpSync` with `dereference` would throw on it regardless.
+ *
+ * @param dir - The skill directory being copied, absolute.
+ * @param packRoot - The pack's root; nothing may resolve outside it.
+ * @param packName - Named in the error, so the offending pack is obvious.
+ * @throws When any entry beneath `dir` escapes `packRoot`.
+ * @note Impure — walks and `realpath`s the real filesystem.
+ */
+function assertContainedSymlinks(
+  dir: string,
+  packRoot: string,
+  packName: string,
+): void {
+  const root = realpathSync(packRoot);
+  const contained = (real: string): boolean => {
+    const rel = relative(root, real);
+    return rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+  };
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const child = join(current, entry.name);
+      if (entry.isSymbolicLink()) {
+        let real: string;
+        try {
+          real = realpathSync(child);
+        } catch {
+          throw new Error(
+            `${packName}: ${child} is a broken symlink — refusing to bundle it.`,
+          );
+        }
+        if (!contained(real)) {
+          throw new Error(
+            `${packName}: ${child} resolves to ${real}, outside the pack — refusing to bundle it.`,
+          );
+        }
+        continue;
+      }
+      if (entry.isDirectory()) walk(child);
+    }
+  };
+  walk(dir);
+}
+
 function writeBundledSkills(packs: readonly { name: string; root: string }[]): {
   folders: string[];
   bytes: number;
@@ -222,7 +272,13 @@ function writeBundledSkills(packs: readonly { name: string; root: string }[]): {
       seen.add(folder);
       // `dereference`: a pack whose `skills/<name>` (or a file beneath it) is a
       // symlink must contribute its CONTENT, never a link that resolves only on
-      // the build machine.
+      // the build machine. But dereferencing follows a link ANYWHERE, so an
+      // entry pointing outside the pack would copy a release-host file into a
+      // committed, published artifact — a symlink to a credential file becomes
+      // its contents. Every link is checked against the pack's real root first,
+      // and an escaping one FAILS the bundle rather than being skipped: a
+      // silently dropped file would ship an incomplete skill that looks whole.
+      assertContainedSymlinks(dir, pkg.root, pkg.name);
       cpSync(dir, join(skillsOutDir, folder), {
         recursive: true,
         dereference: true,

--- a/packages/cli/pragma/src/capabilities/doctor/checks/targetHealth.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/targetHealth.ts
@@ -202,6 +202,22 @@ function skillsHealth(
   // and reporting the two the same way made this row say "links current" where
   // no link exists at all. Setup will never clear such a path — it is not this
   // command's to delete — so the row carries the only remedy that settles it.
+  // A symlink pointing outside every root pragma owns is `skipped` so setup
+  // will never delete it — which would make this row claim "links current" over
+  // a path where the user's own link shadows a shipped skill. `skipped` also
+  // covers an already-correct link (owned) and a real directory (blocked), so
+  // the foreign case is what is left.
+  const foreign = d.actions.filter(
+    (a) => a.action === "skipped" && !a.owned && !a.blocked,
+  ).length;
+  if (foreign > 0) {
+    return {
+      status: "available",
+      detail: `${foreign} of ${d.actions.length} link paths hold a symlink pragma does not own`,
+      remedy:
+        "Move or delete the symlink at that path, then link the skills again.",
+    };
+  }
   const blocked = d.actions.filter((a) => a.blocked).length;
   if (blocked > 0) {
     return {

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
@@ -5,9 +5,14 @@
  * the two always match.
  *
  * - global (the default): INSTALLED skills (`$XDG_DATA_HOME/<bin>/skills`, where
- *   `sources update` puts package skills) link into user-level harness skill
- *   directories — the cross-client `~/.agents/skills`, plus the user-level
+ *   `sources update` puts package skills) AND the BUNDLED snapshot this package
+ *   ships (`bundled-skills/`, last in precedence) link into user-level harness
+ *   skill directories — the cross-client `~/.agents/skills`, plus the user-level
  *   directory of each detected harness whose user-level location is verified.
+ *   The global band is therefore a root SET, and every rule below that used to
+ *   read one `sourceRoot` ranges over it: what a skill resolves to (first-seen
+ *   wins, so an installed skill beats the shipped copy), what this command
+ *   OWNS, and what its stale sweep is entitled to touch.
  * - project (`--local`): PROJECT skills (`<cwd>/.<bin>/skills`) link into the
  *   project's harness directories — the checked-in, team-shared arrangement.
  *
@@ -15,6 +20,29 @@
  * repository's directories leaks machine state into a checkout, and linking a
  * repository's skills into the home directory applies one project's skills
  * machine-wide. Neither is ever what the user asked for.
+ *
+ * A BUNDLED SKILL IS LINKED, NOT COPIED, and that is a decision about who owns
+ * the target directory. Every other link this command writes points into a
+ * directory pragma controls (`$XDG_DATA_HOME/<bin>/skills`, or the user's own
+ * repository); a bundled one points into the package directory, which the
+ * PACKAGE MANAGER owns and may move or delete without telling us — a pnpm or
+ * npx layout puts the version in the path, so an upgrade leaves the link
+ * dangling. Copying would avoid that and cost more than it saves: `linkState`
+ * classifies a real directory as `other`, and this module treats `other` as
+ * hand-placed and never touches it. So a copied skill could never be updated,
+ * never be retired, and never be removed by `--undo` — pragma would be writing
+ * permanent, silently stale directories into `~/.claude/skills`.
+ *
+ * A dangling link, by contrast, the reconcile ALREADY repairs, and this was
+ * checked rather than assumed: `detectSkills` classifies a link that does not
+ * resolve to the current skill as `replaced` (delete + relink) whatever it
+ * points at, so the next `setup skills` — or the layer-2 pass `sources update`
+ * runs — moves it onto the new package directory. The one thing that had to
+ * change is ownership: `withinRoot` against the installed root alone read a
+ * bundled-pointing link as somebody else's and skipped it, so the sweep and the
+ * relink both range over the root SET now ({@link withinAnyRoot}). The residual
+ * window is between an upgrade and the next reconcile, which is the same window
+ * a `sources update` link into a cleared ref cache already has.
  *
  * Split into `detectSkills` (discovery, harness detection, and the per-link
  * create/skip/replace DECISION, all against the real filesystem up front, so
@@ -85,11 +113,24 @@ export interface SymlinkAction {
  */
 export interface SkillsDetection {
   readonly band: ScopeBand;
-  /** The band's source root — the directory skills are discovered from. */
+  /**
+   * The band's source roots, in PRECEDENCE order — the directories skills are
+   * discovered from, and the set every ownership test ranges over. One entry
+   * for the project band; installed-then-bundled for the global one.
+   */
+  readonly sourceRoots: readonly string[];
+  /**
+   * The band's PRIMARY source root — `sourceRoots[0]`, and the one the skip
+   * reason and the doctor row name. It is the root a user can DO something
+   * about: the project directory they fill by hand, or the installed root
+   * `sources update` writes. Naming the bundled snapshot instead would point
+   * them at a directory inside their node_modules that they must never edit.
+   */
   readonly sourceRoot: string;
   /**
-   * Whether the source root EXISTS on disk — deliberately NOT the same question
-   * as {@link available}, which asks only whether the root holds a skill.
+   * Whether ANY of {@link sourceRoots} exists on disk — deliberately NOT the
+   * same question as {@link available}, which asks only whether they hold a
+   * skill.
    *
    * The two were one flag, and conflating them is a wipe hazard. A run where
    * `XDG_DATA_HOME` points somewhere else, or where `sources update` has never
@@ -154,6 +195,29 @@ export function withinRoot(
     !rel.startsWith(`..${sep}`) &&
     !isAbsolute(rel)
   );
+}
+
+/**
+ * Whether a link's destination lives inside ANY of the band's skill roots.
+ *
+ * The band ownership test, once the global band stopped being a single
+ * directory. Every caller that used to ask {@link withinRoot} about one path
+ * asks this about the set, so a link into the bundled snapshot is as much this
+ * command's to maintain as one into the installed root — and a link into
+ * neither is still nobody's business but the user's.
+ *
+ * @param roots - The band's skill source roots, absolute.
+ * @param linkPath - The absolute path of the link being classified.
+ * @param rawTarget - The link's destination exactly as `readlink` reported it.
+ * @returns Whether the destination is a path under one of the roots.
+ * @note Pure — {@link withinRoot} reads nothing, and neither does this.
+ */
+export function withinAnyRoot(
+  roots: readonly string[],
+  linkPath: string,
+  rawTarget: string,
+): boolean {
+  return roots.some((root) => withinRoot(root, linkPath, rawTarget));
 }
 
 /**
@@ -293,20 +357,28 @@ function rootIsPresent(root: string): boolean {
  * target is gone; the root's own existence is the separate question of whether
  * this command is entitled to answer at all.
  *
+ * THE GATE IS PER ROOT, not per band. A band with two roots must not let one
+ * of them vouch for the other: if the installed root is deleted (or
+ * `XDG_DATA_HOME` points elsewhere for one invocation) while the bundled
+ * snapshot — which ships inside the package and so is essentially always there
+ * — still exists, a band-wide "some root exists" gate would hand the sweep every
+ * link into the vanished root and call it stale. So `existingRoots` is passed
+ * already filtered, and a link is orphanable only when the root it points into
+ * is one of them.
+ *
  * @param targets - The band's link directories.
- * @param sourceRoot - The band's skill source root.
- * @param rootExists - Whether that root exists (false ⇒ no orphans at all).
+ * @param existingRoots - The band's source roots that EXIST (empty ⇒ no
+ *   orphans at all).
  * @param covered - Link paths the per-skill pass already decided.
  * @returns The owned links no current skill accounts for.
  * @note Impure — reads each target directory and lstats its entries.
  */
 function orphanedLinks(
   targets: readonly { dir: string; name: string }[],
-  sourceRoot: string,
-  rootExists: boolean,
+  existingRoots: readonly string[],
   covered: ReadonlySet<string>,
 ): SymlinkAction[] {
-  if (!rootExists) return [];
+  if (existingRoots.length === 0) return [];
   const orphans: SymlinkAction[] = [];
   for (const { dir, name } of targets) {
     let entries: string[];
@@ -320,7 +392,7 @@ function orphanedLinks(
       if (covered.has(linkPath)) continue;
       const state = linkState(linkPath);
       if (state.kind !== "symlink") continue;
-      if (!withinRoot(sourceRoot, linkPath, state.target)) continue;
+      if (!withinAnyRoot(existingRoots, linkPath, state.target)) continue;
       orphans.push({
         skillName: entry,
         target: resolve(dirname(linkPath), state.target),
@@ -354,7 +426,7 @@ export async function detectSkills(
 ): Promise<SkillsDetection> {
   const cwd = rt.cwd;
   const [
-    { discoverSkillsFrom, installedSkillsDir, projectSkillsDir },
+    { discoverSkillsFrom, globalSkillRoots, projectSkillsDir },
     { detectHarnesses, readPlatformEnv, userHome },
     { runTask },
   ] = await Promise.all([
@@ -363,11 +435,18 @@ export async function detectSkills(
     import("@canonical/task/node"),
   ]);
 
-  const sourceRoot =
-    band === "project" ? projectSkillsDir(cwd) : installedSkillsDir();
+  // The band picks the root SET; `globalSkillRoots` owns the global band's
+  // order (installed, then bundled) so this module and `sources update` cannot
+  // drift on which directories the band is.
+  const sourceRoots =
+    band === "project" ? [projectSkillsDir(cwd)] : globalSkillRoots();
+  const sourceRoot = sourceRoots[0] as string;
   const linkRoot = band === "project" ? cwd : userHome(readPlatformEnv());
-  const skills = discoverSkillsFrom([sourceRoot]);
-  const rootExists = rootIsPresent(sourceRoot);
+  // First-seen wins, so an installed skill shadows the bundled copy of the same
+  // name: someone who ran `sources update` links the CURRENT skill.
+  const skills = discoverSkillsFrom(sourceRoots);
+  const existingRoots = sourceRoots.filter(rootIsPresent);
+  const rootExists = existingRoots.length > 0;
   const detected = await runTask(detectHarnesses(cwd));
   const targets = linkTargets(detected, band, linkRoot);
 
@@ -405,7 +484,7 @@ export async function detectSkills(
         blocked: state.kind === "other",
         owned:
           state.kind === "symlink" &&
-          withinRoot(sourceRoot, linkPath, state.target),
+          withinAnyRoot(sourceRoots, linkPath, state.target),
       });
     }
   }
@@ -418,15 +497,19 @@ export async function detectSkills(
 
   return {
     band,
+    sourceRoots,
     sourceRoot,
     rootExists,
     available: skills.length > 0,
     targets,
     actions,
+    // Ownership above spans EVERY root (a pure string test that reads nothing,
+    // so it still answers after a target is gone); the sweep below spans only
+    // the roots that EXIST. Those are two different questions and the split is
+    // deliberate — see {@link orphanedLinks}.
     orphans: orphanedLinks(
       targets,
-      sourceRoot,
-      rootExists,
+      existingRoots,
       new Set(actions.map((a) => a.linkPath)),
     ),
     skillCount: skills.length,

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
@@ -50,7 +50,13 @@
  * only the symlink/delete effects the dry-run interpreter mocks.
  */
 
-import { lstatSync, readdirSync, readlinkSync, statSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readlinkSync,
+  statSync,
+} from "node:fs";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import {
   deleteFile,
@@ -218,6 +224,50 @@ export function withinAnyRoot(
   rawTarget: string,
 ): boolean {
   return roots.some((root) => withinRoot(root, linkPath, rawTarget));
+}
+
+/**
+ * The directory a release's bundled skills live in, inside the package.
+ *
+ * Named here because it is the ONE shape that identifies a link as pragma's
+ * without asking where the package currently sits.
+ */
+const BUNDLED_DIR_SEGMENT = "bundled-skills";
+
+/**
+ * Whether this link is pragma's to rewrite or remove.
+ *
+ * Residence in a current root is not sufficient, in EITHER direction.
+ *
+ * Too narrow: after an upgrade under a version-stamped layout (pnpm, npx,
+ * volta) a link points into `…/pragma-cli@0.34.0/bundled-skills/<name>`, a
+ * directory that no longer exists and is inside no current root. Ownership by
+ * residence alone reads pragma's own link as somebody else's, so the sweep
+ * declines it and the per-skill pass cannot reach it once the skill is gone —
+ * the dangling link then survives every reconcile, invisible to setup and to
+ * doctor. The path SHAPE still says whose it is.
+ *
+ * Too wide: the bundled root is present on every install now, so a folder name
+ * that collides with a bundled skill is reachable with no user action at all.
+ * A user's own `~/.claude/skills/design-auditor -> ~/work/design-auditor`
+ * must not become this command's to delete just because a bundled skill shares
+ * its name. That is the same rule a hand-placed real directory already gets.
+ *
+ * @param roots - The band's source roots.
+ * @param linkPath - The link's own path, absolute.
+ * @param rawTarget - Its unresolved `readlink` value.
+ * @returns Whether pragma created this link.
+ * @note Pure — resolves strings, reads nothing.
+ */
+function ownsLink(
+  roots: readonly string[],
+  linkPath: string,
+  rawTarget: string,
+): boolean {
+  if (withinAnyRoot(roots, linkPath, rawTarget)) return true;
+  return resolve(dirname(linkPath), rawTarget)
+    .split(sep)
+    .includes(BUNDLED_DIR_SEGMENT);
 }
 
 /**
@@ -392,7 +442,11 @@ function orphanedLinks(
       if (covered.has(linkPath)) continue;
       const state = linkState(linkPath);
       if (state.kind !== "symlink") continue;
-      if (!withinAnyRoot(existingRoots, linkPath, state.target)) continue;
+      // `ownsLink`, not `withinAnyRoot`: a link into a REMOVED version-stamped
+      // package directory is inside no current root, and once its skill is gone
+      // from the release no per-skill action covers the path either. Residence
+      // alone would leave it dangling forever.
+      if (!ownsLink(existingRoots, linkPath, state.target)) continue;
       orphans.push({
         skillName: entry,
         target: resolve(dirname(linkPath), state.target),
@@ -467,12 +521,32 @@ export async function detectSkills(
       const resolvesToSkill =
         state.kind === "symlink" &&
         resolve(dirname(linkPath), state.target) === skill.sourcePath;
+      const owned =
+        state.kind === "symlink" &&
+        ownsLink(sourceRoots, linkPath, state.target);
+      // A link is FOREIGN when it resolves to something real that pragma does
+      // not own — a user's own `~/.claude/skills/design-auditor ->
+      // ~/work/design-auditor`. That is `skipped`, the same answer a
+      // hand-placed real directory gets: `composeSkills` composes every
+      // non-skipped row, so calling it `replaced` would delete the link. The
+      // bundled root is on every install now, so a name collision with a
+      // shipped skill is reachable with no user action at all.
+      //
+      // A DANGLING link is replaced regardless of where it pointed. Nothing
+      // depends on a broken link, so deleting it destroys nothing — while
+      // leaving it blocks the skill forever and, for pragma's own link into a
+      // cleared cache or a replaced package directory, is the repair. An
+      // unresolvable target cannot vouch for its owner either way.
+      const foreign =
+        state.kind === "symlink" &&
+        !owned &&
+        existsSync(resolve(dirname(linkPath), state.target));
       const action: SymlinkAction["action"] =
         state.kind === "absent"
           ? "created"
           : resolvesToSkill
             ? "skipped"
-            : state.kind === "symlink"
+            : state.kind === "symlink" && !foreign
               ? "replaced"
               : "skipped";
       actions.push({
@@ -482,9 +556,7 @@ export async function detectSkills(
         action,
         harnessName: name,
         blocked: state.kind === "other",
-        owned:
-          state.kind === "symlink" &&
-          withinAnyRoot(sourceRoots, linkPath, state.target),
+        owned,
       });
     }
   }

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -26,7 +26,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, relative } from "node:path";
+import { join, relative, sep } from "node:path";
 import { execute } from "@canonical/summon-core";
 import { collectUndos, dryRun, type Effect, type Task } from "@canonical/task";
 import { runTask, runUndo } from "@canonical/task/node";
@@ -48,6 +48,8 @@ import {
   composeSkillsRemoval,
   detectSkills,
   ownedSkillLinks,
+  skillsSkipReason,
+  skillsSkipRemedy,
 } from "./operations/setupSkills.js";
 import { DRY_RUN_HINT, PREVIEW_HINT } from "./setup.render.js";
 import { setupModule } from "./setup.verb.js";
@@ -883,8 +885,15 @@ describe("setup (run-all wizard) — scope threading", () => {
       // prefix repeated on every line.
       expect(plan).toMatch(new RegExp(`completions\\s+install\\s+${SHELL} →`));
       expect(plan).toContain("lsp");
-      // The project-band skills step is gone (the bug: it used to run under --global).
-      expect(plan).not.toContain(".agents/skills");
+      // The project-band skills step is gone (the bug: it used to run under
+      // --global). `shortenPath` renders a project path as `./…` and a global
+      // one as `~/…`, and the two bands' cross-client directories differ only
+      // by that marker — so the covenant is asserted on the PROJECT spelling.
+      // A bare "not .agents/skills" no longer separates them: the global band
+      // legitimately links its own `~/.agents/skills` now that the bundled
+      // snapshot gives it skills on a machine that has run nothing.
+      expect(plan).not.toContain(`.${sep}.agents${sep}skills`);
+      expect(plan).toContain(`~${sep}.agents${sep}skills`);
     },
   );
 });
@@ -942,10 +951,14 @@ describe("setup skills", () => {
     expect(row?.reason).toContain("does not exist");
   });
 
-  it("the GLOBAL skip names `sources update`, the command that fills its root", async () => {
-    // Skills ship in the configured packages, not in this CLI, and the global
-    // band's source root is written only by `sources update`. Saying "no skills
-    // installed" and stopping there left the user with no next step at all.
+  it("the GLOBAL band OFFERS skills on a machine that has run nothing", async () => {
+    // THE BEHAVIOUR CHANGE, asserted at the band that used to be empty. The
+    // global band's only source was the installed root, so an empty
+    // `XDG_DATA_HOME` — a fresh install — planned `skip` and told the user to
+    // go and run `sources update` first. The bundled snapshot is the band's
+    // second root, so the row is actionable with no network and no prior
+    // command. The empty-root WORDING this replaces is still asserted, on the
+    // pure reason/remedy pair, in the cell below.
     const prevData = process.env.XDG_DATA_HOME;
     process.env.XDG_DATA_HOME = tmp("pragma-skills-data-");
     try {
@@ -955,17 +968,11 @@ describe("setup skills", () => {
         "global",
       );
       const row = plan.rows.find((r) => r.target === "skills");
-      expect(row?.action).toBe("skip");
-      expect(row?.reason).toBe(
-        "nothing to link — no skills installed yet; they arrive with the packs `pragma sources update` builds",
-      );
+      expect(row?.action).toBe("link");
+      expect(row?.detail).toMatch(/\d+ skills? →/);
 
-      // BOTH assertions belong inside the jail. The end-to-end invocation is
-      // asserting the SAME empty-global-root condition, so it has to read the
-      // empty root this test established — restoring `XDG_DATA_HOME` first
-      // handed it back to whatever the ambient environment points at, and an
-      // ambient root that happens to hold a skill stops exercising the skip.
-      // A skip stays exit 0 — and the recap carries the remedy beneath the row.
+      // End to end, inside the same jail (an ambient data root that happened to
+      // hold a skill would stop this exercising the fresh-machine condition).
       const outcome = await executeVerb(
         verbOf("skills"),
         {},
@@ -973,8 +980,7 @@ describe("setup skills", () => {
         bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
       );
       expect(outcome.exitCode).toBe(0);
-      expect(outcome.stdout).toContain("no skills installed yet");
-      expect(outcome.stdout).toContain(`${BIN_NAME} sources update`);
+      expect(outcome.stdout).not.toContain("no skills installed");
     } finally {
       // `process.env.X = undefined` STORES THE STRING "undefined"; it does not
       // unset. The variable is always set here (`setupXdgIsolation.ts` gives
@@ -984,6 +990,24 @@ describe("setup skills", () => {
       if (prevData === undefined) delete process.env.XDG_DATA_HOME;
       else process.env.XDG_DATA_HOME = prevData;
     }
+  });
+
+  it("the GLOBAL skip still names `sources update` when it does happen", async () => {
+    // The remedy the cell above used to assert end-to-end. That state is no
+    // longer reachable with a snapshot in the package — it takes a build whose
+    // `bundled-skills/` is missing AND an empty installed root — so it is
+    // asserted where it actually lives: on the pure pair that both the setup row
+    // and the doctor row read, which is what stops the two surfaces wording one
+    // finding differently. A skip with no next step is the defect.
+    expect(
+      skillsSkipReason("~/.local/share/pragma/skills", "global", true),
+    ).toBe(
+      "nothing to link — no skills installed yet; they arrive with the packs " +
+        `\`${BIN_NAME} sources update\` builds`,
+    );
+    expect(
+      skillsSkipRemedy("~/.local/share/pragma/skills", "global"),
+    ).toContain(`${BIN_NAME} sources update`);
   });
 
   it("detects a created action and composes a symlink carrying an undo", async () => {
@@ -1825,11 +1849,17 @@ describe("setup (run-all wizard)", () => {
   });
 
   it("omits skills gracefully when none are discovered (no mid-wizard EMPTY_RESULTS)", async () => {
-    // A run-all in a project with no skills must NOT throw — it just doesn't
-    // offer the skills step. Reaching a clean plan proves the graceful degrade.
+    // A run-all in a band with no skills must NOT throw — it just doesn't offer
+    // the skills step. Reaching a clean plan proves the graceful degrade.
+    //
+    // POINTED AT THE PROJECT BAND, which is where an empty skills root is still
+    // an ordinary condition: the global band now always has the bundled
+    // snapshot behind it, so a run-all there can no longer produce the empty
+    // row this cell exists to survive. The condition is the same one; only the
+    // band that can still reach it has changed.
     const outcome = await executeVerb(
       setupSelfVerb,
-      {},
+      { local: true },
       DRY,
       bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
     );
@@ -1837,8 +1867,31 @@ describe("setup (run-all wizard)", () => {
     // The skills row is PRESENT and says why it cannot act, rather than being
     // dropped from a plan that then claims completeness.
     expect(outcome.stdout).toContain("skills");
-    expect(outcome.stdout).toContain("no skills installed");
+    expect(outcome.stdout).toContain("this project holds no skills");
     expect(outcome.stdout).toContain("lsp");
+  });
+
+  it("the GLOBAL run-all offers the skills row on a fresh machine", async () => {
+    // The other side of the same graceful-degrade question, and the one a fresh
+    // install actually meets: a bare run-all is the global band, whose skills
+    // row is now offerable from the bundled snapshot rather than skipped with a
+    // remedy the user has to go away and run.
+    const prevData = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = tmp("pragma-runall-data-");
+    try {
+      const outcome = await executeVerb(
+        setupSelfVerb,
+        {},
+        DRY,
+        bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
+      );
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stdout).toContain("skills");
+      expect(outcome.stdout).not.toContain("no skills installed");
+    } finally {
+      if (prevData === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = prevData;
+    }
   });
 });
 

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -1033,6 +1033,77 @@ describe("setup skills", () => {
     expect(existsSync(join(cwd, ".agents", "skills", "my-skill"))).toBe(false);
   });
 
+  it("NEVER deletes a user's own symlink that collides with a shipped skill (REGRESSION)", async () => {
+    // Bundled skills ship on every install, so a folder-name collision with a
+    // user's own link is reachable with NO user action — where previously an
+    // empty skill set meant no action was ever composed for that path.
+    // `composeSkills` composes every non-skipped row, so classifying a
+    // resolving foreign link as `replaced` deletes the user's link.
+    const cwd = tmp("pragma-setup-proj-");
+    const skillDir = join(cwd, ".pragma", "skills", "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: my-skill\ndescription: A test skill.\n---\n",
+    );
+
+    // Somewhere entirely outside every pragma root, and it RESOLVES.
+    const mine = join(cwd, "my-own-work", "my-skill");
+    mkdirSync(mine, { recursive: true });
+    writeFileSync(join(mine, "SKILL.md"), "---\nname: mine\n---\n");
+
+    const linkDir = join(cwd, ".agents", "skills");
+    mkdirSync(linkDir, { recursive: true });
+    const linkPath = join(linkDir, "my-skill");
+    symlinkSync(mine, linkPath);
+
+    const detected = await detectSkills(bootRuntime(FLAGS, cwd), "project");
+    const action = detected.actions.find((a) => a.linkPath === linkPath);
+    expect(action?.action).toBe("skipped");
+    expect(action?.owned).toBe(false);
+
+    // Neither the preview nor the real run may touch it.
+    const { effects } = dryRun(composeSkills(detected));
+    expect(
+      effects.filter(
+        (e) =>
+          e._tag === "DeleteFile" && (e as { path?: string }).path === linkPath,
+      ),
+    ).toHaveLength(0);
+
+    await runTask(composeSkills(detected));
+    expect(readlinkSync(linkPath)).toBe(mine);
+    expect(existsSync(join(linkPath, "SKILL.md"))).toBe(true);
+  });
+
+  it("sweeps a link into a REMOVED package directory once its skill is gone (REGRESSION)", async () => {
+    // The upgrade shape under a version-stamped layout (pnpm, npx, volta): the
+    // link points into `…@0.34.0/bundled-skills/<name>`, a directory the
+    // upgrade replaced. Ownership by residence in a CURRENT root cannot see it,
+    // and once the release drops that skill no per-skill action covers the path
+    // either — so the dangling link would survive every reconcile, invisible to
+    // setup and to doctor alike.
+    const cwd = tmp("pragma-setup-proj-");
+    const skillDir = join(cwd, ".pragma", "skills", "still-here");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: still-here\ndescription: A test skill.\n---\n",
+    );
+
+    const linkDir = join(cwd, ".agents", "skills");
+    mkdirSync(linkDir, { recursive: true });
+    // Never created: this is the point — the old package directory is gone.
+    const retired = join(cwd, "pragma-cli@0.34.0", "bundled-skills", "retired");
+    const linkPath = join(linkDir, "retired");
+    symlinkSync(retired, linkPath);
+
+    const detected = await detectSkills(bootRuntime(FLAGS, cwd), "project");
+    const orphan = detected.orphans.find((o) => o.linkPath === linkPath);
+    expect(orphan).toBeDefined();
+    expect(orphan?.owned).toBe(true);
+  });
+
   it("classifies a DANGLING symlink as replaced and repairs it (S1-2)", async () => {
     // `existsSync` FOLLOWS a symlink, so a dangling link used to read as
     // "absent" → plan `created` → the real symlink() crashed EEXIST labeled

--- a/packages/cli/pragma/src/capabilities/skill/bundledSkills.test.ts
+++ b/packages/cli/pragma/src/capabilities/skill/bundledSkills.test.ts
@@ -1,0 +1,347 @@
+/**
+ * The BUNDLED skills snapshot — the third discovery root, last in precedence.
+ *
+ * `scripts/bundle.ts` already resolved every declared pack to read its TTL into
+ * `pack.generated.ts`; it now also copies each pack's `skills/<name>/` into the
+ * committed `bundled-skills/` directory at the package root. So a fresh install
+ * lists skills for the same reason it answers `block lookup`: the release
+ * carries a snapshot of what its packs shipped.
+ *
+ * WHAT THESE CELLS SAMPLE. Every expectation about skill CONTENT is read out of
+ * the committed artifact rather than written into a fixture beside the code.
+ * Inventing "a bundled skill" here would prove that a directory this test wrote
+ * can be discovered — which is already covered — while a snapshot that shipped
+ * empty, shipped a folder with no `SKILL.md`, or was dropped from `files` would
+ * stay green. The artifact is real upstream data; it is what has to work.
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dryRun } from "@canonical/task";
+import { runTask } from "@canonical/task/node";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BIN_NAME } from "../../constants.js";
+import { bootRuntime } from "../../kernel/runtime/boot.js";
+import type { GlobalFlags } from "../../kernel/runtime/types.js";
+import { runCli } from "../../testing/helpers/runCli.js";
+import { bandedChecks } from "../doctor/checks/targetHealth.js";
+import {
+  composeSkills,
+  detectSkills,
+  staleSkillLinks,
+} from "../setup/operations/setupSkills.js";
+import {
+  bundledSkillsDir,
+  discoverSkills,
+  globalSkillRoots,
+  installedSkillsDir,
+  parseFrontmatter,
+} from "./discover.js";
+
+const packageRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+/** The snapshot's folder → declared `name`, read from the shipped bytes. */
+function shippedSkills(): { folder: string; name: string }[] {
+  const root = bundledSkillsDir();
+  if (root === undefined) return [];
+  return readdirSync(root)
+    .map((folder) => {
+      const skillMd = join(root, folder, "SKILL.md");
+      if (!existsSync(skillMd)) return undefined;
+      const frontmatter = parseFrontmatter(readFileSync(skillMd, "utf-8"));
+      return frontmatter ? { folder, name: frontmatter.name } : undefined;
+    })
+    .filter((entry): entry is { folder: string; name: string } => !!entry);
+}
+
+/** A FRESH INSTALL's environment: nothing of this machine is inherited. */
+function freshInstallEnv(): Record<string, string> {
+  const home = mkdtempSync(join(tmpdir(), "pragma-fresh-home-"));
+  return {
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: mkdtempSync(join(tmpdir(), "pragma-fresh-cfg-")),
+    XDG_DATA_HOME: mkdtempSync(join(tmpdir(), "pragma-fresh-data-")),
+    XDG_STATE_HOME: mkdtempSync(join(tmpdir(), "pragma-fresh-state-")),
+    XDG_CACHE_HOME: mkdtempSync(join(tmpdir(), "pragma-fresh-cache-")),
+  };
+}
+
+describe("bundled skills — the shipped snapshot", () => {
+  it("the committed artifact is a real, well-formed skills root", () => {
+    const root = bundledSkillsDir();
+    expect(root).toBeDefined();
+    const entries = readdirSync(root as string);
+    // Not merely non-empty: EVERY entry must be a discoverable skill. A folder
+    // the copy pass half-wrote (or a stray file) would be skipped silently by
+    // discovery, which is exactly how a thinned snapshot ships unnoticed.
+    expect(entries.length).toBeGreaterThan(0);
+    expect(
+      shippedSkills()
+        .map((s) => s.folder)
+        .sort(),
+    ).toEqual([...entries].sort());
+  });
+
+  it("is the LAST discovery root, after project and installed", () => {
+    const roots = globalSkillRoots();
+    expect(roots[0]).toBe(installedSkillsDir());
+    expect(roots.at(-1)).toBe(bundledSkillsDir());
+  });
+});
+
+describe("bundled skills — a fresh install, through the shipped entry", () => {
+  it("lists the packs' skills with no `sources update` (REGRESSION)", () => {
+    // THE DEFECT. A fresh install had zero skills and a two-command, network-
+    // dependent recovery (`sources update` then `setup skills`) for content the
+    // release had already resolved at bundle time. Isolated HOME + all four XDG
+    // roots, so anything answered here was answered from the package itself.
+    const cwd = mkdtempSync(join(tmpdir(), "pragma-fresh-proj-"));
+    const outcome = runCli(["skill", "list", "--format", "json"], {
+      cwd,
+      env: freshInstallEnv(),
+    });
+    expect(outcome.exitCode).toBe(0);
+    const envelope = JSON.parse(outcome.stdout) as {
+      data: { name: string }[];
+    };
+    const listed = envelope.data.map((skill) => skill.name).sort();
+    expect(listed.length).toBeGreaterThan(0);
+    // Every skill the snapshot ships is listed — not just "some skills".
+    expect(listed).toEqual(
+      expect.arrayContaining(
+        shippedSkills()
+          .map((s) => s.name)
+          .sort(),
+      ),
+    );
+    expect(outcome.stderr).not.toContain("No skills found");
+  });
+
+  it("`setup --dry-run` OFFERS a skills row instead of skipping it", () => {
+    // The other half of the same defect: the global band's only source was the
+    // installed root, so a fresh machine's setup plan skipped skills entirely
+    // and pointed at `sources update` as the remedy.
+    const cwd = mkdtempSync(join(tmpdir(), "pragma-fresh-setup-"));
+    const outcome = runCli(["setup", "--dry-run", "--global"], {
+      cwd,
+      env: freshInstallEnv(),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.stdout).toMatch(/skills\s+link\s+\d+ skills? →/);
+    expect(outcome.stdout).not.toContain("no skills installed");
+  });
+});
+
+describe("bundled skills — precedence", () => {
+  let previousDataHome: string | undefined;
+  let dataHome: string;
+  let cwd: string;
+
+  /** The first skill the snapshot ships — the name both overrides reuse. */
+  const shadowed = (): { folder: string; name: string } => {
+    const first = shippedSkills()[0];
+    if (first === undefined) throw new Error("no bundled skills to shadow");
+    return first;
+  };
+
+  /** Write a `SKILL.md` for `name` under `root/folder`, with a marker body. */
+  const writeSkill = (root: string, folder: string, name: string): void => {
+    mkdirSync(join(root, folder), { recursive: true });
+    writeFileSync(
+      join(root, folder, "SKILL.md"),
+      `---\nname: ${name}\ndescription: OVERRIDE.\n---\n`,
+    );
+  };
+
+  beforeEach(() => {
+    previousDataHome = process.env.XDG_DATA_HOME;
+    dataHome = mkdtempSync(join(tmpdir(), "pragma-prec-data-"));
+    process.env.XDG_DATA_HOME = dataHome;
+    cwd = mkdtempSync(join(tmpdir(), "pragma-prec-proj-"));
+  });
+
+  afterEach(() => {
+    process.env.XDG_DATA_HOME = previousDataHome;
+  });
+
+  it("an INSTALLED skill of the same name wins over the bundled copy", () => {
+    // The rule someone who ran `sources update` is relying on: the update they
+    // asked for must reach them, never the copy frozen at release time.
+    const { folder, name } = shadowed();
+    writeSkill(installedSkillsDir(), folder, name);
+    const found = discoverSkills(cwd).find((skill) => skill.name === name);
+    expect(found?.description).toBe("OVERRIDE.");
+    expect(found?.sourcePath).toBe(join(installedSkillsDir(), folder));
+  });
+
+  it("a PROJECT skill wins over both", () => {
+    const { folder, name } = shadowed();
+    writeSkill(installedSkillsDir(), folder, name);
+    writeSkill(join(cwd, ".pragma", "skills"), folder, `${name}`);
+    const found = discoverSkills(cwd).find((skill) => skill.name === name);
+    expect(found?.sourcePath).toBe(join(cwd, ".pragma", "skills", folder));
+  });
+
+  it("shadowing REPLACES rather than duplicates the name", () => {
+    const { folder, name } = shadowed();
+    writeSkill(installedSkillsDir(), folder, name);
+    const matches = discoverSkills(cwd).filter((skill) => skill.name === name);
+    expect(matches).toHaveLength(1);
+  });
+});
+
+describe("bundled skills — the upgrade hazard", () => {
+  // THE HAZARD, spelled out. Every other link `setup skills` writes points into
+  // a directory pragma controls; a bundled one points into the package
+  // directory, which the PACKAGE MANAGER owns. `npm i -g` reuses the same path,
+  // but a pnpm / npx / versioned layout does not — so an upgrade can leave a
+  // harness link dangling at a package directory that no longer exists.
+  //
+  // The design turns on whether the EXISTING reconcile repairs that or leaves
+  // it, and that is answered here by construction rather than by reading the
+  // code: a link to a plausible previous release's path is planted in the
+  // harness directory, and the forward plan is inspected.
+  const FLAGS: GlobalFlags = {
+    format: "plain",
+    color: false,
+    quiet: false,
+    verbose: false,
+  };
+
+  let prevHome: string | undefined;
+  let prevDataHome: string | undefined;
+  let home: string;
+
+  beforeEach(() => {
+    prevHome = process.env.HOME;
+    prevDataHome = process.env.XDG_DATA_HOME;
+    home = mkdtempSync(join(tmpdir(), "pragma-upgrade-home-"));
+    process.env.HOME = home;
+    // An empty installed root, so the bundled snapshot is the band's only
+    // source — exactly a fresh install that has never run `sources update`.
+    process.env.XDG_DATA_HOME = mkdtempSync(
+      join(tmpdir(), "pragma-upgrade-data-"),
+    );
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevDataHome === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = prevDataHome;
+  });
+
+  it("repairs a link into a REPLACED package directory (REGRESSION)", async () => {
+    const first = shippedSkills()[0];
+    if (first === undefined) throw new Error("no bundled skills");
+    // The harness directory as an upgrade would leave it: a link at the right
+    // name pointing into the version-stamped path of the release before this
+    // one, which no longer exists.
+    const harnessDir = join(home, ".agents", "skills");
+    mkdirSync(harnessDir, { recursive: true });
+    const linkPath = join(harnessDir, first.folder);
+    symlinkSync(
+      join(tmpdir(), "pragma-cli@0.34.0", "bundled-skills", first.folder),
+      linkPath,
+    );
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true); // present…
+    expect(existsSync(linkPath)).toBe(false); // …and dangling.
+
+    const cwd = mkdtempSync(join(tmpdir(), "pragma-upgrade-proj-"));
+    const detected = await detectSkills(bootRuntime(FLAGS, cwd), "global");
+
+    // Planned as `replaced` — NOT skipped as somebody else's link, and NOT
+    // swept as an orphan: the per-skill pass covers the path, so the sweep
+    // never sees it. Both halves matter; either one alone would lose the link.
+    const action = detected.actions.find((a) => a.linkPath === linkPath);
+    expect(action?.action).toBe("replaced");
+    expect(action?.skillName).toBe(first.name);
+    expect(staleSkillLinks(detected).map((a) => a.linkPath)).not.toContain(
+      linkPath,
+    );
+
+    // And the forward run is delete-then-relink onto the CURRENT package, so
+    // one `setup skills` after an upgrade converges the harness.
+    expect(
+      dryRun(composeSkills(detected)).effects.map((e) => e._tag),
+    ).toContain("DeleteFile");
+    await runTask(composeSkills(detected));
+    expect(existsSync(linkPath)).toBe(true);
+    expect(readFileSync(join(linkPath, "SKILL.md"), "utf-8")).toContain(
+      `name: ${first.name}`,
+    );
+  });
+
+  it("doctor makes the upgrade window VISIBLE, with the command that closes it", async () => {
+    // The residual risk is the gap between an upgrade and the next
+    // `setup skills`: the link dangles and the harness sees a broken skill.
+    // One command converges it (above) — so what has to be true is that
+    // something TELLS the user to run it. This is that assertion. Without it
+    // the window is real but silent, which is the "doctor blind to orphans"
+    // shape sitting on a path an upgrade reaches routinely.
+    const first = shippedSkills()[0];
+    if (first === undefined) throw new Error("no bundled skills");
+    const harnessDir = join(home, ".agents", "skills");
+    mkdirSync(harnessDir, { recursive: true });
+    symlinkSync(
+      join(tmpdir(), "pragma-cli@0.34.0", "bundled-skills", first.folder),
+      join(harnessDir, first.folder),
+    );
+
+    const cwd = mkdtempSync(join(tmpdir(), "pragma-upgrade-doctor-"));
+    const rows = await bandedChecks(bootRuntime(FLAGS, cwd), BIN_NAME);
+    const row = rows.find((r) => r.name === "skills" && r.band === "global");
+    expect(row?.status).toBe("fail");
+    expect(row?.detail).toContain("point elsewhere");
+    // No AUTHORED remedy on this branch: the row takes the derived one, which
+    // is exactly the command proven to repair it in the cell above.
+    expect(row?.remedy).toBe(`${BIN_NAME} setup skills`);
+  });
+
+  it("discovery itself cannot degrade on an upgrade", () => {
+    // The other half of the worry — that a moved package directory would make
+    // the snapshot vanish from DISCOVERY too, silently returning the CLI to the
+    // skips-everything state this change removes. It cannot: `bundledSkillsDir`
+    // walks up from `import.meta.url`, so it resolves against whichever copy of
+    // the package is EXECUTING, which is the new one by definition. There is no
+    // recorded path anywhere that an upgrade could invalidate.
+    expect((bundledSkillsDir() as string).startsWith(packageRoot)).toBe(true);
+    const cwd = mkdtempSync(join(tmpdir(), "pragma-upgrade-disc-"));
+    expect(discoverSkills(cwd).length).toBeGreaterThan(0);
+  });
+});
+
+describe("bundled skills — packaging", () => {
+  // Generous timeout: this shells out to the real packer over ~950 files.
+  it("the snapshot is in the published tarball (`files` allowlist)", () => {
+    // `files` allowlists are exactly the kind of thing that looks right and
+    // ships nothing: the directory would exist in the repo, every test above
+    // would pass from the source tree, and a consumer's install would carry no
+    // skills at all. Only the packer's own answer settles it.
+    const packed = spawnSync(
+      "npm",
+      ["pack", "--dry-run", "--json", "--ignore-scripts"],
+      { cwd: packageRoot, encoding: "utf-8", timeout: 120_000 },
+    );
+    expect(packed.status).toBe(0);
+    const files = (
+      JSON.parse(packed.stdout) as { files: { path: string }[] }[]
+    )[0]?.files.map((file) => file.path);
+    for (const { folder } of shippedSkills()) {
+      expect(files).toContain(`bundled-skills/${folder}/SKILL.md`);
+    }
+  }, 120_000);
+});

--- a/packages/cli/pragma/src/capabilities/skill/discover.ts
+++ b/packages/cli/pragma/src/capabilities/skill/discover.ts
@@ -4,15 +4,17 @@
  * A skill is a folder with a `SKILL.md` carrying YAML frontmatter (`name`,
  * `description`, and the #856 `prompt` flag among others). Skills are discovered
  * from conventional roots — project skills under `<cwd>/.pragma/skills`, which
- * take precedence, then installed skills under `$XDG_DATA_HOME/pragma/skills` —
- * with missing files and invalid frontmatter skipped gracefully. Reads only the
+ * take precedence, then installed skills under `$XDG_DATA_HOME/pragma/skills`,
+ * then the BUNDLED snapshot this package ships (`bundled-skills/`) — with
+ * missing files and invalid frontmatter skipped gracefully. Reads only the
  * filesystem, never the graph store, so `skill list`/`lookup` are storeless
  * (needsStore: false).
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { BIN_NAME } from "../../constants.js";
 
 /** Parsed SKILL.md frontmatter. */
@@ -134,14 +136,101 @@ export function projectSkillsDir(cwd: string): string {
 }
 
 /**
+ * The directory name of the SNAPSHOT of pack skills this package ships, at its
+ * own root. Written by `scripts/bundle.ts` and COMMITTED, exactly as
+ * `src/kernel/runtime/graphpack/embedded/pack.generated.ts` is — see
+ * {@link bundledSkillsDir}.
+ */
+const BUNDLED_SKILLS_DIRNAME = "bundled-skills";
+
+/**
+ * How far above this module the package root can be. `src/capabilities/skill`
+ * is three levels up; the emitted `dist/src/capabilities/skill` is four. The
+ * bound exists so a tree that is MISSING the artifact stops at the package
+ * instead of walking to `/` and adopting an unrelated directory.
+ */
+const BUNDLED_SEARCH_DEPTH = 6;
+
+/**
+ * The BUNDLED-skills root: `<package root>/bundled-skills`, the snapshot of the
+ * declared packs' `skills/<name>/` that `scripts/bundle.ts` commits alongside
+ * the embedded graph — `undefined` when this build ships none.
+ *
+ * WHY IT EXISTS. The embedded pack (`pack.generated.ts`) is what lets a fresh
+ * install answer `block lookup` offline. The skills came out of the very same
+ * `resolvePackage` calls and were left on the build machine's disk, so the same
+ * fresh install listed ZERO skills and told the user to run `sources update`
+ * first — a network round trip and two commands for something already resolved
+ * at release time. This is the skills half of the snapshot the graph has had
+ * all along.
+ *
+ * WHY IT IS FOUND BY WALKING UP rather than by a fixed relative path. `files`
+ * ships BOTH `src` and `dist`, and `tsconfig.build.json` sets `rootDir: "."`,
+ * so this module runs from `src/capabilities/skill/` in a source or test run
+ * and from `dist/src/capabilities/skill/` in the shipped one — the package root
+ * is three levels up in one and four in the other, and no single
+ * `new URL("../../..")` is right for both. The walk anchors on the artifact's
+ * own name sitting NEXT TO a `package.json`, which is true only at the package
+ * root: `dist/` carries a `package.json` too (`resolveJsonModule` copies it)
+ * but never the snapshot.
+ *
+ * @returns The bundled root, or `undefined` when no ancestor holds one.
+ * @note Impure — stats up to {@link BUNDLED_SEARCH_DEPTH} ancestor directories.
+ *   Reached from the `__complete` fast path, so it stays `node:fs` /
+ *   `node:path` / `node:url` only and costs a handful of `stat`s.
+ */
+export function bundledSkillsDir(): string | undefined {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let up = 0; up < BUNDLED_SEARCH_DEPTH; up += 1) {
+    const candidate = join(dir, BUNDLED_SKILLS_DIRNAME);
+    if (existsSync(join(dir, "package.json")) && existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
  * The conventional roots skills are discovered from, in PRECEDENCE order: the
  * project root (`<cwd>/.<bin>/skills`) FIRST so a project-local skill overrides
  * an installed skill of the same name (`discoverSkills` dedups first-seen-wins),
  * then installed skills under `$XDG_DATA_HOME/<bin>/skills` (where package
- * skills land on `sources update`).
+ * skills land on `sources update`), then the BUNDLED snapshot
+ * ({@link bundledSkillsDir}).
+ *
+ * BUNDLED IS LAST, and that order is the whole contract. The snapshot is as old
+ * as the release; an installed skill came from a `sources update` the user ran
+ * deliberately, and a project skill is the repository's own. So someone who
+ * updates gets the CURRENT skill and never the shipped copy, while a fresh
+ * install — which has neither of the first two roots — still gets the packs'
+ * skills instead of an empty list and a two-command recovery.
  */
 export function skillRoots(cwd: string): string[] {
-  return [projectSkillsDir(cwd), installedSkillsDir()];
+  return [projectSkillsDir(cwd), ...globalSkillRoots()];
+}
+
+/**
+ * The GLOBAL band's source roots, in precedence order: the INSTALLED root
+ * (`sources update`'s output) first, then the BUNDLED snapshot.
+ *
+ * Named separately from {@link skillRoots} for the reason
+ * {@link projectSkillsDir} is: these are the two roots `setup skills --global`
+ * links into the user-level harness directories, and `skillRoots` is discovery,
+ * which spans both bands. Reading the project root for the global band is
+ * exactly the cross-band leak the band split exists to prevent.
+ *
+ * A BAND CAN HOLD MORE THAN ONE ROOT, and this is where that became true. The
+ * global band's ownership test and its stale-link sweep therefore range over
+ * the SET (see `setup/operations/setupSkills.ts`), never over one path.
+ */
+export function globalSkillRoots(): string[] {
+  const bundled = bundledSkillsDir();
+  return bundled === undefined
+    ? [installedSkillsDir()]
+    : [installedSkillsDir(), bundled];
 }
 
 /** Immediate subdirectories of `root` (each a candidate skill folder). */

--- a/packages/cli/pragma/src/capabilities/skill/skill.test.ts
+++ b/packages/cli/pragma/src/capabilities/skill/skill.test.ts
@@ -15,7 +15,11 @@ import { bootRuntime } from "../../kernel/runtime/boot.js";
 import type { PragmaRuntime } from "../../kernel/runtime/types.js";
 import type { VerbSpec } from "../../kernel/spec/types.js";
 import { TEST_FLAGS } from "../../testing/helpers/projectCli.js";
-import type { DiscoveredSkill } from "./discover.js";
+import {
+  bundledSkillsDir,
+  type DiscoveredSkill,
+  discoverSkillsFrom,
+} from "./discover.js";
 import { skillModule } from "./index.js";
 import { skillListFormatters } from "./render.js";
 import type { SkillLookup } from "./verbs.js";
@@ -60,7 +64,16 @@ afterAll(() => {
 describe("skill list (storeless)", () => {
   it("discovers skills by name, carrying the prompt flag", async () => {
     const skills = (await listVerb.run({}, rt)) as DiscoveredSkill[];
-    expect(skills.map((s) => s.name)).toEqual(["docx", "pdf"]);
+    // The list is the project root's two skills UNION the bundled snapshot the
+    // package ships (`bundledSkills.test.ts` owns the snapshot's own cells).
+    // Derived from the shipped artifact rather than spelled out, so a release
+    // that changes which skills the packs provide does not rewrite this test.
+    const bundled = discoverSkillsFrom([bundledSkillsDir() as string]).map(
+      (s) => s.name,
+    );
+    expect(skills.map((s) => s.name)).toEqual(
+      [...new Set(["docx", "pdf", ...bundled])].sort(),
+    );
     expect(skills.find((s) => s.name === "pdf")?.frontmatter.prompt).toBe(true);
     expect(
       skills.find((s) => s.name === "docx")?.frontmatter.prompt,

--- a/packages/cli/pragma/src/capabilities/sources/installSkills.ts
+++ b/packages/cli/pragma/src/capabilities/sources/installSkills.ts
@@ -39,7 +39,7 @@ import type { ResolvedPackage } from "../../kernel/runtime/refs/index.js";
 // this module must not be able to disagree about which links belong to pragma.
 // `setupSkills.ts` reaches `@canonical/harnesses` only through a DYNAMIC
 // import, so this edge adds no static one (`capabilities/lazy.test.ts`).
-import { withinRoot } from "../setup/operations/setupSkills.js";
+import { withinAnyRoot } from "../setup/operations/setupSkills.js";
 import { installedSkillsDir } from "../skill/discover.js";
 
 /** One planned skill symlink into the installed-skills root. */
@@ -264,32 +264,58 @@ export interface BandLinkAction {
  *    that materialised `~/.claude/skills` would be litter, and would silently
  *    opt the user into linking they never asked for.
  * 2. OWNERSHIP, by the SAME test `setup skills` uses. A path is this command's
- *    to touch only when it holds a symlink resolving INSIDE the installed root
- *    (`withinRoot`, a pure path-SEGMENT test that reads nothing — so it still
- *    answers correctly after the layer-1 target is gone, which is exactly the
- *    stale case). A real directory is a hand-installed skill; a symlink
- *    pointing anywhere else is the user's own; a `<root>-backup/foo` sibling is
- *    not "inside" despite sharing a string prefix. None is ever removed.
+ *    to touch only when it holds a symlink resolving INSIDE one of the global
+ *    band's roots (`withinAnyRoot`, a pure path-SEGMENT test that reads nothing
+ *    — so it still answers correctly after the layer-1 target is gone, which is
+ *    exactly the stale case). A real directory is a hand-installed skill; a
+ *    symlink pointing anywhere else is the user's own; a `<root>-backup/foo`
+ *    sibling is not "inside" despite sharing a string prefix. None is removed.
+ *
+ *    THE SET, NOT JUST THE INSTALLED ROOT, and that is what keeps precedence
+ *    true one layer up. A harness link left pointing at the BUNDLED snapshot
+ *    for a skill this update has just installed for real is owned, so it is
+ *    `replaced` onto the installed copy. Tested against the installed root
+ *    alone it read as "someone else's link" and was skipped — and the user who
+ *    deliberately ran `sources update` would have kept running the shipped copy.
  *
  * The plan is derived from the layer-1 plan rather than from a filesystem
  * re-read, because at planning time the layer-1 writes have not happened yet:
  * `surviving` is the post-update truth, and reading the disk would see the
- * pre-update state.
+ * pre-update state. That is also why a surviving name always targets
+ * `roots[0]`: layer 1 is about to hold it, whether or not it does now.
+ *
+ * A RETIRED NAME IS NOT AUTOMATICALLY DEBRIS any more. The fallback roots
+ * (today: the bundled snapshot) are NOT written by this update, so their
+ * contents ARE readable at plan time — and a skill the packages dropped that
+ * the shipped snapshot still carries is still discoverable, still listed by
+ * `skill list`, and so still belongs in the harness directory. Such a link is
+ * RETARGETED onto the surviving root rather than pruned; only a name no root
+ * provides at all is deleted.
  *
  * @param dirs - The EXISTING global link directories.
- * @param dest - The installed-skills root (layer 1), which is also the
- *   ownership root every candidate link is tested against.
+ * @param roots - The global band's source roots in PRECEDENCE order.
+ *   `roots[0]` is the installed root (layer 1) every surviving name targets;
+ *   the rest are fallbacks a retired name may still resolve in. The whole set
+ *   is the ownership set.
  * @param surviving - Folder names layer 1 will hold after this update.
  * @param retired - Folder names layer 1 is pruning in this update.
  * @returns The layer-2 actions, for the plan and its effects.
- * @note Impure — lstats each candidate link path.
+ * @note Impure — lstats each candidate link path, and stats the fallback roots
+ *   for each retired name.
  */
 export function planBandSkillLinks(
   dirs: readonly { dir: string; name: string }[],
-  dest: string,
+  roots: readonly string[],
   surviving: readonly string[],
   retired: readonly string[],
 ): BandLinkAction[] {
+  const dest = resolve(roots[0] as string);
+  /** The first FALLBACK root that still holds `folderName`, if any. */
+  const fallback = (folderName: string): string | undefined =>
+    roots
+      .slice(1)
+      .map((root) => resolve(root, folderName))
+      .find((candidate) => existsSync(candidate));
   const out: BandLinkAction[] = [];
   for (const { dir, name } of dirs) {
     for (const folderName of surviving) {
@@ -308,9 +334,9 @@ export function planBandSkillLinks(
         continue;
       }
       if (resolve(dir, state.target) === target) continue; // Already correct.
-      // A symlink pointing outside the installed root is the user's own link
-      // into their own checkout. Unplanned does not make it ours to replace.
-      if (!withinRoot(dest, linkPath, state.target)) continue;
+      // A symlink pointing outside every band root is the user's own link into
+      // their own checkout. Unplanned does not make it ours to replace.
+      if (!withinAnyRoot(roots, linkPath, state.target)) continue;
       out.push({
         target,
         linkPath,
@@ -324,7 +350,22 @@ export function planBandSkillLinks(
       const linkPath = resolve(dir, folderName);
       const state = linkState(linkPath);
       if (state.kind !== "symlink") continue;
-      if (!withinRoot(dest, linkPath, state.target)) continue;
+      if (!withinAnyRoot(roots, linkPath, state.target)) continue;
+      const surviving = fallback(folderName);
+      if (surviving !== undefined) {
+        // Dropped upstream, still shipped: retarget rather than delete. Already
+        // correct is nothing to do.
+        if (resolve(dir, state.target) === surviving) continue;
+        out.push({
+          target: surviving,
+          linkPath,
+          action: "replaced",
+          folderName,
+          dirName: name,
+          previousTarget: state.target,
+        });
+        continue;
+      }
       out.push({
         target: resolve(dir, state.target),
         linkPath,

--- a/packages/cli/pragma/src/capabilities/sources/runUpdate.ts
+++ b/packages/cli/pragma/src/capabilities/sources/runUpdate.ts
@@ -53,7 +53,7 @@ import {
 // band covenant — so `sources update` cannot drift away from what
 // `setup skills --global` links, or widen the band on its own.
 import { existingGlobalSkillDirs } from "../setup/operations/setupSkills.js";
-import { installedSkillsDir } from "../skill/discover.js";
+import { globalSkillRoots, installedSkillsDir } from "../skill/discover.js";
 import { planBandSkillLinks, planSkillInstall } from "./installSkills.js";
 import type { SourcesUpdateData } from "./types.js";
 
@@ -361,12 +361,14 @@ export async function buildUpdateTask(
   // `~/.claude/skills` into being and opting the user into linking they never
   // asked for. Refresh what is there; never bring a directory into existence.
   //
-  // Ownership is the SAME `withinRoot` test `setup skills` applies, so a real
-  // directory, a still-resolving link into the user's own checkout, and a
-  // `<root>-backup/foo` sibling are all left exactly as found.
+  // Ownership is the SAME `withinAnyRoot` test `setup skills` applies, over the
+  // SAME root set (`globalSkillRoots`), so a real directory, a still-resolving
+  // link into the user's own checkout, and a `<root>-backup/foo` sibling are all
+  // left exactly as found — while a link still pointing at the BUNDLED snapshot
+  // for a skill this update just installed is ours, and is moved onto it.
   const bandPlan = planBandSkillLinks(
     await existingGlobalSkillDirs(runtime.cwd),
-    installedSkillsDir(),
+    globalSkillRoots(),
     skillPlan
       .filter((link) => link.action !== "pruned")
       .map((link) => link.folderName),

--- a/packages/cli/pragma/src/identity.test.ts
+++ b/packages/cli/pragma/src/identity.test.ts
@@ -217,15 +217,25 @@ describe("identity projection — a fork changes values, not code (PROTECTED)", 
     // `$XDG_DATA_HOME/pragma/skills` and one `<cwd>/.pragma/skills`, so a fork
     // read the other's skills and could not install its own without collision.
     process.env.XDG_DATA_HOME = join(tmpdir(), "identity-data");
-    const { skillRoots, installedSkillsDir } = await import(
+    const { skillRoots, installedSkillsDir, bundledSkillsDir } = await import(
       "./capabilities/skill/discover.js"
     );
     expect(installedSkillsDir().endsWith(join("recipes", "skills"))).toBe(true);
-    expect(skillRoots("/work")).toEqual([
+    // The two roots that live on SHARED ground — the user's data home and the
+    // user's repository — are the ones a fork must namespace.
+    const namespaced = [
       join("/work", ".recipes", "skills"),
       installedSkillsDir(),
-    ]);
-    for (const root of skillRoots("/work")) {
+    ];
+    // The bundled snapshot is the third, and it is deliberately NOT namespaced
+    // by the bin name: it is the distribution's OWN package directory, which is
+    // already private to the install. A fork is a different package and ships
+    // its own `bundled-skills/`, so there is no shared ground to collide on —
+    // and it is exempt from the check below for exactly that reason, since the
+    // path this repository's package sits at necessarily says "pragma".
+    expect(bundledSkillsDir()).toBeDefined();
+    expect(skillRoots("/work")).toEqual([...namespaced, bundledSkillsDir()]);
+    for (const root of namespaced) {
       expect(root).not.toMatch(THIS_DISTRIBUTION);
     }
   });

--- a/packages/cli/pragma/src/kernel/completion/entitySource.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/entitySource.test.ts
@@ -2,6 +2,10 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  bundledSkillsDir,
+  discoverSkillsFrom,
+} from "../../capabilities/skill/discover.js";
 import { readConfig } from "../config/readConfig.js";
 import { embeddedManifest } from "../runtime/graphpack/embedded.js";
 import { activePackPath, packDir } from "../runtime/paths.js";
@@ -121,10 +125,19 @@ describe("indexCompletionEnv — multi-source names(ref)", () => {
       join(skillDir, "SKILL.md"),
       "---\nname: docx\ndescription: Word docs.\n---\n",
     );
+    // The BUNDLED snapshot ships inside the package, so it is a discovery root
+    // on every machine — including this one. The project root's skill is what
+    // this cell is about; the expectation is derived from the shipped artifact
+    // rather than pinned to a list, so a release that changes which skills the
+    // packs provide does not rewrite this test.
+    const bundled = discoverSkillsFrom([bundledSkillsDir() as string]).map(
+      (skill) => skill.name,
+    );
+    const expected = [...new Set(["docx", ...bundled])].sort();
     const env = indexCompletionEnv(cwd);
-    expect(await env.names({ from: "skills" })).toEqual(["docx"]);
+    expect(await env.names({ from: "skills" })).toEqual(expected);
     // A second read returns the same list (one filesystem walk per env).
-    expect(await env.names({ from: "skills" })).toEqual(["docx"]);
+    expect(await env.names({ from: "skills" })).toEqual(expected);
   });
 
   it("a type nothing matches yields [] (prefixes still list the default map)", async () => {

--- a/packages/cli/pragma/src/kernel/completion/safety.test.ts
+++ b/packages/cli/pragma/src/kernel/completion/safety.test.ts
@@ -331,15 +331,22 @@ describe("storeless guarantee (PROTECTED)", () => {
       runComplete(["tier", "lookup", "ap"], capabilities, env),
     ).resolves.toContain("ds:apps");
 
-    // skills (no skills root here) and prompt labels (this graph carries no
-    // prompt entities) have nothing to offer, and the honest storeless answer
-    // is an empty list rather than a store boot.
-    for (const words of [
-      ["skill", "lookup", "do"],
-      ["prompt", "lookup", "bu"],
-    ]) {
-      await expect(runComplete(words, capabilities, env)).resolves.toEqual([]);
-    }
+    // skills: the BUNDLED snapshot ships inside the package, so even this
+    // fresh cwd with an empty XDG data home completes REAL skill names — and
+    // does it storelessly, which is the whole point of the cell. (It used to
+    // assert `[]` here, which was true only because a fresh machine had no
+    // skills at all; that is the defect the snapshot fixes.) The names are not
+    // spelled out: an empty prefix asks for all of them.
+    await expect(
+      runComplete(["skill", "lookup", ""], capabilities, env),
+    ).resolves.not.toHaveLength(0);
+
+    // prompt labels: this graph carries no prompt entities and no shipped skill
+    // declares `prompt: true`, so the honest storeless answer is still an empty
+    // list rather than a store boot.
+    await expect(
+      runComplete(["prompt", "lookup", "bu"], capabilities, env),
+    ).resolves.toEqual([]);
 
     expect(vi.mocked(createStore)).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Done

A fresh `pragma` install had **zero skills**. `pragma skill list` printed "No skills found" and a two-command, network-dependent recovery — while the same `scripts/bundle.ts` run that inlines the packs' TTL into `pack.generated.ts` already had every pack's `skills/<name>/SKILL.md` on disk and dropped it with the throwaway cache. The CLI shipped a snapshot of the graph but not of the skills that came with it.

- **`bundle` now also ships the skills.** `writeBundledSkills` copies each resolved pack's `skills/*` into `bundled-skills/` at the **package root** — committed, exactly as `pack.generated.ts` is. `bundle` is a release-time step deliberately outside `build`/`build:all` (a PR build must not clone three repositories), so an artifact only `bundle` writes has to live where git holds it. Not `dist/`, which no committed step produces; not `src/`, which `tsc` does not copy from and which biome's include list covers (so an upstream skill's JSON would start being linted). `files` allowlists the directory; `biome.json` excludes it.
- **All four declared packs contribute**, for the same reason the graph snapshot takes all four — a subset would mean the shipped skills and the shipped graph disagreed about which packs the release is. First-seen-wins on a folder-name clash, the same rule `planSkillInstall` applies. `@canonical/anatomy-dsl` resolves through `SOURCE_OVERRIDES` from `node_modules`, the identical caveat the manifest's `sourceRef` already records for its triples.
- **The copy runs outside the unchanged-manifest skip.** A file copy is byte-reproducible, so it needs no skip to stay diff-free; and the manifest's `contentHash` covers the resolved TTL inputs only, so a pack that edits a `SKILL.md` and no `.ttl` is invisible to it — skipping on that hash would ship the previous release's skills forever. `bundle` also **fails loudly on zero skills** rather than committing an empty directory that looks like a working snapshot.
- **`bundled-skills/` is a third discovery root, LAST in precedence:** project → installed → bundled. `discoverSkillsFrom` already dedups first-seen-wins, so there is **no new discovery code**. Someone who runs `sources update` gets the current skill, never the shipped copy.
- **The root is found by walking up from `import.meta.url`** to the directory holding both the artifact and a `package.json`. `files` ships `src` *and* `dist`, and `rootDir: "."` puts the module three levels below the package root in one layout and four in the other, so no single relative path is right for both. It also means there is **no recorded path an upgrade can invalidate** — discovery resolves against whichever copy of the package is executing.
- **The global setup band is now a root SET**, and every rule that read one `sourceRoot` ranges over it: what a skill resolves to, what the command **owns** (`withinAnyRoot`), and what the stale sweep may touch. The ownership change is load-bearing: `withinRoot` against the installed root alone read pragma's own bundled-pointing links as *somebody else's* and skipped them, which would have inverted precedence at the harness layer after a `sources update`. `sources update`'s layer-2 pass takes the same set, and a retired pack skill the snapshot still carries is now **retargeted rather than pruned**.
- **The orphan sweep is gated PER ROOT, not per band.** An always-present bundled root must never vouch for a vanished installed one, or the sweep would read every link into the missing root as garbage — the wipe hazard `rootExists` exists to prevent, restated for a band with two roots.

### Decisions, with the reasoning written into the code

**Linked, not copied, into harness directories** (`setup/operations/setupSkills.ts` module docblock). A copy is a real directory, which this module classifies as hand-placed and never touches — so a copied skill could never be updated, retired, or removed by `--undo`, and pragma would be writing permanently stale directories into `~/.claude/skills`.

**The upgrade hazard, answered rather than assumed.** Plain `npm i -g` reinstalls into the same `<prefix>/lib/node_modules/...` path, so its links do not dangle; the affected case is **version-stamped layouts — pnpm, npx caches, volta-style shims** — where an upgrade moves the package directory. The existing reconcile already handles it, and the PR asserts it: the plan says `replaced`, `staleSkillLinks` leaves it alone, one `setup skills` converges it, and `doctor` reports the window as `fail — N of M links point elsewhere` with the derived fix `pragma setup skills`. The residual window is between an upgrade and the next reconcile, which is the same window a `sources update` link into a cleared ref cache already has.

**Size.** 9 skills, 10 files, **160.5 KiB** (`164 316` bytes) — the largest single file is `anatomy-author/SKILL.md` at 40 kB. Tarball goes from 943 → **944 files**, packed **1.95 → 2.1 MB**, unpacked **8.86 → 9.3 MB**.

### Tests

- `bundledSkills.test.ts` (new, 11 cells). Every expectation about skill CONTENT is read out of the committed artifact rather than written into a fixture beside the code — inventing "a bundled skill" would prove only that a directory the test wrote can be discovered, while a snapshot that shipped empty, shipped a folder with no `SKILL.md`, or fell out of `files` would stay green.
- **Red before.** All 11 fail on unmodified `origin/main` (checked in a scratch worktree built from `origin/main`), including the two behavioural ones on the assertion itself rather than on a missing symbol: `expected 0 to be greater than 0`, and the setup row not matching `/skills\s+link\s+\d+ skills? →/`.
- The band covenant (`setup.test.ts`) is **not weakened**. Its `--global` proxy assertion moved from a bare "the plan must not contain `.agents/skills`" to the project spelling `./.agents/skills`, because `shortenPath` renders project paths as `./…` and global as `~/…`, and the global band now legitimately links its own `~/.agents/skills`. `VERIFIED_GLOBAL_SKILL_HARNESSES` is untouched.
- Two `setup.test.ts` cells that asserted the global band's *empty* state were re-pointed rather than deleted: the "no skills installed" wording is now asserted on the pure `skillsSkipReason`/`skillsSkipRemedy` pair both surfaces read, and the graceful-degrade cell moved to the project band, where an empty skills root is still an ordinary condition. Each gained a companion cell asserting the new behaviour.
- `safety.test.ts`'s storeless guarantee is **strengthened, not weakened**: it asserted `[]` for `skill lookup` only because a fresh machine had no skills at all. It now asserts real candidates come back *without* the store booting.

## QA

```
cd packages/cli/pragma
bun run test           # 1588 passed | 13 skipped | 5 todo, + 22 perf; green
bun run gen:reference  # "Wrote 0 changed reference page(s)" — no diff
cd ../../.. && bun run check   # 62 projects, all green
```

End to end with the real binary, isolated `HOME` and all four XDG roots:

```
$ node dist/src/bin.js skill list         # no `sources update` first
## Skills (9)
- **add-standard** — …
- **adoption-a1-styles** — …
…
$ node dist/src/bin.js skill list --format json | jq -r '.data[0].sourcePath'
…/packages/cli/pragma/bundled-skills/add-standard

# with the installed root populated (what `sources update` writes):
$ node dist/src/bin.js skill list --format json | jq -r '.data[].sourcePath'
…/.local/share/pragma/skills/add-standard          # all 9 — none from the snapshot
```

The same commands on `origin/main` print `## Skills (0)` / "No skills found", and `setup --dry-run --global` shows `skills  skip  no skills installed`.

Packaging is proven by the packer itself, not by the repo tree: `npm pack --dry-run --json` lists every `bundled-skills/<folder>/SKILL.md` (a `files` allowlist is exactly the kind of thing that looks right and ships nothing).

---

## Separate finding — the embedded graph as a `dist/` file asset (measured, NOT changed here)

`embedded.ts`'s docblock justifies inlining the pack as escaped JS strings with "no asset step in any build, and no file lookup at run time". That argument was written when the package shipped a `bun build --compile` binary; it now ships plain emitted JavaScript, so a `.nq` file asset is possible where it once was not. The alternative was measured. **Nothing in this PR changes the graph** — it is a 2 MB change to the boot path of every command and deserves its own review.

**1. Import vs `readFileSync`.** Method reused from `src/testing/perf/measure.ts` + BUDGETS.md (spawn-timed, round-robin over arms with a rotating start index, warmups discarded, netted against a `--version`/empty-script control, median of three replications; box process-start baseline 37.6–45.5 ms):

| arm | net-of-control median |
|---|---|
| `import(pack.generated.js)`, touching all 3 exports | **+22.8 ms** |
| `readFileSync` ×3 of the same bytes, utf-8 | **+9.8 ms** |
| same, as `Buffer` | **+6.2 ms** |
| `import(pack.index.generated.js)` | +2.8 ms |
| `readFileSync(index.json)` | +3.7 ms |

A file read saves ≈13 ms (utf-8) / ≈16.6 ms (Buffer) on the n-quads. For the 244 KB index there is **no win at all** — the ESM import is marginally cheaper.

**2. It is not on either fast path.** Measured with `NODE_V8_COVERAGE` against the shipped entry (fresh `HOME` + all XDG roots), which records every script V8 actually compiled:

| argv | graphpack modules loaded |
|---|---|
| `--version` | none |
| `--help` | `pack.index.generated.js`, `manifest.js`, `types.js` |
| `__complete -- config` / `-- block lookup Butt` | same three |
| `__store-probe` *(positive control)* | + **`pack.generated.js`**, `embedded.js`, `pack.stories.generated.js`, … |

The control proves the probe can see `pack.generated.js`; its absence from `--help` and both `__complete` argvs is real. Its 22.8 ms lands only on the store/dispatch path — ~4.5 % of the ~285 ms of store work under `BUDGET_WARM_STORE_MS = 500`. **This makes the inlining question much less interesting than it looks.** (Secondary: `pack.index.generated.js` *is* on the `--help` graph, not just `__complete`.)

**3. Escaping overhead is small.** `pack.generated.ts` 2 030 886 B on disk vs 1 971 945 B encoded = **+2.99 %**; the index is +10.8 %. Compressed the delta nearly vanishes (`gzip -9`: +0.5 % for the n-quads). **The real packaging cost is duplication, not escaping:** `files` lists both `src` and `dist`, so the pack ships twice — 4.34 MB, **49 % of the unpacked tarball**, ~35 % of the packed one.

**4. What a migration would have to change.** `tsc` copies no non-TS file (the monorepo's pattern is `scripts/copy-templates.ts`, Bun `Glob` → `Bun.write`), so `scripts/build.ts` and the perf `globalSetup` would need an asset step — unless the asset goes at the **package root** and is found by the walk this PR introduces, which ships once and needs no copy step. `lazy.test.ts`'s "dispatch never reaches the embedded n-quads module" assertion would go **vacuously green** if the file stopped existing and would need rewriting, not just re-running; `safety.test.ts`'s forbidden-module graph is unaffected (a `readFileSync` adds no import edges); `wasmEmbed.test.ts` (dist) and `probe.test.ts` (src tree) run from different trees, so a package-root asset satisfies both with one file; `biome.json`'s `**/*.json` would match a `src/`-placed `index.json`/`schema.json`.

**Recommendation (a recommendation, not a change): don't migrate for latency; consider it for tarball weight, as a follow-on.** The 22.8 ms is off every fast path, 3 % escaping is too small to act on, and the only large number is the src/dist duplication — which a package-root asset would cut by roughly **−2.15 MB unpacked (−24 %) / −340 KB packed (−17 %)**. `pack.index.generated` should not move under any option. The cheapest correct action, if nothing else comes of this, is to fix `embedded.ts`'s docblock: its `--compile` premise is gone, and the honest reason to keep inlining is that the module is off the fast paths.

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards) — `bun run check` green at the repo root (biome, tsc, webarchitect `tool-ts`).
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` / `build:all`. Unchanged — `bundle` stays deliberately outside both, which is why the artifact is committed.
- [ ] If this PR introduces a **new package** — n/a, no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.


---

## Follow-up commit — three defects found in review (`fix(pragma-cli): gate skill-link replacement on ownership, and contain bundled copies`)

Read the second commit as part of this PR; it corrects the first, and two of the three are regressions the first commit **introduced**. Where it disagrees with the text above, it wins.

1. **A user's own harness link was deleted.** `detectSkills` classified any symlink that did not resolve to the current skill as `replaced`, and `composeSkills` composes every non-`skipped` row — so `~/.claude/skills/design-auditor -> ~/work/design-auditor` was deleted and relinked. Before this PR a fresh machine had no skills, so no action was composed for that path at all; shipping skills on every install is what made the collision reachable **with no user action**. A link that resolves to something pragma does not own is now `skipped`, the same answer a hand-placed real directory already gets. A **dangling** link is still replaced regardless of where it pointed — nothing depends on a broken link, and for pragma's own link into a cleared cache or a replaced package directory that is the repair.
2. **Ownership by residence in a current root was too narrow**, which is where the "the reconcile already repairs it" claim above was incomplete. After an upgrade under a version-stamped layout the link points into `…@0.34.0/bundled-skills/<name>` — inside no current root. The per-skill pass covers it *only while the release still ships that skill*; once the skill is dropped, nothing covers the path and the orphan sweep rejected it, so the dangling link survived every reconcile, invisible to setup and doctor. `ownsLink` now also accepts the bundled path **shape**, which identifies a link as pragma's without asking where the package sits.
3. **`cpSync(..., { dereference: true })` followed links anywhere.** An entry escaping the pack would copy a release-host file into a committed, published artifact — a symlink to a credential file becomes its contents. Every link beneath a skill directory is now resolved and checked against the pack's real root, and an escaping or broken one **fails the bundle** rather than being skipped, since a silently dropped file would ship an incomplete skill that looks whole.

Doctor gained the matching row: `skipped && !owned && !blocked` is exactly the foreign-link case, and it now gets its own detail and remedy instead of being counted as "links current" over a shadowed path.

Both setup fixes carry regression cells, confirmed red without the change. The bundle guard has none: `scripts/bundle.ts` runs its pipeline at module scope, so importing it in a test would perform a real bundle — making it testable means splitting it into a `main()` plus exports, left as a follow-up.

Re-verified on the merged branch: `bun run test` → **1613 passed | 13 skipped | 5 todo**, plus 22 perf; `gen:reference` no diff; repo-root `bun run check` green.


🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
