### PR TITLE
test(ke-graphql): cover the third Object.hasOwn branch, unclaim the contract assertion

### DIFF
--- a/packages/runtime/ke-graphql/src/lib/compiler/compose.test.ts
+++ b/packages/runtime/ke-graphql/src/lib/compiler/compose.test.ts
@@ -470,6 +470,51 @@ describe("compose full construction", () => {
     expect(Object.hasOwn(queryFields, "ontologies")).toBe(true);
   });
 
+  it("C002 — a Query EXTENSION named after an Object.prototype member is no conflict", () => {
+    // The third map carrying the same hazard, and the one the case above does
+    // not reach: it exercises the object-type extension merge (ToString) and
+    // the Query plan merge (Query.toString), but never the Query EXTENSION
+    // merge. That map is a plain object too, so `valueOf` — a legal extension
+    // field name colliding with no TBox root and no generated root — reads as
+    // occupied under a truthy `fields[name]` and is dropped under a fatal C002
+    // that no rename on the ontology side can clear.
+    //
+    // Both directions ride one compose, because "no C002" on its own would
+    // also be satisfied by deleting the check outright: `ontologies` IS a TBox
+    // root, so the conflict it names is real and must still be caught while
+    // `valueOf` passes. Own-property is what separates the two.
+    const plan = emptyPlan({
+      types: new Map([
+        [
+          "Thing",
+          objectPlan("Thing", new Map([["name", scalarField("name")]])),
+        ],
+      ]),
+    });
+    const extensions: SchemaExtensionsInput = {
+      Query: {
+        valueOf: { type: GraphQLString },
+        ontologies: { type: GraphQLString },
+      },
+    };
+    const { output, diagnostics } = compose(plan, { extensions });
+    expect(output.schema).not.toBeNull();
+    const queryFields = output.schema?.getQueryType()?.getFields() ?? {};
+    // The inherited name survives, and reaches the printed SDL.
+    expect(Object.hasOwn(queryFields, "valueOf")).toBe(true);
+    expect(output.sdl).toContain("valueOf: String");
+    // The genuine conflict on the same map is still fatal — exactly one C002,
+    // naming that field — and the TBox root it collided with is the survivor,
+    // not the planted String.
+    const c002 = diagnostics.filter((d) => d.code === "C002");
+    expect(c002).toHaveLength(1);
+    expect(c002[0]?.severity).toBe("error");
+    expect(c002[0]?.message).toBe(
+      "extension field Query.ontologies conflicts with a generated field",
+    );
+    expect(String(queryFields.ontologies?.type)).toBe("[Ontology!]!");
+  });
+
   it("C001 — object-form extension references an unknown type", () => {
     const thing: TypePlan = {
       name: "Thing",

--- a/packages/runtime/ke-graphql/src/testing/integration/modes.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/modes.test.ts
@@ -82,7 +82,18 @@ describe("mode matrix — unannotated input", () => {
     expect(bodyOf(auto.result.sdl)).toBe(bodyOf(annotated.result.sdl));
   });
 
-  it("explicit: the zero-type schema — TBox + node survive, A007 lists every class, contract satisfied", async () => {
+  // The name once ended "…, contract satisfied", backed by a
+  // satisfiesContract() call on the emitted SDL. `@canonical/prism-contract`
+  // is deliberately not a dependency of this package — the contract is
+  // authored by the documentation site, and a compiler that vendored its own
+  // conformance check would be marking its own homework (see the README) — so
+  // that assertion cannot live here. The claim is struck from the name rather
+  // than left standing over nothing; it returns, in the contract package's own
+  // gate, when that package does. What it was defending for the zero-type case
+  // is pinned below in local terms anyway: the root set is EXACTLY node plus
+  // the four TBox roots, so the contract base survives a projection that keeps
+  // no ontology class at all.
+  it("explicit: the zero-type schema — TBox + node survive, A007 lists every class", async () => {
     const { result } = await compileFixture(MINIMAL_TTL, { mode: "explicit" });
     expect([...result.mapped.types.keys()]).toEqual([]);
     expect([...result.mapped.interfaces.keys()]).toEqual([]);
@@ -235,6 +246,23 @@ describe("mode matrix — annotated input", () => {
     expect(roots).toContain("author");
     expect(roots).not.toContain("secret");
     expect(roots).not.toContain("badge");
+    // …but the relay/Node base does NOT fall out with them. The allowlist
+    // filters ontology classes; it must not take the contract base with it,
+    // and nothing else pins that for a PARTIAL allowlist — the zero-type case
+    // above pins it for the empty one, and the goldens only cover the default
+    // annotated mode. This is the locally expressible core of the
+    // satisfiesContract() call that stood here before
+    // `@canonical/prism-contract` left the tree: the contract's own relay
+    // control fails by exactly one violation, FIELD_REMOVED on Query.node.
+    expect(roots).toContain("node");
+    expect(result.sdl).toContain("interface Node {");
+    // Every projected type still implements it (member order is not pinned).
+    expect(
+      /type Publication implements ([^{]*)\{/.exec(result.sdl)?.[1],
+    ).toContain("Node");
+    expect(/type Author implements ([^{]*)\{/.exec(result.sdl)?.[1]).toContain(
+      "Node",
+    );
     // A007 aggregates the dropped set once, sorted.
     const a007 = result.diagnostics.filter((d) => d.code === "A007");
     expect(a007).toHaveLength(1);


### PR DESCRIPTION
Follow-up to review findings on #1084. Both findings are about test coverage of code **on `main`**, and #1084 takes `main`'s ke-graphql tree wholesale — amending them there would re-create the divergence that PR exists to end. They are treated here. Sibling to #1085, which treats the documentation findings the same way.

Both findings arrived asserted. Both were adjudicated against the code before being treated; one is upheld in full, one in part.

## Done

### Finding 1 — the third `Object.hasOwn` branch was genuinely uncovered — **upheld**

A recent fix replaced truthy `fields[name]` lookups with `Object.hasOwn` at **three** sites in `compose.ts`, because an inherited `Object.prototype` member made a valid generated field look occupied and produced a spurious fatal `C002`:

| # | Site | `compose.ts` | Covered before? |
|---|---|---|---|
| 1 | object-type extension merge | L388 | yes — `ToString` + `valueOf` extension |
| 2 | Query plan merge (generated root vs TBox root) | L441 | yes — `Query.toString` |
| 3 | **Query extension merge** | **L459** | **no** |

The reviewer's claim holds exactly. The existing regression test reaches sites 1 and 2 and never constructs a `Query` extension at all, so site 3's branch was never entered by any test in the file.

**The new test is proven able to fail.** With the truthy lookup restored at site 3 *alone* (`if (fields[name]) {`), it is the **only** failure in the file — the twelve pre-existing tests, including the sibling `Object.prototype` case, all still pass. That is the direct demonstration that site 3 was uncovered:

```
FAIL  src/lib/compiler/compose.test.ts > compose full construction >
      C002 — a Query EXTENSION named after an Object.prototype member is no conflict
AssertionError: expected false to be true // Object.is equality

- Expected
+ Received

- true
+ false

 ❯ src/lib/compiler/compose.test.ts:504:51
    504|     expect(Object.hasOwn(queryFields, "valueOf")).toBe(true);
```

`compose.ts` was restored byte-for-byte afterwards; this PR changes no source file.

The test pins **both directions in one compose** — `Query.valueOf` (inherited name, no real collision, must survive) and `Query.ontologies` (a real TBox root, must still be fatal). A test asserting only "no `C002`" would also pass if the check were deleted outright; own-property is what separates the two, so the test has to show the discrimination, not just the permission.

### Finding 2 — upheld at line 101, **not** as stated at line 271

`satisfiesContract` left with `@canonical/prism-contract`, which does not exist anywhere in this repo on `main` — not as a package, not as a dependency of anything. So **neither remedy the reviewer proposed is available here**: there is no `satisfiesContract` to retain, and no `contract.test.ts` in this tree to add an explicit-mode case to. That is by design, not omission — the README says so directly:

> **That gate does not live here.** […] the contract is authored by the documentation site, not by the compiler, and a compiler that vendored its own conformance check would be marking its own homework.

**Line 101 — the finding holds.** The test name ended `…, contract satisfied` and nothing verified it. Rather than invent a local assertion to make the name true — which the README rules out on principle, and which would be worse than a renamed test — the unbacked clause is **struck from the name**, with a comment recording that the assertion returns in the contract package's own gate when that package does. Nothing is lost in substance: that test already pins the property the contract check was defending for the zero-type case, in local terms — the root set is *exactly* `node` plus the four TBox roots.

**Line 271 — the stated reason does not hold, but there was a real gap.** That test is `explicit projects the allowlist and nothing else, loudly`; it never claimed contract satisfaction, so "the test name still claims 'contract satisfied'" is not true of this site. The *substantive* half is true, though: its explicit-mode emission lost its only base check. So it gains what the contract check was actually defending here, expressed without the contract — **the relay/Node base survives a PARTIAL allowlist**:

```ts
expect(roots).toContain("node");
expect(result.sdl).toContain("interface Node {");
// …plus: every projected type still implements Node.
```

This is not filler to justify a title — the title needed no rescuing. It pins a genuinely unasserted invariant: the allowlist filters ontology classes and must not take the contract base with it. Nothing else covers that for a partial allowlist (the zero-type case covers the empty one; the goldens only cover the default annotated mode), and it is breakable.

**Teeth confirmed empirically.** Compiled with `relay: false`, these exact assertions fail on `Query.node` — which is precisely the single violation (`FIELD_REMOVED` on `Query.node`) the README records the contract's own relay control producing. The local assertion catches the same break the contract gate catches.

## QA

Tests only — no source file is modified, and no existing assertion was weakened or deleted. The only non-additive edit is the removal of an unbacked claim from a test name.

From `packages/runtime/ke-graphql`:

| | `bun run check` | `bun run test` | Coverage |
|---|---|---|---|
| `main` baseline | pass | 39 files / **582** tests | 100% |
| this branch | pass | 39 files / **583** tests | 100% |

`check` is clean across biome, `tsc --noEmit`, and webarchitect.

### PR readiness check

- [x] PR title follows Conventional Commits — `test` label applied from the title
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json`
- [x] No new package
- [x] `Chromatic: skip` — tests only, no visual change

> The two threads on #1084 are **left open deliberately**. They are treated here, not there, so they stay open until this lands — a thread resolved before its treatment merges reads as a false receipt.

https://claude.ai/code/session_017kMyeg9h6sBs7FsKyofJ4e
