### PR TITLE
fix(pragma-cli): move `colophon` out of the AI-agent help section

### DIFF
--- a/packages/cli/pragma/src/kernel/project/cli/rootHelp.ts
+++ b/packages/cli/pragma/src/kernel/project/cli/rootHelp.ts
@@ -83,6 +83,14 @@ function buildKernelGroups(programName: string): readonly HelpGroup[] {
         },
         { noun: "info", summary: "Show version, config, and update status" },
         { noun: "version", summary: "Print the CLI version" },
+        // A colophon is the note at the back of a book: the typeface, the
+        // press, the paper. Nothing depends on it, which is the point — so
+        // this line does not argue for it. Every other summary in this column
+        // promises work done; this one just invites you to look. It sits with
+        // the other commands that describe the distribution rather than act on
+        // it; "For AI agents" is for surfaces an agent drives, and credits are
+        // for a person reading.
+        { noun: "colophon", summary: "Read the credits" },
         {
           noun: "upgrade",
           summary: `Upgrade the ${programName} CLI to the latest version`,
@@ -96,11 +104,6 @@ function buildKernelGroups(programName: string): readonly HelpGroup[] {
           noun: "capabilities",
           summary: "Discover conventions, tools, and the discovery sequence",
         },
-        // A colophon is the note at the back of a book: the typeface, the
-        // press, the paper. Nothing depends on it, which is the point — so
-        // this line does not argue for it. Every other summary in this column
-        // promises work done; this one just invites you to look.
-        { noun: "colophon", summary: "Read the credits" },
         { noun: "skill", summary: "Browse agent skills from the active packs" },
         { noun: "prompt", summary: "Browse reusable prompt templates" },
         // Curated for PLACEMENT, not for existence: `mcp serve` is an


### PR DESCRIPTION
## Done

- Move `colophon` from the **For AI agents** help section to **Set up & maintain**, beside `info` and `version`.

`colophon` prints the credits. It sat with `capabilities`, `skill`, `prompt` and `mcp` — surfaces an agent actually drives — where the other four promise work done and this one invites you to look. It now sits with the commands that *describe the distribution* rather than act on it.

The existing comment explaining the entry is kept and extended with the section rationale, so whoever moves it next knows what the boundary means.

```
 Set up & maintain
   …
   info            Show version, config, and update status
   version         Print the CLI version
   colophon        Read the credits          ← moved here
   upgrade         Upgrade the pragma CLI to the latest version

 For AI agents
   capabilities    Discover conventions, tools, and the discovery sequence
   skill           Browse agent skills from the active packs
   prompt          Browse reusable prompt templates
   mcp             Start the MCP server over stdio
```

## QA

- `pragma --help` from a fresh build renders the two sections as above.
- `bunx vitest run src/kernel/project/cli` — 7 files, 114 tests pass.
- `bun run gen:reference` — no diff (the reference pages do not enumerate help sections).
- `bun run check` — green, 62 projects.

No behaviour change: the verb, its flags and its output are untouched, and the surface covenant does not record help-section membership.

### PR readiness check

- [x] PR should have one of the following labels: `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

## Screenshots

n/a — terminal help text, shown above.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
