### PR TITLE
docs(agents): keep internal planning references out of PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,15 @@ precedent.
 - Branch from up-to-date `origin/main`; never push to `main` directly — **all changes
   land via PR** on a feature branch.
 - Fill in `.github/PULL_REQUEST_TEMPLATE.md` (Done / QA / readiness checklist).
+- **A PR description must stand on its own. Never cite an internal planning
+  document in it** — no ADR rung numbers, session ledgers, `pragma-adrs` paths, or
+  any other coordinate into a repo the reader may not be able to open. Outside
+  contributors and other teams review these PRs; sending them looking for a
+  document they do not have access to costs them time and tells them nothing. A
+  citation is not a reason. State what the change does and why, in full, in the PR
+  itself. The same goes for commit subjects, which Lerna puts in the CHANGELOG.
+  Internal sequencing stays in the planning repo; when merge order matters, name
+  the PR that must land first **by number** and say why in one line.
 - Add `no visual change` to skip Chromatic when there's no visual diff.
 - New package? First-time publish is manual (`npm publish --access public` from the
   package dir); verify with `bun run publish:status` from the root.


### PR DESCRIPTION
## Done

- Added a rule to **PR mechanics** in `AGENTS.md`: a PR description must stand on its own, and must never cite an internal planning document.

**Why.** A description that opens with a rung number and a path into a planning repo tells the reader nothing and costs them time. Outside contributors and other teams review these PRs and cannot open the document being cited — so the citation sends them looking for something they may not have access to, in place of the reason they actually needed. A coordinate is not a reason.

The rule names the alternative rather than only forbidding the habit. Merge order is real and sometimes has to be stated, so it says to state it as **a PR number plus a one-line why** — something any reviewer can act on — instead of a position in a ladder only the author can see.

Extended to commit subjects for the same reason: Lerna puts them in the CHANGELOG, where the audience is wider still.

**Drive-by:** #1070's description has been cleaned of the two references it carried. A sweep of all open PRs found one remaining (#1069), left to its owner.

## QA

Documentation-only change to `AGENTS.md`; no runtime or build surface.

```bash
bun install    # clean; bun.lock unchanged
bun run check  # Successfully ran target check for 62 projects — exit 0
```

`bun run test` was not run: nothing in a Markdown edit can reach a test suite, and three separate runs of it on this machine today exited 130 (SIGINT) under load, naming a different set of projects each time. CI `build-matrix` on Node 22 and 24 is the verdict of record.

### PR readiness check

- [x] PR should have one of the following labels: `Documentation 📝` applied.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test` — no package manifests touched.
  - [x] Packages with build steps: `build` / `build:all` — n/a.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `no visual change` label — applied; one Markdown file.

## Screenshots

n/a — no visual surface.
