### PR TITLE
test(pragma-cli): make the interactive cancel + no-freeze guarantees executable under a real pty

### DIFF
--- a/packages/cli/pragma/package.json
+++ b/packages/cli/pragma/package.json
@@ -41,9 +41,10 @@
     "check:biome": "biome check",
     "check:biome:fix": "biome check --write",
     "check:ts": "tsc --noEmit",
-    "test": "bun run test:vitest && bun run test:perf",
+    "test": "bun run test:vitest && bun run test:perf && bun run test:tty",
     "test:vitest": "vitest run --coverage",
     "test:perf": "vitest run --config vitest.perf.config.ts",
+    "test:tty": "vitest run --config vitest.tty.config.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "eval": "bun run src/testing/eval/report.ts"

--- a/packages/cli/pragma/src/capabilities/create/mount.ts
+++ b/packages/cli/pragma/src/capabilities/create/mount.ts
@@ -175,8 +175,9 @@ export function explicitLeafAnswers(
 
 /**
  * The mount's mode resolution — `decideInteraction` over the leaf's five
- * inputs, with the TTY fact INJECTED so the resolution is testable with
- * `tty: true` (no suite can drive a real TTY through a subprocess). The
+ * inputs, with the TTY fact INJECTED so the resolution is testable in-process
+ * with `tty: true` (the real-terminal half is exercised end to end by the
+ * pty journeys in `testing/behavioral/journeys.interactiveTty.e2e.test.ts`). The
  * action calls it with {@link canPrompt} — the same exported H3 gate the
  * kernel's interaction context reads — so the mount and `runCreate` can
  * never disagree about interactivity.

--- a/packages/cli/pragma/src/testing/behavioral/journeys.interactiveTty.e2e.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/journeys.interactiveTty.e2e.test.ts
@@ -1,66 +1,269 @@
 /**
- * E4 (AV-231, Backlog E) — the interactive TTY journey. SCAFFOLD.
+ * E4 (AV-231, Backlog E) — the interactive TTY journeys: cancel + no-freeze,
+ * driven end to end through a REAL pseudo-terminal.
  *
- * No test in the suite ever drove a REAL terminal, so the interactive-cancel and
- * no-freeze guarantees (H1–H3, C3/C4) were never exercised end to end. Confirming
- * them needs a pseudo-terminal: spawn the compiled `pragma` under a PTY, send raw
- * keystrokes (Ctrl-C = `\x03`, EOF = `\x04`), and observe the exit code + output.
+ * Until this suite, no test ever drove the shipped binary under a terminal:
+ * the interactive-cancel and no-freeze guarantees the CLI promises (see
+ * `kernel/project/cli/dispatch.ts` and `kernel/interactivity.ts`) were pinned
+ * in-process only. Here the compiled `pragma` entry is spawned under a pty
+ * (`ptyDriver.ts` — util-linux `script(1)`, see that module for why not
+ * `node-pty`), sent raw keystrokes, and observed for output + exit code:
  *
- * `node-pty` is NOT available in this environment (it is a native addon, absent
- * from the dependency set — verified at authoring time), so the journey is
- * scaffolded as `it.todo` behind a `node-pty` availability gate rather than
- * blocking the P0 work. Each todo names the exact behaviour and the exit contract
- * the CLI already promises (see `kernel/project/cli/dispatch.ts`):
- *
- *  - H1: an at-prompt Ctrl-C is a DECLINE — a clean cancel, "Cancelled." on
- *    stderr, exit 0 (`EXIT.OK`).
+ *  - H1: an at-prompt Ctrl-C is a DECLINE — clean cancel, "Cancelled." on
+ *    stderr, exit 0 (`EXIT.OK`), nothing written.
  *  - H2: a Ctrl-C DURING execution is an INTERRUPT — aborts work underway,
- *    "Cancelled." on stderr, exit 130 (`EXIT.INTERRUPTED`, 128 + SIGINT).
- *  - H3: `create 2>/dev/null` must not freeze — interactivity gates on stderr
- *    being a TTY, so a redirected stderr picks the non-interactive strategy
- *    instead of mounting an invisible wizard that blocks on stdin.
- *  - C3: EOF (`\x04`) on a prompt resolves to a usage error, never a hang.
- *  - C4: an empty select (Enter on a no-default list) does not hang.
+ *    "Cancelled." on stderr, exit 130 (`EXIT.INTERRUPTED`, 128+SIGINT).
+ *    H1 and H2 must exit DIFFERENTLY: each test asserts which phase the
+ *    wizard actually reached (H1 never executes, H2 provably does), so the
+ *    two cannot both pass by hitting the same code path.
+ *  - H3: `create 2>/dev/null` must not freeze — interactivity gates on
+ *    STDERR being a TTY (`canPrompt`), so a redirected stderr must pick the
+ *    non-interactive strategy (a refusal, exit 2) rather than mounting an
+ *    invisible wizard that blocks on stdin.
+ *  - C3: EOF (`\x04`) on a prompt resolves to a usage error naming the
+ *    unanswered prompt (exit 2), never a hang. This was NOT true when the
+ *    suite was written: the wizard had no `\x04` handling at all — Ink handed
+ *    the byte to the focused text input as a literal character and the run
+ *    hung until killed. Fixed alongside this suite in summon-core's
+ *    `SessionController.eof` (+ the Wizard Ctrl-D binding); this journey is
+ *    the end-to-end proof, and it FAILED against the pre-fix binary.
+ *  - C4: Enter on a select list resolves and the wizard advances — no hang.
+ *    Scope honesty: every SHIPPED generator select declares a default, so the
+ *    "no-default list" wording from the scaffold cannot be driven end to end
+ *    against a real generator; Enter submits the highlighted row through the
+ *    same submit path whether or not a default moved the initial highlight,
+ *    and the degenerate lists (zero options, one option) are pinned
+ *    in-process in summon-core's `wizard.test.tsx` (C4 suite).
  *
- * TODO(AV-231/E4): when `node-pty` (or an equivalent PTY shim) is on the
- * devDependency set, replace each `it.todo` with a PTY-driven `it` that spawns
- * the shipped `pragma create …` under a pty, writes the keystroke, and asserts the exit
- * code + "Cancelled." line. The shipped entry is already provisioned for the
- * spawn-e2e layer by `testing/perf/globalSetup.ts`.
+ * A MISSING PTY DRIVER FAILS; AN UNSUPPORTED PLATFORM SKIPS — LOUDLY. The
+ * scaffold gated on `hasPty ? describe : describe.skip`, which made the
+ * guarantee able to STOP RUNNING silently — the exact blind-spot shape
+ * review flagged elsewhere (an allowlist that skipped an assertion without
+ * verifying it still applied). The boundary is drawn by what the absence
+ * MEANS: on Linux — every CI lane, and every environment this repo develops
+ * on — `script(1)` is part of an Essential package, so its absence (or a
+ * failing smoke run) is a broken environment and the probe FAILURE is thrown
+ * from `beforeAll`, failing all five journeys with the probe's reason. On a
+ * non-Linux platform the driver is not merely missing, it is unsupportable
+ * (BSD `script` has incompatible flags), and CI still runs the suite on
+ * Linux, so the file skips with the reason printed — a visible skip in a
+ * place the guarantee is exercised anyway, not a silent pass where it is not.
+ *
+ * STABILITY (this suite must not inherit `crossCli.subprocess.test.ts`'s
+ * failure modes): content is asserted BEFORE exit codes, so a failure
+ * arrives with its diagnosis; every wait shares one generous deadline whose
+ * expiry rejects WITH the captured transcript; the driver kills and reaps
+ * its child on every path and `afterEach` sweeps stragglers; and H2 makes
+ * its interrupt window DETERMINISTIC by injecting write latency
+ * (`NODE_OPTIONS --require` shim delaying `fs.promises.writeFile`) instead
+ * of racing the real ~10 ms scaffold — the subject's control flow is
+ * untouched; it simply runs on a slow disk.
+ *
+ * The shipped entry is provisioned by `testing/perf/globalSetup.ts` (shared
+ * via `vitest.tty.config.ts`), which also rebuilds stale workspace dep dists
+ * — so the binary under test always includes the current summon-core wizard.
  */
 
-import { describe, it } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { CANCELLED_MESSAGE } from "../../kernel/error/fromTaskError.js";
+import { EXIT } from "../../kernel/project/cli/exitCodes.js";
+import { killLiveChildren, probePtyDriver, runUnderPty } from "./ptyDriver.js";
 
-/** True when a real PTY driver is importable (kept async-free: a resolve probe). */
-async function ptyAvailable(): Promise<boolean> {
+const here = dirname(fileURLToPath(import.meta.url));
+/** The shipped entry (`node <entry>`), emitted by the shared globalSetup. */
+const entry = resolve(here, "../../../dist/src/bin.js");
+
+/** POSIX-quote one argument for the `sh -c` command line `script -c` runs. */
+const sq = (value: string): string => `'${value.replaceAll("'", `'\\''`)}'`;
+
+/** The command prefix every journey spawns: the real runtime, real entry. */
+const pragma = `${sq(process.execPath)} ${sq(entry)}`;
+
+/** A fresh cwd for one journey (inside the isolated, auto-cleaned run root). */
+const freshCwd = (label: string): string =>
+  mkdtempSync(join(tmpdir(), `tty-${label}-`));
+
+/** Read a file captured by an in-command redirection, or "" if never written. */
+function captured(cwd: string, name: string): string {
   try {
-    await import("node-pty" as string);
-    return true;
+    return readFileSync(join(cwd, name), "utf8");
   } catch {
-    return false;
+    return "";
   }
 }
 
-// Authoring-time: `node-pty` is absent, so this resolves to `describe.skip` and
-// the todos below stand in as the recorded, unblocked plan. The probe is awaited
-// lazily so a future environment with node-pty flips the gate with no edit here.
-const hasPty = await ptyAvailable();
-const ptyGate = hasPty ? describe : describe.skip;
+// The platform ruling (see module doc): non-Linux skips loudly; on Linux a
+// failed probe FAILS in beforeAll rather than skipping.
+const onLinux = process.platform === "linux";
+if (!onLinux) {
+  console.warn(
+    "[journeys.interactiveTty] skipped: non-Linux platform " +
+      `(${process.platform}); the pty driver needs util-linux script(1). ` +
+      "CI exercises these journeys on Linux.",
+  );
+}
+const suite = onLinux ? describe : describe.skip;
 
-ptyGate(
-  "interactive TTY journey — cancel + no-freeze (E4, node-pty) [SCAFFOLD]",
-  () => {
-    // These become PTY-driven `it`s once node-pty is available (see module TODO).
-    it.todo(
-      "H1: Ctrl-C at a wizard prompt cancels cleanly (stderr 'Cancelled.', exit 0)",
+suite("interactive TTY journeys — cancel + no-freeze (E4, real pty)", () => {
+  beforeAll(() => {
+    const status = probePtyDriver();
+    if (!status.ok) {
+      // FAIL, do not skip: on Linux the driver's absence is a broken
+      // environment, and a guarantee that can quietly stop running is a
+      // permanent blind spot (module doc, "A MISSING PTY DRIVER FAILS").
+      throw new Error(
+        `pty driver unavailable on Linux — failing the TTY journeys instead ` +
+          `of silently skipping them: ${status.reason}`,
+      );
+    }
+  });
+
+  afterEach(() => {
+    killLiveChildren();
+  });
+
+  it("H1: Ctrl-C at a wizard prompt is a DECLINE (stderr 'Cancelled.', exit 0, nothing written)", async () => {
+    const cwd = freshCwd("h1");
+    // stdout → file: the pty transcript is then the wizard's stderr render
+    // plus the boundary's stderr epilogue, assertable as the stderr surface.
+    const outcome = await runUnderPty({
+      command: `${pragma} create component react > stdout.txt`,
+      cwd,
+      steps: [{ waitFor: /Component path:/, send: "\x03" }],
+    });
+
+    // Diagnosis before verdict: the message, then the phase, then the code.
+    expect(outcome.transcript).toContain(CANCELLED_MESSAGE);
+    expect(outcome.transcript).toContain("No files were written.");
+    // The cancel landed AT THE PROMPT: execution (and even the confirm gate)
+    // was never reached — this is what makes H1's exit 0 mean "decline",
+    // where H2 proves the same keystroke mid-execution means exit 130.
+    expect(outcome.transcript).not.toContain("Proceed?");
+    expect(outcome.transcript).not.toContain("Generating");
+    // A decline is a user choice, not a failure — and not an interrupt.
+    expect(outcome.exitCode).toBe(EXIT.OK);
+    // Nothing reached stdout (the data stream) and nothing was scaffolded.
+    expect(captured(cwd, "stdout.txt")).toBe("");
+    expect(captured(cwd, "src/components/MyComponent/index.ts")).toBe("");
+  });
+
+  it("H2: Ctrl-C during execution is an INTERRUPT (stderr 'Cancelled.', exit 130)", async () => {
+    const cwd = freshCwd("h2");
+    // Deterministic interrupt window: delay every generator file write by
+    // 300 ms (≈8 writes ⇒ ≳2 s of executing phase) so the Ctrl-C sent on the
+    // first progress frame always lands mid-run. Control flow is untouched —
+    // the run simply executes on a slow disk.
+    const shim = join(freshCwd("h2-shim"), "slowWrites.cjs");
+    writeFileSync(
+      shim,
+      `"use strict";
+const fsp = require("node:fs/promises");
+const realWriteFile = fsp.writeFile;
+fsp.writeFile = function (...args) {
+  return new Promise((r) => setTimeout(r, 300)).then(() =>
+    realWriteFile.apply(fsp, args),
+  );
+};
+`,
     );
-    it.todo(
-      "H2: Ctrl-C during execution aborts the run (stderr 'Cancelled.', exit 130)",
+    const outcome = await runUnderPty({
+      command: `${pragma} create component react > stdout.txt`,
+      cwd,
+      env: { NODE_OPTIONS: `--require ${shim}` },
+      steps: [
+        // Enter accepts each prompt's default; 'y' takes the confirm gate.
+        { waitFor: /Component path:/, send: "\r" },
+        { waitFor: /Include styles\?/, send: "\r" },
+        { waitFor: /Storybook stories\?/, send: "\r" },
+        { waitFor: /SSR tests\?/, send: "\r" },
+        { waitFor: /Proceed\? \(Y\/n\)/, send: "y" },
+        // The executing phase is rendering progress — NOW Ctrl-C.
+        { waitFor: /Generating/, send: "\x03", settleMs: 250 },
+      ],
+      timeoutMs: 90_000,
+    });
+
+    expect(outcome.transcript).toContain(CANCELLED_MESSAGE);
+    // The run provably ENTERED execution (H1 asserts it never does) and was
+    // stopped before finishing — the same keystroke, a different meaning.
+    expect(outcome.transcript).toContain("Generating");
+    expect(outcome.transcript).not.toContain("Generation complete");
+    // Work underway was aborted: UNIX 128+SIGINT, out-of-band from the
+    // frozen {0,1,2,3} classification set — and provably NOT H1's exit 0.
+    expect(outcome.exitCode).toBe(EXIT.INTERRUPTED);
+    expect(captured(cwd, "stdout.txt")).toBe("");
+  });
+
+  it("H3: `create 2>/dev/null` does not freeze — non-TTY stderr picks the non-interactive strategy", async () => {
+    const cwd = freshCwd("h3");
+    // stdin IS a tty here (the pty); only stderr is detached — captured to a
+    // file so the refusal (which rides stderr) can be asserted. If the gate
+    // read the wrong stream, the wizard would mount invisibly (rendering
+    // into stderr.txt) and block on stdin forever: the driver's deadline
+    // would kill it and this test would fail with the transcript.
+    const outcome = await runUnderPty({
+      command: `${pragma} create component react 2>stderr.txt > stdout.txt`,
+      cwd,
+      steps: [],
+    });
+
+    // The refusal names the fix — this is stderr content, asserted first.
+    const stderr = captured(cwd, "stderr.txt");
+    expect(stderr).toContain("Refusing to scaffold in a non-interactive run");
+    expect(stderr).toContain("--component-path");
+    // No wizard mounted: no prompt frame anywhere, nothing on the terminal.
+    expect(stderr).not.toContain("Component path:");
+    expect(outcome.transcript).not.toContain("Component path:");
+    // A refusal is a usage error the shell can fix.
+    expect(outcome.exitCode).toBe(EXIT.USAGE);
+  });
+
+  it("C3: EOF (Ctrl-D) at a prompt resolves to a usage error naming it — never a hang", async () => {
+    const cwd = freshCwd("c3");
+    const outcome = await runUnderPty({
+      command: `${pragma} create component react > stdout.txt`,
+      cwd,
+      steps: [{ waitFor: /Component path:/, send: "\x04" }],
+    });
+
+    // The error names the unanswered prompt and the recovery — stderr first.
+    expect(outcome.transcript).toContain(
+      'Input ended (EOF) before "componentPath" was answered.',
     );
-    it.todo(
-      "H3: `create 2>/dev/null` does not freeze (non-TTY stderr -> non-interactive)",
-    );
-    it.todo("C3: EOF on a prompt resolves to a usage error, never a hang");
-    it.todo("C4: an empty select does not hang");
-  },
-);
+    expect(outcome.transcript).toContain("pass --yes");
+    // EOF is not a decline (that is H1's exit 0) and not an interrupt (H2's
+    // 130): input ENDED without the required answer, which is the same usage
+    // class as a missing non-interactive answer.
+    expect(outcome.exitCode).toBe(EXIT.USAGE);
+    expect(captured(cwd, "stdout.txt")).toBe("");
+    expect(captured(cwd, "src/components/MyComponent/index.ts")).toBe("");
+  });
+
+  it("C4: Enter on a select resolves it and the wizard advances — no hang", async () => {
+    const cwd = freshCwd("c4");
+    // `create package` carries the one shipped select (`type`). Enter must
+    // submit the highlighted row and move on; reaching the NEXT prompt is
+    // the proof. The journey then exits via the H1 path (Ctrl-C, clean
+    // decline) so its own teardown is itself an asserted behaviour.
+    const outcome = await runUnderPty({
+      command: `${pragma} create package > stdout.txt`,
+      cwd,
+      steps: [
+        { waitFor: /Package name:/, send: "\r" },
+        { waitFor: /Package type:/, send: "\r" },
+        { waitFor: /Package description:/, send: "\x03", settleMs: 250 },
+      ],
+    });
+
+    // The select resolved: the wizard reached the prompt AFTER it.
+    expect(outcome.transcript).toContain("Package type:");
+    expect(outcome.transcript).toContain("Package description:");
+    expect(outcome.transcript).toContain(CANCELLED_MESSAGE);
+    expect(outcome.exitCode).toBe(EXIT.OK);
+    expect(captured(cwd, "stdout.txt")).toBe("");
+  });
+});

--- a/packages/cli/pragma/src/testing/behavioral/ptyDriver.ts
+++ b/packages/cli/pragma/src/testing/behavioral/ptyDriver.ts
@@ -1,0 +1,294 @@
+/**
+ * The pseudo-terminal driver for the interactive TTY journeys (E4).
+ *
+ * WHY `script(1)` AND NOT `node-pty`. Driving the shipped binary under a real
+ * terminal needs a pty, and a pty needs syscalls Node does not expose — some
+ * native layer is unavoidable. The candidates, evaluated on 2026-08-29:
+ *
+ * - `node-pty` (the scaffold's named candidate) is a native addon with NO
+ *   Linux prebuilds: `bun add node-pty` runs `node-gyp rebuild` at install,
+ *   which requires python3 + a C++ toolchain on every dev machine. It failed
+ *   outright on a NixOS host with no compiler profile ("Could not find any
+ *   Python installation"), and would also require a root-level
+ *   `trustedDependencies` entry for bun to run its install script at all.
+ * - `@homebridge/node-pty-prebuilt-multiarch` DOES install and load here
+ *   (prebuilt N-API binary; verified spawning a pty on the same host), but it
+ *   is a third-party fork, needs the same root `trustedDependencies` edit,
+ *   and fetches a platform binary from GitHub releases at install time —
+ *   three new failure modes in shared install infrastructure, bought for a
+ *   suite that only ever runs on Linux CI.
+ * - `script(1)` (util-linux) allocates the same kernel pty with ZERO
+ *   dependency-graph changes. It is preinstalled on the CI runner
+ *   (ubuntu-latest ships it in `bsdutils`, an Essential package built from
+ *   the util-linux sources, so `-qec` semantics hold) and on any Linux dev
+ *   box. `script -e` propagates the child's exit code, including 130 for a
+ *   SIGINT death, which is exactly the surface under test.
+ *
+ * So: `script -qec '<command>' /dev/null` with the harness writing raw
+ * keystrokes to script's stdin (forwarded byte-for-byte to the pty master)
+ * and reading the pty slave's output from its stdout. The child sees a real
+ * TTY on stdin/stdout/stderr; a test that needs a redirected stream applies
+ * the redirection INSIDE the command string, which is also how stderr (the
+ * wizard's render stream and the pty transcript) is separated from stdout
+ * (redirected to a file and asserted separately).
+ *
+ * WHAT THIS DRIVER CANNOT TEST: anything off-Linux (macOS `script` is the
+ * BSD variant with incompatible flags — the suite skips there, loudly), and
+ * per-stream capture of stdout/stderr INTERLEAVING (a pty merges everything
+ * written to the terminal; stream identity is recovered via in-command
+ * redirection instead).
+ *
+ * STABILITY RULES (learned from `crossCli.subprocess.test.ts`, the suite's
+ * least deterministic spawn test): every wait has one generous overall
+ * deadline; a timeout REJECTS with the pending step and the captured
+ * transcript, never a bare assertion mismatch; the child is killed and reaped
+ * on every path (a per-run `finally` plus the module-level registry swept by
+ * {@link killLiveChildren}); and the pty window is given a real size first —
+ * a pipe-backed `script` starts with a 0×0 winsize, which makes Ink wrap
+ * every frame at column zero.
+ */
+
+import {
+  type ChildProcessWithoutNullStreams,
+  spawn,
+  spawnSync,
+} from "node:child_process";
+
+/** Whether the `script(1)` pty driver can run here, and if not, why. */
+export type PtyDriverStatus =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string };
+
+/**
+ * Probe the pty driver: platform, `script(1)` presence, and a real smoke run
+ * that allocates a pty and sizes it with `stty` — the two externals every
+ * journey depends on. Synchronous, so a test module can rule at load time.
+ */
+export function probePtyDriver(): PtyDriverStatus {
+  if (process.platform !== "linux") {
+    return {
+      ok: false,
+      reason:
+        `platform is ${process.platform}: the driver needs util-linux ` +
+        "script(1) semantics (-qec, -e exit propagation), which only Linux provides",
+    };
+  }
+  const smoke = spawnSync(
+    "script",
+    ["-qec", "stty cols 80 rows 24", "/dev/null"],
+    {
+      encoding: "utf8",
+      timeout: 15_000,
+    },
+  );
+  if (smoke.error !== undefined) {
+    return {
+      ok: false,
+      reason: `script(1) could not be spawned: ${smoke.error.message}`,
+    };
+  }
+  if (smoke.status !== 0) {
+    return {
+      ok: false,
+      reason: `script(1) smoke run exited ${String(smoke.status)}: ${smoke.stderr}`,
+    };
+  }
+  return { ok: true };
+}
+
+/** One scripted interaction: when the terminal shows this, type that. */
+export interface PtyStep {
+  /**
+   * Fires when this matches the CLEANED transcript at or beyond the previous
+   * step's match — forward-only, so a repainted earlier frame (Ink redraws
+   * the whole screen per keystroke) cannot re-trigger a step.
+   */
+  readonly waitFor: RegExp;
+  /** Raw bytes to type (`\r` Enter, `\x03` Ctrl-C, `\x04` Ctrl-D). */
+  readonly send: string;
+  /**
+   * Pause between the match and the keystroke (default 150 ms): the frame
+   * that matched renders before Ink's input hooks for it are necessarily
+   * active, and a keystroke into the gap is dropped or misread.
+   */
+  readonly settleMs?: number;
+}
+
+/** What a pty run produced. */
+export interface PtyOutcome {
+  /** Everything the terminal showed, ANSI-stripped ({@link cleanTranscript}). */
+  readonly transcript: string;
+  /** The raw pty byte stream, for when an escape sequence itself matters. */
+  readonly raw: string;
+  /**
+   * The command's exit code (`script -e` propagates the child's, mapping a
+   * signal death to 128+N). Null only for an abnormal `script` death.
+   */
+  readonly exitCode: number | null;
+}
+
+/** Options for one {@link runUnderPty} run. */
+export interface PtyRunOptions {
+  /**
+   * The shell command to run INSIDE the pty (after the harness's `stty`
+   * sizing). Redirections in it are how a test detaches a stream from the
+   * terminal (`2>/dev/null`) or captures it for assertion (`> stdout.txt`).
+   */
+  readonly command: string;
+  /** Working directory for the run. */
+  readonly cwd: string;
+  /**
+   * Extra environment. The child inherits the test process env (XDG/TMPDIR
+   * isolation included) with `TERM` set and `NODE_OPTIONS` REMOVED — a test
+   * that wants an injected preamble passes its own `NODE_OPTIONS` here.
+   */
+  readonly env?: Record<string, string>;
+  /** The scripted keystrokes, applied in order. */
+  readonly steps?: readonly PtyStep[];
+  /**
+   * Overall deadline for the whole run (default 60 s — generous, because a
+   * loaded CI box is the norm; the passing path settles in low seconds). On
+   * expiry the child is SIGKILLed, reaped, and the promise REJECTS with the
+   * pending step and the transcript, so a hang diagnoses itself.
+   */
+  readonly timeoutMs?: number;
+}
+
+/** Strip ANSI escapes and carriage returns from a pty byte stream. */
+export function cleanTranscript(raw: string): string {
+  return (
+    raw
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
+      .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "")
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: charset-selection escapes (ESC ( B and kin).
+      .replace(/\x1b[()][A-Z0-9]/g, "")
+      .replace(/\r/g, "")
+  );
+}
+
+/** Live children, so a torn-down test can never leak a pty holder. */
+const liveChildren = new Set<ChildProcessWithoutNullStreams>();
+
+/** SIGKILL anything a failed/timed-out test left behind (afterEach hygiene). */
+export function killLiveChildren(): void {
+  for (const child of liveChildren) {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Already gone — reaping is what mattered.
+    }
+  }
+  liveChildren.clear();
+}
+
+/**
+ * Run one command under a real pty and drive it with scripted keystrokes.
+ *
+ * Resolves when the command exits (steps consumed or not — a run that exits
+ * before its steps is asserted through the outcome). Rejects ONLY on the
+ * deadline, with the pending step and transcript in the message — the child
+ * is already killed and reaped by then.
+ */
+export function runUnderPty(options: PtyRunOptions): Promise<PtyOutcome> {
+  const { command, cwd, steps = [], timeoutMs = 60_000 } = options;
+  // A pipe-backed pty starts 0×0 (Ink then wraps at column zero); size it
+  // before the subject runs. `exec` keeps the exit status the command's own.
+  const sized = `stty cols 120 rows 40; exec ${command}`;
+  const env: NodeJS.ProcessEnv = { ...process.env, TERM: "xterm-256color" };
+  delete env.NODE_OPTIONS;
+  Object.assign(env, options.env);
+
+  return new Promise<PtyOutcome>((resolve, reject) => {
+    const child = spawn("script", ["-qec", sized, "/dev/null"], {
+      cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    liveChildren.add(child);
+
+    let raw = "";
+    let settled = false;
+    let stepIndex = 0;
+    let cursor = 0; // forward-only match position in the cleaned transcript
+    let typing = false;
+
+    const finish = (outcome: PtyOutcome): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      clearInterval(pump);
+      liveChildren.delete(child);
+      resolve(outcome);
+    };
+
+    const fail = (message: string): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      clearInterval(pump);
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Exit raced the kill; either way it is being reaped below.
+      }
+      liveChildren.delete(child);
+      reject(
+        new Error(
+          `${message}\n--- transcript (cleaned) ---\n${cleanTranscript(raw).slice(-4000)}`,
+        ),
+      );
+    };
+
+    const deadline = setTimeout(() => {
+      const pending =
+        stepIndex < steps.length
+          ? `waiting for step ${stepIndex + 1}/${steps.length} (${String(steps[stepIndex]?.waitFor)})`
+          : "all steps sent; waiting for exit";
+      fail(`pty run timed out after ${timeoutMs}ms: ${pending}`);
+    }, timeoutMs);
+
+    const advance = (): void => {
+      if (settled || typing || stepIndex >= steps.length) return;
+      const step = steps[stepIndex] as PtyStep;
+      const cleaned = cleanTranscript(raw);
+      const match = step.waitFor.exec(cleaned.slice(cursor));
+      if (match === null) return;
+      cursor += match.index + match[0].length;
+      stepIndex += 1;
+      typing = true;
+      setTimeout(() => {
+        try {
+          child.stdin.write(step.send);
+        } catch {
+          // The run ended first; the outcome assertions will say how.
+        }
+        typing = false;
+      }, step.settleMs ?? 150);
+    };
+
+    // Advance on output AND on a timer: a step whose frame already rendered
+    // before the previous keystroke's settle delay elapsed emits no further
+    // output to re-trigger the check.
+    const pump = setInterval(advance, 50);
+    child.stdout.on("data", (chunk: Buffer) => {
+      raw += chunk.toString();
+      advance();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      raw += chunk.toString();
+    });
+    child.on("error", (error) => {
+      fail(`script(1) failed to spawn: ${error.message}`);
+    });
+    child.on("exit", (code) => {
+      // Give the last pty flush a beat to land before the transcript is read.
+      setTimeout(() => {
+        finish({
+          transcript: cleanTranscript(raw),
+          raw,
+          exitCode: code,
+        });
+      }, 100);
+    });
+  });
+}

--- a/packages/cli/pragma/vitest.config.ts
+++ b/packages/cli/pragma/vitest.config.ts
@@ -9,7 +9,16 @@ export default defineConfig({
     // timing the shipped entry inside this parallel, coverage-instrumented run
     // measures CPU contention, not the binary, so the ceilings flake red. They
     // stay ENFORCED, just out of this pass.
-    exclude: [...configDefaults.exclude, "src/testing/perf/**"],
+    exclude: [
+      ...configDefaults.exclude,
+      "src/testing/perf/**",
+      // The pty-driven TTY journeys are likewise isolated into their own
+      // SERIAL pass (vitest.tty.config.ts / the `test:tty` script): they
+      // spawn the shipped entry under a real pseudo-terminal and wait on
+      // wall-clock deadlines, which the parallel coverage run starves into
+      // flakes. They stay ENFORCED, just out of this pass.
+      "src/testing/behavioral/journeys.interactiveTty.e2e.test.ts",
+    ],
     // safety.test.ts's storeless-guarantee guards spawn the shipped entry
     // — a correctness check (exit/stdout), not a timing one, so it belongs in
     // this pass. Reuse the perf suite's "emit once if missing"

--- a/packages/cli/pragma/vitest.tty.config.ts
+++ b/packages/cli/pragma/vitest.tty.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * The SERIAL pty-journey pass — the interactive TTY journeys
+ * (`src/testing/behavioral/journeys.interactiveTty.e2e.test.ts`), split out of
+ * the default (parallel, coverage-instrumented) `vitest.config.ts` the same
+ * way the perf budgets are, and for the same class of reason.
+ *
+ * Each journey spawns the shipped entry under a real pseudo-terminal
+ * (`script(1)`), types keystrokes against live Ink frames, and waits on
+ * wall-clock deadlines. Inside the ~65-file parallel coverage run those waits
+ * compete with every other worker for the CPU (this box routinely runs under
+ * heavy parallel load), which is how a spawn-driven test becomes the least
+ * deterministic thing in the suite. Running the five journeys ALONE, serially,
+ * in a single pass keeps the driver's generous deadlines meaningful: a timeout
+ * then indicates a hung subject (exactly what H3/C3/C4 guard against), not a
+ * starved runner.
+ *
+ * NO NEW CI JOB: `pr.yml` is shared infrastructure. This pass rides the
+ * package's own `test` target (`test:vitest && test:perf && test:tty`),
+ * exactly as `test:perf` already does.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/testing/behavioral/journeys.interactiveTty.e2e.test.ts"],
+    setupFiles: ["./src/testing/setupXdgIsolation.ts"],
+    globalSetup: [
+      // Emits `dist/` (and rebuilds stale workspace dep dists) once if
+      // missing — the entry the journeys spawn.
+      "./src/testing/perf/globalSetup.ts",
+      // Allocates the run-level temp root BEFORE any worker starts and
+      // removes it after the last one exits. `setupXdgIsolation.ts` reads it.
+      "./src/testing/tempRoot.globalSetup.ts",
+    ],
+    environment: "node",
+    // One file, run alone: no cross-file parallelism to starve the pty waits.
+    fileParallelism: false,
+    // Generous per-test ceiling: the driver's own 60–90 s deadlines must be
+    // the thing that fires (they carry the transcript); vitest's timeout is
+    // only the backstop above them.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+});

--- a/packages/summon/core/src/prompt/ink/Wizard.tsx
+++ b/packages/summon/core/src/prompt/ink/Wizard.tsx
@@ -212,8 +212,12 @@ export const Wizard = ({ controller }: WizardProps) => {
 
   // Ctrl-C cancels from any phase (Ink is mounted with exitOnCtrlC:false, so the
   // key reaches here). Cancelling rejects the pending prompt, failing the task.
+  // Ctrl-D is EOF (C3): input has ENDED, so a pending prompt resolves to a
+  // usage error naming the unanswered question rather than hanging (and, with
+  // nothing pending, aborts like a cancel) — see SessionController.eof.
   useInput((input, key) => {
     if (key.ctrl && input === "c") controller.cancel();
+    else if (key.ctrl && input === "d") controller.eof();
   });
 
   useInput(

--- a/packages/summon/core/src/prompt/ink/session.test.ts
+++ b/packages/summon/core/src/prompt/ink/session.test.ts
@@ -230,6 +230,35 @@ describe("SessionController", () => {
     expect(c.getSnapshot().phase).toBe("cancelled");
   });
 
+  it("eof rejects the pending prompt as MISSING_REQUIRED_ANSWER, naming it (C3)", async () => {
+    let aborts = 0;
+    const c = new SessionController(gen, () => aborts++);
+    const p = c.request(ask("path"));
+    c.eof();
+    // NOT GENERATOR_CANCELLED: an EOF is not a decline. The code is what the
+    // CLI boundary maps to a usage error (exit 2) instead of a clean exit 0 —
+    // and instead of the pre-fix behaviour, which was no handling at all (the
+    // \x04 byte fell through to the focused text input and the wizard hung).
+    await expect(p).rejects.toMatchObject({
+      code: "MISSING_REQUIRED_ANSWER",
+      message: expect.stringContaining('Input ended (EOF) before "path"'),
+    });
+    // The run aborts too — a generator with follow-up work must not keep
+    // running against an input source that has ended.
+    expect(aborts).toBe(1);
+    expect(c.getSnapshot().phase).toBe("cancelled");
+  });
+
+  it("eof with nothing pending defers to cancel — an abort, not a reject (C3)", () => {
+    let aborts = 0;
+    const c = new SessionController(gen, () => aborts++);
+    // Models an EOF DURING execution: no prompt to reject, so the abort is
+    // what stops the run (the interpreter surfaces TASK_INTERRUPTED, 130).
+    c.eof();
+    expect(aborts).toBe(1);
+    expect(c.getSnapshot().phase).toBe("cancelled");
+  });
+
   it("folds host step reports into live rows, measuring wall time per step", async () => {
     const c = new SessionController(gen);
     const gate = c.request(confirm());

--- a/packages/summon/core/src/prompt/ink/session.ts
+++ b/packages/summon/core/src/prompt/ink/session.ts
@@ -23,6 +23,7 @@ import {
   GENERATOR_CANCELLED,
 } from "../../execute/execute.js";
 import type GeneratorDefinition from "../../types/GeneratorDefinition.js";
+import { MISSING_REQUIRED_ANSWER } from "../autoPrompt.js";
 import type { StepReport } from "../inkPrompt.js";
 import type { PromptEffect } from "../types.js";
 
@@ -454,6 +455,42 @@ export class SessionController {
       new TaskExecutionError({
         code: GENERATOR_CANCELLED,
         message: "Cancelled.",
+      }),
+    );
+  }
+
+  /**
+   * The user sent EOF (Ctrl-D) — input has ENDED (C3). Distinct from a
+   * decline: a Ctrl-C at a prompt is a user CHOOSING not to proceed (a clean
+   * cancel, exit 0), while an EOF says the input source can never produce the
+   * pending answer. The pending prompt therefore rejects with the SAME
+   * `MISSING_REQUIRED_ANSWER` code the non-interactive strategy raises for an
+   * absent answer — the CLI boundary maps it to a usage error (exit 2) with a
+   * message that names the unanswered prompt, instead of hanging a wizard
+   * whose stdin has nothing more to say. Before this method existed the \x04
+   * byte was not handled at all: Ink handed it to the focused text input as a
+   * literal character and the wizard waited forever.
+   *
+   * With NO prompt pending (an EOF mid-execution), it defers to {@link cancel}
+   * — work already underway aborts exactly as a Ctrl-C would (exit 130).
+   */
+  eof(): void {
+    const pending = this.pending;
+    if (pending === undefined) {
+      this.cancel();
+      return;
+    }
+    this.pending = undefined;
+    // Abort the run too: the reject fails the current Prompt effect, and the
+    // abort stops the drive loop at its next `checkInterrupted` — same pairing
+    // as cancel(), so a generator with follow-up work cannot keep running
+    // against an input source that has ended.
+    this.onUserCancel?.();
+    this.set({ phase: "cancelled" });
+    pending.reject(
+      new TaskExecutionError({
+        code: MISSING_REQUIRED_ANSWER,
+        message: `Input ended (EOF) before "${pending.effect.question.name}" was answered. Provide the answer as a flag, or pass --yes to accept the defaults.`,
       }),
     );
   }

--- a/packages/summon/core/src/prompt/ink/wizard.test.tsx
+++ b/packages/summon/core/src/prompt/ink/wizard.test.tsx
@@ -328,6 +328,45 @@ describe("keyboard bindings (one prompt, one render each)", () => {
     },
     TEST_TIMINGS.testBudgetMs,
   );
+
+  it(
+    "text prompt: Ctrl-D (EOF) resolves to MISSING_REQUIRED_ANSWER, no hang (C3)",
+    async () => {
+      const c = new SessionController(gen);
+      const { lastFrame, stdin, unmount } = render(<Wizard controller={c} />);
+      const frame = (): string => lastFrame() ?? "";
+      const wedged = describeWedge(c, frame);
+      try {
+        const pending = c.request(
+          text("componentPath", "Component path:", "src/components/Button"),
+        );
+        // Idempotent: a late duplicate \x04 finds nothing pending and defers
+        // to cancel(), which re-sets the already-cancelled phase - no state
+        // can change, so the fake stdin's late-delivery caveat is satisfied.
+        pending.catch(() => {
+          // The rejection is asserted below; this handler only keeps a
+          // pre-assertion rejection from surfacing as unhandled.
+        });
+        await waitFor(() => frame().includes("Component path:"), wedged);
+        await pressUntil(
+          stdin,
+          "\u0004",
+          () => c.getSnapshot().phase === "cancelled",
+          wedged,
+        );
+        // The pre-fix wizard had NO \x04 handling: Ink handed the byte to the
+        // focused text input as a literal character and this promise never
+        // settled. The code (not GENERATOR_CANCELLED) is what routes an EOF to
+        // a usage error at the CLI boundary instead of a clean exit 0.
+        await expect(pending).rejects.toMatchObject({
+          code: "MISSING_REQUIRED_ANSWER",
+        });
+      } finally {
+        unmount();
+      }
+    },
+    TEST_TIMINGS.testBudgetMs,
+  );
 });
 
 describe("cancelled frame is truthful about files written (H2)", () => {


### PR DESCRIPTION
## Done

The interactive-cancel and no-freeze guarantees (E4 / AV-231) are now **executable**: a pseudo-terminal test layer replaces the five scaffolded `it.todo`s in `journeys.interactiveTty.e2e.test.ts` with real PTY-driven journeys that spawn the shipped `dist/src/bin.js` under a terminal, type raw keystrokes, and assert stderr content + exit codes against `EXIT` (`kernel/project/cli/exitCodes.ts`).

**The pty layer** (`src/testing/behavioral/ptyDriver.ts`) drives the binary under util-linux **`script(1)`**, not `node-pty`:

- `node-pty` has no Linux prebuilds — `bun add node-pty` runs `node-gyp rebuild` at install (needs python3 + a C++ toolchain on every dev machine, plus a root-level `trustedDependencies` entry for bun to run the install script at all). It fails outright on hosts without a compiler profile.
- The prebuilt fork (`@homebridge/node-pty-prebuilt-multiarch`) does install and load, but is a third-party fork that fetches a platform binary from GitHub releases at install time and still needs the root `trustedDependencies` edit — new failure modes in shared install infrastructure for a suite that only runs on Linux CI.
- `script -qec … /dev/null` allocates the same kernel pty with **zero dependency-graph changes** (nothing new near the runtime graph, the lazy-graph guard, or the perf fast paths), is preinstalled on ubuntu-latest (`bsdutils`, an Essential package built from util-linux), and `-e` propagates the child's exit code including 130.

What the five journeys prove (each shown red against a deliberately broken variant — see QA):

- **H1** — Ctrl-C at a wizard prompt: `Cancelled.` on stderr, exit 0, nothing written, and the transcript proves execution was never entered.
- **H2** — Ctrl-C during execution: `Cancelled.`, exit **130**, transcript proves the run entered `Generating` and never completed. The interrupt window is made deterministic with an injected `fs.promises.writeFile` latency shim (`NODE_OPTIONS --require`) — the subject's control flow is untouched; it just runs on a slow disk.
- **H3** — `create 2>stderr.txt` with stdin still a TTY: the refusal (usage error, exit 2) instead of an invisible wizard blocked on stdin.
- **C3** — EOF (`\x04`) at a prompt resolves to a usage error naming the unanswered prompt, exit 2 — **this required a product fix**, see below.
- **C4** — Enter at the shipped select (`create package` → `type`) submits the highlighted row and the wizard advances to the next prompt; clean Ctrl-C teardown asserted after.

**Drive-by that is really the headline: C3 was not true before this PR.** The scaffold recorded EOF-at-prompt as a guarantee "the CLI already promises", but the wizard had **no `\x04` handling at all**: Ink handed the byte to the focused text input as a literal character and the run hung until killed (reproduced under a real pty before writing the fix). Fixed in summon-core: `SessionController.eof()` rejects the pending prompt with `MISSING_REQUIRED_ANSWER` (the same code the non-interactive strategy raises for an absent answer, so the CLI boundary maps it to a usage error, exit 2) and aborts the run; the Wizard binds Ctrl-D to it. Covered in-process in `session.test.ts` and `wizard.test.tsx`, and end-to-end by the C3 journey. An EOF is deliberately **not** a decline (H1's exit 0) and not an interrupt (H2's 130).

Two deliberate rulings, written into the files:

- **A missing pty driver FAILS, not skips.** On Linux (every CI lane) `script(1)`'s absence or a failing smoke probe throws from `beforeAll`, failing all five journeys with the reason — the scaffold's `describe.skip` gate could let the guarantee silently stop running. Non-Linux platforms skip with the reason printed (BSD `script` is flag-incompatible; CI exercises the suite on Linux regardless).
- **No new CI job.** The journeys run as their own serial pass (`vitest.tty.config.ts`, `test:tty`) chained into the package's `test` target, exactly the `test:perf` precedent — excluded from the parallel coverage pass, where pty deadline waits are starved into flakes.

Stability (the suite must not inherit `crossCli.subprocess.test.ts`'s failure modes): content is asserted **before** exit codes; every wait shares one generous deadline whose expiry rejects **with the captured transcript** (never a bare assertion mismatch); the driver kills and reaps its child on every path and `afterEach` sweeps stragglers; the harness survives its subject hanging (that is exactly what H3/C3/C4 test — verified by red runs).

Noted, not fixed here (its own ledger item): `crossCli.subprocess.test.ts` fails opaquely because it asserts `.status` before stderr (`expect(pragma.status).toBe(2)` at e.g. lines 388/435/490 → "expected null to be 2" on a spawn timeout) and its `helpOf`/producer helpers drop `spawnSync`'s `.error` (ETIMEDOUT) entirely. The cheap diagnosability fix is to assert the captured stderr/text first (or fold the buffers + `.error` into the status assertion's message).

Also updated the now-stale "no suite can drive a real TTY through a subprocess" comment in `create/mount.ts`.

## QA

- `bun run check && bun run test:vitest && bun run test:perf && bun run test:tty` in `packages/cli/pragma`; `bun run check && bun run test` in `packages/summon/core`.
- Red-proofs (run locally, then reverted — each journey fails diagnosably against a broken subject):
  - interrupt exit collapsed to 0 in `dispatch.ts` → H2 fails `expected +0 to be 130`;
  - `canPrompt` gating on stdin only → H3's invisible wizard hangs; the driver's deadline kills it and fails with the transcript;
  - Ctrl-D binding stripped from the built wizard → C3 hangs; same diagnosed failure.
- `bun run gen:reference` produces no diff.
- Interactive wizard still behaves normally on a real terminal (H1/H2/C3/C4 transcripts in the test output are the wizard's actual frames).

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` and `build:all`.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011B8Z3Lq1eARN1wLfKGvzqC
