### PR TITLE
feat(prism-contract): add the documentation site's data contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,25 @@ sibling package/domain and match its layout, naming, error handling, and test
 placement — rather than inventing a new pattern. Match the surrounding code's idioms;
 a new file should be indistinguishable in style from its neighbours.
 
+### The documentation site depends on the runtime, never the reverse
+
+`packages/prism/*` and the documentation-site app are the site layer. They may
+depend on anything below them — `packages/runtime/*`, `packages/cli/*`,
+`packages/summon/*`, and the component packages.
+
+**Nothing in those depended-upon packages may depend on `packages/prism/*` —
+not even as a devDependency.** The usual pressure to reverse the arrow is a
+conformance check: the site authors a contract, and it is tempting to have the
+package that must satisfy the contract assert that it does. That is the package
+marking its own homework, and it costs it a dependency on the site it exists to
+be independent of. Site-side packages hold those gates instead, reading whatever
+they need to read.
+
+Nothing enforces this, so it is a review obligation: a new `@canonical/prism-*`
+entry in a manifest under `packages/runtime/`, `packages/cli/`,
+`packages/summon/` or a component package is a change to challenge, whatever it
+is for.
+
 ### Module imports — use relative paths, not `#` subpath aliases
 
 Do **not** use `#`-prefixed `package.json` `"imports"` (Node subpath imports) for

--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ The following tables list all workspace packages with their location and purpose
 | `@canonical/harnesses` | `packages/runtime/harnesses` | AI harness detection and MCP config read/write (Claude Code, Cursor, Windsurf, Cline, Roo Code) |
 | `@canonical/ds-utils` | `packages/runtime/ds-utils` | Framework-agnostic design system helpers: navigation trees, debounce, throttle, humanizeNumber, pluralize |
 
+### Prism
+
+The documentation-site layer. The dependency arrow points one way — see "The documentation site depends on the runtime, never the reverse" in [AGENTS.md](AGENTS.md).
+
+| Package | Path | Description |
+|---------|------|-------------|
+| `@canonical/prism-contract` | `packages/prism/contract` | The minimal GraphQL surface a documentation-site provider must offer, plus a subsumption check that a provider satisfies it |
+
 ### Core Infrastructure
 
 | Package | Path | Description |

--- a/bun.lock
+++ b/bun.lock
@@ -418,6 +418,25 @@
         "vitest": "^4.0.18",
       },
     },
+    "packages/prism/contract": {
+      "name": "@canonical/prism-contract",
+      "version": "0.37.0",
+      "devDependencies": {
+        "@biomejs/biome": "2.5.11",
+        "@canonical/biome-config": "^0.37.0",
+        "@canonical/ke-graphql": "^0.37.0",
+        "@canonical/typescript-config": "^0.37.0",
+        "@canonical/webarchitect": "^0.37.0",
+        "@types/node": "^24.12.0",
+        "@vitest/coverage-v8": "^4.0.18",
+        "graphql": "^16.11.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
+      },
+      "peerDependencies": {
+        "graphql": "^16.11.0 || ^17.0.0-rc.0",
+      },
+    },
     "packages/react/ds-app": {
       "name": "@canonical/react-ds-app",
       "version": "0.37.0",
@@ -1821,6 +1840,8 @@
     "@canonical/lit-ds-prototype": ["@canonical/lit-ds-prototype@workspace:packages/lit/ds-prototype"],
 
     "@canonical/pragma-cli": ["@canonical/pragma-cli@workspace:packages/cli/pragma"],
+
+    "@canonical/prism-contract": ["@canonical/prism-contract@workspace:packages/prism/contract"],
 
     "@canonical/react-boilerplate-vite": ["@canonical/react-boilerplate-vite@workspace:apps/react/boilerplate-vite"],
 
@@ -4534,6 +4555,10 @@
 
     "@canonical/ke-graphql/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
+    "@canonical/prism-contract/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
+    "@canonical/prism-contract/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
+
     "@canonical/react-boilerplate-vite/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
     "@canonical/svelte-ds-app/@canonical/design-tokens": ["@canonical/design-tokens@0.6.2-contrasted.0", "", { "dependencies": { "@canonical/terrazzo-lsp": "^0.6.0" } }, "sha512-JLzc2tsSbuINFk4adbNGyFhnuKXLiIzE6ntwqigrL4vJoSTuj/OkaJLiLPB12LlQYOT3vnBiL+JmouZgDflNgQ=="],
@@ -5111,6 +5136,8 @@
     "@bundled-es-modules/glob/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "@canonical/ke-graphql/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@canonical/prism-contract/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@canonical/svelte-ds-app-launchpad/@canonical/design-tokens/@canonical/terrazzo-lsp": ["@canonical/terrazzo-lsp@0.6.0", "", { "dependencies": { "@canonical/token-types": "^0.6.0", "@lezer/common": "^1.3.0", "@lezer/css": "^1.3.0", "colorjs.io": "^0.6.1" }, "bin": { "terrazzo-lsp": "dist/esm/cli.js" } }, "sha512-6b8IsmRF9VJJ6zWyz6XDZxm65tjWPnl5dce/abM2tRJaeBV3ewDLnSWS/BPoHhqDBEFTdo8Rb7o5mg44RzKN7A=="],
 

--- a/docs/how-to-guides/ADDING_A_PACKAGE.md
+++ b/docs/how-to-guides/ADDING_A_PACKAGE.md
@@ -57,6 +57,7 @@ The root `package.json` `workspaces` array lists each category explicitly, and e
   "workspaces": [
     "configs/*",
     "packages/*",
+    "packages/prism/*",
     "packages/react/*",
     "packages/runtime/*",
     "packages/storybook/*",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "workspaces": [
     "configs/*",
     "packages/*",
+    "packages/prism/*",
     "packages/react/*",
     "packages/runtime/*",
     "packages/storybook/*",

--- a/packages/prism/contract/README.md
+++ b/packages/prism/contract/README.md
@@ -1,0 +1,243 @@
+# @canonical/prism-contract
+
+The **data contract** between a Prism docsite and whatever GraphQL backend
+serves it: the minimal schema surface a provider must offer, plus a check that
+answers one question — *does this provider satisfy the contract?*
+
+The docsite is being de-specialised: it should run against any conformant
+provider, not only against the one ke-graphql happens to compile today. This
+package is the machine-checkable statement of what "conformant" means.
+
+## Installation
+
+```bash
+bun add @canonical/prism-contract
+```
+
+`graphql` is a **peer** dependency (`^16.11.0 || ^17.0.0-rc.0`) — you supply
+it, and the check builds both schemas with your copy. That is deliberate: see
+[The check](#the-check).
+
+## What is in the contract
+
+The contract is the compiler's **required surface**: what a ke-graphql emission
+offers in its default configuration, and what any provider must offer to stand
+in its place.
+
+| Group | Members |
+| --- | --- |
+| Relay structure | `Node`, `PageInfo`, `NodeConnection`, `NodeEdge` |
+| TBox (hand-written) | `Ontology`, `OntologyClass`, `ClassProperty`, `OntologyProperty`, `PropertyKind`, `EntityMeta` |
+| Root fields | `ontologies`, `ontology`, `ontologyClass`, `ontologyProperty`, `node(id:)` |
+
+Independence from the **ontology** is unconditional — the contract names no
+ontology terms, so nothing loaded can move it. Independence from the compiler's
+**options** is not, and saying so would be wrong: `relay: false` skips the pass
+that wires `node(id:)`, and a schema compiled that way does not satisfy the
+contract. That is the option withholding part of the surface a docsite needs,
+not a defect in the contract — and it is measured rather than asserted, by the
+relay control described under [Where the gate runs](#where-the-gate-runs).
+
+`Node` is identity plus self-description and nothing else — the absolute IRI
+and the `_meta` hatch every descriptive fact lives behind:
+
+```graphql
+interface Node {
+  uri: ID!
+  _meta: EntityMeta!
+}
+```
+
+`EntityMeta.title` is **total**: the provider computes a fallback chain whose
+tail is the IRI **local name** (`…#Film` answers `"Film"`), with the whole IRI
+below it for an IRI that ends in a separator and so has no local name — the
+degenerate tier that keeps the field total rather than an exception to it.
+`label`, `comment`, and `definition` are asserted-only and
+nullable. `OntologyClass` implements `Node`, so classes resolve through
+`node(id:)` and ride `NodeConnection`s like any other entity;
+`OntologyProperty` deliberately does not (identity, but no `_meta` — an
+asymmetry of scope, not principle).
+
+The contract names **no ontology terms** — its surface is purely structural —
+so it is independent of the provider's field-name `prefixing` knob: a schema
+compiled with `prefixing: "all"` satisfies it exactly as one compiled with
+`prefixing: "none"` does.
+
+`Query.ontologyClass(uri:)` and `Query.ontologyProperty(uri:)` take
+`String!`, **not** `ID!`: those arguments accept the prefixed convenience form
+(`"ds:Component"`) and live client operations already declare
+`$uri: String!`, which `ID!` would invalidate. `node(id:)` is the strict
+lookup by absolute IRI.
+
+### What is deliberately excluded
+
+- **`@defer` / `@stream`.** The compiler adds them only when composed with
+  `incremental: true`. A provider that does not do incremental delivery is
+  still conformant, so requiring them would be wrong.
+- **Every ontology-derived type** (`Component`, `Job`, `CodeStandard`, …).
+  Those are a function of the loaded ontology, not of the contract.
+- **Provider extension fields** such as
+  `OntologyProperty.acceptanceCriteria` / `.completionGuidance`.
+  Annotation-derived and provider-specific — extensions, not base.
+
+`EntityMeta` **is** in the contract: `Node` selects it through `_meta`, and
+the compiler attaches `_meta: EntityMeta!` to every generated type, so a
+provider cannot omit it.
+
+## The check
+
+```ts
+import {
+  satisfiesContract,
+  assertSatisfiesContract,
+} from "@canonical/prism-contract";
+
+const result = satisfiesContract(providerSdl);
+// { satisfied: boolean, violations: readonly ContractViolation[] }
+
+assertSatisfiesContract(providerSdl, { providerName: "ke-graphql backend" });
+// throws, listing every violation, unless satisfied
+```
+
+### Why it is not a diff
+
+A real provider's SDL is a **strict superset** of the contract — it adds every
+ontology-derived type — so it always differs textually and always will.
+Comparing ASTs or text would fail on every conformant provider.
+
+The right predicate is *semantic subsumption*: could every operation legal
+against the contract also run against the provider? graphql-js already answers
+exactly that for the shape of the two schemas, so:
+
+```
+provider satisfies contract  ⇔  findBreakingChanges(contract, provider).length === 0
+                                AND the provider serves each of the contract's
+                                operations from a root type of the same name
+```
+
+The second conjunct is not decoration. `findBreakingChanges` compares type maps
+by NAME and never looks at which type a schema uses as a root, so a provider
+that declares `schema { query: RootQuery }` and leaves a conforming but
+unreachable `type Query` in its type map is structurally indistinguishable from
+a conformant one — and serves nothing. That is the one conformance failure
+graphql-js cannot report, so this package reports it, as `ROOT_TYPE_MISMATCH`.
+An operation the contract does not name (it names no mutation today) puts no
+obligation on a provider.
+
+`findDangerousChanges` is **not** consulted. Adding an optional argument or a
+new enum value is dangerous for a *client* but perfectly legal for a superset
+*provider*, and every real provider does both.
+
+### SDL in, never a schema object
+
+Both entry points take the provider's SDL as a **string**, never a
+`GraphQLSchema`. Two graphql versions coexist in this repo (the app's v16 and
+ke-graphql's pinned v17 RC) and an object built by one must never reach the
+other — the app documents the same hazard on its execute boundary. Text is the
+only safe currency across that line, which is why **graphql** is a *peer*
+dependency here and accepts either major.
+
+### Failure modes
+
+| Situation | Behaviour |
+| --- | --- |
+| Provider SDL does not parse | one violation, code `INVALID_SDL` — a provider that cannot be parsed has failed the contract; that is a result, not a crash |
+| Provider SDL parses but is not a valid schema | one violation per schema error, code `INVALID_SCHEMA` — a schema graphql refuses to execute cannot subsume anything, however few structural differences it has |
+| Contract SDL does not parse, or is not a valid schema | **throws** — the contract is ours, so a broken one is a programmer error |
+| Provider is missing/narrows anything | one violation per graphql-js `BreakingChangeType` |
+| Provider serves a contract operation from a differently named root type | one violation, code `ROOT_TYPE_MISMATCH` — the type map may match perfectly and the operation still not reach it |
+
+### Match on `code`, not on `message`
+
+`code` is typed as `ContractViolationCode`: graphql-js's sixteen
+`BreakingChangeType` members, whose set is identical in v16 and v17, plus the
+three this package defines itself (`INVALID_SDL`, `INVALID_SCHEMA`,
+`ROOT_TYPE_MISMATCH`). It is
+stable, it completes and switches exhaustively, and it is what you should assert
+on. The `message` is graphql-js's own prose and it is **not** stable across
+majors:
+
+| | v16.13.1 | v17.0.0-rc.0 |
+| --- | --- | --- |
+| field | `Node._meta was removed.` | `Field Node._meta was removed.` |
+| argument | `Query.ontology arg prefix was removed.` | `Argument Query.ontology(prefix:) was removed.` |
+
+Messages are for humans reading a failure; codes are for machines gating one.
+
+### A note on `TYPE_REMOVED` noise
+
+When a provider is deficient enough that it stops referencing a built-in scalar
+the contract uses, graphql-js also reports e.g. `Standard scalar Int was
+removed because it is not referenced anymore.` This is not filtered out. It
+never appears
+on its own — a genuinely conformant provider produces zero violations — and
+suppressing `TYPE_REMOVED` would mask a real type removal, which is exactly the
+kind of breakage this package exists to catch.
+
+## Where the gate runs
+
+The check runs on the **provider's** side, never on the compiler's. A GraphQL
+compiler that carried its own conformance check would be marking its own
+homework, and the repository's layering rule settles it independently — see
+"The documentation site depends on the runtime, never the reverse" in
+`AGENTS.md`. So `@canonical/ke-graphql` does not depend on this package and
+holds no contract test.
+
+Two gates exist today, with a third arriving per provider package.
+
+The first is in this package, in `src/lib/satisfiesContract.test.ts`. It runs
+the check against hand-maintained illustrations of a compiler emission
+(`src/testing/__fixtures__/emitted*.sdl.txt` — approximations of the shape, not
+byte captures) and pins three properties:
+
+- the emitted base satisfies the contract;
+- `prefixing: "all"` still satisfies it — the contract names no ontology
+  terms, so the knob cannot affect conformance. Measured, not assumed;
+- `relay: false` fails by **exactly one** violation, `FIELD_REMOVED` on
+  `Query.node` — the control that proves the gate has teeth.
+
+The second, `src/testing/integration/emittedGoldens.test.ts`, is the currency
+gate. The fixtures above are frozen captures, so on their own they would go on
+satisfying the fixture-era contract forever. This one reads
+`@canonical/ke-graphql`'s own golden SDLs — which that package regenerates and
+pins byte-for-byte against a live `compile()` — and checks all of them against
+`schema/contract.graphql` as read live. Both halves move on their own, so it
+turns red when they stop agreeing.
+
+A third belongs to each provider package built on this contract, as those land:
+it calls `assertSatisfiesContract` on that provider's own SDL, so the gate
+fails the moment that provider drifts. Siting those there rather than here is
+what keeps this package free of any dependency on a particular provider.
+
+The SDL crosses every one of those boundaries as a **string**, so the
+two-graphql-versions hazard never materializes.
+
+## Reading the contract SDL
+
+```ts
+import { readContractSdl } from "@canonical/prism-contract";
+```
+
+`readContractSdl()` returns the shipped SDL text. It reads the filesystem, and
+`satisfiesContract` imports it statically and calls it live whenever the
+`contractSdl` option is omitted — so the whole package is **Node/Bun only**.
+For a consumer that wants the file rather than its contents, the
+`./schema/contract.graphql` subpath export is the handle; the package
+deliberately publishes no constant naming its own on-disk layout. There is no browser entry
+point: the check belongs in provider gates and CI steps, which run
+server-side. (The `contractSdl` option exists to substitute a toy contract in
+tests, not to make the module bundleable.)
+
+The SDL itself lives in the `schema/` directory at the package root and is
+published alongside `dist/`.
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `bun run build` | `tsc -p tsconfig.build.json` |
+| `bun run check` | biome + `tsc --noEmit` + `webarchitect library` |
+| `bun run test` | `vitest run --coverage` |
+
+Coverage thresholds sit at 100% — the repo standard for a shipped package.
+Never lower them.

--- a/packages/prism/contract/biome.json
+++ b/packages/prism/contract/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["**/src/**", "**/*.json"]
+  }
+}

--- a/packages/prism/contract/package.json
+++ b/packages/prism/contract/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@canonical/prism-contract",
+  "description": "The minimal GraphQL surface a Prism docsite provider must offer, plus a semantic-subsumption check that a provider's SDL satisfies it",
+  "version": "0.37.0",
+  "type": "module",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    },
+    "./schema/contract.graphql": "./schema/contract.graphql"
+  },
+  "files": [
+    "dist",
+    "schema"
+  ],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun run build:package",
+    "build:all": "bun run build:package",
+    "build:package": "bun run build:package:tsc",
+    "build:package:tsc": "tsc -p tsconfig.build.json",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "check:webarchitect": "webarchitect library",
+    "test": "bun run test:vitest",
+    "test:vitest": "vitest run --coverage",
+    "test:vitest:watch": "vitest"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.11",
+    "@canonical/biome-config": "^0.37.0",
+    "@canonical/ke-graphql": "^0.37.0",
+    "@canonical/typescript-config": "^0.37.0",
+    "@canonical/webarchitect": "^0.37.0",
+    "@types/node": "^24.12.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "graphql": "^16.11.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  },
+  "peerDependencies": {
+    "graphql": "^16.11.0 || ^17.0.0-rc.0"
+  }
+}

--- a/packages/prism/contract/schema/contract.graphql
+++ b/packages/prism/contract/schema/contract.graphql
@@ -1,0 +1,211 @@
+# =============================================================================
+# The Prism data contract.
+#
+# The MINIMAL GraphQL surface any provider must offer for the docsite to run.
+# It is derived from a ke-graphql emission in its DEFAULT configuration — the
+# part no ontology choice can vary:
+#
+#   - the Node interface and PageInfo (compiler/compose.ts)
+#   - NodeConnection / NodeEdge (compiler/compose.ts, the connection factory)
+#   - the hand-written TBox (lib/tbox/buildTBoxSchema.ts): Ontology,
+#     OntologyClass, ClassProperty, OntologyProperty, PropertyKind, EntityMeta
+#   - root fields ontologies / ontology / ontologyClass / ontologyProperty
+#     (buildTBoxSchema.ts) and node(id:) (compiler/wireRelay.ts)
+#
+# Identity is `uri: ID!` — the entity's ABSOLUTE IRI — and every descriptive
+# fact lives behind `_meta: EntityMeta!`. There is no `id`, no `kind`, and no
+# top-level label/comment/definition on Node: the interface is identity plus
+# self-description and nothing else. `_meta.title` is TOTAL (the provider
+# computes a fallback), `_meta.label` is asserted-only and may be null.
+#
+# The contract names NO ontology terms — every type and field here is
+# structural. It is therefore independent of the provider's field-name
+# `prefixing` knob: a schema compiled with `prefixing: "all"` satisfies it
+# exactly as one compiled with `prefixing: "none"` does.
+#
+# Not every compiler option is neutral, though. `relay: false` skips the pass
+# that wires `node(id:)`, so a schema compiled that way fails this contract by
+# exactly that one field. An option that withholds part of the surface the
+# docsite needs produces a non-conforming provider by construction; the relay
+# control in satisfiesContract.test.ts pins that it fails by that field and no
+# other.
+#
+# Deliberately NOT in the contract:
+#
+#   - @defer / @stream. Conditional on `incremental: true`, so a provider that
+#     runs without incremental delivery is still conformant.
+#   - Every ontology-derived type (Component, Job, CodeStandard, ...). Those
+#     depend on which ontology a provider loaded and are not universal.
+#   - Provider extension fields such as OntologyProperty.acceptanceCriteria /
+#     .completionGuidance. Annotation-derived, provider-specific — extensions,
+#     not base.
+#
+# EntityMeta IS in the contract: `Node` selects it through `_meta`, and the
+# compiler puts `_meta: EntityMeta!` on every generated type, so no provider
+# can omit the type.
+#
+# A provider satisfies this contract when its schema is a SUPERSET of it —
+# see satisfiesContract(). Extra types, extra fields and extra optional
+# arguments are all fine; anything this file names must be present, at least
+# as permissive, and at least as wide.
+# =============================================================================
+
+"""
+Everything addressable by an absolute IRI. Every non-embeddable type the
+compiler generates implements this: identity plus self-description, nothing
+else.
+"""
+interface Node {
+  "The entity's absolute IRI — the primary key."
+  uri: ID!
+  "Self-describing TBox access for this entity."
+  _meta: EntityMeta!
+}
+
+"""
+Self-describing TBox access attached to every Node, plus the generic
+descriptive fields a lens renders without knowing the concrete type. `title`
+is total: the provider computes a fallback chain whose tail is the IRI LOCAL
+NAME (`…#Film` answers "Film"), with the whole IRI below it for the degenerate
+case of an IRI that ends in a separator and so has no local name. `label`,
+`comment`, and
+`definition` are asserted-only and null when nothing is asserted.
+
+`curie` is the DISPLAY form of `uri`, and it lives here rather than beside
+`uri` on `Node` for the reason every derived value does: `uri` is asserted
+identity, `curie` is computed from the provider's namespace inventory, and
+`_meta` is where computed things go. It never replaces `uri` — an address a
+consumer stores, sends, or compares must be the absolute IRI.
+"""
+type EntityMeta {
+  """
+  Compact display form of `uri`: `prefix:local` when the provider's namespace
+  inventory has a match, else the absolute IRI unchanged, else — for a value
+  with no IRI at all (an embedded blank node) — the GraphQL type name. TOTAL,
+  exactly like `title`, and never an identity: `uri` is the only address.
+  """
+  curie: String!
+  title(lang: String = "en"): String!
+  label(lang: String = "en"): String
+  comment(lang: String = "en"): String
+  definition(lang: String = "en"): String
+  type: OntologyClass!
+  fields: [ClassProperty!]!
+  field(name: String!): ClassProperty
+}
+
+"Relay cursor pagination metadata."
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+"Relay connection over the Node interface."
+type NodeConnection {
+  edges: [NodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+"One edge of a NodeConnection."
+type NodeEdge {
+  node: Node!
+  cursor: String!
+}
+
+"A loaded ontology namespace."
+type Ontology {
+  prefix: String!
+  namespace: String!
+  label: String
+  classes: [OntologyClass!]!
+  properties: [OntologyProperty!]!
+}
+
+"""
+A class in the TBox — itself a Node, so classes resolve through `node(id:)`
+and appear in NodeConnections like any other entity.
+"""
+type OntologyClass implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  label: String
+  definition: String
+  superclass: OntologyClass
+  superclasses: [OntologyClass!]!
+  subclasses: [OntologyClass!]!
+  properties: [ClassProperty!]!
+  instances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): NodeConnection!
+  instanceCount: Int!
+  isAbstract: Boolean!
+  namespace: String!
+}
+
+"""
+Class-scoped view of a property: SHACL cardinality is a fact about a
+(class, property) pair, not about the property alone — and so is `name`.
+"""
+type ClassProperty {
+  """
+  The field name this property answers to ON THIS CLASS — the exact string
+  `EntityMeta.field(name:)` accepts, so `fields { name }` and `field(name:)`
+  round-trip. Class-scoped because the name is: per-class cardinality decides
+  whether the field is pluralized, so one property can be `part` on one class
+  and `parts` on another, and no consumer can derive that from `property.uri`.
+
+  When the property projects no field on this class at all (a provider may
+  omit one — SHACL `sh:maxCount 0`, an unexposed range, an unprojected class)
+  there is no name `field(name:)` would accept; the OWL local name is returned
+  as a label. It tells a consumer nothing `property.uri` did not already, which
+  is the point: the fallback never fabricates a plausible-but-wrong field name.
+  """
+  name: String!
+  property: OntologyProperty!
+  required: Boolean!
+  singular: Boolean!
+  inherited: Boolean!
+}
+
+"A property in the TBox. Not a Node — it has identity but no `_meta`."
+type OntologyProperty {
+  uri: ID!
+  label: String
+  definition: String
+  domain: OntologyClass
+  range: String!
+  kind: PropertyKind!
+  functional: Boolean!
+  inverse: OntologyProperty
+  namespace: String!
+}
+
+"How a property relates its subject to its object."
+enum PropertyKind {
+  DATATYPE
+  OBJECT
+  ANNOTATION
+}
+
+"""
+The universal root fields. A provider adds its own ontology-derived fields.
+
+`ontologyClass(uri:)` and `ontologyProperty(uri:)` take `String!`, not `ID!`:
+these arguments accept the PREFIXED convenience form ("ds:Component") as well
+as the absolute IRI, and live client operations already declare
+`$uri: String!` — promoting the argument to `ID!` would invalidate them
+(String is not a subtype of ID). `node(id:)` is the strict lookup: its
+argument keeps Relay's name `id` and its value is the absolute IRI.
+"""
+type Query {
+  node(id: ID!): Node
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+}

--- a/packages/prism/contract/src/index.ts
+++ b/packages/prism/contract/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `@canonical/prism-contract` — the data contract between a Prism
+ * documentation site and whatever GraphQL backend serves it.
+ *
+ * The package states the minimal schema surface a provider must offer, as SDL,
+ * and answers one question about any candidate provider: does it satisfy that
+ * contract? The answer is semantic subsumption, not a diff — a conformant
+ * provider is a strict superset of the contract and always differs textually.
+ *
+ * @module prism-contract
+ */
+
+export * from "./lib/index.js";

--- a/packages/prism/contract/src/lib/constants.ts
+++ b/packages/prism/contract/src/lib/constants.ts
@@ -1,0 +1,48 @@
+/**
+ * Domain constants for the contract check: the three synthetic violation codes
+ * the check adds to graphql-js's own set, the default provider name used in
+ * thrown text, and the relative paths the shipped SDL is located through.
+ */
+
+/**
+ * Violation code used when the provider's SDL cannot be parsed. A provider
+ * whose schema does not parse has failed the contract; that is a result to
+ * return, not a crash to propagate.
+ */
+export const INVALID_SDL = "INVALID_SDL";
+
+/**
+ * Violation code used when the provider's SDL parses but does not build a
+ * valid schema — an interface implemented without all its fields, say.
+ *
+ * `buildSchema` runs document-level SDL rules only; it does not run schema
+ * validation, and a schema that fails validation executes NOTHING. Such a
+ * provider cannot subsume the contract however few structural differences it
+ * has, so this is a failure in its own right rather than an absence of one.
+ */
+export const INVALID_SCHEMA = "INVALID_SCHEMA";
+
+/**
+ * Violation code used when the provider serves an operation from a type other
+ * than the one the contract names as that operation's root.
+ *
+ * `findBreakingChanges` compares TYPE MAPS by name and never looks at which
+ * type a schema actually uses as a root. A provider that declares
+ * `schema { query: RootQuery }` while leaving a conforming but unreachable
+ * `type Query` in its type map is therefore structurally indistinguishable
+ * from a conformant one, and serves nothing. graphql-js cannot report that,
+ * so this check reports it.
+ */
+export const ROOT_TYPE_MISMATCH = "ROOT_TYPE_MISMATCH";
+
+/** Name used in thrown-error text when the caller supplies none. */
+export const DEFAULT_PROVIDER_NAME = "provider";
+
+/** The schema directory sits at the package root, beside src/ and dist/. */
+export const SCHEMA_RELATIVE_PATH = "schema/contract.graphql";
+
+/** From src/lib/ (vitest, ts-node) the package root is two levels up. */
+export const SOURCE_LAYOUT_PREFIX = "../..";
+
+/** From dist/esm/lib/ (the published tsc build) it is three levels up. */
+export const BUILD_LAYOUT_PREFIX = "../../..";

--- a/packages/prism/contract/src/lib/contractSdl.test.ts
+++ b/packages/prism/contract/src/lib/contractSdl.test.ts
@@ -1,0 +1,221 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertInterfaceType,
+  assertNonNullType,
+  assertObjectType,
+  assertScalarType,
+  buildSchema,
+  Kind,
+} from "graphql";
+import { describe, expect, it } from "vitest";
+import {
+  CONTRACT_SCHEMA_PATH,
+  readContractSdl,
+  resolveContractSchemaPath,
+} from "./contractSdl.js";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const shippedSchema = join(packageRoot, "schema/contract.graphql");
+
+describe("resolveContractSchemaPath", () => {
+  it("resolves the source layout: src/lib is two levels below the root", () => {
+    expect(resolveContractSchemaPath(join(packageRoot, "src/lib"))).toBe(
+      shippedSchema,
+    );
+  });
+
+  it("resolves the build layout: dist/esm/lib is three levels below the root", () => {
+    // dist/esm/lib need not exist on disk — resolve() is pure path math — and
+    // the source candidate (dist/schema/contract.graphql) genuinely misses,
+    // so this exercises the second probe.
+    expect(resolveContractSchemaPath(join(packageRoot, "dist/esm/lib"))).toBe(
+      shippedSchema,
+    );
+  });
+
+  it("throws, naming both candidates, when neither exists", () => {
+    // The failure mode this guards is a published package whose `files` lost
+    // schema/. Returning a path in that case produces an ENOENT naming a
+    // directory chosen by which probe ran last, which sends the reader to the
+    // wrong place; the throw names both and says what their absence means.
+    const nowhere = "/nowhere/definitely/missing/src/lib";
+    let message = "";
+    try {
+      resolveContractSchemaPath(nowhere);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("@canonical/prism-contract");
+    expect(message).toContain(
+      "/nowhere/definitely/missing/schema/contract.graphql",
+    );
+    expect(message).toContain("/nowhere/definitely/schema/contract.graphql");
+  });
+});
+
+describe("readContractSdl", () => {
+  it("points at a file that exists", () => {
+    expect(existsSync(CONTRACT_SCHEMA_PATH)).toBe(true);
+    expect(CONTRACT_SCHEMA_PATH.endsWith("contract.graphql")).toBe(true);
+  });
+
+  it("returns SDL that parses into a valid schema", () => {
+    const schema = buildSchema(readContractSdl());
+    expect(schema.getQueryType()?.name).toBe("Query");
+  });
+});
+
+describe("the shipped contract SDL", () => {
+  it("declares the unconditional structural surface", () => {
+    const schema = buildSchema(readContractSdl());
+    for (const name of [
+      "Node",
+      "PageInfo",
+      "NodeConnection",
+      "NodeEdge",
+      "Ontology",
+      "OntologyClass",
+      "ClassProperty",
+      "OntologyProperty",
+      "PropertyKind",
+      "EntityMeta",
+    ]) {
+      expect(
+        schema.getType(name) ?? null,
+        `missing type ${name}`,
+      ).not.toBeNull();
+    }
+  });
+
+  it("keeps Node to identity plus self-description and nothing else", () => {
+    const schema = buildSchema(readContractSdl());
+    const node = assertInterfaceType(schema.getType("Node"));
+    expect(Object.keys(node.getFields())).toEqual(["uri", "_meta"]);
+    expect(String(node.getFields().uri?.type)).toBe("ID!");
+    expect(String(node.getFields()._meta?.type)).toBe("EntityMeta!");
+  });
+
+  it("puts the descriptive quartet behind _meta, each with lang defaulting to en", () => {
+    const schema = buildSchema(readContractSdl());
+    const meta = assertObjectType(schema.getType("EntityMeta"));
+    const fields = meta.getFields();
+    // title is total; the other three are asserted-only and nullable.
+    expect(String(fields.title?.type)).toBe("String!");
+    expect(String(fields.label?.type)).toBe("String");
+    expect(String(fields.comment?.type)).toBe("String");
+    expect(String(fields.definition?.type)).toBe("String");
+    for (const name of ["title", "label", "comment", "definition"]) {
+      const lang = fields[name]?.args.find((arg) => arg.name === "lang");
+      expect(String(lang?.type), `${name}(lang:)`).toBe("String");
+      // Read off the AST, not off the argument object: v16 exposes the coerced
+      // default as `arg.defaultValue`, v17 as `arg.default`, and this package
+      // supports both. `astNode.defaultValue` is a ValueNode in either.
+      const fallback = lang?.astNode?.defaultValue;
+      expect(fallback?.kind, `${name}(lang:) default kind`).toBe(Kind.STRING);
+      expect(
+        fallback?.kind === Kind.STRING ? fallback.value : undefined,
+        `${name}(lang:) default`,
+      ).toBe("en");
+    }
+    // ...plus the self-description triple.
+    expect(String(fields.type?.type)).toBe("OntologyClass!");
+    expect(String(fields.fields?.type)).toBe("[ClassProperty!]!");
+    expect(String(fields.field?.type)).toBe("ClassProperty");
+  });
+
+  it("puts the compact form on _meta, not on Node, and makes it total", () => {
+    // RULING PIN: `uri` is the ABSOLUTE IRI and stays the only identity; the
+    // compact form is a DERIVED display value, so it lives behind `_meta`
+    // (where derived things go) and never beside `uri` on the interface —
+    // which the "identity plus self-description and nothing else" test above
+    // pins from the other side. String! because it is total: prefixed, else
+    // the absolute IRI, else the type name for a value with no IRI.
+    const schema = buildSchema(readContractSdl());
+    const meta = assertObjectType(schema.getType("EntityMeta"));
+    expect(String(meta.getFields().curie?.type)).toBe("String!");
+    // No `lang` — a CURIE is not a lexical form, so it takes no arguments.
+    expect(meta.getFields().curie?.args).toEqual([]);
+  });
+
+  it("gives ClassProperty the name field(name:) accepts", () => {
+    // RULING PIN: `fields` hands back ClassProperty rows and `field(name:)`
+    // takes a name, so without this a consumer had to reconstruct the name
+    // from `property.uri` through naming rules it does not own (pluralization
+    // is decided by PER-CLASS cardinality, so it genuinely cannot).
+    const schema = buildSchema(readContractSdl());
+    const classProperty = assertObjectType(schema.getType("ClassProperty"));
+    expect(String(classProperty.getFields().name?.type)).toBe("String!");
+    const meta = assertObjectType(schema.getType("EntityMeta"));
+    const lookupArg = meta
+      .getFields()
+      .field?.args.find((a) => a.name === "name");
+    // The two must agree, or `fields { name }` cannot feed `field(name:)`.
+    expect(String(lookupArg?.type)).toBe("String!");
+  });
+
+  it("makes OntologyClass a Node; OntologyProperty stays a non-Node with ID identity", () => {
+    const schema = buildSchema(readContractSdl());
+    const ontologyClass = assertObjectType(schema.getType("OntologyClass"));
+    expect(ontologyClass.getInterfaces().map((i) => i.name)).toEqual(["Node"]);
+    expect(String(ontologyClass.getFields()._meta?.type)).toBe("EntityMeta!");
+    // The asymmetry is scope, not principle: the property side has identity
+    // (uri: ID!) but no _meta and no Node membership.
+    const ontologyProperty = assertObjectType(
+      schema.getType("OntologyProperty"),
+    );
+    expect(ontologyProperty.getInterfaces()).toEqual([]);
+    expect(String(ontologyProperty.getFields().uri?.type)).toBe("ID!");
+    expect(ontologyProperty.getFields()._meta).toBeUndefined();
+  });
+
+  it("exposes the universal root fields and nothing ontology-specific", () => {
+    const schema = buildSchema(readContractSdl());
+    const query = schema.getQueryType();
+    expect(Object.keys(query?.getFields() ?? {})).toEqual([
+      "node",
+      "ontologies",
+      "ontology",
+      "ontologyClass",
+      "ontologyProperty",
+    ]);
+  });
+
+  it("takes String!, not ID!, for the TBox convenience lookups", () => {
+    // RULING PIN: ontologyClass(uri:)/ontologyProperty(uri:) accept the
+    // PREFIXED form and live client operations declare `$uri: String!`.
+    // Promoting the argument to ID! would invalidate them. node(id:) is the
+    // strict lookup and stays ID!.
+    const schema = buildSchema(readContractSdl());
+    const fields = schema.getQueryType()?.getFields() ?? {};
+    for (const name of ["ontologyClass", "ontologyProperty"]) {
+      const arg = fields[name]?.args.find((a) => a.name === "uri");
+      const inner = assertScalarType(assertNonNullType(arg?.type).ofType);
+      expect(inner.name, `${name}(uri:)`).toBe("String");
+    }
+    const nodeArg = fields.node?.args.find((a) => a.name === "id");
+    expect(String(nodeArg?.type)).toBe("ID!");
+  });
+
+  it("omits the incremental-delivery directives", () => {
+    const schema = buildSchema(readContractSdl());
+    expect(schema.getDirective("defer") ?? null).toBeNull();
+    expect(schema.getDirective("stream") ?? null).toBeNull();
+  });
+
+  it("omits ontology-derived types and provider extension fields", () => {
+    const schema = buildSchema(readContractSdl());
+    for (const name of ["Component", "Job", "CodeStandard", "Lens"]) {
+      expect(
+        schema.getType(name) ?? null,
+        `unexpected type ${name}`,
+      ).toBeNull();
+    }
+    // acceptanceCriteria/completionGuidance are annotation-derived provider
+    // extensions — deliberately absent from the base.
+    const property = assertObjectType(schema.getType("OntologyProperty"));
+    expect(property.getFields().acceptanceCriteria).toBeUndefined();
+    expect(property.getFields().completionGuidance).toBeUndefined();
+  });
+});

--- a/packages/prism/contract/src/lib/contractSdl.ts
+++ b/packages/prism/contract/src/lib/contractSdl.ts
@@ -1,0 +1,83 @@
+/**
+ * Locating and reading the shipped contract SDL.
+ *
+ * NODE / BUN ONLY. This module reads from the filesystem through `node:fs` and
+ * resolves paths from `import.meta.url` — and `satisfiesContract` imports it
+ * statically and calls it live whenever the `contractSdl` option is omitted,
+ * so the whole package is Node/Bun only. There is no browser entry point: the
+ * check belongs in provider gates and CI steps, which run server-side.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  BUILD_LAYOUT_PREFIX,
+  SCHEMA_RELATIVE_PATH,
+  SOURCE_LAYOUT_PREFIX,
+} from "./constants.js";
+
+/**
+ * Resolve the contract schema file for whichever layout `here` — the directory
+ * this module was loaded from — belongs to.
+ *
+ * Exported for tests, which probe the build and fallback layouts this module
+ * cannot occupy at test time. Deliberately absent from the package barrel: a
+ * consumer has the `./schema/contract.graphql` subpath export for the file and
+ * {@link readContractSdl} for its contents, and neither pins this package's
+ * on-disk shape into its public API.
+ *
+ * @note Impure: probes the filesystem with `existsSync`. The two layouts are
+ * the source tree and the published build, and which one is live is not
+ * knowable from the module's own text.
+ */
+export const resolveContractSchemaPath = (here: string): string => {
+  const sourceCandidate = resolve(
+    here,
+    SOURCE_LAYOUT_PREFIX,
+    SCHEMA_RELATIVE_PATH,
+  );
+  if (existsSync(sourceCandidate)) {
+    return sourceCandidate;
+  }
+  const buildCandidate = resolve(
+    here,
+    BUILD_LAYOUT_PREFIX,
+    SCHEMA_RELATIVE_PATH,
+  );
+  if (existsSync(buildCandidate)) {
+    return buildCandidate;
+  }
+  // Neither exists. Returning either candidate would send the reader to a
+  // directory chosen by which branch of a probe ran last, so name both and say
+  // what their absence means: a published package missing its schema/.
+  throw new Error(
+    `@canonical/prism-contract: the contract SDL is missing. Looked for ${sourceCandidate} and ${buildCandidate}. An installed copy that reaches here is missing its schema/ directory.`,
+  );
+};
+
+/**
+ * Absolute path to the shipped contract SDL file. Module-internal, like
+ * {@link resolveContractSchemaPath}: deliberately absent from the package
+ * barrel so the package's on-disk shape stays out of its public API.
+ *
+ * @note Impure: resolved once at module load, which costs one or two
+ * `existsSync` calls per process. Module-scope so the probe runs once rather
+ * than per read.
+ */
+export const CONTRACT_SCHEMA_PATH: string = resolveContractSchemaPath(
+  dirname(fileURLToPath(import.meta.url)),
+);
+
+/**
+ * Read the shipped contract SDL as a string.
+ *
+ * The SDL is the artifact, not a GraphQLSchema: handing callers text keeps
+ * every consumer free to build it with THEIR graphql instance. Two graphql
+ * versions coexist in this repo (the app's v16, ke-graphql's pinned v17 RC)
+ * and objects must never cross that boundary.
+ *
+ * @note Impure: reads the filesystem on every call.
+ */
+export const readContractSdl = (): string =>
+  readFileSync(CONTRACT_SCHEMA_PATH, "utf8");

--- a/packages/prism/contract/src/lib/contractViolationCodes.test.ts
+++ b/packages/prism/contract/src/lib/contractViolationCodes.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The union in `types.ts` is hand-spelled rather than imported, because the two
+ * graphql majors this package supports declare `BreakingChangeType`
+ * differently — v16 as a `declare enum`, v17 as a const-object union — and
+ * importing it would make the shipped `.d.ts` vary with the consumer's
+ * installed major.
+ *
+ * Hand-spelling it buys that independence and costs a promise: that the sixteen
+ * names really are graphql's set. That promise is this file. A failure here
+ * means graphql changed the set, and the union must be updated and the peer
+ * range reconsidered — not that the assertion should be relaxed.
+ *
+ * The import is type-and-value from `graphql`, which is fine: test files are
+ * excluded from the build, so nothing here reaches `dist/`.
+ */
+
+import { BreakingChangeType } from "graphql";
+import { describe, expect, it } from "vitest";
+import {
+  INVALID_SCHEMA,
+  INVALID_SDL,
+  ROOT_TYPE_MISMATCH,
+} from "./constants.js";
+import type { ContractViolationCode } from "./types.js";
+
+/**
+ * The sixteen graphql codes, spelled out exactly as `types.ts` spells them.
+ * Typed as the union, so removing a name from `types.ts` fails to compile here
+ * before it fails to run.
+ */
+const GRAPHQL_CODES: readonly ContractViolationCode[] = [
+  "TYPE_REMOVED",
+  "TYPE_CHANGED_KIND",
+  "TYPE_REMOVED_FROM_UNION",
+  "VALUE_REMOVED_FROM_ENUM",
+  "REQUIRED_INPUT_FIELD_ADDED",
+  "IMPLEMENTED_INTERFACE_REMOVED",
+  "FIELD_REMOVED",
+  "FIELD_CHANGED_KIND",
+  "REQUIRED_ARG_ADDED",
+  "ARG_REMOVED",
+  "ARG_CHANGED_KIND",
+  "DIRECTIVE_REMOVED",
+  "DIRECTIVE_ARG_REMOVED",
+  "REQUIRED_DIRECTIVE_ARG_ADDED",
+  "DIRECTIVE_REPEATABLE_REMOVED",
+  "DIRECTIVE_LOCATION_REMOVED",
+];
+
+describe("ContractViolationCode", () => {
+  it("carries exactly graphql's BreakingChangeType set, and nothing invented", () => {
+    expect([...GRAPHQL_CODES].sort()).toEqual(
+      Object.values(BreakingChangeType).sort(),
+    );
+  });
+
+  it("adds exactly the three codes this package defines itself", () => {
+    // The synthetic set: graphql has no notion of "your SDL did not parse" or
+    // "your SDL is not a schema", because it never returns a verdict on one
+    // schema alone — and its schema comparison never looks at root-type
+    // assignments, so "you serve queries from another type" is ours too.
+    // Everything else in the union is graphql's.
+    const synthetic: readonly ContractViolationCode[] = [
+      INVALID_SDL,
+      INVALID_SCHEMA,
+      ROOT_TYPE_MISMATCH,
+    ];
+    expect(synthetic).toEqual([
+      "INVALID_SDL",
+      "INVALID_SCHEMA",
+      "ROOT_TYPE_MISMATCH",
+    ]);
+    for (const code of synthetic) {
+      expect(Object.values(BreakingChangeType)).not.toContain(code);
+    }
+  });
+});

--- a/packages/prism/contract/src/lib/index.ts
+++ b/packages/prism/contract/src/lib/index.ts
@@ -1,0 +1,19 @@
+/**
+ * The contract check's public surface: the shipped SDL, the predicate, and the
+ * assertion built on it.
+ *
+ * @module lib
+ */
+
+export { readContractSdl } from "./contractSdl.js";
+export {
+  assertSatisfiesContract,
+  satisfiesContract,
+} from "./satisfiesContract.js";
+export type {
+  AssertSatisfiesContractOptions,
+  ContractResult,
+  ContractViolation,
+  ContractViolationCode,
+  SatisfiesContractOptions,
+} from "./types.js";

--- a/packages/prism/contract/src/lib/satisfiesContract.test.ts
+++ b/packages/prism/contract/src/lib/satisfiesContract.test.ts
@@ -1,0 +1,390 @@
+import { readFileSync } from "node:fs";
+import { buildSchema } from "graphql";
+import { describe, expect, it } from "vitest";
+import { INVALID_SCHEMA, INVALID_SDL } from "./constants.js";
+import { readContractSdl } from "./contractSdl.js";
+import {
+  assertSatisfiesContract,
+  satisfiesContract,
+} from "./satisfiesContract.js";
+import type { ContractResult } from "./types.js";
+
+const loadFixture = (name: string): string =>
+  readFileSync(
+    new URL(`../testing/__fixtures__/${name}.sdl.txt`, import.meta.url),
+    "utf8",
+  );
+
+const toyContract = loadFixture("toyContract");
+const getCodes = (sdl: string, contractSdl: string): string[] =>
+  satisfiesContract(sdl, { contractSdl }).violations.map((v) => v.code);
+
+/**
+ * Assertions match on `code` and on the schema coordinate inside the message,
+ * never on the whole message. `code` is a stable BreakingChangeType member in
+ * both supported graphql majors; the surrounding prose is not — v16 says
+ * "Widget.size was removed." where v17 says "Field Widget.size was removed."
+ */
+const joinMessages = (result: ContractResult): string =>
+  result.violations.map((v) => v.message).join("\n");
+
+/** The real contract with one coordinate mutated, for the negative cases. */
+const mutateContract = (from: string, to: string): string => {
+  const sdl = readContractSdl();
+  if (!sdl.includes(from)) {
+    throw new Error(
+      `the contract no longer contains "${from}"; this test's mutation is stale`,
+    );
+  }
+  return sdl.replace(from, to);
+};
+
+describe("satisfiesContract", () => {
+  it("accepts a schema identical to the contract", () => {
+    const result = satisfiesContract(toyContract, { contractSdl: toyContract });
+    expect(result).toEqual({ satisfied: true, violations: [] });
+  });
+
+  it("accepts a strict superset: extra types, fields, optional args, enum values", () => {
+    const result = satisfiesContract(loadFixture("toySuperset"), {
+      contractSdl: toyContract,
+    });
+    expect(result.violations).toEqual([]);
+    expect(result.satisfied).toBe(true);
+  });
+
+  it("rejects a provider that dropped a field", () => {
+    const result = satisfiesContract(loadFixture("toyMissingField"), {
+      contractSdl: toyContract,
+    });
+    expect(result.satisfied).toBe(false);
+    expect(result.violations.map((v) => v.code)).toContain("FIELD_REMOVED");
+    expect(joinMessages(result)).toContain("Widget.size");
+  });
+
+  it("rejects a provider that narrowed a field type", () => {
+    expect(getCodes(loadFixture("toyNarrowedField"), toyContract)).toContain(
+      "FIELD_CHANGED_KIND",
+    );
+  });
+
+  it("rejects a provider that removed an argument", () => {
+    expect(getCodes(loadFixture("toyRemovedArg"), toyContract)).toContain(
+      "ARG_REMOVED",
+    );
+  });
+
+  it("rejects a provider that removed an enum value", () => {
+    expect(getCodes(loadFixture("toyRemovedEnumValue"), toyContract)).toContain(
+      "VALUE_REMOVED_FROM_ENUM",
+    );
+  });
+
+  it("returns one INVALID_SDL violation for an unparseable provider", () => {
+    const result = satisfiesContract(loadFixture("toyMalformed"), {
+      contractSdl: toyContract,
+    });
+    expect(result.satisfied).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]?.code).toBe(INVALID_SDL);
+    expect(result.violations[0]?.message).toContain("could not be parsed");
+  });
+
+  it("throws when the CONTRACT itself is malformed: that is a programmer error", () => {
+    expect(() =>
+      satisfiesContract(toyContract, {
+        contractSdl: loadFixture("toyMalformed"),
+      }),
+    ).toThrow(/Syntax Error/);
+  });
+
+  it("throws when the CONTRACT parses but is not a valid schema", () => {
+    // The OTHER half of "broken contract", and the half a syntax-error fixture
+    // cannot reach: this SDL parses, so `buildSchema` returns happily and only
+    // `assertValidSchema` refuses it. Without a fixture that gets that far, the
+    // validity check could be deleted and this suite would stay green while
+    // the package certified providers against a schema graphql will not run.
+    expect(() =>
+      satisfiesContract(toyContract, {
+        contractSdl: loadFixture("toyInvalidContract"),
+      }),
+    ).toThrow(/Interface field Described\.label expected/);
+  });
+});
+
+describe("satisfiesContract: which type serves the operation", () => {
+  it("rejects a provider that serves queries from another type", () => {
+    // Every type the contract names is present and unchanged here, so
+    // `findBreakingChanges` reports nothing at all — the provider just serves
+    // its queries from `RootQuery` and leaves the conforming `Query` in the
+    // type map unreachable. This is the one conformance failure graphql-js
+    // structurally cannot see.
+    const result = satisfiesContract(loadFixture("toyRootTypeMismatch"), {
+      contractSdl: toyContract,
+    });
+    expect(result.satisfied).toBe(false);
+    expect(result.violations.map((v) => v.code)).toEqual([
+      "ROOT_TYPE_MISMATCH",
+    ]);
+    expect(joinMessages(result)).toContain('"RootQuery"');
+  });
+
+  it("puts no obligation on operations the contract does not name", () => {
+    // The contract names a query root and nothing else, so a provider is free
+    // to add a mutation root of any name: there is no contract operation that
+    // could be routed to the wrong type.
+    const result = satisfiesContract(
+      `${toyContract}\ntype Mutation { rename(id: ID!, label: String!): Widget }\n`,
+      { contractSdl: toyContract },
+    );
+    expect(result).toEqual({ satisfied: true, violations: [] });
+  });
+});
+
+describe("the real contract", () => {
+  it("satisfies itself, and is not degenerate", () => {
+    // findBreakingChanges(X, X) is [] for EVERY X, including a truncated or
+    // accidentally emptied contract.graphql — so this assertion alone would
+    // survive the file being gutted. The floor underneath it is what makes it
+    // mean anything.
+    const sdl = readContractSdl();
+    expect(satisfiesContract(sdl)).toEqual({ satisfied: true, violations: [] });
+    expect(Object.keys(buildSchema(sdl).getTypeMap())).toEqual(
+      expect.arrayContaining([
+        "Node",
+        "PageInfo",
+        "NodeConnection",
+        "NodeEdge",
+        "Ontology",
+        "OntologyClass",
+        "ClassProperty",
+        "OntologyProperty",
+        "PropertyKind",
+        "EntityMeta",
+      ]),
+    );
+  });
+
+  it("is satisfied by the post-1.6 provider emission shape", () => {
+    // The fixture embeds what ke-graphql emits for a one-class ontology once
+    // OntologyClass implements Node and carries _meta (the 1.6 change).
+    expect(satisfiesContract(loadFixture("emittedProvider"))).toEqual({
+      satisfied: true,
+      violations: [],
+    });
+  });
+
+  it("is satisfied by a fully prefixed emission: the contract names no ontology terms", () => {
+    // prefixing: "all" renames every GENERATED field (name -> exName). The
+    // contract's surface is purely structural, so the knob cannot affect it.
+    expect(satisfiesContract(loadFixture("emittedPrefixedProvider"))).toEqual({
+      satisfied: true,
+      violations: [],
+    });
+  });
+
+  it("flags a relay-less emission by exactly the field relay wiring adds", () => {
+    // relay: false keeps the whole TBox (which still references Node) but
+    // never claims Query.node. One violation — no more, no less — is the
+    // teeth control: the gate distinguishes the two emissions precisely.
+    const result = satisfiesContract(loadFixture("emittedNoRelayProvider"));
+    expect(result.satisfied).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]?.code).toBe("FIELD_REMOVED");
+    expect(result.violations[0]?.message).toContain("Query.node");
+  });
+
+  it("rejects a provider deficient in three independent ways", () => {
+    const result = satisfiesContract(loadFixture("deficientProvider"));
+    expect(result.satisfied).toBe(false);
+    expect(result.violations.map((v) => v.code)).toEqual(
+      expect.arrayContaining([
+        "FIELD_REMOVED",
+        "FIELD_CHANGED_KIND",
+        "ARG_REMOVED",
+      ]),
+    );
+    const messages = joinMessages(result);
+    expect(messages).toContain("Node._meta");
+    expect(messages).toContain("PageInfo.hasNextPage");
+    expect(messages).toContain("Query.ontology");
+  });
+
+  it("rejects an empty provider", () => {
+    const result = satisfiesContract("type Query { noop: String }");
+    expect(result.satisfied).toBe(false);
+    expect(result.violations.map((v) => v.code)).toContain("TYPE_REMOVED");
+  });
+});
+
+describe("satisfiesContract: a provider that parses but is not a schema", () => {
+  it("rejects a type that implements an interface without providing its fields", () => {
+    // buildSchema runs DOCUMENT-level SDL rules only, so this builds happily
+    // and differs from the contract in no way findBreakingChanges can see —
+    // and then fails every query at execution with the message below. Calling
+    // that conformance would be the worst answer this function can give.
+    const result = satisfiesContract(
+      `${loadFixture("emittedProvider")}\ntype Broken implements Node { uri: ID! }\n`,
+    );
+    expect(result.satisfied).toBe(false);
+    expect(result.violations.map((v) => v.code)).toEqual([INVALID_SCHEMA]);
+    expect(joinMessages(result)).toContain(
+      "Interface field Node._meta expected but Broken does not provide it.",
+    );
+  });
+
+  it("reports a parse failure with its source location, not just its message", () => {
+    // GraphQLError.toString() prints the line, the column and a caret-marked
+    // excerpt. Reading .message alone throws all of that away, which for a
+    // package whose job is telling a provider author what is wrong with their
+    // SDL is the difference between an answer and a shrug.
+    const result = satisfiesContract(loadFixture("toyMalformed"));
+    expect(result.violations.map((v) => v.code)).toEqual([INVALID_SDL]);
+    expect(joinMessages(result)).toContain("Syntax Error");
+    expect(joinMessages(result)).toMatch(/\d+:\d+/);
+  });
+
+  it("reports an SDL-validation failure, which is not a GraphQLError", () => {
+    // The other half of the parse branch: assertValidSDL aggregates its
+    // findings into a PLAIN Error with no location to print, so the two cases
+    // are rendered differently on purpose.
+    const result = satisfiesContract(
+      "type Query { a: Int }\ntype Query { b: Int }",
+    );
+    expect(result.violations.map((v) => v.code)).toEqual([INVALID_SDL]);
+    expect(joinMessages(result)).toContain(
+      'There can be only one type named "Query".',
+    );
+  });
+});
+
+describe("satisfiesContract: the rulings the contract argues for", () => {
+  // Each case mutates ONE coordinate of the real contract and offers the
+  // result as a provider. These are the rulings the contract changed shape
+  // for, so a check that cannot flag their loss is not checking them.
+
+  it("rejects a provider whose OntologyClass stopped implementing Node", () => {
+    // The post-1.6 headline ruling: OntologyClass implements Node, so classes
+    // resolve through node(id:) and ride NodeConnections like any other entity.
+    const result = satisfiesContract(
+      mutateContract(
+        "type OntologyClass implements Node {",
+        "type OntologyClass {",
+      ),
+    );
+    expect(result.satisfied).toBe(false);
+    // One violation, no more: the mutation moved this coordinate and nothing
+    // else, so the test still isolates it if the contract grows around it.
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations.map((v) => v.code)).toContain(
+      "IMPLEMENTED_INTERFACE_REMOVED",
+    );
+    expect(joinMessages(result)).toContain("OntologyClass");
+  });
+
+  it("rejects a provider that promoted a TBox lookup argument to ID!", () => {
+    // The String!-not-ID! ruling: the argument accepts the prefixed
+    // convenience form and live client operations declare $uri: String!.
+    const result = satisfiesContract(
+      mutateContract("ontologyClass(uri: String!)", "ontologyClass(uri: ID!)"),
+    );
+    expect(result.satisfied).toBe(false);
+    // One violation, no more: the mutation moved this coordinate and nothing
+    // else, so the test still isolates it if the contract grows around it.
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations.map((v) => v.code)).toContain("ARG_CHANGED_KIND");
+    expect(joinMessages(result)).toContain("Query.ontologyClass");
+  });
+
+  it("rejects a provider that added a required argument to a root field", () => {
+    // Not a removal, so no fixture shape resembles it — and it silently breaks
+    // every operation the docsite already ships.
+    const result = satisfiesContract(
+      mutateContract(
+        "ontology(prefix: String!)",
+        "ontology(prefix: String!, tenant: String!)",
+      ),
+    );
+    expect(result.satisfied).toBe(false);
+    // One violation, no more: the mutation moved this coordinate and nothing
+    // else, so the test still isolates it if the contract grows around it.
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations.map((v) => v.code)).toContain(
+      "REQUIRED_ARG_ADDED",
+    );
+    expect(joinMessages(result)).toContain("Query.ontology");
+  });
+
+  it("rejects a provider that changed a contract type's kind", () => {
+    const result = satisfiesContract(
+      mutateContract("type EntityMeta {", "interface EntityMeta {"),
+    );
+    expect(result.satisfied).toBe(false);
+    // One violation, no more: the mutation moved this coordinate and nothing
+    // else, so the test still isolates it if the contract grows around it.
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations.map((v) => v.code)).toContain("TYPE_CHANGED_KIND");
+    expect(joinMessages(result)).toContain("EntityMeta");
+  });
+});
+
+describe("satisfiesContract: what the check deliberately does NOT enforce", () => {
+  // Negative space, measured rather than assumed. Both of these are supersets
+  // in the sense the contract cares about — every operation legal against the
+  // contract still runs — so accepting them is correct, not a gap. Pinned so
+  // that a future change to the accepted set is a decision rather than a
+  // side effect.
+
+  it("accepts a provider that changed an argument's default value", () => {
+    // A default changes what an OMITTED argument means, not which operations
+    // are legal. graphql-js agrees: ARG_DEFAULT_VALUE_CHANGE is a DANGEROUS
+    // change, not a breaking one, and findDangerousChanges is not consulted.
+    const result = satisfiesContract(
+      mutateContract('lang: String = "en"', 'lang: String = "fr"'),
+    );
+    expect(result).toEqual({ satisfied: true, violations: [] });
+  });
+
+  it("accepts a provider that added a value to a contract enum", () => {
+    const result = satisfiesContract(
+      mutateContract(
+        "enum PropertyKind {",
+        "enum PropertyKind {\n  PROVIDER_EXTENSION",
+      ),
+    );
+    expect(result).toEqual({ satisfied: true, violations: [] });
+  });
+});
+
+describe("assertSatisfiesContract", () => {
+  it("returns quietly for a conformant provider", () => {
+    expect(() =>
+      assertSatisfiesContract(loadFixture("toySuperset"), {
+        contractSdl: toyContract,
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws listing every violation, naming the provider", () => {
+    let message = "";
+    try {
+      assertSatisfiesContract(loadFixture("deficientProvider"), {
+        providerName: "ke-graphql backend",
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("ke-graphql backend");
+    expect(message).toContain("3 violation(s)");
+    expect(message).toContain("[FIELD_REMOVED]");
+    expect(message).toContain("Node._meta");
+    expect(message).toContain("[ARG_REMOVED]");
+    expect(message).toContain("[FIELD_CHANGED_KIND]");
+  });
+
+  it("defaults the provider name", () => {
+    expect(() =>
+      assertSatisfiesContract("type Query { noop: String }"),
+    ).toThrow(/^provider does not satisfy the Prism data contract/);
+  });
+});

--- a/packages/prism/contract/src/lib/satisfiesContract.ts
+++ b/packages/prism/contract/src/lib/satisfiesContract.ts
@@ -1,0 +1,218 @@
+/**
+ * The contract check: does a provider's schema SUBSUME the contract?
+ *
+ * This is deliberately NOT an AST or text comparison. A real provider's SDL is
+ * a strict superset of the contract (it adds every ontology-derived type), so
+ * it always differs textually and always will. The question that actually
+ * matters is semantic: could every operation that is legal against the
+ * contract also run against the provider?
+ *
+ * graphql-js answers most of that. `findBreakingChanges(old, new)` reports
+ * every way in which `new` fails to remain compatible with `old`, so with the
+ * contract as `old` and the provider as `new`, zero breaking changes means the
+ * provider kept everything the contract promised.
+ *
+ * Most, not all — so two things are settled around it:
+ *
+ * - `findBreakingChanges` compares TYPE MAPS by name and never looks at which
+ *   type a schema actually uses as a root. A provider that declares
+ *   `schema { query: RootQuery }` while leaving a conforming but unreachable
+ *   `type Query` in its type map would therefore pass while serving nothing.
+ *   The root-assignment check below closes that: for every operation the
+ *   contract names a root for, the provider must serve that operation from a
+ *   type of the same name. Every real provider already does, because the
+ *   contract is the shape it was compiled from — but "already does" is not a
+ *   check, and this predicate is quoted as an equivalence.
+ * - `findDangerousChanges` is not consulted. Adding an optional argument, a
+ *   union member, or an enum value is dangerous for a CLIENT and perfectly
+ *   legal for a superset PROVIDER, and every real provider does several. One
+ *   member of that set is a genuine divergence rather than a superset —
+ *   `ARG_DEFAULT_VALUE_CHANGE` — and it is knowingly out of scope: a default
+ *   changes what an omitted argument MEANS, not which operations are legal,
+ *   and the contract's promise is about legality. `satisfiesContract.test.ts`
+ *   pins that acceptance so the boundary is measured rather than assumed.
+ */
+
+import {
+  assertValidSchema,
+  buildSchema,
+  findBreakingChanges,
+  GraphQLError,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+  validateSchema,
+} from "graphql";
+import {
+  DEFAULT_PROVIDER_NAME,
+  INVALID_SCHEMA,
+  INVALID_SDL,
+  ROOT_TYPE_MISMATCH,
+} from "./constants.js";
+import { readContractSdl } from "./contractSdl.js";
+import type {
+  AssertSatisfiesContractOptions,
+  ContractResult,
+  ContractViolation,
+  SatisfiesContractOptions,
+} from "./types.js";
+
+/**
+ * Render a `buildSchema` failure for a provider author.
+ *
+ * `buildSchema` throws two different things, and the difference is worth the
+ * branch. A PARSE failure is a `GraphQLError`, whose `toString()` prints the
+ * message, the line and column, and a caret-annotated excerpt of the offending
+ * source — everything the author needs, and all of it lost if only `.message`
+ * is read. An SDL-VALIDATION failure (a duplicated type name, say) is a plain
+ * `Error` aggregating several messages, with no location to print.
+ */
+const describeError = (error: unknown): string => {
+  if (error instanceof GraphQLError) {
+    return String(error);
+  }
+  /* v8 ignore else -- unreachable: buildSchema throws GraphQLError for a parse failure and a plain aggregated Error for an SDL-validation failure, both handled above; the String(error) arm stays because `catch` is typed `unknown` and dropping it would mean asserting a type the language does not guarantee */
+  if (error instanceof Error) {
+    return error.message;
+  } else {
+    return String(error);
+  }
+};
+
+/**
+ * How to read each operation's root type off a schema, by operation name.
+ *
+ * Keyed rather than hard-coded to `query` so that a contract which later names
+ * a mutation or subscription root is covered the day it does, without a second
+ * edit here.
+ */
+const ROOT_TYPE_READERS: Readonly<
+  Record<
+    string,
+    (schema: GraphQLSchema) => GraphQLObjectType | null | undefined
+  >
+> = {
+  query: (schema) => schema.getQueryType(),
+  mutation: (schema) => schema.getMutationType(),
+  subscription: (schema) => schema.getSubscriptionType(),
+};
+
+/**
+ * Every operation whose root type the provider does not share with the
+ * contract.
+ *
+ * The contract's own roots are the subject: an operation the contract does not
+ * name (it names no mutation today) puts no obligation on a provider, so a
+ * provider is free to add one.
+ */
+const findRootTypeMismatches = (
+  contractSchema: GraphQLSchema,
+  providerSchema: GraphQLSchema,
+): ContractViolation[] =>
+  Object.entries(ROOT_TYPE_READERS).flatMap(([operation, readRootType]) => {
+    const expected = readRootType(contractSchema)?.name;
+    const actual = readRootType(providerSchema)?.name;
+    if (expected === undefined || expected === actual) {
+      return [];
+    }
+    return [
+      {
+        code: ROOT_TYPE_MISMATCH,
+        message: `the contract serves ${operation} operations from type "${expected}", but the provider serves them from "${actual}": every ${operation} the contract promises would be executed against a different type`,
+      },
+    ];
+  });
+
+/**
+ * Check a provider's SDL against the contract.
+ *
+ * Takes SDL as a STRING, never a GraphQLSchema. Two graphql versions coexist
+ * in this repo and a schema object built by one must never be handed to the
+ * other; text is the only safe currency across that boundary.
+ *
+ * A malformed CONTRACT throws (the contract is ours: that is a programmer
+ * error). A provider that does not parse comes back as a single
+ * `INVALID_SDL` violation, one that parses into an invalid schema as
+ * `INVALID_SCHEMA` violations, and one that serves a contract operation from a
+ * differently named root type as a `ROOT_TYPE_MISMATCH` violation.
+ *
+ * @note Impure: reads the shipped contract SDL from the filesystem unless
+ * `contractSdl` is supplied. This is the documented default path, so the
+ * common call is a reading one.
+ */
+export const satisfiesContract = (
+  providerSdl: string,
+  options: SatisfiesContractOptions = {},
+): ContractResult => {
+  // Outside the try: a broken contract must surface as a thrown error. Both
+  // halves of "broken" are checked, because parsing is not validity here
+  // either — a contract that builds into a schema graphql refuses to execute
+  // could otherwise certify a provider as conforming to something unservable.
+  const contractSchema = buildSchema(options.contractSdl ?? readContractSdl());
+  assertValidSchema(contractSchema);
+
+  let providerSchema: GraphQLSchema;
+  try {
+    providerSchema = buildSchema(providerSdl);
+  } catch (error) {
+    return {
+      satisfied: false,
+      violations: [
+        {
+          code: INVALID_SDL,
+          message: `provider SDL could not be parsed: ${describeError(error)}`,
+        },
+      ],
+    };
+  }
+
+  // Parsing is not validity. `buildSchema` runs document-level SDL rules only,
+  // so a type that implements an interface without providing its fields builds
+  // happily, differs from the contract in no way findBreakingChanges can see,
+  // and then fails EVERY query at execution. Reporting that as conformance
+  // would be the worst answer this function can give, so it is checked before
+  // the comparison rather than after.
+  const schemaErrors = validateSchema(providerSchema);
+  if (schemaErrors.length > 0) {
+    return {
+      satisfied: false,
+      violations: schemaErrors.map((error) => ({
+        code: INVALID_SCHEMA,
+        message: `provider schema is not valid: ${error.message}`,
+      })),
+    };
+  }
+
+  const violations: ContractViolation[] = [
+    ...findBreakingChanges(contractSchema, providerSchema).map((change) => ({
+      code: change.type as ContractViolation["code"],
+      message: change.description,
+    })),
+    ...findRootTypeMismatches(contractSchema, providerSchema),
+  ];
+
+  return { satisfied: violations.length === 0, violations };
+};
+
+/**
+ * Throw unless the provider's SDL satisfies the contract. The thrown message
+ * lists every violation, so one run reports the whole gap rather than the
+ * first item of it.
+ *
+ * @note Impure: inherits {@link satisfiesContract}'s filesystem read.
+ */
+export const assertSatisfiesContract = (
+  providerSdl: string,
+  options: AssertSatisfiesContractOptions = {},
+): void => {
+  const result = satisfiesContract(providerSdl, options);
+  if (result.satisfied) {
+    return;
+  }
+  const name = options.providerName ?? DEFAULT_PROVIDER_NAME;
+  const detail = result.violations
+    .map((violation) => `  - [${violation.code}] ${violation.message}`)
+    .join("\n");
+  throw new Error(
+    `${name} does not satisfy the Prism data contract (${result.violations.length} violation(s)):\n${detail}`,
+  );
+};

--- a/packages/prism/contract/src/lib/types.ts
+++ b/packages/prism/contract/src/lib/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Public types for the contract check.
+ *
+ * Type-only: no runtime code lives here, which is why the coverage config
+ * excludes this file.
+ */
+
+/**
+ * Every code a {@link ContractViolation} can carry.
+ *
+ * The first sixteen are graphql-js's `BreakingChangeType` members, spelled out
+ * locally rather than imported. The member set is identical in both graphql
+ * majors this package supports, but the two declare it differently — v16 as a
+ * `declare enum`, v17 as a const-object union — so importing it would make the
+ * emitted `.d.ts` vary with the consumer's installed major, which is exactly
+ * the version-independence this package exists to preserve. Owning it also
+ * gives a consumer completion and exhaustiveness on `code`, which a bare
+ * `string` cannot. `contractViolationCodes.test.ts` pins the union against
+ * graphql's own set, so a drift is a failure rather than a silent divergence.
+ *
+ * The last three are this package's own: see `constants.ts`.
+ */
+export type ContractViolationCode =
+  | "TYPE_REMOVED"
+  | "TYPE_CHANGED_KIND"
+  | "TYPE_REMOVED_FROM_UNION"
+  | "VALUE_REMOVED_FROM_ENUM"
+  | "REQUIRED_INPUT_FIELD_ADDED"
+  | "IMPLEMENTED_INTERFACE_REMOVED"
+  | "FIELD_REMOVED"
+  | "FIELD_CHANGED_KIND"
+  | "REQUIRED_ARG_ADDED"
+  | "ARG_REMOVED"
+  | "ARG_CHANGED_KIND"
+  | "DIRECTIVE_REMOVED"
+  | "DIRECTIVE_ARG_REMOVED"
+  | "REQUIRED_DIRECTIVE_ARG_ADDED"
+  | "DIRECTIVE_REPEATABLE_REMOVED"
+  | "DIRECTIVE_LOCATION_REMOVED"
+  | "INVALID_SDL"
+  | "INVALID_SCHEMA"
+  | "ROOT_TYPE_MISMATCH";
+
+/** One way in which a provider's schema fails to subsume the contract. */
+export interface ContractViolation {
+  readonly code: ContractViolationCode;
+  readonly message: string;
+}
+
+/** The outcome of checking one provider's SDL against the contract. */
+export interface ContractResult {
+  readonly satisfied: boolean;
+  readonly violations: readonly ContractViolation[];
+}
+
+/** Options for {@link satisfiesContract}. */
+export interface SatisfiesContractOptions {
+  /**
+   * Contract SDL to check against. Defaults to this package's shipped
+   * schema/contract SDL file. A malformed value here THROWS — the contract is
+   * ours, so a broken one is a programmer error, not a provider failure.
+   */
+  readonly contractSdl?: string;
+}
+
+/**
+ * Options for {@link assertSatisfiesContract}.
+ *
+ * Separate from {@link SatisfiesContractOptions} because `providerName` only
+ * has anywhere to go in a thrown message: a shared type would let
+ * `satisfiesContract(sdl, { providerName })` type-check and silently do
+ * nothing.
+ */
+export interface AssertSatisfiesContractOptions
+  extends SatisfiesContractOptions {
+  /** Name used in thrown-error text. Defaults to `"provider"`. */
+  readonly providerName?: string;
+}

--- a/packages/prism/contract/src/testing/__fixtures__/deficientProvider.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/deficientProvider.sdl.txt
@@ -1,0 +1,101 @@
+# A provider that is deficient against the REAL contract, three ways at once:
+#   1. Node._meta is missing            -> FIELD_REMOVED
+#   2. PageInfo.hasNextPage is nullable -> FIELD_CHANGED_KIND
+#   3. Query.ontology lost its `prefix` -> ARG_REMOVED
+# Everything else is a faithful copy of schema/contract.graphql — including
+# OntologyClass implementing Node, which stays legal here because an
+# implementor may carry fields the (broken) interface no longer declares.
+
+interface Node {
+  uri: ID!
+}
+
+type EntityMeta {
+  curie: String!
+  title(lang: String = "en"): String!
+  label(lang: String = "en"): String
+  comment(lang: String = "en"): String
+  definition(lang: String = "en"): String
+  type: OntologyClass!
+  fields: [ClassProperty!]!
+  field(name: String!): ClassProperty
+}
+
+type PageInfo {
+  hasNextPage: Boolean
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type NodeConnection {
+  edges: [NodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NodeEdge {
+  node: Node!
+  cursor: String!
+}
+
+type Ontology {
+  prefix: String!
+  namespace: String!
+  label: String
+  classes: [OntologyClass!]!
+  properties: [OntologyProperty!]!
+}
+
+type OntologyClass implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  label: String
+  definition: String
+  superclass: OntologyClass
+  superclasses: [OntologyClass!]!
+  subclasses: [OntologyClass!]!
+  properties: [ClassProperty!]!
+  instances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): NodeConnection!
+  instanceCount: Int!
+  isAbstract: Boolean!
+  namespace: String!
+}
+
+type ClassProperty {
+  name: String!
+  property: OntologyProperty!
+  required: Boolean!
+  singular: Boolean!
+  inherited: Boolean!
+}
+
+type OntologyProperty {
+  uri: ID!
+  label: String
+  definition: String
+  domain: OntologyClass
+  range: String!
+  kind: PropertyKind!
+  functional: Boolean!
+  inverse: OntologyProperty
+  namespace: String!
+}
+
+enum PropertyKind {
+  DATATYPE
+  OBJECT
+  ANNOTATION
+}
+
+type Query {
+  node(id: ID!): Node
+  ontologies: [Ontology!]!
+  ontology: Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+}

--- a/packages/prism/contract/src/testing/__fixtures__/emittedNoRelayProvider.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/emittedNoRelayProvider.sdl.txt
@@ -1,0 +1,112 @@
+# The same one-class emission compiled with `relay: false`: Pass 6 is
+# skipped, so the generated Thing loses Node membership, its uri/_meta
+# structural fields, its connection pair, and its root lookup/listing — and
+# Query has no `node` field. The TBox (which still references Node through
+# OntologyClass and the instances NodeConnection) survives untouched.
+#
+# Against the contract this is EXACTLY ONE violation: FIELD_REMOVED on
+# Query.node. The teeth control — proving the gate distinguishes this
+# emission from a conformant one by precisely the field relay wiring adds.
+# ke-graphql · canonical SDL
+# graphql-schema-spec: 1
+# provider: fixture
+# mode: annotated
+# validated-store: false
+# revision: 0
+# prefixing: none
+
+type Query {
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+}
+
+type Ontology {
+  prefix: String!
+  namespace: String!
+  label: String
+  classes: [OntologyClass!]!
+  properties: [OntologyProperty!]!
+}
+
+type OntologyClass implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  label: String
+  definition: String
+  superclass: OntologyClass
+  superclasses: [OntologyClass!]!
+  subclasses: [OntologyClass!]!
+  properties: [ClassProperty!]!
+  instances(first: Int, after: String, last: Int, before: String): NodeConnection!
+  instanceCount: Int!
+  isAbstract: Boolean!
+  namespace: String!
+}
+
+interface Node {
+  uri: ID!
+  _meta: EntityMeta!
+}
+
+type EntityMeta {
+  curie: String!
+  title(lang: String = "en"): String!
+  label(lang: String = "en"): String
+  comment(lang: String = "en"): String
+  definition(lang: String = "en"): String
+  type: OntologyClass!
+  field(name: String!): ClassProperty
+  fields: [ClassProperty!]!
+}
+
+type ClassProperty {
+  name: String!
+  property: OntologyProperty!
+  required: Boolean!
+  singular: Boolean!
+  inherited: Boolean!
+}
+
+type OntologyProperty {
+  uri: ID!
+  label: String
+  definition: String
+  domain: OntologyClass
+  range: String!
+  kind: PropertyKind!
+  functional: Boolean!
+  inverse: OntologyProperty
+  acceptanceCriteria: String
+  completionGuidance: String
+  namespace: String!
+}
+
+enum PropertyKind {
+  DATATYPE
+  OBJECT
+  ANNOTATION
+}
+
+type NodeConnection {
+  edges: [NodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NodeEdge {
+  node: Node!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type Thing {
+  name: String
+  count: Int
+}

--- a/packages/prism/contract/src/testing/__fixtures__/emittedPrefixedProvider.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/emittedPrefixedProvider.sdl.txt
@@ -1,0 +1,123 @@
+# The same one-class emission compiled with `prefixing: "all"`: every
+# GENERATED field name carries its property's namespace prefix (name ->
+# exName, count -> exCount). The structural fields (uri, _meta) and the whole
+# TBox surface carry no prefix, and the contract names no ontology terms —
+# so this schema satisfies the contract exactly as the unprefixed one does.
+# ke-graphql · canonical SDL
+# graphql-schema-spec: 1
+# provider: fixture
+# mode: annotated
+# validated-store: false
+# revision: 0
+# prefixing: all
+
+type Query {
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+  node(id: ID!): Node
+  thing(uri: String!): Thing
+  things(first: Int, after: String, last: Int, before: String): ThingConnection!
+}
+
+type Ontology {
+  prefix: String!
+  namespace: String!
+  label: String
+  classes: [OntologyClass!]!
+  properties: [OntologyProperty!]!
+}
+
+type OntologyClass implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  label: String
+  definition: String
+  superclass: OntologyClass
+  superclasses: [OntologyClass!]!
+  subclasses: [OntologyClass!]!
+  properties: [ClassProperty!]!
+  instances(first: Int, after: String, last: Int, before: String): NodeConnection!
+  instanceCount: Int!
+  isAbstract: Boolean!
+  namespace: String!
+}
+
+interface Node {
+  uri: ID!
+  _meta: EntityMeta!
+}
+
+type EntityMeta {
+  curie: String!
+  title(lang: String = "en"): String!
+  label(lang: String = "en"): String
+  comment(lang: String = "en"): String
+  definition(lang: String = "en"): String
+  type: OntologyClass!
+  field(name: String!): ClassProperty
+  fields: [ClassProperty!]!
+}
+
+type ClassProperty {
+  name: String!
+  property: OntologyProperty!
+  required: Boolean!
+  singular: Boolean!
+  inherited: Boolean!
+}
+
+type OntologyProperty {
+  uri: ID!
+  label: String
+  definition: String
+  domain: OntologyClass
+  range: String!
+  kind: PropertyKind!
+  functional: Boolean!
+  inverse: OntologyProperty
+  acceptanceCriteria: String
+  completionGuidance: String
+  namespace: String!
+}
+
+enum PropertyKind {
+  DATATYPE
+  OBJECT
+  ANNOTATION
+}
+
+type NodeConnection {
+  edges: [NodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NodeEdge {
+  node: Node!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type Thing implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  exName: String
+  exCount: Int
+}
+
+type ThingConnection {
+  edges: [ThingEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ThingEdge {
+  node: Thing!
+  cursor: String!
+}

--- a/packages/prism/contract/src/testing/__fixtures__/emittedProvider.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/emittedProvider.sdl.txt
@@ -1,0 +1,122 @@
+# The shape ke-graphql emits for a one-class ontology (post-1.6: OntologyClass
+# implements Node and carries _meta). A strict superset of the contract: the
+# generated Thing type, its connection pair, its root fields, and the
+# annotation-derived extension fields on OntologyProperty are all extra.
+# ke-graphql · canonical SDL
+# graphql-schema-spec: 1
+# provider: fixture
+# mode: annotated
+# validated-store: false
+# revision: 0
+# prefixing: none
+
+type Query {
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+  node(id: ID!): Node
+  thing(uri: String!): Thing
+  things(first: Int, after: String, last: Int, before: String): ThingConnection!
+}
+
+type Ontology {
+  prefix: String!
+  namespace: String!
+  label: String
+  classes: [OntologyClass!]!
+  properties: [OntologyProperty!]!
+}
+
+type OntologyClass implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  label: String
+  definition: String
+  superclass: OntologyClass
+  superclasses: [OntologyClass!]!
+  subclasses: [OntologyClass!]!
+  properties: [ClassProperty!]!
+  instances(first: Int, after: String, last: Int, before: String): NodeConnection!
+  instanceCount: Int!
+  isAbstract: Boolean!
+  namespace: String!
+}
+
+interface Node {
+  uri: ID!
+  _meta: EntityMeta!
+}
+
+type EntityMeta {
+  curie: String!
+  title(lang: String = "en"): String!
+  label(lang: String = "en"): String
+  comment(lang: String = "en"): String
+  definition(lang: String = "en"): String
+  type: OntologyClass!
+  field(name: String!): ClassProperty
+  fields: [ClassProperty!]!
+}
+
+type ClassProperty {
+  name: String!
+  property: OntologyProperty!
+  required: Boolean!
+  singular: Boolean!
+  inherited: Boolean!
+}
+
+type OntologyProperty {
+  uri: ID!
+  label: String
+  definition: String
+  domain: OntologyClass
+  range: String!
+  kind: PropertyKind!
+  functional: Boolean!
+  inverse: OntologyProperty
+  acceptanceCriteria: String
+  completionGuidance: String
+  namespace: String!
+}
+
+enum PropertyKind {
+  DATATYPE
+  OBJECT
+  ANNOTATION
+}
+
+type NodeConnection {
+  edges: [NodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NodeEdge {
+  node: Node!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type Thing implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  name: String
+  count: Int
+}
+
+type ThingConnection {
+  edges: [ThingEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ThingEdge {
+  node: Thing!
+  cursor: String!
+}

--- a/packages/prism/contract/src/testing/__fixtures__/toyContract.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toyContract.sdl.txt
@@ -1,0 +1,16 @@
+type Query {
+  widget(id: ID!): Widget
+  widgets: [Widget!]!
+}
+
+type Widget {
+  id: ID!
+  label: String
+  size: Int!
+  kind: WidgetKind!
+}
+
+enum WidgetKind {
+  ROUND
+  SQUARE
+}

--- a/packages/prism/contract/src/testing/__fixtures__/toyInvalidContract.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toyInvalidContract.sdl.txt
@@ -1,0 +1,17 @@
+# Parses, builds, and is NOT a valid schema: `Widget` claims `Described` and
+# omits `label`. `buildSchema` runs document-level SDL rules only, so this gets
+# past the parse; `assertValidSchema` is what refuses it. Used as a CONTRACT,
+# where a schema graphql will not execute is a programmer error and must throw
+# rather than certify anything.
+type Query {
+  widget(id: ID!): Widget
+}
+
+interface Described {
+  id: ID!
+  label: String!
+}
+
+type Widget implements Described {
+  id: ID!
+}

--- a/packages/prism/contract/src/testing/__fixtures__/toyMalformed.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toyMalformed.sdl.txt
@@ -1,0 +1,2 @@
+type Query {
+  widget(id: ID!) Widget

--- a/packages/prism/contract/src/testing/__fixtures__/toyMissingField.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toyMissingField.sdl.txt
@@ -1,0 +1,15 @@
+type Query {
+  widget(id: ID!): Widget
+  widgets: [Widget!]!
+}
+
+type Widget {
+  id: ID!
+  label: String
+  kind: WidgetKind!
+}
+
+enum WidgetKind {
+  ROUND
+  SQUARE
+}

--- a/packages/prism/contract/src/testing/__fixtures__/toyNarrowedField.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toyNarrowedField.sdl.txt
@@ -1,0 +1,16 @@
+type Query {
+  widget(id: ID!): Widget
+  widgets: [Widget!]!
+}
+
+type Widget {
+  id: ID!
+  label: String
+  size: Int
+  kind: WidgetKind!
+}
+
+enum WidgetKind {
+  ROUND
+  SQUARE
+}

--- a/packages/prism/contract/src/testing/__fixtures__/toyRemovedArg.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toyRemovedArg.sdl.txt
@@ -1,0 +1,16 @@
+type Query {
+  widget: Widget
+  widgets: [Widget!]!
+}
+
+type Widget {
+  id: ID!
+  label: String
+  size: Int!
+  kind: WidgetKind!
+}
+
+enum WidgetKind {
+  ROUND
+  SQUARE
+}

--- a/packages/prism/contract/src/testing/__fixtures__/toyRemovedEnumValue.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toyRemovedEnumValue.sdl.txt
@@ -1,0 +1,15 @@
+type Query {
+  widget(id: ID!): Widget
+  widgets: [Widget!]!
+}
+
+type Widget {
+  id: ID!
+  label: String
+  size: Int!
+  kind: WidgetKind!
+}
+
+enum WidgetKind {
+  ROUND
+}

--- a/packages/prism/contract/src/testing/__fixtures__/toyRootTypeMismatch.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toyRootTypeMismatch.sdl.txt
@@ -1,0 +1,29 @@
+# The provider `findBreakingChanges` alone cannot catch: every type the toy
+# contract names is present and unchanged, so the type-map comparison is empty
+# — but queries are served from `RootQuery`, and the conforming `Query` sitting
+# in the type map is unreachable. Structurally conformant, serves nothing.
+schema {
+  query: RootQuery
+}
+
+type RootQuery {
+  widget(id: ID!): Widget
+  widgets: [Widget!]!
+}
+
+type Query {
+  widget(id: ID!): Widget
+  widgets: [Widget!]!
+}
+
+type Widget {
+  id: ID!
+  label: String
+  size: Int!
+  kind: WidgetKind!
+}
+
+enum WidgetKind {
+  ROUND
+  SQUARE
+}

--- a/packages/prism/contract/src/testing/__fixtures__/toySuperset.sdl.txt
+++ b/packages/prism/contract/src/testing/__fixtures__/toySuperset.sdl.txt
@@ -1,0 +1,29 @@
+type Query {
+  widget(id: ID!, locale: String): Widget
+  widgets: [Widget!]!
+  gadget(id: ID!): Gadget
+}
+
+type Widget implements Thing {
+  id: ID!
+  label: String
+  size: Int!
+  kind: WidgetKind!
+  color: String
+  gadgets: [Gadget!]!
+}
+
+type Gadget {
+  id: ID!
+  weight: Float
+}
+
+interface Thing {
+  id: ID!
+}
+
+enum WidgetKind {
+  ROUND
+  SQUARE
+  TRIANGULAR
+}

--- a/packages/prism/contract/src/testing/integration/emittedGoldens.test.ts
+++ b/packages/prism/contract/src/testing/integration/emittedGoldens.test.ts
@@ -1,0 +1,84 @@
+// =============================================================================
+// The currency gate: the compiler's COMMITTED emissions still satisfy the
+// contract as it stands right now.
+//
+// WHY THIS EXISTS. `src/testing/__fixtures__/emitted*.sdl.txt` are frozen
+// captures. If the contract gains a promise the compiler does not keep, or the
+// compiler's emitted base loses something the contract requires, nothing above
+// this file would notice: the fixtures would go on satisfying the fixture-era
+// contract forever. This gate reads the compiler's OWN golden SDLs — the ones
+// `@canonical/ke-graphql` regenerates and pins byte-for-byte against a live
+// `compile()` in its `emittedSdl.test.ts` — and checks them against the
+// contract as read live from `schema/`. Both halves therefore move on their
+// own, and this turns red when they stop agreeing.
+//
+// WHY IT READS BY PATH RATHER THAN IMPORTING. Those goldens live in
+// ke-graphql's `src/testing/`, which is excluded from that package's build and
+// never published, so there is nothing to import. A path is the only handle.
+// The reach is in the permitted direction — `packages/prism/*` may depend on
+// the runtime packages, never the reverse — and the dependency is DECLARED as
+// a devDependency rather than left implicit, so `nx affected` schedules this
+// suite when the compiler's goldens change. Without that edge the gate would
+// simply not run on the change it exists to catch, which is the same outcome
+// as not having it.
+//
+// WHY IT THROWS RATHER THAN SKIPS. A gate that goes quiet when its subject
+// disappears is worse than no gate: it would report success for a repository
+// in which the compiler's goldens had been deleted or moved, which is exactly
+// the state worth noticing.
+// =============================================================================
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { satisfiesContract } from "../../lib/index.js";
+
+/** From this file, five directories up is the repository root. */
+const GOLDEN_DIRECTORY: string = fileURLToPath(
+  new URL(
+    "../../../../../../packages/runtime/ke-graphql/src/testing/integration/__fixtures__",
+    import.meta.url,
+  ),
+);
+
+const readGoldenNames = (): string[] => {
+  if (!existsSync(GOLDEN_DIRECTORY)) {
+    throw new Error(
+      `no compiler goldens at ${GOLDEN_DIRECTORY}. This gate measures @canonical/ke-graphql's committed emissions against the contract; it cannot run without them, and it must not pass without them either.`,
+    );
+  }
+  const names = readdirSync(GOLDEN_DIRECTORY)
+    .filter((entry) => entry.endsWith(".sdl.txt"))
+    .sort();
+  if (names.length === 0) {
+    throw new Error(`no *.sdl.txt goldens in ${GOLDEN_DIRECTORY}`);
+  }
+  return names;
+};
+
+describe("the compiler's committed emissions satisfy the contract", () => {
+  const names = readGoldenNames();
+
+  it("finds the whole corpus, not a subset that happens to pass", () => {
+    // The set is whatever the directory holds — narrowing it to the entries
+    // that pass is the failure mode this gate exists to prevent. The floor is
+    // a deletion tripwire only: ke-graphql's own emittedSdl.test.ts pins the
+    // corpus at eight entries, so fewer here means goldens went missing rather
+    // than that the corpus shrank on purpose.
+    expect(names.length).toBeGreaterThanOrEqual(8);
+  });
+
+  for (const name of names) {
+    it(`${name.replace(".sdl.txt", "")} is a conformant superset`, () => {
+      const sdl = readFileSync(join(GOLDEN_DIRECTORY, name), "utf8");
+      const result = satisfiesContract(sdl);
+      expect(
+        result.violations.map(
+          (violation) => `${violation.code}: ${violation.message}`,
+        ),
+      ).toEqual([]);
+      expect(result.satisfied).toBe(true);
+    });
+  }
+});

--- a/packages/prism/contract/tsconfig.build.json
+++ b/packages/prism/contract/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/testing/**"]
+}

--- a/packages/prism/contract/tsconfig.json
+++ b/packages/prism/contract/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@canonical/typescript-config",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/prism/contract/vitest.config.ts
+++ b/packages/prism/contract/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["**/index.ts", "**/*.test.ts", "**/*.d.ts", "**/types.ts"],
+      // The repo standard for a shipped package: 100%. Do not lower these.
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Done

`@canonical/prism-contract` states the minimal GraphQL surface a
documentation-site provider must offer, as SDL, and answers one question about
any candidate: does it satisfy that contract?

The answer is **semantic subsumption**, not a diff. A conformant provider is a
strict superset of the contract — it adds every ontology-derived type — so it
always differs textually and always will. What matters is whether every
operation legal against the contract can also run against the provider, and
`findBreakingChanges` with the contract as the old schema answers exactly that.

Source: `feat/prism-docsite`, `24fe66cb0..6bbf65f9c`, where the package was
authored under `packages/docsite/contract` and later moved to `packages/prism`.

### Reconciled against `main`

`main` wins on all of it: version `0.36.0` → `0.37.0`, biome `2.4.9` → `2.5.11`,
every `^0.36.0` sibling range → `^0.37.0`.

### Corrected while landing it

Each of these came out of review of the inherited code:

| What was wrong | Why it mattered |
| --- | --- |
| A provider whose SDL **parsed but built an invalid schema** was certified `satisfied: true` | `buildSchema` runs document-level SDL rules only. A type implementing an interface without its fields builds happily, differs from the contract in no way `findBreakingChanges` can see, and then fails *every* query at execution. Now reported as `INVALID_SCHEMA` — and the contract itself is validated too, since the same argument applies to it |
| The suite **failed on `graphql@17.0.0-rc.0`** | One of the two majors the package declares as a peer. It read an argument's default off the runtime argument object, which v17 renamed; it now reads the AST node, which both majors agree on |
| `providerName` was accepted by `satisfiesContract` and silently ignored | That function has nowhere to put a name. The option types are now split, so only the throwing entry point takes it |
| `code` was typed `string` | Now `ContractViolationCode` — owned here rather than imported, so the shipped `.d.ts` does not vary with the consumer's graphql major, and pinned against graphql's own set by test |
| Four `BreakingChangeType` classes were exercised but never asserted | Including the loss of `OntologyClass implements Node`, the ruling the contract changed shape for. Each now mutates one coordinate of the real contract and requires **exactly one** violation |
| Nothing checked the compiler's *current* emission against the *current* contract | The fixtures are frozen, so both halves could drift apart in silence. A gate now reads `@canonical/ke-graphql`'s committed golden SDLs and checks them against the contract as read live |
| `@vitest/coverage-v8` was undeclared | The 100% threshold depended on a package the manifest never asked for |
| The peer range pinned exactly one prerelease build | `17.0.0-rc.0` and nothing else; it would have broken on the next RC |
| The contract was described as the compiler's **unconditional** output (raised in review) | Two claims run together, and only one is unconditional. The ontology cannot move the contract — it names no ontology terms. A compiler OPTION can: `relay: false` skips the pass that wires `node(id:)`, and this package's own relay control pins that such a schema fails by exactly that field. The README and the schema header now state the split, name the option, and point at the control that measures it |
| A comment pointed at a fixture directory that does not exist (raised in review) | `emittedGoldens.test.ts` cited `src/__fixtures__/emitted*.sdl.txt`; those captures are at `src/testing/__fixtures__/`, so the one paragraph explaining what the gate is contrasted with sent a maintainer nowhere |

The suite went from 32 tests to 52, still at 100% statements, branches,
functions and lines.

### A note on the new gate's dependency

`src/testing/integration/emittedGoldens.test.ts` declares a devDependency on
`@canonical/ke-graphql` even though it reads that package's goldens by path
rather than importing them. The dependency is there for the **project graph**:
CI runs `nx affected -t test`, and without the edge a PR that regenerates a
golden would not mark this package affected, so the gate would not run on the
one change it exists to catch. Verified:

```
$ bunx nx show projects --affected --files=packages/runtime/ke-graphql/src/testing/integration/__fixtures__/minimal.sdl.txt
["@canonical/ke-graphql","@canonical/prism-contract","@canonical/pragma-cli"]
```

The arrow points site → runtime, which is the permitted direction.

### Registering a new package family

`packages/prism/*` is new, so: the workspace glob in the root `package.json`, a
`### Prism` section in the root README's package reference, and the workspaces
array reproduced in `docs/how-to-guides/ADDING_A_PACKAGE.md`. `AGENTS.md` gains
the layering rule the package depends on — nothing under `packages/runtime/`,
`packages/cli/`, `packages/summon/` or a component package may depend on
`packages/prism/*`, not even as a devDependency.

## Before the next release

**`@canonical/prism-contract` is a new publishable package, so its first publish
is a manual human step** — `npm publish --access public` from the package
directory — and a human must then configure its npm trusted publisher before
automated releases can ship it. Merging this does not make it releasable. See
`docs/how-to-guides/PUBLISH_A_PACKAGE.md`.

## QA

Root gate, from the repository root:

- `bun run check` — 63 projects / 102 tasks, green
- `bun run test` — 46 projects, green; this package 4 files / 52 tests at 100% coverage
- `bun run build` — 52 projects, green
- `bun run check:ranges` — 63 workspace packages, every sibling range satisfied
- `bun run collect:check` — clean, `data/` unchanged

Environment notes, all reproducible on an unmodified `main` and none touched by
this diff: the three Playwright-tagged svelte projects cannot start a browser in
this sandbox (`libglib-2.0.so.0` absent) and were excluded; `@canonical/pragma-cli`
has tests that hit a 5s timeout under load and pass in isolation, so the run
above used `--concurrency 1`.

## Carried

Raised in review, deliberately not fixed here:

- **Fixture format.** `cs:testing.unit.fixtures_pattern` wants fixtures as typed
  named exports in `testing/fixtures.ts`; these are `.sdl.txt` files. They were
  moved from `src/__fixtures__/` to `src/testing/__fixtures__/` so they at least
  match `@canonical/ke-graphql`'s shape, but SDL documents are poor TypeScript
  literals and two sibling packages arriving later share the format. Worth one
  follow-up across all of them, not a divergence in one.
- **`cs:testing.integration.structure` says library packages should not test
  cross-package integration.** The currency gate does. The alternative is that
  nothing checks the compiler against the contract, which is the gap this PR was
  asked to close; the dependency is declared and the direction is legal. Flagging
  it rather than hiding it.
- **The `prefixing: "all"` and `relay: false` controls** are pinned against this
  package's own illustrations, not against compiler output — `ke-graphql` commits
  goldens only for the default mode. Extending the gate needs goldens for those
  two modes, which belongs on that side.
- **graphql v17 is verified by hand, not by CI.** The suite was run against
  `17.0.0-rc.0` and passes 52/52, but the devDependency pins v16, so only one
  major runs on every commit. A matrix project would close it.
- **`vitest` 4.1.2 and `@vitest/coverage-v8` 4.1.0** resolve to different
  versions and print a mixed-version warning. Both are declared `^4.0.18`; this
  is a repo-wide lockfile resolution, not something this package chose.
- **`findBreakingChanges` is deprecated in graphql v17** in favour of
  `findSchemaChanges(...).filter(...)`, and removed in v18.

## Readiness

- [x] Conventional-commit title
- [x] New behaviour covered by tests
- [x] Root gate green
- [ ] First npm publish and trusted-publisher setup — human step, see above

Chromatic: skip

https://claude.ai/code/session_01PUNAcTepWDfnyfNYqBnzbn
