### PR TITLE
chore(renovate): review the toolchain on every bump, not only on majors

### DIFF
--- a/configs/renovate/default.json
+++ b/configs/renovate/default.json
@@ -80,6 +80,27 @@
         "- [ ] **Toolchain coupling checked** — lockfile format, package manager and peer ranges that other tools parse.",
         "> If this body was truncated, the upstream release notes for the major are **not** shown above. Read them at the source before ticking."
       ]
+    },
+    {
+      "description": "The toolchain is reviewed on every bump, not only on majors. Bun, Lerna and Nx decide whether the repo builds at all, and their breaking changes do not arrive labelled as breaking: a patch can change lockfile output, and a range can narrow without the changelog saying so",
+      "matchPackageNames": [
+        "bun",
+        "oven-sh/setup-bun",
+        "lerna",
+        "nx",
+        "@nx/{/,}**"
+      ],
+      "automerge": false,
+      "prBodyNotes": [
+        "### Toolchain impact review — required on every bump, not just majors",
+        "These packages decide whether the repository builds. Green CI is necessary and not sufficient; each box needs a person.",
+        "- [ ] **Lockfile output is unchanged.** `setup-env` runs `bun install --ignore-scripts && git diff --exit-code bun.lock`. A package manager that rewrites the lockfile — new `lockfileVersion`, reordering, formatting — turns **every** job red at once. Verify by installing with the new version and running that exact assertion.",
+        "- [ ] **Every pin moved together.** The Bun version is pinned in more places than Renovate can see: it reads `bun-version` on a `setup-bun` step, and is blind to a workflow matrix entry and to a composite action's input `default`. A partial bump goes green precisely because the untested half did not move.",
+        "- [ ] **The release path was considered.** `tag.yml` runs only on a tag, so `lerna version`, `lerna publish` and changelog generation are never exercised by a PR. A change to any of them ships unverified.",
+        "- [ ] **The supported Node range was diffed, not read.** Compare `engines.node` old against new on the registry. Lerna 10 dropped Node 20 *and* Node 25 — the second only visible by diffing `>=24.0.0` against `^24.0.0 || ^26.0.0`, and stated nowhere in the changelog.",
+        "- [ ] **Cross-tool coupling checked.** Nx parses `bun.lock`; Lerna drives Nx; Bun writes the lockfile both read. A version of one can require a version of another.",
+        "> If this body was truncated, the upstream release notes are **not** shown above. Read them at the source before ticking."
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Done

- Added a `packageRules` entry to `configs/renovate/default.json` attaching an impact-review checklist to **every** Bun, Lerna and Nx bump, regardless of semver type, with `automerge: false`.

**Why these three, and why not only majors.** They decide whether the repository builds at all, and their breaking changes do not arrive labelled as breaking. Three cases from this week, none of which a semver type would have caught:

- **#1075** moves the Bun version in two places and leaves two behind. It is green *because* of that: Renovate reads `bun-version` on a `setup-bun` step and is structurally blind to a workflow matrix entry (`pr.yml`) and a composite action's input `default` (`setup-env/action.yml`). The half that never moved is the half CI actually exercises.
- **Lerna 10 drops Node 25.** Visible only by diffing `>=24.0.0` against `^24.0.0 || ^26.0.0` on the registry. No changelog line states it.
- **Nx 23.1.2** added `bun.lock` lockfileVersion 2 and 3 support — coupling an Nx floor to a Bun version, in a direction neither changelog describes.

The existing majors rule cannot cover these: a Bun patch that changes lockfile output is not a major, and would have gone straight through the preset's patch/minor devDependency automerge.

**On the checklist's content.** Each item names the assertion a reviewer should *run*, not the risk in the abstract — `bun install --ignore-scripts && git diff --exit-code bun.lock` is the test that actually cleared Bun 1.4.0 today, after an inference from the Nx changelog had wrongly condemned it. It also records the Renovate blind spot explicitly, so the next reviewer does not have to rediscover why a Bun PR is only half a change.

**Placement.** Deliberately after the majors rule: when several `packageRules` match, Renovate replaces the notes array rather than appending, so a Lerna major would otherwise receive one block or the other. This rule is self-contained and wins.

**Better fix this does not replace.** The Bun pin should be a single `.bun-version` file, which `oven-sh/setup-bun` supports via `bun-version-file` and Renovate supports natively. That removes the split-pin failure mode instead of documenting it. This rule is the guard; that is the cure.

## QA

Config-only; no runtime surface.

```bash
cd configs/renovate
renovate-config-validator --strict default.json ../../renovate.json
# INFO: Config validated successfully against 2 file(s)
bun install    # clean; bun.lock unchanged
bun run check  # Successfully ran target check for 62 projects — exit 0
```

A negative control run earlier in this series confirmed `--strict` rejects an unknown key at `packageRules[n]`, so a clean pass is meaningful rather than vacuous.

`bun run test` not run: a JSON config file reaches no test suite, and this machine has been exiting 130 (SIGINT) on the full suite under load. CI `build-matrix` is the verdict of record.

## Blast radius

`configs/renovate/default.json` is the published `@canonical/renovate-config`. This changes the PR body and automerge behaviour for Bun, Lerna and Nx updates in **every repository extending the preset**. It adds body text and disables automerge for three packages; no scheduling or grouping changes.

### PR readiness check

- [x] PR should have one of the following labels: `chore` is derived from the title automatically.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged; no manifests touched.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — applied; one JSON config file.

## Screenshots

n/a — no visual surface.
