### PR TITLE
feat(styles): export density and spacing subpaths

### DIFF
--- a/packages/styles/main/package.json
+++ b/packages/styles/main/package.json
@@ -8,7 +8,9 @@
     "./fonts": "./src/fonts.css",
     "./modifiers.states.shim.css": "./src/modifiers.states.shim.css",
     "./modifiers.importance.shim.css": "./src/modifiers.importance.shim.css",
-    "./modifiers.criticality.shim.css": "./src/modifiers.criticality.shim.css"
+    "./modifiers.criticality.shim.css": "./src/modifiers.criticality.shim.css",
+    "./modifiers.density.css": "./src/modifiers.density.css",
+    "./spacing.css": "./src/spacing.css"
   },
   "files": [
     "src"


### PR DESCRIPTION
## Done

- Added `./modifiers.density.css` and `./spacing.css` subpath exports to `@canonical/styles`, so a package migrating gradually (ds-app-launchpad) can `@import` the density control-seat system directly instead of carrying verbatim copies that must be kept in sync by hand (same motivation as #1099).
- The two ship together deliberately: the density math is built on `--baseline-height`, which `spacing.css` defines. Exporting density alone would hand consumers a file whose seat formulas cannot resolve.

## QA

- `bun -e "console.log(require.resolve('@canonical/styles/modifiers.density.css'), require.resolve('@canonical/styles/spacing.css'))"` resolves both subpaths from a workspace consumer.
- `ds-app-launchpad` will swap its copied density/baseline sections in `ds-shim.css` for these imports in a follow-up once this lands (its storybook build exercises the resolution end to end, as it does today for the #1099 subpaths).

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.
- [ ] If this PR introduces a **new package**: not applicable — no new package.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic.

## Screenshots

Not applicable — exports-map-only change, no visual output.