### PR TITLE
feat(pragma-cli): show setup's wizard progress as the plan's rows, not the effect transcript

### DIFF
--- a/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
@@ -76,6 +76,24 @@ const CHILD_ANSWER: Partial<Record<TargetId, string>> = {
 const rowKey = (scope: Scope, target: TargetId): string => `${scope}:${target}`;
 
 /**
+ * One live row-progress event: a plan row starting, finishing, or failing,
+ * reported WHILE the composed task is being interpreted. `label` is the row's
+ * progress sentence — the same `target  detail — note` shape
+ * `renderProgressLine` prints — so the listener (the Ink wizard's step view)
+ * shows the run in the plan's own vocabulary, not the effect transcript's.
+ *
+ * Structurally identical to summon-core's `StepReport` ON PURPOSE: the wizard
+ * branch forwards these events verbatim, and this module must not import
+ * summon-core values (it stays behind the verb's lazy import).
+ */
+export interface RowEvent {
+  /** The row's stable identity — `scope:target`. */
+  readonly key: string;
+  readonly label: string;
+  readonly status: "start" | "done" | "failed";
+}
+
+/**
  * A ready-to-run setup invocation: the plan as detected, the synthesized
  * generator, and a projection from the completed answers back onto the plan with
  * outcomes filled in — the recap, and the `--format json` body.
@@ -85,6 +103,15 @@ export interface SetupRun {
   readonly generator: GeneratorDefinition;
   /** The plan with the wizard's selection and the run's outcomes applied. */
   applied(answers: Record<string, unknown>): SetupPlan;
+  /**
+   * Register THE live row listener (the Ink wizard's step adapter). The
+   * composed rows emit through it while they are interpreted — which means
+   * EVERY interpretation fires it, the confirm gate's honest preview included;
+   * the receiving session drops reports outside its executing phase, exactly
+   * as the {@link OutcomeSink} relies on last-drive-wins for its records. No
+   * listener registered (a `--yes` run, `--dry-run`, MCP) costs nothing.
+   */
+  setRowListener(listener: (event: RowEvent) => void): void;
 }
 
 /**
@@ -143,25 +170,50 @@ const rowPragmaError = (error: TaskError): PragmaError =>
  * throw bypasses the trampoline's recovery frames — which is why the row bodies
  * raise via `checkExecOk`/`failPragma`, never a bare throw. Interruption bypasses
  * recovery by interpreter invariant, so Ctrl-C still stops the whole run.
+ *
+ * Each row is also BRACKETED with {@link RowEvent}s — `start` as its body is
+ * entered, `done`/`failed` as it settles — emitted from the continuations,
+ * which run at interpretation time. Like the sink writes beside them, the
+ * emits capture nothing IN the task: the composition stays pure and
+ * re-interpretable, and each drive simply narrates itself as it runs.
  */
 const runRowsIsolated = (
   sink: OutcomeSink,
-  rows: readonly { key: string; task: Task<void> }[],
+  rows: readonly {
+    key: string;
+    label: string;
+    doneLabel: string;
+    task: Task<void>;
+  }[],
+  emit: (event: RowEvent) => void,
 ): Task<void> =>
   flatMap(pure(undefined), (): Task<void> => {
     sink.clear();
     return sequence_(
-      rows.map(({ key, task }) =>
-        recover(task, (error) =>
-          flatMap(
-            warn(
-              `The ${key.split(":")[1]} step did not complete — continuing with the remaining targets.`,
-            ),
-            () => {
-              sink.record(key, error);
+      rows.map(({ key, label, doneLabel, task }) =>
+        recover(
+          flatMap(pure(undefined), () => {
+            emit({ key, label, status: "start" });
+            return flatMap(task, () => {
+              emit({ key, label: doneLabel, status: "done" });
               return pure(undefined);
-            },
-          ),
+            });
+          }),
+          (error) =>
+            flatMap(
+              warn(
+                `The ${key.split(":")[1]} step did not complete — continuing with the remaining targets.`,
+              ),
+              () => {
+                sink.record(key, error);
+                emit({
+                  key,
+                  label: `${label} — ${rowPragmaError(error).message}`,
+                  status: "failed",
+                });
+                return pure(undefined);
+              },
+            ),
         ),
       ),
     );
@@ -370,6 +422,31 @@ export async function buildSetupRun(
   const detectionFor = (row: PlanRow): DetectedRow | undefined =>
     detected.find((d) => d.target.id === row.target && d.scope === row.scope);
 
+  /**
+   * The success note a row's completion carries — ONE derivation for the
+   * recap's outcome and the live row event's `done` label, so the sentence a
+   * watcher saw land is the sentence the recap repeats. A removal never
+   * borrows the forward child summary: its children are the files the entry is
+   * being taken OUT of, and counting them as `1 updated` described the
+   * opposite of what the run had just done.
+   */
+  const noteFor = (
+    row: PlanRow,
+    answers: Record<string, unknown>,
+  ): string | undefined => {
+    if (removal) return ACTION_NOTES[row.action];
+    const childKey = CHILD_ANSWER[row.target];
+    const kept =
+      childKey === undefined ? undefined : readList(answers, childKey);
+    return childNote(row, kept) ?? ACTION_NOTES[row.action];
+  };
+
+  /** The live row listener, when a wizard is watching. See {@link SetupRun}. */
+  let rowListener: ((event: RowEvent) => void) | undefined;
+
+  /** The id column width — the recap's own rule, so the columns agree. */
+  const idWidth = Math.max(...plan.rows.map((row) => row.target.length));
+
   const generator: GeneratorDefinition = {
     meta: buildMeta(
       rt,
@@ -389,9 +466,21 @@ export async function buildSetupRun(
         const task = removal
           ? hit.target.composeRemoval(hit.detection)
           : hit.target.compose(hit.detection, children);
-        return [{ key: rowKey(row.scope, row.target), task }];
+        // The row's progress sentence — the `target  detail — note` shape
+        // `renderProgressLine` prints — so the live view and the recap say the
+        // same thing about the same row.
+        const label = `${row.target.padEnd(idWidth)}  ${row.detail}`;
+        const note = noteFor(row, answers);
+        return [
+          {
+            key: rowKey(row.scope, row.target),
+            label,
+            doneLabel: note === undefined ? label : `${label} — ${note}`,
+            task,
+          },
+        ];
       });
-      return runRowsIsolated(sink, tasks);
+      return runRowsIsolated(sink, tasks, (event) => rowListener?.(event));
     },
   };
 
@@ -434,15 +523,7 @@ export async function buildSetupRun(
       };
     }
     if (!isActionable(row.action)) return { status: "noop" };
-    // A removal never borrows the forward child summary: its children are the
-    // files the entry is being taken OUT of, and counting them as "1 updated"
-    // described the opposite of what the run had just done.
-    const childKey = CHILD_ANSWER[row.target];
-    const kept =
-      childKey === undefined ? undefined : readList(answers, childKey);
-    const note = removal
-      ? ACTION_NOTES[row.action]
-      : (childNote(row, kept) ?? ACTION_NOTES[row.action]);
+    const note = noteFor(row, answers);
     return {
       status: removal ? "removed" : "done",
       ...(note === undefined ? {} : { note }),
@@ -452,6 +533,9 @@ export async function buildSetupRun(
   return {
     plan,
     generator,
+    setRowListener: (listener) => {
+      rowListener = listener;
+    },
     applied: (answers) => {
       const chosen = readList(answers, ROWS_ANSWER);
       return withRows(

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -42,7 +42,7 @@ import { projectCli } from "../../testing/helpers/projectCli.js";
 import { projectMcp } from "../../testing/helpers/projectMcp.js";
 import { capabilities } from "../index.js";
 import { detectCompletions } from "./operations/setupCompletions.js";
-import { buildSetupRun } from "./operations/setupGenerator.js";
+import { buildSetupRun, type RowEvent } from "./operations/setupGenerator.js";
 import {
   composeSkills,
   composeSkillsRemoval,
@@ -532,6 +532,67 @@ describe("setup mcp — the per-file question, asked directly", () => {
     expect(applied.rows.find((r) => r.target === "mcp")?.outcome?.note).toBe(
       "1 added",
     );
+  });
+});
+
+describe("setup — live row events (the wizard's step feed)", () => {
+  it("brackets each row with start/done, in the recap's own sentence", async () => {
+    // The wizard's live progress renders the PLAN's rows, not the effect
+    // transcript — one `start` as a row's body is entered, one `done` carrying
+    // the same `target  detail — note` sentence the recap will print, so the
+    // watcher and the recap reader see one dialect.
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".cursor"), { recursive: true });
+    const run = await buildSetupRun(bootRuntime(FLAGS, cwd), "mcp", "project");
+    const events: RowEvent[] = [];
+    run.setRowListener((event) => events.push(event));
+    await runTask(run.generator.generate({}), { onLog: () => {} });
+    expect(events.map((event) => event.status)).toEqual(["start", "done"]);
+    expect(events[0]?.key).toBe("project:mcp");
+    // The start label is the row without an outcome; the done label appends
+    // the SAME note `applied()` puts on the recap row.
+    const applied = run.applied({});
+    const note = applied.rows.find((r) => r.target === "mcp")?.outcome?.note;
+    expect(note).toBe("1 added");
+    expect(events[1]?.label).toBe(`${events[0]?.label} — ${note}`);
+  });
+
+  it("no listener registered costs nothing — the run is unchanged", async () => {
+    // `--yes`, `--dry-run` and MCP never register one; the bracket emits into
+    // the void and the composed effects are identical.
+    const cwd = tmp("pragma-setup-proj-");
+    mkdirSync(join(cwd, ".cursor"), { recursive: true });
+    const run = await buildSetupRun(bootRuntime(FLAGS, cwd), "mcp", "project");
+    await runTask(run.generator.generate({}), { onLog: () => {} });
+    expect(existsSync(join(cwd, ".cursor", "mcp.json"))).toBe(true);
+  });
+
+  it("a failing row reports `failed` with its cause, and its siblings still bracket", async () => {
+    // Same arrangement as the S1-1 isolation test: an editor on PATH with no
+    // `bun`, so the LSP row's compose fails. The event stream must name the
+    // failure — the wizard paints that row ✗ live — while the run continues.
+    const prevPath = process.env.PATH;
+    const prevData = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = tmp("pragma-rowevents-data-");
+    const dir = stubPath();
+    writeFileSync(join(dir, "code"), "");
+    process.env.PATH = dir;
+    try {
+      const run = await buildSetupRun(
+        bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
+        "lsp",
+        "global",
+      );
+      const events: RowEvent[] = [];
+      run.setRowListener((event) => events.push(event));
+      await runTask(run.generator.generate({}), { onLog: () => {} });
+      expect(events.map((event) => event.status)).toEqual(["start", "failed"]);
+      expect(events[1]?.label).toContain("bun");
+    } finally {
+      process.env.PATH = prevPath;
+      if (prevData === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = prevData;
+    }
   });
 });
 

--- a/packages/cli/pragma/src/capabilities/setup/setup.verb.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.verb.ts
@@ -271,6 +271,19 @@ async function runSetup(
       signal,
       onCancel: abort,
     });
+    // Live progress in the PLAN's units, not the interpreter's: the wizard's
+    // default execution view is the per-effect transcript — right for `create`,
+    // whose unit of work IS the file, and wrong here, where one unit is one
+    // configured target and the transcript renders eighteen symlink rows for
+    // the row the plan called `skills  link  9 skills → 2 folders`. Each row
+    // event carries the SAME sentence `renderProgressLine` prints, so the
+    // watcher and the recap reader see one dialect. `--verbose` withholds the
+    // listener, which falls the wizard back to the full effect transcript —
+    // the same detected-only-unless-verbose rule the detection summary and
+    // doctor already follow.
+    if (rt.globalFlags.verbose !== true) {
+      run.setRowListener((event) => session.reportStep(event));
+    }
     rt.exec = {
       promptHandler: session.promptHandler,
       onEffectStart: session.onEffectStart,

--- a/packages/cli/pragma/src/kernel/project/cli/dispatch.ts
+++ b/packages/cli/pragma/src/kernel/project/cli/dispatch.ts
@@ -416,17 +416,22 @@ export async function executeVerb(
     }
     // Real execution: spread the verb's runner options into the node
     // interpreter (prompt handler, stamping/progress callbacks, log routing,
-    // signal). Teardown (e.g. unmount an Ink render) runs in `finally`.
+    // signal). Teardown (e.g. unmount an Ink render) runs in `finally` —
+    // BEFORE the outcome is rendered: an interactive session's closing frame
+    // flushes on its dispose, so printing the result first put the verb's
+    // stdout recap ABOVE a frame that then repainted stale beneath it. Tear
+    // the UI down, then report; the error path gets the same order for free.
     const exec = mutationRuntime.exec ?? {};
     const onSigint = (): void => controller.abort();
     process.once("SIGINT", onSigint);
+    let value: unknown;
     try {
-      const value = await runTask(task, { onLog: logSink(flags), ...exec });
-      return renderData(verb, flags, value, {});
+      value = await runTask(task, { onLog: logSink(flags), ...exec });
     } finally {
       process.removeListener("SIGINT", onSigint);
       await exec.dispose?.();
     }
+    return renderData(verb, flags, value, {});
   }
 
   const data = await Promise.resolve(

--- a/packages/summon/core/package.json
+++ b/packages/summon/core/package.json
@@ -58,7 +58,7 @@
     "check:webarchitect": "webarchitect library --license GPL-3.0",
     "test": "bun run test:vitest && bun run test:ink",
     "test:vitest": "vitest run --coverage --exclude '**/*.test.tsx'",
-    "test:ink": "vitest run --no-coverage 'src/prompt/ink/wizard.test.tsx'",
+    "test:ink": "vitest run --no-coverage src/prompt/ink/wizard.test.tsx src/prompt/ink/mount.test.tsx",
     "test:vitest:watch": "vitest"
   },
   "devDependencies": {

--- a/packages/summon/core/src/index.ts
+++ b/packages/summon/core/src/index.ts
@@ -68,6 +68,7 @@ export type {
   PromptHandler,
   PromptQuestion,
   SelectPrompt,
+  StepReport,
   TextPrompt,
 } from "./prompt/index.js";
 export {

--- a/packages/summon/core/src/prompt/index.ts
+++ b/packages/summon/core/src/prompt/index.ts
@@ -12,7 +12,7 @@ export {
   MISSING_REQUIRED_ANSWER,
   missingRequiredError,
 } from "./autoPrompt.js";
-export type { InkPromptOptions, InkSession } from "./inkPrompt.js";
+export type { InkPromptOptions, InkSession, StepReport } from "./inkPrompt.js";
 export { default as inkPrompt } from "./inkPrompt.js";
 export { default as mcpPrompt } from "./mcpPrompt.js";
 export type {

--- a/packages/summon/core/src/prompt/ink/Wizard.tsx
+++ b/packages/summon/core/src/prompt/ink/Wizard.tsx
@@ -17,7 +17,11 @@ import {
 } from "./progressWindow.js";
 import { AnswersTable, ProgressHeader, QuestionView } from "./prompts.js";
 import { Spinner } from "./Spinner.js";
-import type { SessionController, WizardState } from "./session.js";
+import type {
+  SessionController,
+  StepProgress,
+  WizardState,
+} from "./session.js";
 
 /** A compact summary of the effects the confirm gate is about to apply. */
 const EffectsSummary = ({ effects }: { effects: readonly Effect[] }) => {
@@ -103,6 +107,56 @@ const EffectsSummary = ({ effects }: { effects: readonly Effect[] }) => {
  * reserved out of it ({@link describedWidthBudget}), so neither the glyph nor
  * the timing can push the row past the one-line cap.
  */
+/**
+ * Live progress in the HOST's units — rendered whenever the host has reported
+ * steps ({@link SessionController.reportStep}), in place of the per-effect
+ * transcript below. One row per step: a settled row wears the shared outcome
+ * glyph and its wall time, the running one a spinner. The glyphs, the duration
+ * spelling and the one-row truncation are the transcript's own — the two views
+ * share one dialect; they differ only in what a row IS.
+ *
+ * Rendered in the LIVE region, never under `<Static>`, and that is
+ * load-bearing: `execute` walks `generate` on the mock interpreter once after
+ * consent (the outcome summary's file list), so the board fills with
+ * near-zero-duration rows once before the real drive resets and repaints it
+ * (see {@link SessionController.reportStep}) — and a static row cannot be
+ * taken back. The list is bounded by the host's own step count (one row per
+ * setup target), so the full-repaint cost `<Static>` exists to avoid does not
+ * arise.
+ */
+const StepRow = ({ step }: { step: StepProgress }) => {
+  if (step.status === "running") {
+    return (
+      <Box>
+        <Spinner
+          color="blue"
+          label={truncateMiddle(step.label, describedWidthBudget(""))}
+        />
+      </Box>
+    );
+  }
+  const duration = formatEffectDuration(step.duration ?? 0);
+  return (
+    <Text>
+      {step.status === "failed" ? (
+        <Text color="red">{FAILURE_GLYPH}</Text>
+      ) : (
+        <Text color="green">{COMPLETED_GLYPH}</Text>
+      )}{" "}
+      {truncateMiddle(step.label, describedWidthBudget(duration))}{" "}
+      <Text dimColor>{duration}</Text>
+    </Text>
+  );
+};
+
+const StepsProgress = ({ state }: { state: WizardState }) => (
+  <Box flexDirection="column">
+    {state.steps.map((step) => (
+      <StepRow key={step.key} step={step} />
+    ))}
+  </Box>
+);
+
 const Progress = ({ state }: { state: WizardState }) => {
   const shown = state.progress.filter(
     (t) =>
@@ -232,11 +286,21 @@ export const Wizard = ({ controller }: WizardProps) => {
         </Box>
       )}
 
-      {(state.phase === "executing" || state.phase === "complete") && (
-        <Progress state={state} />
-      )}
+      {(state.phase === "executing" || state.phase === "complete") &&
+        (state.steps.length > 0 ? (
+          <StepsProgress state={state} />
+        ) : (
+          <Progress state={state} />
+        ))}
 
-      {state.phase === "complete" && (
+      {/*
+        The banner belongs to the DEFAULT transcript only. A host that narrates
+        its run in its own steps also owns its own epilogue (pragma's `setup`
+        prints its recap right after the unmount), and "Generation complete!"
+        over a run that is not a generation was exactly the vocabulary leak the
+        step rows exist to close.
+      */}
+      {state.phase === "complete" && state.steps.length === 0 && (
         <Box marginTop={1}>
           <Text color="green">{COMPLETED_GLYPH} Generation complete!</Text>
         </Box>

--- a/packages/summon/core/src/prompt/ink/mount.test.tsx
+++ b/packages/summon/core/src/prompt/ink/mount.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * The mounted session's DISPOSAL contract: one disposal, memoized, resolving
+ * only after the final frame is flushed. A boolean guard here once let a
+ * second concurrent `dispose()` resolve immediately — before the first had
+ * flushed — so a caller that awaited it could print into a still-mounted UI.
+ *
+ * Mounting for real needs a raw-mode-capable stdin (the wizard's `useInput`
+ * throws without one) and writes its frames to stderr; both are stubbed for
+ * the duration of the test and restored after.
+ */
+
+import { Console } from "node:console";
+import { pure } from "@canonical/task";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type GeneratorDefinition from "../../types/GeneratorDefinition.js";
+import { mountPromptSession } from "./mount.js";
+
+const gen: GeneratorDefinition = {
+  meta: { name: "g", displayName: "g", description: "d", version: "1.0.0" },
+  prompts: [],
+  generate: () => pure(undefined),
+};
+
+/** Make `process.stdin` claim raw-mode support; returns the restore. */
+function stubRawModeStdin(): () => void {
+  const stdin = process.stdin as NodeJS.ReadStream & {
+    isTTY?: boolean;
+    setRawMode?: (mode: boolean) => NodeJS.ReadStream;
+  };
+  const prevIsTTY = stdin.isTTY;
+  const prevSetRawMode = stdin.setRawMode;
+  stdin.isTTY = true;
+  stdin.setRawMode = () => stdin;
+  return () => {
+    stdin.isTTY = prevIsTTY;
+    stdin.setRawMode = prevSetRawMode;
+  };
+}
+
+describe("mountPromptSession disposal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is memoized: concurrent and repeated dispose() share ONE disposal", async () => {
+    const restoreStdin = stubRawModeStdin();
+    // Swallow the Ink frames — the session renders to the real stderr.
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    // Vitest swaps in a console with no Console constructor; Ink patches the
+    // console on mount and needs the real one.
+    const patched = console as unknown as { Console?: unknown };
+    const prevConsole = patched.Console;
+    patched.Console = Console;
+    try {
+      const session = mountPromptSession(gen);
+      const first = session.dispose();
+      const second = session.dispose();
+      // The SAME promise, not a fast-path void: a second concurrent caller
+      // must wait for the same final-frame flush the first is waiting for.
+      expect(second).toBe(first);
+      await expect(first).resolves.toBeUndefined();
+      // After settlement it stays memoized — no second unmount is attempted.
+      expect(session.dispose()).toBe(first);
+    } finally {
+      patched.Console = prevConsole;
+      restoreStdin();
+    }
+  });
+});

--- a/packages/summon/core/src/prompt/ink/mount.tsx
+++ b/packages/summon/core/src/prompt/ink/mount.tsx
@@ -58,7 +58,7 @@ export function mountPromptSession(
   const onAbort = (): void => controller.cancel();
   signal?.addEventListener("abort", onAbort);
 
-  let disposed = false;
+  let disposal: Promise<void> | undefined;
   return {
     answerPrompt: (effect) => controller.request(effect),
     reportEffectStart: (effect) => controller.reportEffectStart(effect),
@@ -66,18 +66,24 @@ export function mountPromptSession(
       controller.reportEffectComplete(effect, duration),
     reportLog: (level, message) => controller.reportLog(level, message),
     reportStep: (report) => controller.reportStep(report),
-    dispose: async () => {
-      if (disposed) return;
-      disposed = true;
-      controller.markComplete();
-      signal?.removeEventListener("abort", onAbort);
-      // Let React COMMIT the state just reported (markComplete, and a run's
-      // last effect/step — its scheduler commits on a macrotask) before the
-      // unmount flushes the final frame. Unmounting in the same continuation
-      // flushed the previously committed tree, so the last row of a run was
-      // permanently painted as still in progress.
-      await new Promise((resolve) => setImmediate(resolve));
-      instance.unmount();
+    dispose: () => {
+      // MEMOIZED, not boolean-guarded: every caller — however many, however
+      // concurrent — gets THE one disposal. A guard that returned early made
+      // a second concurrent dispose() resolve BEFORE the first had flushed
+      // the final frame, which breaks the contract awaiting dispose() exists
+      // for: a caller could print into a still-mounted UI.
+      disposal ??= (async () => {
+        controller.markComplete();
+        signal?.removeEventListener("abort", onAbort);
+        // Let React COMMIT the state just reported (markComplete, and a run's
+        // last effect/step — its scheduler commits on a macrotask) before the
+        // unmount flushes the final frame. Unmounting in the same continuation
+        // flushed the previously committed tree, so the last row of a run was
+        // permanently painted as still in progress.
+        await new Promise((resolve) => setImmediate(resolve));
+        instance.unmount();
+      })();
+      return disposal;
     },
   };
 }

--- a/packages/summon/core/src/prompt/ink/mount.tsx
+++ b/packages/summon/core/src/prompt/ink/mount.tsx
@@ -11,7 +11,7 @@
 import type { Effect, LogLevel } from "@canonical/task";
 import { render } from "ink";
 import type GeneratorDefinition from "../../types/GeneratorDefinition.js";
-import type { InkPromptOptions } from "../inkPrompt.js";
+import type { InkPromptOptions, StepReport } from "../inkPrompt.js";
 import type { PromptEffect } from "../types.js";
 import { SessionController } from "./session.js";
 import { Wizard } from "./Wizard.js";
@@ -22,7 +22,8 @@ export interface MountedSession {
   reportEffectStart: (effect: Effect) => void;
   reportEffectComplete: (effect: Effect, duration: number) => void;
   reportLog: (level: LogLevel, message: string) => void;
-  dispose: () => void;
+  reportStep: (report: StepReport) => void;
+  dispose: () => Promise<void>;
 }
 
 /**
@@ -64,11 +65,18 @@ export function mountPromptSession(
     reportEffectComplete: (effect, duration) =>
       controller.reportEffectComplete(effect, duration),
     reportLog: (level, message) => controller.reportLog(level, message),
-    dispose: () => {
+    reportStep: (report) => controller.reportStep(report),
+    dispose: async () => {
       if (disposed) return;
       disposed = true;
       controller.markComplete();
       signal?.removeEventListener("abort", onAbort);
+      // Let React COMMIT the state just reported (markComplete, and a run's
+      // last effect/step — its scheduler commits on a macrotask) before the
+      // unmount flushes the final frame. Unmounting in the same continuation
+      // flushed the previously committed tree, so the last row of a run was
+      // permanently painted as still in progress.
+      await new Promise((resolve) => setImmediate(resolve));
       instance.unmount();
     },
   };

--- a/packages/summon/core/src/prompt/ink/session.test.ts
+++ b/packages/summon/core/src/prompt/ink/session.test.ts
@@ -230,10 +230,13 @@ describe("SessionController", () => {
     expect(c.getSnapshot().phase).toBe("cancelled");
   });
 
-  it("folds host step reports into live rows, measuring wall time per step", () => {
+  it("folds host step reports into live rows, measuring wall time per step", async () => {
     const c = new SessionController(gen);
-    void c.request(confirm());
-    c.submitConfirm(true); // enters "executing" — the only phase steps land in
+    const gate = c.request(confirm());
+    c.submitConfirm(true);
+    // Consent is released once the gate's preview walk settles; only then is
+    // the session executing — the one phase step reports land in.
+    await gate;
     c.reportStep({ key: "global:mcp", label: "mcp  3 files", status: "start" });
     expect(c.getSnapshot().steps).toEqual([
       { key: "global:mcp", label: "mcp  3 files", status: "running" },
@@ -270,15 +273,53 @@ describe("SessionController", () => {
     expect(c.getSnapshot().steps).toEqual([]);
   });
 
-  it("a start for a settled key resets the board — execute's mock walk paints first", () => {
+  it("consent does not enter executing while the gate's preview can still emit", async () => {
+    // THE preview race: loadPreview walks the same `generate` the run will,
+    // asynchronously — a fast Y lands while that walk is still in flight.
+    // Flipping to `executing` at the instant of consent accepted the
+    // pre-consent walk's late reports as live rows (and a late `start` on a
+    // key the real walk had settled reset the board mid-run). Consent must be
+    // released only once the preview walk has COMPLETED, so in the consent
+    // tick the session is still `confirming` and a straggler report — this
+    // one stands in for the pre-consent walk's — is dropped.
+    const c = new SessionController(gen);
+    const gate = c.request(confirm());
+    c.submitConfirm(true);
+    expect(c.getSnapshot().phase).toBe("confirming");
+    c.reportStep({ key: "a", label: "phantom", status: "start" });
+    expect(c.getSnapshot().steps).toEqual([]);
+    await expect(gate).resolves.toBe(true);
+    expect(c.getSnapshot().phase).toBe("executing");
+    // Reports from the walks consent released ARE accepted.
+    c.reportStep({ key: "a", label: "real", status: "start" });
+    expect(c.getSnapshot().steps).toEqual([
+      { key: "a", label: "real", status: "running" },
+    ]);
+  });
+
+  it("a cancel while consent waits on the preview rejects the gate cleanly", async () => {
+    // submitConfirm(true) claims the pending slot before deferring on the
+    // preview, so cancel() finds nothing to reject — the deferred consent
+    // must settle the gate itself, with the same code an at-prompt cancel
+    // carries, or the task would hang on a prompt that never resolves.
+    const c = new SessionController(gen);
+    const gate = c.request(confirm());
+    c.submitConfirm(true);
+    c.cancel();
+    await expect(gate).rejects.toMatchObject({ code: "GENERATOR_CANCELLED" });
+    expect(c.getSnapshot().phase).toBe("cancelled");
+  });
+
+  it("a start for a settled key resets the board — execute's mock walk paints first", async () => {
     // After consent, `execute` synchronously walks `generate` on the MOCK
     // interpreter (the outcome summary's file list), so a full set of settled
     // steps lands in-phase with ~0ms durations before the real drive begins.
     // Sequential steps have per-walk-unique keys, so a `start` on a settled
     // key can only mean a new interpretation: the board starts over.
     const c = new SessionController(gen);
-    void c.request(confirm());
+    const gate = c.request(confirm());
     c.submitConfirm(true);
+    await gate;
     // The mock walk: both steps settle instantly.
     c.reportStep({ key: "a", label: "a", status: "start" });
     c.reportStep({ key: "a", label: "a — installed", status: "done" });
@@ -299,24 +340,26 @@ describe("SessionController", () => {
     ]);
   });
 
-  it("a completion whose start was gated away still lands, with no timing claim", () => {
-    // The overlap case: a step STARTED during the confirm gate's preview walk
-    // (dropped by the phase gate) can complete after consent. The row is
-    // real — it appends — but there is no start to measure from, so the
-    // duration is 0 rather than an invented number.
+  it("a completion whose start was gated away still lands, with no timing claim", async () => {
+    // Defensive: with consent deferred on the preview settling, no known walk
+    // can deliver a `done` without its `start` any more — but a report stream
+    // that misbehaves must degrade to a row with no timing claim (duration 0),
+    // never to an invented number or a crash.
     const c = new SessionController(gen);
-    void c.request(confirm());
+    const gate = c.request(confirm());
     c.submitConfirm(true);
+    await gate;
     c.reportStep({ key: "k", label: "k — installed", status: "done" });
     expect(c.getSnapshot().steps).toEqual([
       { key: "k", label: "k — installed", status: "done", duration: 0 },
     ]);
   });
 
-  it("marks a failed step failed, keeping its completed siblings", () => {
+  it("marks a failed step failed, keeping its completed siblings", async () => {
     const c = new SessionController(gen);
-    void c.request(confirm());
+    const gate = c.request(confirm());
     c.submitConfirm(true);
+    await gate;
     c.reportStep({ key: "a", label: "a ok", status: "start" });
     c.reportStep({ key: "a", label: "a ok — installed", status: "done" });
     c.reportStep({ key: "b", label: "b bad", status: "start" });

--- a/packages/summon/core/src/prompt/ink/session.test.ts
+++ b/packages/summon/core/src/prompt/ink/session.test.ts
@@ -230,6 +230,103 @@ describe("SessionController", () => {
     expect(c.getSnapshot().phase).toBe("cancelled");
   });
 
+  it("folds host step reports into live rows, measuring wall time per step", () => {
+    const c = new SessionController(gen);
+    void c.request(confirm());
+    c.submitConfirm(true); // enters "executing" — the only phase steps land in
+    c.reportStep({ key: "global:mcp", label: "mcp  3 files", status: "start" });
+    expect(c.getSnapshot().steps).toEqual([
+      { key: "global:mcp", label: "mcp  3 files", status: "running" },
+    ]);
+    c.reportStep({
+      key: "global:mcp",
+      label: "mcp  3 files — 3 added",
+      status: "done",
+    });
+    const [step] = c.getSnapshot().steps;
+    // Completion REPLACES the running row (same key), carries the completion
+    // label, and the duration is the controller's own start→done measurement.
+    expect(c.getSnapshot().steps.length).toBe(1);
+    expect(step).toMatchObject({
+      status: "done",
+      label: "mcp  3 files — 3 added",
+    });
+    expect(step?.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("drops step reports outside the executing phase (the preview walks too)", async () => {
+    // Step reports originate INSIDE the host's task composition, so the
+    // confirm gate's honest preview fires them while the phase is still
+    // `confirming` — before the user has consented. Those must not paint rows.
+    const c = new SessionController(gen);
+    const gate = c.request(confirm());
+    expect(c.getSnapshot().phase).toBe("confirming");
+    c.reportStep({ key: "k", label: "previewed", status: "start" });
+    expect(c.getSnapshot().steps).toEqual([]);
+    // A report after cancel is likewise inert.
+    c.cancel();
+    await expect(gate).rejects.toMatchObject({ code: "GENERATOR_CANCELLED" });
+    c.reportStep({ key: "k", label: "late", status: "done" });
+    expect(c.getSnapshot().steps).toEqual([]);
+  });
+
+  it("a start for a settled key resets the board — execute's mock walk paints first", () => {
+    // After consent, `execute` synchronously walks `generate` on the MOCK
+    // interpreter (the outcome summary's file list), so a full set of settled
+    // steps lands in-phase with ~0ms durations before the real drive begins.
+    // Sequential steps have per-walk-unique keys, so a `start` on a settled
+    // key can only mean a new interpretation: the board starts over.
+    const c = new SessionController(gen);
+    void c.request(confirm());
+    c.submitConfirm(true);
+    // The mock walk: both steps settle instantly.
+    c.reportStep({ key: "a", label: "a", status: "start" });
+    c.reportStep({ key: "a", label: "a — installed", status: "done" });
+    c.reportStep({ key: "b", label: "b", status: "start" });
+    c.reportStep({ key: "b", label: "b — linked", status: "done" });
+    expect(c.getSnapshot().steps.length).toBe(2);
+    // The real drive starts over with the same first key.
+    c.reportStep({ key: "a", label: "a", status: "start" });
+    expect(c.getSnapshot().steps).toEqual([
+      { key: "a", label: "a", status: "running" },
+    ]);
+    c.reportStep({ key: "a", label: "a — installed", status: "done" });
+    c.reportStep({ key: "b", label: "b", status: "start" });
+    c.reportStep({ key: "b", label: "b — linked", status: "done" });
+    expect(c.getSnapshot().steps.map((s) => s.status)).toEqual([
+      "done",
+      "done",
+    ]);
+  });
+
+  it("a completion whose start was gated away still lands, with no timing claim", () => {
+    // The overlap case: a step STARTED during the confirm gate's preview walk
+    // (dropped by the phase gate) can complete after consent. The row is
+    // real — it appends — but there is no start to measure from, so the
+    // duration is 0 rather than an invented number.
+    const c = new SessionController(gen);
+    void c.request(confirm());
+    c.submitConfirm(true);
+    c.reportStep({ key: "k", label: "k — installed", status: "done" });
+    expect(c.getSnapshot().steps).toEqual([
+      { key: "k", label: "k — installed", status: "done", duration: 0 },
+    ]);
+  });
+
+  it("marks a failed step failed, keeping its completed siblings", () => {
+    const c = new SessionController(gen);
+    void c.request(confirm());
+    c.submitConfirm(true);
+    c.reportStep({ key: "a", label: "a ok", status: "start" });
+    c.reportStep({ key: "a", label: "a ok — installed", status: "done" });
+    c.reportStep({ key: "b", label: "b bad", status: "start" });
+    c.reportStep({ key: "b", label: "b bad — no bun", status: "failed" });
+    expect(c.getSnapshot().steps.map((s) => s.status)).toEqual([
+      "done",
+      "failed",
+    ]);
+  });
+
   it("ignores answer/confirm submitted against the wrong pending kind", () => {
     const c = new SessionController(gen);
     c.submitAnswer("noop"); // nothing pending

--- a/packages/summon/core/src/prompt/ink/session.ts
+++ b/packages/summon/core/src/prompt/ink/session.ts
@@ -245,7 +245,14 @@ export class SessionController {
     } catch {
       previewEffects = [];
     }
-    if (this.current.phase !== "confirming") return;
+    // Stale once the gate is no longer both showing AND unanswered. The phase
+    // check alone stopped covering the second half when submitConfirm began
+    // deferring the executing transition on this very promise: consent clears
+    // `pending` immediately but flips the phase only after this settles, so a
+    // result landing in that window would repaint a pane already answered.
+    if (this.current.phase !== "confirming" || this.pending === undefined) {
+      return;
+    }
     this.set({ previewEffects });
   }
 
@@ -295,13 +302,17 @@ export class SessionController {
    * step reports originate INSIDE the host's task composition, so every
    * interpretation of it fires them — including the confirm gate's own honest
    * preview, which walks the same task before the user has consented. Dropping
-   * reports outside `executing` (entered at `submitConfirm(true)`, strictly
-   * after the preview walk began) is what keeps a previewed step from painting
-   * itself as work in progress.
+   * reports outside `executing` keeps a previewed step from painting itself
+   * as work in progress — and the gate is sound only because of the pairing
+   * invariant {@link submitConfirm} enforces: `executing` begins strictly
+   * AFTER the preview walk has completed (consent is released on
+   * `previewSettled()`), so no pre-consent walk can still be emitting once
+   * reports are accepted. Testing arrival time alone could not close that —
+   * a report says nothing about which walk produced it.
    *
-   * The phase gate alone is not enough: `execute` walks `generate` once more
-   * on the MOCK interpreter right after consent — synchronously, to give the
-   * outcome summary its file list — so a full set of settled steps arrives
+   * The phase gate alone is still not enough: `execute` walks `generate` once
+   * more on the MOCK interpreter right after consent — synchronously, to give
+   * the outcome summary its file list — so a full set of settled steps arrives
    * (in-phase, near-zero durations) before the real drive begins. Steps run
    * sequentially with per-walk-unique keys, so a `start` for a key that has
    * ALREADY settled can only mean a new interpretation: the board resets and
@@ -368,14 +379,53 @@ export class SessionController {
     pending.resolve(value);
   }
 
-  /** The user answered the confirm gate. */
+  /**
+   * The user answered the confirm gate.
+   *
+   * Consent does NOT begin execution by itself. The gate's honest preview
+   * ({@link loadPreview}) walks the same `generate` the run will, and it is
+   * async — a fast Y can land while that walk is still in flight. Entering
+   * `executing` at that instant re-opened the gap {@link reportStep}'s phase
+   * gate exists to close: the pre-consent walk's late step reports arrived
+   * in-phase and were accepted, and one naming a key the real walk had
+   * already settled hit the fresh-walk reset and cleared the board mid-run.
+   * Step reports carry no walk identity — they are plain closures fired from
+   * task continuations — so the sound closure is to ensure NO pre-consent
+   * walk survives into the executing phase: consent is released only once
+   * {@link previewSettled} resolves, which is `runPreview` COMPLETING its
+   * walk (loadPreview catches its failure), not merely having started it.
+   * The pane has usually settled long before the user answers, so the
+   * deferral is normally one microtask.
+   *
+   * A cancel that lands while consent waits on the preview rejects the gate
+   * here, with the same `GENERATOR_CANCELLED` an at-prompt cancel carries —
+   * {@link cancel} cannot reach it, this method already claimed the pending
+   * slot — so the task fails cleanly instead of hanging on a prompt that
+   * would otherwise never settle.
+   */
   submitConfirm(proceed: boolean): void {
     const pending = this.pending;
     if (!pending || !pending.isConfirm) return;
     this.pending = undefined;
-    if (proceed) this.executionStart = performance.now();
-    this.set({ phase: proceed ? "executing" : "cancelled" });
-    pending.resolve(proceed);
+    if (!proceed) {
+      this.set({ phase: "cancelled" });
+      pending.resolve(false);
+      return;
+    }
+    void this.previewSettled().then(() => {
+      if (this.current.phase === "cancelled") {
+        pending.reject(
+          new TaskExecutionError({
+            code: GENERATOR_CANCELLED,
+            message: "Cancelled.",
+          }),
+        );
+        return;
+      }
+      this.executionStart = performance.now();
+      this.set({ phase: "executing" });
+      pending.resolve(true);
+    });
   }
 
   /**

--- a/packages/summon/core/src/prompt/ink/session.ts
+++ b/packages/summon/core/src/prompt/ink/session.ts
@@ -23,6 +23,7 @@ import {
   GENERATOR_CANCELLED,
 } from "../../execute/execute.js";
 import type GeneratorDefinition from "../../types/GeneratorDefinition.js";
+import type { StepReport } from "../inkPrompt.js";
 import type { PromptEffect } from "../types.js";
 
 /** The wizard's coarse lifecycle phase. */
@@ -48,6 +49,20 @@ export interface TimedEffect {
   readonly duration: number;
 }
 
+/**
+ * One host-named step's live state — a {@link StepReport} folded into the
+ * view model. `duration` is measured HERE, from the step's `start` report to
+ * its completion report, so it covers the step's whole wall time (every effect
+ * it spans) rather than any single effect's.
+ */
+export interface StepProgress {
+  readonly key: string;
+  readonly label: string;
+  readonly status: "running" | "done" | "failed";
+  /** Wall-clock ms from `start` to completion; set on `done`/`failed`. */
+  readonly duration?: number;
+}
+
 /** The immutable snapshot the React view renders. A new object per change. */
 export interface WizardState {
   readonly phase: WizardPhase;
@@ -63,6 +78,12 @@ export interface WizardState {
   readonly previewEffects: readonly Effect[];
   /** Effects completed so far during execution. */
   readonly progress: readonly TimedEffect[];
+  /**
+   * Host-named steps reported so far ({@link SessionController.reportStep}).
+   * Non-empty ONLY for a host that narrates its run in its own units; the
+   * view then renders these rows instead of the per-effect transcript.
+   */
+  readonly steps: readonly StepProgress[];
   /** A failure, when `phase === "error"`. */
   readonly error?: TaskError;
 }
@@ -145,6 +166,7 @@ export class SessionController {
       total: countApplicable(generator, { ...initialAnswers }),
       previewEffects: [],
       progress: [],
+      steps: [],
     };
   }
 
@@ -261,6 +283,59 @@ export class SessionController {
 
   /** A task log line (kept for parity; not surfaced by the default view). */
   reportLog(_level: LogLevel, _message: string): void {}
+
+  /** Per-step `start` timestamps, so completion can measure wall time. */
+  private readonly stepStarts = new Map<string, number>();
+
+  /**
+   * Fold a host step report into the live view (see {@link StepProgress}).
+   *
+   * GATED to the executing phase, unlike {@link reportEffectComplete}: effect
+   * callbacks only ever arrive from the real interpreter through the seam, but
+   * step reports originate INSIDE the host's task composition, so every
+   * interpretation of it fires them — including the confirm gate's own honest
+   * preview, which walks the same task before the user has consented. Dropping
+   * reports outside `executing` (entered at `submitConfirm(true)`, strictly
+   * after the preview walk began) is what keeps a previewed step from painting
+   * itself as work in progress.
+   *
+   * The phase gate alone is not enough: `execute` walks `generate` once more
+   * on the MOCK interpreter right after consent — synchronously, to give the
+   * outcome summary its file list — so a full set of settled steps arrives
+   * (in-phase, near-zero durations) before the real drive begins. Steps run
+   * sequentially with per-walk-unique keys, so a `start` for a key that has
+   * ALREADY settled can only mean a new interpretation: the board resets and
+   * the real walk repaints it with real timings. This is also why the view
+   * renders steps in the LIVE region, never under `<Static>` — a static row
+   * cannot be taken back, and the mock walk's rows must be.
+   */
+  reportStep(report: StepReport): void {
+    if (this.current.phase !== "executing") return;
+    let steps = [...this.current.steps];
+    const at = steps.findIndex((step) => step.key === report.key);
+    let entry: StepProgress;
+    if (report.status === "start") {
+      if (at >= 0 && steps[at]?.status !== "running") {
+        // A settled key starting again: a fresh walk. Reset the board.
+        steps = [];
+        this.stepStarts.clear();
+      }
+      this.stepStarts.set(report.key, performance.now());
+      entry = { key: report.key, label: report.label, status: "running" };
+    } else {
+      const started = this.stepStarts.get(report.key);
+      entry = {
+        key: report.key,
+        label: report.label,
+        status: report.status,
+        duration: started === undefined ? 0 : performance.now() - started,
+      };
+    }
+    const target = steps.findIndex((step) => step.key === report.key);
+    if (target >= 0) steps[target] = entry;
+    else steps.push(entry);
+    this.set({ steps });
+  }
 
   /** Mark the run complete (the view flashes a completion summary). */
   markComplete(): void {

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -486,6 +486,115 @@ describe("degenerate-choice prompt wiring (C4)", () => {
   );
 });
 
+describe("host step rows replace the effect transcript", () => {
+  // A host whose unit of work is coarser than one effect (pragma's `setup`:
+  // one step = one configured target spanning a dozen effects) reports steps,
+  // and the wizard renders THOSE rows — the effect transcript would render
+  // eighteen symlink lines for the row the host calls `skills  9 skills → 2
+  // folders`. Rendered from an already-driven controller: a static frame.
+  const drive = (c: SessionController): void => {
+    void c.request(gate());
+    c.submitConfirm(true); // "executing" — the only phase steps land in
+  };
+
+  it(
+    "renders one row per step — the host's sentence, the shared glyph, the wall time",
+    async () => {
+      const c = new SessionController(gen);
+      drive(c);
+      c.reportStep({
+        key: "global:skills",
+        label: "skills  9 skills → 2 folders",
+        status: "start",
+      });
+      // The effects the step spans still stream through the seam; with steps
+      // present they must NOT paint their own rows.
+      c.reportEffectComplete(writeFileEffect("src/a.ts", "x"), 4);
+      c.reportStep({
+        key: "global:skills",
+        label: "skills  9 skills → 2 folders — linked",
+        status: "done",
+      });
+      c.markComplete();
+      const { lastFrame, unmount } = render(<Wizard controller={c} />);
+      try {
+        await waitFor(() => (lastFrame() ?? "").includes("linked"));
+        const frame = stripStyles(lastFrame() ?? "");
+        expect(frame).toMatch(
+          /✓ skills {2}9 skills → 2 folders — linked \(\d+ms\)/,
+        );
+        expect(frame).not.toContain("Write file:");
+        // The host owns its own epilogue (pragma prints its recap after the
+        // unmount) — the framework's banner would misname the run.
+        expect(frame).not.toContain("Generation complete");
+      } finally {
+        unmount();
+      }
+    },
+    TEST_TIMINGS.testBudgetMs,
+  );
+
+  it(
+    "marks a failed step with the failure glyph, keeping completed siblings",
+    async () => {
+      const c = new SessionController(gen);
+      drive(c);
+      c.reportStep({ key: "a", label: "config  ~/.config", status: "start" });
+      c.reportStep({
+        key: "a",
+        label: "config  ~/.config — installed",
+        status: "done",
+      });
+      c.reportStep({ key: "b", label: "lsp  codium", status: "start" });
+      c.reportStep({
+        key: "b",
+        label: "lsp  codium — `bun` is not found",
+        status: "failed",
+      });
+      c.markComplete();
+      const { lastFrame, unmount } = render(<Wizard controller={c} />);
+      try {
+        await waitFor(() => (lastFrame() ?? "").includes("bun"));
+        const frame = stripStyles(lastFrame() ?? "");
+        expect(frame).toContain("✓ config  ~/.config — installed");
+        expect(frame).toContain("✗ lsp  codium — `bun` is not found");
+      } finally {
+        unmount();
+      }
+    },
+    TEST_TIMINGS.testBudgetMs,
+  );
+
+  it(
+    "keeps a long step row on ONE line once the duration is appended",
+    async () => {
+      const c = new SessionController(gen);
+      drive(c);
+      const label = `skills  ${"deep/".repeat(30)}skills — linked`;
+      c.reportStep({ key: "k", label, status: "start" });
+      c.reportStep({ key: "k", label, status: "done" });
+      c.markComplete();
+      const { lastFrame, unmount } = render(<Wizard controller={c} />);
+      try {
+        await waitFor(() => (lastFrame() ?? "").includes("skills"));
+        // Trimmed: the live region sits inside the wizard's one-column frame
+        // padding, which is layout, not row content.
+        const line = (lastFrame() ?? "")
+          .split("\n")
+          .map((l) => stripStyles(l).trim())
+          .find((l) => l.startsWith("✓ skills"));
+        expect(line).toBeDefined();
+        expect(measureDisplayWidth(line ?? "")).toBeLessThanOrEqual(
+          MAX_PROGRESS_LINE,
+        );
+      } finally {
+        unmount();
+      }
+    },
+    TEST_TIMINGS.testBudgetMs,
+  );
+});
+
 /**
  * The two colour states Ink can render the same frame in. Ink styles through
  * `chalk`, and `chalk` decides at import time whether the process's stdout looks

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -492,16 +492,19 @@ describe("host step rows replace the effect transcript", () => {
   // and the wizard renders THOSE rows — the effect transcript would render
   // eighteen symlink lines for the row the host calls `skills  9 skills → 2
   // folders`. Rendered from an already-driven controller: a static frame.
-  const drive = (c: SessionController): void => {
-    void c.request(gate());
-    c.submitConfirm(true); // "executing" — the only phase steps land in
+  const drive = async (c: SessionController): Promise<void> => {
+    const consent = c.request(gate());
+    c.submitConfirm(true);
+    // Consent is released once the gate's preview walk settles; only then is
+    // the session executing — the one phase step reports land in.
+    await consent;
   };
 
   it(
     "renders one row per step — the host's sentence, the shared glyph, the wall time",
     async () => {
       const c = new SessionController(gen);
-      drive(c);
+      await drive(c);
       c.reportStep({
         key: "global:skills",
         label: "skills  9 skills → 2 folders",
@@ -538,7 +541,7 @@ describe("host step rows replace the effect transcript", () => {
     "marks a failed step with the failure glyph, keeping completed siblings",
     async () => {
       const c = new SessionController(gen);
-      drive(c);
+      await drive(c);
       c.reportStep({ key: "a", label: "config  ~/.config", status: "start" });
       c.reportStep({
         key: "a",
@@ -569,7 +572,7 @@ describe("host step rows replace the effect transcript", () => {
     "keeps a long step row on ONE line once the duration is appended",
     async () => {
       const c = new SessionController(gen);
-      drive(c);
+      await drive(c);
       const label = `skills  ${"deep/".repeat(30)}skills — linked`;
       c.reportStep({ key: "k", label, status: "start" });
       c.reportStep({ key: "k", label, status: "done" });

--- a/packages/summon/core/src/prompt/inkPrompt.ts
+++ b/packages/summon/core/src/prompt/inkPrompt.ts
@@ -50,6 +50,24 @@ export interface InkPromptOptions {
 }
 
 /**
+ * One host-named unit of work, reported through {@link InkSession.reportStep}.
+ *
+ * The wizard's default live progress is the per-effect transcript — the right
+ * grain for a scaffolder, whose unit of work IS the file. A host whose unit is
+ * coarser (pragma's `setup`, where one step is one configured target spanning
+ * a dozen effects) reports its own steps instead, in its own vocabulary, and
+ * the view renders those rows in place of the transcript. `label` is the whole
+ * row body, unstyled — the glyph, spinner and duration are the view's.
+ */
+export interface StepReport {
+  /** Stable identity — a `start` and its `done`/`failed` share it. */
+  readonly key: string;
+  /** The row body (unstyled); the completion report may extend it. */
+  readonly label: string;
+  readonly status: "start" | "done" | "failed";
+}
+
+/**
  * A running Ink session's seam surface: the prompt handler plus the effect
  * callbacks the runner wires into `runtime.exec`, and its teardown.
  */
@@ -62,8 +80,18 @@ export interface InkSession {
   readonly onEffectComplete: (effect: Effect, duration: number) => void;
   /** Feed a task log line into the live view. */
   readonly onLog: (level: LogLevel, message: string) => void;
-  /** Tear down the Ink render. Safe to call more than once. */
-  readonly dispose: () => void;
+  /**
+   * Report a host-named step ({@link StepReport}). Once any step is reported,
+   * the live progress renders the host's step rows INSTEAD of the per-effect
+   * transcript; a session that never receives one renders exactly as before.
+   */
+  readonly reportStep: (report: StepReport) => void;
+  /**
+   * Tear down the Ink render. Safe to call more than once. Resolves once the
+   * final frame is flushed — AWAIT it before printing to the same terminal,
+   * or the closing frame and the caller's output interleave.
+   */
+  readonly dispose: () => Promise<void>;
 }
 
 /** The handle {@link mountPromptSession} returns (in `./ink/mount.js`). */
@@ -72,7 +100,8 @@ interface MountedSession {
   reportEffectStart: (effect: Effect) => void;
   reportEffectComplete: (effect: Effect, duration: number) => void;
   reportLog: (level: LogLevel, message: string) => void;
-  dispose: () => void;
+  reportStep: (report: StepReport) => void;
+  dispose: () => Promise<void>;
 }
 
 /**
@@ -125,6 +154,13 @@ export default function inkPrompt(
     onEffectComplete: (effect, duration) =>
       mounted?.reportEffectComplete(effect, duration),
     onLog: (level, message) => mounted?.reportLog(level, message),
-    dispose: () => mounted?.dispose(),
+    // Steps can only originate from the running task, and the session mounts
+    // on the FIRST Prompt effect — which precedes execution (the confirm gate
+    // is itself a prompt) — so by the time a step is reported the session
+    // exists; the guard only covers a host reporting outside a run.
+    reportStep: (report) => mounted?.reportStep(report),
+    dispose: async () => {
+      await mounted?.dispose();
+    },
   };
 }


### PR DESCRIPTION
## Done

- **`pragma setup`'s attended (wizard) run now presents its execution through the plan projection** — one live row per TARGET in the plan's own vocabulary, instead of the kernel/interpreter effect transcript. Before, after the questions were answered in plan vocabulary, execution feedback switched dialects to the framework's:

  ```
  ✓ Created /home/adrian/.zfunc/ (2ms)
  ✓ Write file: /home/adrian/.zfunc/_pragma (8424 bytes) (5ms)
  ✓ Write file: /home/adrian/.claude.json (68172 bytes) (3ms)
  ✓ Symlink: /home/adrian/.claude/sk…hare/pragma/skills/add-standard (3ms)
  … 17 more near-identical symlink rows …
  ✓ Generation complete!
  ```

  Now (real run, VSCodium + zsh on the test machine):

  ```
  ✓ config       ~/.config/pragma/config.json — installed (5ms)
  ✓ completions  zsh → ~/.zfunc/_pragma — installed (575ms)
  ✓ lsp          Terrazzo extension → VSCodium — 1 added (25663ms)
  ✓ mcp          3 config files — 3 added (2176ms)
  ✓ skills       9 skills → 2 folders (~/.claude/skills, ~/.agents/skills) — linked (5525ms)
  ```

  Each row is the SAME `target  detail — note` sentence `renderProgressLine` prints in the `--yes` progress stream and the recap — derived once (`noteFor`) — so the watcher and the recap reader see one dialect. The running row shows a spinner with its label, so the slow target (an editor extension install) is named while it runs. `--verbose` falls back to the full per-effect transcript — the same detected-only-unless-verbose rule the detection summary and doctor follow.

- **summon-core: the Ink session grows one optional channel, `InkSession.reportStep`** (`StepReport { key, label, status }`). A host that reports steps gets step rows in place of the transcript; a session that never receives one renders exactly as before, so the summon bin and pragma `create` are untouched (byte-equality suites green). Two properties are load-bearing:
  - Steps originate inside the host's task, so **every** interpretation fires them. Reports outside the executing phase are dropped (the confirm gate's honest preview), and a `start` for an already-settled key resets the board (`execute` mock-walks `generate` synchronously right after consent to build the outcome summary). The reset is why step rows live in the LIVE region, never under `<Static>` — a static row cannot be taken back.
  - `dispose()` now awaits one macrotask before unmounting and resolves once the final frame is flushed. React commits on a macrotask; unmounting in the same continuation permanently painted a finished run's last row as still in progress (observed: the `skills` row frozen as a spinner above the recap).

- **pragma: each composed setup row is bracketed with `start`/`done`/`failed` events** emitted from the task's own continuations — the same nothing-captured-in-the-task discipline the `OutcomeSink` already uses, so the composition stays pure and re-interpretable. A failing row (e.g. `lsp` with no `bun` on PATH) paints ✗ with its cause live, while its siblings continue.

- **Drive-by (kernel): `dispatch` tears down the interactive session BEFORE rendering the verb's outcome**, so the wizard's closing frame lands above the recap instead of repainting stale beneath it. The error path gets the same order for free.

### What this PR deliberately does NOT change

- `setup --dry-run` and the non-interactive `setup --yes` already present the plan projection (the aligned target table, per-row progress lines, the recap) — they are byte-identical before/after this PR.
- `create`'s per-effect rows are unchanged everywhere: per-file IS the right unit for a scaffolder. The two verbs share the glyph alphabet (#1052's vocabulary, pinned by `renderVocabularySync.test.ts`), the duration spelling, the one-row truncation, the interaction decision and the confirm gate; the row SOURCE differs because the unit of work differs — a difference with something behind it, unlike the one `create.render.ts` warns about.
- The harmful middle-truncation (`~/.claude/sk…hare/pragma/skills/add-standard`, eliding the harness dir while keeping the source) disappears from the default surface because symlink paths no longer appear there; the `--verbose` transcript keeps the framework rows as-is.
- The summon binary's own `ExecutionProgress` is untouched (out of scope per its own fork).

## QA

- `bun run check` and `bun run test` green from the repo root (101 tasks).
- `bun run gen:reference` — no diff. PROTECTED suites green and unweakened: `create.test.ts` (dynamic-import pins), `lazy.test.ts` (summon-core off the static graph, walker-verified), `reference.test.ts`, `decideInteraction` matrix, `byteEquality*`, `crossCli.subprocess`, `parity`, `renderVocabularySync`. Perf budgets untouched (`BUDGET_HELP_MS`/`BUDGET_COMPLETE_MS` suites green); nothing new lands on a fast path — the step seam is behind the existing lazy `inkPrompt` boundary.
- Hand-verified in a real pty (`script(1)`, isolated `$HOME`): the interactive wizard end-to-end (targets multiselect → MCP-files multiselect → confirm → live per-target rows with real durations → recap), plus `setup --dry-run` and `setup --yes` unchanged. An interactive `create component react Sth` run still renders its per-effect transcript and scaffolds the same tree.
- New tests: session step folding/gating/reset (summon-core `session.test.ts`), step-row rendering incl. failure glyph and one-row cap (`wizard.test.tsx`), and pragma row-event bracketing incl. the failure-isolation path (`setup.test.ts`).

### PR readiness check

- [x] PR has one of the required labels (`Feature 🎁`).
- [x] PR title follows Conventional Commits.
- [x] Code follows the appropriate code standards.
- [x] All packages define the required scripts in `package.json` (unchanged).
- [x] No new package.
- [x] `no visual change` label added (terminal UI only; no Chromatic surface).

## Screenshots

Terminal output shown above (captured from a scripted pty run).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
