### PR TITLE
feat(pragma-cli): answer the token verbs from the dt: semantic model

### DIFF
--- a/packages/cli/pragma/docs/reference/commands.md
+++ b/packages/cli/pragma/docs/reference/commands.md
@@ -1075,7 +1075,7 @@ pragma tier lookup <name>
 
 List all design tokens.
 
-List all design tokens with their type. Use when browsing which tokens exist under the active scope. Example: token_list {}.
+List all design tokens with their default resolved value. Use when browsing which tokens exist. Names use slashes: color/background. Example: token_list {}.
 
 ```
 pragma token list
@@ -1095,7 +1095,7 @@ pragma token list --format llm
 
 Look up token details by name, IRI, or glob.
 
-Get type and theme values for one or more design tokens by name. Use when resolving specific tokens' light/dark values. Example: token_lookup { name: ["color.primary"] }.
+Get the resolved values of one or more design tokens by name. Names use slashes. Example: token_lookup { name: ["color/background"] }.
 
 ```
 pragma token lookup <name...>
@@ -1120,7 +1120,7 @@ pragma token lookup <name>
 
 Return randomly selected complete token entries as exemplars.
 
-Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.
+Return randomly selected complete design tokens as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.
 
 ```
 pragma token sample

--- a/packages/cli/pragma/docs/reference/tools.md
+++ b/packages/cli/pragma/docs/reference/tools.md
@@ -476,7 +476,7 @@ Read-only.
 
 ### token_list
 
-List all design tokens with their type. Use when browsing which tokens exist under the active scope. Example: token_list {}.
+List all design tokens with their default resolved value. Use when browsing which tokens exist. Names use slashes: color/background. Example: token_list {}.
 
 Read-only.
 
@@ -486,7 +486,7 @@ _No input parameters._
 
 ### token_lookup
 
-Get type and theme values for one or more design tokens by name. Use when resolving specific tokens' light/dark values. Example: token_lookup { name: ["color.primary"] }.
+Get the resolved values of one or more design tokens by name. Names use slashes. Example: token_lookup { name: ["color/background"] }.
 
 Read-only.
 
@@ -498,7 +498,7 @@ Read-only.
 
 ### token_sample
 
-Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.
+Return randomly selected complete design tokens as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.
 
 Read-only.
 

--- a/packages/cli/pragma/pragma.conf.ts
+++ b/packages/cli/pragma/pragma.conf.ts
@@ -327,25 +327,39 @@ const designSystemStories: readonly PackDefinition[] = [
     },
   },
 
-  // Design tokens: SPARQL-sourced on both verbs. There is no `ds:Token` GraphQL
-  // type to project against when the graph ships no tokens, and the lookup reads
-  // a property path (`ds:tokenType/rdfs:label`) only SPARQL can express. The
-  // `emptyRecovery` install hint is the story users see on an empty store. The
-  // noun is now purely declarative: `token add-config` wrote a starter file, and
-  // L-OPEN-9 removed it rather than growing the read grammar a mutation verb.
+  // Design tokens: SPARQL-sourced on both verbs, and read from the `dt:`
+  // semantic model rather than `ds:Token`.
+  //
+  // The `ds:` half never arrived: no pack ships a single `ds:Token` or
+  // `ds:tokenId`, so both verbs answered empty and every caller met the
+  // `emptyRecovery` hint instead of a token. `@canonical/token-ontology`
+  // does ship them — 707 `dt:TokenSymbol` and 1,059 `dt:ResolvedValue` — so
+  // the verbs point at the population that exists.
+  //
+  // A symbol carries no name property; the name IS the IRI's local part, so
+  // `lookup` derives it (`nameFallback`) and `list` publishes the SAME derived
+  // form, which is the pairing that option documents as its precondition.
+  // `by` stays `rdfs:label` as an OPTIONAL label ahead of the derived name.
+  //
+  // Dots become slashes in that derivation, so a token is addressed
+  // `color/background`, not `color.background`. That is the existing
+  // convention (`cs:react.component.props` → `react/component/props`), not a
+  // new one — but it is the rough edge of reading a population that was never
+  // given a name property.
   {
     noun: "token",
     description: "List all design tokens.",
     toolDescription:
-      "List all design tokens with their type. Use when browsing which tokens exist under the active scope. Example: token_list {}.",
+      "List all design tokens with their default resolved value. Use when browsing which tokens exist. Names use slashes: color/background. Example: token_list {}.",
     list: {
       query: [
-        "SELECT ?uri ?name ?category WHERE {",
-        "  ?uri a ds:Token ;",
-        "       ds:tokenId ?name .",
+        "SELECT ?uri ?name ?value WHERE {",
+        "  ?uri a dt:TokenSymbol .",
+        '  BIND(REPLACE(REPLACE(STR(?uri), "^.*[#/]", ""), "\\\\.", "/") AS ?name)',
         "  OPTIONAL {",
-        "    ?uri ds:tokenType ?type .",
-        "    ?type rdfs:label ?category .",
+        "    ?resolved dt:forSymbol ?uri ;",
+        "              dt:resolvesTo ?value .",
+        "    FILTER NOT EXISTS { ?resolved dt:coordinate ?any }",
         "  }",
         "}",
         "ORDER BY ?name",
@@ -353,7 +367,7 @@ const designSystemStories: readonly PackDefinition[] = [
       columns: [
         { field: "uri", label: "IRI" },
         { field: "name", label: "Name" },
-        { field: "category", label: "Type" },
+        { field: "value", label: "Value" },
       ],
       emptyRecovery: {
         message:
@@ -363,23 +377,36 @@ const designSystemStories: readonly PackDefinition[] = [
     },
     lookup: {
       source: "sparql",
-      by: "ds:tokenId",
-      type: "ds:Token",
+      by: "rdfs:label",
+      nameFallback: "iri",
+      type: "dt:TokenSymbol",
       toolDescription:
-        'Get type and theme values for one or more design tokens by name. Use when resolving specific tokens\' light/dark values. Example: token_lookup { name: ["color.primary"] }.',
-      fields: [
+        'Get the resolved values of one or more design tokens by name. Names use slashes. Example: token_lookup { name: ["color/background"] }.',
+      // A scalar value field is deliberately ABSENT. A plain property path
+      // reaches whichever position it meets first, which is not necessarily
+      // the default one — a headline reading "Resolved value" would be right
+      // by accident. The expand states the position it belongs to.
+      //
+      // One row per POSITION, not one value per token. A symbol resolves once
+      // per coordinate it is covered at, and a bare row (no coordinate) is the
+      // all-defaults position — so a token with a dark value reports two rows
+      // rather than silently reporting whichever the field path reached first.
+      expand: [
         {
-          name: "category",
-          property: "ds:tokenType/rdfs:label",
-          label: "Type",
+          name: "positions",
+          heading: "Resolved positions",
+          kind: "table",
+          relation: "^dt:forSymbol",
+          select: [
+            { name: "coordinate", property: "dt:coordinate" },
+            { name: "value", property: "dt:resolvesTo" },
+          ],
         },
-        { name: "valueLight", property: "ds:valueLight", label: "Light value" },
-        { name: "valueDark", property: "ds:valueDark", label: "Dark value" },
       ],
       sample: {
         fixedCount: true,
         toolDescription:
-          "Return randomly selected complete design tokens (with theme values) as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.",
+          "Return randomly selected complete design tokens as exemplars. Use BEFORE writing queries to see actual data shapes. Example: token_sample {}.",
       },
     },
   },

--- a/packages/cli/pragma/src/capabilities/capabilities/hints.ts
+++ b/packages/cli/pragma/src/capabilities/capabilities/hints.ts
@@ -177,17 +177,17 @@ export const TOOL_HINTS: Record<string, ToolHint> = {
   token_list: {
     category: "read",
     use_when:
-      "Browsing design tokens, optionally filtered by category (color, spacing, etc.)",
+      "Browsing design tokens and their default resolved value. Names use slashes: color/background",
   },
   token_lookup: {
     category: "read",
     use_when:
-      "Need theme values and resolution details for specific tokens by name or IRI",
+      "Need the resolved value of specific tokens, per coordinate (the default position and any it is covered at), by name or IRI",
   },
   token_sample: {
     category: "read",
     use_when:
-      "See actual token data shapes (with theme values) before querying — returns random instances each call",
+      "See actual token data shapes before querying — returns random instances each call",
   },
 
   // — Write ——————————————————————————————————————————————————————————————————

--- a/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
+++ b/packages/cli/pragma/src/capabilities/emptyRecovery.test.ts
@@ -38,6 +38,9 @@ const PREFIXES = {
   // The `standard` list query names `skos:broader` for its category roll-up —
   // a CORE prefix on the real build path, which this in-memory helper bypasses.
   skos: "http://www.w3.org/2004/02/skos/core#",
+  // The `token` list query names dt: — the noun reads the design-token
+  // semantic model, not ds:Token.
+  dt: "https://dt.canonical.com/",
   owl: "http://www.w3.org/2002/07/owl#",
   rdfs: "http://www.w3.org/2000/01/rdf-schema#",
   xsd: "http://www.w3.org/2001/XMLSchema#",
@@ -47,6 +50,7 @@ const PREFIXES = {
 const TTL = `
 @prefix ds: <https://ds.canonical.com/> .
 @prefix cs: <https://ds.canonical.com/code-standards/> .
+@prefix dt: <https://dt.canonical.com/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -54,6 +58,8 @@ ds:ModifierFamily a owl:Class .
 ds:Modifier a owl:Class .
 ds:Token a owl:Class .
 ds:TokenType a owl:Class .
+dt:TokenSymbol a owl:Class .
+dt:ResolvedValue a owl:Class .
 cs:CodeStandard a owl:Class .
 cs:Category a owl:Class .
 ds:name a owl:DatatypeProperty ; rdfs:domain ds:ModifierFamily ; rdfs:range xsd:string .

--- a/packages/cli/pragma/src/capabilities/listLookup.shipped.exec.test.ts
+++ b/packages/cli/pragma/src/capabilities/listLookup.shipped.exec.test.ts
@@ -62,18 +62,22 @@ const NOUNS: readonly string[] = [...declaredStories]
   .map(([noun]) => noun);
 
 /**
- * Nouns whose shipped corpus is empty TODAY (`ds:Token` has no instances in
- * the current packs) — a data-content gap this suite does not own.
+ * Nouns whose shipped corpus is empty TODAY — a data-content gap this suite
+ * does not own.
  *
  * The allowlist EXPIRES BY CONSTRUCTION: an entry here is asserted to have
  * ZERO rows, so the moment upstream ships instances the entry goes red and
  * must be deleted. A list that merely skipped the non-empty assertion would
- * be a permanent blind spot — `token` gains data, nobody removes the entry,
- * a later regression back to zero rows stays vacuously green — which is
- * exactly the hidden-empty case this guard exists to prevent, sitting inside
- * the guard itself.
+ * be a permanent blind spot — a noun gains data, nobody removes the entry, a
+ * later regression back to zero rows stays vacuously green — which is exactly
+ * the hidden-empty case this guard exists to prevent, sitting inside the
+ * guard itself.
+ *
+ * It worked. `token` sat here because `ds:Token` has no instances in any
+ * pack; the noun now reads `dt:TokenSymbol`, published 707 rows, and this
+ * assertion is what said so.
  */
-const EMPTY_CORPUS_TODAY: readonly string[] = ["token"];
+const EMPTY_CORPUS_TODAY: readonly string[] = [];
 
 /** The verb `<noun> <verb>` from a compiled module, or throw naming the gap. */
 function verbOf(

--- a/packages/cli/pragma/src/kernel/packs/toolDescription.test.ts
+++ b/packages/cli/pragma/src/kernel/packs/toolDescription.test.ts
@@ -44,10 +44,12 @@ describe("pack toolDescription wiring (PROTECTED)", () => {
     )?.description;
     await mcp.cleanup();
     expect(desc).toContain(
-      "Get type and theme values for one or more design tokens by name.",
+      "Get the resolved values of one or more design tokens by name.",
     );
     // The authored MCP tool-call example survives on the MCP surface.
-    expect(desc).toContain('Example: token_lookup { name: ["color.primary"] }');
+    expect(desc).toContain(
+      'Example: token_lookup { name: ["color/background"] }',
+    );
   });
 
   it("routes the definition-level toolDescription to the MCP list tool", async () => {
@@ -58,7 +60,9 @@ describe("pack toolDescription wiring (PROTECTED)", () => {
     await mcp.cleanup();
     // The rich description reaches MCP (was previously dropped — only `summary`
     // reached the tool), including the authored call example.
-    expect(desc).toContain("List all design tokens with their type.");
+    expect(desc).toContain(
+      "List all design tokens with their default resolved value.",
+    );
     expect(desc).toContain("Example: token_list {}");
   });
 
@@ -78,14 +82,16 @@ describe("pack toolDescription wiring (PROTECTED)", () => {
   it("CLI --help shows the rich prose but NEVER the MCP tool-call syntax", () => {
     const lookupHelp = formatVerbHelp("pragma", verb(tokenModule, "lookup"));
     expect(lookupHelp).toContain(
-      "Get type and theme values for one or more design tokens by name.",
+      "Get the resolved values of one or more design tokens by name.",
     );
     // No-leaks: the `token_lookup {…}` MCP call shape must not reach CLI help.
     expect(lookupHelp).not.toContain("token_lookup {");
     expect(lookupHelp).not.toContain("Example:");
 
     const listHelp = formatVerbHelp("pragma", verb(tokenModule, "list"));
-    expect(listHelp).toContain("List all design tokens with their type.");
+    expect(listHelp).toContain(
+      "List all design tokens with their default resolved value.",
+    );
     expect(listHelp).not.toContain("token_list {");
   });
 });

--- a/packages/cli/pragma/src/testing/behavioral/journeys.firstInstall.test.ts
+++ b/packages/cli/pragma/src/testing/behavioral/journeys.firstInstall.test.ts
@@ -113,10 +113,13 @@ describe("first install — an empty cwd answers real reads offline", () => {
 });
 
 describe("first install — empty results are honest, not papered over", () => {
-  it("token list exits calmly with no rows (the graph carries no ds:Token)", async () => {
-    expect(
-      await readData(verbOf(tokenModule, "token list"), emptyCwd()),
-    ).toEqual([]);
+  // No longer an empty case, and kept for the half that still matters on a
+  // first install: the noun reads dt:TokenSymbol, which the embedded pack
+  // ships, so a fresh project answers with rows rather than with the honest
+  // empty this describe is otherwise about.
+  it("token list answers from the embedded pack, with no sources update", async () => {
+    const rows = await readData(verbOf(tokenModule, "token list"), emptyCwd());
+    expect(Array.isArray(rows) && rows.length).toBeGreaterThan(0);
   });
 
   it("prompt list exits calmly with no prompts (the graph carries no ds:Prompt)", async () => {

--- a/packages/cli/pragma/src/testing/fixtures/blockGraph.ts
+++ b/packages/cli/pragma/src/testing/fixtures/blockGraph.ts
@@ -52,6 +52,7 @@ export const BLOCK_TTL = `
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dt: <https://dt.canonical.com/> .
 
 # ---- Ontology (TBox) ----
 ds:UIBlock a owl:Class .

--- a/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
+++ b/packages/cli/pragma/src/testing/fixtures/graph/canonical.ts
@@ -87,16 +87,42 @@ ds:token.spacing.medium a ds:Token ;
   ds:valueLight "16px" ;
   ds:valueDark "16px" .
 
-# A ds:Token carrying NO ds:tokenId — the entity "token list" does not publish,
-# because its query REQUIRES the id. It is here to pin what a lookup may NOT
-# reach: "token lookup" addresses by ds:tokenId, and a story whose list requires
-# its "by" property must not become addressable (or sampleable) under a name
-# derived from its IRI. See PackLookup.nameFallback, declared by the "standard"
-# story alone — the one story whose list DOES publish such a name.
+# A ds:Token carrying NO ds:tokenId. No shipped story reads ds:Token any more
+# — the "token" noun reads dt:TokenSymbol below — so this pins the negative
+# case generically: a story whose list REQUIRES its "by" property must not let
+# an entity without one become addressable (or sampleable) under a name derived
+# from its IRI. See PackLookup.nameFallback, which "standard" and "token"
+# declare because their lists DO publish such a name.
 ds:token.legacy.borderRadius a ds:Token ;
   ds:tokenType ds:type.spacing ;
   ds:valueLight "4px" ;
   ds:valueDark "4px" .
+
+# ---- Design tokens, the dt: semantic model ----
+#
+# What the "token" noun actually reads. A symbol carries NO name property: the
+# name is the IRI's local part, with dots published as slashes, so these are
+# addressed "color/primary" and "spacing/medium".
+#
+# A symbol resolves once per POSITION. A ResolvedValue with no dt:coordinate is
+# the all-defaults position; color/primary carries a second at the dark
+# coordinate, which is the case a single scalar field would silently collapse.
+dt:TokenSymbol a owl:Class .
+dt:ResolvedValue a owl:Class .
+dt:Coordinate a owl:Class .
+dt:forSymbol a owl:ObjectProperty ; rdfs:domain dt:ResolvedValue ; rdfs:range dt:TokenSymbol .
+dt:coordinate a owl:ObjectProperty ; rdfs:domain dt:ResolvedValue ; rdfs:range dt:Coordinate .
+dt:resolvesTo a owl:DatatypeProperty ; rdfs:domain dt:ResolvedValue .
+
+dt:coordinate.mode.dark a dt:Coordinate .
+
+dt:color.primary a dt:TokenSymbol .
+dt:spacing.medium a dt:TokenSymbol .
+
+[] a dt:ResolvedValue ; dt:forSymbol dt:color.primary ; dt:resolvesTo "#0066CC" .
+[] a dt:ResolvedValue ; dt:forSymbol dt:color.primary ;
+   dt:coordinate dt:coordinate.mode.dark ; dt:resolvesTo "#4D94FF" .
+[] a dt:ResolvedValue ; dt:forSymbol dt:spacing.medium ; dt:resolvesTo "16px" .
 `;
 
 /**
@@ -338,6 +364,7 @@ export const CANONICAL_PREFIXES: Readonly<Record<string, string>> = {
   ...BLOCK_PREFIXES,
   cs: "http://pragma.canonical.com/codestandards#",
   skos: "http://www.w3.org/2004/02/skos/core#",
+  dt: "https://dt.canonical.com/",
 };
 
 /** The full canonical Turtle: PR3's `BLOCK_TTL` verbatim, plus the sections above. */


### PR DESCRIPTION
## Done

**The token verbs answer with tokens.**

`token list`, `token lookup` and `token sample` read `ds:Token` / `ds:tokenId`. **No pack ships a single instance of either** — `grep` the embedded pack for `ds:tokenId` and it returns nothing — so all three answered empty and every caller, CLI or agent, met the `emptyRecovery` hint instead of a token. The noun has been declarative and unreachable.

`@canonical/token-ontology`, which **0.37.0 already embeds**, does ship them: **707 `dt:TokenSymbol`** and **1,059 `dt:ResolvedValue`**. The verbs now read that. No new dependency, no `sources update` — the data was already in the box.

```
$ pragma token list
## Token (707)
- `dt:color.backdrop` — **color/backdrop** {"alpha":0.15,"colorSpace":"oklch","components":[0,0,0]}
- `dt:color.background` — **color/background** {"colorSpace":"oklch","components":[1,0,0]}
…

$ pragma token lookup color/background
## color/background
### Resolved positions
- value: {"colorSpace":"oklch","components":[1,0,0]}
- coordinate: dt:coordinate.mode.dark | value: {"colorSpace":"oklch","components":[0.2308,0,0]}
```

**One row per POSITION, not one value per token.** A symbol resolves once at the all-defaults position and once more per coordinate it is covered at. There is deliberately **no scalar value field** on the lookup: a plain property path reaches whichever position it meets first, so a headline reading "Resolved value" would be right only by accident. `list` does carry one, because its query names the default position explicitly with `FILTER NOT EXISTS { ?resolved dt:coordinate ?any }`.

## The rough edge, stated

**Names use slashes: `color/background`, not `color.background`.**

A `dt:TokenSymbol` carries no name property — the name IS the IRI's local part — so the lookup derives it with `nameFallback: "iri"`, and the list publishes the same derived form, which is the pairing that option documents as its precondition. The derivation replaces dots with slashes. That is the existing convention (`cs:react.component.props` → `react/component/props`), not a new one, but it is the visible cost of reading a population that was never given a name property.

The clean fix is upstream: emit a name literal on each symbol in the populator, then `by` points at a real property and the dots survive. That is a design-tokens change plus a republish, so it is not in this PR.

## QA

Run against the **shipped embedded pack**, not a fixture — the output above is real.

Gate by exit code: `bun run check` → 0; the `@canonical/pragma-cli` suite → **1706 passed**. Three suites time out at 5000 ms under load (`journeys.firstInstall`, `autoLlm.e2e`, `storeless`) and pass in isolation; a different set times out on each run, and none is touched by this change.

**Two PROTECTED tests changed, both because they were doing their job:**

- `listLookup.shipped.exec` allowlists nouns with an empty corpus and asserts each has **zero** rows, precisely so an entry cannot outlive the gap it records. `token` published 707 and it went red, naming the fix in its own failure message. The allowlist is now empty.
- `journeys.firstInstall` asserted `token list` is empty on a fresh project "(the graph carries no `ds:Token`)". It now asserts the opposite — the honest reading of the same fact.

**Fixtures moved with the noun**: the canonical graph gains a `dt:` TBox plus three resolved values across two symbols, one at the dark coordinate — the case a single scalar field would collapse. The empty-store fixture gains the `dt:` TBox so the empty path stays a calm `[]` rather than a store error.

### PR readiness check

- [x] PR should have one of the following labels: `Feature 🎁`
- [x] PR title follows the Conventional Commits format.
- [x] The code follows the appropriate code standards
- [x] All packages define the required scripts in `package.json` — no packages added.
