### PR TITLE
fix(ds-global)!: a menu separator is presentational, not disabled

### DIFF
--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/types.ts
@@ -36,8 +36,8 @@ export type MenuItem = _DistributiveOmit<Item, "items"> & {
 
 /**
  * A non-interactive divider between menu entries, rendered as a horizontal
- * rule. It is fed to the navigation tree as a disabled, label-less node, so
- * the shared navigation machinery (arrow keys, Home/End, type-ahead, roving
+ * rule. It is fed to the navigation tree as a PRESENTATIONAL, label-less node,
+ * so the shared navigation machinery (arrow keys, Home/End, type-ahead, roving
  * focus) skips it without any separator awareness of its own.
  */
 export interface MenuSeparator {
@@ -50,11 +50,15 @@ export interface MenuSeparator {
    */
   key: string;
   /**
-   * Set by {@link useContextualMenu} before the tree is annotated — disabled
-   * is what makes the navigation machinery skip the separator. Consumers
-   * never set it.
+   * Set by {@link useContextualMenu} before the tree is annotated — being
+   * presentational is what makes the navigation machinery skip the separator.
+   * Consumers never set it.
+   *
+   * Deliberately not `disabled`: that would claim this is a menu item the
+   * user may not choose, and a renderer would be entitled to announce it
+   * `aria-disabled`. A separator is not an item.
    */
-  disabled?: true;
+  presentational?: true;
 }
 
 /**

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.tests.tsx
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.tests.tsx
@@ -83,18 +83,34 @@ describe("useContextualMenu", () => {
     expect(result.current.highlightedItems.at(-2)?.key).toBe("menu");
   });
 
-  it("feeds separators to the tree as disabled nodes", () => {
-    // The tree machinery skips DISABLED nodes — that, plus the key every
+  it("feeds separators to the tree as presentational nodes", () => {
+    // The tree machinery skips PRESENTATIONAL nodes — that, plus the key every
     // navigation item carries, is the entire separator contract. The
     // discriminant survives annotation for the render layer.
     const { result } = renderHook(() => useContextualMenu({ root: menu }));
 
     const separator = result.current.index["before-b1"];
     expect(separator).toBeDefined();
-    expect(separator?.disabled).toBe(true);
+    expect(separator?.presentational).toBe(true);
     expect(separator && "type" in separator ? separator.type : undefined).toBe(
       "separator",
     );
+  });
+
+  it("does not mark a separator disabled", () => {
+    // The regression this guards: a separator used to be fed in as
+    // `disabled: true` purely to make the tree skip it. `disabled` means the
+    // user may not choose an item that IS one, and a renderer may draw it
+    // greyed and announce it `aria-disabled` on that basis. A separator must
+    // not answer yes to that question.
+    const { result } = renderHook(() => useContextualMenu({ root: menu }));
+
+    const separator = result.current.index["before-b1"];
+    expect(separator).toBeDefined();
+    // Not merely unset: `MenuSeparator` has no `disabled` field, so the old
+    // overload is now unrepresentable and reintroducing it fails to compile.
+    // This asserts the runtime object agrees with the type.
+    expect(separator && "disabled" in separator).toBe(false);
   });
 
   it("passes positioning props through to useWindowFitment", () => {
@@ -107,7 +123,7 @@ describe("useContextualMenu", () => {
   });
 
   it("skips a separator on ArrowDown through the composed hook", () => {
-    // The separator sits between "a2" and "b1"; the tree's disabled-skipping
+    // The separator sits between "a2" and "b1"; the tree's interactive-only
     // sibling walk must step straight over it, with no separator logic here.
     const { result } = renderHook(() => useContextualMenu({ root: menu }));
 

--- a/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
+++ b/packages/react/ds-global/src/lib/hooks/useContextualMenu/useContextualMenu.ts
@@ -16,15 +16,23 @@ import type {
 
 /**
  * Prepare a menu entry for the navigation tree. A separator becomes a
- * disabled, label-less node: `disabled` is what makes the shared navigation
+ * PRESENTATIONAL, label-less node, which is what makes the shared navigation
  * machinery (arrow keys, Home/End, type-ahead, roving focus) skip it with no
- * separator awareness of its own. Its `key` is the identity the tree's index
- * requires, and the type already guarantees it. Items recurse into their
- * submenu entries.
+ * separator awareness of its own.
+ *
+ * Not `disabled`. A disabled entry is a menu item the user may not choose
+ * right now, and a renderer is entitled to draw it greyed and announce it
+ * `aria-disabled`; a separator is not an item at all. Marking it disabled
+ * made one flag mean two things depending on the node you read it from, and
+ * left `disabled` unable to answer "may the user choose this?" on its own.
+ *
+ * The word "separator" stops here: the core learns only that the node is
+ * presentational. Its `key` is the identity the tree's index requires, and
+ * the type already guarantees it. Items recurse into their submenu entries.
  */
 const prepareEntry = (entry: MenuEntry): MenuEntry => {
   if (isMenuSeparator(entry)) {
-    return { ...entry, disabled: true };
+    return { ...entry, presentational: true };
   }
   if (!entry.items?.length) return entry;
   return {
@@ -40,7 +48,7 @@ const prepareEntry = (entry: MenuEntry): MenuEntry => {
  * Positioning, open state, outside-click and Escape dismissal come from
  * {@link useDisclosure} in `click` mode. Roving focus, type-ahead, and ARIA
  * wiring come from `useNavigationTree`, unmodified: separators enter the tree
- * as disabled, label-less nodes, which the tree already skips.
+ * as presentational, label-less nodes, which the tree already skips.
  *
  * @param root The menu tree (menu -> entries; an item's `items` is its submenu).
  * @param wrap Whether arrow keys wrap at the first/last item.
@@ -68,8 +76,8 @@ const useContextualMenu = ({
     getToggleProps: getDisclosureToggleProps,
   } = useDisclosure({ ...props, mode: "click" });
 
-  // Separators become disabled nodes BEFORE the tree annotates the root, so
-  // useNavigationTree runs unmodified.
+  // Separators become presentational nodes BEFORE the tree annotates the root,
+  // so useNavigationTree runs unmodified.
   const preparedRoot = useMemo(() => prepareEntry(root) as MenuItem, [root]);
 
   const nav = useNavigationTree<MenuEntry>({
@@ -81,8 +89,9 @@ const useContextualMenu = ({
 
   // The disclosure owns the open state (it drives positioning and dismissal);
   // mirror it into the navigation tree so roving focus follows open/close. The
-  // reducer's OPEN highlights the first enabled child — a real menuitem, since
-  // the root's children are the items themselves (separators are disabled).
+  // reducer's OPEN highlights the first interactive child — a real menuitem,
+  // since the root's children are the items themselves (separators are
+  // presentational, and the tree passes over them).
   useEffect(() => {
     if (isOpen) {
       nav.openMenu();


### PR DESCRIPTION
## Done

Closes the navigation work started in #1142 and #1150 by landing the half that lives at the component boundary.

`useContextualMenu` fed separators to the navigation tree as `disabled: true`, purely so the shared machinery would skip them:

```ts
if (isMenuSeparator(entry)) {
  return { ...entry, disabled: true };
}
```

That overloaded one flag with two meanings. `disabled` says *the user may not choose an item that is one* — a renderer is entitled to draw it greyed and announce it `aria-disabled` on that basis. A separator is not an item, so `disabled` could not answer "may the user choose this?" without the reader first knowing what kind of node it had. #1150 added `presentational` to the core for exactly this; this PR does the mapping.

The core still never learns the word "separator" — `MenuSeparator → presentational: true` happens here, in the component layer, and `useNavigationTree` runs unmodified.

**`MenuSeparator.disabled` becomes `MenuSeparator.presentational`.** That is the part worth more than the flag rename: the old overload is now *unrepresentable* rather than merely unset, so reintroducing it is a compile error instead of a silent regression. The test that guards it asserts the runtime object agrees with the type.

### Breaking

`MenuSeparator` no longer has a `disabled` field. It was documented as set by `useContextualMenu` and never by consumers, so code that only builds menus is unaffected. Code that read `separator.disabled` reads `separator.presentational`.

## QA

```bash
bun run check   # Successfully ran target check for 62 projects — exit 0
cd packages/react/ds-global && bunx vitest run \
  src/lib/hooks/useContextualMenu src/lib/component/ContextualMenu
                # 4 files, 40 tests passed
```

Checked in both directions. With the flag dropped from `prepareEntry`, **six specs fail** — the same six that used to pin the `disabled` preparation, now pinning this one:

```
× feeds separators to the tree as presentational nodes
× skips a separator on ArrowDown through the composed hook
× arrow keys skip the separator in both directions
× skips leading and trailing separators on open, Home and End
× wraps by default, looping past leading and trailing separators
× renders and skips a separator INSIDE a submenu
```

Worth noting how the type error in this change was caught: `tsc` rejected the first draft, while all 40 tests passed against it, because vitest strips types without checking them. `packages/react/ds-global` includes its tests in `tsc`; the 14 packages listed in #1152 do not, and would have shipped it green.

### PR readiness check

- [x] PR should have one of the following labels — `fix` and `breaking`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json` — unchanged.
- [x] If this PR introduces a **new package** — n/a.
- [x] If this PR does not require visual testing, add the `Chromatic: skip` label — **not applied.** A separator still renders as `<hr class="separator">` and nothing about the visual output changes, but ContextualMenu has stories covering separators and the change touches what the tree does with them, so the render is worth a look rather than a claim.

## Screenshots

No visual change intended — a separator renders as the same `<hr class="separator">` before and after. Chromatic is left on to confirm that rather than assert it.

https://claude.ai/code/session_017aLWZCu6ivk6BR8f3jZ7xL
