### PR TITLE
docs(ke-graphql): correct three diagnostic descriptions against the code

### DIFF
--- a/packages/runtime/ke-graphql/README.md
+++ b/packages/runtime/ke-graphql/README.md
@@ -471,4 +471,8 @@ The intermediate representations (`RawExtraction`, `OntologyIR`, `MappedIR`) are
 
 The emitted base is additionally gated by `@canonical/prism-contract` — semantic subsumption via `findBreakingChanges` over the **live emitted SDL** of every fixture, with the SDL crossing the package boundary as a string, plus two controls: `prefixing: "all"` still conforms (the contract names no ontology terms), and `relay: false` fails by exactly one violation (`FIELD_REMOVED` on `Query.node`).
 
-**That gate does not live here.** `@canonical/prism-contract` is not a dependency of this package and `contract.test.ts` is not in this tree: the contract is authored by the documentation site, not by the compiler, and a compiler that vendored its own conformance check would be marking its own homework. The gate ships with the contract package and runs against this compiler's output from there.
+**Where that gate lives depends on whether the contract package exists.** The contract is authored by the documentation site, not by the compiler, and a compiler that vendored its own conformance check would be marking its own homework — so the gate belongs with the contract, not here.
+
+On `main` the contract package does not exist, so neither does the gate: `@canonical/prism-contract` is absent from this package's dependencies and there is no `contract.test.ts`.
+
+On `feat/prism-docsite` the package **does** exist, so both are present: `@canonical/prism-contract` is a devDependency and `src/testing/integration/contract.test.ts` runs the gate against this compiler's live output. That is the only difference between this package on the two branches, and it disappears when the contract package lands on `main`.

--- a/packages/runtime/ke-graphql/docs/graphql-vocabulary.md
+++ b/packages/runtime/ke-graphql/docs/graphql-vocabulary.md
@@ -169,13 +169,13 @@ Annotation resolution reports in the **A band**; naming and collisions report in
 | Code | Severity | Meaning |
 |---|---|---|
 | `A001` | **error** | Two sources at one precedence level disagree on one term for one target. Never resolved by an alphabetical tiebreak (B.03, R-9). |
-| `A002` | **error** | The term was applied to an illegal target — a class-only term on a property, or the reverse. |
+| `A002` | **error** | The term's **target does not resolve** — it is not a declared class or property of the compiled ontology, or it sits in a namespace hosting none. Also raised when a `graphql:prefix` subject resolves to no discovered namespace. |
 | `A003` | **error** | The value has the wrong type for the term, or is empty where a value is required. |
-| `A004` | warning | An unrecognised term in the `graphql:` namespace — a typo, or a term this release does not mint. |
+| `A004` | warning | Two cases, both leaving the annotation ignored: an **unrecognised term** in the `graphql:` namespace — a typo, or one this release does not mint — or a recognised term on the **wrong kind of target**, such as a class-only term applied to a property. |
 | `A005` | warning | Workspace-local configuration shadows an upstream annotation. A deliberate asymmetry: the draft-locally workflow stays a warning where a same-level conflict is an error. |
 | `A006` | info | Annotations are present but were not consulted, because the mode is `auto`. |
 | `A007` | info | Under `explicit`, the classes the allowlist excluded — aggregated, one diagnostic. |
-| `A008` | warning | An annotation resolved but had no effect. |
+| `A008` | warning | Under `explicit`, a field is **omitted because its range is unexposed** — its range class carries no `graphql:expose`, or no member of its union range does. |
 | `M001` | **error** | A naming collision the compiler cannot resolve. |
 | `M002` | warning | A name is not a legal GraphQL name and was sanitized — a class local name, or a `graphql:name` value. Includes the introspection-reserved leading `__`, whose underscore run collapses to one. |
 | `M003` | warning | *(retired with the config-mapping surface it described.)* |


### PR DESCRIPTION
Follow-up to review findings on #1084. Those findings are about documentation **on `main`**, and #1084 takes `main`'s ke-graphql tree wholesale — amending them there would re-create the divergence that PR exists to end. They are treated here.

## Done

### `A002` and `A004` were described the wrong way round

`annotations.ts` raises **`A002`** when the **target does not resolve** — not a declared class or property of the compiled ontology, or in a namespace hosting none — and also when a `graphql:prefix` subject resolves to no discovered namespace. **`A004`** is the warning band, covering two cases: an unrecognised term, *and* a recognised term on the **wrong kind of target**.

The reference gave `A002`'s row `A004`'s second case, and gave `A004` only the typo case. A reader hitting either was sent to the wrong code, the wrong severity, and the wrong remedy.

### `A008` was simply wrong

It did not mean *"an annotation resolved but had no effect."* `map.ts` raises it under `explicit` mode when a field is **omitted because its range is unexposed** — its range class carries no `graphql:expose`, or no member of its union range does. This also contradicted `docs/api.md` and `docs/architecture.md`, both of which had it right.

### The README's contract-gate paragraph

It asserted that this package has no `@canonical/prism-contract` dependency and no `contract.test.ts` — true on `main`, false on `feat/prism-docsite`, and phrased as a property of the package rather than of the branch.

Rewritten to describe the condition: the gate belongs with the contract package, so where it lives depends on whether that package exists, with both states named. **The wording is identical to #1084's**, so the two stop differing the moment both land.

## QA

Documentation only — no code path changes. Each correction was verified by reading the emitting site, not by reading another document:

| Diagnostic | Emitted at | What the code actually says |
|---|---|---|
| `A002` | `annotations.ts` | `targets ${target}, which is not a declared class or property of the compiled ontology` |
| `A004` | `annotations.ts` | `graphql:${local} applies to ${targets} only; ${target} is a ${kind} — the annotation is ignored` |
| `A008` | `map.ts` | `mode "explicit": ${type}.${name} is omitted — its range class ${c} is not exposed` |

### PR readiness check

- [x] PR has a label: `docs`
- [x] PR title follows Conventional Commits
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts
- [x] No new package
- [x] `Chromatic: skip` — documentation only

> **Note for `AGENTS.md`:** its labels section still names `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`. None of those exist any more — the repo uses `feat` / `breaking` / `fix` / `docs` / `chore` / `refactor`, and `Chromatic: skip` in place of `no visual change`. Filed separately rather than folded in here.

https://claude.ai/code/session_017kMyeg9h6sBs7FsKyofJ4e