### PR TITLE
docs(ke-graphql): say where contract conformance is checked

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -38,6 +38,21 @@ jobs:
     name: Apply type label
     needs: validate-pr-metadata
     runs-on: ubuntu-latest
+    # ONE run at a time per pull request. Two edits in quick succession queue
+    # two runs, and run side by side they can each read the labels before the
+    # other writes them: a `feat` → `docs` → `fix` retitle then leaves BOTH
+    # `docs` and `fix` behind, each run having removed only the `feat` it saw.
+    # A newer run cancels an older one, whether that older run is still queued
+    # or already executing. Only the newest run can be right: the label is
+    # reconciled from the title read live below, so a run still working on a
+    # title that has since been edited is doing work that will be undone.
+    # Cancelling has one window — this job adds labels before it removes them,
+    # so an interrupted run can leave the old label sitting beside the new one
+    # — and the run whose arrival caused the cancellation closes it, because it
+    # reconciles the whole managed set against the current title.
+    concurrency:
+      group: apply-type-label-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       pull-requests: write
       # Creating a managed label that does not exist yet goes through the issues API.
@@ -60,7 +75,16 @@ jobs:
             COLORS[BREAKING] = "b60205";
 
             const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
+            // Read the pull request as it stands NOW, not as the event payload
+            // snapshotted it when the edit was queued. A run that starts after
+            // a later edit would otherwise reconcile a title and a label set
+            // that are already history, and converge on the wrong answer while
+            // reporting success.
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: context.payload.pull_request.number,
+            });
 
             // A fork PR gets a read-only token, so labelling would fail the run.
             if (pr.head.repo.full_name !== `${owner}/${repo}`) {
@@ -99,6 +123,19 @@ jobs:
               await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: add });
             }
             for (const name of remove) {
-              await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+              // A label that is already gone is the outcome this loop wants,
+              // not an error. Anyone may remove one between the read above and
+              // the write here — a maintainer clicking it off, another
+              // automation — and GitHub answers a removal of an absent label
+              // with a 404, which would fail the whole job over a state that
+              // is already correct. The add loop above also catches a 404,
+              // but for a different condition: there it means the repository
+              // has no such label defined yet, and the answer is to create it.
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                core.info(`Label "${name}" was already absent`);
+              }
             }
             core.info(`${pr.title}\n  added:   ${add.join(", ") || "—"}\n  removed: ${remove.join(", ") || "—"}`);

--- a/packages/runtime/ke-graphql/README.md
+++ b/packages/runtime/ke-graphql/README.md
@@ -469,10 +469,8 @@ tarball.
 
 The intermediate representations (`RawExtraction`, `OntologyIR`, `MappedIR`) are exported public contracts, not internals — tooling can consume them the way Prisma generators consume the DMMF. They are pinned by the golden-SDL snapshot in the test suite, so changes to the emitted shape are caught.
 
-The emitted base is additionally gated by `@canonical/prism-contract` — semantic subsumption via `findBreakingChanges` over the **live emitted SDL** of every fixture, with the SDL crossing the package boundary as a string, plus two controls: `prefixing: "all"` still conforms (the contract names no ontology terms), and `relay: false` fails by exactly one violation (`FIELD_REMOVED` on `Query.node`).
+A separate, coarser question can be asked of the same emission: does it satisfy `@canonical/prism-contract`, the data contract a documentation-site provider must offer? That is semantic subsumption — `findBreakingChanges` with the contract as the old schema and an emitted SDL as the new one, zero violations meaning the emission is a conformant superset.
 
-**Where that gate lives depends on whether the contract package exists.** The contract is authored by the documentation site, not by the compiler, and a compiler that vendored its own conformance check would be marking its own homework — so the gate belongs with the contract, not here.
+**That check does not belong here**, and is not run here. The contract is authored by the documentation site, not by the compiler, and a compiler that vendored its own conformance check would be marking its own homework — so it belongs on the contract's side, published separately and reading the golden SDLs above. One consequence is worth knowing before you regenerate them: those goldens are that check's input, so a change to the emitted shape can turn a suite red in a package you never opened.
 
-On `main` the contract package does not exist, so neither does the gate: `@canonical/prism-contract` is absent from this package's dependencies and there is no `contract.test.ts`.
-
-On `feat/prism-docsite` the package **does** exist, so both are present: `@canonical/prism-contract` is a devDependency and `src/testing/integration/contract.test.ts` runs the gate against this compiler's live output. That is the only difference between this package on the two branches, and it disappears when the contract package lands on `main`.
+This package therefore takes no dependency on `packages/prism/*`, not even a devDependency, and carries no `contract.test.ts`. The arrow points one way.

--- a/packages/runtime/ke-graphql/src/testing/integration/emittedSdl.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/emittedSdl.test.ts
@@ -3,9 +3,9 @@
 // byte-for-byte in __fixtures__/<name>.sdl.txt.
 //
 // This is the cross-version pin the other suites do not provide: the
-// determinism test proves one build agrees with itself, the header test pins
-// seven lines, gate G-1 checks contract subsumption — none of them compare
-// against a PRE-CHANGE emission. These goldens do. Any commit that moves a
+// determinism test proves one build agrees with itself and the header test
+// pins seven lines, but neither compares against a PRE-CHANGE emission. These
+// goldens do. Any commit that moves a
 // single byte of the default emission fails here and must justify itself by
 // regenerating the goldens in the same change — silently shifting emitted
 // names, order, or descriptions is not a thing that can happen.
@@ -41,7 +41,11 @@ afterEach(() => {
   cleanups = [];
 });
 
-/** The same eight-fixture corpus gate G-1 runs over. */
+/**
+ * The eight-fixture corpus. These goldens are also what the conformance check
+ * reads from outside this package, so regenerating them can turn that
+ * package's suite red — see the README.
+ */
 const FIXTURES: Record<string, string> = {
   minimal: MINIMAL_TTL,
   inheritance: INHERITANCE_TTL,

--- a/packages/runtime/ke-graphql/src/testing/integration/modes.test.ts
+++ b/packages/runtime/ke-graphql/src/testing/integration/modes.test.ts
@@ -82,17 +82,15 @@ describe("mode matrix — unannotated input", () => {
     expect(bodyOf(auto.result.sdl)).toBe(bodyOf(annotated.result.sdl));
   });
 
-  // The name once ended "…, contract satisfied", backed by a
-  // satisfiesContract() call on the emitted SDL. `@canonical/prism-contract`
-  // is deliberately not a dependency of this package — the contract is
+  // The name claims "contract satisfied" nowhere, and must not:
+  // `@canonical/prism-contract` is deliberately not a dependency of this package — the contract is
   // authored by the documentation site, and a compiler that vendored its own
   // conformance check would be marking its own homework (see the README) — so
-  // that assertion cannot live here. The claim is struck from the name rather
-  // than left standing over nothing; it returns, in the contract package's own
-  // gate, when that package does. What it was defending for the zero-type case
-  // is pinned below in local terms anyway: the root set is EXACTLY node plus
-  // the four TBox roots, so the contract base survives a projection that keeps
-  // no ontology class at all.
+  // that assertion cannot live here. It lives on the contract's side instead,
+  // run over the golden SDLs committed here. What it would defend for the
+  // zero-type case is pinned below in local terms anyway: the root set is
+  // EXACTLY node plus the four TBox roots, so the contract base survives a
+  // projection that keeps no ontology class at all.
   it("explicit: the zero-type schema — TBox + node survive, A007 lists every class", async () => {
     const { result } = await compileFixture(MINIMAL_TTL, { mode: "explicit" });
     expect([...result.mapped.types.keys()]).toEqual([]);
@@ -250,10 +248,9 @@ describe("mode matrix — annotated input", () => {
     // filters ontology classes; it must not take the contract base with it,
     // and nothing else pins that for a PARTIAL allowlist — the zero-type case
     // above pins it for the empty one, and the goldens only cover the default
-    // annotated mode. This is the locally expressible core of the
-    // satisfiesContract() call that stood here before
-    // `@canonical/prism-contract` left the tree: the contract's own relay
-    // control fails by exactly one violation, FIELD_REMOVED on Query.node.
+    // annotated mode. This is the locally expressible core of the conformance
+    // check that lives on the contract's side: its relay control fails by
+    // exactly one violation, FIELD_REMOVED on Query.node.
     expect(roots).toContain("node");
     expect(result.sdl).toContain("interface Node {");
     // Every projected type still implements it (member order is not pinned).

--- a/packages/summon/monorepo/src/templates/pr-lint.yml.ejs
+++ b/packages/summon/monorepo/src/templates/pr-lint.yml.ejs
@@ -38,6 +38,21 @@ jobs:
     name: Apply type label
     needs: validate-pr-metadata
     runs-on: ubuntu-latest
+    # ONE run at a time per pull request. Two edits in quick succession queue
+    # two runs, and run side by side they can each read the labels before the
+    # other writes them: a `feat` → `docs` → `fix` retitle then leaves BOTH
+    # `docs` and `fix` behind, each run having removed only the `feat` it saw.
+    # A newer run cancels an older one, whether that older run is still queued
+    # or already executing. Only the newest run can be right: the label is
+    # reconciled from the title read live below, so a run still working on a
+    # title that has since been edited is doing work that will be undone.
+    # Cancelling has one window — this job adds labels before it removes them,
+    # so an interrupted run can leave the old label sitting beside the new one
+    # — and the run whose arrival caused the cancellation closes it, because it
+    # reconciles the whole managed set against the current title.
+    concurrency:
+      group: apply-type-label-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       pull-requests: write
       # Creating a managed label that does not exist yet goes through the issues API.
@@ -60,7 +75,16 @@ jobs:
             COLORS[BREAKING] = "b60205";
 
             const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
+            // Read the pull request as it stands NOW, not as the event payload
+            // snapshotted it when the edit was queued. A run that starts after
+            // a later edit would otherwise reconcile a title and a label set
+            // that are already history, and converge on the wrong answer while
+            // reporting success.
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: context.payload.pull_request.number,
+            });
 
             // A fork PR gets a read-only token, so labelling would fail the run.
             if (pr.head.repo.full_name !== `${owner}/${repo}`) {
@@ -99,6 +123,19 @@ jobs:
               await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: add });
             }
             for (const name of remove) {
-              await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+              // A label that is already gone is the outcome this loop wants,
+              // not an error. Anyone may remove one between the read above and
+              // the write here — a maintainer clicking it off, another
+              // automation — and GitHub answers a removal of an absent label
+              // with a 404, which would fail the whole job over a state that
+              // is already correct. The add loop above also catches a 404,
+              // but for a different condition: there it means the repository
+              // has no such label defined yet, and the answer is to create it.
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                core.info(`Label "${name}" was already absent`);
+              }
             }
             core.info(`${pr.title}\n  added:   ${add.join(", ") || "—"}\n  removed: ${remove.join(", ") || "—"}`);


### PR DESCRIPTION
## Done

The README described the `@canonical/prism-contract` conformance check as a
*condition* — where it lives "depends on whether the contract package exists" —
and then answered separately for `main` and for a feature branch. The question
was never branch-shaped:

- the contract is authored by the documentation site, not by this compiler, and
  a compiler that vendored its own conformance check would be marking its own
  homework;
- so the check belongs on the contract's side whatever packages happen to
  exist, reading the golden SDLs this package already commits.

The section now says that once, in the prospective voice it needs while the
contract package is published separately, and records the consequence as a rule
rather than a state: this package takes no dependency on `packages/prism/*`, not
even a devDependency, and carries no `contract.test.ts`. It also warns the one
reader who is affected — those goldens are that check's input, so regenerating
them can turn a suite red in a package you never opened.

Three comments carried the retired framing and are corrected with it:

| Where | What it said | Why it is wrong |
| --- | --- | --- |
| `modes.test.ts` | a struck assertion "returns, in the contract package's own gate, when that package does" | it does not return here at all |
| `modes.test.ts` | the contract package having "left the tree" | it was never in this tree |
| `emittedSdl.test.ts` ×2 | "gate G-1 checks contract subsumption" | `grep -rn "G-1"` finds nothing but those two lines |

Comments and prose only. No behaviour, assertion, or manifest change.

## Drive-by: a CI job that could not go green again

`.github/workflows/pr-lint.yml`'s type-label job reads a pull request's labels
from the **event payload** — a snapshot — and then removes the stale ones
without guarding a 404. Two edits in quick succession (retitling and rewriting a
body) queue two runs, the second carrying the first's pre-run labels, so it asks
GitHub to remove a label the first run already removed and the job fails with
`Label does not exist`. Re-running cannot clear it, because a re-run replays the
same stale payload: the check stays red until some unrelated event fires, even
though the labels are already exactly right.

This PR hit it. Three changes, and the 404 guard is the smallest of them:

- the job now reads the pull request's **title and labels from the live API**
  rather than from the payload snapshot, so a run that starts after a later
  edit reconciles against the pull request as it now stands;
- the job is **serialised per pull request** (`concurrency`, with
  `cancel-in-progress: true`), so two runs cannot each read the label set
  before the other writes it. Without that, raised in review, `feat` → `docs`
  → `fix` in quick succession could leave BOTH `docs` and `fix` on the pull
  request with each run passing, having removed only the `feat` it saw. A
  newer run cancels an older one because only the newest can be right: the
  label is reconciled from the live title, so a run still working on a
  superseded title is doing work that will be undone. Cancelling has one
  window — the job adds before it removes, so an interrupted run can leave the
  old label beside the new one — and the run whose arrival caused the
  cancellation closes it, reconciling the whole managed set against the
  current title;
- the removal **tolerates a 404** and logs it — a label someone else removed
  between the read and the write is the outcome the loop wants, not an error.
  The `add` loop above also catches a 404, but for a different condition:
  there it means the repository has no such label defined yet, and the answer
  is to create it.

### The script now lives in its own file

Those ninety lines were a JavaScript program inside a YAML string: no syntax
checking, no editor support, nothing able to load it. They now live in a local
composite action, `.github/actions/apply-type-label`, whose `action.yml` wraps
`actions/github-script` around a sibling `apply-type-label.cjs` — the shape
`lerna-version` already uses for its own `version.sh` and `semver.cjs`. The
module exports the github-script contract (`async ({ github, context, core })`)
and is unchanged line for line from the block it replaces, comments included.

Three consequences worth reviewing:

- **The job now checks the repository out.** A local `uses: ./…` action has to
  be on disk first, and the workspace starts empty. The checkout is shallow
  (`fetch-depth: 1`) and sparse (`.github/actions`), and lands on the merge
  commit — the same ref this workflow file itself is read from on a
  `pull_request` event, so the action is no more trusted than the workflow
  already was. A comment in the file says not to move the job to
  `pull_request_target`, where that equivalence would stop holding.
- **`contents: read` was added to the job's permissions.** Declaring any
  permission on a job zeroes every scope it does not name, so the checkout
  would have failed with a 403 without it.
- **The two actions this job uses are now pinned by SHA** with a `# v7`
  comment, matching `pr.yml` and `push.yml`.

The generator carried the same fault and the same inline block, so
`packages/summon/monorepo`'s `pr-lint.yml` template gets all three corrections
*and* the same split — a new template pair emitting
`.github/actions/apply-type-label/{action.yml,apply-type-label.cjs}` —
otherwise every newly generated monorepo is born with the bug and the mess.
Two new tests in that package guard what the split newly makes possible: that
the `types:` vocabulary and the module's `TYPES` cannot drift apart, and that
the file the action requires at runtime is one the generator actually writes.

AGENTS.md asks that a workflow change say why and expect to be challenged, so:
this is not a package-scoped check being added, it is a correctness fix to a
global job that can otherwise leave any retitled PR permanently red, plus the
tidy-up it earned on the way. If you would rather it landed on its own, say so
and I will split it out.

### Why this is first in a series

This is the bottom of a chained series landing the documentation site. The
series was planned to open by taking `main`'s tree for this package, because the
site's branch carries its own older copy of it. Measured against `main`, that
take is a **no-op** — every file that branch touches under
`packages/runtime/ke-graphql` and `packages/runtime/ke` is `main`'s own content
at an earlier point (the `subdir` pack-ref support, `Store.size`, the
vocabulary-reference corrections, the biome 2.5.11 reformat). `main` wins on all
of it, so no tree change is proposed. What did not survive the arithmetic is the
prose above.

## QA

Root gate, from the repository root:

- `bun run check` — 62 projects / 101 tasks, green
- `bunx lerna run test --concurrency 1 --no-bail` — 48 projects, green but for
  the three environment failures noted below
- `@canonical/summon-monorepo` alone — 6 files / 31 tests, 100% coverage
- `bun run build` — 51 tasks, green
- `bun run check:ranges` — 62 workspace packages, every sibling range satisfied
- `bun run collect:check` — clean, `data/` unchanged

One environment note, reproducible on an unmodified `main` and untouched by
this diff: the three Playwright-tagged svelte projects cannot start a browser
in this sandbox (`libglib-2.0.so.0` absent). Lerna's default parallelism also
exhausts the machine, so the run above used `--concurrency 1`.

## Carried

Raised in review, deliberately not fixed here:

- The layering rule this README states is enforced by nothing. It is scoped here
  to a statement about *this* package; the general rule lands in `AGENTS.md` in
  the next PR of the series, where the directory it names first exists.
- The branch name still says `chore/`, which no longer matches the `docs` type.
  Only the PR title is CI-enforced; renaming the branch now would orphan this PR.
- The generator's templates stay on floating `@vN` action refs while this repo
  pins by SHA. The pinning here comes from Renovate's
  `helpers:pinGitHubActionDigests`, which the generated `renovate.json` does not
  extend — a SHA in a template would go stale with nothing to bump it. Pinning
  generated repos means adding that helper to the template first.
- Nothing tests the copy of the module under `.github/actions`. Its twin in the
  generator is tested because that rides the package's own `test` target; a
  root-level equivalent would need a new shared CI job, which AGENTS.md reserves
  for repo-wide invariants.
- The conformance check covers default-mode emissions. The `prefixing: "all"`
  and `relay: false` controls are pinned on the contract's side against its own
  captures, not against this compiler's live output.

## Readiness

- [x] Conventional-commit title (`docs`, matching `docs(ke-graphql): say where
      contract conformance is checked`)
- [x] No behaviour change to `ke-graphql`; the drive-by is a CI correctness
      fix plus a refactor with the behaviour held constant
- [x] Root gate green
- [ ] Workflow change reviewed — see the drive-by section

Chromatic: skip
