### PR TITLE
docs(react-ds-global-form): correct the middleware composition order

### DIFF
--- a/packages/react/ds-global-form/src/docs/CreatingMiddleware.mdx
+++ b/packages/react/ds-global-form/src/docs/CreatingMiddleware.mdx
@@ -399,14 +399,14 @@ When a field needs several middleware, pass them as an array. The composition or
   inputType="combobox"
   label="Product"
   middleware={[
-    withAnalytics("product-search"),   // Outermost — sees all props
-    addRESTOptions("/api/products"),    // Middle — injects options
-    withDebouncedValidation("/api/v"), // Innermost — closest to input
+    withAnalytics("product-search"),   // Outermost — sees only the Wrapper's props
+    addRESTOptions("/api/products"),   // Middle — injects options, visible to everything below it
+    withDebouncedValidation("/api/v"), // Innermost — sees options; its props reach the input
   ]}
 />
 ```
 
-Each middleware receives the component returned by the next one. This means outer middleware can observe props set by inner middleware, but not vice versa.
+Each middleware receives the component returned by the next one and renders it. Props flow downward through the chain: an inner middleware receives everything an outer middleware injected, but an outer middleware never sees what an inner one adds. When two middleware inject the same prop, the innermost one — the last in the array — wins, because its props are the last written before they reach `bindField`.
 
 ## Type safety
 

--- a/packages/react/ds-global-form/src/lib/common/Wrapper/withWrapper.ts
+++ b/packages/react/ds-global-form/src/lib/common/Wrapper/withWrapper.ts
@@ -33,8 +33,9 @@ const withWrapper = <
     WrapperComponent = Wrapper,
     ...props
   }: WrappedComponentPropsInternal<ComponentProps>): React.ReactElement {
-    // We apply the middleware to the component in reverse orderso
-    // so that the first middleware in the array is the first to be applied to the component
+    // We apply the middleware to the component in reverse array order: the LAST
+    // entry is applied to the component first, so it ends up innermost (closest
+    // to the input), and the FIRST entry is applied last, so it ends up outermost.
 
     const ExtendedComponent = useMemo(
       () =>


### PR DESCRIPTION
## Done

The middleware guide's closing sentence and its example comments state the opposite of what the code does — and the opposite of the guide's own tree diagram, which was already correct.

**The trace.** `withWrapper.ts` does:

```ts
[...middleware].reverse().reduce((acc, hoc) => hoc(acc), MemoizedComponent)
```

For `middleware={[A, B]}`: `reverse()` gives `[B, A]`; the reduce seeds with the memoized (bound) input, so step 1 yields `B(Input)` and step 2 yields `A(B(Input))`.

So **A is outermost**. A renders B, B renders the input. Props flow parent to child, therefore the **inner** middleware receives everything the outer injected; the **outer** never sees what the inner adds; and on a conflicting prop the **innermost wins**, because its props are the last written before `bindField`. The guide said the reverse of all three.

- `CreatingMiddleware.mdx` — the closing sentence of "Composing multiple middleware", rewritten to state the direction of prop flow and the conflict rule.
- `CreatingMiddleware.mdx` — the three inline comments in that section's example. "Outermost — sees all props" was exactly backwards: the outermost sees the *fewest* injected props.
- `withWrapper.ts` — the comment claiming "the first middleware in the array is the first to be applied to the component" was ambiguous at best; the *last* entry is applied first, which is what makes it innermost. Also clears an `orderso`/`so that` typo.

Documentation and comments only. No runtime change.

**Verified correct and left alone:** the tree diagram at the top of the guide (`Middleware[0] ← outermost`), the surrounding prose about `bindField` receiving the innermost middleware, and the ordering statements in `WrapperPattern.mdx`, `GettingStarted.mdx` and the package README.

**Worth a follow-up, not in this PR.** "Innermost wins on conflict" is a *convention* of how each middleware spreads props (`{ ...props, options }`), not something `withWrapper` enforces. A middleware written `{ extra, ...props }` would invert it. Both shipped middleware and both doc examples follow the convention, so the sentence is accurate today — but if that rule is to be a contract clause across platforms, it should either be documented as a convention or enforced.

## QA

The claim under test is a reading of `withWrapper.ts`, so the check is to read it back:

```bash
sed -n '/reverse()/,/MemoizedComponent/p' \
  packages/react/ds-global-form/src/lib/common/Wrapper/withWrapper.ts
```

`[...middleware].reverse().reduce((acc, hoc) => hoc(acc), MemoizedComponent)` — the last array entry is applied to the seed first, so it ends up innermost, and `middleware[0]` ends up outermost. That is what the tree diagram already said and what the prose now says.

```bash
bun run check      # unchanged by this PR — docs and one comment
```

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format — `docs(react-ds-global-form)`, and the `docs` label is applied from it.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged; no manifest is touched.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — applied. One MDX guide and one source comment; no component, style or rendered output changes.

## Screenshots

n/a — no visual surface.
