### PR TITLE
feat(ke-graphql)!: a namespace-prefix collision is an error, not a warning

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/compiler/build.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.test.ts
@@ -962,11 +962,13 @@ describe("build — effective prefix injectivity", () => {
     expect(a001[0]?.message).toContain("graphql:prefix");
   });
 
-  it("warns instead of refusing when NO declaration is in play (B005)", () => {
+  it("refuses, without blaming annotations, when NO declaration is in play (B005)", () => {
     // Reachable with zero annotations: registering the prefix "ns" collides
     // with the first serial synthetic. Calling that an ANNOTATION conflict
-    // sent operators hunting for assertions that do not exist, and refusing
-    // the compile rejected input that compiled before the vocabulary landed.
+    // would send operators hunting for assertions that do not exist, so the
+    // code and the remedy stay distinct from A001's — but the SEVERITY is the
+    // same, per the owner ruling of 2026-08-30. A non-injective namespace map
+    // silently drops a claimant, which is exactly what R-4 forbids.
     const { diagnostics } = build(
       makeExtraction({
         classes: [
@@ -982,7 +984,7 @@ describe("build — effective prefix injectivity", () => {
     expect(diagnostics.filter((d) => d.code === "A001")).toEqual([]);
     const b005 = diagnostics.filter((d) => d.code === "B005");
     expect(b005).toHaveLength(1);
-    expect(b005[0]?.severity).toBe("warning");
+    expect(b005[0]?.severity).toBe("error");
     expect(b005[0]?.source).toBe("ns");
     expect(b005[0]?.message).toContain("StoreConfig.prefixes");
     expect(b005[0]?.message).not.toContain("graphql:prefix");

--- a/packages/runtime/ke-graphql/src/lib/compiler/build.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/build.ts
@@ -168,9 +168,19 @@ export default function build(
   // A collision among registered and serial synthetic prefixes needs no
   // annotation at all — registering the prefix "ns" is enough — so calling it
   // an ANNOTATION conflict would send an operator hunting for graphql:
-  // assertions that do not exist, and refusing the compile would reject input
-  // that compiled before the vocabulary landed. That case is B005: a warning
-  // naming the registration remedy.
+  // assertions that do not exist. That case is B005, which names the
+  // registration remedy instead.
+  //
+  // B005 IS AN ERROR, by owner ruling 2026-08-30, and was a warning until
+  // then. The warning existed to avoid rejecting input that compiled before
+  // the vocabulary landed — a real cost, and the ruling accepts it, because
+  // the alternative is worse: the namespace→prefix map is keyed by prefix, so
+  // a surviving warning means one claimant silently overwrites the other,
+  // `ontologies` omits it, and `toFull()` resolves the shared prefix to
+  // whichever won. That is R-4's rule — a collision is an error, never a
+  // silent rename — reaching the one place it had not yet been applied. The
+  // remedy is one line of `StoreConfig.prefixes`, which is why the migration
+  // cost was judged payable rather than deferred again.
   const namespacesByPrefix = new Map<string, string[]>();
   for (const [ns, prefix] of effectiveNamespaces) {
     const list = namespacesByPrefix.get(prefix) ?? [];
@@ -195,7 +205,7 @@ export default function build(
             phase: PHASE,
           }
         : {
-            severity: "warning",
+            severity: "error",
             code: "B005",
             message: `${shared}; register a distinct prefix for each in StoreConfig.prefixes`,
             source: prefix,


### PR DESCRIPTION
Implements the owner ruling of 2026-08-30 on **B005**.

## What changes

`B005` — two namespaces claiming one prefix, with no `graphql:prefix` declaration in play — moves from **warning** to **error**, and is therefore fatal on ke-graphql under R-4's escalation.

## Why the warning existed, and why it loses

The warning was not an oversight. It protected two things:

1. **Not blaming annotations.** The collision needs no annotation to construct — registering the prefix `ns` twice is enough — so reporting it as `A001` would send an operator hunting for `graphql:` assertions that do not exist. **This half survives.** B005 keeps its own code and its own remedy, naming `StoreConfig.prefixes`.
2. **Not rejecting input that compiled before the vocabulary landed.** **This half is overruled**, knowingly. It is a migration cost, and the ruling accepts it.

What tips the balance is what the warning actually permits: the namespace→prefix map is **keyed by prefix**, so a surviving warning means one claimant silently overwrites the other, `ontologies` omits it, and `toFull()` resolves the shared prefix to whichever won. The compile then succeeds and hands out a schema that is quietly wrong about which namespace a term belongs to.

That is precisely what **R-4** forbids — *a collision is an error, never a silent rename* — reaching the one place it had not yet been applied. And the remedy is one line of configuration, which is why the migration cost was judged payable rather than deferred a second time.

## Tests

The test that pinned *"warns instead of refusing"* is **inverted, not deleted**, so the behaviour stays pinned in both directions. The sibling test that exercises the guard under `mode: "auto"` — the mode that resolves no overlay at all, and therefore the one that most needs the guard — is unchanged and still passes.

**ke-graphql: 40 files / 589 tests green.**

## Watch item for review

This makes a previously-tolerated corpus state fatal. `pragma.conf.ts` notes that the design system declares `ds:` twice — once for `definitions/` and once for `data/` — and that harvesting is last-wins with the config layer pinning the result. If any real pack combination reaches the compiler with two namespaces on one prefix, this change turns that from a warning into a refused build. I could not exercise the full three-pack corpus here (the embedded-pack regeneration is blocked on an unrelated npm pin, see #953), so that is the one thing worth a reviewer's eye rather than my assurance.