### PR TITLE
feat(harnesses): register the pragma MCP server with Charm's Crush

### DIFF
--- a/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/doctor.test.ts
@@ -348,9 +348,9 @@ describe("doctor — the harness inventory", () => {
     const { global, project } = inventory(rows);
 
     // Every harness the registry knows, in both scopes.
-    expect(project?.items).toHaveLength(12);
-    expect(global?.items).toHaveLength(12);
-    expect(project?.detail).toBe("1 detected · 0 registered · 12 known");
+    expect(project?.items).toHaveLength(13);
+    expect(global?.items).toHaveLength(13);
+    expect(project?.detail).toBe("1 detected · 0 registered · 13 known");
 
     // `types.ts` forbids inflating the failure count: a machine that simply
     // does not have Cursor is not a broken machine.

--- a/packages/runtime/harnesses/src/lib/config.test.ts
+++ b/packages/runtime/harnesses/src/lib/config.test.ts
@@ -237,6 +237,100 @@ describe("writeMcpConfig", () => {
   });
 });
 
+describe("Crush config (crush.json)", () => {
+  const crush = findHarnessById("crush") as (typeof harnesses)[number];
+
+  it("writes under the top-level `mcp` key with the REQUIRED type discriminator, and no cwd", () => {
+    // Crush requires `type` on every MCP entry and applies no default on
+    // load — a typeless entry LOOKS configured but hits createTransport's
+    // "unsupported mcp type" arm and silently never starts. This asserts on
+    // the WRITTEN FILE, so a regression to the default serializer (which
+    // emits no `type` and a schema-unknown `cwd`) fails here.
+    const result = dryRunWith(
+      writeMcpConfig(crush, "/project", "pragma", {
+        command: "pragma",
+        args: ["mcp"],
+        cwd: "/project",
+      }),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    expect(writeEffects.length).toBe(1);
+    expect(writeEffects[0].path).toBe("/project/crush.json");
+
+    const written = JSON.parse(writeEffects[0].content);
+    expect(written.mcp.pragma).toEqual({
+      type: "stdio",
+      command: "pragma",
+      args: ["mcp"],
+    });
+    expect(written).not.toHaveProperty("mcpServers");
+  });
+
+  it("merges into an existing `mcp` block preserving the user's other servers", () => {
+    const existingConfig = JSON.stringify({
+      $schema: "https://charm.land/crush.json",
+      mcp: {
+        context7: { type: "http", url: "https://mcp.context7.com/mcp" },
+      },
+      options: { debug: true },
+    });
+
+    const result = dryRunWith(
+      writeMcpConfig(crush, "/project", "pragma", {
+        command: "pragma",
+        args: ["mcp"],
+      }),
+      buildMocks({
+        Exists: existsMock(() => true),
+        ReadFile: readFileMock(existingConfig),
+        WriteFile: writeMock,
+      }),
+    );
+
+    const written = JSON.parse(
+      filterEffects(result.effects, "WriteFile")[0].content,
+    );
+    expect(written.mcp.context7).toEqual({
+      type: "http",
+      url: "https://mcp.context7.com/mcp",
+    });
+    expect(written.mcp.pragma).toEqual({
+      type: "stdio",
+      command: "pragma",
+      args: ["mcp"],
+    });
+    expect(written.$schema).toBe("https://charm.land/crush.json");
+    expect(written.options).toEqual({ debug: true });
+  });
+
+  it("writes the global band into $XDG_CONFIG_HOME/crush/crush.json", () => {
+    const result = dryRunWith(
+      writeMcpConfig(
+        crush,
+        "/project",
+        "pragma",
+        { command: "pragma" },
+        "global",
+        { ...PLATFORM, env: { XDG_CONFIG_HOME: "/xdg" } },
+      ),
+      buildMocks({
+        Exists: existsMock(() => false),
+        MakeDir: mkdirMock,
+        WriteFile: writeMock,
+      }),
+    );
+
+    const writeEffects = filterEffects(result.effects, "WriteFile");
+    expect(writeEffects[0].path).toBe("/xdg/crush/crush.json");
+  });
+});
+
 describe("removeMcpConfig", () => {
   it("is a no-op when config file does not exist", () => {
     const result = dryRunWith(

--- a/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/detectHarnesses.test.ts
@@ -339,3 +339,101 @@ describe("detectHarnesses — VS Code installation signals", () => {
     expect(result.value).toEqual([]);
   });
 });
+
+/**
+ * Crush's signal set, one probe per case (the same discipline as the VS Code
+ * block above): a project config name Crush itself looks up, the per-project
+ * data directory, the global XDG config dir, and the binary on PATH. The
+ * hostile guard at the end proves the set cannot false-positive: with a
+ * populated PATH and nothing on disk, no signal fires.
+ */
+describe("detectHarnesses — Crush signals", () => {
+  const withPath = (path: string): PlatformEnv => ({
+    ...PLATFORM,
+    env: { ...PLATFORM.env, PATH: path },
+  });
+
+  const only = (
+    wanted: string,
+    seen?: string[],
+  ): Map<string, (effect: Effect) => unknown> =>
+    new Map([
+      [
+        "Exists",
+        (effect: Effect): unknown => {
+          const { path } = effect as Effect & { _tag: "Exists"; path: string };
+          seen?.push(path);
+          return path === wanted;
+        },
+      ],
+    ]);
+
+  it("detects Crush from a project crush.json alone, at high confidence", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", PLATFORM),
+      only("/project/crush.json"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["crush"]);
+    expect(result.value[0]?.confidence).toBe("high");
+    expect(result.value[0]?.configExists).toBe(true);
+    expect(result.value[0]?.configPath).toBe("/project/crush.json");
+  });
+
+  it("detects Crush from its .crush data directory alone", () => {
+    // `.crush/` is state Crush itself creates — a true "Crush ran in this
+    // repo" signal with a single owner. Detection only: nothing here reads
+    // or writes `.crush/crush.json`, Crush's own workspace-state file.
+    const result = dryRunWith(
+      detectHarnesses("/project", PLATFORM),
+      only("/project/.crush"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["crush"]);
+    expect(result.value[0]?.confidence).toBe("high");
+  });
+
+  it("honours $XDG_CONFIG_HOME for the global config dir and never probes ~/.config", () => {
+    const seen: string[] = [];
+    const platform: PlatformEnv = {
+      ...PLATFORM,
+      env: { ...PLATFORM.env, XDG_CONFIG_HOME: "/xdg/config" },
+    };
+    const result = dryRunWith(
+      detectHarnesses("/project", platform),
+      only("/xdg/config/crush", seen),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["crush"]);
+    expect(result.value[0]?.confidence).toBe("high");
+    expect(seen).toContain("/xdg/config/crush");
+    expect(seen).not.toContain("/home/tester/.config/crush");
+  });
+
+  it("detects an installed Crush from the binary on PATH alone", () => {
+    const result = dryRunWith(
+      detectHarnesses("/project", withPath("/usr/bin:/bin:/usr/local/bin")),
+      only("/usr/local/bin/crush"),
+    );
+
+    expect(result.value.map((d) => d.harness.id)).toEqual(["crush"]);
+    // On PATH means "installed", not "this project uses it".
+    expect(result.value[0]?.confidence).toBe("medium");
+    expect(result.value[0]?.configExists).toBe(false);
+  });
+
+  it("detects nothing from a populated PATH when nothing exists on disk", () => {
+    const result = dryRunWith(
+      detectHarnesses(
+        "/project",
+        withPath("/usr/bin:/bin:/snap/bin:/usr/local/bin"),
+      ),
+      new Map<string, (effect: Effect) => unknown>([
+        ["Exists", () => false],
+        ["Glob", () => ["anything-1.0.0/package.json"]],
+      ]),
+    );
+
+    expect(result.value).toEqual([]);
+  });
+});

--- a/packages/runtime/harnesses/src/lib/harnesses.test.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import harnesses from "./harnesses.js";
-import { opendesignMcpEntry } from "./mcpEntries.js";
+import { crushMcpEntry, opendesignMcpEntry } from "./mcpEntries.js";
 
 describe("harnesses registry", () => {
   it("contains all known harnesses", () => {
-    expect(harnesses).toHaveLength(12);
+    expect(harnesses).toHaveLength(13);
     const ids = harnesses.map((h) => h.id);
     expect(ids).toEqual([
       "claude-code",
@@ -19,6 +19,7 @@ describe("harnesses registry", () => {
       "antigravity",
       "vscode",
       "opendesign",
+      "crush",
     ]);
   });
 
@@ -259,6 +260,82 @@ describe("harnesses registry", () => {
       type: "directory",
       path: "$XDG_CONFIG_HOME/opencode",
     });
+  });
+
+  it("crush is dual-scope: project crush.json, global under $XDG_CONFIG_HOME/crush", () => {
+    // Crush merges a global config with project files (lookupConfigs,
+    // load.go @7944b8e); a project-only row would be skipped by the DEFAULT
+    // global band entirely — the same hole opencode and vscode fell into.
+    const crush = harnesses.find((h) => h.id === "crush");
+    expect(crush?.scope).toBe("both");
+    expect(crush?.configPath("/project")).toBe("/project/crush.json");
+    expect(crush?.homeConfigPath?.(PLATFORM)).toBe(
+      "/home/tester/.config/crush/crush.json",
+    );
+    expect(crush?.skillsPath("/project")).toBe("/project/.agents/skills");
+  });
+
+  it("crush's global config follows $XDG_CONFIG_HOME on every platform, and $CRUSH_GLOBAL_CONFIG wins", () => {
+    // Crush's home.Config() is `$XDG_CONFIG_HOME ?? ~/.config` with NO
+    // platform switch — macOS included, there is no ~/Library arm — and
+    // GlobalConfig() prefers $CRUSH_GLOBAL_CONFIG as the DIRECTORY holding
+    // crush.json.
+    const crush = harnesses.find((h) => h.id === "crush");
+    expect(
+      crush?.homeConfigPath?.({
+        ...PLATFORM,
+        env: { XDG_CONFIG_HOME: "/xdg" },
+      }),
+    ).toBe("/xdg/crush/crush.json");
+    expect(
+      crush?.homeConfigPath?.({
+        ...PLATFORM,
+        platform: "darwin",
+        home: "/Users/tester",
+      }),
+    ).toBe("/Users/tester/.config/crush/crush.json");
+    expect(
+      crush?.homeConfigPath?.({
+        ...PLATFORM,
+        env: { CRUSH_GLOBAL_CONFIG: "/custom" },
+      }),
+    ).toBe("/custom/crush.json");
+  });
+
+  it("crush uses the top-level `mcp` key and the type-carrying entry shape", () => {
+    // The JSON key is `mcp`, not `mcpServers` (config.go `MCP MCPs
+    // json:"mcp"`), and the entry MUST carry `type` — without it Crush's
+    // createTransport errors "unsupported mcp type" and the server silently
+    // never starts.
+    const crush = harnesses.find((h) => h.id === "crush");
+    expect(crush?.mcpKey).toBe("mcp");
+    expect(crush?.mcpEntry).toBe(crushMcpEntry);
+  });
+
+  it("crush is detectable from the global config dir, not just a project file", () => {
+    // Same reasoning as opencode: before the first project config exists,
+    // the only filesystem trace of an installed Crush is its global config
+    // dir — declared in $XDG_CONFIG_HOME form so a relocated config base
+    // still resolves.
+    const crush = harnesses.find((h) => h.id === "crush");
+    expect(crush?.detect).toContainEqual({
+      type: "directory",
+      path: "$XDG_CONFIG_HOME/crush",
+    });
+  });
+
+  it("crush never keys detection on Crush's own state files", () => {
+    // `.crush/` (the data DIRECTORY) is a truthful "Crush ran here" signal
+    // with a single owner, but `.crush/crush.json` and the machine-owned
+    // data config are Crush's write targets — pragma neither probes nor
+    // writes those files.
+    const crush = harnesses.find((h) => h.id === "crush");
+    const paths = (crush?.detect ?? []).flatMap((s) =>
+      "path" in s ? [s.path] : [],
+    );
+    expect(paths).toContain(".crush");
+    expect(paths).not.toContain(".crush/crush.json");
+    expect(paths.some((p) => p.includes(".local/share"))).toBe(false);
   });
 
   it("roo-code skillsPath", () => {

--- a/packages/runtime/harnesses/src/lib/harnesses.ts
+++ b/packages/runtime/harnesses/src/lib/harnesses.ts
@@ -8,6 +8,7 @@
 
 import {
   copilotMcpEntry,
+  crushMcpEntry,
   cursorMcpEntry,
   opencodeMcpEntry,
   opendesignMcpEntry,
@@ -302,6 +303,68 @@ const harnesses: readonly HarnessDefinition[] = [
     configFormat: "json",
     mcpKey: "mcpServers",
     skillsPath: (root) => `${root}/.od/skills`,
+  },
+  {
+    id: "crush",
+    name: "Crush",
+    version: "*",
+    // All paths below verified against Crush's source @7944b8e
+    // (charmbracelet/crush, `internal/config/load.go` + `config.go`), not its
+    // README. Crush merges a GLOBAL config with project files walked from cwd
+    // to the git root, later layers overriding earlier — a project-only row
+    // would be excluded from setup's DEFAULT global band entirely (the
+    // opencode/vscode lesson), so: both.
+    scope: "both",
+    detect: [
+      // The two JSON config names Crush itself looks up per project
+      // directory (`configNames`, load.go — `.crush.json` outranks
+      // `crush.json`; the `crushrc`/`.crushrc` pair are BASH scripts pragma
+      // never writes and never keys on).
+      { type: "file", path: "crush.json" },
+      { type: "file", path: ".crush.json" },
+      // Crush's per-project DATA directory (`defaultDataDirectory`,
+      // config.go). State-derived and usually gitignored, but Crush and
+      // nothing else creates it — "Crush ran in this repo" is a true signal
+      // with a single owner, unlike a bare `.vscode/`. Detection ONLY:
+      // `.crush/crush.json` is Crush's own workspace-state write target,
+      // never pragma's.
+      { type: "directory", path: ".crush" },
+      // The global config dir, in `$XDG_CONFIG_HOME/` form for the usual
+      // reason (see `resolveFsPath`): a user who relocates the config base
+      // keeps nothing under `~/.config`. (`$CRUSH_GLOBAL_CONFIG` is honoured
+      // on the write path below; the signal grammar has no env-prefix form,
+      // and a user who sets it has `crush` on PATH for the process probe.)
+      { type: "directory", path: "$XDG_CONFIG_HOME/crush" },
+      { type: "process", name: "crush" },
+    ],
+    configPath: (root) => `${root}/crush.json`,
+    // `GlobalConfig()` (load.go): `$CRUSH_GLOBAL_CONFIG` names the DIRECTORY
+    // holding crush.json when set; else `$XDG_CONFIG_HOME/crush/crush.json`.
+    // Through `xdgConfigHome`, not `userHome` — and on EVERY platform:
+    // Crush's `home.Config()` has no platform switch, so there is no
+    // `~/Library/Application Support` or `%APPDATA%` config arm to cover.
+    homeConfigPath: (p) =>
+      `${p.env.CRUSH_GLOBAL_CONFIG ?? `${xdgConfigHome(p)}/crush`}/crush.json`,
+    configFormat: "json",
+    // Top-level `mcp`, not `mcpServers` (config.go: `MCP MCPs json:"mcp"`).
+    mcpKey: "mcp",
+    // Crush REQUIRES the `type` discriminator — an entry without it reaches
+    // `createTransport`'s default arm ("unsupported mcp type") and silently
+    // never starts, so the default `{command, args, cwd}` shape would write
+    // a dead server. See `crushMcpEntry` (it also drops the schema-unknown
+    // `cwd`).
+    mcpEntry: crushMcpEntry,
+    // First of Crush's `projectSkillSubdirs` (load.go); it also reads
+    // `.crush/skills`, `.claude/skills` and `.cursor/skills`, but
+    // `.agents/skills` is the cross-client directory `setup skills` links.
+    skillsPath: (root) => `${root}/.agents/skills`,
+    // Shadowing caveats, not reasons to decline: a `crushrc` beside the
+    // global crush.json (`shellConfigSibling`), or a
+    // `.crushrc`/`crushrc`/`.crush.json` beside the project one, merges
+    // ABOVE it, so a conflicting server name there wins (disjoint names
+    // merge fine); and Crush's own state
+    // (`.crush/crush.json`, `$XDG_DATA_HOME/crush/crush.json`) merges above
+    // everything. Both state files are Crush's write targets, never ours.
   },
 ];
 

--- a/packages/runtime/harnesses/src/lib/mcpEntries.test.ts
+++ b/packages/runtime/harnesses/src/lib/mcpEntries.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   copilotMcpEntry,
+  crushMcpEntry,
   cursorMcpEntry,
   defaultMcpEntry,
   mcpEntryMatches,
@@ -83,6 +84,40 @@ describe("copilotMcpEntry", () => {
       args: ["mcp"],
       tools: ["*"],
     });
+  });
+});
+
+describe("crushMcpEntry", () => {
+  it('ALWAYS emits the required `type: "stdio"` discriminator', () => {
+    // The one assertion that makes this row work at all: Crush's MCPConfig
+    // requires `type` and applies no default on load — an entry without it
+    // hits createTransport's "unsupported mcp type" arm and silently never
+    // starts.
+    expect(crushMcpEntry({ command: "pragma" })).toEqual({
+      type: "stdio",
+      command: "pragma",
+    });
+  });
+
+  it("keeps args and env under their canonical spellings", () => {
+    expect(
+      crushMcpEntry({
+        command: "pragma",
+        args: ["mcp"],
+        env: { KEY: "value" },
+      }),
+    ).toEqual({
+      type: "stdio",
+      command: "pragma",
+      args: ["mcp"],
+      env: { KEY: "value" },
+    });
+  });
+
+  it("drops `cwd` — Crush's schema has no such field and rejects unknowns", () => {
+    expect(
+      crushMcpEntry({ command: "pragma", cwd: "/project" }),
+    ).not.toHaveProperty("cwd");
   });
 });
 

--- a/packages/runtime/harnesses/src/lib/mcpEntries.ts
+++ b/packages/runtime/harnesses/src/lib/mcpEntries.ts
@@ -20,6 +20,10 @@
  *   `type: "stdio"` + `command` + optional `args`/`env`).
  * - Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
  *   (local entries: `type: "local"`, `command`, `args`, `env`, `tools`).
+ * - Crush: source @7944b8e (`internal/config/config.go` `MCPConfig` —
+ *   `type` required with enum `stdio|sse|http` and NO load-time default;
+ *   `command`, `args`, `env`; no `cwd` field; published `schema.json` stamps
+ *   `additionalProperties: false`).
  */
 
 import type { McpServerConfig } from "./types.js";
@@ -89,6 +93,29 @@ export const copilotMcpEntry: McpEntrySerializer = (config) => ({
   ...defaultMcpEntry(config),
   tools: ["*"],
 });
+
+/**
+ * Crush's `MCPConfig` (crush @7944b8e, `internal/config/config.go`): the
+ * `type` discriminator is REQUIRED — the published schema declares
+ * `required: ["type"]` and Go applies no default on load, so an entry
+ * without it reaches `createTransport`'s default arm and errors
+ * "unsupported mcp type: " (`internal/agent/tools/mcp/init.go`). The config
+ * then LOOKS correct and the server silently never starts — which is why the
+ * default shape cannot serve here. `cwd` is dropped, not passed through: the
+ * schema has no such field and stamps `additionalProperties: false`, so a
+ * `$schema`-validating editor would flag it, and at runtime Crush ignores it
+ * anyway (a project-band server runs from Crush's own working dir, which IS
+ * the project). `args`/`env` keep their canonical spellings.
+ */
+export const crushMcpEntry: McpEntrySerializer = (config) => {
+  const entry: Record<string, unknown> = {
+    type: "stdio",
+    command: config.command,
+  };
+  if (config.args !== undefined) entry.args = [...config.args];
+  if (config.env !== undefined) entry.env = { ...config.env };
+  return entry;
+};
 
 /**
  * OpenDesign requires the entry's `env` to be present as a JSON object/map —


### PR DESCRIPTION
## Done

- Added a `crush` row to the harness registry, so `pragma setup mcp` registers the pragma MCP server with [Charm's Crush](https://github.com/charmbracelet/crush) and `pragma doctor` inventories it. Every path and shape below was verified against Crush's source at `charmbracelet/crush@7944b8e` (`internal/config/load.go`, `config.go`, `internal/agent/tools/mcp/init.go`, `internal/skills`, and the published `schema.json`), not its README:
  - **`scope: "both"`** — Crush merges a global config with project files walked from cwd to the git root (`lookupConfigs`); a project-only row would have been excluded from setup's default global band entirely (the hole `opencode`/`vscode` previously fell into).
  - **Project band**: `<root>/crush.json`, top-level **`mcp`** key (not `mcpServers`).
  - **Global band**: `$CRUSH_GLOBAL_CONFIG/crush.json` when set (the env var names the directory), else `$XDG_CONFIG_HOME/crush/crush.json` — through `xdgConfigHome`, on every platform: Crush's `home.Config()` has no platform switch, so there is no `~/Library` or `%APPDATA%` config arm to cover.
  - **Detection signals**: project `crush.json` / `.crush.json` (the two JSON names Crush itself looks up; the `crushrc` pair are bash scripts we never write or key on), the `.crush/` per-project data directory (created by Crush and nothing else — detection only, never a write target), `$XDG_CONFIG_HOME/crush`, and `crush` on PATH.
- Added `crushMcpEntry`, a Crush-specific entry serializer. This is the load-bearing part: Crush's `MCPConfig` **requires the `type` discriminator** (schema `required: ["type"]`, no load-time default in Go) — an entry without it reaches `createTransport`'s default arm (`unsupported mcp type`) and silently never starts, so the shared `{command, args, cwd}` shape would have written a server that looks configured and does nothing. The serializer emits `type: "stdio"` and drops `cwd`, which Crush's schema does not know (`additionalProperties: false`).
- Tests: the deliberate registry pin moves 12 → 13; serializer tests assert `type: "stdio"` on the **written file**, so a regression to the default shape fails; fixture-driven detection tests cover each signal alone (project config, `.crush/` dir, `$XDG_CONFIG_HOME` honoured — `~/.config` is never probed when XDG points elsewhere — and the binary on PATH) plus a populated-PATH/nothing-on-disk false-positive guard; a round-trip test shows a write into an existing `crush.json` preserving the user's other `mcp` servers, `$schema`, and options. Doctor's inventory pins updated (13 known).
- `bun run gen:reference` produced no diff (the reference pages don't enumerate harness names).

## QA

- `bun run check` and `bun run test` pass from the repo root.
- In a repo with a `crush.json` (or with `crush` on PATH), `pragma setup mcp` now lists Crush and writes, e.g.:

  ```json
  {
    "mcp": {
      "pragma": { "type": "stdio", "command": "pragma", "args": ["mcp"] }
    }
  }
  ```

- `pragma doctor --verbose` lists Crush in both scope inventories.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.
- [x] This PR introduces no new package.
- [x] No visual change — `no visual change` label added.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
