### PR TITLE
feat(styles): export modifier shim subpaths

### DIFF
--- a/packages/styles/main/package.json
+++ b/packages/styles/main/package.json
@@ -5,7 +5,10 @@
   "main": "src/index.css",
   "exports": {
     ".": "./src/index.css",
-    "./fonts": "./src/fonts.css"
+    "./fonts": "./src/fonts.css",
+    "./modifiers.states.shim.css": "./src/modifiers.states.shim.css",
+    "./modifiers.importance.shim.css": "./src/modifiers.importance.shim.css",
+    "./modifiers.criticality.shim.css": "./src/modifiers.criticality.shim.css"
   },
   "files": [
     "src"


### PR DESCRIPTION
The temporary modifier shims (`modifiers.states.shim.css`, `modifiers.importance.shim.css`, `modifiers.criticality.shim.css`) are only reachable through the root `@canonical/styles` entry, which also pulls in `normalize.css` and the typography baseline. A package migrating gradually (ds-app-launchpad) cannot take those yet, so it currently carries verbatim copies of the shim rules that must be kept in sync by hand.

This adds explicit subpath exports for the three shim files so such consumers can `@import` them directly and drop the copies.

Notes:
- The subpaths mirror the real file names, keeping the shims' provenance obvious at the import site.
- The shims are documented as temporary; when a shim's channels are generated upstream in design-tokens, the file and its export are expected to be removed together as part of that cleanup.
- `ds-app-launchpad` will swap its copied blocks for these imports in a follow-up once this lands.