### PR TITLE
fix(storybook-addon-utils): render the story inside the router provider, not into its children

### DIFF
--- a/data/svelte-ds-global/implementationObjects.ttl
+++ b/data/svelte-ds-global/implementationObjects.ttl
@@ -8,7 +8,7 @@ ds:implementation.svelte-ds-global.global.component.announcement a ds:Implementa
     ds:implementsBlock ds:global.component.announcement;
     ds:headLink "https://github.com/canonical/pragma/blob/main/packages/svelte/ds-global/src/lib/_work_in_progress/Announcement/Announcement.svelte";
     ds:importStatement "import { Announcement } from \"@canonical/svelte-ds-global\";";
-    ds:versionedLink "https://github.com/canonical/pragma/blob/v0.35.0/packages/svelte/ds-global/src/lib/_work_in_progress/Announcement/Announcement.svelte".
+    ds:versionedLink "https://github.com/canonical/pragma/blob/v0.36.0/packages/svelte/ds-global/src/lib/_work_in_progress/Announcement/Announcement.svelte".
 ds:implementation.svelte-ds-global.global.component.breadcrumbs a ds:ImplementationObject;
     ds:implementsBlock ds:global.component.breadcrumbs;
     ds:headLink "https://github.com/canonical/pragma/blob/main/packages/svelte/ds-global/src/lib/component/Breadcrumbs/Breadcrumbs.svelte";

--- a/packages/react/ds-app/src/storybook/router/RouterInstance.tests.tsx
+++ b/packages/react/ds-app/src/storybook/router/RouterInstance.tests.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "@canonical/router-react";
+import { useRoute, useRouter } from "@canonical/router-react";
 import { withHashRouter } from "@canonical/storybook-addon-utils";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -22,10 +22,34 @@ const RouterProbe = (): ReactNode => {
   return <p data-testid="router-probe">{typeof router.navigate}</p>;
 };
 
+/**
+ * A story whose `render` calls a router hook *itself*, rather than delegating
+ * to a child component — the shape ds-global's Tabs `WithRouterLink` story
+ * uses to derive `currentUrl` from the live route.
+ */
+const routeProbeStory = (): ReactNode => {
+  const { pathname } = useRoute();
+  return <p data-testid="route-probe">{pathname}</p>;
+};
+
 describe("withHashRouter (addon-utils)", () => {
   it("resolves the same router-react instance as its consumer", () => {
     render(withHashRouter()(() => <RouterProbe />));
 
     expect(screen.getByTestId("router-probe")).toHaveTextContent("function");
+  });
+
+  it("provides the router to hooks called in the story function itself", () => {
+    // Storybook invokes the decorator during the story's render pass, so the
+    // decorator is exercised the same way here. If the decorator calls the
+    // story into the provider's JSX children instead of rendering it as a
+    // component, the story's hooks run before React descends into
+    // `RouterProvider` and `useRoute()` throws.
+    const DecoratedStory = (): ReactNode =>
+      withHashRouter()(routeProbeStory) as ReactNode;
+
+    render(<DecoratedStory />);
+
+    expect(screen.getByTestId("route-probe")).toBeInTheDocument();
   });
 });

--- a/packages/storybook/addon-utils/src/withHashRouter.tsx
+++ b/packages/storybook/addon-utils/src/withHashRouter.tsx
@@ -5,6 +5,7 @@ import {
   route,
 } from "@canonical/router-core";
 import { RouterProvider } from "@canonical/router-react";
+import { type ReactNode, useState } from "react";
 import type {
   Renderer,
   StoryContext,
@@ -29,6 +30,52 @@ export interface WithHashRouterOptions {
   readonly routes?: RouteMap;
 }
 
+interface StoryProps {
+  readonly StoryFn: StoryFunction<Renderer>;
+}
+
+/**
+ * Invokes the story from inside a component, so it renders as its own fiber.
+ *
+ * `{StoryFn()}` placed in the provider's JSX children runs the story's `render`
+ * body during the *parent's* render pass, before React descends into
+ * `RouterProvider`. A `useRoute()` called directly in a story's `render` then
+ * reads the context above the provider — empty — and throws "RouterProvider is
+ * required to use router-react hooks." Under `<Story />` the call happens
+ * inside the provider's subtree, and the story owns the hooks it declares
+ * rather than appending them to the decorator's list.
+ *
+ * Declared at module scope, not inside the decorator: a component type
+ * recreated per render would remount the story on every navigation.
+ */
+const Story = ({ StoryFn }: StoryProps): ReactNode => StoryFn() as ReactNode;
+
+interface HashRouterStoryProps extends StoryProps {
+  readonly routes: RouteMap;
+}
+
+/**
+ * Owns the router instance for one mounted story.
+ *
+ * Held in state so there is one router per mount rather than one per render:
+ * navigating rerenders the story, and a router rebuilt each time would drop the
+ * hash subscription and reset the location the story just navigated to.
+ */
+const HashRouterStory = ({
+  routes,
+  StoryFn,
+}: HashRouterStoryProps): ReactNode => {
+  const [router] = useState(() =>
+    createRouter(routes, { adapter: createHashAdapter() }),
+  );
+
+  return (
+    <RouterProvider router={router}>
+      <Story StoryFn={StoryFn} />
+    </RouterProvider>
+  );
+};
+
 /**
  * Storybook decorator that wraps a story in a hash-based router context
  * (`@canonical/router-react`). A hash router is used because the Storybook
@@ -42,9 +89,10 @@ export interface WithHashRouterOptions {
  * function stays required), so it doubles as a plain "wrap this subtree in a
  * hash router" helper for decorators that need to render something extra
  * *inside* the provider (an `<Outlet />`, a `useRoute()` bridge) without
- * fabricating a `StoryContext`. That keeps `createRouter` +
- * `createHashAdapter` + `RouterProvider` owned here instead of being
- * hand-rolled per call site.
+ * fabricating a `StoryContext`. It returns an element and calls no hooks of its
+ * own, so it is also safe to invoke outside a React render — as the headless
+ * probe in ds-app does. That keeps `createRouter` + `createHashAdapter` +
+ * `RouterProvider` owned here instead of being hand-rolled per call site.
  *
  * @example
  * const meta = {
@@ -64,7 +112,6 @@ export interface WithHashRouterOptions {
  */
 export const withHashRouter =
   ({ routes = defaultRoutes }: WithHashRouterOptions = {}) =>
-  (StoryFn: StoryFunction<Renderer>, _context?: StoryContext<Renderer>) => {
-    const router = createRouter(routes, { adapter: createHashAdapter() });
-    return <RouterProvider router={router}>{StoryFn()}</RouterProvider>;
-  };
+  (StoryFn: StoryFunction<Renderer>, _context?: StoryContext<Renderer>) => (
+    <HashRouterStory routes={routes} StoryFn={StoryFn} />
+  );


### PR DESCRIPTION
## The failure

ds-global's Chromatic build fails to render Tabs' `WithRouterLink` story, which blocks any PR that touches ds-global — #1039 (Modal) among them:

```
Error: RouterProvider is required to use router-react hooks.
    at u (.../assets/Tabs.stories-2cF6Nerx.js:1:311)
```

## The cause

`withHashRouter` called the story into the provider's JSX children:

```tsx
<RouterProvider router={router}>{StoryFn()}</RouterProvider>
```

Children are evaluated before React descends into the provider, so `StoryFn()` runs the story's `render` body while the context *above* the provider — empty — is still the one in scope. A `useRoute()` written directly in a story's `render` therefore throws. It also appends the story's hooks to the decorator's hook list rather than the story's: the same fiber-ownership problem #1073 fixes in `Outlet`.

Tabs' `WithRouterLink` is exactly that shape:

```tsx
export const WithRouterLink: Story = {
  decorators: [withHashRouter],
  render: (args) => {
    const { pathname } = useRoute();   // ← hook in the story's own render
    return <Component {...args} currentUrl={pathname} LinkComponent={HashLink} />;
  },
};
```

Regression from #996, which replaced Tabs' local decorator with this shared one. The local one rendered `<Story />` correctly:

```tsx
// pre-#996, ds-global/src/storybook/tabs/story-utils.tsx
export const withHashRouter: Decorator = (Story) => (
  <RouterProvider router={router}><Story /></RouterProvider>
);
```

ds-app's `withNavigationRouterProps` escaped it only because it wraps `useRoute()` in an inner bridge component. Tabs is the one story calling the hook in `render` itself.

## The fix

The story is rendered as `<Story StoryFn={StoryFn} />` — a component declared at module scope, since a type rebuilt per render would remount the story on every navigation — so the call happens inside the provider's subtree and the story owns the hooks it declares.

While here, the router moves into `useState` so there is one per mount rather than one per render: navigating rerenders the story, and a router rebuilt each time would drop the hash subscription and reset the location the story just navigated to. It lives in a component rather than the decorator body, so the decorator still calls no hooks of its own and stays safe to invoke outside a React render, as ds-app's headless probe does.

## The gate

`RouterInstance.tests.tsx`'s existing probe passed straight through the bug — it returns `<RouterProbe />`, an element, which always gets its own fiber. It gains a sibling that calls the hook in the story function itself, the shape Tabs uses. Against the previous decorator it fails with the reported message:

```
Error: RouterProvider is required to use router-react hooks.
 ❯ useRouter ../router/src/lib/hooks/useRouter.ts:20:11
 ❯ routeProbeStory .../RouterInstance.tests.tsx:31:24
 ❯ ../../storybook/addon-utils/src/withHashRouter.tsx:69:45
```

That test runs in the default `bun run test` gate on every PR, which is what ds-app's headless twin exists for: ds-global's Chromatic workflow would not fire on a change to addon-utils alone.

## Checks

- `addon-utils`: biome + tsc pass
- `ds-app`: biome + tsc + webarchitect pass, 52 tests pass
- `ds-global`: Tabs, 14 tests pass

Note for local testing: ds-app consumes addon-utils through its built `dist`, so `bun run build` in `packages/storybook/addon-utils` is needed before the test reflects a source change. CI builds fresh.

https://claude.ai/code/session_01TqaQvKCqCSpvQcmfAoaPw9
