### PR TITLE
fix(task): report per-undo outcomes and isolate undo failures, so `setup --undo` tells the truth

### DIFF
--- a/packages/cli/pragma/src/capabilities/setup/operations/setupCompletions.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupCompletions.ts
@@ -204,11 +204,18 @@ export function composeCompletions(d: CompletionsDetection): Task<void> {
  * machine that never installed one reverses zero steps and says so.
  *
  * @param d - The detection gathered up front.
+ * @param undoKey - Correlation key stamped on the reversal(s), echoed on
+ *   their undo outcomes so the caller can read results back per row.
  * @returns A Task whose undo deletes the installed script.
  */
-export function composeCompletionsRemoval(d: CompletionsDetection): Task<void> {
+export function composeCompletionsRemoval(
+  d: CompletionsDetection,
+  undoKey?: string,
+): Task<void> {
   if (d.path === null || d.script === null || d.state === "absent") {
     return sequence_([]);
   }
-  return sequence_([writeFile(d.path, d.script, { undo: deleteFile(d.path) })]);
+  return sequence_([
+    writeFile(d.path, d.script, { undo: deleteFile(d.path), undoKey }),
+  ]);
 }

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupConfig.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupConfig.ts
@@ -110,12 +110,17 @@ export function composeConfigFile(d: ConfigDetection): Task<void> {
  * delete as its `undo`, which is what the undo interpreter executes.
  *
  * @param d - The detection gathered up front.
+ * @param undoKey - Correlation key stamped on the reversal(s), echoed on
+ *   their undo outcomes so the caller can read results back per row.
  * @returns A Task whose undo removes a seed-only config, or an empty Task.
  */
-export function composeConfigRemoval(d: ConfigDetection): Task<void> {
+export function composeConfigRemoval(
+  d: ConfigDetection,
+  undoKey?: string,
+): Task<void> {
   if (!d.exists || !d.isSeed) return sequence_([]);
   return sequence_([
-    writeFile(d.path, SEED_CONFIG, { undo: deleteFile(d.path) }),
+    writeFile(d.path, SEED_CONFIG, { undo: deleteFile(d.path), undoKey }),
   ]);
 }
 

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupGenerator.ts
@@ -34,6 +34,7 @@ import {
   type TaskError,
   warn,
 } from "@canonical/task";
+import type { UndoOutcome } from "@canonical/task/node";
 import { BIN_NAME } from "../../../constants.js";
 import { PragmaError } from "../../../kernel/error/index.js";
 import type { PragmaRuntime } from "../../../kernel/runtime/index.js";
@@ -103,6 +104,20 @@ export interface SetupRun {
   readonly generator: GeneratorDefinition;
   /** The plan with the wizard's selection and the run's outcomes applied. */
   applied(answers: Record<string, unknown>): SetupPlan;
+  /**
+   * The plan graded by the EXECUTED reversals — `--undo`'s own `applied`.
+   *
+   * A real `--undo` never interprets the composed task for real: the undo
+   * interpreter walks it with every effect mocked (to collect the
+   * reversals), so the {@link OutcomeSink} the forward run fills stays
+   * empty, and only the interpreter's per-undo outcomes — correlated by the
+   * `undoKey` each reversal was stamped with in `generate` — say what
+   * actually happened. This projection writes those outcomes onto the SAME
+   * sink and reads the plan back through the SAME `outcomeFor` the forward
+   * run uses: one outcome model, both directions. An actionable row none of
+   * whose reversals reported back is a failure, never a quiet `removed`.
+   */
+  appliedUndo(outcomes: readonly UndoOutcome[]): SetupPlan;
   /**
    * Register THE live row listener (the Ink wizard's step adapter). The
    * composed rows emit through it while they are interpreted — which means
@@ -463,8 +478,15 @@ export async function buildSetupRun(
         // MCP file paths to every other target's compose.
         const key = CHILD_ANSWER[row.target];
         const children = key === undefined ? undefined : readList(answers, key);
+        // A removal stamps the row's identity on every reversal it composes:
+        // `--undo` executes those reversals in a LATER phase (the undo
+        // interpreter's), whose outcomes come back correlated by this key —
+        // see `appliedUndo`.
         const task = removal
-          ? hit.target.composeRemoval(hit.detection)
+          ? hit.target.composeRemoval(
+              hit.detection,
+              rowKey(row.scope, row.target),
+            )
           : hit.target.compose(hit.detection, children);
         // The row's progress sentence — the `target  detail — note` shape
         // `renderProgressLine` prints — so the live view and the recap say the
@@ -509,7 +531,17 @@ export async function buildSetupRun(
     // outcome at all left a converged re-run with a plan-shaped output that
     // claimed nothing had run — while the row still rendered a bare green ✓.
     // Convergence is a real result: one quiet line per row, zero writes.
-    if (row.action === "none") return { status: "noop", note: "unchanged" };
+    //
+    // On a REMOVAL the same state is `kept`, not `noop`: the run owned
+    // nothing here and deliberately left the machine's state standing (the
+    // config the user edited, the editor with no extension copy). That is
+    // standing aside, which the vocabulary marks inert (○), where `noop`'s
+    // green ✓ would claim removal work that never existed.
+    if (row.action === "none") {
+      return removal
+        ? { status: "kept" }
+        : { status: "noop", note: "unchanged" };
+    }
     if (!isChosen(row, chosen)) return undefined;
     const error = sink.get(rowKey(row.scope, row.target));
     if (error !== undefined) {
@@ -530,25 +562,62 @@ export async function buildSetupRun(
     };
   };
 
+  /** The one answers→plan projection both `applied` faces share. */
+  const project = (answers: Record<string, unknown>): SetupPlan => {
+    const chosen = readList(answers, ROWS_ANSWER);
+    return withRows(
+      plan,
+      plan.rows.map((row): PlanRow => {
+        const outcome = outcomeFor(row, chosen, answers);
+        return {
+          ...row,
+          selected: isChosen(row, chosen),
+          ...(outcome === undefined ? {} : { outcome }),
+        };
+      }),
+    );
+  };
+
   return {
     plan,
     generator,
     setRowListener: (listener) => {
       rowListener = listener;
     },
-    applied: (answers) => {
-      const chosen = readList(answers, ROWS_ANSWER);
-      return withRows(
-        plan,
-        plan.rows.map((row): PlanRow => {
-          const outcome = outcomeFor(row, chosen, answers);
-          return {
-            ...row,
-            selected: isChosen(row, chosen),
-            ...(outcome === undefined ? {} : { outcome }),
-          };
-        }),
+    applied: project,
+    appliedUndo: (outcomes) => {
+      // The undo path's sink fill. The forward run's recover frames write the
+      // sink WHILE the task is interpreted; a real `--undo` interprets the
+      // task only as the mocked collection walk, so the executed reversals'
+      // outcomes land here instead — same sink, same reader (`outcomeFor`),
+      // other direction. The first failure per row wins: it is the earliest
+      // cause, and the row's note should name it, not the knock-on.
+      sink.clear();
+      for (const outcome of outcomes) {
+        if (outcome.status !== "failed" || outcome.key === undefined) continue;
+        if (sink.get(outcome.key) !== undefined) continue;
+        sink.record(outcome.key, outcome.error);
+      }
+      // A row that owed reversals and heard back from NONE of them cannot
+      // report `removed` — nothing proved anything happened. Structurally
+      // every actionable removal row composes at least one keyed reversal,
+      // so this is a guard against a future target breaking that invariant,
+      // not a path any current target takes.
+      const reported = new Set(
+        outcomes.flatMap((o) => (o.key === undefined ? [] : [o.key])),
       );
+      for (const row of plan.rows) {
+        const id = rowKey(row.scope, row.target);
+        if (!isActionable(row.action) || !row.selected) continue;
+        if (reported.has(id) || sink.get(id) !== undefined) continue;
+        sink.record(id, {
+          code: "UNSUPPORTED",
+          message: "no reversal was executed for this target",
+        });
+      }
+      // No answers: `--undo` asks nothing, so every row falls back to its
+      // own default selection — exactly the set `generate` composed from.
+      return project({});
     },
   };
 }

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupLsp.ts
@@ -36,13 +36,21 @@ import type { EditorCliDefinition, PlatformEnv } from "@canonical/harnesses";
 import {
   type ExecResult,
   exec,
+  exists,
   flatMap,
   mkdir,
+  pure,
+  sequence,
   sequence_,
   type Task,
 } from "@canonical/task";
 import { BIN_NAME } from "../../../constants.js";
-import { checkExecOk, guardMissingBinary } from "../../shared/index.js";
+import { PragmaError } from "../../../kernel/error/index.js";
+import {
+  checkExecOk,
+  failPragma,
+  guardMissingBinary,
+} from "../../shared/index.js";
 import type { LspState } from "../types.js";
 
 /** The full extension id, as the editor's extensions dir spells it. */
@@ -76,6 +84,15 @@ export interface DetectedEditor {
    * {@link composeLspRemoval}); when `present` is true, this is that path.
    */
   readonly extensionsDir: string;
+  /**
+   * The matching entry NAMES under {@link extensionsDir} — the artifacts
+   * `present` is true about. The removal's postcondition probes exactly
+   * these after the uninstall (see {@link composeLspRemoval}): the editor
+   * CLI's exit code and the directory listing are DIFFERENT success
+   * criteria, and only the directory is the one detection (and doctor)
+   * believe.
+   */
+  readonly presentEntries: readonly string[];
 }
 
 /**
@@ -187,12 +204,13 @@ const compareVersions = (left: number[], right: number[]): number => {
 const extensionState = (
   editor: EditorCliDefinition,
   platform: PlatformEnv,
-): { present: boolean; current: boolean } => {
+): { present: boolean; current: boolean; entries: string[] } => {
   let entries: string[];
   try {
     entries = readdirSync(editor.extensionsDir(platform));
   } catch {
-    return { present: false, current: false }; // No dir — nothing installed.
+    // No dir — nothing installed.
+    return { present: false, current: false, entries: [] };
   }
   const prefix = `${EXTENSION_ID}-`;
   const matching = entries.filter((entry) =>
@@ -203,7 +221,7 @@ const extensionState = (
     if (version === undefined) return false; // Unreadable: cannot vouch for it.
     return compareVersions(version, MINIMUM) >= 0;
   });
-  return { present: matching.length > 0, current };
+  return { present: matching.length > 0, current, entries: matching };
 };
 
 /**
@@ -221,12 +239,13 @@ export async function detectLsp(_cwd: string): Promise<LspDetection> {
   const editors: DetectedEditor[] = editorClis
     .filter((editor) => cliOnPath(executableCandidates(editor.cli, platform)))
     .map((editor) => {
-      const { present, current } = extensionState(editor, platform);
+      const { present, current, entries } = extensionState(editor, platform);
       return {
         editor,
         present,
         installed: current,
         extensionsDir: editor.extensionsDir(platform),
+        presentEntries: entries,
       };
     });
   const state: LspState =
@@ -377,7 +396,8 @@ export const ownedLspEditors = (d: LspDetection): readonly DetectedEditor[] =>
 
 /**
  * Compose the removal: one `<editor cli> --uninstall-extension <id>` per owned
- * editor, carried as the `undo` of a forward no-op.
+ * editor, carried as the `undo` of a forward no-op — and each uninstall
+ * asserts its own GOAL, not just its exit code.
  *
  * The docblock this replaces claimed "an `exec` carries no reversal". That was
  * factually wrong about the effect model — `Exec` has an `undo` slot and `exec`
@@ -391,37 +411,90 @@ export const ownedLspEditors = (d: LspDetection): readonly DetectedEditor[] =>
  * `present` proves already exists — reads nothing and is a genuine no-op. Phase
  * two then runs the uninstall against the real editor.
  *
+ * THE POSTCONDITION is the removal's real success criterion. The exec's exit
+ * code and the extensions DIRECTORY are two different judges — detection
+ * deliberately reads the directory (probing via the CLI can launch an
+ * editor), and VS Code-family CLIs are known to exit 0 while deferring or
+ * skipping the deletion — so after `checkExecOk` the undo probes the exact
+ * entries detection said this command owns, and FAILS (with the manual
+ * deletion as the remedy — never the command that just claimed success) when
+ * any survived. An in-task failure here is safe precisely because
+ * `runCollectedUndos` executes each undo isolated: it used to abort every
+ * reversal still pending, which is why no removal could afford to assert its
+ * own goal.
+ *
  * @param d - The detection gathered up front.
- * @returns A Task whose undo uninstalls the extension from each owned editor.
+ * @param undoKey - Correlation key stamped on each reversal, echoed on its
+ *   `UndoOutcome` so the caller can read the outcomes back per row.
+ * @returns A Task whose undo uninstalls the extension from each owned editor
+ *   and verifies the copy is gone.
  */
-export function composeLspRemoval(d: LspDetection): Task<void> {
+export function composeLspRemoval(
+  d: LspDetection,
+  undoKey?: string,
+): Task<void> {
   const owned = ownedLspEditors(d);
   // Nothing on this machine carries a copy — there is no honest work to model,
   // and the plan row says so. Same shape as the other rows' empty removals.
   if (owned.length === 0) return sequence_([]);
   return sequence_(
-    owned.map(({ editor, extensionsDir }) => {
+    owned.map(({ editor, extensionsDir, presentEntries }) => {
       const command = `${editor.cli} --uninstall-extension ${EXTENSION_ID}`;
+      const ownedPaths = presentEntries.map((entry) =>
+        join(extensionsDir, entry),
+      );
+      const uninstall = flatMap(
+        exec(
+          editor.cli,
+          ["--uninstall-extension", EXTENSION_ID],
+          extensionsDir,
+        ),
+        (result) =>
+          checkExecOk(command, result as ExecResult, {
+            message:
+              `${editor.name} refused the uninstall (its output is above). ` +
+              `Remove it by hand with \`${command}\`.`,
+          }),
+      );
+      // The probe must apply DETECTION'S presence criterion, or the check can
+      // quietly stop checking: `extensionState` calls an entry present when
+      // `readdirSync` lists it, and a default `exists` (`fs.access`) follows
+      // symlinks — so a dangling matching symlink would be "installed" to
+      // detection and "absent" here, and an editor that exits 0 without
+      // removing it would report `undone` while the next detection finds it
+      // again. `followSymlinks: false` is `lstat` semantics: the entry
+      // itself, exactly what the directory listing answers.
+      const verified = flatMap(uninstall, () =>
+        flatMap(
+          sequence(ownedPaths.map((p) => exists(p, { followSymlinks: false }))),
+          (stillThere) => {
+            const survivors = ownedPaths.filter((_, i) => stillThere[i]);
+            if (survivors.length === 0) return pure(undefined);
+            // The remedy presents the surviving paths as DATA, never as a
+            // synthesized shell line: the names come from `readdirSync`, so
+            // no quoting is trustworthy, and one command cannot be right for
+            // every platform the editor registry supports.
+            return failPragma(
+              new PragmaError({
+                code: "UNSUPPORTED",
+                message: `\`${command}\` exited 0, but the extension is still present after the undo ran.`,
+                recovery: {
+                  message: `Delete ${survivors.length === 1 ? "this entry" : "these entries"} from ${editor.name}'s extensions folder by hand, then restart it: ${survivors.join(" · ")}`,
+                },
+              }),
+            );
+          },
+        ),
+      );
       return mkdir(extensionsDir, true, {
         undo: guardMissingBinary(
           editor.cli,
           {
             message: `The \`${editor.cli}\` CLI disappeared from PATH mid-run — restore it, then run \`${BIN_NAME} setup lsp --undo\` again.`,
           },
-          flatMap(
-            exec(
-              editor.cli,
-              ["--uninstall-extension", EXTENSION_ID],
-              extensionsDir,
-            ),
-            (result) =>
-              checkExecOk(command, result as ExecResult, {
-                message:
-                  `${editor.name} refused the uninstall (its output is above). ` +
-                  `Remove it by hand with \`${command}\`.`,
-              }),
-          ),
+          verified,
         ),
+        undoKey,
       });
     }),
   );

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupMcp.ts
@@ -356,9 +356,14 @@ export const ownedMcpGroups = (d: McpDetection): readonly TargetGroup[] =>
  * same file is never touched.
  *
  * @param d - The detection gathered up front.
+ * @param undoKey - Correlation key stamped on the reversal(s), echoed on
+ *   their undo outcomes so the caller can read results back per row.
  * @returns A Task whose undo removes the pragma entry from each owned file.
  */
-export function composeMcpRemoval(d: McpDetection): Task<void> {
+export function composeMcpRemoval(
+  d: McpDetection,
+  undoKey?: string,
+): Task<void> {
   return sequence_(
     ownedMcpGroups(d).map((group) =>
       mkdir(dirname(group.path), true, {
@@ -367,6 +372,7 @@ export function composeMcpRemoval(d: McpDetection): Task<void> {
             d.removeMcpConfigFrom(write, MCP_SERVER_NAME),
           ),
         ),
+        undoKey,
       }),
     ),
   );

--- a/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
+++ b/packages/cli/pragma/src/capabilities/setup/operations/setupSkills.ts
@@ -754,14 +754,19 @@ export const ownedSkillLinks = (
  * this command owns, never from what a fresh forward plan would create.
  *
  * @param d - The detection gathered up front.
+ * @param undoKey - Correlation key stamped on the reversal(s), echoed on
+ *   their undo outcomes so the caller can read results back per row.
  * @returns A Task whose undo removes every owned link.
  */
-export function composeSkillsRemoval(d: SkillsDetection): Task<void> {
+export function composeSkillsRemoval(
+  d: SkillsDetection,
+  undoKey?: string,
+): Task<void> {
   const owned = ownedSkillLinks(d);
   if (owned.length === 0) return sequence_([]);
   return sequence_(
     owned.map((a) =>
-      symlink(a.target, a.linkPath, { undo: deleteFile(a.linkPath) }),
+      symlink(a.target, a.linkPath, { undo: deleteFile(a.linkPath), undoKey }),
     ),
   );
 }

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -1296,6 +1296,40 @@ describe("setup skills", () => {
     expect(() => lstatSync(linkPath)).toThrow();
   });
 
+  it("the removal plan's children are the FOLDERS the links live in, deduped", async () => {
+    // `dirs` mapped `a.linkPath` — one path per LINK — so the `new Set(…)`
+    // deduped nothing and the removal preview printed an N-path wall where
+    // the forward plan says `N skills → M folders`. The folders are the
+    // links' parent directories.
+    const cwd = tmp("pragma-setup-proj-");
+    const linkDir = join(cwd, ".agents", "skills");
+    mkdirSync(linkDir, { recursive: true });
+    for (const name of ["s1", "s2"]) {
+      const skillDir = join(cwd, ".pragma", "skills", name);
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, "SKILL.md"),
+        `---\nname: ${name}\ndescription: A test skill.\n---\n`,
+      );
+      symlinkSync(skillDir, join(linkDir, name));
+    }
+    const detected = await detectSkills(bootRuntime(FLAGS, cwd), "project");
+    expect(ownedSkillLinks(detected)).toHaveLength(2);
+
+    const { findTarget } = await import("./targets.js");
+    const draft = findTarget("skills")?.removalPlan(
+      detected as never,
+      "project",
+      { global: process.env.HOME ?? "", project: cwd },
+    );
+    expect(draft?.action).toBe("remove");
+    expect(draft?.detail).toBe("2 links");
+    // TWO links, ONE folder: the children name the folder once, not each link.
+    expect(draft?.children?.map((c) => c.label)).toEqual([
+      `.${sep}${join(".agents", "skills")}`,
+    ]);
+  });
+
   it("owns a RELATIVE link into the skill root, resolved against the link dir", async () => {
     // `readlink` reports the raw target, which may be relative — resolving it
     // against the link's own directory is what makes the containment test

--- a/packages/cli/pragma/src/capabilities/setup/setup.test.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.test.ts
@@ -101,6 +101,14 @@ const stubPath = (): string => {
   return dir;
 };
 
+/**
+ * The machine's real PATH, captured before the suite isolates it. A stub
+ * editor script that has to run a real utility (`rm`) restores this INSIDE
+ * itself — hardcoding `/bin:/usr/bin` breaks on hosts that keep coreutils
+ * elsewhere, and the isolated PATH the tests run under has no `rm`.
+ */
+const HOST_PATH = process.env.PATH ?? "";
+
 let prevHome: string | undefined;
 let prevPath: string | undefined;
 beforeEach(() => {
@@ -835,12 +843,16 @@ describe("setup lsp — the removal contract the other four rows implement", () 
   it("end to end: `setup lsp --undo` reports `Undid 1 step(s)` against a STUB cli", async () => {
     // The reported symptom was `Undid 0 step(s).` at exit 0. The stub is a
     // marker-writing script — never a real editor: an undo test must not be
-    // able to mutate the machine running it.
+    // able to mutate the machine running it. It DOES delete the seeded
+    // extension entry (inside this test's temp HOME), because the removal now
+    // asserts its own goal against the extensions directory: a stub that
+    // exits 0 leaving the entry behind is the LYING-editor case, pinned as a
+    // failure below.
     const marker = join(tmp("pragma-lsp-undo-"), "uninstalled");
     const dir = stubPath();
     writeFileSync(
       join(dir, "code"),
-      `#!/bin/sh\nprintf '%s\\n' "$@" > ${marker}\n`,
+      `#!/bin/sh\nprintf '%s\\n' "$@" > ${marker}\nPATH='${HOST_PATH}' rm -rf "$HOME/.vscode/extensions/canonical.terrazzo-lsp-extension-"*\n`,
       { mode: 0o755 },
     );
     process.env.PATH = dir;
@@ -871,6 +883,205 @@ describe("setup lsp — the removal contract the other four rows implement", () 
     ];
     expect(all.some((e) => e._tag === "DeleteFile")).toBe(false);
     expect(all.some((e) => e._tag === "DeleteDirectory")).toBe(false);
+  });
+
+  /** Drive `setup lsp --undo` capturing stderr (where the row lines land). */
+  const undoLspCapturing = async (): Promise<{
+    chunks: string[];
+    outcome?: { stdout?: string; stderr?: string; exitCode: number };
+    thrown?: unknown;
+  }> => {
+    const chunks: string[] = [];
+    const spy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: unknown): boolean => {
+        chunks.push(String(chunk));
+        return true;
+      });
+    try {
+      const outcome = await executeVerb(
+        verbOf("lsp"),
+        {},
+        UNDO,
+        bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
+      );
+      return { chunks, outcome };
+    } catch (thrown) {
+      return { chunks, thrown };
+    } finally {
+      spy.mockRestore();
+    }
+  };
+
+  it("HEADLINE: an uninstall that exits 0 leaving the extension on disk reports FAILED, never `✓ removed`", async () => {
+    // The observed field defect: VS Code-family CLIs can exit 0 while
+    // deferring or skipping the deletion. The reversal's success criterion
+    // was that exit code; detection's criterion is the extensions DIRECTORY.
+    // The two disagreed permanently and the run printed `✓ … removed` over an
+    // extension that was still installed. The removal now asserts its own
+    // goal in-task — probe the owned entries after the uninstall — and the
+    // run reports the survival as a failure with a manual remedy.
+    const dir = stubPath();
+    writeFileSync(join(dir, "code"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    seedExtension(".vscode", "1.2.3");
+    const survivor = join(
+      process.env.HOME ?? "",
+      ".vscode",
+      "extensions",
+      "canonical.terrazzo-lsp-extension-1.2.3",
+    );
+
+    const { chunks, outcome, thrown } = await undoLspCapturing();
+    const stderrText = chunks.join("");
+
+    // The world: the artifact survived, and the run must not claim otherwise.
+    expect(existsSync(survivor)).toBe(true);
+    expect(stderrText).not.toContain("— removed");
+    expect(outcome).toBeUndefined();
+    expect(thrown).toBeDefined();
+    const err = asPragmaError(thrown);
+    expect(err.code).toBe("UNSUPPORTED");
+    expect(err.message).toContain("lsp");
+    expect(err.message).toContain("still present after the undo ran");
+    // The remedy names the surviving path as DATA for a manual deletion —
+    // not the CLI command that has just demonstrably done nothing while
+    // reporting success, and not a synthesized shell line (the entry names
+    // come off the filesystem, so no quoting is trustworthy, and one command
+    // cannot be right for every supported platform).
+    expect(err.recovery?.message ?? "").toContain(survivor);
+    expect(err.recovery?.message ?? "").not.toContain("rm -rf");
+    expect(err.recovery?.message ?? "").not.toContain("--uninstall-extension");
+    // The truthful row is reported (stderr), naming the survival.
+    expect(stderrText).toContain("still present after the undo ran");
+  });
+
+  it("a DANGLING matching symlink still counts as a survivor — the probe uses detection's criterion", async () => {
+    // Detection calls an entry present when `readdirSync` lists it. A probe
+    // built on default `exists` (`fs.access`) FOLLOWS symlinks, so a dangling
+    // matching symlink would be "installed" to detection and "absent" to the
+    // probe: an editor that exits 0 without removing it would report
+    // `undone`, and the next detection would find it again — the exact
+    // "reports success it did not achieve" this fix exists to close, rebuilt
+    // inside the fix. The probe therefore asks about the entry itself
+    // (lstat semantics), the same question the directory listing answers.
+    const dir = stubPath();
+    writeFileSync(join(dir, "code"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    const extensionsDir = join(process.env.HOME ?? "", ".vscode", "extensions");
+    mkdirSync(extensionsDir, { recursive: true });
+    const entry = join(extensionsDir, "canonical.terrazzo-lsp-extension-1.2.3");
+    symlinkSync(join(extensionsDir, "no-such-target"), entry);
+
+    const { chunks, outcome, thrown } = await undoLspCapturing();
+
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true); // still there
+    expect(chunks.join("")).not.toContain("— removed");
+    expect(outcome).toBeUndefined();
+    const err = asPragmaError(thrown);
+    expect(err.message).toContain("still present after the undo ran");
+    expect(err.recovery?.message ?? "").toContain(entry);
+  });
+
+  it("a truthful uninstall reports its `removed` row from the executed reversal", async () => {
+    // The positive half of the headline: when the editor really deletes the
+    // entry, the in-task postcondition passes, the reversal's outcome comes
+    // back `undone`, and the row reports `removed` — same sentence as before
+    // the fix, now derived from what ran instead of from the plan.
+    const dir = stubPath();
+    writeFileSync(
+      join(dir, "code"),
+      `#!/bin/sh\nPATH='${HOST_PATH}' rm -rf "$HOME/.vscode/extensions/canonical.terrazzo-lsp-extension-"*\n`,
+      { mode: 0o755 },
+    );
+    process.env.PATH = dir;
+    seedExtension(".vscode", "1.2.3");
+
+    const { chunks, outcome, thrown } = await undoLspCapturing();
+    expect(thrown).toBeUndefined();
+    expect(outcome?.exitCode).toBe(0);
+    expect(outcome?.stdout).toBe("Undid 1 step(s).\n");
+    expect(chunks.join("")).toContain("— removed");
+  });
+
+  it("the `✓ … removed` rows cannot be produced by the collection walk alone", async () => {
+    // The collection walk mocks every exec to exit 0 and every prompt to its
+    // default — under the old code that was enough to print the whole green
+    // recap before one real process had spawned. With an uninstall that
+    // GENUINELY fails (exit 1), the executed reversal fails; if any `removed`
+    // row still appeared on stderr, it could only have come from the mocked
+    // walk.
+    const dir = stubPath();
+    writeFileSync(join(dir, "code"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    seedExtension(".vscode", "1.2.3");
+
+    const { chunks, outcome, thrown } = await undoLspCapturing();
+    expect(chunks.join("")).not.toContain("— removed");
+    expect(outcome).toBeUndefined();
+    expect(thrown).toBeDefined();
+    const err = asPragmaError(thrown);
+    expect(err.message).toContain("--uninstall-extension");
+    expect(err.message).toContain("exited with code 1");
+  });
+
+  it("appliedUndo grades rows from the outcomes — one model, both directions", async () => {
+    // The projection unit: the sink the FORWARD run fills is fed by the undo
+    // interpreter's outcomes instead, and the same `outcomeFor` reads it
+    // back. A failed outcome keyed to the row fails the row (carrying the
+    // reversal's own remedy); an actionable row that no reversal reported
+    // back for cannot claim `removed`; a run with clean outcomes reports
+    // `removed`.
+    seedExtension(".vscode", "1.2.3");
+    const run = await buildSetupRun(
+      bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
+      "lsp",
+      "global",
+      true,
+    );
+
+    const clean = run.appliedUndo([{ key: "global:lsp", status: "undone" }]);
+    expect(clean.rows.find((r) => r.target === "lsp")?.outcome).toMatchObject({
+      status: "removed",
+      note: "removed",
+    });
+
+    const failed = run.appliedUndo([
+      {
+        key: "global:lsp",
+        status: "failed",
+        error: { code: "UNSUPPORTED", message: "still there" },
+      },
+    ]);
+    expect(failed.rows.find((r) => r.target === "lsp")?.outcome).toMatchObject({
+      status: "failed",
+      note: "still there",
+    });
+
+    // No reversal reported back at all for an actionable row: never `removed`.
+    const silent = run.appliedUndo([]);
+    expect(silent.rows.find((r) => r.target === "lsp")?.outcome).toMatchObject({
+      status: "failed",
+      note: "no reversal was executed for this target",
+    });
+  });
+
+  it("a removal row with nothing owned reports `kept`, not a green noop", async () => {
+    // The `kept` status was declared in the vocabulary and counted by
+    // `planTally` but no producer ever emitted it. On a removal, a `none`
+    // row IS the kept case: the run owned nothing here and deliberately left
+    // the machine's state standing — standing aside (○), not work done (✓).
+    const run = await buildSetupRun(
+      bootRuntime(FLAGS, tmp("pragma-setup-proj-")),
+      "lsp",
+      "global",
+      true,
+    );
+    expect(run.plan.rows.find((r) => r.target === "lsp")?.action).toBe("none");
+    const kept = run.appliedUndo([]);
+    expect(kept.rows.find((r) => r.target === "lsp")?.outcome).toEqual({
+      status: "kept",
+    });
   });
 });
 

--- a/packages/cli/pragma/src/capabilities/setup/setup.verb.ts
+++ b/packages/cli/pragma/src/capabilities/setup/setup.verb.ts
@@ -209,6 +209,31 @@ async function runSetup(
   // to know which of the two it is.
   const previewing = interactionMode === "batch-dry-run";
 
+  // The undo truth channel. A real `--undo` interprets this verb's task ONLY
+  // as the undo interpreter's mocked collection walk — every exec exits 0,
+  // every prompt answers its default, and the OutcomeSink is never written —
+  // so nothing the task body could report describes what the collected
+  // reversals later did. The body therefore says NOTHING on the undo path
+  // (see the guard in the gen body below); the kernel calls this seam after
+  // the reversals actually ran, handing over the interpreter's per-undo
+  // outcomes, and `appliedUndo` projects them onto the rows through the SAME
+  // sink + `applied` path the forward run reports through. One outcome
+  // model, both directions.
+  if (!previewing && input.undo) {
+    rt.undoReport = (outcomes) => {
+      const applied = run.appliedUndo(outcomes);
+      const width = Math.max(...applied.rows.map((row) => row.target.length));
+      for (const row of applied.rows) {
+        if (row.outcome === undefined) continue;
+        rt.report?.(renderProgressLine(row, width));
+      }
+      if (planExitFailed(applied)) {
+        rt.report?.(renderRecap(applied, "Removed"));
+        raiseFailedRows(applied, true);
+      }
+    };
+  }
+
   // A CONVERGED machine has no question to ask. Every row is `none` or `skip`,
   // so nothing composes an effect — and the wizard's confirm gate then mounted
   // Ink to render summon-core's "No operations planned." above a "Proceed?"
@@ -313,6 +338,16 @@ async function runSetup(
     const result = yield* $(task);
     const applied = run.applied(result.answers);
 
+    // A real `--undo` only ever drives this body under the undo
+    // interpreter's COLLECTION walk, with every effect mocked. `applied` is
+    // then a projection of the mocked walk (`removed` rows for reversals
+    // that have not run yet), so reporting it here printed green checks
+    // before anything happened. Say nothing; the kernel hands the executed
+    // reversals' outcomes to `rt.undoReport` afterwards, and `appliedUndo`
+    // grades the rows from those. (`--undo --dry-run` stays on the shared
+    // preview path below, where the same suppressions already apply.)
+    if (input.undo && !previewing) return applied;
+
     // Progress: one line per row on stderr for an unattended run (the Ink
     // session already draws them for the wizard). stdout stays the data stream.
     //
@@ -333,45 +368,58 @@ async function runSetup(
     // stdout on a failing run.
     if (planExitFailed(applied)) {
       rt.report?.(renderRecap(applied));
-      const failed = applied.rows.filter(
-        (row) => row.outcome?.status === "failed",
-      );
-
-      // ONE failure reports itself. The row already carries the cause it was
-      // given ("`bun` is not found on your PATH") and a remedy that runs on
-      // this machine; replacing them with a count would throw away the only
-      // two sentences that say what is wrong and what to do about it.
-      const only = failed.length === 1 ? failed[0] : undefined;
-      if (only?.outcome !== undefined) {
-        throw new PragmaError({
-          code: "UNSUPPORTED",
-          message: `${only.target}: ${only.outcome.note ?? "the step did not complete"}`,
-          ...(only.outcome.remedy === undefined
-            ? {}
-            : { recovery: { message: only.outcome.remedy } }),
-        });
-      }
-
-      // Several failures: name every one with its own cause, then point at the
-      // recap above. A bare list of target names would make the reader re-run
-      // each one to find out why it failed.
-      const named = failed
-        .map(
-          (row) =>
-            `${row.target} (${row.outcome?.note ?? "no cause recorded"})`,
-        )
-        .join("; ");
-      throw new PragmaError({
-        code: "UNSUPPORTED",
-        message: `${failed.length} of ${planTally(applied).accountable} targets did not complete: ${named}.`,
-        recovery: {
-          message: `The other targets are configured. Re-run the ones that did not complete: ${failed
-            .map((row) => `\`${BIN_NAME} setup ${row.target}\``)
-            .join(", ")}.`,
-        },
-      });
+      raiseFailedRows(applied);
     }
     return applied;
+  });
+}
+
+/**
+ * Raise the run's failure from its rows — shared by the forward run's recap
+ * and the post-undo truth report, so the two paths name a shortfall in the
+ * same words. `undo` only re-words the multi-failure recovery line: the
+ * command that retries a removal is `setup <target> --undo`, not the
+ * installer.
+ *
+ * @param applied - The plan with outcomes filled in (at least one `failed`).
+ * @param undo - Whether the failed run was a removal.
+ * @throws PragmaError naming the failed row(s), always.
+ */
+function raiseFailedRows(applied: SetupPlan, undo = false): never {
+  const failed = applied.rows.filter((row) => row.outcome?.status === "failed");
+
+  // ONE failure reports itself. The row already carries the cause it was
+  // given ("`bun` is not found on your PATH") and a remedy that runs on
+  // this machine; replacing them with a count would throw away the only
+  // two sentences that say what is wrong and what to do about it.
+  const only = failed.length === 1 ? failed[0] : undefined;
+  if (only?.outcome !== undefined) {
+    throw new PragmaError({
+      code: "UNSUPPORTED",
+      message: `${only.target}: ${only.outcome.note ?? "the step did not complete"}`,
+      ...(only.outcome.remedy === undefined
+        ? {}
+        : { recovery: { message: only.outcome.remedy } }),
+    });
+  }
+
+  // Several failures: name every one with its own cause, then point at the
+  // recap above. A bare list of target names would make the reader re-run
+  // each one to find out why it failed.
+  const named = failed
+    .map((row) => `${row.target} (${row.outcome?.note ?? "no cause recorded"})`)
+    .join("; ");
+  throw new PragmaError({
+    code: "UNSUPPORTED",
+    message: `${failed.length} of ${planTally(applied).accountable} targets did not complete: ${named}.`,
+    recovery: {
+      message: `The other targets are ${undo ? "removed" : "configured"}. Re-run the ones that did not complete: ${failed
+        .map(
+          (row) =>
+            `\`${BIN_NAME} setup ${row.target}${undo ? " --undo" : ""}\``,
+        )
+        .join(", ")}.`,
+    },
   });
 }
 

--- a/packages/cli/pragma/src/capabilities/setup/targets.ts
+++ b/packages/cli/pragma/src/capabilities/setup/targets.ts
@@ -24,6 +24,7 @@
  * doctor's), so nothing here lands on the `--help`/`__complete` fast path.
  */
 
+import { dirname } from "node:path";
 import type { Task } from "@canonical/task";
 import { BIN_NAME } from "../../constants.js";
 import type { PragmaRuntime } from "../../kernel/runtime/index.js";
@@ -402,7 +403,12 @@ const skillsTarget = defineTarget<SkillsDetection>({
     if (owned.length === 0) {
       return { action: "none", detail: "no link to remove" };
     }
-    const dirs = [...new Set(owned.map((a) => shortenPath(a.linkPath, roots)))];
+    // Dedupe to the FOLDERS the links live in — `linkPath` itself is one path
+    // per link, so a Set over it deduped nothing and the removal preview
+    // printed an 18-path wall where the forward plan says `… → 2 folders`.
+    const dirs = [
+      ...new Set(owned.map((a) => shortenPath(dirname(a.linkPath), roots))),
+    ];
     return {
       action: "remove",
       detail: `${owned.length} ${owned.length === 1 ? "link" : "links"}`,

--- a/packages/cli/pragma/src/capabilities/setup/targets.ts
+++ b/packages/cli/pragma/src/capabilities/setup/targets.ts
@@ -113,8 +113,12 @@ export interface TargetDefinition<D> {
    * paths); a row without children ignores it.
    */
   compose(detection: D, chosen?: readonly string[]): Task<void>;
-  /** The removal effects: forward re-assertion carrying the reversal as `undo`. */
-  composeRemoval(detection: D): Task<void>;
+  /**
+   * The removal effects: forward re-assertion carrying the reversal as
+   * `undo`. `undoKey` (the row's identity) is stamped on every reversal so
+   * the undo interpreter's outcomes can be read back per row.
+   */
+  composeRemoval(detection: D, undoKey?: string): Task<void>;
 }
 
 /** A table row with its detection type erased — how every consumer holds one. */
@@ -151,7 +155,7 @@ const configTarget = defineTarget<ConfigDetection>({
     return { action: "remove", detail: path };
   },
   compose: (d) => composeConfigFile(d),
-  composeRemoval: (d) => composeConfigRemoval(d),
+  composeRemoval: (d, undoKey) => composeConfigRemoval(d, undoKey),
 });
 
 const completionsTarget = defineTarget<CompletionsDetection>({
@@ -208,7 +212,7 @@ const completionsTarget = defineTarget<CompletionsDetection>({
     return { action: "remove", detail: shortenPath(d.path, roots) };
   },
   compose: (d) => composeCompletions(d),
-  composeRemoval: (d) => composeCompletionsRemoval(d),
+  composeRemoval: (d, undoKey) => composeCompletionsRemoval(d, undoKey),
 });
 
 const lspTarget = defineTarget<LspDetection>({
@@ -284,7 +288,7 @@ const lspTarget = defineTarget<LspDetection>({
     };
   },
   compose: (d, chosen) => composeLsp(d, chosen),
-  composeRemoval: (d) => composeLspRemoval(d),
+  composeRemoval: (d, undoKey) => composeLspRemoval(d, undoKey),
 });
 
 /**
@@ -357,7 +361,7 @@ const mcpTarget = defineTarget<McpDetection>({
   },
   compose: (d, chosen) =>
     composeMcp(d, chosen ? selectedGroups(d, chosen) : d.groups),
-  composeRemoval: (d) => composeMcpRemoval(d),
+  composeRemoval: (d, undoKey) => composeMcpRemoval(d, undoKey),
 });
 
 const skillsTarget = defineTarget<SkillsDetection>({
@@ -420,7 +424,7 @@ const skillsTarget = defineTarget<SkillsDetection>({
     };
   },
   compose: (d) => composeSkills(d),
-  composeRemoval: (d) => composeSkillsRemoval(d),
+  composeRemoval: (d, undoKey) => composeSkillsRemoval(d, undoKey),
 });
 
 /** THE table, in display order. */

--- a/packages/cli/pragma/src/capabilities/shared/index.ts
+++ b/packages/cli/pragma/src/capabilities/shared/index.ts
@@ -25,6 +25,7 @@
 export {
   assertExecOk,
   checkExecOk,
+  failPragma,
   guardMissingBinary,
 } from "./assertExecOk.js";
 export type {

--- a/packages/cli/pragma/src/kernel/project/cli/dispatch.ts
+++ b/packages/cli/pragma/src/kernel/project/cli/dispatch.ts
@@ -411,7 +411,29 @@ export async function executeVerb(
       }
     }
     if (mutation.undo) {
-      const { undoCount } = await runUndo(task, { onLog: logSink(flags) });
+      // The truth seam. `runUndo`'s collection phase drove the verb's task
+      // with every effect mocked, so anything the task body reported was a
+      // narration of the mocked walk, not of the reversals — which have only
+      // JUST run, each isolated, each with its own outcome. Those outcomes
+      // are the one honest record of what the undo did: a verb that reports
+      // per-target results sets `undoReport` (like `exec`/`planData`) and
+      // projects them onto its own rows; a throw from it renders as the
+      // run's error, exactly like a failed real run. Verbs without a
+      // projector of their own still may not exit 0 over a failed reversal,
+      // so the outcomes are re-checked here as the backstop.
+      const { undoCount, outcomes } = await runUndo(task, {
+        onLog: logSink(flags),
+      });
+      await mutationRuntime.undoReport?.(outcomes);
+      const failed = outcomes.filter((o) => o.status === "failed");
+      if (failed.length > 0) {
+        throw new PragmaError({
+          code: "UNSUPPORTED",
+          message: `${failed.length} of ${outcomes.length} undo step(s) did not complete: ${failed
+            .map((o) => o.error.message)
+            .join("; ")}`,
+        });
+      }
       return renderUndo(flags, undoCount);
     }
     // Real execution: spread the verb's runner options into the node

--- a/packages/cli/pragma/src/kernel/runtime/types.ts
+++ b/packages/cli/pragma/src/kernel/runtime/types.ts
@@ -8,6 +8,7 @@
  * that are actually populated by the time it runs.
  */
 
+import type { UndoOutcome } from "@canonical/task/node";
 import type { DetailLevel, OutputFormat } from "../../constants.js";
 import type { ConfigLayers } from "../config/types.js";
 
@@ -221,4 +222,20 @@ export interface PragmaRuntime {
    * plan of its own, which is what keeps the raw-effect render the default.
    */
   planData?: unknown;
+  /**
+   * The post-undo projection seam. `--undo` is two-phase: the undo
+   * interpreter WALKS the verb's task with every effect mocked to collect the
+   * reversals, and only then executes what it collected — so nothing the task
+   * body says while it is interpreted describes what the reversals did (the
+   * body only ever runs under the mocked walk). What DOES describe them is
+   * the interpreter's own per-undo outcomes, correlated by the `undoKey` each
+   * reversal was declared with. A verb that reports per-target results sets
+   * this (the same way it sets `exec`/`planData`, before returning its Task);
+   * the projector's undo branch awaits it with those outcomes AFTER the
+   * collected undos executed and before the `Undid N step(s).` line, so the
+   * verb projects them onto its own rows through the same path its forward
+   * run uses. A throw here is rendered as the run's error (nonzero exit) —
+   * the honest outcome when a reversal did not take.
+   */
+  undoReport?: (outcomes: readonly UndoOutcome[]) => void | Promise<void>;
 }

--- a/packages/cli/summon/src/components/App.tsx
+++ b/packages/cli/summon/src/components/App.tsx
@@ -909,8 +909,30 @@ export const App = ({
     ) => {
       (async () => {
         try {
-          const { undoCount } = await runCollectedUndos(undos);
-          setState({ phase: "undone", undoCount, unreversible });
+          const result = await runCollectedUndos(undos);
+          // Failure no longer aborts the pending undos — every step is
+          // attempted and reported in `outcomes` — so the verdict is read
+          // off the outcomes here: any failed step fails the undo, naming
+          // each cause, instead of a green "complete" over partial work.
+          const failed = result.outcomes.filter((o) => o.status === "failed");
+          if (failed.length > 0) {
+            setState({
+              phase: "error",
+              error: {
+                code: "UNDO_ERROR",
+                message: `${failed.length} of ${result.outcomes.length} undo step${result.outcomes.length === 1 ? "" : "s"} did not complete: ${failed
+                  .map((o) => o.error.message)
+                  .join("; ")}`,
+              },
+              answers: promptAnswers,
+            });
+            return;
+          }
+          setState({
+            phase: "undone",
+            undoCount: result.undoCount,
+            unreversible,
+          });
         } catch (err) {
           setState({
             phase: "error",

--- a/packages/cli/summon/src/registration/registerFromBarrel.tsx
+++ b/packages/cli/summon/src/registration/registerFromBarrel.tsx
@@ -164,6 +164,23 @@ async function runBatchUndo(
       return;
     }
     const result = await runCollectedUndos(undos);
+    // A failed undo no longer aborts the ones still pending — every step is
+    // attempted and reported in `outcomes` — so the aggregate verdict is
+    // decided HERE, from the outcomes. Printing "Undo complete" over a
+    // partial reversal would claim work that did not happen.
+    const failed = result.outcomes.filter((o) => o.status === "failed");
+    if (failed.length > 0) {
+      process.stderr.write(
+        `${failed.length} step${failed.length === 1 ? "" : "s"} could not be reversed:\n${failed
+          .map((o) => `  - ${o.error.message}`)
+          .join("\n")}\n`,
+      );
+      console.error(
+        `Undo incomplete (${result.undoCount} of ${result.outcomes.length} step${result.outcomes.length === 1 ? "" : "s"} reversed).`,
+      );
+      process.exitCode = 1;
+      return;
+    }
     console.log(
       `Undo complete (${result.undoCount} step${result.undoCount === 1 ? "" : "s"} reversed).`,
     );

--- a/packages/runtime/task/src/lib/effect.test.ts
+++ b/packages/runtime/task/src/lib/effect.test.ts
@@ -209,6 +209,18 @@ describe("Effect Constructors - File System", () => {
 
       expect(effect._tag).toBe("Exists");
       expect((effect as { path: string }).path).toBe("/path/to/check");
+      // Without the option the effect stays byte-identical to the old shape.
+      expect("followSymlinks" in effect).toBe(false);
+    });
+
+    it("carries followSymlinks only when the declaration sets it", () => {
+      const effect = existsEffect("/path/to/check", { followSymlinks: false });
+
+      expect(effect).toMatchObject({
+        _tag: "Exists",
+        path: "/path/to/check",
+        followSymlinks: false,
+      });
     });
   });
 

--- a/packages/runtime/task/src/lib/effect.ts
+++ b/packages/runtime/task/src/lib/effect.ts
@@ -5,7 +5,13 @@
  * Effects are pure data that describe operations without performing them.
  */
 
-import type { Effect, LogLevel, PromptQuestion, Task } from "./types.js";
+import type {
+  Effect,
+  LogLevel,
+  PromptQuestion,
+  Task,
+  UndoTask,
+} from "./types.js";
 
 // =============================================================================
 // Undo Options
@@ -20,6 +26,18 @@ import type { Effect, LogLevel, PromptQuestion, Task } from "./types.js";
  */
 export interface UndoOptions {
   undo?: Task<void> | null;
+  /**
+   * Correlation key for this effect's undo, echoed back on the
+   * `UndoOutcome` the undo interpreter reports for it. Outcomes come back
+   * in execution order, not declaration order, so a caller that composes
+   * many effects and needs to know WHICH reversal failed tags each one
+   * here and reads the outcomes back by key — never by index arithmetic.
+   * Keys need not be unique: several effects may share one (e.g. all the
+   * steps of one logical unit), and the caller aggregates. Applies to the
+   * default undo as much as to an explicit one; ignored when the undo is
+   * disabled with `undo: null`.
+   */
+  undoKey?: string;
 }
 
 /**
@@ -27,14 +45,20 @@ export interface UndoOptions {
  * - explicit Task → use it
  * - null → no undo (disabled)
  * - undefined → use the default
+ *
+ * A resolved undo is tagged with the declaration's `undoKey` (when given) so
+ * the key travels ON the task the undo interpreter later executes — see
+ * {@link UndoTask}.
  */
 const resolveUndo = (
   option: Task<void> | null | undefined,
   defaultUndo: Task<void> | undefined,
-): Task<void> | undefined => {
-  if (option === null) return undefined;
-  if (option !== undefined) return option;
-  return defaultUndo;
+  key?: string,
+): UndoTask | undefined => {
+  const resolved =
+    option === null ? undefined : option !== undefined ? option : defaultUndo;
+  if (resolved === undefined || key === undefined) return resolved;
+  return { ...resolved, undoKey: key };
 };
 
 /**
@@ -65,7 +89,11 @@ export const writeFileEffect = (
   path,
   content,
   ...(opts?.verbatim !== undefined ? { verbatim: opts.verbatim } : {}),
-  undo: resolveUndo(opts?.undo, bareTask({ _tag: "DeleteFile", path })),
+  undo: resolveUndo(
+    opts?.undo,
+    bareTask({ _tag: "DeleteFile", path }),
+    opts?.undoKey,
+  ),
 });
 
 export const appendFileEffect = (
@@ -78,7 +106,7 @@ export const appendFileEffect = (
   path,
   content,
   createIfMissing,
-  undo: resolveUndo(opts?.undo, undefined),
+  undo: resolveUndo(opts?.undo, undefined, opts?.undoKey),
 });
 
 export const transformFileEffect = (
@@ -92,7 +120,7 @@ export const transformFileEffect = (
   // No default undo: the original contents are not captured anywhere, so there
   // is nothing to restore automatically. Provide `{ undo }` (e.g. an inverse
   // transform) to make it reversible.
-  undo: resolveUndo(opts?.undo, undefined),
+  undo: resolveUndo(opts?.undo, undefined, opts?.undoKey),
 });
 
 export const copyFileEffect = (
@@ -103,7 +131,11 @@ export const copyFileEffect = (
   _tag: "CopyFile",
   source,
   dest,
-  undo: resolveUndo(opts?.undo, bareTask({ _tag: "DeleteFile", path: dest })),
+  undo: resolveUndo(
+    opts?.undo,
+    bareTask({ _tag: "DeleteFile", path: dest }),
+    opts?.undoKey,
+  ),
 });
 
 export const copyDirectoryEffect = (
@@ -117,13 +149,14 @@ export const copyDirectoryEffect = (
   undo: resolveUndo(
     opts?.undo,
     bareTask({ _tag: "DeleteDirectory", path: dest }),
+    opts?.undoKey,
   ),
 });
 
 export const deleteFileEffect = (path: string, opts?: UndoOptions): Effect => ({
   _tag: "DeleteFile",
   path,
-  undo: resolveUndo(opts?.undo, undefined),
+  undo: resolveUndo(opts?.undo, undefined, opts?.undoKey),
 });
 
 export const deleteDirectoryEffect = (
@@ -133,7 +166,7 @@ export const deleteDirectoryEffect = (
   _tag: "DeleteDirectory",
   path,
   onlyIfEmpty: opts?.onlyIfEmpty,
-  undo: resolveUndo(opts?.undo, undefined),
+  undo: resolveUndo(opts?.undo, undefined, opts?.undoKey),
 });
 
 export const makeDirEffect = (
@@ -153,12 +186,19 @@ export const makeDirEffect = (
   undo: resolveUndo(
     opts?.undo,
     bareTask({ _tag: "DeleteDirectory", path, onlyIfEmpty: true }),
+    opts?.undoKey,
   ),
 });
 
-export const existsEffect = (path: string): Effect => ({
+export const existsEffect = (
+  path: string,
+  opts?: { followSymlinks?: boolean },
+): Effect => ({
   _tag: "Exists",
   path,
+  ...(opts?.followSymlinks === undefined
+    ? {}
+    : { followSymlinks: opts.followSymlinks }),
 });
 
 export const symlinkEffect = (
@@ -169,7 +209,11 @@ export const symlinkEffect = (
   _tag: "Symlink",
   target,
   path,
-  undo: resolveUndo(opts?.undo, bareTask({ _tag: "DeleteFile", path })),
+  undo: resolveUndo(
+    opts?.undo,
+    bareTask({ _tag: "DeleteFile", path }),
+    opts?.undoKey,
+  ),
 });
 
 export const globEffect = (pattern: string, cwd: string): Effect => ({
@@ -192,7 +236,7 @@ export const execEffect = (
   command,
   args,
   cwd,
-  undo: resolveUndo(opts?.undo, undefined),
+  undo: resolveUndo(opts?.undo, undefined, opts?.undoKey),
 });
 
 // =============================================================================

--- a/packages/runtime/task/src/lib/index.ts
+++ b/packages/runtime/task/src/lib/index.ts
@@ -37,6 +37,7 @@ export type {
   TextPrompt,
   TraceResult,
   TraceSpan,
+  UndoTask,
 } from "./types.js";
 
 // =============================================================================

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -1294,6 +1294,43 @@ describe("Interpreter - executeEffect for Exists", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("a dangling symlink is absent by default but PRESENT with followSymlinks: false", async () => {
+    // The two semantics answer different questions: `fs.access` follows the
+    // link (is the TARGET reachable?), `lstat` sees the entry itself (does a
+    // `readdir` of the parent list it?). A postcondition mirroring a
+    // readdir-based detection needs the entry answer, or a dangling symlink
+    // makes the check quietly pass over an artifact that is still there.
+    const tempDir = mkdtempSync(join(tmpdir(), "task-exists-lstat-"));
+
+    try {
+      const linkPath = join(tempDir, "dangling");
+      symlinkSync(join(tempDir, "no-such-target"), linkPath);
+
+      expect(
+        await executeEffect({ _tag: "Exists", path: linkPath }, new Map()),
+      ).toBe(false);
+      expect(
+        await executeEffect(
+          { _tag: "Exists", path: linkPath, followSymlinks: false },
+          new Map(),
+        ),
+      ).toBe(true);
+      // A genuinely missing entry is absent under both semantics.
+      expect(
+        await executeEffect(
+          {
+            _tag: "Exists",
+            path: join(tempDir, "missing"),
+            followSymlinks: false,
+          },
+          new Map(),
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // =============================================================================

--- a/packages/runtime/task/src/lib/interpreter.test.ts
+++ b/packages/runtime/task/src/lib/interpreter.test.ts
@@ -1401,8 +1401,12 @@ describe("Interpreter - executeEffect for Exec", () => {
     expect(result.exitCode).toBe(42);
   });
 
-  it("returns zero exit code when process is killed by signal", async () => {
-    // When a process is killed by a signal, Node.js close event passes null code
+  it("returns a NONZERO exit code when the process is killed by a signal", async () => {
+    // A signal-killed child closes with `code === null` (the signal name rides
+    // the second argument). This used to map to 0 — reporting a killed process
+    // as a successful exec, which let exit-code gates wave through work the
+    // child never finished. There is no numeric code to forward, so the
+    // interpreter reports the conventional failure exit instead.
     const result = (await executeEffect(
       {
         _tag: "Exec",
@@ -1413,8 +1417,7 @@ describe("Interpreter - executeEffect for Exec", () => {
       new Map(),
     )) as ExecResult;
 
-    // code ?? 0 — process killed by signal, code is null, falls back to 0
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
   });
 
   it("respects cwd option", async () => {

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -233,7 +233,14 @@ export const executeEffect = async (
 
     case "Exists": {
       try {
-        await fs.access(at(effect.path));
+        // `followSymlinks: false` asks about the directory ENTRY (`lstat`),
+        // not the target behind it (`access`) — a dangling symlink is then
+        // present, matching what a `readdir` of its parent reports.
+        if (effect.followSymlinks === false) {
+          await fs.lstat(at(effect.path));
+        } else {
+          await fs.access(at(effect.path));
+        }
         return true;
       } catch {
         return false;

--- a/packages/runtime/task/src/lib/interpreter.ts
+++ b/packages/runtime/task/src/lib/interpreter.ts
@@ -294,7 +294,14 @@ export const executeEffect = async (
         });
 
         child.on("close", (code) => {
-          resolve({ stdout, stderr, exitCode: code ?? 0 });
+          // A child killed by a signal closes with `code === null` (the
+          // signal name rides the second argument; exactly one of the two is
+          // non-null). Mapping that null to 0 reported a killed process as a
+          // SUCCESSFUL exec — an exit-code gate (`checkExecOk` and friends)
+          // then waved through work the child never finished. There is no
+          // numeric exit code to forward, so a signal-killed child reports
+          // the conventional failure exit instead.
+          resolve({ stdout, stderr, exitCode: code ?? 1 });
         });
         child.on("error", reject);
       });

--- a/packages/runtime/task/src/lib/primitives.ts
+++ b/packages/runtime/task/src/lib/primitives.ts
@@ -131,9 +131,16 @@ export const mkdir = (
 
 /**
  * Check if a file or directory exists.
+ *
+ * Follows symlinks by default (`fs.access` semantics), so a dangling symlink
+ * reports absent. Pass `{ followSymlinks: false }` to ask about the directory
+ * ENTRY itself (`lstat` semantics) — the criterion a `readdir`-based probe
+ * uses, so a postcondition can apply the same presence rule its detection did.
  */
-export const exists = (path: string): Task<boolean> =>
-  effect(existsEffect(path));
+export const exists = (
+  path: string,
+  opts?: { followSymlinks?: boolean },
+): Task<boolean> => effect(existsEffect(path, opts));
 
 /**
  * Create a symbolic link.

--- a/packages/runtime/task/src/lib/types.ts
+++ b/packages/runtime/task/src/lib/types.ts
@@ -91,6 +91,19 @@ export type PromptQuestion =
 // =============================================================================
 
 /**
+ * An undo task as an effect carries it: the reversal itself, optionally
+ * tagged with the correlation key its declaration supplied
+ * (`UndoOptions.undoKey` in `effect.js`).
+ *
+ * The key rides the very object whose outcome it names, so the undo
+ * interpreter can echo it back on the matching `UndoOutcome` with no
+ * positional pairing between collection order and execution order — and a
+ * bare `Task<void>` remains a valid (unkeyed) undo, so nothing that builds
+ * or consumes undos without keys changes shape.
+ */
+export type UndoTask = Task<void> & { readonly undoKey?: string };
+
+/**
  * Effect represents a pure data description of a side-effecting operation.
  *
  * Effects are not executed directly - they are data structures that describe
@@ -113,7 +126,7 @@ export type Effect =
       path: string;
       content: string;
       verbatim?: boolean;
-      undo?: Task<void>;
+      undo?: UndoTask;
     }
   /** Append content to file */
   | {
@@ -121,7 +134,7 @@ export type Effect =
       path: string;
       content: string;
       createIfMissing: boolean;
-      undo?: Task<void>;
+      undo?: UndoTask;
     }
   /**
    * Read a file, apply a pure transform to its contents, and write it back.
@@ -133,19 +146,19 @@ export type Effect =
       _tag: "TransformFile";
       path: string;
       transform: (source: string) => string;
-      undo?: Task<void>;
+      undo?: UndoTask;
     }
   /** Copy a single file */
-  | { _tag: "CopyFile"; source: string; dest: string; undo?: Task<void> }
+  | { _tag: "CopyFile"; source: string; dest: string; undo?: UndoTask }
   /** Recursively copy a directory */
   | {
       _tag: "CopyDirectory";
       source: string;
       dest: string;
-      undo?: Task<void>;
+      undo?: UndoTask;
     }
   /** Delete a file */
-  | { _tag: "DeleteFile"; path: string; undo?: Task<void> }
+  | { _tag: "DeleteFile"; path: string; undo?: UndoTask }
   /**
    * Delete a directory — recursively by default, or non-recursively
    * (skipped when missing or non-empty) when `onlyIfEmpty` is set.
@@ -156,12 +169,18 @@ export type Effect =
       _tag: "DeleteDirectory";
       path: string;
       onlyIfEmpty?: boolean;
-      undo?: Task<void>;
+      undo?: UndoTask;
     }
   /** Create directory and parents */
-  | { _tag: "MakeDir"; path: string; recursive: boolean; undo?: Task<void> }
-  /** Check if path exists */
-  | { _tag: "Exists"; path: string }
+  | { _tag: "MakeDir"; path: string; recursive: boolean; undo?: UndoTask }
+  /**
+   * Check if path exists. By default the check follows symlinks (`fs.access`
+   * semantics): a dangling symlink reports absent. `followSymlinks: false`
+   * asks about the directory ENTRY itself (`lstat` semantics): a dangling
+   * symlink reports present — the criterion a `readdir`-based probe uses, so
+   * a postcondition can ask the same question its detection did.
+   */
+  | { _tag: "Exists"; path: string; followSymlinks?: boolean }
   /** Find files matching glob pattern */
   | { _tag: "Glob"; pattern: string; cwd: string }
   /** Execute shell command */
@@ -170,7 +189,7 @@ export type Effect =
       command: string;
       args: string[];
       cwd?: string;
-      undo?: Task<void>;
+      undo?: UndoTask;
     }
   /** Interactive prompt */
   | { _tag: "Prompt"; question: PromptQuestion }
@@ -183,7 +202,7 @@ export type Effect =
   /** Run tasks in parallel */
   | { _tag: "Parallel"; tasks: Task<unknown>[] }
   /** Create a symbolic link */
-  | { _tag: "Symlink"; target: string; path: string; undo?: Task<void> }
+  | { _tag: "Symlink"; target: string; path: string; undo?: UndoTask }
   /** Race tasks, return first to complete */
   | { _tag: "Race"; tasks: Task<unknown>[] };
 

--- a/packages/runtime/task/src/lib/undo-interpreter.test.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.test.ts
@@ -1,4 +1,11 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -810,6 +817,180 @@ describe("runCollectedUndos", () => {
   it("returns undoCount 0 for an empty plan", async () => {
     const result = await runCollectedUndos([]);
     expect(result.undoCount).toBe(0);
+    expect(result.outcomes).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Per-undo outcomes and failure isolation
+// =============================================================================
+
+describe("runCollectedUndos - per-undo outcomes and failure isolation", () => {
+  it("attempts EVERY undo when one fails, and reports each outcome", async () => {
+    // The red cell against the abort-on-first-failure loop: three collected
+    // undos, the middle one fails. A reversal's job is to undo as much as it
+    // can and report what it could not — so both healthy undos must run
+    // against the real filesystem, and the failure must come back as data.
+    const tempDir = mkdtempSync(join(tmpdir(), "task-undo-isolation-"));
+    const a = join(tempDir, "a.txt");
+    const b = join(tempDir, "b.txt");
+    const c = join(tempDir, "c.txt");
+    try {
+      for (const p of [a, b, c]) writeFileSync(p, "seeded");
+      const task = sequence_([
+        writeFile(a, "a"), // default undo: delete a
+        writeFile(b, "b", {
+          undo: fail({ code: "EXEC_FAILED", message: "the middle undo broke" }),
+        }),
+        writeFile(c, "c"), // default undo: delete c
+      ]);
+
+      const result = await runCollectedUndos(collectUndos(task));
+
+      // Execution (LIFO) order: c's undo, b's failing undo, a's undo.
+      expect(result.outcomes.map((o) => o.status)).toEqual([
+        "undone",
+        "failed",
+        "undone",
+      ]);
+      expect(result.undoCount).toBe(2);
+      expect(result.outcomes[1].error).toMatchObject({
+        code: "EXEC_FAILED",
+        message: "the middle undo broke",
+      });
+      // Both healthy undos really ran — the failure consumed neither of them.
+      expect(existsSync(a)).toBe(false);
+      expect(existsSync(c)).toBe(false);
+      expect(existsSync(b)).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("echoes each undo declaration's `undoKey` on its outcome", async () => {
+    // Correlation is by key, never by index: outcomes come back in execution
+    // order, which is the reverse of declaration order.
+    const task = sequence_([
+      writeFile("/tmp/x.txt", "x", {
+        undo: fail({ code: "EXEC_FAILED", message: "boom" }),
+        undoKey: "unit:x",
+      }),
+      writeFile("/tmp/y.txt", "y", {
+        undo: pure(undefined),
+        undoKey: "unit:y",
+      }),
+      writeFile("/tmp/z.txt", "z", { undo: pure(undefined) }), // unkeyed
+    ]);
+
+    const undos = collectUndos(task);
+    // The key rides the collected undo task itself, so a caller previewing
+    // the plan can already see which unit each step belongs to.
+    expect(undos.map((u) => u.undoKey)).toEqual([
+      "unit:x",
+      "unit:y",
+      undefined,
+    ]);
+
+    const result = await runCollectedUndos(undos);
+    expect(result.outcomes).toEqual([
+      { status: "undone" },
+      { key: "unit:y", status: "undone" },
+      { key: "unit:x", status: "failed", error: expect.anything() },
+    ]);
+  });
+
+  it("a key without an undo declares nothing to correlate", () => {
+    // `exec` has no default undo, and `null` disables one — in both cases the
+    // declaration carries no reversal, so the key is inert and nothing is
+    // collected for it.
+    expect(collectUndos(exec("noop", [], undefined, { undoKey: "k" }))).toEqual(
+      [],
+    );
+    expect(
+      collectUndos(writeFile("/tmp/w.txt", "w", { undo: null, undoKey: "k" })),
+    ).toEqual([]);
+  });
+
+  it("tags the DEFAULT undo with the declaration's key too", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "task-undo-key-"));
+    const p = join(tempDir, "keyed.txt");
+    try {
+      writeFileSync(p, "seeded");
+      const result = await runCollectedUndos(
+        collectUndos(writeFile(p, "keyed", { undoKey: "row:1" })),
+      );
+      expect(result.outcomes).toEqual([{ key: "row:1", status: "undone" }]);
+      expect(existsSync(p)).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalises a raw (non-task) throw into an INTERNAL TaskError", async () => {
+    const rawThrow = flatMap(pure(undefined), (): Task<void> => {
+      throw new Error("raw boom");
+    });
+    const result = await runCollectedUndos(
+      collectUndos(writeFile("/tmp/raw.txt", "raw", { undo: rawThrow })),
+    );
+    expect(result.undoCount).toBe(0);
+    expect(result.outcomes).toEqual([
+      {
+        status: "failed",
+        error: { code: "INTERNAL", message: "Error: raw boom" },
+      },
+    ]);
+  });
+
+  it("rethrows interruption and leaves the pending undos unattempted", async () => {
+    // Cancellation is the one failure isolation must NOT absorb — the same
+    // invariant the interpreter's recovery frames hold. A pre-aborted signal
+    // interrupts the first undo; the rest must never run.
+    const tempDir = mkdtempSync(join(tmpdir(), "task-undo-interrupt-"));
+    const a = join(tempDir, "a.txt");
+    try {
+      writeFileSync(a, "seeded");
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        runCollectedUndos(collectUndos(writeFile(a, "a")), {
+          signal: controller.signal,
+        }),
+      ).rejects.toMatchObject({ code: "TASK_INTERRUPTED" });
+      expect(existsSync(a)).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("runUndo surfaces the same outcomes end to end", async () => {
+    // The two-phase entry point returns the execution phase's outcomes, so a
+    // caller that never touches `collectUndos` still gets per-undo truth.
+    const tempDir = mkdtempSync(join(tmpdir(), "task-run-undo-outcomes-"));
+    const kept = join(tempDir, "kept.txt");
+    try {
+      writeFileSync(kept, "seeded");
+      const task = sequence_([
+        writeFile(kept, "kept", { undoKey: "row:kept" }),
+        mkdir(join(tempDir, "made"), true, {
+          undo: fail({ code: "EXEC_FAILED", message: "cannot remove" }),
+          undoKey: "row:made",
+        }),
+      ]);
+      mkdirSync(join(tempDir, "made"), { recursive: true });
+
+      const result = await runUndo(task);
+
+      expect(result.undoCount).toBe(1);
+      expect(result.outcomes).toEqual([
+        { key: "row:made", status: "failed", error: expect.anything() },
+        { key: "row:kept", status: "undone" },
+      ]);
+      expect(existsSync(kept)).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/runtime/task/src/lib/undo-interpreter.ts
+++ b/packages/runtime/task/src/lib/undo-interpreter.ts
@@ -15,17 +15,56 @@
 
 import { existsSync } from "node:fs";
 import * as path from "node:path";
+import { TaskExecutionError } from "./errors.js";
 import { type RunTaskOptions, runTask } from "./interpreter.js";
-import type { Task } from "./types.js";
+import type { Task, TaskError, UndoTask } from "./types.js";
 import { collectUndos } from "./undo.js";
 
 // =============================================================================
 // Undo Result
 // =============================================================================
 
+/**
+ * How one collected undo ended — a discriminated union, so the type itself
+ * enforces that a failed outcome always carries its cause and a successful
+ * one never does: no consumer needs an "unknown cause" fallback, and no
+ * producer can report a failure without saying what failed.
+ *
+ * `key` is the correlation key the undo's declaration supplied
+ * (`UndoOptions.undoKey`), echoed verbatim — absent when the declaration
+ * carried none. It is the ONLY correlation contract: outcomes are reported in
+ * execution (LIFO) order, which is not the order a caller composed its
+ * effects in, so reading them back by index is wrong by construction.
+ */
+export type UndoOutcome =
+  | {
+      /** Echoed from the undo declaration's `undoKey`, when it had one. */
+      readonly key?: string;
+      readonly status: "undone";
+    }
+  | {
+      /** Echoed from the undo declaration's `undoKey`, when it had one. */
+      readonly key?: string;
+      readonly status: "failed";
+      /** The structured failure — always present on a failed outcome. */
+      readonly error: TaskError;
+    };
+
 export interface UndoResult {
-  /** Number of undo tasks that were collected and executed */
+  /**
+   * Number of undo tasks that completed successfully — the honest count for
+   * a "reversed N step(s)" line. Failures are not steps that were undone, so
+   * they are excluded here and reported in `outcomes` instead; a caller that
+   * wants "attempted" reads `outcomes.length`.
+   */
   undoCount: number;
+  /**
+   * One entry per attempted undo, in execution (LIFO) order. A failed undo
+   * does not abort the ones still pending — a reversal's job is to undo as
+   * much as it can and report what it could not — so the caller decides the
+   * aggregate outcome (typically: exit non-zero when any entry failed).
+   */
+  outcomes: readonly UndoOutcome[];
 }
 
 // =============================================================================
@@ -69,7 +108,7 @@ export const hostExistsResolver =
  * @param task - The task to undo (same task that was originally run forward)
  * @param options - RunTaskOptions passed to the undo execution phase; `cwd`
  *   also anchors the collection walk's `Exists` resolution
- * @returns The number of undo steps executed
+ * @returns The per-undo outcomes and the count of undos that succeeded
  *
  * @example
  * ```typescript
@@ -102,23 +141,56 @@ export const runUndo = async <A>(
  * the plan or ask for confirmation — and must not walk the task a second
  * time (collect once, then execute exactly what was shown).
  *
+ * Each undo runs ISOLATED: a failure is recorded as a `failed`
+ * {@link UndoOutcome} and the remaining undos still run. Aborting a reversal
+ * at its first failure is wrong for a reversal — every skipped undo is an
+ * artifact knowingly left behind — so failure here is data for the caller,
+ * not an abort. The one exception is interruption (`TASK_INTERRUPTED`):
+ * cancellation must stop the run, exactly as the interpreter's recovery
+ * frames refuse to swallow it, so it rethrows and the pending undos are not
+ * attempted.
+ *
  * @param undos - Undo tasks in forward execution order (as `collectUndos`
- *   returns them); executed here in reverse
+ *   returns them, each possibly carrying its declaration's `undoKey`);
+ *   executed here in reverse
  * @param options - RunTaskOptions passed to each undo execution
- * @returns The number of undo steps executed
+ * @returns The per-undo outcomes (in execution order) and the count of undos
+ *   that succeeded
  */
 export const runCollectedUndos = async (
-  undos: readonly Task<void>[],
+  undos: readonly UndoTask[],
   options?: RunTaskOptions,
 ): Promise<UndoResult> => {
-  if (undos.length === 0) {
-    return { undoCount: 0 };
+  const outcomes: UndoOutcome[] = [];
+  let undoCount = 0;
+
+  for (const undoTask of [...undos].reverse()) {
+    const key = undoTask.undoKey === undefined ? {} : { key: undoTask.undoKey };
+    try {
+      await runTask(undoTask, options);
+      undoCount += 1;
+      outcomes.push({ ...key, status: "undone" });
+    } catch (error) {
+      if (
+        error instanceof TaskExecutionError &&
+        error.taskError.code === "TASK_INTERRUPTED"
+      ) {
+        throw error;
+      }
+      // Normalise the throw to the structured TaskError the framework already
+      // speaks (same rule as the interpreter's Parallel branch), so consumers
+      // read one error shape whether the undo failed via the task failure
+      // channel or via a raw synchronous throw.
+      outcomes.push({
+        ...key,
+        status: "failed",
+        error:
+          error instanceof TaskExecutionError
+            ? error.taskError
+            : { code: "INTERNAL", message: String(error) },
+      });
+    }
   }
 
-  const reversed = [...undos].reverse();
-  for (const undoTask of reversed) {
-    await runTask(undoTask, options);
-  }
-
-  return { undoCount: reversed.length };
+  return { undoCount, outcomes };
 };

--- a/packages/runtime/task/src/lib/undo.ts
+++ b/packages/runtime/task/src/lib/undo.ts
@@ -1,7 +1,7 @@
 import driveSync from "./driveSync.js";
 import { mockEffectWithFs } from "./dry-run.js";
 import { TaskExecutionError } from "./errors.js";
-import type { Effect, Task } from "./types.js";
+import type { Effect, Task, UndoTask } from "./types.js";
 
 /**
  * Options for {@link collectUndos}.
@@ -67,7 +67,7 @@ interface WalkState {
   /** Paths created by write-like effects earlier in this attempt. */
   virtualFs: Set<string>;
   /** Undos collected this attempt, in forward order. */
-  undos: Task<void>[];
+  undos: UndoTask[];
   /** Leaf forward effects of this attempt, in forward order. */
   forwardEffects: Effect[];
   /** Free `Exists` decisions in encounter order. */
@@ -95,6 +95,11 @@ interface WalkState {
  * base entry; executing the collected undos against the host is `runUndo`'s
  * job (`@canonical/task/node`).
  *
+ * Each collected undo is the `undo` task exactly as its effect carries it —
+ * including the correlation `undoKey` its declaration may have tagged it with
+ * (see {@link UndoTask}) — so executing the collected plan can echo each
+ * undo's key on its outcome.
+ *
  * @param task - The task to collect undos from
  * @param options - Optional host-state resolution, see {@link CollectUndosOptions}
  * @returns Array of undo tasks in forward execution order
@@ -102,7 +107,7 @@ interface WalkState {
 export const collectUndos = <A>(
   task: Task<A>,
   options?: CollectUndosOptions,
-): Task<void>[] => {
+): UndoTask[] => {
   const walk = (
     overrides: readonly boolean[],
   ): { state: WalkState; error: TaskExecutionError | null } => {

--- a/packages/runtime/task/src/node.ts
+++ b/packages/runtime/task/src/node.ts
@@ -39,7 +39,10 @@ export { runPreview } from "./lib/preview-interpreter.js";
 // `collectUndos` ships from `@canonical/task`; only execution lives here)
 // =============================================================================
 
-export type { UndoResult } from "./lib/undo-interpreter.js";
+export type {
+  UndoOutcome,
+  UndoResult,
+} from "./lib/undo-interpreter.js";
 export {
   hostExistsResolver,
   runCollectedUndos,


### PR DESCRIPTION
## Done

`pragma setup --undo` printed `✓ lsp … — removed` while the extension was still on disk. Two defects stacked into that lie, and both are retired **upstream in `@canonical/task`, through the one outcome model the forward run already uses** — not with a CLI-side workaround.

### The two defects

1. **The ✓ rows were printed before anything ran.** `--undo` is two-phase: the undo interpreter walks the forward task with every effect MOCKED to collect the reversals, then executes them. The verb's progress loop is plain JavaScript in the task body, so it narrated the mocked walk — every exec "exited 0", every prompt answered its default — and the executed reversals had **no channel back to any row**: `UndoResult` was `{ undoCount }`, a bare count, and a single failing undo abandoned every reversal still pending.
2. **The uninstall genuinely exits 0 without removing.** Removal's success criterion was the editor CLI's exit code; detection's criterion is the extensions DIRECTORY (deliberately — probing via the CLI can launch an editor). VS Code-family CLIs are known to exit 0 while deferring or skipping the deletion, so the two criteria could disagree forever.

### The fix, in three layers

- **`fix(task)`: per-undo outcomes + failure isolation.** `runCollectedUndos` now runs each collected undo isolated — a failure becomes a `failed` `UndoOutcome` (with the structured `TaskError`) and the remaining undos still run; only interruption (`TASK_INTERRUPTED`) rethrows, matching the interpreter's recovery-frame invariant. `UndoResult.outcomes` reports every attempt in execution order; `undoCount` counts the undos that **succeeded** — the honest number for `Undid N step(s).`, unchanged on a clean run. Correlation is by declaration, never by index: the undo options bag gains `undoKey`, the resolved undo task carries it (`UndoTask = Task<void> & { undoKey?: string }`), and the outcome echoes it. The key rides the very object whose outcome it names, so a bare `Task<void>` stays a valid unkeyed undo and **no existing caller changes shape**. `UndoOutcome` is a discriminated union — a failed outcome always carries its `TaskError`, an undone one never does — so no consumer needs an "unknown cause" fallback.
- **`fix(pragma-cli)`: the lsp removal asserts its own goal in the composition.** After `checkExecOk`, the reversal probes the exact extension entries detection said it owns — with **detection's own presence criterion**: `exists(p, { followSymlinks: false })` (lstat semantics, a small upstream extension of the existing `Exists` effect — no new effect type), so a dangling matching symlink is still a survivor, exactly as `readdirSync` reports it. On survival it fails, naming the surviving entries as data for a manual deletion — never the command that just claimed success, and never a synthesized shell line (the names come off the filesystem, so no quoting is trustworthy, and one command cannot fit every supported platform). An in-task failure is safe now *precisely because* layer 1 made undo execution isolated; it used to abort every reversal still pending. The other four targets need no postcondition: their removals are interpreter fs effects, which throw rather than lie.
- **`fix(pragma-cli)`: the CLI projects through the existing model.** Each removal stamps its row's identity (`scope:target`) on the reversals it composes; the kernel's undo branch hands the executed outcomes to the verb's `rt.undoReport` seam; `appliedUndo` writes failures onto the **same `OutcomeSink`** and reads rows back through the **same `outcomeFor`/`applied()`** the forward run reports through. One outcome model, both directions — which also finally gives `kept` (a removal-direction `none` row) and `renderRecap`'s `Removed` lead a producer, after being declared, counted and never emitted. The kernel backstops the exit rule: any failed outcome exits non-zero even for a verb with no projector of its own.
- **`fix(summon)`** (consequence of layer 1): both undo surfaces of the summon CLI read the verdict off the outcomes instead of off "the call returned", so a partial reversal reports `Undo incomplete` at exit 1 rather than a green "Undo complete".

Also on the branch (independent keepers):
- `fix(task)`: a signal-killed exec child reported exit 0 — a killed process read as a successful exec; it now reports the conventional failure exit.
- `fix(pragma-cli)`: the skills removal preview deduped nothing (it Set-wrapped one path per LINK) — it now dedupes to the link folders the forward plan names.

### Design note — the shape was chosen, not stumbled into

A CLI-side approach was built first and **rejected**: a `rt.undoRecap` callback that re-ran detection after the reversals and reported rows from the re-probed world. It worked, and its instinct (verify against the world) was right — but it created a **second outcome channel** (forward: `OutcomeSink` → `applied()` → rows; undo: a parallel re-detection pass) and muzzled the root cause instead of removing it. The correct seam is upstream: the undo interpreter is the only party that knows what each reversal did, so it reports outcomes, and the world-verification lives where the work is claimed — as a postcondition inside the removal composition itself, which generalises to any removal.

The pinned e2e test's stub editor was itself encoding the bug — it exited 0 and removed nothing while the test asserted success. The stub now actually deletes the seeded entry, and the lying-editor case is pinned as a failure (`HEADLINE` test).

The `mutationContract` is untouched: `--undo` stays a stateless same-task reversal — no journal, no new flags, `Undid N step(s).` unchanged.

## QA

- `bun run check` and `bun run test` green from the root (known environmental exceptions on this host: perf budgets and `@canonical/svelte-ds-global` Playwright libs fail identically on a clean `origin/main`).
- `packages/runtime/task` holds its 100% coverage gate; new red-first cell: three collected undos with the middle one failing — all three attempted, one failure and two successes reported.
- Headline red-first: a stubbed editor CLI that exits 0 and deletes nothing produces a `failed` row whose remedy names the surviving entry, never `✓ … removed`; a dangling matching symlink counts as a survivor (lstat criterion, same as detection's); a stub that genuinely deletes still prints `Undid 1 step(s).` at exit 0.
- Byte-equality and cross-CLI conformance suites green; `gen:reference` produces no diff.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (no package added).
- [x] This PR introduces no new package.
- [x] No visual change — `no visual change` label applied.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
