### PR TITLE
feat(prism-graph-example): add a hand-written provider for the contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ The documentation-site layer. The dependency arrow points one way — see "The d
 |---------|------|-------------|
 | `@canonical/prism-contract` | `packages/prism/contract` | The minimal GraphQL surface a documentation-site provider must offer, plus a subsumption check that a provider satisfies it |
 | `@canonical/prism-pragma-provider` | `packages/prism/pragma-provider` | **internal** — pragma's own provider: the repository's TTL corpus compiled into a conformant GraphQL schema |
+| `@canonical/prism-graph-example` | `packages/prism/graph-example` | **internal** — a hand-written provider that satisfies the same contract without the compiler, so the site's neutrality is measured rather than asserted |
 
 ### Core Infrastructure
 

--- a/bun.lock
+++ b/bun.lock
@@ -482,6 +482,25 @@
         "graphql": "^16.11.0 || ^17.0.0-rc.0",
       },
     },
+    "packages/prism/graph-example": {
+      "name": "@canonical/prism-graph-example",
+      "version": "0.37.0",
+      "dependencies": {
+        "@canonical/prism-contract": "^0.37.0",
+        "graphql": "^16.11.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.5.11",
+        "@canonical/biome-config": "^0.37.0",
+        "@canonical/typescript-config": "^0.37.0",
+        "@canonical/webarchitect": "^0.37.0",
+        "@types/bun": "^1.3.10",
+        "@types/node": "^24.12.0",
+        "@vitest/coverage-v8": "^4.0.18",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
+      },
+    },
     "packages/prism/pragma-provider": {
       "name": "@canonical/prism-pragma-provider",
       "version": "0.37.0",
@@ -1920,6 +1939,8 @@
     "@canonical/pragma-docs": ["@canonical/pragma-docs@workspace:apps/react/pragma-docs"],
 
     "@canonical/prism-contract": ["@canonical/prism-contract@workspace:packages/prism/contract"],
+
+    "@canonical/prism-graph-example": ["@canonical/prism-graph-example@workspace:packages/prism/graph-example"],
 
     "@canonical/prism-pragma-provider": ["@canonical/prism-pragma-provider@workspace:packages/prism/pragma-provider"],
 
@@ -4683,6 +4704,10 @@
 
     "@canonical/prism-contract/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
+    "@canonical/prism-graph-example/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
+    "@canonical/prism-graph-example/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
+
     "@canonical/prism-pragma-provider/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "@canonical/react-boilerplate-vite/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
@@ -5266,6 +5291,8 @@
     "@canonical/pragma-docs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@canonical/prism-contract/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@canonical/prism-graph-example/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@canonical/prism-pragma-provider/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/packages/prism/graph-example/README.md
+++ b/packages/prism/graph-example/README.md
@@ -1,0 +1,411 @@
+# @canonical/prism-graph-example
+
+A **second, hand-written implementation of [`@canonical/prism-contract`](../contract)**,
+serving a fictional metro network.
+
+It exists so that one sentence in the Prism acceptance criteria becomes runnable rather
+than rhetorical:
+
+> the lenses render against a provider that has never heard of pragma.
+
+Everything here is built to make that measurable. If the contract were secretly shaped
+around ke-graphql, or secretly required a compiler, this package is where it would show
+— as awkwardness, as a field that cannot be answered, or as a line count that runs away.
+Two of those three happened. They are written down below rather than smoothed over.
+
+> **Deliberately not published.** `"private": true`. A new public package needs a manual
+> first `npm publish --access public` plus human OIDC trusted-publisher setup before
+> release automation works, and a reference implementation whose only consumer is this
+> repository should not need that to merge. Flipping it later is a one-line change:
+> drop `"private"`, add `"publishConfig": { "access": "public" }`.
+
+---
+
+## Why it does not use ke-graphql
+
+ke-graphql could produce a conformant schema from a metro ontology in an afternoon. That
+would prove almost nothing.
+
+- **It would be the same engine over different data.** One compiler satisfying the
+  contract twice measures the compiler, not the contract.
+- **It inverts the arrow.** The compiler *derives* a schema from an ontology; the
+  contract is *authored*. Conformance-by-compiler therefore degrades into shaping the
+  data until the compiler happens to emit the right names — which is a test of patience,
+  not of the specification.
+
+So this provider is `buildSchema(sdl)` and plain TypeScript objects. It starts **from**
+the authored contract SDL, which it reads at runtime from `@canonical/prism-contract`,
+so it cannot drift from it: change the contract and this package's contract gate is red
+on the next run.
+
+### `mode` and `prefixing` do not apply here
+
+`mode` (`"auto" | "annotated" | "explicit"`) and `prefixing` are **ke-graphql compiler**
+options. They govern how the compiler derives GraphQL names from an ontology.
+
+**This provider derives nothing.** It implements the contract's fixed, structural names —
+`uri`, `_meta`, `instances`, `superclasses`. There is no naming decision to configure,
+so neither knob has an equivalent here. Do not go looking for them.
+
+---
+
+## What a provider must add to the contract — Finding A
+
+**`buildSchema(contractSdl)` on its own cannot serve instance data.**
+
+The contract declares exactly one type that `implements Node`: `OntologyClass`. So a
+`NodeConnection` returned by `OntologyClass.instances` can legally contain nothing but
+ontology classes. There is no type an ABox entity could *be*.
+
+Every provider therefore extends the contract SDL with its own concrete `Node`
+implementers. That extension is precisely what the contract's superset rule exists for:
+
+```ts
+const sdl = readContractSdl() + readExtensionSdl();   // src/lib/provider/providerSdl.ts
+```
+
+`schema/extension.graphql` adds `Line`, `Station`, `Interchange`, `Zone` and the
+embeddable `GeoPoint`. `findBreakingChanges(contractOnly, extended)` returns zero, and
+`satisfiesContract(readProviderSdl())` returns **zero violations**.
+
+**Note what the extension does *not* contain: `extend type Query`.** Every type this
+provider declares is reachable through the contract's own five root fields — `node(id:)`
+and `OntologyClass.instances`. Adding provider root fields would have been easier and
+would have demonstrated less.
+
+---
+
+## The dataset
+
+A small fictional **metro/transit network**, in `src/lib/provider/dataset.ts`.
+
+The subject matter is load-bearing. pragma's own graph is design systems, components,
+code standards, jobs, personas, surfaces and layouts. A transit network shares **no**
+vocabulary with any of it, so nothing here can be mistaken for a pragma fixture that
+happens to have been renamed. (Biology and taxonomy were deliberately avoided: a domain
+with its own taxonomic ranks blurs the line between the subject's hierarchy and RDFS
+subclassing, and this dataset needs that line sharp.)
+
+The file contains **inert records only** — no functions, no getters. All view
+construction lives in `createExampleProvider.ts`, which keeps "a provider is some code
+and a data file" literally true.
+
+| What is in it | Which contract obligation it discharges |
+| --- | --- |
+| `metro:Stop` (abstract) → `metro:Station` → `metro:Interchange` | `superclass`, `superclasses` (transitive), `subclasses`, `isAbstract` |
+| `metro:Line`, a second root class | `superclass: null` |
+| a second ontology `geo:` with no label | `Query.ontologies` > 1, `Ontology.label` nullability |
+| `rdfs:Class`, the metaclass | `EntityMeta.type` on an `OntologyClass` — see Finding B |
+| `geo:Zone` with real instances, in the **second** namespace | `_meta.curie` must resolve a prefix per entity, not hardcode one |
+| `metro:name` (DATATYPE, no domain), `metro:servesLine` (OBJECT, with `inverse`), `metro:note` (ANNOTATION) | all three `PropertyKind` values, `functional`, `inverse`, nullable `domain` |
+| 14 stations + 2 interchanges + 2 fare zones | `instances(first/after/last/before)` with real `hasNextPage` |
+| `metro:ghost` — **no descriptive predicates at all** | the local-name tier of `_meta.title` |
+| `https://metro.example/onto#` — **IRI with an empty local name** | the whole-IRI tier of `_meta.title` |
+| `geo:GeoPoint`, an embeddable with no `uri` | the typename tier of `_meta.title` |
+| a station labelled `{"": "Northgate", "fr": "Porte-Nord"}` | `title(lang:)` / `label(lang:)` are genuinely implemented, not accepted and ignored |
+| instance IRIs that live **inside** the declared namespaces | `_meta.curie` can compact at all — see the curie section |
+
+The embeddable is **not required by the contract** — nothing in the contract references a
+non-Node value type. It is here to reach `_meta.title`'s last tier and to show that a
+provider may add value types freely.
+
+---
+
+## `_meta.title` by hand — the verdict
+
+`title(lang: String = "en"): String!` is **non-null**, so every provider owes a total
+fallback chain. The ticket suspected this would be the awkward part. It is not.
+
+The whole of it, in `src/lib/provider/descriptive.ts`:
+
+1. the asserted label for the requested language, else the untagged literal
+2. else any asserted literal in any language
+3. else the IRI's local name
+4. else the whole IRI
+5. else the GraphQL typename (reachable only for something with no IRI — an embeddable)
+
+**Verdict: writing it by hand was trivial, not awkward — eight lines of body, and a point
+in the base's favour.** Two honest caveats:
+
+- It is trivial *partly because* this provider chose a shape (a language → string map)
+  that mirrors RDF literals. A provider whose records have a plain `name: string` writes
+  `name ?? localName(uri)` and is done in two lines. Either way `title`'s totality costs
+  nothing worth arguing about.
+- What is genuinely expensive is not `title`. It is `type` and `fields` — see Finding B.
+  The easy win here should not be allowed to obscure that.
+
+The gate for this (`src/testing/integration/titleTotality.test.ts`) is driven **from the
+dataset**, never from a hand-listed set of URIs: every entity, every class, and every
+embeddable is checked, including in a language nobody wrote.
+
+---
+
+## Finding B — the contract makes a TBox mandatory
+
+`EntityMeta.type: OntologyClass!` and `EntityMeta.fields: [ClassProperty!]!` are
+**non-null**. A provider whose data is a flat list of records therefore **cannot be
+conformant without inventing an ontology**.
+
+This is the single largest cost the contract imposes on a hand-written provider, and it
+is the honest answer to "is the base implementable without the compiler": yes — but only
+if you are willing to author a TBox alongside your data.
+
+It is arguably the correct design; self-description is the contract's whole premise. But
+it is a *consequence*, and it should be stated rather than discovered. Measured cost, in
+`createExampleProvider.ts`:
+
+| Region | Code lines |
+| --- | --- |
+| TBox views and traversal (`ancestorsOf`, `fieldsOf`, `propertyView`, `classPropertyView`, `classView`, `nullableClassView`, `superclassOf`) | **94** |
+| the `_meta` wrapper itself (`metaView`) | **17** |
+| **total attributable to the non-null TBox** | **111** |
+| everything else in the function body (entities, connections, ontologies, root fields) | 122 |
+
+Nearly half the provider is TBox machinery that exists only because those two fields are
+non-null. A `type: OntologyClass` (nullable) and `fields: [ClassProperty!]` (nullable)
+would let a flat-record provider conform in roughly half the code.
+
+One side effect worth naming: because `OntologyClass` itself implements `Node`, a class
+needs a class. This dataset declares `rdfs:Class` for that, which is an instance of
+itself — so the tower terminates honestly rather than by fiat.
+
+---
+
+## Finding C — `_meta.field(name:)` had no defined key. **The contract closed it.**
+
+Building this provider surfaced a real hole. `_meta.fields` returned `[ClassProperty!]!`,
+and neither `ClassProperty` nor `OntologyProperty` exposed anything called `name` — so a
+client that enumerated `_meta.fields` **could not derive a legal argument for
+`_meta.field(name:)`**. The argument round-tripped through nothing. It worked in
+ke-graphql only because there `name` means "the GraphQL field name the compiler derived",
+a *compiler* concept leaking into a surface that claims to be provider-neutral.
+
+**`ClassProperty` now carries `name: String!`.** The argument round-trips properly:
+enumerate `_meta.fields`, read `name`, pass it straight back to `field(name:)`.
+
+### What this provider puts in `name`, and why it has to say so
+
+The contract can require the field but cannot say what a *hand-written* provider should
+put in it — "the name the compiler derived" means nothing where nothing is derived. So
+each provider states its own rule. **This one serves the property IRI's local name:**
+
+| `property.uri` | `name` |
+| --- | --- |
+| `https://metro.example/onto#platformCount` | `platformCount` |
+| `https://geo.example/onto#inZone` | `inZone` |
+
+`_meta.field(name:)` matches **that exact value and nothing else** — passing the full IRI
+returns null. Accepting extra aliases would make "the value `fields` publishes" stop
+being the whole answer, which is the property worth having.
+
+The one caveat: local names are not globally unique, so two properties from different
+namespaces with the same local name would collide on one class. This dataset has none;
+a provider whose ontology does should serve the curie (`geo:inZone`) instead — which the
+contract now makes derivable, since `_meta.curie` and `Query.ontologies` are both public.
+
+---
+
+## `_meta.curie` by hand — the second verdict
+
+`curie: String!` is the compact display form of the entity's IRI: `metro:northgate` for
+`https://metro.example/onto#northgate`. Like `title`, it is **non-null**, so it is a
+totality obligation.
+
+**Verdict: not awkward — eight lines — but only because the dataset was honest about its
+namespaces.** The implementation is:
+
+> the declared prefix of the **longest** namespace the IRI starts with, plus the
+> remainder; the whole IRI if nothing matches.
+
+Three things are worth reporting:
+
+1. **It resolves against `dataset.ontologies` — the very prefix/namespace pairs
+   `Query.ontologies` publishes.** So a client can derive exactly the same string itself;
+   the field is a convenience, never a secret. There is a test that does precisely that
+   derivation and asserts it matches. A `curie` computed from anything a client cannot
+   see would be a much worse field.
+2. **Longest-match matters.** First-match would let a namespace shadow a longer one that
+   extends it. That is two words of code, but getting it wrong is silent.
+3. **It forced a real dataset change, and that is the interesting part.** Instance IRIs
+   originally lived at `https://metro.example/stop/…` while the ontology lived at
+   `https://metro.example/onto#…`. That is normal RDF practice, but it means **instances
+   are in no declared namespace** and every curie would have degraded to the full IRI.
+   Serving `curie` well is therefore a constraint on how a provider *names its data*, not
+   just on how it answers a field. Instances moved into the declared namespaces, and a
+   `geo:Zone` class with real instances was added so that entities genuinely span two
+   prefixes — otherwise an implementation that hardcoded `metro:` would have passed every
+   test. The totality gate asserts that more than one prefix appears across the dataset.
+
+Edge cases, all gated: an IRI whose local name is empty compacts to a bare `metro:`; the
+embeddable, having no IRI of its own, answers its **GraphQL type name** (`GeoPoint`).
+That last one is the contract's own third tier, quoted: "for a value with no IRI at all
+(an embedded blank node) — the GraphQL type name". Compacting the embeddable's CLASS
+instead (`geo:GeoPoint`) reads better in isolation and is the wrong answer; a provider
+whose job is to demonstrate the contract does not get to serve a nicer one. The typename
+tier is also the tail `_meta.title` falls back to, so the two agree.
+
+---
+
+## Size — measured, not estimated
+
+The ticket's premise was "a provider is ~150–200 lines and a data file". Here is what it
+actually took. Code lines exclude blank lines and comments; "with docs" is the physical
+file length in this repo's TSDoc-heavy house style.
+
+| Module set | Code | With docs |
+| --- | --- | --- |
+| `createExampleProvider.ts` | 304 | 466 |
+| `connection.ts` (Relay paging) | 47 | 90 |
+| `providerSdl.ts` (SDL loading) | 33 | 70 |
+| `descriptive.ts` (**the whole `_meta.title` chain**) | **26** | 54 |
+| barrels | 10 | 10 |
+| **provider runtime total** | **420** | **690** |
+| `dataset.ts` (the data file — inert records) | 372 | 446 |
+| `types.ts` + `constants.ts` (declarations only) | 71 | 153 |
+| HTTP server (`createExampleHandler` + GraphiQL) | 95 | 140 |
+| `schema/extension.graphql` | 82 | 88 |
+| tests + test infrastructure | 1836 | 2208 |
+
+**420 code lines against a 150–200 target — roughly 2.1×.**
+Where it goes, and which parts are anybody's fault:
+
+1. **The contract declares 54 fields** across `Node`, `EntityMeta`, `PageInfo`,
+   `NodeConnection`, `NodeEdge`, `Ontology`, `OntologyClass`, `ClassProperty`,
+   `OntologyProperty` and `Query` (52 before `ClassProperty.name` and `EntityMeta.curie`).
+   A provider must answer every one. At the ~4.5 lines per field this implementation
+   averages, **the 150–200 target was unreachable before a line was written** — it appears
+   to have been set without counting the contract's surface. That is the main correction
+   to the original estimate, and it means the target should be restated as a function of
+   the contract's size rather than as a constant.
+2. **The mandatory TBox (Finding B) is 111 of those lines** — 95 of TBox views and
+   traversal plus the 16-line `_meta` wrapper, out of a 258-line function body. This is
+   the one number that is genuinely evidence *about the converged base*, and the only one
+   a contract change could meaningfully reduce.
+3. **Relay paging is 47 lines and is not the base's fault.** `first/after/last/before` on
+   `OntologyClass.instances` is Relay's cost and would be present in any
+   connection-shaped specification.
+4. **`_meta.title` is 26 lines including all five fallback tiers and its TSDoc**, and
+   **`_meta.curie` is 8** — the two totality obligations the ticket most suspected both
+   came out cheap. The expensive obligation was the one nobody flagged: the non-null TBox.
+5. **The two new fields cost ~12 lines of permanent code between them** (`curieOf` 8,
+   `ClassProperty.name` 1, `_meta.curie` 1, the `inZone` relation 3). Adding fields to
+   this contract is cheap for providers; it is the *non-null* ones that carry structure
+   behind them that are not.
+
+---
+
+## Running it
+
+```bash
+bun run serve                       # http://127.0.0.1:5176/graphql, with GraphiQL
+NODE_ENV=production bun run serve   # no GraphiQL, no CORS
+```
+
+Port 5176 so it never collides with the docsite's own graph on 5175 — the point is to run
+both and see the same lenses render against either.
+
+```bash
+bun run check   # biome + tsc --noEmit + webarchitect
+bun run test    # vitest with 100% coverage thresholds
+```
+
+The HTTP handler is ~70 lines and is **deliberately not** ke-graphql's
+`createGraphQLHandler`: that one is 505 lines and imports the other graphql major pinned
+in this repo, so reusing it would put two graphql instances in one process — and it would
+contradict the premise that this contract is implementable without pragma's machinery.
+
+---
+
+## The lens gate, and the two things it does not guard
+
+`src/testing/integration/lensOperations.test.ts` harvests **every** query operation
+declared under `apps/react/pragma-docs/src/domains/lenses/**` — the docsite's **core lens
+set** — at run time, from the committed Relay artifacts, never from a snapshot, and
+executes each one against this provider.
+
+It started life red by design, as a to-do list. **It is now green.** The definitions lens
+and the standards lens were despecialised onto the contract and execute here:
+`DefinitionsExplorerQuery`, `StandardsIndexQuery`, `StandardsIndexPaginationQuery` and
+`StandardEntityQuery` — four operations, zero failures.
+
+**Four out of the docsite's ten shipped query operations.** That denominator
+belongs next to the numerator, because the other six do not execute against
+this provider and the scan root does not say so on its own:
+
+| Where | Operations | Why they do not run here |
+| --- | --- | --- |
+| `src/domains/components` | `ComponentsCatalogQuery`, `CatalogListPaginationQuery`, `ComponentEntityQuery` | select `Component` / `Query.component` |
+| `src/domains/marketing` | `LobbyQuery` (the home page) | selects `Component` |
+| `src/domains/playground` | `ComponentProbeQuery` | selects `Query.component` |
+| `src/addons/journeys` | `JourneysExplorerQuery` | selects `jobs` |
+
+All six name pragma-ontology terms this provider's dataset has no class for.
+So what this gate establishes is narrow and worth stating narrowly: **the four
+operations under `src/domains/lenses` are provider-neutral.** It does not
+establish that the docsite as a whole runs against any conformant provider —
+five mounted routes, the home page among them, currently do not. Widening the
+scan root to `src/domains` is the intended direction and would turn this gate
+red today; that red would be the to-do list, which is the state this gate was
+designed to be useful in.
+
+### The core set, and the one thing outside it
+
+The last red operation was `JourneysExplorerQuery`, which joins four ontology-derived root
+fields and walks eleven ontology-derived properties. It was never fixable by rewriting the
+operation: **the contract has no field anywhere that returns the value of an arbitrary
+property on an arbitrary entity** (`EntityMeta.field(name:)` returns cardinality metadata,
+not a value), and generic instance-level relation traversal is all that lens is. The
+README used to say the resolution was an owner's decision. **The owner decided**, in these
+words: *"keep it on side for now, it will be an add-on plugin not a core view."*
+
+Journeys is therefore **no longer a core lens**. It lives at
+`apps/react/pragma-docs/src/addons/journeys/**`, which this gate does not scan — and it is
+still fully built, routed, listed in the rail, and covered by its own tests in the app.
+Nothing was deleted. `src/addons/**` is the docsite's home for views that are openly
+pragma-specific and make no neutrality claim; journeys is expected to become a plugin
+proper once the docsite has a plugin mechanism.
+
+That distinction is the whole point, so state it plainly: **the scanned directory defines
+an obligation.** Membership of `src/domains/lenses/**` *is* the promise to be
+provider-neutral. A view either makes that promise and must execute here, or it is an
+add-on and does not. There is no third state, and nothing sits in the lens tree with an
+exemption.
+
+**`src/addons/**` is not an escape hatch.** Do not make this gate green by narrowing the
+operation set, marking it `it.fails`, adding `skipIf`, gating it behind an env var, or
+moving a core operation into the add-on tree — that last one is narrowing the set under a
+different name, and it is expressly forbidden. Only an owner reclassifying a view as an
+add-on may move one, and the move must land with the reasoning written down (see
+`src/addons/journeys/index.ts`). Every other route converts a real signal into a silent
+one, and the operation set must stay directory-derived so a new lens is covered the day it
+lands. The gate also asserts it discovered a non-zero number of operations, so it cannot
+pass vacuously if the app moves.
+
+Going forward, what this gate guards is one specific claim: **no lens operation asks for a
+field that exists only because pragma's compiler generated it from pragma's ontology.** It
+parses each operation against this provider's schema, executes it, and rejects a result
+whose every root field came back null — so an operation cannot pass by looking nothing up.
+
+Two things it does **not** guard, both worth knowing before trusting a green run.
+
+**It does not guard the app's runtime bindings.** The contract's root surface names no
+subject, so a lens that enumerates things is handed a class URI from outside the graph.
+This gate supplies its OWN (`metro:Station`, in `src/testing/fixtures.ts`); the app
+supplies its own from `apps/react/pragma-docs/src/lib/graphBindings`. **The two must never
+meet.** Importing the app's binding here would make the gate go green because the app
+agreed with itself, when the point is that the operation is neutral about which class it
+is pointed at. The consequence is that an operation can be contract-clean here and still
+be handed the wrong thing in production — which is why, for example, the standards reading
+page carries its own wrong-class guard and its own test for it, in the app.
+
+**It does not guard cursor continuity.** It executes each operation exactly once, with
+`cursor: null`. `src/testing/integration/lensPagination.test.ts` covers that separately:
+it pages through a real connection, asserts page 2 is non-empty and disjoint from page 1,
+and — the load-bearing part — asserts every cursor decodes to the absolute IRI of the node
+it belongs to. That bond is the only reason a cursor minted by ke-graphql is located by
+this provider and vice versa, and a broken cursor is otherwise invisible: an unrecognised
+cursor is answered with page 1 and no error, deliberately, so drift would show up as a
+reader stuck on page 1 rather than as a failure.
+
+This gate's natural long-term home is the app, which owns the lenses. It lives here only
+because the app could not take a dependency on this package while both were being written.

--- a/packages/prism/graph-example/biome.json
+++ b/packages/prism/graph-example/biome.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "includes": ["**/src/**", "**/demo/**", "**/*.json"]
+  }
+}

--- a/packages/prism/graph-example/demo/server.ts
+++ b/packages/prism/graph-example/demo/server.ts
@@ -1,0 +1,51 @@
+/**
+ * A runnable endpoint for the example provider.
+ *
+ *   bun run serve                       # GraphiQL at http://127.0.0.1:5176/graphql
+ *   NODE_ENV=production bun run serve   # no GraphiQL, no CORS
+ *
+ * Port 5176 by default so it never collides with the docsite's own graph on
+ * 5175 — the point is to run BOTH and see the same lenses render against
+ * either one.
+ *
+ * Not part of the published build (tsconfig.build.json covers src/ only); it
+ * is type-checked and linted like everything else.
+ */
+
+import {
+  createExampleHandler,
+  createExampleProvider,
+  GRAPHQL_PATH,
+} from "../src/index.js";
+
+const port = Number(process.env.PORT ?? 5176);
+const provider = createExampleProvider();
+const handler = createExampleHandler(provider, {
+  endpoint: `http://127.0.0.1:${port}${GRAPHQL_PATH}`,
+});
+
+Bun.serve({
+  // Bun binds every interface when `hostname` is omitted, and this process
+  // serves GraphiQL and permissive CORS outside production — so an unbound
+  // demo hands the whole local network a development endpoint. Loopback, the
+  // same address the banner and the GraphiQL endpoint advertise, and the same
+  // choice the sibling prism provider demo makes.
+  hostname: "127.0.0.1",
+  port,
+  fetch: async (request: Request): Promise<Response> => {
+    const { pathname } = new URL(request.url);
+    if (pathname !== GRAPHQL_PATH) {
+      return Response.json(
+        {
+          errors: [{ message: `Not found. The endpoint is ${GRAPHQL_PATH}.` }],
+        },
+        { status: 404 },
+      );
+    }
+    return handler(request);
+  },
+});
+
+console.log(
+  `prism-graph-example listening on http://127.0.0.1:${port}${GRAPHQL_PATH}`,
+);

--- a/packages/prism/graph-example/package.json
+++ b/packages/prism/graph-example/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@canonical/prism-graph-example",
+  "description": "A second, hand-written implementation of the Prism data contract over a fictional metro network, so the contract's provider-neutrality is measurable rather than asserted",
+  "version": "0.37.0",
+  "private": true,
+  "type": "module",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    },
+    "./schema/extension.graphql": "./schema/extension.graphql"
+  },
+  "files": [
+    "dist",
+    "schema"
+  ],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/pragma"
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/pragma/issues"
+  },
+  "homepage": "https://github.com/canonical/pragma#readme",
+  "scripts": {
+    "build": "bun run build:package",
+    "build:all": "bun run build:package",
+    "build:package": "bun run build:package:tsc",
+    "build:package:tsc": "tsc -p tsconfig.build.json",
+    "check": "bun run check:biome && bun run check:ts && bun run check:webarchitect",
+    "check:fix": "bun run check:biome:fix && bun run check:ts",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write",
+    "check:ts": "tsc --noEmit",
+    "check:webarchitect": "webarchitect library",
+    "serve": "bun demo/server.ts",
+    "test": "bun run test:vitest",
+    "test:vitest": "vitest run --coverage",
+    "test:vitest:watch": "vitest"
+  },
+  "dependencies": {
+    "@canonical/prism-contract": "^0.37.0",
+    "graphql": "^16.11.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.11",
+    "@canonical/biome-config": "^0.37.0",
+    "@canonical/typescript-config": "^0.37.0",
+    "@canonical/webarchitect": "^0.37.0",
+    "@types/bun": "^1.3.10",
+    "@types/node": "^24.12.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/prism/graph-example/schema/extension.graphql
+++ b/packages/prism/graph-example/schema/extension.graphql
@@ -1,0 +1,114 @@
+# =============================================================================
+# This provider's own types, appended to the authored contract SDL.
+#
+# WHY THIS FILE EXISTS AT ALL. The contract declares exactly one type that
+# `implements Node` — OntologyClass. A NodeConnection built from the contract
+# alone can therefore contain nothing but ontology classes: there is no type
+# an ABox entity could be. Every provider must extend the contract SDL with
+# its own concrete Node implementers, and that extension is precisely what the
+# contract's superset rule is for (contract.graphql:39-42). `buildSchema` over
+# the contract alone cannot serve instance data.
+#
+# NOTE WHAT IS ABSENT: there is no `extend type Query`. Every type below is
+# reachable through the contract's own root fields — `node(id:)` and
+# `OntologyClass.instances`. Adding provider root fields would have been
+# easier and would have proved less: the point is that the contract's five
+# roots suffice.
+# =============================================================================
+
+"""
+A metro line. A root class in the TBox (no superclass), so it demonstrates
+that `OntologyClass.superclass` is legitimately null.
+"""
+type Line implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  name: String
+  servedBy: [Stop!]!
+}
+
+"""
+Anything that serves a line: the GraphQL face of the TBox's `metro:Stop`
+class, which `Station` and its subclass `Interchange` both instantiate.
+
+WHY IT HAS TO EXIST. `Line.servedBy` walks the inverse of `servesLine`, and
+both concrete types carry that property — so the list genuinely holds a mix.
+Declaring it `[Station!]!` said otherwise: an `Interchange` came back through
+it dressed as a `Station`, `... on Interchange` could not be written against
+it, and the schema disagreed with the values it served. GraphQL has no type
+inheritance, so the TBox's subclassing cannot carry the list; an interface
+can, and this is the smallest one that does.
+
+It does NOT try to mirror the class tree. `Stop` is one interface over the
+fields both implementers share; the hierarchy itself still lives in the TBox
+and shows up through `superclasses` / `subclasses` / `inherited`.
+"""
+interface Stop implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  name: String
+  platformCount: Int
+  location: GeoPoint
+  servesLine: [Line!]!
+  inZone: Zone
+}
+
+"""
+A station on the network. `name` is nullable in GraphQL even though the TBox
+marks `metro:name` required on this class: SHACL cardinality is an assertion
+about the data, and this dataset deliberately contains stations that violate
+it so `_meta.title`'s fallback chain has something to fall back from.
+"""
+type Station implements Node & Stop {
+  uri: ID!
+  _meta: EntityMeta!
+  name: String
+  platformCount: Int
+  location: GeoPoint
+  servesLine: [Line!]!
+  inZone: Zone
+}
+
+"""
+A fare band. Lives in the SECOND namespace (`geo:`), which is the point: with
+entities in only one namespace, a `_meta.curie` implementation could hardcode
+a single prefix and still look correct on every row.
+"""
+type Zone implements Node {
+  uri: ID!
+  _meta: EntityMeta!
+  name: String
+}
+
+"""
+A station where two or more lines meet — a subclass of Station in the TBox.
+GraphQL has no type inheritance, so the relationship lives entirely in the
+TBox and shows up through `superclasses` / `subclasses` / `inherited`.
+"""
+type Interchange implements Node & Stop {
+  uri: ID!
+  _meta: EntityMeta!
+  name: String
+  platformCount: Int
+  location: GeoPoint
+  servesLine: [Line!]!
+  inZone: Zone
+  transferMinutes: Int
+}
+
+"""
+A latitude/longitude pair. NOT a Node: it has no IRI, so it is unreachable
+through `node(id:)` and can never appear in a NodeConnection.
+
+The contract does not require an embeddable — nothing in it references a
+non-Node value type. This one exists to probe the last tier of `_meta.title`'s
+fallback chain (the typename tier, reached only when there is no IRI to fall
+back to) and to show that a provider may add value types freely. Note that it
+still carries `_meta: EntityMeta!`, and EntityMeta.type is non-null, so even a
+coordinate pair needs a class in the TBox.
+"""
+type GeoPoint {
+  _meta: EntityMeta!
+  latitude: Float!
+  longitude: Float!
+}

--- a/packages/prism/graph-example/src/index.ts
+++ b/packages/prism/graph-example/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `@canonical/prism-graph-example` — a second implementation of
+ * `@canonical/prism-contract`, written by hand and WITHOUT the ke-graphql
+ * compiler.
+ *
+ * It is the control in a two-provider experiment: a documentation site that
+ * runs against both this and the compiler-backed provider is provider-neutral
+ * by measurement rather than by assertion.
+ *
+ * @module prism-graph-example
+ */
+
+export * from "./lib/index.js";

--- a/packages/prism/graph-example/src/lib/index.ts
+++ b/packages/prism/graph-example/src/lib/index.ts
@@ -1,0 +1,19 @@
+/**
+ * The package's public surface: the provider factory, the fetch handler built
+ * on it, and the path that handler serves.
+ *
+ * The internal cross-domain surface — the dataset, the connection helpers, the
+ * descriptive fallback chain, the SDL readers and the eleven constants — is
+ * deliberately NOT re-exported. This package exists to be BOOTED and pointed
+ * at, not to have its internals composed by a caller; its own tests reach them
+ * by relative path, which is the right amount of access for them to have.
+ *
+ * @module lib
+ */
+
+export {
+  createExampleProvider,
+  type ExampleProvider,
+  GRAPHQL_PATH,
+} from "./provider/index.js";
+export { createExampleHandler } from "./server/index.js";

--- a/packages/prism/graph-example/src/lib/provider/connection.test.ts
+++ b/packages/prism/graph-example/src/lib/provider/connection.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { fromCursor, sliceConnection, toCursor } from "./connection.js";
+
+const items = ["a", "b", "c", "d", "e"];
+const identify = (item: string): string => item;
+const slice = (args: Parameters<typeof sliceConnection>[2]) =>
+  sliceConnection(items, identify, args);
+
+describe("cursors", () => {
+  it("round-trip", () => {
+    const uri = "https://metro.example/stop/northgate";
+    expect(fromCursor(toCursor(uri))).toBe(uri);
+  });
+
+  it("are opaque base64, not the IRI itself", () => {
+    expect(toCursor("a")).not.toBe("a");
+  });
+});
+
+describe("sliceConnection", () => {
+  it("returns everything, unflagged, when no arguments are given", () => {
+    expect(slice({})).toEqual({
+      items,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("takes `first` from the head and flags a next page", () => {
+    expect(slice({ first: 2 })).toEqual({
+      items: ["a", "b"],
+      hasNextPage: true,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("does not flag a next page when `first` exceeds the list", () => {
+    expect(slice({ first: 99 }).hasNextPage).toBe(false);
+  });
+
+  it("cuts to `after` and flags a previous page", () => {
+    expect(slice({ after: toCursor("c") })).toEqual({
+      items: ["d", "e"],
+      hasNextPage: false,
+      hasPreviousPage: true,
+    });
+  });
+
+  // The two cells where the count cut and the cursor cut DISAGREE, and where
+  // seeding the flags from the cursor answer got them backwards. Both are
+  // client-supplied counts, so the spec's count answer takes precedence.
+  it("first + before: the window fits, so there is no next page", () => {
+    // Window is [a, b] and `first` is 2 — nothing was trimmed, so nothing
+    // lies beyond this page. Reporting a next page here walks a client into
+    // an empty one.
+    expect(slice({ before: toCursor("c"), first: 2 })).toEqual({
+      items: ["a", "b"],
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("last + after: the window fits, so there is no previous page", () => {
+    expect(slice({ after: toCursor("a"), last: 5 })).toEqual({
+      items: ["b", "c", "d", "e"],
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("cuts to `before` and flags a next page", () => {
+    expect(slice({ before: toCursor("c") })).toEqual({
+      items: ["a", "b"],
+      hasNextPage: true,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("takes `last` from the tail without claiming a next page", () => {
+    expect(slice({ last: 2 })).toEqual({
+      items: ["d", "e"],
+      hasNextPage: false,
+      hasPreviousPage: true,
+    });
+  });
+
+  it("does not flag a previous page when `last` exceeds the list", () => {
+    expect(slice({ last: 99 }).hasPreviousPage).toBe(false);
+  });
+
+  it("applies `after` and `before` together", () => {
+    expect(slice({ after: toCursor("a"), before: toCursor("e") })).toEqual({
+      items: ["b", "c", "d"],
+      hasNextPage: true,
+      hasPreviousPage: true,
+    });
+  });
+
+  it("applies `first` and `last` together, head first", () => {
+    expect(slice({ first: 4, last: 2 })).toEqual({
+      items: ["c", "d"],
+      hasNextPage: true,
+      hasPreviousPage: true,
+    });
+  });
+
+  it("ignores an unknown `after` cursor rather than throwing", () => {
+    expect(slice({ after: toCursor("zzz") }).items).toEqual(items);
+  });
+
+  it("ignores an unknown `before` cursor rather than throwing", () => {
+    expect(slice({ before: toCursor("zzz") }).items).toEqual(items);
+  });
+
+  it("treats an explicitly null cursor as absent", () => {
+    expect(slice({ after: null, before: null }).items).toEqual(items);
+  });
+
+  it("yields no edges for `first: 0`, and still reports the next page", () => {
+    expect(slice({ first: 0 })).toEqual({
+      items: [],
+      hasNextPage: true,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("yields no edges for `last: 0`", () => {
+    expect(slice({ last: 0 }).items).toEqual([]);
+  });
+
+  it("rejects a negative `first`", () => {
+    // The spec says a negative count is an error, and clamping is the worse
+    // answer anyway: `first: -1` quietly returning a default page is a client
+    // bug that never surfaces.
+    expect(() => slice({ first: -3 })).toThrow(/first must not be negative/);
+  });
+
+  it("rejects a negative `last`", () => {
+    expect(() => slice({ last: -3 })).toThrow(/last must not be negative/);
+  });
+
+  it("handles an empty input list", () => {
+    expect(sliceConnection([], identify, { first: 5 })).toEqual({
+      items: [],
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("yields nothing when `before` precedes `after`", () => {
+    expect(
+      slice({ after: toCursor("d"), before: toCursor("b") }).items,
+    ).toEqual([]);
+  });
+
+  it("caps an unbounded query at the default page size", () => {
+    const many = Array.from({ length: 25 }, (_, index) => `item-${index}`);
+    const page = sliceConnection(many, identify, {});
+    expect(page.items).toHaveLength(20);
+    expect(page.hasNextPage).toBe(true);
+  });
+});
+
+describe("sliceConnection: the flags come from the cursor window", () => {
+  // The three points the module header names, each with the value the spec
+  // requires rather than the one an obvious implementation produces.
+  it("reads `last` against the cursor window, not the window `first` left", () => {
+    // ApplyCursorsToEdges holds five; `last: 4` is fewer than five, so there
+    // IS a previous page. Asking after `first: 2` had shortened the window to
+    // two answered false, and a backward-paging client stopped one page early.
+    expect(slice({ first: 2, last: 4 })).toEqual({
+      items: ["a", "b"],
+      hasNextPage: true,
+      hasPreviousPage: true,
+    });
+  });
+
+  it("treats an explicit null count as no count at all", () => {
+    // GraphQL delivers an omitted argument and an explicit null differently;
+    // the spec treats them alike. With neither count supplied the flags are
+    // the CURSOR answer, so a full list has nothing before or after it.
+    expect(slice({ first: null, last: null })).toEqual({
+      items,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("still answers from the cursor when only the default page size trimmed", () => {
+    expect(slice({ after: toCursor("b") })).toEqual({
+      items: ["c", "d", "e"],
+      hasNextPage: false,
+      hasPreviousPage: true,
+    });
+  });
+});

--- a/packages/prism/graph-example/src/lib/provider/connection.ts
+++ b/packages/prism/graph-example/src/lib/provider/connection.ts
@@ -1,0 +1,126 @@
+/**
+ * Relay cursor pagination over a plain array.
+ *
+ * Cursor = base64 of the item's absolute IRI, the same convention ke-graphql
+ * uses. Opaque to clients, stable across requests, and impossible to drift
+ * from the identity it pages over because it IS that identity.
+ *
+ * This file is NOT evidence about the converged base: `first`/`after`/`last`/
+ * `before` on `OntologyClass.instances` is Relay's cost, and it would be
+ * present in any connection-shaped spec.
+ */
+
+import { DEFAULT_PAGE_SIZE } from "./constants.js";
+
+/** Arguments of a Relay connection field. */
+export interface ConnectionArgs {
+  readonly first?: number | null;
+  readonly after?: string | null;
+  readonly last?: number | null;
+  readonly before?: string | null;
+}
+
+/** One page: the surviving items plus the flags Relay needs to page on. */
+export interface ConnectionPage<T> {
+  readonly items: readonly T[];
+  readonly hasNextPage: boolean;
+  readonly hasPreviousPage: boolean;
+}
+
+/** Encode an IRI as an opaque cursor. */
+export const toCursor = (uri: string): string =>
+  Buffer.from(uri, "utf-8").toString("base64");
+
+/** Decode a cursor back to the IRI it was made from. */
+export const fromCursor = (cursor: string): string =>
+  Buffer.from(cursor, "base64").toString("utf-8");
+
+/**
+ * Locate a cursor in `items`, or -1. An absent cursor and an unknown cursor
+ * are the same answer on purpose: cursors are client-supplied, so a stale one
+ * should degrade to a full page rather than a 500.
+ */
+const indexOfCursor = <T>(
+  items: readonly T[],
+  identify: (item: T) => string,
+  cursor: string | null | undefined,
+): number =>
+  cursor === null || cursor === undefined
+    ? -1
+    : items.findIndex((item) => identify(item) === fromCursor(cursor));
+
+/**
+ * Slice `items` per the Cursor Connections spec: cut to `after`/`before`
+ * first, then take `first` from the head and `last` from the tail.
+ *
+ * The page flags say whether anything was cut off that end — by a cursor OR
+ * by a count. That distinction matters: `last: 2` with no `before` reaches the
+ * end of the list, so `hasNextPage` is false even though 14 items were
+ * dropped from the head.
+ *
+ * `first` falls back to a default page size only when neither count is given,
+ * so an unbounded query cannot walk the whole ABox by accident.
+ *
+ * THREE POINTS WHERE THE SPEC IS EXACT AND AN OBVIOUS IMPLEMENTATION IS NOT:
+ *
+ * 1. A NEGATIVE count is an error, not a value to clamp. The spec says so, and
+ *    clamping is the worse answer either way: `first: -1` silently returning a
+ *    default page is a client bug that never surfaces.
+ * 2. BOTH flags are computed from the CURSOR-cut window, before either count
+ *    trims it. `HasPreviousPage` is defined as "does ApplyCursorsToEdges hold
+ *    more than `last`" — not "did the tail cut fire". Asking after `first` had
+ *    already shortened the window made `first: 2, last: 4` over five items
+ *    report no previous page, because by then the window held two.
+ * 3. An explicit `null` count is NOT a supplied count. GraphQL delivers an
+ *    omitted argument and an explicit `null` differently, and the spec treats
+ *    them alike; testing `!== undefined` made `first: null` look like a client
+ *    request for a page size and answered from the DEFAULT rather than from
+ *    the cursor.
+ */
+export const sliceConnection = <T>(
+  items: readonly T[],
+  identify: (item: T) => string,
+  args: ConnectionArgs,
+): ConnectionPage<T> => {
+  // Omitted and explicitly null are the same absence — see point 3 above.
+  const requestedFirst = args.first ?? null;
+  const requestedLast = args.last ?? null;
+  if (requestedFirst !== null && requestedFirst < 0) {
+    throw new Error(`first must not be negative (received ${requestedFirst})`);
+  }
+  if (requestedLast !== null && requestedLast < 0) {
+    throw new Error(`last must not be negative (received ${requestedLast})`);
+  }
+
+  const start = indexOfCursor(items, identify, args.after) + 1;
+  const beforeIndex = indexOfCursor(items, identify, args.before);
+  const end = beforeIndex === -1 ? items.length : beforeIndex;
+
+  // ApplyCursorsToEdges: the window the spec computes both flags against.
+  const cursorWindow = items.slice(start, Math.max(start, end));
+
+  const first =
+    requestedFirst ?? (requestedLast === null ? DEFAULT_PAGE_SIZE : null);
+
+  let window = cursorWindow;
+  if (first !== null && window.length > first) {
+    window = window.slice(0, first);
+  }
+  if (requestedLast !== null && window.length > requestedLast) {
+    window = window.slice(window.length - requestedLast);
+  }
+
+  // The spec's precedence keys on the count the CLIENT asked for, not on the
+  // default this function supplies when it asked for neither. A defaulted
+  // `first` that did not trim says nothing about what lies beyond `before`,
+  // so in that case the cursor answer still stands — and a defaulted `first`
+  // that DID trim is itself proof of a next page.
+  const hasNextPage =
+    requestedFirst !== null
+      ? cursorWindow.length > requestedFirst
+      : (first !== null && cursorWindow.length > first) || end < items.length;
+  const hasPreviousPage =
+    requestedLast !== null ? cursorWindow.length > requestedLast : start > 0;
+
+  return { items: window, hasNextPage, hasPreviousPage };
+};

--- a/packages/prism/graph-example/src/lib/provider/constants.ts
+++ b/packages/prism/graph-example/src/lib/provider/constants.ts
@@ -1,0 +1,42 @@
+/**
+ * Fixed strings for the example provider. Data, not logic — excluded from
+ * coverage per the repo's constants-file convention.
+ */
+
+/** Namespace IRI of the transit ontology. */
+export const METRO_NAMESPACE = "https://metro.example/onto#";
+
+/** Prefix bound to {@link METRO_NAMESPACE}. */
+export const METRO_PREFIX = "metro";
+
+/** Namespace IRI of the geography ontology. */
+export const GEO_NAMESPACE = "https://geo.example/onto#";
+
+/** Prefix bound to {@link GEO_NAMESPACE}. */
+export const GEO_PREFIX = "geo";
+
+/** Namespace IRI of RDF Schema, which supplies this TBox's metaclass. */
+export const RDFS_NAMESPACE = "http://www.w3.org/2000/01/rdf-schema#";
+
+/** Prefix bound to {@link RDFS_NAMESPACE}. */
+export const RDFS_PREFIX = "rdfs";
+
+/**
+ * The class every OntologyClass is an instance of. `EntityMeta.type` is
+ * non-null and OntologyClass implements Node, so classes need a class of
+ * their own — and `rdfs:Class` is an instance of itself, so the TBox is
+ * reflexive at the top rather than arbitrarily terminated.
+ */
+export const META_CLASS_URI = `${RDFS_NAMESPACE}Class`;
+
+/** The class the embeddable coordinate pair is an instance of. */
+export const GEO_POINT_CLASS_URI = `${GEO_NAMESPACE}GeoPoint`;
+
+/** Language `EntityMeta`'s arguments default to, per the contract SDL. */
+export const DEFAULT_LANG = "en";
+
+/** Page size used when a connection query supplies neither `first` nor `last`. */
+export const DEFAULT_PAGE_SIZE = 20;
+
+/** The single path the demo server answers on. */
+export const GRAPHQL_PATH = "/graphql";

--- a/packages/prism/graph-example/src/lib/provider/createExampleProvider.test.ts
+++ b/packages/prism/graph-example/src/lib/provider/createExampleProvider.test.ts
@@ -1,0 +1,1046 @@
+import { type ExecutionResult, graphql } from "graphql";
+import { beforeAll, describe, expect, it } from "vitest";
+import { toCursor } from "./connection.js";
+import { GEO_POINT_CLASS_URI, META_CLASS_URI } from "./constants.js";
+import { createExampleProvider } from "./createExampleProvider.js";
+import {
+  BARE_ENTITY_URI,
+  EMPTY_LOCAL_NAME_URI,
+  exampleDataset,
+  MULTILINGUAL_ENTITY_URI,
+  SECOND_NAMESPACE_ENTITY_URI,
+} from "./dataset.js";
+import type { ExampleDataset } from "./types.js";
+
+const provider = createExampleProvider();
+
+/** Execute against the default dataset and fail loudly on any GraphQL error. */
+const run = async (
+  source: string,
+  variableValues?: Record<string, unknown>,
+): Promise<Record<string, unknown>> => {
+  const result: ExecutionResult = await graphql({
+    schema: provider.schema,
+    source,
+    rootValue: provider.rootValue,
+    variableValues,
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).not.toBeNull();
+  return result.data as Record<string, unknown>;
+};
+
+/** Execute against a purpose-built dataset — used for the defensive paths. */
+const runWith = async (
+  dataset: ExampleDataset,
+  source: string,
+): Promise<Record<string, unknown>> => {
+  const custom = createExampleProvider(dataset);
+  const result = await graphql({
+    schema: custom.schema,
+    source,
+    rootValue: custom.rootValue,
+  });
+  expect(result.errors).toBeUndefined();
+  return result.data as Record<string, unknown>;
+};
+
+describe("the schema", () => {
+  it("is built from the authored contract plus this package's extension", () => {
+    expect(provider.sdl).toContain("interface Node");
+    expect(provider.sdl).toContain("type Station implements Node");
+  });
+
+  it("adds no root fields — the contract's five must suffice", () => {
+    const query = provider.schema.getQueryType();
+    expect(Object.keys(query?.getFields() ?? {}).sort()).toEqual([
+      "node",
+      "ontologies",
+      "ontology",
+      "ontologyClass",
+      "ontologyProperty",
+    ]);
+  });
+
+  it("declares the provider's own types as Node implementers", () => {
+    const node = provider.schema.getType("Node");
+    const names = provider.schema
+      .getPossibleTypes(
+        // biome-ignore lint/suspicious/noExplicitAny: narrowing an abstract type for a schema assertion
+        node as any,
+      )
+      .map((type) => type.name)
+      .sort();
+    expect(names).toEqual([
+      "Interchange",
+      "Line",
+      "OntologyClass",
+      "Station",
+      "Zone",
+    ]);
+  });
+});
+
+describe("Query.node", () => {
+  it("resolves an entity by absolute IRI", async () => {
+    const data = await run(
+      `{ node(id: "${MULTILINGUAL_ENTITY_URI}") { __typename uri } }`,
+    );
+    expect(data.node).toEqual({
+      __typename: "Station",
+      uri: MULTILINGUAL_ENTITY_URI,
+    });
+  });
+
+  it("resolves an ontology class, which is also a Node", async () => {
+    const data = await run(
+      `{ node(id: "https://metro.example/onto#Station") { __typename uri } }`,
+    );
+    expect(data.node).toEqual({
+      __typename: "OntologyClass",
+      uri: "https://metro.example/onto#Station",
+    });
+  });
+
+  it("is null for an unknown IRI", async () => {
+    const data = await run(
+      `{ node(id: "https://metro.example/onto#nope") { uri } }`,
+    );
+    expect(data.node).toBeNull();
+  });
+
+  it("gives every entity a __typename the schema declares", async () => {
+    const data = await run(
+      `{ ontologyClass(uri: "metro:Stop") { instances(first: 99) { edges { node { __typename } } } } }`,
+    );
+    const cls = data.ontologyClass as {
+      instances: { edges: { node: { __typename: string } }[] };
+    };
+    for (const edge of cls.instances.edges) {
+      expect(["Station", "Interchange", "Line"]).toContain(
+        edge.node.__typename,
+      );
+    }
+  });
+});
+
+describe("Query.ontologies / ontology", () => {
+  it("returns every loaded namespace", async () => {
+    const data = await run(`{ ontologies { prefix namespace label } }`);
+    expect(data.ontologies).toEqual([
+      {
+        prefix: "metro",
+        namespace: "https://metro.example/onto#",
+        label: "Metro Network Ontology",
+      },
+      { prefix: "geo", namespace: "https://geo.example/onto#", label: null },
+      {
+        prefix: "rdfs",
+        namespace: "http://www.w3.org/2000/01/rdf-schema#",
+        label: "RDF Schema",
+      },
+    ]);
+  });
+
+  it("scopes classes and properties to the namespace", async () => {
+    const data = await run(
+      `{ ontology(prefix: "geo") { classes { uri } properties { uri } } }`,
+    );
+    expect(data.ontology).toEqual({
+      classes: [
+        { uri: GEO_POINT_CLASS_URI },
+        { uri: "https://geo.example/onto#Zone" },
+      ],
+      properties: [
+        { uri: "https://geo.example/onto#location" },
+        { uri: "https://geo.example/onto#latitude" },
+        { uri: "https://geo.example/onto#longitude" },
+        { uri: "https://geo.example/onto#inZone" },
+      ],
+    });
+  });
+
+  it("is null for an unknown prefix", async () => {
+    const data = await run(`{ ontology(prefix: "nope") { prefix } }`);
+    expect(data.ontology).toBeNull();
+  });
+});
+
+describe("Query.ontologyClass", () => {
+  it("accepts the prefixed convenience form", async () => {
+    const data = await run(`{ ontologyClass(uri: "metro:Station") { uri } }`);
+    expect(data.ontologyClass).toEqual({
+      uri: "https://metro.example/onto#Station",
+    });
+  });
+
+  it("accepts the absolute IRI", async () => {
+    const data = await run(
+      `{ ontologyClass(uri: "https://metro.example/onto#Station") { uri } }`,
+    );
+    expect(data.ontologyClass).toEqual({
+      uri: "https://metro.example/onto#Station",
+    });
+  });
+
+  it("is null for an unknown class", async () => {
+    const data = await run(`{ ontologyClass(uri: "metro:Nope") { uri } }`);
+    expect(data.ontologyClass).toBeNull();
+  });
+
+  it("resolves the hierarchy transitively", async () => {
+    const data = await run(`{
+      ontologyClass(uri: "metro:Interchange") {
+        isAbstract namespace
+        superclass { uri }
+        superclasses { uri }
+        subclasses { uri }
+      }
+    }`);
+    expect(data.ontologyClass).toEqual({
+      isAbstract: false,
+      namespace: "https://metro.example/onto#",
+      superclass: { uri: "https://metro.example/onto#Station" },
+      superclasses: [
+        { uri: "https://metro.example/onto#Station" },
+        { uri: "https://metro.example/onto#Stop" },
+      ],
+      subclasses: [],
+    });
+  });
+
+  it("reports a null superclass and real subclasses for a root class", async () => {
+    const data = await run(
+      `{ ontologyClass(uri: "metro:Stop") { isAbstract superclass { uri } superclasses { uri } subclasses { uri } } }`,
+    );
+    expect(data.ontologyClass).toEqual({
+      isAbstract: true,
+      superclass: null,
+      superclasses: [],
+      subclasses: [{ uri: "https://metro.example/onto#Station" }],
+    });
+  });
+
+  it("marks own properties own and ancestors' properties inherited", async () => {
+    const data = await run(`{
+      ontologyClass(uri: "metro:Station") {
+        properties { required singular inherited property { uri } }
+      }
+    }`);
+    const properties = (
+      data.ontologyClass as {
+        properties: {
+          required: boolean;
+          singular: boolean;
+          inherited: boolean;
+          property: { uri: string };
+        }[];
+      }
+    ).properties;
+    expect(properties).toEqual([
+      {
+        required: false,
+        singular: true,
+        inherited: false,
+        property: { uri: "https://metro.example/onto#platformCount" },
+      },
+      {
+        required: true,
+        singular: false,
+        inherited: false,
+        property: { uri: "https://metro.example/onto#servesLine" },
+      },
+      {
+        required: false,
+        singular: true,
+        inherited: false,
+        property: { uri: "https://geo.example/onto#location" },
+      },
+      {
+        required: false,
+        singular: true,
+        inherited: false,
+        property: { uri: "https://geo.example/onto#inZone" },
+      },
+      {
+        required: true,
+        singular: true,
+        inherited: true,
+        property: { uri: "https://metro.example/onto#name" },
+      },
+      {
+        required: false,
+        singular: true,
+        inherited: true,
+        property: { uri: "https://metro.example/onto#note" },
+      },
+    ]);
+  });
+});
+
+describe("OntologyClass.instances", () => {
+  it("counts subclass instances as instances of the superclass", async () => {
+    const data = await run(`{
+      station: ontologyClass(uri: "metro:Station") { instanceCount }
+      interchange: ontologyClass(uri: "metro:Interchange") { instanceCount }
+      line: ontologyClass(uri: "metro:Line") { instanceCount }
+    }`);
+    expect(data.station).toEqual({ instanceCount: 16 });
+    expect(data.interchange).toEqual({ instanceCount: 2 });
+    expect(data.line).toEqual({ instanceCount: 3 });
+  });
+
+  it("counts nothing for a class with no ABox members", async () => {
+    const data = await run(
+      `{ ontologyClass(uri: "rdfs:Class") { instanceCount instances { edges { cursor } } } }`,
+    );
+    expect(data.ontologyClass).toEqual({
+      instanceCount: 0,
+      instances: { edges: [] },
+    });
+  });
+
+  it("pages forward with a real hasNextPage", async () => {
+    const data = await run(`{
+      ontologyClass(uri: "metro:Station") {
+        instances(first: 3) {
+          edges { cursor node { uri } }
+          pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+        }
+      }
+    }`);
+    const instances = (
+      data.ontologyClass as {
+        instances: {
+          edges: { cursor: string; node: { uri: string } }[];
+          pageInfo: Record<string, unknown>;
+        };
+      }
+    ).instances;
+    expect(instances.edges).toHaveLength(3);
+    expect(instances.pageInfo).toEqual({
+      hasNextPage: true,
+      hasPreviousPage: false,
+      startCursor: instances.edges[0]?.cursor,
+      endCursor: instances.edges[2]?.cursor,
+    });
+  });
+
+  it("pages backward from the tail", async () => {
+    const data = await run(`{
+      ontologyClass(uri: "metro:Station") {
+        instances(last: 2) { edges { node { uri } } pageInfo { hasNextPage hasPreviousPage } }
+      }
+    }`);
+    expect(data.ontologyClass).toEqual({
+      instances: {
+        edges: [
+          { node: { uri: "https://metro.example/onto#verge-park" } },
+          { node: { uri: "https://metro.example/onto#willowbank" } },
+        ],
+        pageInfo: { hasNextPage: false, hasPreviousPage: true },
+      },
+    });
+  });
+
+  it("resumes from a cursor", async () => {
+    const after = toCursor(EMPTY_LOCAL_NAME_URI);
+    const data = await run(`{
+      ontologyClass(uri: "metro:Station") {
+        instances(first: 1, after: "${after}") { edges { node { uri } } }
+      }
+    }`);
+    expect(data.ontologyClass).toEqual({
+      instances: {
+        edges: [
+          { node: { uri: "https://metro.example/onto#central-exchange" } },
+        ],
+      },
+    });
+  });
+
+  it("reports null cursors for an empty page", async () => {
+    const data = await run(
+      `{ ontologyClass(uri: "metro:Station") { instances(first: 0) { pageInfo { startCursor endCursor } } } }`,
+    );
+    expect(data.ontologyClass).toEqual({
+      instances: { pageInfo: { startCursor: null, endCursor: null } },
+    });
+  });
+});
+
+describe("Query.ontologyProperty", () => {
+  it("resolves every field, including a round-tripping inverse", async () => {
+    const data = await run(`{
+      ontologyProperty(uri: "metro:servesLine") {
+        uri label definition range kind functional namespace
+        domain { uri }
+        inverse { uri kind inverse { uri } }
+      }
+    }`);
+    expect(data.ontologyProperty).toEqual({
+      uri: "https://metro.example/onto#servesLine",
+      label: "serves line",
+      definition: null,
+      range: "metro:Line",
+      kind: "OBJECT",
+      functional: false,
+      namespace: "https://metro.example/onto#",
+      domain: { uri: "https://metro.example/onto#Station" },
+      inverse: {
+        uri: "https://metro.example/onto#servedBy",
+        kind: "OBJECT",
+        inverse: { uri: "https://metro.example/onto#servesLine" },
+      },
+    });
+  });
+
+  it("serves all three PropertyKind members", async () => {
+    const data = await run(`{
+      datatype: ontologyProperty(uri: "metro:name") { kind functional domain { uri } }
+      object: ontologyProperty(uri: "metro:servesLine") { kind }
+      annotation: ontologyProperty(uri: "metro:note") { kind functional inverse { uri } }
+    }`);
+    expect(data.datatype).toEqual({
+      kind: "DATATYPE",
+      functional: true,
+      domain: null,
+    });
+    expect(data.object).toEqual({ kind: "OBJECT" });
+    expect(data.annotation).toEqual({
+      kind: "ANNOTATION",
+      functional: false,
+      inverse: null,
+    });
+  });
+
+  it("is null for an unknown property", async () => {
+    const data = await run(`{ ontologyProperty(uri: "metro:nope") { uri } }`);
+    expect(data.ontologyProperty).toBeNull();
+  });
+});
+
+describe("_meta", () => {
+  it("serves the language-tagged fields off a multilingual entity", async () => {
+    const data = await run(`{
+      node(id: "${MULTILINGUAL_ENTITY_URI}") {
+        _meta {
+          title
+          french: title(lang: "fr")
+          label
+          frenchLabel: label(lang: "fr")
+          comment
+          definition
+          type { uri }
+        }
+      }
+    }`);
+    expect(data.node).toEqual({
+      _meta: {
+        title: "Northgate",
+        french: "Porte-Nord",
+        label: "Northgate",
+        frenchLabel: "Porte-Nord",
+        comment: null,
+        definition: "The northern terminus.",
+        type: { uri: "https://metro.example/onto#Station" },
+      },
+    });
+  });
+
+  it("makes a class an instance of the metaclass, which instances itself", async () => {
+    const data = await run(`{
+      ontologyClass(uri: "metro:Station") {
+        _meta { title fields { inherited } type { uri _meta { type { uri } } } }
+      }
+    }`);
+    expect(data.ontologyClass).toEqual({
+      _meta: {
+        title: "Station",
+        fields: [],
+        type: { uri: META_CLASS_URI, _meta: { type: { uri: META_CLASS_URI } } },
+      },
+    });
+  });
+
+  it("lists the entity's class fields, own then inherited", async () => {
+    const data = await run(`{
+      node(id: "${MULTILINGUAL_ENTITY_URI}") {
+        _meta { fields { inherited property { uri } } }
+      }
+    }`);
+    expect(data.node).toEqual({
+      _meta: {
+        fields: [
+          {
+            inherited: false,
+            property: { uri: "https://metro.example/onto#platformCount" },
+          },
+          {
+            inherited: false,
+            property: { uri: "https://metro.example/onto#servesLine" },
+          },
+          {
+            inherited: false,
+            property: { uri: "https://geo.example/onto#location" },
+          },
+          {
+            inherited: false,
+            property: { uri: "https://geo.example/onto#inZone" },
+          },
+          {
+            inherited: true,
+            property: { uri: "https://metro.example/onto#name" },
+          },
+          {
+            inherited: true,
+            property: { uri: "https://metro.example/onto#note" },
+          },
+        ],
+      },
+    });
+  });
+
+  it("looks a field up by the exact `name` it serves, and misses cleanly", async () => {
+    const data = await run(`{
+      node(id: "${MULTILINGUAL_ENTITY_URI}") {
+        _meta {
+          own: field(name: "platformCount") { name required singular inherited }
+          inherited: field(name: "name") { name required inherited }
+          miss: field(name: "nope") { name }
+          notTheIri: field(name: "https://metro.example/onto#name") { name }
+        }
+      }
+    }`);
+    expect(data.node).toEqual({
+      _meta: {
+        own: {
+          name: "platformCount",
+          required: false,
+          singular: true,
+          inherited: false,
+        },
+        inherited: { name: "name", required: true, inherited: true },
+        miss: null,
+        // The key is `ClassProperty.name`, not the IRI. Only what `fields`
+        // publishes is accepted — that is what "round-trips" means.
+        notTheIri: null,
+      },
+    });
+  });
+
+  it("publishes a `name` for every property, projected or not", async () => {
+    const data = await run(`{
+      node(id: "${MULTILINGUAL_ENTITY_URI}") { _meta { fields { name } } }
+    }`);
+    const names = (
+      data.node as { _meta: { fields: { name: string }[] } }
+    )._meta.fields.map((field) => field.name);
+    expect(names).toEqual([
+      "platformCount",
+      "servesLine",
+      "location",
+      "inZone",
+      "name",
+      // Declared on the abstract `Stop` and inherited by every station. No
+      // concrete type in `schema/extension.graphql` exposes a `note` field,
+      // so this entry is the contract's LABEL fallback rather than an
+      // address — see the next test.
+      "note",
+    ]);
+  });
+
+  it("accepts every PROJECTED name back, and only those", async () => {
+    // The contract's rule, in two halves. `ClassProperty.name` is "the exact
+    // string `EntityMeta.field(name:)` accepts" for a property that projects
+    // a field — so those round-trip. For a property that projects no field on
+    // this class, the same doc says "there is no name `field(name:)` would
+    // accept; the OWL local name is returned as a label", so the round-trip
+    // must NOT close. Answering with metadata there would hand a consumer a
+    // field name it can never select.
+    const projected = [
+      "platformCount",
+      "servesLine",
+      "location",
+      "inZone",
+      "name",
+    ];
+    for (const name of projected) {
+      const roundTrip = await run(`{
+        node(id: "${MULTILINGUAL_ENTITY_URI}") { _meta { field(name: "${name}") { name } } }
+      }`);
+      expect(roundTrip.node).toEqual({ _meta: { field: { name } } });
+    }
+
+    const unprojected = await run(`{
+      node(id: "${MULTILINGUAL_ENTITY_URI}") { _meta { field(name: "note") { name } } }
+    }`);
+    expect(unprojected.node).toEqual({ _meta: { field: null } });
+  });
+
+  it("answers null for a real GraphQL field with no property behind it", async () => {
+    // The other half of the gate. `namespace` IS a field on `OntologyClass`,
+    // so the schema check passes — and the metaclass declares no properties,
+    // so there is no `ClassProperty` to return. A class's `_meta.fields` is
+    // empty by construction here; asking it for one must not invent an entry.
+    const data = await run(`{
+      ontologyClass(uri: "${META_CLASS_URI}") {
+        _meta { fields { name } field(name: "namespace") { name } }
+      }
+    }`);
+    expect(data.ontologyClass).toEqual({
+      _meta: { fields: [], field: null },
+    });
+  });
+});
+
+describe("_meta.curie", () => {
+  it("compacts against the entity's own namespace, per entity", async () => {
+    const data = await run(`{
+      metro: node(id: "${MULTILINGUAL_ENTITY_URI}") { _meta { curie } }
+      geo: node(id: "${SECOND_NAMESPACE_ENTITY_URI}") { __typename _meta { curie } }
+    }`);
+    expect(data.metro).toEqual({ _meta: { curie: "metro:northgate" } });
+    expect(data.geo).toEqual({
+      __typename: "Zone",
+      _meta: { curie: "geo:central-zone" },
+    });
+  });
+
+  it("compacts classes too, including the metaclass", async () => {
+    const data = await run(`{
+      station: ontologyClass(uri: "metro:Station") { _meta { curie } }
+      zone: ontologyClass(uri: "geo:Zone") { _meta { curie } }
+      meta: ontologyClass(uri: "rdfs:Class") { _meta { curie } }
+    }`);
+    expect(data.station).toEqual({ _meta: { curie: "metro:Station" } });
+    expect(data.zone).toEqual({ _meta: { curie: "geo:Zone" } });
+    expect(data.meta).toEqual({ _meta: { curie: "rdfs:Class" } });
+  });
+
+  it("compacts to a bare prefix when the local name is empty", async () => {
+    const data = await run(
+      `{ node(id: "${EMPTY_LOCAL_NAME_URI}") { _meta { curie } } }`,
+    );
+    expect(data.node).toEqual({ _meta: { curie: "metro:" } });
+  });
+
+  it("gives the embeddable its GraphQL type name, having no IRI of its own", async () => {
+    // The contract's third tier, verbatim: "for a value with no IRI at all (an
+    // embedded blank node) — the GraphQL type name". NOT the compacted class
+    // IRI, which would read as `geo:GeoPoint` and look like an address the
+    // value does not have.
+    const data = await run(`{
+      node(id: "${MULTILINGUAL_ENTITY_URI}") {
+        ... on Station { location { _meta { curie } } }
+      }
+    }`);
+    expect(data.node).toEqual({
+      location: { _meta: { curie: "GeoPoint" } },
+    });
+  });
+
+  it("is derivable by a client from Query.ontologies alone", async () => {
+    const data = await run(`{
+      ontologies { prefix namespace }
+      node(id: "${SECOND_NAMESPACE_ENTITY_URI}") { uri _meta { curie } }
+    }`);
+    const ontologies = data.ontologies as {
+      prefix: string;
+      namespace: string;
+    }[];
+    const node = data.node as { uri: string; _meta: { curie: string } };
+    const match = ontologies
+      .filter((ontology) => node.uri.startsWith(ontology.namespace))
+      .sort((a, b) => b.namespace.length - a.namespace.length)[0];
+    expect(`${match?.prefix}:${node.uri.slice(match?.namespace.length)}`).toBe(
+      node._meta.curie,
+    );
+  });
+
+  it("falls back to the whole IRI when no namespace is declared", async () => {
+    const data = await runWith(
+      {
+        ontologies: [],
+        classes: [{ uri: "urn:C", isAbstract: false, properties: [] }],
+        properties: [],
+        entities: [{ uri: "urn:e1", type: "urn:C", typename: "Station" }],
+      },
+      `{ node(id: "urn:e1") { _meta { curie } } }`,
+    );
+    expect(data.node).toEqual({ _meta: { curie: "urn:e1" } });
+  });
+
+  it("prefers the longest matching namespace, so one cannot shadow another", async () => {
+    const data = await runWith(
+      {
+        ontologies: [
+          { prefix: "short", namespace: "urn:a:" },
+          { prefix: "long", namespace: "urn:a:b:" },
+        ],
+        classes: [{ uri: "urn:a:b:C", isAbstract: false, properties: [] }],
+        properties: [],
+        entities: [
+          { uri: "urn:a:b:e1", type: "urn:a:b:C", typename: "Station" },
+        ],
+      },
+      `{ node(id: "urn:a:b:e1") { _meta { curie } } }`,
+    );
+    expect(data.node).toEqual({ _meta: { curie: "long:e1" } });
+  });
+});
+
+describe("the awkward entities", () => {
+  it("titles an entity with no descriptive predicates from its local name", async () => {
+    const data = await run(`{
+      node(id: "${BARE_ENTITY_URI}") {
+        uri
+        _meta { title label comment definition type { uri } }
+        ... on Station { name platformCount location { latitude } servesLine { uri } }
+      }
+    }`);
+    expect(data.node).toEqual({
+      uri: BARE_ENTITY_URI,
+      _meta: {
+        title: "ghost",
+        label: null,
+        comment: null,
+        definition: null,
+        type: { uri: "https://metro.example/onto#Station" },
+      },
+      name: null,
+      platformCount: null,
+      location: null,
+      servesLine: [],
+    });
+  });
+
+  it("titles an entity whose local name is empty from the whole IRI", async () => {
+    const data = await run(
+      `{ node(id: "${EMPTY_LOCAL_NAME_URI}") { _meta { title } } }`,
+    );
+    expect(data.node).toEqual({ _meta: { title: EMPTY_LOCAL_NAME_URI } });
+  });
+});
+
+describe("the embeddable", () => {
+  it("is reachable, carries _meta, and has no uri to be titled from", async () => {
+    const data = await run(`{
+      node(id: "${MULTILINGUAL_ENTITY_URI}") {
+        ... on Station {
+          location { latitude longitude _meta { title label type { uri } } }
+        }
+      }
+    }`);
+    expect(data.node).toEqual({
+      location: {
+        latitude: 51.5412,
+        longitude: -0.1435,
+        _meta: {
+          title: "GeoPoint",
+          label: null,
+          type: { uri: GEO_POINT_CLASS_URI },
+        },
+      },
+    });
+  });
+
+  it("cannot be reached through node(id:) — it has no identity", async () => {
+    const data = await run(`{ node(id: "${GEO_POINT_CLASS_URI}") { uri } }`);
+    expect(data.node).toEqual({ uri: GEO_POINT_CLASS_URI });
+  });
+});
+
+describe("the provider's own relational fields", () => {
+  it("walks a station to its lines and back again", async () => {
+    const data = await run(`{
+      node(id: "https://metro.example/onto#central-exchange") {
+        ... on Interchange {
+          name transferMinutes platformCount
+          servesLine { uri name servedBy { uri } }
+        }
+      }
+    }`);
+    const node = data.node as {
+      servesLine: { uri: string; servedBy: { uri: string }[] }[];
+    };
+    expect(node.servesLine.map((line) => line.uri)).toEqual([
+      "https://metro.example/onto#north-line",
+      "https://metro.example/onto#circle-line",
+      "https://metro.example/onto#coastal-line",
+    ]);
+    expect(
+      node.servesLine[0]?.servedBy.map((station) => station.uri),
+    ).toContain("https://metro.example/onto#central-exchange");
+  });
+
+  it("serves a line's stops under their real types, interchanges included", async () => {
+    // `servedBy` is the inverse of `servesLine`, and `Interchange` carries
+    // that property too — so the list is genuinely mixed. Declared
+    // `[Station!]!` it handed an interchange back wearing the wrong type name
+    // and `... on Interchange` could not be written against it at all. The
+    // `Stop` interface is what makes the declared type match the values.
+    const data = await run(`{
+      node(id: "https://metro.example/onto#north-line") {
+        ... on Line {
+          servedBy {
+            __typename
+            uri
+            ... on Interchange { transferMinutes }
+          }
+        }
+      }
+    }`);
+    const node = data.node as {
+      servedBy: { __typename: string; uri: string; transferMinutes?: number }[];
+    };
+    expect(node.servedBy.map((stop) => stop.__typename)).toContain(
+      "Interchange",
+    );
+    const interchange = node.servedBy.find(
+      (stop) => stop.__typename === "Interchange",
+    );
+    expect(interchange?.transferMinutes).toEqual(expect.any(Number));
+  });
+});
+
+describe("defensive paths, exercised with purpose-built datasets", () => {
+  const cls = {
+    uri: "urn:C",
+    isAbstract: false,
+    properties: [],
+  } as const;
+
+  it("drops an entity whose class the TBox does not declare", async () => {
+    const data = await runWith(
+      {
+        ontologies: [{ prefix: "urn", namespace: "urn:" }],
+        classes: [cls],
+        properties: [],
+        entities: [
+          { uri: "urn:e1", type: "urn:Missing", typename: "Station" },
+          { uri: "urn:e2", type: "urn:C", typename: "Station" },
+        ],
+      },
+      `{ dropped: node(id: "urn:e1") { uri } kept: node(id: "urn:e2") { uri }
+         c: ontologyClass(uri: "urn:C") { instanceCount } }`,
+    );
+    expect(data.dropped).toBeNull();
+    expect(data.kept).toEqual({ uri: "urn:e2" });
+    expect(data.c).toEqual({ instanceCount: 1 });
+  });
+
+  it("drops a class property whose property the TBox does not declare", async () => {
+    const data = await runWith(
+      {
+        ontologies: [],
+        classes: [
+          {
+            uri: "urn:C",
+            isAbstract: false,
+            properties: [
+              { property: "urn:missing", required: true, singular: true },
+              { property: "urn:real", required: false, singular: false },
+            ],
+          },
+        ],
+        properties: [
+          {
+            uri: "urn:real",
+            range: "String",
+            kind: "DATATYPE",
+            functional: false,
+          },
+        ],
+        entities: [],
+      },
+      `{ ontologyClass(uri: "urn:C") { properties { property { uri } } } }`,
+    );
+    expect(data.ontologyClass).toEqual({
+      properties: [{ property: { uri: "urn:real" } }],
+    });
+  });
+
+  it("terminates on a superclass cycle instead of recursing forever", async () => {
+    const data = await runWith(
+      {
+        ontologies: [],
+        classes: [
+          {
+            uri: "urn:A",
+            superclass: "urn:B",
+            isAbstract: false,
+            properties: [],
+          },
+          {
+            uri: "urn:B",
+            superclass: "urn:A",
+            isAbstract: false,
+            properties: [],
+          },
+        ],
+        properties: [],
+        entities: [],
+      },
+      `{ ontologyClass(uri: "urn:A") { superclasses { uri } } }`,
+    );
+    expect(data.ontologyClass).toEqual({
+      superclasses: [{ uri: "urn:B" }],
+    });
+  });
+
+  it("ignores a superclass IRI the TBox does not declare", async () => {
+    const data = await runWith(
+      {
+        ontologies: [],
+        classes: [
+          {
+            uri: "urn:A",
+            superclass: "urn:Gone",
+            isAbstract: false,
+            properties: [],
+          },
+        ],
+        properties: [],
+        entities: [],
+      },
+      `{ ontologyClass(uri: "urn:A") { superclass { uri } superclasses { uri } } }`,
+    );
+    expect(data.ontologyClass).toEqual({ superclass: null, superclasses: [] });
+  });
+
+  it("makes a class an instance of itself when no metaclass is declared", async () => {
+    const data = await runWith(
+      { ontologies: [], classes: [cls], properties: [], entities: [] },
+      `{ ontologyClass(uri: "urn:C") { _meta { type { uri } } } }`,
+    );
+    expect(data.ontologyClass).toEqual({ _meta: { type: { uri: "urn:C" } } });
+  });
+
+  it("omits the embeddable when its class is not declared", async () => {
+    const data = await runWith(
+      {
+        ontologies: [],
+        classes: [cls],
+        properties: [],
+        entities: [
+          {
+            uri: "urn:e1",
+            type: "urn:C",
+            typename: "Station",
+            location: { latitude: 1, longitude: 2 },
+          },
+        ],
+      },
+      `{ node(id: "urn:e1") { ... on Station { location { latitude } } } }`,
+    );
+    expect(data.node).toEqual({ location: null });
+  });
+
+  it("nulls a zone reference that points at nothing", async () => {
+    const data = await runWith(
+      {
+        ontologies: [],
+        classes: [cls],
+        properties: [],
+        entities: [
+          {
+            uri: "urn:e1",
+            type: "urn:C",
+            typename: "Station",
+            inZone: "urn:gone",
+          },
+          {
+            uri: "urn:e2",
+            type: "urn:C",
+            typename: "Station",
+            inZone: "urn:e3",
+          },
+          { uri: "urn:e3", type: "urn:C", typename: "Zone" },
+          { uri: "urn:e4", type: "urn:C", typename: "Station" },
+        ],
+      },
+      `{ dangling: node(id: "urn:e1") { ... on Station { inZone { uri } } }
+         real: node(id: "urn:e2") { ... on Station { inZone { uri } } }
+         unset: node(id: "urn:e4") { ... on Station { inZone { uri } } } }`,
+    );
+    expect(data.dangling).toEqual({ inZone: null });
+    expect(data.real).toEqual({ inZone: { uri: "urn:e3" } });
+    expect(data.unset).toEqual({ inZone: null });
+  });
+
+  it("skips a line reference that points at nothing", async () => {
+    const data = await runWith(
+      {
+        ontologies: [],
+        classes: [cls],
+        properties: [],
+        entities: [
+          {
+            uri: "urn:e1",
+            type: "urn:C",
+            typename: "Station",
+            servesLine: ["urn:gone", "urn:e2"],
+          },
+          { uri: "urn:e2", type: "urn:C", typename: "Line" },
+        ],
+      },
+      `{ node(id: "urn:e1") { ... on Station { servesLine { uri } } } }`,
+    );
+    expect(data.node).toEqual({ servesLine: [{ uri: "urn:e2" }] });
+  });
+
+  it("leaves an IRI whose scheme is not a declared prefix alone", async () => {
+    const data = await runWith(
+      {
+        ontologies: [{ prefix: "https", namespace: "urn:trap:" }],
+        classes: [{ uri: "urn:trap:C", isAbstract: false, properties: [] }],
+        properties: [],
+        entities: [],
+      },
+      `{ expanded: ontologyClass(uri: "https:C") { uri } }`,
+    );
+    // A prefix that collides with a URL scheme is pathological, and the
+    // expansion is textual — this documents that, rather than pretending
+    // the collision cannot happen.
+    expect(data.expanded).toEqual({ uri: "urn:trap:C" });
+  });
+});
+
+describe("the shipped dataset", () => {
+  it("declares every entity's class", () => {
+    const declared = new Set(exampleDataset.classes.map((each) => each.uri));
+    for (const entity of exampleDataset.entities) {
+      expect(declared).toContain(entity.type);
+    }
+  });
+
+  it("declares every class property's property", () => {
+    const declared = new Set(exampleDataset.properties.map((each) => each.uri));
+    for (const each of exampleDataset.classes) {
+      for (const cp of each.properties) {
+        expect(declared).toContain(cp.property);
+      }
+    }
+  });
+});
+
+describe("determinism", () => {
+  let first: Record<string, unknown>;
+
+  beforeAll(async () => {
+    first = await run(
+      `{ ontologyClass(uri: "metro:Station") { instances(first: 5) { edges { cursor } } } }`,
+    );
+  });
+
+  it("returns the same cursors across independent provider instances", async () => {
+    const other = createExampleProvider();
+    const result = await graphql({
+      schema: other.schema,
+      source: `{ ontologyClass(uri: "metro:Station") { instances(first: 5) { edges { cursor } } } }`,
+      rootValue: other.rootValue,
+    });
+    expect(result.data).toEqual(first);
+  });
+});

--- a/packages/prism/graph-example/src/lib/provider/createExampleProvider.ts
+++ b/packages/prism/graph-example/src/lib/provider/createExampleProvider.ts
@@ -1,0 +1,477 @@
+/**
+ * The provider itself: a schema built from the authored contract, and a tree
+ * of plain objects to execute it against.
+ *
+ * THERE IS NO RESOLVER MAP IN THIS FILE, OR ANYWHERE IN THIS PACKAGE. Two
+ * graphql-js behaviours make one unnecessary:
+ *
+ *   - `defaultFieldResolver` invokes a function-valued property as
+ *     `source[field](args, context, info)`, so an argument-taking field is
+ *     just a method on the view object.
+ *   - `defaultTypeResolver` reads a string `__typename` off the value, so
+ *     Node polymorphism needs no `resolveType`.
+ *
+ * Derived and relational fields are therefore zero-argument arrow functions,
+ * and scalars are plain values. Using functions uniformly for derived fields
+ * also sidesteps every construction-order cycle in the graph (a station's
+ * `_meta.type` is a class, whose `instances` are stations) without lazy
+ * getters, which only complicate coverage.
+ */
+
+import { buildSchema, isObjectType } from "graphql";
+import {
+  type ConnectionArgs,
+  sliceConnection,
+  toCursor,
+} from "./connection.js";
+import {
+  DEFAULT_LANG,
+  GEO_POINT_CLASS_URI,
+  META_CLASS_URI,
+} from "./constants.js";
+import { exampleDataset } from "./dataset.js";
+import { localName, resolveLabel, resolveTitle } from "./descriptive.js";
+import { readProviderSdl } from "./providerSdl.js";
+import type {
+  ExampleClass,
+  ExampleClassProperty,
+  ExampleDataset,
+  ExampleEntity,
+  ExampleGeoPoint,
+  ExampleOntology,
+  ExampleProperty,
+  ExampleProvider,
+  LangMap,
+} from "./types.js";
+
+/**
+ * A view object: scalars, nested views, and zero-argument thunks. The schema
+ * is the type system here — graphql-js checks every field against the SDL at
+ * execution time, so restating the SDL in TypeScript would buy nothing.
+ */
+type View = Record<string, unknown>;
+
+/** Arguments of the language-tagged `EntityMeta` fields. */
+interface LangArgs {
+  readonly lang: string;
+}
+
+/** Everything `_meta` needs. `uri` is null for an embeddable. */
+interface MetaSource {
+  readonly labels?: LangMap;
+  readonly comments?: LangMap;
+  readonly definitions?: LangMap;
+  readonly uri: string | null;
+  readonly typename: string;
+  readonly cls: ExampleClass;
+}
+
+/** An entity paired with its resolved class and its built view. */
+interface EntityRecord {
+  readonly entity: ExampleEntity;
+  readonly view: View;
+}
+
+/** The namespace part of an IRI — everything before the local name. */
+const namespaceOf = (uri: string): string =>
+  uri.slice(0, uri.length - localName(uri).length);
+
+/**
+ * Build an executable provider over `dataset`. The dataset is a parameter, not
+ * a hard-wired import, so the defensive paths below (a dangling property
+ * reference, a class cycle, an entity of an unknown class) are reachable from
+ * tests with a purpose-built dataset rather than being untestable dead code.
+ *
+ * @note Impure: reads the provider SDL from the filesystem on every call.
+ */
+export const createExampleProvider = (
+  dataset: ExampleDataset = exampleDataset,
+): ExampleProvider => {
+  const sdl = readProviderSdl();
+  const schema = buildSchema(sdl);
+
+  /**
+   * The field names each object type in this provider's schema declares.
+   *
+   * Read off the BUILT SCHEMA rather than a hand-kept list, so adding a field
+   * to `schema/extension.graphql` is all it takes for that field to become
+   * addressable through `_meta.field(name:)`.
+   */
+  const fieldNamesByType = new Map(
+    Object.values(schema.getTypeMap())
+      .filter(isObjectType)
+      .map((type): [string, ReadonlySet<string>] => [
+        type.name,
+        new Set(Object.keys(type.getFields())),
+      ]),
+  );
+
+  /**
+   * Does this entity's GraphQL type actually declare a field called `name`?
+   *
+   * The contract makes `ClassProperty.name` "the field name this property
+   * answers to ON THIS CLASS — the exact string `EntityMeta.field(name:)`
+   * accepts", and says what to do when a property projects no field at all:
+   * return the OWL local name as a LABEL, and accept no such name at
+   * `field(name:)`. This dataset has such a case — `metro:note` is declared
+   * on the abstract `Stop` and inherited by every station, and no concrete
+   * type in the extension SDL exposes a `note` field — so without this the
+   * provider fabricated a plausible-but-wrong field name and then honoured it,
+   * which is the outcome the contract's fallback clause exists to forbid.
+   *
+   * PRECONDITION: every `typename` reaching here is an object type this
+   * schema declares. The entity typenames are a literal union the extension
+   * SDL declares, and the two synthetic ones (`OntologyClass`, `GeoPoint`)
+   * are written a few lines below. There is deliberately no "unknown type"
+   * arm: an arm no test can reach is dead code rather than defence.
+   */
+  const projectsField = (typename: string, name: string): boolean =>
+    (fieldNamesByType.get(typename) as ReadonlySet<string>).has(name);
+
+  const classByUri = new Map(dataset.classes.map((cls) => [cls.uri, cls]));
+  const propertyByUri = new Map(dataset.properties.map((p) => [p.uri, p]));
+
+  // -------------------------------------------------------------------
+  // TBox traversal
+  // -------------------------------------------------------------------
+
+  /**
+   * The compact (curie) form of an IRI: the declared prefix of the longest
+   * namespace the IRI starts with, plus the remainder.
+   *
+   * Longest-match, not first-match, so a namespace that is a prefix of another
+   * cannot shadow it. Falls back to the whole IRI when nothing is declared,
+   * which keeps the field total.
+   *
+   * Note this resolves against `dataset.ontologies` — the same prefix/namespace
+   * pairs `Query.ontologies` publishes — so a client can derive exactly the
+   * same string itself. The compact form is a convenience, never a secret.
+   */
+  const curieOf = (uri: string): string => {
+    const match = dataset.ontologies
+      .filter((ontology) => uri.startsWith(ontology.namespace))
+      .sort((a, b) => b.namespace.length - a.namespace.length)[0];
+    return match === undefined
+      ? uri
+      : `${match.prefix}:${uri.slice(match.namespace.length)}`;
+  };
+
+  const superclassOf = (cls: ExampleClass): ExampleClass | undefined =>
+    cls.superclass === undefined ? undefined : classByUri.get(cls.superclass);
+
+  /** The transitive superclass chain, nearest first. `seen` breaks cycles. */
+  const ancestorsOf = (
+    cls: ExampleClass,
+    seen: Set<string> = new Set([cls.uri]),
+  ): ExampleClass[] => {
+    const parent = superclassOf(cls);
+    if (parent === undefined || seen.has(parent.uri)) {
+      return [];
+    }
+    seen.add(parent.uri);
+    return [parent, ...ancestorsOf(parent, seen)];
+  };
+
+  /**
+   * The class's own cardinality declarations followed by every ancestor's,
+   * marked `inherited`. Paired with the property IRI so `_meta.field(name:)`
+   * has something to match on — see the note on that field below.
+   */
+  const fieldsOf = (cls: ExampleClass): { uri: string; view: View }[] =>
+    [
+      ...cls.properties.map((cp) => ({ cp, inherited: false })),
+      ...ancestorsOf(cls).flatMap((ancestor) =>
+        ancestor.properties.map((cp) => ({ cp, inherited: true })),
+      ),
+    ].flatMap(({ cp, inherited }) => {
+      const property = propertyByUri.get(cp.property);
+      return property === undefined
+        ? []
+        : [
+            {
+              uri: property.uri,
+              view: classPropertyView(cp, property, inherited),
+            },
+          ];
+    });
+
+  // -------------------------------------------------------------------
+  // Views
+  // -------------------------------------------------------------------
+
+  const nullableClassView = (uri: string | undefined): View | null => {
+    const cls = uri === undefined ? undefined : classByUri.get(uri);
+    return cls === undefined ? null : classView(cls);
+  };
+
+  function propertyView(property: ExampleProperty): View {
+    return {
+      uri: property.uri,
+      label: resolveLabel(property.labels, DEFAULT_LANG),
+      definition: resolveLabel(property.definitions, DEFAULT_LANG),
+      domain: () => nullableClassView(property.domain),
+      range: property.range,
+      kind: property.kind,
+      functional: property.functional,
+      inverse: () => {
+        const inverse =
+          property.inverse === undefined
+            ? undefined
+            : propertyByUri.get(property.inverse);
+        return inverse === undefined ? null : propertyView(inverse);
+      },
+      namespace: namespaceOf(property.uri),
+    };
+  }
+
+  function classPropertyView(
+    cp: ExampleClassProperty,
+    property: ExampleProperty,
+    inherited: boolean,
+  ): View {
+    return {
+      // The key `_meta.field(name:)` accepts — WHEN this property projects a
+      // field at all. The contract requires the field but cannot say what a
+      // hand-written provider should put in it: for the compiler `name` means
+      // "the GraphQL field name I derived", and this provider derives nothing.
+      // So it states its own rule — the property IRI's local name — and serves
+      // it here so the argument round-trips: read `name` off `_meta.fields`,
+      // pass it straight back to `field()`.
+      //
+      // For a property the schema does not expose the same string is the
+      // contract's LABEL fallback instead, and `field()` above declines it.
+      // The two readings are deliberately the same characters: the contract
+      // asks that the fallback tell a consumer nothing `property.uri` did not
+      // already, not that it be visibly different.
+      name: localName(property.uri),
+      property: () => propertyView(property),
+      required: cp.required,
+      singular: cp.singular,
+      inherited,
+    };
+  }
+
+  function metaView(source: MetaSource): View {
+    return {
+      title: (args: LangArgs) =>
+        resolveTitle(source.labels, args.lang, source.uri, source.typename),
+      label: (args: LangArgs) => resolveLabel(source.labels, args.lang),
+      comment: (args: LangArgs) => resolveLabel(source.comments, args.lang),
+      definition: (args: LangArgs) =>
+        resolveLabel(source.definitions, args.lang),
+      // The compact display form of this entity's IRI, and the contract fixes
+      // what an embeddable answers: "for a value with no IRI at all (an
+      // embedded blank node) — the GraphQL type name". Compacting the CLASS
+      // IRI instead reads better in isolation ("this is a geo:GeoPoint") and
+      // is the wrong answer: a provider whose job is to demonstrate the
+      // contract cannot quietly serve a nicer one. The typename tier is the
+      // same tail `title` falls back to, so the two agree.
+      curie: () =>
+        source.uri === null ? source.typename : curieOf(source.uri),
+      type: () => classView(source.cls),
+      fields: () => fieldsOf(source.cls).map((field) => field.view),
+      // Matches `ClassProperty.name` — but only where that name is a REAL
+      // field on this entity's GraphQL type. `fields` publishes an entry for
+      // every property the class declares, including ones this provider's
+      // schema does not expose (`note`, inherited from `Stop`); for those the
+      // published `name` is a label rather than an address, and the contract
+      // says plainly that no such name is one `field(name:)` would accept. So
+      // the round-trip holds for every PROJECTED field, and an unprojected one
+      // answers null rather than handing back metadata for a field a consumer
+      // could never select.
+      field: (args: { name: string }) =>
+        !projectsField(source.typename, args.name)
+          ? null
+          : (fieldsOf(source.cls).find(
+              (field) => localName(field.uri) === args.name,
+            )?.view ?? null),
+    };
+  }
+
+  function classView(cls: ExampleClass): View {
+    return {
+      __typename: "OntologyClass",
+      uri: cls.uri,
+      _meta: () =>
+        metaView({
+          labels: cls.labels,
+          comments: cls.comments,
+          definitions: cls.definitions,
+          uri: cls.uri,
+          typename: "OntologyClass",
+          // A class is an instance of the metaclass when the dataset declares
+          // one, and of itself otherwise: `type` is non-null, so there is no
+          // third answer.
+          cls: classByUri.get(META_CLASS_URI) ?? cls,
+        }),
+      label: resolveLabel(cls.labels, DEFAULT_LANG),
+      definition: resolveLabel(cls.definitions, DEFAULT_LANG),
+      superclass: () => nullableClassView(cls.superclass),
+      superclasses: () => ancestorsOf(cls).map(classView),
+      subclasses: () =>
+        dataset.classes
+          .filter((other) => other.superclass === cls.uri)
+          .map(classView),
+      properties: () => fieldsOf(cls).map((field) => field.view),
+      instances: (args: ConnectionArgs) =>
+        connectionView(instancesOf(cls), args),
+      instanceCount: () => instancesOf(cls).length,
+      isAbstract: cls.isAbstract,
+      namespace: namespaceOf(cls.uri),
+    };
+  }
+
+  const geoPointClass = classByUri.get(GEO_POINT_CLASS_URI);
+
+  const geoPointView = (point: ExampleGeoPoint | undefined): View | null =>
+    point === undefined || geoPointClass === undefined
+      ? null
+      : {
+          _meta: () =>
+            metaView({ uri: null, typename: "GeoPoint", cls: geoPointClass }),
+          latitude: point.latitude,
+          longitude: point.longitude,
+        };
+
+  const entityView = (entity: ExampleEntity, cls: ExampleClass): View => ({
+    __typename: entity.typename,
+    uri: entity.uri,
+    _meta: () =>
+      metaView({
+        labels: entity.labels,
+        comments: entity.comments,
+        definitions: entity.definitions,
+        uri: entity.uri,
+        typename: entity.typename,
+        cls,
+      }),
+    name: resolveLabel(entity.labels, DEFAULT_LANG),
+    platformCount: entity.platformCount ?? null,
+    transferMinutes: entity.transferMinutes ?? null,
+    location: () => geoPointView(entity.location),
+    inZone: () =>
+      entity.inZone === undefined
+        ? null
+        : (viewByUri.get(entity.inZone) ?? null),
+    servesLine: () =>
+      (entity.servesLine ?? []).flatMap((uri) => {
+        const line = viewByUri.get(uri);
+        return line === undefined ? [] : [line];
+      }),
+    // The inverse of `servesLine`, over every entity that carries it — which
+    // is `Station` AND `Interchange`. The SDL says `[Stop!]!` for exactly that
+    // reason: this list is genuinely mixed, and typing it `[Station!]!` served
+    // an `Interchange` under the wrong type name. `defaultResolveTypeFn` picks
+    // the concrete type off each view's own `__typename`.
+    servedBy: () =>
+      records
+        .filter((record) =>
+          (record.entity.servesLine ?? []).includes(entity.uri),
+        )
+        .map((record) => record.view),
+  });
+
+  const ontologyView = (ontology: ExampleOntology): View => ({
+    prefix: ontology.prefix,
+    namespace: ontology.namespace,
+    label: ontology.label ?? null,
+    classes: () =>
+      dataset.classes
+        .filter((cls) => cls.uri.startsWith(ontology.namespace))
+        .map(classView),
+    properties: () =>
+      dataset.properties
+        .filter((property) => property.uri.startsWith(ontology.namespace))
+        .map(propertyView),
+  });
+
+  // -------------------------------------------------------------------
+  // ABox index. Entities of an unknown class are dropped: `_meta.type` is
+  // non-null, so an entity whose class the TBox does not declare has no
+  // conformant representation and must not be served at all.
+  // -------------------------------------------------------------------
+
+  const records: EntityRecord[] = [...dataset.entities]
+    .sort((a, b) => a.uri.localeCompare(b.uri))
+    .flatMap((entity) => {
+      const cls = classByUri.get(entity.type);
+      return cls === undefined
+        ? []
+        : [{ entity, view: entityView(entity, cls) }];
+    });
+
+  const viewByUri = new Map(
+    records.map((record) => [record.entity.uri, record.view]),
+  );
+
+  /** Instances of a class, including instances of its subclasses. */
+  const instancesOf = (cls: ExampleClass): EntityRecord[] =>
+    records.filter((record) => {
+      const recordClass = classByUri.get(record.entity.type);
+      return (
+        recordClass !== undefined &&
+        (recordClass.uri === cls.uri ||
+          ancestorsOf(recordClass).some((ancestor) => ancestor.uri === cls.uri))
+      );
+    });
+
+  const connectionView = (
+    items: readonly EntityRecord[],
+    args: ConnectionArgs,
+  ): View => {
+    const page = sliceConnection(items, (record) => record.entity.uri, args);
+    const edges = page.items.map((record) => ({
+      node: record.view,
+      cursor: toCursor(record.entity.uri),
+    }));
+    return {
+      edges,
+      pageInfo: {
+        hasNextPage: page.hasNextPage,
+        hasPreviousPage: page.hasPreviousPage,
+        startCursor: edges[0]?.cursor ?? null,
+        endCursor: edges[edges.length - 1]?.cursor ?? null,
+      },
+    };
+  };
+
+  /**
+   * Expand the prefixed convenience form (`"metro:Station"`) to an absolute
+   * IRI. An absolute IRI passes through untouched: its scheme is never a
+   * declared prefix.
+   */
+  const expandUri = (value: string): string => {
+    const colon = value.indexOf(":");
+    const ontology = dataset.ontologies.find(
+      (candidate) => candidate.prefix === value.slice(0, colon),
+    );
+    return ontology === undefined
+      ? value
+      : `${ontology.namespace}${value.slice(colon + 1)}`;
+  };
+
+  // -------------------------------------------------------------------
+  // The contract's five root fields. Nothing is added to Query: every type
+  // this provider declares is reachable from here.
+  // -------------------------------------------------------------------
+
+  const rootValue: Record<string, unknown> = {
+    node: (args: { id: string }) =>
+      viewByUri.get(args.id) ?? nullableClassView(args.id),
+    ontologies: () => dataset.ontologies.map(ontologyView),
+    ontology: (args: { prefix: string }) => {
+      const ontology = dataset.ontologies.find(
+        (candidate) => candidate.prefix === args.prefix,
+      );
+      return ontology === undefined ? null : ontologyView(ontology);
+    },
+    ontologyClass: (args: { uri: string }) =>
+      nullableClassView(expandUri(args.uri)),
+    ontologyProperty: (args: { uri: string }) => {
+      const property = propertyByUri.get(expandUri(args.uri));
+      return property === undefined ? null : propertyView(property);
+    },
+  };
+
+  return { schema, rootValue, sdl };
+};

--- a/packages/prism/graph-example/src/lib/provider/dataset.ts
+++ b/packages/prism/graph-example/src/lib/provider/dataset.ts
@@ -1,0 +1,446 @@
+/**
+ * The data file. A small fictional metro network — a TBox and an ABox.
+ *
+ * WHY A METRO NETWORK. This provider exists to show that the contract is
+ * implementable by someone who has never heard of pragma, so its subject
+ * matter must share no vocabulary with pragma's own graph (design systems,
+ * components, code standards, jobs, personas, surfaces, layouts). A transit
+ * network shares none. Biology and taxonomy were deliberately avoided: a
+ * domain with its own taxonomic ranks blurs the line between the subject's
+ * hierarchy and RDFS subclassing, and this file needs that line sharp.
+ *
+ * EVERYTHING HERE IS INERT. No functions, no getters, no computation — records
+ * and nothing else. All view construction lives in createExampleProvider.ts,
+ * which is what makes "a provider is some code and a data file" literally
+ * true rather than a figure of speech.
+ */
+
+import {
+  GEO_NAMESPACE,
+  GEO_PREFIX,
+  META_CLASS_URI,
+  METRO_NAMESPACE,
+  METRO_PREFIX,
+  RDFS_NAMESPACE,
+  RDFS_PREFIX,
+} from "./constants.js";
+import type { ExampleDataset } from "./types.js";
+
+const STOP = `${METRO_NAMESPACE}Stop`;
+const STATION = `${METRO_NAMESPACE}Station`;
+const INTERCHANGE = `${METRO_NAMESPACE}Interchange`;
+const LINE = `${METRO_NAMESPACE}Line`;
+const GEO_POINT = `${GEO_NAMESPACE}GeoPoint`;
+const ZONE = `${GEO_NAMESPACE}Zone`;
+
+const NAME = `${METRO_NAMESPACE}name`;
+const NOTE = `${METRO_NAMESPACE}note`;
+const PLATFORM_COUNT = `${METRO_NAMESPACE}platformCount`;
+const SERVES_LINE = `${METRO_NAMESPACE}servesLine`;
+const SERVED_BY = `${METRO_NAMESPACE}servedBy`;
+const TRANSFER_MINUTES = `${METRO_NAMESPACE}transferMinutes`;
+const LOCATION = `${GEO_NAMESPACE}location`;
+const LATITUDE = `${GEO_NAMESPACE}latitude`;
+const LONGITUDE = `${GEO_NAMESPACE}longitude`;
+const IN_ZONE = `${GEO_NAMESPACE}inZone`;
+
+/** IRI of the entity carrying no descriptive predicates whatsoever. */
+export const BARE_ENTITY_URI = `${METRO_NAMESPACE}ghost`;
+
+/**
+ * IRI whose local name is empty — the deepest fallback tier for a Node, and
+ * the edge case that keeps `curie` honest (it compacts to a bare `metro:`).
+ */
+export const EMPTY_LOCAL_NAME_URI = METRO_NAMESPACE;
+
+/** IRI of the station carrying labels in more than one language. */
+export const MULTILINGUAL_ENTITY_URI = `${METRO_NAMESPACE}northgate`;
+
+/** IRI of an entity in the SECOND namespace — the curie prefix must differ. */
+export const SECOND_NAMESPACE_ENTITY_URI = `${GEO_NAMESPACE}central-zone`;
+
+export const exampleDataset: ExampleDataset = {
+  ontologies: [
+    {
+      prefix: METRO_PREFIX,
+      namespace: METRO_NAMESPACE,
+      label: "Metro Network Ontology",
+    },
+    // No label: Ontology.label is nullable, and something has to prove it.
+    { prefix: GEO_PREFIX, namespace: GEO_NAMESPACE },
+    { prefix: RDFS_PREFIX, namespace: RDFS_NAMESPACE, label: "RDF Schema" },
+  ],
+
+  // ---------------------------------------------------------------------
+  // TBox. Three levels of metro hierarchy (Stop -> Station -> Interchange)
+  // so `superclasses` has something transitive to be transitive about, plus
+  // two further roots so `superclass: null` is exercised.
+  // ---------------------------------------------------------------------
+  classes: [
+    {
+      uri: STOP,
+      labels: { "": "Stop" },
+      definitions: { "": "Any place a service calls at." },
+      comments: { "": "Abstract: instantiate Station or a subclass instead." },
+      isAbstract: true,
+      properties: [
+        { property: NAME, required: true, singular: true },
+        { property: NOTE, required: false, singular: true },
+      ],
+    },
+    {
+      uri: STATION,
+      labels: { "": "Station", fr: "Gare" },
+      definitions: { "": "A staffed stop with platforms." },
+      superclass: STOP,
+      isAbstract: false,
+      properties: [
+        { property: PLATFORM_COUNT, required: false, singular: true },
+        { property: SERVES_LINE, required: true, singular: false },
+        { property: LOCATION, required: false, singular: true },
+        { property: IN_ZONE, required: false, singular: true },
+      ],
+    },
+    {
+      uri: INTERCHANGE,
+      labels: { "": "Interchange" },
+      definitions: { "": "A station where two or more lines meet." },
+      superclass: STATION,
+      isAbstract: false,
+      properties: [
+        { property: TRANSFER_MINUTES, required: false, singular: true },
+      ],
+    },
+    {
+      uri: LINE,
+      labels: { "": "Line" },
+      definitions: { "": "A named route through the network." },
+      isAbstract: false,
+      properties: [
+        { property: NAME, required: true, singular: true },
+        { property: SERVED_BY, required: false, singular: false },
+      ],
+    },
+    {
+      uri: GEO_POINT,
+      labels: { "": "Geo point" },
+      definitions: { "": "A latitude/longitude pair on the WGS 84 datum." },
+      isAbstract: false,
+      properties: [
+        { property: LATITUDE, required: true, singular: true },
+        { property: LONGITUDE, required: true, singular: true },
+      ],
+    },
+    {
+      // A class in the SECOND namespace that actually has instances. Without
+      // it every entity would compact to `metro:` and the curie logic could
+      // hardcode one prefix and still look correct.
+      uri: ZONE,
+      labels: { "": "Fare zone" },
+      definitions: { "": "A fare band covering part of the network." },
+      isAbstract: false,
+      properties: [{ property: NAME, required: true, singular: true }],
+    },
+    {
+      // The metaclass. Present because `EntityMeta.type` is non-null and
+      // OntologyClass implements Node, so a class needs a class. In RDFS
+      // `rdfs:Class` is an instance of itself, so the tower terminates
+      // honestly rather than by fiat. It declares no properties, which also
+      // gives `_meta.fields` an empty-list case to be tested against.
+      uri: META_CLASS_URI,
+      labels: { "": "Class" },
+      definitions: { "": "The class of classes." },
+      isAbstract: false,
+      properties: [],
+    },
+  ],
+
+  // ---------------------------------------------------------------------
+  // Properties. All three PropertyKind members appear, `functional` appears
+  // in both states, `domain` appears both asserted and absent (the contract
+  // makes it nullable), and one inverse pair round-trips.
+  // ---------------------------------------------------------------------
+  properties: [
+    {
+      uri: NAME,
+      labels: { "": "name" },
+      definitions: { "": "The name shown to passengers." },
+      range: "String",
+      kind: "DATATYPE",
+      functional: true,
+    },
+    {
+      uri: NOTE,
+      labels: { "": "note" },
+      range: "String",
+      kind: "ANNOTATION",
+      functional: false,
+    },
+    {
+      uri: PLATFORM_COUNT,
+      labels: { "": "platform count" },
+      domain: STATION,
+      range: "Int",
+      kind: "DATATYPE",
+      functional: true,
+    },
+    {
+      uri: SERVES_LINE,
+      labels: { "": "serves line" },
+      domain: STATION,
+      range: "metro:Line",
+      kind: "OBJECT",
+      functional: false,
+      inverse: SERVED_BY,
+    },
+    {
+      uri: SERVED_BY,
+      labels: { "": "served by" },
+      domain: LINE,
+      range: "metro:Station",
+      kind: "OBJECT",
+      functional: false,
+      inverse: SERVES_LINE,
+    },
+    {
+      uri: TRANSFER_MINUTES,
+      labels: { "": "transfer minutes" },
+      domain: INTERCHANGE,
+      range: "Int",
+      kind: "DATATYPE",
+      functional: true,
+    },
+    {
+      uri: LOCATION,
+      labels: { "": "location" },
+      domain: STATION,
+      range: "geo:GeoPoint",
+      kind: "OBJECT",
+      functional: true,
+    },
+    {
+      uri: LATITUDE,
+      labels: { "": "latitude" },
+      domain: GEO_POINT,
+      range: "Float",
+      kind: "DATATYPE",
+      functional: true,
+    },
+    {
+      uri: LONGITUDE,
+      labels: { "": "longitude" },
+      domain: GEO_POINT,
+      range: "Float",
+      kind: "DATATYPE",
+      functional: true,
+    },
+    {
+      uri: IN_ZONE,
+      labels: { "": "in zone" },
+      domain: STATION,
+      range: "geo:Zone",
+      kind: "OBJECT",
+      functional: true,
+    },
+  ],
+
+  // ---------------------------------------------------------------------
+  // ABox. Fourteen direct Stations plus two Interchanges, so `instances`
+  // paging has more than one page to page over and `hasNextPage` is a real
+  // answer rather than a constant.
+  // ---------------------------------------------------------------------
+  entities: [
+    {
+      uri: `${METRO_NAMESPACE}north-line`,
+      type: LINE,
+      typename: "Line",
+      labels: { "": "North Line" },
+      definitions: { "": "Northgate to Marsh End, via the old cutting." },
+    },
+    {
+      uri: `${METRO_NAMESPACE}circle-line`,
+      type: LINE,
+      typename: "Line",
+      labels: { "": "Circle Line", fr: "Ligne Circulaire" },
+      comments: { "": "Runs both directions; timetable is symmetric." },
+    },
+    {
+      uri: `${METRO_NAMESPACE}coastal-line`,
+      type: LINE,
+      typename: "Line",
+      labels: { "": "Coastal Line" },
+    },
+
+    // Entities in the geo namespace. Their curies must come out `geo:…`
+    // while every station comes out `metro:…`, which is only possible if the
+    // prefix is resolved per entity.
+    {
+      uri: SECOND_NAMESPACE_ENTITY_URI,
+      type: ZONE,
+      typename: "Zone",
+      labels: { "": "Central Zone" },
+      definitions: { "": "The innermost fare band." },
+    },
+    {
+      uri: `${GEO_NAMESPACE}coastal-zone`,
+      type: ZONE,
+      typename: "Zone",
+      labels: { "": "Coastal Zone" },
+    },
+
+    {
+      uri: MULTILINGUAL_ENTITY_URI,
+      type: STATION,
+      typename: "Station",
+      inZone: SECOND_NAMESPACE_ENTITY_URI,
+      // Two languages, so `title(lang:)` and `label(lang:)` are demonstrably
+      // implemented rather than accepted and ignored.
+      labels: { "": "Northgate", fr: "Porte-Nord" },
+      definitions: { "": "The northern terminus." },
+      platformCount: 4,
+      location: { latitude: 51.5412, longitude: -0.1435 },
+      servesLine: [`${METRO_NAMESPACE}north-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}harbourside`,
+      inZone: `${GEO_NAMESPACE}coastal-zone`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Harbourside" },
+      comments: { "": "Step-free to all platforms." },
+      platformCount: 2,
+      location: { latitude: 51.5008, longitude: -0.1246 },
+      servesLine: [`${METRO_NAMESPACE}coastal-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}kilnwood`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Kilnwood" },
+      platformCount: 2,
+      servesLine: [`${METRO_NAMESPACE}circle-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}marsh-end`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Marsh End" },
+      platformCount: 1,
+      servesLine: [`${METRO_NAMESPACE}north-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}quarry-hill`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Quarry Hill" },
+      platformCount: 2,
+      servesLine: [`${METRO_NAMESPACE}circle-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}saltford`,
+      inZone: `${GEO_NAMESPACE}coastal-zone`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Saltford" },
+      platformCount: 3,
+      servesLine: [`${METRO_NAMESPACE}coastal-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}tannery-lane`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Tannery Lane" },
+      platformCount: 2,
+      servesLine: [`${METRO_NAMESPACE}circle-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}verge-park`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Verge Park" },
+      platformCount: 2,
+      servesLine: [`${METRO_NAMESPACE}north-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}willowbank`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Willowbank" },
+      platformCount: 1,
+      servesLine: [`${METRO_NAMESPACE}circle-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}eastcliff`,
+      inZone: `${GEO_NAMESPACE}coastal-zone`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Eastcliff" },
+      platformCount: 2,
+      location: { latitude: 51.4934, longitude: 0.0098 },
+      servesLine: [`${METRO_NAMESPACE}coastal-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}foundry-row`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Foundry Row" },
+      platformCount: 2,
+      servesLine: [`${METRO_NAMESPACE}north-line`],
+    },
+    {
+      uri: `${METRO_NAMESPACE}greenhithe`,
+      type: STATION,
+      typename: "Station",
+      labels: { "": "Greenhithe" },
+      platformCount: 1,
+      servesLine: [`${METRO_NAMESPACE}coastal-line`],
+    },
+
+    // The awkward two. Neither has a single descriptive predicate, and the
+    // contract still demands a non-null `_meta.title` for both.
+    {
+      // No label, no comment, no definition, no name, no line. Only an IRI
+      // and a class — the minimum an entity can be. Title falls to the local
+      // name, "ghost".
+      uri: BARE_ENTITY_URI,
+      type: STATION,
+      typename: "Station",
+    },
+    {
+      // IRI ends in a separator, so the local name is the empty string and
+      // the title has to fall through to the whole IRI.
+      uri: EMPTY_LOCAL_NAME_URI,
+      type: STATION,
+      typename: "Station",
+    },
+
+    {
+      uri: `${METRO_NAMESPACE}central-exchange`,
+      inZone: `${GEO_NAMESPACE}central-zone`,
+      type: INTERCHANGE,
+      typename: "Interchange",
+      labels: { "": "Central Exchange" },
+      definitions: { "": "The busiest transfer point on the network." },
+      platformCount: 8,
+      transferMinutes: 4,
+      location: { latitude: 51.5074, longitude: -0.1278 },
+      servesLine: [
+        `${METRO_NAMESPACE}north-line`,
+        `${METRO_NAMESPACE}circle-line`,
+        `${METRO_NAMESPACE}coastal-line`,
+      ],
+    },
+    {
+      uri: `${METRO_NAMESPACE}riverside-junction`,
+      type: INTERCHANGE,
+      typename: "Interchange",
+      labels: { "": "Riverside Junction" },
+      platformCount: 5,
+      transferMinutes: 7,
+      servesLine: [
+        `${METRO_NAMESPACE}circle-line`,
+        `${METRO_NAMESPACE}coastal-line`,
+      ],
+    },
+  ],
+};

--- a/packages/prism/graph-example/src/lib/provider/descriptive.test.ts
+++ b/packages/prism/graph-example/src/lib/provider/descriptive.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { localName, resolveLabel, resolveTitle } from "./descriptive.js";
+
+describe("localName", () => {
+  it("takes everything after the last hash", () => {
+    expect(localName("https://metro.example/onto#Station")).toBe("Station");
+  });
+
+  it("takes everything after the last slash when there is no hash", () => {
+    expect(localName("https://metro.example/stop/northgate")).toBe("northgate");
+  });
+
+  it("splits on whichever separator comes last, not on the hash by rank", () => {
+    expect(localName("https://metro.example/onto#a/b")).toBe("b");
+  });
+
+  it("is empty when the IRI ends in a separator", () => {
+    expect(localName("https://metro.example/stop/")).toBe("");
+  });
+
+  it("returns the whole string when there is no separator at all", () => {
+    expect(localName("bare")).toBe("bare");
+  });
+});
+
+describe("resolveLabel", () => {
+  it("prefers an exact language tag", () => {
+    expect(resolveLabel({ "": "Northgate", fr: "Porte-Nord" }, "fr")).toBe(
+      "Porte-Nord",
+    );
+  });
+
+  it("falls back to the untagged literal", () => {
+    expect(resolveLabel({ "": "Northgate", fr: "Porte-Nord" }, "de")).toBe(
+      "Northgate",
+    );
+  });
+
+  it("is null when nothing is asserted", () => {
+    expect(resolveLabel({ fr: "Porte-Nord" }, "de")).toBeNull();
+  });
+
+  it("is null when there is no label map at all", () => {
+    expect(resolveLabel(undefined, "en")).toBeNull();
+  });
+
+  it("treats an asserted empty string as a value, not a miss", () => {
+    expect(resolveLabel({ fr: "" }, "fr")).toBe("");
+  });
+});
+
+describe("resolveTitle", () => {
+  const uri = "https://metro.example/stop/northgate";
+
+  it("uses the label for the requested language", () => {
+    expect(
+      resolveTitle({ "": "Northgate", fr: "Porte-Nord" }, "fr", uri, "Station"),
+    ).toBe("Porte-Nord");
+  });
+
+  it("uses the untagged label when the language has none", () => {
+    expect(
+      resolveTitle({ "": "Northgate", fr: "Porte-Nord" }, "de", uri, "Station"),
+    ).toBe("Northgate");
+  });
+
+  it("falls through an empty label to any other asserted literal", () => {
+    expect(
+      resolveTitle({ "": "", fr: "Porte-Nord" }, "en", uri, "Station"),
+    ).toBe("Porte-Nord");
+  });
+
+  it("falls back to the IRI's local name when nothing is asserted", () => {
+    expect(resolveTitle(undefined, "en", uri, "Station")).toBe("northgate");
+  });
+
+  it("falls back to the local name when every literal is empty", () => {
+    expect(resolveTitle({ "": "" }, "en", uri, "Station")).toBe("northgate");
+  });
+
+  it("falls back to the whole IRI when the local name is empty", () => {
+    expect(
+      resolveTitle(undefined, "en", "https://metro.example/stop/", "Station"),
+    ).toBe("https://metro.example/stop/");
+  });
+
+  it("falls back to the typename when there is no IRI at all", () => {
+    expect(resolveTitle(undefined, "en", null, "GeoPoint")).toBe("GeoPoint");
+  });
+
+  it("prefers an asserted label over the typename for an embeddable", () => {
+    expect(resolveTitle({ "": "Here" }, "en", null, "GeoPoint")).toBe("Here");
+  });
+});

--- a/packages/prism/graph-example/src/lib/provider/descriptive.ts
+++ b/packages/prism/graph-example/src/lib/provider/descriptive.ts
@@ -1,0 +1,64 @@
+/**
+ * `_meta.title` by hand.
+ *
+ * The contract makes `title(lang: String = "en"): String!` NON-NULL, so every
+ * provider owes a total fallback chain — there is no "no title" answer. This
+ * file is that chain, written out longhand with no compiler involved. It is
+ * the honest test the ticket asked for: if computing the fallback by hand were
+ * awkward, the base would be wrong. It is eight lines.
+ */
+
+import type { LangMap } from "./types.js";
+
+/**
+ * The IRI's local name: everything after the last `#` or `/`. Empty when the
+ * IRI ends in a separator — which is why `resolveTitle` has a tier below this.
+ */
+export const localName = (uri: string): string =>
+  uri.slice(Math.max(uri.lastIndexOf("#"), uri.lastIndexOf("/")) + 1);
+
+/**
+ * The asserted label for a language: exact tag first, then the untagged
+ * literal, then nothing. Asserted-only — `null` is a legitimate answer, and
+ * an asserted empty string is a value, not a miss.
+ *
+ * `lang` is CLIENT-SUPPLIED, so the lookup goes through `Object.hasOwn`
+ * rather than plain indexing. A plain `labels[lang]` inherits
+ * `Object.prototype`, so `title(lang: "constructor")` returned a FUNCTION,
+ * which `String!` cannot represent — the field errored and nulled the whole
+ * node. That is the one thing `resolveTitle` promises cannot happen, reachable
+ * from an argument anyone can type.
+ */
+const own = (labels: LangMap | undefined, key: string): string | undefined =>
+  labels !== undefined && Object.hasOwn(labels, key) ? labels[key] : undefined;
+
+export const resolveLabel = (
+  labels: LangMap | undefined,
+  lang: string,
+): string | null => own(labels, lang) ?? own(labels, "") ?? null;
+
+/**
+ * The total title chain: asserted label for the language, then any asserted
+ * literal in any language, then the IRI's local name, then the whole IRI, then
+ * the GraphQL typename. `uri` is null for an embeddable, which has no identity
+ * to fall back to — that is the only path that reaches the typename tier.
+ */
+export const resolveTitle = (
+  labels: LangMap | undefined,
+  lang: string,
+  uri: string | null,
+  typename: string,
+): string => {
+  const labelled = resolveLabel(labels, lang);
+  if (labelled !== null && labelled !== "") {
+    return labelled;
+  }
+  const anyLanguage = Object.values(labels ?? {}).find((value) => value !== "");
+  if (anyLanguage !== undefined) {
+    return anyLanguage;
+  }
+  if (uri === null) {
+    return typename;
+  }
+  return localName(uri) || uri;
+};

--- a/packages/prism/graph-example/src/lib/provider/index.ts
+++ b/packages/prism/graph-example/src/lib/provider/index.ts
@@ -1,0 +1,13 @@
+/**
+ * The provider domain's barrel.
+ *
+ * @module provider
+ */
+
+export * from "./connection.js";
+export * from "./constants.js";
+export * from "./createExampleProvider.js";
+export * from "./dataset.js";
+export * from "./descriptive.js";
+export * from "./providerSdl.js";
+export * from "./types.js";

--- a/packages/prism/graph-example/src/lib/provider/providerSdl.test.ts
+++ b/packages/prism/graph-example/src/lib/provider/providerSdl.test.ts
@@ -1,0 +1,60 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildSchema } from "graphql";
+import { describe, expect, it } from "vitest";
+import {
+  EXTENSION_SCHEMA_PATH,
+  readExtensionSdl,
+  readProviderSdl,
+  resolveExtensionSchemaPath,
+} from "./providerSdl.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(here, "../../..");
+
+describe("resolveExtensionSchemaPath", () => {
+  it("finds the schema from the source layout", () => {
+    expect(resolveExtensionSchemaPath(here)).toBe(
+      resolve(packageRoot, "schema/extension.graphql"),
+    );
+  });
+
+  it("finds the schema from the built layout", () => {
+    expect(
+      resolveExtensionSchemaPath(resolve(packageRoot, "dist/esm/lib/provider")),
+    ).toBe(resolve(packageRoot, "schema/extension.graphql"));
+  });
+
+  it("falls back to a real, expected path when the file is missing", () => {
+    expect(resolveExtensionSchemaPath("/nowhere/a/b/c")).toBe(
+      "/nowhere/schema/extension.graphql",
+    );
+  });
+});
+
+describe("the shipped paths", () => {
+  it("point at a file that exists", () => {
+    expect(existsSync(EXTENSION_SCHEMA_PATH)).toBe(true);
+  });
+});
+
+describe("readProviderSdl", () => {
+  it("is the contract followed by the extension, never a vendored copy", () => {
+    const sdl = readProviderSdl();
+    const extension = readExtensionSdl();
+    expect(sdl).toContain("interface Node");
+    expect(sdl.endsWith(extension)).toBe(true);
+    expect(sdl.indexOf("interface Node")).toBeLessThan(
+      sdl.indexOf("type Station implements Node"),
+    );
+  });
+
+  it("carries no vendored contract text in this package's own schema dir", () => {
+    expect(readExtensionSdl()).not.toContain("interface Node");
+  });
+
+  it("builds", () => {
+    expect(() => buildSchema(readProviderSdl())).not.toThrow();
+  });
+});

--- a/packages/prism/graph-example/src/lib/provider/providerSdl.ts
+++ b/packages/prism/graph-example/src/lib/provider/providerSdl.ts
@@ -1,0 +1,79 @@
+/**
+ * The provider's SDL = the authored contract, verbatim, plus this package's
+ * extension types.
+ *
+ * The contract half is READ AT RUNTIME from @canonical/prism-contract. It is
+ * never vendored, never copied, never pinned to a snapshot: the whole reason
+ * this package is worth having is that it starts FROM the authored SDL, so it
+ * cannot drift from it. If the contract changes, this provider's contract test
+ * turns red on the next run — which is the mechanism working, not a break.
+ *
+ * NODE / BUN ONLY, for the same reason the contract package is: the extension
+ * file is read through node:fs off import.meta.url.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readContractSdl } from "@canonical/prism-contract";
+
+/** The schema directory sits at the package root, beside src/ and dist/. */
+const SCHEMA_RELATIVE_PATH = "schema/extension.graphql";
+
+/** From src/lib/provider/ (vitest) the package root is three levels up. */
+const SOURCE_LAYOUT_PREFIX = "../../..";
+
+/** From dist/esm/lib/provider/ (the tsc build) it is four levels up. */
+const BUILD_LAYOUT_PREFIX = "../../../..";
+
+/**
+ * Resolve the extension SDL for whichever layout `here` — the directory this
+ * module was loaded from — belongs to. Falls back to the source layout so a
+ * missing file names a real, expected path. Exported for tests, which probe
+ * the layouts this module cannot occupy at test time.
+ *
+ * @note Impure: probes the filesystem with `existsSync`. Which of the two
+ * layouts (source tree or published build) is live is not knowable from this
+ * module's own text.
+ */
+export const resolveExtensionSchemaPath = (here: string): string => {
+  const sourceCandidate = resolve(
+    here,
+    SOURCE_LAYOUT_PREFIX,
+    SCHEMA_RELATIVE_PATH,
+  );
+  if (existsSync(sourceCandidate)) {
+    return sourceCandidate;
+  }
+  const buildCandidate = resolve(
+    here,
+    BUILD_LAYOUT_PREFIX,
+    SCHEMA_RELATIVE_PATH,
+  );
+  if (existsSync(buildCandidate)) {
+    return buildCandidate;
+  }
+  return sourceCandidate;
+};
+
+/** Absolute path to this package's extension SDL file. */
+export const EXTENSION_SCHEMA_PATH: string = resolveExtensionSchemaPath(
+  dirname(fileURLToPath(import.meta.url)),
+);
+
+/** Read this package's extension SDL as a string. *
+ * @note Impure: reads the filesystem on every call.
+ */
+export const readExtensionSdl = (): string =>
+  readFileSync(EXTENSION_SCHEMA_PATH, "utf8");
+
+/**
+ * The full SDL this provider serves: the contract first, the extension after.
+ * Handing callers text rather than a GraphQLSchema keeps every consumer free
+ * to build it with THEIR graphql instance — two majors coexist in this repo.
+ *
+ * @note Impure: reads both this package's extension SDL and the contract's
+ * own SDL from the filesystem, on every call.
+ */
+export const readProviderSdl = (): string =>
+  [readContractSdl(), readExtensionSdl()].join("\n");

--- a/packages/prism/graph-example/src/lib/provider/types.ts
+++ b/packages/prism/graph-example/src/lib/provider/types.ts
@@ -1,0 +1,111 @@
+/**
+ * The shapes of the example dataset, and of the provider it is served through.
+ *
+ * Type-only: no runtime code, which is why the coverage config excludes this
+ * file. Everything here describes INERT data — dataset.ts contains records of
+ * these shapes and nothing else, no functions. All view construction lives in
+ * createExampleProvider.ts, so "a provider is some code and a data file"
+ * stays literally true.
+ */
+
+import type { GraphQLSchema } from "graphql";
+
+/**
+ * Literals keyed by BCP-47 language tag. The empty-string key is the untagged
+ * literal — the one a non-RDF provider would simply call "the value".
+ */
+export type LangMap = Readonly<Record<string, string>>;
+
+/** How a property relates its subject to its object. Mirrors `PropertyKind`. */
+export type ExamplePropertyKind = "DATATYPE" | "OBJECT" | "ANNOTATION";
+
+/** A property in the TBox. */
+export interface ExampleProperty {
+  readonly uri: string;
+  readonly labels?: LangMap;
+  readonly definitions?: LangMap;
+  /** IRI of the class this property applies to, or absent for a global one. */
+  readonly domain?: string;
+  /** Stringly-typed by the contract: `"String"`, `"Int"`, `"metro:Line"`, … */
+  readonly range: string;
+  readonly kind: ExamplePropertyKind;
+  readonly functional: boolean;
+  /** IRI of the property that reads this one backwards, if any. */
+  readonly inverse?: string;
+}
+
+/** Class-scoped cardinality: a fact about a (class, property) pair. */
+export interface ExampleClassProperty {
+  /** IRI of the property. */
+  readonly property: string;
+  readonly required: boolean;
+  readonly singular: boolean;
+}
+
+/** A class in the TBox. */
+export interface ExampleClass {
+  readonly uri: string;
+  readonly labels?: LangMap;
+  readonly definitions?: LangMap;
+  readonly comments?: LangMap;
+  /** IRI of the direct superclass, if any. */
+  readonly superclass?: string;
+  readonly isAbstract: boolean;
+  /** Cardinality declared ON this class; ancestors' arrive as inherited. */
+  readonly properties: readonly ExampleClassProperty[];
+}
+
+/** A loaded namespace. */
+export interface ExampleOntology {
+  readonly prefix: string;
+  readonly namespace: string;
+  readonly label?: string;
+}
+
+/** An embeddable coordinate pair. No IRI — deliberately not an entity. */
+export interface ExampleGeoPoint {
+  readonly latitude: number;
+  readonly longitude: number;
+}
+
+/** One instance-level record. */
+export interface ExampleEntity {
+  readonly uri: string;
+  /** IRI of this entity's class. Non-optional: EntityMeta.type is non-null. */
+  readonly type: string;
+  /** GraphQL type name — what `defaultTypeResolver` reads off the view. */
+  readonly typename: "Line" | "Station" | "Interchange" | "Zone";
+  readonly labels?: LangMap;
+  readonly comments?: LangMap;
+  readonly definitions?: LangMap;
+  readonly platformCount?: number;
+  readonly transferMinutes?: number;
+  readonly location?: ExampleGeoPoint;
+  /** IRIs of the lines this station serves. */
+  readonly servesLine?: readonly string[];
+  /** IRI of the fare zone this station sits in — an entity in the geo namespace. */
+  readonly inZone?: string;
+}
+
+/** The whole dataset: a TBox and an ABox. */
+export interface ExampleDataset {
+  readonly ontologies: readonly ExampleOntology[];
+  readonly classes: readonly ExampleClass[];
+  readonly properties: readonly ExampleProperty[];
+  readonly entities: readonly ExampleEntity[];
+}
+
+/**
+ * An executable provider. `rootValue` rather than a resolver map: graphql-js's
+ * `defaultFieldResolver` invokes a function-valued property as
+ * `source[field](args, context, info)`, and `defaultTypeResolver` reads
+ * `__typename`, so plain objects carrying zero-argument arrow functions cover
+ * every field this contract declares. There is no resolver map anywhere in
+ * this package.
+ */
+export interface ExampleProvider {
+  readonly schema: GraphQLSchema;
+  readonly rootValue: Record<string, unknown>;
+  /** The exact SDL `schema` was built from — contract first, extension after. */
+  readonly sdl: string;
+}

--- a/packages/prism/graph-example/src/lib/server/createExampleHandler.test.ts
+++ b/packages/prism/graph-example/src/lib/server/createExampleHandler.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createExampleProvider } from "../provider/index.js";
+import { createExampleHandler } from "./createExampleHandler.js";
+
+const provider = createExampleProvider();
+
+const post = (body: unknown, init: RequestInit = {}): Request =>
+  new Request("http://localhost/graphql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    ...init,
+  });
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("POST", () => {
+  it("executes an operation and returns its data", async () => {
+    const handler = createExampleHandler(provider);
+    const response = await handler(
+      post({ query: "{ ontologies { prefix } }" }),
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        ontologies: [
+          { prefix: "metro" },
+          { prefix: "geo" },
+          { prefix: "rdfs" },
+        ],
+      },
+    });
+  });
+
+  it("passes variables and an operation name through", async () => {
+    const handler = createExampleHandler(provider);
+    const response = await handler(
+      post({
+        query: `query A($uri: String!) { ontologyClass(uri: $uri) { uri } }
+                query B { ontologies { prefix } }`,
+        variables: { uri: "metro:Station" },
+        operationName: "A",
+      }),
+    );
+    await expect(response.json()).resolves.toEqual({
+      data: { ontologyClass: { uri: "https://metro.example/onto#Station" } },
+    });
+  });
+
+  it("returns GraphQL errors in the body, not as an HTTP failure", async () => {
+    const handler = createExampleHandler(provider);
+    const response = await handler(post({ query: "{ nope }" }));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { errors: unknown[] };
+    expect(body.errors).toHaveLength(1);
+  });
+
+  it("rejects a body that is not JSON", async () => {
+    const handler = createExampleHandler(provider);
+    const response = await handler(post("not json at all"));
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a JSON body with no query string", async () => {
+    const handler = createExampleHandler(provider);
+    const response = await handler(post({ variables: {} }));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      errors: [{ message: "Expected a JSON body with a `query` string." }],
+    });
+  });
+
+  it("rejects a JSON body whose query is not a string", async () => {
+    const handler = createExampleHandler(provider);
+    expect((await handler(post({ query: 42 }))).status).toBe(400);
+  });
+});
+
+describe("GET", () => {
+  it("serves GraphiQL when enabled", async () => {
+    const handler = createExampleHandler(provider, { graphiql: true });
+    const response = await handler(new Request("http://localhost/graphql"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    await expect(response.text()).resolves.toContain('<div id="graphiql">');
+  });
+
+  it("bakes the configured endpoint into the page", async () => {
+    const handler = createExampleHandler(provider, {
+      graphiql: true,
+      endpoint: "http://example.test/api",
+    });
+    const response = await handler(new Request("http://localhost/graphql"));
+    await expect(response.text()).resolves.toContain(
+      'url: "http://example.test/api"',
+    );
+  });
+
+  it("404s when GraphiQL is disabled", async () => {
+    const handler = createExampleHandler(provider, { graphiql: false });
+    const response = await handler(new Request("http://localhost/graphql"));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("CORS", () => {
+  it("answers a preflight with 204 and the allow headers", async () => {
+    const handler = createExampleHandler(provider, { cors: true });
+    const response = await handler(
+      new Request("http://localhost/graphql", { method: "OPTIONS" }),
+    );
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Methods")).toBe(
+      "GET, POST, OPTIONS",
+    );
+  });
+
+  it("sends no allow headers when disabled", async () => {
+    const handler = createExampleHandler(provider, { cors: false });
+    const response = await handler(
+      new Request("http://localhost/graphql", { method: "OPTIONS" }),
+    );
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("sends the headers on a real response too", async () => {
+    const handler = createExampleHandler(provider, { cors: true });
+    const response = await handler(
+      post({ query: "{ ontologies { prefix } }" }),
+    );
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("other methods", () => {
+  it("405s", async () => {
+    const handler = createExampleHandler(provider);
+    const response = await handler(
+      new Request("http://localhost/graphql", { method: "DELETE" }),
+    );
+    expect(response.status).toBe(405);
+  });
+});
+
+describe("the production posture", () => {
+  it("serves neither GraphiQL nor CORS when NODE_ENV is production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const handler = createExampleHandler(provider);
+    const page = await handler(new Request("http://localhost/graphql"));
+    expect(page.status).toBe(404);
+    const preflight = await handler(
+      new Request("http://localhost/graphql", { method: "OPTIONS" }),
+    );
+    expect(preflight.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("serves both outside production", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const handler = createExampleHandler(provider);
+    const page = await handler(new Request("http://localhost/graphql"));
+    expect(page.status).toBe(200);
+    const preflight = await handler(
+      new Request("http://localhost/graphql", { method: "OPTIONS" }),
+    );
+    expect(preflight.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("still executes operations in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const handler = createExampleHandler(provider);
+    const response = await handler(
+      post({ query: "{ ontologies { prefix } }" }),
+    );
+    expect(response.status).toBe(200);
+  });
+});

--- a/packages/prism/graph-example/src/lib/server/createExampleHandler.ts
+++ b/packages/prism/graph-example/src/lib/server/createExampleHandler.ts
@@ -1,0 +1,102 @@
+/**
+ * A fetch-native GraphQL endpoint of this provider's own.
+ *
+ * DELIBERATELY NOT ke-graphql's createGraphQLHandler. That one is 505 lines
+ * and imports the other graphql major pinned in this repo, so reusing it would
+ * put two graphql instances in one process — and it would also contradict the
+ * premise, which is that implementing this contract does not require pragma's
+ * machinery. This is the whole of what the contract needs: POST JSON, execute,
+ * respond. No persisted queries, no depth limiting, no incremental delivery,
+ * no error masking.
+ */
+
+import { graphql } from "graphql";
+import type { ExampleProvider } from "../provider/index.js";
+import graphiqlHtml from "./graphiqlHtml.js";
+
+/** Options for {@link createExampleHandler}. */
+export interface ExampleHandlerOptions {
+  /** Serve GraphiQL on GET. Defaults to on outside production. */
+  readonly graphiql?: boolean;
+  /** Send permissive CORS headers. Defaults to on outside production. */
+  readonly cors?: boolean;
+  /** Endpoint URL baked into the GraphiQL page. Defaults to `"/graphql"`. */
+  readonly endpoint?: string;
+}
+
+/** The JSON body of a GraphQL-over-HTTP POST. */
+interface GraphQLRequestBody {
+  query?: string;
+  variables?: Record<string, unknown> | null;
+  operationName?: string | null;
+}
+
+// `process` is absent on Workers/edge isolates — default to the hardened
+// posture there, exactly as ke-graphql's handler does.
+const isProduction = (): boolean =>
+  typeof process === "undefined" || process.env.NODE_ENV === "production";
+
+const corsHeaders = (enabled: boolean): Record<string, string> =>
+  enabled
+    ? {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Accept",
+      }
+    : {};
+
+/**
+ * Create a `(Request) => Promise<Response>` serving `provider`. No framework,
+ * no adapter: the platform's own fetch types are the whole interface.
+ *
+ * @note Impure — the returned handler performs request/response I/O.
+ */
+export const createExampleHandler = (
+  provider: ExampleProvider,
+  options: ExampleHandlerOptions = {},
+): ((request: Request) => Promise<Response>) => {
+  const graphiqlEnabled = options.graphiql ?? !isProduction();
+  const corsEnabled = options.cors ?? !isProduction();
+  const endpoint = options.endpoint ?? "/graphql";
+  const cors = corsHeaders(corsEnabled);
+
+  return async (request: Request): Promise<Response> => {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: cors });
+    }
+
+    if (request.method === "GET") {
+      return graphiqlEnabled
+        ? new Response(graphiqlHtml(endpoint), {
+            status: 200,
+            headers: { ...cors, "Content-Type": "text/html; charset=utf-8" },
+          })
+        : new Response("Not Found", { status: 404, headers: cors });
+    }
+
+    if (request.method !== "POST") {
+      return new Response("Method Not Allowed", { status: 405, headers: cors });
+    }
+
+    const body = (await request
+      .json()
+      .catch(() => null)) as GraphQLRequestBody | null;
+    if (body === null || typeof body.query !== "string") {
+      return Response.json(
+        {
+          errors: [{ message: "Expected a JSON body with a `query` string." }],
+        },
+        { status: 400, headers: cors },
+      );
+    }
+
+    const result = await graphql({
+      schema: provider.schema,
+      source: body.query,
+      rootValue: provider.rootValue,
+      variableValues: body.variables ?? undefined,
+      operationName: body.operationName ?? undefined,
+    });
+    return Response.json(result, { status: 200, headers: cors });
+  };
+};

--- a/packages/prism/graph-example/src/lib/server/graphiqlHtml.test.ts
+++ b/packages/prism/graph-example/src/lib/server/graphiqlHtml.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import graphiqlHtml from "./graphiqlHtml.js";
+
+describe("graphiqlHtml", () => {
+  it("interpolates the endpoint as a JSON string literal", () => {
+    expect(graphiqlHtml("/graphql")).toContain('url: "/graphql"');
+  });
+
+  it("escapes an endpoint that would otherwise break out of the literal", () => {
+    expect(graphiqlHtml('/a"b')).toContain('url: "/a\\"b"');
+  });
+
+  it("escapes an endpoint that would otherwise close the script element", () => {
+    // The JSON literal is well formed either way; what matters is that the
+    // HTML tokenizer never sees `</script`, because that — not the JavaScript
+    // grammar — is what decides where this element ends.
+    const html = graphiqlHtml("/graphql</script><script>alert(1)</script>");
+    expect(html).toContain(
+      String.raw`url: "/graphql\u003c/script>\u003cscript>alert(1)\u003c/script>"`,
+    );
+    // The three pinned CDN bundles plus the inline one is four closing tags;
+    // an injected pair would raise the count.
+    expect(html.match(/<\/script>/g)).toHaveLength(4);
+  });
+
+  it("renders a self-contained HTML document", () => {
+    const html = graphiqlHtml("/graphql");
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain('<div id="graphiql">');
+  });
+});

--- a/packages/prism/graph-example/src/lib/server/graphiqlHtml.ts
+++ b/packages/prism/graph-example/src/lib/server/graphiqlHtml.ts
@@ -1,0 +1,59 @@
+/**
+ * Render the embedded GraphiQL page for an endpoint. Served on GET when
+ * GraphiQL is enabled, which is dev-only by default.
+ *
+ * The assets load as version-pinned UMD bundles from unpkg at runtime — a
+ * dev-tool surface, not a production dependency of the API. Pinned to
+ * graphiql 3.x because that line ships a single UMD bundle carrying its own
+ * CodeMirror, so the page cannot end up with two CodeMirror instances; 4+ is
+ * Monaco-based and ESM-only. React 18 for the same reason: 19 dropped UMD.
+ */
+/**
+ * Embed a string as a JavaScript literal that is safe INSIDE an inline
+ * `<script>` element.
+ *
+ * `JSON.stringify` alone is not enough, because two parsers read this text.
+ * JSON escaping satisfies the JavaScript grammar, but the HTML tokenizer is
+ * what decides where the `<script>` element ends, and it decides by scanning
+ * the raw element text for `</script` — a sequence JSON escaping leaves
+ * completely intact. An endpoint of `</script><script>…` closes this element
+ * and opens an attacker-controlled one while remaining a well-formed JSON
+ * string. (`<!--` is the same class of hazard: it moves the tokenizer into the
+ * script-data-escaped state and with it where the element is believed to end.)
+ *
+ * Escaping every `<` as `\u003c` removes both sequences at their source,
+ * rather than matching `</script` alone — the tokenizer has more than one
+ * exit and a denylist has to know them all. `\u003c` is a JavaScript string
+ * escape, so the value the page receives is unchanged; only its spelling in
+ * the document differs. The sibling template in `@canonical/ke-graphql` escapes the same way and says
+ * the same thing; the two are kept in step deliberately.
+ */
+const asInlineScriptString = (value: string): string =>
+  JSON.stringify(value).replace(/</g, "\\u003c");
+
+export default function graphiqlHtml(endpoint: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>GraphiQL — prism-graph-example</title>
+  <style>
+    html, body, #graphiql { height: 100%; margin: 0; }
+  </style>
+  <link rel="stylesheet" href="https://unpkg.com/graphiql@3.9.0/graphiql.min.css" />
+</head>
+<body>
+  <div id="graphiql">Loading GraphiQL…</div>
+  <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/graphiql@3.9.0/graphiql.min.js"></script>
+  <script>
+    const fetcher = GraphiQL.createFetcher({ url: ${asInlineScriptString(endpoint)} });
+    ReactDOM.createRoot(document.getElementById("graphiql")).render(
+      React.createElement(GraphiQL, { fetcher }),
+    );
+  </script>
+</body>
+</html>
+`;
+}

--- a/packages/prism/graph-example/src/lib/server/index.ts
+++ b/packages/prism/graph-example/src/lib/server/index.ts
@@ -1,0 +1,8 @@
+/**
+ * The server domain's barrel: the fetch handler and its GraphiQL page.
+ *
+ * @module server
+ */
+
+export * from "./createExampleHandler.js";
+export { default as graphiqlHtml } from "./graphiqlHtml.js";

--- a/packages/prism/graph-example/src/testing/fixtures.ts
+++ b/packages/prism/graph-example/src/testing/fixtures.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared test fixtures.
+ *
+ * The lens variables are keyed by operation name and use metro-network IRIs
+ * throughout — if a lens can only be satisfied by a pragma IRI, it is not
+ * provider-neutral, and that is exactly what this gate is for.
+ */
+
+/** A class every lens that looks a term up can be pointed at. */
+export const SAMPLE_CLASS_URI = "metro:Station";
+
+/**
+ * An entity every lens that looks an instance up can be pointed at.
+ *
+ * This MUST be an IRI the dataset actually carries, and it must be
+ * absolute: `node(id:)` takes the absolute IRI and nothing else, so
+ * `metro:northgate` resolves to null here exactly as it would against
+ * ke-graphql. The value was previously `https://metro.example/stop/…`,
+ * which resolved to nothing at all after the dataset moved its instances
+ * into the declared namespaces — harmless only for as long as every
+ * operation that used it failed validation first, and a confusing
+ * green-nulls failure the moment one of them started validating.
+ */
+export const SAMPLE_ENTITY_URI = "https://metro.example/onto#northgate";
+
+/**
+ * Variables for each lens operation, by operation name.
+ *
+ * An operation discovered without an entry here FAILS the gate rather than
+ * skipping it: a lens nobody wrote variables for is a lens nobody tested.
+ */
+export const LENS_OPERATION_VARIABLES: Record<
+  string,
+  Record<string, unknown>
+> = {
+  DefinitionsExplorerQuery: { uri: SAMPLE_CLASS_URI, hasTerm: true },
+  // `JourneysExplorerQuery` used to be listed here. Journeys is no longer a
+  // core lens — an owner reclassified it as a pragma-specific add-on and it
+  // now lives in `apps/react/pragma-docs/src/addons/journeys`, outside the
+  // scanned set — so the gate never discovers the operation and the entry was
+  // dead config. Note the direction the gate checks: it walks DISCOVERED names
+  // and demands a variables entry for each, so a leftover entry here would
+  // never have failed anything. It was removed because it described nothing,
+  // not to make a test pass.
+  //
+  // The standards lens now reaches its collection through the TBox, so it
+  // needs a class binding — and this is the gate's OWN binding, never the
+  // app's. The app's runtime binding lives in
+  // `apps/react/pragma-docs/src/lib/graphBindings`; importing it here would
+  // couple the neutrality proof to the deployment it exists to be
+  // independent of, and the gate would go green because the app agreed
+  // with itself.
+  StandardEntityQuery: { uri: SAMPLE_ENTITY_URI, classUri: SAMPLE_CLASS_URI },
+  StandardsIndexQuery: {
+    classUri: SAMPLE_CLASS_URI,
+    count: 5,
+    cursor: null,
+  },
+  StandardsIndexPaginationQuery: {
+    classUri: SAMPLE_CLASS_URI,
+    count: 5,
+    cursor: null,
+  },
+};

--- a/packages/prism/graph-example/src/testing/integration/contract.test.ts
+++ b/packages/prism/graph-example/src/testing/integration/contract.test.ts
@@ -1,0 +1,139 @@
+// =============================================================================
+// The gate of record: this provider's SDL must subsume the authored contract,
+// AND its runtime views must actually answer what that SDL promises.
+//
+// The contract half of the SDL is read live from @canonical/prism-contract on
+// every run. Never vendor a copy of the contract to make it quiet.
+//
+// WHY SUBSUMPTION ALONE IS NOT ENOUGH, which is easy to get wrong here.
+// `readProviderSdl()` PREPENDS the very contract that `satisfiesContract` uses
+// as its baseline, so the schema half of this gate compares the contract with
+// itself and can only ever fail on the extension. A field added to the
+// contract tomorrow is in this provider's schema the moment it is published —
+// with nothing behind it. If it is nullable the provider serves null and no
+// test notices; if it is non-null it is a runtime error on a query nobody
+// here runs.
+//
+// So the second gate below EXECUTES. It builds its selection set from the
+// live schema rather than from a list, asks a real entity for every field of
+// `EntityMeta` and `ClassProperty` that can be asked without arguments, and
+// asserts the execution reports no errors. That is the pairing that makes the
+// opening claim true: subsumption says the shape is there, execution says
+// something answers.
+// =============================================================================
+
+import { satisfiesContract } from "@canonical/prism-contract";
+import {
+  type GraphQLObjectType,
+  getNamedType,
+  graphql,
+  isLeafType,
+  isObjectType,
+} from "graphql";
+import { describe, expect, it } from "vitest";
+import { MULTILINGUAL_ENTITY_URI } from "../../lib/provider/dataset.js";
+import {
+  createExampleProvider,
+  readProviderSdl,
+} from "../../lib/provider/index.js";
+
+describe("satisfiesContract(readProviderSdl())", () => {
+  // No `providerName`: `satisfiesContract` does not take one — it names the
+  // provider in a THROWN message, and this gate asserts on the result instead.
+  const result = satisfiesContract(readProviderSdl());
+
+  it("reports zero violations", () => {
+    // Mapped to strings so a failure prints what is actually wrong rather
+    // than "[Object]". Asserting emptiness, not prose.
+    expect(
+      result.violations.map(
+        (violation) => `${violation.code}: ${violation.message}`,
+      ),
+    ).toEqual([]);
+  });
+
+  it("is satisfied", () => {
+    expect(result.satisfied).toBe(true);
+  });
+});
+
+describe("the extension is a superset, not a redefinition", () => {
+  it("keeps every contract root field reachable and adds none", () => {
+    const { schema } = createExampleProvider();
+    expect(
+      Object.keys(schema.getQueryType()?.getFields() ?? {}).sort(),
+    ).toEqual([
+      "node",
+      "ontologies",
+      "ontology",
+      "ontologyClass",
+      "ontologyProperty",
+    ]);
+  });
+
+  it("declares more Node implementers than the contract alone can", () => {
+    const { schema } = createExampleProvider();
+    const node = schema.getType("Node");
+    expect(
+      schema
+        // biome-ignore lint/suspicious/noExplicitAny: narrowing an abstract type for a schema assertion
+        .getPossibleTypes(node as any)
+        .map((type) => type.name),
+    ).toContain("Station");
+  });
+});
+
+describe("the runtime view answers what the schema promises", () => {
+  const { schema, rootValue } = createExampleProvider();
+
+  /**
+   * Every field of `type` that can be selected with no arguments, spelled as
+   * a selection set. Leaves are selected bare; object-valued fields get
+   * `{ __typename }`, which is enough to force the resolver to run and to
+   * fail a non-null field that resolves to nothing.
+   *
+   * Derived from the schema, so a field ADDED to the contract is selected here
+   * the day it lands — which is the whole point. A field taking a required
+   * argument (`field(name:)`) is skipped: there is no value to invent for it,
+   * and its own tests cover it.
+   */
+  const probe = (type: GraphQLObjectType): string =>
+    Object.values(type.getFields())
+      .filter((field) =>
+        field.args.every(
+          (arg) =>
+            arg.defaultValue !== undefined ||
+            !arg.type.toString().endsWith("!"),
+        ),
+      )
+      .map((field) =>
+        isLeafType(getNamedType(field.type))
+          ? field.name
+          : `${field.name} { __typename }`,
+      )
+      .join(" ");
+
+  const typeNamed = (name: string): GraphQLObjectType => {
+    const type = schema.getType(name);
+    if (!isObjectType(type)) {
+      throw new Error(`${name} is not an object type in the provider schema`);
+    }
+    return type;
+  };
+
+  const run = async (source: string) => graphql({ schema, source, rootValue });
+
+  it("resolves every argument-free EntityMeta field on a real entity", async () => {
+    const result = await run(
+      `{ node(id: "${MULTILINGUAL_ENTITY_URI}") { _meta { ${probe(typeNamed("EntityMeta"))} } } }`,
+    );
+    expect(result.errors?.map((error) => error.message) ?? []).toEqual([]);
+  });
+
+  it("resolves every argument-free ClassProperty field on a real entity", async () => {
+    const result = await run(
+      `{ node(id: "${MULTILINGUAL_ENTITY_URI}") { _meta { fields { ${probe(typeNamed("ClassProperty"))} } } } }`,
+    );
+    expect(result.errors?.map((error) => error.message) ?? []).toEqual([]);
+  });
+});

--- a/packages/prism/graph-example/src/testing/integration/lensOperations.test.ts
+++ b/packages/prism/graph-example/src/testing/integration/lensOperations.test.ts
@@ -1,0 +1,264 @@
+// =============================================================================
+// THE ACCEPTANCE GATE: every CORE lens operation the docsite ships must
+// execute against a provider that has never heard of pragma.
+//
+// WHAT THE SCANNED DIRECTORY MEANS, AND WHAT IT DOES NOT.
+// `apps/react/pragma-docs/src/domains/lenses/**` is the docsite's CORE LENS
+// SET, and this gate's subject is exactly that directory — never a
+// hand-maintained allowlist. Membership of the core set IS the obligation to
+// be provider-neutral: put a lens there and it must execute here, the day it
+// lands.
+//
+// That is FOUR of the docsite's ten shipped query operations, and the other
+// six are outside the scan for two different reasons. Do not read the scan
+// root as "everything except add-ons" — five of the six are ordinary domain
+// code:
+//
+//   src/domains/components   CatalogListPaginationQuery, ComponentsCatalogQuery,
+//                            ComponentEntityQuery
+//   src/domains/marketing    LobbyQuery  (the home page)
+//   src/domains/playground   ComponentProbeQuery
+//   src/addons/journeys      JourneysExplorerQuery
+//
+// The first five select `Component` or `Query.component` — pragma-ontology
+// terms this provider's dataset has no class for — so widening the root to
+// `src/domains` would turn this gate red today. That red would be a to-do
+// list rather than a defect in the gate, and widening is the intended
+// direction; `lensOperations.ts` carries the same enumeration beside the path
+// constant so the two cannot drift.
+//
+// The sixth is different in kind. `src/addons/**` holds views that are openly
+// pragma-specific — they read pragma's own ontology and make no claim to run
+// anywhere else — and are expected to become plugins once the docsite has a
+// plugin mechanism. An add-on is NOT a core lens, so it owes this gate
+// nothing, while remaining fully built, routed and tested in the app.
+// `JourneysExplorerQuery` was moved there by an OWNER DECISION, recorded
+// verbatim: "keep it on side for now, it will be an add-on plugin not a core
+// view." It was reclassified because it is not a core view; it was not
+// reclassified because it was red.
+//
+// 🔴 `src/addons/**` IS NOT AN ESCAPE HATCH. A red operation does not get to
+// move there. If a lens is meant to be part of the core set and cannot execute
+// against this provider, the answer is to despecialise the operation — the
+// failure report below is the to-do list. Relocating a core operation out of
+// the scanned directory is "narrowing the operation set" under another name,
+// and it is exactly the failure mode this gate exists to catch. Only an owner
+// reclassifying a view as an add-on can move one, and the move must land with
+// that reasoning written down (see `src/addons/journeys/index.ts`, which
+// states what the contract cannot express and why).
+//
+// Journeys is on side for a reason no rewrite can fix: the contract exposes an
+// entity's class and that class's SCHEMA, but `EntityMeta.field(name:)`
+// returns CARDINALITY METADATA rather than a value, and no contract field
+// returns the value of an arbitrary property on an arbitrary entity. Generic
+// instance-level relation traversal is all that lens is.
+//
+// SO WHAT THIS GATE PROVES, EXACTLY: the four operations under
+// `src/domains/lenses` are provider-neutral. It does not establish that the
+// docsite as a whole runs against any conformant provider — five mounted
+// routes, the home page among them, currently do not.
+//
+// It is otherwise implemented at FULL STRENGTH. It is not filtered to
+// the operations that happen to validate, not marked `it.fails`, not
+// `skipIf`'d, and not hidden behind an env var. Every one of those turns a
+// real signal into a silent one, and a silent gate is worse than a red one:
+// the red gate is a to-do list, the silent one is a lie. It also asserts it
+// discovered a non-zero number of operations, so it cannot pass vacuously if
+// the core lens set is emptied or moved.
+// =============================================================================
+
+import {
+  type ExecutionResult,
+  type GraphQLError,
+  graphql,
+  parse,
+  validate,
+} from "graphql";
+import { describe, expect, it } from "vitest";
+import { createExampleProvider } from "../../lib/provider/index.js";
+import { LENS_OPERATION_VARIABLES } from "../fixtures.js";
+import {
+  APP_ROOT,
+  discoverLensOperationNames,
+  readOperationText,
+} from "../lensOperations.js";
+
+const provider = createExampleProvider();
+
+/**
+ * The lane that owns any failure printed below.
+ *
+ * As of the journeys reclassification every operation in the core lens set
+ * executes green here, so this string is unreachable — it renders again the
+ * moment a core lens regresses or a new one lands unfinished.
+ */
+const BLOCKING_LANE =
+  "Lane A (apps/react/pragma-docs) — a core lens operation is written against " +
+  "something other than @canonical/prism-contract. Until it is despecialised " +
+  "onto the contract, no contract-conformant provider can serve it.";
+
+interface OperationFailure {
+  readonly name: string;
+  readonly problems: readonly string[];
+}
+
+const describeErrors = (errors: readonly GraphQLError[]): string[] =>
+  errors.map((error) => error.message);
+
+/** Validate, then execute, one operation. Returns its problems, if any. */
+const checkOperation = async (name: string): Promise<OperationFailure> => {
+  const variables = LENS_OPERATION_VARIABLES[name];
+  if (variables === undefined) {
+    return {
+      name,
+      problems: [
+        "No entry in LENS_OPERATION_VARIABLES. A lens nobody wrote variables " +
+          "for is a lens nobody tested — add one to src/testing/fixtures.ts.",
+      ],
+    };
+  }
+
+  const text = readOperationText(name);
+
+  let document: ReturnType<typeof parse>;
+  try {
+    document = parse(text);
+  } catch (error) {
+    return {
+      name,
+      problems: [`Operation text does not parse: ${String(error)}`],
+    };
+  }
+
+  const validationErrors = validate(provider.schema, document);
+  if (validationErrors.length > 0) {
+    return { name, problems: describeErrors(validationErrors) };
+  }
+  /**
+   * Did a resolved root field actually look something up? An empty connection
+   * or an empty list is a green null wearing a different shape.
+   *
+   * THE CONNECTION IS RARELY AT THE ROOT. `StandardsIndexQuery` selects
+   * `ontologyClass { instances { edges } }` — the root field resolves to a
+   * perfectly good class, and the connection that is empty is two levels down.
+   * Checking only the root value for an `edges` key therefore passed exactly
+   * the operations this guard exists for. So the search is RECURSIVE: any
+   * connection anywhere under a root field must have edges, or the field
+   * looked nothing up.
+   *
+   * ANYWHERE INCLUDES INSIDE A LIST. A non-empty array used to answer "not
+   * empty" and stop, so an empty connection sitting in a list ITEM — an edge's
+   * node, a class in a list of classes — was never reached, and the guarantee
+   * this comment states was not the one the code kept.
+   */
+  const isEmptyResult = (value: unknown): boolean => {
+    if (Array.isArray(value)) {
+      return value.length === 0 || value.some(isEmptyResult);
+    }
+    if (typeof value !== "object" || value === null) return false;
+    const edges = (value as { edges?: unknown }).edges;
+    if (Array.isArray(edges)) return edges.length === 0;
+    // Not a connection itself: an empty one may still be nested inside it.
+    return Object.values(value as Record<string, unknown>).some((nested) =>
+      nested === null || typeof nested !== "object"
+        ? false
+        : isEmptyResult(nested),
+    );
+  };
+
+  const result: ExecutionResult = await graphql({
+    schema: provider.schema,
+    source: text,
+    rootValue: provider.rootValue,
+    variableValues: variables,
+  });
+
+  if (result.errors !== undefined && result.errors.length > 0) {
+    return { name, problems: describeErrors(result.errors) };
+  }
+  if (result.data === null || result.data === undefined) {
+    return {
+      name,
+      problems: ["Executed without errors but returned no data."],
+    };
+  }
+  // Guard against green nulls: an operation that ran but looked nothing up
+  // "passed" only because its variables pointed at nothing.
+  //
+  // The bar is that AT LEAST ONE root field actually resolved to something.
+  // Not every root: a lens may legitimately probe a term as two shapes and
+  // expect one to miss — `DefinitionsExplorerQuery` asks the same URI of
+  // `ontologyClass` and `ontologyProperty`, and exactly one of them answers.
+  // But "something" has to mean something: an empty list and a connection
+  // with no edges are nothing looked up, and `[]` is not `null`, so the
+  // plain null test let them through. The connection is usually NESTED
+  // (`ontologyClass.instances.edges`), which is why `isEmptyResult` searches
+  // rather than reading one key off the root value.
+  if (
+    Object.values(result.data).every(
+      (value) => value === null || isEmptyResult(value),
+    )
+  ) {
+    return {
+      name,
+      problems: [
+        "Every root field resolved to null or to an empty result — the " +
+          "operation ran but looked nothing up. Check " +
+          "LENS_OPERATION_VARIABLES for this operation.",
+      ],
+    };
+  }
+  return { name, problems: [] };
+};
+
+const buildReport = (failures: readonly OperationFailure[]): string =>
+  [
+    `${failures.length} lens operation(s) cannot execute against a ` +
+      "contract-conformant provider.",
+    "",
+    ...failures.flatMap((failure) => [
+      `  ${failure.name} — ${failure.problems.length} problem(s)`,
+      ...failure.problems.map((problem) => `    - ${problem}`),
+      "",
+    ]),
+    `Provider: @canonical/prism-graph-example (metro network, zero pragma vocabulary)`,
+    `Operations harvested at run time from: ${APP_ROOT}`,
+    "",
+    `WAITING ON: ${BLOCKING_LANE}`,
+    "",
+    "Do NOT fix this by narrowing the operation set, by marking the test " +
+      "`fails`, by gating it on an env var, or by relocating the operation " +
+      "into src/addons — that last one is narrowing the set under another " +
+      "name, and only an owner reclassifying a view as a pragma-specific " +
+      "add-on may move it. The list above IS the remaining despecialisation " +
+      "work.",
+  ].join("\n");
+
+describe("the lens operations", () => {
+  const names = discoverLensOperationNames();
+
+  it("discovers at least one operation (anti-vacuity)", () => {
+    expect(names.length).toBeGreaterThan(0);
+  });
+
+  it("has variables declared for every discovered operation", () => {
+    expect(
+      names.filter((name) => LENS_OPERATION_VARIABLES[name] === undefined),
+    ).toEqual([]);
+  });
+
+  it("all carry an inline operation text (not persisted queries)", () => {
+    for (const name of names) {
+      expect(readOperationText(name).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every one of them executes green against this provider", async () => {
+    const results = await Promise.all(names.map(checkOperation));
+    const failures = results.filter((result) => result.problems.length > 0);
+    if (failures.length > 0) {
+      throw new Error(buildReport(failures));
+    }
+    expect(failures).toEqual([]);
+  });
+});

--- a/packages/prism/graph-example/src/testing/integration/lensPagination.test.ts
+++ b/packages/prism/graph-example/src/testing/integration/lensPagination.test.ts
@@ -1,0 +1,166 @@
+// =============================================================================
+// THE PAGINATION GUARD: the acceptance gate's blind spot, covered.
+//
+// The gate next door executes each lens operation ONCE, with `cursor: null`.
+// It therefore cannot see a cursor regression at all — and a cursor regression
+// is silent by construction on both known providers, which is what makes it
+// worth a file of its own.
+//
+// WHY IT IS SILENT. A cursor that matches no item's identity is treated
+// exactly like no cursor: `sliceConnection`'s `indexOfCursor` returns -1, the
+// window starts at 0, and page 1 comes back verbatim with no error. That is a
+// deliberate, documented choice (`lib/provider/connection.ts`) — cursors are
+// client-supplied, and a stale one should degrade to a full page rather than a
+// 500. It is the right behaviour AND it is why "the cursor stopped working"
+// looks identical, at the wire, to "the reader asked for the first page".
+//
+// SO THE GUARD IS THE BOND, NOT THE DEGRADATION. Both providers derive a
+// cursor as `base64(the node's absolute IRI)` — graph-example's `toCursor`,
+// ke-graphql's `toBase64(node.uri)` — which is why a cursor minted by one is
+// located by the other. The assertions below check that derivation directly:
+// every cursor must decode to the IRI of the node it belongs to.
+//
+// 🔴 IT PINS ONE SIDE OF THE CONVENTION, AND CANNOT PIN BOTH HERE. Every
+// cursor read below is minted by THIS provider, so a change to ke-graphql's
+// derivation would leave this file green. The two halves are pinned in two
+// suites: this one, and ke-graphql's own
+// `src/testing/integration/queries.test.ts`, which asserts its cursors are
+// base64 of the very IRI their node reports. One cross-provider assertion
+// would need this package to depend on `@canonical/ke-graphql`, which pins
+// graphql v17 where this package peers v16 — the two-majors hazard the whole
+// contract arrangement exists to keep out of a single process. So the
+// agreement is stated here and measured on each side separately. Read this
+// file as graph-example's half, not as a guard over both.
+//
+// This file only ever STRENGTHENS the gate. It adds an operation nobody was
+// executing under conditions nobody was executing it under; it narrows
+// nothing.
+//
+// Test infrastructure: excluded from the build (tsconfig.build.json) and from
+// coverage (vitest.config.ts).
+// =============================================================================
+
+import { type ExecutionResult, graphql } from "graphql";
+import { describe, expect, it } from "vitest";
+import { createExampleProvider } from "../../lib/provider/index.js";
+import { SAMPLE_CLASS_URI } from "../fixtures.js";
+import {
+  discoverLensOperationNames,
+  readOperationText,
+} from "../lensOperations.js";
+
+const provider = createExampleProvider();
+
+/**
+ * The paginating lens operation, DISCOVERED rather than hard-coded, so this
+ * file dies loudly if the operation is renamed instead of quietly testing
+ * nothing.
+ */
+const PAGINATION_OPERATION = "StandardsIndexPaginationQuery";
+
+/** A page size small enough that the metro ABox has more than one page. */
+const PAGE_SIZE = 5;
+
+interface Edge {
+  readonly cursor: string;
+  readonly node: { readonly uri: string };
+}
+
+interface Page {
+  readonly edges: readonly Edge[];
+  readonly pageInfo: {
+    readonly endCursor: string | null;
+    readonly hasNextPage: boolean;
+  };
+}
+
+const decodeCursor = (cursor: string): string =>
+  Buffer.from(cursor, "base64").toString("utf-8");
+
+/** Execute the operation and return the connection it selected. */
+const fetchPage = async (cursor: string | null): Promise<Page> => {
+  const result: ExecutionResult = await graphql({
+    schema: provider.schema,
+    source: readOperationText(PAGINATION_OPERATION),
+    rootValue: provider.rootValue,
+    variableValues: { classUri: SAMPLE_CLASS_URI, count: PAGE_SIZE, cursor },
+  });
+  expect(result.errors ?? []).toEqual([]);
+  const data = result.data as {
+    ontologyClass: { instances: Page } | null;
+  } | null;
+  const ontologyClass = data?.ontologyClass;
+  if (ontologyClass === null || ontologyClass === undefined) {
+    throw new Error(
+      `${SAMPLE_CLASS_URI} resolved to null — this guard needs a class with ` +
+        "instances to page over.",
+    );
+  }
+  return ontologyClass.instances;
+};
+
+describe("the lens pagination guard", () => {
+  it("is measuring an operation the lens directory actually declares", () => {
+    // The gate derives its operation set from the app; so does this file,
+    // rather than trusting a constant to stay true.
+    expect(discoverLensOperationNames()).toContain(PAGINATION_OPERATION);
+  });
+
+  it("returns a first page with more to come", async () => {
+    const page = await fetchPage(null);
+
+    expect(page.edges.length).toBe(PAGE_SIZE);
+    expect(page.pageInfo.hasNextPage).toBe(true);
+    expect(page.pageInfo.endCursor).not.toBeNull();
+    // `endCursor` is the last edge's cursor, not something computed
+    // separately — a mismatch here means the two are derived independently,
+    // which is the shape the drift takes.
+    expect(page.pageInfo.endCursor).toBe(page.edges.at(-1)?.cursor);
+  });
+
+  it("bonds every cursor to the identity it pages over", async () => {
+    // THE LOAD-BEARING ASSERTION OF THIS FILE. Both providers mint
+    // `base64(absolute IRI)`, which is the only reason a cursor from one is
+    // located by the other. This checks the derivation rather than its
+    // effect, because the effect of a broken cursor is indistinguishable
+    // from a first-page request.
+    const page = await fetchPage(null);
+
+    expect(page.edges.map((edge) => decodeCursor(edge.cursor))).toEqual(
+      page.edges.map((edge) => edge.node.uri),
+    );
+  });
+
+  it("advances: page 2 is non-empty and disjoint from page 1", async () => {
+    const first = await fetchPage(null);
+    const second = await fetchPage(first.pageInfo.endCursor);
+
+    expect(second.edges.length).toBeGreaterThan(0);
+    const firstUris = new Set(first.edges.map((edge) => edge.node.uri));
+    expect(second.edges.filter((edge) => firstUris.has(edge.node.uri))).toEqual(
+      [],
+    );
+    // …and it really is the continuation, not an arbitrary other window:
+    // page 2 starts immediately after page 1's last identity.
+    expect(decodeCursor(first.pageInfo.endCursor ?? "")).toBe(
+      first.edges.at(-1)?.node.uri,
+    );
+  });
+
+  it("degrades a cursor that names nothing to the first page, silently", async () => {
+    // Pinned because it is the documented behaviour AND because it is the
+    // reason the assertion above has to exist. A cursor whose identity is
+    // not in the list is answered with page 1 and no error, so a consumer
+    // that lost cursor compatibility sees a reader stuck on page 1 rather
+    // than an exception. If this ever changes — to an error, or to an empty
+    // page — that is a contract-visible change and it should be a decision,
+    // not a surprise.
+    const first = await fetchPage(null);
+    const strayCursor = Buffer.from("not-an-iri", "utf-8").toString("base64");
+    const stray = await fetchPage(strayCursor);
+
+    expect(stray.edges.map((edge) => edge.node.uri)).toEqual(
+      first.edges.map((edge) => edge.node.uri),
+    );
+  });
+});

--- a/packages/prism/graph-example/src/testing/integration/titleTotality.test.ts
+++ b/packages/prism/graph-example/src/testing/integration/titleTotality.test.ts
@@ -1,0 +1,259 @@
+// =============================================================================
+// `_meta.title` is NON-NULL in the contract, so this gate is about totality,
+// not about correctness of any one title.
+//
+// It is driven FROM THE DATASET, never from a hand-listed set of URIs: a new
+// entity added without a label must be caught by this test on the run it is
+// added, which cannot happen if the list of things to check is maintained by
+// hand alongside the data.
+// =============================================================================
+
+import { type ExecutionResult, graphql } from "graphql";
+import { describe, expect, it } from "vitest";
+import {
+  BARE_ENTITY_URI,
+  createExampleProvider,
+  EMPTY_LOCAL_NAME_URI,
+  exampleDataset,
+} from "../../lib/provider/index.js";
+
+const provider = createExampleProvider();
+
+const execute = async (
+  source: string,
+  variableValues?: Record<string, unknown>,
+): Promise<ExecutionResult> =>
+  graphql({
+    schema: provider.schema,
+    source,
+    rootValue: provider.rootValue,
+    variableValues,
+  });
+
+/** A title is only total if it is present AND says something. */
+const expectUsableTitle = (title: unknown): void => {
+  expect(typeof title).toBe("string");
+  expect(title).not.toBeNull();
+  expect((title as string).length).toBeGreaterThan(0);
+};
+
+describe("every entity in the dataset has a title", () => {
+  it.each(exampleDataset.entities.map((entity) => entity.uri))(
+    "%s",
+    async (uri) => {
+      const result = await execute(
+        `query T($id: ID!) { node(id: $id) { _meta { title } } }`,
+        { id: uri },
+      );
+      expect(result.errors).toBeUndefined();
+      const node = (
+        result.data as { node: { _meta: { title: string } } | null }
+      ).node;
+      expect(node).not.toBeNull();
+      expectUsableTitle(node?._meta.title);
+    },
+  );
+});
+
+describe("every class in the dataset has a title", () => {
+  it.each(exampleDataset.classes.map((cls) => cls.uri))("%s", async (uri) => {
+    const result = await execute(
+      `query T($uri: String!) { ontologyClass(uri: $uri) { _meta { title } } }`,
+      { uri },
+    );
+    expect(result.errors).toBeUndefined();
+    const cls = (
+      result.data as { ontologyClass: { _meta: { title: string } } | null }
+    ).ontologyClass;
+    expect(cls).not.toBeNull();
+    expectUsableTitle(cls?._meta.title);
+  });
+});
+
+describe("the embeddable has a title despite having no IRI", () => {
+  const embedded = exampleDataset.entities.filter(
+    (entity) => entity.location !== undefined,
+  );
+
+  it("has at least one embeddable in the dataset to check", () => {
+    expect(embedded.length).toBeGreaterThan(0);
+  });
+
+  it.each(embedded.map((entity) => entity.uri))("%s", async (uri) => {
+    const result = await execute(
+      `query T($id: ID!) {
+         node(id: $id) { ... on Station { location { _meta { title } } }
+                         ... on Interchange { location { _meta { title } } } }
+       }`,
+      { id: uri },
+    );
+    expect(result.errors).toBeUndefined();
+    const node = result.data as {
+      node: { location: { _meta: { title: string } } | null } | null;
+    };
+    expect(node.node?.location).not.toBeNull();
+    expectUsableTitle(node.node?.location?._meta.title);
+  });
+});
+
+describe("titles survive a language that names a prototype member", () => {
+  // `lang` is an argument a CLIENT types. A plain `labels[lang]` inherits
+  // Object.prototype, so these tags returned a FUNCTION where the schema
+  // promises `String!` — the field errored and nulled the whole node, which is
+  // precisely the "no title answer" the chain is documented to make impossible.
+  // "zxx" below is the easy half of totality (a MISSING key); these are the
+  // half that actually broke it.
+  it.each(["constructor", "toString", "hasOwnProperty", "__proto__"])(
+    "lang=%s still answers with a usable title",
+    async (lang) => {
+      const uri = exampleDataset.entities[0]?.uri as string;
+      const result = await execute(
+        `query T($id: ID!, $lang: String) { node(id: $id) { _meta { title(lang: $lang) } } }`,
+        { id: uri, lang },
+      );
+      expect(result.errors).toBeUndefined();
+      const node = (
+        result.data as { node: { _meta: { title: string } } | null }
+      ).node;
+      expect(node).not.toBeNull();
+      expectUsableTitle(node?._meta.title);
+    },
+  );
+});
+
+describe("titles survive a language nobody wrote", () => {
+  it.each(exampleDataset.entities.map((entity) => entity.uri))(
+    "%s in an unwritten language",
+    async (uri) => {
+      const result = await execute(
+        `query T($id: ID!) { node(id: $id) { _meta { title(lang: "zxx") } } }`,
+        { id: uri },
+      );
+      expect(result.errors).toBeUndefined();
+      const node = (
+        result.data as { node: { _meta: { title: string } } | null }
+      ).node;
+      expectUsableTitle(node?._meta.title);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// `_meta.curie` is non-null for the same reason `title` is, so it gets the
+// same treatment: driven from the dataset, never a hand-listed set.
+// ---------------------------------------------------------------------------
+
+describe("every entity in the dataset has a curie", () => {
+  it.each(exampleDataset.entities.map((entity) => entity.uri))(
+    "%s",
+    async (uri) => {
+      const result = await execute(
+        `query C($id: ID!) { node(id: $id) { _meta { curie } } }`,
+        { id: uri },
+      );
+      expect(result.errors).toBeUndefined();
+      const node = (
+        result.data as { node: { _meta: { curie: string } } | null }
+      ).node;
+      expect(node).not.toBeNull();
+      expectUsableTitle(node?._meta.curie);
+    },
+  );
+});
+
+describe("every class in the dataset has a curie", () => {
+  it.each(exampleDataset.classes.map((cls) => cls.uri))("%s", async (uri) => {
+    const result = await execute(
+      `query C($uri: String!) { ontologyClass(uri: $uri) { _meta { curie } } }`,
+      { uri },
+    );
+    expect(result.errors).toBeUndefined();
+    const cls = (
+      result.data as { ontologyClass: { _meta: { curie: string } } | null }
+    ).ontologyClass;
+    expect(cls).not.toBeNull();
+    expectUsableTitle(cls?._meta.curie);
+  });
+});
+
+describe("the embeddable has a curie despite having no IRI", () => {
+  const embedded = exampleDataset.entities.filter(
+    (entity) => entity.location !== undefined,
+  );
+
+  it.each(embedded.map((entity) => entity.uri))("%s", async (uri) => {
+    const result = await execute(
+      `query C($id: ID!) {
+         node(id: $id) { ... on Station { location { _meta { curie } } }
+                         ... on Interchange { location { _meta { curie } } } }
+       }`,
+      { id: uri },
+    );
+    expect(result.errors).toBeUndefined();
+    const data = result.data as {
+      node: { location: { _meta: { curie: string } } | null } | null;
+    };
+    expectUsableTitle(data.node?.location?._meta.curie);
+  });
+});
+
+describe("curies actually compact, and resolve per namespace", () => {
+  it("uses more than one prefix across the dataset", async () => {
+    const result = await execute(`{ ontologies { prefix namespace } }`);
+    const ontologies = (
+      result.data as { ontologies: { prefix: string; namespace: string }[] }
+    ).ontologies;
+
+    const curies = await Promise.all(
+      exampleDataset.entities.map(async (entity) => {
+        const one = await execute(
+          `query C($id: ID!) { node(id: $id) { _meta { curie } } }`,
+          { id: entity.uri },
+        );
+        return (one.data as { node: { _meta: { curie: string } } }).node._meta
+          .curie;
+      }),
+    );
+    const prefixes = new Set(curies.map((curie) => curie.split(":")[0]));
+    // Two namespaces hold entities, so a hardcoded prefix cannot pass here.
+    expect(prefixes.size).toBeGreaterThan(1);
+    for (const prefix of prefixes) {
+      expect(ontologies.map((ontology) => ontology.prefix)).toContain(prefix);
+    }
+  });
+
+  it("is shorter than the IRI it compacts, for every entity", async () => {
+    for (const entity of exampleDataset.entities) {
+      const result = await execute(
+        `query C($id: ID!) { node(id: $id) { uri _meta { curie } } }`,
+        { id: entity.uri },
+      );
+      const node = (
+        result.data as { node: { uri: string; _meta: { curie: string } } }
+      ).node;
+      expect(node._meta.curie.length).toBeLessThan(node.uri.length);
+    }
+  });
+});
+
+describe("the two entities that have nothing to be titled from", () => {
+  it("titles the entity with no descriptive predicates at all", async () => {
+    const result = await execute(
+      `{ node(id: "${BARE_ENTITY_URI}") { _meta { title label comment definition } } }`,
+    );
+    expect(result.data).toEqual({
+      node: {
+        _meta: { title: "ghost", label: null, comment: null, definition: null },
+      },
+    });
+  });
+
+  it("titles the entity whose IRI has an empty local name", async () => {
+    const result = await execute(
+      `{ node(id: "${EMPTY_LOCAL_NAME_URI}") { _meta { title } } }`,
+    );
+    expect(result.data).toEqual({
+      node: { _meta: { title: EMPTY_LOCAL_NAME_URI } },
+    });
+  });
+});

--- a/packages/prism/graph-example/src/testing/lensOperations.ts
+++ b/packages/prism/graph-example/src/testing/lensOperations.ts
@@ -1,0 +1,157 @@
+/**
+ * Harvesting the docsite's lens operations, at RUN time.
+ *
+ * The operation texts are NEVER snapshotted into this package. They are read
+ * out of the app's committed Relay artifacts on every run, so this gate always
+ * measures the operations as they are now — not as they were when someone last
+ * remembered to update a fixture.
+ *
+ * Within its scan root the operation SET is derived from the tree, never from
+ * a hand-maintained allowlist. Narrowing that set to the operations that
+ * happen to pass is exactly the "shape it until it goes green" failure mode
+ * this gate exists to prevent.
+ *
+ * 🔴 WHAT THE SCAN ROOT IS, AND WHAT IT IS NOT. The root is
+ * `src/domains/lenses`, and that is FOUR of the docsite's ten shipped query
+ * operations. The other six do not execute against this provider, and it
+ * would be dishonest to let the scan root imply otherwise, so they are named
+ * here with the reason:
+ *
+ *   src/domains/components   CatalogListPaginationQuery, ComponentsCatalogQuery,
+ *                            ComponentEntityQuery
+ *   src/domains/marketing    LobbyQuery  (the home page)
+ *   src/domains/playground   ComponentProbeQuery
+ *   src/addons/journeys      JourneysExplorerQuery
+ *
+ * The first five select `Component` or `Query.component` and the last selects
+ * `jobs` — pragma-ontology terms this provider's dataset has no class for, so
+ * they fail with "Unknown type" or "Cannot query field". The honest statement
+ * of what this gate proves is therefore narrow, and worth stating narrowly:
+ * the four operations under `src/domains/lenses` are provider-neutral. It does
+ * NOT establish that the docsite as a whole runs against any conformant
+ * provider — five mounted routes, the home page among them, currently do not.
+ *
+ * Widening the root to `src/domains` is the intended direction and would turn
+ * this gate red today. That red would be a to-do list rather than a defect in
+ * the gate; a silent gate implying coverage it does not have is the worse of
+ * the two, which is why the exclusions are enumerated here rather than left
+ * implicit in one path constant.
+ *
+ * 🔴 SCHEDULING. The reach into the app is a filesystem path, not a manifest
+ * dependency, and the app depends on nothing here — so `nx affected` does not
+ * schedule this project when a lens changes. The gate runs on every full
+ * `bun run test` and post-merge, not on a PR that touches only a lens.
+ *
+ * Test infrastructure: excluded from the build (tsconfig.build.json) and from
+ * coverage (vitest.config.ts).
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** From src/testing/ the repo root is five levels up. */
+const APP_RELATIVE_PATH = "../../../../../apps/react/pragma-docs";
+
+/** The docsite app this provider is measured against. */
+export const APP_ROOT: string = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  APP_RELATIVE_PATH,
+);
+
+/**
+ * The scan root: the CORE lens components. The operation set is whatever is
+ * declared under here — and nothing else. See this module's header for the
+ * six operations that live outside it, and why.
+ */
+export const LENS_DIRECTORY: string = join(APP_ROOT, "src/domains/lenses");
+
+/** Relay's committed artifacts, which carry the full operation text. */
+export const ARTIFACT_DIRECTORY: string = join(
+  APP_ROOT,
+  "src/relay/__generated__",
+);
+
+const tsxFilesUnder = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return tsxFilesUnder(full);
+    }
+    // `.ts` as well as `.tsx`: the lens tree already carries *Query.ts
+    // modules by convention, and a `graphql` tag in one of them would otherwise
+    // be invisible to a gate whose whole claim is that the set is derived
+    // from the tree.
+    return entry.isFile() && /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+
+/**
+ * Every query operation declared under the lens directory, sorted.
+ *
+ * Template bodies are captured FIRST and operation names read out of those
+ * bodies, never out of the raw file text: these components carry extensive
+ * TSDoc prose, and matching `query X(` against it would invent operations
+ * that do not exist.
+ *
+ * Throws — never returns empty, never skips — when the app is missing. A gate
+ * that goes quiet when its subject disappears is worse than no gate.
+ */
+export const discoverLensOperationNames = (): string[] => {
+  if (!existsSync(LENS_DIRECTORY)) {
+    throw new Error(
+      `Lens directory not found at ${LENS_DIRECTORY}. This gate measures the ` +
+        "docsite's own lens operations against this provider; it cannot run " +
+        "without the app, and it must not pass without it either.",
+    );
+  }
+
+  const names = new Set<string>();
+  for (const file of tsxFilesUnder(LENS_DIRECTORY)) {
+    const text = readFileSync(file, "utf8");
+    for (const [, body] of text.matchAll(/graphql`([\s\S]*?)`/g)) {
+      for (const [, name] of (body ?? "").matchAll(
+        /\bquery\s+([A-Za-z_]\w*)\s*[({]/g,
+      )) {
+        names.add(name as string);
+      }
+      for (const [, name] of (body ?? "").matchAll(
+        /@refetchable\(\s*queryName:\s*"([^"]+)"/g,
+      )) {
+        names.add(name as string);
+      }
+    }
+  }
+  return [...names].sort();
+};
+
+/**
+ * The full operation text of a committed Relay artifact.
+ *
+ * Read as TEXT and parsed out of the `params.text` literal rather than
+ * imported: the artifact modules open with a value-position import of
+ * `relay-runtime`, a package this one does not and should not depend on.
+ *
+ * A null `text` means the app switched to persisted queries, and the operation
+ * text no longer lives in the repo. That must fail loudly rather than quietly
+ * testing nothing.
+ */
+export const readOperationText = (name: string): string => {
+  const artifact = join(ARTIFACT_DIRECTORY, `${name}.graphql.ts`);
+  if (!existsSync(artifact)) {
+    throw new Error(
+      `No Relay artifact for the lens operation "${name}" at ${artifact}. ` +
+        "Either the operation was renamed without regenerating artifacts, or " +
+        "relay-compiler has not been run.",
+    );
+  }
+  const source = readFileSync(artifact, "utf8");
+  const match = /"text":\s*("(?:[^"\\]|\\.)*")/.exec(source);
+  if (match?.[1] === undefined) {
+    throw new Error(
+      `The Relay artifact for "${name}" carries no operation text (${artifact}). ` +
+        "This is what persisted queries look like — the text is no longer in " +
+        "the repo, so this gate cannot execute it.",
+    );
+  }
+  return JSON.parse(match[1]) as string;
+};

--- a/packages/prism/graph-example/tsconfig.build.json
+++ b/packages/prism/graph-example/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/testing/**"]
+}

--- a/packages/prism/graph-example/tsconfig.json
+++ b/packages/prism/graph-example/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@canonical/typescript-config",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["node", "bun"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "demo/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/prism/graph-example/vitest.config.ts
+++ b/packages/prism/graph-example/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: [
+        "**/index.ts",
+        "**/*.test.ts",
+        "**/*.d.ts",
+        "**/types.ts",
+        "**/constants.ts",
+        "src/testing/**",
+      ],
+      // The repo standard for a shipped package: 100%, matching the sibling
+      // contract package (packages/prism/contract/vitest.config.ts). Do not
+      // lower these — a reference implementation that cannot hold its own bar
+      // is not a reference.
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Done

A second implementation of `@canonical/prism-contract`, written **by hand and
without the ke-graphql compiler**: a small metro-network dataset, a Relay
connection slicer, a total title chain, and a fetch handler. Private.

It is the control in a two-provider experiment. A documentation site that runs
against both this and the compiler-backed provider is provider-neutral by
*measurement* rather than by assertion — and this is the half that cannot be
neutral by accident, because nothing here shares a line with the compiler.

It lands **after** the site because its gate reads the site:
`src/testing/lensOperations.ts` discovers the site's lens operations from the
site's own tree at run time, out of the committed Relay artifacts, and executes
each against this provider.

Source: `feat/prism-docsite`, `24fe66cb0..6bbf65f9c`.

### Reconciled against `main`

Version `0.36.0` → `0.37.0`, biome `2.4.9` → `2.5.11` (one file reformats),
every `^0.36.0` sibling range → `^0.37.0`. The `biome.json` pinned `"$schema"`
at 2.4.9, which made `biome check` report a version mismatch on every run.

### Corrected while landing it

| What was wrong | Why it mattered |
| --- | --- |
| **`EntityMeta.title` was not total** | `lang` is an argument a client types, and the label lookup inherited `Object.prototype` — so `title(lang: "constructor")` returned a *function* where the schema promises `String!`. The field errored and nulled the whole node: the one outcome the fallback chain exists to make impossible |
| **The connection's page flags contradicted the Relay spec** | They took the cursor cut's answer where the spec takes the count's, so `first` with `before` reported a next page over a window that fit — a client following `endCursor` walks into an empty page. The two cells where the answers diverge were exactly the two the test matrix omitted |
| **The lens gate overstated its own scope** | Its prose said the scan root was the core set with exactly one documented exclusion, and that there was "no third state". There were five |
| **The green-null guard was weaker than documented** | It fired only when *every* root field came back `null`, so an empty list or an edgeless connection counted as having looked something up |
| **The barrels published the internals** | The dataset, the connection helpers, the SDL readers, eleven constants. The consumer boots this package and points at it; that is the surface now |
| **The operation scan collected `.tsx` only** | A `graphql` tag in one of the lens tree's `*Query.ts` modules would have been invisible to a gate whose whole claim is that the set comes from the tree |
| **`_meta.field(name:)` answered for unprojected properties** (second review pass) | `metro:note` is declared on the abstract `Stop` and inherited by every station, and no GraphQL type here exposes a `note` field. The provider handed back metadata for a field a consumer can never select — the contract says plainly that "there is no name `field(name:)` would accept" in that case. The lookup is gated on the built schema now: `fields` still publishes the local name as a label, `field(name: "note")` answers null |
| **The contract gate could not see an unimplemented contract field** (second review pass) | `readProviderSdl()` prepends the very contract `satisfiesContract` measures against, so a field added to the contract is in this schema the moment it is published, with nothing behind it. An execution gate now asks a real entity for every argument-free `EntityMeta` and `ClassProperty` field, with the selection built from the live schema so a new field is covered the day it lands |
| **The green-null guard stopped at the first non-empty array** (second review pass) | An empty connection inside a list item was never reached, so the "any connection anywhere" guarantee its own comment states was not the one the code kept |
| **The forward-compatibility shim was unreachable code** (second review pass) | It declared `ClassProperty.name` and `EntityMeta.curie` for a contract that lacked them; the supported range starts at 0.37.0, which has both. Removed, with its synthetic tests and its README section — 33 code lines |
| **The demo server bound every interface** (second review pass) | Bun binds `0.0.0.0` when `hostname` is omitted, and this process serves GraphiQL and permissive CORS outside production. It binds loopback now, as the sibling provider's demo does |
| **The README described the embeddable's `curie` backwards** (second review pass) | It said the value compacts its class (`geo:GeoPoint`); the code answers the GraphQL type name (`GeoPoint`), which is what the contract asks for |

## What this gate actually proves — please read this bit

The gate is green over **four of the documentation site's ten shipped query
operations**. The other six do not execute against a conformant provider at all:

| Where | Operations | Why |
| --- | --- | --- |
| `src/domains/components` | `ComponentsCatalogQuery`, `CatalogListPaginationQuery`, `ComponentEntityQuery` | select `Component` / `Query.component` |
| `src/domains/marketing` | `LobbyQuery` — **the home page** | selects `Component` |
| `src/domains/playground` | `ComponentProbeQuery` | selects `Query.component` |
| `src/addons/journeys` | `JourneysExplorerQuery` | selects `jobs` |

All six name pragma-ontology terms this provider's dataset has no class for.
Only the last was documented as an exclusion; the other five were invisible,
because the exclusion lived implicitly in one path constant while the prose
claimed there was "no third state".

So the honest claim is narrow: **the four operations under `src/domains/lenses`
are provider-neutral.** The site as a whole is not yet — five mounted routes,
the home page among them, cannot run against any conformant provider. Widening
the scan root to `src/domains` is the intended direction and would turn this
gate red today; that red is the to-do list, which is the state this gate was
built to be useful in. The exclusions are now enumerated in both the module
header and the README, with the reason for each.

## QA

Root gate, from the repository root:

- `bun run check` — 66 projects / 107 tasks, green
- `bun run test` — 49 projects, green; this package 10 files / 233 tests at 100% coverage
- `bun run build` — 55 projects, green
- `bun run check:ranges` — 66 workspace packages, every sibling range satisfied
- `bun run collect:check` — clean, `data/` unchanged

Environment notes, reproducible on unmodified `main`: the three
Playwright-tagged svelte projects cannot start a browser here
(`libglib-2.0.so.0` absent) and were excluded; the run used `--concurrency 1`.

## Carried

Raised in review, deliberately not fixed here:

- **The gate is invisible to `nx affected`.** The reach into the app is a
  filesystem path, not a manifest dependency, and the app depends on nothing
  here — so a PR that adds a lens does not schedule this project. Same shape as
  the provider package's gate, and the same trade: the alternative closes a
  cycle. Stated in the module header rather than left to be discovered.
- **Four dataset URIs are test-selection data exported from the data file**;
  they belong in `src/testing/fixtures.ts`.
- **`graphiqlHtml` and `localName` are noun-named** where
  `cs:code.naming.function_verb` wants verbs, and `descriptive.ts` /
  `connection.ts` are named for a topic rather than their primary export.
- **Bracket index access** in three places, where
  `@canonical/typescript-config` does not set `noUncheckedIndexedAccess`, so
  the type hides the `undefined`.
- **Two discovery regexes are tighter than the syntax they scan** — a
  variable-less query carrying a directive, and `@refetchable` with
  `queryName` other than first, are both skipped silently.
- **Several README measurements disagree with each other** (line counts for
  the same functions, reported two ways). The size table itself was recomputed
  when the shim came out, so its totals are current; the disagreement is
  between that table and figures quoted elsewhere in the prose.

## Readiness

- [x] Conventional-commit title
- [x] New behaviour covered by tests
- [x] Root gate green
- [x] Private package — no publish step

Chromatic: skip

https://claude.ai/code/session_01PUNAcTepWDfnyfNYqBnzbn
