### PR TITLE
feat(Button)!: migrate to design tokens. Adopt new density across the design system

### DIFF
--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.ssr.test.ts
@@ -65,11 +65,39 @@ describe("Button SSR", () => {
   });
 
   describe("modifiers", () => {
-    it("applies severity class", () => {
+    it("applies the default importance class", () => {
       const page = render(Component, {
-        props: { ...baseProps, severity: "brand" },
+        props: { ...baseProps },
       });
-      expect(componentLocator(page).classList).toContain("brand");
+      expect(componentLocator(page).classList).toContain("secondary");
+    });
+
+    it("applies the importance class", () => {
+      const page = render(Component, {
+        props: { ...baseProps, importance: "primary" },
+      });
+      expect(componentLocator(page).classList).toContain("primary");
+    });
+
+    it("applies the anticipation class", () => {
+      const page = render(Component, {
+        props: { ...baseProps, anticipation: "destructive" },
+      });
+      expect(componentLocator(page).classList).toContain("destructive");
+    });
+
+    it("applies the emphasis class", () => {
+      const page = render(Component, {
+        props: { ...baseProps, emphasis: "branded" },
+      });
+      expect(componentLocator(page).classList).toContain("branded");
+    });
+
+    it("applies the criticality class", () => {
+      const page = render(Component, {
+        props: { ...baseProps, criticality: "information" },
+      });
+      expect(componentLocator(page).classList).toContain("information");
     });
 
     it("applies density class", () => {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.ssr.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.ssr.test.ts
@@ -93,13 +93,6 @@ describe("Button SSR", () => {
       expect(componentLocator(page).classList).toContain("branded");
     });
 
-    it("applies the criticality class", () => {
-      const page = render(Component, {
-        props: { ...baseProps, criticality: "information" },
-      });
-      expect(componentLocator(page).classList).toContain("information");
-    });
-
     it("applies density class", () => {
       const page = render(Component, {
         props: { ...baseProps, density: "dense" },

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.stories.svelte
@@ -2,15 +2,31 @@
   import { ArchiveIcon } from "@canonical/svelte-icons";
   import { defineMeta } from "@storybook/addon-svelte-csf";
   import { fn } from "storybook/test";
+  import type { ModifierFamilyValues } from "../../modifier-families/index.js";
   import { MODIFIER_FAMILIES } from "../../modifier-families/index.js";
   import Button from "./Button.svelte";
-  import type { ButtonProps } from "./types.js";
 
-  const BUTTON_SEVERITIES = [
-    "brand",
-    "base",
-    ...MODIFIER_FAMILIES.severity,
-  ] as const satisfies readonly NonNullable<ButtonProps["severity"]>[];
+  type ButtonVariant = {
+    importance?: ModifierFamilyValues["importance"];
+    anticipation?: ModifierFamilyValues["anticipation"];
+    emphasis?: Extract<ModifierFamilyValues["emphasis"], "branded">;
+    criticality?: Extract<ModifierFamilyValues["criticality"], "information">;
+  };
+
+  type MatrixColumn = {
+    label: string;
+    variant: ButtonVariant;
+  };
+
+  const MATRIX_COLUMNS: MatrixColumn[] = [
+    { label: "default", variant: {} },
+    ...MODIFIER_FAMILIES.anticipation.map((anticipation) => ({
+      label: anticipation,
+      variant: { anticipation },
+    })),
+    { label: "information", variant: { criticality: "information" } },
+    { label: "branded", variant: { emphasis: "branded" } },
+  ];
 
   const { Story } = defineMeta({
     title: "Components/Button",
@@ -27,6 +43,21 @@
   };
 </script>
 
+{#snippet variantMatrix(props: { disabled?: boolean; loading?: boolean })}
+  <div class="matrix">
+    <span></span>
+    {#each MATRIX_COLUMNS as column (column.label)}
+      <span class="matrix-label">{column.label}</span>
+    {/each}
+    {#each MODIFIER_FAMILIES.importance as importance (importance)}
+      <span class="matrix-label">{importance}</span>
+      {#each MATRIX_COLUMNS as column (column.label)}
+        <Button {importance} {...column.variant} {...props}>Button</Button>
+      {/each}
+    {/each}
+  </div>
+{/snippet}
+
 <Story
   name="Default"
   args={{
@@ -38,19 +69,51 @@
   {/snippet}
 </Story>
 
-<Story name="Severities">
+<Story name="Importance">
   {#snippet template(args)}
     <div class="row">
-      {#each BUTTON_SEVERITIES as severity (severity)}
-        <Button {...args} {severity} onclick={fn()}>
-          {severity}
+      {#each MODIFIER_FAMILIES.importance as importance (importance)}
+        <Button {...args} {importance} onclick={fn()}>
+          {importance}
         </Button>
       {/each}
     </div>
   {/snippet}
 </Story>
 
-<Story name="Densities">
+<Story name="Anticipation">
+  {#snippet template(args)}
+    <div class="row">
+      {#each MODIFIER_FAMILIES.anticipation as anticipation (anticipation)}
+        <Button {...args} {anticipation} onclick={fn()}>
+          {anticipation}
+        </Button>
+      {/each}
+    </div>
+  {/snippet}
+</Story>
+
+<Story name="Criticality">
+  {#snippet template(args)}
+    <Button {...args} criticality="information" onclick={fn()}>
+      information
+    </Button>
+  {/snippet}
+</Story>
+
+<Story name="Emphasis">
+  {#snippet template(args)}
+    <Button {...args} emphasis="branded" onclick={fn()}>branded</Button>
+  {/snippet}
+</Story>
+
+<Story name="Matrix">
+  {#snippet template()}
+    {@render variantMatrix({})}
+  {/snippet}
+</Story>
+
+<Story name="Density">
   {#snippet template(args)}
     <div class="row">
       {#each MODIFIER_FAMILIES.density as density (density)}
@@ -107,7 +170,7 @@
       <br />
       <br />
     </div>
-    <p style="font-size: 12px; color: var(--lp-color-text-muted);">
+    <p style="font-size: 12px; color: var(--color-text-muted);">
       Click the button to toggle the loading state.
     </p>
   {/snippet}
@@ -122,6 +185,23 @@
   Disabled button
 </Story>
 
+<Story name="Disabled matrix">
+  {#snippet template()}
+    {@render variantMatrix({ disabled: true })}
+  {/snippet}
+</Story>
+
+<Story name="Loading matrix">
+  {#snippet template()}
+    {@render variantMatrix({ loading: true })}
+    <div class="row loading-disabled">
+      <Button importance="primary" anticipation="destructive" loading disabled>
+        loading + disabled
+      </Button>
+    </div>
+  {/snippet}
+</Story>
+
 <Story
   name="As link"
   args={{
@@ -131,13 +211,21 @@
   Link button
 </Story>
 
-<Story name="Brand with icon">
-  {#snippet template(args)}
-    <Button {...args} severity="brand" onclick={fn()}>
-      {#snippet iconLeft()}
-        <ArchiveIcon />
-      {/snippet}
-      Brand action
-    </Button>
-  {/snippet}
-</Story>
+<style>
+  .matrix {
+    display: grid;
+    grid-template-columns: repeat(7, max-content);
+    gap: var(--dimension-150);
+    align-items: center;
+    justify-items: start;
+  }
+
+  .matrix-label {
+    font: var(--ds-typography-text-secondary);
+    color: var(--color-text-muted);
+  }
+
+  .loading-disabled {
+    margin-block-start: var(--dimension-150);
+  }
+</style>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.stories.svelte
@@ -10,7 +10,6 @@
     importance?: ModifierFamilyValues["importance"];
     anticipation?: ModifierFamilyValues["anticipation"];
     emphasis?: Extract<ModifierFamilyValues["emphasis"], "branded">;
-    criticality?: Extract<ModifierFamilyValues["criticality"], "information">;
   };
 
   type MatrixColumn = {
@@ -24,7 +23,6 @@
       label: anticipation,
       variant: { anticipation },
     })),
-    { label: "information", variant: { criticality: "information" } },
     { label: "branded", variant: { emphasis: "branded" } },
   ];
 
@@ -46,6 +44,10 @@
 {#snippet variantMatrix(props: { disabled?: boolean; loading?: boolean })}
   <div class="matrix">
     <span></span>
+    <span></span>
+    <span class="matrix-family matrix-family-anticipation">anticipation</span>
+    <span class="matrix-family">emphasis</span>
+    <span class="matrix-family">importance</span>
     {#each MATRIX_COLUMNS as column (column.label)}
       <span class="matrix-label">{column.label}</span>
     {/each}
@@ -90,14 +92,6 @@
         </Button>
       {/each}
     </div>
-  {/snippet}
-</Story>
-
-<Story name="Criticality">
-  {#snippet template(args)}
-    <Button {...args} criticality="information" onclick={fn()}>
-      information
-    </Button>
   {/snippet}
 </Story>
 
@@ -214,10 +208,19 @@
 <style>
   .matrix {
     display: grid;
-    grid-template-columns: repeat(7, max-content);
+    grid-template-columns: repeat(6, max-content);
     gap: var(--dimension-150);
     align-items: center;
     justify-items: start;
+  }
+
+  .matrix-family {
+    font: var(--ds-typography-text-secondary);
+    color: var(--color-text-muted);
+  }
+
+  .matrix-family-anticipation {
+    grid-column: span 3;
   }
 
   .matrix-label {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.stories.svelte
@@ -2,19 +2,16 @@
   import { ArchiveIcon } from "@canonical/svelte-icons";
   import { defineMeta } from "@storybook/addon-svelte-csf";
   import { fn } from "storybook/test";
-  import type { ModifierFamilyValues } from "../../modifier-families/index.js";
   import { MODIFIER_FAMILIES } from "../../modifier-families/index.js";
   import Button from "./Button.svelte";
-
-  type ButtonVariant = {
-    importance?: ModifierFamilyValues["importance"];
-    anticipation?: ModifierFamilyValues["anticipation"];
-    emphasis?: Extract<ModifierFamilyValues["emphasis"], "branded">;
-  };
+  import type { ButtonProps } from "./types.js";
 
   type MatrixColumn = {
     label: string;
-    variant: ButtonVariant;
+    variant: {
+      anticipation?: ButtonProps["anticipation"];
+      emphasis?: ButtonProps["emphasis"];
+    };
   };
 
   const MATRIX_COLUMNS: MatrixColumn[] = [
@@ -25,6 +22,12 @@
     })),
     { label: "branded", variant: { emphasis: "branded" } },
   ];
+
+  const MATRIX_ARG_TYPES = {
+    importance: { control: false },
+    anticipation: { control: false },
+    emphasis: { control: false },
+  } as const;
 
   const { Story } = defineMeta({
     title: "Components/Button",
@@ -41,25 +44,6 @@
   };
 </script>
 
-{#snippet variantMatrix(props: ButtonProps)}
-  <div class="matrix">
-    <span></span>
-    <span></span>
-    <span class="matrix-family matrix-family-anticipation">anticipation</span>
-    <span class="matrix-family">emphasis</span>
-    <span class="matrix-family">importance</span>
-    {#each MATRIX_COLUMNS as column (column.label)}
-      <span class="matrix-label">{column.label}</span>
-    {/each}
-    {#each MODIFIER_FAMILIES.importance as importance (importance)}
-      <span class="matrix-label">{importance}</span>
-      {#each MATRIX_COLUMNS as column (column.label)}
-        <Button {importance} {...column.variant} {...props}>Button</Button>
-      {/each}
-    {/each}
-  </div>
-{/snippet}
-
 <Story
   name="Default"
   args={{
@@ -71,7 +55,7 @@
   {/snippet}
 </Story>
 
-<Story name="Importance">
+<Story name="Importance" argTypes={{ importance: { control: false } }}>
   {#snippet template(args)}
     <div class="row">
       {#each MODIFIER_FAMILIES.importance as importance (importance)}
@@ -83,7 +67,7 @@
   {/snippet}
 </Story>
 
-<Story name="Anticipation">
+<Story name="Anticipation" argTypes={{ anticipation: { control: false } }}>
   {#snippet template(args)}
     <div class="row">
       {#each MODIFIER_FAMILIES.anticipation as anticipation (anticipation)}
@@ -95,19 +79,24 @@
   {/snippet}
 </Story>
 
-<Story name="Emphasis">
+<Story name="Emphasis" args={{ emphasis: "branded" }}>
   {#snippet template(args)}
-    <Button {...args} emphasis="branded" onclick={fn()}>branded</Button>
+    <Button {...args} onclick={fn()}>branded</Button>
   {/snippet}
 </Story>
 
-<Story name="Matrix">
-  {#snippet template()}
-    {@render variantMatrix({})}
+<Story
+  name="Matrix"
+  tags={["!autodocs"]}
+  argTypes={MATRIX_ARG_TYPES}
+  args={{ disabled: false, loading: false }}
+>
+  {#snippet template(args)}
+    {@render variantMatrix(args)}
   {/snippet}
 </Story>
 
-<Story name="Density">
+<Story name="Density" argTypes={{ density: { control: false } }}>
   {#snippet template(args)}
     <div class="row">
       {#each MODIFIER_FAMILIES.density as density (density)}
@@ -157,7 +146,7 @@
   {/snippet}
 </Story>
 
-<Story name="Loading">
+<Story name="Loading" argTypes={{ loading: { control: false } }}>
   {#snippet template(args)}
     <div class="row">
       <Button {...args} {loading} onclick={toggleLoading}>Click to load</Button>
@@ -179,23 +168,6 @@
   Disabled button
 </Story>
 
-<Story name="Disabled matrix">
-  {#snippet template()}
-    {@render variantMatrix({ disabled: true })}
-  {/snippet}
-</Story>
-
-<Story name="Loading matrix">
-  {#snippet template()}
-    {@render variantMatrix({ loading: true })}
-    <div class="row loading-disabled">
-      <Button importance="primary" anticipation="destructive" loading disabled>
-        loading + disabled
-      </Button>
-    </div>
-  {/snippet}
-</Story>
-
 <Story
   name="As link"
   args={{
@@ -205,30 +177,58 @@
   Link button
 </Story>
 
+{#snippet variantMatrix(props: ButtonProps)}
+  <table class="matrix" aria-label="Button modifier combinations">
+    <colgroup span="2"></colgroup>
+    <colgroup span={MODIFIER_FAMILIES.anticipation.length}></colgroup>
+    <colgroup></colgroup>
+    <thead>
+      <tr>
+        <th scope="col" rowspan="2" style="vertical-align:bottom">importance</th>
+        <th scope="col" rowspan="2" style="vertical-align:top">default</th>
+        <th scope="colgroup" colspan={MODIFIER_FAMILIES.anticipation.length}>
+          anticipation
+        </th>
+        <th scope="colgroup">emphasis</th>
+      </tr>
+      <tr>
+        {#each MATRIX_COLUMNS.slice(1) as column (column.label)}
+          <th scope="col">{column.label}</th>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      {#each MODIFIER_FAMILIES.importance as importance (importance)}
+        <tr>
+          <th scope="row">{importance}</th>
+          {#each MATRIX_COLUMNS as column (column.label)}
+            <td>
+              <Button
+                {...props}
+                {importance}
+                anticipation={column.variant.anticipation}
+                emphasis={column.variant.emphasis}
+              >
+                Button
+              </Button>
+            </td>
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+{/snippet}
+
 <style>
   .matrix {
-    display: grid;
-    grid-template-columns: repeat(6, max-content);
-    gap: var(--dimension-150);
-    align-items: center;
-    justify-items: start;
+    border-collapse: separate;
+    border-spacing: var(--dimension-150);
+    text-align: start;
   }
 
-  .matrix-family {
+  .matrix th {
     font: var(--ds-typography-text-secondary);
     color: var(--color-text-muted);
-  }
-
-  .matrix-family-anticipation {
-    grid-column: span 3;
-  }
-
-  .matrix-label {
-    font: var(--ds-typography-text-secondary);
-    color: var(--color-text-muted);
-  }
-
-  .loading-disabled {
-    margin-block-start: var(--dimension-150);
+    text-align: start;
   }
 </style>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.stories.svelte
@@ -41,7 +41,7 @@
   };
 </script>
 
-{#snippet variantMatrix(props: { disabled?: boolean; loading?: boolean })}
+{#snippet variantMatrix(props: ButtonProps)}
   <div class="matrix">
     <span></span>
     <span></span>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte
@@ -10,7 +10,10 @@
   let {
     class: className,
     ref = $bindable(),
-    severity,
+    importance = "secondary",
+    anticipation,
+    emphasis,
+    criticality,
     density,
     children,
     iconLeft,
@@ -28,7 +31,10 @@
   class={[
     componentCssClassName,
     className,
-    severity,
+    importance,
+    anticipation,
+    emphasis,
+    criticality,
     density,
     { loading, "explicit-disabled": disabled },
   ]}
@@ -50,7 +56,7 @@
 
 ## Example Usage
 ```svelte
-<Button density="dense" severity="brand">
+<Button density="dense" importance="primary" emphasis="branded">
   {#snippet iconLeft()}
     <Check />
   {/snippet}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte
@@ -13,7 +13,6 @@
     importance = "secondary",
     anticipation,
     emphasis,
-    criticality,
     density,
     children,
     iconLeft,
@@ -34,7 +33,6 @@
     importance,
     anticipation,
     emphasis,
-    criticality,
     density,
     { loading, "explicit-disabled": disabled },
   ]}

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte.test.ts
@@ -90,12 +90,41 @@ describe("Button component", () => {
   });
 
   describe("modifiers", () => {
-    it("applies severity class", async () => {
+    it("applies the default importance class", async () => {
+      const page = render(Component, { ...baseProps });
+      await expect.element(componentLocator(page)).toHaveClass("secondary");
+    });
+
+    it("applies importance class", async () => {
       const page = render(Component, {
         ...baseProps,
-        severity: "brand",
+        importance: "primary",
       });
-      await expect.element(componentLocator(page)).toHaveClass("brand");
+      await expect.element(componentLocator(page)).toHaveClass("primary");
+    });
+
+    it("applies anticipation class", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        anticipation: "destructive",
+      });
+      await expect.element(componentLocator(page)).toHaveClass("destructive");
+    });
+
+    it("applies emphasis class", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        emphasis: "branded",
+      });
+      await expect.element(componentLocator(page)).toHaveClass("branded");
+    });
+
+    it("applies criticality class", async () => {
+      const page = render(Component, {
+        ...baseProps,
+        criticality: "information",
+      });
+      await expect.element(componentLocator(page)).toHaveClass("information");
     });
 
     it("applies density class", async () => {

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte.test.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/Button.svelte.test.ts
@@ -119,14 +119,6 @@ describe("Button component", () => {
       await expect.element(componentLocator(page)).toHaveClass("branded");
     });
 
-    it("applies criticality class", async () => {
-      const page = render(Component, {
-        ...baseProps,
-        criticality: "information",
-      });
-      await expect.element(componentLocator(page)).toHaveClass("information");
-    });
-
     it("applies density class", async () => {
       const page = render(Component, {
         ...baseProps,

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/common/Content/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/common/Content/styles.css
@@ -4,20 +4,11 @@
   grid-auto-rows: minmax(1lh, auto);
   align-items: center;
 
-  gap: var(--lp-dimension-spacing-inline-xs);
-  padding-block: var(
-    --lp-dimension-padding-block-context,
-    var(--lp-dimension-spacing-block-xxs)
-  );
-  padding-inline: var(
-    --lp-dimension-padding-inline-context,
-    var(--lp-dimension-spacing-inline-s)
-  );
+  gap: var(--dimension-100);
+  padding-block: var(--dimension-padding-block-button, var(--dimension-050));
+  padding-inline: var(--dimension-padding-inline-button, var(--dimension-150));
   --icon-padding-subtract: calc(
-    var(
-      --lp-dimension-padding-inline-context,
-      var(--lp-dimension-spacing-inline-s)
-    ) /
+    var(--dimension-padding-inline-button, var(--dimension-150)) /
     2
   );
 

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
@@ -1,35 +1,42 @@
 .ds.button.button-primitive {
   --color-background-button-active: var(
-    --lp-color-background-active-context,
-    var(--lp-color-background-neutral-active)
+    --modifier-surface-active,
+    var(--active--color-foreground-ghost)
   );
   --color-background-button-hover: var(
-    --lp-color-background-hover-context,
-    var(--lp-color-background-neutral-hover)
+    --modifier-surface-hover,
+    var(--hover--color-foreground-ghost)
   );
   --color-background-button: var(
-    --lp-color-background-context,
-    var(--lp-color-background-default)
+    --modifier-surface,
+    var(--color-foreground-ghost)
   );
-  --color-border-button: var(
-    --lp-color-border-context,
-    var(--lp-color-border-high-contrast)
+  --color-border-button: color-mix(
+    in srgb,
+    var(--modifier-color-border, var(--color-border))
+      calc(var(--modifier-outline, 0) * 100%),
+    transparent
   );
-  --color-border-button-hover: var(
-    --lp-color-border-hover-context,
-    var(--color-border-button)
+  --color-text-button: var(--modifier-color-text, var(--color-text));
+  --dimension-block-size-button: var(
+    --density-line-height-effective,
+    calc(var(--baseline-height, 0.25rem) * 8)
   );
-  --color-border-button-active: var(
-    --lp-color-border-active-context,
-    var(--color-border-button)
+  --dimension-padding-block-button: max(
+    0px,
+    calc(
+      (
+        var(--dimension-block-size-button) -
+        1lh -
+        2 *
+        var(--dimension-border-width-button, 0px)
+      ) /
+      2
+    )
   );
-  --color-text-button: var(
-    --lp-color-text-context,
-    var(--lp-color-text-default)
-  );
-  --typography-button: var(
-    --lp-typography-context,
-    var(--lp-typography-paragraph-default)
+  --dimension-padding-inline-button: var(
+    --density-padding-inline,
+    calc(var(--baseline-height, 0.25rem) * 4)
   );
 
   padding-inline: 0;
@@ -38,12 +45,29 @@
   display: inline-flex;
   justify-content: center;
 
-  &:not(.explicit-disabled) {
-    --opacity-button-disabled: 1;
+  &:disabled,
+  &[aria-disabled="true"] {
+    color: var(--modifier-color-text-disabled, var(--disabled--color-text));
+    background-color: var(
+      --modifier-surface-disabled,
+      var(--disabled--color-foreground-ghost)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--modifier-color-border-disabled, var(--disabled--color-border))
+        calc(var(--modifier-outline, 0) * 100%),
+      transparent
+    );
   }
 
   &.loading {
     position: relative;
+
+    &:not(.explicit-disabled) {
+      color: var(--color-text-button);
+      background-color: var(--color-background-button);
+      border-color: var(--color-border-button);
+    }
 
     > .button-content {
       visibility: hidden;
@@ -59,16 +83,26 @@
   }
 
   /* Button-specific modifiers */
-  &.brand {
-    --lp-color-text-context: var(--lp-color-text-white);
-    --lp-color-border-context: var(--lp-color-brand-default);
-    --lp-color-background-context: var(--lp-color-brand-default);
-    --lp-color-background-hover-context: var(--lp-color-brand-hover);
-    --lp-color-background-active-context: var(--lp-color-brand-active);
+  &.information {
+    --modifier-color-foreground-primary-hover: var(
+      --color-foreground-primary-information-hover
+    );
+    --modifier-color-foreground-primary-active: var(
+      --color-foreground-primary-information-active
+    );
+    --modifier-color-foreground-primary-disabled: var(
+      --color-foreground-primary-information-disabled
+    );
+    --modifier-color-border-disabled: var(--color-border-information-disabled);
   }
 
-  &.base {
-    --lp-color-border-context: transparent;
-    --lp-color-background-context: transparent;
+  &.information.tertiary {
+    --modifier-color-text-disabled: var(--color-text-information-disabled);
+    --modifier-color-icon-disabled: var(--color-icon-information-disabled);
+  }
+  &.compact {
+    --dimension-padding-block-button: 0;
+    --dimension-padding-inline-button: var(--dimension-100);
+    --typography-button: var(--ds-typography-text-secondary);
   }
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/styles.css
@@ -82,24 +82,6 @@
     }
   }
 
-  /* Button-specific modifiers */
-  &.information {
-    --modifier-color-foreground-primary-hover: var(
-      --color-foreground-primary-information-hover
-    );
-    --modifier-color-foreground-primary-active: var(
-      --color-foreground-primary-information-active
-    );
-    --modifier-color-foreground-primary-disabled: var(
-      --color-foreground-primary-information-disabled
-    );
-    --modifier-color-border-disabled: var(--color-border-information-disabled);
-  }
-
-  &.information.tertiary {
-    --modifier-color-text-disabled: var(--color-text-information-disabled);
-    --modifier-color-icon-disabled: var(--color-icon-information-disabled);
-  }
   &.compact {
     --dimension-padding-block-button: 0;
     --dimension-padding-inline-button: var(--dimension-100);

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/types.ts
@@ -6,6 +6,9 @@ export type ButtonProps = ButtonPrimitiveProps & {
   iconLeft?: Snippet;
   iconRight?: Snippet;
   loading?: boolean;
-  severity?: ModifierFamilyValues["severity"] | "base" | "brand";
+  importance?: ModifierFamilyValues["importance"];
+  anticipation?: ModifierFamilyValues["anticipation"];
+  emphasis?: Extract<ModifierFamilyValues["emphasis"], "branded">;
+  criticality?: Extract<ModifierFamilyValues["criticality"], "information">;
   density?: ModifierFamilyValues["density"];
 };

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Button/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Button/types.ts
@@ -9,6 +9,5 @@ export type ButtonProps = ButtonPrimitiveProps & {
   importance?: ModifierFamilyValues["importance"];
   anticipation?: ModifierFamilyValues["anticipation"];
   emphasis?: Extract<ModifierFamilyValues["emphasis"], "branded">;
-  criticality?: Extract<ModifierFamilyValues["criticality"], "information">;
   density?: ModifierFamilyValues["density"];
 };

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/Modal.stories.svelte
@@ -60,7 +60,8 @@
                 // doSomething();
                 close();
               }}
-              severity="negative"
+              importance="primary"
+              anticipation="destructive"
             >
               Discard review
             </Button>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/stories/Modal.Content.Footer.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/stories/Modal.Content.Footer.stories.svelte
@@ -13,6 +13,6 @@
 <Story name="Default" asChild>
   <Modal.Content.Footer>
     <Button>Cancel</Button>
-    <Button severity="positive">Save</Button>
+    <Button importance="primary" anticipation="constructive">Save</Button>
   </Modal.Content.Footer>
 </Story>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Modal/stories/Modal.Content.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Modal/stories/Modal.Content.stories.svelte
@@ -22,7 +22,9 @@
     </Modal.Content.Body>
     <Modal.Content.Footer>
       <Button>Keep review</Button>
-      <Button severity="negative">Discard review</Button>
+      <Button importance="primary" anticipation="destructive">
+        Discard review
+      </Button>
     </Modal.Content.Footer>
   </Modal.Content>
 </Story>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/NumberInput/NumberInput.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/NumberInput/NumberInput.stories.svelte
@@ -33,7 +33,7 @@
     <div
       style="display: flex; flex-direction: column; gap: 0.5rem; align-items: flex-start;"
     >
-      {#each ["dense", "medium"] as const as density (density)}
+      {#each ["comfortable", "dense"] as const as density (density)}
         <NumberInput {density} placeholder={density} {...args} />
       {/each}
     </div>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/NumberInput/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/NumberInput/types.ts
@@ -7,5 +7,5 @@ import type { NumberInputPrimitiveProps } from "../common/index.js";
 export interface NumberInputProps
   extends Omit<NumberInputPrimitiveProps, "type">,
     ModifierFamily<"severity"> {
-  density?: Extract<ModifierFamilyValues["density"], "dense" | "medium">;
+  density?: Extract<ModifierFamilyValues["density"], "comfortable" | "dense">;
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/Select/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/Select/types.ts
@@ -5,6 +5,6 @@ import type { ModifierFamilyValues } from "../../modifier-families/index.js";
 
 export interface SelectProps extends HTMLSelectAttributes {
   ref?: HTMLSelectElement;
-  density?: Extract<ModifierFamilyValues["density"], "dense" | "medium">;
+  density?: Extract<ModifierFamilyValues["density"], "comfortable" | "dense">;
   severity?: ModifierFamilyValues["severity"] | "base";
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/stories/SidePanel.Content.Footer.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/stories/SidePanel.Content.Footer.stories.svelte
@@ -13,6 +13,6 @@
 <Story name="Default" asChild>
   <SidePanel.Content.Footer>
     <Button>Reset</Button>
-    <Button severity="positive">Apply</Button>
+    <Button importance="primary" anticipation="constructive">Apply</Button>
   </SidePanel.Content.Footer>
 </Story>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/stories/SidePanel.Content.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/SidePanel/stories/SidePanel.Content.stories.svelte
@@ -22,7 +22,9 @@
     </SidePanel.Content.Body>
     <SidePanel.Content.Footer>
       <Button>Reset</Button>
-      <Button severity="positive">Apply changes</Button>
+      <Button importance="primary" anticipation="constructive">
+        Apply changes
+      </Button>
     </SidePanel.Content.Footer>
   </SidePanel.Content>
 </Story>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/TextInput.stories.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/TextInput.stories.svelte
@@ -62,7 +62,7 @@
     <div
       style="display: flex; flex-direction: column; gap: 0.5rem; align-items: flex-start;"
     >
-      {#each ["dense", "medium"] as const as density (density)}
+      {#each ["comfortable", "dense"] as const as density (density)}
         <TextInput {density} placeholder={density} {...args} />
       {/each}
     </div>

--- a/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/TextInput/types.ts
@@ -7,5 +7,5 @@ import type { TextInputPrimitiveProps } from "../common/index.js";
 export interface TextInputProps
   extends TextInputPrimitiveProps,
     ModifierFamily<"severity"> {
-  density?: Extract<ModifierFamilyValues["density"], "dense" | "medium">;
+  density?: Extract<ModifierFamilyValues["density"], "comfortable" | "dense">;
 }

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/common/CloseButton/CloseButton.svelte
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/common/CloseButton/CloseButton.svelte
@@ -18,7 +18,7 @@
 <Button
   class={[componentCssClassName, className]}
   aria-label={ariaLabel}
-  severity="base"
+  importance="tertiary"
   {type}
   {...rest}
 >

--- a/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/common/CloseButton/types.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/components/common/DialogContent/common/Header/common/CloseButton/types.ts
@@ -4,5 +4,12 @@ import type { ButtonProps } from "../../../../../../Button/index.js";
 
 export type CloseButtonProps = Omit<
   Extract<ButtonProps, { href?: never }>,
-  "children" | "iconLeft" | "iconRight" | "severity" | "density"
+  | "children"
+  | "iconLeft"
+  | "iconRight"
+  | "importance"
+  | "anticipation"
+  | "emphasis"
+  | "criticality"
+  | "density"
 >;

--- a/packages/svelte/ds-app-launchpad/src/lib/modifier-families/constants.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/modifier-families/constants.ts
@@ -6,5 +6,5 @@ export const MODIFIER_FAMILIES = {
   // TODO: old modifier family. Remove severity after its no longer used
   severity: ["neutral", "positive", "negative", "caution", "information"],
   // compact is launchpad-only; the global density family is comfortable/dense
-  density: ["comfortable", "dense", "compact"],
+  density: ["dense", "compact", "comfortable"],
 } as const satisfies Record<string, readonly string[]>;

--- a/packages/svelte/ds-app-launchpad/src/lib/modifier-families/constants.ts
+++ b/packages/svelte/ds-app-launchpad/src/lib/modifier-families/constants.ts
@@ -1,9 +1,10 @@
 export const MODIFIER_FAMILIES = {
   criticality: ["success", "error", "warning", "information"],
+  anticipation: ["constructive", "destructive", "caution"],
+  importance: ["primary", "secondary", "tertiary"],
+  emphasis: ["muted", "branded"],
   // TODO: old modifier family. Remove severity after its no longer used
   severity: ["neutral", "positive", "negative", "caution", "information"],
-  // TODO: new modifier family is also used density, but the values
-  // are different. Keep in mind when updating a component that uses it
-  // New values: comfortable, dense
-  density: ["dense", "compact", "medium"],
+  // compact is launchpad-only; the global density family is comfortable/dense
+  density: ["comfortable", "dense", "compact"],
 } as const satisfies Record<string, readonly string[]>;

--- a/packages/svelte/ds-app-launchpad/src/lib/styles/ds-tokens.css
+++ b/packages/svelte/ds-app-launchpad/src/lib/styles/ds-tokens.css
@@ -14,8 +14,12 @@
 @import "@canonical/design-tokens/dist/modifiers.importance.css";
 @import "@canonical/design-tokens/dist/modifiers.lifecycle.css";
 @import "@canonical/design-tokens/dist/modifiers.release.css";
+@import "@canonical/styles/modifiers.states.shim.css";
+@import "@canonical/styles/modifiers.importance.shim.css";
 @import "@canonical/design-tokens/dist/states.css";
 @import "@canonical/design-tokens/dist/sets.semantic.css";
+@import "@canonical/styles/spacing.css";
+@import "@canonical/styles/modifiers.density.css";
 
 /* Verbatim :root shim from packages/styles/typography/src/mapper.css
  * (@canonical/styles-typography) avoiding h1-h6/p element selectors


### PR DESCRIPTION
## Done

Migrated Button from the legacy `severity` API to the DS25 modifier families:

- `importance` (`primary | secondary | tertiary`, default `secondary` = the legacy default outlined look), `anticipation` (`constructive | destructive | caution`), `emphasis` (narrowed to `branded`).
- `information` was dropped because it is not used anywhere
-  `emphasis=branded` is a launchpad extra: the global Button's modifier families are anticipation + importance only. 
- CloseButton: `severity="base"` becomes `importance="tertiary"`. Modal/SidePanel stories moved to the new props.

Adopted the shared density system:

- Density family renamed to the global vocabulary: `comfortable | dense | compact` 
- Button consumes the `@canonical/styles` density channels (`--density-line-height-effective`, `--density-padding-inline`) via plain var().
- Heights: comfortable/default 32px, dense 26px, compact 22px — dense and compact are pixel-identical to the shipped Chromatic baseline; the default normalizes 34→32 (and inline padding 12→16) onto the design-system size, folded into this migration's visual review.
- `compact` is a launchpad-only extra 
- 

Stories reworked

! Breaking: the `severity` prop is removed and density values are renamed.

## QA
Visual review

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts.
- [ ] If this PR introduces a **new package**: not applicable — no new package.
- [ ] Chromatic must run — no skip label; this is a visual migration.

## Screenshots

### Color modifiers
Information is not used anywhere, therefore dropped
Now
<img width="1161" height="442" alt="image" src="https://github.com/user-attachments/assets/88099221-5a28-4dbc-8022-678c942d695f" />
Was
<img width="1507" height="445" alt="image" src="https://github.com/user-attachments/assets/2951438a-0c19-49f0-86cf-49d18df3fde7" />

Now
I'm to lazy to screenshot a light theme without information. Please imagine its not there
<img width="1507" height="445" alt="image" src="https://github.com/user-attachments/assets/b6803b07-8b6b-4e7b-85df-fe4c1cd5caaa" />
Was
<img width="1507" height="445" alt="image" src="https://github.com/user-attachments/assets/539e9aef-4932-4501-bc68-f7918539e18b" />

### Densities

Now
<img width="694" height="222" alt="image" src="https://github.com/user-attachments/assets/06464bc5-da53-4ba8-b039-c70edd70fb35" />
Was
<img width="694" height="222" alt="image" src="https://github.com/user-attachments/assets/4bdd9971-90e3-4b2e-8e27-88d25817bd3e" />
