### PR TITLE
chore(renovate): require an impact review on every major bump

### DIFF
--- a/configs/renovate/default.json
+++ b/configs/renovate/default.json
@@ -68,6 +68,19 @@
         "renovate"
       ],
       "addLabels": ["no visual change"]
+    },
+    {
+      "description": "Majors carry an impact review: the generated body is often truncated, and PR CI rarely exercises the release path, so the breaking surface has to be triaged by hand",
+      "matchUpdateTypes": ["major"],
+      "prBodyNotes": [
+        "### Impact review",
+        "A major is not merged on green CI alone. Before approving:",
+        "- [ ] **Breaking entries triaged against this repo** — most upstream ⚠️ entries target plugins or entry points a given repo does not use. Name the ones that actually apply.",
+        "- [ ] **Release and publish path assessed** — PR CI usually does not run tag/release workflows, so changes to versioning, changelog generation or publishing are unexercised here.",
+        "- [ ] **Node and engines floor still satisfied** — including any range a package declares for itself.",
+        "- [ ] **Toolchain coupling checked** — lockfile format, package manager and peer ranges that other tools parse.",
+        "> If this body was truncated, the upstream release notes for the major are **not** shown above. Read them at the source before ticking."
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Done

- Added a `packageRules` entry to `configs/renovate/default.json` attaching an impact-review checklist to the body of every **major** dependency PR, via [`prBodyNotes`](https://docs.renovatebot.com/configuration-options/#prbodynotes) scoped by `matchUpdateTypes: ["major"]`.

**Why.** A major bump arrives as a green PR whose body is a version table and a wall of upstream changelog. Neither says what the bump means for the repo receiving it, and two structural gaps make that worse:

- **The body gets truncated.** #957 (lerna 9→10, nx 22→23) lost nx's entire `23.0.0` section to GitHub's size limit — every ⚠️ breaking entry in the bump was absent from the PR describing it. You cannot review what is not shown.
- **PR CI does not cover the release path.** `tag.yml` runs only on a tag, so `lerna version`, `lerna publish` and changelog generation are never exercised by the checks that turn a dependency PR green. lerna 10 converts a stale remote in CI mode into a hard error ([lerna#4369](https://github.com/lerna/lerna/pull/4369)) — nothing in a green PR would have said so, on a release path that already produced a 53/55 split publish at v0.36.0.

The rule cannot do the analysis. It makes the omission visible instead of implicit.

Two deliberate omissions:

- **`prBodyTemplate` is not overridden.** The default already orders `{{{notes}}}` before `{{{changelogs}}}`, so the checklist survives exactly the truncation that hid nx's notes. Reordering it would risk the opposite.
- **No `addLabels`.** This preset is consumed by other repositories which may not define a matching label, so the change is confined to body text.

**Scope — please read before approving.** `configs/renovate/default.json` is the published `@canonical/renovate-config`. This changes the PR body of major bumps in **every repository extending the preset**, not only `pragma`. It adds body text only: no scheduling, grouping, automerge or labelling behaviour changes.

## QA

Config-only change with no runtime surface. Verified with the repo's own validator — the command behind `bun run check:renovate`:

```bash
cd configs/renovate
renovate-config-validator --strict default.json ../../renovate.json
# INFO: Config validated successfully against 2 file(s)
```

A passing validator only means something if it can fail, so two further checks:

- The rule was validated a second time under the **repo-config** schema (a bare `renovate.json` path — the script above resolves both files as *global* config).
- **Negative control:** renaming the key to `prBodyNotesTYPO` is rejected with `Invalid configuration option: packageRules[0].prBodyNotesTYPO`, confirming `--strict` catches an unknown key at this position rather than passing everything.

Root gate from the repo root, per AGENTS.md:

```bash
bun install      # clean; bun.lock unchanged
bun run check    # Successfully ran target check for 62 projects
bun run test     # see note below
```

`bun run check` passes across all 62 projects. That is the target which actually covers this change: `configs/renovate`'s own `check` script *is* `renovate-config-validator`.

`bun run test` produced timeout-shaped failures locally — individual tests at 5–14s that normally run in milliseconds, in `router-react`, `pragma-cli`, `react-ds-global` and others, with Nx flagging the same tasks as flaky. Those are packages a Renovate JSON file cannot reach. Rather than discount them, they were checked against a clean baseline as AGENTS.md requires: CI `build-matrix` on Node 22 and 24 runs the same fan-out and is green on this branch.

The rule's effect becomes visible on the next major bump Renovate opens or rebases.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Maintenance 🔨` applied.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`. — no package manifests changed; `configs/renovate` already defines all three.
  - [x] Packages with build steps: `build` / `build:all`. — n/a, no build step added or changed.
- [x] If this PR introduces a **new package** — n/a, no new package.
- [x] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic. — applied; the diff is one JSON config file with no rendered surface.

## Screenshots

n/a — no visual surface.
