### PR TITLE
fix(router-react): render route content and wrappers as their own fibers

### DIFF
--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -427,7 +427,9 @@ hydrateRoot(
 
 ### `Outlet`
 
-`Outlet` subscribes to router state, calls `router.render()`, and wraps the matched subtree in `Suspense`.
+`Outlet` subscribes to router state, builds the matched subtree with `createElement`, and wraps it in `Suspense`.
+
+It does **not** call `router.render()`. Core `render()` invokes the route's content and each wrapper as plain functions, which gives them no fiber of their own — every hook they declare would attach to `Outlet`'s hook list, and navigating between routes whose components declare different numbers of hooks would throw *"Rendered fewer hooks than expected"*. Constructing elements instead gives each component its own fiber, so its hooks belong to it. `render()` remains the correct shape for a non-React consumer.
 
 ```tsx
 <Outlet fallback={<p>Loading route…</p>} />

--- a/packages/react/router/src/lib/Outlet/Outlet.test.tsx
+++ b/packages/react/router/src/lib/Outlet/Outlet.test.tsx
@@ -1,10 +1,15 @@
+import type { WrapperComponentProps } from "@canonical/router-core";
 import {
   createMemoryAdapter,
   createRouter,
   route,
+  wrapper,
 } from "@canonical/router-core";
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import type { ReactElement, ReactNode } from "react";
+import { createElement, useEffect, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RouterProvider from "../RouterProvider/Provider.js";
 import Outlet from "./Outlet.js";
 
@@ -91,5 +96,241 @@ describe("Outlet", () => {
     // No load has been called and the URL doesn't match, so Outlet is empty.
     expect(screen.queryByText("page")).toBeNull();
     expect(container).toBeTruthy();
+  });
+});
+
+describe("Outlet hook ownership (AV-340)", () => {
+  // Bare function components with intentionally different hook counts. Route
+  // content and wrapper components must each get their own fiber; hooks they
+  // call must never attach to Outlet's fiber.
+  let manyHooksMounts = 0;
+
+  function ManyHooksPage(): ReactElement {
+    const [label] = useState(() => {
+      manyHooksMounts += 1;
+
+      return `many-hooks-mount-${manyHooksMounts}`;
+    });
+    const renderCount = useRef(0);
+
+    useEffect(() => {
+      // Present purely to give this component a third hook.
+    }, []);
+
+    renderCount.current += 1;
+
+    return <span>{label}</span>;
+  }
+
+  function FewHooksPage(): ReactElement {
+    const [label] = useState("few-hooks");
+
+    return <span>{label}</span>;
+  }
+
+  const hookRoutes = {
+    many: route({ url: "/", content: ManyHooksPage }),
+    few: route({ url: "/few", content: FewHooksPage }),
+  };
+
+  let hadActFlag: boolean;
+  let previousActFlag: unknown;
+
+  beforeEach(() => {
+    manyHooksMounts = 0;
+
+    const actGlobal = globalThis as { IS_REACT_ACT_ENVIRONMENT?: unknown };
+
+    hadActFlag = "IS_REACT_ACT_ENVIRONMENT" in actGlobal;
+    previousActFlag = actGlobal.IS_REACT_ACT_ENVIRONMENT;
+    actGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    const actGlobal = globalThis as { IS_REACT_ACT_ENVIRONMENT?: unknown };
+
+    if (hadActFlag) {
+      actGlobal.IS_REACT_ACT_ENVIRONMENT = previousActFlag;
+    } else {
+      delete actGlobal.IS_REACT_ACT_ENVIRONMENT;
+    }
+  });
+
+  it("navigates between bare-component routes with different hook counts", async () => {
+    const router = createRouter(hookRoutes, {
+      adapter: createMemoryAdapter("/"),
+    });
+    // A raw root with an `onUncaughtError` spy: React 19 reports uncaught
+    // render errors (such as "Rendered fewer hooks than expected") there
+    // instead of rethrowing, so a console/error-boundary-free assertion needs
+    // the root option.
+    const onUncaughtError = vi.fn();
+    const container = document.createElement("div");
+
+    document.body.appendChild(container);
+
+    const root = createRoot(container, { onUncaughtError });
+
+    await act(async () => {
+      root.render(
+        <RouterProvider router={router}>
+          <Outlet />
+        </RouterProvider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("many-hooks-mount-1");
+    });
+
+    // More hooks -> fewer hooks: the direction React 19 throws on.
+    await act(async () => {
+      await router.navigate("few");
+    });
+
+    expect(onUncaughtError.mock.calls.map((call) => String(call[0]))).toEqual(
+      [],
+    );
+    expect(container.textContent).toContain("few-hooks");
+
+    // And back: fewer -> more.
+    await act(async () => {
+      await router.navigate("many");
+    });
+
+    expect(onUncaughtError.mock.calls.map((call) => String(call[0]))).toEqual(
+      [],
+    );
+    expect(container.textContent).toContain("many-hooks");
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("supports hooks in wrapper components across navigation", async () => {
+    function StatefulShell({
+      children,
+    }: WrapperComponentProps<ReactNode>): ReactElement {
+      const [shellId] = useState("stateful-shell");
+
+      return <div data-testid={shellId}>{children}</div>;
+    }
+
+    const shell = wrapper<ReactNode>({
+      id: "shell",
+      component: StatefulShell,
+    });
+    const wrappedRoutes = {
+      many: route({
+        url: "/",
+        content: ManyHooksPage,
+        wrappers: [shell] as const,
+      }),
+      few: route({
+        url: "/few",
+        content: FewHooksPage,
+        wrappers: [shell] as const,
+      }),
+    };
+    const router = createRouter(wrappedRoutes, {
+      adapter: createMemoryAdapter("/"),
+    });
+
+    render(
+      <RouterProvider router={router}>
+        <Outlet />
+      </RouterProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stateful-shell")).toBeTruthy();
+      expect(screen.getByText("many-hooks-mount-1")).toBeTruthy();
+    });
+
+    await act(async () => {
+      await router.navigate("few");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stateful-shell")).toBeTruthy();
+      expect(screen.getByText("few-hooks")).toBeTruthy();
+    });
+  });
+
+  it("renders element-creating arrow content identically to bare components", async () => {
+    function GreetingPage({
+      params,
+    }: {
+      readonly params: { readonly name: string };
+    }): ReactElement {
+      return <span>hello-{params.name}</span>;
+    }
+
+    const mixedRoutes = {
+      bare: route({ url: "/bare/:name", content: GreetingPage }),
+      arrow: route({
+        url: "/arrow/:name",
+        content: (props) =>
+          createElement(GreetingPage, { params: props.params }),
+      }),
+    };
+    const router = createRouter(mixedRoutes, {
+      adapter: createMemoryAdapter("/bare/world"),
+    });
+
+    render(
+      <RouterProvider router={router}>
+        <Outlet />
+      </RouterProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("hello-world")).toBeTruthy();
+    });
+
+    await act(async () => {
+      await router.navigate("arrow", { params: { name: "world" } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("hello-world")).toBeTruthy();
+    });
+  });
+
+  it("remounts route content with fresh hook state when navigating away and back", async () => {
+    const router = createRouter(hookRoutes, {
+      adapter: createMemoryAdapter("/"),
+    });
+
+    render(
+      <RouterProvider router={router}>
+        <Outlet />
+      </RouterProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("many-hooks-mount-1")).toBeTruthy();
+    });
+
+    await act(async () => {
+      await router.navigate("few");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("few-hooks")).toBeTruthy();
+    });
+
+    await act(async () => {
+      await router.navigate("many");
+    });
+
+    // The rendered content is keyed by route name, so returning to the route
+    // remounts its content with fresh hook state (a second useState
+    // initializer run), rather than reusing the previous state.
+    await waitFor(() => {
+      expect(screen.getByText("many-hooks-mount-2")).toBeTruthy();
+    });
   });
 });

--- a/packages/react/router/src/lib/Outlet/Outlet.test.tsx
+++ b/packages/react/router/src/lib/Outlet/Outlet.test.tsx
@@ -210,53 +210,119 @@ describe("Outlet hook ownership (AV-340)", () => {
   });
 
   it("supports hooks in wrapper components across navigation", async () => {
-    function StatefulShell({
+    // The PAGES here declare NO hooks, deliberately.
+    //
+    // An earlier version of this test wrapped ManyHooksPage and FewHooksPage
+    // in a SINGLE one-hook shell, so the hook-count difference came from the
+    // PAGES. That version would have passed with wrappers reverted to direct
+    // calls: Outlet would have owned exactly one wrapper hook on both routes,
+    // and the difference React saw would have been the page half — already
+    // covered by the test above. The wrapper half was unguarded.
+    //
+    // Here the pages contribute nothing and the SHELLS differ in hook count,
+    // so any change in Outlet's own hook list is attributable to the wrappers
+    // alone. Outlet is not keyed (only the Suspense inside it is), so its
+    // fiber survives navigation — which is precisely why hooks attributed to
+    // it, rather than to the wrapper's own fiber, break on the next render.
+    function HookFreePage(): ReactElement {
+      return <span>page</span>;
+    }
+
+    function ManyHooksShell({
       children,
     }: WrapperComponentProps<ReactNode>): ReactElement {
-      const [shellId] = useState("stateful-shell");
+      const [shellId] = useState("many-hooks-shell");
+      const renderCount = useRef(0);
+
+      useEffect(() => {
+        // Present only to give this shell a third hook.
+      }, []);
+
+      renderCount.current += 1;
 
       return <div data-testid={shellId}>{children}</div>;
     }
 
-    const shell = wrapper<ReactNode>({
-      id: "shell",
-      component: StatefulShell,
+    function FewHooksShell({
+      children,
+    }: WrapperComponentProps<ReactNode>): ReactElement {
+      const [shellId] = useState("few-hooks-shell");
+
+      return <div data-testid={shellId}>{children}</div>;
+    }
+
+    const manyShell = wrapper<ReactNode>({
+      id: "many-shell",
+      component: ManyHooksShell,
+    });
+    const fewShell = wrapper<ReactNode>({
+      id: "few-shell",
+      component: FewHooksShell,
     });
     const wrappedRoutes = {
       many: route({
         url: "/",
-        content: ManyHooksPage,
-        wrappers: [shell] as const,
+        content: HookFreePage,
+        wrappers: [manyShell] as const,
       }),
       few: route({
         url: "/few",
-        content: FewHooksPage,
-        wrappers: [shell] as const,
+        content: HookFreePage,
+        wrappers: [fewShell] as const,
       }),
     };
     const router = createRouter(wrappedRoutes, {
       adapter: createMemoryAdapter("/"),
     });
+    const onUncaughtError = vi.fn();
+    const container = document.createElement("div");
 
-    render(
-      <RouterProvider router={router}>
-        <Outlet />
-      </RouterProvider>,
-    );
+    document.body.appendChild(container);
 
-    await waitFor(() => {
-      expect(screen.getByTestId("stateful-shell")).toBeTruthy();
-      expect(screen.getByText("many-hooks-mount-1")).toBeTruthy();
+    const root = createRoot(container, { onUncaughtError });
+
+    await act(async () => {
+      root.render(
+        <RouterProvider router={router}>
+          <Outlet />
+        </RouterProvider>,
+      );
     });
 
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="many-hooks-shell"]'),
+      ).toBeTruthy();
+    });
+
+    // Three wrapper hooks -> one: the direction React 19 throws on.
     await act(async () => {
       await router.navigate("few");
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId("stateful-shell")).toBeTruthy();
-      expect(screen.getByText("few-hooks")).toBeTruthy();
+    expect(onUncaughtError.mock.calls.map((call) => String(call[0]))).toEqual(
+      [],
+    );
+    expect(
+      container.querySelector('[data-testid="few-hooks-shell"]'),
+    ).toBeTruthy();
+
+    // And back: one -> three.
+    await act(async () => {
+      await router.navigate("many");
     });
+
+    expect(onUncaughtError.mock.calls.map((call) => String(call[0]))).toEqual(
+      [],
+    );
+    expect(
+      container.querySelector('[data-testid="many-hooks-shell"]'),
+    ).toBeTruthy();
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
   });
 
   it("renders element-creating arrow content identically to bare components", async () => {

--- a/packages/react/router/src/lib/Outlet/Outlet.tsx
+++ b/packages/react/router/src/lib/Outlet/Outlet.tsx
@@ -1,5 +1,11 @@
-import type { ReactElement, ReactNode } from "react";
-import { Suspense, useCallback, useRef, useSyncExternalStore } from "react";
+import type { ComponentType, ReactElement, ReactNode } from "react";
+import {
+  createElement,
+  Suspense,
+  useCallback,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import useRouter from "../hooks/useRouter.js";
 import type { OutletProps } from "./types.js";
 
@@ -49,7 +55,39 @@ export default function Outlet({ fallback = null }: OutletProps): ReactElement {
     match && "name" in match && typeof match.name === "string"
       ? match.name
       : undefined;
-  const rendered = router.render() as ReactNode;
+  // Build ELEMENTS instead of calling `router.render()`.
+  //
+  // Core's `render()` INVOKES the route's component and its wrappers as
+  // plain functions — `content({ params, search })`, `wrapper.component({
+  // children })` — so any hooks they declare run inside THIS component's
+  // hook list. Navigating between two routes whose components use different
+  // numbers of hooks then throws "Rendered fewer hooks than expected",
+  // because React sees Outlet's own hook count change between renders.
+  //
+  // `createElement` gives each component its own fiber, so its hooks belong
+  // to it. Core's `render()` is left alone: it is the correct shape for a
+  // non-React consumer, and this is a React-layer concern.
+  let rendered: ReactNode = null;
+
+  if (match && "route" in match && match.route.content) {
+    const contentElement = createElement(
+      match.route.content as ComponentType<{
+        readonly params: unknown;
+        readonly search: unknown;
+      }>,
+      { params: match.params, search: match.search },
+    );
+
+    rendered = (
+      match.route.wrappers as readonly {
+        readonly component: ComponentType<{ readonly children: ReactNode }>;
+      }[]
+    ).reduceRight<ReactNode>(
+      (children, currentWrapper) =>
+        createElement(currentWrapper.component, null, children),
+      contentElement,
+    );
+  }
 
   return (
     <Suspense key={routeKey} fallback={fallback}>


### PR DESCRIPTION
## Done

Navigating between two routes whose components declare **different numbers of hooks** throws:

```
Rendered fewer hooks than expected. This may be caused by an accidental early return statement.
```

There is no early return. `packages/runtime/router/src/lib/createRouter.ts:1579-1589` **invokes** a route's UI as a plain function:

```ts
currentRoute.content({ params, search })      // called, not createElement'd
currentWrapper.component({ children })         // same for every wrapper
```

and `Outlet` rendered that return value directly. **A function component that is called rather than instantiated does not get a fiber**, so every hook it declares attaches to the *caller's* hook list — `Outlet`'s. React then sees Outlet's own hook count change between renders, and refuses.

`Outlet` now builds elements with `createElement`, so each route component and each wrapper owns the hooks it declares.

**Core's `render()` is deliberately left alone.** Calling the content is a reasonable shape for a non-React consumer, and hook ownership is a React-layer concern; changing core would break its contract for no benefit to the bug.

### The guard this repo did not have

`Outlet.test.tsx` carried three tests, **none about hook ownership** — which is how a crash on ordinary navigation sits in `main` unnoticed. This adds `Outlet hook ownership (AV-340)`: bare components, wrapper components, and remount-with-fresh-state.

## QA

**Verified by reintroducing the defect, not by watching it pass.**

| | result |
|---|---|
| `Outlet.tsx` reverted to main's version | **3 of 7 fail**, each with `Rendered fewer hooks than expected` |
| with this change | **7 of 7 pass** |
| `packages/react/router` full suite | 13 files / 38 tests green |
| root `bun run check` | green across **62 projects** |
| router dependents (`react-ds-global`, `react-ds-app`, `react-boilerplate-vite`, `storybook-addon-utils`) | green — 349, 293, 90, 51 tests |

A gate never seen failing is indistinguishable from one that passes vacuously, so the first row is the one that matters.

### How it was found

While reconciling `feat/prism-docsite` onto main's router. That branch had fixed this; `main` never received the fix. The app's own integration test (`clientNavigation.tests.tsx`) catches it on every run.

> Note on the root `test` gate: it reported failures in `react-ds-app`, `react-ds-app-launchpad` and `react-ds-global-form`, and **nx labels all three flaky** — they pass on re-run, and the root invocation itself exited 130 (interrupted). Re-ran every reported package individually; all green.

### PR readiness check

- [x] PR has a label: `Bug 🐛`
- [x] PR title follows Conventional Commits
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts
- [x] No new package
- [x] `no visual change` — hook ownership only; rendered output is identical

https://claude.ai/code/session_017kMyeg9h6sBs7FsKyofJ4e