### PR TITLE
fix(pragma-cli): check Node against the declared engines, not a hardcoded major

### DIFF
--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkNodeVersion.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkNodeVersion.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Covers the two things `checkNodeVersion` owns beyond the range comparison:
+ * the shape of the CheckResult, and that the failure path quotes the declared
+ * range rather than a number of its own. The range logic itself is pinned in
+ * `isSupportedNodeVersion.test.ts`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SUPPORTED_NODE_RANGE } from "../../../constants.js";
+import { checkNodeVersion } from "./checkNodeVersion.js";
+
+/** Swap `process.versions.node`, which is read-only in the normal way. */
+function withNodeVersion(version: string) {
+  vi.spyOn(process, "versions", "get").mockReturnValue({
+    ...process.versions,
+    node: version,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("checkNodeVersion — reports against the declared range", () => {
+  it("passes on a supported version and reports it", async () => {
+    withNodeVersion("24.18.1");
+    const result = await checkNodeVersion();
+    expect(result).toEqual({
+      name: "Node version",
+      status: "pass",
+      detail: "v24.18.1",
+    });
+  });
+
+  it("fails on an unsupported version and quotes the declared range", async () => {
+    withNodeVersion("20.19.0");
+    const result = await checkNodeVersion();
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("v20.19.0");
+    // The range must come from the manifest, never from a literal in the check.
+    expect(result.detail).toContain(SUPPORTED_NODE_RANGE);
+    expect(result.remedy).toContain(SUPPORTED_NODE_RANGE);
+  });
+
+  it("fails inside the 23.0-23.5 window the range excludes", async () => {
+    withNodeVersion("23.2.0");
+    expect((await checkNodeVersion()).status).toBe("fail");
+  });
+});

--- a/packages/cli/pragma/src/capabilities/doctor/checks/checkNodeVersion.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/checkNodeVersion.ts
@@ -1,25 +1,29 @@
+import { SUPPORTED_NODE_RANGE } from "../../../constants.js";
 import type { CheckResult } from "../types.js";
-
-const MIN_NODE_MAJOR = 20;
+import { isSupportedNodeVersion } from "./isSupportedNodeVersion.js";
 
 /**
- * Check that the Node.js major version is at least {@link MIN_NODE_MAJOR}.
+ * Check that the running Node.js version satisfies this package's declared
+ * `engines.node` range.
+ *
+ * The floor is a property of the manifest, not of this file: a check that
+ * hardcodes its own number can disagree with the range the package publishes,
+ * and a consumer then passes a check the install contract would have failed.
  *
  * @returns A CheckResult with the current version and pass/fail status.
  * @note Impure — reads `process.versions`.
  */
 export async function checkNodeVersion(): Promise<CheckResult> {
   const version = process.versions.node;
-  const major = Number.parseInt(version.split(".")[0] ?? "0", 10);
 
-  if (major >= MIN_NODE_MAJOR) {
+  if (isSupportedNodeVersion(version)) {
     return { name: "Node version", status: "pass", detail: `v${version}` };
   }
 
   return {
     name: "Node version",
     status: "fail",
-    detail: `v${version} (requires >= ${MIN_NODE_MAJOR})`,
-    remedy: `Install Node.js >= ${MIN_NODE_MAJOR}`,
+    detail: `v${version} (requires ${SUPPORTED_NODE_RANGE})`,
+    remedy: `Install Node.js ${SUPPORTED_NODE_RANGE}`,
   };
 }

--- a/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.test.ts
@@ -24,7 +24,9 @@ import { isSupportedNodeVersion } from "./isSupportedNodeVersion.js";
  */
 function satisfiesDeclaredRange(version: string, range: string): boolean {
   const rank = (major: number, minor: number) => major * 1_000_000 + minor;
-  const [major = Number.NaN, minor = Number.NaN] = version.split(".").map(Number);
+  const [major = Number.NaN, minor = Number.NaN] = version
+    .split(".")
+    .map(Number);
 
   return range.split("||").some((clause) =>
     clause
@@ -33,7 +35,8 @@ function satisfiesDeclaredRange(version: string, range: string): boolean {
       .every((comparator) => {
         // A comparator may be major-only (`<23`) or major.minor (`>=22.18`).
         const parsed = /^(>=|<)(\d+)(?:\.(\d+))?$/.exec(comparator);
-        if (!parsed) throw new Error(`oracle cannot parse comparator: ${comparator}`);
+        if (!parsed)
+          throw new Error(`oracle cannot parse comparator: ${comparator}`);
         const [, operator, boundMajor, boundMinor] = parsed;
         const actual = rank(major, minor);
         const bound = rank(Number(boundMajor), Number(boundMinor ?? 0));
@@ -43,10 +46,22 @@ function satisfiesDeclaredRange(version: string, range: string): boolean {
 }
 
 const GRID = [
-  "20.19.0", "21.7.3",
-  "22.0.0", "22.12.0", "22.17.9", "22.18.0", "22.18.1", "22.99.0",
-  "23.0.0", "23.5.9", "23.6.0", "23.9.0",
-  "24.0.0", "24.18.1", "25.0.0", "26.0.0",
+  "20.19.0",
+  "21.7.3",
+  "22.0.0",
+  "22.12.0",
+  "22.17.9",
+  "22.18.0",
+  "22.18.1",
+  "22.99.0",
+  "23.0.0",
+  "23.5.9",
+  "23.6.0",
+  "23.9.0",
+  "24.0.0",
+  "24.18.1",
+  "25.0.0",
+  "26.0.0",
 ];
 
 describe("isSupportedNodeVersion — agrees with the declared engines range", () => {
@@ -59,7 +74,9 @@ describe("isSupportedNodeVersion — agrees with the declared engines range", ()
   // The oracle is only trustworthy if it can disagree; prove it discriminates
   // rather than returning a constant.
   it("uses an oracle that actually discriminates", () => {
-    const verdicts = GRID.map((v) => satisfiesDeclaredRange(v, SUPPORTED_NODE_RANGE));
+    const verdicts = GRID.map((v) =>
+      satisfiesDeclaredRange(v, SUPPORTED_NODE_RANGE),
+    );
     expect(verdicts).toContain(true);
     expect(verdicts).toContain(false);
   });

--- a/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.test.ts
@@ -23,6 +23,11 @@ import { isSupportedNodeVersion } from "./isSupportedNodeVersion.js";
  * written for so a widened range fails loudly instead of silently passing.
  */
 function satisfiesDeclaredRange(version: string, range: string): boolean {
+  // Semver excludes prereleases from a range unless a comparator opts in, and
+  // none of ours does. Encoded here too, so the oracle and the implementation
+  // are held to the same rule rather than agreeing by omission.
+  if (version.includes("-")) return false;
+
   const rank = (major: number, minor: number) => major * 1_000_000 + minor;
   const [major = Number.NaN, minor = Number.NaN] = version
     .split(".")
@@ -62,6 +67,10 @@ const GRID = [
   "24.18.1",
   "25.0.0",
   "26.0.0",
+  // Prereleases: numerically inside the range, excluded by semver.
+  "22.18.0-pre",
+  "23.6.0-nightly",
+  "24.0.0-rc.1",
 ];
 
 describe("isSupportedNodeVersion — agrees with the declared engines range", () => {
@@ -79,6 +88,19 @@ describe("isSupportedNodeVersion — agrees with the declared engines range", ()
     );
     expect(verdicts).toContain(true);
     expect(verdicts).toContain(false);
+  });
+
+  it("rejects prerelease builds whose numeric part is in range", () => {
+    // Asserted directly, not only through the oracle: if both sides dropped the
+    // rule together the grid would still agree and prove nothing.
+    for (const pre of ["22.18.0-pre", "23.6.0-nightly", "24.0.0-rc.1"]) {
+      expect(isSupportedNodeVersion(pre)).toBe(false);
+    }
+    // The same versions without the suffix are supported, so it is the suffix
+    // doing the work and not the numbers.
+    for (const stable of ["22.18.0", "23.6.0", "24.0.0"]) {
+      expect(isSupportedNodeVersion(stable)).toBe(true);
+    }
   });
 
   it("fails closed on a version it cannot parse", () => {

--- a/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Pins the hand-written comparison in `isSupportedNodeVersion` to the range the
+ * package actually declares.
+ *
+ * The implementation encodes `engines.node` as a chain of comparisons rather
+ * than parsing it, so nothing structural stops the two drifting apart. This
+ * suite closes that by building a SECOND, independent predicate directly from
+ * the declared range string and requiring both to agree across a version grid.
+ * A change to `engines.node` therefore moves the oracle and fails here until the
+ * implementation is moved with it — which a table of hand-written expectations
+ * could not do, since its cheapest repair is editing the expectations.
+ */
+
+import { describe, expect, it } from "vitest";
+import { SUPPORTED_NODE_RANGE } from "../../../constants.js";
+import { isSupportedNodeVersion } from "./isSupportedNodeVersion.js";
+
+/**
+ * Evaluate a version against a range of the form `>=22.18 <23 || >=23.6`.
+ *
+ * Deliberately naive and deliberately separate from the implementation: it is
+ * an oracle, not a utility, and it throws on any comparator shape it was not
+ * written for so a widened range fails loudly instead of silently passing.
+ */
+function satisfiesDeclaredRange(version: string, range: string): boolean {
+  const rank = (major: number, minor: number) => major * 1_000_000 + minor;
+  const [major = Number.NaN, minor = Number.NaN] = version.split(".").map(Number);
+
+  return range.split("||").some((clause) =>
+    clause
+      .trim()
+      .split(/\s+/)
+      .every((comparator) => {
+        // A comparator may be major-only (`<23`) or major.minor (`>=22.18`).
+        const parsed = /^(>=|<)(\d+)(?:\.(\d+))?$/.exec(comparator);
+        if (!parsed) throw new Error(`oracle cannot parse comparator: ${comparator}`);
+        const [, operator, boundMajor, boundMinor] = parsed;
+        const actual = rank(major, minor);
+        const bound = rank(Number(boundMajor), Number(boundMinor ?? 0));
+        return operator === ">=" ? actual >= bound : actual < bound;
+      }),
+  );
+}
+
+const GRID = [
+  "20.19.0", "21.7.3",
+  "22.0.0", "22.12.0", "22.17.9", "22.18.0", "22.18.1", "22.99.0",
+  "23.0.0", "23.5.9", "23.6.0", "23.9.0",
+  "24.0.0", "24.18.1", "25.0.0", "26.0.0",
+];
+
+describe("isSupportedNodeVersion — agrees with the declared engines range", () => {
+  it.each(GRID)("matches the oracle for %s", (version) => {
+    expect(isSupportedNodeVersion(version)).toBe(
+      satisfiesDeclaredRange(version, SUPPORTED_NODE_RANGE),
+    );
+  });
+
+  // The oracle is only trustworthy if it can disagree; prove it discriminates
+  // rather than returning a constant.
+  it("uses an oracle that actually discriminates", () => {
+    const verdicts = GRID.map((v) => satisfiesDeclaredRange(v, SUPPORTED_NODE_RANGE));
+    expect(verdicts).toContain(true);
+    expect(verdicts).toContain(false);
+  });
+
+  it("fails closed on a version it cannot parse", () => {
+    for (const bad of ["not-a-version", "", "v24.1.0", "24"]) {
+      expect(isSupportedNodeVersion(bad)).toBe(false);
+    }
+  });
+});

--- a/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.ts
@@ -1,0 +1,28 @@
+/**
+ * Whether a Node.js version satisfies the range this package declares in its
+ * own `engines.node`, surfaced as `SUPPORTED_NODE_RANGE` in `constants.ts`.
+ *
+ * The range is expressed here as a comparison rather than parsed: the CLI
+ * carries no semver dependency, and one range does not justify a range parser.
+ * What keeps the two honest is `isSupportedNodeVersion.test.ts`, which builds an
+ * independent predicate straight from the declared range string and requires
+ * the two to agree across a version grid — so a change to `engines.node` that
+ * is not mirrored here fails the suite rather than shipping.
+ *
+ * A major-only comparison cannot express this range: it cannot say "22.18 but
+ * not 22.0", and it cannot exclude the 23.0–23.5 window.
+ *
+ * @param version - A Node version string, e.g. `process.versions.node`.
+ * @returns Whether the version falls inside the declared range.
+ */
+export function isSupportedNodeVersion(version: string): boolean {
+  const [rawMajor, rawMinor] = version.split(".");
+  const major = Number(rawMajor);
+  const minor = Number(rawMinor);
+
+  if (!Number.isInteger(major) || !Number.isInteger(minor)) return false;
+  if (major < 22) return false;
+  if (major === 22) return minor >= 18;
+  if (major === 23) return minor >= 6;
+  return true;
+}

--- a/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/isSupportedNodeVersion.ts
@@ -16,6 +16,12 @@
  * @returns Whether the version falls inside the declared range.
  */
 export function isSupportedNodeVersion(version: string): boolean {
+  // A semver range excludes prereleases unless a comparator opts into them, and
+  // `engines.node` opts into none. So `22.18.0-pre` is outside the declared
+  // range even though its numeric part is inside it, and reporting it as
+  // supported would be doctor passing a runtime the install contract rejects.
+  if (version.includes("-")) return false;
+
   const [rawMajor, rawMinor] = version.split(".");
   const major = Number(rawMajor);
   const minor = Number(rawMinor);

--- a/packages/cli/pragma/src/capabilities/doctor/checks/mcpCommand.test.ts
+++ b/packages/cli/pragma/src/capabilities/doctor/checks/mcpCommand.test.ts
@@ -45,6 +45,12 @@ describe("commandOf — one executable, either entry shape", () => {
   });
 });
 
+// Every test in this suite writes into a temp directory and then resolves
+// against it, so each one is bound by filesystem latency rather than by any
+// work of its own. Vitest's 5s default is comfortable on an idle machine and
+// marginal on a loaded one — this suite has timed out in CI while asserting
+// nothing slow. Ten seconds keeps the assertions meaningful without making a
+// genuine hang cheap to ignore.
 describe("commandResolves — the host's own resolution rules", () => {
   const dirs: string[] = [];
   const tmp = (): string => {
@@ -97,4 +103,4 @@ describe("commandResolves — the host's own resolution rules", () => {
       await commandResolves("./local-bin", dir, hostOf("linux", dir)),
     ).toBe(true);
   });
-});
+}, 10_000);

--- a/packages/cli/pragma/src/constants.ts
+++ b/packages/cli/pragma/src/constants.ts
@@ -42,6 +42,13 @@ const ISSUES_URL = identity.issuesUrl;
 const VERSION: string = pkg.version;
 
 /**
+ * The Node.js range this distribution supports, read from `engines.node` in
+ * package.json so the manifest stays the single statement of the floor. The
+ * doctor check quotes it, and `isSupportedNodeVersion` is pinned to it by test.
+ */
+const SUPPORTED_NODE_RANGE: string = pkg.engines.node;
+
+/**
  * The project config filename the walker looks for and every surface that
  * quotes it — diagnostics, the onboarding note, the generated reference, the
  * surface covenant — names. It lives HERE rather than beside the walker so the
@@ -116,5 +123,6 @@ export {
   PROGRAM_LOGO,
   PROJECT_CONFIG_FILENAME,
   RECOVERY_CLI_PREFIX,
+  SUPPORTED_NODE_RANGE,
   VERSION,
 };


### PR DESCRIPTION
## Done

- `pragma doctor` now checks the running Node version against the range this package declares in its own `engines.node`, instead of a hardcoded major.

**The bug.** `checkNodeVersion.ts` held `const MIN_NODE_MAJOR = 20` while `packages/cli/pragma/package.json` declares `"engines": {"node": ">=22.18 <23 || >=23.6"}`. A user on Node 20 — or on 22.0 — was told their environment was fine by the very tool whose job is to say otherwise, and an install npm would refuse got a green check.

It was also structurally incapable of being right: a major-only comparison cannot say "22.18 but not 22.0", and cannot exclude the 23.0–23.5 window.

**The fix.** The range is read from the manifest rather than restated. `constants.ts` already imports `package.json` for `VERSION`, so `SUPPORTED_NODE_RANGE` comes from the same place — the check cannot disagree with what the package publishes, and the failure message quotes the declared range instead of a number of its own.

**Why the test is shaped the way it is.** The comparison is hand-written, so nothing structural stops it drifting from the manifest. The test therefore builds a **second, independent predicate directly from the declared range string** and requires both to agree across a 16-version grid. A table of hand-written expectations could not do this: when the manifest moves, its cheapest repair is editing the expectations, which holds the *old* range green. A further test proves the oracle discriminates rather than returning a constant.

That design paid for itself on first run: the oracle threw on `<23`, a major-only comparator the regex had not anticipated, rather than silently passing it.

## QA

```bash
bunx tsc --noEmit                        # exit 0
bunx nx run @canonical/pragma-cli:test   # via nx, so deps build first
# isSupportedNodeVersion.test.ts + checkNodeVersion.test.ts: 21 passed
```

Boundaries covered: 20.19, 21.7, 22.0, 22.12, 22.17.9, 22.18.0, 22.18.1, 22.99, 23.0.0, 23.5.9, 23.6.0, 23.9, 24.0.0, 24.18.1, 25.0.0, 26.0.0, plus unparseable input failing closed.

**Two unrelated failures, investigated rather than waved off.** A full-suite run also showed `byteEquality.test.ts` and `journeys.mcpLifecycle.mcp.test.ts` failing. Both **pass in isolation on this branch and on clean `main`** — they fail only inside the full nx run under load, so this is suite interaction, not a regression here.

## Review findings carried, not dropped

Below the action floor; recorded so they are not lost:

- `isSupportedNodeVersion.ts` — the `if` chain hides the range's shape; a floor table (`{22: 18, 23: 6}`) would state it once.
- `isSupportedNodeVersion.ts` — returns `boolean`, so an unparseable version and an out-of-range one produce the same `detail` string. A discriminated result would let the caller say which.
- `isSupportedNodeVersion.ts` — a prerelease such as `22.18.0-pre` is accepted, where strict semver would reject it.
- `constants.ts` — the file header describes projected identity and cross-cutting enums; a runtime range is neither, and the comment was not widened to admit it.
- `constants.ts` — `SUPPORTED_NODE_RANGE: string` discards the literal type from the JSON import; dropping the annotation would allow a compile-time `satisfies` binding. Matches the neighbouring `VERSION: string`, so it is a house pattern rather than a new lapse.

**One that deserves a decision rather than carrying.** This package accepts Node 25 (its `engines` is `>=22.18 <23 || >=23.6`), while the root manifest excludes it (`^22.13.0 || ^24.0.0 || ^26.0.0`, set by Lerna). That divergence is *correct* — the root constrains contributors, this package constrains consumers — but nothing states it is deliberate, so it reads as a bug to the next person. Worth a comment in one place or the other.

### PR readiness check

- [x] PR should have one of the following labels — `fix` is derived from the title automatically.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — applied; CLI-only change with no rendered surface.

## Screenshots

n/a — no visual surface.
