### PR TITLE
fix(biome): ignore .build-cache once, in the shared config

### DIFF
--- a/configs/biome/biome.json
+++ b/configs/biome/biome.json
@@ -13,7 +13,8 @@
       "!**/dist",
       "!**/*.gen.ts",
       "!**/storybook-static",
-      "!**/coverage"
+      "!**/coverage",
+      "!**/.build-cache"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## Done

- Added `"!**/.build-cache"` to `files.includes` in `configs/biome/biome.json`.

**The state this fixes.** All four SvelteKit packages set `kit.outDir: ".build-cache"` in `svelte.config.js`, and each carries a per-package `biome.json` repeating `"includes": ["!.build-cache"]` so Biome does not lint the build output. The shared preset never learned about the directory, so the same ignore is written four times with no variation between the copies — and a newly created SvelteKit package lints its own build cache until somebody notices and adds a fifth.

That fifth copy was about to happen: #853's Svelte library template carries the pattern into generated packages.

Stating it once in the preset makes new packages inherit it, and means the generator does not have to remember.

## What is deliberately NOT in this change

**The four per-package overrides stay.** In Biome 2 a child's `files.includes` *replaces* the extended config's array rather than merging with it, so deleting those blocks could silently change what each package lints — and a silent change to lint scope is exactly the kind of thing that shows up months later as "why was this never checked". Consolidating them wants an empirical probe of that behaviour, not an assumption, and belongs in its own change.

## Answers issue #838

That issue asked whether the SvelteKit cache output and its Biome ignore should be standardised. The `outDir` half was already settled — all four packages agree. The open half was where the ignore lives. This is that answer.

## QA

Configuration-only; one line in a JSON file.

`configs/biome/` is a CODEOWNERS path (`@canonical/launchpad-ui`, `@canonical/workplace-engineering-ui`), so this will sit `BLOCKED` pending a cross-team approval — that is expected, not a problem with the change.

### PR readiness check

- [x] PR should have one of the following labels — `fix` is derived from the title automatically.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged, no manifests touched.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — applied; one JSON config line.

## Screenshots

n/a — no visual surface.

https://claude.ai/code/session_017aLWZCu6ivk6BR8f3jZ7xL



https://claude.ai/code/session_017aLWZCu6ivk6BR8f3jZ7xL
