### PR TITLE
chore(codeowners): give the pragma team ownership of Svelte and the Biome config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,12 @@
-/packages/svelte/ds-app-launchpad/   @canonical/launchpad-ui
-/packages/svelte/ds-app-wpe/         @canonical/workplace-engineering-ui
+# Svelte is owned by the pragma team by default. The app packages below add
+# their own product team on top, so either side can approve a change to them;
+# ds-app and ds-global match only this line, which is what makes them owned at
+# all — before it, they had no owner and any review satisfied them.
+/packages/svelte/                    @canonical/pragma
 
-/packages/svelte/ssr-test/    @canonical/launchpad-ui  @canonical/workplace-engineering-ui
-/configs/typescript-svelte/   @canonical/launchpad-ui  @canonical/workplace-engineering-ui
-/configs/biome/               @canonical/launchpad-ui  @canonical/workplace-engineering-ui  @advl
+/packages/svelte/ds-app-launchpad/   @canonical/launchpad-ui  @canonical/pragma
+/packages/svelte/ds-app-wpe/         @canonical/workplace-engineering-ui  @canonical/pragma
+
+/packages/svelte/ssr-test/    @canonical/launchpad-ui  @canonical/workplace-engineering-ui  @canonical/pragma
+/configs/typescript-svelte/   @canonical/launchpad-ui  @canonical/workplace-engineering-ui  @canonical/pragma
+/configs/biome/               @canonical/launchpad-ui  @canonical/workplace-engineering-ui  @canonical/pragma


### PR DESCRIPTION
## Done

- `@canonical/pragma` now owns `/packages/svelte/` by default.
- The Svelte app packages and `configs/typescript-svelte` gain the team alongside their existing product teams.
- `configs/biome` swaps its individual `@advl` entry for the team.

**Two Svelte packages had no owner at all.** `packages/svelte/ds-app` and `packages/svelte/ds-global` matched no CODEOWNERS pattern, so any approval satisfied a change to them — while their sibling app packages each required a named product team. That is the wrong way round: the shared packages everything else builds on were the least protected.

A default owner on `/packages/svelte/` is what makes those two owned rather than merely unlisted. The app packages keep their product team **and** gain the pragma team, so either side can approve instead of one waiting on the other.

**Why `configs/biome` changed from a person to a team.** A single-person entry cannot unblock the person it names. GitHub never counts an author as a reviewer of their own pull request — being a code owner does not change that — so an `@advl` entry only ever served *other* people's changes to that path. Naming the team means any of its other members can approve, which is the behaviour the entry was presumably meant to have.

## Why this matters more than it looks

The `main` ruleset sets `required_approving_review_count: 0` with `require_code_owner_review: true`. There is no general approval requirement in this repository — a pull request touching no code-owned path can merge with no review at all. **CODEOWNERS is the entire review policy.** Every path added here is a real gate, and every path missing from it is genuinely ungated.

## Scope

Ownership only; no code, no configuration behaviour. Three people are in the team (`advl`, `stavropouloskonstantinoss`, `potentialwook`), so this grants all three approval rights on Svelte and on the Biome config — the point of a team rather than an individual, but worth stating plainly since it is a permissions change.

There is also a **disabled** ruleset named `Svelte Config: Multi Team Approval` covering related ground. Left alone here, but somebody previously tried to express this through a ruleset and turned it off; worth knowing before more policy is added.

## QA

No runtime or build surface. GitHub validates CODEOWNERS on push and flags unparseable lines or unknown owners in the repository's settings; the team, its slug and its three members were confirmed against the API before writing the file.

### PR readiness check

- [x] PR should have one of the following labels — `chore` is derived from the title automatically.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — applied; one ownership file.

## Screenshots

n/a — no visual surface.

https://claude.ai/code/session_017aLWZCu6ivk6BR8f3jZ7xL
