### PR TITLE
test(pragma-cli): say when a spawned CLI timed out, and show what it wrote

### DIFF
--- a/packages/cli/pragma/src/testing/helpers/runCli.test.ts
+++ b/packages/cli/pragma/src/testing/helpers/runCli.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Pins how `runCli` reports a child that does not finish.
+ *
+ * `spawnSync` reports a timeout the same way it reports a failure to spawn —
+ * through `error` — and a caller that does not look will see only
+ * `status: null`, which reads downstream as an ordinary non-zero exit or, worse,
+ * as a content mismatch. These tests hold the boundary where that distinction
+ * is made, because the cost of losing it is paid in diagnosis rather than in a
+ * red test.
+ */
+
+import { describe, expect, it } from "vitest";
+import { runCli } from "./runCli.js";
+
+describe("runCli — a child that does not finish", () => {
+  it("reports a timeout as a timeout, with the duration", async () => {
+    // `--help` on a 1ms budget cannot complete; any real CLI start-up exceeds it.
+    await expect(async () =>
+      runCli(["--help"], { timeoutMs: 1 }),
+    ).rejects.toThrow(/timed out after 1ms/);
+  });
+
+  it("names the signal that killed it, so a hang is distinguishable", async () => {
+    await expect(async () =>
+      runCli(["--help"], { timeoutMs: 1 }),
+    ).rejects.toThrow(/killed by SIG/);
+  });
+
+  it("does not describe a timeout as a failure to spawn", async () => {
+    // The previous message said "failed to spawn", which sent a reader looking
+    // for a missing binary or a bad path instead of a slow or hung command.
+    await expect(async () =>
+      runCli(["--help"], { timeoutMs: 1 }),
+    ).rejects.not.toThrow(/failed to spawn/);
+  });
+
+  it("attaches whatever the child managed to write", async () => {
+    // Empty streams are still reported explicitly: "(empty)" is evidence, an
+    // absent section is an omission the reader has to interpret.
+    await expect(async () =>
+      runCli(["--help"], { timeoutMs: 1 }),
+    ).rejects.toThrow(/stdout:[\s\S]*stderr:/);
+  });
+});

--- a/packages/cli/pragma/src/testing/helpers/runCli.ts
+++ b/packages/cli/pragma/src/testing/helpers/runCli.ts
@@ -46,9 +46,16 @@ export interface RunCliOptions {
    * test the shipped-entry boundary itself.
    */
   readonly mode?: "shipped" | "source";
-  /** Spawn timeout in milliseconds (default 20000). */
+  /** Spawn timeout in milliseconds (default {@link DEFAULT_TIMEOUT_MS}). */
   readonly timeoutMs?: number;
 }
+
+/**
+ * How long a spawned CLI may run before it is killed. Twenty seconds is far
+ * past any assertion these tests make; a run that reaches it has hung, not
+ * been slow.
+ */
+const DEFAULT_TIMEOUT_MS = 20_000;
 
 /** The captured outcome of a `runCli` invocation. */
 export interface RunCliResult {
@@ -114,12 +121,29 @@ export function runCli(
     cwd: options.cwd,
     env: { ...env, ...options.env },
     encoding: "utf-8",
-    timeout: options.timeoutMs ?? 20_000,
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
   });
 
   if (result.error) {
+    // A timeout is not a spawn failure, and saying so costs real diagnosis
+    // time: `spawnSync` reports both through `error`, but a timed-out child
+    // has already produced output worth seeing, and the duration is the whole
+    // finding. Separated here so the message names what happened, and carries
+    // the evidence rather than making the reader go and get it.
+    const timedOutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const invocation = `${command} ${spawnArgs.join(" ")}`;
+    const captured = [
+      result.stdout ? `stdout:\n${result.stdout}` : "stdout: (empty)",
+      result.stderr ? `stderr:\n${result.stderr}` : "stderr: (empty)",
+    ].join("\n");
+
+    if ((result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
+      throw new Error(
+        `runCli: ${invocation} timed out after ${timedOutMs}ms (killed by ${result.signal ?? "signal"}).\n${captured}`,
+      );
+    }
     throw new Error(
-      `runCli: failed to spawn ${command} ${spawnArgs.join(" ")} — ${result.error.message}`,
+      `runCli: failed to spawn ${invocation} — ${result.error.message}.\n${captured}`,
     );
   }
 


### PR DESCRIPTION
## Done

- `runCli` now distinguishes a child that **timed out** from one that **failed to spawn**, and attaches the output the child produced before it was killed.

**Why this is worth a PR.** `spawnSync` reports both conditions through the same `error` field, so the helper threw correctly on both — but described both as `failed to spawn`. That phrasing sends a reader looking for a missing binary or a bad path when the real problem is a command that hung, and the message carried neither the duration exceeded nor anything the child had already written.

That cost real diagnosis time today. A test elsewhere in this repo took 123,462ms against a 120s budget and surfaced as `expected null to be 0` — a content mismatch, with no hint that nothing had been produced because nothing had finished. A separate investigation into a one-leg CI failure spent ten minutes and produced two wrong hypotheses, because the only evidence in the failure was an empty stdout.

The new message:

```
runCli: node dist/src/bin.js --help timed out after 20000ms (killed by SIGTERM).
stdout: (empty)
stderr: (empty)
```

Three deliberate choices:

- **The duration is usually the whole finding.** A budget and the fact it was exceeded turns "why is this empty" into "it never ran to completion".
- **The signal distinguishes a kill from a clean exit**, which an exit code alone cannot.
- **Empty streams print as `(empty)` rather than being omitted.** An absent section is something a reader has to interpret; an explicit empty one is evidence.

The 20s budget is named as `DEFAULT_TIMEOUT_MS` rather than repeated, so the message cannot drift from the behaviour it reports.

## What this does NOT fix

Twelve of the fourteen test files in this repo that spawn subprocesses use raw `spawnSync` and **never check `result.error`** at all. That is where a timeout still reaches an assertion as `status: null` — the 123-second case above is one of them. Adopting this helper (or at minimum checking `error`) across those call sites is the larger win, and a separate mechanical change.

Also unaddressed: `bin.tsx` exits 1 for every error path, so `status === 1` cannot distinguish "rendered the error correctly" from "crashed before printing anything". Tests asserting a rendered failure should assert `stderr` too.

## QA

```bash
bunx tsc --noEmit        # clean
bun run check:biome      # 439 files, no fixes applied
bunx vitest run src/testing/helpers/runCli.test.ts   # 4 passed
```

Four tests pin the behaviour: that a timeout reports as a timeout with its duration, that it names the killing signal, that both streams are attached, and — the one that matters most — that a timeout is **not** reported as a failure to spawn. The wording is the finding here, not an incidental, so it is asserted rather than left to drift.

### PR readiness check

- [x] PR should have one of the following labels — `test` is derived from the title automatically.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — applied; a test helper with no rendered surface.

## Screenshots

n/a — no visual surface.
