### PR TITLE
feat(ds-app): collapsed rail behaviour, tooltips, inert shortcut scaffold

### DIFF
--- a/packages/react/ds-app/src/lib/SideNavigation/SPEC.md
+++ b/packages/react/ds-app/src/lib/SideNavigation/SPEC.md
@@ -372,14 +372,17 @@ entirely and repositions `CollapseToggle` below the logo (§1.2, §10.9).
 
   ```ts
   // common/hooks/useCollapseShortcut/useCollapseShortcut.ts
-  export const COLLAPSE_SHORTCUT = { ctrlOrMeta: true, key: "e" } as const;
+  export const COLLAPSE_SHORTCUT = { key: "e", ctrlKey: true } as const;
   ```
 
   `SideNavigation` calls `useCollapseShortcut({ enabled: keyboardShortcut,
   onTrigger: handleToggle })`; `keyboardShortcut` defaults to `false`, so no
   listener attaches and no keydown is ever handled. The single named constant
   is the one place the key changes if/when design ratifies "Ctrl+E" vs. a
-  single letter (§10.1). Tested for both: enabling attaches and fires the
+  single letter (§10.1) — matching the spec's literal "Ctrl + E" only
+  (`event.ctrlKey`, not also `event.metaKey`/Cmd); extending it to Cmd on
+  macOS is a separate decision, not assumed here. Tested for both: enabling
+  attaches and fires the
   handler, and — the guarantee that matters — the *default* (disabled) case
   never does, even on the exact key combination.
 - **Enter key** — on a `link`/`button` item, activates it (native semantics —
@@ -463,7 +466,7 @@ file):
 | 3 | Provisional navigation tokens + full-spec styling (AC2) | ✅ this PR |
 | 4 | Group/GroupHeader/Separator/ItemExpandable, depth-1 type | ✅ this PR |
 | 5 | ItemButton/ItemSwitch/ContextSwitcher (AC3, AC4) | ✅ this PR |
-| 6 | Collapsed rail behaviour, tooltips, inert shortcut scaffold | pending |
+| 6 | Collapsed rail behaviour, tooltips, inert shortcut scaffold | ✅ this PR (footer-item tooltips deferred — §10.14) |
 | 7 | Secondary navigation, Help item, footerItems, certificate user | pending |
 | 8 | Responsive (<768px), text-overflow tooltips, focus-order/reduced-motion tests | pending |
 
@@ -690,4 +693,14 @@ Carried forward for design/engineering resolution; none block PR1.
     tests. Fixed to a plain class, matching `@canonical/react-ds-global`'s
     own working setup. Latent since ds-app had nothing exercising this path
     before.
+14. **Collapsed-footer tooltips are deferred.** The spec calls for footer
+    item labels to appear in a tooltip after an 800ms hover once collapsed
+    (§7, distinct from the collapse button's own 1000ms tooltip, §9.4). The
+    collapsed layout itself ships (icon-only footer rows, §2/§7), but wiring
+    the tooltip requires threading a "collapsed" flag through
+    `Footer` → `NavTree` → `renderEntry` → `Item`/`ItemButton` so each
+    footer row can conditionally wrap itself — cross-cutting, unlike the
+    collapse button's tooltip (self-contained in one component, shipped this
+    PR). Tracked as a follow-up rather than rushed alongside the rest of
+    PR6's collapsed-state mechanics.
 </content>

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tests.tsx
@@ -107,4 +107,20 @@ describe("SideNavigation", () => {
   //   fireEvent.click(screen.getByRole("button"));
   //   expect(onExpandedChange).toHaveBeenCalledWith(false);
   // });
+
+  it("does not respond to the collapse shortcut by default", () => {
+    const { container } = render(<SideNavigation root={root} />);
+    const el = container.firstElementChild as HTMLElement;
+    fireEvent.keyDown(window, { key: "e", ctrlKey: true });
+    expect(el.dataset.expanded).toBe("true");
+  });
+
+  it("responds to Ctrl+E when keyboardShortcut is enabled", () => {
+    const { container } = render(
+      <SideNavigation root={root} keyboardShortcut />,
+    );
+    const el = container.firstElementChild as HTMLElement;
+    fireEvent.keyDown(window, { key: "e", ctrlKey: true });
+    expect(el.dataset.expanded).toBe("false");
+  });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useCallback, useId, useState } from "react";
+import { useCollapseShortcut } from "./common/hooks/useCollapseShortcut/index.js";
 import {
   CollapseToggle,
   Content,
@@ -23,7 +24,8 @@ const componentCssClassName = "ds side-navigation";
  * SideNavigation — full-height application navigation rendered from a WD405
  * Item tree. Owns its expand/collapse (rail) state — uncontrolled, seeded by
  * `defaultExpanded` — and wires the header's collapse toggle to the content
- * region it controls.
+ * region it controls. Collapsed, the rail narrows to the logo and shows no
+ * navigation items at all (SPEC.md §1.2, §7) — only the header and footer.
  *
  * Renders as a self-contained `<nav>` landmark (SPEC.md §1, §6); `aria-label`
  * defaults to `"Main navigation"` and may be overridden by the consumer.
@@ -46,6 +48,7 @@ const SideNavigation = ({
   // expanded: expandedProp,
   defaultExpanded = true,
   // onExpandedChange,
+  keyboardShortcut = false,
   "aria-label": ariaLabel,
   ...props
 }: SideNavigationProps): React.ReactElement => {
@@ -56,6 +59,10 @@ const SideNavigation = ({
   const handleToggle = useCallback(() => {
     setExpanded((current) => !current);
   }, []);
+
+  // Reserved (§10.1) — inert until a consumer opts in via `keyboardShortcut`,
+  // which defaults to `false`. See common/hooks/useCollapseShortcut.
+  useCollapseShortcut({ enabled: keyboardShortcut, onTrigger: handleToggle });
 
   // --- Controlled circuit (not official yet) -------------------------------
   // const [uncontrolledExpanded, setUncontrolledExpanded] =

--- a/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.tests.tsx
@@ -38,4 +38,16 @@ describe("CollapseToggle", () => {
     expect(element.className).toContain("ds collapse-toggle");
     expect(element.className).toContain("custom-class");
   });
+
+  it("wires a tooltip naming the action for each state (SPEC.md §5, §9.4)", () => {
+    const { rerender } = render(<CollapseToggle expanded />);
+    expect(screen.getByRole("tooltip", { hidden: true })).toHaveTextContent(
+      "Collapse",
+    );
+
+    rerender(<CollapseToggle expanded={false} />);
+    expect(screen.getByRole("tooltip", { hidden: true })).toHaveTextContent(
+      "Expand",
+    );
+  });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.tsx
@@ -1,19 +1,11 @@
-import { Icon } from "@canonical/react-ds-global";
+import { Icon, withTooltip } from "@canonical/react-ds-global";
 import type React from "react";
 import type { CollapseToggleProps } from "./types.js";
 import "./styles.css";
 
 const componentCssClassName = "ds collapse-toggle";
 
-/**
- * SideNavigation.CollapseToggle — icon-only button that expands or collapses
- * the navigation rail. Carries the disclosure ARIA contract: `aria-expanded`
- * reflects the current state and `aria-controls` should point at the id of the
- * navigation region it toggles.
- *
- * @implements ds:apps.subcomponent.side-navigation-collapse-toggle
- */
-const CollapseToggle = ({
+const CollapseToggleButton = ({
   className,
   expanded = true,
   "aria-label": ariaLabel,
@@ -32,6 +24,42 @@ const CollapseToggle = ({
       <Icon icon={expanded ? "collapse-side-nav" : "expand-side-nav"} />
     </button>
   );
+};
+
+// Spec: hovering the collapse button for 1s shows a tooltip reading
+// "Collapse" or "Expand" depending on state. withTooltip's Message is fixed
+// at wrap time — it isn't reactive to the wrapped component's props — so two
+// stable wrapped components are built once here (not inside CollapseToggle's
+// render: recreating a component type on every render would force React to
+// remount it, losing focus/hover state) and CollapseToggle below just picks
+// between them.
+const CollapseToggleWithCollapseTooltip = withTooltip(
+  CollapseToggleButton,
+  "Collapse",
+  { activateDelay: 1000 },
+);
+const CollapseToggleWithExpandTooltip = withTooltip(
+  CollapseToggleButton,
+  "Expand",
+  { activateDelay: 1000 },
+);
+
+/**
+ * SideNavigation.CollapseToggle — icon-only button that expands or collapses
+ * the navigation rail. Carries the disclosure ARIA contract: `aria-expanded`
+ * reflects the current state and `aria-controls` should point at the id of the
+ * navigation region it toggles. Hovering for 1s shows a tooltip naming the
+ * action ("Collapse"/"Expand" — SPEC.md §5, §9.4); the `<button>`'s own
+ * `aria-label` carries the fuller "Collapse/Expand navigation" text.
+ *
+ * @implements ds:apps.subcomponent.side-navigation-collapse-toggle
+ */
+const CollapseToggle = (props: CollapseToggleProps): React.ReactElement => {
+  const Wrapped =
+    (props.expanded ?? true)
+      ? CollapseToggleWithCollapseTooltip
+      : CollapseToggleWithExpandTooltip;
+  return <Wrapped {...props} />;
 };
 
 export default CollapseToggle;

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/Header.tsx
@@ -10,7 +10,9 @@ const componentCssClassName = "ds side-navigation-header";
 /**
  * SideNavigation.Header — top region holding the brand (the `brand` node, at the
  * start) and the collapse toggle (at the end). The toggle is omitted when no
- * `onToggle` handler is provided.
+ * `onToggle` handler is provided. Collapsed (SPEC.md §1.2): the layout
+ * switches to a centred column — the toggle relocates below the logo rather
+ * than beside it — driven by `data-expanded` on the root.
  *
  * @implements ds:apps.subcomponent.side-navigation-header
  */
@@ -26,11 +28,13 @@ const Header = ({
   return (
     <header
       className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      data-expanded={expanded}
       {...props}
     >
       <div className="brand">{brand}</div>
       {/* Optional, consumer-supplied; the grid's middle column is simply empty
-          when no application name is given. */}
+          when no application name is given. Hidden entirely when collapsed —
+          there's no room, and the spec's collapsed header has no title. */}
       {applicationName != null && (
         <span className="title p">{applicationName}</span>
       )}

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
@@ -23,4 +23,21 @@
   .title {
     min-width: 0;
   }
+
+  /* Collapsed (SPEC.md §1.2): a centred column — logo on top, the collapse
+     toggle relocates below it rather than beside it. DOM order already
+     places the toggle last, so switching the axis alone moves it there; no
+     title has room, so it's dropped entirely rather than left to overflow
+     a rail this narrow. No stated transition for this rearrangement
+     (SPEC.md §10.4), so no `transition` property here. */
+  &[data-expanded="false"] {
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding-inline: 0;
+
+    .title {
+      display: none;
+    }
+  }
 }

--- a/packages/react/ds-app/src/lib/SideNavigation/common/hooks/useCollapseShortcut/index.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/hooks/useCollapseShortcut/index.ts
@@ -1,0 +1,5 @@
+export type * from "./types.js";
+export {
+  COLLAPSE_SHORTCUT,
+  useCollapseShortcut,
+} from "./useCollapseShortcut.js";

--- a/packages/react/ds-app/src/lib/SideNavigation/common/hooks/useCollapseShortcut/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/hooks/useCollapseShortcut/types.ts
@@ -1,0 +1,14 @@
+export interface UseCollapseShortcutProps {
+  /**
+   * Whether the shortcut listener is attached at all. Defaults to `false` —
+   * the spec's own prose is self-contradictory on the key (states "Ctrl + E",
+   * then argues for a single letter instead, in the same paragraph), so this
+   * ships disabled pending a design ruling (SPEC.md §5, §10.1).
+   */
+  enabled?: boolean;
+  /** Called when the shortcut is triggered. */
+  onTrigger: () => void;
+}
+
+/** The hook attaches a window listener as a side effect; it returns nothing. */
+export type UseCollapseShortcutResult = undefined;

--- a/packages/react/ds-app/src/lib/SideNavigation/common/hooks/useCollapseShortcut/useCollapseShortcut.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/hooks/useCollapseShortcut/useCollapseShortcut.tests.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useCollapseShortcut } from "./useCollapseShortcut.js";
+
+describe("useCollapseShortcut", () => {
+  it("does not attach a listener when disabled (the default)", () => {
+    const onTrigger = vi.fn();
+    renderHook(() => useCollapseShortcut({ onTrigger }));
+    fireEvent.keyDown(window, { key: "e", ctrlKey: true });
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  it("calls onTrigger on Ctrl+E when enabled", () => {
+    const onTrigger = vi.fn();
+    renderHook(() => useCollapseShortcut({ enabled: true, onTrigger }));
+    fireEvent.keyDown(window, { key: "e", ctrlKey: true });
+    expect(onTrigger).toHaveBeenCalledOnce();
+  });
+
+  it("ignores the key without the Ctrl modifier, even when enabled", () => {
+    const onTrigger = vi.fn();
+    renderHook(() => useCollapseShortcut({ enabled: true, onTrigger }));
+    fireEvent.keyDown(window, { key: "e", ctrlKey: false });
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  it("ignores an unrelated key, even with Ctrl held", () => {
+    const onTrigger = vi.fn();
+    renderHook(() => useCollapseShortcut({ enabled: true, onTrigger }));
+    fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  it("detaches the listener when enabled flips back to false", () => {
+    const onTrigger = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useCollapseShortcut({ enabled, onTrigger }),
+      { initialProps: { enabled: true } },
+    );
+    rerender({ enabled: false });
+    fireEvent.keyDown(window, { key: "e", ctrlKey: true });
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/ds-app/src/lib/SideNavigation/common/hooks/useCollapseShortcut/useCollapseShortcut.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/hooks/useCollapseShortcut/useCollapseShortcut.ts
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import type {
+  UseCollapseShortcutProps,
+  UseCollapseShortcutResult,
+} from "./types.js";
+
+/**
+ * The reserved rail-collapse shortcut. Ctrl+E, per the spec's prose — kept as
+ * a single named constant so the key can change in one place if/when design
+ * rules between it and the single-letter alternative the same prose argues
+ * for (SPEC.md §5, §10.1).
+ */
+export const COLLAPSE_SHORTCUT = { key: "e", ctrlKey: true } as const;
+
+/**
+ * Reserved: binds `COLLAPSE_SHORTCUT` to `onTrigger` while `enabled`.
+ * `SideNavigation` calls this with `enabled: keyboardShortcut`, which
+ * defaults to `false` — no listener is ever attached, and the shortcut is
+ * inert, until a consumer opts in (and design ratifies the key).
+ */
+export const useCollapseShortcut = ({
+  enabled = false,
+  onTrigger,
+}: UseCollapseShortcutProps): UseCollapseShortcutResult => {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (
+        event.ctrlKey === COLLAPSE_SHORTCUT.ctrlKey &&
+        event.key.toLowerCase() === COLLAPSE_SHORTCUT.key
+      ) {
+        event.preventDefault();
+        onTrigger();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enabled, onTrigger]);
+};

--- a/packages/react/ds-app/src/lib/SideNavigation/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/styles.css
@@ -25,4 +25,38 @@
      in @canonical/styles/overflow.css): the spec calls for 1.75rem
      specifically at the Header/Content and Content/Footer seams. */
   --overflow-gradient-height: 1.75rem;
+
+  /* Collapsed (SPEC.md §1.2, §7): the rail narrows to fit just the logo
+     (see packages/styles/main/src/navigation.css §9.2), and no navigation
+     items show at all — not a styling choice, a deliberate scope cut (five
+     listed reasons in SPEC.md §7: icons aren't guaranteed, context
+     switchers can't render collapsed, expandable-item state is undefined,
+     the toggle needs to move, icon-only buttons are poor UX). The footer
+     stays visible (icon-only, SPEC.md §10 tooltip enhancement tracked
+     separately) — only Content is hidden. No stated transition for either
+     change (SPEC.md §10.4), so no `transition` property here. */
+  &.collapsed {
+    inline-size: var(--sidenav-rail-inline-size-collapsed);
+
+    & > .ds.content {
+      display: none;
+    }
+
+    /* Footer stays visible, icon-only — spec: "the collapsed state footer
+       items show their labels in tooltips when hovered after 800ms delay."
+       The tooltip itself is a documented follow-up (SPEC.md §10.14); this is
+       the icon-only layout half. */
+    & > .ds.footer {
+      .label,
+      .end {
+        display: none;
+      }
+
+      .row {
+        grid-template-columns: var(--sidenav-icon-column-inline-size);
+        justify-content: center;
+        padding-inline: 0;
+      }
+    }
+  }
 }

--- a/packages/react/ds-app/src/lib/SideNavigation/types.ts
+++ b/packages/react/ds-app/src/lib/SideNavigation/types.ts
@@ -197,6 +197,14 @@ type OwnProps = {
   currentUrl?: string;
   /** Initial expanded (rail) state when uncontrolled. Defaults to `true`. */
   defaultExpanded?: boolean;
+  /**
+   * Reserved. Binds the Ctrl+E rail-collapse shortcut when `true`. Defaults
+   * to `false` — the spec's own prose is self-contradictory on the key
+   * (states "Ctrl + E", then argues for a single letter instead, in the
+   * same paragraph), so this ships disabled pending a design ruling
+   * (SPEC.md §5, §10.1). No story enables it.
+   */
+  keyboardShortcut?: boolean;
 };
 
 /**

--- a/packages/react/ds-app/src/storybook/navigation/story-utils.tsx
+++ b/packages/react/ds-app/src/storybook/navigation/story-utils.tsx
@@ -91,9 +91,9 @@ export const withNavigationRouterProps: Decorator = (Story, context) => {
  * render unstyled in isolation (they consume CSS defined on the root).
  */
 export const withSideNavShell: Decorator = (Story) => (
-  <div className="ds side-navigation">
+  <nav className="ds side-navigation">
     <Story />
-  </div>
+  </nav>
 );
 
 /**


### PR DESCRIPTION
## Done

Implements `SPEC.md` §1.2/§7 (collapsed state) and §5/§9.4 (tooltips, keyboard shortcut) — PR 6 of the sequence tracked in `SPEC.md` §8:

- The rail narrows to `--sidenav-rail-inline-size-collapsed` (derived in `navigation.css`, PR 3) and `Content` is hidden entirely — not a styling choice, the spec's own deliberate scope cut (five listed reasons: icons aren't guaranteed, context switchers can't render collapsed, expandable state is undefined, the toggle needs to move, icon-only buttons are poor UX).
- `Header` switches to a centred column when collapsed (`data-expanded` on its root, newly wired from the `expanded` prop it already received): the logo centres and the collapse toggle relocates below it purely by changing `flex-direction` — DOM order (brand, then the toggle) already puts the toggle last, so no reordering is needed. The title is dropped entirely; there's no room for it in a rail this narrow.
- The footer stays visible but goes icon-only when collapsed (labels and end slots hidden, icon column centred) — labels return via tooltip in a follow-up (`SPEC.md` §10.14: threading a "collapsed" flag through `Footer` → `NavTree` → `renderEntry` → `Item`/`ItemButton` is cross-cutting, unlike the collapse button's own tooltip below).
- `CollapseToggle` gains a 1-second hover tooltip reading "Collapse" or "Expand" (distinct from its longer `aria-label`). `withTooltip`'s `Message` is fixed at wrap time, not reactive to the wrapped component's props, so two stable wrapped components are built once at module scope (not per render, which would force a remount every toggle) and the exported `CollapseToggle` just picks between them.
- New `common/hooks/useCollapseShortcut`: binds Ctrl+E to the rail toggle, but only when `enabled` — `SideNavigation`'s new `keyboardShortcut` prop defaults to `false`, so no listener ever attaches. Scaffolded per `SPEC.md` §5/§10.1 because the spec's own prose is self-contradictory on the key (states "Ctrl + E", then argues for a single letter instead, in the same paragraph) — ships inert pending a design ruling. Tested for both states, including that the default (disabled) case truly never fires, on the exact key combination.

Drive-by: the Storybook `withSideNavShell` decorator wrapped subcomponent stories in a `<div>`; updated to `<nav>` to match the real component's root since PR 2's `<nav>` landmark change.

## QA

- `bun run test` and `bun run check` pass.
- Manually toggle collapse/expand and confirm the tooltip text, the header's centred layout, and the footer's icon-only state.
- Confirm Ctrl+E does nothing by default, and (in a follow-up consumer opt-in) fires only when `keyboardShortcut` is `true`.

### PR readiness check

- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`
- [ ] No new package introduced
- [ ] Chromatic: skip — visual collapsed-state changes; leaving default Chromatic review enabled.
