### PR TITLE
fix(storybook-helpers): let IconExplorer follow the docs page colour scheme

### DIFF
--- a/packages/storybook/helpers/src/IconExplorer/IconExplorer.css
+++ b/packages/storybook/helpers/src/IconExplorer/IconExplorer.css
@@ -91,8 +91,9 @@
     align-items: start;
     padding: 0.5rem;
     border-radius: var(--icon-explorer-radius);
-    background: light-dark(#fff, #111);
-    color: light-dark(#111, #eee);
+    /* Inherits the docs page scheme; surfaces derive from currentColor. */
+    background: transparent;
+    color: inherit;
 
     /* The detail column exists only when something is selected, so the grid
        uses the full width until then. */

--- a/packages/storybook/helpers/src/IconExplorer/IconExplorer.tests.tsx
+++ b/packages/storybook/helpers/src/IconExplorer/IconExplorer.tests.tsx
@@ -357,21 +357,14 @@ describe("IconExplorer", () => {
     expect(root.style.getPropertyValue("--icon-explorer-size")).toBe("40px");
   });
 
-  it("previews on a dark surface using the scheme class convention", () => {
+  it("follows the page colour scheme instead of forcing its own", () => {
     const { container } = renderExplorer();
-    const body = () => container.querySelector(".preview-area") as HTMLElement;
+    const body = container.querySelector(".preview-area") as HTMLElement;
 
-    expect(body()).toHaveClass("light");
-    expect(body()).not.toHaveClass("dark");
-    expect(body().style.colorScheme).toBe("light");
-
-    fireEvent.click(screen.getByLabelText(/dark preview/i));
-
-    expect(body()).toHaveClass("dark");
-    expect(body()).not.toHaveClass("light");
-    // The class alone would be inert without a stylesheet; the block sets the
-    // scheme itself so the preview really changes.
-    expect(body().style.colorScheme).toBe("dark");
+    expect(screen.queryByLabelText(/dark preview/i)).toBeNull();
+    expect(body.style.colorScheme).toBe("");
+    expect(body).not.toHaveClass("light");
+    expect(body).not.toHaveClass("dark");
   });
 
   it("suggests related icons by shared tags", () => {

--- a/packages/storybook/helpers/src/IconExplorer/IconExplorer.tsx
+++ b/packages/storybook/helpers/src/IconExplorer/IconExplorer.tsx
@@ -23,8 +23,6 @@ const MAX_SIZE = 48;
 const RELATED_LIMIT = 5;
 const NEAREST_LIMIT = 5;
 
-type Scheme = "light" | "dark";
-
 /**
  * How many cells fit on a row, read back from the rendered layout.
  *
@@ -140,7 +138,6 @@ export function IconExplorer<Name extends string = string>({
   const [category, setCategory] = useState("");
   const [showDeprecated, setShowDeprecated] = useState(false);
   const [size, setSize] = useState(24);
-  const [scheme, setScheme] = useState<Scheme>("light");
   const [selected, setSelected] = useState<Name | null>(null);
   const [active, setActive] = useState(0);
   const [columns, setColumns] = useState(1);
@@ -474,17 +471,6 @@ export function IconExplorer<Name extends string = string>({
         <output className="hint" htmlFor={sizeId}>
           {size}px
         </output>
-
-        <label>
-          <input
-            type="checkbox"
-            checked={scheme === "dark"}
-            onChange={(event) =>
-              setScheme(event.target.checked ? "dark" : "light")
-            }
-          />
-          Dark preview
-        </label>
       </div>
 
       <p className="count" id={countId}>
@@ -494,15 +480,9 @@ export function IconExplorer<Name extends string = string>({
         {announced}
       </p>
 
-      {/* `.light`/`.dark` are the class names @canonical/storybook-addon-utils
-          uses for the page-wide scheme, kept here so the vocabulary matches.
-          `color-scheme` is set from here rather than in the stylesheet so there
-          is one source of truth, and so the `light-dark()` surfaces resolve
-          against the previewed scheme rather than the page. */}
-      <div
-        className={["preview-area", scheme].join(" ")}
-        style={{ colorScheme: scheme }}
-      >
+      {/* No scheme control of its own: the block inherits the docs page
+          colour scheme, which the shared docs container already follows. */}
+      <div className="preview-area">
         {results.length === 0 ? (
           <div className="empty">
             {query.trim() === "" ? (


### PR DESCRIPTION
## Done

- Removed the IconExplorer block's own "Dark preview" toggle. The block now inherits the colour scheme of the docs page it sits on, which the shared docs container already follows, instead of forcing a scheme of its own on the preview area.
- The preview area no longer paints a fixed `light-dark()` background and text colour; it is transparent and inherits, so the surfaces (which are all derived from `currentColor`) follow the page in both schemes.
- Replaced the test that exercised the toggle with one asserting the block sets no scheme of its own.

Follow-up to #1111.

## QA

- `cd packages/react/ds-global && bun run storybook`, open `?path=/docs/components-icon--docs`.
- The toolbar above the icon grid has Category, Show deprecated and Size only; there is no Dark preview control.
- Switch the operating system to dark mode (or back): the docs page and the explorer change together, with legible cells, hover surfaces, detail panel and the 16 px preview grid in both schemes.
- `cd packages/storybook/helpers && bun run check && bun run test` (71 tests).

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` (no package added).
- [x] No new package.
- [ ] Visual change, so Chromatic runs.

## Screenshots

Not applicable; the change removes a control and a fixed background.

https://claude.ai/code/session_01Ap5zMj4Nnzy76ZZqioNMXZ
