### PR TITLE
fix(pragma-cli): detect the install source from the filesystem, and name the linked state

### DIFF
--- a/packages/cli/pragma/src/capabilities/info/collectInfo.ts
+++ b/packages/cli/pragma/src/capabilities/info/collectInfo.ts
@@ -26,6 +26,7 @@ import {
   detectInstallSource,
   PRAGMA_PACKAGE,
   pmUpdateCommand,
+  updateGuidance,
 } from "../shared/index.js";
 import type { InfoData, InfoUpdate } from "./types.js";
 
@@ -44,12 +45,17 @@ export async function collectInfo(runtime: PragmaRuntime): Promise<InfoData> {
 
   // Update-check: unconditional (no flag exists), 3s timeout, silent-fail.
   const registry = await checkRegistryVersion(PRAGMA_PACKAGE, config.channel);
+  // Only a GLOBAL install gets a command; every other state gets the honest
+  // guidance sentence — a confidently wrong `npm i -g` against a linked
+  // checkout would overwrite the development link.
   const update: InfoUpdate | undefined =
     registry && registry.latest !== runtime.version
       ? {
           current: runtime.version,
           latest: registry.latest,
-          command: pmUpdateCommand(install.pm, PRAGMA_PACKAGE),
+          ...(install.kind === "global"
+            ? { command: pmUpdateCommand(install, PRAGMA_PACKAGE) }
+            : { guidance: updateGuidance(install) }),
         }
       : undefined;
   const updateSkipped = registry === undefined;
@@ -62,6 +68,7 @@ export async function collectInfo(runtime: PragmaRuntime): Promise<InfoData> {
   return {
     version: runtime.version,
     installSource: install.label,
+    installKind: install.kind,
     ...(update ? { update } : {}),
     updateSkipped,
     ...(entities !== undefined ? { entities } : {}),

--- a/packages/cli/pragma/src/capabilities/info/info.render.ts
+++ b/packages/cli/pragma/src/capabilities/info/info.render.ts
@@ -37,7 +37,9 @@ export const infoFormatters: Formatters<InfoData> = {
       lines.push(
         "",
         `Update available: ${data.update.current} → ${data.update.latest}`,
-        `  Run: ${data.update.command}`,
+        data.update.command
+          ? `  Run: ${data.update.command}`
+          : `  ${data.update.guidance}`,
       );
     }
     return lines.join("\n");
@@ -61,7 +63,9 @@ export const infoFormatters: Formatters<InfoData> = {
     }
     if (data.update) {
       lines.push(
-        `- Update available: ${data.update.current} → ${data.update.latest} (\`${data.update.command}\`)`,
+        data.update.command
+          ? `- Update available: ${data.update.current} → ${data.update.latest} (\`${data.update.command}\`)`
+          : `- Update available: ${data.update.current} → ${data.update.latest} — ${data.update.guidance}`,
       );
     }
     return lines.join("\n");

--- a/packages/cli/pragma/src/capabilities/info/info.test.ts
+++ b/packages/cli/pragma/src/capabilities/info/info.test.ts
@@ -17,8 +17,25 @@ import { bootRuntime } from "../../kernel/runtime/boot.js";
 import type { GlobalFlags, PragmaRuntime } from "../../kernel/runtime/types.js";
 import type { VerbSpec } from "../../kernel/spec/types.js";
 import { projectMcp } from "../../testing/helpers/projectMcp.js";
+import type { InstallSource } from "../shared/index.js";
 import { infoModule } from "./index.js";
 import type { InfoData } from "./types.js";
+
+// Pin the install-source detection: the real detector reads THIS process
+// (whose entry is a source checkout — an honest `unknown`), and these tests
+// are about the enrichment around it, not the detection itself (covered by
+// `shared/packageManager.test.ts`). The holder lets a case retarget it.
+const detection = vi.hoisted(() => ({ install: undefined as unknown }));
+vi.mock("../shared/index.js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  detectInstallSource: () => detection.install,
+}));
+
+const GLOBAL_NPM: InstallSource = {
+  kind: "global",
+  pm: "npm",
+  label: "npm (global)",
+};
 
 const infoVerb = infoModule.verbs[0] as VerbSpec;
 const FLAGS_JSON: GlobalFlags = {
@@ -54,6 +71,7 @@ let prevXdg: string | undefined;
 beforeEach(() => {
   prevXdg = process.env.XDG_CONFIG_HOME;
   process.env.XDG_CONFIG_HOME = tmpCwd();
+  detection.install = GLOBAL_NPM;
 });
 afterEach(() => {
   process.env.XDG_CONFIG_HOME = prevXdg;
@@ -74,10 +92,28 @@ describe("info — update-check enrichment", () => {
     const data = await collect(rt);
 
     expect(data.update).toMatchObject({ current: VERSION, latest: "99.0.0" });
-    expect(data.update?.command).toContain("@canonical/pragma-cli");
+    expect(data.update?.command).toBe("npm i -g @canonical/pragma-cli");
+    expect(data.installSource).toBe("npm (global)");
+    expect(data.installKind).toBe("global");
     expect(data.updateSkipped).toBe(false);
     // The storeless invariant: the enrichment must NOT boot the store.
     expect(rt.store.booted).toBe(false);
+  });
+
+  it("a LINKED install gets guidance, never a command (would clobber the link)", async () => {
+    detection.install = {
+      kind: "linked",
+      pm: "npm",
+      target: "/home/u/code/pragma/packages/cli/pragma",
+      label: "npm link (development checkout)",
+    } satisfies InstallSource;
+    stubRegistry("99.0.0");
+    const data = await collect(bootRuntime(FLAGS_JSON, tmpCwd()));
+
+    expect(data.installKind).toBe("linked");
+    expect(data.installSource).toBe("npm link (development checkout)");
+    expect(data.update?.command).toBeUndefined();
+    expect(data.update?.guidance).toMatch(/development checkout/i);
   });
 
   it("marks `updateSkipped` when the registry is unreachable", async () => {

--- a/packages/cli/pragma/src/capabilities/info/types.ts
+++ b/packages/cli/pragma/src/capabilities/info/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ConfigOrigins } from "../../kernel/config/types.js";
+import type { InstallKind } from "../../kernel/render/vocabulary.js";
 
 /** The config summary `info` reports — resolved values plus provenance. */
 export interface InfoConfig {
@@ -20,8 +21,12 @@ export interface InfoConfig {
 export interface InfoUpdate {
   readonly current: string;
   readonly latest: string;
-  /** The package-manager command that would apply the update. */
-  readonly command: string;
+  /** The package-manager command that would apply the update — only for a
+   * GLOBAL install; every other state carries {@link guidance} instead. */
+  readonly command?: string;
+  /** The honest sentence for an install with no sanctioned update command
+   * (linked / ephemeral / workspace / unknown). */
+  readonly guidance?: string;
 }
 
 /**
@@ -31,7 +36,10 @@ export interface InfoUpdate {
  */
 export interface InfoData {
   readonly version: string;
+  /** The install-source display label (e.g. `npm (global)`). */
   readonly installSource: string;
+  /** The install-source state the label renders. */
+  readonly installKind: InstallKind;
   /** Set when a newer CLI release is available on the active channel. */
   readonly update?: InfoUpdate;
   /** True when the registry could not be reached (the update-check was skipped). */

--- a/packages/cli/pragma/src/capabilities/shared/index.ts
+++ b/packages/cli/pragma/src/capabilities/shared/index.ts
@@ -27,7 +27,17 @@ export {
   checkExecOk,
   guardMissingBinary,
 } from "./assertExecOk.js";
-export type { InstallSource } from "./packageManager.js";
-export { detectInstallSource, pmUpdateCommand } from "./packageManager.js";
+export type {
+  EphemeralRunner,
+  GlobalInstall,
+  InstallProbe,
+  InstallSource,
+  PackageManager,
+} from "./packageManager.js";
+export {
+  detectInstallSource,
+  pmUpdateCommand,
+  updateGuidance,
+} from "./packageManager.js";
 export type { RegistryCheckResult } from "./registry.js";
 export { checkRegistryVersion, PRAGMA_PACKAGE } from "./registry.js";

--- a/packages/cli/pragma/src/capabilities/shared/packageManager.test.ts
+++ b/packages/cli/pragma/src/capabilities/shared/packageManager.test.ts
@@ -1,14 +1,399 @@
 /**
- * The install-scope heuristic's two path questions.
+ * The install-source detector, driven entirely by fixtures.
  *
- * `detectInstallSource` itself reads `import.meta.url` and the real working
- * directory, so the decision it makes is exercised here through the two pure
- * helpers it composes — which is where every case that has ever been wrong
- * lives.
+ * `detectInstallSource` itself captures the live process; the decision lives
+ * in the pure `classifyInstall`, which takes an {@link InstallProbe} — paths,
+ * environment, and injected filesystem readers — so every layout that has
+ * ever been wrong is a deterministic case here, independent of the machine
+ * the suite runs on (the `PlatformEnv` fixture pattern from
+ * `@canonical/harnesses`).
+ *
+ * The headline case is the LINKED development install (`npm link`/`bun link`):
+ * the old env-var heuristic reported it as `node (global)` and would have
+ * offered `npm i -g`, which overwrites the link to the worktree being
+ * developed. Here it must be identified as linked — and the type of
+ * `pmUpdateCommand` (global arm only) makes producing a command for it a
+ * compile error, which is the strongest "no upgrade command" assertion there
+ * is.
  */
 
 import { describe, expect, it } from "vitest";
-import { containsPath, findInstallRoot } from "./packageManager.js";
+import {
+  classifyInstall,
+  containsPath,
+  ephemeralRunner,
+  findInstallRoot,
+  type InstallProbe,
+  managerFromPath,
+  pmUpdateCommand,
+} from "./packageManager.js";
+import { PRAGMA_PACKAGE } from "./registry.js";
+
+/** The module-relative suffix the running entry carries under `dist`. */
+const ENTRY = "dist/src/capabilities/shared/packageManager.js";
+
+/** Build a probe whose filesystem is the given symlink map + file list. */
+function probeOf(
+  over: Partial<InstallProbe>,
+  fs: { links?: Record<string, string>; files?: string[] } = {},
+): InstallProbe {
+  const links = fs.links ?? {};
+  const resolveLink = (path: string): string | undefined => {
+    const target = links[path];
+    if (target === undefined) return undefined;
+    const base = path.slice(0, path.lastIndexOf("/"));
+    return target.startsWith("/") ? target : `${base}/${target}`;
+  };
+  return {
+    entry: "/unset",
+    invoked: undefined,
+    cwd: "/somewhere/else",
+    userAgent: undefined,
+    runtime: "node",
+    readLink: (path) => links[path],
+    realPath: (path) => {
+      // Follow the final component's link chain, normalizing `..` segments —
+      // enough realpath for these fixtures.
+      let current = path;
+      for (let hop = 0; hop < 10; hop++) {
+        const next = resolveLink(current);
+        if (next === undefined) break;
+        current = next;
+      }
+      const segments: string[] = [];
+      for (const part of current.split("/")) {
+        if (part === "..") segments.pop();
+        else if (part !== "." && part !== "") segments.push(part);
+      }
+      return `/${segments.join("/")}`;
+    },
+    exists: (path) => fs.files?.includes(path) ?? false,
+    ...over,
+  };
+}
+
+const G = "/home/u/.npm-global";
+const NPM_PKG = `${G}/lib/node_modules/@canonical/pragma-cli`;
+
+describe("classifyInstall — global installs", () => {
+  it("npm global: bin symlink into an unmarked global tree", () => {
+    const install = classifyInstall(
+      probeOf(
+        { entry: `${NPM_PKG}/${ENTRY}`, invoked: `${G}/bin/pragma` },
+        {
+          links: {
+            [`${G}/bin/pragma`]:
+              "../lib/node_modules/@canonical/pragma-cli/dist/src/bin.js",
+          },
+        },
+      ),
+    );
+    expect(install).toMatchObject({ kind: "global", pm: "npm" });
+    expect(install.label).toBe("npm (global)");
+    if (install.kind === "global") {
+      expect(pmUpdateCommand(install, PRAGMA_PACKAGE)).toBe(
+        `npm i -g ${PRAGMA_PACKAGE}`,
+      );
+    }
+  });
+
+  it("the user-agent NEVER overrides the path shape (corroboration only)", () => {
+    // `bun run some-script` invoking a globally npm-installed pragma sets a
+    // bun user-agent — the install is still npm's.
+    const install = classifyInstall(
+      probeOf({
+        entry: `${NPM_PKG}/${ENTRY}`,
+        userAgent: "bun/1.2.19 npm/? node/v24.3.0 linux x64",
+      }),
+    );
+    expect(install).toMatchObject({ kind: "global", pm: "npm" });
+  });
+
+  it("bun global: ~/.bun/install/global shape", () => {
+    const pkg =
+      "/home/u/.bun/install/global/node_modules/@canonical/pragma-cli";
+    const install = classifyInstall(
+      probeOf(
+        { entry: `${pkg}/${ENTRY}`, invoked: "/home/u/.bun/bin/pragma" },
+        {
+          links: {
+            "/home/u/.bun/bin/pragma":
+              "../install/global/node_modules/@canonical/pragma-cli/dist/src/bin.js",
+          },
+        },
+      ),
+    );
+    expect(install).toMatchObject({ kind: "global", pm: "bun" });
+    if (install.kind === "global") {
+      expect(pmUpdateCommand(install, PRAGMA_PACKAGE)).toBe(
+        `bun add -g ${PRAGMA_PACKAGE}`,
+      );
+    }
+  });
+
+  it("pnpm global: the .pnpm store segment names the manager", () => {
+    const store =
+      "/home/u/.local/share/pnpm/global/5/.pnpm/@canonical+pragma-cli@0.35.0/node_modules/@canonical/pragma-cli";
+    const install = classifyInstall(probeOf({ entry: `${store}/${ENTRY}` }));
+    expect(install).toMatchObject({ kind: "global", pm: "pnpm" });
+  });
+
+  it("volta: ~/.volta/tools/image/packages shape, with volta's own command", () => {
+    const pkg =
+      "/home/u/.volta/tools/image/packages/pragma-cli/lib/node_modules/@canonical/pragma-cli";
+    // Volta's bin shim is a real executable, not a symlink — the chain walk
+    // yields nothing and the entry path decides.
+    const install = classifyInstall(
+      probeOf({
+        entry: `${pkg}/${ENTRY}`,
+        invoked: "/home/u/.volta/bin/pragma",
+      }),
+    );
+    expect(install).toMatchObject({ kind: "global", pm: "volta" });
+    if (install.kind === "global") {
+      expect(pmUpdateCommand(install, PRAGMA_PACKAGE)).toBe(
+        `volta install ${PRAGMA_PACKAGE}`,
+      );
+    }
+  });
+
+  it("asdf hosts an ordinary npm global tree", () => {
+    const pkg =
+      "/home/u/.asdf/installs/nodejs/22.5.0/lib/node_modules/@canonical/pragma-cli";
+    const install = classifyInstall(probeOf({ entry: `${pkg}/${ENTRY}` }));
+    expect(install).toMatchObject({ kind: "global", pm: "npm" });
+  });
+});
+
+describe("classifyInstall — the LINKED development install (the headline)", () => {
+  // The layout measured on a real machine: `which pragma` →
+  // ~/.npm-global/bin/pragma → node_modules/@canonical/pragma-cli, which is
+  // itself a symlink OUT of the global root into a development worktree. The
+  // module loader realpath-resolves `import.meta.url`, so the entry has
+  // already escaped to the worktree — only the argv[1] chain can see the link.
+  const worktree =
+    "/home/u/code/cn/pragma/.claude/worktrees/try-main/packages/cli/pragma";
+
+  const linkedProbe = (over: Partial<InstallProbe> = {}): InstallProbe =>
+    probeOf(
+      {
+        entry: `${worktree}/${ENTRY}`,
+        invoked: `${G}/bin/pragma`,
+        ...over,
+      },
+      {
+        links: {
+          [`${G}/bin/pragma`]:
+            "../lib/node_modules/@canonical/pragma-cli/dist/src/bin.js",
+          [NPM_PKG]:
+            "../../../../code/cn/pragma/.claude/worktrees/try-main/packages/cli/pragma",
+        },
+      },
+    );
+
+  it("identifies npm link — never 'global'", () => {
+    const install = classifyInstall(linkedProbe());
+    expect(install.kind).toBe("linked");
+    expect(install.label).toBe("linked (development checkout)");
+    if (install.kind === "linked") {
+      expect(install.target).toBe(worktree);
+    }
+    // No upgrade command exists for it: `pmUpdateCommand` only accepts the
+    // global arm, so the following would not compile —
+    //   pmUpdateCommand(install, PRAGMA_PACKAGE)
+    // — and the runtime data carries guidance instead (see upgrade.test.ts).
+  });
+
+  it("identifies bun link, naming the hosting manager", () => {
+    const pkg =
+      "/home/u/.bun/install/global/node_modules/@canonical/pragma-cli";
+    const checkout =
+      "/home/u/code/cn/pragma/.claude/worktrees/fix-tier-rank/packages/cli/pragma";
+    const install = classifyInstall(
+      probeOf(
+        {
+          entry: `${checkout}/${ENTRY}`,
+          invoked: "/home/u/.bun/bin/pragma",
+          runtime: "bun",
+        },
+        {
+          links: {
+            "/home/u/.bun/bin/pragma":
+              "../install/global/node_modules/@canonical/pragma-cli/dist/src/bin.js",
+            [pkg]: checkout,
+          },
+        },
+      ),
+    );
+    expect(install).toMatchObject({ kind: "linked", pm: "bun" });
+    expect(install.label).toBe("bun link (development checkout)");
+  });
+
+  it("a workspace-internal package symlink is NOT a link — it stays inside the root", () => {
+    // A monorepo's own `node_modules/<pkg>` → `packages/<pkg>` symlink points
+    // outside node_modules but INSIDE the project — a workspace install.
+    const root = "/home/u/proj";
+    const install = classifyInstall(
+      probeOf(
+        {
+          entry: `${root}/packages/cli/pragma/${ENTRY}`,
+          invoked: `${root}/node_modules/.bin/pragma`,
+          cwd: `${root}/apps/site`,
+        },
+        {
+          links: {
+            [`${root}/node_modules/.bin/pragma`]:
+              "../@canonical/pragma-cli/dist/src/bin.js",
+            [`${root}/node_modules/@canonical/pragma-cli`]:
+              "../../packages/cli/pragma",
+          },
+          files: [`${root}/bun.lock`],
+        },
+      ),
+    );
+    expect(install).toMatchObject({ kind: "workspace", pm: "bun", root });
+    expect(install.label).toBe("bun (local project)");
+  });
+});
+
+describe("classifyInstall — ephemeral runners (no upgrade command)", () => {
+  it("npx resolves into the ~/.npm/_npx cache", () => {
+    const pkg =
+      "/home/u/.npm/_npx/beb367dfa21eb3f5/node_modules/@canonical/pragma-cli";
+    const install = classifyInstall(probeOf({ entry: `${pkg}/${ENTRY}` }));
+    expect(install).toMatchObject({ kind: "ephemeral", runner: "npx" });
+    expect(install.label).toBe("npx (ephemeral)");
+  });
+
+  it("bunx resolves into a bunx-* temp dir", () => {
+    const pkg =
+      "/tmp/bunx-1000-@canonical/pragma-cli@latest/node_modules/@canonical/pragma-cli";
+    const install = classifyInstall(
+      probeOf({ entry: `${pkg}/${ENTRY}`, runtime: "bun" }),
+    );
+    expect(install).toMatchObject({ kind: "ephemeral", runner: "bunx" });
+  });
+});
+
+describe("classifyInstall — workspace installs", () => {
+  const root = "/home/u/proj";
+  const pkg = `${root}/node_modules/@canonical/pragma-cli`;
+
+  it("names the manager from the lockfile beside the install root", () => {
+    const install = classifyInstall(
+      probeOf(
+        { entry: `${pkg}/${ENTRY}`, cwd: `${root}/packages/site` },
+        { files: [`${root}/package-lock.json`] },
+      ),
+    );
+    expect(install).toMatchObject({ kind: "workspace", pm: "npm", root });
+    expect(install.label).toBe("npm (local project)");
+  });
+
+  it("falls back to the user-agent when no lockfile marks the tree", () => {
+    const install = classifyInstall(
+      probeOf({
+        entry: `${pkg}/${ENTRY}`,
+        cwd: root,
+        userAgent: "pnpm/9.1.0 npm/? node/v20.11.0 linux x64",
+      }),
+    );
+    expect(install).toMatchObject({ kind: "workspace", pm: "pnpm" });
+  });
+
+  it("stays honest with no marker at all", () => {
+    const install = classifyInstall(
+      probeOf({ entry: `${pkg}/${ENTRY}`, cwd: root }),
+    );
+    expect(install.kind).toBe("workspace");
+    expect(install.label).toBe("local project dependency");
+  });
+});
+
+describe("classifyInstall — unknown (the honest fallback)", () => {
+  it("a source checkout run directly is unknown, not global", () => {
+    const entry =
+      "/work/pragma/packages/cli/pragma/src/capabilities/shared/packageManager.ts";
+    const install = classifyInstall(
+      probeOf({
+        entry,
+        invoked: "/work/pragma/packages/cli/pragma/src/bin.ts",
+      }),
+    );
+    expect(install.kind).toBe("unknown");
+    expect(install.label).toBe("unknown (node runtime)");
+  });
+
+  it("a FOREIGN bin on argv[1] (a test runner) never misattributes the install", () => {
+    const repo = "/repo";
+    const install = classifyInstall(
+      probeOf(
+        {
+          entry: `${repo}/packages/cli/pragma/src/capabilities/shared/packageManager.ts`,
+          invoked: `${repo}/node_modules/.bin/vitest`,
+        },
+        {
+          links: {
+            [`${repo}/node_modules/.bin/vitest`]: "../vitest/vitest.mjs",
+          },
+        },
+      ),
+    );
+    expect(install.kind).toBe("unknown");
+  });
+
+  it("a symlink cycle on the invoked path is bounded, not spun", () => {
+    const install = classifyInstall(
+      probeOf(
+        { entry: "/src/tree/file.ts", invoked: "/a" },
+        { links: { "/a": "/b", "/b": "/a" } },
+      ),
+    );
+    expect(install.kind).toBe("unknown");
+  });
+});
+
+describe("path-shape helpers (win32 shapes exercised, not host-validated)", () => {
+  it("managerFromPath reads win32 volta and posix shapes alike", () => {
+    expect(
+      managerFromPath(
+        "C:\\Users\\u\\AppData\\Local\\Volta\\tools\\image\\packages\\pragma-cli\\node_modules\\@canonical\\pragma-cli\\dist\\src\\bin.js",
+      ),
+    ).toBe("volta");
+    expect(
+      managerFromPath(
+        "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@canonical\\pragma-cli\\dist\\src\\bin.js",
+      ),
+    ).toBeUndefined();
+    expect(
+      managerFromPath("/home/u/.config/yarn/global/node_modules/x/bin.js"),
+    ).toBe("yarn");
+    expect(
+      managerFromPath("/home/u/.nvm/versions/node/v20/lib/node_modules/x"),
+    ).toBe("npm");
+    // A project merely NAMED volta must not read as the volta layout.
+    expect(
+      managerFromPath("/home/u/volta/node_modules/x/bin.js"),
+    ).toBeUndefined();
+  });
+
+  it("ephemeralRunner reads npx/bunx/dlx cache shapes on both separator styles", () => {
+    expect(
+      ephemeralRunner(
+        "C:\\Users\\u\\AppData\\Local\\npm-cache\\_npx\\abc\\node_modules\\x\\bin.js",
+      ),
+    ).toBe("npx");
+    expect(
+      ephemeralRunner("/tmp/bunx-1000-x@latest/node_modules/x/bin.js"),
+    ).toBe("bunx");
+    expect(
+      ephemeralRunner("/home/u/.cache/pnpm/dlx/abc/node_modules/x/bin.js"),
+    ).toBe("pnpm dlx");
+    expect(
+      ephemeralRunner("/home/u/proj/node_modules/x/bin.js"),
+    ).toBeUndefined();
+  });
+});
 
 describe("findInstallRoot", () => {
   it("yields the directory the package was installed into", () => {
@@ -23,6 +408,14 @@ describe("findInstallRoot", () => {
     expect(
       findInstallRoot("/proj/node_modules/a/node_modules/b/dist/bin.js"),
     ).toBe("/proj/node_modules/a");
+  });
+
+  it("reads a win32 path with its own separator", () => {
+    expect(
+      findInstallRoot(
+        "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@canonical\\pragma-cli\\dist\\src\\bin.js",
+      ),
+    ).toBe("C:\\Users\\u\\AppData\\Roaming\\npm");
   });
 
   it("reports no install root for a source checkout", () => {

--- a/packages/cli/pragma/src/capabilities/shared/packageManager.test.ts
+++ b/packages/cli/pragma/src/capabilities/shared/packageManager.test.ts
@@ -377,6 +377,28 @@ describe("path-shape helpers (win32 shapes exercised, not host-validated)", () =
     ).toBeUndefined();
   });
 
+  it("ephemeralRunner ignores ordinary directories that merely share a name (REGRESSION)", () => {
+    // The patterns are anchored to each runner's real cache layout. Matching a
+    // bare segment anywhere would reclassify a project living under a directory
+    // called `dlx`, `_npx` or `bunx-something` as ephemeral — and since that
+    // verdict is reached before the workspace check, it wins even with a
+    // lockfile beside the root, leaving the user with no upgrade command and no
+    // error explaining why.
+    expect(
+      ephemeralRunner("/work/dlx/app/node_modules/@canonical/pragma-cli"),
+    ).toBeUndefined();
+    expect(
+      ephemeralRunner("/srv/_npx/site/node_modules/@canonical/pragma-cli"),
+    ).toBeUndefined();
+    expect(
+      ephemeralRunner("/home/u/bunx-tools/node_modules/@canonical/pragma-cli"),
+    ).toBeUndefined();
+    // `dlx` outside a pnpm cache, and `_npx` outside npm's, stay ordinary.
+    expect(
+      ephemeralRunner("/home/u/.cache/yarn/dlx/abc/node_modules/x/bin.js"),
+    ).toBeUndefined();
+  });
+
   it("ephemeralRunner reads npx/bunx/dlx cache shapes on both separator styles", () => {
     expect(
       ephemeralRunner(

--- a/packages/cli/pragma/src/capabilities/shared/packageManager.ts
+++ b/packages/cli/pragma/src/capabilities/shared/packageManager.ts
@@ -1,40 +1,146 @@
 /**
- * Storeless install-source heuristic, shared by `info`, `upgrade`, and
+ * Storeless install-source detector, shared by `info`, `upgrade`, and
  * `doctor`'s `pragma version` check.
  *
- * Promotes the detector that lived inline in `info/collectInfo.ts`: the package
- * manager comes from npm's `npm_config_user_agent` (set by npm/pnpm/yarn/bun
- * when they run a script), the scope from whether the installed entry sits
- * under the CURRENT PROJECT. With no agent we report the honest runtime rather
- * than guessing. The old shell's full package.json walk (`#package-manager`) is
- * dropped — only this heuristic and the update-command map survive.
+ * Detection is driven by the FILESYSTEM — the resolved entry path, the invoked
+ * bin path, and the symlinks between them — not by environment variables. The
+ * previous heuristic read `npm_config_user_agent`, which npm/pnpm/yarn/bun set
+ * only when THEY run a script; a user typing the bin name in a shell never has
+ * it, so on the path that mattered the detector always fell through to the
+ * honest runtime and reported `node` for every install. The agent survives
+ * only as a last-resort corroboration for a workspace install whose tree
+ * carries no other marker.
+ *
+ * The two paths that matter, and why both are needed:
+ *
+ * - `import.meta.url` is REALPATH-RESOLVED by the module loader. For a normal
+ *   install it sits inside `node_modules/<pkg>`; for a linked development
+ *   install (`npm link` / `bun link`) it has already escaped to the source
+ *   checkout and contains no `node_modules` at all — which is precisely why an
+ *   entry-only detector cannot see a link.
+ * - `process.argv[1]` preserves the path the user actually invoked, symlinks
+ *   intact. Walking its link chain finds the `node_modules/<pkg>` entry the
+ *   bin points through, and whether THAT directory is itself a symlink
+ *   pointing outside the install root — the linked-install signal. The chain
+ *   is only trusted when the package directory it names really contains the
+ *   running module (`realPath` identity check), so a foreign bin on argv[1]
+ *   (vitest, a wrapper script) never misattributes the install.
+ *
+ * The manager is identified by path SHAPE (`.bun/`, `.pnpm`/`pnpm`, `.volta`,
+ * `.asdf`, yarn's global dir), ephemeral runners by their cache shapes
+ * (`_npx`, `bunx-*`, pnpm's `dlx`), and a workspace's manager by the lockfile
+ * beside the install root. When no signal is conclusive the detector answers
+ * `unknown` — a state with NO update command, because a confidently wrong
+ * `npm i -g` is worse than none (against a linked checkout it would overwrite
+ * the link to the tree being developed). `pmUpdateCommand` accepts only the
+ * {@link GlobalInstall} arm, so offering a command to any other state is a
+ * type error, not a convention.
+ *
+ * Read-only and storeless: a handful of `lstat`/`readlink`/`realpath`/`exists`
+ * probes, bounded by the link-chain cap — nothing is ever written. The module
+ * sits on the fast-path static graph (via the shared barrel), so all probing
+ * happens at call time; module load stays inert.
+ *
+ * Windows note: segment matching splits on both separators, so the SHAPE
+ * checks (`managerFromPath`, `ephemeralRunner`) are exercised against
+ * win32-style fixtures — but scope containment goes through the host's
+ * `node:path` and, like `platformPaths.ts`, the win32 arm is a conventional
+ * best guess that has NOT been validated on a real Windows machine.
  */
 
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { existsSync, readlinkSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  INSTALL_UPDATE_GUIDANCE,
+  installSourceLabel,
+} from "../../kernel/render/vocabulary.js";
 
-/** The install source: package manager and a display label. */
-export interface InstallSource {
-  /** Package-manager name (`bun`/`npm`/`pnpm`/`yarn`), else the honest runtime. */
-  readonly pm: string;
-  /** `${pm} (${scope})` — the string `info`/`doctor` display. */
+/** The package managers the detector can name (volta counts: it owns the
+ * install and its own update command). */
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun" | "volta";
+
+/** The ephemeral runners — cache-resolved, with no meaningful upgrade. */
+export type EphemeralRunner = "npx" | "bunx" | "pnpm dlx";
+
+/** A global install by a known manager — the ONLY updatable state. */
+export interface GlobalInstall {
+  readonly kind: "global";
+  readonly pm: PackageManager;
   readonly label: string;
 }
 
-/** The package manager from npm's user-agent, else the honest runtime. */
-function packageManager(): string {
-  const agent = process.env.npm_config_user_agent;
-  const name = agent?.split("/")[0];
-  if (name) return name;
-  return process.versions.bun ? "bun" : "node";
+/** Installed as a dependency of the project the command runs in. */
+export interface WorkspaceInstall {
+  readonly kind: "workspace";
+  /** The project's manager, when a lockfile/shape/agent names one. */
+  readonly pm?: PackageManager;
+  /** The project directory the package is installed into. */
+  readonly root: string;
+  readonly label: string;
 }
 
+/** A linked development install: `node_modules/<pkg>` is a symlink pointing
+ * OUTSIDE the install root (`npm link` / `bun link` / `pnpm link`). */
+export interface LinkedInstall {
+  readonly kind: "linked";
+  /** The manager whose global tree hosts the link, when its shape names one. */
+  readonly pm?: PackageManager;
+  /** The resolved link target — the development checkout. */
+  readonly target: string;
+  readonly label: string;
+}
+
+/** An `npx`/`bunx`/`pnpm dlx` run out of a runner cache. */
+export interface EphemeralInstall {
+  readonly kind: "ephemeral";
+  readonly runner: EphemeralRunner;
+  readonly label: string;
+}
+
+/** No conclusive signal — report the honest runtime and offer nothing. */
+export interface UnknownInstall {
+  readonly kind: "unknown";
+  readonly runtime: "node" | "bun";
+  readonly label: string;
+}
+
+/** The install source — a closed union; only {@link GlobalInstall} updates. */
+export type InstallSource =
+  | GlobalInstall
+  | WorkspaceInstall
+  | LinkedInstall
+  | EphemeralInstall
+  | UnknownInstall;
+
 /**
- * Detect how the binary was installed — package manager and scope.
- *
- * @returns The install source (pm, label).
- * @note Impure — reads `import.meta.url`, the working directory, and `process.env`.
+ * Everything the classifier reads, captured as a value so tests drive any
+ * layout as a fixture — the `PlatformEnv` pattern from
+ * `@canonical/harnesses/platformPaths.ts`, with the filesystem probes
+ * injected the way `detectWsl` injects its `/proc/version` reader.
  */
+export interface InstallProbe {
+  /** The running module's own path (`import.meta.url`, realpath-resolved). */
+  readonly entry: string;
+  /** The invoked script path (`process.argv[1]`), symlinks preserved. */
+  readonly invoked: string | undefined;
+  readonly cwd: string;
+  /** `npm_config_user_agent` — corroboration only, absent on a bare run. */
+  readonly userAgent: string | undefined;
+  readonly runtime: "node" | "bun";
+  /** A symlink's raw target, or `undefined` when not a symlink/unreadable. */
+  readonly readLink: (path: string) => string | undefined;
+  /** Fully-resolved real path, or `undefined` when unresolvable. */
+  readonly realPath: (path: string) => string | undefined;
+  readonly exists: (path: string) => boolean;
+}
+
+/** Split on both separators, so shape checks read win32 paths too. */
+const splitPath = (path: string): string[] => path.split(/[\\/]/);
+
+/** The separator the input path itself uses (win32 fixtures keep theirs). */
+const sepOf = (path: string): string => (path.includes("\\") ? "\\" : "/");
+
 /**
  * The directory a package was installed INTO — the parent of the `node_modules`
  * holding it, so `/proj/node_modules/@scope/x/dist/bin.js` yields `/proj`.
@@ -48,9 +154,9 @@ function packageManager(): string {
  * @remarks Exported for its unit test; not part of the package's public surface.
  */
 export function findInstallRoot(entry: string): string | undefined {
-  const segments = entry.split(sep);
+  const segments = splitPath(entry);
   const index = segments.lastIndexOf("node_modules");
-  return index === -1 ? undefined : segments.slice(0, index).join(sep);
+  return index === -1 ? undefined : segments.slice(0, index).join(sepOf(entry));
 }
 
 /**
@@ -70,49 +176,260 @@ export function containsPath(directory: string, candidate: string): boolean {
   return offset === "" || (!offset.startsWith("..") && !isAbsolute(offset));
 }
 
-export function detectInstallSource(): InstallSource {
-  // The entry's own location, NOT `process.argv[1]`. Under the compiled binary
-  // argv[1] was the user's FIRST ARGUMENT (the executable was argv[0]), so the
-  // old `includes("node_modules")` test read a command word and answered
-  // "global" for almost everything. Shipping `node dist/src/bin.js` moves the
-  // entry path INTO argv[1], where it always contains `node_modules` — which
-  // would answer "local" for everything, the same bug facing the other way.
-  // `import.meta.url` is the honest source either way.
-  const entry = fileURLToPath(import.meta.url);
-  // LOCAL means the working directory sits inside the project this package was
-  // installed into — not merely that the entry sits under the cwd. Asking the
-  // narrower question called a perfectly ordinary local install "global" the
-  // moment the user ran it from a subdirectory, which in a monorepo is the
-  // usual case. Going the other way, deriving the install root also settles the
-  // $HOME-nested global prefixes (nvm, `~/.npm-global`): their root is the
-  // prefix, which contains no user project.
-  const root = findInstallRoot(entry);
-  const scope =
-    root !== undefined && containsPath(root, resolve(process.cwd()))
-      ? "local"
-      : "global";
-  const pm = packageManager();
-  return { pm, label: `${pm} (${scope})` };
+/** A located installed package: its tree's root and its own directory. */
+interface LocatedPackage {
+  /** The directory the package was installed into (parent of node_modules). */
+  readonly root: string;
+  /** The `node_modules/<pkg>` directory itself (scoped-aware). */
+  readonly pkgDir: string;
 }
 
-/** The npm global-update command — also the fallback for an unknown manager. */
-const npmUpdateCommand = (pkg: string): string => `npm i -g ${pkg}`;
+/**
+ * Locate the `node_modules` package a path sits inside — root and package
+ * directory, scope-aware. `node_modules/.bin/...` is NOT a package (the shim
+ * there is a symlink the chain walk should follow instead).
+ */
+function locatePackage(path: string): LocatedPackage | undefined {
+  const segments = splitPath(path);
+  const index = segments.lastIndexOf("node_modules");
+  if (index === -1) return undefined;
+  const first = segments[index + 1];
+  if (first === undefined || first === ".bin") return undefined;
+  const span = first.startsWith("@") ? 2 : 1;
+  if (span === 2 && segments[index + 2] === undefined) return undefined;
+  const sep = sepOf(path);
+  return {
+    root: segments.slice(0, index).join(sep),
+    pkgDir: segments.slice(0, index + 1 + span).join(sep),
+  };
+}
+
+/** The manager a path's shape names, or `undefined` when it names none. */
+export function managerFromPath(path: string): PackageManager | undefined {
+  const segments = splitPath(path).map((s) => s.toLowerCase());
+  const has = (name: string): boolean => segments.includes(name);
+  if (has(".bun")) return "bun";
+  if (has(".pnpm") || has("pnpm")) return "pnpm";
+  if (
+    has(".volta") ||
+    segments.some((s, i) => s === "volta" && segments[i + 1] === "tools")
+  ) {
+    return "volta";
+  }
+  // asdf/nvm host an ordinary npm global tree inside a versioned node install.
+  if (has(".asdf") || has(".nvm")) return "npm";
+  const yarn = segments.findIndex((s) => s === "yarn" || s === ".yarn");
+  if (yarn !== -1 && segments.indexOf("global", yarn) !== -1) return "yarn";
+  return undefined;
+}
+
+/** The ephemeral runner a path's cache shape names, if any. */
+export function ephemeralRunner(path: string): EphemeralRunner | undefined {
+  const segments = splitPath(path);
+  if (segments.includes("_npx")) return "npx";
+  if (segments.some((s) => s.startsWith("bunx-"))) return "bunx";
+  if (segments.includes("dlx")) return "pnpm dlx";
+  return undefined;
+}
+
+/** The lockfile beside an install root, mapped to its manager. */
+function lockfileManager(
+  root: string,
+  exists: InstallProbe["exists"],
+  sep: string,
+): PackageManager | undefined {
+  const beside = (name: string): boolean => exists(`${root}${sep}${name}`);
+  if (beside("bun.lock") || beside("bun.lockb")) return "bun";
+  if (beside("pnpm-lock.yaml")) return "pnpm";
+  if (beside("yarn.lock")) return "yarn";
+  if (beside("package-lock.json")) return "npm";
+  return undefined;
+}
+
+/** The manager `npm_config_user_agent` names, when present and recognized. */
+function agentManager(agent: string | undefined): PackageManager | undefined {
+  const name = agent?.split("/")[0];
+  return name === "npm" || name === "pnpm" || name === "yarn" || name === "bun"
+    ? name
+    : undefined;
+}
+
+/** The link-chain hop cap — a symlink cycle must not spin the detector. */
+const MAX_LINK_HOPS = 10;
+
+/**
+ * Walk `argv[1]`'s symlink chain to the `node_modules` entry it points
+ * through, and trust it only when that package directory really contains the
+ * running module. Returns the FIRST chain path inside a package — before the
+ * package-level symlink is resolved away, which is where the linked-install
+ * signal lives.
+ */
+function resolveInvokedEntry(probe: InstallProbe): string | undefined {
+  if (probe.invoked === undefined) return undefined;
+  let path = resolve(probe.cwd, probe.invoked);
+  for (let hop = 0; hop < MAX_LINK_HOPS; hop++) {
+    const located = locatePackage(path);
+    if (located !== undefined) {
+      // Identity check: only OUR package's bin may classify this process.
+      const real = probe.realPath(located.pkgDir);
+      return real !== undefined && containsPath(real, probe.entry)
+        ? path
+        : undefined;
+    }
+    const target = probe.readLink(path);
+    if (target === undefined) return undefined;
+    path = resolve(dirname(path), target);
+  }
+  return undefined;
+}
+
+const unknownInstall = (runtime: "node" | "bun"): UnknownInstall => ({
+  kind: "unknown",
+  runtime,
+  label: installSourceLabel("unknown", runtime),
+});
+
+/**
+ * Classify an install from a captured probe — the PURE core of
+ * {@link detectInstallSource}, exercised by the fixture matrix in its test.
+ *
+ * @param probe - The captured paths, environment, and filesystem readers.
+ * @returns The classified install source.
+ */
+export function classifyInstall(probe: InstallProbe): InstallSource {
+  const invokedEntry = resolveInvokedEntry(probe);
+  const installed =
+    invokedEntry ??
+    (locatePackage(probe.entry) !== undefined ? probe.entry : undefined);
+  if (installed === undefined) return unknownInstall(probe.runtime);
+  const located = locatePackage(installed);
+  /* v8 ignore next -- `installed` is only set when locatePackage succeeded */
+  if (located === undefined) return unknownInstall(probe.runtime);
+  const { root, pkgDir } = located;
+
+  // A package dir that is a symlink pointing OUTSIDE its install root is a
+  // linked development install (`npm link`/`bun link`). Inside the root it is
+  // a store or workspace layout (pnpm's `.pnpm`, a monorepo package) — normal.
+  const rawTarget = probe.readLink(pkgDir);
+  if (rawTarget !== undefined) {
+    const target = resolve(dirname(pkgDir), rawTarget);
+    if (!containsPath(root, target)) {
+      const pm = managerFromPath(installed);
+      return {
+        kind: "linked",
+        ...(pm !== undefined ? { pm } : {}),
+        target,
+        label: installSourceLabel("linked", pm),
+      };
+    }
+  }
+
+  const runner = ephemeralRunner(installed);
+  if (runner !== undefined) {
+    return {
+      kind: "ephemeral",
+      runner,
+      label: installSourceLabel("ephemeral", runner),
+    };
+  }
+
+  const shaped = managerFromPath(installed);
+  if (containsPath(root, resolve(probe.cwd))) {
+    // A workspace tree can belong to any manager; the lockfile beside its
+    // root is the marker, the user-agent (when a script runner set it) the
+    // corroboration of last resort.
+    const pm =
+      shaped ??
+      lockfileManager(root, probe.exists, sepOf(installed)) ??
+      agentManager(probe.userAgent);
+    return {
+      kind: "workspace",
+      ...(pm !== undefined ? { pm } : {}),
+      root,
+      label: installSourceLabel("workspace", pm),
+    };
+  }
+
+  // A global tree with none of the distinctive shapes is npm's: bun, pnpm,
+  // volta and yarn all mark their global roots, npm (and nvm/asdf node
+  // installs, which npm serves) do not. The user-agent is NOT consulted here —
+  // it names whoever ran the script (`bun run …`), not who installed the bin.
+  const pm = shaped ?? "npm";
+  return { kind: "global", pm, label: installSourceLabel("global", pm) };
+}
+
+/** Capture the live process into a probe (the only impure code here). */
+function liveProbe(): InstallProbe {
+  return {
+    entry: fileURLToPath(import.meta.url),
+    invoked: process.argv[1],
+    cwd: process.cwd(),
+    userAgent: process.env.npm_config_user_agent,
+    runtime: process.versions.bun ? "bun" : "node",
+    readLink: (path) => {
+      try {
+        return readlinkSync(path);
+      } catch {
+        return undefined;
+      }
+    },
+    realPath: (path) => {
+      try {
+        return realpathSync(path);
+      } catch {
+        return undefined;
+      }
+    },
+    exists: (path) => existsSync(path),
+  };
+}
+
+/**
+ * Detect how the binary was installed.
+ *
+ * @param probe - Injected probe (tests); defaults to the live process.
+ * @returns The classified install source.
+ * @note Impure by default — reads `import.meta.url`, `process`, and a bounded
+ *   handful of symlink/realpath/exists probes. Never writes.
+ */
+export function detectInstallSource(
+  probe: InstallProbe = liveProbe(),
+): InstallSource {
+  return classifyInstall(probe);
+}
 
 /** The global-update command per package manager (install-style). */
-const PM_UPDATE_COMMAND: Record<string, (pkg: string) => string> = {
+const PM_UPDATE_COMMAND: Record<PackageManager, (pkg: string) => string> = {
   bun: (pkg) => `bun add -g ${pkg}`,
-  npm: npmUpdateCommand,
+  npm: (pkg) => `npm i -g ${pkg}`,
   pnpm: (pkg) => `pnpm add -g ${pkg}`,
   yarn: (pkg) => `yarn global add ${pkg}`,
+  volta: (pkg) => `volta install ${pkg}`,
 };
 
 /**
- * The command that updates `pkg` globally for a package manager.
+ * The command that updates a GLOBAL install of `pkg`. Accepting only the
+ * {@link GlobalInstall} arm is the point: a linked, ephemeral, workspace, or
+ * unknown install has no sanctioned command, and asking for one is a type
+ * error — {@link updateGuidance} is what those states say instead.
  *
- * @param pm - The package-manager name (`bun`/`npm`/`pnpm`/`yarn`).
+ * @param install - The detected global install.
  * @param pkg - The package to update.
- * @returns The shell command; falls back to npm for an unknown manager.
+ * @returns The shell command.
  */
-export function pmUpdateCommand(pm: string, pkg: string): string {
-  return (PM_UPDATE_COMMAND[pm] ?? npmUpdateCommand)(pkg);
+export function pmUpdateCommand(install: GlobalInstall, pkg: string): string {
+  return PM_UPDATE_COMMAND[install.pm](pkg);
+}
+
+/**
+ * The honest sentence a command-less install state shows when a newer release
+ * exists — see {@link INSTALL_UPDATE_GUIDANCE} for the words.
+ *
+ * @param install - Any non-global install.
+ * @returns The guidance sentence for its state.
+ */
+export function updateGuidance(
+  install: Exclude<InstallSource, GlobalInstall>,
+): string {
+  return INSTALL_UPDATE_GUIDANCE[install.kind];
 }

--- a/packages/cli/pragma/src/capabilities/shared/packageManager.ts
+++ b/packages/cli/pragma/src/capabilities/shared/packageManager.ts
@@ -223,12 +223,30 @@ export function managerFromPath(path: string): PackageManager | undefined {
   return undefined;
 }
 
-/** The ephemeral runner a path's cache shape names, if any. */
+/**
+ * The ephemeral runner a path's cache shape names, if any.
+ *
+ * Each pattern is anchored to the runner's ACTUAL cache layout, not to a bare
+ * directory name appearing anywhere in the path. A loose match reclassifies an
+ * ordinary project — `/work/dlx/app`, or anything under a directory someone
+ * named `_npx` — as ephemeral, and because that verdict is reached BEFORE the
+ * workspace containment check it wins even when a lockfile sits beside the
+ * root. The failure is quiet rather than loud: an ephemeral install correctly
+ * offers no upgrade command, so the user simply never learns how to update.
+ */
 export function ephemeralRunner(path: string): EphemeralRunner | undefined {
   const segments = splitPath(path);
-  if (segments.includes("_npx")) return "npx";
-  if (segments.some((s) => s.startsWith("bunx-"))) return "bunx";
-  if (segments.includes("dlx")) return "pnpm dlx";
+  // npx caches at `<npm cache>/_npx/<hash>/…` — `~/.npm` on unix,
+  // `%LOCALAPPDATA%\npm-cache` on Windows.
+  const npx = segments.indexOf("_npx");
+  const npxParent = npx > 0 ? segments[npx - 1] : undefined;
+  if (npxParent === ".npm" || npxParent === "npm-cache") return "npx";
+  // bunx materialises `$TMPDIR/bunx-<uid>-<pkg>@<ver>/…`; requiring the uid
+  // keeps a hand-made `bunx-tools` directory from matching.
+  if (segments.some((s) => /^bunx-\d+-/.test(s))) return "bunx";
+  // pnpm caches at `<pnpm cache>/dlx/<hash>/…`.
+  const dlx = segments.indexOf("dlx");
+  if (dlx > 0 && segments[dlx - 1] === "pnpm") return "pnpm dlx";
   return undefined;
 }
 

--- a/packages/cli/pragma/src/capabilities/upgrade/runUpgrade.ts
+++ b/packages/cli/pragma/src/capabilities/upgrade/runUpgrade.ts
@@ -13,6 +13,11 @@
  *   by `assertExecOk` as an actionable UNSUPPORTED (exit 1) — the interpreter
  *   RESOLVES on a nonzero exit, so the check is the consumer's job.
  * - offline / already-latest carry NO exec — a real run just returns the status.
+ * - a non-global install (linked / ephemeral / workspace / unknown) also
+ *   carries NO exec even when an update exists: there is no command pragma may
+ *   run for it, so the task reports the delta plus the state's guidance and
+ *   mutates nothing. `pmUpdateCommand` only accepts the global arm, so this is
+ *   enforced by the types, not by convention.
  *
  * The whole registry read is preview-safe, so no `mutation.preview` gating is
  * needed here (unlike `sources update`, whose heavy resolve must be gated).
@@ -29,6 +34,7 @@ import {
   guardMissingBinary,
   PRAGMA_PACKAGE,
   pmUpdateCommand,
+  updateGuidance,
 } from "../shared/index.js";
 import type { UpgradeData } from "./types.js";
 
@@ -46,8 +52,15 @@ export async function runUpgrade(
 ): Promise<Task<UpgradeData>> {
   const { channel } = (await rt.loadConfig()).config;
   const install = detectInstallSource();
-  const command = pmUpdateCommand(install.pm, PRAGMA_PACKAGE);
+  // Only a GLOBAL install has a sanctioned update command — the type of
+  // `pmUpdateCommand` enforces the narrowing. A linked checkout in particular
+  // must never be handed `npm i -g`: it would overwrite the development link.
+  const command =
+    install.kind === "global"
+      ? pmUpdateCommand(install, PRAGMA_PACKAGE)
+      : undefined;
   const pm = install.label;
+  const kind = install.kind;
   const current = rt.version;
 
   const registry = await checkRegistryVersion(PRAGMA_PACKAGE, channel);
@@ -55,9 +68,10 @@ export async function runUpgrade(
   if (registry === undefined) {
     const data: UpgradeData = {
       pm,
+      kind,
       current,
       latest: undefined,
-      command,
+      ...(command !== undefined ? { command } : {}),
       offline: true,
       alreadyLatest: false,
       executed: false,
@@ -71,9 +85,10 @@ export async function runUpgrade(
   if (registry.latest === current) {
     const data: UpgradeData = {
       pm,
+      kind,
       current,
       latest: registry.latest,
-      command,
+      ...(command !== undefined ? { command } : {}),
       offline: false,
       alreadyLatest: true,
       executed: false,
@@ -84,16 +99,40 @@ export async function runUpgrade(
     });
   }
 
+  if (install.kind !== "global") {
+    // An update exists, but this install has no command pragma may run for
+    // it — say so honestly and run NOTHING. (The discriminant narrowing is
+    // what lets `updateGuidance` accept `install` here.)
+    const guidance = updateGuidance(install);
+    const data: UpgradeData = {
+      pm,
+      kind,
+      current,
+      latest: registry.latest,
+      guidance,
+      offline: false,
+      alreadyLatest: false,
+      executed: false,
+    };
+    return gen(function* () {
+      yield* $(info(`${current} → ${registry.latest}`));
+      yield* $(warn(`No automatic upgrade for this install: ${guidance}`));
+      return data;
+    });
+  }
+
+  const updateCommand = pmUpdateCommand(install, PRAGMA_PACKAGE);
   const data: UpgradeData = {
     pm,
+    kind,
     current,
     latest: registry.latest,
-    command,
+    command: updateCommand,
     offline: false,
     alreadyLatest: false,
     executed: true,
   };
-  const parts = command.split(" ");
+  const parts = updateCommand.split(" ");
   const bin = parts[0] ?? "npm";
   const args = parts.slice(1);
   // Guard the spawn: an absent package manager (`bin` not on PATH) REJECTS the
@@ -112,7 +151,7 @@ export async function runUpgrade(
       // so inspect the result: a failed install (e.g. EACCES on a global
       // `npm i -g`) must fail loudly, not report a silent success.
       const result = yield* $(exec(bin, args, rt.cwd));
-      assertExecOk(command, result);
+      assertExecOk(updateCommand, result);
       return data;
     }),
   );

--- a/packages/cli/pragma/src/capabilities/upgrade/types.ts
+++ b/packages/cli/pragma/src/capabilities/upgrade/types.ts
@@ -2,16 +2,24 @@
  * Data shape for `pragma upgrade`.
  */
 
+import type { InstallKind } from "../../kernel/render/vocabulary.js";
+
 /** The outcome of an upgrade run (or its plan). */
 export interface UpgradeData {
   /** The install-source label (e.g. `bun (global)`). */
   readonly pm: string;
+  /** The install-source state behind the label. */
+  readonly kind: InstallKind;
   /** The currently-installed version. */
   readonly current: string;
   /** The latest published version, or `undefined` when offline. */
   readonly latest: string | undefined;
-  /** The package-manager command that applies the update. */
-  readonly command: string;
+  /** The package-manager command that applies the update — only for a GLOBAL
+   * install; every other state carries {@link guidance} instead. */
+  readonly command?: string;
+  /** The honest sentence for an install with no sanctioned update command
+   * (linked / ephemeral / workspace / unknown). */
+  readonly guidance?: string;
   /** True when the registry could not be reached. */
   readonly offline: boolean;
   /** True when the installed version is already the latest. */

--- a/packages/cli/pragma/src/capabilities/upgrade/upgrade.render.ts
+++ b/packages/cli/pragma/src/capabilities/upgrade/upgrade.render.ts
@@ -33,8 +33,12 @@ export const upgradeFormatters: Formatters<UpgradeData> = {
         "",
         `Updated to ${data.latest}.`,
       );
-    } else {
+    } else if (data.command) {
       lines.push(`Run: ${chalk.cyan(data.command)}`);
+    } else {
+      // No sanctioned command for this install (linked / ephemeral /
+      // workspace / unknown) — the guidance sentence is the whole story.
+      lines.push(`No automatic upgrade for this install: ${data.guidance}`);
     }
     return lines.join("\n");
   },
@@ -45,7 +49,10 @@ export const upgradeFormatters: Formatters<UpgradeData> = {
       return `Already at the latest version (${data.current}).`;
     }
     if (data.executed) return `Upgraded: ${data.current} → ${data.latest}`;
-    return `Update available: ${data.current} → ${data.latest} (\`${data.command}\`)`;
+    if (data.command) {
+      return `Update available: ${data.current} → ${data.latest} (\`${data.command}\`)`;
+    }
+    return `Update available: ${data.current} → ${data.latest} — ${data.guidance}`;
   },
 
   json(data) {

--- a/packages/cli/pragma/src/capabilities/upgrade/upgrade.test.ts
+++ b/packages/cli/pragma/src/capabilities/upgrade/upgrade.test.ts
@@ -28,6 +28,7 @@ import {
   guardMissingBinary,
   isMissingBinaryError,
 } from "../shared/assertExecOk.js";
+import type { InstallSource } from "../shared/index.js";
 import {
   checkRegistryVersion,
   REGISTRY_TIMEOUT_MS,
@@ -35,6 +36,22 @@ import {
 import { runUpgrade } from "./runUpgrade.js";
 import type { UpgradeData } from "./types.js";
 import { upgradeModule } from "./upgrade.verb.js";
+
+// Pin the install-source detection: the real detector reads THIS process
+// (whose entry is a source checkout — an honest `unknown` with no command,
+// which would starve every update-needed case of its exec). Detection itself
+// is covered by `shared/packageManager.test.ts`; here it is a fixture.
+const detection = vi.hoisted(() => ({ install: undefined as unknown }));
+vi.mock("../shared/index.js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  detectInstallSource: () => detection.install,
+}));
+
+const GLOBAL_NPM: InstallSource = {
+  kind: "global",
+  pm: "npm",
+  label: "npm (global)",
+};
 
 const upgradeVerb = upgradeModule.verbs[0] as VerbSpec;
 const FLAGS_JSON: GlobalFlags = {
@@ -71,6 +88,7 @@ let prevXdg: string | undefined;
 beforeEach(() => {
   prevXdg = process.env.XDG_CONFIG_HOME;
   process.env.XDG_CONFIG_HOME = tmpCwd();
+  detection.install = GLOBAL_NPM;
 });
 afterEach(() => {
   process.env.XDG_CONFIG_HOME = prevXdg;
@@ -178,6 +196,60 @@ describe("upgrade — update needed", () => {
     expect(value.executed).toBe(true);
     expect(value.latest).toBe("99.0.0");
     expect(value.alreadyLatest).toBe(false);
+  });
+});
+
+describe("upgrade — a non-global install NEVER gets an exec (the headline)", () => {
+  const LINKED: InstallSource = {
+    kind: "linked",
+    pm: "npm",
+    target: "/home/u/code/pragma/packages/cli/pragma",
+    label: "npm link (development checkout)",
+  };
+
+  it("linked + update available: no command, no exec — guidance instead", async () => {
+    // The case that must never regress: `npm i -g` against an npm-linked
+    // install would OVERWRITE the symlink to the development worktree.
+    detection.install = LINKED;
+    stubRegistry("99.0.0");
+    const task = await runUpgrade(bootRuntime(FLAGS_JSON, tmpCwd()));
+    const { value, effects } = dryRun(task);
+    expect(value.executed).toBe(false);
+    expect(value.command).toBeUndefined();
+    expect(value.kind).toBe("linked");
+    expect(value.guidance).toMatch(/development checkout/i);
+    expect(effects.some((e) => e._tag === "Exec")).toBe(false);
+  });
+
+  it("--dry-run through dispatch plans NO Execute line for a linked install", async () => {
+    detection.install = LINKED;
+    stubRegistry("99.0.0");
+    const outcome = await executeVerb(
+      upgradeVerb,
+      {},
+      DRY,
+      bootRuntime(FLAGS_JSON, tmpCwd()),
+    );
+    const plan = JSON.parse(outcome.stdout as string).data.plan as string[];
+    expect(plan.some((line) => line.startsWith("Execute:"))).toBe(false);
+    expect(plan.some((line) => line.includes("No automatic upgrade"))).toBe(
+      true,
+    );
+  });
+
+  it("an ephemeral run reports its state with no command either", async () => {
+    detection.install = {
+      kind: "ephemeral",
+      runner: "npx",
+      label: "npx (ephemeral)",
+    } satisfies InstallSource;
+    stubRegistry("99.0.0");
+    const { value, effects } = dryRun(
+      await runUpgrade(bootRuntime(FLAGS_JSON, tmpCwd())),
+    );
+    expect(value.executed).toBe(false);
+    expect(value.command).toBeUndefined();
+    expect(effects.some((e) => e._tag === "Exec")).toBe(false);
   });
 });
 

--- a/packages/cli/pragma/src/kernel/render/vocabulary.ts
+++ b/packages/cli/pragma/src/kernel/render/vocabulary.ts
@@ -209,3 +209,68 @@ export const OUTCOME_GLYPHS: Record<OutcomeStatus, string> = {
  */
 export const outcomeRemedyWord = (status: OutcomeStatus): "fix" | "next" =>
   status === "failed" ? "fix" : "next";
+
+// =============================================================================
+// Install-source states
+// =============================================================================
+
+/**
+ * How the running CLI got onto the machine — the state `info`, `upgrade`, and
+ * doctor's `pragma version` row all report, so its words live here with the
+ * other shared states. Only a `global` install has a sanctioned update
+ * command; the type layer in `capabilities/shared/packageManager.ts` makes the
+ * others structurally command-less, and {@link INSTALL_UPDATE_GUIDANCE} is
+ * what those states say instead. `linked` in particular must never be handed
+ * an install command: `npm i -g` against a linked checkout would overwrite the
+ * link to the development tree the user is working in.
+ */
+export type InstallKind =
+  | "global"
+  | "workspace"
+  | "linked"
+  | "ephemeral"
+  | "unknown";
+
+/** The install kinds that carry NO update command (everything but `global`). */
+export type NoCommandInstallKind = Exclude<InstallKind, "global">;
+
+/**
+ * The display label for an install source, e.g. `npm (global)`, `bun link
+ * (development checkout)`, `npx (ephemeral)`, `unknown (node runtime)`. The
+ * `via` word is the manager/runner/runtime name the detector resolved —
+ * absent only for a `workspace`/`linked` install whose manager could not be
+ * told, which then reads as the bare state.
+ */
+export const installSourceLabel = (kind: InstallKind, via?: string): string => {
+  switch (kind) {
+    case "global":
+      return `${via} (global)`;
+    case "workspace":
+      return via ? `${via} (local project)` : "local project dependency";
+    case "linked":
+      return via
+        ? `${via} link (development checkout)`
+        : "linked (development checkout)";
+    case "ephemeral":
+      return `${via} (ephemeral)`;
+    case "unknown":
+      return `unknown (${via} runtime)`;
+  }
+};
+
+/**
+ * What each command-less install state says when a newer release exists —
+ * honest guidance in place of a command that would be wrong to run. The
+ * `linked` sentence is the load-bearing one: it replaces the `npm i -g` that
+ * would clobber the development link.
+ */
+export const INSTALL_UPDATE_GUIDANCE: Record<NoCommandInstallKind, string> = {
+  workspace:
+    "Installed as a project dependency — update it through the project's package.json.",
+  linked:
+    "Linked development checkout — update it from its source tree, or unlink it before installing a release.",
+  ephemeral:
+    "Ephemeral run — invoke it again with an explicit @latest version to pick up the newest release.",
+  unknown:
+    "The install method cannot be determined — update it the same way it was installed.",
+};


### PR DESCRIPTION
## Done

- Replaced the env-var install-source heuristic in `capabilities/shared/packageManager.ts` with filesystem-driven detection. The old code read `npm_config_user_agent`, which package managers set only when *they* run a script — a user typing `pragma` in a shell never has it, so on the path that mattered it always fell through to the honest runtime and reported `node (global)` for **every** install, including an `npm link` into a development worktree.
- Detection now walks the resolved entry (`import.meta.url`, realpath-resolved by the loader) *and* the invoked bin path (`argv[1]`, symlinks intact). The loader realpaths the entry, so a linked install's entry has already escaped to the checkout — only the argv chain can still see the link. The chain is trusted only when the package dir it names really contains the running module, so a foreign bin on argv[1] (a test runner) can never misattribute the install.
- Five states, as a closed union: **global** (manager from path shape: `.bun/`, `.pnpm`/pnpm, `.volta`, `.asdf`→npm, yarn's global dir; unmarked global trees are npm's), **workspace** (install root contains the cwd; lockfile names the manager, `npm_config_user_agent` corroborates at most and never overrides a path shape), **linked** (`node_modules/<pkg>` is a symlink pointing *outside* the install root — a workspace-internal symlink stays a workspace), **ephemeral** (`_npx`, `bunx-*`, pnpm `dlx` cache shapes), and **unknown** (no conclusive signal — report the honest runtime, offer nothing).
- `pmUpdateCommand` now accepts only the `GlobalInstall` arm, so producing an upgrade command for a linked/ephemeral/workspace/unknown install is a **compile error**, not a convention. Those states carry an honest guidance sentence instead; the linked one exists because `npm i -g` against a linked install would overwrite the symlink to the worktree being developed.
- All three consumers report the new states: doctor's `pragma version` row names the state (`installed via linked (development checkout)` / `bun link (development checkout)` / `npx (ephemeral)` / …), `info` prints guidance in place of a command, and `upgrade` plans **no exec** for a non-global install even when the registry has a newer version.
- The state words and guidance sentences live in `kernel/render/vocabulary.ts` beside the other shared states (inert data + one pure function — fast-path safe).
- The classifier is pure over an injected `InstallProbe` (the `PlatformEnv` fixture pattern); `detectInstallSource()` only captures the live process. The fixture matrix covers npm/bun/pnpm/volta/asdf global, npm link + bun link, npx/bunx, workspace (lockfile / agent / unmarked), monorepo-internal symlink, unknown, foreign-argv, and a symlink cycle. Windows path *shapes* are exercised via fixtures but — like `platformPaths.ts` — not validated on a real Windows host.

Fixes doctor reporting `pragma version: v0.35.0 (installed via node (global))` for an `npm link`ed development worktree.

## QA

Measured on the machine that exhibited the defect (`~/.npm-global/bin/pragma` → `node_modules/@canonical/pragma-cli` → symlink into a development worktree, `npm_config_user_agent` unset):

- RED (unmodified detector, the code `origin/main` ships): `pragma doctor` → `✓ pragma version: v0.35.0 (installed via node (global))`
- GREEN (this branch, same layout rebuilt through a fake npm-global prefix): `✓ pragma version: v0.35.0 (installed via linked (development checkout))`; the same layout under a `.bun` prefix → `installed via bun link (development checkout)`; `pragma upgrade --dry-run` on the linked layout plans no `Execute:` line.
- `bun run check` green from the repo root across all 62 projects. `@canonical/pragma-cli` test suite (1640 tests) and its perf-budget suite green — the detector does no filesystem work at module load, and nothing on the `--help`/`__complete` fast paths calls it. A root-parallel `bun run test` on the dev box flaked ~23 unrelated suites with 5s timeouts (react/jsdom renders, `@canonical/task` stack-safety timing) under full fan-out load; each affected suite passes in isolation (`@canonical/task`: 817/817), and none imports `pragma-cli`.
- `bun run gen:reference` produces no diff.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.
- [ ] If this PR introduces a **new package**: n/a
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
