### PR TITLE
refactor(ds-types)!: require a key or url on the navigation item

### DIFF
--- a/packages/ds-types/src/navigation/types.ts
+++ b/packages/ds-types/src/navigation/types.ts
@@ -154,6 +154,13 @@ export type _Item<T extends Item = Item> = _DistributiveOmit<T, "items"> & {
  * member-shaped. The conditional is only on the `Omit` half — the annotation
  * fields above stay a concrete object type, so generic code can access
  * `parentUrl`/`depth`/`items` without resolving the conditional.
+ *
+ * Exported, but private in the same sense as `_Item` and `_Index`: it is for
+ * code that DEFINES an item type, not for code that passes items around. An
+ * application composing its own item adds fields with `&` and needs nothing
+ * from here; it is the packages declaring `BreadcrumbItem`, `TabItem` and the
+ * rest that must drop a field from a union, and they live behind this same
+ * `_` convention.
  */
 export type _DistributiveOmit<T, K extends PropertyKey> = T extends unknown
   ? Omit<T, K>

--- a/packages/ds-types/src/navigation/types.ts
+++ b/packages/ds-types/src/navigation/types.ts
@@ -1,27 +1,8 @@
 /**
- * Navigation item - Public API (WD405)
- *
- * A unified type for navigation items across the design system.
- * Used by Breadcrumbs, SiteNavigation, FileTree, MegaMenu, etc.
- *
- * Only fields consumed by the shared navigation utilities belong here.
- * Styling and rendering customization (CSS classes, custom renderers)
- * belong on the item types that components declare by extending this
- * one (e.g. BreadcrumbItem, MenuItem), using each framework's own idioms.
+ * Fields every navigation item carries, independent of its identity.
+ * Composed into `Item` alongside `ItemIdentity`.
  */
-export interface Item {
-  /**
-   * Unique identifier for the item when a URL is not provided.
-   * e.g. 'section-header' for a non-navigable grouping item.
-   */
-  key?: string;
-
-  /**
-   * Navigation URL for the item, used for navigable links.
-   * e.g. '/dashboard' for directing to the dashboard page.
-   */
-  url?: string;
-
+interface ItemFields {
   /**
    * Display text for the item in the navigation UI.
    * e.g. 'Dashboard' as the visible label.
@@ -40,6 +21,75 @@ export interface Item {
    */
   items?: Item[];
 }
+
+/**
+ * The identity of a navigation item - Public API (WD405)
+ *
+ * Every item must be addressable: the shared navigation utilities index a tree
+ * by item id, so an item with no identity has no place in that index. One of
+ * `url` or `key` is therefore required — either, or both — and the requirement
+ * is carried by the type instead of being checked at runtime.
+ *
+ * `url` wins when both are present, so the union discriminates on it: the
+ * `key`-only arm states `url?: undefined`, which is what lets a check on `url`
+ * prove that `key` is there.
+ */
+type ItemIdentity =
+  | {
+      /**
+       * Unique identifier for the item, required when no URL is provided.
+       * This is the answer for a non-navigable node,
+       * e.g. 'section-header' for a grouping item.
+       */
+      key: string;
+
+      /** Absent — an item without a URL is identified by its `key`. */
+      url?: undefined;
+    }
+  | {
+      /**
+       * Unique identifier for the item, optional alongside a URL.
+       * `url` takes precedence over it when both are present.
+       */
+      key?: string;
+
+      /**
+       * Navigation URL for the item, used for navigable links.
+       * e.g. '/dashboard' for directing to the dashboard page.
+       * Doubles as the item's identity, taking precedence over `key`.
+       */
+      url: string;
+    };
+
+/**
+ * Navigation item - Public API (WD405)
+ *
+ * A unified type for navigation items across the design system.
+ * Used by Breadcrumbs, SiteNavigation, FileTree, MegaMenu, etc.
+ *
+ * Only fields consumed by the shared navigation utilities belong here.
+ * Styling and rendering customization (CSS classes, custom renderers)
+ * belong on the item types that components declare by composing this
+ * one (e.g. BreadcrumbItem, MenuItem), using each framework's own idioms.
+ *
+ * The identity requirement makes `Item` a union, so compose it with `&`
+ * rather than `interface … extends` (which cannot extend a union), and drop
+ * fields from it with `_DistributiveOmit` rather than `Omit`.
+ */
+export type Item = ItemFields & ItemIdentity;
+
+/** Type-level assertion: fails to compile unless `T` resolves to `true`. */
+type Assert<T extends true> = T;
+
+/**
+ * Compile-time proof of the identity requirement: an object carrying neither a
+ * `key` nor a `url` is not an `Item`. That is what lets `getItemId` be total,
+ * so it is asserted where the type is declared rather than left to a runtime
+ * check downstream.
+ */
+type _IdentityIsRequired = Assert<
+  { label: string } extends Item ? false : true
+>;
 
 /**
  * Annotated navigation item - Private API (WD405)
@@ -92,15 +142,20 @@ export type _Item<T extends Item = Item> = _DistributiveOmit<T, "items"> & {
 };
 
 /**
+ * A distributing `Omit` - Private API (WD405)
+ *
  * An `Omit` that distributes over union types: `_DistributiveOmit<A | B, K>`
  * is `Omit<A, K> | Omit<B, K>`, where the plain `Omit<A | B, K>` would first
- * collapse the union to its common keys. Intersecting the annotation fields
+ * collapse the union to its common keys. `Item` is itself a union — its
+ * identity requirement is one — so dropping a field from it (a flat trail with
+ * no `items`, say) needs this rather than `Omit`, which would quietly make
+ * both `key` and `url` optional again. Intersecting the annotation fields
  * with the distributed union then distributes too, keeping `_Item<A | B>`
  * member-shaped. The conditional is only on the `Omit` half — the annotation
  * fields above stay a concrete object type, so generic code can access
  * `parentUrl`/`depth`/`items` without resolving the conditional.
  */
-type _DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+export type _DistributiveOmit<T, K extends PropertyKey> = T extends unknown
   ? Omit<T, K>
   : never;
 

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/types.ts
@@ -9,9 +9,9 @@ import type { LinkComponentProps, NavItem } from "../../types.js";
  * lives in NavTree's two loops. The end slot is derived — an item with subitems
  * shows a disclosure caret; a leaf shows its optional `slot`.
  */
-export interface ItemProps extends NavItem {
+export type ItemProps = NavItem & {
   /** Whether this item is the active (current) page. */
   active?: boolean;
   /** Component used to render navigable items. Defaults to `"a"`. */
   LinkComponent?: ComponentType<LinkComponentProps> | "a";
-}
+};

--- a/packages/react/ds-app/src/lib/SideNavigation/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/types.ts
@@ -1,5 +1,5 @@
 import type { IconName } from "@canonical/ds-assets";
-import type { Item } from "@canonical/ds-types";
+import type { _DistributiveOmit, Item } from "@canonical/ds-types";
 // The custom-link contract is shared across every link-injecting component
 // (cs:react.component.link_component); sourced from ds-global so SideNavigation,
 // Breadcrumbs, and Tabs use one interface. Re-exported so this module's existing
@@ -21,7 +21,7 @@ export type { LinkComponentProps };
  * No discriminated union to author: the caret-vs-slot choice is structural,
  * derived from whether the item has `items`.
  */
-export interface NavItem extends Omit<Item, "items"> {
+export type NavItem = _DistributiveOmit<Item, "items"> & {
   /** Leading icon (start slot), by ds-assets icon name. */
   icon?: IconName;
   /** Trailing content for leaf items (end slot). Ignored if the item has subitems. */
@@ -30,7 +30,7 @@ export interface NavItem extends Omit<Item, "items"> {
   items?: NavItem[];
   /** CSS class name applied to this item's row, in addition to the base classes. */
   className?: string;
-}
+};
 
 type OwnProps = {
   /** Brand content (logo/wordmark) rendered in the header. */

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/common/Item/Item.stories.tsx
@@ -58,7 +58,9 @@ const meta = {
 } satisfies Meta<typeof Component>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+// Typed off the component, not `typeof meta`: these props carry the WD405
+// `Item` identity union, which Storybook's meta-driven arg inference collapses.
+type Story = StoryObj<typeof Component>;
 
 /**
  * Default breadcrumb item with link.
@@ -75,6 +77,7 @@ export const Default: Story = {
  */
 export const Current: Story = {
   args: {
+    url: "/products/details",
     label: "Product Details",
     current: true,
   },

--- a/packages/react/ds-global/src/lib/component/Breadcrumbs/types.ts
+++ b/packages/react/ds-global/src/lib/component/Breadcrumbs/types.ts
@@ -18,7 +18,7 @@ import type { ItemProps, LinkComponentProps } from "./common/Item/types.js";
  * products only. Not designed/approved for Canonical products; Canonical
  * products must use the default Breadcrumbs.Item.
  */
-export interface BreadcrumbItem extends Item {
+export type BreadcrumbItem = Item & {
   /**
    * Whether this is the current page.
    * When true, renders as text instead of link.
@@ -32,7 +32,7 @@ export interface BreadcrumbItem extends Item {
    */
   // biome-ignore lint/suspicious/noExplicitAny: Component accepts any props
   Component?: ComponentType<any>;
-}
+};
 
 type OwnProps = {
   /**

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.hydration.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.hydration.tests.tsx
@@ -7,7 +7,7 @@ import type { MenuEntry } from "./types.js";
 
 const items: MenuEntry[] = [
   { key: "cut", label: "Cut", url: "#cut" },
-  { type: "separator" },
+  { type: "separator", key: "before-zoom" },
   { key: "zoom", label: "Zoom", url: "#zoom" },
 ];
 

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.ssr.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.ssr.tests.tsx
@@ -5,7 +5,7 @@ import type { MenuEntry } from "./types.js";
 
 const items: MenuEntry[] = [
   { key: "cut", label: "Cut", url: "#cut" },
-  { type: "separator" },
+  { type: "separator", key: "before-zoom" },
   { key: "zoom", label: "Zoom", url: "#zoom" },
 ];
 

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.stories.tsx
@@ -51,10 +51,10 @@ const rowActions: MenuEntry[] = [
   { key: "view", label: "View details", url: "#view" },
   { key: "edit", label: "Edit configuration", url: "#edit" },
   { key: "tags", label: "Edit tags", url: "#tags" },
-  { type: "separator" },
+  { type: "separator", key: "before-power" },
   { key: "restart", label: "Restart", url: "#restart" },
   { key: "shutdown", label: "Shut down", url: "#shutdown" },
-  { type: "separator" },
+  { type: "separator", key: "before-delete" },
   { key: "delete", label: "Delete", url: "#delete" },
 ];
 
@@ -101,7 +101,7 @@ export const AccountMenu: Story = {
       { key: "profile", label: "Your profile", url: "#profile" },
       { key: "subs", label: "Subscriptions", url: "#subscriptions" },
       { key: "billing", label: "Billing", url: "#billing", disabled: true },
-      { type: "separator" },
+      { type: "separator", key: "before-signout" },
       { key: "signout", label: "Sign out", url: "#signout" },
     ],
   },
@@ -121,7 +121,7 @@ export const WithShortcuts_NotCoreApi: Story = {
     items: [
       { key: "undo", label: "Undo", url: "#undo", slot: "⌘Z" },
       { key: "redo", label: "Redo", url: "#redo", slot: "⇧⌘Z" },
-      { type: "separator" },
+      { type: "separator", key: "before-clipboard" },
       { key: "cut", label: "Cut", url: "#cut", slot: "⌘X" },
       { key: "copy", label: "Copy", url: "#copy", slot: "⌘C" },
       { key: "paste", label: "Paste", url: "#paste", slot: "⌘V" },
@@ -183,7 +183,7 @@ const nestedActions: MenuEntry[] = [
     items: [
       { key: "share-link", label: "Copy link", url: "#link" },
       { key: "share-email", label: "Email", url: "#email" },
-      { type: "separator" },
+      { type: "separator", key: "share-before-teams" },
       {
         key: "share-teams",
         label: "Send to team",
@@ -205,7 +205,7 @@ const nestedActions: MenuEntry[] = [
       { key: "export-json", label: "JSON", url: "#json" },
     ],
   },
-  { type: "separator" },
+  { type: "separator", key: "before-delete" },
   { key: "delete", label: "Delete", url: "#delete" },
 ];
 
@@ -261,7 +261,7 @@ const rtlActions: MenuEntry[] = [
     ],
   },
   { key: "rename", label: "إعادة تسمية", url: "#rename" },
-  { type: "separator" },
+  { type: "separator", key: "before-delete" },
   { key: "delete", label: "حذف", url: "#delete" },
 ];
 

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/ContextualMenu.tests.tsx
@@ -6,7 +6,7 @@ import type { MenuEntry, MenuItem } from "./types.js";
 const items: MenuEntry[] = [
   { key: "cut", label: "Cut", url: "#cut" },
   { key: "copy", label: "Copy", url: "#copy" },
-  { type: "separator" },
+  { type: "separator", key: "before-zoom" },
   { key: "zoom", label: "Zoom", url: "#zoom" },
 ];
 
@@ -333,10 +333,10 @@ describe("ContextualMenu", () => {
 
     it("skips leading and trailing separators on open, Home and End", () => {
       const edged: MenuEntry[] = [
-        { type: "separator" },
+        { type: "separator", key: "leading" },
         { key: "alpha", label: "Alpha", url: "#alpha" },
         { key: "beta", label: "Beta", url: "#beta" },
-        { type: "separator" },
+        { type: "separator", key: "trailing" },
       ];
       render(<ContextualMenu trigger="Actions" items={edged} wrap={false} />);
       const menu = openMenu();
@@ -358,10 +358,10 @@ describe("ContextualMenu", () => {
 
     it("wraps by default, looping past leading and trailing separators", () => {
       const edged: MenuEntry[] = [
-        { type: "separator" },
+        { type: "separator", key: "leading" },
         { key: "alpha", label: "Alpha", url: "#alpha" },
         { key: "beta", label: "Beta", url: "#beta" },
-        { type: "separator" },
+        { type: "separator", key: "trailing" },
       ];
       render(<ContextualMenu trigger="Actions" items={edged} />);
       const menu = openMenu();
@@ -385,7 +385,7 @@ describe("ContextualMenu", () => {
           label: "Parent",
           items: [
             { key: "sub1", label: "Sub one", url: "#sub1" },
-            { type: "separator" },
+            { type: "separator", key: "sub-divider" },
             { key: "sub2", label: "Sub two", url: "#sub2" },
           ],
         },

--- a/packages/react/ds-global/src/lib/component/ContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/component/ContextualMenu/types.ts
@@ -27,7 +27,7 @@ type OwnProps = Pick<
   trigger: ReactNode;
   /**
    * The menu entries: one flat list of items and separators
-   * (`{ type: "separator" }`). An item's own `items` form its submenu, which
+   * (`{ type: "separator", key: "…" }`). An item's own `items` form its submenu, which
    * may itself contain separators.
    */
   items: MenuEntry[];

--- a/packages/react/ds-global/src/lib/component/Tabs/Tabs.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Tabs/Tabs.tests.tsx
@@ -35,7 +35,7 @@ describe("Tabs", () => {
     render(
       <Tabs
         aria-label="Sections"
-        navigationRoot={{ label: "Root label", items: root.items }}
+        navigationRoot={{ key: "root", label: "Root label", items: root.items }}
       />,
     );
     expect(screen.queryByText("Root label")).not.toBeInTheDocument();
@@ -58,7 +58,10 @@ describe("Tabs", () => {
     render(
       <Tabs
         aria-label="Sections"
-        navigationRoot={{ items: [{ key: "soon", label: "Coming soon" }] }}
+        navigationRoot={{
+          key: "root",
+          items: [{ key: "soon", label: "Coming soon" }],
+        }}
       />,
     );
     expect(screen.queryByRole("link")).not.toBeInTheDocument();

--- a/packages/react/ds-global/src/lib/component/Tabs/common/Item/Item.tests.tsx
+++ b/packages/react/ds-global/src/lib/component/Tabs/common/Item/Item.tests.tsx
@@ -22,7 +22,11 @@ describe("Tabs Item (internal renderer)", () => {
 
   it("renders an item without a url as inert text (a span), marked data-inert", () => {
     inList(
-      <Item item={{ label: "Coming soon" }} active={false} LinkComponent="a" />,
+      <Item
+        item={{ key: "soon", label: "Coming soon" }}
+        active={false}
+        LinkComponent="a"
+      />,
     );
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
     expect(screen.getByText("Coming soon").tagName).toBe("SPAN");

--- a/packages/react/ds-global/src/lib/component/Tabs/types.ts
+++ b/packages/react/ds-global/src/lib/component/Tabs/types.ts
@@ -8,10 +8,10 @@ import type { LinkComponent } from "../../types/link.js";
  * `label` (visible text), `key` (identity when there is no url), and
  * `disabled`. Nested `items` are ignored (tabs cannot nest).
  */
-export interface TabItem extends Item {
+export type TabItem = Item & {
   /** CSS class name applied to this tab's `<li>`, in addition to the base classes. */
   className?: string;
-}
+};
 
 type OwnProps = {
   /**

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
@@ -1,4 +1,4 @@
-import type { _Item, Item } from "@canonical/ds-types";
+import type { _DistributiveOmit, _Item, Item } from "@canonical/ds-types";
 import type {
   ItemProps,
   MenuItemPropsResult,
@@ -16,7 +16,7 @@ import type {
  * shortcut) in addition to the base navigation fields. The slot is an optional
  * extension that survives tree annotation.
  */
-export interface MenuItem extends Item {
+export type MenuItem = _DistributiveOmit<Item, "items"> & {
   /** Content rendered right-aligned within the item, such as a badge or shortcut. */
   slot?: React.ReactNode;
   /** Icon rendered left of the label. */
@@ -32,7 +32,7 @@ export interface MenuItem extends Item {
   displayItemsType?: "default" | "custom";
   /** Custom component for rendering this item itself, when `displayItemsType` is `"custom"`. */
   Component?: React.ComponentType<{ item: MenuItem }>;
-}
+};
 
 /**
  * A non-interactive divider between menu entries, rendered as a horizontal
@@ -45,9 +45,10 @@ export interface MenuSeparator {
   type: "separator";
   /**
    * Unique identity within the menu, used as the React key and the navigation
-   * index id. Auto-generated when omitted.
+   * index id. Required: a separator is a node in the navigation tree, and
+   * every navigation item is identified by a `key` or a `url`.
    */
-  key?: string;
+  key: string;
   /**
    * Set by {@link useContextualMenu} before the tree is annotated — disabled
    * is what makes the navigation machinery skip the separator. Consumers

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.tests.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.tests.tsx
@@ -17,7 +17,7 @@ const menu: MenuItem = {
   items: [
     { key: "a1", label: "A one", url: "/a1" },
     { key: "a2", label: "A two", url: "/a2" },
-    { type: "separator" },
+    { type: "separator", key: "before-b1" },
     { key: "b1", label: "B one", url: "/b1" },
   ],
 };
@@ -83,13 +83,13 @@ describe("useContextualMenu", () => {
     expect(result.current.highlightedItems.at(-2)?.key).toBe("menu");
   });
 
-  it("feeds separators to the tree as disabled nodes with generated keys", () => {
-    // The tree machinery skips DISABLED nodes — that, plus a guaranteed key
-    // (the index throws on identity-less nodes), is the entire separator
-    // contract. The discriminant survives annotation for the render layer.
+  it("feeds separators to the tree as disabled nodes", () => {
+    // The tree machinery skips DISABLED nodes — that, plus the key every
+    // navigation item carries, is the entire separator contract. The
+    // discriminant survives annotation for the render layer.
     const { result } = renderHook(() => useContextualMenu({ root: menu }));
 
-    const separator = result.current.index["separator-0"];
+    const separator = result.current.index["before-b1"];
     expect(separator).toBeDefined();
     expect(separator?.disabled).toBe(true);
     expect(separator && "type" in separator ? separator.type : undefined).toBe(

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
@@ -16,27 +16,20 @@ import type {
 
 /**
  * Prepare a menu entry for the navigation tree. A separator becomes a
- * disabled, label-less node with a guaranteed-unique key: `disabled` is what
- * makes the shared navigation machinery (arrow keys, Home/End, type-ahead,
- * roving focus) skip it with no separator awareness of its own, and the key
- * gives it the identity the tree's index requires. Items recurse into their
- * submenu entries; `counter` numbers auto-keyed separators tree-wide.
+ * disabled, label-less node: `disabled` is what makes the shared navigation
+ * machinery (arrow keys, Home/End, type-ahead, roving focus) skip it with no
+ * separator awareness of its own. Its `key` is the identity the tree's index
+ * requires, and the type already guarantees it. Items recurse into their
+ * submenu entries.
  */
-const prepareEntry = (
-  entry: MenuEntry,
-  counter: { next: number },
-): MenuEntry => {
+const prepareEntry = (entry: MenuEntry): MenuEntry => {
   if (isMenuSeparator(entry)) {
-    return {
-      ...entry,
-      key: entry.key ?? `separator-${counter.next++}`,
-      disabled: true,
-    };
+    return { ...entry, disabled: true };
   }
   if (!entry.items?.length) return entry;
   return {
     ...entry,
-    items: entry.items.map((child) => prepareEntry(child, counter)),
+    items: entry.items.map(prepareEntry),
   };
 };
 
@@ -75,12 +68,9 @@ const useContextualMenu = ({
     getToggleProps: getDisclosureToggleProps,
   } = useDisclosure({ ...props, mode: "click" });
 
-  // Separators become disabled nodes with guaranteed keys BEFORE the tree
-  // annotates the root, so useNavigationTree runs unmodified.
-  const preparedRoot = useMemo(
-    () => prepareEntry(root, { next: 0 }) as MenuItem,
-    [root],
-  );
+  // Separators become disabled nodes BEFORE the tree annotates the root, so
+  // useNavigationTree runs unmodified.
+  const preparedRoot = useMemo(() => prepareEntry(root) as MenuItem, [root]);
 
   const nav = useNavigationTree<MenuEntry>({
     root: preparedRoot,

--- a/packages/svelte/ds-global/src/lib/component/Breadcrumbs/common/Item/types.ts
+++ b/packages/svelte/ds-global/src/lib/component/Breadcrumbs/common/Item/types.ts
@@ -1,4 +1,4 @@
-import type { Item } from "@canonical/ds-types";
+import type { _DistributiveOmit, Item } from "@canonical/ds-types";
 import type { Snippet } from "svelte";
 import type { ClassValue, SvelteHTMLElements } from "svelte/elements";
 
@@ -20,22 +20,23 @@ export type ItemAnchorProps = Omit<
  *
  * @implements ds:global.subcomponent.breadcrumbs-item
  */
-export interface ItemProps extends ItemAnchorProps, Omit<Item, "items"> {
-  /**
-   * The link content (snippet)
-   * Falls back to `label` from Item if not provided
-   */
-  children?: Snippet;
-  /**
-   * Whether this is the current/active breadcrumb
-   * When true, renders as text instead of link
-   */
-  current?: boolean;
-  /** CSS class applied to this item's `<li>`, in addition to the base classes. */
-  class?: ClassValue;
-  /**
-   * Custom separator character or snippet
-   * @default "/"
-   */
-  separator?: Snippet | string;
-}
+export type ItemProps = ItemAnchorProps &
+  _DistributiveOmit<Item, "items"> & {
+    /**
+     * The link content (snippet)
+     * Falls back to `label` from Item if not provided
+     */
+    children?: Snippet;
+    /**
+     * Whether this is the current/active breadcrumb
+     * When true, renders as text instead of link
+     */
+    current?: boolean;
+    /** CSS class applied to this item's `<li>`, in addition to the base classes. */
+    class?: ClassValue;
+    /**
+     * Custom separator character or snippet
+     * @default "/"
+     */
+    separator?: Snippet | string;
+  };

--- a/packages/svelte/ds-global/src/lib/component/Breadcrumbs/types.ts
+++ b/packages/svelte/ds-global/src/lib/component/Breadcrumbs/types.ts
@@ -1,4 +1,4 @@
-import type { Item } from "@canonical/ds-types";
+import type { _DistributiveOmit, Item } from "@canonical/ds-types";
 import type { Snippet } from "svelte";
 import type { ClassValue, SvelteHTMLElements } from "svelte/elements";
 import type { ItemAnchorProps } from "./common/Item/types.js";
@@ -17,15 +17,16 @@ import type { ItemAnchorProps } from "./common/Item/types.js";
  * Omits `items` (nested children) from the shared Item type: breadcrumbs
  * are always a flat trail, so that field has no meaning here.
  */
-export interface BreadcrumbItem extends ItemAnchorProps, Omit<Item, "items"> {
-  /**
-   * Whether this is the current page.
-   * When true, renders as text instead of link.
-   */
-  current?: boolean;
-  /** CSS class applied to this item's `<li>`, in addition to the base classes. */
-  class?: ClassValue;
-}
+export type BreadcrumbItem = ItemAnchorProps &
+  _DistributiveOmit<Item, "items"> & {
+    /**
+     * Whether this is the current page.
+     * When true, renders as text instead of link.
+     */
+    current?: boolean;
+    /** CSS class applied to this item's `<li>`, in addition to the base classes. */
+    class?: ClassValue;
+  };
 
 type BaseProps = SvelteHTMLElements["nav"];
 

--- a/packages/utils/src/lib/navigation/annotateTree.test.ts
+++ b/packages/utils/src/lib/navigation/annotateTree.test.ts
@@ -74,9 +74,9 @@ describe("annotateTree", () => {
   });
 
   it("preserves extra properties on items", () => {
-    interface EnhancedItem extends Item {
-      icon?: string;
-    }
+    // `Item` is a union, so extra fields compose with `&`. An
+    // `interface … extends Item` here is TS2312 — see the note on `Item`.
+    type EnhancedItem = Item & { icon?: string };
     const root: EnhancedItem = {
       url: "/home",
       label: "Home",

--- a/packages/utils/src/lib/navigation/getItemId.test.ts
+++ b/packages/utils/src/lib/navigation/getItemId.test.ts
@@ -4,20 +4,24 @@ import { getItemId } from "./getItemId.js";
 
 describe("getItemId", () => {
   it("returns url when present", () => {
-    expect(getItemId({ url: "/about" } as Item)).toBe("/about");
+    expect(getItemId({ url: "/about" })).toBe("/about");
   });
 
   it("returns key when url is absent", () => {
-    expect(getItemId({ key: "section" } as Item)).toBe("section");
+    expect(getItemId({ key: "section" })).toBe("section");
   });
 
   it("prefers url over key", () => {
-    expect(getItemId({ url: "/about", key: "section" } as Item)).toBe("/about");
+    expect(getItemId({ url: "/about", key: "section" })).toBe("/about");
   });
 
-  it("throws when neither url nor key is present", () => {
-    expect(() => getItemId({} as Item)).toThrow(
-      "Item must have either url or key",
-    );
+  it("rejects an item with neither url nor key at the type level", () => {
+    // The identity is a requirement of `Item`, which is what makes getItemId
+    // total. Type-checking is the assertion here; the runtime expectation
+    // below only keeps the binding used.
+    // @ts-expect-error - an item with neither url nor key is not an Item
+    const withoutIdentity: Item = { label: "no identity" };
+
+    expect(withoutIdentity).toBeDefined();
   });
 });

--- a/packages/utils/src/lib/navigation/getItemId.ts
+++ b/packages/utils/src/lib/navigation/getItemId.ts
@@ -3,12 +3,13 @@ import type { _Item, Item } from "@canonical/ds-types";
 /**
  * Get the unique identifier for a navigation item (url or key)
  *
+ * Total: `Item` requires one of the two, so there is no third case to handle.
+ * `url` takes precedence when both are present.
+ *
  * @param item - The navigation item
  * @returns The item's url or key
- * @throws Error if item has neither url nor key
  */
 export function getItemId(item: Item | _Item): string {
-  if (item.url) return item.url;
-  if (item.key) return item.key;
-  throw new Error("Item must have either url or key");
+  if (item.url !== undefined) return item.url;
+  return item.key;
 }


### PR DESCRIPTION
## Done

Makes a navigation item's identity a requirement of the shared WD405 `Item`
type, so `getItemId` can no longer throw.

**The problem.** `Item` declared both identity fields optional (`key?`, `url?`),
so "this item has an identity" was not expressible. The invariant lived in
`getItemId` instead:

```ts
if (item.url) return item.url;
if (item.key) return item.key;
throw new Error("Item must have either url or key");
```

An item with neither compiled fine and then crashed the moment the tree was
indexed.

**The change.** `Item` is now its non-identity fields intersected with a two-arm
union requiring one of `key` or `url` — either, or both:

```ts
type ItemIdentity =
  | { key: string; url?: undefined }   // non-navigable node, identified by key
  | { key?: string; url: string };     // navigable; url is also the identity
export type Item = ItemFields & ItemIdentity;
```

`url` keeps its precedence, and the union discriminates on it (`url?: undefined`
on the key-only arm), which is what lets a check on `url` prove the `key` is
there. `getItemId` is now total and the `throw` is deleted; a compile-time
assertion in `ds-types` fails the type-check if the requirement is ever loosened.

Two principles from `CONSTITUTION.md` back this:

- **IV. Functional core** — "start with pure functions, add effects only where
  the problem requires them, and keep the effectful boundary as thin as
  possible". A getter that throws is an effect in the core; making the type carry
  the requirement makes the function total.
- **VII. Explicit conventions** — "The code itself is the authoritative source of
  what the conventions are." The identity rule was a convention enforced by a
  runtime check and, for menu separators, by a key the framework silently
  generated at render time. Both are now stated in the type, where a reader and
  the compiler can see them.

**Composition.** Because `Item` is a union, item types compose it with `&`
instead of `interface … extends` (which cannot extend a union), and drop fields
from it with the now-exported `_DistributiveOmit` instead of `Omit` — a plain
`Omit` collapses a union to its common keys and would quietly make both fields
optional again. This is the intersection-over-`interface extends` rule
`AGENTS.md` already sets for React props, applied to the item types:
`BreadcrumbItem`, `TabItem`, `MenuItem`, `NavItem`, `SideNavigation`'s
`ItemProps`, and the two Svelte breadcrumb item types.

**Fallout — 20 item literals stopped compiling.** Each is an item that had no
identity:

- **16 ContextualMenu separators** (`{ type: "separator" }` in its stories and
  tests). `useContextualMenu` was generating their keys at render time precisely
  because the tree's index requires one. `MenuSeparator.key` is now required, the
  generation step and its counter are gone, and the separators are keyed where
  they are written.
- **2 Tabs roots** and **1 Tabs item** in tests — container/inert nodes with
  neither `key` nor `url`; given a `key`.
- **1 Breadcrumbs.Item story** (`Current`) — given the `url` of the page it
  represents.

Nothing was weakened to make an error go away.

One incidental adjustment: `Breadcrumbs/common/Item/Item.stories.tsx` types its
stories as `StoryObj<typeof Component>` rather than `StoryObj<typeof meta>`
(a form already used elsewhere in the package). Storybook's meta-driven arg
inference runs the props through `Omit`, which collapses the identity union.

Fixes nothing tracked; no drive-bys.

### Migration

- An item needs a `key` or a `url`. Give a navigable item its `url`; give a
  non-navigable one (a section header, a group, a container root) a `key`.
- Replace `interface X extends Item` with `type X = Item & { … }`.
- Replace `Omit<Item, K>` with `_DistributiveOmit<Item, K>` (exported from
  `@canonical/ds-types`).
- Separators are authored with a key: `{ type: "separator", key: "before-delete" }`.

## QA

- `bun run check` from the repo root: exit 0 (62 projects).
- `bun run collect:check`: exit 0 — `@implements ds:` annotations unchanged.
- `bun run test` in each affected package: `@canonical/utils` (227), 
  `@canonical/react-hooks` (148), `@canonical/react-ds-global` (369 passed, 5
  skipped), `@canonical/react-ds-app` (52) — all exit 0.
- `@canonical/svelte-ds-global`: `check` passes (`svelte-check`, 0 errors); its
  browser-mode tests cannot launch Chromium in this environment (missing
  `libglib-2.0.so.0`), so they were not run here. That package's change is
  types-only.
- Behaviour worth a look in Storybook: ContextualMenu separators still render as
  dividers and are still skipped by arrow keys, Home/End and type-ahead — they
  now carry authored keys instead of generated ones.

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. See [CONTRIBUTING.md](../old/CONTRIBUTING.md#24-full-artifact-builds-buildall) for details.
- [x] If this PR introduces a **new package**: first-time publish has been done manually from inside the package directory using `npm publish --access public` (first-time publishing is not automated). Run `bun run publish:status` from the repo root to verify. Then configure an OIDC [trusted publisher](https://docs.npmjs.com/trusted-publishers) for the package on npmjs.com (repo `canonical/pragma`, workflow `tag.yml`) and set publishing access to disallow tokens, so the automated release workflow can publish future versions. — n/a, no new package.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic.

## Screenshots

n/a — types only; no rendered output changes.

https://claude.ai/code/session_017aLWZCu6ivk6BR8f3jZ7xL
