### PR TITLE
ci: schedule the two despecialization gates on every PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,6 +71,17 @@ jobs:
       - name: Test
         run: bunx nx affected -t test --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD
 
+      # The two despecialization gates, run on EVERY PR rather than through
+      # `affected`. Their subjects live in a project they have no dependency
+      # edge to — G-2 reads the app's committed `schema.graphql`, and the
+      # acceptance gate scans the app's lens directory — so a PR touching only
+      # those files schedules neither. The edge cannot simply be declared: the
+      # app already depends on the provider, so an implicit dependency back
+      # would close a cycle. Running them unconditionally costs ~2s and closes
+      # the hole both gates document in their own headers.
+      - name: Gates (contract conformance, provider neutrality)
+        run: bunx nx run-many -t test -p @canonical/prism-pragma-provider @canonical/prism-graph-example
+
   build-gate:
     runs-on: ubuntu-latest
     needs: build-matrix

--- a/packages/docsite/pragma-provider/src/testing/integration/committedSdl.test.ts
+++ b/packages/docsite/pragma-provider/src/testing/integration/committedSdl.test.ts
@@ -30,11 +30,15 @@
 // what closes the currency gap they leave: it measures the schema as it is
 // now, on every run.
 //
-// KNOWN LIMITATION, pre-existing and not fixed here. `nx affected` sees no
-// dependency edge from this package to the app, so a PR touching only
-// `schema.graphql` will not schedule this project's `test` target. graph-example's
-// acceptance gate has had the same hole since it landed. Run both by hand in
-// any PR that moves the schema until the edge is declared.
+// SCHEDULING, and why it is not a dependency edge. `nx affected` sees no edge
+// from this package to the app, so a PR touching only `schema.graphql` does not
+// schedule this project's `test` target — and the edge cannot simply be
+// declared, because the app already depends on this provider and an implicit
+// dependency back would close a cycle. CI therefore runs this gate and
+// graph-example's acceptance gate UNCONDITIONALLY, in `pr.yml`'s "Gates" step,
+// outside `affected`. If that step is ever removed, this comment is a lie and
+// the gate is asleep: it is cheap (~2s for both) precisely so that nobody has
+// a reason to remove it.
 // =============================================================================
 
 import { existsSync, readFileSync } from "node:fs";


### PR DESCRIPTION
## The hole

Both despecialization gates judge a subject that lives in a project they have **no dependency edge to**:

- **G-2** — `packages/docsite/pragma-provider/src/testing/integration/committedSdl.test.ts` — reads the app's committed `apps/react/pragma-docs/src/relay/schema.graphql` and runs `satisfiesContract` over it.
- **The acceptance gate** — `packages/docsite/graph-example/src/testing/integration/lensOperations.test.ts` — scans the app's lens directory and executes every core lens operation against a provider that has never heard of pragma.

`nx affected -t test` therefore schedules **neither** for a PR that touches only those files. That is exactly the PR both gates exist to judge — a schema change, or a lens added outside the scanned set. G-2's own header has carried the note since it landed in #910: *"pre-existing and not fixed here … run both by hand in any PR that moves the schema."* A gate that depends on someone remembering is not a gate.

## Why not just declare the edge

The app depends on `@canonical/prism-pragma-provider`. An implicit dependency back from the provider to the app closes a cycle, which nx will not accept. The gates point *up* the dependency graph by design — that is what makes them gates rather than unit tests.

## The fix

One step in `pr.yml`, outside `affected`:

```yaml
- name: Gates (contract conformance, provider neutrality)
  run: bunx nx run-many -t test -p @canonical/prism-pragma-provider @canonical/prism-graph-example
```

Cheap on purpose — 45 + 227 tests, ~2s, and nx caches them when nothing they depend on moved. `test` already `dependsOn: ["^build"]`, so `@canonical/prism-contract` builds first.

The gate's header comment is updated to record what schedules it and why the fix is a CI step rather than an edge — including the line that matters most: if that step is ever removed, the comment is a lie and the gate is asleep.

## Verified

`bunx nx run-many -t test -p @canonical/prism-pragma-provider @canonical/prism-graph-example` → *Successfully ran target test for 2 projects and 4 tasks they depend on*, green.

## Note for the record

`canonical/pragma-adrs` `session/B/B.04` currently states that G-2 *does not exist*. It does — it landed in #910 and passes. What did not exist is its scheduling. The ADR is being corrected in the same pass.