### PR TITLE
chore(toolchain): state one Node floor, and the one Lerna 10 requires

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,11 @@ file is the PR workflow contract.
 ## Toolchain
 
 - **Bun is required** and is the canonical package manager/runner (`bun install`,
-  `bun run <script>`). Node.js 20+ must also be present (the floor `pragma doctor`
-  enforces and `old/CONTRIBUTING.md` documents); avoid Node 23.
+  `bun run <script>`). Node.js `^22.13.0 || ^24.0.0 || ^26.0.0` must also be
+  present — the range Lerna requires, and therefore the range the root gate
+  runs under. Node 20, 23 and 25 are all excluded: 23 additionally has a known
+  compatibility issue. The root `package.json` declares this range, so
+  `bun install` warns when the local Node is outside it.
 - **npm appears only for first-time package publishing** (`npm publish --access public`
   from inside a new package dir) — never for day-to-day dev. Don't use `npm install`.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The server starts at http://localhost:6006. Each component package has its own S
 
 - **React 19 or later** for component packages (Svelte 5 for Svelte packages).
 
-- **Node.js 22.12 or 24** using nvm for Storybook and Lerna.
+- **Node.js 22.13+, 24 or 26** using nvm for Storybook and Lerna.
 
   ```bash
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
@@ -72,8 +72,8 @@ The server starts at http://localhost:6006. Each component package has its own S
 
 **Notes:**
 
-- Node 22.x earlier than 22.12 have module resolution issues.
-- Node 23 has a [known compatibility issue](https://github.com/canonical/pragma/issues/226) and should be avoided.
+- Node 22.x earlier than 22.13 is not supported by Lerna, and versions before 22.12 also have module resolution issues.
+- Node 23 has a [known compatibility issue](https://github.com/canonical/pragma/issues/226) and should be avoided; Lerna does not support it, nor Node 25.
 - Installing Node via the snap package is not recommended as it may cause build issues.
 - Installing Bun via the snap package is not recommended as it may cause permission issues. This is a known [issue](https://github.com/shakeelansari63/snap-packages/issues/79). Use the official installation script instead.
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -56,6 +56,8 @@ The pipeline uses several tools, each chosen for specific reasons.
 
 **Node.js** runs Storybook and Lerna. The pipeline installs both Bun and Node, using Bun for package management and Node for tools that require fuller Node.js compatibility. The build matrix tests against Node 22 (LTS) and Node 24 (current) to catch compatibility issues.
 
+The supported range is `^22.13.0 || ^24.0.0 || ^26.0.0`, declared in the root `package.json` and set by Lerna, which supports no others. **The matrix tests two of the three majors in that range: Node 26 is supported but never exercised in CI.** That is a deliberate trade — a third matrix leg runs on every PR in the repository, including outside contributors', and the cost of one job is not one job. If a Node 26 regression is ever reported, this is the gap it came through.
+
 **Chromatic** provides visual regression testing. It captures screenshots of Storybook stories, stores baselines, and highlights visual differences between builds. Chromatic runs as a separate workflow with path filtering, so changes to `react-ds-global` only trigger visual tests for that package. This conserves snapshot credits while ensuring visual changes are reviewed. Chromatic workflows are focused solely on visual baselines — they do not run code quality checks or tests. Correctness is owned by `pr.yml` (on PRs) and `push.yml` (on main).
 
 ## Caching

--- a/old/CONTRIBUTING.md
+++ b/old/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Before you can start contributing, you'll need to set up your local development 
 1. **Install Bun:** Install the [bun package manager](https://bun.sh/). This is our preferred package manager for this
    project.
    Make sure you install Bun version 1.2.0 or later, as earlier versions do not generate text-based lockfiles by default.
-2. **Install Node.js:** Ensure you have [Node.js](https://nodejs.org/en/download/package-manager) version 20 or later
+2. **Install Node.js:** Ensure you have [Node.js](https://nodejs.org/en/download/package-manager) version 22.13 or later (Node 22.13+, 24 or 26 — Lerna supports no others)
    installed. This may be used by some packages that are not fully using Bun.
 
 #### 1.2 Installation

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
     "react-relay@21.0.1": "patches/react-relay@21.0.1.patch",
     "relay-runtime@21.0.1": "patches/relay-runtime@21.0.1.patch",
     "sigstore@4.1.0": "patches/sigstore@4.1.0.patch"
+  },
+  "engines": {
+    "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
   }
 }


### PR DESCRIPTION
## Done

- Declared `engines.node` on the root `package.json`.
- Corrected the Node floor in `AGENTS.md`, `README.md` and `old/CONTRIBUTING.md`.

> **Merge after #957.** That PR bumps Lerna 9 → 10, which is what makes this range true. Until it lands, Lerna 9 genuinely does support Node 20, and merging this first would make all four documents wrong in the other direction.

**Four documents claimed a Node floor and three disagreed**, before any of today's bumps:

| Source | Claimed |
|---|---|
| `AGENTS.md` | Node.js 20+, avoid Node 23 |
| `old/CONTRIBUTING.md` | version 20 or later |
| `README.md` (requirement) | Node.js 22.12 or 24 |
| `README.md` (notes) | 22.x before 22.12 has module resolution issues |

Lerna 10 settles it by making three of them wrong. Its `engines.node` is `^22.13.0 || ^24.0.0 || ^26.0.0` — verified against the registry, not the changelog.

That drops **Node 20**, and less visibly **Node 25**: Lerna 9's range was `^20.19.0 || ^22.12.0 || >=24.0.0`, whose open-ended final clause admitted 25; Lerna 10 caps it to `^24.0.0 || ^26.0.0`. Nothing in the changelog says "Node 25 is dropped" — it only appears by diffing the two ranges.

**Why the root manifest.** The root is `private: true`, so this is a statement about the development toolchain, not a published contract. Declaring it means `bun install` warns a contributor whose Node cannot run `lerna run check|test|build` — the whole root gate — instead of letting them discover it from a failing run.

**What is deliberately unchanged.** The published packages keep their own `engines.node`. Lerna is a dev dependency: it constrains contributors, not consumers, and the published range answers to `commander@15` (`>=22.12`), which is a different question.

**Related, not included:** `pragma doctor`'s Node check hardcodes major 20 and contradicts its own package's `engines.node`. That is a source fix in `packages/cli/pragma` with no dependency on #957, so it goes separately rather than being bundled here.

## QA

Documentation plus one manifest field; no runtime or build surface.

```bash
bun install    # clean; bun.lock unchanged; no EBADENGINE (local Node v24.18.1)
bun run check  # Successfully ran target check for 62 projects — exit 0
```

`bun run test` was not run: nothing here can reach a test suite, and this machine has been exiting 130 (SIGINT) on it under load all day, naming a different set of projects each time. CI `build-matrix` on Node 22 and 24 is the verdict of record.

Worth flagging for a separate decision: the range now admits **Node 26**, which CI never exercises — the matrix tests 22 and 24. Declaring support for a version nothing tests is a gap, but adding a third matrix leg is a cost decision for the CI owners, not something to slip into this PR.

### PR readiness check

- [x] PR should have one of the following labels: `Maintenance 🔨` applied.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test` — unchanged; only root `engines` was added.
  - [x] Packages with build steps: `build` / `build:all` — unchanged.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `no visual change` label — applied; docs and one manifest field.

## Screenshots

n/a — no visual surface.
