### PR TITLE
ci(cli): take the perf budgets off automated runs

### DIFF
--- a/packages/cli/pragma/BUDGETS.md
+++ b/packages/cli/pragma/BUDGETS.md
@@ -6,6 +6,38 @@ without hesitation. These budgets are enforced by the protected perf tests
 discard warmups, and assert median/p95 against the ceilings in
 `src/testing/perf/budgets.ts`.
 
+> **They do not gate pull requests — owner ruling, 2026-08-30.** `test` no longer
+> chains `test:perf`, and that chain was the only path by which
+> `nx affected -t test` reached this suite. The tests and every ceiling are
+> unchanged, and still enforced for anyone who runs `bun run test:perf`.
+>
+> **This reaches further than PR CI, and that is worth naming.** `push.yml` and
+> `tag.yml` — the post-merge and release runs — invoke the same `bun run test`
+> (via the root `lerna run test`), so unchaining it takes the budgets off those
+> too. The ruling was about pull requests; the mechanism does not distinguish,
+> because that one script chain is the only thing any workflow calls. Confining
+> it to PRs alone would mean minting a second test target across every package
+> and pointing `pr.yml` at it — a far larger change than the ruling asked for.
+> The release path is the obvious candidate for open question (1) below.
+>
+> The ruling followed a re-derivation that did not converge. Two ceilings went
+> red on GitHub-hosted runners while measuring green on the reference box, and
+> raising one of them moved the failure from the budget to vitest's per-test
+> timeout rather than clearing it — 15 spawns at ~800 ms against a 5 s limit.
+> Chasing a contract that does not hold on the machine enforcing it, one
+> constant at a time, is not a derivation.
+>
+> **Two questions are deliberately left open**, neither answered here:
+>
+> 1. **Where perf runs instead** — a scheduled job, a release gate, or a
+>    maintainer's run before a release. Nothing runs it automatically today.
+> 2. **Whether `BUDGET_WARM_STORE_MS` reverts to its reference-box value.** It
+>    was raised for a runner class that no longer gates anything.
+>
+> Until (1) is answered, a performance regression reaches `main` unobserved.
+> That is the accepted cost of the ruling, written down so it stays a decision
+> rather than becoming an accident.
+
 ## Designed targets (surface covenant)
 
 | Path                         | Designed target |

--- a/packages/cli/pragma/package.json
+++ b/packages/cli/pragma/package.json
@@ -46,7 +46,7 @@
     "check:biome": "biome check",
     "check:biome:fix": "biome check --write",
     "check:ts": "tsc --noEmit",
-    "test": "bun run test:vitest && bun run test:perf",
+    "test": "bun run test:vitest",
     "test:vitest": "vitest run --coverage",
     "test:perf": "vitest run --config vitest.perf.config.ts",
     "test:watch": "vitest",

--- a/packages/cli/pragma/vitest.perf.config.ts
+++ b/packages/cli/pragma/vitest.perf.config.ts
@@ -14,9 +14,13 @@ import { defineConfig } from "vitest/config";
  *
  * So this pass runs the perf tests ALONE, serially, in a single fork, with NO
  * coverage instrumentation — the only way spawn-latency budgets measure the
- * binary rather than the test runner. The ceilings themselves are unchanged and
- * still ENFORCED here; they are simply enforced in isolation. Invoked by the
- * `test:perf` script (and chained into `test`); excluded from `test:vitest`.
+ * binary rather than the test runner. The ceilings themselves are unchanged.
+ *
+ * NOT RUN BY CI, by owner ruling 2026-08-30. `test` no longer chains this pass,
+ * which is how `nx affected -t test` used to reach it, so nothing here gates a
+ * pull request. It stays enforced for anyone who runs `bun run test:perf`, and
+ * the ceilings are untouched. The reasoning, the measurements that forced the
+ * ruling, and the two questions it deliberately left open are in BUDGETS.md.
  */
 export default defineConfig({
   test: {


### PR DESCRIPTION
Implements the owner ruling of 2026-08-30: **performance gates come off PR CI.** No replacement home is chosen and no ceiling is changed — both are deliberately follow-ups, not part of this unit.

## The change

`test` no longer chains `test:perf`. That chain was the only path by which `nx affected -t test` reached the suite, so nothing here gates a pull request any more. The tests, both vitest configs and every ceiling are untouched; `bun run test:perf` still enforces them for anyone who runs it.

## Why

The budgets do not hold on GitHub-hosted runners. Two ceilings went red there while measuring green on the reference box, and raising one of them moved the failure from the budget to vitest's 5 s per-test timeout — 15 spawns at ~800 ms — rather than clearing it. Chasing a contract that does not hold on the machine enforcing it, one constant at a time, is not a derivation.

## It reaches further than PR CI

Named rather than glossed: `push.yml` and `tag.yml` invoke the same `bun run test` through the root `lerna run test`, so the post-merge and release runs lose the budgets too. Confining this to pull requests alone would mean minting a second test target across every package and repointing `pr.yml` at it — a far larger change than the ruling asked for. The release path is the obvious candidate when the follow-up picks a new home.

## Carried, not dropped

Both open questions are recorded at the top of `BUDGETS.md`, where the next person to touch a budget will meet them:

1. **Where perf runs instead** — scheduled job, release gate, or a maintainer's run. Nothing runs it automatically today.
2. **Whether `BUDGET_WARM_STORE_MS` reverts to its reference-box value**, having been raised for a runner class that no longer gates anything.

Until (1) is answered, a performance regression reaches `main` unobserved. That is the accepted cost, written down so it stays a decision rather than becoming an accident.

## Verified

- `bun run test` → **123 files / 1101 tests green**, with `src/testing/perf/**` excluded and no perf pass in the run.
- `bun run test:perf` still runs the suite standalone.

## Note on durability

This lands on `feat/prism-docsite`. The reconciliation with `main` takes main's side for `packages/cli/pragma` wholesale, so the same change is opened separately against `main`; if that one has not landed by reconciliation time, this must be re-applied on top.