### PR TITLE
refactor(ds-app)!: render SideNavigation as a self-contained nav landmark

### DIFF
--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tests.tsx
@@ -26,6 +26,20 @@ const footerRoot: NavItem = {
 };
 
 describe("SideNavigation", () => {
+  it("renders as a self-contained nav landmark", () => {
+    render(<SideNavigation root={root} />);
+    expect(
+      screen.getByRole("navigation", { name: "Main navigation" }),
+    ).toBeInTheDocument();
+  });
+
+  it("allows overriding the default aria-label", () => {
+    render(<SideNavigation root={root} aria-label="Product navigation" />);
+    expect(
+      screen.getByRole("navigation", { name: "Product navigation" }),
+    ).toBeInTheDocument();
+  });
+
   it("renders the root items in the content region", () => {
     render(<SideNavigation root={root} />);
     expect(screen.getByText("Machines")).toBeInTheDocument();

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tsx
@@ -12,6 +12,9 @@ const componentCssClassName = "ds side-navigation";
  * `defaultExpanded` — and wires the header's collapse toggle to the content
  * region it controls.
  *
+ * Renders as a self-contained `<nav>` landmark (SPEC.md §1, §6); `aria-label`
+ * defaults to `"Main navigation"` and may be overridden by the consumer.
+ *
  * Routing-agnostic: navigable items render via `LinkComponent` (default `"a"`);
  * pass a router `Link` to integrate client-side navigation. The active item is
  * resolved from `currentUrl`.
@@ -30,6 +33,7 @@ const SideNavigation = ({
   // expanded: expandedProp,
   defaultExpanded = true,
   // onExpandedChange,
+  "aria-label": ariaLabel,
   ...props
 }: SideNavigationProps): React.ReactElement => {
   const contentId = useId();
@@ -54,12 +58,13 @@ const SideNavigation = ({
   // -------------------------------------------------------------------------
 
   return (
-    <div
+    <nav
       className={[componentCssClassName, !expanded && "collapsed", className]
         .filter(Boolean)
         .join(" ")}
       data-expanded={expanded}
       {...props}
+      aria-label={ariaLabel ?? "Main navigation"}
     >
       <Header
         brand={brand}
@@ -81,7 +86,7 @@ const SideNavigation = ({
           currentUrl={currentUrl}
         />
       )}
-    </div>
+    </nav>
   );
 };
 

--- a/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.tsx
@@ -21,13 +21,13 @@ const CollapseToggle = ({
 }: CollapseToggleProps): React.ReactElement => {
   return (
     <button
-      type="button"
       className={[componentCssClassName, className].filter(Boolean).join(" ")}
       aria-expanded={expanded}
       aria-label={
         ariaLabel ?? (expanded ? "Collapse navigation" : "Expand navigation")
       }
       {...props}
+      type="button"
     >
       <Icon icon={expanded ? "collapse-side-nav" : "expand-side-nav"} />
     </button>

--- a/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/types.ts
@@ -8,5 +8,10 @@ type OwnProps = {
   expanded?: boolean;
 };
 
+/**
+ * `type` is excluded in addition to `OwnProps`: this is always a disclosure
+ * trigger, never a form submit/reset control, so the DS fixes it to
+ * `"button"` rather than exposing it.
+ */
 export type CollapseToggleProps = OwnProps &
-  Omit<ComponentProps<"button">, keyof OwnProps>;
+  Omit<ComponentProps<"button">, keyof OwnProps | "type">;

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react";
+import type { ComponentProps, ComponentType } from "react";
 import type { LinkComponentProps, NavItem } from "../../types.js";
 
 /**
@@ -9,9 +9,11 @@ import type { LinkComponentProps, NavItem } from "../../types.js";
  * lives in NavTree's two loops. The end slot is derived — an item with subitems
  * shows a disclosure caret; a leaf shows its optional `slot`.
  */
-export type ItemProps = NavItem & {
+type OwnProps = NavItem & {
   /** Whether this item is the active (current) page. */
   active?: boolean;
   /** Component used to render navigable items. Defaults to `"a"`. */
   LinkComponent?: ComponentType<LinkComponentProps> | "a";
 };
+
+export type ItemProps = OwnProps & Omit<ComponentProps<"li">, keyof OwnProps>;

--- a/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/NavTree.tsx
@@ -7,6 +7,8 @@ import { Item } from "../Item/index.js";
 import type { NavTreeProps } from "./types.js";
 import "./styles.css";
 
+const componentCssClassName = "ds nav-tree";
+
 /**
  * Internal: renders a navigation tree with two explicit loops (no recursion),
  * deriving active state from useNavigationTree. Shared by Content and Footer —
@@ -25,6 +27,8 @@ const NavTree = ({
   root,
   currentUrl,
   LinkComponent = "a",
+  className,
+  ...props
 }: NavTreeProps): React.ReactElement => {
   const nav = useNavigationTree<NavItem>({ root, initialUrl: currentUrl });
   const { index, selectItem } = nav;
@@ -38,7 +42,10 @@ const NavTree = ({
   const groups = nav.annotatedRoot.items ?? [];
 
   return (
-    <div className="ds nav-tree">
+    <div
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      {...props}
+    >
       {/* Loop 1 — level-1 groups */}
       {groups.map((group) => {
         const groupId = getItemId(group);

--- a/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/NavTree/types.ts
@@ -1,11 +1,14 @@
-import type { ComponentType } from "react";
+import type { ComponentProps, ComponentType } from "react";
 import type { LinkComponentProps, NavItem } from "../../types.js";
 
-export interface NavTreeProps {
+type OwnProps = {
   /** Root NavItem whose direct children (level-1 groups) are rendered. */
   root: NavItem;
   /** Live current location; resolves and keeps the active item in sync. */
   currentUrl?: string;
   /** Component used to render navigable items. Defaults to `"a"`. */
   LinkComponent?: ComponentType<LinkComponentProps> | "a";
-}
+};
+
+export type NavTreeProps = OwnProps &
+  Omit<ComponentProps<"div">, keyof OwnProps>;

--- a/packages/react/ds-app/src/lib/SideNavigation/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/types.ts
@@ -20,6 +20,12 @@ export type { LinkComponentProps };
  *
  * No discriminated union to author: the caret-vs-slot choice is structural,
  * derived from whether the item has `items`.
+ *
+ * @deprecated The caret-vs-slot derivation above describes the pre-24.04
+ * model. SPEC.md §4.3 replaces it with a `LeafNavItem | ExpandableNavItem`
+ * discriminated union (depth-1, no `url` on an expandable item) landing in
+ * the PR that adds `SideNavigation.ItemExpandable`. Unchanged here to keep
+ * this PR's scope to the `<nav>` landmark and prop-type conformance only.
  */
 export type NavItem = _DistributiveOmit<Item, "items"> & {
   /** Leading icon (start slot), by ds-assets icon name. */
@@ -58,5 +64,11 @@ type OwnProps = {
   defaultExpanded?: boolean;
 };
 
+/**
+ * SideNavigation renders a self-contained `<nav>` landmark (SPEC.md §1, §6);
+ * `aria-label` defaults to `"Main navigation"` and can be overridden via the
+ * inherited `ComponentProps<"nav">` surface, same as every other native
+ * attribute (`id`, `data-*`, `style`, …).
+ */
 export type SideNavigationProps = OwnProps &
-  Omit<ComponentProps<"div">, keyof OwnProps>;
+  Omit<ComponentProps<"nav">, keyof OwnProps>;


### PR DESCRIPTION
## Done

**BREAKING CHANGE:** `SideNavigation`'s root element changes from `<div>` to `<nav>`, with `aria-label` defaulting to `"Main navigation"` (overridable). Consumers querying by role or asserting on the root tag (e.g. `getByRole("generic")`) need to update to `getByRole("navigation")`. No other package in this repo consumes `SideNavigation` yet, so the blast radius is contained to this PR.

Per `SPEC.md` §1 and §6 (AC1: "The Side Navigation must have a self-contained `<nav>` tag") — PR 2 of the sequence tracked in `SPEC.md` §8:

- `SideNavigation.tsx` now renders `<nav>`, not `<div>`.
- Every `SideNavigation` prop-types file converts from `interface extends HTMLAttributes<HTMLDivElement>`/`ButtonHTMLAttributes<HTMLButtonElement>` to the house style — a `type` alias intersecting an `OwnProps` object with `Omit<ComponentProps<"tag">, keyof OwnProps>`, per this repo's React component props convention. This was more than a mechanical rename: none of these types previously extended their root element's native props at all (`HeaderProps`/`ContentProps`/`FooterProps` used `HTMLDivElement` while the components never spread the rest onto a typed native surface; `ItemProps` and `NavTreeProps` had no native props at all), so native attributes like `id`, `data-*`, or `aria-*` were previously accepted at runtime (via an untyped `...props` spread) but rejected by the type checker. They are now both accepted and typed.
- `CollapseToggleProps` additionally excludes `type` from its native surface (documented inline) since this is always a disclosure trigger, never a submit/reset control; `CollapseToggle.tsx` moves `type="button"` after the props spread so a consumer cannot override it via a wider `Omit` in the future.
- `NavTree` (private, not part of the public barrel) gains the same `className`/native-prop passthrough as its siblings, for consistency within the component family.
- Adds two tests asserting the nav landmark and the `aria-label` override.

## QA

- `bun run test` — new tests assert `getByRole("navigation", { name: "Main navigation" })` and the `aria-label` override.
- `bun run check` passes (biome + tsc + webarchitect).

### PR readiness check

- [x] PR title follows Conventional Commits, marked `!` for the breaking root-element change.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`
- [ ] No new package introduced
- [ ] Chromatic: skip — root tag change may affect snapshots; leaving default Chromatic run enabled.
