### PR TITLE
fix(react/ds-global)!: make ChipProps the public prop type again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * `ButtonBaseProps` is no longer exported from
   `@canonical/react-ds-global`. Use `ButtonProps`.
+* `ChipPropsType` is removed. `ChipProps` is again the full prop surface —
+  import that. 0.37.0 briefly made `ChipProps` the design-system half only,
+  which broke references such as `ChipProps["onClick"]`; those resolve again.
+  `ChipProps` is a discriminated union on `onClick` (a chip with a handler
+  renders a `<button>`, one without renders a `<span>`), so a value assigned
+  to it may need narrowing where a single object type was assumed.
 * **storybook-config:** `disabledAddons` has been removed from CreateConfigOptions.
 * the legacy hand-rolled schema shape
   `{ "~standard": { output, validate } }` is no longer accepted — use full

--- a/packages/react/ds-global/CHANGELOG.md
+++ b/packages/react/ds-global/CHANGELOG.md
@@ -19,6 +19,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * `ButtonBaseProps` is no longer exported from
   `@canonical/react-ds-global`. Use `ButtonProps`.
+* `ChipPropsType` is removed. `ChipProps` is again the full prop surface —
+  import that. 0.37.0 briefly made `ChipProps` the design-system half only,
+  which broke references such as `ChipProps["onClick"]`; those resolve again.
+  `ChipProps` is a discriminated union on `onClick` (a chip with a handler
+  renders a `<button>`, one without renders a `<span>`), so a value assigned
+  to it may need narrowing where a single object type was assumed.
 
 
 # [0.36.0](https://github.com/canonical/pragma/compare/v0.35.0...v0.36.0) (2026-08-29)

--- a/packages/react/ds-global/src/lib/component/Chip/Chip.tsx
+++ b/packages/react/ds-global/src/lib/component/Chip/Chip.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import "./styles.css";
-import type { ChipPropsType } from "./types.js";
+import type { ChipProps } from "./types.js";
 
 const componentCssClassName = "ds chip";
 
@@ -15,7 +15,7 @@ const componentCssClassName = "ds chip";
  *
  * @implements ds:global.component.chip
  */
-const Chip = (props: ChipPropsType): React.ReactElement => {
+const Chip = (props: ChipProps): React.ReactElement => {
   const className = [
     componentCssClassName,
     props.criticality,

--- a/packages/react/ds-global/src/lib/component/Chip/types.ts
+++ b/packages/react/ds-global/src/lib/component/Chip/types.ts
@@ -2,9 +2,11 @@ import type { ModifierFamily } from "@canonical/ds-types";
 import type { ComponentProps, MouseEventHandler } from "react";
 
 /**
- * The Chip's DS-owned props, shared by both of its possible roots.
+ * The Chip's design-system props, shared by both of its possible roots.
+ * Private: `ChipProps` below is the public type, so the name a consumer
+ * imports is the one that describes what `<Chip>` accepts.
  */
-export interface ChipProps {
+type OwnProps = {
   /**
    * Criticality modifier for status indication.
    * - "success": Positive status
@@ -31,29 +33,29 @@ export interface ChipProps {
 
   /** Called when the chip is dismissed. */
   onDismiss?: () => void;
-}
+};
 
 /**
  * Interactive chip — rendered as a `<button>` when an `onClick` handler is
  * supplied, so it extends native `<button>` props.
  */
-type InteractiveChipProps = ChipProps & {
+type InteractiveChipProps = OwnProps & {
   /** Called when the chip is clicked. Its presence makes the chip a button. */
   onClick: MouseEventHandler<HTMLButtonElement>;
-} & Omit<ComponentProps<"button">, keyof ChipProps | "onClick" | "children">;
+} & Omit<ComponentProps<"button">, keyof OwnProps | "onClick" | "children">;
 
 /**
  * Static chip — rendered as a `<span>` when no `onClick` is supplied, so it
  * extends native `<span>` props.
  */
-type StaticChipProps = ChipProps & {
+type StaticChipProps = OwnProps & {
   /** A static chip has no click handler and renders a `<span>`. */
   onClick?: undefined;
-} & Omit<ComponentProps<"span">, keyof ChipProps | "onClick" | "children">;
+} & Omit<ComponentProps<"span">, keyof OwnProps | "onClick" | "children">;
 
 /**
  * Chip props: a discriminated union on `onClick` (issue #628 precedent). A chip
  * with an `onClick` renders a `<button>` and extends button props; one without
  * renders a `<span>` and extends span props. No polymorphic `as` generic.
  */
-export type ChipPropsType = InteractiveChipProps | StaticChipProps;
+export type ChipProps = InteractiveChipProps | StaticChipProps;


### PR DESCRIPTION
## Done

- `ChipProps` is again the public prop type — the discriminated union `<Chip>` accepts.
- The design-system half becomes module-private `OwnProps`.
- `ChipPropsType` is removed.
- The 0.37.0 changelog entry is corrected in both changelogs.

**What 0.37.0 did.** #851 gave the name `ChipProps` to the design-system half of the props and invented `ChipPropsType` for the union consumers actually need. That inverts the convention the very same PR established and wrote into `AGENTS.md`: the design-system half is private `OwnProps`, and `XProps` is the finished type.

**Why the name matters more than it sounds.** Chip was **the only one of 42 component types in this package** exporting a `PropsType`. The suffix carries no information — in TypeScript the position already tells you it is a type, so it is Hungarian notation for a language that does not need it. And it is a symptom rather than a decision: nobody sets out to name a type `FooType`, it appears when the good name is already taken. That is precisely what happened.

The practical cost is that it put the wrong name in front of the consumer. Someone importing `ChipProps` reasonably believes they have the props of `<Chip>`. They had five design-system fields and none of the native ones — the name that reads correctly was the one that was wrong.

## This restores source compatibility

References that broke in 0.37.0 resolve again:

```ts
ChipProps["onClick"]        // compiled on 0.36, broke on 0.37, works again
Pick<ChipProps, "id">       // same
```

Passing props to `<Chip>` was never affected — the component was typed on the union throughout.

## Changelog correction, in the same change

v0.37.0 documented one of its two breaking changes (`ButtonBaseProps`) and missed the other. Both changelogs now carry the `Chip` entry as well, describing what actually happened rather than the intermediate state: `ChipPropsType` is gone, `ChipProps` is the full surface again, and it is a discriminated union on `onClick`, so a value assigned to it may need narrowing where a single object type was assumed.

Editing the released entry rather than noting it under a future version is deliberate: someone upgrading *to* 0.37.0 reads 0.37.0's notes. Lerna appends new sections on release rather than regenerating old ones, so the correction persists.

## Breaking

Marked `!` because `ChipPropsType` is removed. It existed for four days, in one release, so the realistic migration is `ChipPropsType` → `ChipProps` — and for most consumers this is a net *un*-breaking.

## QA

```bash
bunx tsc --noEmit        # clean
bun run check:biome      # 373 files, no fixes applied
```

Repo-wide grep confirms no `ChipPropsType` remains. The Svelte `ChipProps` in `ds-app-launchpad` is a different component in a different package and is untouched.

### PR readiness check

- [x] PR should have one of the following labels — `fix` and `breaking` are derived from the title automatically.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — applied; a type rename and two changelog entries, no rendered output.

## Screenshots

n/a — no visual surface.

https://claude.ai/code/session_017aLWZCu6ivk6BR8f3jZ7xL
