### PR TITLE
feat(ds-app): responsive layout, text-overflow tooltips, focus-order and reduced-motion tests

### DIFF
--- a/packages/react/ds-app/src/lib/SideNavigation/SPEC.md
+++ b/packages/react/ds-app/src/lib/SideNavigation/SPEC.md
@@ -1,11 +1,13 @@
 # SideNavigation — Component Specification
 
-> **Status:** Draft — rewritten against the 24.04 Side Navigation spec
-> (Figma: [App Mafia exploration](https://www.figma.com/design/4BxGmZUlhgWChPWu4lGzZv/24.04-Side-Navigation-exploration---App-Mafia?node-id=656-31955),
-> prose spec: *Side Navigation (App Layout)*). Anatomy, token pairings,
-> properties, state/keyboard, accessibility, and responsive behaviour are all
-> specified below; implementation lands across the PR sequence in
-> [§8 Implementation status](#8-implementation-status).
+> **Status:** Implemented, against the 24.04 Side Navigation spec (Figma:
+> [App Mafia exploration](https://www.figma.com/design/4BxGmZUlhgWChPWu4lGzZv/24.04-Side-Navigation-exploration---App-Mafia?node-id=656-31955),
+> prose spec: *Side Navigation (App Layout)*). All 8 PRs in
+> [§8 Implementation status](#8-implementation-status) have landed; several
+> spec details are deliberately deferred with rationale rather than rushed —
+> see [§10 Known issues](#10-known-issues) for the full list (mobile
+> drill-down, pixel-accurate truncation tooltips, collapsed-footer tooltips,
+> `brandHref`, and several inferred values pending design confirmation).
 
 ---
 
@@ -485,7 +487,7 @@ file):
 | 5 | ItemButton/ItemSwitch/ContextSwitcher (AC3, AC4) | ✅ this PR |
 | 6 | Collapsed rail behaviour, tooltips, inert shortcut scaffold | ✅ this PR (footer-item tooltips deferred — §10.14) |
 | 7 | Secondary navigation, Help item, footerItems, certificate user | ✅ this PR (`brandHref` deferred — §10.15) |
-| 8 | Responsive (<768px), text-overflow tooltips, focus-order/reduced-motion tests | pending |
+| 8 | Responsive (<768px), text-overflow tooltips, focus-order/reduced-motion tests | ✅ this PR (mobile drill-down and pixel-accurate truncation tooltips deferred — §10.17, §10.18) |
 
 ---
 
@@ -736,4 +738,26 @@ Carried forward for design/engineering resolution; none block PR1.
     `packages/react/ds-app/src/lib/SideNavigation/helpItem.ts`) only makes
     authoring it correctly (right icon, right external-link child, right
     field names) a one-line call instead of five.
+17. **Truncated-text tooltips use the native `title` attribute, not the
+    spec's custom 800ms-delay styled tooltip.** Every label (`Item`/
+    `ItemButton`/`ItemSwitch`/`ItemExpandable`/`GroupHeader`/`Secondary`'s
+    title) now sets `title` to its own text — a real, working fallback
+    (the browser's own tooltip, on native hover timing) but not a
+    pixel-accurate implementation of §7's spec. A precise version needs to
+    detect *actual* truncation (`scrollWidth > clientWidth`, typically via a
+    ResizeObserver-backed hook) and only then show the styled tooltip —
+    unconditionally wrapping every label in `withTooltip` would show it even
+    when the text isn't truncated at all. That detection hook doesn't exist
+    yet in either `ds-app` or `ds-global`; building and testing it properly
+    is a separable piece of work from the rest of PR8.
+18. **The mobile (<768px) drill-down is out of scope.** SPEC.md §7
+    describes expandable/secondary-opening items switching to a
+    `chevron-right` affordance that navigates to a full-screen "page" of
+    just that item's children, with a back button (`chevron-left`) to
+    return. This needs its own navigation-stack state (which "page" — root,
+    or a specific item's children — is currently shown) and a mobile-only
+    rendering path for `ItemExpandable`, distinct from its desktop
+    disclosure behaviour; it is a separate interaction mode, not a CSS
+    variation of what PR8 already ships (Menu/Close-menu button, fullscreen
+    reveal, header layout preserved on mobile). Tracked as a follow-up.
 </content>

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.stories.tsx
@@ -77,3 +77,27 @@ export const CertificateUser: Story = {
     certificateUser: true,
   },
 };
+
+/**
+ * Below Vanilla's small breakpoint (SPEC.md §7): the collapse toggle
+ * becomes a "Menu"/"Close menu" text button; the header stays in its
+ * normal row layout (not the desktop centred-column collapsed state); and
+ * the body goes fullscreen when open rather than a 240px rail. A fixed
+ * narrow wrapper stands in for an actual small-viewport preview. The
+ * mobile drill-down for expandable/secondary-opening items (chevron-right,
+ * back button) is out of scope — SPEC.md §10.18.
+ */
+export const Mobile: Story = {
+  args: {
+    applicationName: "MAAS",
+    root: maasContentRoot,
+    footerRoot: maasFooterRoot,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ inlineSize: "375px", blockSize: "100dvh" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/SideNavigation.tests.tsx
@@ -123,4 +123,27 @@ describe("SideNavigation", () => {
     fireEvent.keyDown(window, { key: "e", ctrlKey: true });
     expect(el.dataset.expanded).toBe("false");
   });
+
+  it("orders focusable elements logo → collapse toggle → content → footer (SPEC.md §6)", () => {
+    const { container } = render(
+      <SideNavigation
+        root={root}
+        footerRoot={footerRoot}
+        brand={<a href="/">Home</a>}
+      />,
+    );
+    const focusable = Array.from(
+      container.querySelectorAll("a, button"),
+    ) as HTMLElement[];
+    const labels = focusable.map(
+      (el) => el.getAttribute("aria-label") || el.textContent,
+    );
+    expect(labels).toEqual([
+      "Home", // brand/logo
+      "Collapse navigation", // collapse toggle
+      "Machines", // content, top-to-bottom
+      "Devices",
+      "Settings", // footer, top-to-bottom
+    ]);
+  });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/CollapseToggle.tsx
@@ -21,7 +21,16 @@ const CollapseToggleButton = ({
       {...props}
       type="button"
     >
-      <Icon icon={expanded ? "collapse-side-nav" : "expand-side-nav"} />
+      {/* Desktop: an icon (SPEC.md §5, §9). Below the spec's small breakpoint
+          (<768px — SPEC.md §7), the icon gives way to a text label reading
+          "Menu"/"Close menu" instead — the two are simple CSS-toggled
+          siblings (see styles.css) rather than a media-query read in JS, so
+          this needs no client-only branch and stays SSR-identical. */}
+      <Icon
+        icon={expanded ? "collapse-side-nav" : "expand-side-nav"}
+        className="desktop-only"
+      />
+      <span className="mobile-only p">{expanded ? "Close menu" : "Menu"}</span>
     </button>
   );
 };

--- a/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/CollapseToggle/styles.css
@@ -25,4 +25,29 @@
   &:active {
     background: var(--sidenav-row-background-active);
   }
+
+  /* Icon (desktop) vs "Menu"/"Close menu" text (mobile) — plain CSS-toggled
+     siblings, not a JS media-query read, so the choice needs no client-only
+     branch and stays SSR-identical. */
+  .mobile-only {
+    display: none;
+  }
+
+  /* Vanilla's "small" breakpoint (SPEC.md §7: "on all breakpoints above the
+     small breakpoint of Vanilla" / "at breakpoints below small"). */
+  @media (max-width: 767px) {
+    .desktop-only {
+      display: none;
+    }
+
+    .mobile-only {
+      display: inline;
+    }
+
+    /* No longer an icon-only square — a text button sized to its content. */
+    inline-size: auto;
+    block-size: auto;
+    padding-block: var(--sidenav-icon-gap); /* 0.5rem */
+    padding-inline: var(--sidenav-inset-start); /* 1rem */
+  }
 }

--- a/packages/react/ds-app/src/lib/SideNavigation/common/GroupHeader/GroupHeader.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/GroupHeader/GroupHeader.tests.tsx
@@ -19,4 +19,17 @@ describe("GroupHeader", () => {
     render(<GroupHeader data-testid="header">Hardware</GroupHeader>);
     expect(screen.getByTestId("header")).toBeInTheDocument();
   });
+
+  it("sets title as a native tooltip fallback for truncation when children is text (SPEC.md §10.17)", () => {
+    render(<GroupHeader>Hardware</GroupHeader>);
+    expect(screen.getByText("Hardware")).toHaveAttribute("title", "Hardware");
+  });
+
+  it("lets a consumer-supplied title override the default", () => {
+    render(<GroupHeader title="Custom tooltip">Hardware</GroupHeader>);
+    expect(screen.getByText("Hardware")).toHaveAttribute(
+      "title",
+      "Custom tooltip",
+    );
+  });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/GroupHeader/GroupHeader.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/GroupHeader/GroupHeader.tsx
@@ -18,6 +18,10 @@ const GroupHeader = ({
 }: GroupHeaderProps): React.ReactElement => (
   <span
     className={[componentCssClassName, className].filter(Boolean).join(" ")}
+    // `title` — native tooltip fallback for a truncated header; SPEC.md
+    // §10.17. Only meaningful when the header is plain text (the common
+    // case — Group always passes its string `label` here).
+    title={typeof children === "string" ? children : undefined}
     {...props}
   >
     {children}

--- a/packages/react/ds-app/src/lib/SideNavigation/common/GroupHeader/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/GroupHeader/styles.css
@@ -16,4 +16,8 @@
   font-weight: var(--typography-heading-5-font-weight);
   line-height: var(--typography-heading-5-line-height);
   letter-spacing: var(--typography-heading-5-letter-spacing);
+  /* Spec: group headers are single-line and truncate (§7 text overflow). */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Header/styles.css
@@ -40,4 +40,16 @@
       display: none;
     }
   }
+
+  /* Responsive (SPEC.md §7): "On mobile the header is always shown" in its
+     normal row layout — collapsed there means "menu closed", not "narrow
+     icon rail", so the centred-column rearrangement above doesn't apply. */
+  @media (max-width: 767px) {
+    &[data-expanded="false"] {
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: space-between;
+      padding-inline: var(--sidenav-inset-start) var(--sidenav-inset-end);
+    }
+  }
 }

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tests.tsx
@@ -62,4 +62,9 @@ describe("Item", () => {
     expect(el?.className).toContain("ds side-navigation-item");
     expect(el?.className).toContain("custom-class");
   });
+
+  it("sets title on the label as a native tooltip fallback for truncation (SPEC.md §10.17)", () => {
+    render(<Item url="/machines" label="Machines" />);
+    expect(screen.getByText("Machines")).toHaveAttribute("title", "Machines");
+  });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/Item.tsx
@@ -37,7 +37,12 @@ const Item = ({
       {/* Start cell is always rendered (empty when no icon) so the label stays
           in the middle column — labels align whether or not a row has an icon. */}
       <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
-      <span className="label p">{label}</span>
+      {/* `title` is a progressive-enhancement fallback for the spec's
+         truncated-label tooltip (§7): the browser's own native tooltip,
+         not the custom 800ms-delay styled one — SPEC.md §10.17. */}
+      <span className="label p" title={label}>
+        {label}
+      </span>
       {slot ? <span className="end slot">{slot}</span> : null}
     </>
   );

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Item/styles.css
@@ -68,8 +68,12 @@
   }
 
   /* Label → middle (1fr) column. */
+  /* Spec: item labels are single-line and truncate (§7 text overflow). */
   & .label {
     min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* Trailing slot (e.g. a badge) → end (auto) column. */

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/ItemButton.tsx
@@ -26,7 +26,10 @@ const ItemButton = ({
       {/* Start cell is always rendered (empty when no icon), matching Item,
           so labels align whether or not a row has an icon. */}
       <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
-      <span className="label p">{label}</span>
+      {/* `title` — native tooltip fallback for a truncated label; SPEC.md §10.17. */}
+      <span className="label p" title={label}>
+        {label}
+      </span>
       {slot ? <span className="end slot">{slot}</span> : null}
     </button>
   </li>

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemButton/styles.css
@@ -55,8 +55,12 @@
     color: var(--color-icon-disabled);
   }
 
+  /* Spec: item labels are single-line and truncate (§7 text overflow). */
   & .label {
     min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   & .end {

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.tests.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.tests.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import ItemExpandable from "./ItemExpandable.js";
@@ -69,5 +71,27 @@ describe("ItemExpandable", () => {
     const el = container.firstElementChild;
     expect(el?.className).toContain("ds side-navigation-item-expandable");
     expect(el?.className).toContain("custom-class");
+  });
+
+  it("gates the caret's rotation transition behind prefers-reduced-motion (SPEC.md §6)", () => {
+    // jsdom doesn't apply this package's CSS (confirmed in PR3/PR6 — nested
+    // `&` rules and @media blocks aren't evaluated against computed styles
+    // here), so this asserts the guard exists in the stylesheet source
+    // rather than a computed transition value. Vitest runs with cwd at the
+    // package root, so a cwd-relative path resolves reliably regardless of
+    // how the test module's own URL is transformed.
+    const css = readFileSync(
+      join(
+        process.cwd(),
+        "src/lib/SideNavigation/common/ItemExpandable/styles.css",
+      ),
+      "utf-8",
+    );
+    const mediaBlockStart = css.indexOf(
+      "@media (prefers-reduced-motion: no-preference)",
+    );
+    expect(mediaBlockStart).toBeGreaterThan(-1);
+    const transitionIndex = css.indexOf("transition: transform");
+    expect(transitionIndex).toBeGreaterThan(mediaBlockStart);
   });
 });

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/ItemExpandable.tsx
@@ -64,7 +64,10 @@ const ItemExpandable = ({
           {/* Start cell is always rendered (empty when no icon), matching
               Item, so labels align whether or not a row has an icon. */}
           <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
-          <span className="label p">{label}</span>
+          {/* `title` — native tooltip fallback for a truncated label; SPEC.md §10.17. */}
+          <span className="label p" title={label}>
+            {label}
+          </span>
           <Icon icon="chevron-down" className="end caret" />
         </summary>
         <ul className="children">{children}</ul>

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemExpandable/styles.css
@@ -63,8 +63,12 @@
     color: var(--color-icon-disabled);
   }
 
+  /* Spec: item labels are single-line and truncate (§7 text overflow). */
   & .label {
     min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* Disclosure caret — rotates open. Spec: "The transition is animated as

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/ItemSwitch.tsx
@@ -46,7 +46,10 @@ const ItemSwitch = ({
         {/* Start cell is always rendered (empty when no icon), matching
             Item, so labels align whether or not a row has an icon. */}
         <span className="start p">{icon ? <Icon icon={icon} /> : null}</span>
-        <span className="label p">{label}</span>
+        {/* `title` — native tooltip fallback for a truncated label; SPEC.md §10.17. */}
+        <span className="label p" title={label}>
+          {label}
+        </span>
         <span className="end">
           <SwitchInput
             checked={checked}

--- a/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/ItemSwitch/styles.css
@@ -40,8 +40,12 @@
     color: var(--color-icon-disabled);
   }
 
+  /* Spec: item labels are single-line and truncate (§7 text overflow). */
   & .label {
     min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   & .end {

--- a/packages/react/ds-app/src/lib/SideNavigation/common/Secondary/Secondary.tsx
+++ b/packages/react/ds-app/src/lib/SideNavigation/common/Secondary/Secondary.tsx
@@ -35,7 +35,10 @@ const Secondary = ({
     aria-label={ariaLabel ?? title}
   >
     <header className="header">
-      <span className="title p">{title}</span>
+      {/* `title` attribute — native tooltip fallback for a truncated title; SPEC.md §10.17. */}
+      <span className="title p" title={title}>
+        {title}
+      </span>
     </header>
     <Content
       root={root}

--- a/packages/react/ds-app/src/lib/SideNavigation/styles.css
+++ b/packages/react/ds-app/src/lib/SideNavigation/styles.css
@@ -59,4 +59,36 @@
       }
     }
   }
+
+  /* Responsive (SPEC.md §7): below Vanilla's "small" breakpoint, the rail
+     stops being a rail — the header is always shown; the body (Content AND
+     Footer, unlike the desktop collapsed state which keeps the footer
+     visible) is hidden until Menu is activated, then takes over the full
+     screen. Same `expanded` state and `collapsed` class as desktop; only
+     what they mean visually changes here. Drill-down navigation for
+     expandable/secondary-opening items (chevron-right + a back button) is
+     out of scope — SPEC.md §10.18. */
+  @media (max-width: 767px) {
+    inline-size: 100%;
+    flex-shrink: 1;
+    block-size: auto;
+
+    &:not(.collapsed) {
+      position: fixed;
+      inset: 0;
+      z-index: var(--z-index-overlay, 100);
+      inline-size: 100%;
+      block-size: 100dvh;
+    }
+
+    &.collapsed {
+      inline-size: 100%;
+
+      /* Overrides the desktop collapsed rule above: the body is hidden
+         entirely on mobile, not shown icon-only. */
+      & > .ds.footer {
+        display: none;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Done

Implements `SPEC.md` §7 (responsive, text overflow) and closes out §6/§8 (focus order, reduced motion) with dedicated coverage — PR 8 of the sequence tracked in `SPEC.md` §8:

- Below Vanilla's small breakpoint (<768px): `CollapseToggle` swaps its icon for a "Menu"/"Close menu" text label — plain CSS-toggled siblings (an icon and a text span, one hidden per breakpoint via media query), not a JS media-query read, so the choice needs no client-only branch and stays SSR-identical. `SideNavigation`'s own collapsed state means "menu closed" (header only, both `Content` AND `Footer` hidden — unlike the desktop collapsed rail, which keeps the footer visible icon-only) and expanded means a fullscreen fixed overlay rather than a 240px rail. `Header`'s centred-column collapsed layout (built for the desktop icon rail) is suppressed under the same breakpoint, since mobile's header stays in its normal row layout.
- Every label (`Item`/`ItemButton`/`ItemSwitch`/`ItemExpandable`/`GroupHeader`/`Secondary`'s title) now truncates with an ellipsis on overflow and sets a native `title` attribute as a working, if not pixel-accurate, fallback for the spec's custom 800ms-delay tooltip (`SPEC.md` §10.17 — a precise version needs to detect *actual* truncation via a `ResizeObserver`-backed hook that doesn't exist yet in this repo; unconditionally wrapping every label in `withTooltip` would show a tooltip even when nothing is truncated).
- New tests: focus order across the whole component (logo → collapse toggle → content → footer, matching DOM order, `SPEC.md` §6) and a reduced-motion regression guard reading `ItemExpandable`'s own stylesheet source to confirm the caret's rotation transition stays behind `@media (prefers-reduced-motion: no-preference)` — jsdom doesn't evaluate this package's CSS at all (confirmed in PR 3/PR 6: nested `&` rules and `@media` blocks aren't applied to computed styles), so a source-level assertion is the reliable option available without a real browser.

The mobile drill-down for expandable/secondary-opening items (chevron-right navigating to a full-screen sub-page, with a back button) is out of scope (`SPEC.md` §10.18) — it needs its own navigation-stack state and a mobile-only `ItemExpandable` rendering path, a separate interaction mode rather than a CSS variation of what ships here.

## QA

- `bun run test` and `bun run check` pass, including the new focus-order and reduced-motion regression tests.
- Resize the viewport below 768px and confirm the menu/close-menu label swap and fullscreen overlay behaviour.

### PR readiness check

- [x] PR title follows Conventional Commits.
- [x] The code follows the appropriate [code standards](https://github.com/canonical/web-code-standards)
- [x] All packages define the required scripts in `package.json`
- [ ] No new package introduced
- [ ] Chromatic: skip — responsive behaviour change; leaving default Chromatic review enabled.
