### PR TITLE
feat(styles-typography)!: the mapper and the engines in ds.typography

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1298,6 +1298,7 @@
         "@types/bun": "^1.3.10",
         "@types/node": "^26.0.0",
         "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
       },
       "peerDependencies": {
         "typescript": "^5.9.3",

--- a/packages/styles/typography/README.md
+++ b/packages/styles/typography/README.md
@@ -16,6 +16,28 @@ Import the default engine (cap-unit) and set your baseline height:
 
 That's it. All `h1`–`h6` and `p` elements will align to the baseline grid. The default engine uses the CSS `cap` unit and requires no JavaScript font extraction.
 
+## Cascade layers
+
+Two facts about the CSS cascade shape this package.
+
+A rule in no cascade layer outranks a rule in any layer, whatever the selectors on either side. And within one layer, two rules of equal specificity are settled by which one loaded second. This package used to ship its rules in no layer at all, at specificity `(0,0,1)` — `p`, `h1`, `body` — so an application's own `p` rule tied with this one and the bundler's output order decided the winner, one property at a time. Layered, the design system loses to an application's unlayered CSS, deliberately and predictably, and beats the layers below it, also deliberately.
+
+| What | Layer |
+| --- | --- |
+| `mapper.css` — the design-tokens naming shims (`:root`, custom properties only) | `ds.tokens` |
+| `mapper.css` — the `body`, `h1`–`h6`, `p`, `.p`, `.code` and `.editorial` rules | `ds.typography` |
+| `baseline-cap.css`, `baseline-metrics.css`, `baseline-trim.css` — every rule | `ds.typography` |
+| `baseline-shim.css` — the `@property` registration | none, by design |
+| `@canonical/design-tokens/dist/modifiers.typography.css`, imported by each engine | `ds.modifiers`, which that file opens itself |
+
+`ds.typography` sits above `ds.reset` and below `ds.modifiers` in the order `@canonical/styles` declares, so the typographic scale in `ds.modifiers` can retune what the engine produces, and a component stylesheet — higher still — is always the final word on its own text.
+
+The naming shims are in `ds.tokens` and not `ds.typography` because they are custom properties and nothing else: a custom property does nothing where it is declared, only where a rule reads it, so they belong beside the other primitive values. The `@property` registration is in no layer because a registration is not cascaded at all — the last one in document order wins whatever layer it sits in, so a layer would have nothing to order it against.
+
+These rules select elements by name — `body`, `h1`, `p` — so they apply to the whole document. That is what a design system's typography is for.
+
+This package states no layer order of its own: it is imported by `@canonical/styles` after that package's order statement, which is the first rule of the first stylesheet and names both layers. Linked on its own, as the example does, the layers are created where they first appear, which is well defined for a single package and settles nothing this package needs settled — no custom property is declared in more than one of the layers involved.
+
 ## How It Works
 
 The browser adds invisible **half-leading** above and below each line of text. The exact amount depends on the font's internal metrics, the computed `font-size`, and `line-height`. This makes vertical alignment between different text elements unpredictable.
@@ -62,11 +84,13 @@ Uses the browser-native `cap` CSS unit to resolve font metrics at render time. N
 
 The baseline position formula is `(line-height + 1cap) / 2` — the browser resolves `1cap` from the font's OpenType tables natively.
 
-| Browser | Minimum version |
-|---------|-----------------|
-| Chrome  | 117+            |
-| Safari  | 17.2+           |
-| Firefox | 97+             |
+| Browser | `mod()` | `cap` unit | `@property` | This engine's floor |
+|---------|----------|------------|--------------|---------------------|
+| Chrome  | 125+     | 118+       | 85+          | **125+**            |
+| Safari  | 15.4+    | 17.2+      | 16.4+        | **17.2+**           |
+| Firefox | 118+     | 97+        | 128+         | **128+**            |
+
+A different feature binds each column: `mod()` in Chrome, the `cap` unit in Safari, `@property` in Firefox — and see the note under "Browser Support" about that last one.
 
 ### baseline-metrics.css — Extracted metrics
 
@@ -94,11 +118,13 @@ The baseline position is computed from these metrics: `((line-height - line-heig
 
 The most modern approach. Uses `text-box: trim-both cap alphabetic` to remove half-leading entirely, then compensates with `mod()`-based margin to restore grid alignment. Results in tighter content boxes (useful for buttons, cards, optical centering).
 
-| Browser | Minimum version | Notes |
-|---------|-----------------|-------|
-| Chrome  | 133+            |       |
-| Safari  | 18.2+           |       |
-| Firefox | —               | Not yet implemented |
+| Browser | `text-box-trim` | `mod()` | `@property` | This engine's floor |
+|---------|-----------------|----------|--------------|---------------------|
+| Chrome  | 133+            | 125+     | 85+          | **133+**            |
+| Safari  | 18.2+           | 15.4+    | 16.4+        | **18.2+**           |
+| Firefox | 154+            | 118+     | 128+         | **154+**            |
+
+`text-box-trim` binds every column.
 
 Falls back gracefully: if `text-box-trim` is unsupported, the element keeps its default half-leading and the nudge still applies.
 
@@ -219,10 +245,26 @@ The baseline grid is rendered as a red 1px line overlay so alignment errors are 
 
 All engines require `mod()` for the grid-snap calculation:
 
-| Browser | `mod()` support |
-|---------|-----------------|
-| Chrome  | 125+            |
-| Safari  | 17.4+           |
-| Firefox | 128+            |
+| Feature | Used by | Chrome | Safari | Firefox |
+|---------|---------|--------|--------|---------|
+| `mod()` | all three engines | 125 | 15.4 | 118 |
+| `round()` | the mapper's line-height fallback | 125 | 15.4 | 118 |
+| `@property` | the `--baseline-height` registration | 85 | 16.4 | 128 |
+| `cap` unit | the cap and text-trim engines | 118 | 17.2 | 97 |
+| `text-box-trim` | the text-trim engine only | 133 | 18.2 | 154 |
 
-The **cap-unit** and **text-trim** engines additionally require the `cap` CSS unit (Chrome 117+, Safari 17.2+, Firefox 97+) and `round()` function respectively. See each engine section above for specific requirements.
+Read the table by engine, not row by row — an engine's floor is the highest number in its column among the features it uses:
+
+| Engine | Chrome | Safari | Firefox | What binds |
+|--------|--------|--------|---------|------------|
+| `baseline-cap.css` | 125 | 17.2 | 128 | `mod()`, then the `cap` unit, then `@property` |
+| `baseline-metrics.css` | 125 | 16.4 | 128 | `mod()`, then `@property` |
+| `baseline-trim.css` | 133 | 18.2 | 154 | `text-box-trim` throughout |
+
+Two caveats on that table, both real.
+
+`@property` holds the Firefox column for two of the engines, and Safari for one, for a registration **no browser currently accepts**. `baseline-shim.css` writes its initial value in `rem`, which is not computationally independent, so Chromium and Firefox alike throw the whole rule away and the 4px fallback it promises does not exist. The next change in this series removes the registration and gives the engines a fallback of their own; those numbers drop to Chrome 125, Safari 15.4, Firefox 118 with it.
+
+`text-box-trim` is soft in a different way: below it the trim is skipped and the element keeps its default half-leading, but the nudge still applies and the grid still holds, so the text-trim engine degrades to the alignment the other two give rather than failing.
+
+`mod()` is the hard one. Below it no engine computes a nudge and text falls back to its natural leading.

--- a/packages/styles/typography/README.md
+++ b/packages/styles/typography/README.md
@@ -20,7 +20,11 @@ That's it. All `h1`–`h6` and `p` elements will align to the baseline grid. The
 
 Two facts about the CSS cascade shape this package.
 
-A rule in no cascade layer outranks a rule in any layer, whatever the selectors on either side. And within one layer, two rules of equal specificity are settled by which one loaded second. This package used to ship its rules in no layer at all, at specificity `(0,0,1)` — `p`, `h1`, `body` — so an application's own `p` rule tied with this one and the bundler's output order decided the winner, one property at a time. Layered, the design system loses to an application's unlayered CSS, deliberately and predictably, and beats the layers below it, also deliberately.
+A rule in no cascade layer outranks a rule in any layer, whatever the selectors on either side. And within one layer, two rules of equal specificity are settled by which one loaded second.
+
+This package used to ship every one of its rules in no layer at all, so the first fact applied to all of them: nothing an application wrote in a layer could beat them. The second fact bit hardest on the element selectors, `body`, `h1`–`h6` and `p`, which sit at specificity `(0,0,1)`: an application's own `p` rule tied with this one exactly, and the bundler's output order decided the winner, one property at a time. The rest of the file is more specific than that — `.p`, `.code` and `.editorial` are classes, `:root` is a pseudo-class, and `.editorial h1` is a class and an element together — so those won on specificity rather than by luck, which is its own problem when an application meant to override them.
+
+Layered, the design system loses to an application's unlayered CSS, deliberately and predictably, and beats the layers below it, also deliberately.
 
 | What | Layer |
 | --- | --- |
@@ -88,9 +92,9 @@ The baseline position formula is `(line-height + 1cap) / 2` — the browser reso
 |---------|----------|------------|--------------|---------------------|
 | Chrome  | 125+     | 118+       | 85+          | **125+**            |
 | Safari  | 15.4+    | 17.2+      | 16.4+        | **17.2+**           |
-| Firefox | 118+     | 97+        | 128+         | **128+**            |
+| Firefox | 118+     | 97+        | 128+         | **118+**            |
 
-A different feature binds each column: `mod()` in Chrome, the `cap` unit in Safari, `@property` in Firefox — and see the note under "Browser Support" about that last one.
+`mod()` binds Chrome and Firefox, the `cap` unit binds Safari. The `@property` column is listed for completeness and does not enter the floor: the registration it refers to is invalid and discarded in every browser, so raising a browser to 128 buys nothing. See the note under "Browser Support".
 
 ### baseline-metrics.css — Extracted metrics
 
@@ -124,9 +128,9 @@ The most modern approach. Uses `text-box: trim-both cap alphabetic` to remove ha
 | Safari  | 18.2+           | 15.4+    | 16.4+        | **18.2+**           |
 | Firefox | 154+            | 118+     | 128+         | **154+**            |
 
-`text-box-trim` binds every column.
+`text-box-trim` binds every column. The `@property` column is listed for completeness and does not enter the floor; see the note under "Browser Support".
 
-Falls back gracefully: if `text-box-trim` is unsupported, the element keeps its default half-leading and the nudge still applies.
+**It does not fall back to the grid.** Below the floor the trim is skipped and the element gets its half-leading back, but the nudge that survives was computed for a trimmed box and never reads the line height, so the text lands off the grid by a fraction of a unit — measured, 6.516px on a 16px serif at a 24px line, whatever the unit is. Use the cap engine for those browsers.
 
 ## Consumer Contract
 
@@ -257,14 +261,14 @@ Read the table by engine, not row by row — an engine's floor is the highest nu
 
 | Engine | Chrome | Safari | Firefox | What binds |
 |--------|--------|--------|---------|------------|
-| `baseline-cap.css` | 125 | 17.2 | 128 | `mod()`, then the `cap` unit, then `@property` |
-| `baseline-metrics.css` | 125 | 16.4 | 128 | `mod()`, then `@property` |
+| `baseline-cap.css` | 125 | 17.2 | 118 | `mod()`, and the `cap` unit in Safari |
+| `baseline-metrics.css` | 125 | 15.4 | 118 | `mod()` throughout |
 | `baseline-trim.css` | 133 | 18.2 | 154 | `text-box-trim` throughout |
 
-Two caveats on that table, both real.
+Two things that table does not say, and both matter.
 
-`@property` holds the Firefox column for two of the engines, and Safari for one, for a registration **no browser currently accepts**. `baseline-shim.css` writes its initial value in `rem`, which is not computationally independent, so Chromium and Firefox alike throw the whole rule away and the 4px fallback it promises does not exist. The next change in this series removes the registration and gives the engines a fallback of their own; those numbers drop to Chrome 125, Safari 15.4, Firefox 118 with it.
+**`@property` is not in it, on purpose.** The registration in `baseline-shim.css` writes its initial value in `rem`, which is not computationally independent, so Chromium and Firefox alike throw the whole rule away: it is invalid everywhere and cannot raise a minimum version, because there is no version at which it starts working. The engines therefore run wherever `mod()` does, given a consumer-declared `--baseline-height` — which the consumer contract asks for. Without that declaration no browser gives the engine a grid, old or new, because the fallback the registration promises does not exist. The next change in this series deletes the registration and gives every read of the unit a `0.25rem` fallback, which is what makes the contract's "optional" true.
 
-`text-box-trim` is soft in a different way: below it the trim is skipped and the element keeps its default half-leading, but the nudge still applies and the grid still holds, so the text-trim engine degrades to the alignment the other two give rather than failing.
+**Below `text-box-trim`, the text-trim engine does not hold the grid.** The trim is skipped, the element gets its half-leading back, and the nudge that survives — `mod(calc(-1 * 1cap), unit)` — was computed for a trimmed box and never reads the line height, so it cannot compensate. Measured in Chromium with a 16px serif on a 24px line: with the trim applied the first baseline sits at 12px on a 4px grid, 16px on an 8px grid and 12px on a 12px grid, every one a whole number of units; with the trim ignored it moves 6.516px in each case, which is 1.63, 0.81 and 0.54 units. The element's outer height stays a whole number of units, so blocks still stack on the grid, but the text inside them does not sit on it. A browser below the floor should use the cap engine, whose nudge is computed from the untrimmed line box.
 
-`mod()` is the hard one. Below it no engine computes a nudge and text falls back to its natural leading.
+`mod()` is the hard floor. Below it no engine computes a nudge at all and text falls back to its natural leading.

--- a/packages/styles/typography/package.json
+++ b/packages/styles/typography/package.json
@@ -20,7 +20,9 @@
     "check:fix": "bun run check:biome:fix && bun run check:ts",
     "check:biome": "biome check",
     "check:biome:fix": "biome check --write",
-    "check:ts": "tsc --noEmit"
+    "check:ts": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest"
   },
   "author": {
     "email": "webteam@canonical.com",
@@ -41,7 +43,8 @@
     "@canonical/typescript-config": "^0.37.0",
     "@types/bun": "^1.3.10",
     "@types/node": "^26.0.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   },
   "peerDependencies": {
     "typescript": "^5.9.3"

--- a/packages/styles/typography/src/baseline-cap.css
+++ b/packages/styles/typography/src/baseline-cap.css
@@ -1,13 +1,40 @@
 /* @canonical/styles-typography — Cap-unit engine (default)
  *
- * No JS font extraction required. Uses CSS `cap` unit and `mod()` for
- * baseline alignment. Broad browser support: Chrome 113+, Safari 17.4+,
- * Firefox 113+.
+ * No JS font extraction required. Uses the CSS `cap` unit and `mod()` for
+ * baseline alignment.
  *
  * Consumer contract:
  *   :root { --baseline-height: <length>; }
  *   element { --font-size: <length>; --line-height: <length>; }
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
+ *
+ * Browser floor: Chrome 125, Safari 17.2, Firefox 128. A different feature binds
+ * each column, and this engine uses three:
+ *
+ *   mod()            Chrome 125, Safari 15.4, Firefox 118
+ *   cap unit         Chrome 118, Safari 17.2, Firefox 97
+ *   @property        Chrome 85,  Safari 16.4, Firefox 128 (baseline-shim.css)
+ *
+ * So Chrome is held by `mod()`, Safari by the `cap` unit and Firefox by
+ * `@property`. That last one is a floor for a registration that no browser
+ * currently accepts: its initial value is written in `rem`, which is not
+ * computationally independent, so every engine throws the rule away. The next
+ * change in this series removes the registration and gives the engines a
+ * fallback of their own, and the Firefox number drops to 118 with it.
+ *
+ * Layers:
+ *   Every rule below sits in `ds.typography`. Unlayered, these rules outranked
+ *   every layered rule in the page whatever the selectors on either side, and
+ *   tied with an application's own `p` rule on specificity so that load order
+ *   decided the winner one property at a time. In a layer the design system
+ *   loses to the application's own layered CSS, deliberately, and beats the
+ *   layers below it, also deliberately.
+ *
+ *   The rules select elements by name, so they apply to the whole document,
+ *   which is what a design system's typography is for. The `@property`
+ *   registration this file imports stays outside the layer, because a
+ *   registration is not cascaded: the last one in document order wins whatever
+ *   layer it sits in, so a layer would have nothing to order it against.
  */
 
 /* Baseline unit shim (--baseline-height 4px fallback) */
@@ -19,77 +46,79 @@
 /* Semantic token → engine variable mapper */
 @import url("./mapper.css");
 
-/* Reset */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p,
-.code {
-  margin-block: 0;
-}
+@layer ds.typography {
+  /* Reset */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p,
+  .code {
+    margin-block: 0;
+  }
 
-/* Baseline alignment — cap-unit engine
- *
- * Each text element's total height snaps to a multiple of --baseline-height.
- * The engine achieves this by adding padding nudges inside the element box:
- *
- *   padding-block-start = start nudge (pushes the first baseline onto the grid)
- *   padding-block-end   = end nudge   (fills the remainder so total block size
- *                                      is a whole number of baseline units)
- *
- * Both nudges are padding (not margin) so the element's border-box block size
- * participates correctly in flex and grid layouts. margin-block-end is reserved
- * solely for --space-after (editorial element-owned spacing, default 0).
- */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p,
-.code {
-  --computed-line-height: var(
-    --line-height,
-    calc(var(--baseline-height) * var(--line-height-multiplier))
-  );
-  line-height: var(--computed-line-height);
-  font-size: var(--font-size);
+  /* Baseline alignment — cap-unit engine
+   *
+   * Each text element's total height snaps to a multiple of --baseline-height.
+   * The engine achieves this by adding padding nudges inside the element box:
+   *
+   *   padding-block-start = start nudge (pushes the first baseline onto the grid)
+   *   padding-block-end   = end nudge   (fills the remainder so total block size
+   *                                      is a whole number of baseline units)
+   *
+   * Both nudges are padding (not margin) so the element's border-box block size
+   * participates correctly in flex and grid layouts. margin-block-end is reserved
+   * solely for --space-after (editorial element-owned spacing, default 0).
+   */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p,
+  .code {
+    --computed-line-height: var(
+      --line-height,
+      calc(var(--baseline-height) * var(--line-height-multiplier))
+    );
+    line-height: var(--computed-line-height);
+    font-size: var(--font-size);
 
-  --baseline-position: calc((var(--computed-line-height) + 1cap) / 2);
-  --start-nudge: calc(
-    var(--baseline-height) -
-    mod(var(--baseline-position), var(--baseline-height))
-  );
-  --end-nudge: calc(var(--baseline-height) - var(--start-nudge));
-}
+    --baseline-position: calc((var(--computed-line-height) + 1cap) / 2);
+    --start-nudge: calc(
+      var(--baseline-height) -
+      mod(var(--baseline-position), var(--baseline-height))
+    );
+    --end-nudge: calc(var(--baseline-height) - var(--start-nudge));
+  }
 
-/* Block-level baseline nudges.
- *
- * The padding-block nudges snap a BLOCK element's box onto the baseline grid.
- * They must not apply to inline `.code` (e.g. InlineCode's <code> or
- * KeyboardKey's <kbd>) nested in a paragraph — there the parent line already
- * owns the baseline, and adding the nudge double-pads the top, breaking
- * alignment. So bare `.code` is inline-only (typography, no nudges); combine
- * `.p.code` for a standalone monospace code *block* that needs the nudges.
- */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p {
-  /* Nudges as padding — inside the box for flex/grid compatibility */
-  padding-block-start: var(--start-nudge);
-  padding-block-end: var(--end-nudge);
+  /* Block-level baseline nudges.
+   *
+   * The padding-block nudges snap a BLOCK element's box onto the baseline grid.
+   * They must not apply to inline `.code` (e.g. InlineCode's <code> or
+   * KeyboardKey's <kbd>) nested in a paragraph — there the parent line already
+   * owns the baseline, and adding the nudge double-pads the top, breaking
+   * alignment. So bare `.code` is inline-only (typography, no nudges); combine
+   * `.p.code` for a standalone monospace code *block* that needs the nudges.
+   */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p {
+    /* Nudges as padding — inside the box for flex/grid compatibility */
+    padding-block-start: var(--start-nudge);
+    padding-block-end: var(--end-nudge);
 
-  /* Element-owned spacing — only active in .editorial contexts */
-  margin-block-end: calc(var(--space-after, 0) * var(--baseline-height));
+    /* Element-owned spacing — only active in .editorial contexts */
+    margin-block-end: calc(var(--space-after, 0) * var(--baseline-height));
+  }
 }

--- a/packages/styles/typography/src/baseline-cap.css
+++ b/packages/styles/typography/src/baseline-cap.css
@@ -8,19 +8,22 @@
  *   element { --font-size: <length>; --line-height: <length>; }
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  *
- * Browser floor: Chrome 125, Safari 17.2, Firefox 128. A different feature binds
- * each column, and this engine uses three:
+ * Browser floor: Chrome 125, Safari 17.2, Firefox 118. Two features bind it:
  *
  *   mod()            Chrome 125, Safari 15.4, Firefox 118
  *   cap unit         Chrome 118, Safari 17.2, Firefox 97
- *   @property        Chrome 85,  Safari 16.4, Firefox 128 (baseline-shim.css)
  *
- * So Chrome is held by `mod()`, Safari by the `cap` unit and Firefox by
- * `@property`. That last one is a floor for a registration that no browser
- * currently accepts: its initial value is written in `rem`, which is not
- * computationally independent, so every engine throws the rule away. The next
- * change in this series removes the registration and gives the engines a
- * fallback of their own, and the Firefox number drops to 118 with it.
+ * Chrome and Firefox are held by `mod()`, Safari by the `cap` unit. Given the
+ * consumer-declared --baseline-height the contract above asks for, that is the
+ * whole requirement.
+ *
+ * The `@property` registration this file imports does not enter the floor. Its
+ * initial value is written in `rem`, which is not computationally independent,
+ * so every browser throws the rule away: it is invalid everywhere, not
+ * unsupported below some version, and there is no version at which it starts
+ * working. So an application that declares no --baseline-height gets no grid in
+ * any browser, new or old. The next change in this series deletes the
+ * registration and gives every read of the unit a 0.25rem fallback.
  *
  * Layers:
  *   Every rule below sits in `ds.typography`. Unlayered, these rules outranked

--- a/packages/styles/typography/src/baseline-metrics.css
+++ b/packages/styles/typography/src/baseline-metrics.css
@@ -14,20 +14,19 @@
  *   element { --font-size: <length>; --line-height: <length>; }
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
  *
- * Browser floor: Chrome 125, Safari 16.4, Firefox 128. This engine uses two
- * features, and needs no `cap` unit, which is why its Safari number differs
- * from the cap engine's:
+ * Browser floor: Chrome 125, Safari 15.4, Firefox 118, all three set by
+ * `mod()`, the only feature this engine needs. It needs no `cap` unit, which is
+ * why it reaches further than the cap engine in Safari; what it buys beyond that
+ * is not reach but control, since the metrics are numbers you supply rather than
+ * the font the browser happens to use.
  *
- *   mod()            Chrome 125, Safari 15.4, Firefox 118
- *   @property        Chrome 85,  Safari 16.4, Firefox 128 (baseline-shim.css)
- *
- * Chrome is held by `mod()`, Safari and Firefox by `@property` — a registration
- * no browser currently accepts, because its initial value is written in `rem`,
- * which is not computationally independent. The next change in this series
- * removes it and gives the engines a fallback of their own; this engine's floor
- * becomes Chrome 125, Safari 15.4, Firefox 118 with it. What it buys is not
- * reach but control: the metrics are numbers you supply, rather than the font
- * the browser happens to use.
+ * The `@property` registration this file imports does not enter the floor. Its
+ * initial value is written in `rem`, which is not computationally independent,
+ * so every browser throws the rule away: it is invalid everywhere rather than
+ * unsupported below some version. An application that declares no
+ * --baseline-height therefore gets no grid in any browser. The next change in
+ * this series deletes the registration and gives every read of the unit a
+ * 0.25rem fallback.
  *
  * Layers:
  *   Every rule below sits in `ds.typography`. Unlayered, these rules outranked

--- a/packages/styles/typography/src/baseline-metrics.css
+++ b/packages/styles/typography/src/baseline-metrics.css
@@ -1,7 +1,7 @@
 /* @canonical/styles-typography — Classic engine
  *
- * Widest browser support. Requires JS font extraction via `extractFontData`
- * and the following :root variables:
+ * Requires JS font extraction via `extractFontData` and the following :root
+ * variables:
  *   --ascender, --descender, --units-per-em
  *
  * Consumer contract:
@@ -13,6 +13,35 @@
  *   }
  *   element { --font-size: <length>; --line-height: <length>; }
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
+ *
+ * Browser floor: Chrome 125, Safari 16.4, Firefox 128. This engine uses two
+ * features, and needs no `cap` unit, which is why its Safari number differs
+ * from the cap engine's:
+ *
+ *   mod()            Chrome 125, Safari 15.4, Firefox 118
+ *   @property        Chrome 85,  Safari 16.4, Firefox 128 (baseline-shim.css)
+ *
+ * Chrome is held by `mod()`, Safari and Firefox by `@property` — a registration
+ * no browser currently accepts, because its initial value is written in `rem`,
+ * which is not computationally independent. The next change in this series
+ * removes it and gives the engines a fallback of their own; this engine's floor
+ * becomes Chrome 125, Safari 15.4, Firefox 118 with it. What it buys is not
+ * reach but control: the metrics are numbers you supply, rather than the font
+ * the browser happens to use.
+ *
+ * Layers:
+ *   Every rule below sits in `ds.typography`. Unlayered, these rules outranked
+ *   every layered rule in the page whatever the selectors on either side, and
+ *   tied with an application's own `p` rule on specificity so that load order
+ *   decided the winner one property at a time. In a layer the design system
+ *   loses to the application's own layered CSS, deliberately, and beats the
+ *   layers below it, also deliberately.
+ *
+ *   The rules select elements by name, so they apply to the whole document,
+ *   which is what a design system's typography is for. The `@property`
+ *   registration this file imports stays outside the layer, because a
+ *   registration is not cascaded: the last one in document order wins whatever
+ *   layer it sits in, so a layer would have nothing to order it against.
  */
 
 /* Baseline unit shim (--baseline-height 4px fallback) */
@@ -21,88 +50,90 @@
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 
-:root {
-  /* Agnostic values */
-  --natural-line-height: calc((var(--ascender) - var(--descender)));
-  --line-height-scale: calc(
-    var(--natural-line-height) *
-    1rem /
-    var(--units-per-em)
-  );
-  --ascender-scale: calc(var(--ascender) * 1rem / var(--units-per-em));
-}
+@layer ds.typography {
+  :root {
+    /* Agnostic values */
+    --natural-line-height: calc((var(--ascender) - var(--descender)));
+    --line-height-scale: calc(
+      var(--natural-line-height) *
+      1rem /
+      var(--units-per-em)
+    );
+    --ascender-scale: calc(var(--ascender) * 1rem / var(--units-per-em));
+  }
 
-/* Reset */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p,
-.code {
-  margin-block: 0;
-}
+  /* Reset */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p,
+  .code {
+    margin-block: 0;
+  }
 
-/* Baseline alignment — classic engine
- *
- * Both nudges use padding (not margin) so the element's border-box block size
- * participates correctly in flex and grid layouts. margin-block-end is reserved
- * solely for --space-after (editorial element-owned spacing, default 0).
- */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p,
-.code {
-  --computed-line-height: var(
-    --line-height,
-    calc(var(--baseline-height) * var(--line-height-multiplier))
-  );
-  line-height: var(--computed-line-height);
-  font-size: var(--font-size);
+  /* Baseline alignment — classic engine
+   *
+   * Both nudges use padding (not margin) so the element's border-box block size
+   * participates correctly in flex and grid layouts. margin-block-end is reserved
+   * solely for --space-after (editorial element-owned spacing, default 0).
+   */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p,
+  .code {
+    --computed-line-height: var(
+      --line-height,
+      calc(var(--baseline-height) * var(--line-height-multiplier))
+    );
+    line-height: var(--computed-line-height);
+    font-size: var(--font-size);
 
-  --line-height-scale: calc(
-    var(--natural-line-height) *
-    var(--font-size) /
-    var(--units-per-em)
-  );
-  --ascender-scale: calc(
-    var(--ascender) *
-    var(--font-size) /
-    var(--units-per-em)
-  );
+    --line-height-scale: calc(
+      var(--natural-line-height) *
+      var(--font-size) /
+      var(--units-per-em)
+    );
+    --ascender-scale: calc(
+      var(--ascender) *
+      var(--font-size) /
+      var(--units-per-em)
+    );
 
-  --baseline-position: calc(
-    ((var(--computed-line-height) - var(--line-height-scale)) / 2) +
-    var(--ascender-scale)
-  );
-  --start-nudge: calc(
-    var(--baseline-height) -
-    mod(var(--baseline-position), var(--baseline-height))
-  );
-  --end-nudge: calc(var(--baseline-height) - var(--start-nudge));
-}
+    --baseline-position: calc(
+      ((var(--computed-line-height) - var(--line-height-scale)) / 2) +
+      var(--ascender-scale)
+    );
+    --start-nudge: calc(
+      var(--baseline-height) -
+      mod(var(--baseline-position), var(--baseline-height))
+    );
+    --end-nudge: calc(var(--baseline-height) - var(--start-nudge));
+  }
 
-/* Block-level baseline nudges only — bare inline `.code` is excluded so it
- * does not double-pad inside a paragraph. Combine `.p.code` for a code block. */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p {
-  /* Nudges as padding — inside the box for flex/grid compatibility */
-  padding-block-start: var(--start-nudge);
-  padding-block-end: var(--end-nudge);
+  /* Block-level baseline nudges only — bare inline `.code` is excluded so it
+   * does not double-pad inside a paragraph. Combine `.p.code` for a code block. */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p {
+    /* Nudges as padding — inside the box for flex/grid compatibility */
+    padding-block-start: var(--start-nudge);
+    padding-block-end: var(--end-nudge);
 
-  /* Element-owned spacing — only active in .editorial contexts */
-  margin-block-end: calc(var(--space-after, 0) * var(--baseline-height));
+    /* Element-owned spacing — only active in .editorial contexts */
+    margin-block-end: calc(var(--space-after, 0) * var(--baseline-height));
+  }
 }

--- a/packages/styles/typography/src/baseline-trim.css
+++ b/packages/styles/typography/src/baseline-trim.css
@@ -15,11 +15,17 @@
  *   mod()            Chrome 125, Safari 15.4, Firefox 118
  *   @property        Chrome 85,  Safari 16.4, Firefox 128 (baseline-shim.css)
  *
- * `text-box-trim` binds every column. Below it the trim is skipped, the element
- * keeps its default half-leading and the nudge still applies, so the engine
- * degrades rather than failing; on that reading its floor is the one the other
- * two engines have. What a browser below 133 / 18.2 / 154 loses is the tighter
- * content box, not the grid.
+ * `text-box-trim` binds every column, and below it this engine does not hold
+ * the grid. The trim is skipped, the element gets its half-leading back, and the
+ * nudge that survives — `mod(calc(-1 * 1cap), unit)` — was computed for a
+ * trimmed box: it never reads the line height, so it cannot compensate for
+ * leading it did not expect. Measured in Chromium with a 16px serif on a 24px
+ * line, the first baseline moves 6.516px when the trim is ignored, which is 1.63
+ * units on a 4px grid, 0.81 on an 8px grid and 0.54 on a 12px grid — a fraction
+ * of a unit every time. The element's outer height stays a whole number of
+ * units, so blocks still stack on the grid; the text inside them does not sit on
+ * it. Use the cap engine below the floor: its nudge is computed from the
+ * untrimmed line box, which is what such a browser has.
  *
  * Layers:
  *   Every rule below sits in `ds.typography`. Unlayered, these rules outranked

--- a/packages/styles/typography/src/baseline-trim.css
+++ b/packages/styles/typography/src/baseline-trim.css
@@ -1,6 +1,5 @@
 /* @canonical/styles-typography — Text-trim engine
  *
- * Most modern, narrowest browser support: Chrome 133+, Safari 18.2+.
  * Uses `text-box: trim-both cap alphabetic` for intrinsic baseline snapping.
  * No JS font extraction required.
  *
@@ -8,6 +7,33 @@
  *   :root { --baseline-height: <length>; }
  *   element { --font-size: <length>; --line-height: <length>; }
  *   (fallback: --line-height-multiplier: <number> if --line-height is unset)
+ *
+ * Browser floor: Chrome 133, Safari 18.2, Firefox 154. This engine uses three
+ * features:
+ *
+ *   text-box-trim    Chrome 133, Safari 18.2, Firefox 154
+ *   mod()            Chrome 125, Safari 15.4, Firefox 118
+ *   @property        Chrome 85,  Safari 16.4, Firefox 128 (baseline-shim.css)
+ *
+ * `text-box-trim` binds every column. Below it the trim is skipped, the element
+ * keeps its default half-leading and the nudge still applies, so the engine
+ * degrades rather than failing; on that reading its floor is the one the other
+ * two engines have. What a browser below 133 / 18.2 / 154 loses is the tighter
+ * content box, not the grid.
+ *
+ * Layers:
+ *   Every rule below sits in `ds.typography`. Unlayered, these rules outranked
+ *   every layered rule in the page whatever the selectors on either side, and
+ *   tied with an application's own `p` rule on specificity so that load order
+ *   decided the winner one property at a time. In a layer the design system
+ *   loses to the application's own layered CSS, deliberately, and beats the
+ *   layers below it, also deliberately.
+ *
+ *   The rules select elements by name, so they apply to the whole document,
+ *   which is what a design system's typography is for. The `@property`
+ *   registration this file imports stays outside the layer, because a
+ *   registration is not cascaded: the last one in document order wins whatever
+ *   layer it sits in, so a layer would have nothing to order it against.
  */
 
 /* Baseline unit shim (--baseline-height 4px fallback) */
@@ -16,61 +42,63 @@
 /* Typography scale tokens from design-tokens */
 @import url("@canonical/design-tokens/dist/modifiers.typography.css");
 
-/* Reset */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p,
-.code {
-  margin-block: 0;
-}
+@layer ds.typography {
+  /* Reset */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p,
+  .code {
+    margin-block: 0;
+  }
 
-/* Baseline alignment — text-trim engine
- *
- * Both nudges use padding (not margin) so the element's border-box block size
- * participates correctly in flex and grid layouts. margin-block-end is reserved
- * solely for --space-after (editorial element-owned spacing, default 0).
- */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p,
-.code {
-  --computed-line-height: var(
-    --line-height,
-    calc(var(--baseline-height) * var(--line-height-multiplier))
-  );
-  line-height: var(--computed-line-height);
-  font-size: var(--font-size);
-}
+  /* Baseline alignment — text-trim engine
+   *
+   * Both nudges use padding (not margin) so the element's border-box block size
+   * participates correctly in flex and grid layouts. margin-block-end is reserved
+   * solely for --space-after (editorial element-owned spacing, default 0).
+   */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p,
+  .code {
+    --computed-line-height: var(
+      --line-height,
+      calc(var(--baseline-height) * var(--line-height-multiplier))
+    );
+    line-height: var(--computed-line-height);
+    font-size: var(--font-size);
+  }
 
-/* Block-level baseline trimming/nudges only — bare inline `.code` is excluded
- * so it does not double-pad inside a paragraph. Combine `.p.code` for a block. */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-.p {
-  text-box: trim-both cap alphabetic;
+  /* Block-level baseline trimming/nudges only — bare inline `.code` is excluded
+   * so it does not double-pad inside a paragraph. Combine `.p.code` for a block. */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  .p {
+    text-box: trim-both cap alphabetic;
 
-  /* Nudges as padding — inside the box for flex/grid compatibility */
-  padding-block-start: mod(calc(-1 * 1cap), var(--baseline-height));
-  padding-block-end: calc(
-    var(--baseline-height) -
-    mod(calc(-1 * 1cap), var(--baseline-height))
-  );
+    /* Nudges as padding — inside the box for flex/grid compatibility */
+    padding-block-start: mod(calc(-1 * 1cap), var(--baseline-height));
+    padding-block-end: calc(
+      var(--baseline-height) -
+      mod(calc(-1 * 1cap), var(--baseline-height))
+    );
 
-  /* Element-owned spacing — only active in .editorial contexts */
-  margin-block-end: calc(var(--space-after, 0) * var(--baseline-height));
+    /* Element-owned spacing — only active in .editorial contexts */
+    margin-block-end: calc(var(--space-after, 0) * var(--baseline-height));
+  }
 }

--- a/packages/styles/typography/src/mapper.css
+++ b/packages/styles/typography/src/mapper.css
@@ -31,13 +31,17 @@
  *   Set --heading-padding-inline on a layout context to activate.
  *
  * Layers:
- *   Everything here used to sit in no cascade layer at all, at the specificity
- *   of a bare element selector. A rule in no layer outranks a rule in any layer,
- *   whatever the selectors on either side, and two unlayered rules of equal
- *   specificity are settled by whichever stylesheet the bundler emitted second.
- *   So an application's own `p` rule competed with this one by load order and
- *   won about half the time, one property at a time. In a layer it loses or wins
- *   for a stated reason.
+ *   Everything here used to sit in no cascade layer at all, and a rule in no
+ *   layer outranks a rule in any layer whatever the selectors on either side, so
+ *   nothing an application wrote in a layer could beat any of it.
+ *
+ *   Among themselves the rules differ. The element selectors — `body`, `h1`–`h6`
+ *   and `p` — sit at specificity (0,0,1), so an application's own `p` rule tied
+ *   with this one and the bundler's output order decided the winner, one property
+ *   at a time. `.p`, `.code` and `.editorial` are classes, `:root` is a
+ *   pseudo-class, and the nested editorial rules are more specific still, so
+ *   those beat an application's element rules outright. In a layer, all of them
+ *   lose or win for a stated reason instead.
  *
  *   The shim block below is custom properties and nothing else, and a custom
  *   property does nothing where it is declared — only where a rule reads it — so

--- a/packages/styles/typography/src/mapper.css
+++ b/packages/styles/typography/src/mapper.css
@@ -29,6 +29,30 @@
  *   Headings receive --heading-padding-inline (default: 0) so they can
  *   optionally align with padded blocks (cards, inputs, containers).
  *   Set --heading-padding-inline on a layout context to activate.
+ *
+ * Layers:
+ *   Everything here used to sit in no cascade layer at all, at the specificity
+ *   of a bare element selector. A rule in no layer outranks a rule in any layer,
+ *   whatever the selectors on either side, and two unlayered rules of equal
+ *   specificity are settled by whichever stylesheet the bundler emitted second.
+ *   So an application's own `p` rule competed with this one by load order and
+ *   won about half the time, one property at a time. In a layer it loses or wins
+ *   for a stated reason.
+ *
+ *   The shim block below is custom properties and nothing else, and a custom
+ *   property does nothing where it is declared — only where a rule reads it — so
+ *   it sits in `ds.tokens`, beside the other primitive values @canonical/styles
+ *   ships, which is where a maintainer looking for a token name will look.
+ *
+ *   Everything after it selects elements, and sits in `ds.typography`. That
+ *   layer is above `ds.reset`, because this is a more specific statement about
+ *   text than the reset's baseline, and below `ds.modifiers`, so the typographic
+ *   scale can retune what the mapper produces; a component stylesheet, higher
+ *   still, is always the final word on its own text.
+ *
+ *   These rules select elements by name — `body`, `h1`–`h6`, `p` — so they
+ *   apply to the whole document. That is what a design system's typography is
+ *   for.
  */
 
 /* ── TEMP FIX: design-tokens naming mismatch ──────────────────────
@@ -36,264 +60,268 @@
  * sets.primitive.css defines camelCase tokens. This shim bridges the
  * gap until the tokens package is fixed upstream.
  */
-:root {
-  /* ── Font family shims ────────────────────────────────────────── */
-  --typography-font-family-default: var(--typography-fontFamily-default);
-  --typography-font-family-code: var(--typography-fontFamily-code);
-  --typography-font-family-sans-serif: var(--typography-fontFamily-sansSerif);
-  --typography-font-family-monospace: var(--typography-fontFamily-monospace);
+@layer ds.tokens {
+  :root {
+    /* ── Font family shims ────────────────────────────────────────── */
+    --typography-font-family-default: var(--typography-fontFamily-default);
+    --typography-font-family-code: var(--typography-fontFamily-code);
+    --typography-font-family-sans-serif: var(--typography-fontFamily-sansSerif);
+    --typography-font-family-monospace: var(--typography-fontFamily-monospace);
 
-  /* ── Font weight shims ────────────────────────────────────────── */
-  --typography-weight-semi-bold: var(--typography-weight-semiBold);
-  --typography-weight-extra-bold: var(--typography-weight-extraBold);
-  --typography-weight-extra-light: var(--typography-weight-extraLight);
+    /* ── Font weight shims ────────────────────────────────────────── */
+    --typography-weight-semi-bold: var(--typography-weight-semiBold);
+    --typography-weight-extra-bold: var(--typography-weight-extraBold);
+    --typography-weight-extra-light: var(--typography-weight-extraLight);
 
-  /* ── Font size shims ──────────────────────────────────────────── */
-  --dimension-size-font-size-250: var(--dimension-size-fontSize-250);
-  --dimension-size-font-size-300: var(--dimension-size-fontSize-300);
-  --dimension-size-font-size-350: var(--dimension-size-fontSize-350);
-  --dimension-size-font-size-400: var(--dimension-size-fontSize-400);
-  --dimension-size-font-size-500: var(--dimension-size-fontSize-500);
-  --dimension-size-font-size-600: var(--dimension-size-fontSize-600);
-  --dimension-size-font-size-700: var(--dimension-size-fontSize-700);
+    /* ── Font size shims ──────────────────────────────────────────── */
+    --dimension-size-font-size-250: var(--dimension-size-fontSize-250);
+    --dimension-size-font-size-300: var(--dimension-size-fontSize-300);
+    --dimension-size-font-size-350: var(--dimension-size-fontSize-350);
+    --dimension-size-font-size-400: var(--dimension-size-fontSize-400);
+    --dimension-size-font-size-500: var(--dimension-size-fontSize-500);
+    --dimension-size-font-size-600: var(--dimension-size-fontSize-600);
+    --dimension-size-font-size-700: var(--dimension-size-fontSize-700);
 
-  /* ── Letter spacing shims ─────────────────────────────────────── */
-  --dimension-letter-spacing-default: var(--dimension-letterSpacing-default);
-  --dimension-letter-spacing-wide: var(--dimension-letterSpacing-wide);
+    /* ── Letter spacing shims ─────────────────────────────────────── */
+    --dimension-letter-spacing-default: var(--dimension-letterSpacing-default);
+    --dimension-letter-spacing-wide: var(--dimension-letterSpacing-wide);
 
-  /* ── Line height shims ────────────────────────────────────────── *
-   * number.tokens.json defines these as $type:"number" but the
-   * terrazzo plugin does not emit them in sets.primitive.css.
-   * Hardcoded here until the build pipeline includes number tokens.
-   *
-   * These are unitless RATIOS (font-size × ratio = target line-height). The
-   * engine then does round(up, font-size × ratio, --baseline-height), which
-   * snaps the result onto the grid. So the 4px baseline needs NO change here:
-   * a 1rem × 1.5 = 24px line snaps to 24px at both 8px (3 units) and 4px
-   * (6 units) — the px is identical, only the unit COUNT differs. (An earlier
-   * pass wrongly doubled these, which doubled the actual line-height and drifted
-   * from the controls; reverted to the design-token ratios.) */
-  --number-line-height-250: 1.3333;
-  --number-line-height-300: 1.4286;
-  --number-line-height-350: 1.5;
-  --number-line-height-400: 1.3333;
-  --number-line-height-500: 1.3333;
-  --number-line-height-600: 1.25;
-  --number-line-height-700: 1.1429;
+    /* ── Line height shims ────────────────────────────────────────── *
+     * number.tokens.json defines these as $type:"number" but the
+     * terrazzo plugin does not emit them in sets.primitive.css.
+     * Hardcoded here until the build pipeline includes number tokens.
+     *
+     * These are unitless RATIOS (font-size × ratio = target line-height). The
+     * engine then does round(up, font-size × ratio, --baseline-height), which
+     * snaps the result onto the grid. So the 4px baseline needs NO change here:
+     * a 1rem × 1.5 = 24px line snaps to 24px at both 8px (3 units) and 4px
+     * (6 units) — the px is identical, only the unit COUNT differs. (An earlier
+     * pass wrongly doubled these, which doubled the actual line-height and drifted
+     * from the controls; reverted to the design-token ratios.) */
+    --number-line-height-250: 1.3333;
+    --number-line-height-300: 1.4286;
+    --number-line-height-350: 1.5;
+    --number-line-height-400: 1.3333;
+    --number-line-height-500: 1.3333;
+    --number-line-height-600: 1.25;
+    --number-line-height-700: 1.1429;
+  }
 }
 
-/* Base font — inherited by all elements unless overridden */
-body {
-  font-family: var(--typography-text-primary-font-family);
-}
+@layer ds.typography {
+  /* Base font — inherited by all elements unless overridden */
+  body {
+    font-family: var(--typography-text-primary-font-family);
+  }
 
-/* ── Headings ── */
+  /* ── Headings ── */
 
-h1 {
-  --font-size: var(--typography-heading-1-font-size);
-  --font-weight: var(--typography-heading-1-font-weight);
-  --line-height: var(
-    --typography-heading-1-line-height-dimension,
-    round(
-      up,
-      calc(
-        var(--typography-heading-1-font-size) *
-        var(--typography-heading-1-line-height)
-      ),
-      var(--baseline-height)
-    )
-  );
-  --space-after: 0;
-  font-family: var(--typography-heading-1-font-family);
-  font-weight: var(--font-weight);
-  letter-spacing: var(--typography-heading-1-letter-spacing);
-  padding-inline: var(--heading-padding-inline, 0);
-}
+  h1 {
+    --font-size: var(--typography-heading-1-font-size);
+    --font-weight: var(--typography-heading-1-font-weight);
+    --line-height: var(
+      --typography-heading-1-line-height-dimension,
+      round(
+        up,
+        calc(
+          var(--typography-heading-1-font-size) *
+          var(--typography-heading-1-line-height)
+        ),
+        var(--baseline-height)
+      )
+    );
+    --space-after: 0;
+    font-family: var(--typography-heading-1-font-family);
+    font-weight: var(--font-weight);
+    letter-spacing: var(--typography-heading-1-letter-spacing);
+    padding-inline: var(--heading-padding-inline, 0);
+  }
 
-h2 {
-  --font-size: var(--typography-heading-2-font-size);
-  --font-weight: var(--typography-heading-2-font-weight);
-  --line-height: var(
-    --typography-heading-2-line-height-dimension,
-    round(
-      up,
-      calc(
-        var(--typography-heading-2-font-size) *
-        var(--typography-heading-2-line-height)
-      ),
-      var(--baseline-height)
-    )
-  );
-  --space-after: 0;
-  font-family: var(--typography-heading-2-font-family);
-  font-weight: var(--font-weight);
-  letter-spacing: var(--typography-heading-2-letter-spacing);
-  padding-inline: var(--heading-padding-inline, 0);
-}
-
-h3 {
-  --font-size: var(--typography-heading-3-font-size);
-  --font-weight: var(--typography-heading-3-font-weight);
-  --line-height: var(
-    --typography-heading-3-line-height-dimension,
-    round(
-      up,
-      calc(
-        var(--typography-heading-3-font-size) *
-        var(--typography-heading-3-line-height)
-      ),
-      var(--baseline-height)
-    )
-  );
-  --space-after: 0;
-  font-family: var(--typography-heading-3-font-family);
-  font-weight: var(--font-weight);
-  letter-spacing: var(--typography-heading-3-letter-spacing);
-  padding-inline: var(--heading-padding-inline, 0);
-}
-
-h4 {
-  --font-size: var(--typography-heading-4-font-size);
-  --font-weight: var(--typography-heading-4-font-weight);
-  --line-height: var(
-    --typography-heading-4-line-height-dimension,
-    round(
-      up,
-      calc(
-        var(--typography-heading-4-font-size) *
-        var(--typography-heading-4-line-height)
-      ),
-      var(--baseline-height)
-    )
-  );
-  --space-after: 0;
-  font-family: var(--typography-heading-4-font-family);
-  font-weight: var(--font-weight);
-  letter-spacing: var(--typography-heading-4-letter-spacing);
-  padding-inline: var(--heading-padding-inline, 0);
-}
-
-h5 {
-  --font-size: var(--typography-heading-5-font-size);
-  --font-weight: var(--typography-heading-5-font-weight);
-  --line-height: var(
-    --typography-heading-5-line-height-dimension,
-    round(
-      up,
-      calc(
-        var(--typography-heading-5-font-size) *
-        var(--typography-heading-5-line-height)
-      ),
-      var(--baseline-height)
-    )
-  );
-  --space-after: 0;
-  font-family: var(--typography-heading-5-font-family);
-  font-weight: var(--font-weight);
-  letter-spacing: var(--typography-heading-5-letter-spacing);
-  /* Heading 5 is styled as small-caps with old-style figures (design review):
-     the design tokens carry these under `--typography-heading-5-font-variant(-numeric)`
-     — small-caps in :root/.app/.site, normal in docs — so the tier difference
-     flows automatically. `normal` fallbacks keep h5 unchanged if a theme ships
-     without the tokens. */
-  font-variant: var(--typography-heading-5-font-variant, normal);
-  font-variant-numeric: var(
-    --typography-heading-5-font-variant-numeric,
-    normal
-  );
-  padding-inline: var(--heading-padding-inline, 0);
-}
-
-h6 {
-  --font-size: var(--typography-heading-6-font-size);
-  --font-weight: var(--typography-heading-6-font-weight);
-  --line-height: var(
-    --typography-heading-6-line-height-dimension,
-    round(
-      up,
-      calc(
-        var(--typography-heading-6-font-size) *
-        var(--typography-heading-6-line-height)
-      ),
-      var(--baseline-height)
-    )
-  );
-  --space-after: 0;
-  font-family: var(--typography-heading-6-font-family);
-  font-weight: var(--font-weight);
-  letter-spacing: var(--typography-heading-6-letter-spacing);
-  padding-inline: var(--heading-padding-inline, 0);
-}
-
-/* ── Text ── */
-
-p,
-.p {
-  --font-size: var(--typography-text-primary-font-size);
-  --font-weight: var(--typography-text-primary-font-weight);
-  --line-height: var(
-    --typography-text-primary-line-height-dimension,
-    round(
-      up,
-      calc(
-        var(--typography-text-primary-font-size) *
-        var(--typography-text-primary-line-height)
-      ),
-      var(--baseline-height)
-    )
-  );
-  --space-after: 0;
-  font-family: var(--typography-text-primary-font-family);
-  font-weight: var(--font-weight);
-  letter-spacing: var(--typography-text-primary-letter-spacing);
-}
-
-/* ── Code ── */
-
-/* Monospace counterpart of `.p`, mapped to the `text-primary-code` typography
-   tier (monospace family). Class-only — consumers opt in with `class="code"`
-   (e.g. InlineCode's <code>, KeyboardKey's <kbd>); bare <code>/<kbd> are not
-   targeted.
-
-   `.code` alone is INLINE: it applies the monospace typography but NOT the
-   block-level baseline padding nudges (those live on `.p`/headings only), so an
-   inline <code> inside a paragraph inherits the parent line's baseline instead
-   of double-padding its top. For a standalone monospace code *block* that must
-   snap to the grid, combine both classes: `class="p code"` gives `.p`'s block
-   nudges plus `.code`'s monospace mapping. */
-.code {
-  --font-size: var(--typography-text-primary-code-font-size);
-  --font-weight: var(--typography-text-primary-code-font-weight);
-  --line-height: var(
-    --typography-text-primary-code-line-height-dimension,
-    round(
-      up,
-      calc(
-        var(--typography-text-primary-code-font-size) *
-        var(--typography-text-primary-code-line-height)
-      ),
-      var(--baseline-height)
-    )
-  );
-  --space-after: 0;
-  font-family: var(--typography-text-primary-code-font-family);
-  font-weight: var(--font-weight);
-  letter-spacing: var(--typography-text-primary-code-letter-spacing);
-}
-
-.editorial {
-  h1,
   h2 {
-    --space-after: 2;
+    --font-size: var(--typography-heading-2-font-size);
+    --font-weight: var(--typography-heading-2-font-weight);
+    --line-height: var(
+      --typography-heading-2-line-height-dimension,
+      round(
+        up,
+        calc(
+          var(--typography-heading-2-font-size) *
+          var(--typography-heading-2-line-height)
+        ),
+        var(--baseline-height)
+      )
+    );
+    --space-after: 0;
+    font-family: var(--typography-heading-2-font-family);
+    font-weight: var(--font-weight);
+    letter-spacing: var(--typography-heading-2-letter-spacing);
+    padding-inline: var(--heading-padding-inline, 0);
   }
-  h3,
-  h4,
-  h5,
+
+  h3 {
+    --font-size: var(--typography-heading-3-font-size);
+    --font-weight: var(--typography-heading-3-font-weight);
+    --line-height: var(
+      --typography-heading-3-line-height-dimension,
+      round(
+        up,
+        calc(
+          var(--typography-heading-3-font-size) *
+          var(--typography-heading-3-line-height)
+        ),
+        var(--baseline-height)
+      )
+    );
+    --space-after: 0;
+    font-family: var(--typography-heading-3-font-family);
+    font-weight: var(--font-weight);
+    letter-spacing: var(--typography-heading-3-letter-spacing);
+    padding-inline: var(--heading-padding-inline, 0);
+  }
+
+  h4 {
+    --font-size: var(--typography-heading-4-font-size);
+    --font-weight: var(--typography-heading-4-font-weight);
+    --line-height: var(
+      --typography-heading-4-line-height-dimension,
+      round(
+        up,
+        calc(
+          var(--typography-heading-4-font-size) *
+          var(--typography-heading-4-line-height)
+        ),
+        var(--baseline-height)
+      )
+    );
+    --space-after: 0;
+    font-family: var(--typography-heading-4-font-family);
+    font-weight: var(--font-weight);
+    letter-spacing: var(--typography-heading-4-letter-spacing);
+    padding-inline: var(--heading-padding-inline, 0);
+  }
+
+  h5 {
+    --font-size: var(--typography-heading-5-font-size);
+    --font-weight: var(--typography-heading-5-font-weight);
+    --line-height: var(
+      --typography-heading-5-line-height-dimension,
+      round(
+        up,
+        calc(
+          var(--typography-heading-5-font-size) *
+          var(--typography-heading-5-line-height)
+        ),
+        var(--baseline-height)
+      )
+    );
+    --space-after: 0;
+    font-family: var(--typography-heading-5-font-family);
+    font-weight: var(--font-weight);
+    letter-spacing: var(--typography-heading-5-letter-spacing);
+    /* Heading 5 is styled as small-caps with old-style figures (design review):
+       the design tokens carry these under `--typography-heading-5-font-variant(-numeric)`
+       — small-caps in :root/.app/.site, normal in docs — so the tier difference
+       flows automatically. `normal` fallbacks keep h5 unchanged if a theme ships
+       without the tokens. */
+    font-variant: var(--typography-heading-5-font-variant, normal);
+    font-variant-numeric: var(
+      --typography-heading-5-font-variant-numeric,
+      normal
+    );
+    padding-inline: var(--heading-padding-inline, 0);
+  }
+
   h6 {
-    --space-after: 1;
+    --font-size: var(--typography-heading-6-font-size);
+    --font-weight: var(--typography-heading-6-font-weight);
+    --line-height: var(
+      --typography-heading-6-line-height-dimension,
+      round(
+        up,
+        calc(
+          var(--typography-heading-6-font-size) *
+          var(--typography-heading-6-line-height)
+        ),
+        var(--baseline-height)
+      )
+    );
+    --space-after: 0;
+    font-family: var(--typography-heading-6-font-family);
+    font-weight: var(--font-weight);
+    letter-spacing: var(--typography-heading-6-letter-spacing);
+    padding-inline: var(--heading-padding-inline, 0);
   }
+
+  /* ── Text ── */
+
   p,
   .p {
-    --space-after: 1;
+    --font-size: var(--typography-text-primary-font-size);
+    --font-weight: var(--typography-text-primary-font-weight);
+    --line-height: var(
+      --typography-text-primary-line-height-dimension,
+      round(
+        up,
+        calc(
+          var(--typography-text-primary-font-size) *
+          var(--typography-text-primary-line-height)
+        ),
+        var(--baseline-height)
+      )
+    );
+    --space-after: 0;
+    font-family: var(--typography-text-primary-font-family);
+    font-weight: var(--font-weight);
+    letter-spacing: var(--typography-text-primary-letter-spacing);
+  }
+
+  /* ── Code ── */
+
+  /* Monospace counterpart of `.p`, mapped to the `text-primary-code` typography
+     tier (monospace family). Class-only — consumers opt in with `class="code"`
+     (e.g. InlineCode's <code>, KeyboardKey's <kbd>); bare <code>/<kbd> are not
+     targeted.
+
+     `.code` alone is INLINE: it applies the monospace typography but NOT the
+     block-level baseline padding nudges (those live on `.p`/headings only), so an
+     inline <code> inside a paragraph inherits the parent line's baseline instead
+     of double-padding its top. For a standalone monospace code *block* that must
+     snap to the grid, combine both classes: `class="p code"` gives `.p`'s block
+     nudges plus `.code`'s monospace mapping. */
+  .code {
+    --font-size: var(--typography-text-primary-code-font-size);
+    --font-weight: var(--typography-text-primary-code-font-weight);
+    --line-height: var(
+      --typography-text-primary-code-line-height-dimension,
+      round(
+        up,
+        calc(
+          var(--typography-text-primary-code-font-size) *
+          var(--typography-text-primary-code-line-height)
+        ),
+        var(--baseline-height)
+      )
+    );
+    --space-after: 0;
+    font-family: var(--typography-text-primary-code-font-family);
+    font-weight: var(--font-weight);
+    letter-spacing: var(--typography-text-primary-code-letter-spacing);
+  }
+
+  .editorial {
+    h1,
+    h2 {
+      --space-after: 2;
+    }
+    h3,
+    h4,
+    h5,
+    h6 {
+      --space-after: 1;
+    }
+    p,
+    .p {
+      --space-after: 1;
+    }
   }
 }


### PR DESCRIPTION
## Done

This package shipped every one of its rules in no cascade layer at all, at the specificity of a bare
element selector: `body`, `h1`–`h6`, `p`, `.p`, `.code`, `.editorial`. A rule in no layer outranks a
rule in any layer, whatever the selectors on either side, and two unlayered rules of equal specificity
are settled by whichever stylesheet the bundler emitted second. So an application's own `p` rule tied
with this one and won about half the time, one property at a time.

This puts those rules in the layers `@canonical/styles` has always declared for them. Nothing else
changes — the same selectors, the same declarations, the same order, the same imports.

- **The mapper's naming shims go into `ds.tokens`.** They are custom properties and nothing else, and a
  custom property does nothing where it is declared, only where a rule reads it, so they belong beside
  the other primitive values.
- **Every element rule of the mapper and of all three engines goes into `ds.typography`**, above the
  reset because it is a more specific statement about text, and below the modifiers so the typographic
  scale can retune it.
- **The `@property` registration stays outside every layer.** A registration is not cascaded: the last
  one in document order wins whatever layer it sits in, so a layer would have nothing to order it
  against.

The rules still select elements by name, so they still apply to the whole document. That is what a
design system's typography is for, and keeping them off a page that also runs another CSS framework is
that framework's adapter's job.

### The browser floors, corrected

All three engine headers were wrong, so they were rewritten from the features each file uses while
they were open. The cap engine advertised Chrome 113 and Firefox 113, which is where the `cap` unit
landed rather than where the engine runs; the metrics engine called itself the widest-support one,
which it stopped being when `mod()` became a requirement.

| Feature | Chrome | Safari | Firefox |
| --- | --- | --- | --- |
| `mod()`, `round()` | 125 | 15.4 | 118 |
| `@property` | 85 | 16.4 | 128 |
| `cap` unit | 118 | 17.2 | 97 |
| `text-box-trim` | 133 | 18.2 | 154 |

| Engine | Chrome | Safari | Firefox | What binds |
| --- | --- | --- | --- | --- |
| `baseline-cap.css` | 125 | 17.2 | 128 | `mod()`, then the `cap` unit, then `@property` |
| `baseline-metrics.css` | 125 | 16.4 | 128 | `mod()`, then `@property` |
| `baseline-trim.css` | 133 | 18.2 | 154 | `text-box-trim` throughout |

**Two of those numbers rest on a registration no browser accepts.** `baseline-shim.css` writes the
initial value of `--baseline-height` in `rem`, which is not computationally independent, so Chromium
and Firefox alike throw the whole rule away and the 4px fallback it promises does not exist. The
headers and the README say so, and the next pull request in this stack removes the registration and
gives the engines a fallback of their own, which drops those numbers to Chrome 125, Safari 15.4,
Firefox 118.

## QA

**Checks run**

- `bun run check` in `packages/styles/typography`: green (biome over 19 files, then `tsc`).
- `bun run test` in `packages/styles/typography`: green. The package gains the `test` script the
  repository asks every package for; it has no tests, so the script passes with none.
- `bun run check` in `packages/styles/main`: green — nothing in that package changes here.
- `bun run check:ranges` at the root: green, 62 workspace packages.

**What a reader should check by eye:** the diff is a header rewrite and two `@layer` wrappers. No
selector, declaration or import moved, and `src/index.css`, `src/baseline-shim.css` and the scripts are
untouched.

### This stack

1. **this pull request** — the layering
2. `fix(styles-typography): the baseline unit works undeclared, in rem or px` — removes the dead
   registration
3. `refactor(styles-typography)!: tokens and elements as separate files`
4. `feat(styles)!: tokens, elements and layout entries`

### PR readiness check

- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, using one of the allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`, `revert`.
  - The matching type label is applied automatically from the title — there is no type label to add by hand.
  - Breaking changes are marked with `!` in the title (e.g. `feat(router)!: …`), which adds the `breaking` label.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`. — this adds the missing `test` script here.
  - [x] Packages with build steps: `build` to build the package for development or distribution, `build:all` to build **all** artifacts. — not applicable, this package has no build step.
- [x] If this PR introduces a **new package**: not applicable, no new package.
- [ ] If this PR does not require visual testing, add the `Chromatic: skip` label to skip Chromatic. — visual review is wanted, although nothing an element computes changes.

## Screenshots

Not applicable; the change is a stylesheet's cascade structure.

https://claude.ai/code/session_01MS2nYHcgSsxHVNGsB4gYBp
