### PR TITLE
feat(prism-pragma-provider): compile pragma's TTL corpus into a schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ The documentation-site layer. The dependency arrow points one way — see "The d
 | Package | Path | Description |
 |---------|------|-------------|
 | `@canonical/prism-contract` | `packages/prism/contract` | The minimal GraphQL surface a documentation-site provider must offer, plus a subsumption check that a provider satisfies it |
+| `@canonical/prism-pragma-provider` | `packages/prism/pragma-provider` | **internal** — pragma's own provider: the repository's TTL corpus compiled into a conformant GraphQL schema |
 
 ### Core Infrastructure
 

--- a/apps/react/pragma-docs/src/relay/schema.graphql
+++ b/apps/react/pragma-docs/src/relay/schema.graphql
@@ -1,0 +1,4610 @@
+"""
+Directs the executor to defer this fragment when the `if` argument is true or undefined.
+"""
+directive @defer(
+  """Deferred when true or undefined."""
+  if: Boolean! = true
+
+  """Unique name"""
+  label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"""
+Directs the executor to stream plural fields when the `if` argument is true or undefined.
+"""
+directive @stream(
+  """Number of items to return immediately"""
+  initialCount: Int! = 0
+
+  """Stream when true or undefined."""
+  if: Boolean! = true
+
+  """Unique name"""
+  label: String
+) on FIELD
+
+"""
+Why an item is no longer (or never was) live: Superseded, Deprecated, Cancelled, Rejected (data/validities.ttl). Invalid items STAY in the graph with a mandatory note — the know-your-neighbour rule: anyone who finds the node learns its fate and its reason. Distinct from deferred (still wanted, consciously parked) and from assume:status (the epistemics of assumptions). Absence of validity means live.
+"""
+type Validity implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+Everything addressable by an absolute IRI.
+"""
+interface Node {
+  """The entity's absolute IRI — the primary key."""
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+}
+
+type LensConnection {
+  edges: [LensEdge!]!
+  pageInfo: PageInfo!
+}
+
+type LensEdge {
+  node: Lens!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type ValidityConnection {
+  edges: [ValidityEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ValidityEdge {
+  node: Validity!
+  cursor: String!
+}
+
+type SlotConnection {
+  edges: [SlotEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SlotEdge {
+  node: Slot!
+  cursor: String!
+}
+
+type LayoutConnection {
+  edges: [LayoutEdge!]!
+  pageInfo: PageInfo!
+}
+
+type LayoutEdge {
+  node: Layout!
+  cursor: String!
+}
+
+type RegionConnection {
+  edges: [RegionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RegionEdge {
+  node: Region!
+  cursor: String!
+}
+
+type CapabilityConnection {
+  edges: [CapabilityEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CapabilityEdge {
+  node: Capability!
+  cursor: String!
+}
+
+type JobConnection {
+  edges: [JobEdge!]!
+  pageInfo: PageInfo!
+}
+
+type JobEdge {
+  node: Job!
+  cursor: String!
+}
+
+type SubstrateConnection {
+  edges: [SubstrateEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SubstrateEdge {
+  node: Substrate!
+  cursor: String!
+}
+
+"""
+The result of walking an exemplar: Renders (completes cleanly), Ceremony (completes but awkwardly — a friction worth recording), Wall (cannot complete — a real gap). Instances in data/verdicts.ttl. A verdict is dated and cites the surfaces walked; re-walking on a spec change is the regression test.
+"""
+type Verdict implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A worked story walked against the specification to a verdict — the sufficiency test that jobs (existence) and bets (assumption) cannot give. Where the no-job-no-element law grounds why a surface exists, an exemplar grounds whether the surfaces a job touches actually let a real person complete it. A story that cannot complete across a job's served surfaces is a WALL found before anything is built; one that completes only awkwardly is CEREMONY; one that completes cleanly RENDERS. Ported from the source falsification traditions (mriya's CLEAN/PIN/BREAK, the docsite's pilot go/no-go).
+"""
+type Exemplar implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """How the walk came out: Renders, Ceremony, or Wall."""
+  verdict: Verdict
+
+  """
+  The surface(s) the story passes through — what a Wall or Ceremony verdict indicts, and what a spec change must re-walk.
+  """
+  walksSurfaces(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The job(s) this exemplar exercises — the demand it puts under load. Multi-valued: the strongest exemplars walk several jobs in one story.
+  """
+  walksJobs(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What the walk revealed — the wall's location, the ceremony's friction, or the clean-completion note. The reason the exemplar is kept.
+  """
+  finding: String
+
+  """
+  The story, walked step by step — what the person does, in order, against the named surfaces.
+  """
+  narratives: [String!]!
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+type SurfaceConnection {
+  edges: [SurfaceEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SurfaceEdge {
+  node: Surface!
+  cursor: String!
+}
+
+"""
+A named, reusable discipline of well-specified surfaces — the distilled cross-corpus rules (one substrate many projections; every word has one home; four states or it doesn't ship). Laws are cited by grammars (grammar:law) and instantiated by project rulings (assume:derivedFrom). A sibling of Axiom and Heuristic under assume:Assumption, deliberately outside their id/phase regimes: laws are timeless, not scheduled.
+"""
+type Law implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A falsifiable design assumption with a named test or kill-criterion — the third species of assumption beside the hard axiom and the soft heuristic. A bet without a kill-criterion is an opinion. Bets live in one shared ledger; jobs reference them by id; ids are stable and never renumbered (gaps mean retired bets). Modal character: P? — wagered, awaiting evidence.
+"""
+type Bet implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The prior, 0..1 — how strongly the bet is believed before the instrument reports (D28). A ledger you can be measurably wrong about builds judgment; scoring recorded confidence against outcomes is calibration. Distinct from assume:status (the epistemic state); this is the number.
+  """
+  confidence: Float
+
+  """
+  The concrete instrument that arms this bet — the thing that must exist and run to produce the evidence (a CI job, referrer analytics, a parity diff). A bet with a test but no instrument names a kill-criterion nobody is measuring; naming the instrument is what makes an armed bet continuously tested (D28).
+  """
+  instruments: [String!]!
+
+  """The test or kill-criterion that would validate or kill this bet."""
+  test: String
+}
+
+"""
+A layout's declaration of a region: which region, whether required, and — if optional — WHICH JOB SUMMONS IT (shape F8: no job, no region). One canvas always; everything else earns its slot. Layouts themselves are ds:Layout instances, reused directly (D12), carrying ds:grid/ds:name; surface adds the slot-and-demand layer ds lacks.
+"""
+type Slot implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  The job that summons this optional slot into existence. The load-bearing traceability rule of layout: no job → the region does not exist there. What keeps layout job-derived rather than template-derived.
+  """
+  summonedBies(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """The region kind this slot instantiates."""
+  ofRegion: Region
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  Always present (true) or optional (false). Optional slots MUST name their summoning job — the grid collapses over undemanded regions.
+  """
+  required: Boolean
+}
+
+"""
+A typed slot kind, one shared vocabulary so 'where is it' means the same thing on every surface (canvas, rails, controls, status, aside…). Base instances in data/regions.ttl; projects extend (mriya adds rail). A region type never changes side — the compass is part of the stationary frame.
+"""
+type Region implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+The reified job↔surface edge: THIS job reaches THIS surface, as primary or secondary, arriving with THIS preservation (curated surfaces only — ports take no arrival). The set of a job's pairings is how the spec answers 'is this job served, and at what cost'.
+"""
+type Pairing implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """Primary or Secondary."""
+  pairingRole: PairingRole
+
+  """
+  What this arrival preserves. Required for curated surfaces; absent for ports (shape F7).
+  """
+  arrivals(first: Int, after: String, last: Int, before: String): PreservationConnection!
+
+  """The surface the job reaches."""
+  pairsSurface: Surface
+
+  """The job this pairing serves."""
+  forJob: Job
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+type PreservationConnection {
+  edges: [PreservationEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PreservationEdge {
+  node: Preservation!
+  cursor: String!
+}
+
+"""
+Whether a pairing is the job's Primary serving surface or a Secondary route. Instances in data/arrivals.ttl.
+"""
+type PairingRole implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+What an arrival keeps, ordered by reorientation cost: ColdEntry(4) keeps nothing; SubjectKept(3) keeps the subject; ViewKept(2) keeps view and subject; NoMove(1) is in-place reach. Pure edge vocabulary — the ex-grade, minus the abolished CallGrade (invocability is a node fact). Instances in data/arrivals.ttl.
+"""
+type Preservation implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  Cost rank of the arrival, 4 (cold) to 1 (in place). Lets coverage ask: is a job whose story says 'without context-switching' really served at order 4?
+  """
+  reorientationOrder: Int
+}
+
+"""
+The invocable surface: where machine consumers call instead of look — API, MCP, CLI. Exposes capabilities directly; it curates nothing, so it has no slice (shape F6 forbids one), and pairings to it carry no arrival (agents have no reorientation to preserve).
+"""
+type Port implements Node & Surface {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  What is callable at this port. Expose the passable units (bundles) rather than raw verbs — handles do the granting. A capability serving an agent-inclusive job but exposed on no port is unreachable by its own demand: the bi-modality gap, one query.
+  """
+  exposes(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The protocol(s) this port speaks (MCP, GraphQL, CLI, a control socket).
+  """
+  protocol: String
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+type PairingConnection {
+  edges: [PairingEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PairingEdge {
+  node: Pairing!
+  cursor: String!
+}
+
+type AnchoringConnection {
+  edges: [AnchoringEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AnchoringEdge {
+  node: Anchoring!
+  cursor: String!
+}
+
+type DirectionConnection {
+  edges: [DirectionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type DirectionEdge {
+  node: Direction!
+  cursor: String!
+}
+
+type RenderingConnection {
+  edges: [RenderingEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RenderingEdge {
+  node: Rendering!
+  cursor: String!
+}
+
+"""
+A standalone writing surface you dwell in: authoring against the substrate at large rather than at one subject.
+"""
+type Editor implements Node & Surface {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+An anchored writing surface: where a consumer puts value INTO the substrate at a subject — the run's composer, a proposal form on an entity. The write quadrant the kind-enum scheme could not express.
+"""
+type ComposerSurface implements Node & Surface {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+A View woven through everything: inline mentions, status glyphs. Its pairings arrive at NoMove — reaching it costs nothing, which is its entire point.
+"""
+type Mechanism implements Node & Surface {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+A View you pass through: preview without commitment, one step back up. Its pairings typically arrive at SubjectKept.
+"""
+type Peek implements Node & Surface {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+A View you dwell in: one entity in depth — the entity page, the spec sheet. Its pairings typically arrive at ColdEntry (deeplinks) or SubjectKept.
+"""
+type Detail implements Node & Surface {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+An anchored reading surface — curated, read-facing, subject-bound: it shows something OF something. Whether it is ambient (chips), transient (a peek), or dwelt-in (a detail page) is not a node fact: it shows in its pairings' arrivals.
+"""
+type View implements Node & Surface {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+A way of looking at the substrate, tuned for one kind of task: curated, read-facing, standalone. You don't navigate into a lens like a folder — you switch lenses and the same entities re-present. A lens without a slice is a folder (shape F5).
+"""
+type Lens implements Node & Surface {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """The job that orders this lens's space — not role, not alphabet."""
+  dominantJobs(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The shape of looking this lens is tuned for — the clustering key that derived it from the jobs (entity browsing, narrative reading, live record…).
+  """
+  kindOfLooking: String
+
+  """
+  Which slice of the substrate this lens projects. No lens shows the whole substrate; a lens without a slice is a folder.
+  """
+  slice: String
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+Whether the surface is coherent standalone (Free) or meaningless without a subject (SubjectBound — a peek OF something).
+"""
+type Anchoring implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+Which way value flows at this surface: ReadFace (consumer takes) or WriteFace (consumer puts). Multi-valued — a surface may carry both.
+"""
+type Direction implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+What the surface does with the substrate: Curated (re-presents a chosen slice for perception) or Invocable (exposes operations for calling). Instances in data/dimensions.ttl.
+"""
+type Rendering implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+The species of authority a capability requires. Base instances (data/authority-families.ttl): read, observe, write, control, genesis. Projects extend with their own families (freefold adds ingress, derive, operator). Reachability and authorization are two layers: authority flows through handles, but write-authorization is checked at the target regardless of which handle called.
+"""
+type AuthorityFamily implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A named, grantable operation over the substrate — the unit of 'what the system can do'. Verbs in a grammar name capabilities; projections bind them; channels expose them to machine consumers. Object-capability shaped: authority flows through whoever hands you the handle; bundles compose capabilities; attenuation only narrows (the derived capability's authority is a subset of its parent's).
+"""
+type Capability implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  This capability is a narrowing of another: same operations over less (fewer names, fewer targets), authority a subset of the parent's. Attenuation is the only sanctioned derivation of authority — it never widens.
+  """
+  attenuates(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  This capability is a thin bundle over the listed capabilities (a reader bundles read + snapshot + follow; a controller bundles deliver + lifecycle). Bundles exist to pass and attenuate scoped authority, never to add operations.
+  """
+  bundles(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The authority families this capability needs (multi-valued). Authority is explicit, never ambient.
+  """
+  requiresAuthorities(first: Int, after: String, last: Int, before: String): AuthorityFamilyConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The capability's data contract: the query, signature, or verb form that every face of the surface binds. One contract, two faces — the human projection and the machine tool carry the same one, so they cannot drift.
+  """
+  contract: String
+}
+
+type AuthorityFamilyConnection {
+  edges: [AuthorityFamilyEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AuthorityFamilyEdge {
+  node: AuthorityFamily!
+  cursor: String!
+}
+
+"""
+The single source of truth a surface projects: a knowledge graph, a journal, a store. One substrate, many projections — every view shows its own slice, no view shows all of it, and state is derived from the substrate, never duplicated beside it. If two surfaces disagree, the substrate arbitrates.
+"""
+type Substrate implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A named region in coordinate space — an archetype used for coverage planning and QA, never for navigation. A persona's jobs are DERIVED by overlap of its region with each job's coordinates; asserting the persona↔job link directly is a modelling error (the link is derived, not stored).
+"""
+type Persona implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The coordinate region this persona names. Same type as a job's coordinates, so matching is axis-by-axis overlap.
+  """
+  region: Coordinate
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """The persona in one line — what this archetype is about."""
+  essence: String
+}
+
+"""
+Ordinal familiarity with the system on a coordinate axis: Newcomer < Fluent < Expert (data/fluencies.ttl, ordered by fluencyOrder). Expert is a fluency waypoint, not a role — authority positions are roles. Landed by D17 after the trigger fired twice (Yuki≡Dev in mriya; prose-only waypoint arcs in the docs graph).
+"""
+type Fluency implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """Ordinal position on the arc (1 = newcomer)."""
+  fluencyOrder: Int
+}
+
+"""
+A consumer's discipline or authority position on a coordinate axis (engineer, designer, writer; author, operator). Authority is a role, not a fluency level. Project vocabulary: no base instances ship — each spec graph defines its own. An axis left unconstrained matches any role (wildcard). Added by D9 when the two-graph confrontation fired D5's reversal trigger.
+"""
+type Role implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+The species of consumer on a coordinate axis. Base instances: Human, Agent (data/actors.ttl). Surfaces are bi-modal by default — a machine consumer is a first-class actor, not an afterthought.
+"""
+type Actor implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A reified position or region in demand space. Currently one axis (actor); role and fluency axes join by discussion (decision D5). Reified so that jobs and personas share ONE type: a job's coordinates and a persona's region are compared axis by axis, and the persona↔job link is derived by overlap, never stored.
+"""
+type Coordinate implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The fluency axis. Multi-valued (a region may span an arc); ABSENT MEANS ANY — wildcard, else intersection (same rule as role).
+  """
+  fluencies(first: Int, after: String, last: Int, before: String): FluencyConnection!
+
+  """
+  The role axis of the coordinate. Multi-valued; ABSENT MEANS ANY ROLE — matching treats an unconstrained axis as a wildcard, otherwise requires intersection.
+  """
+  roles(first: Int, after: String, last: Int, before: String): RoleConnection!
+
+  """
+  The actor axis of the coordinate (human, agent). Multi-valued: a region may span both.
+  """
+  actors(first: Int, after: String, last: Int, before: String): ActorConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+type FluencyConnection {
+  edges: [FluencyEdge!]!
+  pageInfo: PageInfo!
+}
+
+type FluencyEdge {
+  node: Fluency!
+  cursor: String!
+}
+
+type RoleConnection {
+  edges: [RoleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RoleEdge {
+  node: Role!
+  cursor: String!
+}
+
+type ActorConnection {
+  edges: [ActorEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ActorEdge {
+  node: Actor!
+  cursor: String!
+}
+
+"""
+The unit of demand and of value (jobs-to-be-done). One thing a consumer is trying to get done, written as a story: when [circumstance], I want [desire], so I can [outcome], without [pain]. Jobs — not personas, not features — drive surface requirements: every surface element must trace back to at least one job; a job with no serving surface is a coverage gap, and a surface element with no job is decoration.
+"""
+type Job implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  The assumptions this job's design leans on — typically Bets from the shared ledger. Shared across jobs: they live once, referenced by id.
+  """
+  bets: [String!]!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  Who has this job, as a coordinate region. The single source of truth for 'who'; persona columns in any table are derived views over this value.
+  """
+  coordinates: Coordinate
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferreds: [Boolean!]!
+
+  """
+  A done-test clause for this job (multi-valued). The falsifiable answer to 'is this job served?' — a job without at least one acceptance clause is an opinion, not demand. Surfaces paired to the job inherit the clauses that mention them.
+  """
+  acceptances: [String!]!
+
+  """
+  The full job story in one sentence carrying the four slots: 'When [circumstance], I want [desire], so I can [outcome], without [pain]'. Kept as one string by decision D2 (data/decisions.ttl); reify the slots only when a real query needs slot-level joins.
+  """
+  story: String
+}
+
+"""
+A single dated record of a change to a UIBlock, with a timestamp, the change description, an owner, an optional GitHub link, and a change type.
+"""
+type ChangeLogEntry {
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The category of change (e.g. change, addition, deprecation)"""
+  changeType: String
+
+  """Optional link to a GitHub issue, PR or discussion for this change"""
+  githubLink: String
+
+  """The person responsible for the change"""
+  owner: String
+
+  """Human-readable description of what changed"""
+  change: String
+
+  """The date and time at which the change was recorded"""
+  timestamp: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A facet that groups related Tags (e.g. 'documentation stage', 'review status', 'channel', 'implementation status').
+"""
+type TagCategory implements Node & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A controlled-vocabulary label applied to a UIBlock. Tags are grouped into facets by their category (e.g. 'documentation stage', 'review status', 'channel', 'implementation status'). The category-typed views over this vocabulary are tracked as future work; for now a Tag carries its name, category, and apply/remove guidance.
+"""
+type Tag implements Node & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The category (facet) a Tag belongs to, e.g. documentation stage, review status, channel, implementation status
+  """
+  categories(first: Int, after: String, last: Int, before: String): TagCategoryConnection!
+
+  """
+  Guidance on the conditions under which this tag should be removed from a UI Block
+  """
+  whenToRemove: String
+
+  """
+  Guidance on the conditions under which this tag should be applied to a UI Block
+  """
+  whenToApply: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type TagCategoryConnection {
+  edges: [TagCategoryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TagCategoryEdge {
+  node: TagCategory!
+  cursor: String!
+}
+
+"""
+A code library or package that provides platform-specific implementations of UIBlocks
+"""
+type ImplementationLibrary implements Node & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The design system tier that this library implements"""
+  libraryTiers(first: Int, after: String, last: Int, before: String): TierConnection!
+
+  """Documentation link if different from main artifact"""
+  documentation: String
+
+  """URL to the library's main artifact or repository"""
+  link: String
+
+  """
+  The platform or technology this library targets (e.g. React, Web Components, Flutter)
+  """
+  platform: String
+
+  """The package or library name as published (e.g. npm package name)"""
+  libraryName: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type TierConnection {
+  edges: [TierEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TierEdge {
+  node: Tier!
+  cursor: String!
+}
+
+"""Platform-specific implementation of a UI Block"""
+type ImplementationObject implements Node & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The implementation library that contains this implementation"""
+  library: ImplementationLibrary
+
+  """The UIBlock that this implementation realises in code"""
+  implementsBlock: UIBlock
+
+  """
+  Whether this implementation is in draft state and not yet ready for production use
+  """
+  draft: Boolean
+
+  """
+  URL to a specific tagged version of this implementation in source control
+  """
+  versionedLink: String
+
+  """
+  URL to the latest/HEAD version of this implementation in source control
+  """
+  headLink: String
+
+  """
+  Version of this specific implementation, independent of the UIBlock version
+  """
+  implementationVersion: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A scope level in the design system hierarchy that determines where UIBlocks are intended to be used (e.g. global, apps, site)
+"""
+type Tier implements Node & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A configurable property of a UI Block"""
+type Property {
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  Constraints on valid values for this property. For choice types, lists allowed values (e.g. '[primary, secondary, tertiary]'). For numbers, specifies ranges. For objects, describes required structure.
+  """
+  constraints: String
+
+  """
+  The default value for this property when not explicitly set by the consumer
+  """
+  defaultValue: String
+
+  """Whether this property is optional when configuring the UI Block"""
+  optional: Boolean
+
+  """
+  The data type of this configurable property (e.g. text, choice, boolean, node)
+  """
+  propertyType: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A grouping of related modifiers that can be applied to UI Blocks"""
+type ModifierFamily implements Node & UIElement & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Modifiers belonging to this modifier family"""
+  modifiers(first: Int, after: String, last: Int, before: String): ModifierConnection!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type ModifierConnection {
+  edges: [ModifierEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ModifierEdge {
+  node: Modifier!
+  cursor: String!
+}
+
+"""
+A named variant value within a ModifierFamily that alters the appearance or behaviour of a UIBlock (e.g. 'primary', 'secondary' within the 'importance' family)
+"""
+type Modifier implements Node & UIElement & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The modifier family to which this modifier belongs"""
+  modifierFamily: ModifierFamily
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A collection UIBlock: a container that arranges multiple instances of a single sibling UIBlock (typically a Component) as a repeating series. The plural counterpart of a singular Component (e.g. Cards groups Card units, Tiles groups Tile units), responsible for their shared layout rather than for any content of its own.
+"""
+type Group implements Node & UIBlock & UIElement & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type UIBlockConnection {
+  edges: [UIBlockEdge!]!
+  pageInfo: PageInfo!
+}
+
+type UIBlockEdge {
+  node: UIBlock!
+  cursor: String!
+}
+
+type TagConnection {
+  edges: [TagEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TagEdge {
+  node: Tag!
+  cursor: String!
+}
+
+type ModifierFamilyConnection {
+  edges: [ModifierFamilyEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ModifierFamilyEdge {
+  node: ModifierFamily!
+  cursor: String!
+}
+
+"""
+A named part of a Component that has design-system identity but is typically not used independently outside its parent
+"""
+type Subcomponent implements Node & UIBlock & UIElement & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The component to which this subcomponent structurally belongs"""
+  parentComponents(first: Int, after: String, last: Int, before: String): ComponentConnection!
+
+  """
+  Whether this subcomponent can be used independently outside its parent component
+  """
+  standalone: Boolean
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type ComponentConnection {
+  edges: [ComponentEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ComponentEdge {
+  node: Component!
+  cursor: String!
+}
+
+"""
+Layouts are an opinionated division of space to navigate a domain of information.
+"""
+type Layout implements Node & UIBlock & UIElement & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Device form factors this layout targets"""
+  targetDevices: String
+
+  """Named CSS grid areas defined by this layout"""
+  gridAreas: String
+
+  """The information domain this layout is designed to navigate"""
+  domain: String
+
+  """CSS grid template definition for this layout"""
+  grid: String
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A reusable solution to a recurring user problem in a specific context"""
+type Pattern implements Node & UIBlock & UIElement & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+An implementable piece of user interface defined by its appearance and behaviour
+"""
+type Component implements Node & UIBlock & UIElement & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Subcomponents that are structural parts of this component"""
+  subcomponents(first: Int, after: String, last: Int, before: String): SubcomponentConnection!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type SubcomponentConnection {
+  edges: [SubcomponentEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SubcomponentEdge {
+  node: Subcomponent!
+  cursor: String!
+}
+
+"""
+A single do or don't example with a description, optional language tag, and optional code block
+"""
+type Example implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The code content of the example"""
+  code: String
+
+  """
+  The programming language of the example code block (e.g., 'typescript', 'rust', 'css', 'bash', 'svg', 'turtle')
+  """
+  language: String
+
+  """A general description of the code standard or example"""
+  description: String
+}
+
+"""
+A category for grouping related code standards (e.g., testing, components, react, typescript)
+"""
+type Category implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """A general description of the code standard or example"""
+  description: String
+
+  """
+  A short identifier for the category or standard, used for domain annotation.
+  """
+  slug: String
+}
+
+"""A coding standard or best practice guideline for software development"""
+type CodeStandard implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """A negative example showing what should not be done"""
+  donts(first: Int, after: String, last: Int, before: String): ExampleConnection!
+
+  """A positive example showing what should be done"""
+  dos(first: Int, after: String, last: Int, before: String): ExampleConnection!
+
+  """
+  Associates a code standard with another standard that it extends or adds further context to
+  """
+  extends(first: Int, after: String, last: Int, before: String): CodeStandardConnection!
+
+  """Associates a code standard with its category"""
+  categories(first: Int, after: String, last: Int, before: String): CategoryConnection!
+
+  """A general description of the code standard or example"""
+  description: String
+
+  """
+  An optional human-readable display title for a code standard. This is not an identifier and must not duplicate the canonical role of the subject IRI.
+  """
+  name: String
+}
+
+type ExampleConnection {
+  edges: [ExampleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ExampleEdge {
+  node: Example!
+  cursor: String!
+}
+
+type CodeStandardConnection {
+  edges: [CodeStandardEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CodeStandardEdge {
+  node: CodeStandard!
+  cursor: String!
+}
+
+type CategoryConnection {
+  edges: [CategoryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CategoryEdge {
+  node: Category!
+  cursor: String!
+}
+
+"""One alternative within a Switch."""
+type SwitchCase implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Node this case resolves to."""
+  caseNode: AnatomyNode
+}
+
+"""Polymorphic position admitting several alternatives."""
+type Switch implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """An alternative within this switch."""
+  cases(first: Int, after: String, last: Int, before: String): SwitchCaseConnection!
+
+  """What determines which case applies."""
+  discriminator: String
+}
+
+type SwitchCaseConnection {
+  edges: [SwitchCaseEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SwitchCaseEdge {
+  node: SwitchCase!
+  cursor: String!
+}
+
+"""A single style declaration binding a property key to a value."""
+type Style implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Value for a style property."""
+  styleValue: String
+
+  """Platform-agnostic style property identifier."""
+  styleKey: String
+}
+
+"""Metadata qualifying a parent-child relationship."""
+type Relation implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Named slot in the parent that this child maps to."""
+  slotName: String
+
+  """Instance count constraint on the child."""
+  cardinality: String
+}
+
+"""Reified parent-child relationship in the anatomy tree."""
+type Edge implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Polymorphic switch this edge connects to."""
+  edgeSwitch: Switch
+
+  """Child node this edge connects to."""
+  edgeTarget: AnatomyNode
+
+  """Relation qualifying this edge."""
+  relation: Relation
+}
+
+"""Structural element without design system identity."""
+type AnonymousNode implements Node & AnatomyNode {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Human-readable purpose of an anonymous node."""
+  role: String
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+type StyleConnection {
+  edges: [StyleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type StyleEdge {
+  node: Style!
+  cursor: String!
+}
+
+type EdgeConnection {
+  edges: [EdgeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type EdgeEdge {
+  node: Edge!
+  cursor: String!
+}
+
+"""Design system entity instantiable by consumers."""
+type NamedNode implements Node & AnatomyNode {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Unique identifier for a named node within the design system."""
+  anatomyUri: String
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+"""Root of an anatomy file."""
+type Specification implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Top-level node of an anatomy specification."""
+  rootNode: NamedNode
+}
+
+"""
+An addressable place of encounter between a consumer and the substrate. Its nature is carried by three dimensions (rendering, direction, anchoring); the idiom classes below are named cells whose dimension values materialize through the closure — assert the idiom, infer the physics. A surface matching no idiom is asserted as a plain Surface with raw dimensions: fully described, honestly unnamed. How a surface is PRESENT (ambient, transient, dwelt-in) is edge information and lives on pairings as arrival — never on the node (the presence-dimension deletion, D11).
+"""
+interface Surface implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A category of visual or abstract entity that fulfills a particular role in composing user interfaces
+"""
+interface UIBlock implements Node & UIElement & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""Base class for all visual and interactive design system elements"""
+interface UIElement implements Node & Entity {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+Abstract root class for all design system entities. Provides common properties (name, summary) inherited by all classes.
+"""
+interface Entity implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""Position in the anatomy tree."""
+interface AnatomyNode implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+"""Self-describing TBox access attached to ABox types."""
+type EntityMeta {
+  """
+  Compact display form of `uri`: `prefix:local` from the compiled namespace inventory, else the absolute IRI unchanged, else the GraphQL type name when the value has no IRI at all (an embedded blank node). TOTAL, exactly like `title`. NEVER an identity — `uri` is the only address; this string is not accepted by `node(id:)` and never appears in a cursor.
+  """
+  curie: String!
+  title(lang: String = "en"): String!
+  label(lang: String = "en"): String
+  comment(lang: String = "en"): String
+  definition(lang: String = "en"): String
+  type: OntologyClass!
+  field(name: String!): ClassProperty
+  fields: [ClassProperty!]!
+}
+
+type OntologyClass implements Node {
+  uri: ID!
+
+  """Self-describing TBox access for this class."""
+  _meta: EntityMeta!
+  label: String
+  definition: String
+  superclass: OntologyClass
+  superclasses: [OntologyClass!]!
+  subclasses: [OntologyClass!]!
+  properties: [ClassProperty!]!
+
+  """
+  Named instances of this class (blank-node instances are embeddable and not standalone-resolvable).
+  """
+  instances(first: Int, after: String, last: Int, before: String): NodeConnection!
+
+  """Count of NAMED instances (matches `instances`)."""
+  instanceCount: Int!
+  isAbstract: Boolean!
+  namespace: String!
+}
+
+"""
+Class-scoped view of a property: SHACL cardinality is a fact about a (class, property) pair — and so is `name`.
+"""
+type ClassProperty {
+  """
+  The field name this property answers to ON THIS CLASS — the exact string `EntityMeta.field(name:)` accepts, so `fields { name }` and `field(name:)` round-trip. Class-scoped because per-class cardinality decides pluralization: one property is `part` on one class and `parts` on another. When the property projects no field on this class (SHACL sh:maxCount 0, an unexposed range, an unprojected class) the OWL local name is returned as a label — there is no name `field(name:)` would accept.
+  """
+  name: String!
+  property: OntologyProperty!
+  required: Boolean!
+  singular: Boolean!
+  inherited: Boolean!
+}
+
+type OntologyProperty {
+  uri: ID!
+  label: String
+  definition: String
+  domain: OntologyClass
+  range: String!
+  kind: PropertyKind!
+  functional: Boolean!
+  inverse: OntologyProperty
+  acceptanceCriteria: String
+  completionGuidance: String
+  namespace: String!
+}
+
+enum PropertyKind {
+  DATATYPE
+  OBJECT
+  ANNOTATION
+}
+
+type NodeConnection {
+  edges: [NodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NodeEdge {
+  node: Node!
+  cursor: String!
+}
+
+type Query {
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+
+  """Relay node resolution by prefixed-URI global ID."""
+  node(id: ID!): Node
+  validity(uri: String!): Validity
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+  verdict(uri: String!): Verdict
+  verdicts(first: Int, after: String, last: Int, before: String): VerdictConnection!
+  exemplar(uri: String!): Exemplar
+  exemplars(first: Int, after: String, last: Int, before: String): ExemplarConnection!
+  law(uri: String!): Law
+  laws(first: Int, after: String, last: Int, before: String): LawConnection!
+  bet(uri: String!): Bet
+  bets(first: Int, after: String, last: Int, before: String): BetConnection!
+  slot(uri: String!): Slot
+  slots(first: Int, after: String, last: Int, before: String): SlotConnection!
+  region(uri: String!): Region
+  regions(first: Int, after: String, last: Int, before: String): RegionConnection!
+  pairing(uri: String!): Pairing
+  pairings(first: Int, after: String, last: Int, before: String): PairingConnection!
+  pairingRole(uri: String!): PairingRole
+  pairingRoles(first: Int, after: String, last: Int, before: String): PairingRoleConnection!
+  preservation(uri: String!): Preservation
+  preservations(first: Int, after: String, last: Int, before: String): PreservationConnection!
+  port(uri: String!): Port
+  ports(first: Int, after: String, last: Int, before: String): PortConnection!
+  editor(uri: String!): Editor
+  editors(first: Int, after: String, last: Int, before: String): EditorConnection!
+  composerSurface(uri: String!): ComposerSurface
+  composerSurfaces(first: Int, after: String, last: Int, before: String): ComposerSurfaceConnection!
+  mechanism(uri: String!): Mechanism
+  mechanisms(first: Int, after: String, last: Int, before: String): MechanismConnection!
+  peek(uri: String!): Peek
+  peeks(first: Int, after: String, last: Int, before: String): PeekConnection!
+  detail(uri: String!): Detail
+  details(first: Int, after: String, last: Int, before: String): DetailConnection!
+  view(uri: String!): View
+  views(first: Int, after: String, last: Int, before: String): ViewConnection!
+  lens(first: Int, after: String, last: Int, before: String): LensConnection!
+  anchoring(uri: String!): Anchoring
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+  direction(uri: String!): Direction
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+  rendering(uri: String!): Rendering
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+  authorityFamily(uri: String!): AuthorityFamily
+  authorityFamilies(first: Int, after: String, last: Int, before: String): AuthorityFamilyConnection!
+  capability(uri: String!): Capability
+  capabilities(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+  substrate(uri: String!): Substrate
+  substrates(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+  persona(uri: String!): Persona
+  personas(first: Int, after: String, last: Int, before: String): PersonaConnection!
+  fluency(uri: String!): Fluency
+  fluencies(first: Int, after: String, last: Int, before: String): FluencyConnection!
+  role(uri: String!): Role
+  roles(first: Int, after: String, last: Int, before: String): RoleConnection!
+  actor(uri: String!): Actor
+  actors(first: Int, after: String, last: Int, before: String): ActorConnection!
+  coordinate(uri: String!): Coordinate
+  coordinates(first: Int, after: String, last: Int, before: String): CoordinateConnection!
+  job(uri: String!): Job
+  jobs(first: Int, after: String, last: Int, before: String): JobConnection!
+  tagCategory(uri: String!): TagCategory
+  tagCategories(first: Int, after: String, last: Int, before: String): TagCategoryConnection!
+  tag(uri: String!): Tag
+  tags(first: Int, after: String, last: Int, before: String): TagConnection!
+  implementationLibrary(uri: String!): ImplementationLibrary
+  implementationLibraries(first: Int, after: String, last: Int, before: String): ImplementationLibraryConnection!
+  implementationObject(uri: String!): ImplementationObject
+  implementationObjects(first: Int, after: String, last: Int, before: String): ImplementationObjectConnection!
+  tier(uri: String!): Tier
+  tiers(first: Int, after: String, last: Int, before: String): TierConnection!
+  modifierFamily(uri: String!): ModifierFamily
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+  modifier(uri: String!): Modifier
+  modifiers(first: Int, after: String, last: Int, before: String): ModifierConnection!
+  group(uri: String!): Group
+  groups(first: Int, after: String, last: Int, before: String): GroupConnection!
+  subcomponent(uri: String!): Subcomponent
+  subcomponents(first: Int, after: String, last: Int, before: String): SubcomponentConnection!
+  layout(uri: String!): Layout
+  layouts(first: Int, after: String, last: Int, before: String): LayoutConnection!
+  pattern(uri: String!): Pattern
+  patterns(first: Int, after: String, last: Int, before: String): PatternConnection!
+  component(uri: String!): Component
+  components(first: Int, after: String, last: Int, before: String): ComponentConnection!
+  example(uri: String!): Example
+  examples(first: Int, after: String, last: Int, before: String): ExampleConnection!
+  category(uri: String!): Category
+  categories(first: Int, after: String, last: Int, before: String): CategoryConnection!
+  codeStandard(uri: String!): CodeStandard
+  codeStandards(first: Int, after: String, last: Int, before: String): CodeStandardConnection!
+  switchCase(uri: String!): SwitchCase
+  switchCases(first: Int, after: String, last: Int, before: String): SwitchCaseConnection!
+  switch(uri: String!): Switch
+  switches(first: Int, after: String, last: Int, before: String): SwitchConnection!
+  style(uri: String!): Style
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+  relation(uri: String!): Relation
+  relations(first: Int, after: String, last: Int, before: String): RelationConnection!
+  edge(uri: String!): Edge
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+  anonymousNode(uri: String!): AnonymousNode
+  anonymousNodes(first: Int, after: String, last: Int, before: String): AnonymousNodeConnection!
+  namedNode(uri: String!): NamedNode
+  namedNodes(first: Int, after: String, last: Int, before: String): NamedNodeConnection!
+  specification(uri: String!): Specification
+  specifications(first: Int, after: String, last: Int, before: String): SpecificationConnection!
+}
+
+type Ontology {
+  prefix: String!
+  namespace: String!
+  label: String
+  classes: [OntologyClass!]!
+  properties: [OntologyProperty!]!
+}
+
+type VerdictConnection {
+  edges: [VerdictEdge!]!
+  pageInfo: PageInfo!
+}
+
+type VerdictEdge {
+  node: Verdict!
+  cursor: String!
+}
+
+type ExemplarConnection {
+  edges: [ExemplarEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ExemplarEdge {
+  node: Exemplar!
+  cursor: String!
+}
+
+type LawConnection {
+  edges: [LawEdge!]!
+  pageInfo: PageInfo!
+}
+
+type LawEdge {
+  node: Law!
+  cursor: String!
+}
+
+type BetConnection {
+  edges: [BetEdge!]!
+  pageInfo: PageInfo!
+}
+
+type BetEdge {
+  node: Bet!
+  cursor: String!
+}
+
+type PairingRoleConnection {
+  edges: [PairingRoleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PairingRoleEdge {
+  node: PairingRole!
+  cursor: String!
+}
+
+type PortConnection {
+  edges: [PortEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PortEdge {
+  node: Port!
+  cursor: String!
+}
+
+type EditorConnection {
+  edges: [EditorEdge!]!
+  pageInfo: PageInfo!
+}
+
+type EditorEdge {
+  node: Editor!
+  cursor: String!
+}
+
+type ComposerSurfaceConnection {
+  edges: [ComposerSurfaceEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ComposerSurfaceEdge {
+  node: ComposerSurface!
+  cursor: String!
+}
+
+type MechanismConnection {
+  edges: [MechanismEdge!]!
+  pageInfo: PageInfo!
+}
+
+type MechanismEdge {
+  node: Mechanism!
+  cursor: String!
+}
+
+type PeekConnection {
+  edges: [PeekEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PeekEdge {
+  node: Peek!
+  cursor: String!
+}
+
+type DetailConnection {
+  edges: [DetailEdge!]!
+  pageInfo: PageInfo!
+}
+
+type DetailEdge {
+  node: Detail!
+  cursor: String!
+}
+
+type ViewConnection {
+  edges: [ViewEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ViewEdge {
+  node: View!
+  cursor: String!
+}
+
+type PersonaConnection {
+  edges: [PersonaEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PersonaEdge {
+  node: Persona!
+  cursor: String!
+}
+
+type CoordinateConnection {
+  edges: [CoordinateEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CoordinateEdge {
+  node: Coordinate!
+  cursor: String!
+}
+
+type ImplementationLibraryConnection {
+  edges: [ImplementationLibraryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ImplementationLibraryEdge {
+  node: ImplementationLibrary!
+  cursor: String!
+}
+
+type ImplementationObjectConnection {
+  edges: [ImplementationObjectEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ImplementationObjectEdge {
+  node: ImplementationObject!
+  cursor: String!
+}
+
+type GroupConnection {
+  edges: [GroupEdge!]!
+  pageInfo: PageInfo!
+}
+
+type GroupEdge {
+  node: Group!
+  cursor: String!
+}
+
+type PatternConnection {
+  edges: [PatternEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PatternEdge {
+  node: Pattern!
+  cursor: String!
+}
+
+type SwitchConnection {
+  edges: [SwitchEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SwitchEdge {
+  node: Switch!
+  cursor: String!
+}
+
+type RelationConnection {
+  edges: [RelationEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RelationEdge {
+  node: Relation!
+  cursor: String!
+}
+
+type AnonymousNodeConnection {
+  edges: [AnonymousNodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AnonymousNodeEdge {
+  node: AnonymousNode!
+  cursor: String!
+}
+
+type NamedNodeConnection {
+  edges: [NamedNodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NamedNodeEdge {
+  node: NamedNode!
+  cursor: String!
+}
+
+type SpecificationConnection {
+  edges: [SpecificationEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SpecificationEdge {
+  node: Specification!
+  cursor: String!
+}

--- a/bun.lock
+++ b/bun.lock
@@ -437,6 +437,26 @@
         "graphql": "^16.11.0 || ^17.0.0-rc.0",
       },
     },
+    "packages/prism/pragma-provider": {
+      "name": "@canonical/prism-pragma-provider",
+      "version": "0.37.0",
+      "dependencies": {
+        "@canonical/ke": "^0.37.0",
+        "@canonical/ke-graphql": "^0.37.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.5.11",
+        "@canonical/biome-config": "^0.37.0",
+        "@canonical/prism-contract": "^0.37.0",
+        "@canonical/typescript-config": "^0.37.0",
+        "@canonical/webarchitect": "^0.37.0",
+        "@types/bun": "^1.3.10",
+        "@types/node": "^24.12.0",
+        "@vitest/coverage-v8": "^4.0.18",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
+      },
+    },
     "packages/react/ds-app": {
       "name": "@canonical/react-ds-app",
       "version": "0.37.0",
@@ -1845,6 +1865,8 @@
     "@canonical/pragma-cli": ["@canonical/pragma-cli@workspace:packages/cli/pragma"],
 
     "@canonical/prism-contract": ["@canonical/prism-contract@workspace:packages/prism/contract"],
+
+    "@canonical/prism-pragma-provider": ["@canonical/prism-pragma-provider@workspace:packages/prism/pragma-provider"],
 
     "@canonical/react-boilerplate-vite": ["@canonical/react-boilerplate-vite@workspace:apps/react/boilerplate-vite"],
 
@@ -4562,6 +4584,8 @@
 
     "@canonical/prism-contract/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
+    "@canonical/prism-pragma-provider/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
     "@canonical/react-boilerplate-vite/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
     "@canonical/svelte-ds-app/@canonical/design-tokens": ["@canonical/design-tokens@0.6.2-contrasted.0", "", { "dependencies": { "@canonical/terrazzo-lsp": "^0.6.0" } }, "sha512-JLzc2tsSbuINFk4adbNGyFhnuKXLiIzE6ntwqigrL4vJoSTuj/OkaJLiLPB12LlQYOT3vnBiL+JmouZgDflNgQ=="],
@@ -5141,6 +5165,8 @@
     "@canonical/ke-graphql/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@canonical/prism-contract/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@canonical/prism-pragma-provider/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@canonical/svelte-ds-app-launchpad/@canonical/design-tokens/@canonical/terrazzo-lsp": ["@canonical/terrazzo-lsp@0.6.0", "", { "dependencies": { "@canonical/token-types": "^0.6.0", "@lezer/common": "^1.3.0", "@lezer/css": "^1.3.0", "colorjs.io": "^0.6.1" }, "bin": { "terrazzo-lsp": "dist/esm/cli.js" } }, "sha512-6b8IsmRF9VJJ6zWyz6XDZxm65tjWPnl5dce/abM2tRJaeBV3ewDLnSWS/BPoHhqDBEFTdo8Rb7o5mg44RzKN7A=="],
 

--- a/packages/prism/pragma-provider/README.md
+++ b/packages/prism/pragma-provider/README.md
@@ -1,0 +1,148 @@
+# @canonical/prism-pragma-provider
+
+**The pragma provider for the Prism docsite contract.** It reads pragma's Turtle
+corpus, compiles it with [`@canonical/ke-graphql`](../../runtime/ke-graphql) into an
+executable GraphQL schema, and serves it as a fetch-native handler.
+
+It exists because the docsite app should not. Until this package landed,
+`apps/react/pragma-docs/src/server/graphql.ts` held the ref-package list, the semantic
+package list, an ontology exclusion, a custom field mapping, and the compiler options —
+296 lines of knowledge about *pragma's specific ontologies* living inside an application
+that claims to render against any conformant provider. After this package, the app
+imports one factory and depends on **no knowledge engine at all**: no `@canonical/ke`,
+no `@canonical/ke-graphql`.
+
+> **Deliberately not published.** `"private": true`, matching
+> `prism-graph-example`. Its only consumer is this repository.
+
+---
+
+## Why it *does* use ke-graphql
+
+This is the exact inverse of `prism-graph-example`, and the
+inversion is the point.
+
+graph-example is hand-written **because** it must not use ke-graphql: one compiler
+satisfying the contract twice measures the compiler, not the contract. That package is
+the control.
+
+This package is the subject. It is what the docsite actually runs on, and ke-graphql
+*is* the thing under test here — whether the compiler, pointed at real ontologies with
+real modelling accidents in them, emits a schema that satisfies the same contract a
+hand-written provider does. Two providers, two engines, one contract. Neither package
+proves anything without the other.
+
+---
+
+## The four pieces of relocated pragma knowledge
+
+Each of these is a fact about a specific upstream ontology, and each has a fix that
+would delete it from this repo. They are pinned constants
+(`src/lib/config/constants.ts`), not options — see that file's header for why.
+
+| Constant | What it encodes | The upstream fix that deletes it |
+|---|---|---|
+| `REF_PACKAGES` | `design-system`, `code-standards`, `anatomy-dsl` — the cached source packages | A manifest in the refs cache the provider could read instead of hard-coding |
+| `SEM_PACKAGES` | `surface`, `design-system-docs` — the docsite's own demand model, in a second root | Publishing the demand model as a ref package, collapsing two roots to one |
+| `EXCLUDED_SOURCES` | drops `design-system-docs/data/shim-concept.ttl`, whose `ds:embodiesConcept rdfs:domain ds:Entity` smears two fields onto all fourteen `ds:` types | A modelling fix: narrow the domain off the class-tree root |
+| `CUSTOM_MAPPINGS` | renames `anatomy:uri` → `anatomyUri`, because `uri` is the compiler-injected primary key | A `graphql:name "anatomyUri"` annotation on the term in the anatomy DSL's own repository |
+
+### The anatomy collision is now a test, not a paragraph
+
+`CUSTOM_MAPPINGS` is the single most load-bearing line in the package, and its
+justification used to be prose in a comment that nothing checked. Two documents in this
+repo disagreed about whether the failure it prevents was fatal yet.
+
+It was settled by running it. **Measured at `4d228c8`**, over the hermetic corpus:
+
+| | Outcome |
+|---|---|
+| **with** the mapping | boots; SDL carries `anatomyUri: String` on `NamedNode`; one `V014` info diagnostic |
+| **without** it | **throws `CompilationError`** — `M005 … maps to NamedNode.uri, a structural field the compiler owns — the field is DROPPED` |
+
+The fatality is live. `src/lib/provider/createPragmaProvider.test.ts` asserts it, both
+halves, on every run.
+
+---
+
+## `mode` and `prefixing` are pinned, not defaulted
+
+The app set neither, so it ran at ke-graphql's defaults *by accident*. This package
+passes both explicitly:
+
+```ts
+mode: "annotated"   // heuristic baseline plus the graphql: annotation overlay
+prefixing: "none"   // field names are the mapped OWL local names
+```
+
+`prefixing: "none"` is what makes the emitted names byte-compatible with the committed
+`apps/react/pragma-docs/src/relay/schema.graphql` that relay-compiler reads.
+`prefixing: "all"` — the blanket M005 remedy — would namespace-prefix **every** field in
+the schema to clear one collision, invalidating every committed Relay artifact at once.
+An implicit default that a dependency bump could change is exactly the kind of unstated
+fact this package exists to write down.
+
+---
+
+## The SDL output path belongs to the caller
+
+`PragmaProviderOptions.sdlOutput` is optional and **absent means no write**. This
+package never derives a path.
+
+The app's former `graphql.ts` derived one from `import.meta.url`. Carried into a package
+unchanged, that resolves relative to the *package* — so the app's schema would be
+written into `node_modules`, and `tsc`, `biome` and every test in the repo would still
+pass. Only a boot reveals it, and a boot needs a refs cache. The guard is therefore
+structural: there is no path in this package to get wrong.
+
+---
+
+## Testing: the hermetic corpus
+
+Pragma's real corpus is the pragma CLI's refs cache plus a semantics working tree.
+Neither exists in CI or in a fresh clone, so a suite that needed them would be skipped —
+and a skipped gate is worse than no gate.
+
+`src/testing/__fixtures__/corpus/` is a hand-written Turtle corpus in the exact shape the
+collector walks, small enough to read in one sitting and complete enough to make every
+property falsifiable: two roots merging, dot-prefixed files skipped, the exclusion
+dropped, channel-dotted references escaped, prefixes harvested, both actionable failure
+messages, and the anatomy collision in both directions. See that directory's README for
+what each file is for. Precedent: `packages/runtime/ke-graphql/demo/graph.ttl`.
+
+### The two SDL captures are stale, and it is written down
+
+`src/testing/__fixtures__/*.sdl.txt` back `src/testing/integration/sourceAdditivity.test.ts` (ported
+unchanged from the app). Measured at `4d228c8` against `@canonical/prism-contract`:
+**12 violations each, identical set**. They predate the converged base.
+
+They are kept because the property that suite asserts — additivity of the second source
+root — is a property of the **source set**, orthogonal to the structural head, and both
+sides of the comparison are equally stale. The type inventory has not drifted: the
+merged capture carries 183 top-level definitions, exactly the live schema's count. They
+cannot be regenerated without a full refs cache, and a capture from a *partial* cache is
+worse than a stale one because it looks current.
+
+What that leaves open is measured only in part. `src/testing/integration/committedSdl.test.ts`
+checks the schema the app **ships** — the committed `schema.graphql` — against the live
+contract on every run, so the structural head those captures are stale against is not
+unmeasured. Its subject is a **committed artifact**, not a live emission, so it cannot
+see that file drift from what `createPragmaProvider` would emit today. Closing that
+second gap needs a boot with a populated refs cache; the test's own header states the
+same limit.
+
+---
+
+## Running it
+
+```bash
+bun run serve   # GraphiQL at http://127.0.0.1:5177/graphql
+```
+
+Port 5177: the docsite's own graph holds 5175 and graph-example holds 5176, so all three
+run at once and the docsite can be pointed at any of them with `VITE_GRAPHQL_URL`.
+
+**It will not boot without a populated pragma refs cache** (`pragma sources update`, or
+`PRAGMA_REFS_DIR`). That is correct: `collectTtlSources` throws with the remedy in the
+message before an Oxigraph store is ever created. A demo that fabricated a graph to have
+something to serve would be demonstrating something other than this provider.

--- a/packages/prism/pragma-provider/biome.json
+++ b/packages/prism/pragma-provider/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["**/src/**", "**/demo/**", "**/*.json"]
+  }
+}

--- a/packages/prism/pragma-provider/demo/server.ts
+++ b/packages/prism/pragma-provider/demo/server.ts
@@ -1,0 +1,58 @@
+/**
+ * A runnable endpoint for the pragma provider.
+ *
+ *   bun run serve                       # GraphiQL at http://127.0.0.1:5177/graphql
+ *   PRAGMA_REFS_DIR=… bun run serve     # against a cache somewhere else
+ *
+ * Port 5177 by default: the docsite's own graph holds 5175 and
+ * prism-graph-example holds 5176, so all three run at once and the same lenses
+ * can be pointed at any of them via the docsite's `VITE_GRAPHQL_URL`.
+ *
+ * ⚠ THIS WILL NOT BOOT WITHOUT A POPULATED PRAGMA REFS CACHE, and that is
+ * correct behaviour rather than a defect. `collectTtlSources` throws before an
+ * Oxigraph store is ever created, carrying the remedy ("run `pragma sources
+ * update`"). A demo that fabricated a graph to have something to serve would
+ * be demonstrating something other than this provider.
+ *
+ * It passes NO `sdlOutput`, so it writes no file. See
+ * `src/lib/provider/createPragmaProvider.ts` for why that is the default.
+ *
+ * Not part of the published build (tsconfig.build.json covers src/ only); it
+ * is type-checked and linted like everything else.
+ */
+
+import { createPragmaProvider } from "../src/index.js";
+
+const GRAPHQL_PATH = "/graphql";
+const port = Number(process.env.PORT ?? 5177);
+
+const provider = await createPragmaProvider().catch((error: unknown): never => {
+  console.error(
+    "[prism-pragma-provider] the provider failed to boot:",
+    error instanceof Error ? error.message : error,
+  );
+  process.exit(1);
+});
+
+Bun.serve({
+  hostname: "127.0.0.1",
+  port,
+  fetch: async (request: Request): Promise<Response> => {
+    const { pathname } = new URL(request.url);
+    if (pathname !== GRAPHQL_PATH) {
+      // JSON, never HTML: this process has no renderer and must never look
+      // like one to a misconfigured client.
+      return Response.json(
+        {
+          errors: [{ message: `Not found. The endpoint is ${GRAPHQL_PATH}.` }],
+        },
+        { status: 404 },
+      );
+    }
+    return provider.handle(request);
+  },
+});
+
+console.log(
+  `prism-pragma-provider listening on http://127.0.0.1:${port}${GRAPHQL_PATH} (${provider.api.diagnostics.length} diagnostics)`,
+);

--- a/packages/prism/pragma-provider/package.json
+++ b/packages/prism/pragma-provider/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@canonical/prism-pragma-provider",
+  "description": "The pragma provider for the Prism docsite contract: ke-graphql compiling pragma's TTL corpus into a conformant executable schema",
+  "version": "0.37.0",
+  "private": true,
+  "type": "module",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "scripts": {
+    "build": "bun run build:package",
+    "build:all": "bun run build:package",
+    "build:package": "bun run build:package:tsc",
+    "build:package:tsc": "tsc -p tsconfig.build.json",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "check:webarchitect": "webarchitect library",
+    "serve": "bun demo/server.ts",
+    "test": "bun run test:vitest",
+    "test:vitest": "vitest run --coverage",
+    "test:vitest:watch": "vitest"
+  },
+  "dependencies": {
+    "@canonical/ke": "^0.37.0",
+    "@canonical/ke-graphql": "^0.37.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.11",
+    "@canonical/biome-config": "^0.37.0",
+    "@canonical/prism-contract": "^0.37.0",
+    "@canonical/typescript-config": "^0.37.0",
+    "@canonical/webarchitect": "^0.37.0",
+    "@types/bun": "^1.3.10",
+    "@types/node": "^24.12.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/prism/pragma-provider/src/index.ts
+++ b/packages/prism/pragma-provider/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * `@canonical/prism-pragma-provider` — pragma's own documentation-site
+ * provider: the repository's TTL corpus compiled by `@canonical/ke-graphql`
+ * into an executable GraphQL schema that satisfies `@canonical/prism-contract`.
+ *
+ * @module prism-pragma-provider
+ */
+
+export * from "./lib/index.js";

--- a/packages/prism/pragma-provider/src/lib/config/constants.ts
+++ b/packages/prism/pragma-provider/src/lib/config/constants.ts
@@ -1,0 +1,169 @@
+/**
+ * The relocated pragma knowledge: every fact about pragma's specific ontologies
+ * that the docsite app used to carry, in one place.
+ *
+ * IMPLEMENTER DECISION (plan OQ-4): `EXCLUDED_SOURCES` and `CUSTOM_MAPPINGS`
+ * are PINNED CONSTANTS, not `PragmaProviderOptions` fields.
+ *
+ * Both are facts about specific upstream ontologies rather than about any
+ * caller, and both have a documented upstream remedy that DELETES them (a
+ * `graphql:name` annotation on `anatomy:uri`; a modelling fix for
+ * `shim-concept.ttl`). Exposing them as options would mean a second caller
+ * could pass a different value and silently compile a schema incompatible with
+ * the `schema.graphql` relay-compiler reads — the same class of divergence
+ * `mode`/`prefixing` are pinned against in `createPragmaProvider`. The whole
+ * point of this file is that there is ONE place these live and one answer to
+ * "why is this here"; an option turns that into "it depends who called".
+ *
+ * The cost is real and accepted: a consumer who needs different exclusions
+ * must fork or send a PR. That is the correct friction for a value whose
+ * existence is a bug report against an ontology.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** The cached source packages whose TTL constitutes the docsite graph. */
+export const REF_PACKAGES: readonly string[] = [
+  "design-system",
+  "code-standards",
+  "anatomy-dsl",
+];
+
+/**
+ * The SECOND source root: the semantic packages that carry the docsite's
+ * own demand model — the surface ontology (jobs, coordinates, pairings,
+ * surfaces, layouts) and the docs graph that instantiates it. These live
+ * in the semantics working tree rather than the pragma CLI's refs cache,
+ * so they are collected from their own root and merged into the same
+ * store: one schema, two roots.
+ *
+ * Compiling them alongside the refs packages is purely additive — no
+ * existing type loses a field and no prefix collides (`sem://surface#Job`
+ * yields `Job`, `sem://design-system-docs#` its own block).
+ */
+export const SEM_PACKAGES: readonly string[] = [
+  "surface",
+  "design-system-docs",
+];
+
+/** The package subdirectories scanned for `.ttl` sources. */
+export const TTL_DIRS: readonly string[] = ["definitions", "data"];
+
+/**
+ * Sources excluded from the semantic root.
+ *
+ * `shim-concept.ttl` declares `ds:embodiesConcept` with `rdfs:domain
+ * ds:Entity`. Because `ds:Entity` is the root of the design-system class
+ * tree, that one domain assertion smears the property (and its inverse)
+ * onto ALL FOURTEEN `ds:` types once both roots compile together — every
+ * existing docsite type would silently gain two fields, and `Concept`
+ * would gain a malformed single-character field. The shim is a modelling
+ * bridge for a graph the docsite does not read; excluding it keeps the
+ * second root additive-only. The exclusion is executed and asserted by
+ * `src/lib/sources/collectTtlSources.test.ts`;
+ * `src/testing/integration/sourceAdditivity.test.ts` records what the second
+ * root did to the schema's shape when the captures were taken, which is
+ * history rather than a guard on this constant.
+ */
+export const EXCLUDED_SOURCES: readonly string[] = [
+  "design-system-docs/data/shim-concept.ttl",
+];
+
+/** The ref (branch) of each source package the provider reads. */
+export const REF_NAME = "main";
+
+/**
+ * A Turtle prefix prologue declaration (`@prefix ex: <iri> .` or the
+ * case-insensitive keyword form). The label group requires at least one
+ * character so the default-namespace form (`@prefix : <iri>`) is skipped.
+ *
+ * It matches these characters ANYWHERE, which is why `harvestPrefixes` runs it
+ * over a copy with comments and string literals blanked out
+ * (`blankTurtleProse`) rather than over the raw source. Without that, a
+ * retired declaration parked in a comment is harvested like a live one, and
+ * last-wins hands the compiler a namespace the Turtle parser never applied.
+ */
+export const PREFIX_DECL = /(?:^|\s)@?prefix\s+([^\s:]+):\s*<([^>]*)>/gi;
+
+/**
+ * The one custom mapping this graph cannot boot without.
+ *
+ * `anatomy:uri` is an ordinary `owl:DatatypeProperty` on the anatomy DSL's
+ * `NamedNode` class, and it maps to the GraphQL field name `uri` — which the
+ * converged base RESERVES: `uri: ID!` is the primary key the compiler
+ * injects on every Node implementer. The compiler used to rename such a
+ * collision silently (M002, which is where the committed `anatomyUri` came
+ * from); the converged compiler removed that branch, because a silent
+ * rename breaks the consumer's query without telling them which IRI did it.
+ * It now reports M005 — DROPPED, severity `error` — and `runPasses` refuses
+ * to hand out a schema with any error in it, so the whole boot dies.
+ *
+ * That last sentence is no longer prose: `createPragmaProvider.test.ts`
+ * boots the hermetic corpus with and without this mapping and asserts the
+ * observed behaviour. See that test's header for the measurement.
+ *
+ * The remedy the diagnostic names is a custom mapping, and this is it. The
+ * name it restores is exactly the one the schema already carried, so nothing
+ * downstream moves. (`prefixing: "all"`, the other remedy, would rename
+ * EVERY field in the schema to clear one collision.)
+ *
+ * `mappings` is deprecated in favour of a `graphql:name` annotation on the
+ * term itself — the right home for this, since the collision is a fact about
+ * the anatomy ontology and not about this package. That ontology lives in the
+ * anatomy DSL's own repository, outside this monorepo, so the annotation is
+ * an upstream change; when it lands, delete this. (MEASURED at pragma
+ * `4d228c8`: the anatomy ontology reaches this package only through the pragma
+ * refs cache. It is deliberately NOT vendored into this repository and must
+ * not be — the corpus under `src/testing/__fixtures__/corpus` is a
+ * hand-written stand-in that declares the colliding IRI verbatim, so the
+ * collision stays testable without a copy of someone else's ontology in our
+ * tree.)
+ */
+export const ANATOMY_URI = "http://anatomy-dsl.example.org/ontology#uri";
+
+/** @see {@link ANATOMY_URI} — the M005 remedy, pinned. */
+export const CUSTOM_MAPPINGS: Readonly<
+  Record<string, { readonly graphqlName: string }>
+> = { [ANATOMY_URI]: { graphqlName: "anatomyUri" } };
+
+/**
+ * A channel-dotted local name reference (`ds:.subcomponent.accordion-item`):
+ * a valid IRI but invalid Turtle, since a PN_LOCAL may not start with an
+ * unescaped dot. Public data files reference experimental-channel entities
+ * this way (the entities' own dot-prefixed files are excluded as sources), so
+ * the reference is escaped (`ds:\.foo` — same IRI) rather than dropped; the
+ * dangling target then reads as honest absence in the graph.
+ *
+ * The same characters inside an annotation or an IRI reference are DATA, not
+ * a reference to escape, and a backslash there breaks the parse rather than
+ * fixing it — so `escapeChannelDottedRefs` applies this through
+ * `mapTurtleSyntax` and never touches prose.
+ */
+export const CHANNEL_DOTTED_REF = /\b([A-Za-z][\w-]*):\.(?=[A-Za-z_])/g;
+
+/** The pragma CLI's cache location — the refs root when nothing overrides it. */
+export const DEFAULT_REFS_ROOT: string = join(
+  homedir(),
+  ".cache",
+  "pragma",
+  "refs",
+  "@canonical",
+);
+
+/**
+ * The sibling semantics working tree — the sem root when nothing overrides it.
+ *
+ * Unlike {@link DEFAULT_REFS_ROOT}, which is a tool-owned cache at a location
+ * the pragma CLI defines, this is a GUESS at where a developer keeps a second
+ * checkout. It is right on the machines the docsite is developed on and wrong
+ * everywhere else, which is why the collector announces the miss rather than
+ * treating it as ordinary: override it with `PRAGMA_SEM_DIR` or the
+ * `semRoot` option rather than relying on this.
+ */
+export const DEFAULT_SEM_ROOT: string = join(
+  homedir(),
+  "code",
+  "cn",
+  "semantics",
+);

--- a/packages/prism/pragma-provider/src/lib/config/index.ts
+++ b/packages/prism/pragma-provider/src/lib/config/index.ts
@@ -1,0 +1,25 @@
+/**
+ * The config domain's barrel.
+ *
+ * @module config
+ */
+
+export {
+  ANATOMY_URI,
+  CHANNEL_DOTTED_REF,
+  CUSTOM_MAPPINGS,
+  DEFAULT_REFS_ROOT,
+  DEFAULT_SEM_ROOT,
+  EXCLUDED_SOURCES,
+  PREFIX_DECL,
+  REF_NAME,
+  REF_PACKAGES,
+  SEM_PACKAGES,
+  TTL_DIRS,
+} from "./constants.js";
+export type {
+  PragmaProvider,
+  PragmaProviderOptions,
+  SourceRoots,
+  TtlSource,
+} from "./types.js";

--- a/packages/prism/pragma-provider/src/lib/config/types.ts
+++ b/packages/prism/pragma-provider/src/lib/config/types.ts
@@ -1,0 +1,45 @@
+import type { SchemaPluginApi } from "@canonical/ke-graphql";
+
+/** One Turtle source: its store-visible label and its (escaped) content. */
+export interface TtlSource {
+  readonly path: string;
+  readonly content: string;
+}
+
+/** The two filesystem roots the collector walks. */
+export interface SourceRoots {
+  /** The pragma CLI's refs cache — `<root>/<pkg>/<ref>/{definitions,data}`. */
+  readonly refsRoot: string;
+  /** The semantics working tree — `<root>/<pkg>/{definitions,data}`. Skipped when absent. */
+  readonly semRoot: string;
+}
+
+export interface PragmaProviderOptions {
+  /** Refs cache root. Default: `$PRAGMA_REFS_DIR`, else {@link DEFAULT_REFS_ROOT}. */
+  readonly refsRoot?: string;
+  /** Semantics working tree. Default: `$PRAGMA_SEM_DIR`, else {@link DEFAULT_SEM_ROOT}. Skipped when absent. */
+  readonly semRoot?: string;
+  /**
+   * Where to write the emitted SDL. ABSENT MEANS NO WRITE.
+   *
+   * The path belongs to the CONSUMER; this package never derives one. See
+   * `createPragmaProvider.ts`'s header for why this is optional rather than
+   * required, and why it has no default.
+   */
+  readonly sdlOutput?: string;
+}
+
+/**
+ * The booted provider: a fetch-native handler plus the compiled schema's API.
+ *
+ * There is no in-process `execute` member. One existed in the app's former
+ * `graphql.ts` so the SSR prepare step could skip the HTTP hop, and it was the
+ * reason a pre-parsed AST from the app's graphql v16 had to be kept away from
+ * ke-graphql's v17 executor. The prepare step now POSTs over HTTP like any
+ * other client, so the two graphql versions no longer share a process at all
+ * and the whole text-only-boundary discipline is moot.
+ */
+export interface PragmaProvider {
+  readonly handle: (request: Request) => Promise<Response>;
+  readonly api: SchemaPluginApi;
+}

--- a/packages/prism/pragma-provider/src/lib/index.ts
+++ b/packages/prism/pragma-provider/src/lib/index.ts
@@ -1,0 +1,19 @@
+/**
+ * The package's public surface: one factory and the two types naming its
+ * options and its result.
+ *
+ * The internal cross-domain surface — the source collector, the prefix
+ * harvester, and the eleven configuration constants — is deliberately NOT
+ * re-exported. Those are decisions this package makes on the consumer's
+ * behalf; `constants.ts` argues at length that they must not be configurable,
+ * which is an argument for keeping them off the public surface rather than for
+ * publishing them.
+ *
+ * @module lib
+ */
+
+export type {
+  PragmaProvider,
+  PragmaProviderOptions,
+} from "./config/index.js";
+export { createPragmaProvider } from "./provider/index.js";

--- a/packages/prism/pragma-provider/src/lib/provider/createPragmaProvider.test.ts
+++ b/packages/prism/pragma-provider/src/lib/provider/createPragmaProvider.test.ts
@@ -1,0 +1,264 @@
+// =============================================================================
+// The boot, against the hermetic corpus — including the anatomy collision.
+//
+// -----------------------------------------------------------------------------
+// 🔬 THE MEASUREMENT THIS FILE EXISTS FOR, AND HOW IT WAS OBTAINED.
+//
+// `CUSTOM_MAPPINGS` carries one entry, `anatomy:uri → anatomyUri`, and the
+// constant's prose says the boot "dies loudly" without it. Two documents in
+// this repo DISAGREED about whether that is true at this commit: R.03 records
+// R-4's fatality escalation as "error+drop implemented; fatality PENDING",
+// while the app's former `graphql.ts` asserted the fatality as established
+// fact. One of them had to be stale.
+//
+// It was resolved by RUNNING IT, not by reading either document: the corpus
+// below was compiled twice at pragma `4d228c8`, once with `CUSTOM_MAPPINGS`
+// and once with `{}`. OBSERVED, verbatim:
+//
+//   WITH    → boot succeeds; SDL carries `anatomyUri: String` on `NamedNode`;
+//             one diagnostic, `V014`, severity `info`.
+//   WITHOUT → boot THROWS `CompilationError`, message
+//             "ke-graphql: compilation failed with 1 error(s)", carrying
+//             `M005 … maps to NamedNode.uri, a structural field the compiler
+//             owns — the field is DROPPED."  The diagnostic's severity is
+//             `error`, and `runPasses`' compile-level fatality gate refuses to
+//             hand out the schema.
+//
+// SO THE FATALITY IS LIVE AT `4d228c8` AND R.03's "pending" IS THE STALE
+// DOCUMENT. The assertions below are written from that observation. If a
+// future ke-graphql change downgrades M005 to a warning, this file goes red —
+// which is the correct outcome, because the app's committed `schema.graphql`
+// would then quietly lose a field instead of refusing to build.
+//
+// -----------------------------------------------------------------------------
+// 🔴 THE DEFAULT IS NO WRITE, AND EXACTLY ONE TEST DEPARTS FROM IT. Omitting
+// `sdlOutput` writes nothing, with no default path to fall back to — a
+// property of the option's shape rather than of this file's discipline, and
+// what makes every other test here safe to run against any root. The one
+// exception is the `sdlOutput` test below, which passes a freshly created
+// temporary destination, asserts the file was written, and removes the
+// directory afterwards: the write is proved somewhere isolated rather than
+// left as an untested claim. See `createPragmaProvider.ts`'s header.
+// =============================================================================
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createStore, type Plugin } from "@canonical/ke";
+import { createSchemaPlugin } from "@canonical/ke-graphql";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CORPUS_REFS_ROOT,
+  CORPUS_SEM_ROOT,
+  MISSING_ROOT,
+} from "../../testing/corpus.js";
+import { ANATOMY_URI, CUSTOM_MAPPINGS } from "../config/index.js";
+import { collectTtlSources, harvestPrefixes } from "../sources/index.js";
+import { createPragmaProvider } from "./createPragmaProvider.js";
+
+/** One boot, shared: Oxigraph is a WASM store and booting it is not free. */
+const booted = createPragmaProvider({
+  refsRoot: CORPUS_REFS_ROOT,
+  semRoot: CORPUS_SEM_ROOT,
+});
+
+describe("createPragmaProvider over both roots", () => {
+  it("compiles a schema from both roots into one store", async () => {
+    const { api } = await booted;
+    expect(api.sdl).toContain("type Component");
+    // `Job` comes only from the semantics tree — proof the second root merged.
+    expect(api.sdl).toContain("type Job");
+  });
+
+  it("keeps the excluded shim out of the compiled schema", async () => {
+    const { api } = await booted;
+    expect(api.sdl).not.toContain("embodiesConcept");
+  });
+
+  it("parses the channel-dotted reference rather than choking on it", async () => {
+    // Unescaped, `ds:.subcomponent.button-label` is invalid Turtle and the
+    // store would refuse the whole file. A successful boot IS the assertion;
+    // the dangling target reads as honest absence.
+    const { api } = await booted;
+    expect(api.schema).toBeDefined();
+  });
+
+  it("serves the compiled schema over the fetch handler", async () => {
+    const { handle } = await booted;
+    const response = await handle(
+      new Request("http://localhost/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: "{ __schema { queryType { name } } }" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { __schema: { queryType: { name: "Query" } } },
+    });
+  });
+});
+
+describe("the anatomy:uri collision", () => {
+  it("keeps the field under the name the committed schema already carries", async () => {
+    const { api } = await booted;
+    // Not merely "some field survived": the mapping's whole justification is
+    // that it restores the EXACT name the schema had, so nothing downstream
+    // moves. `anatomyUri: String` appears in the app's committed
+    // schema.graphql at 4d228c8.
+    expect(api.sdl).toContain("anatomyUri: String");
+    expect(CUSTOM_MAPPINGS[ANATOMY_URI]).toEqual({ graphqlName: "anatomyUri" });
+  });
+
+  it("has NOT quietly renamed the reserved field", async () => {
+    const { api } = await booted;
+    // `uri: ID!` is the compiler-injected primary key. If `anatomy:uri` ever
+    // took it, this is what would change: the field would move off NamedNode
+    // and the compiler's own `uri` would be the casualty.
+    expect(api.sdl).toContain("type NamedNode implements Node");
+    const namedNode = /type NamedNode implements Node[^{]*\{([^}]*)\}/.exec(
+      api.sdl,
+    )?.[1];
+    expect(namedNode, "NamedNode block").toBeDefined();
+    expect(namedNode).toContain("anatomyUri: String");
+    expect(namedNode).toContain("uri: ID!");
+  });
+});
+
+describe("the pinned compiler options", () => {
+  // `mode` and `prefixing` are passed explicitly rather than left to
+  // ke-graphql's defaults, and the module header says why: `prefixing: "all"`
+  // would namespace-prefix EVERY generated field and invalidate every
+  // committed Relay artifact at once. That claim was prose and nothing else —
+  // flipping the constant left the whole suite green. These assertions are the
+  // teeth: they read the emitted names, so the edit that the header calls
+  // catastrophic now fails here rather than in the app.
+
+  it('emits unprefixed field names — the "none" half of the pin', async () => {
+    const { api } = await booted;
+    expect(api.sdl).toContain("jobLabel");
+    expect(api.sdl).toContain("tier");
+  });
+
+  it('carries none of the names `prefixing: "all"` would produce', async () => {
+    // The blanket M005 remedy renames `sur:jobLabel` to `surJobLabel` and
+    // `ds:tier` to `dsTier`. Their absence is what makes the committed
+    // schema.graphql byte-compatible with this emission.
+    const { api } = await booted;
+    expect(api.sdl).not.toContain("surJobLabel");
+    expect(api.sdl).not.toContain("dsTier");
+  });
+
+  it("reports exactly the diagnostics the boot is expected to raise", async () => {
+    // The module header records this as an OBSERVATION — "one diagnostic,
+    // V014, severity info". It was never asserted, so the observation could
+    // rot. It is asserted now.
+    const { api } = await booted;
+    expect(
+      api.diagnostics.map(
+        (diagnostic) => `${diagnostic.code}:${diagnostic.severity}`,
+      ),
+    ).toEqual(["V014:info"]);
+  });
+
+  it("KILLS THE BOOT when the mapping is absent — observed, not assumed", async () => {
+    // THE NEGATIVE HALF, run for real.
+    //
+    // `CUSTOM_MAPPINGS` is a pinned constant (OQ-4), so there is deliberately
+    // no way to unset it through this package's public surface. The negative
+    // case is therefore compiled one layer down — the package's own collector
+    // and prefix harvester, handed to ke-graphql with `mappings: {}` — which
+    // is the honest place for it: the claim is about what the COMPILER does to
+    // this corpus, and that is precisely what justifies the constant existing.
+    //
+    // Everything else is held identical to `createPragmaProvider`: same
+    // sources, same prefixes, same `mode`/`prefixing`/`incremental`. The only
+    // difference is the mapping.
+    const sources = collectTtlSources({
+      refsRoot: CORPUS_REFS_ROOT,
+      semRoot: CORPUS_SEM_ROOT,
+    });
+    const unmapped = createSchemaPlugin({
+      incremental: true,
+      mappings: {},
+      mode: "annotated",
+      prefixing: "none",
+    });
+    const thrown = await createStore({
+      sources: sources.map(({ content, path }) => ({ content, path })),
+      prefixes: harvestPrefixes(sources),
+      // biome-ignore lint: Plugin generic variance requires explicit unknown
+      plugins: [unmapped] as Plugin<any>[],
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    // OBSERVED at 4d228c8: it throws. It does not return a schema minus the
+    // field. R.03's "fatality pending" is the stale document.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("compilation failed");
+    expect((thrown as Error).message).toContain("M005");
+    expect((thrown as Error).message).toContain(ANATOMY_URI);
+    // The diagnostic names the collision AND the remedy this constant is.
+    expect((thrown as Error).message).toContain(
+      "a structural field the compiler owns — the field is DROPPED",
+    );
+    expect((thrown as Error).message).toContain("add a custom mapping");
+  });
+});
+
+describe("sdlOutput", () => {
+  it("writes nothing and says so when it is absent", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    await createPragmaProvider({
+      refsRoot: CORPUS_REFS_ROOT,
+      semRoot: CORPUS_SEM_ROOT,
+    });
+    expect(info).toHaveBeenCalledWith(
+      expect.stringContaining("SDL output disabled (no sdlOutput given)"),
+    );
+    info.mockRestore();
+  });
+
+  it("writes exactly where the CALLER said, and nowhere else", async () => {
+    // 🔴 The destination is a scratch directory outside the repository, on
+    // purpose. This package must never write into a tracked source tree —
+    // not from its demo, not from its tests. The whole reason `sdlOutput` is
+    // an argument with no default is that the path is the caller's to own,
+    // and a test that proved the write by scribbling on
+    // `apps/react/pragma-docs/src/relay/schema.graphql` would be proving the
+    // opposite of the property.
+    const destination = join(
+      mkdtempSync(join(tmpdir(), "prism-pragma-provider-")),
+      "schema.graphql",
+    );
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    await createPragmaProvider({
+      refsRoot: CORPUS_REFS_ROOT,
+      semRoot: CORPUS_SEM_ROOT,
+      sdlOutput: destination,
+    });
+    info.mockRestore();
+
+    expect(existsSync(destination)).toBe(true);
+    const written = readFileSync(destination, "utf-8");
+    expect(written).toContain("type Component");
+    expect(written).toContain("anatomyUri: String");
+    rmSync(dirname(destination), { recursive: true, force: true });
+  });
+});
+
+describe("createPragmaProvider without roots", () => {
+  it("resolves the refs root from the environment and fails actionably", async () => {
+    // Called with NO options at all, so both defaults resolve. In any
+    // environment without a populated pragma cache this is the message a
+    // developer sees, and it must name the remedy.
+    vi.stubEnv("PRAGMA_REFS_DIR", MISSING_ROOT);
+    vi.stubEnv("PRAGMA_SEM_DIR", MISSING_ROOT);
+    await expect(createPragmaProvider()).rejects.toThrow(
+      /pragma refs cache not found at .*— run `pragma sources update`/,
+    );
+    vi.unstubAllEnvs();
+  });
+});

--- a/packages/prism/pragma-provider/src/lib/provider/createPragmaProvider.ts
+++ b/packages/prism/pragma-provider/src/lib/provider/createPragmaProvider.ts
@@ -1,0 +1,144 @@
+/**
+ * The pragma provider: TTL corpus → Oxigraph store → executable schema →
+ * fetch-native handler.
+ *
+ * -----------------------------------------------------------------------------
+ * IMPLEMENTER DECISION 1 (plan OQ-5): `sdlOutput` is OPTIONAL, and its absence
+ * means NO WRITE. It has no default and this package never derives one.
+ *
+ * The alternative — making it REQUIRED, so omitting it is a type error — is a
+ * stronger guard against the specific accident this shape exists to prevent
+ * (see below), and it was a close call. It was rejected because it forces
+ * `demo/server.ts` to invent an SDL path it does not want, and inventing a
+ * path is precisely the failure being designed out: a provider that must name
+ * a file has to have an opinion about where the consumer's source tree is.
+ * Optional-no-write means the default behaviour of this package is to write
+ * nothing, anywhere, ever, which is the safest possible default and the one
+ * that needs no reviewer to check it.
+ *
+ * THE ACCIDENT IT PREVENTS. The app's former `src/server/graphql.ts` derived
+ * the path itself:
+ *
+ *     const SDL_OUTPUT_PATH = fileURLToPath(
+ *       new URL("../relay/schema.graphql", import.meta.url),
+ *     );
+ *
+ * Carried into this package unchanged, that resolves relative to THIS file —
+ * so the app's schema would be written into `packages/prism/pragma-provider/`
+ * (or into `node_modules/`), `tsc --noEmit` would pass, `biome check` would
+ * pass, and every test in the repo would pass. Only a boot reveals it, and a
+ * boot needs a populated refs cache. The guard is therefore structural, not a
+ * test: there is no path in this package to get wrong. The consumer passes one
+ * or nothing happens. `createPragmaProvider.test.ts` covers both branches, and
+ * the boot log names the resolved path so a live run says which it took.
+ *
+ * -----------------------------------------------------------------------------
+ * IMPLEMENTER DECISION 2 (plan §3, item 6 of its bad-ideas list): the
+ * `getGraphqlBackend()` memoising singleton is DROPPED. This is a plain
+ * factory.
+ *
+ * That singleton was a lazy promise cache that forgot a rejected boot so the
+ * next request would retry. Its justification was the pre-split world where
+ * the backend was mounted INSIDE whichever web server was running and booted
+ * on first GraphQL request — retry-on-failure mattered because a request could
+ * arrive before the refs cache was ready. Since the PRD-3 process split the
+ * only caller is the standalone graph server, which awaits exactly one boot at
+ * module top level, before it listens, and exits non-zero if it fails. There is
+ * no second call to memoise and no request to retry. Keeping the machinery
+ * would mean shipping prose describing a world that no longer exists, which is
+ * the thing this despecialization train is mostly about not doing.
+ *
+ * A caller that genuinely wants one shared instance holds the promise itself —
+ * which is one line at the call site.
+ *
+ * -----------------------------------------------------------------------------
+ * `mode` and `prefixing` ARE PASSED EXPLICITLY. The app set neither, so it ran
+ * at ke-graphql's defaults by accident. They are pinned here because
+ * `prefixing: "none"` is what makes the emitted field names byte-compatible
+ * with the committed `schema.graphql` that relay-compiler reads: `prefixing:
+ * "all"` would namespace-prefix EVERY field in the schema (the blanket M005
+ * remedy) and invalidate every committed Relay artifact at once. An implicit
+ * default that a dependency bump could change is exactly the kind of unstated
+ * fact this package exists to write down. They are constants, not options,
+ * for the same reason `CUSTOM_MAPPINGS` is (see config/constants.ts).
+ */
+
+import { relative } from "node:path";
+import { createStore, type Plugin } from "@canonical/ke";
+import {
+  createSchemaPlugin,
+  type SchemaPluginApi,
+} from "@canonical/ke-graphql";
+import { createGraphQLHandler } from "@canonical/ke-graphql/http";
+import {
+  CUSTOM_MAPPINGS,
+  type PragmaProvider,
+  type PragmaProviderOptions,
+} from "../config/index.js";
+import {
+  collectTtlSources,
+  harvestPrefixes,
+  resolveRefsRoot,
+  resolveSemRoot,
+} from "../sources/index.js";
+
+/** Projection mode, pinned — see this module's header. */
+const MODE = "annotated";
+
+/** Field-name prefixing, pinned — see this module's header. */
+const PREFIXING = "none";
+
+/**
+ * Boot the store, compile the schema, and build the fetch handler.
+ *
+ * @note Impure — reads the source cache, boots an Oxigraph WASM store, and
+ * writes the emitted SDL **only** when `sdlOutput` is given.
+ */
+export const createPragmaProvider = async (
+  options: PragmaProviderOptions = {},
+): Promise<PragmaProvider> => {
+  const sources = collectTtlSources({
+    refsRoot: options.refsRoot ?? resolveRefsRoot(),
+    semRoot: options.semRoot ?? resolveSemRoot(),
+  });
+  const prefixes = harvestPrefixes(sources);
+  const graphql = createSchemaPlugin({
+    incremental: true,
+    mappings: CUSTOM_MAPPINGS,
+    mode: MODE,
+    prefixing: PREFIXING,
+    sdlOutput: options.sdlOutput,
+  });
+  // biome-ignore lint/suspicious/noExplicitAny: the Plugin generic is invariant, so the heterogeneous plugin array needs `any` here — matching ke-graphql's own demo
+  const plugins: Plugin<any>[] = [graphql];
+  const store = await createStore({
+    sources: sources.map((source) => ({
+      content: source.content,
+      path: source.path,
+    })),
+    prefixes,
+    plugins,
+  });
+  const api = store.api<SchemaPluginApi>("ke-graphql");
+  /* v8 ignore next 3 -- unreachable via this factory: the plugin is
+     constructed two statements above and registers its API synchronously
+     during createStore, so a missing API means ke changed its plugin
+     protocol. Kept as a loud failure rather than an undefined dereference. */
+  if (!api) {
+    throw new Error("ke-graphql plugin did not register its API");
+  }
+  const handle = createGraphQLHandler(api.schema, {
+    context: () => api.createContext(store),
+    graphiql: true,
+    cors: true,
+    incremental: true,
+  });
+  const destination =
+    options.sdlOutput === undefined
+      ? "SDL output disabled (no sdlOutput given)"
+      : `SDL written to ${relative(process.cwd(), options.sdlOutput)}`;
+  console.info(
+    `[graphql] schema compiled from ${sources.length} TTL sources (${api.diagnostics.length} diagnostics) — ${destination}`,
+  );
+  return { handle, api };
+};

--- a/packages/prism/pragma-provider/src/lib/provider/index.ts
+++ b/packages/prism/pragma-provider/src/lib/provider/index.ts
@@ -1,0 +1,7 @@
+/**
+ * The provider domain's barrel.
+ *
+ * @module provider
+ */
+
+export { createPragmaProvider } from "./createPragmaProvider.js";

--- a/packages/prism/pragma-provider/src/lib/sources/collectTtlSources.test.ts
+++ b/packages/prism/pragma-provider/src/lib/sources/collectTtlSources.test.ts
@@ -1,0 +1,255 @@
+// =============================================================================
+// The collector, against the hermetic corpus.
+//
+// Every property here was previously untestable: the app's `collectTtlSources`
+// read `$PRAGMA_REFS_DIR` internally, so exercising it meant having a populated
+// pragma refs cache — which no CI leg and no fresh clone has. Roots are now an
+// argument and the corpus is checked in, so these are ordinary unit tests.
+//
+// 🔴 NOTHING IN THIS FILE WRITES. `collectTtlSources` reads; the SDL write
+// lives behind `createPragmaProvider`'s optional `sdlOutput`, which nothing
+// here passes. Pointing a root at a real ontology tree is safe here for
+// exactly that reason. The claim is about THIS file, not about the package:
+// `createPragmaProvider.test.ts` does pass `sdlOutput`, to a temporary
+// directory it then removes, which is how the write is proved at all — see
+// `createPragmaProvider.ts`'s header.
+// =============================================================================
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  CORPUS_EMPTY_REFS_ROOT,
+  CORPUS_REFS_ROOT,
+  CORPUS_SEM_ROOT,
+  CORPUS_WRONG_SEM_ROOT,
+  MISSING_ROOT,
+} from "../../testing/corpus.js";
+import {
+  DEFAULT_REFS_ROOT,
+  DEFAULT_SEM_ROOT,
+  REF_PACKAGES,
+  SEM_PACKAGES,
+} from "../config/index.js";
+import {
+  collectTtlSources,
+  escapeChannelDottedRefs,
+  resolveRefsRoot,
+  resolveSemRoot,
+} from "./collectTtlSources.js";
+
+const bothRoots = { refsRoot: CORPUS_REFS_ROOT, semRoot: CORPUS_SEM_ROOT };
+
+describe("the ordering precondition", () => {
+  it("keeps REF_PACKAGES and SEM_PACKAGES disjoint", () => {
+    // `byPath` has no equal arm, and its comment licenses that by asserting
+    // collected paths are unique — which rests on these two lists sharing no
+    // member. Nothing enforced it; a duplicate was one edit away from making a
+    // documented precondition quietly false.
+    expect(REF_PACKAGES.filter((pkg) => SEM_PACKAGES.includes(pkg))).toEqual(
+      [],
+    );
+  });
+});
+
+describe("collectTtlSources over both roots", () => {
+  const paths = collectTtlSources(bothRoots).map((source) => source.path);
+
+  it("collects both roots into one ordered set", () => {
+    // The whole list, pinned. A new corpus file that nothing asserts on is a
+    // fixture nobody is reading; this makes adding one a deliberate act.
+    expect(paths).toStrictEqual([
+      "anatomy-dsl/definitions/anatomy.ttl",
+      "design-system/data/instances.ttl",
+      "design-system/data/tokens/colors.ttl",
+      "design-system/definitions/ontology.ttl",
+      "surface/definitions/surface.ttl",
+    ]);
+  });
+
+  it("skips dot-prefixed files", () => {
+    // `.channel.ttl` is an experimental-channel artifact, not a graph source.
+    expect(paths.some((path) => path.includes(".channel"))).toBe(false);
+    expect(
+      collectTtlSources(bothRoots).some((source) =>
+        source.content.includes("ds:leaked"),
+      ),
+    ).toBe(false);
+  });
+
+  it("skips files that are not .ttl", () => {
+    expect(paths.some((path) => path.endsWith(".md"))).toBe(false);
+  });
+
+  it("descends into nested directories", () => {
+    expect(paths).toContain("design-system/data/tokens/colors.ttl");
+  });
+
+  it("drops EXCLUDED_SOURCES by its store-visible path", () => {
+    // The file is on disk under the sem root; the constant names it; the
+    // collected set must not carry it. This is the shim-concept exclusion —
+    // `ds:embodiesConcept rdfs:domain ds:Entity` would smear two fields onto
+    // every subclass of `ds:Entity` the moment both roots compile together.
+    expect(paths).not.toContain("design-system-docs/data/shim-concept.ttl");
+    expect(
+      collectTtlSources(bothRoots).some((source) =>
+        source.content.includes("embodiesConcept"),
+      ),
+    ).toBe(false);
+  });
+
+  it("tolerates a ref package that is not in the cache", () => {
+    // `code-standards` is in REF_PACKAGES and absent from the corpus — the
+    // state a partially-populated cache is actually in. It contributes
+    // nothing and throws nothing.
+    expect(paths.some((path) => path.startsWith("code-standards/"))).toBe(
+      false,
+    );
+  });
+
+  it("escapes channel-dotted references in the content it hands the store", () => {
+    const instances = collectTtlSources(bothRoots).find(
+      (source) => source.path === "design-system/data/instances.ttl",
+    );
+    expect(instances?.content).toContain("ds:\\.subcomponent.button-label");
+  });
+});
+
+describe("collectTtlSources without the semantics tree", () => {
+  const paths = collectTtlSources({
+    refsRoot: CORPUS_REFS_ROOT,
+    semRoot: MISSING_ROOT,
+  }).map((source) => source.path);
+
+  it("skips the second root entirely rather than failing", () => {
+    // The four shipped lenses read the first root only, so an absent
+    // semantics tree must degrade, not break.
+    expect(paths).not.toContain("surface/definitions/surface.ttl");
+  });
+
+  it("still collects the first root", () => {
+    expect(paths).toStrictEqual([
+      "anatomy-dsl/definitions/anatomy.ttl",
+      "design-system/data/instances.ttl",
+      "design-system/data/tokens/colors.ttl",
+      "design-system/definitions/ontology.ttl",
+    ]);
+  });
+});
+
+describe("collectTtlSources with a semantics tree that is there but wrong", () => {
+  // The case an existence check on the root cannot see: the directory is
+  // present, so the missing-tree warning never fires, and neither expected
+  // package is under it — `walkTtl` contributes nothing and the boot log would
+  // otherwise report a healthy compile of a half-empty schema.
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const paths = collectTtlSources({
+    refsRoot: CORPUS_REFS_ROOT,
+    semRoot: CORPUS_WRONG_SEM_ROOT,
+  }).map((source) => source.path);
+  const warnings = warn.mock.calls.map((call) => String(call[0]));
+  warn.mockRestore();
+
+  it("warns once per package that contributed nothing", () => {
+    expect(warnings).toHaveLength(SEM_PACKAGES.length);
+    for (const pkg of SEM_PACKAGES) {
+      expect(warnings.join("\n")).toContain(`"${pkg}" contributed no .ttl`);
+    }
+  });
+
+  it("does not repeat the missing-tree warning: the tree is not missing", () => {
+    expect(warnings.join("\n")).not.toContain("semantics tree not found");
+  });
+
+  it("still collects the first root", () => {
+    expect(paths).toStrictEqual([
+      "anatomy-dsl/definitions/anatomy.ttl",
+      "design-system/data/instances.ttl",
+      "design-system/data/tokens/colors.ttl",
+      "design-system/definitions/ontology.ttl",
+    ]);
+  });
+});
+
+describe("collectTtlSources when the cache is unusable", () => {
+  it("throws an actionable message when the refs root is missing", () => {
+    expect(() =>
+      collectTtlSources({ refsRoot: MISSING_ROOT, semRoot: CORPUS_SEM_ROOT }),
+    ).toThrow(/pragma refs cache not found at .*— run `pragma sources update`/);
+  });
+
+  it("throws a DIFFERENT message when the refs root is present but empty", () => {
+    // Distinguishable on purpose: "not there" and "there but you have not run
+    // the update" are different mistakes with the same remedy, and a single
+    // message would send someone looking for a directory that exists.
+    expect(() =>
+      collectTtlSources({
+        refsRoot: CORPUS_EMPTY_REFS_ROOT,
+        semRoot: CORPUS_SEM_ROOT,
+      }),
+    ).toThrow(/no \.ttl sources found under /);
+  });
+});
+
+describe("escapeChannelDottedRefs", () => {
+  it("escapes a dot-leading local name", () => {
+    expect(escapeChannelDottedRefs("ex:.foo")).toBe("ex:\\.foo");
+  });
+
+  it("leaves an ordinary prefixed name alone", () => {
+    expect(escapeChannelDottedRefs("ex:foo.bar")).toBe("ex:foo.bar");
+  });
+
+  it("leaves a dot that begins no local name alone", () => {
+    // The trailing statement dot, and a dot followed by a non-name character.
+    expect(escapeChannelDottedRefs("ex:foo .\nex:.9bad")).toBe(
+      "ex:foo .\nex:.9bad",
+    );
+  });
+
+  it("leaves the spelling inside a string literal untouched", () => {
+    // Raised in review. A backslash here would be a parse ERROR, not a
+    // harmless edit: `\\.` is not one of Turtle's string escapes, so a source
+    // whose prose merely mentions the spelling would stop parsing.
+    expect(escapeChannelDottedRefs('ex:a rdfs:comment "see ex:.foo" .')).toBe(
+      'ex:a rdfs:comment "see ex:.foo" .',
+    );
+  });
+
+  it("leaves the spelling inside an IRI reference untouched", () => {
+    // A backslash is not legal anywhere in an IRIREF.
+    expect(escapeChannelDottedRefs("<https://e.example/ex:.foo>")).toBe(
+      "<https://e.example/ex:.foo>",
+    );
+  });
+
+  it("leaves the spelling inside a comment untouched", () => {
+    expect(escapeChannelDottedRefs("# ex:.foo\nex:.foo")).toBe(
+      "# ex:.foo\nex:\\.foo",
+    );
+  });
+});
+
+describe("root resolution", () => {
+  it("prefers PRAGMA_REFS_DIR over the cache default", () => {
+    vi.stubEnv("PRAGMA_REFS_DIR", CORPUS_REFS_ROOT);
+    expect(resolveRefsRoot()).toBe(CORPUS_REFS_ROOT);
+    vi.unstubAllEnvs();
+  });
+
+  it("falls back to the pragma CLI's cache location", () => {
+    vi.stubEnv("PRAGMA_REFS_DIR", undefined);
+    expect(resolveRefsRoot()).toBe(DEFAULT_REFS_ROOT);
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers PRAGMA_SEM_DIR over the working-tree default", () => {
+    vi.stubEnv("PRAGMA_SEM_DIR", CORPUS_SEM_ROOT);
+    expect(resolveSemRoot()).toBe(CORPUS_SEM_ROOT);
+    vi.unstubAllEnvs();
+  });
+
+  it("falls back to the sibling semantics working tree", () => {
+    vi.stubEnv("PRAGMA_SEM_DIR", undefined);
+    expect(resolveSemRoot()).toBe(DEFAULT_SEM_ROOT);
+    vi.unstubAllEnvs();
+  });
+});

--- a/packages/prism/pragma-provider/src/lib/sources/collectTtlSources.ts
+++ b/packages/prism/pragma-provider/src/lib/sources/collectTtlSources.ts
@@ -1,0 +1,179 @@
+/**
+ * Walking pragma's two source roots into one ordered, escaped, filtered list.
+ *
+ * The graph compiles from TWO roots into ONE store:
+ *
+ *   1. the pragma CLI's refs cache — for each cached source package
+ *      (design-system, code-standards, anatomy-dsl), every `.ttl` under
+ *      `definitions/` and `data/`;
+ *   2. the semantics working tree — the `surface` ontology and the
+ *      `design-system-docs` graph that instantiates it: the docsite's own
+ *      demand model (jobs, coordinates, pairings, surfaces, layouts), which
+ *      the journeys lens reads.
+ *
+ * Both roots skip dot-prefixed entries (editor and channel artifacts such as
+ * `.modifier.dark.ttl` are not graph sources, and a dot-prefixed Turtle local
+ * name is not even valid RDF).
+ *
+ * WHY THIS TAKES ROOTS RATHER THAN READING THE ENVIRONMENT. In the app this
+ * function resolved `$PRAGMA_REFS_DIR` itself, which made it untestable: the
+ * only way to exercise it was to have a populated refs cache. Roots are now an
+ * argument, `resolveRefsRoot`/`resolveSemRoot` are separately testable, and
+ * the package's whole test suite runs against a checked-in corpus
+ * (`src/testing/__fixtures__/corpus`) that needs neither cache nor semantics tree.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import {
+  CHANNEL_DOTTED_REF,
+  DEFAULT_REFS_ROOT,
+  DEFAULT_SEM_ROOT,
+  EXCLUDED_SOURCES,
+  REF_NAME,
+  REF_PACKAGES,
+  SEM_PACKAGES,
+  type SourceRoots,
+  TTL_DIRS,
+  type TtlSource,
+} from "../config/index.js";
+import { mapTurtleSyntax } from "./turtleText.js";
+
+/**
+ * Escape channel-dotted local names so strict Turtle parsers accept them.
+ *
+ * Only in the document's SYNTAX. The same spelling inside an `rdfs:comment`
+ * or an `<IRIREF>` is data, and inserting a backslash there would turn a
+ * source that parses into one that does not — `\\.` is not a valid Turtle
+ * string escape, and a backslash is not valid in an IRI reference at all.
+ */
+export const escapeChannelDottedRefs = (content: string): string =>
+  mapTurtleSyntax(content, (syntax) =>
+    syntax.replace(CHANNEL_DOTTED_REF, "$1:\\."),
+  );
+
+/** The refs root: `$PRAGMA_REFS_DIR` or the pragma CLI's cache location. */
+export const resolveRefsRoot = (): string =>
+  process.env.PRAGMA_REFS_DIR ?? DEFAULT_REFS_ROOT;
+
+/** The semantics root: `$PRAGMA_SEM_DIR` or the sibling working tree. */
+export const resolveSemRoot = (): string =>
+  process.env.PRAGMA_SEM_DIR ?? DEFAULT_SEM_ROOT;
+
+/**
+ * Order sources by store-visible path.
+ *
+ * A stable, byte-deterministic order matters: the emitted SDL's field and type
+ * ordering follows the order the store saw its sources in, and the committed
+ * `schema.graphql` is a tracked file that must not churn between boots.
+ *
+ * PRECONDITION: paths are unique. A path is `<package>/<path within package>`,
+ * packages are distinct within each root and `REF_PACKAGES` and `SEM_PACKAGES`
+ * are disjoint, so two collected sources cannot share one. That is why there
+ * is no equal arm — not an oversight. An equal arm here would be dead code
+ * that no test could reach, and dead code in a comparator is a worse thing to
+ * ship than a stated precondition.
+ */
+const byPath = (a: TtlSource, b: TtlSource): number =>
+  a.path < b.path ? -1 : 1;
+
+/**
+ * The store-visible path of one collected source: `<package>/<path within the
+ * package>`, always spelled with forward slashes.
+ *
+ * `relative()` answers in the PLATFORM's separator, so on Windows this would
+ * read `design-system-docs\data\shim-concept.ttl` — a spelling that matches no
+ * `EXCLUDED_SOURCES` entry (the excluded shim would be compiled into the
+ * schema) and that sorts differently from the one every other machine
+ * produces, which the byte-deterministic source order below depends on. The
+ * separator is normalised here, once, at the point the path is minted.
+ */
+const storeVisiblePath = (label: string, base: string, full: string): string =>
+  `${label}/${relative(base, full).split(sep).join("/")}`;
+
+/** Recursively collect `*.ttl` files under a directory, skipping dotfiles. */
+export const walkTtl = (
+  dir: string,
+  base: string,
+  label: string,
+  out: TtlSource[],
+): void => {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkTtl(full, base, label, out);
+    } else if (entry.isFile() && entry.name.endsWith(".ttl")) {
+      out.push({
+        path: storeVisiblePath(label, base, full),
+        content: escapeChannelDottedRefs(readFileSync(full, "utf-8")),
+      });
+    }
+  }
+};
+
+/**
+ * Collect every TTL source across the configured ref and sem packages.
+ *
+ * @note Impure — reads the given roots from disk.
+ */
+export const collectTtlSources = ({
+  refsRoot,
+  semRoot,
+}: SourceRoots): TtlSource[] => {
+  if (!existsSync(refsRoot)) {
+    throw new Error(
+      `pragma refs cache not found at ${refsRoot} — run \`pragma sources update\` (or set PRAGMA_REFS_DIR).`,
+    );
+  }
+  const sources: TtlSource[] = [];
+  for (const pkg of REF_PACKAGES) {
+    const root = join(refsRoot, pkg, REF_NAME);
+    for (const sub of TTL_DIRS) {
+      walkTtl(join(root, sub), root, pkg, sources);
+    }
+  }
+  if (sources.length === 0) {
+    throw new Error(
+      `no .ttl sources found under ${refsRoot} — run \`pragma sources update\`.`,
+    );
+  }
+  // The second root is OPTIONAL by design — the four shipped lenses read the
+  // first root only, so a missing semantics tree must degrade rather than
+  // break. It must not degrade SILENTLY, though: its default location is a
+  // sibling working tree, which most machines do not have, and without it the
+  // whole demand model (Job, Pairing, Coordinate, Persona, Slot, Lens) is
+  // absent from the schema. A boot that says nothing is indistinguishable
+  // from a healthy one, and that is how a half-empty schema ships.
+  if (existsSync(semRoot)) {
+    for (const pkg of SEM_PACKAGES) {
+      const root = join(semRoot, pkg);
+      const before = sources.length;
+      for (const sub of TTL_DIRS) {
+        walkTtl(join(root, sub), root, pkg, sources);
+      }
+      // A root that EXISTS is not a root that answers. `PRAGMA_SEM_DIR`
+      // pointing at a partial checkout, or a package renamed upstream, leaves
+      // `walkTtl` contributing nothing while the success log below still
+      // reports a healthy boot — the same silent half-empty schema the
+      // missing-directory warning exists to prevent, arrived at by a route
+      // that check cannot see. Counted per package, so the warning names the
+      // part of the demand model that is actually absent.
+      if (sources.length === before) {
+        console.warn(
+          `[graphql] semantics package "${pkg}" contributed no .ttl sources from ${root} — the part of the demand model it carries will be absent from the schema. Check that PRAGMA_SEM_DIR names a complete semantics tree.`,
+        );
+      }
+    }
+  } else {
+    console.warn(
+      `[graphql] semantics tree not found at ${semRoot} — compiling the first source root only. The demand model (${SEM_PACKAGES.join(", ")}) will be absent from the schema. Set PRAGMA_SEM_DIR to point at it.`,
+    );
+  }
+  const collected = sources.filter(
+    (source) => !EXCLUDED_SOURCES.includes(source.path),
+  );
+  collected.sort(byPath);
+  return collected;
+};

--- a/packages/prism/pragma-provider/src/lib/sources/harvestPrefixes.test.ts
+++ b/packages/prism/pragma-provider/src/lib/sources/harvestPrefixes.test.ts
@@ -1,0 +1,89 @@
+// =============================================================================
+// Prefix harvesting from Turtle prologues.
+//
+// ke's `createStore` does not fold parsed-Turtle prefixes into
+// `store.prefixes`, so the compiler would see full IRIs and emit field names
+// derived from them. Every prefixed field name in the committed
+// `schema.graphql` depends on this function finding the declaration.
+// =============================================================================
+
+import { describe, expect, it } from "vitest";
+import { CORPUS_REFS_ROOT, CORPUS_SEM_ROOT } from "../../testing/corpus.js";
+import { collectTtlSources } from "./collectTtlSources.js";
+import { harvestPrefixes } from "./harvestPrefixes.js";
+
+const source = (content: string) => [{ path: "x.ttl", content }];
+
+describe("harvestPrefixes over the corpus", () => {
+  const prefixes = harvestPrefixes(
+    collectTtlSources({
+      refsRoot: CORPUS_REFS_ROOT,
+      semRoot: CORPUS_SEM_ROOT,
+    }),
+  );
+
+  it("harvests from both roots", () => {
+    expect(prefixes.ds).toBe("https://design.example.org/ontology#");
+    expect(prefixes.sur).toBe("sem://surface#");
+    expect(prefixes.anatomy).toBe("http://anatomy-dsl.example.org/ontology#");
+  });
+});
+
+describe("harvestPrefixes", () => {
+  it("accepts the SPARQL keyword form without the at-sign", () => {
+    expect(harvestPrefixes(source("PREFIX ex: <https://e.example/>"))).toEqual({
+      ex: "https://e.example/",
+    });
+  });
+
+  it("skips the default-namespace form", () => {
+    // `@prefix : <iri>` has no label, and an empty key would collide with
+    // every other unlabelled declaration in the corpus.
+    expect(harvestPrefixes(source("@prefix : <https://e.example/> ."))).toEqual(
+      {},
+    );
+  });
+
+  it("lets a later declaration win", () => {
+    expect(
+      harvestPrefixes([
+        { path: "a.ttl", content: "@prefix ex: <https://a.example/> ." },
+        { path: "b.ttl", content: "@prefix ex: <https://b.example/> ." },
+      ]),
+    ).toEqual({ ex: "https://b.example/" });
+  });
+
+  it("returns nothing for a prologue-free source", () => {
+    expect(harvestPrefixes(source("<a> <b> <c> ."))).toEqual({});
+  });
+
+  it("ignores a declaration that is only mentioned in a comment", () => {
+    // Raised in review. Last-wins means a retired declaration left behind as
+    // a comment would DISPLACE the live one, and the compiler would then
+    // shorten IRIs with a namespace the Turtle parser never applied.
+    expect(
+      harvestPrefixes(
+        source(
+          "@prefix ex: <https://live.example/> .\n# was @prefix ex: <https://old.example/> .",
+        ),
+      ),
+    ).toEqual({ ex: "https://live.example/" });
+  });
+
+  it("ignores a declaration quoted inside an annotation", () => {
+    expect(
+      harvestPrefixes(
+        source(
+          '@prefix ex: <https://live.example/> .\nex:a rdfs:comment "@prefix ex: <https://old.example/>" .',
+        ),
+      ),
+    ).toEqual({ ex: "https://live.example/" });
+  });
+
+  it("skips a declaration with an empty IRI", () => {
+    // `<>` parses as a group match but is not a usable namespace; letting it
+    // through would map a prefix onto the empty string and silently shorten
+    // every IRI in the store to its own text.
+    expect(harvestPrefixes(source("@prefix ex: <> ."))).toEqual({});
+  });
+});

--- a/packages/prism/pragma-provider/src/lib/sources/harvestPrefixes.ts
+++ b/packages/prism/pragma-provider/src/lib/sources/harvestPrefixes.ts
@@ -1,0 +1,32 @@
+import { PREFIX_DECL, type TtlSource } from "../config/index.js";
+import { blankTurtleProse } from "./turtleText.js";
+
+/**
+ * Merge every prefix declared in the sources' Turtle prologues.
+ *
+ * Necessary because ke's `createStore` does not fold parsed-Turtle prefixes
+ * into `store.prefixes`, and the compiler needs them to shorten IRIs into the
+ * local names that become GraphQL field names. Last declaration wins, which is
+ * sound here: pragma's corpus declares each label consistently, and a genuine
+ * conflict would surface as a renamed field in the emitted SDL rather than
+ * silently.
+ *
+ * Only real directives count. Comments and string literals are blanked first,
+ * so a retired declaration left behind as `# was @prefix ds: <old>`, or one
+ * quoted inside an annotation, cannot win the last-declaration rule and hand
+ * the compiler a namespace the Turtle parser never applied.
+ */
+export const harvestPrefixes = (
+  sources: readonly TtlSource[],
+): Record<string, string> => {
+  const prefixes: Record<string, string> = {};
+  for (const source of sources) {
+    for (const match of blankTurtleProse(source.content).matchAll(
+      PREFIX_DECL,
+    )) {
+      const [, label, iri] = match;
+      if (label && iri) prefixes[label] = iri;
+    }
+  }
+  return prefixes;
+};

--- a/packages/prism/pragma-provider/src/lib/sources/index.ts
+++ b/packages/prism/pragma-provider/src/lib/sources/index.ts
@@ -1,0 +1,14 @@
+/**
+ * The sources domain's barrel.
+ *
+ * @module sources
+ */
+
+export {
+  collectTtlSources,
+  escapeChannelDottedRefs,
+  resolveRefsRoot,
+  resolveSemRoot,
+} from "./collectTtlSources.js";
+export { harvestPrefixes } from "./harvestPrefixes.js";
+export { blankTurtleProse, mapTurtleSyntax } from "./turtleText.js";

--- a/packages/prism/pragma-provider/src/lib/sources/turtleText.test.ts
+++ b/packages/prism/pragma-provider/src/lib/sources/turtleText.test.ts
@@ -1,0 +1,73 @@
+// =============================================================================
+// Confining two text passes to a Turtle document's syntax.
+//
+// Both passes over a source — harvesting the prefix prologue and escaping
+// channel-dotted local names — are regular expressions, and a regular
+// expression cannot tell a prefixed name from the same characters inside an
+// `rdfs:comment`. The corpus is documentation prose about a graph, so those
+// characters DO appear in its annotations. These tests pin that comments,
+// string literals and IRI references are read as opaque data: never harvested
+// from, never rewritten.
+// =============================================================================
+
+import { describe, expect, it } from "vitest";
+import { blankTurtleProse, mapTurtleSyntax } from "./turtleText.js";
+
+const upper = (syntax: string) => syntax.toUpperCase();
+
+describe("mapTurtleSyntax", () => {
+  it("transforms syntax and leaves a comment alone", () => {
+    expect(mapTurtleSyntax("ab # cd\nef", upper)).toBe("AB # cd\nEF");
+  });
+
+  it("leaves each of the four string forms alone", () => {
+    expect(mapTurtleSyntax('a "b" c', upper)).toBe('A "b" C');
+    expect(mapTurtleSyntax("a 'b' c", upper)).toBe("A 'b' C");
+    expect(mapTurtleSyntax('a """b\nb""" c', upper)).toBe('A """b\nb""" C');
+    expect(mapTurtleSyntax("a '''b\nb''' c", upper)).toBe("A '''b\nb''' C");
+  });
+
+  it("leaves an escaped quote inside a string from ending it", () => {
+    expect(mapTurtleSyntax('a "b\\"c" d', upper)).toBe('A "b\\"c" D');
+  });
+
+  it("leaves an IRI reference alone", () => {
+    expect(mapTurtleSyntax("a <http://e.example/x> b", upper)).toBe(
+      "A <http://e.example/x> B",
+    );
+  });
+
+  it("does not read a hash inside an IRI reference as a comment", () => {
+    // The IRI opens first, so it swallows the `#`; `b` is still syntax.
+    expect(mapTurtleSyntax("a <http://e.example/o#t> b", upper)).toBe(
+      "A <http://e.example/o#t> B",
+    );
+  });
+
+  it("does not read a quote inside a comment as a string", () => {
+    expect(mapTurtleSyntax('a # "b\nc', upper)).toBe('A # "b\nC');
+  });
+
+  it("leaves a bare less-than that opens no IRI reference as syntax", () => {
+    expect(mapTurtleSyntax("a < b", upper)).toBe("A < B");
+  });
+});
+
+describe("blankTurtleProse", () => {
+  it("blanks a comment, keeping the newline and the offsets", () => {
+    const source = "ab # cd\nef";
+    const blanked = blankTurtleProse(source);
+    expect(blanked).toBe("ab     \nef");
+    expect(blanked).toHaveLength(source.length);
+  });
+
+  it("blanks a string literal", () => {
+    expect(blankTurtleProse('a "bc" d')).toBe("a      d");
+  });
+
+  it("keeps an IRI reference, which a directive has to match through", () => {
+    expect(blankTurtleProse("@prefix ex: <https://e.example/> .")).toBe(
+      "@prefix ex: <https://e.example/> .",
+    );
+  });
+});

--- a/packages/prism/pragma-provider/src/lib/sources/turtleText.ts
+++ b/packages/prism/pragma-provider/src/lib/sources/turtleText.ts
@@ -1,0 +1,83 @@
+/**
+ * Applying a text transform to the SYNTAX of a Turtle document only.
+ *
+ * Two things this package does to a source before the parser sees it are
+ * spelled as regular expressions over the whole file: harvesting the prefix
+ * prologue (`harvestPrefixes`) and escaping channel-dotted local names
+ * (`escapeChannelDottedRefs`). A regular expression cannot tell a prefixed
+ * name from the same characters sitting inside an `rdfs:comment`, and the
+ * corpus is full of prose annotations, so both were reading — and one was
+ * REWRITING — text that Turtle treats as opaque data. Two ways that bites:
+ *
+ *   - a commented-out or quoted declaration (`# was @prefix ds: <old>`) is
+ *     harvested, and under last-wins it can displace the real namespace, so
+ *     the compiler shortens IRIs with a mapping the parser never applied;
+ *   - a literal that merely mentions the spelling (`"see ds:.foo"`) gets a
+ *     backslash inserted into it. `\.` is not a valid Turtle string escape
+ *     and a backslash is not valid inside an `<IRIREF>` at all, so a source
+ *     that parsed before the rewrite fails to parse after it.
+ *
+ * Neither is hypothetical for a corpus whose whole purpose is documentation
+ * prose about a graph, which is why this is a scanner rather than a warning
+ * in a comment.
+ */
+
+/**
+ * The spans of a Turtle document that are NOT ordinary syntax: comments,
+ * string literals in all four quoting forms, and `<IRIREF>`s.
+ *
+ * The alternatives are ordered and the scan is left to right, so whichever
+ * span opens first swallows the rest: a `#` inside `<http://ex.org#term>`
+ * cannot start a comment, and a quote inside a comment cannot open a string.
+ * That ordering is the whole correctness argument — there is no state to keep
+ * beyond it.
+ *
+ * `<IRIREF>` uses Turtle's own exclusion set (no `<`, `>`, `"`, `{`, `}`,
+ * `|`, `^`, backtick, backslash or newline), so a bare `<` that is not an IRI
+ * simply fails the alternative and is left alone.
+ */
+const OPAQUE_SPAN =
+  /#[^\n]*|"""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*'|<[^<>"{}|^`\\\n]*>/g;
+
+/**
+ * Rewrite only the syntax of a Turtle document, leaving comments, string
+ * literals and IRI references byte-identical.
+ *
+ * `transform` is handed each run of syntax between opaque spans and returns
+ * its replacement. It sees the text in pieces, so it must not depend on
+ * matching across a span boundary — neither caller does: a prefix directive
+ * ends before the `<`, and a channel-dotted reference is a single token.
+ *
+ * @param content - The Turtle source.
+ * @param transform - Applied to each syntax run.
+ * @returns The document with `transform` applied to its syntax alone.
+ */
+export const mapTurtleSyntax = (
+  content: string,
+  transform: (syntax: string) => string,
+): string => {
+  let out = "";
+  let cursor = 0;
+  for (const match of content.matchAll(OPAQUE_SPAN)) {
+    out += transform(content.slice(cursor, match.index)) + match[0];
+    cursor = match.index + match[0].length;
+  }
+  return out + transform(content.slice(cursor));
+};
+
+/**
+ * The same document with every opaque span blanked to spaces (newlines kept,
+ * so offsets and line numbers still line up).
+ *
+ * For the reader that has to MATCH across an IRI reference rather than rewrite
+ * text — a prefix directive is `@prefix ds: <…>`, whose second half is an
+ * IRIREF — masking is the wrong tool, so this deliberately keeps IRI
+ * references intact and blanks only comments and string literals.
+ *
+ * @param content - The Turtle source.
+ * @returns The document with comments and string literals blanked.
+ */
+export const blankTurtleProse = (content: string): string =>
+  content.replace(OPAQUE_SPAN, (span) =>
+    span.startsWith("<") ? span : span.replace(/[^\n]/g, " "),
+  );

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/README.md
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/README.md
@@ -1,0 +1,37 @@
+# The hermetic corpus
+
+A hand-written Turtle corpus laid out in the exact shape `collectTtlSources`
+walks, so every property of the collector and the boot is falsifiable **without
+a populated refs cache**.
+
+This is what makes the package testable at all. Pragma's real corpus is the
+pragma CLI's refs cache (`~/.cache/pragma/refs/@canonical`, three packages,
+~400 `.ttl`) plus a semantics working tree. Neither is obtainable in CI or in a
+fresh clone, so a suite that needed them would either not exist or be skipped —
+and a skipped gate is worse than no gate. Precedent in-repo:
+`packages/runtime/ke-graphql/demo/graph.ttl` is exactly this, and that package
+holds 551 tests at 100%.
+
+## What each file is for
+
+| Path | Property it makes falsifiable |
+|---|---|
+| `refs/@canonical/design-system/main/definitions/ontology.ttl` | the first root compiles; `ds:Entity` roots the class tree the shim would smear across |
+| `refs/@canonical/design-system/main/data/instances.ttl` | instance data merges into the same store; carries a **channel-dotted reference** (`ds:.subcomponent.button-label`) that only parses because `escapeChannelDottedRefs` rewrites it |
+| `refs/@canonical/design-system/main/data/.channel.ttl` | **dot-prefixed files are skipped.** Its one triple would add a `ds:Component` named `leaked`; nothing in the collected set ever mentions it |
+| `refs/@canonical/anatomy-dsl/main/definitions/anatomy.ttl` | declares `<http://anatomy-dsl.example.org/ontology#uri>` **verbatim** — the IRI `ANATOMY_URI` names. This is the M005 collision, reproduced |
+| `sem/surface/definitions/surface.ttl` | the **second root** merges: `sem://surface#Job` yields a `Job` type the first root cannot |
+| `sem/design-system-docs/data/shim-concept.ttl` | the real `EXCLUDED_SOURCES` entry, at its real path. `ds:embodiesConcept rdfs:domain ds:Entity` is the domain smear; the collector must drop this file |
+
+`code-standards` is listed in `REF_PACKAGES` but **deliberately absent from the
+corpus**: that is what exercises `walkTtl`'s "directory does not exist" return,
+which is the state a partially-populated refs cache is actually in.
+
+## What this corpus is not
+
+It is **not** a copy of pragma's ontologies. The IRIs are `example.org` stand-ins
+except for `anatomy:uri`, which must be byte-identical to the real IRI because
+the constant under test names it. Vendoring the real ontologies into this repo
+would be a licensing and staleness problem for no test value: the properties
+under test are about the collector and the compiler, not about pragma's
+modelling.

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/anatomy-dsl/main/definitions/anatomy.ttl
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/anatomy-dsl/main/definitions/anatomy.ttl
@@ -1,0 +1,21 @@
+# THE COLLISION, reproduced.
+#
+# `<http://anatomy-dsl.example.org/ontology#uri>` is byte-identical to the real
+# anatomy DSL's property and to the `ANATOMY_URI` constant. It is an ordinary
+# owl:DatatypeProperty that maps to the GraphQL field name `uri` — which the
+# converged base reserves as the injected primary key on every Node
+# implementer. Compiling this without CUSTOM_MAPPINGS is what
+# `createPragmaProvider.test.ts` measures.
+
+@prefix anatomy: <http://anatomy-dsl.example.org/ontology#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+anatomy:NamedNode a owl:Class ;
+    rdfs:comment "Design system entity instantiable by consumers." .
+
+anatomy:uri a owl:DatatypeProperty ;
+    rdfs:domain anatomy:NamedNode ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Unique identifier for a named node within the design system." .

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/data/.channel.ttl
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/data/.channel.ttl
@@ -1,0 +1,7 @@
+# DOT-PREFIXED: an experimental-channel artifact, not a graph source. The
+# collector must never read this file. If it ever does, `ds:leaked` appears in
+# the collected set and `collectTtlSources.test.ts` goes red.
+
+@prefix ds: <https://design.example.org/ontology#> .
+
+ds:leaked a ds:Component ; ds:tier "channel" .

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/data/instances.ttl
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/data/instances.ttl
@@ -1,0 +1,12 @@
+# Instance data for the first root.
+#
+# `ds:.subcomponent.button-label` is a CHANNEL-DOTTED reference: a valid IRI
+# but invalid Turtle, since a PN_LOCAL may not start with an unescaped dot.
+# Nothing here parses unless `escapeChannelDottedRefs` rewrote it first — which
+# is the point of keeping it in the corpus.
+
+@prefix ds: <https://design.example.org/ontology#> .
+
+ds:button a ds:Component ;
+    ds:tier "core" ;
+    ds:refines ds:.subcomponent.button-label .

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/data/tokens/colors.ttl
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/data/tokens/colors.ttl
@@ -1,0 +1,8 @@
+# NESTED one level below `data/`. The collector walks recursively, and the
+# store-visible path keeps the whole relative segment
+# (`design-system/data/tokens/colors.ttl`), which is what makes an
+# EXCLUDED_SOURCES entry able to name a nested file at all.
+
+@prefix ds: <https://design.example.org/ontology#> .
+
+ds:button ds:tier "core" .

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/definitions/NOTES.md
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/definitions/NOTES.md
@@ -1,0 +1,3 @@
+Not a `.ttl`, and therefore not a source. Real refs packages carry READMEs,
+JSON manifests and lockfiles alongside their Turtle; the collector must ignore
+every one of them by extension rather than by luck.

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/definitions/ontology.ttl
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/refs/@canonical/design-system/main/definitions/ontology.ttl
@@ -1,0 +1,14 @@
+# The first root's ontology. `ds:Entity` roots the class tree — which is what
+# makes `shim-concept.ttl`'s `rdfs:domain ds:Entity` a smear rather than a
+# single field, and therefore what makes EXCLUDED_SOURCES worth having.
+
+@prefix ds: <https://design.example.org/ontology#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ds:Entity a owl:Class .
+ds:Component a owl:Class ; rdfs:subClassOf ds:Entity ;
+    rdfs:comment "A design-system entity consumers instantiate." .
+
+ds:tier a owl:DatatypeProperty ; rdfs:domain ds:Component ; rdfs:range xsd:string .

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/sem/design-system-docs/data/shim-concept.ttl
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/sem/design-system-docs/data/shim-concept.ttl
@@ -1,0 +1,17 @@
+# THE EXCLUDED SOURCE, at its real path
+# (`design-system-docs/data/shim-concept.ttl` — the literal EXCLUDED_SOURCES
+# entry).
+#
+# `ds:embodiesConcept` with `rdfs:domain ds:Entity` smears the property and its
+# inverse onto EVERY subclass of `ds:Entity` the moment both roots compile
+# together. In pragma's real corpus that is all fourteen `ds:` types; here it is
+# `ds:Component`. `collectTtlSources` must drop this file.
+
+@prefix ds: <https://design.example.org/ontology#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ds:Concept a owl:Class .
+ds:embodiesConcept a owl:ObjectProperty ;
+    rdfs:domain ds:Entity ;
+    rdfs:range ds:Concept .

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/sem/surface/definitions/surface.ttl
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/corpus/sem/surface/definitions/surface.ttl
@@ -1,0 +1,13 @@
+# The SECOND root: the docsite's own demand model, from the semantics working
+# tree rather than the refs cache. Merging it must be purely additive — it
+# contributes `Job`, and takes nothing from the first root.
+
+@prefix sur: <sem://surface#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+sur:Job a owl:Class ;
+    rdfs:comment "A job the consumer is trying to get done." .
+
+sur:jobLabel a owl:DatatypeProperty ; rdfs:domain sur:Job ; rdfs:range xsd:string .

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/schemaBeforeSecondRoot.sdl.txt
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/schemaBeforeSecondRoot.sdl.txt
@@ -1,0 +1,1610 @@
+# ==========================================================================
+# The schema at `aea674000`, from the refs cache alone — the first root only.
+# 90 top-level definitions. It carries no trace of the second root's surface
+# namespace — an absence the additivity test asserts by substring, so nothing
+# added to this comment block may spell that namespace out.
+#
+# THESE CAPTURES PREDATE THE CONVERGED BASE. Measured at pragma 4d228c8
+# against @canonical/prism-contract: 12 violations, and the identical set in
+# both files — Node._meta absent; Node.uri is String! not ID!; no
+# EntityMeta.curie / .title / .label / .comment / .definition; OntologyClass
+# neither carries _meta nor implements Node; no ClassProperty.name;
+# OntologyProperty.uri kind change. They still declare
+# `interface Node { id: ID!  uri: String! }` and contain no `curie` at all.
+# The live committed apps/react/pragma-docs/src/relay/schema.graphql, by
+# contrast, satisfies the contract with ZERO violations.
+#
+# THEY ARE KEPT ANYWAY, AND THE TEST THEY BACK IS STILL MEANINGFUL. The
+# property asserted by ../integration/sourceAdditivity.test.ts is ADDITIVITY OF
+# THE SECOND SOURCE ROOT — every pre-merge type keeps every field — and that
+# is a property of the SOURCE SET, orthogonal to the structural head. The type
+# inventory has not drifted: schemaWithSecondRoot.sdl.txt carries 183
+# top-level definitions, exactly the count of the live committed schema.
+# Both sides of the comparison are equally stale, so the property still holds
+# and still means something.
+#
+# THEY CANNOT BE REGENERATED HERE. Regeneration needs the full three-package
+# refs cache; the design-system corpus is not obtainable in the authoring
+# environment, and a capture taken from a PARTIAL cache is worse than a stale
+# one because it looks current. Regenerate only on a machine with
+# `pragma sources update` completed AND the semantics tree present — once with
+# both roots, once without — and say so in the commit that does. A fresh
+# capture will not carry these comment lines; re-add them or delete them
+# deliberately, do not lose the measurement by accident.
+#
+# WHAT THIS LEAVES OPEN, AND WHAT DOES NOT CLOSE IT.
+# ../integration/committedSdl.test.ts checks the schema the app SHIPS — the
+# committed `schema.graphql` — against the live contract on every run, so the
+# structural head these captures are stale against is measured somewhere. It
+# reads a COMMITTED artifact, not a live one: it cannot see that file drift
+# from what `createPragmaProvider` would emit today, and neither can this
+# capture. Closing that second gap needs a boot with a populated refs cache.
+# That test's own header states the same limit; do not read either as covering
+# live-output drift.
+#
+# (Lines beginning `#` are GraphQL comments, added by hand when these files
+# moved out of the docsite app. Everything below this block is the capture.)
+#
+# ==========================================================================
+
+"""
+Directs the executor to defer this fragment when the `if` argument is true or undefined.
+"""
+directive @defer(
+  """Deferred when true or undefined."""
+  if: Boolean! = true
+
+  """Unique name"""
+  label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"""
+Directs the executor to stream plural fields when the `if` argument is true or undefined.
+"""
+directive @stream(
+  """Number of items to return immediately"""
+  initialCount: Int! = 0
+
+  """Stream when true or undefined."""
+  if: Boolean! = true
+
+  """Unique name"""
+  label: String
+) on FIELD
+
+"""
+A single dated record of a change to a UIBlock, with a timestamp, the change description, an owner, an optional GitHub link, and a change type.
+"""
+type ChangeLogEntry {
+  """The category of change (e.g. change, addition, deprecation)"""
+  changeType: String
+
+  """Optional link to a GitHub issue, PR or discussion for this change"""
+  githubLink: String
+
+  """The person responsible for the change"""
+  owner: String
+
+  """Human-readable description of what changed"""
+  change: String
+
+  """The date and time at which the change was recorded"""
+  timestamp: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A facet that groups related Tags (e.g. 'documentation stage', 'review status', 'channel', 'implementation status').
+"""
+type TagCategory implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+interface Node {
+  id: ID!
+  uri: String!
+}
+
+"""
+A controlled-vocabulary label applied to a UIBlock. Tags are grouped into facets by their category (e.g. 'documentation stage', 'review status', 'channel', 'implementation status'). The category-typed views over this vocabulary are tracked as future work; for now a Tag carries its name, category, and apply/remove guidance.
+"""
+type Tag implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The category (facet) a Tag belongs to, e.g. documentation stage, review status, channel, implementation status
+  """
+  categories(first: Int, after: String, last: Int, before: String): TagCategoryConnection!
+
+  """
+  Guidance on the conditions under which this tag should be removed from a UI Block
+  """
+  whenToRemove: String
+
+  """
+  Guidance on the conditions under which this tag should be applied to a UI Block
+  """
+  whenToApply: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type TagCategoryConnection {
+  edges: [TagCategoryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TagCategoryEdge {
+  node: TagCategory!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+"""
+A code library or package that provides platform-specific implementations of UIBlocks
+"""
+type ImplementationLibrary implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The design system tier that this library implements"""
+  libraryTiers(first: Int, after: String, last: Int, before: String): TierConnection!
+
+  """Documentation link if different from main artifact"""
+  documentation: String
+
+  """URL to the library's main artifact or repository"""
+  link: String
+
+  """
+  The platform or technology this library targets (e.g. React, Web Components, Flutter)
+  """
+  platform: String
+
+  """The package or library name as published (e.g. npm package name)"""
+  libraryName: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type TierConnection {
+  edges: [TierEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TierEdge {
+  node: Tier!
+  cursor: String!
+}
+
+"""Platform-specific implementation of a UI Block"""
+type ImplementationObject implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The implementation library that contains this implementation"""
+  library: ImplementationLibrary
+
+  """The UIBlock that this implementation realises in code"""
+  implementsBlock: UIBlock
+
+  """
+  Whether this implementation is in draft state and not yet ready for production use
+  """
+  draft: Boolean
+
+  """
+  URL to a specific tagged version of this implementation in source control
+  """
+  versionedLink: String
+
+  """
+  URL to the latest/HEAD version of this implementation in source control
+  """
+  headLink: String
+
+  """
+  Version of this specific implementation, independent of the UIBlock version
+  """
+  implementationVersion: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A scope level in the design system hierarchy that determines where UIBlocks are intended to be used (e.g. global, apps, site)
+"""
+type Tier implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A configurable property of a UI Block"""
+type Property {
+  """
+  Constraints on valid values for this property. For choice types, lists allowed values (e.g. '[primary, secondary, tertiary]'). For numbers, specifies ranges. For objects, describes required structure.
+  """
+  constraints: String
+
+  """
+  The default value for this property when not explicitly set by the consumer
+  """
+  defaultValue: String
+
+  """Whether this property is optional when configuring the UI Block"""
+  optional: Boolean
+
+  """
+  The data type of this configurable property (e.g. text, choice, boolean, node)
+  """
+  propertyType: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A grouping of related modifiers that can be applied to UI Blocks"""
+type ModifierFamily implements Node & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Modifiers belonging to this modifier family"""
+  modifiers(first: Int, after: String, last: Int, before: String): ModifierConnection!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type ModifierConnection {
+  edges: [ModifierEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ModifierEdge {
+  node: Modifier!
+  cursor: String!
+}
+
+"""
+A named variant value within a ModifierFamily that alters the appearance or behaviour of a UIBlock (e.g. 'primary', 'secondary' within the 'importance' family)
+"""
+type Modifier implements Node & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The modifier family to which this modifier belongs"""
+  modifierFamily: ModifierFamily
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A collection UIBlock: a container that arranges multiple instances of a single sibling UIBlock (typically a Component) as a repeating series. The plural counterpart of a singular Component (e.g. Cards groups Card units, Tiles groups Tile units), responsible for their shared layout rather than for any content of its own.
+"""
+type Group implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type UIBlockConnection {
+  edges: [UIBlockEdge!]!
+  pageInfo: PageInfo!
+}
+
+type UIBlockEdge {
+  node: UIBlock!
+  cursor: String!
+}
+
+type TagConnection {
+  edges: [TagEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TagEdge {
+  node: Tag!
+  cursor: String!
+}
+
+type ModifierFamilyConnection {
+  edges: [ModifierFamilyEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ModifierFamilyEdge {
+  node: ModifierFamily!
+  cursor: String!
+}
+
+"""
+A named part of a Component that has design-system identity but is typically not used independently outside its parent
+"""
+type Subcomponent implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The component to which this subcomponent structurally belongs"""
+  parentComponents(first: Int, after: String, last: Int, before: String): ComponentConnection!
+
+  """
+  Whether this subcomponent can be used independently outside its parent component
+  """
+  standalone: Boolean
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type ComponentConnection {
+  edges: [ComponentEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ComponentEdge {
+  node: Component!
+  cursor: String!
+}
+
+"""
+Layouts are an opinionated division of space to navigate a domain of information.
+"""
+type Layout implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Device form factors this layout targets"""
+  targetDevices: String
+
+  """Named CSS grid areas defined by this layout"""
+  gridAreas: String
+
+  """The information domain this layout is designed to navigate"""
+  domain: String
+
+  """CSS grid template definition for this layout"""
+  grid: String
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A reusable solution to a recurring user problem in a specific context"""
+type Pattern implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+An implementable piece of user interface defined by its appearance and behaviour
+"""
+type Component implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Subcomponents that are structural parts of this component"""
+  subcomponents(first: Int, after: String, last: Int, before: String): SubcomponentConnection!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type SubcomponentConnection {
+  edges: [SubcomponentEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SubcomponentEdge {
+  node: Subcomponent!
+  cursor: String!
+}
+
+"""
+A single do or don't example with a description, optional language tag, and optional code block
+"""
+type Example implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The code content of the example"""
+  code: String
+
+  """
+  The programming language of the example code block (e.g., 'typescript', 'rust', 'css', 'bash', 'svg', 'turtle')
+  """
+  language: String
+
+  """A general description of the code standard or example"""
+  description: String
+}
+
+"""
+A category for grouping related code standards (e.g., testing, components, react, typescript)
+"""
+type Category implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """A general description of the code standard or example"""
+  description: String
+
+  """
+  A short identifier for the category or standard, used for domain annotation.
+  """
+  slug: String
+}
+
+"""A coding standard or best practice guideline for software development"""
+type CodeStandard implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """A negative example showing what should not be done"""
+  donts(first: Int, after: String, last: Int, before: String): ExampleConnection!
+
+  """A positive example showing what should be done"""
+  dos(first: Int, after: String, last: Int, before: String): ExampleConnection!
+
+  """
+  Associates a code standard with another standard that it extends or adds further context to
+  """
+  extends(first: Int, after: String, last: Int, before: String): CodeStandardConnection!
+
+  """Associates a code standard with its category"""
+  categories(first: Int, after: String, last: Int, before: String): CategoryConnection!
+
+  """A general description of the code standard or example"""
+  description: String
+
+  """
+  An optional human-readable display title for a code standard. This is not an identifier and must not duplicate the canonical role of the subject IRI.
+  """
+  name: String
+}
+
+type ExampleConnection {
+  edges: [ExampleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ExampleEdge {
+  node: Example!
+  cursor: String!
+}
+
+type CodeStandardConnection {
+  edges: [CodeStandardEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CodeStandardEdge {
+  node: CodeStandard!
+  cursor: String!
+}
+
+type CategoryConnection {
+  edges: [CategoryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CategoryEdge {
+  node: Category!
+  cursor: String!
+}
+
+"""One alternative within a Switch."""
+type SwitchCase implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Node this case resolves to."""
+  caseNode: AnatomyNode
+}
+
+"""Polymorphic position admitting several alternatives."""
+type Switch implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """An alternative within this switch."""
+  cases(first: Int, after: String, last: Int, before: String): SwitchCaseConnection!
+
+  """What determines which case applies."""
+  discriminator: String
+}
+
+type SwitchCaseConnection {
+  edges: [SwitchCaseEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SwitchCaseEdge {
+  node: SwitchCase!
+  cursor: String!
+}
+
+"""A single style declaration binding a property key to a value."""
+type Style implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Value for a style property."""
+  styleValue: String
+
+  """Platform-agnostic style property identifier."""
+  styleKey: String
+}
+
+"""Metadata qualifying a parent-child relationship."""
+type Relation implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Named slot in the parent that this child maps to."""
+  slotName: String
+
+  """Instance count constraint on the child."""
+  cardinality: String
+}
+
+"""Reified parent-child relationship in the anatomy tree."""
+type Edge implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Polymorphic switch this edge connects to."""
+  edgeSwitch: Switch
+
+  """Child node this edge connects to."""
+  edgeTarget: AnatomyNode
+
+  """Relation qualifying this edge."""
+  relation: Relation
+}
+
+"""Structural element without design system identity."""
+type AnonymousNode implements Node & AnatomyNode {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Human-readable purpose of an anonymous node."""
+  role: String
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+type StyleConnection {
+  edges: [StyleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type StyleEdge {
+  node: Style!
+  cursor: String!
+}
+
+type EdgeConnection {
+  edges: [EdgeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type EdgeEdge {
+  node: Edge!
+  cursor: String!
+}
+
+"""Design system entity instantiable by consumers."""
+type NamedNode implements Node & AnatomyNode {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Unique identifier for a named node within the design system."""
+  anatomyUri: String
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+"""Root of an anatomy file."""
+type Specification implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Top-level node of an anatomy specification."""
+  rootNode: NamedNode
+}
+
+"""
+A category of visual or abstract entity that fulfills a particular role in composing user interfaces
+"""
+interface UIBlock implements Node & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""Base class for all visual and interactive design system elements"""
+interface UIElement implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+Abstract root class for all design system entities. Provides common properties (name, summary) inherited by all classes.
+"""
+interface Entity implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""Position in the anatomy tree."""
+interface AnatomyNode implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+"""Self-describing TBox access attached to ABox types."""
+type EntityMeta {
+  type: OntologyClass!
+  field(name: String!): ClassProperty
+  fields: [ClassProperty!]!
+}
+
+type OntologyClass {
+  uri: String!
+  label: String
+  definition: String
+  superclass: OntologyClass
+  superclasses: [OntologyClass!]!
+  subclasses: [OntologyClass!]!
+  properties: [ClassProperty!]!
+
+  """
+  Named instances of this class (blank-node instances are embeddable and not standalone-resolvable).
+  """
+  instances(first: Int, after: String, last: Int, before: String): NodeConnection!
+
+  """Count of NAMED instances (matches `instances`)."""
+  instanceCount: Int!
+  isAbstract: Boolean!
+  namespace: String!
+}
+
+"""
+Class-scoped view of a property: SHACL cardinality is a fact about a (class, property) pair.
+"""
+type ClassProperty {
+  property: OntologyProperty!
+  required: Boolean!
+  singular: Boolean!
+  inherited: Boolean!
+}
+
+type OntologyProperty {
+  uri: String!
+  label: String
+  definition: String
+  domain: OntologyClass
+  range: String!
+  kind: PropertyKind!
+  functional: Boolean!
+  inverse: OntologyProperty
+  acceptanceCriteria: String
+  completionGuidance: String
+  namespace: String!
+}
+
+enum PropertyKind {
+  DATATYPE
+  OBJECT
+  ANNOTATION
+}
+
+type NodeConnection {
+  edges: [NodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NodeEdge {
+  node: Node!
+  cursor: String!
+}
+
+type Query {
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+
+  """Relay node resolution by prefixed-URI global ID."""
+  node(id: ID!): Node
+  tagCategory(uri: String!): TagCategory
+  tagCategories(first: Int, after: String, last: Int, before: String): TagCategoryConnection!
+  tag(uri: String!): Tag
+  tags(first: Int, after: String, last: Int, before: String): TagConnection!
+  implementationLibrary(uri: String!): ImplementationLibrary
+  implementationLibraries(first: Int, after: String, last: Int, before: String): ImplementationLibraryConnection!
+  implementationObject(uri: String!): ImplementationObject
+  implementationObjects(first: Int, after: String, last: Int, before: String): ImplementationObjectConnection!
+  tier(uri: String!): Tier
+  tiers(first: Int, after: String, last: Int, before: String): TierConnection!
+  modifierFamily(uri: String!): ModifierFamily
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+  modifier(uri: String!): Modifier
+  modifiers(first: Int, after: String, last: Int, before: String): ModifierConnection!
+  group(uri: String!): Group
+  groups(first: Int, after: String, last: Int, before: String): GroupConnection!
+  subcomponent(uri: String!): Subcomponent
+  subcomponents(first: Int, after: String, last: Int, before: String): SubcomponentConnection!
+  layout(uri: String!): Layout
+  layouts(first: Int, after: String, last: Int, before: String): LayoutConnection!
+  pattern(uri: String!): Pattern
+  patterns(first: Int, after: String, last: Int, before: String): PatternConnection!
+  component(uri: String!): Component
+  components(first: Int, after: String, last: Int, before: String): ComponentConnection!
+  example(uri: String!): Example
+  examples(first: Int, after: String, last: Int, before: String): ExampleConnection!
+  category(uri: String!): Category
+  categories(first: Int, after: String, last: Int, before: String): CategoryConnection!
+  codeStandard(uri: String!): CodeStandard
+  codeStandards(first: Int, after: String, last: Int, before: String): CodeStandardConnection!
+  switchCase(uri: String!): SwitchCase
+  switchCases(first: Int, after: String, last: Int, before: String): SwitchCaseConnection!
+  switch(uri: String!): Switch
+  switches(first: Int, after: String, last: Int, before: String): SwitchConnection!
+  style(uri: String!): Style
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+  relation(uri: String!): Relation
+  relations(first: Int, after: String, last: Int, before: String): RelationConnection!
+  edge(uri: String!): Edge
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+  anonymousNode(uri: String!): AnonymousNode
+  anonymousNodes(first: Int, after: String, last: Int, before: String): AnonymousNodeConnection!
+  namedNode(uri: String!): NamedNode
+  namedNodes(first: Int, after: String, last: Int, before: String): NamedNodeConnection!
+  specification(uri: String!): Specification
+  specifications(first: Int, after: String, last: Int, before: String): SpecificationConnection!
+}
+
+type Ontology {
+  prefix: String!
+  namespace: String!
+  label: String
+  classes: [OntologyClass!]!
+  properties: [OntologyProperty!]!
+}
+
+type ImplementationLibraryConnection {
+  edges: [ImplementationLibraryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ImplementationLibraryEdge {
+  node: ImplementationLibrary!
+  cursor: String!
+}
+
+type ImplementationObjectConnection {
+  edges: [ImplementationObjectEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ImplementationObjectEdge {
+  node: ImplementationObject!
+  cursor: String!
+}
+
+type GroupConnection {
+  edges: [GroupEdge!]!
+  pageInfo: PageInfo!
+}
+
+type GroupEdge {
+  node: Group!
+  cursor: String!
+}
+
+type LayoutConnection {
+  edges: [LayoutEdge!]!
+  pageInfo: PageInfo!
+}
+
+type LayoutEdge {
+  node: Layout!
+  cursor: String!
+}
+
+type PatternConnection {
+  edges: [PatternEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PatternEdge {
+  node: Pattern!
+  cursor: String!
+}
+
+type SwitchConnection {
+  edges: [SwitchEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SwitchEdge {
+  node: Switch!
+  cursor: String!
+}
+
+type RelationConnection {
+  edges: [RelationEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RelationEdge {
+  node: Relation!
+  cursor: String!
+}
+
+type AnonymousNodeConnection {
+  edges: [AnonymousNodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AnonymousNodeEdge {
+  node: AnonymousNode!
+  cursor: String!
+}
+
+type NamedNodeConnection {
+  edges: [NamedNodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NamedNodeEdge {
+  node: NamedNode!
+  cursor: String!
+}
+
+type SpecificationConnection {
+  edges: [SpecificationEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SpecificationEdge {
+  node: Specification!
+  cursor: String!
+}

--- a/packages/prism/pragma-provider/src/testing/__fixtures__/schemaWithSecondRoot.sdl.txt
+++ b/packages/prism/pragma-provider/src/testing/__fixtures__/schemaWithSecondRoot.sdl.txt
@@ -1,0 +1,4746 @@
+# ==========================================================================
+# The schema with BOTH roots compiled — what the journeys lens read TWO
+# CONVERGENCES AGO. 183 top-level definitions.
+#
+# THESE CAPTURES PREDATE THE CONVERGED BASE. Measured at pragma 4d228c8
+# against @canonical/prism-contract: 12 violations, and the identical set in
+# both files — Node._meta absent; Node.uri is String! not ID!; no
+# EntityMeta.curie / .title / .label / .comment / .definition; OntologyClass
+# neither carries _meta nor implements Node; no ClassProperty.name;
+# OntologyProperty.uri kind change. They still declare
+# `interface Node { id: ID!  uri: String! }` and contain no `curie` at all.
+# The live committed apps/react/pragma-docs/src/relay/schema.graphql, by
+# contrast, satisfies the contract with ZERO violations.
+#
+# THEY ARE KEPT ANYWAY, AND THE TEST THEY BACK IS STILL MEANINGFUL. The
+# property asserted by ../integration/sourceAdditivity.test.ts is ADDITIVITY OF
+# THE SECOND SOURCE ROOT — every pre-merge type keeps every field — and that
+# is a property of the SOURCE SET, orthogonal to the structural head. The type
+# inventory has not drifted: schemaWithSecondRoot.sdl.txt carries 183
+# top-level definitions, exactly the count of the live committed schema.
+# Both sides of the comparison are equally stale, so the property still holds
+# and still means something.
+#
+# THEY CANNOT BE REGENERATED HERE. Regeneration needs the full three-package
+# refs cache; the design-system corpus is not obtainable in the authoring
+# environment, and a capture taken from a PARTIAL cache is worse than a stale
+# one because it looks current. Regenerate only on a machine with
+# `pragma sources update` completed AND the semantics tree present — once with
+# both roots, once without — and say so in the commit that does. A fresh
+# capture will not carry these comment lines; re-add them or delete them
+# deliberately, do not lose the measurement by accident.
+#
+# WHAT THIS LEAVES OPEN, AND WHAT DOES NOT CLOSE IT.
+# ../integration/committedSdl.test.ts checks the schema the app SHIPS — the
+# committed `schema.graphql` — against the live contract on every run, so the
+# structural head these captures are stale against is measured somewhere. It
+# reads a COMMITTED artifact, not a live one: it cannot see that file drift
+# from what `createPragmaProvider` would emit today, and neither can this
+# capture. Closing that second gap needs a boot with a populated refs cache.
+# That test's own header states the same limit; do not read either as covering
+# live-output drift.
+#
+# (Lines beginning `#` are GraphQL comments, added by hand when these files
+# moved out of the docsite app. Everything below this block is the capture.)
+#
+# ==========================================================================
+
+"""
+Directs the executor to defer this fragment when the `if` argument is true or undefined.
+"""
+directive @defer(
+  """Deferred when true or undefined."""
+  if: Boolean! = true
+
+  """Unique name"""
+  label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"""
+Directs the executor to stream plural fields when the `if` argument is true or undefined.
+"""
+directive @stream(
+  """Number of items to return immediately"""
+  initialCount: Int! = 0
+
+  """Stream when true or undefined."""
+  if: Boolean! = true
+
+  """Unique name"""
+  label: String
+) on FIELD
+
+"""
+Why an item is no longer (or never was) live: Superseded, Deprecated, Cancelled, Rejected (data/validities.ttl). Invalid items STAY in the graph with a mandatory note — the know-your-neighbour rule: anyone who finds the node learns its fate and its reason. Distinct from deferred (still wanted, consciously parked) and from assume:status (the epistemics of assumptions). Absence of validity means live.
+"""
+type Validity implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+interface Node {
+  id: ID!
+  uri: String!
+}
+
+type LensConnection {
+  edges: [LensEdge!]!
+  pageInfo: PageInfo!
+}
+
+type LensEdge {
+  node: Lens!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type ValidityConnection {
+  edges: [ValidityEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ValidityEdge {
+  node: Validity!
+  cursor: String!
+}
+
+type SlotConnection {
+  edges: [SlotEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SlotEdge {
+  node: Slot!
+  cursor: String!
+}
+
+type LayoutConnection {
+  edges: [LayoutEdge!]!
+  pageInfo: PageInfo!
+}
+
+type LayoutEdge {
+  node: Layout!
+  cursor: String!
+}
+
+type RegionConnection {
+  edges: [RegionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RegionEdge {
+  node: Region!
+  cursor: String!
+}
+
+type CapabilityConnection {
+  edges: [CapabilityEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CapabilityEdge {
+  node: Capability!
+  cursor: String!
+}
+
+type JobConnection {
+  edges: [JobEdge!]!
+  pageInfo: PageInfo!
+}
+
+type JobEdge {
+  node: Job!
+  cursor: String!
+}
+
+type SubstrateConnection {
+  edges: [SubstrateEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SubstrateEdge {
+  node: Substrate!
+  cursor: String!
+}
+
+"""
+The result of walking an exemplar: Renders (completes cleanly), Ceremony (completes but awkwardly — a friction worth recording), Wall (cannot complete — a real gap). Instances in data/verdicts.ttl. A verdict is dated and cites the surfaces walked; re-walking on a spec change is the regression test.
+"""
+type Verdict implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A worked story walked against the specification to a verdict — the sufficiency test that jobs (existence) and bets (assumption) cannot give. Where the no-job-no-element law grounds why a surface exists, an exemplar grounds whether the surfaces a job touches actually let a real person complete it. A story that cannot complete across a job's served surfaces is a WALL found before anything is built; one that completes only awkwardly is CEREMONY; one that completes cleanly RENDERS. Ported from the source falsification traditions (mriya's CLEAN/PIN/BREAK, the docsite's pilot go/no-go).
+"""
+type Exemplar implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """How the walk came out: Renders, Ceremony, or Wall."""
+  verdict: Verdict
+
+  """
+  The surface(s) the story passes through — what a Wall or Ceremony verdict indicts, and what a spec change must re-walk.
+  """
+  walksSurfaces(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The job(s) this exemplar exercises — the demand it puts under load. Multi-valued: the strongest exemplars walk several jobs in one story.
+  """
+  walksJobs(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What the walk revealed — the wall's location, the ceremony's friction, or the clean-completion note. The reason the exemplar is kept.
+  """
+  finding: String
+
+  """
+  The story, walked step by step — what the person does, in order, against the named surfaces.
+  """
+  narratives: [String!]!
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+type SurfaceConnection {
+  edges: [SurfaceEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SurfaceEdge {
+  node: Surface!
+  cursor: String!
+}
+
+"""
+A named, reusable discipline of well-specified surfaces — the distilled cross-corpus rules (one substrate many projections; every word has one home; four states or it doesn't ship). Laws are cited by grammars (grammar:law) and instantiated by project rulings (assume:derivedFrom). A sibling of Axiom and Heuristic under assume:Assumption, deliberately outside their id/phase regimes: laws are timeless, not scheduled.
+"""
+type Law implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A falsifiable design assumption with a named test or kill-criterion — the third species of assumption beside the hard axiom and the soft heuristic. A bet without a kill-criterion is an opinion. Bets live in one shared ledger; jobs reference them by id; ids are stable and never renumbered (gaps mean retired bets). Modal character: P? — wagered, awaiting evidence.
+"""
+type Bet implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The prior, 0..1 — how strongly the bet is believed before the instrument reports (D28). A ledger you can be measurably wrong about builds judgment; scoring recorded confidence against outcomes is calibration. Distinct from assume:status (the epistemic state); this is the number.
+  """
+  confidence: Float
+
+  """
+  The concrete instrument that arms this bet — the thing that must exist and run to produce the evidence (a CI job, referrer analytics, a parity diff). A bet with a test but no instrument names a kill-criterion nobody is measuring; naming the instrument is what makes an armed bet continuously tested (D28).
+  """
+  instruments: [String!]!
+
+  """The test or kill-criterion that would validate or kill this bet."""
+  test: String
+}
+
+"""
+A layout's declaration of a region: which region, whether required, and — if optional — WHICH JOB SUMMONS IT (shape F8: no job, no region). One canvas always; everything else earns its slot. Layouts themselves are ds:Layout instances, reused directly (D12), carrying ds:grid/ds:name; surface adds the slot-and-demand layer ds lacks.
+"""
+type Slot implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  The job that summons this optional slot into existence. The load-bearing traceability rule of layout: no job → the region does not exist there. What keeps layout job-derived rather than template-derived.
+  """
+  summonedBies(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """The region kind this slot instantiates."""
+  ofRegion: Region
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  Always present (true) or optional (false). Optional slots MUST name their summoning job — the grid collapses over undemanded regions.
+  """
+  required: Boolean
+}
+
+"""
+A typed slot kind, one shared vocabulary so 'where is it' means the same thing on every surface (canvas, rails, controls, status, aside…). Base instances in data/regions.ttl; projects extend (mriya adds rail). A region type never changes side — the compass is part of the stationary frame.
+"""
+type Region implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+The reified job↔surface edge: THIS job reaches THIS surface, as primary or secondary, arriving with THIS preservation (curated surfaces only — ports take no arrival). The set of a job's pairings is how the spec answers 'is this job served, and at what cost'.
+"""
+type Pairing implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """Primary or Secondary."""
+  pairingRole: PairingRole
+
+  """
+  What this arrival preserves. Required for curated surfaces; absent for ports (shape F7).
+  """
+  arrivals(first: Int, after: String, last: Int, before: String): PreservationConnection!
+
+  """The surface the job reaches."""
+  pairsSurface: Surface
+
+  """The job this pairing serves."""
+  forJob: Job
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+type PreservationConnection {
+  edges: [PreservationEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PreservationEdge {
+  node: Preservation!
+  cursor: String!
+}
+
+"""
+Whether a pairing is the job's Primary serving surface or a Secondary route. Instances in data/arrivals.ttl.
+"""
+type PairingRole implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+What an arrival keeps, ordered by reorientation cost: ColdEntry(4) keeps nothing; SubjectKept(3) keeps the subject; ViewKept(2) keeps view and subject; NoMove(1) is in-place reach. Pure edge vocabulary — the ex-grade, minus the abolished CallGrade (invocability is a node fact). Instances in data/arrivals.ttl.
+"""
+type Preservation implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  Cost rank of the arrival, 4 (cold) to 1 (in place). Lets coverage ask: is a job whose story says 'without context-switching' really served at order 4?
+  """
+  reorientationOrder: Int
+}
+
+"""
+The invocable surface: where machine consumers call instead of look — API, MCP, CLI. Exposes capabilities directly; it curates nothing, so it has no slice (shape F6 forbids one), and pairings to it carry no arrival (agents have no reorientation to preserve).
+"""
+type Port implements Node & Surface {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  What is callable at this port. Expose the passable units (bundles) rather than raw verbs — handles do the granting. A capability serving an agent-inclusive job but exposed on no port is unreachable by its own demand: the bi-modality gap, one query.
+  """
+  exposes(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The protocol(s) this port speaks (MCP, GraphQL, CLI, a control socket).
+  """
+  protocol: String
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+type PairingConnection {
+  edges: [PairingEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PairingEdge {
+  node: Pairing!
+  cursor: String!
+}
+
+type AnchoringConnection {
+  edges: [AnchoringEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AnchoringEdge {
+  node: Anchoring!
+  cursor: String!
+}
+
+type DirectionConnection {
+  edges: [DirectionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type DirectionEdge {
+  node: Direction!
+  cursor: String!
+}
+
+type RenderingConnection {
+  edges: [RenderingEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RenderingEdge {
+  node: Rendering!
+  cursor: String!
+}
+
+"""
+A standalone writing surface you dwell in: authoring against the substrate at large rather than at one subject.
+"""
+type Editor implements Node & Surface {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+An anchored writing surface: where a consumer puts value INTO the substrate at a subject — the run's composer, a proposal form on an entity. The write quadrant the kind-enum scheme could not express.
+"""
+type ComposerSurface implements Node & Surface {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+A View woven through everything: inline mentions, status glyphs. Its pairings arrive at NoMove — reaching it costs nothing, which is its entire point.
+"""
+type Mechanism implements Node & Surface {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+A View you pass through: preview without commitment, one step back up. Its pairings typically arrive at SubjectKept.
+"""
+type Peek implements Node & Surface {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+A View you dwell in: one entity in depth — the entity page, the spec sheet. Its pairings typically arrive at ColdEntry (deeplinks) or SubjectKept.
+"""
+type Detail implements Node & Surface {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+An anchored reading surface — curated, read-facing, subject-bound: it shows something OF something. Whether it is ambient (chips), transient (a peek), or dwelt-in (a detail page) is not a node fact: it shows in its pairings' arrivals.
+"""
+type View implements Node & Surface {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+A way of looking at the substrate, tuned for one kind of task: curated, read-facing, standalone. You don't navigate into a lens like a folder — you switch lenses and the same entities re-present. A lens without a slice is a folder (shape F5).
+"""
+type Lens implements Node & Surface {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """The job that orders this lens's space — not role, not alphabet."""
+  dominantJobs(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The shape of looking this lens is tuned for — the clustering key that derived it from the jobs (entity browsing, narrative reading, live record…).
+  """
+  kindOfLooking: String
+
+  """
+  Which slice of the substrate this lens projects. No lens shows the whole substrate; a lens without a slice is a folder.
+  """
+  slice: String
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+}
+
+"""
+Whether the surface is coherent standalone (Free) or meaningless without a subject (SubjectBound — a peek OF something).
+"""
+type Anchoring implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+Which way value flows at this surface: ReadFace (consumer takes) or WriteFace (consumer puts). Multi-valued — a surface may carry both.
+"""
+type Direction implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+What the surface does with the substrate: Curated (re-presents a chosen slice for perception) or Invocable (exposes operations for calling). Instances in data/dimensions.ttl.
+"""
+type Rendering implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+The species of authority a capability requires. Base instances (data/authority-families.ttl): read, observe, write, control, genesis. Projects extend with their own families (freefold adds ingress, derive, operator). Reachability and authorization are two layers: authority flows through handles, but write-authorization is checked at the target regardless of which handle called.
+"""
+type AuthorityFamily implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A named, grantable operation over the substrate — the unit of 'what the system can do'. Verbs in a grammar name capabilities; projections bind them; channels expose them to machine consumers. Object-capability shaped: authority flows through whoever hands you the handle; bundles compose capabilities; attenuation only narrows (the derived capability's authority is a subset of its parent's).
+"""
+type Capability implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  This capability is a narrowing of another: same operations over less (fewer names, fewer targets), authority a subset of the parent's. Attenuation is the only sanctioned derivation of authority — it never widens.
+  """
+  attenuates(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  This capability is a thin bundle over the listed capabilities (a reader bundles read + snapshot + follow; a controller bundles deliver + lifecycle). Bundles exist to pass and attenuate scoped authority, never to add operations.
+  """
+  bundles(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The authority families this capability needs (multi-valued). Authority is explicit, never ambient.
+  """
+  requiresAuthorities(first: Int, after: String, last: Int, before: String): AuthorityFamilyConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """
+  The capability's data contract: the query, signature, or verb form that every face of the surface binds. One contract, two faces — the human projection and the machine tool carry the same one, so they cannot drift.
+  """
+  contract: String
+}
+
+type AuthorityFamilyConnection {
+  edges: [AuthorityFamilyEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AuthorityFamilyEdge {
+  node: AuthorityFamily!
+  cursor: String!
+}
+
+"""
+The single source of truth a surface projects: a knowledge graph, a journal, a store. One substrate, many projections — every view shows its own slice, no view shows all of it, and state is derived from the substrate, never duplicated beside it. If two surfaces disagree, the substrate arbitrates.
+"""
+type Substrate implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A named region in coordinate space — an archetype used for coverage planning and QA, never for navigation. A persona's jobs are DERIVED by overlap of its region with each job's coordinates; asserting the persona↔job link directly is a modelling error (the link is derived, not stored).
+"""
+type Persona implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The coordinate region this persona names. Same type as a job's coordinates, so matching is axis-by-axis overlap.
+  """
+  region: Coordinate
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """The persona in one line — what this archetype is about."""
+  essence: String
+}
+
+"""
+Ordinal familiarity with the system on a coordinate axis: Newcomer < Fluent < Expert (data/fluencies.ttl, ordered by fluencyOrder). Expert is a fluency waypoint, not a role — authority positions are roles. Landed by D17 after the trigger fired twice (Yuki≡Dev in mriya; prose-only waypoint arcs in the docs graph).
+"""
+type Fluency implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+
+  """Ordinal position on the arc (1 = newcomer)."""
+  fluencyOrder: Int
+}
+
+"""
+A consumer's discipline or authority position on a coordinate axis (engineer, designer, writer; author, operator). Authority is a role, not a fluency level. Project vocabulary: no base instances ship — each spec graph defines its own. An axis left unconstrained matches any role (wildcard). Added by D9 when the two-graph confrontation fired D5's reversal trigger.
+"""
+type Role implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+The species of consumer on a coordinate axis. Base instances: Human, Agent (data/actors.ttl). Surfaces are bi-modal by default — a machine consumer is a first-class actor, not an afterthought.
+"""
+type Actor implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A reified position or region in demand space. Currently one axis (actor); role and fluency axes join by discussion (decision D5). Reified so that jobs and personas share ONE type: a job's coordinates and a persona's region are compared axis by axis, and the persona↔job link is derived by overlap, never stored.
+"""
+type Coordinate implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The fluency axis. Multi-valued (a region may span an arc); ABSENT MEANS ANY — wildcard, else intersection (same rule as role).
+  """
+  fluencies(first: Int, after: String, last: Int, before: String): FluencyConnection!
+
+  """
+  The role axis of the coordinate. Multi-valued; ABSENT MEANS ANY ROLE — matching treats an unconstrained axis as a wildcard, otherwise requires intersection.
+  """
+  roles(first: Int, after: String, last: Int, before: String): RoleConnection!
+
+  """
+  The actor axis of the coordinate (human, agent). Multi-valued: a region may span both.
+  """
+  actors(first: Int, after: String, last: Int, before: String): ActorConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+type FluencyConnection {
+  edges: [FluencyEdge!]!
+  pageInfo: PageInfo!
+}
+
+type FluencyEdge {
+  node: Fluency!
+  cursor: String!
+}
+
+type RoleConnection {
+  edges: [RoleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RoleEdge {
+  node: Role!
+  cursor: String!
+}
+
+type ActorConnection {
+  edges: [ActorEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ActorEdge {
+  node: Actor!
+  cursor: String!
+}
+
+"""
+The unit of demand and of value (jobs-to-be-done). One thing a consumer is trying to get done, written as a story: when [circumstance], I want [desire], so I can [outcome], without [pain]. Jobs — not personas, not features — drive surface requirements: every surface element must trace back to at least one job; a job with no serving surface is a coverage gap, and a surface element with no job is decoration.
+"""
+type Job implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  The assumptions this job's design leans on — typically Bets from the shared ledger. Shared across jobs: they live once, referenced by id.
+  """
+  bets: [String!]!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  Who has this job, as a coordinate region. The single source of truth for 'who'; persona columns in any table are derived views over this value.
+  """
+  coordinates: Coordinate
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferreds: [Boolean!]!
+
+  """
+  A done-test clause for this job (multi-valued). The falsifiable answer to 'is this job served?' — a job without at least one acceptance clause is an opinion, not demand. Surfaces paired to the job inherit the clauses that mention them.
+  """
+  acceptances: [String!]!
+
+  """
+  The full job story in one sentence carrying the four slots: 'When [circumstance], I want [desire], so I can [outcome], without [pain]'. Kept as one string by decision D2 (data/decisions.ttl); reify the slots only when a real query needs slot-level joins.
+  """
+  story: String
+}
+
+"""
+A single dated record of a change to a UIBlock, with a timestamp, the change description, an owner, an optional GitHub link, and a change type.
+"""
+type ChangeLogEntry {
+  """The category of change (e.g. change, addition, deprecation)"""
+  changeType: String
+
+  """Optional link to a GitHub issue, PR or discussion for this change"""
+  githubLink: String
+
+  """The person responsible for the change"""
+  owner: String
+
+  """Human-readable description of what changed"""
+  change: String
+
+  """The date and time at which the change was recorded"""
+  timestamp: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A facet that groups related Tags (e.g. 'documentation stage', 'review status', 'channel', 'implementation status').
+"""
+type TagCategory implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A controlled-vocabulary label applied to a UIBlock. Tags are grouped into facets by their category (e.g. 'documentation stage', 'review status', 'channel', 'implementation status'). The category-typed views over this vocabulary are tracked as future work; for now a Tag carries its name, category, and apply/remove guidance.
+"""
+type Tag implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The category (facet) a Tag belongs to, e.g. documentation stage, review status, channel, implementation status
+  """
+  categories(first: Int, after: String, last: Int, before: String): TagCategoryConnection!
+
+  """
+  Guidance on the conditions under which this tag should be removed from a UI Block
+  """
+  whenToRemove: String
+
+  """
+  Guidance on the conditions under which this tag should be applied to a UI Block
+  """
+  whenToApply: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type TagCategoryConnection {
+  edges: [TagCategoryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TagCategoryEdge {
+  node: TagCategory!
+  cursor: String!
+}
+
+"""
+A code library or package that provides platform-specific implementations of UIBlocks
+"""
+type ImplementationLibrary implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The design system tier that this library implements"""
+  libraryTiers(first: Int, after: String, last: Int, before: String): TierConnection!
+
+  """Documentation link if different from main artifact"""
+  documentation: String
+
+  """URL to the library's main artifact or repository"""
+  link: String
+
+  """
+  The platform or technology this library targets (e.g. React, Web Components, Flutter)
+  """
+  platform: String
+
+  """The package or library name as published (e.g. npm package name)"""
+  libraryName: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type TierConnection {
+  edges: [TierEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TierEdge {
+  node: Tier!
+  cursor: String!
+}
+
+"""Platform-specific implementation of a UI Block"""
+type ImplementationObject implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The implementation library that contains this implementation"""
+  library: ImplementationLibrary
+
+  """The UIBlock that this implementation realises in code"""
+  implementsBlock: UIBlock
+
+  """
+  Whether this implementation is in draft state and not yet ready for production use
+  """
+  draft: Boolean
+
+  """
+  URL to a specific tagged version of this implementation in source control
+  """
+  versionedLink: String
+
+  """
+  URL to the latest/HEAD version of this implementation in source control
+  """
+  headLink: String
+
+  """
+  Version of this specific implementation, independent of the UIBlock version
+  """
+  implementationVersion: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A scope level in the design system hierarchy that determines where UIBlocks are intended to be used (e.g. global, apps, site)
+"""
+type Tier implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A configurable property of a UI Block"""
+type Property {
+  """
+  Constraints on valid values for this property. For choice types, lists allowed values (e.g. '[primary, secondary, tertiary]'). For numbers, specifies ranges. For objects, describes required structure.
+  """
+  constraints: String
+
+  """
+  The default value for this property when not explicitly set by the consumer
+  """
+  defaultValue: String
+
+  """Whether this property is optional when configuring the UI Block"""
+  optional: Boolean
+
+  """
+  The data type of this configurable property (e.g. text, choice, boolean, node)
+  """
+  propertyType: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A grouping of related modifiers that can be applied to UI Blocks"""
+type ModifierFamily implements Node & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Modifiers belonging to this modifier family"""
+  modifiers(first: Int, after: String, last: Int, before: String): ModifierConnection!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type ModifierConnection {
+  edges: [ModifierEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ModifierEdge {
+  node: Modifier!
+  cursor: String!
+}
+
+"""
+A named variant value within a ModifierFamily that alters the appearance or behaviour of a UIBlock (e.g. 'primary', 'secondary' within the 'importance' family)
+"""
+type Modifier implements Node & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The modifier family to which this modifier belongs"""
+  modifierFamily: ModifierFamily
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+A collection UIBlock: a container that arranges multiple instances of a single sibling UIBlock (typically a Component) as a repeating series. The plural counterpart of a singular Component (e.g. Cards groups Card units, Tiles groups Tile units), responsible for their shared layout rather than for any content of its own.
+"""
+type Group implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type UIBlockConnection {
+  edges: [UIBlockEdge!]!
+  pageInfo: PageInfo!
+}
+
+type UIBlockEdge {
+  node: UIBlock!
+  cursor: String!
+}
+
+type TagConnection {
+  edges: [TagEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TagEdge {
+  node: Tag!
+  cursor: String!
+}
+
+type ModifierFamilyConnection {
+  edges: [ModifierFamilyEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ModifierFamilyEdge {
+  node: ModifierFamily!
+  cursor: String!
+}
+
+"""
+A named part of a Component that has design-system identity but is typically not used independently outside its parent
+"""
+type Subcomponent implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The component to which this subcomponent structurally belongs"""
+  parentComponents(first: Int, after: String, last: Int, before: String): ComponentConnection!
+
+  """
+  Whether this subcomponent can be used independently outside its parent component
+  """
+  standalone: Boolean
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type ComponentConnection {
+  edges: [ComponentEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ComponentEdge {
+  node: Component!
+  cursor: String!
+}
+
+"""
+Layouts are an opinionated division of space to navigate a domain of information.
+"""
+type Layout implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Device form factors this layout targets"""
+  targetDevices: String
+
+  """Named CSS grid areas defined by this layout"""
+  gridAreas: String
+
+  """The information domain this layout is designed to navigate"""
+  domain: String
+
+  """CSS grid template definition for this layout"""
+  grid: String
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""A reusable solution to a recurring user problem in a specific context"""
+type Pattern implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+An implementable piece of user interface defined by its appearance and behaviour
+"""
+type Component implements Node & UIBlock & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Subcomponents that are structural parts of this component"""
+  subcomponents(first: Int, after: String, last: Int, before: String): SubcomponentConnection!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+type SubcomponentConnection {
+  edges: [SubcomponentEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SubcomponentEdge {
+  node: Subcomponent!
+  cursor: String!
+}
+
+"""
+A single do or don't example with a description, optional language tag, and optional code block
+"""
+type Example implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """The code content of the example"""
+  code: String
+
+  """
+  The programming language of the example code block (e.g., 'typescript', 'rust', 'css', 'bash', 'svg', 'turtle')
+  """
+  language: String
+
+  """A general description of the code standard or example"""
+  description: String
+}
+
+"""
+A category for grouping related code standards (e.g., testing, components, react, typescript)
+"""
+type Category implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """A general description of the code standard or example"""
+  description: String
+
+  """
+  A short identifier for the category or standard, used for domain annotation.
+  """
+  slug: String
+}
+
+"""A coding standard or best practice guideline for software development"""
+type CodeStandard implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """A negative example showing what should not be done"""
+  donts(first: Int, after: String, last: Int, before: String): ExampleConnection!
+
+  """A positive example showing what should be done"""
+  dos(first: Int, after: String, last: Int, before: String): ExampleConnection!
+
+  """
+  Associates a code standard with another standard that it extends or adds further context to
+  """
+  extends(first: Int, after: String, last: Int, before: String): CodeStandardConnection!
+
+  """Associates a code standard with its category"""
+  categories(first: Int, after: String, last: Int, before: String): CategoryConnection!
+
+  """A general description of the code standard or example"""
+  description: String
+
+  """
+  An optional human-readable display title for a code standard. This is not an identifier and must not duplicate the canonical role of the subject IRI.
+  """
+  name: String
+}
+
+type ExampleConnection {
+  edges: [ExampleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ExampleEdge {
+  node: Example!
+  cursor: String!
+}
+
+type CodeStandardConnection {
+  edges: [CodeStandardEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CodeStandardEdge {
+  node: CodeStandard!
+  cursor: String!
+}
+
+type CategoryConnection {
+  edges: [CategoryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CategoryEdge {
+  node: Category!
+  cursor: String!
+}
+
+"""One alternative within a Switch."""
+type SwitchCase implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Node this case resolves to."""
+  caseNode: AnatomyNode
+}
+
+"""Polymorphic position admitting several alternatives."""
+type Switch implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """An alternative within this switch."""
+  cases(first: Int, after: String, last: Int, before: String): SwitchCaseConnection!
+
+  """What determines which case applies."""
+  discriminator: String
+}
+
+type SwitchCaseConnection {
+  edges: [SwitchCaseEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SwitchCaseEdge {
+  node: SwitchCase!
+  cursor: String!
+}
+
+"""A single style declaration binding a property key to a value."""
+type Style implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Value for a style property."""
+  styleValue: String
+
+  """Platform-agnostic style property identifier."""
+  styleKey: String
+}
+
+"""Metadata qualifying a parent-child relationship."""
+type Relation implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Named slot in the parent that this child maps to."""
+  slotName: String
+
+  """Instance count constraint on the child."""
+  cardinality: String
+}
+
+"""Reified parent-child relationship in the anatomy tree."""
+type Edge implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Polymorphic switch this edge connects to."""
+  edgeSwitch: Switch
+
+  """Child node this edge connects to."""
+  edgeTarget: AnatomyNode
+
+  """Relation qualifying this edge."""
+  relation: Relation
+}
+
+"""Structural element without design system identity."""
+type AnonymousNode implements Node & AnatomyNode {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Human-readable purpose of an anonymous node."""
+  role: String
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+type StyleConnection {
+  edges: [StyleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type StyleEdge {
+  node: Style!
+  cursor: String!
+}
+
+type EdgeConnection {
+  edges: [EdgeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type EdgeEdge {
+  node: Edge!
+  cursor: String!
+}
+
+"""Design system entity instantiable by consumers."""
+type NamedNode implements Node & AnatomyNode {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Unique identifier for a named node within the design system."""
+  anatomyUri: String
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+"""Root of an anatomy file."""
+type Specification implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Top-level node of an anatomy specification."""
+  rootNode: NamedNode
+}
+
+"""
+An addressable place of encounter between a consumer and the substrate. Its nature is carried by three dimensions (rendering, direction, anchoring); the idiom classes below are named cells whose dimension values materialize through the closure — assert the idiom, infer the physics. A surface matching no idiom is asserted as a plain Surface with raw dimensions: fully described, honestly unnamed. How a surface is PRESENT (ambient, transient, dwelt-in) is edge information and lives on pairings as arrival — never on the node (the presence-dimension deletion, D11).
+"""
+interface Surface implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The lens where a noun's mentions land (domain open by design — D1: zero TBox edges to the grammar package; nouns pair in data) (D31: a chip's jump goes to the canonical home). The object form of grammar:home's prose — shapeable: the one-home law becomes checkable data, and a noun without a homedIn target is a visible work item, not a mystery.
+  """
+  homedIns(first: Int, after: String, last: Int, before: String): LensConnection!
+
+  """
+  The successor item. Required when validity is Superseded — a supersession without a forwarding address strands the neighbours.
+  """
+  supersededBies: [String!]!
+
+  """
+  This item's invalidity, when it has one. Requires exactly one validityNote (F12); Superseded requires supersededBy. Never delete — tombstone.
+  """
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+
+  """
+  What fills a slot — a surface now, components later (domain deliberately open). Where a surface has rendersIn, its within is DERIVABLE (slot → layout → composing surface) and an asserted within must agree (D13); within remains the layout-free shorthand for specs that skip layouts.
+  """
+  rendersIns(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A typed slot this layout declares. Domain deliberately open (the subject is a ds:Layout instance).
+  """
+  declaresSlots(first: Int, after: String, last: Int, before: String): SlotConnection!
+
+  """
+  A curated surface composes a layout — its division of space. Domain deliberately open (lenses and views both compose). Range is ds:Layout DIRECTLY: the design system owns layouts; this model attaches demand to them.
+  """
+  composes(first: Int, after: String, last: Int, before: String): LayoutConnection!
+
+  """
+  The pairings this surface participates in (inverse of pairsSurface) — materialized by the closure so surfaces connect outward without walking reification by hand.
+  """
+  pairedIns(first: Int, after: String, last: Int, before: String): PairingConnection!
+
+  """
+  Placement: this surface lives inside another (the composer within the canvas). Altitude is the derived length of the within-chain — never a stored number.
+  """
+  withins(first: Int, after: String, last: Int, before: String): SurfaceConnection!
+
+  """
+  An embedded curated surface can expand out of its host slot into a larger region — the folded-to-fullscreen affordance (D29). A graph shown folded below the fold on an entity page expands into the overlay; a rail can expand into the canvas. The expansion is a presentation state, not a second surface: same slice, more room. When present, the surface owes a stated collapsed floor (it must be usable BEFORE expansion) — expansion is enhancement, never the only working size.
+  """
+  expandsTos(first: Int, after: String, last: Int, before: String): RegionConnection!
+
+  """
+  The surface's anchoring dimension. Usually inferred from the idiom class.
+  """
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+
+  """
+  The surface's direction dimension(s). Usually inferred from the idiom class.
+  """
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+
+  """
+  The surface's rendering dimension. Usually inferred from the idiom class; asserted directly only on unnamed hybrids.
+  """
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+
+  """
+  The capability (usually a bundle) this holder actually receives — the grant record (D26). Grants make authority auditable: the parity query compares what agent and human holders reach; narrowing applies through attenuates chains, never by widening.
+  """
+  granteds(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+
+  """
+  The universal traceability edge: links a capability, surface, or component to a job it serves. Domain deliberately open. Operational grounding in one property — an element with no serves edge (direct or via its pairings) has no reason to exist.
+  """
+  serves(first: Int, after: String, last: Int, before: String): JobConnection!
+
+  """
+  Links a capability (and later a lens) to the substrate it operates over or projects. Domain deliberately open: both capabilities and lenses use it.
+  """
+  overs(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+
+  """
+  The mandatory comment on an invalid item: what happened, decided where, and what to use instead.
+  """
+  validityNote: String
+
+  """
+  What must become true for this deferred item to wake — the written trigger that turns a parked promise into scheduled work (D23). A deferral with a wake condition is a roadmap; without one it is furniture. Sources phrase these as 'when X exists / earns it / matures'; carry that language.
+  """
+  wakeCondition: String
+
+  """
+  This job is explicitly parked by the spec (its status note carries the reason and trigger). Exempts it from the served gate (F10) — a job must be served or consciously deferred, never silently unserved.
+  """
+  deferred: Boolean
+}
+
+"""
+A category of visual or abstract entity that fulfills a particular role in composing user interfaces
+"""
+interface UIBlock implements Node & UIElement & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """
+  The variants of this UI Block (inverse of ds:variantOf). E.g. Tooltip has variant Tooltip+Dense.
+  """
+  variants(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The base UI Block this block is a variant of, by the '+' naming convention (e.g. Tooltip+Dense is a variant of Tooltip). Distinct from ds:inheritsFrom: a variant is a modifier-style derivative rather than a prefixed specialisation.
+  """
+  variantOfs(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Blocks that inherit from / specialise this block (inverse of ds:inheritsFrom). E.g. Tooltip is specialised by DataTooltip.
+  """
+  specializedBies(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """
+  The UI Block this block inherits from / specialises (e.g. a Data tooltip inherits from Tooltip). Distinct from subcomponent containment: inheritance is an is-a-specialisation relationship.
+  """
+  inheritsFroms(first: Int, after: String, last: Int, before: String): UIBlockConnection!
+
+  """Links a UI Block to its dated change log entries."""
+  changeLogs: [ChangeLogEntry!]!
+
+  """
+  Links a UI Block to the documentation-stage Tag(s) applied to it (e.g. needs:documentation). One facet of the wider Tag vocabulary; the other tag facets are tracked as future work.
+  """
+  documentationStages(first: Int, after: String, last: Int, before: String): TagConnection!
+
+  """Links a UI Block to its configurable properties"""
+  properties: [Property!]!
+
+  """Links a UI Block to applicable modifier families"""
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+
+  """The tier to which the UI block belongs to"""
+  tier: Tier
+
+  """
+  Detailed specification for correctly using and implementing the UI block.
+  """
+  guidelines: String
+
+  """
+  Free-text (Markdown) usage documentation for the UI block. Subsumes the former whenToUse/whenNotToUse: a usage entry describes the contexts where the component is most appropriate ('When to use'), the contexts where it is NOT appropriate and what to use instead ('When not to use'), and a general description, typically as Markdown sub-sections.
+  """
+  usage: String
+
+  """
+  YAML specification of component structure using the Anatomy DSL. Describes nodes (named/anonymous), edges with cardinality, slots, and CTI-inspired styles.
+  """
+  anatomyDsl: String
+
+  """
+  DEPRECATED. Legacy anatomy field (free-form text). Superseded by ds:anatomyDsl.
+  """
+  anatomyClassic: String
+
+  """Link to the Figma design file for this UI block"""
+  figmaLink: String
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""Base class for all visual and interactive design system elements"""
+interface UIElement implements Node & Entity {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""
+Abstract root class for all design system entities. Provides common properties (name, summary) inherited by all classes.
+"""
+interface Entity implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Log of decisions with [date][author][content]"""
+  decisionLog: String
+
+  """Semantic version of the entity following semver specification"""
+  version: String
+
+  """
+  A comprehensive paragraph of text that states the singular purpose of the entity.
+  """
+  summary: String
+
+  """
+  A human-readable text for the entity. The primary identifier, used for referencing and display purposes.
+  """
+  name: String
+}
+
+"""Position in the anatomy tree."""
+interface AnatomyNode implements Node {
+  """Relay global ID — the entity's prefixed URI."""
+  id: ID!
+  uri: String!
+
+  """Self-describing TBox access for this entity."""
+  _meta: EntityMeta!
+
+  """Attaches a style declaration to a node."""
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+
+  """Connects a node to a child relationship."""
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+}
+
+"""Self-describing TBox access attached to ABox types."""
+type EntityMeta {
+  type: OntologyClass!
+  field(name: String!): ClassProperty
+  fields: [ClassProperty!]!
+}
+
+type OntologyClass {
+  uri: String!
+  label: String
+  definition: String
+  superclass: OntologyClass
+  superclasses: [OntologyClass!]!
+  subclasses: [OntologyClass!]!
+  properties: [ClassProperty!]!
+
+  """
+  Named instances of this class (blank-node instances are embeddable and not standalone-resolvable).
+  """
+  instances(first: Int, after: String, last: Int, before: String): NodeConnection!
+
+  """Count of NAMED instances (matches `instances`)."""
+  instanceCount: Int!
+  isAbstract: Boolean!
+  namespace: String!
+}
+
+"""
+Class-scoped view of a property: SHACL cardinality is a fact about a (class, property) pair.
+"""
+type ClassProperty {
+  property: OntologyProperty!
+  required: Boolean!
+  singular: Boolean!
+  inherited: Boolean!
+}
+
+type OntologyProperty {
+  uri: String!
+  label: String
+  definition: String
+  domain: OntologyClass
+  range: String!
+  kind: PropertyKind!
+  functional: Boolean!
+  inverse: OntologyProperty
+  acceptanceCriteria: String
+  completionGuidance: String
+  namespace: String!
+}
+
+enum PropertyKind {
+  DATATYPE
+  OBJECT
+  ANNOTATION
+}
+
+type NodeConnection {
+  edges: [NodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NodeEdge {
+  node: Node!
+  cursor: String!
+}
+
+type Query {
+  ontologies: [Ontology!]!
+  ontology(prefix: String!): Ontology
+  ontologyClass(uri: String!): OntologyClass
+  ontologyProperty(uri: String!): OntologyProperty
+
+  """Relay node resolution by prefixed-URI global ID."""
+  node(id: ID!): Node
+  validity(uri: String!): Validity
+  validities(first: Int, after: String, last: Int, before: String): ValidityConnection!
+  verdict(uri: String!): Verdict
+  verdicts(first: Int, after: String, last: Int, before: String): VerdictConnection!
+  exemplar(uri: String!): Exemplar
+  exemplars(first: Int, after: String, last: Int, before: String): ExemplarConnection!
+  law(uri: String!): Law
+  laws(first: Int, after: String, last: Int, before: String): LawConnection!
+  bet(uri: String!): Bet
+  bets(first: Int, after: String, last: Int, before: String): BetConnection!
+  slot(uri: String!): Slot
+  slots(first: Int, after: String, last: Int, before: String): SlotConnection!
+  region(uri: String!): Region
+  regions(first: Int, after: String, last: Int, before: String): RegionConnection!
+  pairing(uri: String!): Pairing
+  pairings(first: Int, after: String, last: Int, before: String): PairingConnection!
+  pairingRole(uri: String!): PairingRole
+  pairingRoles(first: Int, after: String, last: Int, before: String): PairingRoleConnection!
+  preservation(uri: String!): Preservation
+  preservations(first: Int, after: String, last: Int, before: String): PreservationConnection!
+  port(uri: String!): Port
+  ports(first: Int, after: String, last: Int, before: String): PortConnection!
+  editor(uri: String!): Editor
+  editors(first: Int, after: String, last: Int, before: String): EditorConnection!
+  composerSurface(uri: String!): ComposerSurface
+  composerSurfaces(first: Int, after: String, last: Int, before: String): ComposerSurfaceConnection!
+  mechanism(uri: String!): Mechanism
+  mechanisms(first: Int, after: String, last: Int, before: String): MechanismConnection!
+  peek(uri: String!): Peek
+  peeks(first: Int, after: String, last: Int, before: String): PeekConnection!
+  detail(uri: String!): Detail
+  details(first: Int, after: String, last: Int, before: String): DetailConnection!
+  view(uri: String!): View
+  views(first: Int, after: String, last: Int, before: String): ViewConnection!
+  lens(first: Int, after: String, last: Int, before: String): LensConnection!
+  anchoring(uri: String!): Anchoring
+  anchorings(first: Int, after: String, last: Int, before: String): AnchoringConnection!
+  direction(uri: String!): Direction
+  directions(first: Int, after: String, last: Int, before: String): DirectionConnection!
+  rendering(uri: String!): Rendering
+  renderings(first: Int, after: String, last: Int, before: String): RenderingConnection!
+  authorityFamily(uri: String!): AuthorityFamily
+  authorityFamilies(first: Int, after: String, last: Int, before: String): AuthorityFamilyConnection!
+  capability(uri: String!): Capability
+  capabilities(first: Int, after: String, last: Int, before: String): CapabilityConnection!
+  substrate(uri: String!): Substrate
+  substrates(first: Int, after: String, last: Int, before: String): SubstrateConnection!
+  persona(uri: String!): Persona
+  personas(first: Int, after: String, last: Int, before: String): PersonaConnection!
+  fluency(uri: String!): Fluency
+  fluencies(first: Int, after: String, last: Int, before: String): FluencyConnection!
+  role(uri: String!): Role
+  roles(first: Int, after: String, last: Int, before: String): RoleConnection!
+  actor(uri: String!): Actor
+  actors(first: Int, after: String, last: Int, before: String): ActorConnection!
+  coordinate(uri: String!): Coordinate
+  coordinates(first: Int, after: String, last: Int, before: String): CoordinateConnection!
+  job(uri: String!): Job
+  jobs(first: Int, after: String, last: Int, before: String): JobConnection!
+  tagCategory(uri: String!): TagCategory
+  tagCategories(first: Int, after: String, last: Int, before: String): TagCategoryConnection!
+  tag(uri: String!): Tag
+  tags(first: Int, after: String, last: Int, before: String): TagConnection!
+  implementationLibrary(uri: String!): ImplementationLibrary
+  implementationLibraries(first: Int, after: String, last: Int, before: String): ImplementationLibraryConnection!
+  implementationObject(uri: String!): ImplementationObject
+  implementationObjects(first: Int, after: String, last: Int, before: String): ImplementationObjectConnection!
+  tier(uri: String!): Tier
+  tiers(first: Int, after: String, last: Int, before: String): TierConnection!
+  modifierFamily(uri: String!): ModifierFamily
+  modifierFamilies(first: Int, after: String, last: Int, before: String): ModifierFamilyConnection!
+  modifier(uri: String!): Modifier
+  modifiers(first: Int, after: String, last: Int, before: String): ModifierConnection!
+  group(uri: String!): Group
+  groups(first: Int, after: String, last: Int, before: String): GroupConnection!
+  subcomponent(uri: String!): Subcomponent
+  subcomponents(first: Int, after: String, last: Int, before: String): SubcomponentConnection!
+  layout(uri: String!): Layout
+  layouts(first: Int, after: String, last: Int, before: String): LayoutConnection!
+  pattern(uri: String!): Pattern
+  patterns(first: Int, after: String, last: Int, before: String): PatternConnection!
+  component(uri: String!): Component
+  components(first: Int, after: String, last: Int, before: String): ComponentConnection!
+  example(uri: String!): Example
+  examples(first: Int, after: String, last: Int, before: String): ExampleConnection!
+  category(uri: String!): Category
+  categories(first: Int, after: String, last: Int, before: String): CategoryConnection!
+  codeStandard(uri: String!): CodeStandard
+  codeStandards(first: Int, after: String, last: Int, before: String): CodeStandardConnection!
+  switchCase(uri: String!): SwitchCase
+  switchCases(first: Int, after: String, last: Int, before: String): SwitchCaseConnection!
+  switch(uri: String!): Switch
+  switches(first: Int, after: String, last: Int, before: String): SwitchConnection!
+  style(uri: String!): Style
+  styles(first: Int, after: String, last: Int, before: String): StyleConnection!
+  relation(uri: String!): Relation
+  relations(first: Int, after: String, last: Int, before: String): RelationConnection!
+  edge(uri: String!): Edge
+  edges(first: Int, after: String, last: Int, before: String): EdgeConnection!
+  anonymousNode(uri: String!): AnonymousNode
+  anonymousNodes(first: Int, after: String, last: Int, before: String): AnonymousNodeConnection!
+  namedNode(uri: String!): NamedNode
+  namedNodes(first: Int, after: String, last: Int, before: String): NamedNodeConnection!
+  specification(uri: String!): Specification
+  specifications(first: Int, after: String, last: Int, before: String): SpecificationConnection!
+}
+
+type Ontology {
+  prefix: String!
+  namespace: String!
+  label: String
+  classes: [OntologyClass!]!
+  properties: [OntologyProperty!]!
+}
+
+type VerdictConnection {
+  edges: [VerdictEdge!]!
+  pageInfo: PageInfo!
+}
+
+type VerdictEdge {
+  node: Verdict!
+  cursor: String!
+}
+
+type ExemplarConnection {
+  edges: [ExemplarEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ExemplarEdge {
+  node: Exemplar!
+  cursor: String!
+}
+
+type LawConnection {
+  edges: [LawEdge!]!
+  pageInfo: PageInfo!
+}
+
+type LawEdge {
+  node: Law!
+  cursor: String!
+}
+
+type BetConnection {
+  edges: [BetEdge!]!
+  pageInfo: PageInfo!
+}
+
+type BetEdge {
+  node: Bet!
+  cursor: String!
+}
+
+type PairingRoleConnection {
+  edges: [PairingRoleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PairingRoleEdge {
+  node: PairingRole!
+  cursor: String!
+}
+
+type PortConnection {
+  edges: [PortEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PortEdge {
+  node: Port!
+  cursor: String!
+}
+
+type EditorConnection {
+  edges: [EditorEdge!]!
+  pageInfo: PageInfo!
+}
+
+type EditorEdge {
+  node: Editor!
+  cursor: String!
+}
+
+type ComposerSurfaceConnection {
+  edges: [ComposerSurfaceEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ComposerSurfaceEdge {
+  node: ComposerSurface!
+  cursor: String!
+}
+
+type MechanismConnection {
+  edges: [MechanismEdge!]!
+  pageInfo: PageInfo!
+}
+
+type MechanismEdge {
+  node: Mechanism!
+  cursor: String!
+}
+
+type PeekConnection {
+  edges: [PeekEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PeekEdge {
+  node: Peek!
+  cursor: String!
+}
+
+type DetailConnection {
+  edges: [DetailEdge!]!
+  pageInfo: PageInfo!
+}
+
+type DetailEdge {
+  node: Detail!
+  cursor: String!
+}
+
+type ViewConnection {
+  edges: [ViewEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ViewEdge {
+  node: View!
+  cursor: String!
+}
+
+type PersonaConnection {
+  edges: [PersonaEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PersonaEdge {
+  node: Persona!
+  cursor: String!
+}
+
+type CoordinateConnection {
+  edges: [CoordinateEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CoordinateEdge {
+  node: Coordinate!
+  cursor: String!
+}
+
+type ImplementationLibraryConnection {
+  edges: [ImplementationLibraryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ImplementationLibraryEdge {
+  node: ImplementationLibrary!
+  cursor: String!
+}
+
+type ImplementationObjectConnection {
+  edges: [ImplementationObjectEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ImplementationObjectEdge {
+  node: ImplementationObject!
+  cursor: String!
+}
+
+type GroupConnection {
+  edges: [GroupEdge!]!
+  pageInfo: PageInfo!
+}
+
+type GroupEdge {
+  node: Group!
+  cursor: String!
+}
+
+type PatternConnection {
+  edges: [PatternEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PatternEdge {
+  node: Pattern!
+  cursor: String!
+}
+
+type SwitchConnection {
+  edges: [SwitchEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SwitchEdge {
+  node: Switch!
+  cursor: String!
+}
+
+type RelationConnection {
+  edges: [RelationEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RelationEdge {
+  node: Relation!
+  cursor: String!
+}
+
+type AnonymousNodeConnection {
+  edges: [AnonymousNodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AnonymousNodeEdge {
+  node: AnonymousNode!
+  cursor: String!
+}
+
+type NamedNodeConnection {
+  edges: [NamedNodeEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NamedNodeEdge {
+  node: NamedNode!
+  cursor: String!
+}
+
+type SpecificationConnection {
+  edges: [SpecificationEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SpecificationEdge {
+  node: Specification!
+  cursor: String!
+}

--- a/packages/prism/pragma-provider/src/testing/corpus.ts
+++ b/packages/prism/pragma-provider/src/testing/corpus.ts
@@ -1,0 +1,42 @@
+/**
+ * The hermetic corpus's roots, resolved from this file's own location.
+ *
+ * Every test in this package runs against `src/testing/__fixtures__/corpus` rather than
+ * against a populated refs cache, because no CI leg and no fresh clone has one.
+ * See that directory's README for what each file makes falsifiable.
+ *
+ * Test infrastructure: excluded from the build (tsconfig.build.json) and from
+ * coverage (vitest.config.ts).
+ */
+
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** The fixtures sit beside this file, under `src/testing/`. */
+const CORPUS_ROOT: string = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "./__fixtures__/corpus",
+);
+
+/** The corpus's refs cache — the shape `~/.cache/pragma/refs/@canonical` has. */
+export const CORPUS_REFS_ROOT: string = join(CORPUS_ROOT, "refs/@canonical");
+
+/** The corpus's semantics tree — the shape `~/code/cn/semantics` has. */
+export const CORPUS_SEM_ROOT: string = join(CORPUS_ROOT, "sem");
+
+/** A directory that exists but holds no `.ttl` — the empty-cache case. */
+export const CORPUS_EMPTY_REFS_ROOT: string = join(CORPUS_ROOT, "refs");
+
+/**
+ * A directory that EXISTS but is not a semantics tree: neither expected
+ * package sits under it. The `PRAGMA_SEM_DIR` points somewhere wrong case,
+ * which an existence check on the root cannot tell from a healthy one.
+ *
+ * Deliberately the same path as {@link CORPUS_EMPTY_REFS_ROOT}: one directory
+ * answers both descriptions, and inventing a second empty tree to say so would
+ * add a fixture nobody reads.
+ */
+export const CORPUS_WRONG_SEM_ROOT: string = join(CORPUS_ROOT, "refs");
+
+/** A path guaranteed absent — the missing-cache case. */
+export const MISSING_ROOT: string = join(CORPUS_ROOT, "no-such-root");

--- a/packages/prism/pragma-provider/src/testing/integration/committedSdl.test.ts
+++ b/packages/prism/pragma-provider/src/testing/integration/committedSdl.test.ts
@@ -1,0 +1,125 @@
+// =============================================================================
+// GATE G-2: the committed SDL against the authored contract.
+//
+// The subject is `apps/react/pragma-docs/src/relay/schema.graphql` — THIS
+// PROVIDER'S OUTPUT, checked into the consumer's tree because relay-compiler
+// reads it there. The contract half is read live from
+// `@canonical/prism-contract` on every run, so if the contract moves this
+// turns red on the next run. That is the mechanism working. Never vendor a
+// copy of the contract to make it quiet.
+//
+// WHY IT LIVES IN THE PROVIDER PACKAGE RATHER THAN IN THE APP. `schema.graphql`
+// is not something the app authors; it is something the app RECEIVES. Siting
+// the gate here also keeps `@canonical/prism-contract` out of the docsite's
+// dependency list.
+//
+// WHY IT THROWS RATHER THAN SKIPS WHEN THE FILE IS MISSING. A gate that goes
+// quiet when its subject disappears is worse than no gate: a missing schema
+// means the app stopped committing its schema, which is exactly the state this
+// gate exists to notice, and a skip would report that as success.
+//
+// 🔴 IT IS NOT POINTED AT `../__fixtures__/*.sdl.txt`. Those captures predate
+// the converged base and carry 12 violations each; a gate aimed at them would
+// be red by construction and would be silenced within a week. They pin a
+// DIFFERENT property (additivity of the second source root, in
+// `./sourceAdditivity.test.ts`) which survives their staleness. THIS gate is
+// what measures the schema THE APP ACTUALLY SHIPS. Note the limit precisely:
+// the subject is the committed artifact, not a live emission, so this gate
+// catches the committed file drifting from the CONTRACT and cannot catch it
+// drifting from what `createPragmaProvider` would emit today. Closing that
+// second gap needs a boot, which is the app's job and not a unit test's.
+//
+// 🔴 SCHEDULING — READ THIS BEFORE TRUSTING THE GATE. `nx affected` propagates
+// from a changed project to its DEPENDENTS. The app depends on this package,
+// not the reverse, so a pull request that touches only `schema.graphql` marks
+// the app affected and leaves this project's `test` target unscheduled. The
+// edge cannot simply be declared either: an implicit dependency back onto the
+// app would close a cycle, which nx rejects.
+//
+// So this gate runs on every full `bun run test` and on the post-merge
+// workflow, and NOT on a pull request that changes only its subject. That is a
+// real hole, stated rather than papered over. The fix available is to site the
+// gate in the app instead, where nx schedules it — at the cost of putting
+// `@canonical/prism-contract` in the app's dependency list. Nothing here should
+// be read as claiming a CI step exists that closes it.
+// =============================================================================
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { satisfiesContract } from "@canonical/prism-contract";
+import { describe, expect, it } from "vitest";
+
+/** From `src/testing/integration/` the repo root is six levels up. */
+const APP_RELATIVE_PATH = "../../../../../../apps/react/pragma-docs";
+
+const APP_ROOT: string = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  APP_RELATIVE_PATH,
+);
+
+/** The provider's emitted artifact, as committed. */
+const COMMITTED_SDL_PATH: string = join(APP_ROOT, "src/relay/schema.graphql");
+
+const readCommittedSdl = (): string => {
+  if (!existsSync(COMMITTED_SDL_PATH)) {
+    throw new Error(
+      `gate G-2 has no subject: ${COMMITTED_SDL_PATH} does not exist. The docsite commits its emitted schema because relay-compiler reads it; if that stopped being true, this gate needs rewriting, not deleting.`,
+    );
+  }
+  return readFileSync(COMMITTED_SDL_PATH, "utf-8");
+};
+
+describe("the committed schema.graphql is this provider's output", () => {
+  // NON-VACUITY FLOOR, and the reason it is here. The contract names only the
+  // structural base — Node, PageInfo, the TBox roots — and nothing this
+  // provider contributes. So the conformance check below is satisfied by the
+  // CONTRACT ITSELF, by a stub, and by an emission with every ontology-derived
+  // field stripped out: measured, all three pass. A gate that accepts its own
+  // yardstick as a subject is measuring nothing.
+  //
+  // These assertions are the floor that makes the check mean something: the
+  // subject has to actually be a pragma emission before conformance is worth
+  // asserting of it. They name the provider's own signature — the anatomy
+  // mapping CUSTOM_MAPPINGS exists for, an ontology-derived type the contract
+  // knows nothing about, and a size no stub reaches.
+  const sdl = readCommittedSdl();
+
+  it("carries the anatomy mapping this provider configures", () => {
+    expect(sdl).toContain("anatomyUri");
+  });
+
+  it("carries ontology-derived types the contract never names", () => {
+    expect(sdl).toContain("type Component");
+    expect(sdl).toContain("type Job");
+  });
+
+  it("is a whole emission, not a stub", () => {
+    // The contract is ~7KB; a real emission is two orders of magnitude larger.
+    // A generous floor: this fails on a substituted or collapsed schema and
+    // never on an ordinary edit.
+    expect(sdl.length).toBeGreaterThan(50_000);
+  });
+});
+
+describe("satisfiesContract(the committed schema.graphql)", () => {
+  // No `providerName`: `satisfiesContract` does not take one — it names the
+  // provider in a THROWN message, and this gate asserts on the result instead.
+  // It was passed here until now, and only survived because `check:ts`
+  // excludes test files; under a config that saw this file it is a type error.
+  const result = satisfiesContract(readCommittedSdl());
+
+  it("reports zero violations", () => {
+    // Mapped to strings so a failure prints what is actually wrong rather
+    // than "[Object]". Asserting emptiness, not prose.
+    expect(
+      result.violations.map(
+        (violation) => `${violation.code}: ${violation.message}`,
+      ),
+    ).toEqual([]);
+  });
+
+  it("is satisfied", () => {
+    expect(result.satisfied).toBe(true);
+  });
+});

--- a/packages/prism/pragma-provider/src/testing/integration/sourceAdditivity.test.ts
+++ b/packages/prism/pragma-provider/src/testing/integration/sourceAdditivity.test.ts
@@ -1,0 +1,269 @@
+// @vitest-environment node
+
+/**
+ * The SECOND ROOT's additivity claim, pinned against the emitted SDL.
+ *
+ * ---------------------------------------------------------------------------
+ * MOVED HERE FROM THE DOCSITE APP (`src/server/graphqlSources.tests.ts`), with
+ * its assertions unchanged and its filename changed from `.tests.ts` to
+ * `.test.ts` — the app collects the plural form, every package in this repo
+ * collects the singular, and a file keeping the wrong one is collected by
+ * NOTHING and passes by not existing. It belongs here because what it measures
+ * is the PROVIDER's source set, not anything the app does with the result.
+ *
+ * 🔴 ITS TWO FIXTURES ARE STALE, AND KNOWINGLY SO. Measured at pragma
+ * `4d228c8` against `@canonical/prism-contract`: **12 violations each,
+ * identical set** — `Node._meta` absent, `Node.uri` is `String!` not `ID!`, no
+ * `EntityMeta.curie`/`title`/`label`/`comment`/`definition`, `OntologyClass`
+ * neither carries `_meta` nor implements `Node`, no `ClassProperty.name`,
+ * `OntologyProperty.uri` kind change. They predate the converged base.
+ *
+ * The header comment on each fixture carries the full measurement. The short
+ * version of why they are still here:
+ *
+ *   - The property this suite asserts is ADDITIVITY OF THE SECOND ROOT, which
+ *     is a property of the SOURCE SET and orthogonal to the structural head.
+ *     Both sides of the comparison are equally stale, so it still holds.
+ *   - The type inventory has NOT drifted: `schemaWithSecondRoot.sdl.txt`
+ *     carries 183 top-level definitions, exactly the count of the live
+ *     committed `schema.graphql`.
+ *   - They cannot be regenerated in the authoring environment (no refs cache),
+ *     and a capture taken from a partial cache is worse than a stale one
+ *     because it looks current.
+ *
+ * The one claim below that is now FALSE is "the schema with BOTH roots
+ * compiled — what the journeys lens reads": it is what the journeys lens read
+ * two convergences ago. What that leaves open is measured only in part.
+ * `integration/committedSdl.test.ts` checks the schema the app SHIPS — the
+ * committed `schema.graphql` — against the live contract on every run, so the
+ * structural head these captures are stale against is not unmeasured. But its
+ * subject is a COMMITTED artifact, not a live emission: it cannot see that
+ * file drift from what `createPragmaProvider` would emit today. That gap
+ * stays open, and needs a boot with a populated refs cache to close. Its own
+ * header says the same.
+ * ---------------------------------------------------------------------------
+ *
+ * The docsite graph now compiles from two roots: the pragma CLI's refs
+ * cache (design-system, code-standards, anatomy-dsl) and the semantics
+ * working tree (surface, design-system-docs — the demand model the
+ * journeys lens reads). Merging a second root into one store is only safe
+ * if it is PURELY ADDITIVE: the four lenses that already ship read the
+ * first root's types, and a field silently disappearing — or a new domain
+ * assertion smearing fields onto an existing type — would break them
+ * without any test in this app noticing.
+ *
+ * So the property asserted here is exactly that: over the SDL
+ * relay-compiler consumes, every type that existed before the second root
+ * still exists, and every field it carried is still there. The measurement
+ * is structural (type name → field names parsed out of the SDL), because
+ * the claim is about the schema's shape rather than any one query.
+ *
+ * THE EXCLUSION THIS RECORDS. `design-system-docs/data/shim-concept.ttl`
+ * declares `ds:embodiesConcept` with `rdfs:domain ds:Entity`. `ds:Entity`
+ * roots the design-system class tree, so that one assertion smears the
+ * property and its inverse onto ALL FOURTEEN `ds:` types the moment both
+ * roots compile together — every existing docsite type gains two fields it
+ * never had. `EXCLUDED_SOURCES` drops that file.
+ *
+ * 🔴 WHAT THIS SUITE IS, AND IS NOT. It compares two CHECKED-IN CAPTURES to
+ * each other and imports nothing from this package. Nothing here executes
+ * `EXCLUDED_SOURCES`, `escapeChannelDottedRefs` or any other implementation
+ * line, so it does not guard them: gut any of those and this suite stays
+ * green. It is a historical, falsifiable statement about what adding the
+ * second source root did to the schema's shape at the commit the captures
+ * were taken — worth keeping, and worth not mistaking for a live guard.
+ *
+ * The live guards for the exclusion are `collectTtlSources.test.ts` and
+ * `createPragmaProvider.test.ts`, which do boot and do execute it.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * BOTH sides of the comparison are captured fixtures, deliberately.
+ *
+ * The emitted SDL file is a GENERATED artifact: any process that
+ * boots the backend rewrites it, and it is regenerated with only the first
+ * root whenever the semantics tree is unavailable. A suite that read it
+ * directly would therefore measure whichever boot happened to run last —
+ * it would pass or fail on process ordering rather than on the property it
+ * claims to test. So the two schemas are pinned here as fixtures instead,
+ * and this suite compares FIXTURE to FIXTURE: a hermetic, order-independent
+ * statement about what the second root does to the schema's shape.
+ *
+ * Regenerate the pair only when the sources legitimately change (boot the
+ * backend once with the semantics tree present, once without), and say so
+ * in the commit that does.
+ *
+ * They carry a `.sdl.txt` extension on purpose. In the docsite app,
+ * `vite-plugin-relay-lite` compiles every Relay-tagged document in the project
+ * as an OPERATION, and a schema definition is not one — under the compiler's
+ * own extension these fixtures failed the transform before any test could run.
+ * That plugin does not exist in this package and `.graphql` would now be
+ * legal, but the name is kept: it makes the move a pure rename under
+ * `git log --follow`, and the constraint is worth remembering the next time
+ * someone captures a schema into an app.
+ */
+const readFixture = (name: string): string =>
+  readFileSync(
+    fileURLToPath(new URL(`../__fixtures__/${name}`, import.meta.url)),
+    "utf-8",
+  );
+
+/**
+ * The schema with BOTH roots compiled — what the journeys lens read at the
+ * time of capture. See this file's header: that time is two convergences ago.
+ */
+const SDL = readFixture("schemaWithSecondRoot.sdl.txt");
+
+/** The schema at `aea674000`, from the refs cache alone. */
+const SDL_BEFORE = readFixture("schemaBeforeSecondRoot.sdl.txt");
+
+/**
+ * Parse the SDL into `type name → field names`. Deliberately simple: only
+ * top-level definition headers and their directly-indented field lines
+ * count, so docstrings (which are indented but quoted) and nested braces
+ * never register as fields.
+ */
+const parseTypes = (sdl: string): ReadonlyMap<string, ReadonlySet<string>> => {
+  const types = new Map<string, Set<string>>();
+  let current: Set<string> | undefined;
+  let inDocstring = false;
+  for (const line of sdl.split("\n")) {
+    const fenceCount = (line.match(/"""/g) ?? []).length;
+    if (inDocstring) {
+      if (fenceCount % 2 === 1) inDocstring = false;
+      continue;
+    }
+    if (fenceCount % 2 === 1) {
+      inDocstring = true;
+      continue;
+    }
+    const header = /^(?:type|interface|input) (\w+)/.exec(line);
+    if (header?.[1] !== undefined) {
+      current = new Set();
+      types.set(header[1], current);
+      continue;
+    }
+    if (line === "}") {
+      current = undefined;
+      continue;
+    }
+    const field = /^ {2}(\w+)\s*[(:]/.exec(line);
+    if (field?.[1] !== undefined && current !== undefined) {
+      current.add(field[1]);
+    }
+  }
+  return types;
+};
+
+const TYPES = parseTypes(SDL);
+const TYPES_BEFORE = parseTypes(SDL_BEFORE);
+
+/**
+ * The pre-existing types the four shipped lenses read, with the field
+ * count each carried BEFORE the second root landed — captured from the
+ * SDL at commit `aea674000`. A drop here means the merge stopped being
+ * additive; a rise on `Component` specifically means the shim exclusion
+ * regressed.
+ */
+const ESTABLISHED_FIELD_COUNTS: Readonly<Record<string, number>> = {
+  Component: 22,
+  Ontology: 5,
+  OntologyClass: 11,
+  UIBlock: 21,
+};
+
+describe("the second source root", () => {
+  it("loses no type from the pre-merge schema", () => {
+    const missing = [...TYPES_BEFORE.keys()].filter((name) => !TYPES.has(name));
+    expect(missing).toStrictEqual([]);
+  });
+
+  it("loses no FIELD from any pre-merge type", () => {
+    const lost: string[] = [];
+    for (const [name, fields] of TYPES_BEFORE) {
+      const now = TYPES.get(name);
+      if (now === undefined) continue;
+      for (const field of fields) {
+        if (!now.has(field)) lost.push(`${name}.${field}`);
+      }
+    }
+    expect(lost).toStrictEqual([]);
+  });
+
+  it("widens only Query among the pre-merge types", () => {
+    // Additive means: the second root contributes NEW types and NEW root
+    // fields. Any other established type gaining a field is a domain
+    // assertion smearing across the merge — the shim-concept failure mode.
+    const widened = [...TYPES_BEFORE.keys()].filter((name) => {
+      const before = TYPES_BEFORE.get(name)?.size ?? 0;
+      const after = TYPES.get(name)?.size ?? 0;
+      return after > before;
+    });
+    expect(widened).toStrictEqual(["Query"]);
+  });
+
+  it("keeps every established type", () => {
+    for (const name of Object.keys(ESTABLISHED_FIELD_COUNTS)) {
+      expect(TYPES.has(name), `${name} must survive the merge`).toBe(true);
+    }
+  });
+
+  it("changes no established type's field count", () => {
+    const actual = Object.fromEntries(
+      Object.keys(ESTABLISHED_FIELD_COUNTS).map((name) => [
+        name,
+        TYPES.get(name)?.size,
+      ]),
+    );
+    expect(actual).toStrictEqual(ESTABLISHED_FIELD_COUNTS);
+  });
+
+  it("does not smear the concept shim across the ds: types", () => {
+    // With the shim excluded, `ds:embodiesConcept` (rdfs:domain ds:Entity)
+    // does not reach `Component` in the capture. When these captures were
+    // taken, removing the exclusion smeared the field — `Component` went
+    // 22 → 23, gaining `embodiesConcepts` (the compiled name is the PLURAL).
+    // Restoring the shim TODAY would not turn this red, because the capture
+    // would not be retaken; the live assertion is in
+    // `src/lib/sources/collectTtlSources.test.ts`. This names the culprit so
+    // the record says what to look for.
+    const component = TYPES.get("Component");
+    expect(component?.has("embodiesConcepts")).toBe(false);
+  });
+
+  it("adds the demand model's types", () => {
+    for (const name of [
+      "Job",
+      "Pairing",
+      "Coordinate",
+      "Persona",
+      "Slot",
+      "Lens",
+    ]) {
+      expect(TYPES.has(name), `${name} must exist`).toBe(true);
+    }
+  });
+
+  it("pins a merged fixture the live backend can still reproduce", () => {
+    // The fixtures are only trustworthy while they describe the same
+    // sources the backend reads. This does not boot a store (too slow for
+    // a unit suite — the e2e path proves the live schema); it asserts the
+    // captured pair is internally coherent: the merged schema is a strict
+    // superset, and it carries the demand model the first root cannot.
+    expect(SDL.length).toBeGreaterThan(SDL_BEFORE.length);
+    expect(SDL_BEFORE).not.toContain("sem://surface#");
+    expect(TYPES.size).toBeGreaterThan(TYPES_BEFORE.size);
+  });
+
+  it("exposes Surface as an interface the pairing spine can fragment on", () => {
+    expect(SDL).toContain("interface Surface");
+    // The concrete surfaces a pairing can land on — the inline-fragment set.
+    for (const name of ["View", "Lens", "Detail", "Peek", "Port"]) {
+      expect(SDL).toContain(`type ${name} implements`);
+    }
+  });
+});

--- a/packages/prism/pragma-provider/tsconfig.build.json
+++ b/packages/prism/pragma-provider/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/testing/**"]
+}

--- a/packages/prism/pragma-provider/tsconfig.json
+++ b/packages/prism/pragma-provider/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@canonical/typescript-config",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["node", "bun"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "demo/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/prism/pragma-provider/vitest.config.ts
+++ b/packages/prism/pragma-provider/vitest.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    // ⚠ `*.test.ts`, NOT `*.tests.ts`. The docsite app uses the plural form;
+    // this package (like every other package in the repo) uses the singular.
+    // A file ported from the app keeping its `.tests.ts` name is collected by
+    // NOTHING and the suite goes green with fewer tests, silently.
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: [
+        "**/index.ts",
+        "**/*.test.ts",
+        "**/*.d.ts",
+        "**/types.ts",
+        "src/testing/**",
+      ],
+      // The repo standard for a shipped package: 100%, matching the sibling
+      // contract package. Do not lower these — the
+      // provider that backs the docsite cannot hold a lower bar than the
+      // reference implementation it is measured against.
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Done

Pragma's own documentation-site provider. It walks the repository's two TTL
source roots, harvests their prefixes, and compiles the result through
`@canonical/ke-graphql` into an executable GraphQL schema that satisfies
`@canonical/prism-contract`. `private: true` — its only consumer is this
repository.

Source: `feat/prism-docsite`, `24fe66cb0..6bbf65f9c`.

### Reconciled against `main`

`main` wins: version `0.36.0` → `0.37.0`, biome `2.4.9` → `2.5.11`, every
`^0.36.0` sibling range → `^0.37.0`. The `biome.json` pinned `"$schema"` at
2.4.9, which made `biome check` report a version mismatch on every run — every
sibling omits it, and so does this one now.

### One file arrives early

`apps/react/pragma-docs/src/relay/schema.graphql` lands here, ahead of the app.
Gate G-2 reads that file and **throws rather than skips** when it is missing, so
its subject has to arrive with it. The rest of the app follows in the next PR.

### Corrected while landing it

| What was wrong | Why it mattered |
| --- | --- |
| **Gate G-2 passed vacuously** | The contract names only the structural base, so the check was satisfied by the contract *itself*, by a stub, and by an emission with every ontology-derived field stripped out — all three measured. It now requires the subject to carry this provider's own signature first |
| **`prefixing` was pinned by prose only** | The comment says flipping it would "invalidate every committed Relay artifact at once". The flip left all 45 tests green. The emitted field names are asserted now, so that edit fails here rather than in the app |
| **A missing semantics tree degraded silently** | Its default location is a *guess* at a sibling working tree most machines do not have. Without it the entire demand model is absent from the schema, while the boot log reports an ordinary success. The collector says so now |
| **Three comments credited the wrong test** | `sourceAdditivity.test.ts` imports nothing from this package — it compares two frozen captures — yet was described as guarding `EXCLUDED_SOURCES`. `collectTtlSources.test.ts` does that; the comments now say which |
| **G-2's header claimed a CI step that does not exist** | It said CI runs the gate unconditionally in a `pr.yml` "Gates" step. There is no such step on this branch or on `main`. The header now states the real position, including the hole it cannot close — see below |
| **The barrel published the whole internals** | Eleven configuration constants and a recursive helper were public API. The one consumer imports `createPragmaProvider`; that plus its two types is the surface now |
| **Two header observations were never asserted** | The diagnostic set and the `NamedNode` field placement. Both are pinned now |
| **Two text passes read — and one REWROTE — Turtle prose** (raised in review) | Harvesting the prefix prologue and escaping channel-dotted local names are regular expressions over the whole file, and a regular expression cannot tell a prefixed name from the same characters inside an `rdfs:comment`. A commented-out `@prefix` was harvested like a live one, and under last-wins could hand the compiler a namespace the parser never applied; a literal merely mentioning `ex:.foo` had a backslash inserted into it, which is not a valid Turtle string escape and is not valid in an IRI reference at all, so a source that parsed stopped parsing. `sources/turtleText.ts` scans out comments, string literals and IRI references once, and both passes run through it. The corpus's compiled schema is unchanged |

Test infrastructure moved to where the standards put it: fixtures from
`src/__fixtures__/` to `src/testing/__fixtures__/`, and `sourceAdditivity.test.ts`
into `src/testing/integration/`.

## A known hole, stated rather than papered over

`nx affected` propagates from a changed project to its **dependents**. The app
depends on this package, not the reverse, so a PR touching only
`schema.graphql` marks the app affected and leaves this project's `test`
unscheduled. The edge cannot be declared either — an implicit dependency back
onto the app would close a cycle, which nx rejects.

So G-2 runs on every full `bun run test` and post-merge, and **not** on a PR
that changes only its subject. The fix available is to site the gate in the app,
where nx schedules it, at the cost of putting `@canonical/prism-contract` in the
app's dependency list. I have not taken it here because the gate's argument for
living in the provider — the app receives `schema.graphql`, it does not author
it — is sound, and because the app does not exist until the next PR. Say the
word and I will move it there.

## QA

Root gate, from the repository root:

- `bun run check` — 64 projects / 103 tasks, green
- `bun run test` — 47 projects, green; this package 5 files / 52 tests at 100% coverage
- `bun run build` — 53 projects, green
- `bun run check:ranges` — 64 workspace packages, every sibling range satisfied
- `bun run collect:check` — clean, `data/` unchanged

The `prefixing` pin was verified to have teeth by flipping the constant to
`"all"` and watching the two new assertions fail.

Environment notes, reproducible on unmodified `main` and untouched by this diff:
the three Playwright-tagged svelte projects cannot start a browser here
(`libglib-2.0.so.0` absent) and were excluded; `@canonical/pragma-cli` has tests
that hit a 5s timeout under load and pass in isolation, so the run used
`--concurrency 1`.

## Carried

Raised in review, deliberately not fixed here:

- **G-2 measures the committed artifact, not a live emission.** It catches the
  committed schema drifting from the *contract*; it cannot catch it drifting
  from what `createPragmaProvider` would emit today. Closing that needs a boot,
  which is the app's job.
- **The two `.sdl.txt` captures have no regeneration path.** Their stated
  procedure names a program that arrives with the app.
- **`byPath` has no equal arm**, which technically breaks `sort`'s comparator
  contract. Its precondition (the two package lists are disjoint) is now
  asserted by test rather than only claimed, but an equal arm would be
  unreachable and would break the 100% threshold.
- **`CHANNEL_DOTTED_REF`'s lookahead is narrower than Turtle's grammar** — it
  rejects digit-leading local names, so `ds:.9foo` goes unescaped. Widening it
  changes escaping behaviour and wants its own change.
- **Provenance commits cited in comments** (`4d228c8`, `aea674000`) are not
  ancestors of this branch. The measurements they record still check out; only
  the citations dangle.
- **Test-file `// ====` banners** were left as they are — non-test sources were
  converted to TSDoc, but the banner style is the established idiom across
  `ke-graphql`'s test files.

## Readiness

- [x] Conventional-commit title
- [x] New behaviour covered by tests
- [x] Root gate green
- [x] Private package — no publish step needed

Chromatic: skip

https://claude.ai/code/session_01PUNAcTepWDfnyfNYqBnzbn
