### PR TITLE
refactor(ds-global): control the Modal pattern through a ref

### DIFF
--- a/packages/react/ds-global/src/lib/pattern/Modal/Modal.ssr.tests.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/Modal.ssr.tests.tsx
@@ -6,7 +6,7 @@ describe("Modal SSR", () => {
   it("doesn't throw", () => {
     expect(() =>
       renderToString(
-        <Component open>
+        <Component defaultOpen>
           <Component.Content>Placeholder content</Component.Content>
         </Component>,
       ),
@@ -15,7 +15,7 @@ describe("Modal SSR", () => {
 
   it("renders the dialog and its composed parts", () => {
     const html = renderToString(
-      <Component open>
+      <Component defaultOpen>
         <Component.Header>Title</Component.Header>
         <Component.Content>Placeholder content</Component.Content>
         <Component.Footer>
@@ -27,5 +27,17 @@ describe("Modal SSR", () => {
     expect(html).toContain('class="ds modal-header"');
     expect(html).toContain('class="ds modal-content"');
     expect(html).toContain('class="ds modal-footer"');
+  });
+
+  it("renders closed even with defaultOpen", () => {
+    // showModal() is what makes a dialog modal, and it only runs in the mount
+    // effect: a server-rendered `open` attribute would paint a non-modal
+    // dialog with no backdrop and no focus trap.
+    const html = renderToString(
+      <Component defaultOpen>
+        <Component.Content>Placeholder content</Component.Content>
+      </Component>,
+    );
+    expect(html).not.toMatch(/<dialog[^>]*\sopen/);
   });
 });

--- a/packages/react/ds-global/src/lib/pattern/Modal/Modal.stories.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/Modal.stories.tsx
@@ -1,9 +1,40 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement, ReactNode } from "react";
+import { useRef } from "react";
 import { Button } from "../../component/Button/index.js";
 import { Chip } from "../../component/Chip/index.js";
 import { InlineCode } from "../../component/InlineCode/index.js";
 import { KeyboardKey } from "../../component/KeyboardKey/index.js";
 import Modal from "./Modal.js";
+import type { ModalProps } from "./types.js";
+
+/**
+ * Every preview pairs the modal with the trigger a real page would give it, so
+ * dismissing the modal leaves something to click rather than an empty frame,
+ * and hands `close` to the composed sections so the footer actions work.
+ *
+ * The wiring is a ref, `showModal()` to open and `close()` to close. The
+ * trigger needs no already-open guard, because an open modal makes the page
+ * behind it inert and the button unclickable; something that can fire twice —
+ * a shortcut, an effect — would check `ref.current.open` first.
+ */
+const ModalPreview = ({
+  children,
+  ...modalProps
+}: Omit<ModalProps, "children" | "ref"> & {
+  children: (close: () => void) => ReactNode;
+}): ReactElement => {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  return (
+    <>
+      <Button onClick={() => modalRef.current?.showModal()}>Open modal</Button>
+      <Modal {...modalProps} ref={modalRef}>
+        {children(() => modalRef.current?.close())}
+      </Modal>
+    </>
+  );
+};
 
 const meta = {
   title: "patterns/Modal",
@@ -14,6 +45,22 @@ const meta = {
   // contained instead of stacking over the docs page.
   parameters: {
     docs: {
+      description: {
+        component: [
+          "The modal is **self-contained**: its open state lives in the native `<dialog>`, not in a",
+          "prop, so the header's close icon and Escape dismiss it with nothing wired up (and a",
+          "backdrop click too, where `closeOnBackdropClick` opts in). `onClose` is the native way to",
+          "hear that it happened.",
+          "",
+          "**External control is optional and goes through the `ref`**, which is the `<dialog>` itself:",
+          "`ref.current?.showModal()` opens the modal and `ref.current?.close()` closes it. That is all",
+          "a trigger or a footer action needs. For the common case — one control opening one modal —",
+          "`withModal` does the wiring for you.",
+          "",
+          "Each story below opens with `defaultOpen` and keeps its trigger button behind the backdrop,",
+          "so the modal can be closed and reopened while you read.",
+        ].join("\n"),
+      },
       story: {
         inline: false,
         iframeHeight: "480px",
@@ -25,12 +72,15 @@ const meta = {
       source: { type: "code", language: "tsx" },
     },
   },
-  // Every story renders the modal open: a story is a picture of the pattern,
-  // not a demo of its trigger.
-  args: { open: true, children: null },
+  // Every story renders the modal open with `defaultOpen`: a story is first a
+  // picture of the pattern. Its trigger is what makes the picture recoverable.
+  args: { defaultOpen: true, children: null },
   argTypes: {
     // The stories compose their sections in a custom render, never from args.
     children: { control: false },
+    // `defaultOpen` is read once, on mount: a live control over it would do
+    // nothing, because the story re-renders rather than remounting.
+    defaultOpen: { control: false },
   },
 } satisfies Meta<typeof Modal>;
 
@@ -41,21 +91,28 @@ type Story = StoryObj<typeof meta>;
  * The full anatomy, composed from its sections: a header with the title and
  * the dismiss icon, the content, and two actions bounded by the horizontal
  * rules. The affirmative action is last and carries the constructive
- * anticipation, which is where the green fill comes from.
+ * anticipation, which is where the green fill comes from. Both actions close
+ * the modal: closing is what an action does once its own work is done.
  */
 export const Default: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<Modal open={open} onOpenChange={setOpen}>
+        code: `const modalRef = useRef<HTMLDialogElement>(null);
+const close = () => modalRef.current?.close();
+
+<Button onClick={() => modalRef.current?.showModal()}>Open modal</Button>
+<Modal ref={modalRef}>
   <Modal.Header>Title</Modal.Header>
   <Modal.Content>
     lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua.
   </Modal.Content>
   <Modal.Footer>
-    <Button importance="secondary">Cancel</Button>
-    <Button importance="primary" anticipation="constructive">
+    <Button importance="secondary" onClick={close}>
+      Cancel
+    </Button>
+    <Button importance="primary" anticipation="constructive" onClick={close}>
       Confirm
     </Button>
   </Modal.Footer>
@@ -63,20 +120,30 @@ export const Default: Story = {
       },
     },
   },
-  render: ({ open }) => (
-    <Modal open={open}>
-      <Modal.Header>Title</Modal.Header>
-      <Modal.Content>
-        lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua.
-      </Modal.Content>
-      <Modal.Footer>
-        <Button importance="secondary">Cancel</Button>
-        <Button importance="primary" anticipation="constructive">
-          Confirm
-        </Button>
-      </Modal.Footer>
-    </Modal>
+  render: ({ defaultOpen }) => (
+    <ModalPreview defaultOpen={defaultOpen}>
+      {(close) => (
+        <>
+          <Modal.Header>Title</Modal.Header>
+          <Modal.Content>
+            lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </Modal.Content>
+          <Modal.Footer>
+            <Button importance="secondary" onClick={close}>
+              Cancel
+            </Button>
+            <Button
+              importance="primary"
+              anticipation="constructive"
+              onClick={close}
+            >
+              Confirm
+            </Button>
+          </Modal.Footer>
+        </>
+      )}
+    </ModalPreview>
   ),
 };
 
@@ -88,15 +155,28 @@ export const DestructiveConfirmation: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<Modal open={open} onOpenChange={setOpen}>
+        code: `const modalRef = useRef<HTMLDialogElement>(null);
+const close = () => modalRef.current?.close();
+
+<Button onClick={() => modalRef.current?.showModal()}>Open modal</Button>
+<Modal ref={modalRef}>
   <Modal.Header>Delete instance</Modal.Header>
   <Modal.Content>
     Deleting this instance removes its volumes and snapshots. This cannot be
     undone.
   </Modal.Content>
   <Modal.Footer>
-    <Button importance="secondary">Cancel</Button>
-    <Button importance="primary" anticipation="destructive">
+    <Button importance="secondary" onClick={close}>
+      Cancel
+    </Button>
+    <Button
+      importance="primary"
+      anticipation="destructive"
+      onClick={() => {
+        // …delete the instance, then:
+        close();
+      }}
+    >
       Delete
     </Button>
   </Modal.Footer>
@@ -104,20 +184,30 @@ export const DestructiveConfirmation: Story = {
       },
     },
   },
-  render: ({ open }) => (
-    <Modal open={open}>
-      <Modal.Header>Delete instance</Modal.Header>
-      <Modal.Content>
-        Deleting this instance removes its volumes and snapshots. This cannot be
-        undone.
-      </Modal.Content>
-      <Modal.Footer>
-        <Button importance="secondary">Cancel</Button>
-        <Button importance="primary" anticipation="destructive">
-          Delete
-        </Button>
-      </Modal.Footer>
-    </Modal>
+  render: ({ defaultOpen }) => (
+    <ModalPreview defaultOpen={defaultOpen}>
+      {(close) => (
+        <>
+          <Modal.Header>Delete instance</Modal.Header>
+          <Modal.Content>
+            Deleting this instance removes its volumes and snapshots. This
+            cannot be undone.
+          </Modal.Content>
+          <Modal.Footer>
+            <Button importance="secondary" onClick={close}>
+              Cancel
+            </Button>
+            <Button
+              importance="primary"
+              anticipation="destructive"
+              onClick={close}
+            >
+              Delete
+            </Button>
+          </Modal.Footer>
+        </>
+      )}
+    </ModalPreview>
   ),
 };
 
@@ -129,14 +219,20 @@ export const NotDismissible: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<Modal open={open} onOpenChange={setOpen}>
+        code: `const modalRef = useRef<HTMLDialogElement>(null);
+const close = () => modalRef.current?.close();
+
+<Button onClick={() => modalRef.current?.showModal()}>Open modal</Button>
+<Modal ref={modalRef}>
   <Modal.Header dismissible={false}>Unsaved changes</Modal.Header>
   <Modal.Content>
     You have unsaved changes that will be lost if you continue.
   </Modal.Content>
   <Modal.Footer>
-    <Button importance="secondary">Keep editing</Button>
-    <Button importance="primary" anticipation="destructive">
+    <Button importance="secondary" onClick={close}>
+      Keep editing
+    </Button>
+    <Button importance="primary" anticipation="destructive" onClick={close}>
       Discard
     </Button>
   </Modal.Footer>
@@ -144,31 +240,45 @@ export const NotDismissible: Story = {
       },
     },
   },
-  render: ({ open }) => (
-    <Modal open={open}>
-      <Modal.Header dismissible={false}>Unsaved changes</Modal.Header>
-      <Modal.Content>
-        You have unsaved changes that will be lost if you continue.
-      </Modal.Content>
-      <Modal.Footer>
-        <Button importance="secondary">Keep editing</Button>
-        <Button importance="primary" anticipation="destructive">
-          Discard
-        </Button>
-      </Modal.Footer>
-    </Modal>
+  render: ({ defaultOpen }) => (
+    <ModalPreview defaultOpen={defaultOpen}>
+      {(close) => (
+        <>
+          <Modal.Header dismissible={false}>Unsaved changes</Modal.Header>
+          <Modal.Content>
+            You have unsaved changes that will be lost if you continue.
+          </Modal.Content>
+          <Modal.Footer>
+            <Button importance="secondary" onClick={close}>
+              Keep editing
+            </Button>
+            <Button
+              importance="primary"
+              anticipation="destructive"
+              onClick={close}
+            >
+              Discard
+            </Button>
+          </Modal.Footer>
+        </>
+      )}
+    </ModalPreview>
   ),
 };
 
 /**
  * Supplementary context with nothing to decide, so the footer is simply not
- * composed.
+ * composed. The dismiss icon, Escape and — because this one opts in — a
+ * backdrop click are the ways out.
  */
 export const WithoutActions: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<Modal open={open} onOpenChange={setOpen} closeOnBackdropClick>
+        code: `const modalRef = useRef<HTMLDialogElement>(null);
+
+<Button onClick={() => modalRef.current?.showModal()}>Open modal</Button>
+<Modal ref={modalRef} closeOnBackdropClick>
   <Modal.Header>Search syntax</Modal.Header>
   <Modal.Content>
     Combine terms with AND, OR and NOT. Quote a phrase to match it exactly.
@@ -177,13 +287,18 @@ export const WithoutActions: Story = {
       },
     },
   },
-  render: ({ open }) => (
-    <Modal open={open} closeOnBackdropClick>
-      <Modal.Header>Search syntax</Modal.Header>
-      <Modal.Content>
-        Combine terms with AND, OR and NOT. Quote a phrase to match it exactly.
-      </Modal.Content>
-    </Modal>
+  render: ({ defaultOpen }) => (
+    <ModalPreview defaultOpen={defaultOpen} closeOnBackdropClick>
+      {() => (
+        <>
+          <Modal.Header>Search syntax</Modal.Header>
+          <Modal.Content>
+            Combine terms with AND, OR and NOT. Quote a phrase to match it
+            exactly.
+          </Modal.Content>
+        </>
+      )}
+    </ModalPreview>
   ),
 };
 
@@ -199,7 +314,11 @@ export const RichContent: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<Modal open={open} onOpenChange={setOpen}>
+        code: `const modalRef = useRef<HTMLDialogElement>(null);
+const close = () => modalRef.current?.close();
+
+<Button onClick={() => modalRef.current?.showModal()}>Open modal</Button>
+<Modal ref={modalRef}>
   <Modal.Header>Connect to instance</Modal.Header>
   <Modal.Content>
     <div style={{ display: "grid", gap: "var(--dimension-200, 16px)", margin: 0 }}>
@@ -217,8 +336,10 @@ export const RichContent: Story = {
     </div>
   </Modal.Content>
   <Modal.Footer>
-    <Button importance="secondary">Cancel</Button>
-    <Button importance="primary" anticipation="constructive">
+    <Button importance="secondary" onClick={close}>
+      Cancel
+    </Button>
+    <Button importance="primary" anticipation="constructive" onClick={close}>
       Connect
     </Button>
   </Modal.Footer>
@@ -226,43 +347,53 @@ export const RichContent: Story = {
       },
     },
   },
-  render: ({ open }) => (
-    <Modal open={open}>
-      <Modal.Header>Connect to instance</Modal.Header>
-      <Modal.Content>
-        <div
-          style={{
-            display: "grid",
-            gap: "var(--dimension-200, 16px)",
-            margin: 0,
-          }}
-        >
-          <p style={{ margin: 0 }}>
-            The instance accepts SSH on its public address. Press{" "}
-            <KeyboardKey keyValue="cmd" /> <KeyboardKey keyValue="c" /> to copy
-            the command below.
-          </p>
-          <InlineCode>ssh ubuntu@10.0.1.42 -i ~/.ssh/id_ed25519</InlineCode>
-          <div
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "var(--dimension-100, 8px)",
-            }}
-          >
-            <Chip lead="Status" value="Running" criticality="success" />
-            <Chip lead="Image" value="ubuntu:24.04" />
-            <Chip lead="Agent" value="beta" release="beta" />
-          </div>
-        </div>
-      </Modal.Content>
-      <Modal.Footer>
-        <Button importance="secondary">Cancel</Button>
-        <Button importance="primary" anticipation="constructive">
-          Connect
-        </Button>
-      </Modal.Footer>
-    </Modal>
+  render: ({ defaultOpen }) => (
+    <ModalPreview defaultOpen={defaultOpen}>
+      {(close) => (
+        <>
+          <Modal.Header>Connect to instance</Modal.Header>
+          <Modal.Content>
+            <div
+              style={{
+                display: "grid",
+                gap: "var(--dimension-200, 16px)",
+                margin: 0,
+              }}
+            >
+              <p style={{ margin: 0 }}>
+                The instance accepts SSH on its public address. Press{" "}
+                <KeyboardKey keyValue="cmd" /> <KeyboardKey keyValue="c" /> to
+                copy the command below.
+              </p>
+              <InlineCode>ssh ubuntu@10.0.1.42 -i ~/.ssh/id_ed25519</InlineCode>
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "var(--dimension-100, 8px)",
+                }}
+              >
+                <Chip lead="Status" value="Running" criticality="success" />
+                <Chip lead="Image" value="ubuntu:24.04" />
+                <Chip lead="Agent" value="beta" release="beta" />
+              </div>
+            </div>
+          </Modal.Content>
+          <Modal.Footer>
+            <Button importance="secondary" onClick={close}>
+              Cancel
+            </Button>
+            <Button
+              importance="primary"
+              anticipation="constructive"
+              onClick={close}
+            >
+              Connect
+            </Button>
+          </Modal.Footer>
+        </>
+      )}
+    </ModalPreview>
   ),
 };
 
@@ -274,7 +405,10 @@ export const LongContent: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<Modal open={open} onOpenChange={setOpen}>
+        code: `const modalRef = useRef<HTMLDialogElement>(null);
+
+<Button onClick={() => modalRef.current?.showModal()}>Open modal</Button>
+<Modal ref={modalRef}>
   <Modal.Header>Terms</Modal.Header>
   <Modal.Content>
     {paragraphs.map((paragraph) => (
@@ -282,7 +416,11 @@ export const LongContent: Story = {
     ))}
   </Modal.Content>
   <Modal.Footer>
-    <Button importance="primary" anticipation="constructive">
+    <Button
+      importance="primary"
+      anticipation="constructive"
+      onClick={() => modalRef.current?.close()}
+    >
       Accept
     </Button>
   </Modal.Footer>
@@ -290,23 +428,31 @@ export const LongContent: Story = {
       },
     },
   },
-  render: ({ open }) => (
-    <Modal open={open}>
-      <Modal.Header>Terms</Modal.Header>
-      <Modal.Content>
-        {Array.from(
-          { length: 30 },
-          (_, index) =>
-            `Paragraph ${index + 1} of scrolling placeholder content.`,
-        ).map((paragraph) => (
-          <p key={paragraph}>{paragraph}</p>
-        ))}
-      </Modal.Content>
-      <Modal.Footer>
-        <Button importance="primary" anticipation="constructive">
-          Accept
-        </Button>
-      </Modal.Footer>
-    </Modal>
+  render: ({ defaultOpen }) => (
+    <ModalPreview defaultOpen={defaultOpen}>
+      {(close) => (
+        <>
+          <Modal.Header>Terms</Modal.Header>
+          <Modal.Content>
+            {Array.from(
+              { length: 30 },
+              (_, index) =>
+                `Paragraph ${index + 1} of scrolling placeholder content.`,
+            ).map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </Modal.Content>
+          <Modal.Footer>
+            <Button
+              importance="primary"
+              anticipation="constructive"
+              onClick={close}
+            >
+              Accept
+            </Button>
+          </Modal.Footer>
+        </>
+      )}
+    </ModalPreview>
   ),
 };

--- a/packages/react/ds-global/src/lib/pattern/Modal/Modal.tests.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/Modal.tests.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import Component from "./Modal.js";
 
@@ -12,14 +13,27 @@ beforeAll(() => {
     HTMLDialogElement.prototype.showModal = function showModal(
       this: HTMLDialogElement,
     ): void {
+      // The platform throws on an already-open dialog, and the guards against
+      // that are worth testing, so the stub throws too.
+      if (this.open) {
+        throw new DOMException(
+          "The dialog is already open.",
+          "InvalidStateError",
+        );
+      }
       this.open = true;
     };
   }
   if (!HTMLDialogElement.prototype.close) {
     HTMLDialogElement.prototype.close = function close(
       this: HTMLDialogElement,
+      returnValue?: string,
     ): void {
+      // The platform only fires `close` when the dialog was open, and records
+      // the return value the caller passed.
+      if (!this.open) return;
       this.open = false;
+      if (returnValue !== undefined) this.returnValue = returnValue;
       this.dispatchEvent(new Event("close"));
     };
   }
@@ -29,7 +43,7 @@ describe("Modal pattern", () => {
   describe("rendering", () => {
     it("applies base classes", () => {
       render(
-        <Component open>
+        <Component defaultOpen>
           <Component.Content>Placeholder content</Component.Content>
         </Component>,
       );
@@ -38,7 +52,7 @@ describe("Modal pattern", () => {
 
     it("renders the composed sections inside the dialog", () => {
       const { container } = render(
-        <Component open>
+        <Component defaultOpen>
           <Component.Header>Title</Component.Header>
           <Component.Content>Placeholder content</Component.Content>
           <Component.Footer>
@@ -59,7 +73,7 @@ describe("Modal pattern", () => {
 
     it("renders only the sections the consumer composes", () => {
       const { container } = render(
-        <Component open>
+        <Component defaultOpen>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
@@ -70,75 +84,346 @@ describe("Modal pattern", () => {
 
     it("passes the consumer className through", () => {
       render(
-        <Component open className="custom">
+        <Component defaultOpen className="custom">
           <Component.Content>Body</Component.Content>
         </Component>,
       );
       expect(screen.getByRole("dialog")).toHaveClass("custom");
     });
-  });
 
-  describe("open state", () => {
-    it("opens the native dialog when open is true", () => {
-      render(
-        <Component open>
+    /*
+      The backdrop handler is composed with the consumer's, not replaced by it:
+      a plain spread would let an unrelated onClick silently disable
+      closeOnBackdropClick.
+    */
+    it("calls a consumer onClick as well as closing on the backdrop", () => {
+      const onClick = vi.fn();
+      const { container } = render(
+        <Component defaultOpen closeOnBackdropClick onClick={onClick}>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
-      expect(screen.getByRole("dialog")).toHaveAttribute("open");
+
+      screen.getByRole("dialog").click();
+
+      expect(onClick).toHaveBeenCalled();
+      expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+    });
+  });
+
+  describe("accessible name", () => {
+    it("names the dialog with a consumer aria-label when there is no header", () => {
+      render(
+        <Component defaultOpen aria-label="Search syntax">
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+      expect(
+        screen.getByRole("dialog", { name: "Search syntax" }),
+      ).toBeInTheDocument();
     });
 
-    it("leaves the dialog closed when open is false", () => {
+    /*
+      `aria-labelledby` wins over `aria-label` in the accessible-name
+      computation, so the header's title id must not be set when the consumer
+      has named the dialog itself — it would win, and point at nothing.
+    */
+    it("drops the header title id when a consumer aria-label is given", () => {
+      render(
+        <Component defaultOpen aria-label="Named by the consumer">
+          <Component.Header>Title</Component.Header>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).not.toHaveAttribute("aria-labelledby");
+      expect(dialog).toHaveAccessibleName("Named by the consumer");
+    });
+
+    it("prefers a consumer aria-labelledby over the header title", () => {
+      render(
+        <>
+          <h1 id="page-title">Named elsewhere</h1>
+          <Component defaultOpen aria-labelledby="page-title">
+            <Component.Header>Title</Component.Header>
+            <Component.Content>Body</Component.Content>
+          </Component>
+        </>,
+      );
+      expect(screen.getByRole("dialog")).toHaveAttribute(
+        "aria-labelledby",
+        "page-title",
+      );
+    });
+  });
+
+  describe("open state", () => {
+    it("stays closed by default", () => {
       const { container } = render(
-        <Component open={false}>
+        <Component>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
       expect(container.querySelector("dialog")).not.toHaveAttribute("open");
     });
 
-    /*
-      The platform can close the dialog without going through onCancel: close
-      watchers make only the FIRST Escape cancelable, so a second press closes
-      it over the component's head. The modal reports that close so the
-      consumer sets `open` to `false`, as the contract requires — otherwise
-      the `open` prop and the DOM desync and the modal can never be reopened.
-    */
-    it("reports a close the platform performed itself", () => {
-      const onOpenChange = vi.fn();
+    it("opens the native dialog on mount when defaultOpen is set", () => {
       render(
-        <Component open onOpenChange={onOpenChange}>
+        <Component defaultOpen>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
-
-      screen.getByRole("dialog").dispatchEvent(new Event("close"));
-
-      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(screen.getByRole("dialog")).toHaveAttribute("open");
     });
 
-    it("stays quiet when the close came from the open prop", () => {
-      const onOpenChange = vi.fn();
-      const { rerender } = render(
-        <Component open onOpenChange={onOpenChange}>
+    /*
+      `defaultOpen` is the starting state, not a live one: the modal owns its
+      open state from mount onwards, so a render that flips the prop back must
+      not close a modal out from under the user.
+    */
+    it("ignores a later change to defaultOpen", () => {
+      const { container, rerender } = render(
+        <Component defaultOpen>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
 
       rerender(
-        <Component open={false} onOpenChange={onOpenChange}>
+        <Component defaultOpen={false}>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
 
-      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
+    });
+
+    it("does not reopen a closed modal when the consumer re-renders", () => {
+      const ref = createRef<HTMLDialogElement>();
+      const { container, rerender } = render(
+        <Component ref={ref} defaultOpen>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      ref.current?.close();
+      // Two things have to hold for this: the mount effect keeps no reactive
+      // deps, and the `defaultOpen` latch is spent once it has been acted on.
+      // A fresh ref object re-runs the ref callback, which must not be a way
+      // back into either.
+      rerender(
+        <Component ref={createRef<HTMLDialogElement>()} defaultOpen>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+    });
+
+    it("passes the native close event through to the consumer", () => {
+      const onClose = vi.fn();
+      const ref = createRef<HTMLDialogElement>();
+      render(
+        <Component ref={ref} defaultOpen onClose={onClose}>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      ref.current?.close();
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+      `onClose` says the modal is gone, not how it went. An action that has to
+      be told apart from a dismissal closes with a return value, which the
+      platform records on the dialog.
+    */
+    it("carries a close return value to the consumer", () => {
+      const returnValues: string[] = [];
+      const ref = createRef<HTMLDialogElement>();
+      render(
+        <Component
+          ref={ref}
+          defaultOpen
+          onClose={(event) =>
+            returnValues.push(event.currentTarget.returnValue)
+          }
+        >
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      ref.current?.close("confirm");
+
+      expect(returnValues).toEqual(["confirm"]);
+    });
+
+    /*
+      Escape has no handler of its own: the `cancel` event closes the dialog as
+      its default action, so the modal must not cancel that event on the
+      consumer's behalf.
+    */
+    it("leaves the cancel event's default action intact", () => {
+      render(
+        <Component defaultOpen>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      const cancel = new Event("cancel", { cancelable: true });
+      const notPrevented = screen.getByRole("dialog").dispatchEvent(cancel);
+
+      expect(notPrevented).toBe(true);
+      expect(cancel.defaultPrevented).toBe(false);
+    });
+
+    it("passes the native cancel event through to the consumer", () => {
+      const onCancel = vi.fn();
+      render(
+        <Component defaultOpen onCancel={onCancel}>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      screen
+        .getByRole("dialog")
+        .dispatchEvent(new Event("cancel", { cancelable: true }));
+
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe("ref control", () => {
+    it("attaches the consumer ref to the dialog", () => {
+      const ref = createRef<HTMLDialogElement>();
+      render(
+        <Component ref={ref}>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+      expect(ref.current).toBe(screen.getByRole("dialog", { hidden: true }));
+    });
+
+    it("opens through the ref", () => {
+      const ref = createRef<HTMLDialogElement>();
+      const { container } = render(
+        <Component ref={ref}>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      ref.current?.showModal();
+
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
+    });
+
+    it("closes through the ref", () => {
+      const ref = createRef<HTMLDialogElement>();
+      const { container } = render(
+        <Component ref={ref} defaultOpen>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
+
+      ref.current?.close();
+
+      expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+    });
+
+    /*
+      The round trip the controlled implementation could not do: a dismissal
+      from the inside left `open` and the DOM out of step, and the modal could
+      never be reopened. With the state in the element there is nothing to
+      desync.
+    */
+    it("reopens through the ref after a dismissal from the inside", () => {
+      const ref = createRef<HTMLDialogElement>();
+      const { container } = render(
+        <Component ref={ref} defaultOpen>
+          <Component.Header>Title</Component.Header>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      screen.getByRole("button", { name: "Close" }).click();
+      expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+
+      ref.current?.showModal();
+
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
+    });
+
+    it("opens on mount with defaultOpen even when a ref is supplied", () => {
+      const ref = createRef<HTMLDialogElement>();
+      render(
+        <Component ref={ref} defaultOpen>
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+      expect(ref.current).toHaveAttribute("open");
+    });
+
+    it("accepts a callback ref", () => {
+      const received: (HTMLDialogElement | null)[] = [];
+      render(
+        <Component
+          ref={(node) => {
+            received.push(node);
+          }}
+        >
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+      expect(received.at(0)).toBe(screen.getByRole("dialog", { hidden: true }));
+    });
+
+    /*
+      React 19 runs a ref callback's returned cleanup instead of calling the
+      callback with null. Merging the consumer's ref must not swallow that.
+    */
+    it("runs a callback ref's cleanup on unmount", () => {
+      const cleanup = vi.fn();
+      const detached = vi.fn();
+      const { unmount } = render(
+        <Component
+          ref={(node) => {
+            if (!node) detached();
+            return cleanup;
+          }}
+        >
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+
+      unmount();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(detached).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when the consumer opened the dialog before mount effects", () => {
+      // A callback ref runs in the commit phase, before passive effects: a
+      // consumer opening the dialog there would make the defaultOpen effect's
+      // showModal() throw if it did not check first.
+      const { container } = render(
+        <Component
+          defaultOpen
+          ref={(node) => {
+            node?.showModal();
+          }}
+        >
+          <Component.Content>Body</Component.Content>
+        </Component>,
+      );
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
     });
   });
 
   describe("header", () => {
     it("names the dialog with the composed title", () => {
       render(
-        <Component open>
+        <Component defaultOpen>
           <Component.Header>Delete instance</Component.Header>
           <Component.Content>Body</Component.Content>
         </Component>,
@@ -150,7 +435,7 @@ describe("Modal pattern", () => {
 
     it("renders a close button by default", () => {
       render(
-        <Component open>
+        <Component defaultOpen>
           <Component.Header>Title</Component.Header>
           <Component.Content>Body</Component.Content>
         </Component>,
@@ -158,21 +443,20 @@ describe("Modal pattern", () => {
       expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
     });
 
-    it("requests close through the modal when the close button is pressed", () => {
-      const onOpenChange = vi.fn();
-      render(
-        <Component open onOpenChange={onOpenChange}>
+    it("closes the modal when the close button is pressed", () => {
+      const { container } = render(
+        <Component defaultOpen>
           <Component.Header>Title</Component.Header>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
       screen.getByRole("button", { name: "Close" }).click();
-      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(container.querySelector("dialog")).not.toHaveAttribute("open");
     });
 
     it("renders no close button when not dismissible", () => {
       render(
-        <Component open>
+        <Component defaultOpen>
           <Component.Header dismissible={false}>Title</Component.Header>
           <Component.Content>Body</Component.Content>
         </Component>,
@@ -184,7 +468,7 @@ describe("Modal pattern", () => {
 
     it("uses a custom dismiss label", () => {
       render(
-        <Component open>
+        <Component defaultOpen>
           <Component.Header dismissLabel="Dismiss">Title</Component.Header>
           <Component.Content>Body</Component.Content>
         </Component>,
@@ -194,68 +478,59 @@ describe("Modal pattern", () => {
       ).toBeInTheDocument();
     });
 
-    it("prefers an explicit onDismiss over the modal's", () => {
-      const onOpenChange = vi.fn();
+    it("prefers an explicit onDismiss over closing the modal", () => {
       const onDismiss = vi.fn();
-      render(
-        <Component open onOpenChange={onOpenChange}>
+      const { container } = render(
+        <Component defaultOpen>
           <Component.Header onDismiss={onDismiss}>Title</Component.Header>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
       screen.getByRole("button", { name: "Close" }).click();
       expect(onDismiss).toHaveBeenCalled();
-      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
     });
   });
 
   describe("backdrop", () => {
-    it("requests close on a click that lands on the dialog itself", () => {
-      const onOpenChange = vi.fn();
-      render(
-        <Component open closeOnBackdropClick onOpenChange={onOpenChange}>
+    it("closes on a click that lands on the dialog itself", () => {
+      const { container } = render(
+        <Component defaultOpen closeOnBackdropClick>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
       screen.getByRole("dialog").click();
-      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(container.querySelector("dialog")).not.toHaveAttribute("open");
     });
 
     it("ignores backdrop clicks by default", () => {
-      const onOpenChange = vi.fn();
-      render(
-        <Component open onOpenChange={onOpenChange}>
+      const { container } = render(
+        <Component defaultOpen>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
       screen.getByRole("dialog").click();
-      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
     });
 
     it("ignores backdrop clicks when closeOnBackdropClick is false", () => {
-      const onOpenChange = vi.fn();
-      render(
-        <Component
-          open
-          closeOnBackdropClick={false}
-          onOpenChange={onOpenChange}
-        >
+      const { container } = render(
+        <Component defaultOpen closeOnBackdropClick={false}>
           <Component.Content>Body</Component.Content>
         </Component>,
       );
       screen.getByRole("dialog").click();
-      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
     });
 
     it("ignores clicks inside the content pane", () => {
-      const onOpenChange = vi.fn();
-      render(
-        <Component open closeOnBackdropClick onOpenChange={onOpenChange}>
+      const { container } = render(
+        <Component defaultOpen closeOnBackdropClick>
           <Component.Content>Placeholder content</Component.Content>
         </Component>,
       );
       screen.getByText("Placeholder content").click();
-      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(container.querySelector("dialog")).toHaveAttribute("open");
     });
   });
 });

--- a/packages/react/ds-global/src/lib/pattern/Modal/Modal.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/Modal.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
-import { useEffect, useId, useRef } from "react";
+import type { RefCallback } from "react";
+import { useCallback, useEffect, useId, useRef } from "react";
 import { Content, Footer, Header } from "./common/index.js";
 import ModalContext from "./common/ModalContext.js";
 import type { ModalProps } from "./types.js";
@@ -15,11 +16,13 @@ const componentCssClassName = "ds modal";
  *
  * It renders a native `<dialog>` opened with `showModal()`, so the backdrop,
  * focus trap, page inertness and Escape handling come from the platform rather
- * than from JavaScript. `open` is controlled: dismissal — the close button,
- * Escape, or the backdrop — is reported through `onOpenChange`, and the modal
- * closes when the consumer sets `open` to `false`. Escape always closes the
- * modal: `onOpenChange` is where the consumer does pre-close work, not a
- * chance to refuse.
+ * than from JavaScript. The modal is self-contained: the open state lives in
+ * the `<dialog>` element, not in a prop, so the header's close button and
+ * Escape close it — and a backdrop click too, once `closeOnBackdropClick` opts
+ * in — without the consumer wiring anything. `onClose` is the native way to
+ * hear about it. External control is optional and goes through the `ref`:
+ * `ref.current?.showModal()` opens the modal and `ref.current?.close()` closes
+ * it. Pass `defaultOpen` to have it open on mount.
  *
  * The sections are composed by the consumer: render
  * `Modal.Header`, `Modal.Content` and `Modal.Footer` as children and choose
@@ -31,64 +34,87 @@ const componentCssClassName = "ds modal";
  * @implements ds:global.pattern.modal
  */
 const Modal = ({
-  open,
-  onOpenChange,
+  ref,
+  defaultOpen = false,
   closeOnBackdropClick = false,
   children,
   className,
+  onClick,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledby,
   ...props
 }: ModalProps): React.ReactElement => {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  // The dialog is always attached to the component's own ref, because closing
+  // from the inside needs the node whether or not the consumer asked for it. A
+  // consumer ref is merged in rather than substituted, which keeps this ref
+  // stable across renders and lets the prop take a callback ref too.
+  const attachDialog = useCallback<RefCallback<HTMLDialogElement>>(
+    (node) => {
+      dialogRef.current = node;
+      if (typeof ref !== "function") {
+        if (ref) ref.current = node;
+        return;
+      }
+      // A React 19 callback ref may return a cleanup function, and React then
+      // runs that instead of calling the ref with `null`. Returning it from
+      // here — and only here — keeps both conventions intact: the consumer's
+      // cleanup runs, or React detaches by calling this callback with `null`.
+      const cleanup = ref(node);
+      if (typeof cleanup !== "function") return;
+      return () => {
+        dialogRef.current = null;
+        cleanup();
+      };
+    },
+    [ref],
+  );
   const titleId = useId();
 
+  // `defaultOpen` is uncontrolled, so only its mount value counts.
+  const opensOnMount = useRef(defaultOpen);
+
   useEffect(() => {
-    // When open changes this effect is executed. According to the value open has
-    // the modal closes or opens
-    // This is the reason why modal need to know open
-
+    if (!opensOnMount.current) return;
+    // One-shot: once the starting state has been acted on, no later run can
+    // reopen a modal the user has closed.
+    opensOnMount.current = false;
     const dialog = dialogRef.current;
-    if (!dialog) return;
+    // showModal() is what puts the dialog in the top layer — the `open`
+    // attribute alone would render it inline and non-modal — and it throws if
+    // the dialog is open already, which a consumer's own ref may have done
+    // before this effect ran.
+    if (dialog && !dialog.open) dialog.showModal();
+  }, []);
 
-    if (open && !dialog.open) {
-      // showModal() displays a native dialog
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      // close() closes a native dialog
-      dialog.close();
-    }
-  }, [open]);
-
-  const requestClose = (): void => onOpenChange?.(false);
+  const requestClose = (): void => dialogRef.current?.close();
 
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: the click handler only identifies clicks landing on the backdrop, which has no keyboard equivalent; keyboard dismissal is Escape, handled natively by the dialog's cancel event
     <dialog
-      ref={dialogRef}
+      ref={attachDialog}
       className={[componentCssClassName, className].filter(Boolean).join(" ")}
-      // The composed Header sets this id on its title, which names the dialog;
-      // a modal without a header must supply aria-label, which passes through
-      // `props` (and overrides this attribute when provided).
-      aria-labelledby={titleId}
-      // Escape fires `cancel` natively.
-      onCancel={(event) => {
-        event.preventDefault();
-        requestClose();
-      }}
-      // The platform can close the dialog without going through our handlers:
-      // a first Escape is canceled above, but a repeated Escape closes it over
-      // our head. Report that so the consumer's `onOpenChange` sets `open` to
-      // `false` and keeps it matching the DOM — otherwise the two desync and
-      // reopening becomes impossible, because neither `open` nor the effect's
-      // deps ever change.
-
-      onClose={() => {
-        if (open) {
-          requestClose();
-        }
-      }}
+      // The composed Header sets this id on its title, which names the dialog.
+      // A name the consumer gave wins, and it has to be chosen here rather than
+      // left to the spread: `aria-labelledby` beats `aria-label` in the
+      // accessible-name computation, so pointing at the title unconditionally
+      // would silence the `aria-label` a header-less modal must carry.
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby ?? (ariaLabel ? undefined : titleId)}
+      // Escape is not handled here: its `cancel` event closes the dialog as its
+      // own default action, which is what the platform's close watchers are
+      // for. A consumer that must intervene can pass `onCancel` through
+      // `props` and call `preventDefault()` — but only the FIRST Escape is
+      // cancelable, so a repeated press closes the modal over that handler's
+      // head. Escape is a way out the consumer can delay, not deny; `onClose`
+      // is where to hear that it happened.
+      //
       // A click landing on the <dialog> itself is a backdrop click: the box has
-      // no padding of its own, so every inner pixel belongs to a child.
+      // no padding of its own, so every inner pixel belongs to a child. The
+      // consumer's own handler is called first and composed with, not replaced
+      // — a spread would silently drop backdrop dismissal.
       onClick={(event) => {
+        onClick?.(event);
         if (closeOnBackdropClick && event.target === event.currentTarget) {
           requestClose();
         }

--- a/packages/react/ds-global/src/lib/pattern/Modal/common/ModalContext.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/common/ModalContext.tsx
@@ -12,7 +12,7 @@ export interface ModalContextValue {
    * title, which is what gives the dialog its accessible name.
    */
   titleId: string;
-  /** Requests dismissal — reports `false` through the modal's `onOpenChange`. */
+  /** Closes the dialog. What the Header's close button calls. */
   onDismiss: () => void;
 }
 

--- a/packages/react/ds-global/src/lib/pattern/Modal/index.ts
+++ b/packages/react/ds-global/src/lib/pattern/Modal/index.ts
@@ -2,3 +2,4 @@
 
 export { default as Modal } from "./Modal.js";
 export type * from "./types.js";
+export { default as withModal } from "./withModal.js";

--- a/packages/react/ds-global/src/lib/pattern/Modal/styles.css
+++ b/packages/react/ds-global/src/lib/pattern/Modal/styles.css
@@ -102,3 +102,13 @@
     background-color: var(--modal-color-backdrop);
   }
 }
+
+/*
+  The `withModal` HOC wraps the trigger in this span to carry the open-on-click
+  handler. `display: contents` removes the box itself, so the wrapped trigger
+  participates in the parent's layout (flex/grid items, gap) exactly as if it
+  were unwrapped 
+*/
+.ds.modal-trigger {
+  display: contents;
+}

--- a/packages/react/ds-global/src/lib/pattern/Modal/types.ts
+++ b/packages/react/ds-global/src/lib/pattern/Modal/types.ts
@@ -1,4 +1,4 @@
-import type { DialogHTMLAttributes, ReactNode } from "react";
+import type { DialogHTMLAttributes, ReactNode, Ref } from "react";
 
 /**
  * Props for the Modal pattern
@@ -17,26 +17,44 @@ import type { DialogHTMLAttributes, ReactNode } from "react";
  * `title` is omitted from the native attributes because the DOM `title`
  * attribute is a tooltip, while here it would name the modal — which the
  * composed `Modal.Header` does instead.
+ *
+ * `open` is omitted because a `<dialog>` carrying the `open` attribute is
+ * *non-modal*: no top layer, no backdrop, no focus trap. The modal is only
+ * ever opened through `showModal()`, so the open state lives in the DOM
+ * element and not in a prop. Use `defaultOpen` to open it on mount and `ref`
+ * to open or close it later.
+ *
+ * `onClose` is *not* omitted: the native `close` event is how a consumer hears
+ * that the modal is gone, whichever way out the user took, and it replaces the
+ * `onOpenChange` callback a controlled modal would need. It does not say *which*
+ * way out that was — an action that needs to be told apart from a dismissal
+ * should close the modal with `ref.current?.close(value)` and read
+ * `event.currentTarget.returnValue`.
  */
 export interface ModalProps
-  extends Omit<
-    DialogHTMLAttributes<HTMLDialogElement>,
-    "open" | "title" | "onClose"
-  > {
+  extends Omit<DialogHTMLAttributes<HTMLDialogElement>, "open" | "title"> {
   /**
-   * Whether the modal is shown. Controlled: the consumer owns this state, and
-   * the modal asks to change it through `onOpenChange`.
+   * A ref to the underlying `<dialog>`, for the cases that need to drive the
+   * modal from outside it: `ref.current?.showModal()` opens it and
+   * `ref.current?.close()` closes it. Optional — a modal wired up with
+   * {@link withModal}, or one that only has to be dismissed from the inside,
+   * needs no ref at all.
+   *
+   * `showModal()` throws on a dialog that is already open. A trigger sitting
+   * on the page cannot be clicked while the modal holds it inert, so it needs
+   * no guard; anything that can fire twice — a keyboard shortcut, an effect —
+   * should check `ref.current.open` first.
    */
-  open: boolean;
+  ref?: Ref<HTMLDialogElement>;
   /**
-   * Called when the user dismisses the modal — via the close button, Escape,
-   * or the backdrop. Escape always closes the modal. Do any pre-close work
-   * here, but always set `open` to `false` as well: that state change is what
-   * closes the dialog. Skip it and the dismissal will not close the modal —
-   * until a repeated Escape lets the platform close it on its own, leaving
-   * `open` out of sync with the DOM, and the modal can never be reopened.
+   * Whether the modal opens as soon as it mounts. Uncontrolled: this is the
+   * starting state, not a live one, and later changes are ignored — reopening
+   * a closed modal goes through `ref.current?.showModal()`. Defaults to
+   * `false`. Note the dialog still renders closed on the server, because
+   * `showModal()` is what makes a dialog modal and that only runs on the
+   * client.
    */
-  onOpenChange?: (open: boolean) => void;
+  defaultOpen?: boolean;
   /**
    * Whether clicking the backdrop dismisses the modal. Defaults to `false`, so
    * backdrop dismissal is opt-in: a stray click outside the dialog cannot
@@ -59,16 +77,18 @@ export interface ModalProps
  * `<Button onClick={close}>Got it</Button>`.
  *
  * A footer action can only close. If it must do more — submit data, close
- * conditionally, open another modal — skip the HOC and compose the controlled
- * `Modal` with your own `open` state.
+ * conditionally, open another modal — skip the HOC and compose `Modal`
+ * directly, driving it through its `ref`.
  */
 export type WithModalChildren = ReactNode | ((close: () => void) => ReactNode);
 
 /**
  * The modal options for {@link withModal}: everything `Modal` accepts except
- * `open`, `onOpenChange` and `children`, which the HOC owns.
+ * `ref`, `defaultOpen` and `children`. The HOC owns the ref, because the
+ * trigger it wraps is what opens the modal, and a modal that starts open has
+ * no use for a trigger.
  */
 export type WithModalOptions = Omit<
   ModalProps,
-  "open" | "onOpenChange" | "children"
+  "ref" | "defaultOpen" | "children"
 >;

--- a/packages/react/ds-global/src/lib/pattern/Modal/types.ts
+++ b/packages/react/ds-global/src/lib/pattern/Modal/types.ts
@@ -50,3 +50,25 @@ export interface ModalProps
    */
   children: ReactNode;
 }
+
+/**
+ * The content of a {@link withModal} modal: plain JSX, or a function.
+ *
+ * The function form receives the modal's `close` callback — the only action
+ * the HOC can hand to the content — so a footer button can close the modal:
+ * `<Button onClick={close}>Got it</Button>`.
+ *
+ * A footer action can only close. If it must do more — submit data, close
+ * conditionally, open another modal — skip the HOC and compose the controlled
+ * `Modal` with your own `open` state.
+ */
+export type WithModalChildren = ReactNode | ((close: () => void) => ReactNode);
+
+/**
+ * The modal options for {@link withModal}: everything `Modal` accepts except
+ * `open`, `onOpenChange` and `children`, which the HOC owns.
+ */
+export type WithModalOptions = Omit<
+  ModalProps,
+  "open" | "onOpenChange" | "children"
+>;

--- a/packages/react/ds-global/src/lib/pattern/Modal/withModal.ssr.tests.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/withModal.ssr.tests.tsx
@@ -1,0 +1,41 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { withModal } from "./index.js";
+import Modal from "./Modal.js";
+
+const Trigger = ({ children }: { children?: string }) => (
+  <button type="button">{children}</button>
+);
+
+describe("withModal (SSR)", () => {
+  it("renders to static HTML without throwing", () => {
+    const TriggeredModal = withModal(
+      Trigger,
+      <>
+        <Modal.Header>Title</Modal.Header>
+        <Modal.Content>Body</Modal.Content>
+      </>,
+    );
+    expect(() =>
+      renderToString(<TriggeredModal>Open</TriggeredModal>),
+    ).not.toThrow();
+  });
+
+  it("emits the trigger and a closed dialog", () => {
+    const TriggeredModal = withModal(
+      Trigger,
+      <>
+        <Modal.Header>Title</Modal.Header>
+        <Modal.Content>Body</Modal.Content>
+      </>,
+    );
+    const html = renderToString(<TriggeredModal>Open</TriggeredModal>);
+
+    expect(html).toContain("ds modal-trigger");
+    expect(html).toContain("Open");
+    expect(html).toContain('class="ds modal"');
+    // The dialog is only opened by a client-side effect, so it must render
+    // closed on the server.
+    expect(html).not.toMatch(/<dialog[^>]*\sopen/);
+  });
+});

--- a/packages/react/ds-global/src/lib/pattern/Modal/withModal.stories.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/withModal.stories.tsx
@@ -20,8 +20,8 @@ const meta = {
           "`withModal(Button, (close) => <Modal.Footer><Button onClick={close}>Done</Button></Modal.Footer>)`.",
           "",
           "**A footer button can only close the modal.** If an action needs to do anything else —",
-          "save data, open another modal, close conditionally — skip this HOC and compose the",
-          "controlled `Modal` with your own `open` state.",
+          "save data, open another modal, close conditionally — skip this HOC and compose `Modal`",
+          "directly, driving it through its `ref`.",
         ].join("\n"),
       },
       story: {
@@ -78,7 +78,7 @@ Default.parameters = {
  * A footer button can only do one thing here: close the modal. Pass the
  * content as a function to receive the `close` callback and wire it with
  * `onClick={close}`. If a button needs to do more than close — submit a form,
- * open another modal — use the controlled `Modal` instead.
+ * open another modal — compose `Modal` directly and drive it through its `ref`.
  */
 export const FooterAction: StoryFn = () => {
   const AcknowledgeButton = withModal(Button, (close) => (

--- a/packages/react/ds-global/src/lib/pattern/Modal/withModal.stories.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/withModal.stories.tsx
@@ -1,0 +1,204 @@
+import type { Meta, StoryFn } from "@storybook/react-vite";
+import { Button } from "../../component/Button/index.js";
+import { withModal } from "./index.js";
+import Modal from "./Modal.js";
+
+const meta = {
+  title: "patterns/Modal/withModal",
+  // Docs previews render in an iframe: showModal() puts the dialog in the
+  // page's top layer, which escapes every container — inside an iframe the
+  // top layer is the preview window itself, so each story's open modal stays
+  // contained instead of stacking over the docs page.
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          "`withModal` wraps a trigger with a modal: **click the trigger → the modal opens**.",
+          "",
+          "**How it closes:** the header's X button and Escape always work. A footer button can",
+          "close it too — pass the content as a function to receive the `close` callback:",
+          "`withModal(Button, (close) => <Modal.Footer><Button onClick={close}>Done</Button></Modal.Footer>)`.",
+          "",
+          "**A footer button can only close the modal.** If an action needs to do anything else —",
+          "save data, open another modal, close conditionally — skip this HOC and compose the",
+          "controlled `Modal` with your own `open` state.",
+        ].join("\n"),
+      },
+      story: {
+        inline: false,
+        iframeHeight: "480px",
+      },
+      // The stories use custom renders, so autodocs' default "dynamic" source
+      // (reconstructed from args, in the docs frame) has nothing to show —
+      // doubly so with the iframed previews above. Serve the consumer-facing
+      // snippet explicitly instead.
+      source: { type: "code", language: "tsx" },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+
+/**
+ * The simplest form: click the button, the modal opens. Close it with the
+ * header's X button or Escape. No footer — nothing to decide.
+ */
+export const Default: StoryFn = () => {
+  const OpenButton = withModal(
+    Button,
+    <>
+      <Modal.Header>Title</Modal.Header>
+      <Modal.Content>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </Modal.Content>
+    </>,
+  );
+
+  return <OpenButton>Open modal</OpenButton>;
+};
+Default.storyName = "Default";
+Default.parameters = {
+  docs: {
+    source: {
+      code: `const OpenButton = withModal(
+  Button,
+  <>
+    <Modal.Header>Title</Modal.Header>
+    <Modal.Content>...</Modal.Content>
+  </>,
+);
+
+<OpenButton>Open modal</OpenButton>`,
+    },
+  },
+};
+
+/**
+ * A footer button can only do one thing here: close the modal. Pass the
+ * content as a function to receive the `close` callback and wire it with
+ * `onClick={close}`. If a button needs to do more than close — submit a form,
+ * open another modal — use the controlled `Modal` instead.
+ */
+export const FooterAction: StoryFn = () => {
+  const AcknowledgeButton = withModal(Button, (close) => (
+    <>
+      <Modal.Header>Maintenance scheduled</Modal.Header>
+      <Modal.Content>
+        The service will restart at 02:00 UTC to apply security updates.
+      </Modal.Content>
+      <Modal.Footer>
+        <Button importance="primary" onClick={close}>
+          Got it
+        </Button>
+      </Modal.Footer>
+    </>
+  ));
+
+  return (
+    <AcknowledgeButton importance="secondary">
+      Maintenance notice
+    </AcknowledgeButton>
+  );
+};
+FooterAction.parameters = {
+  docs: {
+    source: {
+      code: `const AcknowledgeButton = withModal(
+  Button,
+  (close) => (
+    <>
+      <Modal.Header>Maintenance scheduled</Modal.Header>
+      <Modal.Content>...</Modal.Content>
+      <Modal.Footer>
+        {/* A footer button can only close the modal */}
+        <Button importance="primary" onClick={close}>Got it</Button>
+      </Modal.Footer>
+    </>
+  ),
+);
+
+<AcknowledgeButton importance="secondary">Maintenance notice</AcknowledgeButton>`,
+    },
+  },
+};
+
+/**
+ * `closeOnBackdropClick` is forwarded to the underlying `Modal` through the
+ * optional third argument, so clicking outside the panel also closes it.
+ */
+export const BackdropDismissible: StoryFn = () => {
+  const InfoButton = withModal(
+    Button,
+    <>
+      <Modal.Header>Search syntax</Modal.Header>
+      <Modal.Content>
+        Combine terms with AND, OR and NOT. Quote a phrase to match it exactly.
+      </Modal.Content>
+    </>,
+    { closeOnBackdropClick: true },
+  );
+
+  return <InfoButton importance="secondary">Search syntax</InfoButton>;
+};
+BackdropDismissible.parameters = {
+  docs: {
+    source: {
+      code: `const InfoButton = withModal(
+  Button,
+  <>
+    <Modal.Header>Search syntax</Modal.Header>
+    <Modal.Content>...</Modal.Content>
+  </>,
+  { closeOnBackdropClick: true },
+);
+
+<InfoButton importance="secondary">Search syntax</InfoButton>`,
+    },
+  },
+};
+
+/**
+ * The trigger does not have to be a `Button` — any component that renders a
+ * clickable element works, because the open handler sits on a wrapper span and
+ * catches the bubbled click.
+ */
+export const CustomTrigger: StoryFn = () => {
+  const Link = ({ children }: { children?: string }) => (
+    // biome-ignore lint/a11y/useValidAnchor: demo trigger only
+    <a href="#">{children}</a>
+  );
+  const TermsLink = withModal(
+    Link,
+    <>
+      <Modal.Header>Terms</Modal.Header>
+      <Modal.Content>
+        These are the terms and conditions that apply to this service.
+      </Modal.Content>
+    </>,
+  );
+
+  return (
+    <p>
+      By continuing you agree to the <TermsLink>terms and conditions</TermsLink>
+      .
+    </p>
+  );
+};
+CustomTrigger.parameters = {
+  docs: {
+    source: {
+      code: `const TermsLink = withModal(
+  Link,
+  <>
+    <Modal.Header>Terms</Modal.Header>
+    <Modal.Content>...</Modal.Content>
+  </>,
+);
+
+<p>
+  By continuing you agree to the <TermsLink>terms and conditions</TermsLink>.
+</p>`,
+    },
+  },
+};

--- a/packages/react/ds-global/src/lib/pattern/Modal/withModal.tests.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/withModal.tests.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+import { Button } from "../../component/Button/index.js";
+import { withModal } from "./index.js";
+import Modal from "./Modal.js";
+
+/*
+  jsdom 28 implements HTMLDialogElement but not the top layer: `showModal` and
+  `close` are absent. Stub them to toggle the `open` attribute, which is all
+  the component and these assertions depend on.
+*/
+beforeAll(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function showModal(
+      this: HTMLDialogElement,
+    ): void {
+      this.open = true;
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function close(
+      this: HTMLDialogElement,
+    ): void {
+      this.open = false;
+      this.dispatchEvent(new Event("close"));
+    };
+  }
+});
+
+const modalChildren = (
+  <>
+    <Modal.Header>Title</Modal.Header>
+    <Modal.Content>Body</Modal.Content>
+  </>
+);
+
+describe("withModal", () => {
+  it("renders the wrapped component with a closed dialog", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+
+    expect(screen.getByRole("button", { name: "Open" })).toBeInTheDocument();
+    expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+  });
+
+  it("opens the modal when the trigger is clicked", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    render(<TriggeredModal>Open</TriggeredModal>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toHaveAttribute("open");
+  });
+
+  it("closes the modal through the header close button", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(container.querySelector("dialog")).toHaveAttribute("open");
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+  });
+
+  it("closes the modal when the platform fires cancel", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toHaveAttribute("open");
+
+    fireEvent(dialog as Element, new Event("cancel", { cancelable: true }));
+    expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+  });
+
+  it("closes the modal through a footer action given the close callback", () => {
+    const TriggeredModal = withModal(Button, (close) => (
+      <>
+        <Modal.Header>Title</Modal.Header>
+        <Modal.Content>Body</Modal.Content>
+        <Modal.Footer>
+          <button type="button" onClick={close}>
+            Done
+          </button>
+        </Modal.Footer>
+      </>
+    ));
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(container.querySelector("dialog")).toHaveAttribute("open");
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+  });
+
+  it("forwards props to the wrapped component", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    render(<TriggeredModal importance="secondary">Open</TriggeredModal>);
+
+    expect(screen.getByRole("button", { name: "Open" })).toHaveClass(
+      "secondary",
+    );
+  });
+
+  it("passes modal props through to the dialog", () => {
+    const TriggeredModal = withModal(Button, modalChildren, {
+      className: "custom-modal",
+      closeOnBackdropClick: true,
+    });
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toHaveClass("custom-modal");
+
+    // A click landing on the dialog itself is a backdrop click.
+    fireEvent.click(dialog as Element);
+    expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+  });
+
+  it("wraps the trigger in a modal-trigger span", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+
+    const trigger = container.querySelector(".ds.modal-trigger");
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toContainElement(
+      screen.getByRole("button", { name: "Open" }),
+    );
+  });
+
+  it("sets the wrapped component's displayName", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    expect(TriggeredModal.displayName).toBe("withModal(Button)");
+  });
+});

--- a/packages/react/ds-global/src/lib/pattern/Modal/withModal.tests.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/withModal.tests.tsx
@@ -1,8 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeAll, describe, expect, it } from "vitest";
+import { createRef } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { Button } from "../../component/Button/index.js";
 import { withModal } from "./index.js";
 import Modal from "./Modal.js";
+import type { WithModalOptions } from "./types.js";
 
 /*
   jsdom 28 implements HTMLDialogElement but not the top layer: `showModal` and
@@ -14,14 +16,27 @@ beforeAll(() => {
     HTMLDialogElement.prototype.showModal = function showModal(
       this: HTMLDialogElement,
     ): void {
+      // The platform throws on an already-open dialog, and the guards against
+      // that are worth testing, so the stub throws too.
+      if (this.open) {
+        throw new DOMException(
+          "The dialog is already open.",
+          "InvalidStateError",
+        );
+      }
       this.open = true;
     };
   }
   if (!HTMLDialogElement.prototype.close) {
     HTMLDialogElement.prototype.close = function close(
       this: HTMLDialogElement,
+      returnValue?: string,
     ): void {
+      // The platform only fires `close` when the dialog was open, and records
+      // the return value the caller passed.
+      if (!this.open) return;
       this.open = false;
+      if (returnValue !== undefined) this.returnValue = returnValue;
       this.dispatchEvent(new Event("close"));
     };
   }
@@ -64,16 +79,66 @@ describe("withModal", () => {
     expect(container.querySelector("dialog")).not.toHaveAttribute("open");
   });
 
-  it("closes the modal when the platform fires cancel", () => {
+  it("reopens the modal after it has been closed", () => {
     const TriggeredModal = withModal(Button, modalChildren);
     const { container } = render(<TriggeredModal>Open</TriggeredModal>);
 
     fireEvent.click(screen.getByRole("button", { name: "Open" }));
-    const dialog = container.querySelector("dialog");
-    expect(dialog).toHaveAttribute("open");
-
-    fireEvent(dialog as Element, new Event("cancel", { cancelable: true }));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
     expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(container.querySelector("dialog")).toHaveAttribute("open");
+  });
+
+  /*
+    Escape reaches the dialog as a cancelable `cancel` event whose default
+    action closes it. Nothing in the HOC or the modal may cancel that — jsdom
+    performs no default action, so the assertion is that the event survives.
+  */
+  it("leaves the platform's cancel default action intact", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    const dialog = container.querySelector("dialog") as HTMLDialogElement;
+    const cancel = new Event("cancel", { cancelable: true });
+
+    expect(dialog.dispatchEvent(cancel)).toBe(true);
+    expect(cancel.defaultPrevented).toBe(false);
+  });
+
+  it("keeps the trigger wired when modalProps smuggle in a ref or defaultOpen", () => {
+    // `WithModalOptions` omits both, but a consumer holding a `ModalProps`
+    // value is structurally assignable, and the HOC has to win at runtime.
+    const strayRef = createRef<HTMLDialogElement>();
+    const TriggeredModal = withModal(Button, modalChildren, {
+      ref: strayRef,
+      defaultOpen: true,
+    } as WithModalOptions);
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+
+    expect(container.querySelector("dialog")).not.toHaveAttribute("open");
+    expect(strayRef.current).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(container.querySelector("dialog")).toHaveAttribute("open");
+  });
+
+  it("ignores a trigger click while the modal is already open", () => {
+    const TriggeredModal = withModal(Button, modalChildren);
+    const { container } = render(<TriggeredModal>Open</TriggeredModal>);
+    // showModal() throws on an already-open dialog, so a second click has to
+    // stop at the trigger rather than reach the platform.
+    const showModal = vi.spyOn(HTMLDialogElement.prototype, "showModal");
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    const callCount = showModal.mock.calls.length;
+    showModal.mockRestore();
+
+    expect(callCount).toBe(1);
+    expect(container.querySelector("dialog")).toHaveAttribute("open");
   });
 
   it("closes the modal through a footer action given the close callback", () => {

--- a/packages/react/ds-global/src/lib/pattern/Modal/withModal.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/withModal.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, FC, ReactElement } from "react";
-import { useState } from "react";
+import { useRef } from "react";
 import Modal from "./Modal.js";
 import type { WithModalChildren, WithModalOptions } from "./types.js";
 
@@ -30,12 +30,12 @@ import type { WithModalChildren, WithModalOptions } from "./types.js";
  * ```
  *
  * If an action needs to do more than close — save data, open another modal,
- * close conditionally — don't use this HOC: keep the `open` state yourself
- * and compose the controlled `Modal` directly.
+ * close conditionally — don't use this HOC: compose `Modal` directly and drive
+ * it through its `ref`.
  *
  * @param Component The trigger component to wrap (e.g. `Button`). Clicking it opens the modal.
  * @param modalChildren The modal's content: plain JSX, or a function that receives `close` and returns JSX.
- * @param modalProps Props forwarded to the underlying `Modal` (e.g. `closeOnBackdropClick`), minus `open`, `onOpenChange` and `children`, which the HOC owns.
+ * @param modalProps Props forwarded to the underlying `Modal` (e.g. `closeOnBackdropClick`), minus `ref`, `defaultOpen` and `children`, which the HOC owns.
  */
 const withModal = <TProps extends object>(
   Component: ComponentType<TProps>,
@@ -43,8 +43,17 @@ const withModal = <TProps extends object>(
   modalProps: WithModalOptions = {},
 ): FC<TProps> => {
   const WrappedComponent = (props: TProps): ReactElement => {
-    const [open, setOpen] = useState(false);
-    const close = (): void => setOpen(false);
+    // The modal owns its open state, so the HOC only needs a handle on the
+    // dialog to open it from the trigger and to hand `close` to the content.
+    const dialogRef = useRef<HTMLDialogElement>(null);
+    // showModal() throws on an already-open dialog. The open modal makes the
+    // page inert, so a second trigger click should be impossible — but the
+    // guard costs nothing and a thrown error would cost the whole render.
+    const open = (): void => {
+      const dialog = dialogRef.current;
+      if (dialog && !dialog.open) dialog.showModal();
+    };
+    const close = (): void => dialogRef.current?.close();
 
     return (
       <>
@@ -57,10 +66,14 @@ const withModal = <TProps extends object>(
         */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: the span is a passthrough wrapper; the interactive component inside it handles focus and keyboard activation and bubbles its click here */}
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard activation of the wrapped control fires a click that bubbles to this handler, so no separate key handler is needed */}
-        <span className="ds modal-trigger" onClick={() => setOpen(true)}>
+        <span className="ds modal-trigger" onClick={open}>
           <Component {...props} />
         </span>
-        <Modal open={open} onOpenChange={setOpen} {...modalProps}>
+        {/* The props the HOC owns come last, after the spread. `WithModalOptions`
+            omits them, but a structurally typed variable can still carry them,
+            and neither may be allowed through: a stray `ref` would unwire the
+            trigger, and `defaultOpen` would open a modal nobody asked for. */}
+        <Modal {...modalProps} ref={dialogRef} defaultOpen={false}>
           {typeof modalChildren === "function"
             ? modalChildren(close)
             : modalChildren}

--- a/packages/react/ds-global/src/lib/pattern/Modal/withModal.tsx
+++ b/packages/react/ds-global/src/lib/pattern/Modal/withModal.tsx
@@ -1,0 +1,80 @@
+import type { ComponentType, FC, ReactElement } from "react";
+import { useState } from "react";
+import Modal from "./Modal.js";
+import type { WithModalChildren, WithModalOptions } from "./types.js";
+
+/**
+ * Wraps a trigger with a modal. Click the trigger → the modal opens.
+ *
+ * ```tsx
+ * const OpenButton = withModal(Button, <Modal.Content>Hello</Modal.Content>);
+ * <OpenButton>Open</OpenButton>;
+ * ```
+ *
+ * **How it closes:** the header's X button and Escape always work. Add
+ * `closeOnBackdropClick` to `modalProps` and a backdrop click works too.
+ *
+ * **Footer buttons can only close the modal.** That is the one and only
+ * action this HOC provides. To wire one up, pass the content as a function —
+ * it receives a `close` callback:
+ *
+ * ```tsx
+ * const OpenButton = withModal(
+ *   Button,
+ *   (close) => (
+ *     <Modal.Footer>
+ *       <Button onClick={close}>Got it</Button>
+ *     </Modal.Footer>
+ *   ),
+ * );
+ * ```
+ *
+ * If an action needs to do more than close — save data, open another modal,
+ * close conditionally — don't use this HOC: keep the `open` state yourself
+ * and compose the controlled `Modal` directly.
+ *
+ * @param Component The trigger component to wrap (e.g. `Button`). Clicking it opens the modal.
+ * @param modalChildren The modal's content: plain JSX, or a function that receives `close` and returns JSX.
+ * @param modalProps Props forwarded to the underlying `Modal` (e.g. `closeOnBackdropClick`), minus `open`, `onOpenChange` and `children`, which the HOC owns.
+ */
+const withModal = <TProps extends object>(
+  Component: ComponentType<TProps>,
+  modalChildren: WithModalChildren,
+  modalProps: WithModalOptions = {},
+): FC<TProps> => {
+  const WrappedComponent = (props: TProps): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const close = (): void => setOpen(false);
+
+    return (
+      <>
+        {/*
+          The trigger wiring lives on a wrapper span, mirroring the tooltip
+          engine: the wrapped component renders untouched inside it, and any
+          click it produces — pointer or keyboard activation — bubbles up here
+          to open the modal. The span is layout-neutral (`display: contents`,
+          see styles.css), so the wrapped component lays out as if unwrapped.
+        */}
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: the span is a passthrough wrapper; the interactive component inside it handles focus and keyboard activation and bubbles its click here */}
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard activation of the wrapped control fires a click that bubbles to this handler, so no separate key handler is needed */}
+        <span className="ds modal-trigger" onClick={() => setOpen(true)}>
+          <Component {...props} />
+        </span>
+        <Modal open={open} onOpenChange={setOpen} {...modalProps}>
+          {typeof modalChildren === "function"
+            ? modalChildren(close)
+            : modalChildren}
+        </Modal>
+      </>
+    );
+  };
+
+  // Set the displayName for easier debugging
+  WrappedComponent.displayName = `withModal(${
+    Component.displayName || Component.name || "Component"
+  })`;
+
+  return WrappedComponent;
+};
+
+export default withModal;


### PR DESCRIPTION
Stacked on #1039 — **base is `feat/modal-pattern`**, not `main`.

## Done

Reshapes the `Modal` pattern from a controlled component into a self-contained one, with optional external control through a ref.

- **`open` and `onOpenChange` are gone.** The open state lives in the native `<dialog>`, so the header's close button, Escape and (where `closeOnBackdropClick` opts in) a backdrop click all close the modal with nothing wired up. This removes the desync trap the old contract had to warn about: a consumer who did pre-close work but forgot to set `open` to `false` left the prop and the DOM disagreeing, and the modal could never be reopened.
- **`ref?: Ref<HTMLDialogElement>`** — the escape hatch: `ref.current?.showModal()` opens, `ref.current?.close()` closes. Merged into the component's own ref via a callback ref, so the internal reference stays stable, callback refs work, and a React 19 ref cleanup function is honoured.
- **`defaultOpen?: boolean`** — uncontrolled, acted on once by a mount effect with a spent latch, so no later render can reopen a modal the user has closed. Renders closed on the server, because `showModal()` is what makes a dialog modal.
- **`onClose` is no longer omitted** from the native attributes: the native `close` event is how a consumer hears about a dismissal now, and `close(value)` + `returnValue` is how an action tells itself apart from one.
- **No `onCancel`/`onClose` handlers of our own.** Escape's `cancel` event closes the dialog as its default action — the platform's close watchers do it better than a handler could, and a consumer that must intervene still gets the event.
- **`withModal`** drops `useState` and drives the dialog through a ref. HOC-owned props (`ref`, `defaultOpen`) are now applied after the `modalProps` spread, because `Omit` is a type-level barrier only and a stray `ref` would silently unwire the trigger.

Drive-bys, both found while reviewing the above and both in the lines this PR already rewrites:

- **a11y:** `aria-labelledby={titleId}` was set unconditionally. `aria-labelledby` beats `aria-label` in the accessible-name computation, so a header-less modal's own `aria-label` was being silenced — the exact case the old code comment claimed was handled. A consumer-supplied name now wins.
- **bug:** `{...props}` spread after `onClick` meant any consumer `onClick` silently replaced the backdrop handler and disabled `closeOnBackdropClick`. The two are now composed, consumer first.

Storybook:

- Every story pairs its modal with a trigger button and wires the footer actions to `close`, so dismissing a preview no longer leaves a dead frame with no way back — `NotDismissible` was the real trap, having neither a close icon nor backdrop dismissal.
- Snippets show the wiring a consumer actually writes (ref, trigger, `onClick={close}`) instead of the old `open`/`onOpenChange` pair.

## QA

1. `bun install && cd packages/react/ds-global && bun run check && bun run test`
2. `bun run storybook` → **patterns/Modal**. For each story: dismiss the modal (X, Escape, or backdrop where the story opts in), confirm the trigger button is revealed, and reopen it. Footer `Cancel`/`Confirm`/`Discard`/`Accept` should all close.
3. **patterns/Modal/withModal** → unchanged behaviour: trigger opens, X/Escape close, `FooterAction`'s "Got it" closes.
4. Reopen a modal several times in a row — the state that used to desync now lives in the element, so this must never wedge.

## Notes for the reviewer

- 51 tests over the pattern (was 40). Each new guard was mutation-tested: the fix was reverted one at a time and a named test confirmed to fail. That caught a weak test of my own, since split in two.
- The jsdom `close` stub was made faithful to the platform — it only fires `close` when the dialog was open, and it records `returnValue`.
- **Left for a separate PR:** a header-less modal with no `aria-label` still emits `aria-labelledby` pointing at an unused id, so it has no accessible name (`aria-valid-attr-value`). The fix is the Header registering its title id through context so the Modal only points at an id that exists — a Header/context change, unrelated to ref control.
- No unmount cleanup calling `close()`: the HTML spec's dialog removing steps already drop the element from the top layer, and an unmount is not a dismissal.
- **CI on this branch will show failures inherited from the base.** The base is 33 commits behind `main`, which bumped biome and its shared config: `ds-assets`, `storybook-addon-shell-theme`, `task`, `storybook-helpers`, `ke-graphql` and one Accordion story all fail `check` on files this PR does not touch (`main` has already fixed the Accordion one). It clears when #1039 rebases onto `main`; doing it here would rewrite #1039's commits.

### PR readiness check

- [x] PR should have one of the following labels: `refactor`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — no package added or changed.
- [x] No new package, so no manual first publish or trusted-publisher setup.
- [ ] If this PR does not require visual testing, add the `no visual change` label to skip Chromatic. — **it does**: every Modal story gains a trigger button.

## Screenshots

Chromatic will diff the Modal stories: each preview now renders an "Open modal" button behind the backdrop.
