### PR TITLE
fix(ci): repair the sibling ranges `lerna version` does not rewrite

### DIFF
--- a/.github/actions/lerna-version/action.yml
+++ b/.github/actions/lerna-version/action.yml
@@ -27,6 +27,22 @@ runs:
       id: lerna_version
       run: ${{ github.action_path }}/version.sh ${{ inputs.release_type }} ${{ inputs.tag_prefix }}
 
+      # `lerna version` rewrites sibling ranges in dependencies, devDependencies
+      # and optionalDependencies — but NOT peerDependencies. For a 0.x line every
+      # bump is breaking under caret semantics, so a package that peer-depends on
+      # a sibling is left declaring a range its sibling has just outgrown, and
+      # `check:ranges` below stops the release. That is not hypothetical: it is
+      # how v0.35.0 shipped a broken main, and how v0.36.0 was blocked.
+      #
+      # This runs the SAME script as the verification step, in `--fix` mode, so
+      # the repair and the guard can never disagree about what a satisfiable
+      # range is. It runs BEFORE the lockfile update so `bun install` resolves
+      # against the corrected ranges. Anything it cannot repair — an unparseable
+      # range states an intent no rule can infer — survives to fail the guard.
+    - name: Repair sibling ranges lerna does not rewrite
+      shell: bash
+      run: bun run check:ranges --fix
+
       # `lerna version` updates package numbers, so we must update the root lockfile.
       # This can be removed once https://github.com/lerna/lerna/issues/4234 is closed.
     - name: Update lockfile

--- a/scripts/check-workspace-ranges.test.ts
+++ b/scripts/check-workspace-ranges.test.ts
@@ -6,6 +6,8 @@ import {
 	type WorkspacePackage,
 	findViolations,
 	loadWorkspacePackages,
+	repairedRange,
+	rewriteDeclaration,
 	satisfies,
 } from "./check-workspace-ranges";
 
@@ -236,5 +238,88 @@ describe("against the real repository", () => {
 		expect(
 			violations.map((v) => `${v.file} ${v.field}.${v.sibling} = ${v.range} (actual ${v.actual})`),
 		).toEqual([]);
+	});
+});
+
+describe("repairing what a bump left behind", () => {
+	test("a caret range moves to the sibling's new version", () => {
+		expect(repairedRange("^0.35.0", "0.36.0")).toBe("^0.36.0");
+	});
+
+	test("a tilde range STAYS a tilde range", () => {
+		// A package that pinned with `~` asked for patch-only drift. Repairing it
+		// into `^` would silently widen a deliberate constraint — the fix must
+		// make the range satisfiable, not make it permissive.
+		expect(repairedRange("~0.35.0", "0.36.0")).toBe("~0.36.0");
+	});
+
+	test("a bare version becomes a caret range", () => {
+		expect(repairedRange("0.35.0", "0.36.0")).toBe("^0.36.0");
+	});
+
+	test("a `workspace:` wrapper survives the repair", () => {
+		// The protocol changes who resolves the range, not what it means.
+		expect(repairedRange("workspace:^0.35.0", "0.36.0")).toBe(
+			"workspace:^0.36.0",
+		);
+	});
+
+	test("`workspace:*` is left alone — it links by construction", () => {
+		expect(repairedRange("workspace:*", "0.36.0")).toBeNull();
+	});
+});
+
+describe("rewriting a declaration in a manifest", () => {
+	const manifest = [
+		"{",
+		'  "name": "@canonical/summon-component",',
+		'  "dependencies": {',
+		'    "@canonical/task": "^0.35.0"',
+		"  },",
+		'  "peerDependencies": {',
+		'    "@canonical/summon-core": "^0.35.0",',
+		'    "@canonical/task": "^0.35.0"',
+		"  }",
+		"}",
+	].join("\n");
+
+	test("rewrites the named field only, not the same sibling elsewhere", () => {
+		// `@canonical/task` appears in BOTH blocks with the same range. A rewrite
+		// that matched the first occurrence would move the wrong declaration and
+		// leave the violation in place — while reporting success.
+		const out = rewriteDeclaration(
+			manifest,
+			"peerDependencies",
+			"@canonical/task",
+			"^0.35.0",
+			"^0.36.0",
+		);
+		expect(out).not.toBeNull();
+		const text = out ?? "";
+		expect(text).toContain('"dependencies": {\n    "@canonical/task": "^0.35.0"');
+		expect(text).toContain('"@canonical/task": "^0.36.0"');
+		// The sibling declared beside it is untouched.
+		expect(text).toContain('"@canonical/summon-core": "^0.35.0"');
+	});
+
+	test("leaves everything else byte-identical", () => {
+		const out =
+			rewriteDeclaration(
+				manifest,
+				"peerDependencies",
+				"@canonical/summon-core",
+				"^0.35.0",
+				"^0.36.0",
+			) ?? "";
+		expect(out).toBe(manifest.replace('"@canonical/summon-core": "^0.35.0"', '"@canonical/summon-core": "^0.36.0"'));
+	});
+
+	test("answers null when the declaration is not there", () => {
+		expect(
+			rewriteDeclaration(manifest, "peerDependencies", "@canonical/ke", "^0.35.0", "^0.36.0"),
+		).toBeNull();
+		expect(
+			rewriteDeclaration(manifest, "optionalDependencies", "@canonical/task", "^0.35.0", "^0.36.0"),
+		).toBeNull();
 	});
 });

--- a/scripts/check-workspace-ranges.ts
+++ b/scripts/check-workspace-ranges.ts
@@ -38,7 +38,7 @@
  *   bun scripts/check-workspace-ranges.ts --help
  */
 
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 // -------------------------------------------------------------------
@@ -386,6 +386,68 @@ export function findViolations(packages: WorkspacePackage[]): Violation[] {
 }
 
 /**
+ * The range to write in place of one a bump has outgrown.
+ *
+ * The leading operator is PRESERVED rather than normalised: a package that
+ * pinned a sibling with `~` asked for patch-only drift and a fix must not
+ * silently widen that to `^`. Anything else — a bare version, a range with no
+ * recognised operator — becomes `^`, which is what every sibling range in this
+ * repo already uses and what the report has always told people to write.
+ *
+ * A `workspace:` wrapper is carried across untouched: it changes who resolves
+ * the range, not what the range means.
+ *
+ * @param range - The declared range, exactly as the manifest carries it.
+ * @param actual - The sibling's real in-repo version.
+ * @returns The replacement range, or null when the shape is not one to rewrite.
+ */
+export function repairedRange(range: string, actual: string): string | null {
+	const wsPrefix = range.startsWith("workspace:") ? "workspace:" : "";
+	const bare = range.slice(wsPrefix.length);
+	// `workspace:*` / `workspace:~` / `workspace:^` link by construction and are
+	// never violations, so reaching here with one means something is off.
+	if (bare === "" || bare === "*") return null;
+	const op = bare.startsWith("~") ? "~" : bare.startsWith("^") ? "^" : "^";
+	return `${wsPrefix}${op}${actual}`;
+}
+
+/**
+ * Rewrite one sibling range inside one manifest, textually.
+ *
+ * Textual and field-scoped rather than parse-and-reserialise: a manifest holds
+ * ordering, spacing and comments-by-convention that a round-trip through
+ * `JSON.parse` would silently reflow, turning a one-line release fix into a
+ * whole-file diff. Scoping to the field matters because the same sibling
+ * legitimately appears in several of them with different ranges — rewriting the
+ * first match would move the wrong one.
+ *
+ * @returns The updated text, or null when the expected declaration was absent.
+ */
+export function rewriteDeclaration(
+	text: string,
+	field: DependencyField,
+	sibling: string,
+	range: string,
+	replacement: string,
+): string | null {
+	const esc = (v: string): string =>
+		v.replace(/[.*+?^${}()|[\]\\]/g, (m) => `\\${m}`);
+	// Dependency blocks hold no nested objects, so `[^}]*` is a safe body match.
+	const block = new RegExp(`("${field}"\\s*:\\s*\\{)([^}]*)(\\})`);
+	const found = block.exec(text);
+	if (found === null) return null;
+	const [whole, open, body, close] = found as unknown as [
+		string,
+		string,
+		string,
+		string,
+	];
+	const decl = new RegExp(`("${esc(sibling)}"\\s*:\\s*")${esc(range)}(")`);
+	if (!decl.test(body)) return null;
+	return text.replace(whole, `${open}${body.replace(decl, `$1${replacement}$2`)}${close}`);
+}
+
+/**
  * Human-readable report. Written for someone who hits this in CI at 2am and
  * will not read this file: it names the manifest, the field, the range, the
  * sibling's real version, and the edit to make.
@@ -454,6 +516,53 @@ export function formatViolations(violations: Violation[]): string {
 // -------------------------------------------------------------------
 
 /** Walk up from `start` until a directory holds a package.json with workspaces. */
+/**
+ * Rewrite every repairable violation in place, one manifest read/write per file.
+ *
+ * Only ranges this tool UNDERSTANDS are touched: an unparseable range states an
+ * intent no rule here can infer, so it is left exactly as written and reported
+ * by the caller's second pass. Repairing what it can and re-reporting the rest
+ * is deliberate — a release should not be blocked by the mechanical half of a
+ * problem, and it must still stop for the half that needs a person.
+ *
+ * @param rootDir - The repository root.
+ * @param violations - The violations from a completed check pass.
+ * @returns How many declarations were actually rewritten.
+ * @note Impure — reads and writes package manifests.
+ */
+async function repairViolations(
+	rootDir: string,
+	violations: readonly Violation[],
+): Promise<number> {
+	const byFile = new Map<string, Violation[]>();
+	for (const v of violations) {
+		if (v.unparseable === true) continue;
+		byFile.set(v.file, [...(byFile.get(v.file) ?? []), v]);
+	}
+
+	let count = 0;
+	for (const [file, items] of byFile) {
+		const path = join(rootDir, file);
+		let text = await readFile(path, "utf8");
+		for (const v of items) {
+			const replacement = repairedRange(v.range, v.actual);
+			if (replacement === null) continue;
+			const next = rewriteDeclaration(
+				text,
+				v.field,
+				v.sibling,
+				v.range,
+				replacement,
+			);
+			if (next === null) continue;
+			text = next;
+			count++;
+		}
+		if (count > 0) await writeFile(path, text);
+	}
+	return count;
+}
+
 async function findRepoRoot(start: string): Promise<string> {
 	let dir = start;
 	for (;;) {
@@ -473,11 +582,13 @@ async function main(): Promise<number> {
 	if (process.argv.includes("--help") || process.argv.includes("-h")) {
 		console.log(
 			[
-				"Usage: bun scripts/check-workspace-ranges.ts",
+				"Usage: bun scripts/check-workspace-ranges.ts [--fix]",
 				"",
 				"Fails when a workspace package declares a dependency range on a workspace",
 				"sibling that the sibling's current version does not satisfy, across",
 				`${DEPENDENCY_FIELDS.join(", ")}.`,
+				"",
+				"--fix rewrites every repairable range in place, then reports what is left.",
 				"",
 				"Exit codes: 0 = every sibling range is satisfiable, 1 = at least one is not.",
 			].join("\n"),
@@ -487,7 +598,18 @@ async function main(): Promise<number> {
 
 	const rootDir = await findRepoRoot(resolve(import.meta.dir, ".."));
 	const packages = await loadWorkspacePackages(rootDir);
-	const violations = findViolations(packages);
+	let violations = findViolations(packages);
+
+	if (process.argv.includes("--fix") && violations.length > 0) {
+		const repaired = await repairViolations(rootDir, violations);
+		if (repaired > 0) {
+			console.log(
+				`Rewrote ${repaired} sibling range${repaired === 1 ? "" : "s"} to match the ` +
+					"sibling's current version.",
+			);
+			violations = findViolations(await loadWorkspacePackages(rootDir));
+		}
+	}
 
 	if (violations.length === 0) {
 		console.log(


### PR DESCRIPTION
## Done

- Add `--fix` to `scripts/check-workspace-ranges.ts`, rewriting every sibling range a version bump has outgrown, in the **same script** the release guard runs — so the repair and the check can never disagree about what a satisfiable range is.
- Wire it into `.github/actions/lerna-version/action.yml` as a step between the bump and the lockfile update, so `bun install` resolves against corrected ranges.
- Tests for the two new exported functions, including the case that would silently do nothing (`@canonical/task` declared in both `dependencies` and `peerDependencies` — a rewrite matching the first occurrence moves the wrong one and reports success).

Fixes the blocked v0.36.0 release ([run 33229036702](https://github.com/canonical/pragma/actions/runs/33229036702)).

### Why

`lerna version` rewrites sibling ranges in `dependencies`, `devDependencies` and `optionalDependencies` — but not `peerDependencies`. On a 0.x line every bump is breaking under caret semantics, so a package that peer-depends on a sibling is left declaring a range the sibling has just outgrown.

Five ranges across `ke-graphql`, `summon-component` and `summon-package` still said `^0.35.0`. `check:ranges` refused the release; **both the tag and the publish were skipped**. That is the guard working — it failed the release rather than shipping a broken one — but nothing repaired what it found, so every future release hits the same wall.

This is the second occurrence. v0.35.0 shipped the same defect before the guard existed and went red on `main` instead; the guard's own error text already names that precedent.

### Scope of the repair

Deliberately narrow. It rewrites only ranges it understands:

- a `~` range stays `~` — a package that pinned for patch-only drift did so on purpose, and a "fix" that widened it to `^` would quietly discard a real constraint
- a `workspace:` wrapper is carried across untouched — it changes who resolves the range, not what it means
- an **unparseable** range states an intent no rule here can infer, so it is left alone and still fails the guard

A release should not be blocked by the mechanical half of this problem, and must still stop for the half that needs a person.

## QA

The release sequence was replayed locally against a simulated v0.36.0 bump (versions plus `dependencies`/`devDependencies`/`optionalDependencies` rewritten, `peerDependencies` left behind, exactly as `lerna version` does):

| step | result |
|---|---|
| baseline `check:ranges` on `main` | ✓ 62 packages, all satisfied |
| after simulated bump | ✗ **5 violations reproduced**, all `peerDependencies`, matching the CI failure |
| new `check:ranges --fix` step | rewrote 5 ranges |
| `check:ranges` verification gate | ✓ passes — **exit 0** |
| `bun install --ignore-scripts` | resolves; **no sibling pulled from the registry into a nested `node_modules`** |

That last row is the failure mode the guard's docblock describes: when a declared range does not admit the sibling's version, Bun silently installs a *published* copy instead of linking the in-tree one, and the build then fails later with "Cannot find module" or, worse, succeeds against a stale package.

- `bun run check` — green, 62 projects
- `bun run check:ranges:test` — 29 pass
- Working tree left byte-identical to `main` apart from the two source files (the simulation was reverted).

### PR readiness check

- [x] PR should have one of the following labels: `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged, no package added.
- [x] If this PR introduces a **new package** — n/a, no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

n/a — CI tooling only.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
